### PR TITLE
fix(gateway): keep worker provisioning resumable across restart

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -198,6 +198,8 @@ The enrolled node stores its identity, durable device token, endpoint, worker bu
 
 OpenClaw derives one canonical `cbx_...` lease ID from the durable provision operation and passes it to `crabbox warmup --lease-id`; the deterministic slug is display metadata only. If warmup commits but its response is lost, Gateway reconciliation repeats the same fixed-ID operation and Crabbox returns or adopts only the exactly attested lease. Intent drift, terminal ID reuse, and ambiguous unverified resources fail closed without allocating a replacement.
 
+A Gateway restart that interrupts pending provisioning leaves the placement in `provisioning` and resumes the same environment and provider operation after startup. Explicit **Stop cloud worker…** still requests destruction and prevents replay.
+
 An interrupted legacy dispatch may have allocated a random lease without recording its ID. OpenClaw cannot identify that allocation safely from the old operation alone. It refuses replay and slug adoption, retaining the unresolved allocation and cleanup record across restarts instead of treating the resource as gone. Identify and clean up any prior lease before starting a new dispatch; do not guess by slug. Automatic identification or settlement of the old record is not supported. Legacy records already marked failed are not reopened automatically.
 
 ### The setup command
@@ -463,7 +465,7 @@ rejected for profile or device targets and when the source runner is available
 or cannot be proven to be the exact device binding. This path has the same
 unsynced-file and in-flight-work loss boundary as the Control UI confirmation.
 
-Placement moves through a durable state machine (`local → requested → provisioning → syncing → starting → active`), so a Gateway restart mid-dispatch reconciles instead of leaking machines. A failed model turn keeps the active placement available for a retry. Workspace path conflicts keep the local version, apply the rest of the cloud result, and preserve the staged cloud ref for inspection; other reconciliation or lifecycle failures retain their durable recovery fence and diagnostic tail until recovery can safely retry or reclaim the environment.
+Placement moves through a durable state machine (`local → requested → provisioning → syncing → starting → active`), so a Gateway restart mid-dispatch reconciles instead of leaking machines; interrupted pending provisioning retains its fixed provider operation for startup replay. A failed model turn keeps the active placement available for a retry. Workspace path conflicts keep the local version, apply the rest of the cloud result, and preserve the staged cloud ref for inspection; other reconciliation or lifecycle failures retain their durable recovery fence and diagnostic tail until recovery can safely retry or reclaim the environment.
 
 Recovery requested for one worker inspects that environment and resumes only its associated workspace results and moves. Regular background sweeps still reconcile all environments. Recovery continues to wait for earlier placement operations to finish.
 

