### PR TITLE
fix(gateway): record a transcript notice when a run fails before replying

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -848,6 +848,8 @@ unchanged; click a title to rename it.
 
 Collapsed tool rows keep the tool label visible and truncate long summaries with an ellipsis. Tool and subagent activity rows use the same text size and weight. Running subagents show **Subagent** beside an animated indicator; terminal rows show **Subagent finished**, **Subagent failed**, or **Subagent cancelled**.
 
+A turn that fails before producing any reply leaves a durable notice in the thread.
+
 Chat error banners, including cloud runner failures, show short messages in full. Use **Copy error** beside **Details** in the header to copy the complete diagnostic received by the UI, even while collapsed. **Details** appears only when the complete diagnostic adds information beyond the preview, such as additional lines or text shortened for the preview; repeated lines and whitespace-only differences do not add details. Open it to read and select the complete diagnostic. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Copying does not open or close the details, and neither copying nor expanding an error retries the failed operation. Retry and other recovery actions remain separate from the disclosure.
 
 <AccordionGroup>

--- a/src/config/sessions/session-accessor.sqlite-transcript-reports.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-reports.ts
@@ -6,6 +6,7 @@ import {
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import type { AssistantMessage } from "../../llm/types.js";
+import { readSessionTranscriptRunId } from "../../sessions/transcript-events.js";
 import {
   runOpenClawAgentWriteTransaction,
   type OpenClawAgentDatabase,
@@ -53,6 +54,7 @@ type TranscriptReport =
   | {
       kind: "custom";
       customTypes: readonly string[];
+      suppressWhenAssistantRun?: string;
       selectReport: (
         latest: CustomMessageReport | undefined,
       ) => CustomMessageReportAppend | undefined;
@@ -62,6 +64,7 @@ type ReportNavigationEntry = SessionNavigationEntry & {
   seq: number;
   customType?: string;
   assistantResponseId?: string;
+  assistantRunId?: string;
 };
 
 class TranscriptReportNavigation extends SessionEntryNavigation<ReportNavigationEntry> {
@@ -82,6 +85,9 @@ class TranscriptReportNavigation extends SessionEntryNavigation<ReportNavigation
         appendMode: entry.appendMode,
         seq,
         ...(entry.type === "custom_message" ? { customType: entry.customType } : {}),
+        ...(entry.type === "message" && entry.message.role === "assistant"
+          ? { assistantRunId: readSessionTranscriptRunId(entry.message) }
+          : {}),
         ...(entry.type === "message" &&
         entry.message.role === "assistant" &&
         typeof entry.message.responseId === "string"
@@ -234,6 +240,12 @@ export async function appendSessionTranscriptReport(
         message: applyAssistantDeliveryDirectives(report.message),
         parentId: branch.appendParentId,
       });
+      return;
+    }
+    if (
+      report.suppressWhenAssistantRun !== undefined &&
+      branch.path.some((entry) => entry.assistantRunId === report.suppressWhenAssistantRun)
+    ) {
       return;
     }
     const selected = report.selectReport(

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -23,6 +23,7 @@ import {
 import { buildRestartRecoveryExpectedState } from "../../config/sessions/session-transcript-turn-state.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadOrCreateProcessDeviceIdentity } from "../../infra/device-identity.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { findRestartRecoveryUnsafeChatAdmissionHook } from "../../plugins/restart-recovery-hook-safety.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
 import { isAgentHarnessSessionKey } from "../../sessions/agent-harness-session-key.js";
@@ -31,13 +32,18 @@ import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import { resolveChatRunOwnerAgentId } from "../chat-run-owner.js";
 import type { GatewayRecoveryRuntime } from "../server-instance-runtime.types.js";
-import { deriveGatewaySessionLifecycleSnapshot } from "../session-lifecycle-state.js";
+import {
+  deriveGatewaySessionLifecycleSnapshot,
+  recordGatewaySessionRunFailure,
+} from "../session-lifecycle-state.js";
+import { boundedWorkerError } from "../worker-environments/worker-error.js";
 import { resolveChatSendActiveScopeKey } from "./chat-origin-routing.js";
 import type { GatewayRequestContext } from "./types.js";
 
 export { hasRestartRecoveryTerminalRun };
 
 const RESTART_SAFE_CHAT_REQUEST_VERIFIER_DOMAIN = "openclaw.chat.restart-retry.v1";
+const log = createSubsystemLogger("gateway/restart-recovery");
 
 type RestartSafeChatRequest = {
   fingerprint: string;
@@ -415,7 +421,7 @@ export async function terminalizeRestartSafeChatAdmission(
 ): Promise<boolean> {
   const endedAt = Date.now();
   let terminalized = false;
-  await patchSessionEntryCore(
+  const persisted = await patchSessionEntryCore(
     { sessionKey: params.sessionKey, storePath: params.storePath },
     (current) => {
       if (
@@ -455,5 +461,20 @@ export async function terminalizeRestartSafeChatAdmission(
     },
     { requireWriteSuccess: true, skipMaintenance: true },
   );
+  if (terminalized && persisted && params.status === "failed") {
+    await recordGatewaySessionRunFailure({
+      target: {
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+        sessionId: persisted.sessionId,
+        expectedLifecycleRevision: persisted.lifecycleRevision,
+      },
+      runId: params.clientRunId,
+      error: params.error,
+    }).catch((error: unknown) => {
+      // The claim is already settled; report failure must not trigger a competing terminal write.
+      log.warn(`Failed to record restart-safe chat failure notice: ${boundedWorkerError(error)}`);
+    });
+  }
   return terminalized;
 }

--- a/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
@@ -1,11 +1,21 @@
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../../config/legacy.default-agent-owner.js";
+import {
+  appendTranscriptMessage,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
 import { SessionTranscriptProjectionUnavailableError } from "../../config/sessions/session-transcript-projection-error.js";
 import { onAgentRuntimeEvent } from "../../infra/agent-events.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { abortChatRunById, registerChatAbortController } from "../chat-abort.js";
 import { createChatRunState } from "../server-chat-state.js";
 import * as sessionLifecycleState from "../session-lifecycle-state.js";
+import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
 import {
   createChatSendDispatchErrorLifecycle,
   handleChatSendSetupError,
@@ -57,6 +67,170 @@ describe("handleChatSendSetupError", () => {
 });
 
 describe("createChatSendDispatchErrorLifecycle", () => {
+  it.each(["fallback", "restart-safe"])(
+    "records the rejected input before its durable failure through %s settlement",
+    async (settlement) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const target = {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "dispatch-failure-session",
+          storePath: path.join(state.sessionsDir(), "sessions.json"),
+        };
+        const runId = "dispatch-failure-run";
+        const restartSafe = settlement === "restart-safe";
+        await upsertSessionEntryCore(target, {
+          sessionId: target.sessionId,
+          updatedAt: 1_000,
+          startedAt: 1_000,
+          lifecycleRunId: runId,
+          status: "running",
+          ...(restartSafe
+            ? {
+                restartRecoveryDeliveryRunId: runId,
+                restartRecoveryDeliverySourceRunId: runId,
+              }
+            : {}),
+        });
+        let userPersisted = false;
+        const persistUserTurnTranscript = async () => {
+          await appendTranscriptMessage(target, {
+            message: { role: "user", content: "Please continue." },
+          });
+          userPersisted = true;
+        };
+        if (restartSafe) {
+          await persistUserTurnTranscript();
+        }
+        const warn = vi.fn();
+        const lifecycle = createChatSendDispatchErrorLifecycle({
+          admission: {
+            activeRunAbort: {
+              cleanup: vi.fn(),
+              controller: new AbortController(),
+              entry: undefined,
+              registered: true,
+            } as never,
+            cleanupAdmittedRun: vi.fn(),
+            lifecycleGeneration: "test-generation",
+            restartSafeAdmission: restartSafe
+              ? { requestFingerprint: "test-fingerprint" }
+              : undefined,
+          },
+          context: {
+            agentRunSeq: new Map(),
+            broadcast: vi.fn(),
+            broadcastToConnIds: vi.fn(),
+            chatAbortControllers: new Map(),
+            chatRunState: createChatRunState(),
+            dedupe: new Map(),
+            getRuntimeConfig: () => ({}),
+            getSessionEventSubscriberConnIds: () => new Set<string>(),
+            logGateway: { warn },
+            nodeSendToSession: vi.fn(),
+            removeChatRun: vi.fn(),
+          } as never,
+          isQueuedFollowupEnqueued: () => false,
+          persistUserTurnTranscript,
+          session: {
+            agentId: target.agentId,
+            backingSessionId: target.sessionId,
+            cfg: {},
+            clientRunId: runId,
+            now: 1_000,
+            rawSessionKey: target.sessionKey,
+            sessionKey: target.sessionKey,
+          },
+          terminalizeRestartSafeAdmission: (terminal) =>
+            terminalizeRestartSafeChatAdmission({
+              ...terminal,
+              ...target,
+              admittedSessionId: target.sessionId,
+              clientRunId: runId,
+              startedAt: 1_000,
+            }),
+          userTurnRecorder: { hasPersisted: () => userPersisted, isBlocked: () => false },
+        });
+
+        await lifecycle.handleError(new Error("Cloud worker unavailable"));
+        await lifecycle.finalize();
+
+        expect(warn).not.toHaveBeenCalled();
+        expect(loadSessionEntry(target)).toMatchObject({ status: "failed", lastRunId: runId });
+        const messages = (await loadTranscriptEvents(target)).filter(
+          (entry) =>
+            isRecord(entry) && (entry.type === "message" || entry.type === "custom_message"),
+        );
+        expect(messages).toMatchObject([
+          { type: "message", message: { role: "user", content: "Please continue." } },
+          {
+            type: "custom_message",
+            customType: "run-failed-before-reply",
+            display: true,
+            details: { runId },
+          },
+        ]);
+        if (restartSafe) {
+          expect(loadSessionEntry(target)?.restartRecoveryDeliveryRunId).toBe(runId);
+          const terminal = {
+            ...target,
+            admittedSessionId: target.sessionId,
+            clientRunId: runId,
+            startedAt: 1_000,
+            error: "Late duplicate rejection",
+            status: "failed" as const,
+            retryable: false,
+          };
+          expect(await terminalizeRestartSafeChatAdmission(terminal)).toBe(true);
+          expect(loadSessionEntry(target)?.restartRecoveryDeliveryRunId).toBeUndefined();
+          expect(await terminalizeRestartSafeChatAdmission(terminal)).toBe(false);
+          expect(
+            (await loadTranscriptEvents(target)).filter(
+              (entry) => isRecord(entry) && entry.type === "custom_message",
+            ),
+          ).toHaveLength(1);
+        }
+      });
+    },
+  );
+
+  it("keeps restart-safe settlement successful when its notice cannot be written", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const target = {
+        sessionKey: "agent:main:main",
+        storePath: path.join(state.sessionsDir(), "sessions.json"),
+      };
+      await upsertSessionEntryCore(target, {
+        sessionId: "settled-session",
+        updatedAt: 1_000,
+        restartRecoveryDeliveryRunId: "settled-run",
+      });
+      const report = vi
+        .spyOn(sessionLifecycleState, "recordGatewaySessionRunFailure")
+        .mockRejectedValueOnce(new Error("notice write failed"));
+      try {
+        expect(
+          await terminalizeRestartSafeChatAdmission({
+            ...target,
+            admittedSessionId: "settled-session",
+            clientRunId: "settled-run",
+            startedAt: 1_000,
+            status: "failed",
+            error: "Worker unavailable",
+            retryable: false,
+          }),
+        ).toBe(true);
+        expect(loadSessionEntry(target)).toMatchObject({
+          status: "failed",
+          lastRunId: "settled-run",
+        });
+        expect(loadSessionEntry(target)?.restartRecoveryDeliveryRunId).toBeUndefined();
+      } finally {
+        report.mockRestore();
+      }
+    });
+  });
+
   it("terminalizes an admitted queued followup as successful despite later dispatch failure", async () => {
     const broadcast = vi.fn();
     const cleanupAdmittedRun = vi.fn();

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -301,6 +301,12 @@ export function createChatSendDispatchErrorLifecycle(params: {
     clearAgentRunContext(clientRunId, lifecycleGeneration);
     context.removeChatRun(clientRunId, clientRunId, sessionKey);
     try {
+      // The lifecycle owner may append a failure notice; keep its input first.
+      await persistDispatchErrorUserTurn?.().catch((transcriptErr: unknown) => {
+        context.logGateway.warn(
+          `webchat user transcript update failed after error: ${formatForLog(transcriptErr)}`,
+        );
+      });
       const hasActiveRun = hasTrackedActiveSessionRun({
         context,
         requestedKey: rawSessionKey,
@@ -337,11 +343,6 @@ export function createChatSendDispatchErrorLifecycle(params: {
           );
         }
       }
-      await persistDispatchErrorUserTurn?.().catch((transcriptErr: unknown) => {
-        context.logGateway.warn(
-          `webchat user transcript update failed after error: ${formatForLog(transcriptErr)}`,
-        );
-      });
     } catch (continuationErr: unknown) {
       context.logGateway.warn(
         `webchat session lifecycle continuation failed: ${formatForLog(continuationErr)}`,

--- a/src/gateway/session-lifecycle-run-failure.test.ts
+++ b/src/gateway/session-lifecycle-run-failure.test.ts
@@ -1,0 +1,190 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it } from "vitest";
+import {
+  loadTranscriptEvents,
+  replaceTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { CURRENT_SESSION_VERSION } from "../config/sessions/version.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
+
+const target = {
+  agentId: "main",
+  sessionId: "failed-turn-session",
+  sessionKey: "agent:main:main",
+};
+const runId = "failed-turn-run";
+const error = "Worker turn rejected: cloud worker unavailable";
+const event = {
+  sessionId: target.sessionId,
+  runId,
+  ts: 2_000,
+  data: { phase: "error", startedAt: 1_000, endedAt: 2_000, error },
+};
+
+async function seed(assistantBranch?: "active" | "inactive" | "other-run") {
+  await upsertSessionEntryCore(target, {
+    sessionId: target.sessionId,
+    updatedAt: 1_000,
+    startedAt: 1_000,
+    status: "running",
+    lifecycleRunId: runId,
+  });
+  await replaceTranscriptEvents(target, [
+    { type: "session", id: target.sessionId, version: CURRENT_SESSION_VERSION },
+    {
+      type: "message",
+      id: "user-turn",
+      parentId: null,
+      message: { role: "user", content: "Please continue." },
+    },
+    ...(assistantBranch
+      ? [
+          {
+            type: "message",
+            id: "assistant-error",
+            parentId: "user-turn",
+            message: {
+              role: "assistant",
+              content: [],
+              stopReason: "error",
+              errorMessage: "Provider failed",
+              __openclaw: { runId: assistantBranch === "other-run" ? "previous-run" : runId },
+            },
+          },
+        ]
+      : []),
+    ...(assistantBranch === "inactive"
+      ? [
+          {
+            type: "leaf",
+            id: "selected-branch",
+            parentId: "assistant-error",
+            targetId: "user-turn",
+          },
+        ]
+      : []),
+  ]);
+}
+
+async function reports() {
+  return (await loadTranscriptEvents(target)).filter(
+    (entry) => isRecord(entry) && entry.customType === "run-failed-before-reply",
+  );
+}
+
+describe("durable pre-reply run failure", () => {
+  it("records one displayed failure per run and retains it after the next run starts", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await seed();
+      await persistGatewaySessionLifecycleEvent({ ...target, event });
+      expect(await reports()).toMatchObject([
+        {
+          type: "custom_message",
+          customType: "run-failed-before-reply",
+          content: `This turn did not run: ${error}.`,
+          display: true,
+          details: { runId, error },
+        },
+      ]);
+      await persistGatewaySessionLifecycleEvent({ ...target, event });
+      await persistGatewaySessionLifecycleEvent({
+        ...target,
+        event: {
+          ...event,
+          runId: "next-run",
+          ts: 3_000,
+          data: { phase: "start", startedAt: 3_000 },
+        },
+      });
+      expect(await reports()).toHaveLength(1);
+    });
+  });
+
+  it.each(["active", "inactive", "other-run"] as const)(
+    "checks assistant output on the %s branch for this run",
+    async (branch) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        await seed(branch);
+        await persistGatewaySessionLifecycleEvent({ ...target, event });
+        expect(await reports()).toHaveLength(branch === "active" ? 0 : 1);
+      });
+    },
+  );
+
+  it.each([
+    { phase: "start" },
+    { phase: "end" },
+    { phase: "error", aborted: true, stopReason: "aborted" },
+    { phase: "aborted" },
+    { phase: "completed" },
+  ])("does not report $phase / $stopReason", async (data) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await seed();
+      await persistGatewaySessionLifecycleEvent({ ...target, event: { ...event, data } });
+      expect(await reports()).toEqual([]);
+    });
+  });
+
+  it("sanitizes and bounds the stored error", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await seed();
+      const secret = [
+        String.fromCharCode(115, 107),
+        "proj",
+        "failure",
+        "abcdefghijklmnopqrstuvwxyz",
+      ].join("-");
+      await persistGatewaySessionLifecycleEvent({
+        ...target,
+        event: {
+          ...event,
+          data: {
+            ...event.data,
+            error: `Worker rejected token=${secret}\n${"detail ".repeat(150)}`,
+          },
+        },
+      });
+      const entries = await reports();
+      expect(entries).toHaveLength(1);
+      expect(JSON.stringify(entries)).not.toContain(secret);
+      expect(entries[0]).toMatchObject({ details: { runId, error: expect.any(String) } });
+      const report = entries[0] as { details: { error: string } };
+      expect(report.details.error.length).toBeLessThanOrEqual(512);
+      expect(report.details.error).not.toContain("\n");
+    });
+  });
+
+  it.each(["session", "run"])("does not report a stale %s error", async (stale) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await seed();
+      await persistGatewaySessionLifecycleEvent({
+        ...target,
+        event: {
+          ...event,
+          sessionId: stale === "session" ? "previous-session" : target.sessionId,
+          runId: "previous-run",
+          data: { ...event.data, startedAt: 500 },
+        },
+      });
+      expect(await reports()).toEqual([]);
+    });
+  });
+
+  it("does not report an error whose lifecycle write was refused", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      await seed();
+      await expect(
+        persistGatewaySessionLifecycleEvent({
+          ...target,
+          event,
+          assertCommitAllowed: () => {
+            throw new Error("Run authority expired");
+          },
+        }),
+      ).rejects.toThrow("Run authority expired");
+      expect(await reports()).toEqual([]);
+    });
+  });
+});

