### PR TITLE
fix(anthropic): retain tool schema references and constraints

### DIFF
--- a/packages/ai/src/providers/anthropic-tool-projection.test.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.test.ts
@@ -24,6 +24,56 @@ describe("projectAnthropicTools", () => {
     expect(reversed.tools).toEqual(first.tools);
   });
 
+  it.each([
+    { name: "implicit dialect", dialect: undefined, definitionsKey: "$defs" },
+    {
+      name: "explicit draft-07",
+      dialect: "http://json-schema.org/draft-07/schema#",
+      definitionsKey: "definitions",
+    },
+  ])(
+    "preserves root constraints and tuple definitions for $name",
+    ({ dialect, definitionsKey }) => {
+      const parameters = {
+        ...(dialect ? { $schema: dialect } : {}),
+        type: "object",
+        properties: { range: { $ref: `#/${definitionsKey}/Range` } },
+        required: ["range"],
+        additionalProperties: false,
+        allOf: [{ propertyNames: { enum: ["range"] } }],
+        [definitionsKey]: {
+          Range: {
+            ...(dialect ? { $schema: dialect } : {}),
+            type: "array",
+            items: [{ type: "integer" }, { type: "integer" }],
+            additionalItems: false,
+          },
+        },
+      };
+      const original = structuredClone(parameters);
+      const projection = projectAnthropicTools(
+        [{ name: "select_range", description: "Select a range", parameters }],
+        (name) => name,
+      );
+
+      expect(projection.tools[0]?.inputSchema).toEqual({
+        type: "object",
+        properties: parameters.properties,
+        required: ["range"],
+        additionalProperties: false,
+        allOf: parameters.allOf,
+        [definitionsKey]: {
+          Range: {
+            type: "array",
+            prefixItems: [{ type: "integer" }, { type: "integer" }],
+            items: false,
+          },
+        },
+      });
+      expect(parameters).toEqual(original);
+    },
+  );
+
   it("converts draft-07 tuple items to draft 2020-12 prefixItems for Anthropic", () => {
     const projection = projectAnthropicTools(
       [
@@ -141,6 +191,7 @@ describe("projectAnthropicTools", () => {
 
   it("does not rewrite instance data that resembles a tuple schema", () => {
     const tupleLikeValue = {
+      $schema: "http://json-schema.org/draft-07/schema#",
       items: ["first", "second"],
       additionalItems: false,
     };
@@ -150,6 +201,7 @@ describe("projectAnthropicTools", () => {
           name: "Match",
           description: "Match a literal value",
           parameters: {
+            $schema: "https://json-schema.org/draft/2020-12/schema",
             type: "object",
             properties: {
               value: {
@@ -167,5 +219,8 @@ describe("projectAnthropicTools", () => {
       const: tupleLikeValue,
       default: tupleLikeValue,
     });
+    expect(projection.tools[0]?.inputSchema.$schema).toBe(
+      "https://json-schema.org/draft/2020-12/schema",
+    );
   });
 });

--- a/packages/ai/src/providers/anthropic-tool-projection.ts
+++ b/packages/ai/src/providers/anthropic-tool-projection.ts
@@ -1,3 +1,4 @@
+import type { Tool as AnthropicTool } from "@anthropic-ai/sdk/resources/messages.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AnthropicOptions } from "../provider-options.js";
 import { sortPromptCacheToolsByName } from "../utils/prompt-cache-stability.js";
@@ -13,8 +14,7 @@ type AnthropicProjectedTool = {
   readonly originalName: string;
   readonly wireName: string;
   readonly description?: string;
-  readonly inputSchema: {
-    readonly type: "object";
+  readonly inputSchema: AnthropicTool["input_schema"] & {
     readonly properties: Record<string, unknown>;
     readonly required: string[];
   };
@@ -156,6 +156,10 @@ function normalizeAnthropicJsonSchema(schema: unknown): unknown {
     changed = true;
   }
 
+  if (changed) {
+    // Converted tuples use 2020-12 syntax, including inside referenced schema resources.
+    delete normalized.$schema;
+  }
   return changed ? normalized : schema;
 }
 
@@ -211,6 +215,8 @@ export function projectAnthropicTools(
         wireName,
         ...(description ? { description } : {}),
         inputSchema: {
+          // Root constraints and reference targets belong to the validated schema too.
+          ...anthropicSchema,
           type: "object",
           properties: (properties ?? {}) as Record<string, unknown>,
           required: (required ?? []) as string[],

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -2272,8 +2272,10 @@ describe("Anthropic provider", () => {
             description: "healthy schema",
             parameters: {
               type: "object",
-              properties: { query: { type: "string" } },
+              properties: { query: { $ref: "#/$defs/Query" } },
+              $defs: { Query: { type: "string", minLength: 1 } },
               required: ["query"],
+              additionalProperties: false,
             },
           } as Tool,
         ],
@@ -2286,9 +2288,12 @@ describe("Anthropic provider", () => {
 
     expect(result.stopReason).toBe("error");
     expect(payload.tools?.map((tool) => tool.name)).toEqual(["healthy_tool"]);
-    expect(payload.tools?.[0]?.input_schema).toMatchObject({
-      properties: { query: { type: "string" } },
+    expect(payload.tools?.[0]?.input_schema).toEqual({
+      type: "object",
+      properties: { query: { $ref: "#/$defs/Query" } },
+      $defs: { Query: { type: "string", minLength: 1 } },
       required: ["query"],
+      additionalProperties: false,
     });
   });
 

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -2831,9 +2831,11 @@ describe("anthropic transport stream", () => {
             parameters: {
               type: "object",
               properties: {
-                query: { type: "string" },
+                query: { $ref: "#/$defs/Query" },
               },
+              $defs: { Query: { type: "string", minLength: 1 } },
               required: ["query"],
+              additionalProperties: false,
             },
           },
         ],
@@ -2847,8 +2849,12 @@ describe("anthropic transport stream", () => {
     expect(tools).toHaveLength(1);
     const tool = requireRecord(tools[0], "tool");
     expect(tool.name).toBe("good_plugin_tool");
-    expect(requireRecord(tool.input_schema, "input schema").properties).toEqual({
-      query: { type: "string" },
+    expect(tool.input_schema).toEqual({
+      type: "object",
+      properties: { query: { $ref: "#/$defs/Query" } },
+      $defs: { Query: { type: "string", minLength: 1 } },
+      required: ["query"],
+      additionalProperties: false,
     });
   });
 

--- a/packages/ai/src/transports/anthropic-transport-stream.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.ts
@@ -550,22 +550,11 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   const projection = projectAnthropicTools(tools ?? [], (name) =>
     isOAuthToken ? toClaudeCodeToolName(name) : name,
   );
-  const converted: Array<{
-    name: string;
-    description?: string;
-    input_schema: {
-      type: "object";
-      properties: unknown;
-      required: unknown;
-    };
-  }> = [];
-  for (const tool of projection.tools) {
-    converted.push({
-      name: tool.wireName,
-      description: tool.description,
-      input_schema: tool.inputSchema,
-    });
-  }
+  const converted = projection.tools.map((tool) => ({
+    name: tool.wireName,
+    description: tool.description,
+    input_schema: tool.inputSchema,
+  }));
   return { projection, tools: converted };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where tool calls through Anthropic could fail argument validation when their schemas used root definitions or constraints. Request construction dropped those fields from the model-facing schema, leaving unresolved references and omitting restrictions still enforced by the host.

## Why This Change Was Made

The shared Anthropic projector carries the complete validated schema into both request paths and normalizes legacy tuple syntax with coherent dialect markers. The native request mapping derives from the SDK schema type, removing duplicate typing. Production code decreases by 5 lines.

General JSON Schema dialect conversion is outside this repair. `$ref` sibling constraints retain OpenClaw's existing TypeBox semantics so the model-facing schema agrees with the host validator.

## User Impact

Referenced and composed tool schemas retain their definitions and input constraints when sent to Anthropic. Existing tuple adaptation also works inside referenced definitions.

## Evidence

- All 233 focused tests pass across the Anthropic projection, provider, and native transport suites. Regression checks failed before their respective repairs.
- The complete changed-path gate passes all 28 steps, including core and test typechecks, lint, export scans, and import-cycle checks.
- The canonical AI-only build with `tsdown.ai.config.ts --dts` passes. All 14 runtime/type export pairs exist; the built package accepts a valid two-item tuple and rejects an extra item.
- Serialized SDK and native request bodies retain the full schema. Real `claude-haiku-4-5` calls changed an invalid `"Choice"` argument into the required `"lavender-14"` value, and produced `[14, 27]` valid under both original and emitted tuple schemas. No tools were executed during these probes.
- Managed review is scoped-clean at P2. The proposed strict-draft07 `$ref` migration was checked against the actual producer: production `validateToolArguments`, TypeBox, and recorded Ajv defaults reject the same overlong referenced string before and after, and accept the same short string. Ignoring those sibling constraints would diverge from existing host validation, so a general converter remains a separate, unproven follow-up.
