### PR TITLE
fix(android): complete chat health refresh after overlapping history

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -459,8 +459,6 @@ class ChatController internal constructor(
 
     data object Superseded : HistoryRefreshResult
 
-    data object BranchInvalidated : HistoryRefreshResult
-
     data object OwnerUnavailable : HistoryRefreshResult
 
     data object Failed : HistoryRefreshResult
@@ -4542,21 +4540,14 @@ class ChatController internal constructor(
     try {
       // Cache-first cold open: live history always replaces cached rows wholesale.
       primeFromCache(sessionKey, generation)
-      var historyResult: HistoryRefreshResult
-      do {
-        currentCoroutineContext().ensureActive()
-        if (!isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get())) return@async
-        historyResult =
-          fetchAndApplyHistory(
-            sessionKey,
-            generation,
-            purpose = HistoryRefreshPurpose.RestoreSession,
-            runIdsToReconcile = runIdsToReconcile,
-            refreshBranches = true,
-          )
-        // Branch evidence can fence the only recovery request without a successor load.
-        // Keep this owner, but fetch new history rather than adopting the rejected response.
-      } while (historyResult == HistoryRefreshResult.BranchInvalidated)
+      val historyResult =
+        fetchAndApplyHistory(
+          sessionKey,
+          generation,
+          purpose = HistoryRefreshPurpose.RestoreSession,
+          runIdsToReconcile = runIdsToReconcile,
+          refreshBranches = true,
+        )
       if (historyResult !is HistoryRefreshResult.Applied) return@async
       if (isSwarmEnabled()) refreshSwarmSessions()
     } catch (err: CancellationException) {
@@ -4600,7 +4591,7 @@ class ChatController internal constructor(
     refreshBranches: Boolean = false,
     mutationReconciliationState: ChatOutboxBranchState? = null,
   ): HistoryRefreshResult {
-    val requestSequence = historyRequestSequence.incrementAndGet()
+    var requestSequence = historyRequestSequence.incrementAndGet()
     val healthRefresh =
       synchronized(gatewayScopeApplyLock) {
         if (!isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get())) return HistoryRefreshResult.Superseded
@@ -4615,208 +4606,220 @@ class ChatController internal constructor(
         }
       }
     try {
-      val runIdsOwnedAtRequest = synchronized(pendingRuns) { pendingRuns.toSet() }
-      val reconciliationRunIds =
-        if (purpose == HistoryRefreshPurpose.Transcript) {
-          runIdsOwnedAtRequest + optimisticMessagesByRunId.keys + unresolvedRepliesByRunId.keys
-        } else {
-          runIdsToReconcile
-        }
-      val requestCacheScope = currentCacheScope()
-      val requestTracksDefaultAgent = activeSessionTracksDefaultAgent(sessionKey)
-      awaitMainSessionReadiness(sessionKey, requestCacheScope)
-      val requestSettingsGeneration = settingsPublicationGeneration.get()
-      val requestDefaultAgentRevision = currentDefaultAgentRevision()
-      val requestAgentId = resolveAgentIdForSessionKey(sessionKey) ?: return HistoryRefreshResult.OwnerUnavailable
+      while (true) {
+        currentCoroutineContext().ensureActive()
+        val runIdsOwnedAtRequest = synchronized(pendingRuns) { pendingRuns.toSet() }
+        val reconciliationRunIds =
+          if (purpose == HistoryRefreshPurpose.Transcript) {
+            runIdsOwnedAtRequest + optimisticMessagesByRunId.keys + unresolvedRepliesByRunId.keys
+          } else {
+            runIdsToReconcile
+          }
+        val requestCacheScope = currentCacheScope()
+        val requestTracksDefaultAgent = activeSessionTracksDefaultAgent(sessionKey)
+        awaitMainSessionReadiness(sessionKey, requestCacheScope)
+        val requestSettingsGeneration = settingsPublicationGeneration.get()
+        val requestDefaultAgentRevision = currentDefaultAgentRevision()
+        val requestAgentId = resolveAgentIdForSessionKey(sessionKey) ?: return HistoryRefreshResult.OwnerUnavailable
 
-      fun requestOwnerIsCurrent(): Boolean =
-        resolveAgentIdForSessionKey(_sessionKey.value) == requestAgentId &&
-          (
-            !requestTracksDefaultAgent ||
-              (currentDefaultAgentRevision() == requestDefaultAgentRevision && effectiveDefaultAgentId() == requestAgentId)
-          )
-
-      fun isCurrent(): Boolean =
-        isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get()) &&
-          requestCacheScope == currentCacheScope() &&
-          requestOwnerIsCurrent() &&
-          requestSequence >= latestAppliedHistoryRequest
-
-      if (!synchronized(gatewayScopeApplyLock) { isCurrent() }) return HistoryRefreshResult.Superseded
-      val branchSnapshot = currentSessionActionSnapshot(sessionKey)
-      // Publishing a transcript establishes enqueue intent, not dispatch readiness. A requested
-      // listing must still settle the active branch before health can release this scope.
-      if (refreshBranches) branchSnapshot?.let { markOutboxBranchUnreconciled(it.gatewayScope, it.outboxScope()) }
-      // Only a locally ambiguous mutation carries an earlier adoption boundary. Ordinary history
-      // (including remote branch events) must settle earlier input before becoming visible.
-      var historyBranchState = mutationReconciliationState ?: branchSnapshot?.let { branchState(it) }
-      val history =
-        try {
-          val historyJson =
-            requestGatewayBound(
-              requestCacheScope?.gatewayId,
-              "chat.history",
-              buildJsonObject {
-                put("sessionKey", JsonPrimitive(sessionKey))
-                put("agentId", JsonPrimitive(requestAgentId))
-              }.toString(),
+        fun requestOwnerIsCurrent(): Boolean =
+          resolveAgentIdForSessionKey(_sessionKey.value) == requestAgentId &&
+            (
+              !requestTracksDefaultAgent ||
+                (currentDefaultAgentRevision() == requestDefaultAgentRevision && effectiveDefaultAgentId() == requestAgentId)
             )
-          parseHistory(historyJson, sessionKey = sessionKey, previousMessages = _messages.value)
-        } catch (err: CancellationException) {
-          throw err
-        } catch (err: Throwable) {
-          if (!synchronized(gatewayScopeApplyLock) { isCurrent() }) return HistoryRefreshResult.Superseded
-          throw err
-        }
-      var appliedHistoryEntry: ChatSessionEntry? = null
-      val applied =
-        historyPublicationMutex.withLock {
-          if (!synchronized(gatewayScopeApplyLock) { isCurrent() }) return@withLock HistoryRefreshResult.Superseded
-          val previousState =
-            historyBranchState?.let { captured ->
-              // Continue only a committed history publication from this load. Never recapture after
-              // enqueue or borrow authority from branch listings or mutation-lease changes.
-              publishedHistoryBranch
-                ?.takeIf {
-                  mutationReconciliationState == null &&
-                    it.snapshot == branchSnapshot &&
-                    it.generation == generation &&
-                    it.state.revision > captured.revision
-                }?.state ?: captured
-            }
-          historyBranchState = previousState
-          if (
-            mutationReconciliationState == null &&
-            branchSnapshot != null &&
-            previousState != null
-          ) {
-            historyBranchState = reconcileOutboxHistory(
-              gatewayId = requestCacheScope?.gatewayId ?: return@withLock HistoryRefreshResult.OwnerUnavailable,
-              branchScope = branchSnapshot.outboxScope(),
-              previousState = previousState,
-              history = history,
-            ) ?: return@withLock HistoryRefreshResult.BranchInvalidated
-          }
-          synchronized(gatewayScopeApplyLock) {
-            if (!isCurrent()) return@synchronized HistoryRefreshResult.Superseded
-            // Transcript events do not own settings or run state. They may finish
-            // a pending load only while that exact load still needs its snapshot.
-            val appliedPurpose =
-              if (
-                purpose == HistoryRefreshPurpose.Transcript &&
-                !hasCurrentHistorySnapshot(sessionKey)
-              ) {
-                HistoryRefreshPurpose.RestoreSession
-              } else {
-                purpose
-              }
-            val reconcileRunState = appliedPurpose != HistoryRefreshPurpose.Transcript
-            val runIdsOwnedAfterRequest =
-              synchronized(pendingRuns) {
-                pendingRuns.filterNotTo(mutableSetOf()) { it in runIdsOwnedAtRequest }
-              }
-            latestAppliedHistoryRequest = requestSequence
-            if (mutationReconciliationState == null && branchSnapshot != null && historyBranchState != previousState) {
-              historyBranchState?.let { publishedHistoryBranch = PublishedHistoryBranch(branchSnapshot, generation, it) }
-            }
-            val snapshotRunId =
-              history.inFlightRun
-                ?.runId
-                ?.trim()
-                ?.takeIf { it.isNotEmpty() }
-            if (reconcileRunState) {
-              // A newer settings observation invalidates only this projection,
-              // not the useful transcript carried by the same history response.
-              appliedHistoryEntry =
-                updateSessionFromHistory(
-                  history,
-                  ownerAgentId = requestAgentId,
-                  publishRunState = false,
-                  includeSessionInfo = appliedPurpose == HistoryRefreshPurpose.RestoreSession,
-                  preserveSessionSettings =
-                    requestSettingsGeneration != settingsPublicationGeneration.get() ||
-                      pendingSettingsMutations.containsKey(sessionSettingsKey(sessionKey)),
-                )
-              transferLostAckOwnershipFromHistory(history)
-              latestAppliedRunSnapshot = HistoryRunSnapshot(requestSequence, snapshotRunId)
-            }
-            resolvePersistedReplies(history.messages)
-            val optimisticRunIds = reconciliationRunIds.filterTo(mutableSetOf()) { optimisticMessagesByRunId.containsKey(it) }
-            prunePersistedOptimisticMessages(history.messages)
-            if (reconcileRunState && snapshotRunId == null) {
-              optimisticRunIds
-                .filterNot { runId ->
-                  unknownOutcomeRunIds.contains(runId) && unresolvedRepliesByRunId.containsKey(runId)
-                }.filterNotTo(mutableSetOf()) { optimisticMessagesByRunId.containsKey(it) }
-                .forEach { clearPendingRun(it, publishRunState = false) }
-            }
-            if (reconcileRunState && snapshotRunId != null) {
-              reconciliationRunIds
-                .filterTo(mutableSetOf()) {
-                  it != snapshotRunId &&
-                    !optimisticMessagesByRunId.containsKey(it) &&
-                    !unresolvedRepliesByRunId.containsKey(it)
-                }.forEach { clearPendingRun(it, publishRunState = false) }
-            }
-            val nextMessages = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
-            _messagesFromCache.value = false
-            _messages.value = nextMessages
-            val previousAnchor = _transcriptAnchor.value?.takeIf { it.sessionKey == sessionKey }
-            val completionSettled =
-              markCompletedTranscript &&
-                runIdsToReconcile.none(unresolvedRepliesByRunId::containsKey) &&
-                history.sessionInfo?.endedAt != null
-            _transcriptAnchor.value =
-              ChatTranscriptAnchorState(
-                sessionKey = sessionKey,
-                newestItemId = nextMessages.lastOrNull()?.id,
-                completedEndedAt =
-                  if (completionSettled) history.sessionInfo.endedAt else previousAnchor?.completedEndedAt,
-                completedNewestItemId =
-                  if (completionSettled) history.messages.lastOrNull()?.id else previousAnchor?.completedNewestItemId,
+
+        fun isCurrent(): Boolean =
+          isCurrentHistoryLoad(sessionKey, _sessionKey.value, generation, historyLoadGeneration.get()) &&
+            requestCacheScope == currentCacheScope() &&
+            requestOwnerIsCurrent() &&
+            requestSequence >= latestAppliedHistoryRequest
+
+        if (!synchronized(gatewayScopeApplyLock) { isCurrent() }) return HistoryRefreshResult.Superseded
+        val branchSnapshot = currentSessionActionSnapshot(sessionKey)
+        // Publishing a transcript establishes enqueue intent, not dispatch readiness. A requested
+        // listing must still settle the active branch before health can release this scope.
+        if (refreshBranches) branchSnapshot?.let { markOutboxBranchUnreconciled(it.gatewayScope, it.outboxScope()) }
+        // Only a locally ambiguous mutation carries an earlier adoption boundary. Ordinary history
+        // (including remote branch events) must settle earlier input before becoming visible.
+        var historyBranchState = mutationReconciliationState ?: branchSnapshot?.let { branchState(it) }
+        val history =
+          try {
+            val historyJson =
+              requestGatewayBound(
+                requestCacheScope?.gatewayId,
+                "chat.history",
+                buildJsonObject {
+                  put("sessionKey", JsonPrimitive(sessionKey))
+                  put("agentId", JsonPrimitive(requestAgentId))
+                }.toString(),
               )
-            _sessionId.value = history.sessionId
-            history.sessionId?.let { sessionId ->
-              lastSelectedChatSessionByOwner[ChatAgentSessionSelectionOwner(requestCacheScope?.gatewayId, requestAgentId)]
-                ?.takeIf { it.key == sessionKey }
-                ?.observedSessionId = sessionId
-            }
-            markLiveHistoryApplied(sessionKey = sessionKey, sessionId = history.sessionId, generation = generation)
-            _historyLoading.value = false
-            if (historyLoadErrorGeneration == generation) {
-              updateErrorText(null)
-            }
-            if (reconcileRunState && history.inFlightRun == null) {
-              // Empty history is terminal proof for acknowledged runs. An unknown-outcome
-              // send stays owned until its reply persists, a terminal arrives, or it expires.
-              reconciliationRunIds
-                .filterNot { runId ->
-                  unknownOutcomeRunIds.contains(runId) && unresolvedRepliesByRunId.containsKey(runId)
-                }.forEach { clearPendingRun(it, publishRunState = false) }
-            }
-            if (reconcileRunState) {
-              clearTransientRunUiIfIdle()
-              adoptInFlightRun(history, runIdsOwnedAfterRequest)
-            }
-            publishRunPresentation()
-            enqueueTranscriptCacheWrite(requestCacheScope, requestAgentId, sessionKey, history.messages)
-            HistoryRefreshResult.Applied(historyBranchState, appliedPurpose)
+            parseHistory(historyJson, sessionKey = sessionKey, previousMessages = _messages.value)
+          } catch (err: CancellationException) {
+            throw err
+          } catch (err: Throwable) {
+            if (!synchronized(gatewayScopeApplyLock) { isCurrent() }) return HistoryRefreshResult.Superseded
+            throw err
           }
+        var appliedHistoryEntry: ChatSessionEntry? = null
+        val applied =
+          historyPublicationMutex.withLock {
+            if (!synchronized(gatewayScopeApplyLock) { isCurrent() }) return@withLock HistoryRefreshResult.Superseded
+            val previousState =
+              historyBranchState?.let { captured ->
+                // Continue only a committed history publication from this load. Never recapture after
+                // enqueue or borrow authority from branch listings or mutation-lease changes.
+                publishedHistoryBranch
+                  ?.takeIf {
+                    mutationReconciliationState == null &&
+                      it.snapshot == branchSnapshot &&
+                      it.generation == generation &&
+                      it.state.revision > captured.revision
+                  }?.state ?: captured
+              }
+            historyBranchState = previousState
+            if (
+              mutationReconciliationState == null &&
+              branchSnapshot != null &&
+              previousState != null
+            ) {
+              historyBranchState = reconcileOutboxHistory(
+                gatewayId = requestCacheScope?.gatewayId ?: return@withLock HistoryRefreshResult.OwnerUnavailable,
+                branchScope = branchSnapshot.outboxScope(),
+                previousState = previousState,
+                history = history,
+              ) ?: return@withLock null
+            }
+            synchronized(gatewayScopeApplyLock) {
+              if (!isCurrent()) return@synchronized HistoryRefreshResult.Superseded
+              // Transcript events do not own settings or run state. They may finish
+              // a pending load only while that exact load still needs its snapshot.
+              val appliedPurpose =
+                if (
+                  purpose == HistoryRefreshPurpose.Transcript &&
+                  !hasCurrentHistorySnapshot(sessionKey)
+                ) {
+                  HistoryRefreshPurpose.RestoreSession
+                } else {
+                  purpose
+                }
+              val reconcileRunState = appliedPurpose != HistoryRefreshPurpose.Transcript
+              val runIdsOwnedAfterRequest =
+                synchronized(pendingRuns) {
+                  pendingRuns.filterNotTo(mutableSetOf()) { it in runIdsOwnedAtRequest }
+                }
+              latestAppliedHistoryRequest = requestSequence
+              if (mutationReconciliationState == null && branchSnapshot != null && historyBranchState != previousState) {
+                historyBranchState?.let { publishedHistoryBranch = PublishedHistoryBranch(branchSnapshot, generation, it) }
+              }
+              val snapshotRunId =
+                history.inFlightRun
+                  ?.runId
+                  ?.trim()
+                  ?.takeIf { it.isNotEmpty() }
+              if (reconcileRunState) {
+                // A newer settings observation invalidates only this projection,
+                // not the useful transcript carried by the same history response.
+                appliedHistoryEntry =
+                  updateSessionFromHistory(
+                    history,
+                    ownerAgentId = requestAgentId,
+                    publishRunState = false,
+                    includeSessionInfo = appliedPurpose == HistoryRefreshPurpose.RestoreSession,
+                    preserveSessionSettings =
+                      requestSettingsGeneration != settingsPublicationGeneration.get() ||
+                        pendingSettingsMutations.containsKey(sessionSettingsKey(sessionKey)),
+                  )
+                transferLostAckOwnershipFromHistory(history)
+                latestAppliedRunSnapshot = HistoryRunSnapshot(requestSequence, snapshotRunId)
+              }
+              resolvePersistedReplies(history.messages)
+              val optimisticRunIds = reconciliationRunIds.filterTo(mutableSetOf()) { optimisticMessagesByRunId.containsKey(it) }
+              prunePersistedOptimisticMessages(history.messages)
+              if (reconcileRunState && snapshotRunId == null) {
+                optimisticRunIds
+                  .filterNot { runId ->
+                    unknownOutcomeRunIds.contains(runId) && unresolvedRepliesByRunId.containsKey(runId)
+                  }.filterNotTo(mutableSetOf()) { optimisticMessagesByRunId.containsKey(it) }
+                  .forEach { clearPendingRun(it, publishRunState = false) }
+              }
+              if (reconcileRunState && snapshotRunId != null) {
+                reconciliationRunIds
+                  .filterTo(mutableSetOf()) {
+                    it != snapshotRunId &&
+                      !optimisticMessagesByRunId.containsKey(it) &&
+                      !unresolvedRepliesByRunId.containsKey(it)
+                  }.forEach { clearPendingRun(it, publishRunState = false) }
+              }
+              val nextMessages = mergeOptimisticMessages(incoming = history.messages, optimistic = optimisticMessagesByRunId.values)
+              _messagesFromCache.value = false
+              _messages.value = nextMessages
+              val previousAnchor = _transcriptAnchor.value?.takeIf { it.sessionKey == sessionKey }
+              val completionSettled =
+                markCompletedTranscript &&
+                  runIdsToReconcile.none(unresolvedRepliesByRunId::containsKey) &&
+                  history.sessionInfo?.endedAt != null
+              _transcriptAnchor.value =
+                ChatTranscriptAnchorState(
+                  sessionKey = sessionKey,
+                  newestItemId = nextMessages.lastOrNull()?.id,
+                  completedEndedAt =
+                    if (completionSettled) history.sessionInfo.endedAt else previousAnchor?.completedEndedAt,
+                  completedNewestItemId =
+                    if (completionSettled) history.messages.lastOrNull()?.id else previousAnchor?.completedNewestItemId,
+                )
+              _sessionId.value = history.sessionId
+              history.sessionId?.let { sessionId ->
+                lastSelectedChatSessionByOwner[ChatAgentSessionSelectionOwner(requestCacheScope?.gatewayId, requestAgentId)]
+                  ?.takeIf { it.key == sessionKey }
+                  ?.observedSessionId = sessionId
+              }
+              markLiveHistoryApplied(sessionKey = sessionKey, sessionId = history.sessionId, generation = generation)
+              _historyLoading.value = false
+              if (historyLoadErrorGeneration == generation) {
+                updateErrorText(null)
+              }
+              if (reconcileRunState && history.inFlightRun == null) {
+                // Empty history is terminal proof for acknowledged runs. An unknown-outcome
+                // send stays owned until its reply persists, a terminal arrives, or it expires.
+                reconciliationRunIds
+                  .filterNot { runId ->
+                    unknownOutcomeRunIds.contains(runId) && unresolvedRepliesByRunId.containsKey(runId)
+                  }.forEach { clearPendingRun(it, publishRunState = false) }
+              }
+              if (reconcileRunState) {
+                clearTransientRunUiIfIdle()
+                adoptInFlightRun(history, runIdsOwnedAfterRequest)
+              }
+              publishRunPresentation()
+              enqueueTranscriptCacheWrite(requestCacheScope, requestAgentId, sessionKey, history.messages)
+              HistoryRefreshResult.Applied(historyBranchState, appliedPurpose)
+            }
+          }
+        if (applied == null) {
+          // A branch write can reject current history without replacing its owner.
+          // Keep the health obligation and refetch; never adopt the rejected response.
+          synchronized(gatewayScopeApplyLock) {
+            if (!isCurrent()) return HistoryRefreshResult.Superseded
+            requestSequence = historyRequestSequence.incrementAndGet()
+          }
+          continue
         }
-      if (applied !is HistoryRefreshResult.Applied) return applied
-      // Canonical history retires delivered rows before further RPCs can delay that proof.
-      // Resuming their queued successors still waits for branch reconciliation and health.
-      val outboxChanged =
-        requestCacheScope != null &&
-          reconcileDurableSendsAgainstHistory(requestCacheScope.gatewayId, history, requestAgentId)
-      publishOutbox()
-      appliedHistoryEntry?.let { acknowledgeUnreadIfNeeded(it.key, it, requireActive = true) }
-      if (refreshBranches && branchSnapshot != null) {
-        refreshSessionBranches(branchSnapshot, historyBranchState, BranchRefreshPurpose.Reconcile)
+        if (applied !is HistoryRefreshResult.Applied) return applied
+        // Canonical history retires delivered rows before further RPCs can delay that proof.
+        // Resuming their queued successors still waits for branch reconciliation and health.
+        val outboxChanged =
+          requestCacheScope != null &&
+            reconcileDurableSendsAgainstHistory(requestCacheScope.gatewayId, history, requestAgentId)
+        publishOutbox()
+        appliedHistoryEntry?.let { acknowledgeUnreadIfNeeded(it.key, it, requireActive = true) }
+        if (refreshBranches && branchSnapshot != null) {
+          refreshSessionBranches(branchSnapshot, historyBranchState, BranchRefreshPurpose.Reconcile)
+        }
+        pollHealthIfNeeded(sessionKey, generation)
+        if (outboxChanged) kickFlushForRoutedBacklog()
+        return applied
       }
-      pollHealthIfNeeded(sessionKey, generation)
-      if (outboxChanged) kickFlushForRoutedBacklog()
-      return applied
     } finally {
       finishHistoryHealth(healthRefresh, generation)
     }
@@ -7209,12 +7212,8 @@ class ChatController internal constructor(
           armPendingRunTimeout(runId)
           return@launch
         }
-        if (
-          currentSession &&
-          !freshSnapshotApplied &&
-          (historyResult == HistoryRefreshResult.Superseded || historyResult == HistoryRefreshResult.BranchInvalidated)
-        ) {
-          // A newer load or branch evidence fenced this snapshot. Defer expiry;
+        if (currentSession && !freshSnapshotApplied && historyResult == HistoryRefreshResult.Superseded) {
+          // A newer load or applied history fenced this snapshot. Defer expiry;
           // fresh history or the next watchdog must decide the run.
           armPendingRunTimeout(runId)
           return@launch

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -667,6 +667,11 @@ class ChatControllerBranchCoordinationTest {
     val releaseRefresh = CompletableDeferred<Unit>()
     val branchesStarted = CompletableDeferred<Job>()
     val releaseBranches = CompletableDeferred<Unit>()
+    val earlierBranchesStarted = CompletableDeferred<Job>()
+    val releaseEarlierBranches = CompletableDeferred<Unit>()
+    val holdEarlierBranches = AtomicBoolean(false)
+    val takeoverHistoryStarted = CompletableDeferred<Job>()
+    val releaseTakeoverHistory = CompletableDeferred<Unit>()
     val sent = AtomicReference<JsonObject?>(null)
     gateway.respond("health") {
       check(healthy.get()) { "health unavailable; history transport remains connected" }
@@ -686,9 +691,18 @@ class ChatControllerBranchCoordinationTest {
         refreshStarted.complete(requireNotNull(currentCoroutineContext()[Job]))
         releaseRefresh.await()
       }
+      if (request == 3) {
+        takeoverHistoryStarted.complete(requireNotNull(currentCoroutineContext()[Job]))
+        releaseTakeoverHistory.await()
+      }
       response
     }
     gateway.respond("sessions.branches.list") {
+      if (holdEarlierBranches.compareAndSet(true, false)) {
+        earlierBranchesStarted.complete(requireNotNull(currentCoroutineContext()[Job]))
+        releaseEarlierBranches.await()
+        return@respond """{"branches":[{"leafEntryId":"A","headline":"Current","messageCount":1,"active":true}]}"""
+      }
       if (historyRequests.get() > 1) {
         branchesStarted.complete(requireNotNull(currentCoroutineContext()[Job]))
         releaseBranches.await()
@@ -719,56 +733,74 @@ class ChatControllerBranchCoordinationTest {
         ?.leafEntryId == "A"
     }
     val healthRequestsBeforeRefresh = gateway.callCount("health")
-    healthy.set(healthAvailable)
-    controller.refresh()
-    awaitBranchProgress { refreshStarted.isCompleted }
+    try {
+      holdEarlierBranches.set(true)
+      val earlierBranches = async { controller.refreshSessionBranches() }
+      awaitBranchProgress { earlierBranchesStarted.isCompleted }
+      healthy.set(healthAvailable)
+      controller.refresh()
+      awaitBranchProgress { refreshStarted.isCompleted }
 
-    val attachment = OutgoingAttachment("image", "image/png", "proof.png", "AQIDBA==")
-    assertTrue(controller.sendMessageAwaitAcceptance("during refresh", "off", listOf(attachment)))
-    awaitBranchProgress { branchesStarted.isCompleted }
-    val admitted = outbox.load("gateway-a").single()
-    assertEquals(ChatOutboxStatus.Queued, admitted.status)
-    assertEquals(listOf("A", "A2"), controller.messages.value.map { it.content.single().text })
+      val attachment = OutgoingAttachment("image", "image/png", "proof.png", "AQIDBA==")
+      assertTrue(controller.sendMessageAwaitAcceptance("during refresh", "off", listOf(attachment)))
+      awaitBranchProgress { takeoverHistoryStarted.isCompleted }
+      val takeoverHistory = takeoverHistoryStarted.await()
+      // The earlier listing commits after the takeover captured its Room revision.
+      releaseEarlierBranches.complete(Unit)
+      assertTrue("The earlier branch listing remains authoritative until newer history publishes", earlierBranches.await())
+      releaseTakeoverHistory.complete(Unit)
+      awaitBranchProgress { branchesStarted.isCompleted || takeoverHistory.isCompleted }
+      assertTrue("The current history owner must retry after the older listing fences its response", branchesStarted.isCompleted)
+      assertTrue("Rejected history must be replaced by a fresh Gateway request", historyRequests.get() >= 4)
+      val admitted = outbox.load("gateway-a").single()
+      assertEquals(ChatOutboxStatus.Queued, admitted.status)
+      assertEquals(listOf("A", "A2"), controller.messages.value.map { it.content.single().text })
 
-    releaseRefresh.complete(Unit)
-    runCurrent()
-    assertEquals("Newer history must survive the late explicit refresh", listOf("A", "A2"), controller.messages.value.map { it.content.single().text })
-    assertEquals("No dispatch before authoritative branch evidence", 0, gateway.callCount("chat.send"))
-    assertEquals(admitted, outbox.load("gateway-a").single())
-    assertTrue(byteArrayOf(1, 2, 3, 4).contentEquals(outbox.loadAttachments(admitted.id).single().bytes))
-
-    releaseBranches.complete(Unit)
-    refreshStarted.await().join()
-    branchesStarted.await().join()
-    runCurrent()
-    assertEquals("Refresh must force health even when outbox reconciliation supplied history", healthRequestsBeforeRefresh + 1, gateway.callCount("health"))
-    assertEquals(healthAvailable, controller.healthOk.value)
-    if (healthAvailable) {
-      awaitBranchProgress {
-        outbox.load("gateway-a").isEmpty() && controller.messages.value
-          .lastOrNull()
-          ?.content
-          ?.singleOrNull()
-          ?.text == "delivered"
-      }
-      assertEquals(1, gateway.callCount("chat.send"))
-      val params = requireNotNull(sent.get())
-      assertEquals(admitted.id, params.getValue("idempotencyKey").jsonPrimitive.content)
-      assertEquals(key, params.getValue("sessionKey").jsonPrimitive.content)
-      assertEquals("during refresh", params.getValue("message").jsonPrimitive.content)
-      assertEquals(
-        attachment.base64,
-        params
-          .getValue("attachments")
-          .jsonArray
-          .single()
-          .jsonObject
-          .getValue("content")
-          .jsonPrimitive.content,
-      )
-    } else {
-      assertEquals("Failed health refresh must not dispatch after branch reconciliation completes", 0, gateway.callCount("chat.send"))
+      releaseRefresh.complete(Unit)
+      runCurrent()
+      assertEquals("Newer history must survive the late explicit refresh", listOf("A", "A2"), controller.messages.value.map { it.content.single().text })
+      assertEquals("No dispatch before authoritative branch evidence", 0, gateway.callCount("chat.send"))
       assertEquals(admitted, outbox.load("gateway-a").single())
+      assertTrue(byteArrayOf(1, 2, 3, 4).contentEquals(outbox.loadAttachments(admitted.id).single().bytes))
+
+      releaseBranches.complete(Unit)
+      refreshStarted.await().join()
+      branchesStarted.await().join()
+      runCurrent()
+      assertEquals("Refresh must force health even when outbox reconciliation supplied history", healthRequestsBeforeRefresh + 1, gateway.callCount("health"))
+      assertEquals(healthAvailable, controller.healthOk.value)
+      if (healthAvailable) {
+        awaitBranchProgress {
+          outbox.load("gateway-a").isEmpty() && controller.messages.value
+            .lastOrNull()
+            ?.content
+            ?.singleOrNull()
+            ?.text == "delivered"
+        }
+        assertEquals(1, gateway.callCount("chat.send"))
+        val params = requireNotNull(sent.get())
+        assertEquals(admitted.id, params.getValue("idempotencyKey").jsonPrimitive.content)
+        assertEquals(key, params.getValue("sessionKey").jsonPrimitive.content)
+        assertEquals("during refresh", params.getValue("message").jsonPrimitive.content)
+        assertEquals(
+          attachment.base64,
+          params
+            .getValue("attachments")
+            .jsonArray
+            .single()
+            .jsonObject
+            .getValue("content")
+            .jsonPrimitive.content,
+        )
+      } else {
+        assertEquals("Failed health refresh must not dispatch after branch reconciliation completes", 0, gateway.callCount("chat.send"))
+        assertEquals(admitted, outbox.load("gateway-a").single())
+      }
+    } finally {
+      releaseEarlierBranches.complete(Unit)
+      releaseTakeoverHistory.complete(Unit)
+      releaseRefresh.complete(Unit)
+      releaseBranches.complete(Unit)
     }
   }
 
@@ -899,21 +931,26 @@ class ChatControllerBranchCoordinationTest {
     val key = "agent:main:overlap"
     val branchScope = ChatOutboxScope(key, "main")
     val gateway = ScriptedGateway(json)
-    val entered = List(3) { CompletableDeferred<Unit>() }
-    val release = List(3) { CompletableDeferred<Unit>() }
+    val entered = List(4) { CompletableDeferred<Unit>() }
+    val release = List(4) { CompletableDeferred<Unit>() }
     val requests = AtomicInteger()
     gateway.respond("health") { throw IllegalStateException("health unavailable") }
     gateway.respondWith("sessions.branches.list", """{"branches":[{"leafEntryId":"A1","headline":"Current","messageCount":1,"active":true}]}""")
     gateway.respond("chat.history") {
       val index = requests.getAndIncrement()
-      check(index < 3) { "Unexpected history retry" }
+      check(index < 3 || (independentListing && index == 3)) { "Unexpected history retry" }
       if (index > 0) {
         entered[index].complete(Unit)
         release[index].await()
       }
-      val entries = if (index == 2 && branchSwitch) listOf("B") else (1..index + 1).map { "A$it" }
+      val entries =
+        when {
+          independentListing && index == 3 -> listOf("listed-B")
+          index == 2 && branchSwitch -> listOf("B")
+          else -> (1..index + 1).map { "A$it" }
+        }
       historyResponse(
-        sessionId = if (index == 2 && branchSwitch) "session-B" else "session-A",
+        sessionId = if ((independentListing && index == 3) || (index == 2 && branchSwitch)) "session-B" else "session-A",
         messages = entries.mapIndexed { i, entry -> ReplayHistoryMessage("assistant", entry, i.toLong(), entryId = entry) },
       )
     }
@@ -933,63 +970,77 @@ class ChatControllerBranchCoordinationTest {
         .toList()
         .also { assertTrue(it.isNotEmpty()) }
     }
-    val older = requestHistory("external-older")
-    awaitBranchProgress { entered[1].isCompleted }
-    val newer = requestHistory("external-newer")
-    awaitBranchProgress { entered[2].isCompleted }
-    assertEquals(initial, outbox.branchState("gateway-a", branchScope))
+    try {
+      val older = requestHistory("external-older")
+      awaitBranchProgress { entered[1].isCompleted }
+      val newer = requestHistory("external-newer")
+      awaitBranchProgress { entered[2].isCompleted }
+      assertEquals(initial, outbox.branchState("gateway-a", branchScope))
 
-    release[if (olderFirst) 1 else 2].complete(Unit)
-    awaitBranchProgress { (if (olderFirst) older else newer).all { it.isCompleted } }
-    assertEquals(
-      if (olderFirst) {
-        "A2"
-      } else if (branchSwitch) {
-        "B"
-      } else {
-        "A3"
-      },
-      controller.messages.value
-        .last()
-        .entryId,
-    )
-    assertTrue(controller.sendMessageAwaitAcceptance("between responses", "off", emptyList()))
-    val admitted = outbox.load("gateway-a").single()
-    if (independentListing) {
-      gateway.respondWith(
-        "sessions.branches.list",
-        """{"branches":[
-          {"leafEntryId":"A2","headline":"Earlier","messageCount":2,"active":false},
-          {"leafEntryId":"listed-B","headline":"Current","messageCount":1,"active":true}
-        ]}""",
+      release[if (olderFirst) 1 else 2].complete(Unit)
+      awaitBranchProgress { (if (olderFirst) older else newer).all { it.isCompleted } }
+      assertEquals(
+        if (olderFirst) {
+          "A2"
+        } else if (branchSwitch) {
+          "B"
+        } else {
+          "A3"
+        },
+        controller.messages.value
+          .last()
+          .entryId,
       )
-      assertTrue(controller.refreshSessionBranches())
-    }
-    val beforeLastResponse = requireNotNull(outbox.branchState("gateway-a", branchScope))
-
-    release[if (olderFirst) 2 else 1].complete(Unit)
-    awaitBranchProgress { (older + newer).all { it.isCompleted } }
-    val expectedEntries =
+      assertTrue(controller.sendMessageAwaitAcceptance("between responses", "off", emptyList()))
+      val admitted = outbox.load("gateway-a").single()
       if (independentListing) {
-        listOf("A1", "A2")
-      } else if (branchSwitch) {
-        listOf("B")
-      } else {
-        listOf("A1", "A2", "A3")
+        gateway.respondWith(
+          "sessions.branches.list",
+          """{"branches":[
+            {"leafEntryId":"A2","headline":"Earlier","messageCount":2,"active":false},
+            {"leafEntryId":"listed-B","headline":"Current","messageCount":1,"active":true}
+          ]}""",
+        )
+        assertTrue(controller.refreshSessionBranches())
       }
-    assertEquals("Newest authoritative history must render without a follow-up refresh", expectedEntries, controller.messages.value.map { it.entryId })
-    assertEquals(if (branchSwitch) "session-B" else "session-A", controller.sessionId.value)
-    val finalState = requireNotNull(outbox.branchState("gateway-a", branchScope))
-    assertEquals(if (independentListing) "listed-B" else expectedEntries.last(), finalState.lastActiveLeafEntryId)
-    assertFalse(finalState.needsReconciliation)
-    if (!olderFirst || independentListing) assertEquals(beforeLastResponse, finalState)
-    val retained = outbox.load("gateway-a").single()
-    assertEquals(admitted.id, retained.id)
-    assertEquals(admitted.branchEpoch, retained.branchEpoch)
-    assertEquals(admitted.attemptVersion, retained.attemptVersion)
-    assertEquals(if (independentListing || (olderFirst && branchSwitch)) ChatOutboxStatus.Failed else ChatOutboxStatus.Queued, retained.status)
-    assertEquals(3, gateway.callCount("chat.history"))
-    assertEquals(0, gateway.callCount("chat.send"))
+      val beforeLastResponse = requireNotNull(outbox.branchState("gateway-a", branchScope))
+
+      release[if (olderFirst) 2 else 1].complete(Unit)
+      if (independentListing) {
+        awaitBranchProgress { entered[3].isCompleted }
+        assertEquals("Rejected history must not publish while its fresh replacement waits", listOf("A1", "A2"), controller.messages.value.map { it.entryId })
+        assertEquals(beforeLastResponse, outbox.branchState("gateway-a", branchScope))
+        release[3].complete(Unit)
+      }
+      awaitBranchProgress { (older + newer).all { it.isCompleted } }
+      val expectedEntries =
+        if (independentListing) {
+          listOf("listed-B")
+        } else if (branchSwitch) {
+          listOf("B")
+        } else {
+          listOf("A1", "A2", "A3")
+        }
+      assertEquals("Newest authoritative history must render without a follow-up refresh", expectedEntries, controller.messages.value.map { it.entryId })
+      assertEquals(if (branchSwitch || independentListing) "session-B" else "session-A", controller.sessionId.value)
+      val finalState = requireNotNull(outbox.branchState("gateway-a", branchScope))
+      assertEquals(if (independentListing) "listed-B" else expectedEntries.last(), finalState.lastActiveLeafEntryId)
+      assertFalse(finalState.needsReconciliation)
+      if (!olderFirst) assertEquals(beforeLastResponse, finalState)
+      if (independentListing) {
+        assertTrue(finalState.revision > beforeLastResponse.revision)
+        assertEquals(beforeLastResponse.copy(revision = finalState.revision), finalState)
+      }
+      val retained = outbox.load("gateway-a").single()
+      assertEquals(admitted.id, retained.id)
+      assertEquals(admitted.branchEpoch, retained.branchEpoch)
+      assertEquals(admitted.attemptVersion, retained.attemptVersion)
+      assertEquals(if (independentListing || (olderFirst && branchSwitch)) ChatOutboxStatus.Failed else ChatOutboxStatus.Queued, retained.status)
+      assertEquals(if (independentListing) 4 else 3, gateway.callCount("chat.history"))
+      assertEquals(0, gateway.callCount("chat.send"))
+    } finally {
+      release.forEach { it.complete(Unit) }
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #139411. Follow-up to #136047 / #136413.

## What Problem This Solves

Fixes an issue where users refreshing Android chat could finish loading history without receiving the requested Gateway health check when an overlapping branch listing invalidated the newer history request. That newer request had taken over the pending health check but could finish without continuing it.

## Why This Change Was Made

Fresh history after a branch-revision conflict now belongs to `fetchAndApplyHistory`, the common history owner. Previously only reconnect/bootstrap repeated the request. The common function keeps its health ownership through the fresh read, discards rejected response bytes, and validates the old request's authority before allocating its successor under the existing lock. A newer applied history or changed selection still supersedes it.

This removes the bootstrap loop, outward `BranchInvalidated` result, and watchdog's separate branch-conflict deferral. Only an actual branch-reconciliation rejection takes another fresh read; cancellation, transport/storage failure and unavailable owners retain their existing exits. The Room schema, revision/epoch checks, mutation adoption rules, and dispatch ordering are unchanged. Production is **+216/−217 (net −1)**; tests are **+157/−106 (net +51)**. Most production churn is indentation around the existing publication body.

## User Impact

Refresh can finish its promised health check after overlapping history and branch work. Failed health keeps queued input and attachment bytes available; successful recovery permits the existing exactly-once dispatch flow. Rejected history remains invisible while a fresh response is pending. This restores the existing [Android Refresh contract](https://docs.openclaw.ai/platforms/android); it adds no setting, migration, or UI surface.

## Evidence

- Exact final regression tests against unchanged main base `744fd0d7300653ad1a2f491db9e854bb83931cc6`: **two failures**, both at the direct missing-continuation assertion, in 2.702 seconds. The candidate passes those two cases plus the independent-listing sibling: **3/3**, in 4.031 seconds. These execute the real ChatController and in-memory Room outbox with controlled scripted RPC responses.
- The sibling case holds a fourth, fresh response with different transcript/session data. It verifies rejected bytes never appear, all captured branch state stays unchanged during that wait, and the parked row's identity, epoch, attempt and failed status remain intact afterward. Existing success/failure cases retain health, queued-attachment and exactly-once assertions.
- **408/408 owner/sibling tests** across ten classes: 407 permanent tests plus the original controlled accepted-row scenario. The latter now records the real Room revision conflict, a fresh successful history application, and the second health RPC. Reconnect, watchdog, transcript/cache, session actions, command controls, outbox, model selection, terminal acknowledgement, stream replay, and Room behavior are covered.
- All **14 apps checks** pass, including Android formatting and the unchanged schema-version guard. Independent source review and all **seven managed review passes** are clean on the frozen two-file patch. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33994257304) passed all10 applicable jobs (26 skipped), including all Android test/build variants and formatting. [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139430#issuecomment-5555063745) is clean with no outstanding requests.

The initial CI timeout led to this investigation, but its exact interleaving remains unknown. The controlled failure independently proves this continuation defect; it is not proof of that timeout's precise cause. No device/UI or live-provider reproduction is claimed: the race is ordered at actual controller RPC and Room boundaries in JVM tests. Native-device frequency and the first affected release remain unverified. The related bootstrap-retry and health-handoff mechanisms are present in stable `v2026.9.1`; that history does not establish which change first introduced this ordering.
