### PR TITLE
refactor: simplify pure config validation tests

### DIFF
--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -1,6 +1,6 @@
 // Regresses rejection of legacy routing allowFrom config.
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./validation.js";
+import { validateConfigObject } from "./validation-core.js";
 
 describe("legacy config detection", () => {
   it.each([

--- a/src/config/config.meta-timestamp-coercion.test.ts
+++ b/src/config/config.meta-timestamp-coercion.test.ts
@@ -1,6 +1,6 @@
 // Verifies config metadata timestamp coercion behavior.
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./validation.js";
+import { validateConfigObject } from "./validation-core.js";
 
 describe("config metadata", () => {
   it("rejects retired lastTouchedAt config metadata", () => {

--- a/src/config/config.tools-alsoAllow.test.ts
+++ b/src/config/config.tools-alsoAllow.test.ts
@@ -1,6 +1,6 @@
 // Covers tools alsoAllow config parsing and validation.
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./validation.js";
+import { validateConfigObject } from "./validation-core.js";
 
 // NOTE: These tests ensure allow + alsoAllow cannot be set in the same scope.
 

--- a/src/config/logging-max-file-bytes.test.ts
+++ b/src/config/logging-max-file-bytes.test.ts
@@ -1,6 +1,6 @@
 // Covers logging max-file-size config validation.
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./validation.js";
+import { validateConfigObject } from "./validation-core.js";
 
 describe("logging.maxFileBytes config", () => {
   it("accepts a positive maxFileBytes", () => {

--- a/src/config/session-parent-fork-config-keys.test.ts
+++ b/src/config/session-parent-fork-config-keys.test.ts
@@ -1,6 +1,6 @@
 // Verifies parent-fork session config keys stay aligned with schema.
 import { describe, expect, it } from "vitest";
-import { validateConfigObjectRaw } from "./validation.js";
+import { validateConfigObjectRaw } from "./validation-core.js";
 
 describe("session parent fork config keys", () => {
   it("rejects legacy session.parentForkMaxTokens as an unknown session key", () => {

--- a/src/config/thread-bindings-config-keys.test.ts
+++ b/src/config/thread-bindings-config-keys.test.ts
@@ -1,6 +1,6 @@
 // Checks thread-binding config keys stay aligned with schema metadata.
 import { describe, expect, it } from "vitest";
-import { validateConfigObjectRaw } from "./validation.js";
+import { validateConfigObjectRaw } from "./validation-core.js";
 
 describe("thread binding config keys", () => {
   it("rejects legacy session.threadBindings.ttlHours", () => {

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -1,6 +1,6 @@
 // Verifies config validation rejects unsupported enumerated values.
 import { describe, expect, it } from "vitest";
-import { validateConfigObjectRaw } from "./validation.js";
+import { validateConfigObjectRaw } from "./validation-core.js";
 
 function requireIssue<T extends { path: string }>(issues: T[], path: string): T {
   const issue = issues.find((entry) => entry.path === path);

--- a/src/config/zod-schema.tls.test.ts
+++ b/src/config/zod-schema.tls.test.ts
@@ -1,6 +1,6 @@
 // Schema-level tests for gateway.tls certPath and keyPath validation.
 import { describe, expect, it } from "vitest";
-import { validateConfigObject } from "./validation.js";
+import { validateConfigObject } from "./validation-core.js";
 
 describe("gateway.tls schema", () => {
   it("rejects empty certPath", () => {

--- a/src/config/zod-schema.visible-replies.test.ts
+++ b/src/config/zod-schema.visible-replies.test.ts
@@ -1,113 +1,49 @@
 // Covers visible-reply config schema parsing and defaults.
 import { describe, expect, it } from "vitest";
-import { validateConfigObjectRaw } from "./validation.js";
+import { validateConfigObjectRaw } from "./validation-core.js";
 
 describe("visible reply config schema", () => {
-  it("coerces boolean global visibleReplies values to the enum contract", () => {
-    const automatic = validateConfigObjectRaw({
-      messages: {
-        visibleReplies: true,
-      },
-    });
-    const toolOnly = validateConfigObjectRaw({
-      messages: {
-        visibleReplies: false,
-      },
-    });
+  describe.each(["global", "groupChat"] as const)("%s visibleReplies", (scope) => {
+    it.each([
+      [true, "automatic"],
+      [false, "message_tool"],
+    ] as const)("coerces %s to %s", (visibleReplies, expected) => {
+      const messages = scope === "global" ? { visibleReplies } : { groupChat: { visibleReplies } };
+      const result = validateConfigObjectRaw({ messages });
 
-    expect(automatic.ok).toBe(true);
-    expect(toolOnly.ok).toBe(true);
-    if (automatic.ok) {
-      expect(automatic.config.messages?.visibleReplies).toBe("automatic");
-    }
-    if (toolOnly.ok) {
-      expect(toolOnly.config.messages?.visibleReplies).toBe("message_tool");
-    }
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        const parsed =
+          scope === "global" ? result.config.messages : result.config.messages?.groupChat;
+        expect(parsed?.visibleReplies).toBe(expected);
+      }
+    });
   });
 
-  it("coerces boolean groupChat visibleReplies values to the enum contract", () => {
-    const automatic = validateConfigObjectRaw({
-      messages: {
-        groupChat: {
-          visibleReplies: true,
-        },
-      },
-    });
-    const toolOnly = validateConfigObjectRaw({
-      messages: {
-        groupChat: {
-          visibleReplies: false,
-        },
-      },
-    });
+  it.each(["user_request", "room_event"] as const)(
+    "accepts enum unmentioned group inbound value %s",
+    (unmentionedInbound) => {
+      const result = validateConfigObjectRaw({ messages: { groupChat: { unmentionedInbound } } });
 
-    expect(automatic.ok).toBe(true);
-    expect(toolOnly.ok).toBe(true);
-    if (automatic.ok) {
-      expect(automatic.config.messages?.groupChat?.visibleReplies).toBe("automatic");
-    }
-    if (toolOnly.ok) {
-      expect(toolOnly.config.messages?.groupChat?.visibleReplies).toBe("message_tool");
-    }
-  });
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.config.messages?.groupChat?.unmentionedInbound).toBe(unmentionedInbound);
+      }
+    },
+  );
 
-  it("keeps invalid visibleReplies values rejected", () => {
-    const result = validateConfigObjectRaw({
-      messages: {
-        visibleReplies: "visible",
-      },
-    });
+  it.each([
+    { messages: { visibleReplies: "visible" }, path: "messages.visibleReplies" },
+    {
+      messages: { groupChat: { unmentionedInbound: true } },
+      path: "messages.groupChat.unmentionedInbound",
+    },
+  ])("rejects unsupported values at $path", ({ messages, path }) => {
+    const result = validateConfigObjectRaw({ messages });
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      const visibleRepliesIssue = result.issues.find(
-        (issue) => issue.path === "messages.visibleReplies",
-      );
-      expect(visibleRepliesIssue?.path).toBe("messages.visibleReplies");
-    }
-  });
-
-  it("accepts enum unmentioned group inbound values", () => {
-    const legacy = validateConfigObjectRaw({
-      messages: {
-        groupChat: {
-          unmentionedInbound: "user_request",
-        },
-      },
-    });
-    const roomEvent = validateConfigObjectRaw({
-      messages: {
-        groupChat: {
-          unmentionedInbound: "room_event",
-        },
-      },
-    });
-
-    expect(legacy.ok).toBe(true);
-    expect(roomEvent.ok).toBe(true);
-    if (legacy.ok) {
-      expect(legacy.config.messages?.groupChat?.unmentionedInbound).toBe("user_request");
-    }
-    if (roomEvent.ok) {
-      expect(roomEvent.config.messages?.groupChat?.unmentionedInbound).toBe("room_event");
-    }
-  });
-
-  it("rejects boolean unmentioned group inbound values", () => {
-    const result = validateConfigObjectRaw({
-      messages: {
-        groupChat: {
-          unmentionedInbound: true,
-        },
-      },
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      const issue = result.issues.find(
-        (candidate) => candidate.path === "messages.groupChat.unmentionedInbound",
-      );
-      expect(issue?.path).toBe("messages.groupChat.unmentionedInbound");
+      expect(result.issues).toContainEqual(expect.objectContaining({ path }));
     }
   });
 });


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Pure configuration validation tests load the heavier plugin-validation module solely to reach functions it reexports. The visible-replies schema tests also repeat nearly identical boolean and enum validation bodies.

## Why This Change Was Made

Import the same validator functions directly from their existing implementation owner in nine mock-free tests. Table-drive the visible-replies inputs while preserving all four boolean coercions, both accepted inbound enums, and both invalid inputs with their issue paths. Plugin-validation and public export-contract tests remain at their existing boundaries.

## User Impact

No production behavior changes. Developers maintain 64 fewer test lines, and each schema input now has a separately named result.

## Evidence

All nine focused test files pass: 49 tests, including the same eight visible-replies validation inputs. The complete changed-check gate passes, including core test typechecks, lint, formatting, generated metadata checks, and repository guards. Independent review found no actionable findings through P2. No full-suite speedup is claimed; timing comparison remains part of the campaign.
