### PR TITLE
feat(browser): set up the Chrome extension from this Mac

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChromeExtensionSetup.swift
+++ b/apps/macos/Sources/OpenClaw/ChromeExtensionSetup.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+enum ChromeExtensionSetup {
+    struct Result: Encodable, Equatable {
+        let nativeHostRegistered: Bool
+        let installRequested: Bool
+        let discoveredProfiles: Int
+    }
+
+    private struct Report: Decodable {
+        struct Registration: Decodable {
+            let product: String
+            let state: String
+            let issue: String?
+        }
+
+        struct InstallRequest: Decodable { let state: String }
+        struct Discovery: Decodable { let product: String }
+        struct StoreDiscovery: Decodable {
+            let product: String
+            let enabled: Bool
+        }
+
+        let registrations: [Registration]
+        let storeInstallRequests: [InstallRequest]
+        let storeDiscovered: [StoreDiscovery]
+        let discovered: [Discovery]
+    }
+
+    enum SetupError: LocalizedError {
+        case missingCLI, unavailable, retired
+
+        var errorDescription: String? {
+            switch self {
+            case .missingCLI: "Install the OpenClaw CLI on this Mac, then try setup again."
+            case .unavailable:
+                "Chrome setup could not finish. Run openclaw browser extension install on this Mac for details."
+            case .retired: "The device settings document is no longer available."
+            }
+        }
+    }
+
+    static func readResult(_ stdout: String) throws -> Result {
+        let report = try JSONDecoder().decode(Report.self, from: Data(stdout.utf8))
+        return Result(
+            nativeHostRegistered: report.registrations.contains {
+                $0.product == "chrome" && $0.state == "owned" && $0.issue == nil
+            },
+            installRequested: report.storeInstallRequests.contains { $0.state == "requested" },
+            discoveredProfiles: report.storeDiscovered.filter { $0.product == "chrome" && $0.enabled }.count +
+                report.discovered.filter { $0.product == "chrome" }.count)
+    }
+
+    @MainActor
+    static func install(isCurrent: () -> Bool) async throws -> Result {
+        // The ordinary command resolver follows SSH Gateway settings. This action always owns this Mac.
+        let executable: String? = if case let .ready(location, _) = await CLIInstaller.status() {
+            location
+        } else {
+            CommandResolver.findExecutable(named: "openclaw", searchPaths: CommandResolver.preferredPaths())
+        }
+        guard isCurrent(), !Task.isCancelled else { throw SetupError.retired }
+        guard let executable else { throw SetupError.missingCLI }
+        let command = AppProfile.current.localCLICommand(
+            prefix: [executable], arguments: ["browser", "extension", "install", "--json", "--wait-ms", "1000"])
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = CommandResolver.preferredPaths().joined(separator: ":")
+        let output = await ShellExecutor.runDetailed(command: command, cwd: nil, env: environment, timeout: 30)
+        guard isCurrent(), !Task.isCancelled else { throw SetupError.retired }
+        // A bounded wait expires with exit 1 while Chrome approval is pending; valid JSON retains that outcome.
+        guard !output.timedOut, let result = try? self.readResult(output.stdout) else { throw SetupError.unavailable }
+        return result
+    }
+}

--- a/apps/macos/Sources/OpenClaw/DashboardDeviceSettingsMessageHandler.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardDeviceSettingsMessageHandler.swift
@@ -89,6 +89,21 @@ final class DashboardDeviceSettingsMessageHandler: NSObject, WKScriptMessageHand
                 replyHandler(nil, "The device settings document is no longer available.")
                 return
             }
