### PR TITLE
improve: avoid real cleanup delay in Gateway lifecycle tests

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2423,6 +2423,7 @@ describe("server-channels auto restart", () => {
     const server = createTestGatewayServer({
       resolvedAuth: AUTH_NONE,
       overrides: {
+        getRuntimeConfig: () => ({}),
         handlePluginRequest: createGatewayPluginRequestHandler({
           registry,
           log: createSubsystemLogger("gateway/webhook-reload-test"),

--- a/src/gateway/server-plugins.lifecycle.test-fixtures.ts
+++ b/src/gateway/server-plugins.lifecycle.test-fixtures.ts
@@ -1,6 +1,7 @@
 // Synthetic plugin fixtures for Gateway instance and channel lifecycle tests.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 
@@ -34,6 +35,7 @@ export type InstanceBindingProbeCoordinator = {
   runtimes: PluginRuntime[];
   serviceStarts: number;
   serviceStops: number;
+  onServiceStop?: () => void;
   serviceStopCompletion: ReturnType<typeof createDeferred<void>>;
   serviceStopFailure?: "rejection" | "timeout";
   channelProof?: ChannelBindingProof;
@@ -41,6 +43,39 @@ export type InstanceBindingProbeCoordinator = {
   channelStops?: Array<Pick<ChannelBindingMonitor, "channelId" | "runtimeId" | "abortSignal">>;
   channelCleanup?: Map<ChannelBindingMonitor, { release: () => void; finished: Promise<void> }>;
 };
+
+export async function withPluginServiceStopDeadline<T>(
+  coordinator: InstanceBindingProbeCoordinator,
+  run: () => Promise<T>,
+): Promise<T> {
+  if (coordinator.serviceStopFailure !== "timeout") {
+    return await run();
+  }
+  const started = createDeferred();
+  coordinator.onServiceStop = () => {
+    // Keep startup and request admission on real clocks.
+    vi.useFakeTimers({
+      toFake: ["setTimeout", "clearTimeout"],
+      shouldClearNativeTimers: true,
+    });
+    started.resolve();
+  };
+  const result = run();
+  try {
+    await Promise.race([
+      started.promise,
+      result.then(() => {
+        throw new Error("config.patch settled before plugin cleanup started");
+      }),
+    ]);
+    // The deadline only rejects; restore native timers before recovery continuations run.
+    vi.advanceTimersByTime(5_000);
+  } finally {
+    coordinator.onServiceStop = undefined;
+    vi.useRealTimers();
+  }
+  return await result;
+}
 
 export function installInstanceBindingProbeCoordinator(options?: {
   serviceStopFailure?: InstanceBindingProbeCoordinator["serviceStopFailure"];
@@ -108,6 +143,7 @@ export async function writeInstanceBindingProbePlugin(bundledRoot: string): Prom
         },
         stop() {
           coordinator.serviceStops += 1;
+          coordinator.onServiceStop?.();
           if (coordinator.serviceStopFailure === "rejection") {
             return Promise.reject(new Error("instance-binding service cleanup rejected"));
           }

--- a/src/gateway/server-plugins.lifecycle.test.ts
+++ b/src/gateway/server-plugins.lifecycle.test.ts
@@ -25,6 +25,7 @@ import {
   installInstanceBindingProbeCoordinator,
   writeChannelBindingProbePlugin,
   writeInstanceBindingProbePlugin,
+  withPluginServiceStopDeadline,
   type ChannelBindingMonitor,
   type ChannelBindingProof,
   type InstanceBindingProbeCoordinator,
@@ -777,7 +778,9 @@ describe("gateway plugin instance bindings", () => {
 
       const socket = await connectWebchatClient({ port, scopes: ["operator.admin"] });
       sockets.push(socket);
-      const reload = await patchInstanceBindingTestConfig(socket);
+      const reload = await withPluginServiceStopDeadline(coordinator, () =>
+        patchInstanceBindingTestConfig(socket),
+      );
       expect(reload).toMatchObject({
         ok: false,
         error: {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

A Gateway plugin-replacement regression test waits five real seconds for deliberately stalled service cleanup. A webhook handoff fixture also reads real runtime configuration despite using an explicitly empty synthetic channel configuration.

## Why This Change Was Made

Use the existing synthetic plugin coordinator to enable a narrow fake clock only when service cleanup starts. Fire the unchanged deadline synchronously, then restore native timers before failure/recovery Promise continuations execute. Keep startup, authenticated config.patch, registry preservation, and recovery assertions real. Supply the webhook HTTP fixture's existing config callback with the same empty config as its channel manager.

## User Impact

No production behavior changes. All lifecycle scenarios remain covered. This batch adds 40 net test/support lines to eliminate an intentional wall-clock wait; that increase offsets the campaign's deletion total.

## Evidence

Both affected suites pass: 154 tests. Complete changed checks, typechecks, lint, formatting, and whitespace checks pass. Fresh independent P2 review is scoped-clean after tightening timer restoration order. Diagnostic timeout-case duration fell from approximately 11.2 seconds to 6.55 seconds in separate runs; these contended runs are not a controlled benchmark or a claim of aggregate speedup.
