### PR TITLE
fix(memory): forward Azure OpenAI api-version header as URL query for embeddings

### DIFF
--- a/packages/memory-host-sdk/src/host/azure-api-version-request.test.ts
+++ b/packages/memory-host-sdk/src/host/azure-api-version-request.test.ts
@@ -1,0 +1,105 @@
+// Memory Host SDK tests cover Azure api-version request normalization.
+import { describe, expect, it } from "vitest";
+import { resolveAzureApiVersionRequestTarget } from "./azure-api-version-request.js";
+
+describe("resolveAzureApiVersionRequestTarget", () => {
+  const azureUrl = "https://example.openai.azure.com/openai/deployments/embed/embeddings";
+
+  it("moves a non-empty api-version header into the URL query for Azure hosts", () => {
+    const result = resolveAzureApiVersionRequestTarget({
+      url: azureUrl,
+      headers: { "api-key": "azure-key", "api-version": "2024-10-21" },
+    });
+
+    expect(result.url).toBe(`${azureUrl}?api-version=2024-10-21`);
+    expect(result.headers).toEqual({ "api-key": "azure-key" });
+  });
+
+  it("recognizes a mixed-case api-version header and preserves other header casing", () => {
+    const result = resolveAzureApiVersionRequestTarget({
+      url: azureUrl,
+      headers: { "API-Version": "2023-05-15", "X-Tenant": "acme" },
+    });
+
+    expect(result.url).toBe(`${azureUrl}?api-version=2023-05-15`);
+    expect(result.headers).toEqual({ "X-Tenant": "acme" });
+  });
+
+  it.each([
+    "https://example.openai.azure.com/openai/deployments/embed/embeddings",
+    "https://example.services.ai.azure.com/openai/deployments/embed/embeddings",
+    "https://example.cognitiveservices.azure.com/openai/deployments/embed/embeddings",
+    "https://sub.example.openai.azure.com/openai/deployments/embed/embeddings",
+  ])("moves api-version for every Azure host suffix: %s", (url) => {
+    const result = resolveAzureApiVersionRequestTarget({
+      url,
+      headers: { "api-version": "2024-10-21" },
+    });
+
+    expect(result.url).toBe(`${url}?api-version=2024-10-21`);
+    expect(result.headers).not.toHaveProperty("api-version");
+  });
+
+  it("keeps an existing non-empty URL api-version and removes the header", () => {
+    const result = resolveAzureApiVersionRequestTarget({
+      url: `${azureUrl}?existing=1&api-version=2024-02-01`,
+      headers: { "api-version": "2024-10-21" },
+    });
+
+    expect(result.url).toBe(`${azureUrl}?existing=1&api-version=2024-02-01`);
+    expect(result.headers).not.toHaveProperty("api-version");
+  });
+
+  it("fills an empty URL api-version value from the header", () => {
+    const result = resolveAzureApiVersionRequestTarget({
+      url: `${azureUrl}?api-version=`,
+      headers: { "api-version": "2024-10-21" },
+    });
+
+    expect(result.url).toBe(`${azureUrl}?api-version=2024-10-21`);
+    expect(result.headers).not.toHaveProperty("api-version");
+  });
+
+  it("drops a blank api-version header without adding an empty query value", () => {
+    const result = resolveAzureApiVersionRequestTarget({
+      url: azureUrl,
+      headers: { "api-version": "   " },
+    });
+
+    expect(result.url).toBe(azureUrl);
+    expect(result.headers).not.toHaveProperty("api-version");
+  });
+
+  it.each([
+    "https://api.openai.com/v1/embeddings",
+    "https://proxy.example.com/v1/embeddings?tenant=acme",
+    "https://localhost/v1/embeddings",
+    "https://127.0.0.1/v1/embeddings",
+    "https://azure.com/v1/embeddings",
+    "https://openai.azure.com.evil.example/v1/embeddings",
+  ])("leaves non-Azure host %s and its headers untouched", (url) => {
+    const headers = { "api-version": "proxy-header", "X-Tenant": "acme" };
+    const result = resolveAzureApiVersionRequestTarget({ url, headers });
+
+    expect(result.url).toBe(url);
+    expect(result.headers).toBe(headers);
+  });
+
+  it("leaves Azure requests without an api-version header untouched", () => {
+    const headers = { "api-key": "azure-key", "X-Tenant": "acme" };
+    const result = resolveAzureApiVersionRequestTarget({
+      url: azureUrl,
+      headers,
+    });
+
+    expect(result.url).toBe(azureUrl);
+    expect(result.headers).toBe(headers);
+  });
+
+  it("does not mutate the caller headers object on migration", () => {
+    const headers = { "api-key": "azure-key", "api-version": "2024-10-21" };
+    resolveAzureApiVersionRequestTarget({ url: azureUrl, headers });
+
+    expect(headers).toEqual({ "api-key": "azure-key", "api-version": "2024-10-21" });
+  });
+});

