### PR TITLE
fix(memory): index notes when optional embeddings cannot start

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -125,7 +125,8 @@ tools or Active Memory escalation, but are never injected automatically.
 and search with keywords only. Leaving `provider` unset or set to `"auto"`
 falls back to keyword-only ranking when embedding setup or a request fails, as
 does `provider: "local"` (the GGUF/llama.cpp provider). Creation-time fallback
-still indexes text for keyword search, and `memory_search` includes the
+still indexes text for keyword search, including manual and background indexing
+before the first search. `memory_search` includes the
 redacted embedding-bootstrap reason in `debug.embeddingBootstrap` even when
 there are no matches.
 

--- a/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
+++ b/extensions/memory-core/src/memory/manager-candidate-repair.test.ts
@@ -142,14 +142,24 @@ describe("automatic candidates during provenance repair", () => {
     };
     const runSync = owner.runSync.bind(upgraded);
     let pendingRetry: Promise<void> | undefined;
-    const retryGate = vi.spyOn(owner, "runSync").mockImplementation((params) => {
-      retryStarted.resolve();
-      pendingRetry = retry.promise.then(() => runSync(params));
-      return pendingRetry;
-    });
+    const retryGate = vi
+      .spyOn(owner, "runSync")
+      .mockImplementation((params) => {
+        retryStarted.resolve();
+        pendingRetry = retry.promise.then(() => runSync(params));
+        return pendingRetry;
+      })
+      .mockImplementationOnce(runSync);
     // This is the same public sync admission used by detached startup catch-up.
-    // Attach rejection handling immediately; its failed initialization is expected.
-    const startup = upgraded.sync({ reason: "session-startup-catchup" });
+    // Optional initialization now falls back successfully. Fail its first real
+    // keyword generation so candidate repair must still admit a separate retry.
+    const startupFailure = new Error("startup progress callback failed");
+    const startup = upgraded.sync({
+      reason: "session-startup-catchup",
+      progress: () => {
+        throw startupFailure;
+      },
+    });
     const startupOutcome = startup.then(
       () => undefined,
       (error: unknown) => error,
@@ -169,6 +179,8 @@ describe("automatic candidates during provenance repair", () => {
       await Promise.resolve();
       initialization.resolve();
       await retryStarted.promise;
+      expect(await startupOutcome).toBe(startupFailure);
+      expect(retryGate).toHaveBeenCalledTimes(2);
       // Give teardown a turn to finish while the admitted retry remains gated.
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
@@ -176,7 +188,6 @@ describe("automatic candidates during provenance repair", () => {
       expect(closeSettled).toBe(false);
       retry.resolve();
       await closing;
-      expect(await startupOutcome).toBeInstanceOf(Error);
 
       // Observable persistence proof: close did not merely cancel or abandon
       // the retry; its classified candidates survive a fresh manager open.

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -131,7 +131,7 @@ describe("memory manager FTS-only reindex", () => {
         backend: "builtin",
 
         search: {
-          provider: params.provider ?? "auto",
+          provider: params.provider,
           model: "",
           store,
           cache: { enabled: false },
@@ -209,6 +209,44 @@ describe("memory manager FTS-only reindex", () => {
     });
     expect(createEmbeddingProviderMock).not.toHaveBeenCalled();
   });
+
+  it.each([undefined, "auto", "local"])(
+    "indexes before the first search when optional provider %s cannot initialize",
+    async (provider) => {
+      providerConstructionError = new Error("Embedding provider setup unavailable");
+      const memoryManager = await createManager({ provider });
+
+      await expect(
+        memoryManager.sync({ reason: "session-startup-catchup", force: true }),
+      ).resolves.toBeUndefined();
+      expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", "new-note.md"),
+        "Beta calibration record",
+      );
+      await memoryManager.sync({ reason: "session-delta", force: true });
+      await memoryManager.sync({ reason: "post-compaction", force: true });
+      expect(countChunksContaining("Beta calibration record")).toBeGreaterThan(0);
+      expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
+      expect(memoryManager.status()).toMatchObject({
+        provider: "none",
+        custom: { searchMode: "fts-only", indexIdentity: { status: "valid" } },
+      });
+
+      const debug: unknown[] = [];
+      await expect(
+        memoryManager.search("Beta calibration", { onDebug: (value) => debug.push(value) }),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          path: "memory/new-note.md",
+          snippet: expect.stringContaining("Beta calibration record"),
+        }),
+      ]);
+      expect(JSON.stringify(debug)).toContain("Embedding provider setup unavailable");
+      expect(createEmbeddingProviderMock).toHaveBeenCalledOnce();
+    },
+  );
 
   it("returns keyword matches when optional provider construction fails during search bootstrap", async () => {
     providerConstructionError = Object.assign(
@@ -289,6 +327,9 @@ describe("memory manager FTS-only reindex", () => {
     );
     const memoryManager = await createManager({ provider: "openai" });
 
+    await expect(
+      memoryManager.sync({ reason: "session-startup-catchup", force: true }),
+    ).rejects.toThrow('No API key resolved for provider "openai"');
     await expect(memoryManager.search("Alpha topic")).rejects.toThrow(
       'No API key resolved for provider "openai"',
     );
@@ -457,7 +498,7 @@ describe("memory manager FTS-only reindex", () => {
     const secondSearch = memoryManager.search("Alpha topic");
     releaseProviderConstruction();
 
-    await expect(backgroundSync).resolves.toBe(providerConstructionError);
+    await expect(backgroundSync).resolves.toBeUndefined();
     const results = await Promise.all([firstSearch, secondSearch]);
     expect(results).toEqual([
       [expect.objectContaining({ path: "MEMORY.md", source: "memory" })],

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -366,12 +366,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         try {
           await this.ensureProviderInitialized();
         } catch (err) {
-          if (
-            this.providerRequirement.mode !== "optional" ||
-            (!options?.allowEmbeddingBootstrapFallback && !hadBootstrapFailure)
-          ) {
+          if (this.providerRequirement.mode !== "optional") {
             throw err;
           }
+          // Background indexing must establish optional keyword fallback before the first search.
           this.markEmbeddingBootstrapFailure(err);
           forceFtsOnly = true;
         }


### PR DESCRIPTION
Related: #115397

## What Problem This Solves

Fixes an issue where users indexing memory before their first search would receive a missing embedding-provider credential error, even though their configuration supports keyword-only search. The same startup, session-update, and post-compaction indexing paths repeatedly failed in an Ollama-only profile.

## Why This Change Was Made

The memory manager now applies its existing optional-provider initialization lifecycle to indexing as well as search. Required explicit providers still fail visibly. Provider selection, request-time fallback, retry TTL, index generations, queue ownership, and storage formats remain unchanged.

## User Impact

Manual and background indexing can build the keyword index when optional embeddings cannot initialize. Search can immediately use those indexed notes. The existing diagnostic still explains that semantic vectors are unavailable; this does not provision an embedding model or claim semantic search is working.

## Evidence

A real isolated CLI reproduction used a fresh profile and synthetic note without provider credentials:

| Operation | Baseline | Candidate |
|---|---|---|
| `memory index --agent main --force` before any search | Exit 1: missing OpenAI embedding credential | Exit 0: note indexed |
| Separate `memory search "Orchid compass" --agent main --json` | Exact note returned after search bootstrap | Exact note returned from the built index |
| Configuration and note bytes | Unchanged | Unchanged |

Four regression cases fail on unchanged production. The candidate passes 131 tests across eight memory suites, covering optional omitted/auto/local providers, required-provider failures, concurrent bootstrap, recovery, startup catchup, targeted sync queues, and lease cleanup. Both full builds, changed-file repository checks, and an independent P0–P2 code review passed.

Production is net −2 lines; tests net +52; docs net +1. Timing was recorded but is not presented as a speed improvement because host load differed.

CI initially exposed a stale startup-failure assumption in the existing candidate-repair test. Its follow-up now fails the first real sync through the supported progress callback, requires a separately admitted retry, and verifies close drains that retry and its indexed candidates survive reopening. The focused 43-test set, extension-test typecheck, typed lint, and independent P0–P2 review pass. The follow-up changes tests only; the CLI proof remains bound to production commit `075e3761618a5c35cf9b356b71f7b97b0dc8696e`.
