### PR TITLE
refactor(test): remove obsolete Vitest config adapters

### DIFF
--- a/src/infra/vitest-config.test.ts
+++ b/src/infra/vitest-config.test.ts
@@ -1,180 +1,11 @@
-// Covers default Vitest scheduling config helpers.
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { parseVitestProcessStats } from "../../test/vitest/vitest.system-load.ts";
-import baseConfig, {
-  resolveDefaultVitestPool,
-  resolveLocalVitestMaxWorkers,
-  resolveLocalVitestScheduling,
-} from "../../vitest.config.ts";
+import baseConfig from "../../vitest.config.ts";
 
 function normalizeConfigPath(value: unknown): string {
   return String(value).replaceAll("\\", "/");
 }
-
-describe("resolveLocalVitestMaxWorkers", () => {
-  it("uses a moderate local worker cap on larger hosts", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {
-          RUNNER_OS: "macOS",
-        },
-        {
-          cpuCount: 10,
-          loadAverage1m: 0,
-          totalMemoryBytes: 64 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(6);
-  });
-
-  it("lets OPENCLAW_VITEST_MAX_WORKERS override the inferred cap", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {
-          OPENCLAW_VITEST_MAX_WORKERS: "2",
-        },
-        {
-          cpuCount: 10,
-          loadAverage1m: 0,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(2);
-  });
-
-  it("respects the legacy OPENCLAW_TEST_WORKERS override too", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {
-          OPENCLAW_TEST_WORKERS: "3",
-        },
-        {
-          cpuCount: 16,
-          loadAverage1m: 0,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(3);
-  });
-
-  it("keeps memory-constrained hosts conservative", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {},
-        {
-          cpuCount: 16,
-          loadAverage1m: 0,
-          totalMemoryBytes: 16 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(2);
-  });
-
-  it("lets roomy hosts use more local parallelism", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {},
-        {
-          cpuCount: 16,
-          loadAverage1m: 0,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(8);
-  });
-
-  it("backs off further when the host is already busy", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {},
-        {
-          cpuCount: 16,
-          loadAverage1m: 16,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(2);
-  });
-
-  it("caps very large hosts at six local workers", () => {
-    expect(
-      resolveLocalVitestMaxWorkers(
-        {},
-        {
-          cpuCount: 32,
-          loadAverage1m: 0,
-          totalMemoryBytes: 256 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toBe(12);
-  });
-});
-
-describe("resolveLocalVitestScheduling", () => {
-  it("scales back to half capacity when the host load is already saturated", () => {
-    expect(
-      resolveLocalVitestScheduling(
-        {},
-        {
-          cpuCount: 16,
-          loadAverage1m: 16,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toEqual({
-      maxWorkers: 2,
-      fileParallelism: true,
-      throttledBySystem: true,
-    });
-  });
-
-  it("keeps big hosts parallel under moderate host contention", () => {
-    expect(
-      resolveLocalVitestScheduling(
-        {},
-        {
-          cpuCount: 16,
-          loadAverage1m: 12,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toEqual({
-      maxWorkers: 5,
-      fileParallelism: true,
-      throttledBySystem: true,
-    });
-  });
-
-  it("allows disabling the system throttle probe explicitly", () => {
-    expect(
-      resolveLocalVitestScheduling(
-        {
-          OPENCLAW_VITEST_DISABLE_SYSTEM_THROTTLE: "1",
-        },
-        {
-          cpuCount: 16,
-          loadAverage1m: 0.5,
-          totalMemoryBytes: 128 * 1024 ** 3,
-        },
-        "threads",
-      ),
-    ).toEqual({
-      maxWorkers: 8,
-      fileParallelism: true,
-      throttledBySystem: false,
-    });
-  });
-});
 
 describe("parseVitestProcessStats", () => {
   it("counts other Vitest roots and workers while excluding the current pid", () => {
@@ -199,7 +30,6 @@ describe("parseVitestProcessStats", () => {
 
 describe("base vitest config", () => {
   it("defaults the base pool to threads", () => {
-    expect(resolveDefaultVitestPool()).toBe("threads");
     expect(baseConfig.test?.pool).toBe("threads");
   });
 

--- a/test/scripts/vitest-local-scheduling.test.ts
+++ b/test/scripts/vitest-local-scheduling.test.ts
@@ -1,10 +1,58 @@
-// Vitest Local Scheduling tests cover vitest local scheduling script behavior.
 import { describe, expect, it } from "vitest";
 import {
   resolveLocalVitestEnv,
   resolveLocalFullSuiteProfile,
   resolveLocalVitestScheduling,
 } from "../../scripts/lib/vitest-local-scheduling.mts";
+
+describe("local Vitest scheduling", () => {
+  it.each([
+    ["uses a moderate cap on larger hosts", { RUNNER_OS: "macOS" }, 10, 64, 0, 6, false],
+    [
+      "honors OPENCLAW_VITEST_MAX_WORKERS",
+      { OPENCLAW_VITEST_MAX_WORKERS: "2" },
+      10,
+      128,
+      0,
+      2,
+      false,
+    ],
+    [
+      "honors the legacy OPENCLAW_TEST_WORKERS override",
+      { OPENCLAW_TEST_WORKERS: "3" },
+      16,
+      128,
+      0,
+      3,
+      false,
+    ],
+    ["keeps memory-constrained hosts conservative", {}, 16, 16, 0, 2, false],
+    ["lets roomy hosts use more parallelism", {}, 16, 128, 0, 8, false],
+    ["backs off when host load is saturated", {}, 16, 128, 16, 2, true],
+    ["caps very large hosts at twelve workers", {}, 32, 256, 0, 12, false],
+    ["keeps big hosts parallel under moderate contention", {}, 16, 128, 12, 5, true],
+    [
+      "allows explicitly disabling system throttling",
+      { OPENCLAW_VITEST_DISABLE_SYSTEM_THROTTLE: "1" },
+      16,
+      128,
+      0.5,
+      8,
+      false,
+    ],
+  ] as const)(
+    "%s",
+    (_name, env, cpuCount, totalMemoryGb, loadAverage1m, maxWorkers, throttledBySystem) => {
+      expect(
+        resolveLocalVitestScheduling(env, {
+          cpuCount,
+          totalMemoryBytes: totalMemoryGb * 1024 ** 3,
+          loadAverage1m,
+        }),
+      ).toEqual({ maxWorkers, fileParallelism: true, throttledBySystem });
+    },
+  );
+});
 
 describe("vitest local full-suite profile", () => {
   it("forces local Vitest runs back onto local-check policy", () => {

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -65,7 +65,7 @@ import { createPluginSdkVitestConfig } from "./vitest/vitest.plugin-sdk.config.t
 import { createPluginsVitestConfig } from "./vitest/vitest.plugins.config.ts";
 import { createProcessVitestConfig } from "./vitest/vitest.process.config.ts";
 import { createRuntimeConfigVitestConfig } from "./vitest/vitest.runtime-config.config.ts";
-import { createScopedVitestConfig, resolveVitestIsolation } from "./vitest/vitest.scoped-config.ts";
+import { createScopedVitestConfig } from "./vitest/vitest.scoped-config.ts";
 import { createSecretsVitestConfig } from "./vitest/vitest.secrets.config.ts";
 import { createSharedCoreVitestConfig } from "./vitest/vitest.shared-core.config.ts";
 import { sharedVitestConfig } from "./vitest/vitest.shared.config.ts";
@@ -160,7 +160,7 @@ function expectForkedIsolatedRunner(config: {
   expect(testConfig.runner).toBeUndefined();
 }
 
-describe("resolveVitestIsolation", () => {
+describe("scoped Vitest configuration", () => {
   it("aliases private QA plugin SDK subpaths for source tests only", () => {
     for (const subpath of PRIVATE_PLUGIN_SDK_SUBPATHS) {
       expect(findAlias(sharedVitestConfig.resolve.alias, `openclaw/plugin-sdk/${subpath}`)).toEqual(
@@ -205,9 +205,13 @@ describe("resolveVitestIsolation", () => {
   });
 
   it("ignores the legacy isolation escape hatches", () => {
-    expect(resolveVitestIsolation({ OPENCLAW_TEST_ISOLATE: "1" })).toBe(false);
-    expect(resolveVitestIsolation({ OPENCLAW_TEST_NO_ISOLATE: "0" })).toBe(false);
-    expect(resolveVitestIsolation({ OPENCLAW_TEST_NO_ISOLATE: "false" })).toBe(false);
+    for (const env of [
+      { OPENCLAW_TEST_ISOLATE: "1" },
+      { OPENCLAW_TEST_NO_ISOLATE: "0" },
+      { OPENCLAW_TEST_NO_ISOLATE: "false" },
+    ]) {
+      expect(requireTestConfig(createScopedVitestConfig([], { env })).isolate).toBe(false);
+    }
   });
 
   it("resolves scoped discovery dirs from the repo root after config relocation", () => {

--- a/test/vitest/vitest.boundary.config.ts
+++ b/test/vitest/vitest.boundary.config.ts
@@ -1,7 +1,6 @@
 // Vitest boundary config wires the boundary test shard.
 import { defineProject, type TestProjectInlineConfiguration } from "vitest/config";
 import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
-import { resolveVitestIsolation } from "./vitest.scoped-config.ts";
 import { nonIsolatedRunnerPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 import { boundaryTestFiles } from "./vitest.unit-paths.mjs";
 
@@ -10,14 +9,13 @@ export function createBoundaryVitestConfig(
   argv: string[] = process.argv,
 ) {
   const cliIncludePatterns = narrowIncludePatternsForCli(boundaryTestFiles, argv);
-  const isolate = resolveVitestIsolation(env);
   return defineProject({
     ...sharedVitestConfig,
     test: {
       ...sharedVitestConfig.test,
       name: "boundary",
-      isolate,
-      ...(isolate ? { runner: undefined } : { runner: nonIsolatedRunnerPath }),
+      isolate: false,
+      runner: nonIsolatedRunnerPath,
       include:
         loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env) ??
         cliIncludePatterns ??

--- a/test/vitest/vitest.config.ts
+++ b/test/vitest/vitest.config.ts
@@ -1,15 +1,7 @@
 // Vitest config config wires the config test shard.
 import { defineConfig } from "vitest/config";
 import { agentVitestProjectConfigs } from "./vitest.agents-paths.mjs";
-import {
-  resolveDefaultVitestPool,
-  resolveLocalVitestMaxWorkers,
-  resolveLocalVitestScheduling,
-  nonIsolatedRunnerPath,
-  sharedVitestConfig,
-} from "./vitest.shared.config.ts";
-
-export { resolveDefaultVitestPool, resolveLocalVitestMaxWorkers, resolveLocalVitestScheduling };
+import { nonIsolatedRunnerPath, sharedVitestConfig } from "./vitest.shared.config.ts";
 
 const rootVitestProjects = [
   "test/vitest/vitest.unit.config.ts",

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -65,12 +65,6 @@ export function shouldPassWithNoTestsForCliIncludes(
   );
 }
 
-export function resolveVitestIsolation(
-  _env: Record<string, string | undefined> = process.env,
-): boolean {
-  return false;
-}
-
 const SCOPED_PROJECT_GROUP_ORDER_BY_NAME = new Map(
   [
     "acp",
@@ -229,7 +223,7 @@ export function createScopedVitestConfig(
     ? relativizeScopedPatterns(includeFromEnv, scopedDir)
     : includeFromEnv;
   const scopedCliInclude = cliInclude ? relativizeScopedPatterns(cliInclude, scopedDir) : null;
-  const isolate = options?.isolate ?? resolveVitestIsolation(options?.env);
+  const isolate = options?.isolate ?? false;
   const setupFiles = [
     ...new Set([
       ...(baseTest.setupFiles ?? []),

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -2,21 +2,16 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ViteUserConfig } from "vitest/config";
 import acpCorePackageJson from "../../packages/acp-core/package.json" with { type: "json" };
 import normalizationCorePackageJson from "../../packages/normalization-core/package.json" with { type: "json" };
 import { pluginSdkSubpaths } from "../../scripts/lib/plugin-sdk-entries.mts";
 import privateLocalOnlyPluginSdkSubpaths from "../../scripts/lib/plugin-sdk-private-local-only-subpaths.json" with { type: "json" };
 import { createStateSchemaInlinePlugin } from "../../scripts/lib/state-schema-inline-plugin.mts";
 import {
-  detectVitestHostInfo as detectVitestHostInfoImpl,
   isCiLikeEnv,
-  resolveLocalVitestScheduling as resolveLocalVitestSchedulingImpl,
+  resolveLocalVitestScheduling,
 } from "../../scripts/lib/vitest-local-scheduling.mts";
-import type {
-  LocalVitestScheduling,
-  VitestHostInfo,
-} from "../../scripts/lib/vitest-local-scheduling.mts";
+import type { LocalVitestScheduling } from "../../scripts/lib/vitest-local-scheduling.mts";
 import {
   BUNDLED_PLUGIN_ROOT_DIR,
   BUNDLED_PLUGIN_TEST_GLOB,
@@ -25,8 +20,6 @@ import { loadVitestPerformanceConfig } from "./vitest.performance-config.ts";
 import { shouldPrintVitestThrottle } from "./vitest.system-load.ts";
 import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest.timeouts.ts";
 import { compiledSubprocessesPlugin } from "./vitest.worker-artifacts.ts";
-
-export type OpenClawVitestPool = "forks" | "threads";
 
 export type { LocalVitestScheduling };
 
@@ -38,38 +31,6 @@ export const jsdomOptimizedDeps = {
     },
   },
 };
-
-// Vitest 4 omits `false` from the type because it is the default; Vitest 5
-// accepts it and requires the explicit value to preserve independent projects.
-export function preserveIndependentVitestProject<T extends ViteUserConfig>(project: T): T {
-  return Object.assign(project, { extends: false });
-}
-
-function detectVitestHostInfo(): Required<VitestHostInfo> {
-  return detectVitestHostInfoImpl();
-}
-
-export function resolveLocalVitestMaxWorkers(
-  env: Record<string, string | undefined> = process.env,
-  system: VitestHostInfo = detectVitestHostInfo(),
-  pool: OpenClawVitestPool = resolveDefaultVitestPool(env),
-): number {
-  return resolveLocalVitestSchedulingImpl(env, system, pool).maxWorkers;
-}
-
-export function resolveLocalVitestScheduling(
-  env: Record<string, string | undefined> = process.env,
-  system: VitestHostInfo = detectVitestHostInfo(),
-  pool: OpenClawVitestPool = resolveDefaultVitestPool(env),
-): LocalVitestScheduling {
-  return resolveLocalVitestSchedulingImpl(env, system, pool);
-}
-
-export function resolveDefaultVitestPool(
-  _env: Record<string, string | undefined> = process.env,
-): OpenClawVitestPool {
-  return "threads";
-}
 
 export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 export const nonIsolatedRunnerPath = path.join(repoRoot, "test", "non-isolated-runner.ts");
@@ -83,12 +44,7 @@ export function resolveRepoRootPath(value: string): string {
 }
 const isCI = isCiLikeEnv(process.env);
 const isWindows = process.platform === "win32";
-const defaultPool = resolveDefaultVitestPool();
-const localScheduling = resolveLocalVitestScheduling(
-  process.env,
-  detectVitestHostInfo(),
-  defaultPool,
-);
+const localScheduling = resolveLocalVitestScheduling();
 
 function hasWorkerOverride(env: Record<string, string | undefined>): boolean {
   return Boolean((env.OPENCLAW_VITEST_MAX_WORKERS ?? env.OPENCLAW_TEST_WORKERS)?.trim());
@@ -501,7 +457,7 @@ export const sharedVitestConfig = {
     unstubEnvs: true,
     unstubGlobals: true,
     isolate: false,
-    pool: defaultPool,
+    pool: "threads" as const,
     runner: nonIsolatedRunnerPath,
     maxWorkers: workerConfig.maxWorkers,
     fileParallelism: workerConfig.fileParallelism,

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -5,7 +5,7 @@ import {
   loadPatternListFromEnv,
   narrowIncludePatternsForCli,
 } from "./vitest.pattern-file.ts";
-import { preserveIndependentVitestProject, sharedVitestConfig } from "./vitest.shared.config.ts";
+import { sharedVitestConfig } from "./vitest.shared.config.ts";
 import { UiE2eSequencer } from "./vitest.ui-e2e.sequencer.ts";
 import { controlUiE2eTestGlobs } from "./vitest.ui-paths.mjs";
 
@@ -202,7 +202,7 @@ export function createUiE2eVitestConfig(
             name: "ui-e2e-serial-standalone",
           },
         },
-      ].map(preserveIndependentVitestProject),
+      ],
       // Refit needs native file totals; verbose still reports cases to the output watchdog.
       reporters: [...baseTest.reporters, "default"],
       sequence: { ...baseSequence, sequencer: UiE2eSequencer },

--- a/test/vitest/vitest.unit.config.ts
+++ b/test/vitest/vitest.unit.config.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 import { loadPatternListFromEnv, narrowIncludePatternsForCli } from "./vitest.pattern-file.ts";
-import {
-  resolveVitestIsolation,
-  shouldPassWithNoTestsForCliIncludes,
-} from "./vitest.scoped-config.ts";
+import { shouldPassWithNoTestsForCliIncludes } from "./vitest.scoped-config.ts";
 import {
   nonIsolatedRunnerPath,
   repoRoot,
@@ -106,7 +103,6 @@ export function createUnitVitestConfigWithOptions(
     passWithNoTests?: boolean;
   } = {},
 ) {
-  const isolate = resolveVitestIsolation(env);
   const argv = options.argv ?? process.argv;
   const envIncludePatterns = loadPatternListFromEnv("OPENCLAW_VITEST_INCLUDE_FILE", env);
   const defaultIncludePatterns = options.includePatterns ?? unitTestIncludePatterns;
@@ -143,8 +139,8 @@ export function createUnitVitestConfigWithOptions(
     test: {
       ...sharedTest,
       name: options.name ?? "unit",
-      isolate,
-      ...(isolate ? { runner: undefined } : { runner: nonIsolatedRunnerPath }),
+      isolate: false,
+      runner: nonIsolatedRunnerPath,
       setupFiles: [
         ...new Set(
           [...(sharedTest.setupFiles ?? []), "test/setup-openclaw-runtime.ts"].map(

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -15,8 +15,6 @@ import { loadVitestPerformanceConfig } from "../test/vitest/vitest.performance-c
 import {
   jsdomOptimizedDeps,
   nonIsolatedRunnerPath,
-  preserveIndependentVitestProject,
-  resolveDefaultVitestPool,
   sharedVitestConfig,
 } from "../test/vitest/vitest.shared.config.ts";
 import { uiIsolatedTestFiles } from "../test/vitest/vitest.ui-isolated-paths.mjs";
@@ -111,7 +109,7 @@ const sharedUiTestConfig = {
   // Preserve calls recorded during shared setup and beforeAll hooks.
   clearMocks: false,
   isolate: false,
-  pool: resolveDefaultVitestPool(),
+  pool: "threads",
   // Real-Chromium layout tests exceed Vitest's 5s default on 4vcpu CI runners;
   // without this the checks-ui lane flakes on cold hover/interaction tests.
   testTimeout: 60_000,
@@ -209,7 +207,8 @@ export default defineConfig({
     reporters: sharedVitestConfig.test.reporters,
     // These projects already own their complete plugins, aliases, and test config.
     projects: [
-      defineProject({
+      {
+        extends: false,
         plugins: [controlUiLocaleModulesPlugin()],
         resolve: {
           alias: workspaceSourceAliases,
@@ -237,8 +236,9 @@ export default defineConfig({
           environment: "jsdom",
           setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
         },
-      }),
-      defineProject({
+      },
+      {
+        extends: false,
         plugins: [controlUiLocaleModulesPlugin()],
         resolve: {
           alias: workspaceSourceAliases,
@@ -254,8 +254,9 @@ export default defineConfig({
           environment: "jsdom",
           setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
         },
-      }),
-      defineProject({
+      },
+      {
+        extends: false,
         plugins: [controlUiLocaleModulesPlugin()],
         resolve: {
           alias: workspaceSourceAliases,
@@ -275,8 +276,8 @@ export default defineConfig({
           environment: "jsdom",
           setupFiles: ["./src/test-helpers/lit-warnings.setup.ts"],
         },
-      }),
-      createUiBrowserVitestConfig(),
-    ].map(preserveIndependentVitestProject),
+      },
+      { ...createUiBrowserVitestConfig(), extends: false },
+    ],
   },
 });

--- a/ui/vitest.node.config.ts
+++ b/ui/vitest.node.config.ts
@@ -1,9 +1,6 @@
 // Control UI config module wires vitest behavior.
 import { defineConfig } from "vitest/config";
-import {
-  resolveDefaultVitestPool,
-  sharedVitestConfig,
-} from "../test/vitest/vitest.shared.config.ts";
+import { sharedVitestConfig } from "../test/vitest/vitest.shared.config.ts";
 import { controlUiLocaleModulesPlugin } from "./config/control-ui-locales.ts";
 
 // Node-only tests for pure logic (no Playwright/browser dependency).
@@ -13,7 +10,7 @@ export default defineConfig({
     reporters: sharedVitestConfig.test.reporters,
     clearMocks: false,
     isolate: false,
-    pool: resolveDefaultVitestPool(),
+    pool: "threads",
     testTimeout: 120_000,
     include: [
       "src/**/*.node.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,2 @@
 // Root Vitest config wires the repository Vitest project matrix.
-export {
-  default,
-  resolveDefaultVitestPool,
-  resolveLocalVitestMaxWorkers,
-  resolveLocalVitestScheduling,
-} from "./test/vitest/vitest.config.ts";
+export { default } from "./test/vitest/vitest.config.ts";


### PR DESCRIPTION
Related: #139377, #137201

## What Problem This Solves

The Vitest 5 configuration still carried a Vitest 4 typing workaround, constant-return pool/isolation helpers, and forwarding layers around the canonical scheduler. Tests reached through root config exports to exercise those wrappers, leaving policy duplicated across configuration and scheduler test files.

## Why This Change Was Made

Use Vitest 5's native inline `extends: false` property and remove the mutating compatibility helper. Keep the browser factory's named return type and all explicit project independence settings. Shared configuration now calls the existing scheduler directly; pool/isolation defaults remain explicit, and unit/boundary configs no longer branch on an always-false result.

Move scheduling cases to the canonical scheduler tests and consolidate the one pair with identical saturated-host inputs. Preserve the full worker-count, parallelism, throttling, override, and memory-limit assertions. Root config files now export only their configuration.

## User Impact

Less configuration and test scaffolding to maintain, with unchanged project membership, settings, worker budgets, isolation, aliases, and setup ownership. No new configuration options, dependency changes, or performance claims.

## Evidence

- Fresh frozen Vitest 5 install; directly inspected native `defineProject` passthrough and the `extends: false` inheritance contract.
- Eight before/after config variants compare deeply equal: root, UI, UI Node, unit, boundary, scoped, isolated, and UI E2E. Comparison includes regular expressions and function source.
- All 211 tests passed across six config/scheduler suites, including native Chromium discovery and E2E project inventory, phases, effective workers, and cleanup ownership.
- Independent Codex review through P2 found no actionable issues.
- Full changed checks passed, including all typecheck lanes, lint, import-cycle and export guards. A real Chromium smoke run also passed all eight cases. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33995181140) passed on 452652261d95d96a8af22e95716870c975c826d0. ClawSweeper also completed its review with no findings or pre-merge actions.
- Net 189 lines removed. Scheduling coverage moves to its actual owner; only one genuinely duplicated case is merged.

Dependency review follow-through: the maintainer directly inspected the installed Vitest 5 distribution. `dist/config.js` shows `defineConfig` and `defineProject` return their input unchanged; `TestProjectInlineConfiguration` types allow `extends: false`, and the native inline-project resolver checks that property before parent inheritance. The eight config comparisons and native project tests independently verify the preserved behavior. The reviewer's unavailable dependency checkout is not an unresolved code defect.
