### PR TITLE
fix(channels): restore native subagent progress and pause inactive cards

### DIFF
--- a/docs/concepts/progress-drafts.md
+++ b/docs/concepts/progress-drafts.md
@@ -172,6 +172,12 @@ which keeps the draft quiet: the headline, enabled commentary and reasoning,
 plan milestones, and any approval request or failed command still appear. Set
 it to `true` for the full rolling tool log.
 
+Native subagent spawn and activity events follow the same policy. They start
+the quiet work indicator; with the tool log enabled, lifecycle updates reuse a
+row for each worker. Messages to workers get separate entries because sending a
+message does not prove that a worker started running. Delegation prompts are not
+included in these progress rows.
+
 Tools can also emit typed progress while a single call is still running. That
 is how a slow fetch or search updates the visible draft before the tool
 returns its final result. The progress update is a partial tool result with

--- a/docs/tools/progress-card.md
+++ b/docs/tools/progress-card.md
@@ -95,6 +95,8 @@ Transient refresh failures retain the last loaded card. The dashboard widget sho
 
 The composer and dashboard placements show the local time of the last progress update. The hovercard instead shows the current-or-next plan step and its completed/total count, followed by Markdown in a separate Agent Notepad when a note is present.
 
+Without a matching terminal outcome, unfinished steps appear paused when the Gateway reports no active run or the card predates a later run. The last-update time shows when the agent last revised the card; elapsed time alone does not expire a card belonging to an active run.
+
 ## Gateway requests
 
 `progressCard.get` and `progressCard.put` accept a required `sessionKey` and optional `agentId`. Pass both when selecting an agent explicitly, for example `{ "sessionKey": "global", "agentId": "research" }`. Omitting `agentId` retains the Gateway's existing session-owner resolution. An unknown agent or an agent that conflicts with the session owner is rejected.

