### PR TITLE
fix(tooling): preserve Git hook choices during install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,15 @@ must declare their own development dependencies rather than rely on hoisting.
 
 ## Local commit hook
 
-The normal `pnpm install` setup automatically enables the repository's pre-commit
-formatting hook. Its optional content guard reads a private UTF-8 file selected by
+The normal `pnpm install` setup enables the repository's pre-commit formatting hook
+when `core.hooksPath` is unset. Existing hook selections, including an explicitly
+empty value, are preserved. Git scopes initialization to the current checkout.
+With multiple worktrees, automatic setup requires `extensions.worktreeConfig`;
+otherwise Git reports a warning and installation continues without changing hook
+settings. The repository owner can enable per-worktree configuration following
+[Git's configuration guidance](https://git-scm.com/docs/git-worktree#_configuration_file).
+
+The hook's optional content guard reads a private UTF-8 file selected by
 the native Git setting `hooks.blockedLiteralsFile`. Keep one literal per nonempty
 line in a file outside the checkout, such as
 `~/.config/openclaw/blocked-literals.txt`, then configure this checkout:

--- a/scripts/prepare-git-hooks.mjs
+++ b/scripts/prepare-git-hooks.mjs
@@ -1,5 +1,4 @@
-// Configures this checkout's Git hooks path during package prepare when git
-// and the hooks directory are available.
+// Initializes this checkout's Git hooks path without replacing an existing selection.
 import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -8,23 +7,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_PACKAGE_ROOT = join(scriptDir, "..");
 
-function getMissingGitReason(error) {
-  if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
-    return "missing-git";
-  }
-  return null;
-}
-
-function runGit(spawn, gitBin, args, cwd, stdio) {
-  return spawn(gitBin, args, {
-    cwd,
-    encoding: "utf8",
-    stdio,
-  });
-}
-
 /**
- * Installs the repo-local hooks path and returns a structured reason if skipped.
+ * Initializes an unset hooks path and returns a structured reason if skipped.
  */
 export function configurePrepareGitHooks(params = {}) {
   const cwd = params.cwd ?? DEFAULT_PACKAGE_ROOT;
@@ -32,32 +16,33 @@ export function configurePrepareGitHooks(params = {}) {
   const gitBin = params.gitBin ?? "git";
   const spawn = params.spawnSync ?? spawnSync;
   const warn = params.warn ?? console.warn;
+  const runGit = (args) =>
+    spawn(gitBin, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
 
   if (!exists(join(cwd, "git-hooks"))) {
     return { configured: false, reason: "missing-hooks-dir" };
   }
 
-  const worktree = runGit(spawn, gitBin, ["rev-parse", "--is-inside-work-tree"], cwd, [
-    "ignore",
-    "pipe",
-    "ignore",
-  ]);
-  const missingGitReason = getMissingGitReason(worktree.error);
-  if (missingGitReason) {
-    return { configured: false, reason: missingGitReason };
+  const worktree = runGit(["rev-parse", "--is-inside-work-tree"]);
+  if (worktree.error?.code === "ENOENT") {
+    return { configured: false, reason: "missing-git" };
   }
   if (worktree.status !== 0 || String(worktree.stdout ?? "").trim() !== "true") {
     return { configured: false, reason: "not-worktree" };
   }
 
-  const configured = runGit(spawn, gitBin, ["config", "core.hooksPath", "git-hooks"], cwd, [
-    "ignore",
-    "ignore",
-    "pipe",
-  ]);
-  const configMissingGitReason = getMissingGitReason(configured.error);
-  if (configMissingGitReason) {
-    return { configured: false, reason: configMissingGitReason };
+  // Inherited and explicitly empty selections already have an owner.
+  const existing = runGit(["config", "--get", "core.hooksPath"]);
+  if (existing.status === 0) {
+    return { configured: false, reason: "already-configured" };
+  }
+  // Git refuses a shared write when multiple checkouts lack private worktree config.
+  const configured =
+    existing.status === 1
+      ? runGit(["config", "--worktree", "core.hooksPath", "git-hooks"])
+      : existing;
+  if (configured.error?.code === "ENOENT") {
+    return { configured: false, reason: "missing-git" };
   }
   if (configured.status !== 0) {
     const stderr = String(configured.stderr ?? "").trim();

--- a/test/scripts/prepare-git-hooks.test.ts
+++ b/test/scripts/prepare-git-hooks.test.ts
@@ -1,6 +1,11 @@
-// Prepare Git Hooks tests cover prepare git hooks script behavior.
-import { describe, expect, it, vi } from "vitest";
+import { execFileSync, spawnSync as spawnGit, type SpawnSyncOptions } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { configurePrepareGitHooks } from "../../scripts/prepare-git-hooks.mjs";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 type SpawnResult = {
   error?: NodeJS.ErrnoException;
@@ -21,58 +26,77 @@ function createSpawn(results: SpawnResult[]) {
 
 describe("configurePrepareGitHooks", () => {
   it("configures hooks through git without using a shell", () => {
-    const spawnSync = createSpawn([{ status: 0, stdout: "true\n" }, { status: 0 }]);
+    const spawnSync = createSpawn([{ status: 0, stdout: "true\n" }, { status: 1 }, { status: 0 }]);
 
     expect(
       configurePrepareGitHooks({
         cwd: "C:\\repo",
         existsSync: () => true,
         spawnSync,
+        warn: vi.fn(),
       }),
     ).toEqual({ configured: true, reason: "configured" });
 
-    expect(spawnSync).toHaveBeenCalledWith("git", ["rev-parse", "--is-inside-work-tree"], {
+    const options = {
       cwd: "C:\\repo",
       encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    expect(spawnSync).toHaveBeenCalledWith("git", ["config", "core.hooksPath", "git-hooks"], {
-      cwd: "C:\\repo",
-      encoding: "utf8",
-      stdio: ["ignore", "ignore", "pipe"],
-    });
+      stdio: ["ignore", "pipe", "pipe"],
+    };
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["rev-parse", "--is-inside-work-tree"],
+      options,
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      ["config", "--get", "core.hooksPath"],
+      options,
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      3,
+      "git",
+      ["config", "--worktree", "core.hooksPath", "git-hooks"],
+      options,
+    );
+    expect(spawnSync).toHaveBeenCalledTimes(3);
   });
 
-  it("stays quiet when git is unavailable", () => {
+  it.each([0, 1, 2])("stays quiet when Git is unavailable at command %i", (command) => {
     const warn = vi.fn();
     const enoent = Object.assign(new Error("missing git"), { code: "ENOENT" });
+    const preceding: SpawnResult[] = [{ status: 0, stdout: "true\n" }, { status: 1 }];
 
     expect(
       configurePrepareGitHooks({
         cwd: "C:\\repo",
         existsSync: () => true,
-        spawnSync: createSpawn([{ error: enoent }]),
+        spawnSync: createSpawn([...preceding.slice(0, command), { error: enoent }]),
         warn,
       }),
     ).toEqual({ configured: false, reason: "missing-git" });
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("warns without failing when git config rejects the hooks path", () => {
+  it.each(["read", "write"])("warns without fallback when Git config %s fails", (operation) => {
     const warn = vi.fn();
+    const spawnSync = createSpawn([
+      { status: 0, stdout: "true\n" },
+      ...(operation === "write" ? [{ status: 1 }] : []),
+      { status: 128, stderr: "permission denied" },
+    ]);
 
     expect(
       configurePrepareGitHooks({
         cwd: "/repo",
         existsSync: () => true,
-        spawnSync: createSpawn([
-          { status: 0, stdout: "true\n" },
-          { status: 1, stderr: "permission denied" },
-        ]),
+        spawnSync,
         warn,
       }),
     ).toEqual({ configured: false, reason: "config-failed" });
     expect(warn).toHaveBeenCalledWith("[prepare] could not configure git hooks: permission denied");
+    expect(spawnSync).toHaveBeenCalledTimes(operation === "write" ? 3 : 2);
   });
 
   it("skips packaged installs without the source hook directory", () => {
@@ -86,5 +110,170 @@ describe("configurePrepareGitHooks", () => {
       }),
     ).toEqual({ configured: false, reason: "missing-hooks-dir" });
     expect(spawnSync).not.toHaveBeenCalled();
+  });
+
+  type OwnershipCase = {
+    name: string;
+    linked?: boolean;
+    worktreeConfig?: boolean;
+    local?: string;
+    global?: string;
+    overrides?: boolean;
+    reason: "configured" | "already-configured" | "config-failed";
+    expected: string | null;
+  };
+  const ownershipCases: OwnershipCase[] = [
+    { name: "fresh primary", reason: "configured", expected: "git-hooks" },
+    {
+      name: "explicit local owner",
+      local: "local-hooks",
+      reason: "already-configured",
+      expected: "local-hooks",
+    },
+    {
+      name: "explicit global owner",
+      global: "global-hooks",
+      reason: "already-configured",
+      expected: "global-hooks",
+    },
+    { name: "explicit empty value", local: "", reason: "already-configured", expected: "" },
+    {
+      name: "linked without private config",
+      linked: true,
+      reason: "config-failed",
+      expected: null,
+    },
+    {
+      name: "linked inherited owner",
+      linked: true,
+      local: "shared-hooks",
+      reason: "already-configured",
+      expected: "shared-hooks",
+    },
+    {
+      name: "linked private initialization",
+      linked: true,
+      worktreeConfig: true,
+      reason: "configured",
+      expected: "git-hooks",
+    },
+    {
+      name: "overrides masking shared config",
+      linked: true,
+      worktreeConfig: true,
+      local: "shared-hooks",
+      overrides: true,
+      reason: "already-configured",
+      expected: "linked-hooks",
+    },
+  ];
+
+  it.each(ownershipCases)("preserves Git configuration ownership: $name", (scenario) => {
+    const root = tempDirs.make("prepare-hook-ownership-");
+    const primary = join(root, "primary");
+    const globalConfig = join(root, "global.config");
+    const template = join(root, "empty-template");
+    mkdirSync(template);
+    writeFileSync(globalConfig, "");
+    const env = {
+      PATH: process.env.PATH,
+      SystemRoot: process.env.SystemRoot,
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_CONFIG_GLOBAL: globalConfig,
+      GIT_TEMPLATE_DIR: template,
+      GIT_TERMINAL_PROMPT: "0",
+    };
+    const git = (cwd: string, args: string[]) =>
+      execFileSync("git", ["-C", cwd, ...args], { env, encoding: "utf8", stdio: "pipe" }).trim();
+    git(root, ["init", "-q", "--initial-branch=main", primary]);
+    git(primary, [
+      "-c",
+      "user.name=Fixture",
+      "-c",
+      "user.email=fixture@example.invalid",
+      "-c",
+      "commit.gpgsign=false",
+      "commit",
+      "--allow-empty",
+      "-qm",
+      "fixture",
+    ]);
+    const checkouts = [primary];
+    if (scenario.linked) {
+      for (const name of ["linked", "sibling"]) {
+        const checkout = join(root, name);
+        git(primary, ["worktree", "add", "--detach", "-q", checkout, "HEAD"]);
+        checkouts.push(checkout);
+      }
+    }
+    const target = scenario.linked ? join(root, "linked") : primary;
+    mkdirSync(join(target, "git-hooks"));
+    if (scenario.worktreeConfig) {
+      git(primary, ["config", "extensions.worktreeConfig", "true"]);
+    }
+    if (scenario.local !== undefined) {
+      git(primary, ["config", "--local", "core.hooksPath", scenario.local]);
+    }
+    if (scenario.global !== undefined) {
+      git(primary, ["config", "--file", globalConfig, "core.hooksPath", scenario.global]);
+    }
+    if (scenario.overrides) {
+      checkouts.forEach((checkout) =>
+        git(checkout, ["config", "--worktree", "core.hooksPath", `${basename(checkout)}-hooks`]),
+      );
+    }
+    const hookPath = (cwd: string) => {
+      const result = spawnGit("git", ["-C", cwd, "config", "--get", "core.hooksPath"], {
+        env,
+        encoding: "utf8",
+      });
+      expect([0, 1]).toContain(result.status);
+      return result.status === 0 ? result.stdout.replace(/\r?\n$/u, "") : null;
+    };
+    const effectiveBefore = checkouts.map(hookPath);
+    const unchangedFiles = [
+      globalConfig,
+      ...(scenario.linked || scenario.reason !== "configured"
+        ? [join(primary, ".git", "config")]
+        : []),
+      ...checkouts
+        .filter(
+          (checkout) =>
+            !(checkout === target && scenario.worktreeConfig && scenario.reason === "configured"),
+        )
+        .map((checkout) =>
+          resolve(checkout, git(checkout, ["rev-parse", "--git-path", "config.worktree"])),
+        ),
+    ];
+    const contents = (file: string) => (existsSync(file) ? readFileSync(file, "utf8") : null);
+    const contentsBefore = unchangedFiles.map(contents);
+    const warn = vi.fn();
+    const result = configurePrepareGitHooks({
+      cwd: target,
+      spawnSync: (bin: string, args: string[], options: SpawnSyncOptions) => {
+        expect(bin).toBe("git");
+        expect(options.cwd).toBe(target);
+        return spawnGit(bin, args, { ...options, env });
+      },
+      warn,
+    });
+    // Private overrides can mask a shared write, so compare config bytes as well as effective values.
+    expect(unchangedFiles.map(contents)).toEqual(contentsBefore);
+    expect(result).toEqual({
+      configured: scenario.reason === "configured",
+      reason: scenario.reason,
+    });
+    expect(checkouts.map(hookPath)).toEqual(
+      checkouts.map((checkout, index) =>
+        checkout === target ? scenario.expected : effectiveBefore[index],
+      ),
+    );
+    if (scenario.reason === "config-failed") {
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[prepare] could not configure git hooks"),
+      );
+    } else {
+      expect(warn).not.toHaveBeenCalled();
+    }
   });
 });


### PR DESCRIPTION
Closes #139449.

## What Problem This Solves

Fixes an issue where contributors running dependency installation would have an existing Git hook choice replaced, or a linked checkout would change shared hook settings for its siblings. Private worktree overrides could hide that shared change even while setup reported success.

## Why This Change Was Made

Prepare now reads Git's effective `core.hooksPath` and preserves an existing selection, including inherited and explicitly empty values. Only Git's missing-key result permits initialization, using `--worktree` so Git owns scope selection. Configuration errors keep the existing nonfatal warning; setup does not retry with a shared write or enable the worktree-config extension.

The command closure replaces two passthrough helpers. **Tooling +19/−34 (net −15), tests +207/−18 (net +189), docs +9/−2 (net +7).** The existing package lifecycle entrypoint and hook implementation remain unchanged.

## User Impact

Installation respects configured hook choices and avoids changing sibling-checkout settings. A fresh single checkout still gets the repository hook. An unconfigured repository with multiple worktrees needs owner-enabled `extensions.worktreeConfig` for automatic setup; otherwise Git warns and installation continues with hook settings unchanged. The contributor guide explains this existing [Git configuration mechanism](https://git-scm.com/docs/git-worktree#_configuration_file).

**Maintainer disposition of ClawSweeper's P1 merge risk:** retain the documented safe skip, its recommended option. This deliberately affects only automatic initialization when no hook path is configured and Git cannot provide private worktree scope. Existing configured paths and fresh single checkouts retain their supported behavior. Falling back to a shared write would recreate the reported sibling mutation; automatically enabling the extension would make a broader Git configuration change. The warning and linked owner-controlled setup instructions make the non-initialization visible and actionable. This disposition resolves the requested decision without a code change.

## Evidence

- Seven real-Git ownership regressions fail against the previous helper. The same permanent test file passes all 15 cases after repair, covering a true single checkout, local/global/empty settings, linked initialization, refusal without private configuration, and shared writes masked by private overrides. A later three-brace style correction preserves all assertions; the final file also passes 15/15.
- The 17-stage changed-check plan is satisfied: 16 stages passed initially, then the sole test-lint failure was fixed and targeted lint, three-file formatting and all 15 tests passed. This includes script lint and root test typechecking. Independent peer and both managed review passes are clean.
- Git 2.54's actual config implementation and real-Git scope controls confirm the single-checkout, private-worktree and shared-config refusal branches. Fixtures use isolated configuration and synthetic values; no hook executable runs. No actual Windows or complete package-manager lifecycle execution is claimed, and read-before-write is not atomic against concurrent configuration changes.

The unscoped write dates to 6b83d82e and was preserved by the cross-platform extraction in d21abb88; current main and stable `v2026.9.2` contain the same helper. Draft #114287 overlaps these files for a separate optional publication feature and retains the unscoped write. This PR does not incorporate that proposal. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33995875599) passed 78 jobs (16 skipped). [ClawSweeper's completed review](https://github.com/openclaw/openclaw/pull/139461#issuecomment-5555302465) found no correctness or security issue and requested the maintainer decision recorded above.
