### PR TITLE
fix(tasks): avoid pauses from saved prompts during maintenance

### DIFF
--- a/src/tasks/task-registry.maintenance-projection.test.ts
+++ b/src/tasks/task-registry.maintenance-projection.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
+import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { getDetachedTaskLifecycleRuntime } from "./detached-task-runtime.js";
+import { getTaskById } from "./task-registry.js";
+import {
+  previewTaskRegistryMaintenance,
+  reconcileInspectableTasks,
+  resetTaskRegistryMaintenanceRuntimeForTests,
+  runTaskRegistryMaintenance,
+} from "./task-registry.maintenance.js";
+import { createTaskFixture } from "./task-registry.test-support.js";
+import {
+  resetDetachedTaskLifecycleRuntimeForTests,
+  setDetachedTaskLifecycleRuntime,
+  resetTaskRegistryForTests,
+} from "./task-runtime.test-helpers.js";
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  resetDetachedTaskLifecycleRuntimeForTests();
+  resetTaskRegistryMaintenanceRuntimeForTests();
+  resetTaskRegistryForTests({ persist: false });
+  await drainGlobalSingletonLifecycleState("close");
+});
+
+describe("task maintenance session metadata", () => {
+  it("reconciles backing and wedged children without decoding their saved prompts", async () => {
+    await withStateDirEnv("openclaw-task-maintenance-metadata-", async () => {
+      resetTaskRegistryForTests({ persist: false });
+      const staleAt = Date.now() - 45 * 60_000;
+      for (const agentId of ["main", "worker"]) {
+        for (const suffix of ["healthy", "wedged", "unrelated"]) {
+          replaceSessionEntrySync(
+            { agentId, sessionKey: `agent:${agentId}:subagent:${suffix}` },
+            {
+              sessionId: `${agentId}-${suffix}`,
+              updatedAt: staleAt,
+              skillsSnapshot: { prompt: "maintenance-proof-saved-prompt".repeat(1024), skills: [] },
+              ...(suffix === "wedged"
+                ? { subagentRecovery: { wedgedAt: staleAt, wedgedReason: "Recovery tombstoned" } }
+                : {}),
+            },
+          );
+        }
+      }
+      const tasks = ["healthy", "wedged", "missing"].map((suffix) =>
+        createTaskFixture("subagent", {
+          task: `Check ${suffix}`,
+          runId: `maintenance-${suffix}`,
+          childSessionKey: `agent:worker:subagent:${suffix}`,
+          lastEventAt: staleAt,
+          notifyPolicy: "silent",
+        }),
+      );
+      const parse = vi.spyOn(JSON, "parse");
+      expect(previewTaskRegistryMaintenance().reconciled).toBe(2);
+      expect(reconcileInspectableTasks().map(({ status, error }) => ({ status, error }))).toEqual(
+        expect.arrayContaining([
+          { status: "running", error: undefined },
+          { status: "lost", error: "Recovery tombstoned" },
+          { status: "lost", error: "backing session missing" },
+        ]),
+      );
+      expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 2 });
+      expect(tasks.map((task) => getTaskById(task.taskId)?.status)).toEqual([
+        "running",
+        "lost",
+        "lost",
+      ]);
+      expect(
+        parse.mock.calls.filter(([json]) => json.includes("maintenance-proof-saved-prompt")).length,
+      ).toBe(0);
+    });
+  });
+  it("keeps warm corrupt-row handling while reconciling healthy siblings", async () => {
+    await withStateDirEnv("openclaw-task-maintenance-corruption-", async () => {
+      resetTaskRegistryForTests({ persist: false });
+      const staleAt = Date.now() - 45 * 60_000;
+      const tasks = ["healthy", "corrupt"].map((suffix) => {
+        const sessionKey = `agent:main:subagent:${suffix}`;
+        replaceSessionEntrySync({ sessionKey }, { sessionId: suffix, updatedAt: staleAt });
+        return createTaskFixture("subagent", {
+          task: `Check ${suffix}`,
+          runId: `maintenance-${suffix}`,
+          childSessionKey: sessionKey,
+          lastEventAt: staleAt,
+          notifyPolicy: "silent",
+        });
+      });
+      expect(previewTaskRegistryMaintenance().reconciled).toBe(0);
+      // Existing warm listings skip malformed rows; exact reads intentionally throw.
+      openOpenClawAgentDatabase({ agentId: "main" })
+        .db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .run("{", "agent:main:subagent:corrupt");
+      expect(previewTaskRegistryMaintenance().reconciled).toBe(1);
+      expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 1 });
+      expect(tasks.map((task) => getTaskById(task.taskId)?.status)).toEqual(["running", "lost"]);
+    });
+  });
+
+  it("sees backing metadata repaired by the recovery hook", async () => {
+    await withStateDirEnv("openclaw-task-maintenance-recovery-", async () => {
+      resetTaskRegistryForTests({ persist: false });
+      const staleAt = Date.now() - 45 * 60_000;
+      const scope = { sessionKey: "agent:main:subagent:recovered" };
+      replaceSessionEntrySync(scope, {
+        sessionId: "recovered",
+        updatedAt: staleAt,
+        subagentRecovery: { wedgedAt: staleAt },
+      });
+      const task = createTaskFixture("subagent", {
+        task: "Recover child",
+        runId: "maintenance-recovered",
+        childSessionKey: scope.sessionKey,
+        lastEventAt: staleAt,
+        notifyPolicy: "silent",
+      });
+      setDetachedTaskLifecycleRuntime({
+        ...getDetachedTaskLifecycleRuntime(),
+        tryRecoverTaskBeforeMarkLost: async () => {
+          await Promise.resolve();
+          replaceSessionEntrySync(scope, { sessionId: "recovered", updatedAt: Date.now() });
+          return { recovered: false };
+        },
+      });
+      expect(await runTaskRegistryMaintenance()).toMatchObject({ reconciled: 0 });
+      expect(getTaskById(task.taskId)?.status).toBe("running");
+    });
+  });
+});

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -243,13 +243,14 @@ function buildSessionEntryLookup(entries: SessionEntrySummary[]): SessionEntryLo
   };
 }
 