--- a/src/gateway/session-lifecycle-state.test.ts
+++ b/src/gateway/session-lifecycle-state.test.ts
@@ -18,6 +18,7 @@ const loggerMocks = vi.hoisted(() => ({
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
   patchSessionEntryCore: persistenceMocks.updateSessionEntry,
+  appendSessionTranscriptReport: vi.fn(async () => ({ ok: true, value: undefined })),
 }));
 
 vi.mock("./session-utils.js", () => ({

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -19,6 +19,7 @@ import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js
 import {
   appendSessionTranscriptReport,
   patchSessionEntryCore,
+  type SessionTranscriptWriteScope,
 } from "../config/sessions/session-accessor.js";
 import { getAgentEventLifecycleGeneration, type AgentEventPayload } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -133,6 +134,37 @@ function resolveSettledLifecycleTerminalOutcome(
 
 function sanitizeSessionRunError(error: unknown): string {
   return renderUserFacingText(error, { errorContext: true }).replace(/\s+/g, " ").trim();
+}
+
+/** Shared transcript outcome for owners that already committed a failed run. */
+export async function recordGatewaySessionRunFailure(params: {
+  target: SessionTranscriptWriteScope & { sessionId: string };
+  runId: string;
+  error: unknown;
+  assertCommitAllowed?: () => void;
+}): Promise<void> {
+  const { runId } = params;
+  const error = boundedWorkerError(sanitizeSessionRunError(params.error), 512);
+  const result = await appendSessionTranscriptReport(params.target, {
+    kind: "custom",
+    customTypes: [RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE],
+    suppressWhenAssistantRun: runId,
+    selectReport: (latest) => {
+      params.assertCommitAllowed?.();
+      if (isRecord(latest?.details) && latest.details.runId === runId) {
+        return undefined;
+      }
+      return {
+        customType: RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE,
+        content: `This turn did not run: ${error}.`,
+        display: true,
+        details: { runId, error },
+      };
+    },
+  });
+  if (!result.ok) {
+    throw new Error(`Failed run notice could not be appended: ${result.error.code}`);
+  }
 }
 
 function resolveSessionRunError(
@@ -368,7 +400,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
 
   const exactCronRun = parseCronRunScopeSuffix(sessionEntry.canonicalKey).runId !== undefined;
   let terminalRecovery: { runId: string; outcome: AgentRunTerminalOutcome } | undefined;
-  let failedRun: { runId: string; error: string } | undefined;
+  let failedRun: { runId: string; error: unknown } | undefined;
   const persisted = await patchSessionEntryCore(
     {
       storePath: sessionEntry.storePath,
@@ -424,10 +456,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
       ) {
         failedRun = {
           runId: eventRunId,
-          error: boundedWorkerError(
-            sanitizeSessionRunError(resolveTerminalOutcome(params.event).error),
-            512,
-          ),
+          error: resolveTerminalOutcome(params.event).error,
         };
       }
       const recoveryTerminalRunId = normalizeLifecycleRunId(params.event.runId);
@@ -463,34 +492,17 @@ export async function persistGatewaySessionLifecycleEvent(params: {
     const { runId, error } = failedRun;
     // Only accepted errors pay for branch navigation; assistant detection and
     // report deduplication share the appender's authoritative write snapshot.
-    const result = await appendSessionTranscriptReport(
-      {
+    await recordGatewaySessionRunFailure({
+      target: {
         agentId: sessionEntry.agentId,
         storePath: sessionEntry.storePath,
         sessionKey: sessionEntry.canonicalKey,
         sessionId: persisted.sessionId,
         expectedLifecycleRevision: persisted.lifecycleRevision,
       },
-      {
-        kind: "custom",
-        customTypes: [RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE],
-        suppressWhenAssistantRun: runId,
-        selectReport: (latest) => {
-          params.assertCommitAllowed?.();
-          if (isRecord(latest?.details) && latest.details.runId === runId) {
-            return undefined;
-          }
-          return {
-            customType: RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE,
-            content: `This turn did not run: ${error}.`,
-            display: true,
-            details: { runId, error },
-          };
-        },
-      },
-    );
-    if (!result.ok) {
-      throw new Error(`Failed run notice could not be appended: ${result.error.code}`);
-    }
+      runId,
+      error,
+      assertCommitAllowed: params.assertCommitAllowed,
+    });
   }
 }

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -1,3 +1,4 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 // Gateway session lifecycle state projection.
 // Converts agent run lifecycle events into session row/store status updates.
 import { normalizeOptionalString as normalizeLifecycleRunId } from "@openclaw/normalization-core/string-coerce";
@@ -15,12 +16,16 @@ import {
   projectMainSessionRecoveryLifecycle,
 } from "../agents/main-session-recovery/main-session-recovery-lifecycle.js";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
-import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  appendSessionTranscriptReport,
+  patchSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import { getAgentEventLifecycleGeneration, type AgentEventPayload } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseCronRunScopeSuffix } from "../sessions/session-key-utils.js";
 import { loadSessionEntry } from "./session-utils.js";
 import type { GatewaySessionRow } from "./session-utils.types.js";
+import { boundedWorkerError } from "./worker-environments/worker-error.js";
 
 const restartRecoveryLog = createSubsystemLogger("main-session-restart-recovery");
 
@@ -77,6 +82,7 @@ type PersistedLifecycleSessionShape = Pick<
 type GatewaySessionLifecycleSnapshot = Partial<Pick<SessionEntry, keyof LifecycleSessionShape>>;
 
 const SESSION_RUN_ERROR_MAX_CHARS = 160;
+const RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE = "run-failed-before-reply";
 
 function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
@@ -125,6 +131,10 @@ function resolveSettledLifecycleTerminalOutcome(
     : outcome;
 }
 
+function sanitizeSessionRunError(error: unknown): string {
+  return renderUserFacingText(error, { errorContext: true }).replace(/\s+/g, " ").trim();
+}
+
 function resolveSessionRunError(
   outcome: AgentRunTerminalOutcome,
   status: SessionRunStatus,
@@ -132,9 +142,7 @@ function resolveSessionRunError(
   if ((status !== "failed" && status !== "timeout") || !outcome.error) {
     return undefined;
   }
-  const sanitized = renderUserFacingText(outcome.error, { errorContext: true })
-    .replace(/\s+/g, " ")
-    .trim();
+  const sanitized = sanitizeSessionRunError(outcome.error);
   return sanitized ? truncateUtf16Safe(sanitized, SESSION_RUN_ERROR_MAX_CHARS) : undefined;
 }
 
@@ -360,6 +368,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
 
   const exactCronRun = parseCronRunScopeSuffix(sessionEntry.canonicalKey).runId !== undefined;
   let terminalRecovery: { runId: string; outcome: AgentRunTerminalOutcome } | undefined;
+  let failedRun: { runId: string; error: string } | undefined;
   const persisted = await patchSessionEntryCore(
     {
       storePath: sessionEntry.storePath,
@@ -367,6 +376,7 @@ export async function persistGatewaySessionLifecycleEvent(params: {
     },
     async (storedEntry) => {
       terminalRecovery = undefined;
+      failedRun = undefined;
       const entry = storedEntry as SessionEntry;
       if (
         exactCronRun &&
@@ -406,6 +416,20 @@ export async function persistGatewaySessionLifecycleEvent(params: {
         entry,
         event: params.event,
       });
+      if (
+        phase === "error" &&
+        params.event.data?.aborted !== true &&
+        eventRunId &&
+        (patch.status === "failed" || patch.status === "timeout")
+      ) {
+        failedRun = {
+          runId: eventRunId,
+          error: boundedWorkerError(
+            sanitizeSessionRunError(resolveTerminalOutcome(params.event).error),
+            512,
+          ),
+        };
+      }
       const recoveryTerminalRunId = normalizeLifecycleRunId(params.event.runId);
       const recoveryTerminalIsCurrent =
         params.event.mainSessionRestartRecovery === true &&
@@ -435,4 +459,38 @@ export async function persistGatewaySessionLifecycleEvent(params: {
     restartRecoveryLog[terminalRecovery.outcome.status === "ok" ? "info" : "warn"](message);
   }
   lifecyclePersistenceVersion += 1;
+  if (persisted && failedRun) {
+    const { runId, error } = failedRun;
+    // Only accepted errors pay for branch navigation; assistant detection and
+    // report deduplication share the appender's authoritative write snapshot.
+    const result = await appendSessionTranscriptReport(
+      {
+        agentId: sessionEntry.agentId,
+        storePath: sessionEntry.storePath,
+        sessionKey: sessionEntry.canonicalKey,
+        sessionId: persisted.sessionId,
+        expectedLifecycleRevision: persisted.lifecycleRevision,
+      },
+      {
+        kind: "custom",
+        customTypes: [RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE],
+        suppressWhenAssistantRun: runId,
+        selectReport: (latest) => {
+          params.assertCommitAllowed?.();
+          if (isRecord(latest?.details) && latest.details.runId === runId) {
+            return undefined;
+          }
+          return {
+            customType: RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE,
+            content: `This turn did not run: ${error}.`,
+            display: true,
+            details: { runId, error },
+          };
+        },
+      },
+    );
+    if (!result.ok) {
+      throw new Error(`Failed run notice could not be appended: ${result.error.code}`);
+    }
+  }
 }

--- a/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
+++ b/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
@@ -228,40 +228,54 @@ suite.define(() => {
     );
   });
 
-  it("renders historical workspace recovery failures from transcript history", async () => {
-    await suite.withPage(
-      {
-        colorScheme: "dark",
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1440 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, {
-          historyMessages: [
-            {
-              role: "custom",
-              customType: "cloud-workspace-recovery-failed",
-              content:
-                "Cloud workspace recovery attempt failed: snapshot verification failed. OpenClaw preserved the result and will retry.",
-              timestamp: Date.now() - 500,
-            },
-          ],
-          methodResponses: { "sessions.list": workerRecoverySessionsList(false) },
-          sessionKey,
-        });
-
-        const response = await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
-        expect(response?.status()).toBe(200);
-        await page
-          .getByText("OpenClaw preserved the result and will retry.", { exact: false })
-          .waitFor({
-            timeout: 10_000,
+  it.each([
+    {
+      customType: "cloud-workspace-recovery-failed",
+      content:
+        "Cloud workspace recovery attempt failed: snapshot verification failed. OpenClaw preserved the result and will retry.",
+    },
+    {
+      customType: "run-failed-before-reply",
+      content: "This turn did not run: Cloud worker is unavailable. Choose another runner.",
+    },
+  ])(
+    "renders durable $customType notices from transcript history",
+    async ({ customType, content }) => {
+      await suite.withPage(
+        {
+          colorScheme: "dark",
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1440 },
+        },
+        async ({ page }) => {
+          const gateway = await installMockGateway(page, {
+            historyMessages: [
+              {
+                role: "custom",
+                customType,
+                content,
+                timestamp: Date.now() - 500,
+              },
+            ],
+            methodResponses: { "sessions.list": workerRecoverySessionsList(false) },
+            sessionKey,
           });
-        await capture(page, "04-workspace-recovery-failed-history.png");
-      },
-    );
-  });
+
+          const response = await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+          expect(response?.status()).toBe(200);
+          const notice = page.locator(".chat-group.other").filter({ hasText: content });
+          await notice.waitFor({ timeout: 10_000 });
+          expect(await page.locator(".chat-group.assistant").count()).toBe(0);
+          await page.reload();
+          await notice.waitFor({ timeout: 10_000 });
+          expect(await notice.count()).toBe(1);
+          await gateway.waitForRequest("chat.startup");
+          await capture(page, `04-${customType}-history.png`);
+        },
+      );
+    },
+  );
 
   it.each(["failed", "reclaimed", "request"])(
     "exposes the full %s diagnostic with keyboard and clipboard access",


### PR DESCRIPTION
## Problem

Fixes an issue where a Control UI turn that fails before any assistant output leaves no durable outcome in the thread. A cloud runner rejection updates transient error state, but the thread can look unanswered after reload or later activity.

## Root cause

Terminal session state and transcript history had separate coverage. Native lifecycle errors and fallback dispatch rejection updated the session row without a notice. Restart-safe dispatch settlement committed its diagnostic and claim state directly. Fallback finalization could also defer the failed user input until after terminal persistence.

## Change

One report writer in the lifecycle persistence module records a displayed `run-failed-before-reply` custom message after an accepted failed terminal commit. Native lifecycle persistence and restart-safe settlement both call it. The latter retains its existing atomic diagnostic/claim write; it does not perform a competing lifecycle update. If notice persistence fails after restart-safe settlement, the failure is logged and the already-committed settlement remains successful.

Fallback dispatch finalization persists its deferred user input before lifecycle persistence, so history and subsequent model context receive the input before its failure notice. The active-run check still occurs after awaited work.

The report appender retains assistant run ownership during its existing traversal and suppresses the notice if any assistant message on the active branch already carries that run ID, including assistant error messages. Deduplication uses the latest report's `details.runId` in the same write transaction. The existing full traversal is explicitly accepted for qualifying errors only; no second transcript scan, schema, index, or retry policy is added.

## Impact

Failed pre-reply turns leave `This turn did not run: <error>.` in the thread, with a sanitized/redacted error bounded to 512 characters. Aborts, existing assistant errors, `lastRunError`, and banners retain their prior behavior. The Control UI uses its existing neutral custom-report rendering, matching historical workspace recovery failures.

Custom reports intentionally retain existing model-history behavior: the embedded harness converts them to user-role context, making the bounded failure available on the next turn. This change does not set `excludeFromContext` or alter filtering. See `packages/agent-core/src/harness/session/session.ts` and `packages/agent-core/src/harness/messages.ts`.

## Evidence

Rebased onto `984d417f807736a556aaf2299fcb379d084d5f3e` after main introduced a documentation conflict. Both main's activity-row paragraph and this PR's failure-notice sentence were preserved. All eight production/test files are byte-identical to the previously CI-green repair. The required focused suites were rerun after rebase:

```text
 Test Files  3 passed (3)
      Tests  63 passed (63)
   Start at  16:05:51
   Duration  178.43s (transform 83%, import 7%, tests 6%, worker 4%)
```

Fresh rebased-branch autoreview:

```text
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct (0.87)
No actionable P0–P2 defects were established from the supplied evidence. Fallback persistence now precedes failure reporting, restart-safe report errors preserve committed settlement success, and report writes retain lifecycle fencing and active-branch assistant suppression. Review was static; no project code was executed.
```

The initial owner regression failed because no report was persisted. Dispatch-level regressions then reproduced both ClawSweeper findings on head `473d4ba0ff08dd3e4e206618a9873692b0deac16`: fallback history placed the report before its input, and restart-safe history omitted the report. Both findings are addressed in this revision.

Pre-rebase focused proof (exit 0; production/test files unchanged by rebase):

```sh
node scripts/run-vitest.mjs src/gateway/session-lifecycle-run-failure.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/server-methods/chat-send-dispatch-errors.test.ts
```
```text
Test Files  3 passed (3)
      Tests  63 passed (63)
   Start at  15:26:17
   Duration  59.11s (transform 57%, tests 25%, import 13%, worker 4%)

[vitest-workers] verifying completed generation before cleanup
```

`node scripts/check-changed.mjs` exited 0 on the pre-rebase repair. Final output:

```text
[check:changed] runtime sidecar loader guard
$ node --import ./scripts/tsx.mjs scripts/check-runtime-sidecar-loaders.mts
runtime-sidecar-loaders: local runtime sidecar loaders look OK.

[check:changed] runtime import cycles
$ node --import ./scripts/tsx.mjs scripts/check-import-cycles.ts
Import cycle check: 0 runtime value cycle(s).

[check:changed] webhook body guard
$ node --import ./scripts/tsx.mjs scripts/check-webhook-auth-body-order.mts

[check:changed] pairing store guard
$ node --import ./scripts/tsx.mjs scripts/check-no-pairing-store-group-auth.mts

[check:changed] pairing account guard
$ node --import ./scripts/tsx.mjs scripts/check-pairing-account-scope.mts
```

Fresh independent Codex autoreview, P0–P2 (exit 0):

```text
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct (0.88)
The provided patch addresses both dispatch paths: fallback input persistence precedes failure reporting, and restart-safe settlement uses the shared report writer after its atomic terminal commit while containing report failures. No remaining P0–P2 correctness or concrete security defects are established by the supplied evidence. Tests were reviewed but not executed.
```

The unchanged custom-report UI rendering was also verified with six mocked Control UI E2E tests and inspected synthetic before/after captures. The new backend regressions verify the actual SQLite transcript order through dispatch finalization, retry-identity retention/cleanup, duplicate suppression, and the committed-settlement result after report failure.

## Screenshots

Captures remain local as requested; no upload was performed.

- Before: `/var/folders/gl/hry704r5567fbcvp_mzdpg3m0000gn/T/pr-b-durable-run-failure-6dXDF0/before-no-reply.png`
- After: `/var/folders/gl/hry704r5567fbcvp_mzdpg3m0000gn/T/pr-b-durable-run-failure-6dXDF0/after-durable-notice.png`

## Docs

`docs/web/control-ui.md` states that a turn failing before any reply leaves a durable notice in the thread.
