### PR TITLE
test(ui): retire isolated forks after cleanup failures

### DIFF
--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -198,6 +198,8 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
     );
     try {
       return await Promise.race([operation, expired.promise]);
+    } catch (error) {
+      throw retireFork(error, retainedState);
     } finally {
       clearTimeout(deadline);
     }
@@ -442,9 +444,7 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
             throwControlUiCleanupErrors(errors);
             assertControlUiForkActive();
             await resources?.release?.();
-          })().catch((error: unknown) => {
-            throw retireFork(error, resources?.retainedState);
-          });
+          })();
           return joinCleanup(
             teardown,
             "suite teardown",

--- a/ui/src/test-helpers/control-ui-e2e-suite.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e-suite.test.ts
@@ -14,6 +14,8 @@ const repoRoot = path.resolve(import.meta.dirname, "../../..");
 const helperPath = path.join(repoRoot, "ui/src/e2e/control-ui-e2e-suite.test-support.ts");
 
 type FixtureMode =
+  | "tracked-close-success"
+  | "tracked-close-failure"
   | "concurrent-close"
   | "close-failure"
   | "late-context"
@@ -77,7 +79,8 @@ vi.mock("playwright", () => ({ chromium: { launch: async () => {
         newPage: async () => closedPage,
         close: () => {
           state.closeCalls++;
-          if (${JSON.stringify(mode)} === "close-failure") return Promise.reject(state.closeFault);
+          record();
+          if (["close-failure", "tracked-close-failure"].includes(${JSON.stringify(mode)})) return Promise.reject(state.closeFault);
           return ${JSON.stringify(mode)} === "concurrent-close" && state.closeCalls === 1
             ? state.gate : Promise.resolve();
         }
@@ -97,6 +100,7 @@ fs.writeFileSync(${JSON.stringify(path.join(root, "worker.pid"))}, String(proces
 record();
 let sharedFixture;
 const suite = createControlUiE2eSuite({ name: "owned context fixture",
+  trackBrowserContexts: ${mode.startsWith("tracked-")},
   ...(${JSON.stringify(mode)}.startsWith("resources-") ? {
     resources: {
       retainedState: () => sharedFixture?.root,
@@ -136,6 +140,14 @@ suite.define(() => {
         expect(process.env.OPENCLAW_STATE_DIR).toBe(sharedFixture.stateDir);
         state.events.push(name); record();
       } });
+    });
+  } else if (${JSON.stringify(mode)}.startsWith("tracked-")) {
+    it("first ordinary case acquires a context", async () => {
+      await suite.newBrowserContext({});
+    });
+    it("next ordinary case starts only after context cleanup", async () => {
+      fs.writeFileSync(${JSON.stringify(path.join(root, "successor.txt"))}, "started");
+      await suite.newBrowserContext({});
     });
   } else if (${JSON.stringify(mode)} === "concurrent-close") {
     it("joins the first context close", async () => {
@@ -446,6 +458,26 @@ it.for(["resources-success", "resources-close-failure", "resources-late-setup"] 
       }
       if (mode === "resources-close-failure") {
         expect(result.output).toContain("synthetic shared resource close failure");
+      }
+    }),
+);
+
+it.for(["tracked-close-success", "tracked-close-failure"] as const)(
+  "fences ordinary cases after failed per-test cleanup: %s",
+  (mode, context) =>
+    runJoinedShutdownTest(context, async () => {
+      const result = await runFixture(mode, context.signal);
+      const success = mode === "tracked-close-success";
+      expect(result.code, result.output).toBe(success ? 0 : 1);
+      expect(result.successorStarted, result.output).toBe(success);
+      expect(result.journal).toMatchObject({
+        closeCalls: success ? 2 : 1,
+        browserClosed: success,
+        serverClosed: success,
+      });
+      if (!success) {
+        expect(result.output).toContain("synthetic context close failure");
+        expect(result.output).toContain("retiring owned fork");
       }
     }),
 );


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Fixes an issue where a failed browser-context close between ordinary Control UI E2E cases could allow the next case to run in the same unsafe isolated fork.

## Why This Change Was Made

This is independent tooling stage 2 of the #135868 split, concern G. The shared cleanup boundary now retires the fork when cleanup rejects, as it already does on a cleanup timeout. The existing suite-teardown catch becomes redundant and is removed.

The source branch's extra routing assertions are omitted because main already shares the canonical isolated-suite list. Gateway-readiness workflow changes and the Codex cleanup test registration stay with the stages introducing those consumers.

## User Impact

E2E failures retain their unsafe state and prevent successor cases from running against it. Successful cleanup still permits the next case. This changes test infrastructure only; application UI and runtime behavior are unchanged.

## Evidence

Clean Linux Testbox proof on Vitest 5: https://github.com/openclaw/openclaw/actions/runs/33994866929. The delegated command exited 0, and the owned lease was independently confirmed completed. Its backing Actions step can show cancellation during one-shot cleanup; a later external portal-sync warning did not change the successful command result.

Paired regression proof used a frozen WIP commit and no-commit revert: before the fix, the failed-cleanup case incorrectly started its successor, while the successful-cleanup control passed. After exact restoration, all 14 UI helper tests passed. The full selected `pnpm check:changed` plan passed (including core-test types, UI catalog, dead exports, and lint), followed by the six required tooling suites: 1,661 passed and one unrelated Windows-only test skipped. Total: 1,675 passed.

The final rebase changed no owned files or dependency pins, and the patch hash matches the reviewed candidate.

Both local and branch Codex autoreviews found no accepted/actionable P0–P2 findings. `git diff --check` passed. Existing documentation already requires failed cleanup to block later cases and preserve state. The preserved local Vitest 4 install cannot start current main's Vitest 5 configuration; authoritative proof uses a clean Testbox install.

Judged LOC: production +0/-0; tooling +0/-0; docs +0/-0; tests +36/-4 (net +32), two fewer net test lines than the source extract. The shared retirement boundary replaces the duplicate teardown adapter. No dependencies, configuration options, baselines, or workflow files change.

Exact-head hosted CI for `906adf0fabf213b8cbcda5f4b9918bc6bc5ede9b` is now green: 100 successful checks, no failures or pending checks; the repository CI watcher returned `GREEN`. The first run hit the unrelated `board-a2ui.e2e.test.ts:221` event-delivery flake also documented in #139371. The lead reran the failed jobs on the same head, and they passed without code changes.

[ClawSweeper’s published review](https://github.com/openclaw/openclaw/pull/139460#issuecomment-5555303170) reports no correctness or security findings and no pre-merge actions. No rank-up changes remain.