+// Reconciliation needs existence and recovery metadata, never saved prompt snapshots.
 function getSessionEntryLookup(
   storePath: string,
   context?: BackingSessionLookupContext,
 ): SessionEntryLookup {
   if (!context) {
     return buildSessionEntryLookup(
-      taskRegistryMaintenanceRuntime.listSessionEntries({ storePath }),
+      taskRegistryMaintenanceRuntime.listSessionEntries({ storePath, projection: "list" }),
     );
   }
   const cached = context.sessionEntriesByPath.get(storePath);
@@ -257,7 +258,7 @@ function getSessionEntryLookup(
     return cached;
   }
   const lookup = buildSessionEntryLookup(
-    taskRegistryMaintenanceRuntime.listSessionEntries({ storePath }),
+    taskRegistryMaintenanceRuntime.listSessionEntries({ storePath, projection: "list" }),
   );
   context.sessionEntriesByPath.set(storePath, lookup);
   return lookup;


### PR DESCRIPTION
## What Problem This Solves

Fixes pauses during background task maintenance and task inspection when session histories contain large saved prompts. Checking whether a child session still exists unnecessarily decoded every saved prompt in its agent store.

## Why This Change Was Made

Request the existing metadata projection for maintenance's session lookup. Reconciliation consumes entry presence and recovery tombstones; it never needs skill snapshots or system-prompt reports. The existing per-pass snapshot and recovery refresh remain unchanged, including warm-store corruption handling.

## User Impact

Task checks avoid allocating and decoding saved prompt payloads. Healthy tasks remain running, missing or tombstoned children are reconciled, and a recovery hook's repaired backing metadata is observed before marking work lost.

## Evidence

- Real SQLite regression failed on the original code with nine saved-prompt decodes; it passes after the repair.
- 33 focused task-maintenance tests passed, including healthy, missing, tombstoned, cross-agent, warm-corrupt-row, and recovery-hook cases.
- Synthetic accessor comparison with 1,000 sessions and approximately 60 KiB of saved prompt per session: five alternating warm-read pairs had medians of 482 ms for full entries versus 3.3 ms for metadata using the existing warm metadata cache. Ranges were 402–826 ms and 2.6–150 ms, respectively, under concurrent host load. These accessor measurements do not establish production end-to-end latency; cold stores still require canonical validation and enumeration.
- Built CLI preview, apply, and list commands passed on 100 synthetic sessions and three cross-agent tasks. Independent SQLite reads confirmed the healthy task remained running, the missing and tombstoned tasks were persisted as lost with their expected reasons, and all session rows remained intact. This local build used the pre-commit candidate source (base plus the reviewed patch).
- Independent review found no actionable P0–P2 issue.

Full session enumeration remains a possible follow-up. Naively switching to exact reads would change warm corrupt-row behavior: exact readers throw where the listing contract skips malformed rows. Any bounded-list optimization must preserve that contract rather than add fallback reads.