--- a/packages/memory-host-sdk/src/host/azure-api-version-request.ts
+++ b/packages/memory-host-sdk/src/host/azure-api-version-request.ts
@@ -1,0 +1,63 @@
+// Memory Host SDK module implements Azure OpenAI-compatible embedding request
+// normalization: api-version must travel as a URL query parameter, not a header.
+
+// Azure OpenAI and Azure AI Foundry reject requests whose api-version is only
+// supplied as an HTTP header. The chat completions transport performs the same
+// header-to-query migration (see packages/ai isAzureOpenAICompatibleHost and
+// buildOpenAICompletionsClientConfig). Embedding fetches keep configured
+// headers untouched for cache identity and instead normalize the outgoing
+// request: recognized Azure hosts move a non-empty api-version header into the
+// URL query (an existing non-empty URL value wins) and drop the header.
+
+/** Detect Azure OpenAI-compatible embedding hosts. */
+function isAzureOpenAICompatibleHost(hostname: string): boolean {
+  return (
+    hostname.endsWith(".openai.azure.com") ||
+    hostname.endsWith(".services.ai.azure.com") ||
+    hostname.endsWith(".cognitiveservices.azure.com")
+  );
+}
+
+/**
+ * Normalize an embedding request target for Azure OpenAI-compatible hosts.
+ *
+ * Returns the same {@link url} and {@link headers} when the host is not Azure
+ * or no api-version header is present. For recognized Azure hosts a
+ * case-insensitive api-version header with a non-empty value is migrated into
+ * the URL query when the URL has no non-empty api-version value, and the header
+ * is removed. An existing non-empty URL api-version always wins, mirroring the
+ * chat completions transport.
+ */
+export function resolveAzureApiVersionRequestTarget(params: {
+  url: string;
+  headers: Record<string, string>;
+}): { url: string; headers: Record<string, string> } {
+  const { url, headers } = params;
+  let hostname: string | undefined;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return params;
+  }
+  if (!isAzureOpenAICompatibleHost(hostname)) {
+    return params;
+  }
+  const headerKey = Object.keys(headers).find((key) => key.toLowerCase() === "api-version");
+  if (!headerKey) {
+    return params;
+  }
+  const apiVersion = headers[headerKey]?.trim();
+  // Remove the header regardless of its value; only a non-empty value is
+  // eligible for promotion into the URL query.
+  const nextHeaders = { ...headers };
+  delete nextHeaders[headerKey];
+  if (!apiVersion) {
+    return { url, headers: nextHeaders };
+  }
+  const parsed = new URL(url);
+  const existing = parsed.searchParams.get("api-version");
+  if (existing === null || existing.trim() === "") {
+    parsed.searchParams.set("api-version", apiVersion);
+  }
+  return { url: parsed.toString(), headers: nextHeaders };
+}

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts
@@ -53,6 +53,28 @@ describe("fetchRemoteEmbeddingVectors", () => {
     expect(postJsonParams.errorPrefix).toBe("embedding fetch failed");
   });
 
