### PR TITLE
fix(ci): keep frozen mobile candidates releasable

### DIFF
--- a/.github/actions/mobile-release-authority/authority.mjs
+++ b/.github/actions/mobile-release-authority/authority.mjs
@@ -369,6 +369,20 @@ function parseRawDiff(raw) {
   return paths;
 }
 
+function candidateRawDiff(baseSha, candidateSha) {
+  return gitBuffer(
+    trustedRoot,
+    "diff",
+    "--raw",
+    "-z",
+    "--no-renames",
+    "--no-abbrev",
+    baseSha,
+    candidateSha,
+    "--",
+  );
+}
+
 function verifyCandidateTreeModes(baseSha, candidateSha) {
   for (const filePath of releaseCandidatePaths) {
     for (const ref of [baseSha, candidateSha]) {
@@ -424,13 +438,13 @@ async function releaseTooling(baseSha) {
   return releaseToolingPromises.get(baseSha);
 }
 
-async function regenerateReleaseCandidate(baseSha, candidateSha, gatewayVersion) {
-  const tooling = await releaseTooling(baseSha);
+async function regenerateReleaseCandidate(toolingSha, codeSha, candidateSha, gatewayVersion) {
+  const tooling = await releaseTooling(toolingSha);
   if (JSON.stringify(tooling.mobileReleasePaths) !== JSON.stringify(releaseCandidatePaths)) {
     fail("Trusted mobile cutter release path contract does not match release authority.");
   }
   const baseBlobs = new Map(
-    releaseCandidatePaths.map((filePath) => [filePath, readCandidateBlob(baseSha, filePath)]),
+    releaseCandidatePaths.map((filePath) => [filePath, readCandidateBlob(codeSha, filePath)]),
   );
   const targetBlobs = new Map(
     releaseCandidatePaths.map((filePath) => [filePath, readCandidateBlob(candidateSha, filePath)]),
@@ -500,48 +514,72 @@ async function regenerateReleaseCandidate(baseSha, candidateSha, gatewayVersion)
   return matches[0];
 }
 
-async function validateReleaseCandidate(baseSha) {
+async function validateReleaseCandidate(toolingSha) {
   const gatewayVersion = canonicalReleaseRef(targetRef);
   git(
     trustedRoot,
     "fetch",
     "--no-tags",
-    "--depth=256",
+    "--no-recurse-submodules",
+    "--depth=33",
     "origin",
-    "+refs/heads/main:refs/remotes/origin/mobile-authority-main",
     `+refs/heads/${targetRef}:refs/remotes/origin/mobile-authority-target`,
   );
   if (git(trustedRoot, "rev-parse", "refs/remotes/origin/mobile-authority-target") !== targetSha) {
     fail("Fetched release branch does not match target-sha.");
   }
-  git(trustedRoot, "cat-file", "-e", `${baseSha}^{commit}`);
-  if (git(trustedRoot, "merge-base", baseSha, targetSha) !== baseSha) {
-    fail("Mobile release candidate must descend from its pinned trusted workflow base.");
+  let mergeBases = [];
+  try {
+    mergeBases = git(trustedRoot, "merge-base", "--all", toolingSha, targetSha)
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    mergeBases = [];
   }
-  const commits = git(trustedRoot, "rev-list", "--parents", "--reverse", `${baseSha}..${targetSha}`)
-    .split("\n")
-    .filter(Boolean);
-  if (
-    commits.length < 1 ||
-    commits.length > MAX_RELEASE_CANDIDATE_COMMITS ||
-    commits.some((line) => line.split(" ").length !== 2)
-  ) {
-    fail("Mobile release candidate history must be a bounded linear commit chain.");
+  if (mergeBases.length !== 1) {
+    fail("Mobile release candidate must have exactly one shared Code SHA.");
   }
-  parseRawDiff(
-    gitBuffer(
-      trustedRoot,
-      "diff",
-      "--raw",
-      "-z",
-      "--no-renames",
-      "--no-abbrev",
-      baseSha,
-      targetSha,
-      "--",
-    ),
+  const codeSha = fullSha(mergeBases[0], "derived Code SHA");
+  const distance = Number(
+    git(trustedRoot, "rev-list", "--first-parent", "--count", `${codeSha}..${toolingSha}`),
   );
-  verifyCandidateTreeModes(baseSha, targetSha);
+  if (!Number.isSafeInteger(distance) || distance < 0) {
+    fail("Derived Code SHA is not on the trusted Tooling SHA first-parent history.");
+  }
+  let firstParentAtDistance = "";
+  try {
+    firstParentAtDistance = git(trustedRoot, "rev-parse", `${toolingSha}~${distance}^{commit}`);
+  } catch {
+    firstParentAtDistance = "";
+  }
+  if (firstParentAtDistance !== codeSha) {
+    fail("Derived Code SHA is not on the trusted Tooling SHA first-parent history.");
+  }
+  if (codeSha === targetSha) {
+    fail("Mobile release candidate must contain at least one commit after its Code SHA.");
+  }
+  let commitSha = targetSha;
+  let commitCount = 0;
+  while (commitSha !== codeSha) {
+    if (commitCount === MAX_RELEASE_CANDIDATE_COMMITS) {
+      fail("Mobile release candidate history must be a bounded linear commit chain.");
+    }
+    const parents = git(trustedRoot, "show", "-s", "--format=%P", commitSha)
+      .split(" ")
+      .filter(Boolean);
+    if (parents.length !== 1) {
+      fail("Mobile release candidate history must be a bounded linear commit chain.");
+    }
+    const parentSha = parents[0];
+    const rawDiff = candidateRawDiff(parentSha, commitSha);
+    if (rawDiff.byteLength > 0) {
+      parseRawDiff(rawDiff);
+    }
+    commitSha = parentSha;
+    commitCount += 1;
+  }
+  parseRawDiff(candidateRawDiff(codeSha, targetSha));
+  verifyCandidateTreeModes(codeSha, targetSha);
   const manifest = canonicalJson(
     readCandidateBlob(targetSha, "apps/mobile/version.json"),
     "apps/mobile/version.json",
@@ -554,7 +592,7 @@ async function validateReleaseCandidate(baseSha) {
   }
   return {
     gatewayVersion,
-    ...(await regenerateReleaseCandidate(baseSha, targetSha, gatewayVersion)),
+    ...(await regenerateReleaseCandidate(toolingSha, codeSha, targetSha, gatewayVersion)),
   };
 }
 

--- a/apps/android/fastlane/SETUP.md
+++ b/apps/android/fastlane/SETUP.md
@@ -104,12 +104,13 @@ pnpm android:release:upload
 
 `Android Beta Release` is a separate, manual workflow. Dispatch it from trusted
 `main` with a canonical `release/YYYY.M.PATCH-mobile` branch and that branch's
-exact full commit SHA. The workflow accepts only a candidate that descends from
-the workflow SHA and differs only in a nonempty subset of the five generated
-mobile release metadata files. All five target files must byte-match the trusted
-regenerated release plan. Approval of the `android-beta-release` environment
-gates all access to signing assets, Google Play credentials, and immutable
-release-ref mutation.
+exact full commit SHA. The workflow derives the frozen Code SHA from the release
+branch and the current trusted Tooling SHA. Every later candidate commit must be
+linear and may change only the five generated mobile release metadata files.
+All five target files must byte-match regeneration using current trusted tooling
+and the frozen Code SHA metadata. Approval of the `android-beta-release`
+environment gates all access to signing assets, Google Play credentials, and
+immutable release-ref mutation.
 
 Repository/environment secrets required by name:
 

--- a/apps/ios/fastlane/SETUP.md
+++ b/apps/ios/fastlane/SETUP.md
@@ -146,11 +146,12 @@ same path.
 
 `iOS Beta Release` is a separate, manual workflow. Dispatch it from trusted
 `main` with a canonical `release/YYYY.M.PATCH-mobile` branch and that branch's
-exact full commit SHA. The workflow accepts only a candidate that descends from
-the workflow SHA and differs only in a nonempty subset of the five generated
-mobile release metadata files. All five target files must byte-match the trusted
-regenerated release plan. Approval of the `ios-beta-release` environment gates
-all access to signing assets, App Store Connect credentials, and immutable
+exact full commit SHA. The workflow derives the frozen Code SHA from the release
+branch and the current trusted Tooling SHA. Every later candidate commit must be
+linear and may change only the five generated mobile release metadata files.
+All five target files must byte-match regeneration using current trusted tooling
+and the frozen Code SHA metadata. Approval of the `ios-beta-release` environment
+gates all access to signing assets, App Store Connect credentials, and immutable
 release-ref mutation.
 
 Repository/environment secrets required by name:

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -41,6 +41,7 @@ type Fixture = {
   actionPath: string;
   baseSha: string;
   env: NodeJS.ProcessEnv;
+  gitLog: string;
   ghLog: string;
   outputPath: string;
   platform: Platform;
@@ -57,9 +58,13 @@ type Fixture = {
 
 type FixtureOptions = {
   baseState?: "android-current" | "prepared";
+  beforeCandidate?: (repository: string) => void;
+  buildCandidate?: (repository: string, baseSha: string) => string;
   emptyCandidate?: boolean;
+  mutateBase?: (repository: string) => void;
   mutateCandidate?: (repository: string) => void;
   platform?: Platform;
+  realFetch?: boolean;
 };
 
 function command(
@@ -178,19 +183,21 @@ function createCandidate(repository: string): void {
   );
 }
 
-function writeGitShim(binDir: string): void {
+function writeGitShim(binDir: string, realFetch: boolean): void {
   const shim = path.join(binDir, "git");
   fs.writeFileSync(
     shim,
     `#!/usr/bin/env node
+const fs = require("node:fs");
 const { spawnSync } = require("node:child_process");
 const args = process.argv.slice(2);
 const gitArgs = args[0] === "-C" ? args.slice(2) : args;
+fs.appendFileSync(process.env.GIT_LOG, JSON.stringify(args) + "\\n");
 if (gitArgs[0] === "remote" && gitArgs[1] === "get-url") {
   process.stdout.write("https://github.com/openclaw/openclaw.git\\n");
   process.exit(0);
 }
-if (gitArgs[0] === "fetch") {
+if (gitArgs[0] === "fetch" && !${JSON.stringify(realFetch)}) {
   process.exit(0);
 }
 const result = spawnSync("/usr/bin/git", args, { stdio: "inherit" });
@@ -383,10 +390,14 @@ function createFixture(options: FixtureOptions = {}): Fixture {
       }),
     );
   }
+  options.mutateBase?.(source);
   const baseSha = commit(source, "base");
+  options.beforeCandidate?.(source);
 
   let targetSha: string;
-  if (options.emptyCandidate) {
+  if (options.buildCandidate) {
+    targetSha = options.buildCandidate(source, baseSha);
+  } else if (options.emptyCandidate) {
     targetSha = emptyCommit(source, "candidate");
   } else {
     createCandidate(source);
@@ -394,24 +405,47 @@ function createFixture(options: FixtureOptions = {}): Fixture {
     targetSha = commit(source, "candidate");
   }
 
-  git(root, "clone", "--no-local", source, trusted);
+  if (options.realFetch) {
+    git(source, "branch", TARGET_REF, targetSha);
+    git(source, "reset", "--hard", baseSha);
+  }
+  git(
+    root,
+    "clone",
+    "--no-local",
+    ...(options.realFetch ? ["--single-branch", "--branch", "main"] : []),
+    source,
+    trusted,
+  );
   git(trusted, "checkout", "--detach", baseSha);
   git(trusted, "update-ref", "refs/remotes/origin/mobile-authority-main", baseSha);
-  git(trusted, "update-ref", "refs/remotes/origin/mobile-authority-target", targetSha);
-  git(root, "clone", "--no-local", source, workspace);
+  if (!options.realFetch) {
+    git(trusted, "update-ref", "refs/remotes/origin/mobile-authority-target", targetSha);
+  }
+  git(
+    root,
+    "clone",
+    "--no-local",
+    ...(options.realFetch ? ["--branch", TARGET_REF] : []),
+    source,
+    workspace,
+  );
   git(workspace, "checkout", "--detach", targetSha);
 
-  writeGitShim(binDir);
+  writeGitShim(binDir, options.realFetch === true);
   writeGhShim(binDir);
   const actionPath = path.join(trusted, ".github/actions/mobile-release-authority");
   const workflowPath = `.github/workflows/${platform}-beta-release.yml`;
   const workflowFullRef = `${REPOSITORY}/${workflowPath}@refs/heads/main`;
+  const gitLog = path.join(root, "git.log");
   const ghLog = path.join(root, "gh.log");
+  fs.writeFileSync(gitLog, "");
   fs.writeFileSync(ghLog, "");
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+    GIT_LOG: gitLog,
     GH_TOKEN: "",
     GH_LOG: ghLog,
     GH_MAIN_REFS: `${baseSha},${baseSha},${baseSha},${baseSha}`,
@@ -449,6 +483,7 @@ function createFixture(options: FixtureOptions = {}): Fixture {
     actionPath,
     baseSha,
     env,
+    gitLog,
     ghLog,
     outputPath,
     platform,
@@ -462,6 +497,40 @@ function createFixture(options: FixtureOptions = {}): Fixture {
     workflowFullRef,
     workflowPath,
   };
+}
+
+function useTrustedWorkflow(fixture: Fixture, workflowSha: string): void {
+  git(fixture.trusted, "fetch", "origin", workflowSha);
+  git(fixture.trusted, "checkout", "--detach", workflowSha);
+  git(fixture.trusted, "update-ref", "refs/remotes/origin/mobile-authority-main", workflowSha);
+  Object.assign(fixture.env, {
+    GH_MAIN_REFS: `${workflowSha},${workflowSha},${workflowSha},${workflowSha}`,
+    GH_ORIGINAL_WORKFLOW_SHA: workflowSha,
+    GITHUB_SHA: workflowSha,
+    MOBILE_WORKFLOW_SHA: workflowSha,
+  });
+}
+
+function advanceTrustedTooling(
+  fixture: Fixture,
+  options: {
+    fromSha?: string;
+    mutate?: (repository: string) => void;
+  } = {},
+): string {
+  git(
+    fixture.source,
+    "checkout",
+    "-b",
+    "trusted-main-after-code-freeze",
+    options.fromSha ?? fixture.baseSha,
+  );
+  options.mutate?.(fixture.source);
+  const workflowSha = git(fixture.source, "status", "--porcelain")
+    ? commit(fixture.source, "advance trusted release tooling")
+    : emptyCommit(fixture.source, "advance trusted release tooling");
+  useTrustedWorkflow(fixture, workflowSha);
+  return workflowSha;
 }
 
 function runAuthority(fixture: Fixture, phase: string, overrides: NodeJS.ProcessEnv = {}) {
@@ -659,6 +728,238 @@ describe("mobile release authority", () => {
       });
     },
   );
+
+  it("authorizes a metadata-only candidate frozen before trusted tooling advances", () => {
+    const fixture = createFixture();
+    const workflowSha = advanceTrustedTooling(fixture);
+
+    const outputs = authorize(fixture);
+    const receipt = JSON.parse(
+      fs.readFileSync(path.join(fixture.runnerTemp, "mobile-release-ref-ios/receipt.json"), "utf8"),
+    ) as Record<string, unknown>;
+
+    expect(outputs.target_sha).toBe(fixture.targetSha);
+    expect(receipt.workflowSha).toBe(workflowSha);
+  });
+
+  it("regenerates from Code SHA metadata with the newer Tooling SHA", () => {
+    const fixture = createFixture();
+    advanceTrustedTooling(fixture, {
+      mutate(repository) {
+        writeFile(
+          repository,
+          "apps/ios/CHANGELOG.md",
+          fs
+            .readFileSync(path.join(repository, "apps/ios/CHANGELOG.md"), "utf8")
+            .replace("Adds guarded mobile beta automation.", "Tooling-only unreleased note."),
+        );
+      },
+    });
+
+    expect(authorize(fixture).target_sha).toBe(fixture.targetSha);
+  });
+
+  it("uses the Tooling SHA cutter implementation with the Code SHA baseline", () => {
+    const fixture = createFixture({
+      mutateBase(repository) {
+        writeFile(repository, "scripts/mobile-release-version.ts", 'throw new Error("stale");\n');
+      },
+    });
+    advanceTrustedTooling(fixture, {
+      mutate(repository) {
+        copyFile(repository, "scripts/mobile-release-version.ts");
+      },
+    });
+
+    expect(authorize(fixture).target_sha).toBe(fixture.targetSha);
+  });
+
+  it("rejects a forbidden code commit hidden by a later revert", () => {
+    const fixture = createFixture({
+      beforeCandidate(repository) {
+        writeFile(repository, "scripts/forged-upload.sh", "forged\n");
+        commit(repository, "add forbidden release code");
+        fs.rmSync(path.join(repository, "scripts/forged-upload.sh"));
+        commit(repository, "revert forbidden release code");
+      },
+    });
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("non-metadata or non-regular change");
+  });
+
+  it.each([
+    ["multiple metadata commits", false],
+    ["an empty intermediate commit", true],
+  ] as const)("authorizes a candidate with %s", (_label, includeEmptyCommit) => {
+    const fixture = createFixture({
+      buildCandidate(repository) {
+        writeFile(
+          repository,
+          "apps/android/fastlane/metadata/android/en-US/release_notes.txt",
+          "Intermediate generated notes.\n",
+        );
+        commit(repository, "prepare generated metadata");
+        if (includeEmptyCommit) {
+          emptyCommit(repository, "record release checkpoint");
+        }
+        createCandidate(repository);
+        return commit(repository, "finalize generated metadata");
+      },
+    });
+
+    expect(authorize(fixture).target_sha).toBe(fixture.targetSha);
+  });
+
+  it("rejects a merge commit in the candidate suffix", () => {
+    const fixture = createFixture({
+      buildCandidate(repository, baseSha) {
+        git(repository, "checkout", "-b", "candidate-side", baseSha);
+        emptyCommit(repository, "candidate side");
+        const sideSha = git(repository, "rev-parse", "HEAD");
+        git(repository, "checkout", "-b", "candidate-main", baseSha);
+        createCandidate(repository);
+        commit(repository, "candidate metadata");
+        git(repository, "merge", "--no-ff", "--no-edit", sideSha);
+        return git(repository, "rev-parse", "HEAD");
+      },
+    });
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("bounded linear commit chain");
+  });
+
+  it("rejects an unrelated candidate history", () => {
+    const fixture = createFixture({
+      buildCandidate(repository, baseSha) {
+        git(repository, "checkout", "--orphan", "unrelated-candidate");
+        git(repository, "rm", "-r", "-f", "--quiet", ".");
+        git(repository, "checkout", baseSha, "--", ".");
+        commit(repository, "unrelated root");
+        createCandidate(repository);
+        return commit(repository, "unrelated candidate");
+      },
+    });
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("exactly one shared Code SHA");
+  });
+
+  it("rejects ambiguous Code SHA ancestry", () => {
+    let toolingSha = "";
+    const fixture = createFixture({
+      buildCandidate(repository, baseSha) {
+        git(repository, "checkout", "-b", "left", baseSha);
+        const leftSha = emptyCommit(repository, "left");
+        git(repository, "checkout", "-b", "right", baseSha);
+        const rightSha = emptyCommit(repository, "right");
+        git(repository, "checkout", "left");
+        git(repository, "merge", "--no-ff", "--no-edit", rightSha);
+        toolingSha = git(repository, "rev-parse", "HEAD");
+        git(repository, "checkout", "-b", "candidate-criss-cross", rightSha);
+        git(repository, "merge", "--no-ff", "--no-edit", leftSha);
+        createCandidate(repository);
+        return commit(repository, "candidate after criss-cross");
+      },
+    });
+    useTrustedWorkflow(fixture, toolingSha);
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("exactly one shared Code SHA");
+  });
+
+  it("rejects a Code SHA reachable only through Tooling SHA second-parent history", () => {
+    let codeSha = "";
+    const fixture = createFixture({
+      buildCandidate(repository) {
+        codeSha = emptyCommit(repository, "code branch");
+        createCandidate(repository);
+        return commit(repository, "candidate metadata");
+      },
+    });
+    git(fixture.source, "checkout", "-b", "trusted-first-parent", fixture.baseSha);
+    emptyCommit(fixture.source, "trusted first parent");
+    git(fixture.source, "merge", "--no-ff", "--no-edit", codeSha);
+    useTrustedWorkflow(fixture, git(fixture.source, "rev-parse", "HEAD"));
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("first-parent history");
+  });
+
+  it("rejects a target equal to the derived Code SHA", () => {
+    const fixture = createFixture();
+    advanceTrustedTooling(fixture, { fromSha: fixture.targetSha });
+
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("at least one commit after its Code SHA");
+  });
+
+  it("rejects a candidate suffix longer than 32 commits", () => {
+    const fixture = createFixture({
+      buildCandidate(repository) {
+        for (let index = 0; index < 32; index += 1) {
+          emptyCommit(repository, `candidate checkpoint ${index + 1}`);
+        }
+        createCandidate(repository);
+        return commit(repository, "candidate metadata");
+      },
+      realFetch: true,
+    });
+
+    expect(
+      git(fixture.source, "rev-list", "--count", `${fixture.baseSha}..${fixture.targetSha}`),
+    ).toBe("33");
+    const result = runAuthority(fixture, "authorize");
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("exactly one shared Code SHA");
+  });
+
+  it("fetches enough real candidate history to authorize exactly 32 commits", () => {
+    const fixture = createFixture({
+      buildCandidate(repository) {
+        for (let index = 0; index < 31; index += 1) {
+          emptyCommit(repository, `candidate checkpoint ${index + 1}`);
+        }
+        createCandidate(repository);
+        return commit(repository, "candidate metadata");
+      },
+      realFetch: true,
+    });
+
+    expect(
+      git(fixture.source, "rev-list", "--count", `${fixture.baseSha}..${fixture.targetSha}`),
+    ).toBe("32");
+    expect(authorize(fixture).target_sha).toBe(fixture.targetSha);
+    const fetches = fs
+      .readFileSync(fixture.gitLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as string[])
+      .filter((args) => args.includes("fetch"));
+    expect(fetches).toContainEqual([
+      "-C",
+      fixture.trusted,
+      "fetch",
+      "--no-tags",
+      "--no-recurse-submodules",
+      "--depth=33",
+      "origin",
+      `+refs/heads/${TARGET_REF}:refs/remotes/origin/mobile-authority-target`,
+    ]);
+  });
 
   it("rejects an empty release candidate", () => {
     const fixture = createFixture({ emptyCandidate: true });
@@ -1259,6 +1560,18 @@ describe("mobile release authority", () => {
       expect(workflow.jobs.authorize?.environment).toBeUndefined();
       expect(workflow.jobs.release?.environment).toBe(environment);
       expect(workflow.jobs["recover-record"]?.environment).toBe(environment);
+      const authorityCheckouts = Object.values(workflow.jobs).flatMap((job) =>
+        job.steps.filter(
+          (step) =>
+            typeof step.with?.["sparse-checkout"] === "string" &&
+            step.with["sparse-checkout"].includes(".github/actions/mobile-release-authority"),
+        ),
+      );
+      expect(authorityCheckouts).toHaveLength(5);
+      for (const checkout of authorityCheckouts) {
+        expect(checkout.uses, `${file}:${checkout.name}:uses`).toMatch(/^actions\/checkout@/u);
+        expect(checkout.with?.["fetch-depth"], `${file}:${checkout.name}:fetch-depth`).toBe(0);
+      }
 
       for (const [jobName, job] of Object.entries(workflow.jobs)) {
         if (JSON.stringify(job).includes("GH_APP_PRIVATE_KEY")) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a valid frozen mobile release candidate became impossible to publish whenever unrelated commits reached `main` after the Code SHA was frozen. It also closes a validation gap where a forbidden candidate commit followed by a revert could disappear from the aggregate Code-to-target diff.

## Why This Change Was Made

The authority now derives one frozen Code SHA from the release target and the trusted workflow Tooling SHA. It requires that Code SHA on the Tooling SHA's first-parent history, walks a bounded linear candidate suffix commit by commit, and permits only regular-file modifications to the five generated release metadata paths. Candidate bytes are regenerated with current trusted tooling against the frozen Code SHA metadata baseline.

No workflow inputs, configuration, receipt schema, credential access, release-ref behavior, or store operation changed.

No changelog entry: this repairs internal beta-release authorization without changing shipped app behavior.

## User Impact

Release operators can keep a qualified iOS/Android Code SHA frozen while unrelated work continues landing on `main`, without weakening candidate-history validation.

## Evidence

- Both new regressions failed against the prior authority for the intended reasons: frozen candidates were rejected after Tooling advanced, and a forbidden code commit hidden by a revert was accepted.
- 50/50 focused mobile release authority tests passed at `28cb715babe37375ea5fc4ba9bee9280653289e6`.
- Coverage includes current Tooling with frozen Code metadata, Tooling-owned cutter loading, per-commit code/revert rejection, real local-remote fetch acceptance at exactly 32 candidate commits, rejection at 33, valid multi-commit and empty-intermediate candidates, merge/orphan/criss-cross/second-parent rejection, and target-equals-Code rejection.
- Both beta workflows check out the trusted workflow SHA with full history; the release target fetch remains bounded to 33 commits.
- Changed checks, formatting, and `git diff --check` passed at the exact commit.
- LOC: authority/tooling +71/-33; tests +320/-7; docs +13/-11.