--- a/src/gateway/server-worker-placement-startup.test.ts
+++ b/src/gateway/server-worker-placement-startup.test.ts
@@ -6,6 +6,11 @@ import { getWorkerPlacementStartupMocks } from "./server-worker-placement-startu
 const { runtimeFactoryMocks, moveDestinationMocks } = getWorkerPlacementStartupMocks();
 
 import {
+  beginGatewayRestartSignalAdmission,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import {
   beginSessionWorkAdmission,
   runExclusiveSessionLifecycleMutation,
   startSessionWorkAdmissionInterruption,
@@ -450,7 +455,7 @@ describe("worker placement startup health lifetime", () => {
     }
   });
 
-  it("closes guarded recovery admission and drains it during environment stop", async () => {
+  it("publishes shutdown before enrollment cancellation and drains guarded recovery", async () => {
     type ReconcileGuard = (
       environmentId: string,
       reconcileCore: () => Promise<void>,
@@ -460,6 +465,7 @@ describe("worker placement startup health lifetime", () => {
     const environmentStopStarted = createDeferredCore();
     const events: string[] = [];
     let installedGuard: ReconcileGuard | undefined;
+    let environmentStopping = false;
     const placement = {
       sessionId: "session-close-guard",
       state: "provisioning" as const,
@@ -494,7 +500,15 @@ describe("worker placement startup health lifetime", () => {
         };
       }),
       start: vi.fn(),
+      isStopping: () => environmentStopping,
+      stopNodeEnrollmentWaits: vi.fn(() => {
+        expect(dispatchOptions.isShuttingDown?.()).toBe(true);
+        expect(environmentStopping).toBe(false);
+        expect(environments.stop).not.toHaveBeenCalled();
+        events.push("enrollment:cancel");
+      }),
       stop: vi.fn(async () => {
+        environmentStopping = true;
         events.push("environments:stop");
         environmentStopStarted.resolve();
         await guardedRecovery;
@@ -516,6 +530,26 @@ describe("worker placement startup health lifetime", () => {
       revokeSessionAuthority: vi.fn(),
       warn: vi.fn(),
     });
+    const dispatchOptions = runtimeFactoryMocks.createDispatch.mock.calls.at(-1)?.[0] as {
+      isShuttingDown?: () => boolean;
+    };
+    resetGatewayWorkAdmission();
+    try {
+      expect(dispatchOptions.isShuttingDown?.()).toBe(false);
+      environmentStopping = true;
+      expect(dispatchOptions.isShuttingDown?.()).toBe(true);
+      environmentStopping = false;
+      expect(dispatchOptions.isShuttingDown?.()).toBe(false);
+      const fence = beginGatewayRestartSignalAdmission();
+      expect(fence).not.toBeNull();
+      expect(dispatchOptions.isShuttingDown?.()).toBe(false);
+      markGatewayRestartDraining();
+      expect(dispatchOptions.isShuttingDown?.()).toBe(true);
+      resetGatewayWorkAdmission();
+      expect(dispatchOptions.isShuttingDown?.()).toBe(false);
+    } finally {
+      resetGatewayWorkAdmission();
+    }
     const sidecar = await runtime.startRuntime({
       isClosePreludeStarted: () => false,
       registerSidecar: vi.fn(),
@@ -542,6 +576,7 @@ describe("worker placement startup health lifetime", () => {
     await Promise.all([guardedRecovery, stopping]);
     expect(events).toEqual([
       "recovery:start",
+      "enrollment:cancel",
       "environments:stop",
       "reconcile:core",
       "recovery:end",

--- a/src/gateway/server-worker-placement-startup.ts
+++ b/src/gateway/server-worker-placement-startup.ts
@@ -5,6 +5,7 @@ import { getRuntimeConfig } from "../config/config.js";
 import { registerSessionMaintenancePreserveKeysProvider } from "../config/sessions/store-maintenance-preserve.js";
 import { runExclusiveSessionStoreWrite } from "../config/sessions/store-writer.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { getGatewayRestartDrainSignal } from "../process/gateway-work-admission.js";
 import {
   interruptSessionWorkAdmissions,
   runExclusiveSessionLifecycleMutation,
@@ -112,6 +113,7 @@ export function createGatewayWorkerPlacementRuntime(
   },
 ) {
   let nodeWorkerSupervisorTransport: NodeWorkerSupervisorTransport | undefined;
+  let stopped = false;
   const workspaceOperations = createWorkerWorkspaceOperationCoordinator();
   const {
     coordinator: githubPublication,
@@ -227,6 +229,10 @@ export function createGatewayWorkerPlacementRuntime(
     createWorkerPlacementDispatchService({
       placements: params.placements,
       environments: params.environments,
+      // Must read true before enrollment cancellation in every shutdown path, so an interrupted
+      // provisioning is retained rather than terminalized. Runtime reset replaces the drain signal.
+      isShuttingDown: () =>
+        stopped || params.environments.isStopping() || getGatewayRestartDrainSignal().aborted,
       runnerAvailability,
       resolveDevicePlacementRequirement,
       isCurrentNodePlacement: (node, requirement) => {
@@ -488,7 +494,6 @@ export function createGatewayWorkerPlacementRuntime(
     const placementReconcile = { current: undefined as Promise<void> | undefined };
     const diskSpaceSweep = { current: undefined as Promise<void> | undefined };
     const placementIdleSuspend: { current: Promise<void> | undefined } = { current: undefined };
-    let stopped = false;
     const uninstallEnvironmentReconcileGuard = installWorkerPlacementReconcileGuard({
       placements: params.placements,
       environments: params.environments,

--- a/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.test.ts
@@ -14,37 +14,13 @@ import {
   REQUEST,
   seedActivePlacement,
 } from "./placement-dispatch-test-fixtures.js";
-import { createHarness } from "./placement-dispatch-test-harness.js";
-import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createHarness, createRecoveryService } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import * as support from "./service.test-support.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
-import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
 
 describe("worker placement restart recovery", () => {
   support.setupWorkerEnvironmentServiceSuite();
-
-  const createRecoveryService = (
-    placements: ReturnType<typeof createWorkerSessionPlacementStore>,
-    environments: ReturnType<typeof support.createService>,
-  ) =>
-    createWorkerPlacementDispatchService({
-      placements,
-      environments,
-      runnerAvailability: { read: () => undefined, version: () => 0 },
-      workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
-      runLocalBarrier: async ({ startDispatch }) => startDispatch(),
-      runRecoveryBarrier: async ({ run }) => await run("/gateway/workspace"),
-      runActivationBarrier: async ({ activate }) => activate(),
-      runMoveBarrier: async ({ begin }) => begin(),
-      resolveMoveDestination: async () => undefined,
-      runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
-      runReclaimBarrier: async ({ begin, reclaim }) => await reclaim("/gateway/workspace", begin()),
-      runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
-      resolveWorkspacePath: async () => "/gateway/workspace",
-      reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => undefined,
-    });
 
   describe.each(["startup", "active"] as const)("%s recovery after worker retirement", (mode) => {
     it.each(["idle", "claimed turn", "pending result", "provider loss"] as const)(

--- a/src/gateway/worker-environments/placement-dispatch-shutdown.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-shutdown.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, vi } from "vitest";
+import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { WorkerDispatchTargetChangedError } from "../server-worker-placement-session-target.js";
+import {
+  MANIFEST_REF,
+  REQUEST,
+  seedProvisioningPlacement,
+} from "./placement-dispatch-test-fixtures.js";
+import { createHarness, createRecoveryService } from "./placement-dispatch-test-harness.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import {
+  deriveEnvironmentIntent,
+  WorkerPlacementAdmissionTargetError,
+} from "./service-contract.js";
+import * as support from "./service.test-support.js";
+
+describe("worker placement shutdown replay", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+
+  it("retains interrupted fresh provisioning and activates the same operation after restart", async () => {
+    support.testState.prepareInstallation = async () => ({
+      ...support.BUNDLE_ARTIFACT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    });
+    const interrupted = createDeferredCore<never>();
+    const provisionStarted = createDeferredCore();
+    const operationIds: string[] = [];
+    const destroy = vi.fn(async () => {});
+    const provider = support.createProvider({
+      provision: async (_profile, operationId) => {
+        operationIds.push(operationId);
+        if (operationIds.length === 1) {
+          provisionStarted.resolve();
+          await interrupted.promise;
+        }
+        return { leaseId: "lease-shutdown-replay", ssh: support.SSH_ENDPOINT, sharedHost: false };
+      },
+      destroy,
+    });
+    let placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+    const first = support.createService(provider);
+    let shuttingDown = false;
+    const dispatch = createRecoveryService(placements, first, () => shuttingDown);
+    const transitions: string[] = [];
+    const request = { ...REQUEST, executionMode: "remote-exec" as const };
+    const rejected = expect(
+      dispatch.dispatch(request, (placement) => transitions.push(placement.state)),
+    ).rejects.toThrow("provider interrupted");
+    await provisionStarted.promise;
+    const provisioning = placements.get(REQUEST.sessionId)!;
+    const environmentId = provisioning.environmentId!;
+    const operationId = support.testState.store.get(environmentId)!.provisionOperationId;
+    shuttingDown = true;
+    interrupted.reject(new Error("provider interrupted"));
+    await rejected;
+
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({
+      state: "provisioning",
+      terminalAtMs: null,
+      generation: provisioning.generation,
+      environmentId,
+    });
+    expect(support.testState.store.get(environmentId)).toMatchObject({
+      state: "provisioning",
+      destroyRequestedAtMs: null,
+      provisionOperationId: operationId,
+      lastError: expect.stringContaining("provider interrupted"),
+    });
+    expect(transitions).toEqual(["requested", "provisioning", "provisioning"]);
+    expect(destroy).not.toHaveBeenCalled();
+
+    await support.reopenWorkerEnvironmentStore();
+    placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+    const restarted = support.createService(provider);
+    const syncWorkspace = vi.fn(async () => ({
+      mode: "git" as const,
+      remoteWorkspaceDir: "/worker/workspace",
+      manifestRef: MANIFEST_REF,
+    }));
+    vi.spyOn(restarted, "startTunnel").mockImplementation(async (owner) => ({
+      ...owner,
+      syncWorkspace,
+      runWorkspaceCommand: vi.fn(),
+      quiesceWorkspace: vi.fn(),
+      reconcileWorkspace: vi.fn(),
+      stop: vi.fn(),
+    }));
+    const attach = vi.spyOn(restarted, "attachSession");
+    const recovery = createRecoveryService(placements, restarted);
+    const owner = placements.get(REQUEST.sessionId)!;
+    if (owner.state !== "provisioning") {
+      throw new Error("restart lost its provisioning owner");
+    }
+    await recovery.resumeProvisioning(owner, () => restarted.reconcileEnvironment(environmentId));
+
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({ state: "active", environmentId });
+    expect(support.testState.store.get(environmentId)).toMatchObject({
+      state: "attached",
+      provisionOperationId: operationId,
+      leaseId: "lease-shutdown-replay",
+      attachedSessionIds: [REQUEST.sessionId],
+    });
+    expect(operationIds).toEqual([operationId, operationId]);
+    expect(support.testState.store.list().map((record) => record.environmentId)).toEqual([
+      environmentId,
+    ]);
+    expect(attach).toHaveBeenCalledOnce();
+    expect(syncWorkspace).toHaveBeenCalledOnce();
+    expect(destroy).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    "retains admitted recovery with shutdown=%s and only rethrows shutdown interruptions",
+    async (shutdown) => {
+      const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+      const environments = support.createService(support.createProvider());
+      const intent = deriveEnvironmentIntent(`session-dispatch:${REQUEST.sessionId}:1`);
+      support.testState.store.createIntent({
+        ...intent,
+        providerId: "fake",
+        profileId: "development",
+        profileSnapshot: { settings: { region: "test" } },
+      });
+      const owner = seedProvisioningPlacement(placements, intent.environmentId, "remote-exec");
+      if (owner.state !== "provisioning") {
+        throw new Error("recovery fixture requires provisioning");
+      }
+      const dispatch = createRecoveryService(placements, environments, () => shutdown);
+      const interrupted = new Error(`recovery interrupted ${"x".repeat(2_000)}`);
+      const report = vi.fn();
+      const recordError = vi.spyOn(environments, "recordError");
+      const recovery = dispatch.resumeProvisioning(
+        owner,
+        async () => {
+          throw interrupted;
+        },
+        report,
+      );
+      if (shutdown) {
+        await expect(recovery).rejects.toBe(interrupted);
+        expect(recordError).toHaveBeenCalledOnce();
+        expect(report).toHaveBeenCalledTimes(2);
+        const lastError = support.testState.store.get(intent.environmentId)?.lastError;
+        expect(lastError).toMatch(/^recovery interrupted /);
+        expect(lastError?.length).toBeLessThanOrEqual(1_024);
+      } else {
+        await expect(recovery).resolves.toBeUndefined();
+        expect(recordError).not.toHaveBeenCalled();
+        expect(report).toHaveBeenCalledOnce();
+      }
+      expect(placements.get(REQUEST.sessionId)).toEqual(owner);
+      expect(support.testState.store.get(intent.environmentId)).toMatchObject({
+        state: "requested",
+        provisionOperationId: intent.provisionOperationId,
+        destroyRequestedAtMs: null,
+      });
+    },
+  );
+
+  it.each([
+    new WorkerPlacementAdmissionTargetError("session admission revoked"),
+    new WorkerDispatchTargetChangedError("session runtime changed"),
+  ])("tears down an invalid recovery owner during shutdown: %s", async (error) => {
+    const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+    const harness = createHarness(placements, {
+      isShuttingDown: () => true,
+      recoveryBarrierError: error,
+    });
+    const owner = harness.placements.seedProvisioning();
+    if (owner.state !== "provisioning") {
+      throw new Error("recovery fixture requires provisioning");
+    }
+    vi.mocked(harness.environments.get).mockReturnValue({
+      ...harness.ready,
+      state: "provisioning",
+      leaseId: null,
+      sshEndpoint: null,
+      bootstrapReceipt: null,
+      sharedHost: null,
+    });
+
+    await harness.service.resumeProvisioning(owner, async () => {});
+
+    expect(placements.get(REQUEST.sessionId)).toMatchObject({ state: "failed" });
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+    expect(harness.environments.recordError).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { shutdown: false, destroyRequested: false },
+    { shutdown: true, destroyRequested: true },
+  ])(
+    "tears down rejected provisioning with $shutdown shutdown and $destroyRequested destroy intent",
+    async ({ shutdown, destroyRequested }) => {
+      const provider = support.createProvider({
+        provision: async (_profile, operationId) => {
+          const environment = support.testState.store
+            .list()
+            .find((record) => record.provisionOperationId === operationId)!;
+          if (destroyRequested) {
+            support.testState.store.requestDestroy({
+              environmentId: environment.environmentId,
+              state: environment.state,
+            });
+          }
+          throw new Error("provider interrupted");
+        },
+      });
+      const environments = support.createService(provider);
+      const destroy = vi.spyOn(environments, "destroy");
+      const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+      const dispatch = createRecoveryService(placements, environments, () => shutdown);
+
+      await expect(dispatch.dispatch({ ...REQUEST, executionMode: "remote-exec" })).rejects.toThrow(
+        "provider interrupted",
+      );
+
+      expect(placements.get(REQUEST.sessionId)).toMatchObject({ state: "failed" });
+      expect(placements.get(REQUEST.sessionId)?.terminalAtMs).not.toBeNull();
+      expect(destroy).toHaveBeenCalledOnce();
+      expect(destroy).toHaveBeenCalledWith(
+        deriveEnvironmentIntent(`session-dispatch:${REQUEST.sessionId}:1`).environmentId,
+      );
+    },
+  );
+});

--- a/src/gateway/worker-environments/placement-dispatch-startup.ts
+++ b/src/gateway/worker-environments/placement-dispatch-startup.ts
@@ -1,6 +1,7 @@
 import type { DevicePlacementRequirement } from "../../agents/harness/types.js";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { NodeWorkerSupervisorNodeProof } from "../node-registry-private.js";
+import { WorkerDispatchTargetChangedError } from "../server-worker-placement-session-target.js";
 import { supportsWorkerExecutionContextLaunch } from "./admission.js";
 import { resolveDevicePlacementEligibility } from "./device-placement-eligibility.js";
 import { DEVICE_WORKER_PROVIDER_ID } from "./device-provider-identity.js";
@@ -93,7 +94,8 @@ function requireProvisionedEnvironment(
 
 export function createWorkerPlacementDispatchStartup(options: {
   placements: WorkerDispatchPlacementStore;
-  environments: WorkerDispatchEnvironmentService;
+  environments: WorkerDispatchEnvironmentService & Pick<WorkerEnvironmentService, "recordError">;
+  isShuttingDown?: () => boolean;
   failure: PlacementFailureActions;
   runRecoveryBarrier: WorkerPlacementRecoveryBarrier;
   runActivationBarrier: WorkerActivationBarrier;
@@ -107,6 +109,35 @@ export function createWorkerPlacementDispatchStartup(options: {
   ) => void;
 }) {
   const { environments, failure, placements } = options;
+
+  const retainInterruptedProvisioning = (
+    owned: WorkerDispatchPlacement,
+    error: unknown,
+  ): WorkerDispatchPlacement | undefined => {
+    const current = placements.get(owned.sessionId);
+    if (
+      error instanceof WorkerPlacementAdmissionTargetError ||
+      error instanceof WorkerDispatchTargetChangedError ||
+      !options.isShuttingDown?.() ||
+      current?.state !== "provisioning" ||
+      current.state !== owned.state ||
+      current.generation !== owned.generation ||
+      current.environmentId !== owned.environmentId ||
+      current.sessionKey !== owned.sessionKey ||
+      current.agentId !== owned.agentId ||
+      current.executionMode !== owned.executionMode
+    ) {
+      return undefined;
+    }
+    const environment = current.environmentId ? environments.get(current.environmentId) : undefined;
+    if (!environment || !isPendingProvisioningEnvironment(environment, current.environmentId)) {
+      return undefined;
+    }
+    // No await between owner validation and recording: shutdown retains this exact operation,
+    // while explicit Stop's durable destroy intent must always win.
+    environments.recordError(environment, error);
+    return current;
+  };
 
   const validateDevicePlacement = async (request: WorkerPlacementDispatchRequest) => {
     if (!request.deviceId) {
@@ -330,6 +361,7 @@ export function createWorkerPlacementDispatchStartup(options: {
   ): Promise<WorkerDispatchPlacement | undefined> => {
     const environmentId = placement.environmentId;
     let recoveryRunStarted = false;
+    let interruptedByShutdown = false;
     let result: WorkerDispatchPlacement | undefined;
     let recoveryOwnedPlacement: WorkerDispatchPlacement = placement;
     const report = (next: WorkerDispatchPlacement) => {
@@ -340,6 +372,12 @@ export function createWorkerPlacementDispatchStartup(options: {
     const handleRecoveryFailure = async (
       error: unknown,
     ): Promise<WorkerDispatchPlacement | undefined> => {
+      const retained = retainInterruptedProvisioning(recoveryOwnedPlacement, error);
+      if (retained) {
+        report(retained);
+        interruptedByShutdown = true;
+        throw error;
+      }
       const current = placements.get(placement.sessionId);
       if (
         !current ||
@@ -455,6 +493,9 @@ export function createWorkerPlacementDispatchStartup(options: {
           },
         });
       } catch (error) {
+        if (interruptedByShutdown) {
+          throw error;
+        }
         result = await handleRecoveryFailure(error);
       }
       return result;
@@ -464,12 +505,17 @@ export function createWorkerPlacementDispatchStartup(options: {
     } catch (error) {
       // A refused session owner still owes cleanup. Shutdown and queued cancellation
       // remain with their existing owners and must not destroy an adoptable allocation.
-      if (!(error instanceof WorkerPlacementAdmissionTargetError)) {
+      if (interruptedByShutdown || !(error instanceof WorkerPlacementAdmissionTargetError)) {
         throw error;
       }
       return await handleRecoveryFailure(error);
     }
   };
 
-  return { validateDevicePlacement, continueProvisionedDispatch, resumeProvisioning };
+  return {
+    validateDevicePlacement,
+    continueProvisionedDispatch,
+    retainInterruptedProvisioning,
+    resumeProvisioning,
+  };
 }

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -19,6 +19,7 @@ import {
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { createWorkerPlacementRunnerAvailabilityReader } from "./placement-projector.js";
 import { completeReclaimedWorkspaceTeardown } from "./placement-teardown.js";
+import type { WorkerEnvironmentService } from "./service.js";
 import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type { WorkerTunnelHandle } from "./tunnel.js";
 import type { WorkerWorkspaceRecoveryFailureReport } from "./workspace-conflicts.js";
@@ -65,6 +66,7 @@ export function createHarness(
     failMoveAfterBegin?: boolean;
     runMoveBarrier?: Parameters<typeof createWorkerPlacementDispatchService>[0]["runMoveBarrier"];
     recoveryBarrierError?: Error;
+    isShuttingDown?: () => boolean;
     prepareAcceptedWorkspacePublication?: Parameters<
       typeof createWorkerPlacementDispatchService
     >[0]["prepareAcceptedWorkspacePublication"];
@@ -338,7 +340,9 @@ export function createHarness(
     ownerEpoch: 2,
     expiresAtMs: 10_000,
   };
-  const environments: WorkerDispatchEnvironmentService = {
+  const environments: WorkerDispatchEnvironmentService &
+    Pick<WorkerEnvironmentService, "recordError"> = {
+    recordError: vi.fn((record) => record),
     supportsProviderExecutionMode: vi.fn(() => true),
     create: vi.fn(async () => {
       fail("create");
@@ -395,6 +399,7 @@ export function createHarness(
   const service = createWorkerPlacementDispatchService({
     placements,
     environments,
+    isShuttingDown: options.isShuttingDown,
     runReclaimPreparation:
       options.runReclaimPreparation ?? (async ({ run, authorize }) => await run(authorize)),
     runnerAvailability: createWorkerPlacementRunnerAvailabilityReader({
@@ -566,3 +571,27 @@ export function createHarness(
     attached,
   };
 }
+
+export const createRecoveryService = (
+  placements: PlacementStore,
+  environments: WorkerEnvironmentService,
+  isShuttingDown: () => boolean = () => false,
+) =>
+  createWorkerPlacementDispatchService({
+    placements,
+    environments,
+    isShuttingDown,
+    runnerAvailability: { read: () => undefined, version: () => 0 },
+    workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+    runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+    runRecoveryBarrier: async ({ run }) => await run("/gateway/workspace"),
+    runActivationBarrier: async ({ activate }) => activate(),
+    runMoveBarrier: async ({ begin }) => begin(),
+    resolveMoveDestination: async () => undefined,
+    runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
+    runReclaimBarrier: async ({ begin, reclaim }) => await reclaim("/gateway/workspace", begin()),
+    runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
+    resolveWorkspacePath: async () => "/gateway/workspace",
+    reportWorkspaceResultConflict: async () => {},
+    resolveWorkspaceResultConflict: async () => undefined,
+  });

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -80,7 +80,9 @@ type WorkerLocalDispatchBarrier = (params: {
 type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
   placements: WorkerDispatchPlacementStore;
   environments: WorkerDispatchEnvironmentService &
+    Pick<WorkerEnvironmentService, "recordError"> &
     Partial<Pick<WorkerEnvironmentService, "requiresNodeEnrollment">>;
+  isShuttingDown?: () => boolean;
   runnerAvailability: WorkerPlacementRunnerAvailabilityReader;
   runLocalBarrier: WorkerLocalDispatchBarrier;
   runRecoveryBarrier: WorkerPlacementRecoveryBarrier;
@@ -127,15 +129,8 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
   const failure = createPlacementFailureActions({ environments, placements });
 
   const startup = createWorkerPlacementDispatchStartup({
-    placements,
-    environments,
+    ...options,
     failure,
-    runRecoveryBarrier: options.runRecoveryBarrier,
-    runActivationBarrier: options.runActivationBarrier,
-    onActivated: options.onActivated,
-    resolveGitAuthor: options.resolveGitAuthor,
-    resolveDevicePlacementRequirement: options.resolveDevicePlacementRequirement,
-    isCurrentNodePlacement: options.isCurrentNodePlacement,
     reportTransition: reportPlacementTransition,
   });
 
@@ -260,6 +255,9 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
       });
     } catch (error) {
       try {
+        if (placement && startup.retainInterruptedProvisioning(placement, error)) {
+          throw error;
+        }
         const current = placement ? placements.get(request.sessionId) : undefined;
         if (current && current.state !== "local" && current.state !== "reclaimed") {
           if (current.state === "active") {

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -588,6 +588,8 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   };
 
   const service = {
+    isStopping: () => stopping,
+    recordError: saveError,
     list: environmentAccess.list,
     supportsProviderExecutionMode: providerSupportsExecutionMode,
     supportsExecutionMode: (profileId: string, mode: WorkerExecutionMode) => {

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -12,7 +12,6 @@ import { recoverStuckDiagnosticSession } from "../../logging/diagnostic-stuck-se
 import type { SpawnResult } from "../../process/exec.js";
 import { WORKER_PROVIDER_REPLAY_LOCAL_RETRY_MESSAGE } from "../../worker/transcript-message.js";
 import { STALE_WORKER_BUILD_REASON, StaleWorkerBuildError } from "./admission.js";
-import type { WorkerDispatchEnvironmentService } from "./placement-dispatch-failure.js";
 import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
 import { placementTurnOwner } from "./placement-record.js";
 import {
@@ -411,8 +410,12 @@ describe("worker turn launcher failure recovery", () => {
         error: STALE_WORKER_BUILD_REASON,
       };
     });
-    const environments: WorkerTurnEnvironmentService & WorkerDispatchEnvironmentService = {
+    const environments: WorkerTurnEnvironmentService &
+      Parameters<typeof createWorkerPlacementDispatchService>[0]["environments"] = {
       ...unusedEnvironments(),
+      recordError: vi.fn(() => {
+        throw new Error("unexpected provisioning interruption");
+      }),
       supportsProviderExecutionMode: vi.fn(() => true),
       get: vi.fn(() => environment),
       acquireTurnCredential: vi.fn(async () => credential()),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway restart during cloud worker provisioning could mark the session placement failed and request teardown, preventing startup from resuming its already recorded provider operation.

## Why This Change Was Made

### Root cause

The fresh-dispatch catch in `src/gateway/worker-environments/placement-dispatch.ts:261` on the base revision always tore down pending provisioning. Recovery already retained an admitted pending operation, so graceful interruption could terminalize work that an abrupt process exit left replayable.

### Change

Fresh dispatch and recovery share one synchronous retention decision. It checks the exact provisioning placement tuple, the matching pending environment, null destroy intent, and a live injected shutdown predicate. It records the bounded interruption through the existing environment error path, reports the unchanged placement, and rethrows the interruption.

The Gateway wiring combines sidecar shutdown, the environment service's stopping state, and the current process drain signal. Shutdown is visible before enrollment cancellation, and runtime reset reads the replacement drain controller.

## Invariants Preserved

- Explicit Stop and recorded destroy intent still win and tear down the environment.
- Typed session-authority rejection still fails; shutdown is never inferred from provider error text or the reversible restart-signal fence.
- Existing `recoveryRunStarted && pending` retention remains unchanged, including the direct service-stop replay contract in `provider-provisioning.shutdown-replay.test.ts`.
- Provider operation/environment identities, operation draining, schemas, configuration, retries, timeouts, and provider plugin behavior are unchanged.

## User Impact

An interrupted pending allocation remains in `provisioning` with no terminal timestamp. Startup can adopt the same provider operation and environment, synchronize the workspace, and activate the placement without starting a replacement operation.

## Evidence

The new fresh-dispatch regression failed against the original catch: expected `provisioning` with a null terminal timestamp, received `failed` with a terminal timestamp. It now passes through reopening the SQLite database and activating the same operation, with one attachment and workspace synchronization.

```text
node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch src/gateway/worker-environments/provider-provisioning
 Test Files  5 passed (5)
      Tests  117 passed (117)

node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch*.test.ts src/gateway/worker-environments/provider-provisioning*.test.ts src/gateway/server-worker-placement-startup.test.ts src/gateway/server-worker-placement-provision-cancellation.test.ts src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
 Test Files  18 passed (18)
      Tests  379 passed (379)

autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct (0.87)
```

The explicit file list covers the hyphenated suites omitted by the wrapper's stem selection. The final run includes corrected fixtures and the startup wiring. Validation caught fixture type mismatches and a line-budget violation; the fixtures were corrected and redundant option forwarding was removed without weakening checks.

`node scripts/check-changed.mjs` passed with exit code 0, including core/test types, lint, full export scans, storage guards, and runtime import cycles. Main then added retirement tests at the same insertion point. The conflict resolution preserved both groups, moved the shutdown cases to `placement-dispatch-shutdown.test.ts`, and shared the existing recovery harness. All four production files are byte-identical to the fully checked version; after rebasing, all 379 related tests, targeted Gateway test typechecking, and lint passed. The full changed gate was run before this test-only conflict resolution.

Fresh Codex autoreview found no actionable P0–P2 findings. Provider behavior was exercised with a synthetic provider and real SQLite state; no live cloud allocation was needed.

## Docs

Updated the replay and restart paragraphs in `docs/gateway/cloud-workers.md` to explain same-operation resumption and explicit Stop destruction. The general restart-recovery overview remains accurate. No changelog edit.