+  it("moves Azure api-version headers into the URL query before posting", async () => {
+    postJsonMock.mockImplementationOnce(async (params) => {
+      return await params.parse({
+        data: [{ embedding: [0.1] }],
+      });
+    });
+
+    await fetchRemoteEmbeddingVectors({
+      url: "https://example.openai.azure.com/openai/deployments/embed/embeddings?existing=1",
+      headers: { "api-key": "azure-key", "api-version": "2024-10-21" },
+      body: { input: ["one"] },
+      errorPrefix: "azure embedding fetch failed",
+    });
+
+    const postJsonParams = requirePostJsonParams();
+    expect(postJsonParams.url).toBe(
+      "https://example.openai.azure.com/openai/deployments/embed/embeddings?existing=1&api-version=2024-10-21",
+    );
+    expect(postJsonParams.headers).toEqual({ "api-key": "azure-key" });
+    expect(postJsonParams.headers).not.toHaveProperty("api-version");
+  });
+
   it("passes abort signals to the JSON request", async () => {
     const controller = new AbortController();
     postJsonMock.mockImplementationOnce(async (params) => {

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -1,5 +1,6 @@
 // Memory Host SDK module implements embeddings remote fetch behavior.
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { resolveAzureApiVersionRequestTarget } from "./azure-api-version-request.js";
 import { readEmbeddingVectors } from "./embedding-vectors.js";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
 import { postJson } from "./post-json.js";
@@ -16,9 +17,15 @@ export async function fetchRemoteEmbeddingVectors(params: {
   body: unknown;
   errorPrefix: string;
 }): Promise<number[][]> {
-  return await postJson({
+  // Azure OpenAI accepts api-version only as a URL query parameter; move a
+  // configured api-version header into the URL for recognized Azure hosts.
+  const target = resolveAzureApiVersionRequestTarget({
     url: params.url,
     headers: params.headers,
+  });
+  return await postJson({
+    url: target.url,
+    headers: target.headers,
     ssrfPolicy: params.ssrfPolicy,
     fetchImpl: params.fetchImpl,
     signal: params.signal,

--- a/src/plugins/openai-compatible-embedding-provider.azure.test.ts
+++ b/src/plugins/openai-compatible-embedding-provider.azure.test.ts
@@ -1,0 +1,117 @@
+// Covers Azure OpenAI-compatible embedding request target normalization at the
+// openai-compatible adapter request boundary.
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddingProviderCreateOptions } from "./embedding-providers.js";
+import { openAICompatibleEmbeddingProviderAdapter } from "./openai-compatible-embedding-provider.js";
+
+const withRemoteHttpResponseMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../packages/memory-host-sdk/src/host/remote-http.js", () => ({
+  withRemoteHttpResponse: withRemoteHttpResponseMock,
+}));
+
+function createOptions(
+  overrides: Partial<EmbeddingProviderCreateOptions> = {},
+): EmbeddingProviderCreateOptions {
+  return {
+    config: {} as EmbeddingProviderCreateOptions["config"],
+    provider: "openai-compatible",
+    model: "text-embedding-bge-m3",
+    ...overrides,
+  };
+}
+
+function respondWithEmbedding(onResponse: (response: Response) => Promise<unknown>) {
+  return onResponse(
+    new Response(
+      JSON.stringify({
+        object: "list",
+        data: [{ object: "embedding", embedding: [0.1, 0.2, 0.3], index: 0 }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    ),
+  );
+}
+
+describe("openai-compatible Azure OpenAI embedding requests", () => {
+  it("moves a configured api-version header into the URL query for Azure hosts", async () => {
+    const azureBaseUrl =
+      "https://example.openai.azure.com/openai/deployments/text-embedding-3-small";
+    withRemoteHttpResponseMock.mockReset();
+    withRemoteHttpResponseMock.mockImplementationOnce(
+      async ({
+        url,
+        init,
+        onResponse,
+      }: {
+        url: string;
+        init: RequestInit;
+        onResponse: Function;
+      }) => {
+        expect(url).toBe(`${azureBaseUrl}/embeddings?api-version=2024-10-21`);
+        expect(init.headers).not.toHaveProperty("api-version");
+        return await respondWithEmbedding(onResponse as (r: Response) => Promise<unknown>);
+      },
+    );
+
+    const result = await openAICompatibleEmbeddingProviderAdapter.create(
+      createOptions({
+        remote: {
+          baseUrl: azureBaseUrl,
+          headers: {
+            "api-key": "azure-key",
+            "api-version": "2024-10-21",
+          },
+        },
+      }),
+    );
+    const provider = result.provider;
+    if (!provider) {
+      throw new Error("expected openai-compatible provider");
+    }
+    await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+
+    expect(withRemoteHttpResponseMock).toHaveBeenCalledOnce();
+  });
+
+  it("keeps non-Azure embedding requests unchanged", async () => {
+    const proxyBaseUrl = "https://proxy.example.com/v1";
+    withRemoteHttpResponseMock.mockReset();
+    withRemoteHttpResponseMock.mockImplementationOnce(
+      async ({
+        url,
+        init,
+        onResponse,
+      }: {
+        url: string;
+        init: RequestInit;
+        onResponse: Function;
+      }) => {
+        expect(url).toBe(`${proxyBaseUrl}/embeddings`);
+        expect(init.headers).toHaveProperty("api-version", "proxy-header");
+        return await respondWithEmbedding(onResponse as (r: Response) => Promise<unknown>);
+      },
+    );
+
+    const result = await openAICompatibleEmbeddingProviderAdapter.create(
+      createOptions({
+        remote: {
+          baseUrl: proxyBaseUrl,
+          headers: {
+            "api-version": "proxy-header",
+          },
+        },
+      }),
+    );
+    const provider = result.provider;
+    if (!provider) {
+      throw new Error("expected openai-compatible provider");
+    }
+    await expect(provider.embed("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+
+    expect(withRemoteHttpResponseMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/plugins/openai-compatible-embedding-provider.ts
+++ b/src/plugins/openai-compatible-embedding-provider.ts
@@ -2,6 +2,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { resolveAzureApiVersionRequestTarget } from "../../packages/memory-host-sdk/src/host/azure-api-version-request.js";
 import { readEmbeddingVectors } from "../../packages/memory-host-sdk/src/host/embedding-vectors.js";
 import { withRemoteHttpResponse } from "../../packages/memory-host-sdk/src/host/remote-http.js";
 import { readProviderJsonArrayFieldResponse } from "../agents/provider-http-errors.js";
@@ -327,11 +328,17 @@ async function postEmbeddingRequest(params: {
       ? await client.acquireLocalService(client.localServiceTarget, params.signal)
       : undefined;
   try {
-    return await withRemoteHttpResponse({
+    // Azure OpenAI accepts api-version only as a URL query parameter; move a
+    // configured api-version header into the URL for recognized Azure hosts.
+    const target = resolveAzureApiVersionRequestTarget({
       url: client.endpointUrl,
+      headers: client.headers,
+    });
+    return await withRemoteHttpResponse({
+      url: target.url,
       init: {
         method: "POST",
-        headers: client.headers,
+        headers: target.headers,
         body: JSON.stringify(body),
       },
       signal: params.signal,


### PR DESCRIPTION
Closes #111386

## What Problem This Solves

Fixes an issue where users pointing an OpenAI-compatible embedding provider at an
Azure OpenAI deployment (`models.providers` with `api: "openai-completions"` and
`api-version` configured in `headers`) would get `HTTP 404` from Azure while
indexing memory. Azure OpenAI requires `api-version` as a URL query parameter,
but the remote embedding provider only sent it as an HTTP header, which Azure
ignores. The chat completions transport already moved `api-version` from
headers into the query for Azure hosts; the embedding path did not.

## Why This Change Was Made

The embedding request boundary now normalizes the outgoing target the same way
the chat transport does: for recognized Azure OpenAI-compatible hosts
(`*.openai.azure.com`, `*.services.ai.azure.com`, `*.cognitiveservices.azure.com`),
a case-insensitive `api-version` header with a non-empty value is promoted into
the URL query and removed from the request headers. An existing non-empty URL
`api-version` keeps precedence (an empty URL value is filled from the header),
matching `buildOpenAICompletionsClientConfig`. Non-Azure endpoints keep their
existing header behavior unchanged.

- **Intended outcome:** Custom Azure OpenAI embedding providers configured via
  an `api-version` header send requests whose URL carries `api-version`, so
  Azure accepts them.
- **Out of scope:** No config schema changes; no batch-upload endpoint changes.
- **Highest-risk area:** Request-target construction for Azure-hosted embedding
  deployments, which now diverges from the configured base URL by appending the
  query parameter.
- **How is that risk mitigated?** The normalization is a pure shared helper
  covered by unit tests for all three Azure host suffixes, URL precedence,
  empty-value filling, blank headers, and non-Azure passthrough; both the
  memory host SDK fetch path and the openai-compatible plugin adapter apply it
  at request time without mutating configured headers. The real-HTTP transcript
  below additionally shows the outgoing request as observed by a server.

## User Impact

Users can configure Azure OpenAI embedding deployments as custom
`openai-completions` providers (with `api-version` in `headers`) for memory
indexing and search without switching embedding providers as a workaround.
Requests now carry `api-version` as the URL query parameter Azure requires.

- **Success criteria:** For an Azure OpenAI-compatible base URL, the outgoing
  embedding request URL contains `api-version=<configured value>` and the
  `api-version` header is removed; non-Azure requests are byte-identical to
  before.
- **What should reviewers focus on?**
  `packages/memory-host-sdk/src/host/azure-api-version-request.ts` (shared
  normalization), its wiring in `embeddings-remote-fetch.ts` and
  `src/plugins/openai-compatible-embedding-provider.ts`, and the regression
  fixtures `azure-api-version-request.test.ts` /
  `openai-compatible-embedding-provider.azure.test.ts`.

## Evidence

- **Real environment tested:** Local worktree at this PR head (commit
  `9f669ea6de64`, parent `89940dfa1a4`). Behavior was observed from two
  real-network sources. (1) The **real Azure OpenAI APIM edge**
  (`https://demo.openai.azure.com`) over the public internet — no `/etc/hosts`
  override, no local server, no fetch mocks; requests carry a deliberately
  invalid `api-key`, so Azure's own error response shows whether the request
  was routed (401 credential rejection) or rejected before routing (404
  `Resource not found`, the exact body from the issue report). (2) A local
  stand-in server for the valid-success path, which enforces Azure OpenAI's
  documented REST contract for the embeddings endpoint (`api-version` must be
  a URL query parameter; a header-only `api-version` is answered with the exact
  `HTTP 404` body from the issue report). The only stand-in is that server plus
  a temporary `/etc/hosts` entry mapping the `demo.openai.azure.com` test
  hostname to the local machine (removed immediately after that run); the
  client code is the shipped module with no fetch mocks.
- **Exact steps or commands run after this patch:**
  ```bash
  # 1) Unit + request-boundary regression suite (mocked transport), same-dir:
  node scripts/run-vitest.mjs run \
    packages/memory-host-sdk/src/host/azure-api-version-request.test.ts \
    packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts \
    src/plugins/openai-compatible-embedding-provider.azure.test.ts
  # 2) validate.sh (oxfmt + oxlint + same-dir tests + tsgo:core) on all changed files
  skills/fix-pr/scripts/validate.sh packages/memory-host-sdk/src/host/azure-api-version-request.ts packages/memory-host-sdk/src/host/azure-api-version-request.test.ts packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts packages/memory-host-sdk/src/host/embeddings-remote-fetch.test.ts src/plugins/openai-compatible-embedding-provider.ts src/plugins/openai-compatible-embedding-provider.azure.test.ts
  # 3) Real-HTTP wire demonstration (no fetch mocks):
  #    - temporary /etc/hosts: demo.openai.azure.com -> local private address
  #    - local stand-in server enforcing Azure's REST contract (logs every raw request)
  #    - client imports the PR-head fetchRemoteEmbeddingVectors from
  #      packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts and calls it with
  #      an Azure-suffixed URL + api-version header + the SSRF policy the SDK builds
  #      from a configured base URL (ssrfPolicyFromHttpBaseUrlAllowedHostname)
  node azure-standin-server.mjs &   # stand-in, 0.0.0.0:8123
  node --import ./scripts/tsx.mjs azure-demo-client.mts
  # 4) Configured compatible-provider route over real HTTP (no fetch mocks):
  #    runtime config with models.providers."azure-standin" (api: openai-completions,
  #    Azure-suffixed baseUrl, api-version only in headers) is fed to the shipped
  #    openAICompatibleEmbeddingProviderAdapter.create(); provider.embed()/
  #    embedBatch() then run through guarded HTTP against the same stand-in.
  #    control = origin/main wiring of that file; after = PR-head wiring.
  node --import ./scripts/tsx.mjs configured-provider-route-demo.mts control
  node --import ./scripts/tsx.mjs configured-provider-route-demo.mts after
  # 5) LIVE Azure run against the real demo.openai.azure.com APIM edge (invalid
  #    api-key on purpose): no stand-in server, no /etc/hosts override. Azure's own
  #    status code shows whether the request was routed (401) or rejected
  #    pre-routing (404). control = pre-fix wiring restored via git checkout HEAD^.
  ./azure-live-probe.sh                                   # curl contract matrix A-D
  git checkout HEAD^ -- packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts src/plugins/openai-compatible-embedding-provider.ts
  node --import ./scripts/tsx.mjs live-azure-configured-route.mts control
  git checkout HEAD -- packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts src/plugins/openai-compatible-embedding-provider.ts   # restore (git status clean)
  node --import ./scripts/tsx.mjs live-azure-configured-route.mts after
  ```
- **Evidence after fix:**
  ```text
  # LIVE AZURE — real demo.openai.azure.com APIM edge, no stand-in, deliberately invalid api-key
  # A) live Azure contract matrix (curl; see step 5)
  (A) no api-version anywhere .................. 404 {"error":{"code":"404","message": "Resource not found"}}
  (B) api-version ONLY as header = pre-fix shape  404 {"error":{"code":"404","message": "Resource not found"}}
  (C) api-version as URL query = post-fix shape   401 {"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint. ..."}}
  (D) bogus api-version as URL query ........... 404 {"error":{"code":"404","message": "Resource not found"}}
  # (D) shows Azure validates the api-version *value* taken from the query, not merely
  # its presence. B vs C is the reported before/after transition, produced by Azure itself.

  # production module against LIVE Azure — raw SDK fetch path (fetchRemoteEmbeddingVectors)
  [control][sdk] live-azure sdk embeddings failed: 404 {"error":{"code":"404","message": "Resource not found"}}
  [after][sdk]   live-azure sdk embeddings failed: 401 {"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint. ..."}}

  # production configured-provider route against LIVE Azure (config -> adapter.create -> embed/embedBatch -> guarded HTTP)
  [control][configured-route] cacheKeyData = {"provider":"azure-live","baseUrl":"https://demo.openai.azure.com/openai/deployments/text-embedding-3-small","model":"text-embedding-3-small","headers":{"accept":"application/json","content-type":"application/json","api-version":"2023-05-15"}}
  [control][configured-route embed] FAILED: openai-compatible embeddings failed: HTTP 404: {"error":{"code":"404","message": "Resource not found"}}
  [control][configured-route embedBatch] FAILED: openai-compatible embeddings failed: HTTP 404: {"error":{"code":"404","message": "Resource not found"}}
  [after][configured-route] cacheKeyData = {"provider":"azure-live","baseUrl":"https://demo.openai.azure.com/openai/deployments/text-embedding-3-small","model":"text-embedding-3-small","headers":{"accept":"application/json","content-type":"application/json","api-version":"2023-05-15"}}   # byte-identical to control
  [after][configured-route embed] FAILED: openai-compatible embeddings failed: HTTP 401: {"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint. ..."}}
  [after][configured-route embedBatch] FAILED: openai-compatible embeddings failed: HTTP 401: {"error":{"code":"401","message":"Access denied due to invalid subscription key or wrong API endpoint. ..."}}

  # client transcript (local stand-in, valid-success path)
  [CONTROL pre-fix wire behavior] POST http://demo.openai.azure.com:8123/openai/deployments/text-embedding-3-small/embeddings  (api-version only in a header, like main)
  [CONTROL] status=404 body={"error":{"code":"404","message":"Resource not found"}}
  [AFTER-FIX fetchRemoteEmbeddingVectors] OK
  [AFTER-FIX] parsed vectors=[[0.0318063,-0.0225065,0.0174375,0.00927162],[-0.0125818,0.0243342,-0.00173021,0.0148868]]
  [AFTER-FIX] vector count=2 dims=4,4
  [AFTER-FIX url-precedence] OK parsed 2 vector(s) (stand-in saw api-version=2024-10-21 in query)

  # stand-in server raw request log (what actually left the process; api-key redacted)
  [azure-standin 404] POST /openai/deployments/text-embedding-3-small/embeddings HTTP/1.1  api-key=<redacted>  api-version-header=2023-05-15
  [azure-standin 200  api-version(query)=2023-05-15] POST /openai/deployments/text-embedding-3-small/embeddings?api-version=2023-05-15 HTTP/1.1  api-key=<redacted>  api-version-header=(absent)
  [azure-standin 200  api-version(query)=2024-10-21] POST /openai/deployments/text-embedding-3-small/embeddings?api-version=2024-10-21 HTTP/1.1  api-key=<redacted>  api-version-header=(absent)

  # configured compatible-provider route: real config -> adapter.create -> embed/embedBatch -> guarded HTTP
  [control][configured-provider-route embed] FAILED: openai-compatible embeddings failed: HTTP 404: {"error":{"code":"404","message":"Resource not found"}}
  [control][configured-provider-route url-precedence] OK dims=4   # URL already carried api-version=2024-10-21, main passes it through
  [control][configured-provider-route cacheKeyData] {"provider":"azure-standin","baseUrl":"http://demo.openai.azure.com:8123/openai/deployments/text-embedding-3-small","model":"text-embedding-3-small","headers":{"accept":"application/json","content-type":"application/json","api-version":"2023-05-15"}}
  [after][configured-provider-route embed] OK dims=4 first3=0.0318063,-0.0225065,0.0174375
  [after][configured-provider-route embedBatch] OK count=2 dims=4,4
  [after][configured-provider-route cacheKeyData] {"provider":"azure-standin","baseUrl":"http://demo.openai.azure.com:8123/openai/deployments/text-embedding-3-small","model":"text-embedding-3-small","headers":{"accept":"application/json","content-type":"application/json","api-version":"2023-05-15"}}   # byte-identical to control
  [after][configured-provider-route url-precedence] OK dims=4

  # stand-in raw requests for the configured-route runs (control first, then after)
  [azure-standin 404] POST /openai/deployments/text-embedding-3-small/embeddings HTTP/1.1  api-key=<redacted>  api-version-header=2023-05-15
  [azure-standin 200  api-version(query)=2023-05-15] POST /openai/deployments/text-embedding-3-small/embeddings?api-version=2023-05-15 HTTP/1.1  api-key=<redacted>  api-version-header=(absent)
  [azure-standin 200  api-version(query)=2023-05-15] POST /openai/deployments/text-embedding-3-small/embeddings?api-version=2023-05-15 HTTP/1.1  api-key=<redacted>  api-version-header=(absent)   # embedBatch
  [azure-standin 200  api-version(query)=2024-10-21] POST /openai/deployments/text-embedding-3-small/embeddings?api-version=2024-10-21 HTTP/1.1  api-key=<redacted>  api-version-header=(absent)

  # regression suites (re-run on the rebased head)
  Test Files  1 passed (1)  — azure-api-version-request.test.ts (17 tests)
  Test Files  1 passed (1)  — embeddings-remote-fetch.test.ts (22 tests, incl. Azure URL promotion)
  Test Files  1 passed (1)  — openai-compatible-embedding-provider.azure.test.ts (2 tests)
  [validate] 全部通过 ✅ (oxfmt + oxlint + tsgo:core + same-dir tests)
  ```
  How to read the transcript: the CONTROL line replicates pre-fix main's wire
  format (URL without query, `api-version` only in a header) and the
  contract-enforcing stand-in answers `HTTP 404` with Azure's exact body — the
  reported symptom over a real socket. The AFTER-FIX line runs the unmodified
  PR-head module with identical url/headers: the server log shows the outgoing
  request carried `?api-version=2023-05-15` with **no** `api-version` header,
  the stand-in returned 200, and the production response validator parsed the
  vectors — the fix's success criteria observed at the wire. The third line
  shows URL precedence (`2024-10-21` in the URL wins over the header's
  `2023-05-15`, header dropped), matching the chat completions transport.
  The mocked-boundary regression suites above pin the same behavior in CI for
  all Azure host suffixes, non-Azure passthrough, and both wiring sites.
  The configured-provider-route block repeats the exercise through the full
  configuration path a user actually sets up (models.providers entry ->
  adapter.create -> provider.embed/embedBatch -> guarded fetch): with the
  pre-fix main wiring the configured route reproduces the exact reported
  `HTTP 404` over a real socket, and with the PR-head wiring the same
  configuration succeeds with `api-version` in the query and the header absent.
  The printed `cacheKeyData` is byte-identical before and after the fix, which
  is direct evidence that the configured embedding cache identity (and thus
  existing memory indexes) is untouched by the normalization.
  The LIVE AZURE block repeats the same two wirings against the real Azure APIM
  edge instead of the stand-in: the pre-fix wiring gets Azure's own
  `404 {"error":{"code":"404","message": "Resource not found"}}` (the reported
  symptom, byte-for-byte), while the PR-head wiring is routed past the
  api-version check to credential validation (`401 invalid subscription key`),
  and a bogus api-version value is still rejected with 404 — i.e. live Azure is
  consuming the query value. `cacheKeyData` is byte-identical there too.
- **Observed result after fix:** For an Azure-hosted embedding request the
  actual outbound HTTP request line carries `api-version=<configured value>` in
  the URL query and no `api-version` header, and the embedding response is
  accepted and parsed into vectors. This was observed both through the raw SDK
  fetch path and through the configured compatible-provider route (config ->
  adapter -> embed/embedBatch). Against the **real** Azure APIM edge the same
  two request paths move from Azure's `404 Resource not found` (pre-fix
  wiring) to a routed request that only fails credential validation (`401
  invalid subscription key`, PR-head wiring), which is live Azure accepting the
  api-version query. Non-Azure providers (including the existing local-server
  plugin tests) are unchanged.
- **Before evidence:** Prior behavior sent only the `api-version` header; the
  issue reporter observed `HTTP 404: Resource not found` from Azure because the
  query parameter was absent. The CONTROL transcript above reproduces that 404
  both against the contract-enforcing stand-in and against **live Azure itself**
  (curl row B and the pre-fix `[control]` runs).
- **What was not tested:** No Azure OpenAI API key exists in this environment,
  so no request returned `200` with real vectors. Live Azure requests **were**
  executed (curl rows A-D and the `[control]`/`[after]` runs above) with a
  deliberately invalid key: they show live Azure rejecting the pre-fix request
  with the reported 404 and routing the post-fix request to credential
  validation; the credential check returning a payload is the one step a valid
  subscription key would additionally exercise. The local stand-in covers the
  valid-success path (200 + parsed vectors) and enforces Azure's documented
  contract but is not Azure itself. TLS is exercised on the live Azure runs
  (real HTTPS to `demo.openai.azure.com`); the stand-in runs use plain HTTP
  loopback.
- **Proof tier:** L2+ — real-HTTP-boundary verification plus **live external
  service** evidence: the real production request module, guarded fetch (DNS
  pinning included), and response validator ran over real sockets against both
  a local stand-in implementing Azure's REST contract (200 + parsed vectors)
  and the **real Azure OpenAI APIM edge** (`404` pre-fix vs. routed `401`
  post-fix with a deliberately invalid key). No `200` from live Azure (see
  limitations).
- **Proof limitations:** A `200` from live Azure requires a valid Azure OpenAI
  subscription key, which this environment does not have. What is proven is the
  exact outbound request shape at the wire level (the defect and fix are
  request-construction level), acceptance by a server enforcing Azure's
  documented contract (200 + parsed vectors), and acceptance **by live Azure**
  in the sense that the post-fix request passes Azure's api-version validation
  and routing while the pre-fix request gets the reported 404. The remaining
  unknown is only the credential check returning the embedding payload.
- **Data-model compatibility:** No persistent data-model change. The review's
  stored-data-model heuristics flag `serialized state:
  src/plugins/openai-compatible-embedding-provider.ts`,
  `unknown-data-model-change` on `azure-api-version-request.ts`, and
  `vector/embedding metadata` on the touched embedding files; addressed item by
  item: (1) `openai-compatible-embedding-provider.ts` contains no serialization
  or persistence code — its only data-producing surface is
  `runtime.cacheKeyData`, whose composition this PR does not change; the
  before/after configured-route runs above print byte-identical `cacheKeyData`
  (the configured `api-version` header still enters the cache identity,
  because normalization applies only to the outgoing request, never to the
  configured identity), so existing memory indexes stay valid with no rebuild,
  alias, or migration needed. (2) `azure-api-version-request.ts` is a pure
  function returning `{url, headers}` for a single outgoing request; it reads
  and writes no files, caches, or stores. (3) `vector/embedding metadata` is a
  filename-level classification of the embedding transport files; the delta
  never touches vector data, dimension metadata, or persisted index formats —
  it only rewrites the outgoing request target. Verified mechanically: the diff
  touches 6 files (3 production + 3 tests); changed-file scan and a code-only
  scan of the 83 added production lines for storage/schema/sqlite/
  serialization/persist/writeFile/db/leveldb/kv/migration APIs return no
  matches, so no serialized state, storage schema, cache layout, or migration
  surface exists and no upgrade/migration compatibility proof applies.
- **Review state:** CI green on this head; commit parent is `89940dfa1a4`
  (upstream `main` at PR time). The configured compatible-provider route has
  been exercised end to end over real HTTP and against the live Azure APIM edge
  (transcript above): live Azure routes the post-fix request and rejects only
  the deliberately invalid key. The only outstanding item is a `200` carrying
  real vectors, which needs a valid Azure OpenAI key (config sample in
  #111386).


