### PR TITLE
docs(release): carry stable release authorization through macOS

### DIFF
--- a/.agents/skills/release-openclaw-mac/SKILL.md
+++ b/.agents/skills/release-openclaw-mac/SKILL.md
@@ -11,6 +11,20 @@ This is a regular stable-release skill. Do not invoke it for extended-stable;
 that track does not inherit macOS assets, appcast promotion, or a GitHub Release
 unless the current extended-stable release policy explicitly adds them.
 
+## Release authorization
+
+An explicit stable or full release request includes macOS publication unless
+the operator limits its scope. Continue through validation, signing,
+notarization, promotion, and verification without asking for separate macOS
+consent. Keep the exact release identity and all artifact checks.
+
+Follow the current owner-configured environment policy. Do not invent an extra
+reviewer requirement or recreate an obsolete one. If GitHub still enforces an
+approval, report the actual rule and resolve it through its owner; policy changes
+require explicit organization-owner direction and verified active admin
+membership. Never impersonate a reviewer, fabricate approval, or use another
+signing path to bypass an enforced rule.
+
 ## Credentials
 
 - Resolve Peter-owned ASC item refs, key ids, issuer ids, and service-token provenance from `$release-private`.
@@ -53,10 +67,9 @@ Do not update these from mixed sources. All three ASC fields must come from the 
 - Real mac publish must reuse:
   - a successful release-ops mac preflight run for the same tag/source SHA
   - a successful release-ops mac validation run for the same tag/source SHA
-- Release-ops preflight and real publish enter the protected `mac-release`
-  environment in the `build_sign_and_package` job. Operators may be able to
-  trigger the workflow while Vincent or another environment reviewer approves
-  the paused deployment before signing/notarization/promotion proceeds.
+- Release-ops preflight and real publish use the `mac-release` environment for
+  signing and promotion secrets and its main-only deployment policy. The
+  authorized release operator continues under that environment's current rules.
 - If preflight source SHA differs from tag SHA, validation must also use the same `source_ref`; promotion rejects mismatched proof.
 
 ## Notarization
@@ -71,7 +84,8 @@ Do not update these from mixed sources. All three ASC fields must come from the 
 The public handoff workflow validates the tag, source, build, and package
 metadata before publication. It does not require a GitHub release page because
 it does not upload assets. Keep this validation before the real publish
-workflow; the publisher owns draft creation and final undraft.
+workflow. The core publisher owns GitHub release finalization; macOS promotion
+requires that release to exist and attaches its verified assets.
 
 Public handoff validation:
 
@@ -100,9 +114,9 @@ gh workflow run openclaw-macos-publish.yml --repo openclaw/releases --ref main \
   -f public_release_branch=release/YYYY.M.PATCH
 ```
 
-Wait for the run to reach the `mac-release` environment approval if GitHub
-pauses it, then get approval from Vincent or another configured environment
-reviewer. Record the successful preflight run id.
+Follow the run through signing and notarization under the configured environment
+policy. Record the successful preflight run id; an approval pause is not a
+successful preflight.
 
 Release-ops validation for a branch-variation preflight:
 
@@ -127,8 +141,8 @@ gh workflow run openclaw-macos-publish.yml --repo openclaw/releases --ref main \
   -f public_release_branch=release/YYYY.M.PATCH
 ```
 
-Wait for the `mac-release` environment approval again if GitHub pauses the real
-publish run before it promotes assets.
+Follow promotion through asset upload and appcast publication under the same
+release authorization and current environment policy.
 
 - Release-ops `openclaw/releases` publish/validate workflows run from their own
   trusted `main` workflow ref. Real publish has a guard that rejects any other

--- a/.agents/skills/release-openclaw-maintainer/references/platform-publication.md
+++ b/.agents/skills/release-openclaw-maintainer/references/platform-publication.md
@@ -8,6 +8,11 @@ inherits these platforms.
 
 ## macOS
 
+An explicit stable or full release request includes macOS publication unless
+the operator limits its scope. Continue without a separate macOS consent step,
+following the current owner-configured environment policy. Preserve enforced
+rules and the exact-source validation, signing, and promotion checks.
+
 Use `$release-openclaw-mac` for public handoff validation, release-ops
 validation, signing/notarization preflight, and promotion. Use `$release-private`
 for credential topology. A smoke-test artifact with ad-hoc signing proves no

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -224,6 +224,8 @@ website, and private dist-tags; do not run those steps for this Gateway path.
 
 This checklist is the public shape of the release flow. Private credentials and service-specific signing, notarization, dist-tag recovery, and emergency rollback procedures stay in the maintainer-only release runbook.
 
+An explicit stable or full release request includes macOS publication unless the operator limits its scope. That authorization carries through macOS validation, signing, notarization, promotion, and verification without a separate macOS consent step. Follow the current owner-configured environment policy and retain all enforced rules and exact-source artifact checks.
+
 For beta, stable, and full profiles, Linux (`ubuntu`) cross-OS lanes gate npm publication. Windows and macOS cross-OS lanes run in parallel as advisory coverage; their failures remain visible under **advisory** in `release-ci-summary` and in the evidence manifest without blocking Release Decision or `pnpm release:candidate`. Selected lanes still finish for terminal evidence. npm qualification, Docker, Package Acceptance, normal CI, and the profile's performance and soak gates remain required. macOS app signing/notarization/appcast and Windows Hub asset promotion run in parallel with or after npm publication and never delay it; verify platform readiness separately.
 
 1. Start from current `main`: pull latest, confirm the target commit is pushed, and confirm `main` CI is green enough to branch from.


### PR DESCRIPTION
## What Problem This Solves

Release instructions could ask for another macOS approval after an operator had already authorized a stable or full release.

## Why This Change Was Made

Carry the existing release authorization through macOS validation, signing, notarization, promotion, and verification. Follow the current owner-configured environment policy instead of prescribing an obsolete reviewer requirement. Enforced rules still require their owner to resolve them; impersonation, fabricated approval, and alternate signing bypasses remain prohibited. Clarify that the core publisher finalizes the GitHub release and macOS promotion attaches verified assets to it.

## User Impact

An authorized stable or full release includes macOS publication without another consent request unless the operator limits scope. Beta and extended-stable behavior and all exact-source artifact checks remain unchanged.

## Evidence

- `pnpm docs:list` and the canonical docs-only `check:changed` lane passed, including targeted formatting.
- `git diff --check` passed; this change contains documentation only.
- Independent managed Codex review found no actionable P0–P2 issues.
- The owner-configured environment policy was verified live, and the existing signed preflight proceeded under that policy without a separate approval. This documents authorization, not a claim that signing or publication has completed.
