### PR TITLE
fix: refresh pending approvals when reopening chat

### DIFF
--- a/packages/gateway-client/src/session-subscriptions.test.ts
+++ b/packages/gateway-client/src/session-subscriptions.test.ts
@@ -449,6 +449,102 @@ describe("GatewaySessionMessageSubscriptionCoordinator", () => {
     expect(request).toHaveBeenCalledTimes(3);
   });
 
+  it.each([
+    {
+      name: "a closed approval pane leaves a plain observer",
+      initialApprovals: false,
+      closeFirst: true,
+      before: ["approval-old"],
+      after: [],
+    },
+    {
+      name: "another pane joins an upgraded observer",
+      initialApprovals: false,
+      closeFirst: false,
+      before: [],
+      after: ["approval-new"],
+    },
+    {
+      name: "another pane joins an initial approval observer",
+      initialApprovals: true,
+      closeFirst: false,
+      before: ["approval-old"],
+      after: ["approval-new"],
+    },
+  ])("refreshes pending approvals when $name", async (scenario) => {
+    let replay = { approvals: scenario.before.map((id) => ({ id })) };
+    const { client, request } = createClient(async (method, params) =>
+      method === "sessions.messages.subscribe"
+        ? { key: params.key, ...(params.includeApprovals ? { approvalReplay: replay } : {}) }
+        : {},
+    );
+    const coordinator = new GatewaySessionMessageSubscriptionCoordinator(client);
+    const retained = await coordinator.acquire("main", {
+      includeApprovals: scenario.initialApprovals,
+    });
+    const first = scenario.initialApprovals
+      ? retained
+      : await coordinator.acquire("main", { includeApprovals: true });
+    const handles = new Set([retained, first]);
+    try {
+      if (scenario.closeFirst) {
+        await coordinator.release(first);
+      }
+      replay = { approvals: scenario.after.map((id) => ({ id })) };
+      const next = await coordinator.acquire("main", { includeApprovals: true });
+      handles.add(next);
+      expect(next.approvalReplay).toEqual(replay);
+    } finally {
+      for (const handle of handles) {
+        await coordinator.release(handle);
+      }
+    }
+    expect(
+      request.mock.calls.filter(([method]) => method === "sessions.messages.unsubscribe"),
+    ).toHaveLength(1);
+  });
+
+  it.each(["none", "plain", "approvals"] as const)(
+    "restores the %s owner's capability after an approval replay times out",
+    async (retained) => {
+      let capability: "none" | "plain" | "approvals" = "none";
+      let timeoutNext = false;
+      const timeout = new GatewayProtocolRequestTimeoutError({
+        method: "sessions.messages.subscribe",
+        timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS,
+        requestSent: true,
+      });
+      const { client } = createClient(async (method, params) => {
+        capability =
+          method === "sessions.messages.unsubscribe"
+            ? "none"
+            : params.includeApprovals
+              ? "approvals"
+              : "plain";
+        if (timeoutNext) {
+          timeoutNext = false;
+          throw timeout;
+        }
+        return { key: params.key, approvalReplay: { approvals: [] } };
+      });
+      const coordinator = new GatewaySessionMessageSubscriptionCoordinator(client);
+      const owner =
+        retained === "none"
+          ? null
+          : await coordinator.acquire("main", { includeApprovals: retained === "approvals" });
+      try {
+        timeoutNext = true;
+        await expect(coordinator.acquire("main", { includeApprovals: true })).rejects.toBe(timeout);
+        expect(capability).toBe(retained);
+      } finally {
+        if (owner) {
+          await coordinator.release(owner);
+        }
+      }
+      expect(capability).toBe("none");
+    },
+  );
+
   it("preserves the plain observer when an approval upgrade is unauthorized", async () => {
     let rejectApproval = true;
     const { client, request } = createClient(async (method, params) => {

--- a/packages/gateway-client/src/session-subscriptions.ts
+++ b/packages/gateway-client/src/session-subscriptions.ts
@@ -35,7 +35,6 @@ type SessionMessageSubscriptionEntry = {
   agentId: string | null;
   ready: Promise<SessionMessageSubscriptionResponse>;
   approvalRequest: Promise<SessionMessageSubscriptionResponse> | null;
-  approvalResponse: SessionMessageSubscriptionResponse | null;
   plainFallback: Promise<SessionMessageSubscriptionResponse> | null;
   canonicalSettled: boolean;
   handles: Set<GatewaySessionMessageSubscription>;
@@ -244,23 +243,15 @@ export class GatewaySessionMessageSubscriptionCoordinator {
       agentId,
       ready: Promise.resolve({ key }),
       approvalRequest: null,
-      approvalResponse: null,
       plainFallback: null,
       canonicalSettled: false,
       handles: new Set(),
       pendingOwners: 0,
       release: null,
     };
-    entry.ready = this.#requestSubscribe(entry, includeApprovals).then((result) => {
-      entry.key = result.key;
-      entry.canonicalSettled = true;
-      if (includeApprovals) {
-        entry.approvalResponse = result;
-      }
-      return result;
-    });
+    entry.ready = this.#requestSubscribe(entry, includeApprovals);
     if (includeApprovals) {
-      entry.approvalRequest = entry.ready;
+      entry.ready = this.#trackApprovalRequest(entry, entry.ready);
     }
     // Concurrent owners observe the same rejection; this observer only prevents
     // an unhandled side branch and never changes the rejected acquire result.
@@ -274,7 +265,7 @@ export class GatewaySessionMessageSubscriptionCoordinator {
     includeApprovals: boolean,
   ): Promise<SessionMessageSubscriptionResponse> {
     if (!includeApprovals) {
-      if (entry.approvalRequest === entry.ready && !entry.approvalResponse) {
+      if (entry.approvalRequest === entry.ready) {
         if (!entry.plainFallback) {
           const approvalRequest = entry.ready;
           // Approval authorization is stronger than transcript observation.
@@ -285,8 +276,6 @@ export class GatewaySessionMessageSubscriptionCoordinator {
               throw error;
             }
             const result = await this.#requestSubscribe(entry, false);
-            entry.key = result.key;
-            entry.canonicalSettled = true;
             entry.ready = Promise.resolve(result);
             if (entry.approvalRequest === approvalRequest) {
               entry.approvalRequest = null;
@@ -298,27 +287,29 @@ export class GatewaySessionMessageSubscriptionCoordinator {
       }
       return entry.ready;
     }
-    if (entry.approvalResponse) {
-      return Promise.resolve(entry.approvalResponse);
-    }
     if (entry.approvalRequest) {
       return entry.approvalRequest;
     }
 
-    const upgrade = entry.ready
-      .then(() => this.#requestSubscribe(entry, true))
-      .then((result) => {
-        entry.key = result.key;
-        entry.approvalResponse = result;
-        return result;
-      });
-    entry.approvalRequest = upgrade;
-    void upgrade.catch(() => {
-      if (entry.approvalRequest === upgrade) {
+    return this.#trackApprovalRequest(
+      entry,
+      entry.ready.then(() => this.#requestSubscribe(entry, true)),
+    );
+  }
+
+  #trackApprovalRequest(
+    entry: SessionMessageSubscriptionEntry,
+    request: Promise<SessionMessageSubscriptionResponse>,
+  ): Promise<SessionMessageSubscriptionResponse> {
+    // Replays describe a moment in time. Share concurrent requests, but let
+    // each later viewer retrieve the Gateway's current pending set.
+    const tracked = request.finally(() => {
+      if (entry.approvalRequest === tracked) {
         entry.approvalRequest = null;
       }
     });
-    return upgrade;
+    entry.approvalRequest = tracked;
+    return tracked;
   }
 
   async #requestSubscribe(
@@ -341,13 +332,14 @@ export class GatewaySessionMessageSubscriptionCoordinator {
           throw error;
         }
         try {
-          // A sent request can commit before its acknowledgment; preserve an existing
-          // plain lease while removing any unacknowledged approval authority.
+          // A sent request can commit before its acknowledgment. Restore only
+          // capabilities still owned by acquired leases, including older approval panes.
+          const retainedApprovals = [...entry.handles].some((handle) => handle.includeApprovals);
           await this.#client.request(
             entry.handles.size > 0
               ? "sessions.messages.subscribe"
               : "sessions.messages.unsubscribe",
-            params,
+            retainedApprovals ? { ...params, includeApprovals: true } : params,
             { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
           );
         } catch (recoveryError) {
@@ -364,8 +356,11 @@ export class GatewaySessionMessageSubscriptionCoordinator {
       });
     const response = result && typeof result === "object" ? result : null;
     const responseKey = response && "key" in response ? response.key : undefined;
+    entry.key =
+      typeof responseKey === "string" && responseKey.trim() ? responseKey.trim() : entry.key;
+    entry.canonicalSettled = true;
     return {
-      key: typeof responseKey === "string" && responseKey.trim() ? responseKey.trim() : entry.key,
+      key: entry.key,
       ...(response && "approvalReplay" in response
         ? { approvalReplay: response.approvalReplay }
         : {}),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reopening a chat, or opening the same session in another pane, could see resolved approvals again and miss new pending approvals while the sidebar or another pane kept the session subscribed.

## Why This Change Was Made

The shared connection coordinator now deduplicates in-flight replay requests and fetches the current pending set for each later approval viewer. Removing the lifetime replay cache also consolidates canonical response handling. Timeout recovery preserves the approval capability held by existing leases; server authorization and approval storage remain the authorities.

## User Impact

Newly opened chat panes show the current approvals. A failed refresh does not interrupt approval updates in an already-open pane.

## Evidence

- `node scripts/run-vitest.mjs packages/gateway-client/src/session-subscriptions.test.ts`: **32 passed**, covering replay freshness, concurrent ownership, rejection, timeout compensation, release, and connection retirement. Three freshness cases failed on the baseline before the repair.
- `node scripts/check-changed.mjs -- packages/gateway-client/src/session-subscriptions.ts packages/gateway-client/src/session-subscriptions.test.ts`: **passed**.
- Real Chromium with the source Control UI and canonical mock Gateway: sidebar clicks through four sessions evict the original chat pane while retaining its sidebar subscription. After approvals change, the baseline reopens the resolved approval; the repair fetches and displays the current pending approval. Both runs keep one connection and send no session unsubscribe before reopening. The before/after screenshots were inspected and contain only synthetic data.
- Fresh managed Codex autoreview: **scoped-clean through P2**, no accepted/actionable findings.
- Production **+27/−32 (net −5)**; tests **+96**.

Before: reopening shows the old approval after the pending set changed.

![Before: stale pending approval after reopening chat](https://github.com/user-attachments/assets/08867c3d-aaca-419f-be98-588a9dc46fce)

After: reopening fetches and displays the current pending approval.

![After: current pending approval after reopening chat](https://github.com/user-attachments/assets/6bc172e6-d379-4902-b872-8947af3c35fe)
