### PR TITLE
fix: keep subagent checks responsive in large session stores

### DIFF
--- a/src/agents/subagents/registry/subagent-session-reconciliation.metadata-read.test.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.metadata-read.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { replaceSessionEntrySync } from "../../../config/sessions/session-accessor.js";
+import {
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "../../../config/sessions/session-accessor.sqlite-scope.js";
+import { openOpenClawAgentDatabase } from "../../../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../../../test-utils/env.js";
+import { cleanupSessionStateForTest } from "../../../test-utils/session-state-cleanup.js";
+import {
+  resolveStoredSubagentCapabilities,
+  resolvePersistedSubagentToolPolicyEnvelope,
+} from "../spawn/subagent-capabilities.js";
+import { getSubagentDepthFromSessionStore } from "../spawn/subagent-depth.js";
+import { resolveSubagentSessionCompletion } from "./subagent-session-reconciliation.js";
+
+it("reads subagent lifecycle and policy metadata without decoding unrelated session payloads", async () => {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "subagent-point-read-"));
+  await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+    try {
+      const storePath = path.join(stateDir, "agents/main/sessions/sessions.json");
+      const childSessionKey = "agent:main:subagent:target";
+      for (let i = 0; i < 100; i++) {
+        replaceSessionEntrySync(
+          { storePath, sessionKey: `agent:main:subagent:other-${i}` },
+          {
+            sessionId: `other-${i}`,
+            updatedAt: 1,
+            skillsSnapshot: { prompt: `UNRELATED_PAYLOAD_${"x".repeat(4096)}`, skills: [] },
+          },
+        );
+      }
+      replaceSessionEntrySync(
+        { storePath, sessionKey: childSessionKey },
+        {
+          sessionId: "target",
+          updatedAt: 2000,
+          startedAt: 1000,
+          endedAt: 2000,
+          status: "done",
+          spawnDepth: 2,
+          spawnedBy: "agent:main:main",
+          inheritedToolPolicyVersion: 1,
+          inheritedToolAllow: ["read"],
+          inheritedToolDeny: ["exec"],
+        },
+      );
+      const parse = vi.spyOn(JSON, "parse");
+      let completion;
+      try {
+        completion = resolveSubagentSessionCompletion({
+          childSessionKey,
+          cfg: { session: { store: storePath } },
+          fallbackEndedAt: 3000,
+        });
+        const options = { cfg: { session: { store: storePath } } };
+        expect(getSubagentDepthFromSessionStore(childSessionKey, options)).toBe(2);
+        expect(getSubagentDepthFromSessionStore("target", options)).toBe(2);
+        expect(resolveStoredSubagentCapabilities(childSessionKey, options)).toMatchObject({
+          depth: 2,
+          canSpawn: true,
+        });
+        expect(resolvePersistedSubagentToolPolicyEnvelope(childSessionKey, options)).toMatchObject({
+          spawnedBy: "agent:main:main",
+          inheritedToolAllow: ["read"],
+          inheritedToolDeny: ["exec"],
+        });
+        const unrelatedParses = parse.mock.calls.filter(
+          ([value]) => typeof value === "string" && value.includes("UNRELATED_PAYLOAD_"),
+        ).length;
+        expect(unrelatedParses).toBe(0);
+      } finally {
+        parse.mockRestore();
+      }
+      expect(completion).toMatchObject({
+        startedAt: 1000,
+        endedAt: 2000,
+        outcome: { status: "ok" },
+      });
+      const params = {
+        childSessionKey,
+        cfg: { session: { store: storePath } },
+        fallbackEndedAt: 3000,
+      };
+      const storeCache = new Map();
+      expect(resolveSubagentSessionCompletion({ ...params, storeCache })).toEqual(completion);
+      replaceSessionEntrySync(
+        { storePath, sessionKey: childSessionKey },
+        {
+          sessionId: "successor",
+          updatedAt: 4000,
+          status: "running",
+        },
+      );
+      expect(resolveSubagentSessionCompletion(params)).toBeNull();
+      expect(resolveSubagentSessionCompletion({ ...params, storeCache })).toEqual(completion);
+      expect(
+        resolveSubagentSessionCompletion({
+          ...params,
+          childSessionKey: "agent:main:subagent:missing",
+        }),
+      ).toBeNull();
+
+      const database = openOpenClawAgentDatabase(
+        toDatabaseOptions(resolveSqliteScope({ storePath, sessionKey: childSessionKey })),
+      );
+      database.db
+        .prepare("UPDATE session_nodes SET entry_json = ?, entry_valid = 0 WHERE session_key = ?")
+        .run('{"bad":true}', childSessionKey);
+      expect(resolveSubagentSessionCompletion(params)).toBeNull();
+
+      expect(getSubagentDepthFromSessionStore(childSessionKey, { cfg: params.cfg })).toBe(1);
+      expect(
+        resolvePersistedSubagentToolPolicyEnvelope(childSessionKey, { cfg: params.cfg }),
+      ).toBeUndefined();
+
+      for (const [requested, stored, matches] of [
+        ["Agent:MAIN:telegram:group:ROOM", "agent:main:telegram:group:room", true],
+        ["agent:main:matrix:group:!Room:server", "agent:main:matrix:group:!room:server", false],
+        ["agent:main:signal:group:AbCdEf==", "agent:main:signal:group:abcdef==", false],
+      ] as const) {
+        replaceSessionEntrySync(
+          { storePath, sessionKey: stored },
+          {
+            sessionId: stored,
+            updatedAt: 2000,
+            endedAt: 2000,
+            status: "done",
+          },
+        );
+        const resolved = resolveSubagentSessionCompletion({
+          ...params,
+          childSessionKey: requested,
+        });
+        expect(resolved?.outcome.status === "ok").toBe(matches);
+      }
+    } finally {
+      await cleanupSessionStateForTest({ stateDir });
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/agents/subagents/registry/subagent-session-reconciliation.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.ts
@@ -86,10 +86,9 @@ export function loadSubagentSessionEntry(params: {
   let store = params.storeCache?.get(storePath);
   if (!store) {
     store = Object.fromEntries(
-      listSessionEntriesReadOnly({ storePath, clone: false }).map(({ sessionKey, entry }) => [
-        sessionKey,
-        entry,
-      ]),
+      listSessionEntriesReadOnly({ storePath, clone: false, projection: "list" }).map(
+        ({ sessionKey, entry }) => [sessionKey, entry],
+      ),
     );
     params.storeCache?.set(storePath, store);
   }

--- a/src/agents/subagents/spawn/subagent-depth.ts
+++ b/src/agents/subagents/spawn/subagent-depth.ts
@@ -32,7 +32,7 @@ export function readSubagentSessionStore(
 ): Record<string, SessionEntry> {
   try {
     return Object.fromEntries(
-      listSessionEntriesReadOnly({ agentId, storePath, clone: false }).map(
+      listSessionEntriesReadOnly({ agentId, storePath, clone: false, projection: "list" }).map(
         ({ sessionKey, entry }) => [sessionKey, entry],
       ),
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sub-agent completion processing and cancellation checks can stall the Gateway as the number of saved sessions grows.

## Why This Change Was Made

Child reconciliation, spawn-depth recovery, and inherited tool-policy checks need metadata, but their store listings also loaded every session's saved prompts. Request the existing metadata projection instead. This preserves current snapshot lifetime, row-selection/error behavior, and canonical cache invalidation without introducing another reader or cache.

## User Impact

Completion cleanup, cancellation, depth, and inherited tool-policy checks avoid decoding unrelated saved prompts. Current child identity checks, malformed-row handling, and case-sensitive channel keys retain their existing behavior.

## Evidence

- A real SQLite regression failed before the fix by decoding 100 unrelated saved prompt payloads for one child lookup. The metadata projection removes these payload decodes.
- The regression covers current successor reads, explicitly retained snapshots, missing children, a malformed target after a valid warm read, structural key casing, and distinct Matrix/Signal peers.
- 89 focused tests passed across reconciliation, depth, capability, requester policy, persistence, and sweeper recovery suites. Independent review found no actionable P0–P2 defects.
- Uninstrumented alternating full/metadata read comparison on an isolated macOS fixture: twenty reads with 1,000 unrelated 4 KiB saved prompts used 298 ms versus 30 ms of process CPU. Wall-time medians were 29.6 ms versus 1.67 ms; scheduling produced long outliers in both. This measures the reader and record reconstruction, not overall Gateway or production latency.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33995456208). Supplemental deprecated-API, database-first store, media-helper, and runtime-sidecar checks also passed.
- An actual Linux Node 26.7.0 compiled Gateway restored four completed/failed/timed-out/killed collectors and finished their cleanup while preserving identities, statuses, and 1,000 unrelated saved prompts. Actual HTTP tool calls allowed the orchestrator and denied the leaf and inherited-deny cases. RPC/metrics build identity matched the compiled process; graceful exit and process-group closure passed with stable source/build seals and removed fixtures.

The compiled proof covers behavior on synthetic state. Reader benchmarks do not establish production-wide responsiveness, and metadata record reconstruction still scales with the number of sessions. Further measured stalls and an exact metadata-list accessor remain follow-ups.

The existing strict point accessor has different malformed-row behavior, which can interrupt cleanup after ownership has been recorded. The metadata projection preserves the listing contract; an exact metadata-list reader is a separate shared-owner follow-up.
