### PR TITLE
fix: avoid session deletion slowdown in large session stores

### DIFF
--- a/src/config/sessions/plugin-host-cleanup.ts
+++ b/src/config/sessions/plugin-host-cleanup.ts
@@ -19,7 +19,7 @@ export type PluginHostSessionCleanupStoreParams = {
   sessionEntrySlotKeys?: ReadonlySet<string>;
   /** Locked-harness ids whose sessions this cleanup must leave untouched. */
   preserveLockedHarnessIds?: ReadonlySet<string>;
-  /** Per-store file-backed transaction boundary. */
+  /** Per-store SQLite transaction boundary. */
   storePath: string;
   /** Cancels the cleanup before persistence when host lifecycle state changes. */
   shouldCleanup?: () => boolean;

--- a/src/config/sessions/session-accessor.lifecycle.ts
+++ b/src/config/sessions/session-accessor.lifecycle.ts
@@ -294,16 +294,13 @@ export async function cleanupPluginHostSessionStore(
   }
   const now = Date.now();
   let cleared = 0;
-  // Cleanup selectors use metadata; saved prompts are reserved from plugin slots.
-  // The patch owner rereads each selected full entry before changing it.
+  // Select metadata without yielding; saved prompts are reserved from plugin slots.
+  // Check only selected writes; the patch rereads full entries and rechecks authority at commit.
   for (const { entry, sessionKey } of listSessionEntriesCore({
     agentId: params.agentId,
     storePath: params.storePath,
     projection: "list",
   })) {
-    if (params.shouldCleanup && !params.shouldCleanup()) {
-      break;
-    }
     if (isLockedHarnessSessionOwnedByPlugin(entry, params.preserveLockedHarnessIds)) {
       continue;
     }
@@ -312,6 +309,9 @@ export async function cleanupPluginHostSessionStore(
       !hasPluginHostCleanupTarget(entry, params)
     ) {
       continue;
+    }
+    if (params.shouldCleanup && !params.shouldCleanup()) {
+      break;
     }
     await patchSessionEntryCore(
       { agentId: params.agentId, sessionKey, storePath: params.storePath },

--- a/src/plugins/host-hook-cleanup.ts
+++ b/src/plugins/host-hook-cleanup.ts
@@ -19,7 +19,6 @@ import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginRegistry } from "./runtime.js";
 import { normalizeSessionEntrySlotKey } from "./session-entry-slot-keys.js";
 
-/** Failure captured while running plugin cleanup hooks. */
 /** Failure captured while running one plugin cleanup callback. */
 type PluginHostCleanupFailure = {
   pluginId: string;
@@ -187,7 +186,6 @@ function collectAgentHarnessIds(
 }
 
 /** Runs persistent and in-memory cleanup for a plugin, session, or host lifecycle event. */
-/** Runs cleanup callbacks for one plugin and returns failures instead of throwing. */
 export async function runPluginHostCleanup(params: {
   cfg?: OpenClawConfig;
   registry?: PluginRegistry | null;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where deleting a session became slower as unrelated sessions accumulated in the same agent store.

## Why This Change Was Made

Plugin-session cleanup revalidated the deletion target before filtering every metadata row. The cleanup owner now selects applicable rows first, then checks authority immediately before each selected patch. The initial check, fresh-entry checks and commit-time revalidation remain in place, including revocation while waiting for a writer.

This retains the cancellation protection from #138957 and the metadata-only scan from #138946. It also removes duplicate cleanup documentation and corrects the store-boundary description. Production LOC: +6/-8 (net −2); test LOC unchanged.

## User Impact

Deleting one session avoids repeating target authorization reads for unrelated or preserved rows. Cleanup selection, locked-session preservation and persisted results remain unchanged. Metadata enumeration still scales with store size.

## Evidence

Linux Node 26.7.0, actual `handleGatewayRequest`, isolated synthetic state, unchanged before/after actor: 72 measured deletions passed and every unrelated logical session row remained unchanged. Timing and SQL/JSON instrumentation ran in separate processes.

| Synthetic deletion at 1,000 unrelated rows | Before | After |
| --- | ---: | ---: |
| Owner/write-scoped archived deletion, median handler time | 1,993.91 ms | 1,367.52 ms |
| Admin ordinary deletion, median handler time | 1,457.07 ms | 1,372.75 ms |
| Target-bound session SELECTs, either role | 1,045 | 45 |
| Owner flow, maximum observed 5 ms heartbeat lateness | 657.67 ms | 57.89 ms |
| Admin flow, maximum observed 5 ms heartbeat lateness | 104.33 ms | 28.18 ms |

Target reads stay at 45 across 1, 100 and 1,000 unrelated rows. Metadata enumeration counts are unchanged. Small-store median changes ranged from +0.37% to −0.69%; three samples per case support a descriptive comparison, not a population latency-tail claim. The source-run latency floor remains roughly 1.3 s.

Independent `sourcePerformance` builds of exact baseline `693e8fb9e57b` and public candidate `51c920d6a99c` also passed 30 real CLI/Gateway deletions. In that separate **compiled admin flow**, the warmed native response-log median at 1,000 unrelated rows fell from **545 to 422 ms**; whole-CLI median fell from **1,122 to 995 ms**. Medians use three warmed deletions; the first deletion after readiness is reported separately. Both builds preserved source/dist identity and unrelated rows; invalid-token checks were rejected, and all six Gateways exited cleanly without SIGKILL.

All **116 existing tests** passed: 73 cleanup/projection/registry/data-version cases and 43 Gateway deletion lifecycle cases. The full changed gate passed in 745.6 s. Independent P0–P2 review and the exact-head ClawSweeper review found no actionable issues. [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33996239652) passed on `51c920d6a99c`; all check results are successful or scope-skipped.

[Verified synthetic results bundle](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjU4NDkz/session-delete-20260905-51c920/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260905T230440Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260905%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=099df9cbd68b6d1cca839fbec25853af040d83ebce4b1d8bf593a342ad6171b4) contains separate source-router and compiled-flow datasets. Signed links expire **September 12, 2026 at 23:04 UTC**. Both test leases were stopped after artifact downloads were verified.

A prior repeated-baseline attempt stopped before applying the patch because its first process-group liveness probe observed a group that disappeared before a signal could be delivered. That attempt is retained as failed. The completed comparison phases passed the same closure predicates, with no delivered cleanup signals or escalation; only read-only process observations were added.

No new callback-count unit test was added: callback frequency is not the API contract. The real-store scaling comparison measures the redundant work, while existing tests exercise cancellation after writer admission, committed-only cleanup, locked harnesses, registry replacement, opaque session keys, runtime IDs and promoted slots.
