### PR TITLE
refactor: remove vacuous Ollama test and share model fixtures

### DIFF
--- a/extensions/ollama/model.test-support.ts
+++ b/extensions/ollama/model.test-support.ts
@@ -1,0 +1,21 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
+
+export function createModel(
+  id: string,
+  name: string,
+  {
+    reasoning = false,
+    contextWindow = 128_000,
+    maxTokens = 8_192,
+  }: Partial<Pick<ModelDefinitionConfig, "reasoning" | "contextWindow" | "maxTokens">> = {},
+) {
+  return {
+    id,
+    name,
+    reasoning,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens,
+  } satisfies ModelDefinitionConfig;
+}

--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -4,12 +4,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createModel } from "./model.test-support.js";
 import { ollamaProviderDiscovery } from "./provider-discovery.js";
 
 const OLLAMA_LOCAL_AUTH_MARKER = "ollama-local";
+
+const createConfiguredModel = () =>
+  createModel("gpt-oss:20b", "GPT-OSS 20B", { contextWindow: 8_192, maxTokens: 81_920 });
 
 afterEach(() => {
   clearLiveCatalogCacheForTests();
@@ -381,36 +384,11 @@ describe("Ollama provider", () => {
     expect(models).toHaveLength(200);
   });
 
-  it("should have correct model structure without streaming override", () => {
-    const mockOllamaModel = {
-      id: "llama3.3:latest",
-      name: "llama3.3:latest",
-      reasoning: false,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128000,
-      maxTokens: 8192,
-    };
-
-    // Native Ollama provider does not need streaming: false workaround
-    expect(mockOllamaModel).not.toHaveProperty("params");
-  });
-
   it("should skip discovery fetch when explicit models are configured", async () => {
     await withoutAmbientOllamaEnv(async () => {
       const fetchMock = vi.fn();
       stubOllamaFetch(fetchMock);
-      const explicitModels: ModelDefinitionConfig[] = [
-        {
-          id: "gpt-oss:20b",
-          name: "GPT-OSS 20B",
-          reasoning: false,
-          input: ["text"] as Array<"text" | "image">,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 8192,
-          maxTokens: 81920,
-        },
-      ];
+      const explicitModels = [createConfiguredModel()];
 
       const provider = await runOllamaCatalog({
         config: {
@@ -450,17 +428,7 @@ describe("Ollama provider", () => {
             providers: {
               ollama: {
                 baseUrl: "http://remote-ollama:11434/v1",
-                models: [
-                  {
-                    id: "gpt-oss:20b",
-                    name: "GPT-OSS 20B",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 8192,
-                    maxTokens: 81920,
-                  },
-                ],
+                models: [createConfiguredModel()],
               },
             },
           },
@@ -487,17 +455,7 @@ describe("Ollama provider", () => {
             providers: {
               ollama: {
                 baseUrl: "https://ollama.com/v1",
-                models: [
-                  {
-                    id: "gpt-oss:20b",
-                    name: "GPT-OSS 20B",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 8192,
-                    maxTokens: 81920,
-                  },
-                ],
+                models: [createConfiguredModel()],
               },
             },
           },
@@ -524,17 +482,7 @@ describe("Ollama provider", () => {
             providers: {
               ollama: {
                 baseUrl: "https://ollama.com/v1",
-                models: [
-                  {
-                    id: "gpt-oss:20b",
-                    name: "GPT-OSS 20B",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 8192,
-                    maxTokens: 81920,
-                  },
-                ],
+                models: [createConfiguredModel()],
                 apiKey: "OLLAMA_API_KEY",
               },
             },
@@ -566,17 +514,7 @@ describe("Ollama provider", () => {
             providers: {
               ollama: {
                 baseUrl: "https://ollama.com/v1",
-                models: [
-                  {
-                    id: "gpt-oss:20b",
-                    name: "GPT-OSS 20B",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 8192,
-                    maxTokens: 81920,
-                  },
-                ],
+                models: [createConfiguredModel()],
               },
             },
           },
@@ -607,17 +545,7 @@ describe("Ollama provider", () => {
             providers: {
               ollama: {
                 baseUrl: "http://127.0.0.1:11434/v1",
-                models: [
-                  {
-                    id: "gpt-oss:20b",
-                    name: "GPT-OSS 20B",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 8192,
-                    maxTokens: 81920,
-                  },
-                ],
+                models: [createConfiguredModel()],
                 apiKey: "OLLAMA_API_KEY",
               },
             },
@@ -657,15 +585,9 @@ describe("Ollama provider", () => {
                 baseUrl: "http://remote-ollama:11434/v1",
                 api: "openai-completions",
                 models: [
-                  {
-                    id: "configured-remote-model",
-                    name: "Configured Remote Model",
-                    reasoning: false,
-                    input: ["text"],
-                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                    contextWindow: 8192,
-                    maxTokens: 8192,
-                  },
+                  createModel("configured-remote-model", "Configured Remote Model", {
+                    contextWindow: 8_192,
+                  }),
                 ],
                 apiKey: "config-ollama-key", // pragma: allowlist secret
               },

--- a/extensions/ollama/provider-policy-api.test.ts
+++ b/extensions/ollama/provider-policy-api.test.ts
@@ -1,6 +1,6 @@
 // Ollama tests cover provider policy api plugin behavior.
-import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { describe, expect, it } from "vitest";
+import { createModel } from "./model.test-support.js";
 import {
   normalizeConfig,
   projectConfiguredModelRow,
@@ -8,23 +8,6 @@ import {
   resolveToolSearchMode,
 } from "./provider-policy-api.js";
 import { OLLAMA_DEFAULT_BASE_URL } from "./src/defaults.js";
-
-function createModel(id: string, name: string): ModelDefinitionConfig {
-  return {
-    id,
-    name,
-    reasoning: false,
-    input: ["text"],
-    cost: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-    },
-    contextWindow: 128_000,
-    maxTokens: 8_192,
-  };
-}
 
 describe("ollama provider policy public artifact", () => {
   it.each([
@@ -112,16 +95,10 @@ describe("ollama provider policy public artifact", () => {
         provider,
         modelId: "qwen3.5:9b",
         model: {
+          ...createModel("qwen3.5:9b", "Qwen 3.5 9B", { reasoning: true }),
           provider: provider.trim().toLowerCase(),
-          id: "qwen3.5:9b",
           api: "ollama",
           baseUrl: OLLAMA_DEFAULT_BASE_URL,
-          input: ["text"],
-          name: "Qwen 3.5 9B",
-          reasoning: true,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 128_000,
-          maxTokens: 8_192,
         },
       }),
     ).toBeNull();
@@ -133,16 +110,10 @@ describe("ollama provider policy public artifact", () => {
         provider: "openai",
         modelId: "gpt-5.5",
         model: {
+          ...createModel("gpt-5.5", "GPT-5.5", { reasoning: true }),
           provider: "openai",
-          id: "gpt-5.5",
           api: "openai-responses",
           baseUrl: "https://api.openai.com/v1",
-          input: ["text"],
-          name: "GPT-5.5",
-          reasoning: true,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 128_000,
-          maxTokens: 8_192,
         },
       }),
     ).toBeUndefined();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

One Ollama test creates a local model object and asserts that its own literal has no streaming override; it never invokes production code and cannot catch a production regression. Discovery and policy tests also repeat identical model input fixtures.

## Why This Change Was Made

Remove that vacuous assertion and share the existing model fixture builder between the discovery and policy suites. Each call creates fresh nested values. Preserve every meaningful scenario, assertion, and fixture value, including the configured model's distinct 8,192-token context and 81,920-token output limit.

## User Impact

No production behavior changes. Test and support code shrinks by 86 net lines; failures remain tied to actual discovery, authentication, model projection, and policy behavior.

## Evidence

Both focused files pass: 41 tests. The full classified changed-check gate, formatting, and whitespace checks pass. Independent P2 review found no actionable findings. The helper uses the existing test-support naming convention so changed checks classify it as test code. No aggregate runtime improvement is claimed.