+            if request == .installChromeExtension {
+                do {
+                    let result = try await ChromeExtensionSetup.install {
+                        owner.canUseDeviceSettings(sourceID: sourceID) && !Task.isCancelled
+                    }
+                    guard owner.canUseDeviceSettings(sourceID: sourceID), !Task.isCancelled else {
+                        replyHandler(nil, "The device settings document is no longer available.")
+                        return
+                    }
+                    try replyHandler(JSONSerialization.jsonObject(with: JSONEncoder().encode(result)), nil)
+                } catch {
+                    replyHandler(nil, error.localizedDescription)
+                }
+                return
+            }
             await owner.applyDeviceSettingsRequest(request)
             let snapshot: DeviceSettingsSnapshot? = if case .set = request {
                 await owner.readDeviceSettingsSnapshot(sourceID: sourceID)

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
@@ -55,6 +55,8 @@ extension DashboardWindowController {
             await self.openDeviceSettingsPanel(panel)
         case .checkForUpdates:
             if self.updater?.isAvailable == true { self.updater?.checkForUpdates(nil) }
+        case .installChromeExtension:
+            break // The queued handler returns the installer result directly.
         }
         // All Gateway windows show settings for this Mac; mutations must update each open view.
         NotificationCenter.default.post(name: .openclawDeviceSettingsChanged, object: nil)

--- a/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
@@ -142,6 +142,7 @@ enum DeviceSettingsRequest: Equatable {
     case openSystemSettings(DeviceSettingsPermission)
     case open(DeviceSettingsPanel)
     case checkForUpdates
+    case installChromeExtension
 
     init?(body: Any) {
         guard let payload = body as? [String: Any], let type = payload["type"] as? String else { return nil }
@@ -161,6 +162,9 @@ enum DeviceSettingsRequest: Equatable {
             else { return nil }
             self = .open(panel)
         case "check-for-updates": self = .checkForUpdates
+        case "install-chrome-extension":
+            guard payload.count == 1 else { return nil }
+            self = .installChromeExtension
         default: return nil
         }
     }

--- a/apps/macos/Tests/OpenClawIPCTests/ChromeExtensionSetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ChromeExtensionSetupTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import OpenClaw
+
+struct ChromeExtensionSetupTests {
+    @Test func `registration and pending Chrome approval do not imply installed or connected`() throws {
+        let result = try ChromeExtensionSetup.readResult("""
+        {"registrations":[{"product":"chrome","state":"owned"}],"storeInstallRequests":[{"state":"requested"}],
+         "storeDiscovered":[{"product":"chrome","enabled":false,"awaitingApproval":true}],"discovered":[]}
+        """)
+        #expect(result.nativeHostRegistered)
+        #expect(result.installRequested)
+        #expect(result.discoveredProfiles == 0)
+    }
+
+    @Test func `only enabled Store discoveries count as installed profiles`() throws {
+        let result = try ChromeExtensionSetup.readResult("""
+        {"registrations":[{"product":"chrome","state":"foreign"}],"storeInstallRequests":[{"state":"foreign"}],
+         "storeDiscovered":[{"product":"chrome","enabled":false},{"product":"chrome","enabled":true}],
+         "discovered":[{"product":"chrome"}]}
+        """)
+        #expect(!result.nativeHostRegistered)
+        #expect(!result.installRequested)
+        #expect(result.discoveredProfiles == 2)
+    }
+
+    @Test func `another browser cannot mask failed Chrome registration or pending approval`() throws {
+        let result = try ChromeExtensionSetup.readResult("""
+        {"registrations":[{"product":"chromium","state":"owned"},
+          {"product":"chrome","state":"owned","issue":"runtime unavailable"}],
+         "storeInstallRequests":[{"state":"requested"}],
+         "storeDiscovered":[{"product":"chrome","enabled":false},{"product":"chromium","enabled":true}],
+         "discovered":[{"product":"chrome-for-testing"}]}
+        """)
+        #expect(!result.nativeHostRegistered)
+        #expect(result.discoveredProfiles == 0)
+        #expect(result.installRequested)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsBridgeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsBridgeTests.swift
@@ -119,6 +119,8 @@ struct DeviceSettingsBridgeTests {
     @Test func `action requests retain the closed panel and permission identities`() {
         #expect(DeviceSettingsRequest(body: ["type": "status"]) == .status)
         #expect(DeviceSettingsRequest(body: ["type": "check-for-updates"]) == .checkForUpdates)
+        #expect(DeviceSettingsRequest(body: ["type": "install-chrome-extension"]) == .installChromeExtension)
+        #expect(DeviceSettingsRequest(body: ["type": "install-chrome-extension", "command": "other"]) == nil)
         let panels: [(String, DeviceSettingsPanel)] = [
             ("quick-chat-shortcut", .quickChatShortcut), ("microphone-test", .microphoneTest),
             ("browser-import", .browserImport), ("connection", .connection), ("gateways", .gateways), ("debug", .debug),

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -140,10 +140,12 @@ The macOS app exposes the same capability under **Dashboard → Settings → Thi
 ```bash
 openclaw browser extension path
 openclaw browser extension install
+openclaw browser extension install --no-store
 openclaw browser extension install --json --wait-ms 60000
 openclaw browser extension status
 openclaw browser extension status --json
 openclaw browser extension uninstall-host
+openclaw browser extension uninstall-store
 openclaw browser extension pair
 openclaw browser extension pair --gateway-url wss://gateway.example.com
 openclaw browser extension cdp
@@ -151,14 +153,26 @@ openclaw browser extension cdp --json
 ```
 
 - `extension install` pre-registers the origin-locked native bootstrap host in
-  existing Chrome-family user-data roots. Run it first, then
+  existing Chrome-family user-data roots. On macOS, it then requests the official
+  Store installation in Google Chrome for all profiles in its user-data directory.
+  Chrome discovers this at startup; fully quit and reopen Chrome when convenient,
+  then approve or enable OpenClaw. The command never restarts Chrome or bypasses
+  approval. For other browsers and platforms,
   [add OpenClaw from the Chrome Web Store](https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig).
-  The stable **Load unpacked** path remains available as a development fallback.
-- `extension status` reports Store discovery separately from approved unpacked
-  IDs and paths, plus owned-registration health and whether manual setup is
-  required. JSON output never includes a pairing string or relay key.
+  Linux supports automatic native pairing; Windows retains manual pairing.
+- `extension install --no-store` copies the stable development extension and
+  registers the native host without creating a Store request. Existing requests
+  are unchanged. Use the printed path for **Load unpacked**.
+- `extension status` reports `storeInstallRequests` states (`requested`,
+  `missing`, `foreign`, `invalid`) separately from `storeDiscovered` approval
+  fields (`enabled`, `awaitingApproval`), approved unpacked IDs and paths, and
+  native-host registration health. Local installation status does not prove a
+  live relay connection. JSON output never includes a pairing string or relay key.
 - `extension uninstall-host` removes only verified OpenClaw-owned native-host
   manifests and launchers. It does not remove the extension from Chrome.
+- `extension uninstall-store` removes only OpenClaw-owned macOS Chrome Store
+  requests. Chrome may remove an externally installed extension at its next
+  startup. Native-host registration and the development copy remain intact.
 - `extension path` is read-only. It prints the stable installed copy when
   present and the bundled source directory otherwise.
 - `extension pair` remains the advanced manual flow. `--gateway-url` creates a
@@ -193,6 +207,11 @@ without printing a credential. Use `--json` for machine output; warnings remain
 on stderr so stdout stays valid JSON.
 
 Setup, security model, and recovery steps: [Chrome extension](/tools/chrome-extension).
+
+Run installation on the machine hosting Chrome. In the macOS app,
+**Dashboard → Settings → This Mac → Browser → Set up Chrome on this Mac** invokes
+the local CLI even when connected to a remote Gateway. The browser-based
+dashboard offers Store and documentation links instead.
 
 If the extension already attempted automatic setup before the native host
 existed, Chromium retains that miss for the running browser process. Restart

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -391,9 +391,15 @@ That stages grounded durable candidates into the short-term dreaming store while
     exist, doctor reports registration drift. `openclaw doctor --fix` may repair
     that owned registration, but it never installs the host for every OpenClaw
     user and never overwrites a foreign same-name manifest or launcher. For
-    initial setup, run `openclaw browser extension install` first, then add the
-    official Chrome Web Store extension. The unpacked stable path is a
-    development fallback.
+    initial setup, run `openclaw browser extension install` on the machine hosting
+    Chrome. On macOS, this also requests the official Store installation in
+    Google Chrome; reopen Chrome and approve or enable OpenClaw when prompted.
+    Other browsers and platforms need a manual Store install. Doctor's repair
+    does not create a Store request or approve Chrome permissions. Use
+    `openclaw browser extension status` to distinguish a requested installation,
+    Chrome approval, and native-host registration health; these checks do not
+    prove a live relay connection. The unpacked stable path remains a development
+    fallback with `extension install --no-store`.
 
     Doctor also audits the host-local Chrome MCP path when you use `defaultProfile: "user"` or a configured `existing-session` profile:
 

--- a/docs/tools/chrome-extension.md
+++ b/docs/tools/chrome-extension.md
@@ -32,28 +32,54 @@ a script launcher or registry key without a proven binary framing path.
 
 ## Install
 
-Launch Chrome, then pre-register the native host before adding the extension:
+Launch Chrome at least once, then run this command on the machine that hosts
+Chrome:
 
 ```bash
 openclaw browser extension install
 ```
 
-Keep the command running. It pre-registers an origin-locked native host for the
-exact official Chrome Web Store identity and for OpenClaw's deterministic
-development IDs. After pre-registration succeeds, add
-[OpenClaw from the Chrome Web Store](https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig).
+Keep the command running while you complete Chrome's setup. On macOS, it first
+registers the native host, then asks Google Chrome to install the official
+Store extension. Chrome discovers the request at browser startup. If Chrome is
+already running, fully quit and reopen it when convenient, then approve or
+enable **OpenClaw** in Chrome. OpenClaw never restarts Chrome or approves its
+permission prompt for you. The request applies to all profiles in that Chrome
+user-data directory; Chrome controls approval in each profile.
 
-The extension pairs on its first native call; you do not need to open its
-popup, reload it, or restart Chrome during a normal first-time setup. The
-installer then inspects the profile's `Preferences` and `Secure Preferences`
+In the macOS app, **Dashboard → Settings → This Mac → Browser → Set up Chrome on
+this Mac** runs the same local setup. This always prepares Chrome on this Mac,
+even when the app is connected to a remote Gateway. A browser-based dashboard
+provides Store and setup-guide links instead of installing software locally.
+
+On Linux and in other supported Chromium browsers, add
+[OpenClaw from the Chrome Web Store](https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig)
+after native-host registration succeeds. Linux does not support this per-user
+Store installation request. Windows requires adding the Store extension and
+[manual pairing](#advanced-manual-pairing).
+
+You can also use the Store link if Chrome does not offer the requested install.
+If you previously removed the extension, Chrome remembers that choice; explicitly
+add it again from the Store. OpenClaw does not clear Chrome's removal decision.
+
+On macOS and Linux, the origin-locked native host permits the exact official
+Store identity and OpenClaw's deterministic development IDs. Once enabled, the
+extension pairs on its first native call. The installer inspects the profile's
+`Preferences` and `Secure Preferences`
 backing files and verifies the exact Store ID independently from any extension
 path. Chromium selects the backing file by settings-enforcement policy; Linux
 normally uses `Preferences`. Both files receive the same ownership, path, file
 type, permission, and size checks.
 
-For extension development, the command also copies the bundled extension to a
-stable OpenClaw-owned directory. Use that unpacked copy only as a development
-fallback:
+For extension development, skip creating a Store installation request:
+
+```bash
+openclaw browser extension install --no-store
+```
+
+This still copies the bundled extension to a stable OpenClaw-owned directory
+and registers the native host. It leaves any existing Store request unchanged.
+Use the unpacked copy as a development fallback:
 
 1. Open `chrome://extensions`.
 2. Enable **Developer mode**.
@@ -84,10 +110,12 @@ Use a different bounded wait when needed:
 openclaw browser extension install --wait-ms 60000
 ```
 
-For automation, use `--json`. The result reports Store discovery separately
-from approved unpacked IDs and paths, plus native-host registration health and
-whether manual setup is required. It never includes a relay key or pairing
-string.
+For automation, use `--json`. The result reports Store installation requests,
+Store discovery and approval, approved unpacked IDs and paths, and native-host
+registration health separately. These local observations do not prove a live
+connection. Verify the extension's connected state and run
+`openclaw browser --browser-profile chrome tabs` against the intended Gateway
+or browser node. JSON output never includes a relay key or pairing string.
 
 ## Use it
 
@@ -130,8 +158,8 @@ native host to start a standalone relay when reconnecting to that endpoint.
 Automatic local setup must be enabled. Requests are limited to once per minute;
 the extension still authenticates the relay with connection-bound v2 proofs.
 This requires both the updated native host and an extension build containing
-relay wake-up support. Do not assume the Store v2.2.0 build includes that code;
-the bundled unpacked development copy is the source-build validation path.
+relay wake-up support. Store publication can lag the bundled extension; the
+bundled unpacked development copy is the source-build validation path.
 
 Automatic wake-up requires the exact `127.0.0.1` host that the daemon serves.
 Other loopback aliases, including `localhost` and IPv6, do not trigger wake-up;
@@ -253,12 +281,29 @@ openclaw browser extension status
 openclaw browser extension status --json
 ```
 
-An `owned` registration is not necessarily launchable. Status reports a filesystem
+JSON `storeInstallRequests` entries report `requested` for a verified
+OpenClaw-owned request, `missing` when no request exists, `foreign` for an
+unrecognized registration, or `invalid` when the file cannot be safely read or
+validated. `storeDiscovered` reports `enabled` and `awaitingApproval` separately.
+A requested installation, a discovered extension, or an enabled extension does
+not prove an authenticated relay connection.
+
+An `owned` native-host registration is not necessarily launchable. Status reports a filesystem
 readiness snapshot of its registered runtime and native entry. It does not execute
 either target or verify that its code will run successfully. If an upgrade removes
 either target, rerun `openclaw browser extension install` to repair the owned
 registration. Ownership checks still refuse foreign or malformed manifests and
 launchers.
+
+Remove only OpenClaw's macOS Chrome Store installation request:
+
+```bash
+openclaw browser extension uninstall-store
+```
+
+Chrome may remove an externally installed extension on its next startup after
+the request is removed. This command leaves native-host registration and the
+development copy intact, and refuses foreign or malformed request files.
 
 Remove only OpenClaw-owned native-host manifests and launchers:
 

--- a/extensions/browser/src/browser/extension-install-external.test.ts
+++ b/extensions/browser/src/browser/extension-install-external.test.ts
@@ -1,0 +1,141 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { chromeProductRoots } from "./extension-install-layout.js";
+import {
+  installChromeExtensionBootstrap,
+  removeChromeStoreInstallRequests,
+  uninstallChromeExtensionNativeHosts,
+} from "./extension-install.js";
+import {
+  FOUNDATION_STORE_ID,
+  useExtensionInstallFixture,
+  writeChromePreferences,
+} from "./extension-install.test-support.js";
+
+const fixture = useExtensionInstallFixture();
+
+async function setup(platform: NodeJS.Platform = "darwin") {
+  const value = await fixture(platform);
+  const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+  if (!chrome) {
+    throw new Error("missing Chrome fixture root");
+  }
+  const preferences = await writeChromePreferences({
+    userDataDir: chrome.userDataDir,
+    profile: "Default",
+    entries: {
+      [FOUNDATION_STORE_ID]: { location: 6, from_webstore: true, disable_reasons: [8_192] },
+    },
+  });
+  const requestPath = path.join(
+    chrome.userDataDir,
+    "External Extensions",
+    `${FOUNDATION_STORE_ID}.json`,
+  );
+  const install = (requestStoreInstall?: boolean) =>
+    installChromeExtensionBootstrap({
+      bundledDir: value.bundledDir,
+      pluginRoot: value.pluginRoot,
+      waitMs: 1_000,
+      deps: value.deps,
+      requestStoreInstall,
+    });
+  return { ...value, chrome, preferences, requestPath, install };
+}
+
+describe("Chrome Store installation request", () => {
+  it("requests the official Store install idempotently without approving Chrome's recorded extension", async () => {
+    const value = await setup();
+    const preferencesBefore = await fs.readFile(value.preferences, "utf8");
+    const status = await value.install();
+    const request = await fs.readFile(value.requestPath, "utf8");
+    expect(JSON.parse(request)).toMatchObject({
+      external_update_url: "https://clients2.google.com/service/update2/crx",
+    });
+    expect(status.storeInstallRequests).toEqual([
+      expect.objectContaining({ path: value.requestPath, state: "requested" }),
+    ]);
+    expect(status.storeDiscovered).toEqual([
+      expect.objectContaining({ enabled: false, awaitingApproval: true }),
+    ]);
+    expect(status.manualSetupRequired).toBe(true);
+    expect(status.registrations.find((entry) => entry.product === "chrome")?.state).toBe("owned");
+    const before = await fs.stat(value.requestPath);
+    await value.install();
+    expect((await fs.stat(value.requestPath)).mtimeMs).toBe(before.mtimeMs);
+    expect(await fs.readFile(value.preferences, "utf8")).toBe(preferencesBefore);
+
+    await uninstallChromeExtensionNativeHosts({ deps: value.deps });
+    expect(await fs.readFile(value.requestPath, "utf8")).toBe(request);
+    expect(await removeChromeStoreInstallRequests(value.deps)).toEqual({
+      removed: [value.requestPath],
+      refused: [],
+    });
+    expect(await removeChromeStoreInstallRequests(value.deps)).toEqual({
+      removed: [],
+      refused: [],
+    });
+    expect(await fs.readFile(value.preferences, "utf8")).toBe(preferencesBefore);
+  });
+
+  it.each(["foreign", "malformed", "symlink"] as const)(
+    "preserves a %s external registration on install and cleanup",
+    async (kind) => {
+      const value = await setup();
+      await fs.mkdir(path.dirname(value.requestPath), { recursive: true, mode: 0o700 });
+      const content =
+        kind === "malformed"
+          ? "{"
+          : JSON.stringify({
+              external_update_url: "https://clients2.google.com/service/update2/crx",
+            });
+      const target =
+        kind === "symlink" ? path.join(value.root, "foreign-request.json") : value.requestPath;
+      await fs.writeFile(target, content, { mode: 0o600 });
+      if (kind === "symlink") {
+        await fs.symlink(target, value.requestPath);
+      }
+      const status = await value.install();
+      expect(status.storeInstallRequests[0]?.state).toBe(
+        kind === "foreign" ? "foreign" : "invalid",
+      );
+      expect(status.issues.join("\n")).toContain("Store installation request refused");
+      expect(await removeChromeStoreInstallRequests(value.deps)).toEqual({
+        removed: [],
+        refused: [value.requestPath],
+      });
+      expect(await fs.readFile(target, "utf8")).toBe(content);
+    },
+  );
+
+  it("does not request installation when the native host cannot be registered", async () => {
+    const value = await setup();
+    await fs.mkdir(value.chrome.nativeManifestDir, { recursive: true, mode: 0o700 });
+    await fs.writeFile(
+      path.join(value.chrome.nativeManifestDir, "ai.openclaw.browser_bootstrap.json"),
+      "{}",
+      { mode: 0o600 },
+    );
+    const status = await value.install();
+    expect(status.issues.join("\n")).toContain("native host pre-registration refused");
+    expect(status.storeInstallRequests[0]?.state).toBe("missing");
+    await expect(fs.access(value.requestPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it.each(["linux", "win32"] as const)(
+    "leaves %s external installation unchanged",
+    async (platform) => {
+      const value = await setup(platform);
+      expect((await value.install()).storeInstallRequests).toEqual([]);
+      await expect(fs.access(value.requestPath)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it("allows native-bootstrap-only setup without registering a Store installation", async () => {
+    const value = await setup();
+    const status = await value.install(false);
+    expect(status.registrations.find((entry) => entry.product === "chrome")?.state).toBe("owned");
+    expect(status.storeInstallRequests[0]?.state).toBe("missing");
+  });
+});

--- a/extensions/browser/src/browser/extension-install-external.ts
+++ b/extensions/browser/src/browser/extension-install-external.ts
@@ -15,7 +15,7 @@ const STORE_UPDATE_URL = "https://clients2.google.com/service/update2/crx";
 // Chromium ignores unknown fields in each external-extension dictionary.
 const OWNED_REQUEST = {
   external_update_url: STORE_UPDATE_URL,
-  _openclaw: "browser-store-install-v1",
+  openclawOwnership: "browser-store-install-v1",
 };
 
 export type ChromeStoreInstallRequest = {
@@ -55,8 +55,8 @@ async function inspectRequest(root: ChromeProductRoot): Promise<ChromeStoreInsta
       Object.keys(value).length !== 2 ||
       !("external_update_url" in value) ||
       value.external_update_url !== OWNED_REQUEST.external_update_url ||
-      !("_openclaw" in value) ||
-      value._openclaw !== OWNED_REQUEST._openclaw
+      !("openclawOwnership" in value) ||
+      value.openclawOwnership !== OWNED_REQUEST.openclawOwnership
     ) {
       return {
         ...result,

--- a/extensions/browser/src/browser/extension-install-external.ts
+++ b/extensions/browser/src/browser/extension-install-external.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  assertOwnedPath,
+  chromeProductRoots,
+  type ChromeProductRoot,
+  ensurePrivateDirectory,
+  type ExtensionInstallDeps,
+  pathInfo,
+} from "./extension-install-layout.js";
+
+export const FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
+export const FOUNDATION_CHROME_WEB_STORE_URL = `https://chromewebstore.google.com/detail/openclaw/${FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID}`;
+const STORE_UPDATE_URL = "https://clients2.google.com/service/update2/crx";
+// Chromium ignores unknown fields in each external-extension dictionary.
+const OWNED_REQUEST = {
+  external_update_url: STORE_UPDATE_URL,
+  _openclaw: "browser-store-install-v1",
+};
+
+export type ChromeStoreInstallRequest = {
+  browser: string;
+  path: string;
+  state: "missing" | "requested" | "foreign" | "invalid";
+  issue?: string;
+};
+
+function requestPath(root: ChromeProductRoot): string {
+  // Chromium resolves this beneath DIR_USER_DATA, shared by its profiles.
+  return path.join(
+    root.userDataDir,
+    "External Extensions",
+    `${FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID}.json`,
+  );
+}
+
+async function inspectRequest(root: ChromeProductRoot): Promise<ChromeStoreInstallRequest> {
+  const target = requestPath(root);
+  const result = { browser: root.label, path: target };
+  try {
+    if (!(await pathInfo(target))) {
+      return { ...result, state: "missing" };
+    }
+    await assertOwnedPath(root.userDataDir, "directory");
+    await assertOwnedPath(path.dirname(target), "directory");
+    await assertOwnedPath(target, "file");
+    if ((await fs.stat(target)).size > 4_096) {
+      throw new Error("Store install registration exceeds 4 KiB");
+    }
+    const value: unknown = JSON.parse(await fs.readFile(target, "utf8"));
+    if (
+      !value ||
+      typeof value !== "object" ||
+      Array.isArray(value) ||
+      Object.keys(value).length !== 2 ||
+      !("external_update_url" in value) ||
+      value.external_update_url !== OWNED_REQUEST.external_update_url ||
+      !("_openclaw" in value) ||
+      value._openclaw !== OWNED_REQUEST._openclaw
+    ) {
+      return {
+        ...result,
+        state: "foreign",
+        issue: "Store install registration is not OpenClaw-owned",
+      };
+    }
+    return { ...result, state: "requested" };
+  } catch (error) {
+    return {
+      ...result,
+      state: "invalid",
+      issue: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function supportedRoots(deps: ExtensionInstallDeps): ChromeProductRoot[] {
+  return (deps.platform ?? process.platform) === "darwin"
+    ? chromeProductRoots(deps).filter((root) => root.product === "chrome")
+    : [];
+}
+
+/** Registration requests installation; only Chrome can install and approve it. */
+export async function chromeStoreInstallRequests(
+  deps: ExtensionInstallDeps = {},
+): Promise<ChromeStoreInstallRequest[]> {
+  return await Promise.all(supportedRoots(deps).map(inspectRequest));
+}
+
+/** The caller must register the native host successfully before requesting installation. */
+export async function requestChromeStoreInstall(
+  root: ChromeProductRoot,
+  deps: ExtensionInstallDeps,
+): Promise<ChromeStoreInstallRequest | undefined> {
+  if (!supportedRoots(deps).some((candidate) => candidate.userDataDir === root.userDataDir)) {
+    return undefined;
+  }
+  const before = await inspectRequest(root);
+  if (before.state === "requested") {
+    return before;
+  }
+  if (before.state !== "missing") {
+    throw new Error(before.issue);
+  }
+  await assertOwnedPath(root.userDataDir, "directory");
+  await ensurePrivateDirectory(path.dirname(before.path));
+  await fs.writeFile(before.path, `${JSON.stringify(OWNED_REQUEST, null, 2)}\n`, {
+    mode: 0o600,
+    flag: "wx",
+  });
+  return await inspectRequest(root);
+}
+
+/** Chrome may remove an externally installed extension after this request is removed. */
+export async function removeChromeStoreInstallRequests(
+  deps: ExtensionInstallDeps = {},
+): Promise<{ removed: string[]; refused: string[] }> {
+  const removed: string[] = [];
+  const refused: string[] = [];
+  for (const root of supportedRoots(deps)) {
+    const current = await inspectRequest(root);
+    if (current.state === "requested") {
+      await fs.unlink(current.path);
+      removed.push(current.path);
+    } else if (current.state !== "missing") {
+      refused.push(current.path);
+    }
+  }
+  return { removed, refused };
+}

--- a/extensions/browser/src/browser/extension-install-layout.ts
+++ b/extensions/browser/src/browser/extension-install-layout.ts
@@ -27,7 +27,11 @@ export type DiscoveredChromeExtension = {
   extensionId: string;
   extensionPath: string;
 };
-export type DiscoveredChromeStoreExtension = Omit<DiscoveredChromeExtension, "extensionPath">;
+export type DiscoveredChromeStoreExtension = Omit<DiscoveredChromeExtension, "extensionPath"> & {
+  /** Chrome's recorded state is not proof of an authenticated relay connection. */
+  enabled: boolean;
+  awaitingApproval: boolean;
+};
 export type ExtensionInstallDeps = {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
@@ -385,12 +389,25 @@ export async function discoverChromeExtensionIds(params: {
               from_webstore?: unknown;
               location?: unknown;
               path?: unknown;
+              state?: unknown;
+              disable_reasons?: unknown;
             };
             if (
               extensionId === params.storeExtensionId &&
               entry.from_webstore === true &&
               entry.location !== UNPACKED_MANIFEST_LOCATION
             ) {
+              // Current Chrome stores a reason list; older profiles used a bitmask
+              // plus state (ENABLED = 1). External-install approval is bit 13.
+              const reasons = entry.disable_reasons;
+              const enabled =
+                (entry.state === undefined || entry.state === 1) &&
+                (reasons === undefined ||
+                  reasons === 0 ||
+                  (Array.isArray(reasons) && reasons.length === 0));
+              const awaitingApproval = Array.isArray(reasons)
+                ? reasons.includes(8_192)
+                : typeof reasons === "number" && (reasons & 8_192) !== 0;
               storeDiscovered.push({
                 product: root.product,
                 browser: root.label,
@@ -398,6 +415,8 @@ export async function discoverChromeExtensionIds(params: {
                 profile: profileEntry.name,
                 securePreferencesPath: preferencesPath,
                 extensionId,
+                enabled,
+                awaitingApproval,
               });
               continue;
             }

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -168,39 +168,91 @@ describe("native host registration", () => {
     },
   );
 
-  it("treats the exact Store record as installed without approving its recorded path", async () => {
-    const value = await fixture();
-    const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
-    if (!chrome) {
-      throw new Error("missing Chrome fixture root");
-    }
-    const arbitraryPath = path.join(value.root, "not-an-owned-extension-path");
-    await writeChromePreferences({
-      userDataDir: chrome.userDataDir,
-      profile: "Default",
-      entries: {
-        [FOUNDATION_STORE_ID]: {
-          location: 1,
-          from_webstore: true,
-          path: arbitraryPath,
+  it.each([
+    {
+      label: "current enabled",
+      recorded: { disable_reasons: [] },
+      enabled: true,
+      awaitingApproval: false,
+    },
+    {
+      label: "current enabled with reasons omitted",
+      recorded: {},
+      enabled: true,
+      awaitingApproval: false,
+    },
+    {
+      label: "pending approval",
+      recorded: { disable_reasons: [8_192] },
+      enabled: false,
+      awaitingApproval: true,
+    },
+    {
+      label: "disabled by user",
+      recorded: { disable_reasons: [1] },
+      enabled: false,
+      awaitingApproval: false,
+    },
+    {
+      label: "legacy enabled",
+      recorded: { state: 1, disable_reasons: 0 },
+      enabled: true,
+      awaitingApproval: false,
+    },
+    {
+      label: "legacy pending approval",
+      recorded: { state: 0, disable_reasons: 8_192 },
+      enabled: false,
+      awaitingApproval: true,
+    },
+    {
+      label: "invalid reasons",
+      recorded: { disable_reasons: "invalid" },
+      enabled: false,
+      awaitingApproval: false,
+    },
+  ])(
+    "reports $label Store state without approving its recorded path",
+    async ({ recorded, enabled, awaitingApproval }) => {
+      const value = await fixture();
+      const chrome = chromeProductRoots(value.deps).find((root) => root.product === "chrome");
+      if (!chrome) {
+        throw new Error("missing Chrome fixture root");
+      }
+      const arbitraryPath = path.join(value.root, "not-an-owned-extension-path");
+      await writeChromePreferences({
+        userDataDir: chrome.userDataDir,
+        profile: "Default",
+        entries: {
+          [FOUNDATION_STORE_ID]: {
+            location: 1,
+            from_webstore: true,
+            path: arbitraryPath,
+            ...recorded,
+          },
         },
-      },
-    });
+      });
 
-    const status = await installChromeExtensionBootstrap({
-      bundledDir: value.bundledDir,
-      pluginRoot: value.pluginRoot,
-      waitMs: 1_000,
-      deps: value.deps,
-    });
+      const status = await installChromeExtensionBootstrap({
+        bundledDir: value.bundledDir,
+        pluginRoot: value.pluginRoot,
+        waitMs: 1_000,
+        deps: value.deps,
+      });
 
-    expect(status.discovered).toEqual([]);
-    expect(status.storeDiscovered).toEqual([
-      expect.objectContaining({ extensionId: FOUNDATION_STORE_ID, profile: "Default" }),
-    ]);
-    expect(status.approvedPaths).not.toContain(arbitraryPath);
-    expect(status.manualSetupRequired).toBe(false);
-  });
+      expect(status.discovered).toEqual([]);
+      expect(status.storeDiscovered).toEqual([
+        expect.objectContaining({
+          extensionId: FOUNDATION_STORE_ID,
+          profile: "Default",
+          enabled,
+          awaitingApproval,
+        }),
+      ]);
+      expect(status.approvedPaths).not.toContain(arbitraryPath);
+      expect(status.manualSetupRequired).toBe(!enabled);
+    },
+  );
 
   it("refuses to overwrite or remove a foreign manifest with the same host name", async () => {
     const value = await fixture();

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -3,6 +3,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
+  chromeStoreInstallRequests,
+  type ChromeStoreInstallRequest,
+  FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID,
+  FOUNDATION_CHROME_WEB_STORE_URL,
+  requestChromeStoreInstall,
+} from "./extension-install-external.js";
+import {
   assertOwnedPath,
   chromeProductRoots,
   type ChromeProduct,
@@ -25,11 +32,10 @@ const BROWSER_EXTENSION_INSTALL_WAIT_DEFAULT_MS = 30_000;
 const BROWSER_EXTENSION_INSTALL_WAIT_MIN_MS = 1_000;
 const BROWSER_EXTENSION_INSTALL_WAIT_MAX_MS = 120_000;
 const NATIVE_HOST_DESCRIPTION = "OpenClaw browser extension bootstrap";
-// Chrome authorizes native messaging by extension ID. This trust grant intentionally
-// includes user-loaded unpacked builds that preserve the Store ID; those builds must be trusted.
-// The ID is never proof that an arbitrary extension path is OpenClaw-owned.
-const FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID = "kcdjddhmeafeomebliikmbpblkmkfoig";
-export const FOUNDATION_CHROME_WEB_STORE_URL = `https://chromewebstore.google.com/detail/openclaw/${FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID}`;
+export {
+  FOUNDATION_CHROME_WEB_STORE_URL,
+  removeChromeStoreInstallRequests,
+} from "./extension-install-external.js";
 
 type NativeHostRegistrationStatus = {
   product: ChromeProduct;
@@ -48,6 +54,7 @@ type BrowserExtensionStatus = {
   approvedPaths: string[];
   discovered: DiscoveredChromeExtension[];
   storeDiscovered: DiscoveredChromeStoreExtension[];
+  storeInstallRequests: ChromeStoreInstallRequest[];
   registrations: NativeHostRegistrationStatus[];
   manualSetupRequired: boolean;
   issues: string[];
@@ -100,6 +107,8 @@ function launcherPathForManifest(manifestPath: string, deps: ExtensionInstallDep
 }
 
 function expectedExtensionIds(extensionIds: string[]): string[] {
+  // The Store ID also authorizes trusted unpacked builds that preserve it;
+  // it never proves that an arbitrary extension path is OpenClaw-owned.
   return [...new Set([...extensionIds, FOUNDATION_CHROME_WEB_STORE_EXTENSION_ID])].toSorted();
 }
 
@@ -426,6 +435,7 @@ export async function installChromeExtensionBootstrap(params: {
   bundledDir: string;
   pluginRoot: string;
   waitMs?: number;
+  requestStoreInstall?: boolean;
   deps?: ExtensionInstallDeps;
   onProgress?: (message: string) => void;
 }): Promise<BrowserExtensionStatus> {
@@ -460,6 +470,22 @@ export async function installChromeExtensionBootstrap(params: {
     } catch (error) {
       preRegistrationIssues.push(
         `${root.label}: native host pre-registration refused (${error instanceof Error ? error.message : String(error)})`,
+      );
+      continue;
+    }
+    try {
+      const request =
+        params.requestStoreInstall === false
+          ? undefined
+          : await requestChromeStoreInstall(root, deps);
+      if (request) {
+        params.onProgress?.(
+          `Requested the OpenClaw Store extension for ${root.label}. Restart Chrome if needed, then approve OpenClaw in chrome://extensions.`,
+        );
+      }
+    } catch (error) {
+      preRegistrationIssues.push(
+        `${root.label}: Store installation request refused (${error instanceof Error ? error.message : String(error)}). Add OpenClaw directly: ${FOUNDATION_CHROME_WEB_STORE_URL}`,
       );
     }
   }
@@ -546,6 +572,7 @@ export async function browserExtensionStatus(params: {
       discovery.storeDiscovered.some((entry) => entry.product === registration.product);
     return productWasDiscovered && (registration.state !== "owned" || Boolean(registration.issue));
   });
+  const storeInstallRequests = await chromeStoreInstallRequests(deps);
   return {
     platform,
     platformSupport: platform === "win32" ? "manual_required" : "automatic",
@@ -554,11 +581,13 @@ export async function browserExtensionStatus(params: {
     approvedPaths,
     discovered: discovery.discovered,
     storeDiscovered: discovery.storeDiscovered,
+    storeInstallRequests,
     registrations,
     manualSetupRequired:
       platform === "win32" ||
       (installedCopy.present && !installedCopy.owned) ||
-      (discovery.discovered.length === 0 && discovery.storeDiscovered.length === 0) ||
+      (discovery.discovered.length === 0 &&
+        !discovery.storeDiscovered.some((entry) => entry.enabled)) ||
       discovery.identityMismatches.length > 0 ||
       unavailableRegistration,
     issues: [
@@ -566,6 +595,9 @@ export async function browserExtensionStatus(params: {
         ? [`Chrome extension copy is not OpenClaw-owned: ${installedPath}`]
         : []),
       ...discovery.issues,
+      ...storeInstallRequests.flatMap((entry) =>
+        entry.issue ? [`${entry.browser}: ${entry.issue}`] : [],
+      ),
       ...registrations.flatMap((entry) =>
         entry.issue ? [`${entry.browser}: ${entry.issue}`] : [],
       ),

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -29,6 +29,7 @@ const relayMocks = vi.hoisted(() => {
 const installMocks = vi.hoisted(() => ({
   browserExtensionStatus: vi.fn(),
   installChromeExtensionBootstrap: vi.fn(),
+  removeChromeStoreInstallRequests: vi.fn(),
   uninstallChromeExtensionNativeHosts: vi.fn(),
 }));
 
@@ -41,6 +42,7 @@ vi.mock("../browser/extension-install.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../browser/extension-install.js")>()),
   browserExtensionStatus: installMocks.browserExtensionStatus,
   installChromeExtensionBootstrap: installMocks.installChromeExtensionBootstrap,
+  removeChromeStoreInstallRequests: installMocks.removeChromeStoreInstallRequests,
   uninstallChromeExtensionNativeHosts: installMocks.uninstallChromeExtensionNativeHosts,
 }));
 
@@ -55,6 +57,7 @@ function createExtensionStatus() {
     approvedPaths: ["/stable/openclaw-extension"],
     discovered: [],
     storeDiscovered: [],
+    storeInstallRequests: [],
     registrations: [],
     manualSetupRequired: false,
     issues: [],
@@ -65,6 +68,7 @@ describe("browser extension pairing Gateway URL", () => {
   beforeEach(() => {
     installMocks.browserExtensionStatus.mockResolvedValue(createExtensionStatus());
     installMocks.installChromeExtensionBootstrap.mockResolvedValue(createExtensionStatus());
+    installMocks.removeChromeStoreInstallRequests.mockResolvedValue({ removed: [], refused: [] });
     installMocks.uninstallChromeExtensionNativeHosts.mockResolvedValue({
       removed: [],
       refused: [],
@@ -76,6 +80,7 @@ describe("browser extension pairing Gateway URL", () => {
     vi.restoreAllMocks();
     installMocks.browserExtensionStatus.mockReset();
     installMocks.installChromeExtensionBootstrap.mockReset();
+    installMocks.removeChromeStoreInstallRequests.mockReset();
     installMocks.uninstallChromeExtensionNativeHosts.mockReset();
     resetRuntimeCapture();
   });
@@ -105,6 +110,7 @@ describe("browser extension pairing Gateway URL", () => {
             },
           ],
           storeDiscovered: [],
+          storeInstallRequests: [],
           registrations: [],
           manualSetupRequired: false,
           issues: [],
@@ -126,6 +132,56 @@ describe("browser extension pairing Gateway URL", () => {
       output.findIndex((message) => message.includes("Chrome Web Store")),
     );
     expect(output.at(-1)).toContain("extension identity verified");
+  });
+
+  it("keeps development-only installation from requesting the Store extension", async () => {
+    vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(runtime.writeJson);
+    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const program = new Command();
+    registerBrowserExtensionCommands(program.command("browser"), () => ({}));
+    await program.parseAsync(["browser", "extension", "install", "--no-store", "--json"], {
+      from: "user",
+    });
+    expect(installMocks.installChromeExtensionBootstrap).toHaveBeenCalledWith(
+      expect.objectContaining({ requestStoreInstall: false }),
+    );
+  });
+
+  it("reports Chrome approval as pending without claiming connection", async () => {
+    installMocks.installChromeExtensionBootstrap.mockResolvedValue({
+      ...createExtensionStatus(),
+      manualSetupRequired: true,
+      storeInstallRequests: [
+        {
+          browser: "Google Chrome",
+          path: "/chrome/External Extensions/openclaw.json",
+          state: "requested",
+        },
+      ],
+    });
+    const logSpy = vi.spyOn(cliCoreApiModule.defaultRuntime, "log").mockImplementation(runtime.log);
+    vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(runtime.exit);
+    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const program = new Command();
+    registerBrowserExtensionCommands(program.command("browser"), () => ({}));
+    await expect(
+      program.parseAsync(["browser", "extension", "install"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+    expect(logSpy.mock.calls.map(([message]) => String(message)).join("\n")).toContain(
+      "approve Chrome's prompt",
+    );
+  });
+
+  it("removes Store requests without removing native hosts", async () => {
+    vi.spyOn(cliCoreApiModule.defaultRuntime, "writeJson").mockImplementation(runtime.writeJson);
+    const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+    const program = new Command();
+    registerBrowserExtensionCommands(program.command("browser"), () => ({}));
+    await program.parseAsync(["browser", "extension", "uninstall-store", "--json"], {
+      from: "user",
+    });
+    expect(installMocks.removeChromeStoreInstallRequests).toHaveBeenCalledOnce();
+    expect(installMocks.uninstallChromeExtensionNativeHosts).not.toHaveBeenCalled();
   });
 
   it.each(["0x1000", "1e4", "+50000", " 50000", "50000 ", "50000\t"])(

--- a/extensions/browser/src/cli/browser-cli-extension.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.ts
@@ -11,6 +11,7 @@ import {
   FOUNDATION_CHROME_WEB_STORE_URL,
   installChromeExtensionBootstrap,
   normalizeExtensionInstallWaitMs,
+  removeChromeStoreInstallRequests,
   resolveChromeExtensionLoadPath,
   uninstallChromeExtensionNativeHosts,
 } from "../browser/extension-install.js";
@@ -161,7 +162,11 @@ export function registerBrowserExtensionCommands(
 
   extension
     .command("install")
-    .description("Register the native bootstrap host for Store and development installs")
+    .description("Set up the Chrome extension and request Store installation on macOS")
+    .option(
+      "--no-store",
+      "Prepare native bootstrap and development files without requesting Store installation",
+    )
     .option("--json", "Print a machine-readable status report")
     .option(
       "--wait-ms <ms>",
@@ -176,14 +181,13 @@ export function registerBrowserExtensionCommands(
           const waitMs = normalizeExtensionInstallWaitMs(opts.waitMs);
           const bundledDir = resolveChromeExtensionDir(pluginRoot);
           if (!json) {
-            defaultRuntime.log(
-              info("Preparing the OpenClaw Chrome native bootstrap. Keep Chrome running…"),
-            );
+            defaultRuntime.log(info("Preparing the OpenClaw Chrome extension…"));
           }
           const status = await installChromeExtensionBootstrap({
             bundledDir,
             pluginRoot: resolveBrowserPluginRoot(pluginRoot),
             waitMs,
+            requestStoreInstall: opts.store !== false,
             onProgress: json ? undefined : (message) => defaultRuntime.log(info(message)),
           });
           if (json) {
@@ -197,10 +201,12 @@ export function registerBrowserExtensionCommands(
                 ? theme.warn(
                     status.platformSupport === "manual_required"
                       ? "Automatic native bootstrap is not supported on this platform; use Settings for manual pairing."
-                      : `Automatic setup was not verified. Run install before adding OpenClaw from ${FOUNDATION_CHROME_WEB_STORE_URL}. Use Load unpacked only as a development fallback after pre-registration. If this extension already attempted setup before the host existed, restart Chrome once before retrying.`,
+                      : status.storeInstallRequests.some((entry) => entry.state === "requested")
+                        ? `Store installation requested. Enable OpenClaw in chrome://extensions and approve Chrome's prompt. If it has not appeared, restart Chrome when convenient or add it from ${FOUNDATION_CHROME_WEB_STORE_URL}. Run extension status to check setup again.`
+                        : `Setup needs attention. Add OpenClaw from ${FOUNDATION_CHROME_WEB_STORE_URL} after native registration succeeds. For development, load the printed unpacked path. If the extension attempted setup before the native host existed, restart Chrome once.`,
                   )
                 : info(
-                    `Native host and extension identity verified for ${status.discovered.length + status.storeDiscovered.length} profile registration(s). The extension connects automatically.`,
+                    `Native host and extension identity verified for ${status.discovered.length + status.storeDiscovered.length} profile registration(s). Check the extension popup for Connected before using browser automation.`,
                   ),
             );
           }
@@ -232,13 +238,41 @@ export function registerBrowserExtensionCommands(
         defaultRuntime.log(
           [
             `Extension copy: ${status.installedCopy.owned ? "installed" : "bundled fallback"}`,
-            `Store:          ${status.storeDiscovered.length > 0 ? status.storeDiscovered.map((entry) => `${entry.extensionId} (${entry.browser}/${entry.profile})`).join(", ") : "not detected"}`,
+            `Store request:  ${status.storeInstallRequests.length > 0 ? status.storeInstallRequests.map((entry) => `${entry.browser}: ${entry.state}`).join(", ") : "use the Chrome Web Store"}`,
+            `Store:          ${status.storeDiscovered.length > 0 ? status.storeDiscovered.map((entry) => `${entry.extensionId} (${entry.browser}/${entry.profile}; ${entry.enabled ? "enabled" : entry.awaitingApproval ? "awaiting approval" : "disabled"})`).join(", ") : "not detected"}`,
             `Development:    ${status.discovered.length > 0 ? status.discovered.map((entry) => `${entry.extensionId} (${entry.browser}/${entry.profile})`).join(", ") : "none detected"}`,
             `Load unpacked:  ${status.installedCopy.owned ? status.installedCopy.path : status.bundledPath}`,
             `Native hosts:   ${status.registrations.filter((entry) => entry.state === "owned").length} owned`,
             `Setup:          ${status.manualSetupRequired ? "manual action required" : "automatic bootstrap ready"}`,
           ].join("\n"),
         );
+      });
+    });
+
+  extension
+    .command("uninstall-store")
+    .description(
+      "Remove OpenClaw-owned Store install requests; Chrome may remove the extension on restart",
+    )
+    .option("--json", "Print a machine-readable removal report")
+    .action(async (opts, command) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const result = await removeChromeStoreInstallRequests();
+        if (opts.json === true || parentOpts(command).json === true) {
+          defaultRuntime.writeJson(result);
+        } else {
+          defaultRuntime.log(
+            info(
+              `Removed ${result.removed.length} owned Store install request(s). Chrome may remove externally installed copies on its next start. Native hosts are unchanged.`,
+            ),
+          );
+          for (const refused of result.refused) {
+            defaultRuntime.error(theme.warn(`Refused foreign Store registration: ${refused}`));
+          }
+        }
+        if (result.refused.length > 0) {
+          defaultRuntime.exit(1);
+        }
       });
     });
 

--- a/extensions/browser/src/cli/browser-cli.test.ts
+++ b/extensions/browser/src/cli/browser-cli.test.ts
@@ -34,6 +34,7 @@ describe("Browser CLI import boundary", () => {
       "path",
       "install",
       "status",
+      "uninstall-store",
       "uninstall-host",
       "pair",
       "cdp",

--- a/ui/src/app-navigation-groups.test.ts
+++ b/ui/src/app-navigation-groups.test.ts
@@ -32,6 +32,11 @@ describe("sidebar entries", () => {
       openSystemSettings: () => undefined,
       openPanel: () => undefined,
       checkForUpdates: () => undefined,
+      installChromeExtension: async () => ({
+        nativeHostRegistered: false,
+        installRequested: false,
+        discoveredProfiles: 0,
+      }),
       refresh: () => undefined,
       dispose: () => undefined,
     };

--- a/ui/src/app/native-device-settings.test.ts
+++ b/ui/src/app/native-device-settings.test.ts
@@ -26,6 +26,17 @@ function publish(detail: unknown) {
 }
 
 describe("native device settings wire contract", () => {
+  it("validates setup results and forwards an explicit parameter-free installation action", async () => {
+    const post = installBridge();
+    const result = { nativeHostRegistered: true, installRequested: true, discoveredProfiles: 0 };
+    post.mockResolvedValueOnce(result);
+    await expect(capability!.installChromeExtension()).resolves.toEqual(result);
+    expect(post).toHaveBeenLastCalledWith({ type: "install-chrome-extension" });
+    post.mockResolvedValueOnce({ ...result, discoveredProfiles: -1 });
+    await expect(capability!.installChromeExtension()).rejects.toThrow("invalid result");
+    post.mockRejectedValueOnce(new Error("CLI unavailable"));
+    await expect(capability!.installChromeExtension()).rejects.toThrow("CLI unavailable");
+  });
   it("exists only with the native message handler and reads the document-start snapshot", () => {
     vi.stubGlobal("webkit", undefined);
     expect(createNativeDeviceSettingsCapability()).toBeNull();

--- a/ui/src/app/native-device-settings.ts
+++ b/ui/src/app/native-device-settings.ts
@@ -122,7 +122,14 @@ type NativeDeviceSettingsMessage =
   | { type: "request-permission"; id: PermissionId }
   | { type: "open-system-settings"; id: PermissionId }
   | { type: "open"; panel: NativePanel }
-  | { type: "check-for-updates" };
+  | { type: "check-for-updates" }
+  | { type: "install-chrome-extension" };
+
+export type NativeChromeExtensionSetupResult = {
+  nativeHostRegistered: boolean;
+  installRequested: boolean;
+  discoveredProfiles: number;
+};
 
 export type NativeDeviceSettingsCapability = {
   readonly snapshot: NativeDeviceSettingsSnapshot | null;
@@ -132,6 +139,7 @@ export type NativeDeviceSettingsCapability = {
   openSystemSettings(id: PermissionId): void;
   openPanel(panel: NativePanel): void;
   checkForUpdates(): void;
+  installChromeExtension(): Promise<NativeChromeExtensionSetupResult>;
   refresh(): void;
   dispose(): void;
 };
@@ -337,6 +345,28 @@ export function createNativeDeviceSettingsCapability(): NativeDeviceSettingsCapa
     openSystemSettings: (id) => void send({ type: "open-system-settings", id }),
     openPanel: (panel) => void send({ type: "open", panel }),
     checkForUpdates: () => void send({ type: "check-for-updates" }),
+    async installChromeExtension() {
+      if (disposed) {
+        throw new Error("Native device settings is unavailable");
+      }
+      const reply = await post({ type: "install-chrome-extension" });
+      if (
+        disposed ||
+        !isRecord(reply) ||
+        typeof reply.nativeHostRegistered !== "boolean" ||
+        typeof reply.installRequested !== "boolean" ||
+        typeof reply.discoveredProfiles !== "number" ||
+        !Number.isSafeInteger(reply.discoveredProfiles) ||
+        reply.discoveredProfiles < 0
+      ) {
+        throw new Error("Native Chrome setup returned an invalid result");
+      }
+      return {
+        nativeHostRegistered: reply.nativeHostRegistered,
+        installRequested: reply.installRequested,
+        discoveredProfiles: reply.discoveredProfiles,
+      };
+    },
     refresh,
     dispose() {
       disposed = true;

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -312,6 +312,19 @@ const enSettings = {
       peekabooBridgeHint:
         "Allow signed tools to drive UI automation via Peekaboo Bridge. Requires Computer Control; otherwise run Peekaboo's own Mac app.",
       browser: "Browser",
+      chromeExtension: "Chrome extension",
+      chromeExtensionSetup: "Set up Chrome on this Mac",
+      chromeExtensionHint:
+        "Prepare the OpenClaw extension on this Mac, then approve it in Chrome. This does not install on a remote Gateway.",
+      chromeExtensionPreparing: "Preparing Chrome…",
+      chromeExtensionPending:
+        "Native host registered and installation requested. Open Chrome and approve OpenClaw; restart Chrome if the request has not appeared. Use the Store link if you previously removed it.",
+      chromeExtensionStoreRequired:
+        "Native host registered. Add OpenClaw from the Chrome Web Store to finish setup.",
+      chromeExtensionInstalled:
+        "Native host registered and extension found. Open the extension to check its connection; installation alone does not verify a connection.",
+      chromeExtensionFailed:
+        "Setup could not finish. Install the OpenClaw CLI on this Mac and run openclaw browser extension install for details.",
       browserImport: "Browser logins",
       browserImportHint:
         "Copy cookies from a Chrome-family profile into an isolated managed profile.",

--- a/ui/src/pages/config/talk.test.ts
+++ b/ui/src/pages/config/talk.test.ts
@@ -455,6 +455,7 @@ describe("Talk device and voice wake settings", () => {
       openSystemSettings: vi.fn(),
       openPanel: vi.fn(),
       checkForUpdates: vi.fn(),
+      installChromeExtension: vi.fn(),
       refresh: vi.fn(),
       dispose: vi.fn(),
     } satisfies NativeDeviceSettingsCapability;
@@ -526,6 +527,7 @@ describe("Talk device and voice wake settings", () => {
       openSystemSettings: vi.fn(),
       openPanel: vi.fn(),
       checkForUpdates: vi.fn(),
+      installChromeExtension: vi.fn(),
       refresh: vi.fn(),
       dispose: vi.fn(),
     } satisfies NativeDeviceSettingsCapability;

--- a/ui/src/pages/config/updates.test.ts
+++ b/ui/src/pages/config/updates.test.ts
@@ -88,6 +88,7 @@ describe("renderUpdates", () => {
       openSystemSettings: vi.fn(),
       openPanel: vi.fn(),
       checkForUpdates: vi.fn(),
+      installChromeExtension: vi.fn(),
       refresh: vi.fn(),
       dispose: vi.fn(),
     } satisfies NativeDeviceSettingsCapability;

--- a/ui/src/pages/device/device-page.ts
+++ b/ui/src/pages/device/device-page.ts
@@ -4,6 +4,7 @@ import { state } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import type {
+  NativeChromeExtensionSetupResult,
   NativeDeviceSettingsCapability,
   NativeDeviceSettingsSnapshot,
   SettingKey,
@@ -67,6 +68,9 @@ class DevicePage extends OpenClawLightDomElement {
   private context!: ApplicationContext;
 
   @state() private newDomain = "";
+  @state() private extensionSetupRunning = false;
+  @state() private extensionSetupResult: NativeChromeExtensionSetupResult | null = null;
+  @state() private extensionSetupFailed = false;
   private targetProfileTimer: {
     capability: NativeDeviceSettingsCapability;
     timer: ReturnType<typeof setTimeout>;
@@ -171,6 +175,52 @@ class DevicePage extends OpenClawLightDomElement {
       this.newDomain = "";
     };
     return html`
+      ${renderSettingsSection(
+        { title: t("configPage.deviceSettings.chromeExtension") },
+        renderSettingsRow({
+          title: t("configPage.deviceSettings.chromeExtensionSetup"),
+          description: t("configPage.deviceSettings.chromeExtensionHint"),
+          stacked: true,
+          control: html`
+            <div class="device-extension-setup">
+              <div class="device-extension-setup__actions">
+                <button
+                  type="button"
+                  class="btn"
+                  ?disabled=${this.extensionSetupRunning}
+                  @click=${() => this.installChromeExtension()}
+                >
+                  ${t(this.extensionSetupRunning ? "configPage.deviceSettings.chromeExtensionPreparing" : "configPage.deviceSettings.chromeExtensionSetup")}
+                </button>
+                <a
+                  href="https://chromewebstore.google.com/detail/openclaw/kcdjddhmeafeomebliikmbpblkmkfoig"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >${t("appsPage.ctaChromeWebStore")}</a
+                >
+                ${renderLearnMoreLink("https://docs.openclaw.ai/tools/chrome-extension")}
+              </div>
+              <p role="status">
+                ${
+                  this.extensionSetupFailed
+                    ? t("configPage.deviceSettings.chromeExtensionFailed")
+                    : this.extensionSetupResult
+                      ? t(
+                          this.extensionSetupResult.nativeHostRegistered
+                            ? this.extensionSetupResult.discoveredProfiles > 0
+                              ? "configPage.deviceSettings.chromeExtensionInstalled"
+                              : this.extensionSetupResult.installRequested
+                                ? "configPage.deviceSettings.chromeExtensionPending"
+                                : "configPage.deviceSettings.chromeExtensionStoreRequired"
+                            : "configPage.deviceSettings.chromeExtensionFailed",
+                        )
+                      : nothing
+                }
+              </p>
+            </div>
+          `,
+        }),
+      )}
       ${
         snapshot.browser.importAvailable || !sync.available
           ? renderSettingsSection(
@@ -292,6 +342,28 @@ class DevicePage extends OpenClawLightDomElement {
           : nothing
       }
     `;
+  }
+
+  private async installChromeExtension() {
+    const capability = this.context.nativeDeviceSettings;
+    if (!capability || this.extensionSetupRunning) {
+      return;
+    }
+    this.extensionSetupRunning = true;
+    this.extensionSetupFailed = false;
+    this.extensionSetupResult = null;
+    try {
+      const result = await capability.installChromeExtension();
+      if (this.isConnected && this.context.nativeDeviceSettings === capability) {
+        this.extensionSetupResult = result;
+      }
+    } catch {
+      if (this.isConnected && this.context.nativeDeviceSettings === capability) {
+        this.extensionSetupFailed = true;
+      }
+    } finally {
+      this.extensionSetupRunning = false;
+    }
   }
 
   private renderSettings(snapshot: NativeDeviceSettingsSnapshot) {

--- a/ui/src/pages/device/device-pages.test.ts
+++ b/ui/src/pages/device/device-pages.test.ts
@@ -35,6 +35,7 @@ function createCapability(
     openSystemSettings: vi.fn(),
     openPanel: vi.fn(),
     checkForUpdates: vi.fn(),
+    installChromeExtension: vi.fn(),
     refresh: vi.fn(),
     dispose: vi.fn(),
   } satisfies NativeDeviceSettingsCapability;
@@ -90,6 +91,22 @@ afterEach(() => {
 });
 
 describe("native device settings pages", () => {
+  it("requests setup only on click and reports Chrome approval separately from installation", async () => {
+    const { capability } = createCapability();
+    capability.installChromeExtension.mockResolvedValue({
+      nativeHostRegistered: true,
+      installRequested: true,
+      discoveredProfiles: 0,
+    });
+    const page = await mount("openclaw-device-page", capability);
+    expect(capability.installChromeExtension).not.toHaveBeenCalled();
+    row(page, "Set up Chrome on this Mac").querySelector<HTMLButtonElement>("button")!.click();
+    await vi.waitFor(() => expect(page.textContent).toContain("installation requested"));
+    expect(page.textContent).not.toContain("Native host registered and extension found");
+    capability.installChromeExtension.mockRejectedValueOnce(new Error("CLI missing"));
+    row(page, "Set up Chrome on this Mac").querySelector<HTMLButtonElement>("button")!.click();
+    await vi.waitFor(() => expect(page.textContent).toContain("Setup could not finish"));
+  });
   it.each(["openclaw-device-page", "openclaw-device-permissions-page"] as const)(
     "shows an app-only state without a bridge and waits for the initial snapshot on %s",
     async (tag) => {

--- a/ui/src/pages/device/device.css
+++ b/ui/src/pages/device/device.css
@@ -11,3 +11,20 @@
   flex-wrap: wrap;
   gap: var(--space-2);
 }
+
+.device-extension-setup {
+  display: grid;
+  gap: var(--space-2);
+  width: 100%;
+}
+
+.device-extension-setup__actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.device-extension-setup p {
+  margin: 0;
+}


### PR DESCRIPTION
Closes #139448

## What Problem This Solves

Chrome extension setup requires separate native-host preparation and a manual trip to the Store, and the Mac app has no local setup action. A downloaded but disabled extension can also be mistaken for a ready installation.

## Why This Change Was Made

The installer now registers the native host before creating Chrome's supported per-user external Store request on macOS. Chrome downloads the official extension and retains control of approval, enablement, updates, and uninstall decisions. The Mac dashboard's This Mac → Browser setup action always runs the local CLI, even with a remote Gateway.

Store requests and recorded enablement are reported separately. `--no-store` preserves development-only setup, and `uninstall-store` removes only OpenClaw-owned request metadata without changing native hosts. Linux and Windows retain their documented Store/manual paths. Setup instructions and Doctor guidance match these boundaries.

## User Impact

Mac users can start Chrome extension setup from one dashboard action or CLI command, then approve it in Chrome. Running Chrome may need a restart before it sees the request; OpenClaw does not restart it or bypass approval. Status directs users to check the extension's connected state rather than treating installation as connection proof.

## Evidence

- Focused browser installer/lifecycle/CLI tests: 98 passed.
- Focused dashboard and native-bridge contract tests: 131 passed; 35 bridge/device tests passed again after the final layout and status refinement.
- Native app and test compilation passed locally. Both macOS Swift CI lanes (release and tests) passed on this head; native tests were not run against the operator desktop.
- Actual installer proof in isolated Google Chrome 152.0.7977.76 on macOS: owned request created after native-host registration, Store download visible in two profiles, both correctly pending approval, no reported issues. Removing the request removed the externally installed extension on the next Chrome start.
- Store proof used the currently distributed 2.2.0 extension. It does not claim 2.3 publication or authenticated pairing proof.
- Final focused installer/CLI follow-up: 14 tests passed, plus the native-host E2E test launched the generated host with isolated configuration and verified its framed bootstrap response.
- Docs MDX, formatting, and whitespace checks passed. Independent review found no remaining actionable P0–P2 issues after fixing cross-browser status aggregation.
- Full build passed. Required final-head CI passed. All local changed-check lanes completed: lint, types, docs, state/helper guards, and macOS tooling tests. The final macOS tooling group passed on a focused retry after an unchanged checkout-fixture cleanup case transiently observed a surviving child; no process-management or test-expectation changes were made. Initial CI caught two addressed integration details (ownership-key lint and the CLI command inventory). The unchanged process-group cleanup test passed on this head. A board-widget UI test failed despite a byte-identical UI tree passing on the prior head; its exact-job retry passed without changes to the UI test or production UI.

### Chrome installation: before / awaiting approval

These are actual isolated Chrome screenshots with no signed-in account or personal data.

![Before: no OpenClaw extension](https://github.com/user-attachments/assets/d2c8429c-aa51-42bc-97f5-ea06c941c7fa)

![After installer request and Chrome restart: OpenClaw downloaded, pending approval](https://github.com/user-attachments/assets/d40832f9-e7ad-4a03-8890-46d732643efe)

### Mac settings: before / setup requested

These render the actual dashboard page with a synthetic native bridge. The click forwarded exactly one setup request; these UI captures do not claim native execution or a connected extension.

![Before: browser settings without extension setup](https://github.com/user-attachments/assets/40745b4d-d6d6-4370-8a04-6b6d15ad1673)

![After: local Chrome setup with explicit approval instructions](https://github.com/user-attachments/assets/aae5dad3-dd76-4fa6-9aa9-5bbc364a82d5)

### Upgrade and stored-data compatibility

The new JSON file is Chrome's documented external-extension registration contract. This change adds no SQLite schema, migration, persisted native-device snapshot field, or new OpenClaw runtime store. The ownership marker is new, unpublished metadata; existing Store installations, browser preferences, native-host registrations, and development copies retain their owners and existing repair paths.

The installer lifecycle tests verify repeated setup is idempotent, Chrome preference bytes remain unchanged, foreign/malformed/symlink registrations are preserved, `--no-store` leaves the request absent, and native-host removal does not remove the Store request. Explicit `uninstall-store` removes only our exact owned metadata. Actual Chrome proof covered a fresh profile, a second profile, pending approval, and cleanup followed by browser restart. These are additive installation and removal paths; there is no prior shipped OpenClaw Store-request format to migrate.
