### PR TITLE
docs: fix communication-only session visibility example

### DIFF
--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -344,17 +344,27 @@ Legacy `agents.list` rosters and retired per-agent keys (such as `sandbox.perSes
 
   </Tab>
   <Tab title="Communication-only">
+    This complete configuration applies the tool allow/deny policy to the `communication` agent and sets session visibility for every agent on the Gateway:
+
     ```json
     {
       "tools": {
-        "sessions": { "visibility": "tree" },
-        "allow": ["sessions_list", "sessions_send", "sessions_history", "session_status"],
-        "deny": ["exec", "write", "edit", "apply_patch", "read", "browser"]
+        "sessions": { "visibility": "tree" }
+      },
+      "agents": {
+        "entries": {
+          "communication": {
+            "tools": {
+              "allow": ["sessions_list", "sessions_send", "sessions_history", "session_status"],
+              "deny": ["exec", "write", "edit", "apply_patch", "read", "browser"]
+            }
+          }
+        }
       }
     }
     ```
 
-    Session tools default to Gateway-wide visibility (`all`) with agent-to-agent messaging on; this profile narrows the agent to its own session tree. See [`tools.sessions`](/gateway/config-tools#tools-sessions) and [`tools.agentToAgent`](/gateway/config-tools#tools-agenttoagent).
+    `tools.sessions.visibility` is Gateway-wide and cannot be set per agent. Session tools default to `all` with agent-to-agent messaging on. With `tree`, callers can access their current session and sessions they spawn; the canonical main session can still access every session belonging to its agent. Incognito restrictions and the sandbox spawned-session clamp still apply. See [`tools.sessions`](/gateway/config-tools#tools-sessions) and [`tools.agentToAgent`](/gateway/config-tools#tools-agenttoagent).
 
     `sessions_history` in this profile still returns a bounded, sanitized recall view rather than a raw transcript dump. Assistant recall strips thinking tags, `<relevant-memories>` scaffolding, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks), downgraded tool-call scaffolding, leaked ASCII/full-width model control tokens, and malformed MiniMax tool-call XML before redaction/truncation.
 


### PR DESCRIPTION
Closes #139438

## What Problem This Solves

Fixes an issue where operators copying the Communication-only example into an agent's tool policy would receive `Unrecognized key: "sessions"`. The explanation also implied session visibility could be configured for one agent.

## Why This Change Was Made

Show a complete configuration with global `tools.sessions.visibility` and the allow/deny policy under `agents.entries.communication.tools`. Explain the Gateway-wide scope and the `tree` main-session exception, preserving incognito restrictions and the sandbox clamp, with links to the canonical reference. Per-agent visibility remains a separate feature request in #59149.

## User Impact

Operators can copy a schema-valid example and see which settings affect the named agent and which affect every agent on the Gateway.

## Evidence

- The complete example passes the current `OpenClawSchema`.
- Source inspection confirms that per-agent tools reject `sessions` and the runtime reads global `tools.sessions.visibility`.
- Focused MDX, oxfmt 0.65.0, conflict-marker, and `git diff --check` validation passed.
- [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33996044990) passed on this PR head, including formatting, MDX, links, and 1,217 schema-validated config examples.
- The publishing parser resolves both canonical visibility anchors; all 15 links in the changed page are unchanged.