--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -367,23 +367,52 @@ export class CodexEventProjection {
     if (!item) {
       return;
     }
-    const kind = itemKind(item);
+    const activity = item.type === "subAgentActivity";
+    // Activity notifications complete immediately, even when they announce a worker starting.
+    if (activity && params.phase === "start") {
+      return;
+    }
+    const subagent = activity || item.type === "collabAgentToolCall";
+    const kind = subagent ? "tool" : itemKind(item);
     if (!kind) {
       return;
     }
-    const name = itemName(item);
+    const name = subagent ? "subagents" : itemName(item);
     const args = itemToolArgs(item);
     const commandBearing = isCommandBearingToolItem(item, args);
-    const meta = itemMeta(item, this.toolProgress.toolProgressDetailMode());
+    const subagentStatus = readString(item, activity ? "kind" : "status");
+    // Messaging can queue without starting a turn; it does not own the worker's live row.
+    const interaction = activity && subagentStatus === "interacted";
+    const status =
+      subagent && subagentStatus === "interrupted"
+        ? "failed"
+        : activity
+          ? subagentStatus === "completed" || interaction
+            ? "completed"
+            : "running"
+          : params.phase === "start"
+            ? "running"
+            : itemStatus(item);
+    const meta = subagent
+      ? [
+          interaction ? "message sent" : activity ? subagentStatus : status,
+          readString(item, activity ? "agentPath" : "tool"),
+        ]
+          .filter(Boolean)
+          .join(": ")
+      : itemMeta(item, this.toolProgress.toolProgressDetailMode());
     const suppressChannelProgress = shouldSuppressChannelProgressForItem(item);
     this.emitAgentEvent({
       stream: "item",
       data: {
-        itemId: item.id,
+        itemId:
+          activity && !interaction
+            ? `subagent:${readString(item, "agentThreadId") ?? item.id}`
+            : item.id,
         phase: params.phase,
         kind,
         title: itemTitle(item),
-        status: params.phase === "start" ? "running" : itemStatus(item),
+        status,
         ...(name ? { name } : {}),
         ...(meta ? { meta } : {}),
         ...(commandBearing ? { commandBearing: true } : {}),

--- a/extensions/codex/src/app-server/event-projector.subagent-progress.test.ts
+++ b/extensions/codex/src/app-server/event-projector.subagent-progress.test.ts
@@ -1,0 +1,100 @@
+import { createChannelProgressDraftCompositor } from "openclaw/plugin-sdk/channel-outbound";
+import {
+  createParams,
+  createProjector,
+  expect,
+  forCurrentTurn,
+  it,
+  registerCodexEventProjectorTestLifecycle,
+  vi,
+} from "./event-projector.test-harness.js";
+
+registerCodexEventProjectorTestLifecycle();
+
+it.each([false, true])(
+  "projects native subagent activity under toolProgress=%s",
+  async (toolProgress) => {
+    const update = vi.fn((_text: string) => true);
+    const progress = createChannelProgressDraftCompositor({
+      active: true,
+      mode: "progress",
+      entry: { streaming: { mode: "progress", progress: { toolProgress } } },
+      seed: "subagent-progress",
+      update,
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const projector = await createProjector({
+      ...(await createParams()),
+      onAgentEvent: async (event) => {
+        if (event.stream === "item") {
+          events.push(event.data);
+          await progress.pushItemEvent(event.data);
+        }
+      },
+    });
+    try {
+      for (const kind of ["started", "interrupted", "completed", "interacted"]) {
+        const item = {
+          id: `activity-${kind}`,
+          type: "subAgentActivity",
+          kind,
+          agentThreadId: "child-thread",
+          agentPath: "/root/research",
+        };
+        await projector.handleNotification(forCurrentTurn("item/started", { item }));
+        await projector.handleNotification(forCurrentTurn("item/completed", { item }));
+        await progress.start();
+        const latest = events.at(-1);
+        expect(latest).toMatchObject({
+          status: kind === "interrupted" ? "failed" : kind === "started" ? "running" : "completed",
+        });
+        expect(progress.getSnapshot().lines).toHaveLength(
+          toolProgress ? (kind === "interacted" ? 2 : 1) : kind === "interrupted" ? 1 : 0,
+        );
+        expect(update.mock.lastCall?.[0]).toContain("Working");
+        if (toolProgress) {
+          expect(update.mock.lastCall?.[0]).toContain("research");
+          expect(update.mock.lastCall?.[0]).toContain(
+            kind === "interacted" ? "message sent" : kind,
+          );
+        }
+      }
+      expect(new Set(events.slice(0, -1).map((event) => event.itemId)).size).toBe(1);
+      expect(events.at(-1)?.itemId).not.toBe(events[0]?.itemId);
+    } finally {
+      progress.cancel();
+    }
+  },
+);
+
+it("projects native collaboration calls without exposing their prompts", async () => {
+  const onAgentEvent = vi.fn();
+  const projector = await createProjector({ ...(await createParams()), onAgentEvent });
+  const item = {
+    id: "spawn-1",
+    type: "collabAgentToolCall",
+    tool: "spawnAgent",
+    status: "inProgress",
+    senderThreadId: "thread-1",
+    receiverThreadIds: ["child-thread"],
+    prompt: "Private delegation instructions",
+    agentsStates: {},
+  };
+  await projector.handleNotification(forCurrentTurn("item/started", { item }));
+  expect(onAgentEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      stream: "item",
+      data: expect.objectContaining({ status: "running", name: "subagents" }),
+    }),
+  );
+  await projector.handleNotification(
+    forCurrentTurn("item/completed", { item: { ...item, status: "failed" } }),
+  );
+  expect(onAgentEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      stream: "item",
+      data: expect.objectContaining({ status: "failed", name: "subagents" }),
+    }),
+  );
+  expect(JSON.stringify(onAgentEvent.mock.calls)).not.toContain(item.prompt);
+});

--- a/extensions/discord/src/monitor/message-handler.process-progress.ts
+++ b/extensions/discord/src/monitor/message-handler.process-progress.ts
@@ -11,19 +11,6 @@ type CallbackPayload<K extends keyof ReplyOptions> =
   NonNullable<ReplyOptions[K]> extends (...args: infer Args) => unknown ? Args[0] : never;
 type DraftPreview = ReturnType<typeof createDiscordDraftPreviewController>;
 
-function isFailedProgress(payload: {
-  phase?: string;
-  status?: string;
-  exitCode?: number | null;
-}): boolean {
-  return (
-    payload.phase === "error" ||
-    payload.status === "failed" ||
-    payload.status === "error" ||
-    (typeof payload.exitCode === "number" && payload.exitCode !== 0)
-  );
-}
-
 export function createDiscordMessageProgressRuntime(params: {
   ctx: DiscordMessagePreflightContext;
   sessionKey?: string;
@@ -152,9 +139,6 @@ export function createDiscordMessageProgressRuntime(params: {
       return await draftPreview.pushToolEvent(payload);
     },
     onItemEvent: async (payload) => {
-      if (isFailedProgress(payload)) {
-        return false;
-      }
       if (payload.kind === "preamble") {
         if (shouldYieldDraftCommentary()) {
           return undefined;
@@ -175,9 +159,6 @@ export function createDiscordMessageProgressRuntime(params: {
       return await draftPreview.pushApprovalEvent(payload);
     },
     onCommandOutput: async (payload) => {
-      if (isFailedProgress(payload)) {
-        return false;
-      }
       return await draftPreview.pushCommandOutputEvent(payload);
     },
     onPatchSummary: async (payload) => {

--- a/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-final.test.ts
@@ -469,62 +469,68 @@ describe("processDiscordMessage draft streaming final delivery", () => {
     expect(replyOptions?.narrationHideCommandText).toBe(true);
   });
 
-  it("declines failed item progress without updating the Discord draft", async () => {
-    const draftStream = createMockDraftStreamForTest();
-    let callbackResult: boolean | void = undefined;
+  it.each([false, true])(
+    "shows failed item progress with toolProgress=%s",
+    async (toolProgress) => {
+      const draftStream = createMockDraftStreamForTest();
+      let callbackResult: boolean | void = undefined;
 
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      callbackResult = await params?.replyOptions?.onItemEvent?.({
-        itemId: "tool-1",
-        kind: "tool",
-        name: "exec",
-        phase: "end",
-        status: "failed",
-        progressText: "exec failed",
+      dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+        callbackResult = await params?.replyOptions?.onItemEvent?.({
+          itemId: "tool-1",
+          kind: "tool",
+          name: "exec",
+          phase: "end",
+          status: "failed",
+          progressText: "exec failed",
+        });
+        return createNoQueuedDispatchResult();
       });
-      return createNoQueuedDispatchResult();
-    });
 
-    const ctx = await createAutomaticDraftContext({
-      discordConfig: {
-        streaming: { mode: "progress", progress: { toolProgress: true } },
-        maxLinesPerMessage: 5,
-      },
-    });
-
-    await runProcessDiscordMessage(ctx);
-
-    expect(callbackResult).toBe(false);
-    expect(draftStream.update).not.toHaveBeenCalled();
-  });
-
-  it("declines failed command output without updating the Discord draft", async () => {
-    const draftStream = createMockDraftStreamForTest();
-    let callbackResult: false | void = undefined;
-
-    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
-      callbackResult = await params?.replyOptions?.onCommandOutput?.({
-        phase: "error",
-        title: "Exec",
-        name: "exec",
-        status: "error",
-        exitCode: 1,
+      const ctx = await createAutomaticDraftContext({
+        discordConfig: {
+          streaming: { mode: "progress", progress: { toolProgress } },
+          maxLinesPerMessage: 5,
+        },
       });
-      return createNoQueuedDispatchResult();
-    });
 
-    const ctx = await createAutomaticDraftContext({
-      discordConfig: {
-        streaming: { mode: "progress", progress: { toolProgress: true } },
-        maxLinesPerMessage: 5,
-      },
-    });
+      await runProcessDiscordMessage(ctx);
 
-    await runProcessDiscordMessage(ctx);
+      expect(callbackResult).toBe(true);
+      expect(draftStream.update).toHaveBeenCalledWith(expect.stringContaining("failed"));
+    },
+  );
 
-    expect(callbackResult).toBe(false);
-    expect(draftStream.update).not.toHaveBeenCalled();
-  });
+  it.each([false, true])(
+    "shows failed command output with toolProgress=%s",
+    async (toolProgress) => {
+      const draftStream = createMockDraftStreamForTest();
+      let callbackResult: boolean | void = undefined;
+
+      dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+        callbackResult = await params?.replyOptions?.onCommandOutput?.({
+          phase: "end",
+          title: "Exec",
+          name: "exec",
+          status: "error",
+          exitCode: 1,
+        });
+        return createNoQueuedDispatchResult();
+      });
+
+      const ctx = await createAutomaticDraftContext({
+        discordConfig: {
+          streaming: { mode: "progress", progress: { toolProgress } },
+          maxLinesPerMessage: 5,
+        },
+      });
+
+      await runProcessDiscordMessage(ctx);
+
+      expect(callbackResult).toBe(true);
+      expect(draftStream.update).toHaveBeenCalledWith(expect.stringContaining("exit 1"));
+    },
+  );
 
   it("suppresses terminal progress callbacks without their terminal phase", async () => {
     const draftStream = createMockDraftStreamForTest();

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -4,12 +4,10 @@ import {
   createChannelProgressWorkCounter,
   createDraftStreamLoop,
   formatChannelProgressDraftText,
-  isChannelProgressDraftWorkToolName,
   resolveChannelProgressDraftMaxLineChars,
   resolveChannelStreamingPreviewToolProgress,
   resolveChannelStreamingSuppressDefaultToolProgressMessages,
   type ChannelProgressDraftCompositorSnapshot,
-  type ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { ReplyDispatchKind, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -495,29 +493,6 @@ export function createSlackProgressRuntime(runtimeParams: {
     return false;
   };
 
-  const pushPreviewProgress = async (
-    line?: ChannelProgressDraftLine,
-    options?: { toolName?: string },
-  ) => {
-    if (!draftStream && !useNativeProgressStreaming) {
-      return false;
-    }
-    if (options?.toolName !== undefined && !isChannelProgressDraftWorkToolName(options.toolName)) {
-      return false;
-    }
-    const normalized = line?.text.replace(/\s+/g, " ").trim();
-    if (isProgressMode) {
-      if (!line || !normalized) {
-        return await progressDraft.noteActivity();
-      }
-      return await progressDraft.pushToolProgress(line, options);
-    }
-    if (!line || !normalized || !draftStream || !previewToolProgressEnabled) {
-      return false;
-    }
-    return await progressDraft.pushToolProgress(line, options);
-  };
-
   const updateDraftFromPartial = (text?: string) => {
     const trimmed = text && sanitizeAssistantVisibleText(text).trimEnd();
     if (!trimmed) {
@@ -569,7 +544,7 @@ export function createSlackProgressRuntime(runtimeParams: {
       if (!normalized) {
         return false;
       }
-      const visible = await pushPreviewProgress({
+      const visible = await progressDraft.pushToolProgress({
         id: "reasoning",
         kind: "item",
         text: normalized,

--- a/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts
@@ -414,13 +414,14 @@ function progressConfig(
   channel: "discord" | "slack",
   native: boolean,
   toolProgress: boolean,
+  compact = false,
 ): OpenClawConfig {
   const streaming = {
     mode: "progress" as const,
     progress: {
       label: HEADLINE,
       toolProgress,
-      ...(channel === "slack" ? { style: "card" as const } : {}),
+      ...(channel === "slack" ? { style: compact ? ("compact" as const) : ("card" as const) } : {}),
     },
   };
   return {
@@ -1283,9 +1284,41 @@ describe("channel progress presentation through an isolated Gateway", () => {
     { channel: "slack" as const, native: true, thread: "root", rejectStop: true, tools: true },
     { channel: "slack" as const, native: false, thread: "reply", rejectStop: false, tools: true },
     { channel: "slack" as const, native: false, thread: "current", rejectStop: false, tools: true },
+    {
+      channel: "slack" as const,
+      native: false,
+      thread: "root",
+      rejectStop: false,
+      tools: false,
+      compact: true,
+    },
+    {
+      channel: "slack" as const,
+      native: false,
+      thread: "root",
+      rejectStop: false,
+      tools: true,
+      compact: true,
+    },
+    {
+      channel: "discord" as const,
+      native: false,
+      thread: "root",
+      rejectStop: false,
+      tools: false,
+      failTool: true,
+    },
+    {
+      channel: "discord" as const,
+      native: false,
+      thread: "root",
+      rejectStop: false,
+      tools: true,
+      failTool: true,
+    },
   ])(
-    "renders $channel progress (native=$native, thread=$thread, rejectStop=$rejectStop, toolProgress=$tools)",
-    async ({ channel, native, thread, rejectStop, tools }) => {
+    "renders $channel progress (native=$native, thread=$thread, rejectStop=$rejectStop, toolProgress=$tools, compact=$compact, failTool=$failTool)",
+    async ({ channel, native, thread, rejectStop, tools, compact = false, failTool = false }) => {
       const directory = await fs.mkdtemp(
         path.join(await fs.realpath(os.tmpdir()), "channel-progress-"),
       );
@@ -1308,7 +1341,16 @@ describe("channel progress presentation through an isolated Gateway", () => {
       const provider = await startQaMockOpenAiServer({ modelRefs: [MODEL] });
       cleanups.push(() => provider.stop());
       const owner = createQaGatewayChild();
-      cleanups.push(() => stopQaGatewayFixture(owner));
+      cleanups.push(() =>
+        stopQaGatewayFixture(owner, {
+          preserveToDir: path.join(
+            process.cwd(),
+            ".artifacts",
+            "channel-progress-presentation",
+            path.basename(directory),
+          ),
+        }),
+      );
       const environment = adapter.createProviderReadinessEnv({});
       if (channel === "slack") {
         environment.SLACK_API_URL = `${api.baseUrl}/api/`;
@@ -1337,7 +1379,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
         },
         runtimeEnvPatch: environment,
         mutateConfig: (config) => {
-          const configured = progressConfig(config, channel, native, tools);
+          const configured = progressConfig(config, channel, native, tools, compact);
           if (channel === "discord") {
             configured.channels!.discord!.proxy = api.proxyUrl;
             const qa = configured.agents!.entries!.qa!;
@@ -1416,7 +1458,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
       }
       const finalText = `${thread === "current" ? "[[reply_to_current]] " : ""}${FINAL_MARKER}`;
       const injected = await injectProviderMessage(
-        `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`sleep 3\`. After that command completes, reply exactly \`${finalText}\`.`,
+        `Tool progress QA check: call the exec tool exactly once with this exact command before answering: \`${failTool ? "sleep 3; exit 1" : "sleep 3"}\`. After that command completes or fails, reply exactly \`${finalText}\`.`,
         threadId,
       );
       if (adapter.manifest.provider === "slack") {
@@ -1467,7 +1509,9 @@ describe("channel progress presentation through an isolated Gateway", () => {
               )
             : native
               ? writes.some((write) => write.route.endsWith("chat.stopStream"))
-              : writes.some((write) => write.route.endsWith("chat.update")),
+              : writes.some((write) =>
+                  write.route.endsWith(compact ? "chat.delete" : "chat.update"),
+                ),
         "progress finalization",
       );
 
@@ -1498,6 +1542,9 @@ describe("channel progress presentation through an isolated Gateway", () => {
       } else {
         expect(progressText).not.toMatch(toolRow);
       }
+      if (failTool) {
+        expect(progressText).toContain("exit 1");
+      }
       const reactionAdds = writes.filter((write) =>
         channel === "discord"
           ? write.method === "PUT" && write.route.includes("/reactions/")
@@ -1512,7 +1559,7 @@ describe("channel progress presentation through an isolated Gateway", () => {
       );
       expect([...reactionNames]).toEqual([channel === "discord" ? "👀" : "eyes"]);
       const evidenceDir = path.join(process.cwd(), ".artifacts", "channel-progress-presentation");
-      const evidenceName = `${channel}-${native ? "native" : "draft"}-${thread}${rejectStop ? "-stop-failure" : ""}${tools ? "" : "-quiet"}`;
+      const evidenceName = `${channel}-${native ? "native" : "draft"}-${thread}${rejectStop ? "-stop-failure" : ""}${tools ? "" : "-quiet"}${compact ? "-compact" : ""}${failTool ? "-failed-tool" : ""}`;
       await fs.mkdir(evidenceDir, { recursive: true });
       await fs.writeFile(
         path.join(evidenceDir, `${evidenceName}-diagnostic.json`),

--- a/ui/src/components/app-sidebar-session-catalogs.test.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.test.ts
@@ -86,28 +86,32 @@ describe("findCatalogSessionHovercardRow", () => {
     };
 
     const colorInput = { catalogs: [catalog], sessionKey: "catalog:codex:gateway%3Acodex:colored" };
-    expect(findCatalogSessionHovercardRow(colorInput)?.color).toBe("cyan");
+    expect(findCatalogSessionHovercardRow(colorInput)).toMatchObject({
+      color: "cyan",
+      hasActiveRun: false,
+    });
     // An adopted session's cleared color must not fall back to stale CLI metadata.
     expect(
       findCatalogSessionHovercardRow({
         ...colorInput,
-        liveRow: { label: "Project", hasAutomation: false },
+        liveRow: { label: "Project", hasAutomation: false, hasActiveRun: false },
       })?.color,
     ).toBeUndefined();
     expect(
       findCatalogSessionHovercardRow({
         ...colorInput,
-        liveRow: { label: "Project", color: "red", hasAutomation: false },
+        liveRow: { label: "Project", color: "red", hasAutomation: false, hasActiveRun: false },
       })?.color,
     ).toBe("red");
     expect(
       findCatalogSessionHovercardRow({
         catalogs: [catalog],
         sessionKey: "agent:main:adopted-project",
-        liveRow: { label: "Operator chosen label", hasAutomation: false },
+        liveRow: { label: "Operator chosen label", hasAutomation: false, hasActiveRun: true },
       }),
     ).toMatchObject({
       label: "Operator chosen label",
+      hasActiveRun: true,
       workContext: {
         kind: "project",
         name: "openclaw",

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -65,6 +65,7 @@ export function findCatalogSessionHovercardRow(params: {
         // itself prove repository identity; only projected Git facts do that.
         return {
           ...params.liveRow,
+          hasActiveRun: params.liveRow?.hasActiveRun === true,
           hasAutomation: params.liveRow?.hasAutomation === true,
           label: params.liveRow?.label ?? (session.name || session.threadId),
           // Once adopted, even an unset live color overrides stale catalog metadata.

--- a/ui/src/components/app-sidebar-session-types.ts
+++ b/ui/src/components/app-sidebar-session-types.ts
@@ -150,6 +150,7 @@ export type SidebarSessionHovercardRow = Pick<
   | "color"
   | "endedAt"
   | "hasAutomation"
+  | "hasActiveRun"
   | "label"
   | "lastMessagePreview"
   | "expandedParticipants"

--- a/ui/src/components/session-hovercard.test.ts
+++ b/ui/src/components/session-hovercard.test.ts
@@ -11,6 +11,7 @@ function row(overrides: Partial<SidebarRecentSession> = {}): SidebarRecentSessio
   return {
     key: "agent:main:work",
     label: "Ship the release",
+    hasActiveRun: true,
     createdAt: Date.now() - 2 * 60 * 60_000,
     startedAt: Date.now() - 2 * 60 * 60_000,
     updatedAt: Date.now() - 5 * 60_000,
@@ -398,13 +399,16 @@ describe("renderSessionHovercard", () => {
     expect(container.textContent).not.toContain("This must not appear.");
   });
 
-  it("presents an older progress card as paused during a later run", () => {
+  it.each([
+    { hasActiveRun: true, updateOffset: -1 },
+    { hasActiveRun: false, updateOffset: 1 },
+  ])("pauses unfinished progress with run state %j", ({ hasActiveRun, updateOffset }) => {
     const container = document.createElement("div");
     const startedAt = Date.now();
     render(
       renderSessionHovercard({
-        row: row({ startedAt, status: "running" }),
-        progressCard: { ...progressCard(), updatedAt: startedAt - 1 },
+        row: row({ startedAt, status: "running", hasActiveRun }),
+        progressCard: { ...progressCard(), updatedAt: startedAt + updateOffset },
       }),
       container,
     );

--- a/ui/src/components/session-hovercard.ts
+++ b/ui/src/components/session-hovercard.ts
@@ -412,12 +412,7 @@ function renderHeader(input: SessionHovercardInput) {
   </header>`;
 }
 
-function renderProgressHeadsUp(
-  card: ProgressCard | null | undefined,
-  sessionStatus: SidebarSessionHovercardRow["status"],
-  startedAt: SidebarSessionHovercardRow["startedAt"],
-) {
-  const headsUp = progressCardHeadsUp(card, sessionStatus, startedAt);
+function renderProgressHeadsUp(headsUp: ReturnType<typeof progressCardHeadsUp>) {
   if (!headsUp) {
     return nothing;
   }
@@ -450,7 +445,10 @@ function renderProgressHeadsUp(
   </div>`;
 }
 
-function renderSessionContext({ row, progressCard }: SessionHovercardInput) {
+function renderSessionContext(
+  { row }: SessionHovercardInput,
+  headsUp: ReturnType<typeof progressCardHeadsUp>,
+) {
   const context = row?.workContext;
   const placementIdentity =
     row?.placementProviderId && row.placementProfileId
@@ -462,15 +460,6 @@ function renderSessionContext({ row, progressCard }: SessionHovercardInput) {
           }),
         }
       : undefined;
-  if (
-    !context &&
-    !placementIdentity &&
-    row?.boardFace !== "dashboard" &&
-    row?.hasAutomation !== true &&
-    !progressCardHeadsUp(progressCard, row?.status, row?.startedAt)
-  ) {
-    return nothing;
-  }
   return html`<div class="session-hovercard__context">
     ${
       context
@@ -538,7 +527,7 @@ function renderSessionContext({ row, progressCard }: SessionHovercardInput) {
           </div>`
         : nothing
     }
-    ${renderProgressHeadsUp(progressCard, row?.status, row?.startedAt)}
+    ${renderProgressHeadsUp(headsUp)}
   </div>`;
 }
 
@@ -634,6 +623,12 @@ function renderPullRequestDetails(snapshot: ControlUiSessionPullRequestSnapshot 
 }
 
 export function renderSessionHovercard(input: SessionHovercardInput) {
+  const headsUp = progressCardHeadsUp(
+    input.progressCard,
+    input.row?.status,
+    input.row?.startedAt,
+    input.row?.hasActiveRun ?? false,
+  );
   const hasPullRequestDetails = Boolean(
     input.pullRequests && (input.pullRequests.pullRequests.length > 0 || input.pullRequests.branch),
   );
@@ -642,7 +637,7 @@ export function renderSessionHovercard(input: SessionHovercardInput) {
     (input.row?.placementProviderId && input.row.placementProfileId) ||
     input.row?.boardFace === "dashboard" ||
     input.row?.hasAutomation === true ||
-    progressCardHeadsUp(input.progressCard, input.row?.status, input.row?.startedAt),
+    headsUp,
   );
   const lastMessagePreview = input.progressCard
     ? undefined
@@ -661,7 +656,7 @@ export function renderSessionHovercard(input: SessionHovercardInput) {
     ${
       hasContext
         ? html`<section class="session-hovercard__section session-hovercard__section--metadata">
-            ${renderSessionContext(input)}
+            ${renderSessionContext(input, headsUp)}
           </section>`
         : nothing
     }

--- a/ui/src/components/session-progress-card.ts
+++ b/ui/src/components/session-progress-card.ts
@@ -184,6 +184,7 @@ export function progressCardHeadsUp(
   card: ProgressCard | null | undefined,
   sessionStatus?: SessionRunStatus,
   startedAt?: number,
+  hasActiveRun = true,
 ): ProgressCardHeadsUp | null {
   const staleForRun = card ? isProgressCardStaleForRun(card, startedAt) : false;
   if (sessionStatus && TERMINAL_OUTCOME_LABEL_KEYS[sessionStatus] && !staleForRun) {
@@ -197,7 +198,8 @@ export function progressCardHeadsUp(
   if (!step) {
     return null;
   }
-  const status = step.status === "in_progress" && staleForRun ? "paused" : step.status;
+  const status =
+    step.status === "in_progress" && (staleForRun || !hasActiveRun) ? "paused" : step.status;
   return { ...counts, status, step: step.step };
 }
 

--- a/ui/src/components/session-progress-hovercard.runtime.ts
+++ b/ui/src/components/session-progress-hovercard.runtime.ts
@@ -443,6 +443,7 @@ export class SessionProgressHovercardProvider extends ReactiveElement {
             label: sidebarRow.label,
             boardFace: sidebarRow.boardFace,
             hasAutomation: sidebarRow.hasAutomation,
+            hasActiveRun: sidebarRow.hasActiveRun,
             channelAvatarUrl: sidebarRow.channelAvatarUrl,
             lastMessagePreview: sidebarRow.lastMessagePreview,
             createdActor: sidebarRow.createdActor,

--- a/ui/src/e2e/session-progress-widget.e2e.test.ts
+++ b/ui/src/e2e/session-progress-widget.e2e.test.ts
@@ -24,7 +24,8 @@ suite.define(() => {
     { height: 900, name: "desktop", width: 1440, routeKey: sessionKey },
     { height: 844, name: "mobile", width: 390, routeKey: sessionKey },
     { height: 900, name: "bare-route", width: 1440, routeKey: "progress-dashboard" },
-  ])("keeps an older progress card paused during a later run on $name", async (viewport) => {
+    { height: 900, name: "inactive", width: 1440, routeKey: sessionKey },
+  ])("keeps unowned progress paused on $name", async (viewport) => {
     await suite.withPage({ viewport }, async ({ page }) => {
       const now = Date.now();
       const gateway = await installMockGateway(page, {
@@ -64,7 +65,7 @@ suite.define(() => {
             card: {
               sessionKey,
               revision: 3,
-              updatedAt: now - 5 * 60_000,
+              updatedAt: viewport.name === "inactive" ? now : now - 5 * 60_000,
               markdown: "**Earlier task** remains available for reference.",
               steps: [
                 { step: "Finish the earlier task", status: "completed" },
@@ -75,7 +76,7 @@ suite.define(() => {
           },
           "sessions.list": chatSessionListResponse([
             {
-              hasActiveRun: true,
+              hasActiveRun: viewport.name !== "inactive",
               key: sessionKey,
               kind: "direct",
               label: "Later active run",

--- a/ui/src/lib/board/widgets/session-progress.ts
+++ b/ui/src/lib/board/widgets/session-progress.ts
@@ -9,6 +9,7 @@ import { t } from "../../../i18n/index.ts";
 import { OpenClawLightDomElement } from "../../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../../lit/subscriptions-controller.ts";
 import { resolveSessionProgressCardTarget } from "../../session-progress-cards.ts";
+import { isSessionRunActive } from "../../session-run-state.ts";
 import { parseAgentSessionKey } from "../../sessions/session-key.ts";
 import type { BoardWidget } from "../types.ts";
 
@@ -104,6 +105,7 @@ class OpenClawSessionProgressWidget extends OpenClawLightDomElement {
       row?.status,
       row?.startedAt,
       row?.endedAt,
+      isSessionRunActive(row ?? {}),
     )}`;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native subagent work never reached Discord/Slack progress callbacks, Discord hid failed-command progress even with the documented progress settings, and inactive progress cards kept spinning in dashboard or hovercard views. These are bounded repairs for reports from community members on Discord.

Related: #137342, #136460, #138221, #137323, #138976, #139269. The broader native-hook proposal in #115370 is separate, currently assigned work; this patch does not replace it.

## Why This Change Was Made

The provider's standard item projector discarded native collaboration and activity items before the existing core callback bridge could forward them (`extensions/codex/src/app-server/event-projector-events.ts:370`, `src/auto-reply/reply/agent-runner-event-handler.ts:154`). The projector now emits ordinary progress items. Worker lifecycle updates share a worker identity, while message submissions use separate action identities because a message can queue without starting a run. Activity completion notifications do not imply worker completion. Visible metadata includes state so text-only drafts actually change.

Discord's local failure filter bypassed the shared compositor's attention policy. Removing it restores failed-command visibility in quiet progress. Slack's redundant preview admission wrapper is removed in favor of that same compositor. Dashboard and hovercard views now receive authoritative active-run state, including the refresh fingerprint and catalog-only projection.

Alternatives considered: per-channel subagent branches would duplicate policy; adding collaboration to tool-synthesis classification would also alter transcript/audit behavior; an elapsed-time card timeout could pause legitimate ongoing work. Keeping a yielded parent's callbacks alive is invalid: `src/agents/subagents/registry/subagent-registry-requester-yield.ts:140` clears its child run link, execution closes its admitted owner, and the channel finalizes its draft. The coordinator has accepted that handoff as separately scoped design work.

## User Impact

With `streaming.progress.toolProgress: true`, native activity appears in the existing rolling tool log. Quiet mode retains the headline and attention policy. Discord failures remain visible in quiet and full progress, while Slack's native, Block Kit, and compact presentation choices stay intact. UI cards stop animating when the run is inactive; unfinished steps from older runs remain paused. The existing progress-card tool description already instructs meaningful updates; the docs now clarify run ownership and update age.

Production LOC: **+57/-70 (net -13)**. Tests/test support: **+229/-67 (net +162)**. Docs: **+8/-0**. No configuration, dependency, schema, protocol, public SDK, persistent-store, or changelog change.

Credit: community reports on Discord and the related fixes/proposal linked above. This is an independently authored repair; no contributor patch was replayed.

## Evidence

Exact head: `b5073cf59deb0d33aec4c25a8c1069c111396e4c`.

- Regression tests failed on the frozen base for missing native item events, hidden Discord failures, and inactive-card spinners. A further native regression caught message submission reviving worker status and missing visible state text; both now pass.
- Focused patch/sibling group: 319 passed. Final native refinement: 3 passed. Catalog projection: 7 passed. Initial controls, including the real Slack SDK buffering contract: 294 passed.
- Four mock-Gateway UI scenarios pass: desktop, mobile, bare route, and inactive current run.
- Eleven selected mock-Gateway channel scenarios have passing results: Discord quiet/full, Slack native quiet/full, Block Kit quiet/full, compact quiet/full, rejected native finalization, and Discord failed-command quiet/full.
- The channel matrix first had ten passes and one incorrect label assertion. Quiet failure correctly rendered `🛠️ exit 1`; the corrected test requires that failure text and still forbids ordinary tool rows. A replay timed out at the unchanged limit on the loaded host; the diagnostic replay passed using the unchanged prebuilt channel runtime.
- `pnpm check:changed`: passed. The earlier catalog projection type error was corrected at its producer.
- `git diff --check`: clean.
- Fresh independent review: scoped-clean through P2, including the catalog correction.
- Exact-head [hosted CI](https://github.com/openclaw/openclaw/actions/runs/33996493687) passed. Native review artifact validation and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 139456` passed on the unchanged head. The coordinator approved this bounded repair as it stands; ClawSweeper scope and proof notes are [addressed explicitly](https://github.com/openclaw/openclaw/pull/139456#issuecomment-5555263025).

Principal proof commands (focused tests used `OPENCLAW_VITEST_MAX_WORKERS=1`):

```sh
node scripts/run-vitest.mjs extensions/discord/src/monitor/message-handler.process.draft-final.test.ts extensions/discord/src/monitor/message-handler.process.draft-progress.test.ts extensions/codex/src/app-server/event-projector.subagent-progress.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts ui/src/components/session-hovercard.test.ts ui/src/components/session-progress-card.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.subagent-progress.test.ts
node scripts/run-vitest.mjs ui/src/components/app-sidebar-session-catalogs.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-widget.e2e.test.ts
node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts -t 'renders .*thread=root'
OPENCLAW_E2E_USE_PREBUILT_DIST=1 node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/channel-progress-presentation.e2e.test.ts -t 'renders discord progress .*toolProgress=false, compact=undefined, failTool=true'
pnpm check:changed
git diff --check
```

Native projection was verified separately at the provider/compositor boundary; this is not a live authenticated native-provider run.

Before: the dashboard retained its spinner while the owning run was inactive.

![Inactive card before](https://github.com/user-attachments/assets/9b4b7583-783e-4c33-b95a-34b4cc2bbbab)

After: the same card shows its unfinished step as paused.

![Inactive card after](https://github.com/user-attachments/assets/76fc9623-e6b3-49ca-b2d5-8591271d85d7)


## Follow-up

Ordinary child progress after the parent yields is accepted as a separate design item and is not part of this landing. Yield transfers ownership to a requester settlement batch and clears the child records' requesterTurnRunId, while the parent closes its admitted execution authority and finalizes its channel draft. Keeping the old callbacks alive would use a released owner and an already finalized surface. A settlement-batch/successor-turn handoff needs a progress publisher with explicit ownership transfer, fresh delivery authority, and cancellation/reset cleanup across those lifetimes.
