### PR TITLE
docs: clarify configuration reload outcomes

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -567,9 +567,20 @@ The earlier `hot` and `restart` modes are retired; [`openclaw doctor --fix`](/cl
 
 ### What hot-applies vs what needs a restart
 
-Most fields hot-apply without downtime; some hot-applied sections restart just that
-subsystem (channel, cron, heartbeat) rather than the whole Gateway. In
-`hybrid` mode, Gateway-restart-required changes are handled automatically.
+Reload planning classifies each changed path as one of three outcomes:
+
+- **Gateway restart (`restart`)**: restart the Gateway process.
+- **Hot reload (`hot`)**: apply the change while keeping the Gateway process
+  running. This can include restarting the owning subsystem, such as a channel,
+  cron, or heartbeat.
+- **No reload action (`none`)**: update the runtime config snapshot without
+  scheduling a reload action for that path. Consumers that read the current
+  config can observe the new value on a later read.
+
+In `hybrid` mode, Gateway restarts happen automatically when required. The longest
+matching config prefix determines the outcome. Rules supplied by a plugin apply
+only while that plugin is loaded; a path that matches no rule defaults to a
+Gateway restart.
 
 By default, changing `agents.defaults.mediaMaxMb` restarts channel runtimes so their inherited
 attachment limits take effect together. Automatic reloads preserve manually
@@ -582,7 +593,7 @@ back to OpenClaw.
 
 | Category                  | Fields                                                                                                                                                                                                                                                             | Gateway restart needed?                |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------- |
-| Channels                  | `channels.*`, `web` (WhatsApp) - all built-in and plugin channels                                                                                                                                                                                                  | No (restarts that channel)             |
+| Channels                  | `channels.*`, `web` (WhatsApp)                                                                                                                                                                                                                                     | Depends on setting and loaded plugin   |
 | Agent & models            | `agents`, `models`, `auth.order`, `auth.profiles`, `broadcast`, `worktreeRoot`, `cloudWorkers.projectProfiles`                                                                                                                                                     | No                                     |
 | Automation                | `hooks`, `cron`, `agents.defaults.heartbeat`                                                                                                                                                                                                                       | No (reloads the owning subsystem)      |
 | Sessions & messages       | `session`, `messages`                                                                                                                                                                                                                                              | No                                     |
@@ -604,6 +615,12 @@ back to OpenClaw.
 | Browser defaults          | `browser.profiles`, `browser.defaultProfile`, `browser.headless`, `browser.executablePath`, `browser.attachOnly`, `browser.cdpUrl`, `browser.noSandbox`, `browser.extraArgs`, `browser.snapshotDefaults`, `browser.tabCleanup`, `browser.allowSystemProfileImport` | No                                     |
 | Gateway server            | Other `gateway.*` settings (port, bind, auth mode, roles, tailscale, TLS)                                                                                                                                                                                          | **Yes**                                |
 | Infrastructure            | Other `discovery` and `browser` settings, MCP Apps listener settings, `secrets.egressProxy`, `plugins.load`, `plugins.installs`                                                                                                                                    | **Yes**                                |
+
+Channel plugins declare which settings restart their channel
+(`reload.configPrefixes`) and which need no reload action (`reload.noopPrefixes`).
+For example, with WhatsApp loaded, `channels.whatsapp.enabled` restarts the
+WhatsApp channel, while `channels.whatsapp.replyToMode` matches its broader
+no-action prefix.
 
 Changes to `channels.defaults`, `channels.modelByChannel`, `commands`,
 `accessGroups`, `tts`, `surfaces`, `acp.stream`, and `diagnostics.flags` refresh
@@ -697,7 +714,6 @@ eligible for hot reload. Auth-mode changes still restart the Gateway.
 
 <Note>
 Changing `gateway.reload` or `gateway.remote` also does **not** trigger a restart.
-Individual plugins can declare their own restart-triggering config prefixes.
 </Note>
 
 Canvas enablement uses plugin hot reload. Current-protocol nodes whose hosted


### PR DESCRIPTION
Fixes #137579

## What Problem This Solves

The configuration guide says every channel setting change restarts that channel. Operators cannot tell when a setting instead updates the runtime config without a reload action, or when an unmatched setting requires a Gateway restart.

## Why This Change Was Made

Describe the planner's `restart`, `hot`, and `none` outcomes, longest-prefix matching, and dependence on loaded plugin declarations. Qualify the Channels row and illustrate WhatsApp's narrow restart prefixes and broader no-action prefix. Explain that `none` still updates the runtime config snapshot, which consumers can read later.

## User Impact

Operators can distinguish Gateway restarts, subsystem reload actions, and snapshot-only changes when reading the reload table. The existing MCP Apps listener and secret-egress restart guidance remains accurate.

## Evidence

- Changed-page formatting, targeted MDX validation, conflict-marker checks, and `git diff --check` passed.
- Claims checked against the [reload planner](https://github.com/openclaw/openclaw/blob/9dd869ec98ebd7ac08295f549856ab168d483261/src/gateway/config-reload-plan.ts#L514), [WhatsApp declarations](https://github.com/openclaw/openclaw/blob/9dd869ec98ebd7ac08295f549856ab168d483261/extensions/whatsapp/src/shared.ts#L186), and [managed snapshot publication](https://github.com/openclaw/openclaw/blob/9dd869ec98ebd7ac08295f549856ab168d483261/src/gateway/server-reload-managed.ts#L477).
- Existing planner and snapshot-commit tests were inspected. No runtime tests or live reloads were run for this documentation-only change.
- [Hosted documentation validation](https://github.com/openclaw/openclaw/actions/runs/33995999435/job/101386633242) passed, including formatting, MDX (753 files), 8,196 internal links with zero broken links, and configuration examples. All 68 link/anchor entries in the changed page are unchanged.
