### PR TITLE
fix(sessions): prevent database lock failures during reclamation

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -342,8 +342,12 @@ that mandatory join cannot be abandoned at the append deadline.
 
 Reclamation page maintenance uses a PASSIVE checkpoint and at most 512 pages of
 incremental vacuum per pass. PASSIVE does not wait for readers, but does not cap
-the number of WAL frames copied. Full logical deletion with resumable physical
-cleanup remains a separate design; existing deletion visibility and rollback
+the number of WAL frames copied. Before pruning retained archives, disk-budget
+enforcement drains the initially observed free pages in units of at most 512,
+yields between units, and reacquires the database owner after each yield. It
+preserves physical checkpointing before measuring pressure, so unreclaimed pages
+do not cause unnecessary archive deletion. Full logical deletion with resumable
+physical cleanup remains a separate design; existing deletion visibility and rollback
 semantics are unchanged.
 
 ### Preserve the data and concurrency contracts

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -330,6 +330,22 @@ admission. Publish live session changes and other dependent effects only after
 the durable write succeeds. A future network-backed owner must preserve that
 ordering while awaiting its driver.
 
+Session reclamation keeps its deletion transaction on a worker connection.
+Archive publication and cascading deletion remain atomic. Before COMMIT, the
+worker publishes its authorization request in shared memory and waits for the
+parent's current owner check. Synchronous transcript writers service that request
+between short SQLite lock-admission attempts, in the reclamation owner's captured
+async context. Only admission is retried; append callbacks and mutations are never
+replayed. The original lock-admission deadline is retained. After granting approval,
+the parent synchronously joins transaction settlement before allowing owner retirement;
+that mandatory join cannot be abandoned at the append deadline.
+
+Reclamation page maintenance uses a PASSIVE checkpoint and at most 512 pages of
+incremental vacuum per pass. PASSIVE does not wait for readers, but does not cap
+the number of WAL frames copied. Full logical deletion with resumable physical
+cleanup remains a separate design; existing deletion visibility and rollback
+semantics are unchanged.
+
 ### Preserve the data and concurrency contracts
 
 An adapter must make these contracts explicit and verify them against a real

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts
@@ -7,7 +7,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
 import * as nodeSqlite from "../../infra/node-sqlite.js";
 import * as sqliteTransaction from "../../infra/sqlite-transaction.js";
-import { authorizeSqliteReclamationCommit } from "./session-accessor.sqlite-reclamation-commit.js";
+import { withSqliteReclamationAuthorization } from "./session-accessor.sqlite-reclamation-commit.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => vi.restoreAllMocks());
@@ -61,6 +61,12 @@ function createCommitFixture(
     requested,
     release,
     value: () => database.prepare("SELECT value FROM proof").get()?.value,
+    withAuthorization<T>(
+      assertCurrent: () => void,
+      run: (authorize: () => unknown[]) => Promise<T>,
+    ) {
+      return withSqliteReclamationAuthorization(gate, databasePath, assertCurrent, run);
+    },
     async close() {
       release();
       await exited;
@@ -94,10 +100,9 @@ test.each(["transient", "permanent", "closed"] as const)(
           return actualTransaction(db, operation, options);
         },
       );
-      const recovered = authorizeSqliteReclamationCommit(
-        fixture.gate,
-        fixture.databasePath,
+      const recovered = await fixture.withAuthorization(
         () => {},
+        async (authorize) => authorize(),
       );
       expect(recovered.length).toBeGreaterThan(0);
       expect(
@@ -122,15 +127,20 @@ test.each([
     let retired = false;
     try {
       await fixture.requested;
-      authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {
-        queueMicrotask(() => {
-          retired = true;
-        });
-      });
-      expect(retired).toBe(false);
-      expect(fixture.value()).toBe(value);
-      expect(await fixture.exited).toEqual([exitCode]);
-      expect(retired).toBe(true);
+      await fixture.withAuthorization(
+        () => {
+          queueMicrotask(() => {
+            retired = true;
+          });
+        },
+        async (authorize) => {
+          authorize();
+          expect(retired).toBe(false);
+          expect(fixture.value()).toBe(value);
+          expect(await fixture.exited).toEqual([exitCode]);
+          expect(retired).toBe(true);
+        },
+      );
     } finally {
       await fixture.close();
     }
@@ -141,11 +151,14 @@ test("rolls back when the live authority rejects the prepared deletion", async (
   const fixture = createCommitFixture();
   try {
     await fixture.requested;
-    expect(() =>
-      authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {
+    await fixture.withAuthorization(
+      () => {
         throw new Error("retired owner");
-      }),
-    ).toThrow("retired owner");
+      },
+      async (authorize) => {
+        expect(authorize).toThrow("retired owner");
+      },
+    );
     await fixture.exited;
     expect(fixture.value()).toBe(1);
   } finally {
@@ -158,9 +171,12 @@ test("cannot revive a commit checkpoint after its decision deadline", async () =
   try {
     await fixture.requested;
     await fixture.exited;
-    expect(() =>
-      authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {}),
-    ).toThrow("checkpoint expired");
+    await fixture.withAuthorization(
+      () => {},
+      async (authorize) => {
+        expect(authorize).toThrow("checkpoint expired");
+      },
+    );
     expect(fixture.value()).toBe(1);
   } finally {
     await fixture.close();
@@ -183,17 +199,20 @@ test.each([false, true])(
         });
         return database;
       });
-      const authorize = () =>
-        authorizeSqliteReclamationCommit(fixture.gate, fixture.databasePath, () => {
+      await fixture.withAuthorization(
+        () => {
           if (rejected) {
             throw new Error("retired owner");
           }
-        });
-      if (rejected) {
-        expect(authorize).toThrow("retired owner");
-      } else {
-        expect(authorize().map(String)).toEqual(["Error: injected close failure"]);
-      }
+        },
+        async (authorize) => {
+          if (rejected) {
+            expect(authorize).toThrow("retired owner");
+          } else {
+            expect(authorize().map(String)).toEqual(["Error: injected close failure"]);
+          }
+        },
+      );
       await fixture.exited;
       expect(fixture.value()).toBe(rejected ? 1 : 2);
     } finally {

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
@@ -1,10 +1,20 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
-import { setSqliteBusyTimeout } from "../../infra/sqlite-busy-timeout.js";
+import {
+  readSqliteBusyTimeout,
+  runWithSqliteBusyTimeout,
+  setSqliteBusyTimeout,
+} from "../../infra/sqlite-busy-timeout.js";
 import {
   isSqliteLockError,
   runSqliteImmediateTransactionSync,
 } from "../../infra/sqlite-transaction.js";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import {
+  openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
+} from "../../state/openclaw-agent-db.js";
 
 const COMMIT_DECISION_TIMEOUT_MS = 5_000;
 const WAITING = 0;
@@ -12,9 +22,112 @@ const APPROVED = 1;
 const REJECTED = 2;
 const COMMITTING = 3;
 const SETTLED = 4;
+const REQUESTED = 5;
+
+const pendingAuthorizations = resolveGlobalSingleton(
+  Symbol.for("openclaw.sqliteReclamationAuthorizations"),
+  () => new Map<string, () => void>(),
+);
+
+/** Preserve the reclamation owner's context when an unrelated synchronous writer helps. */
+export async function withSqliteReclamationAuthorization<T>(
+  buffer: SharedArrayBuffer | undefined,
+  databasePath: string,
+  assertCurrent: (() => void) | undefined,
+  run: (authorize: () => unknown[]) => Promise<T>,
+): Promise<T> {
+  if (!buffer || !assertCurrent) {
+    return await run(() => []);
+  }
+  const shared = new Int32Array(buffer);
+  const inOwnerContext = AsyncLocalStorage.snapshot();
+  let consumed = false;
+  let failure: { error: unknown } | undefined;
+  let recovered: unknown[] = [];
+  const authorize = () => {
+    if (failure) {
+      throw failure.error;
+    }
+    if (consumed) {
+      return recovered;
+    }
+    consumed = true;
+    try {
+      recovered = inOwnerContext(
+        authorizeSqliteReclamationCommit,
+        buffer,
+        databasePath,
+        assertCurrent,
+      );
+      return recovered;
+    } catch (error) {
+      failure = { error };
+      throw error;
+    }
+  };
+  const service = () => {
+    if (Atomics.load(shared, 0) === REQUESTED) {
+      try {
+        authorize();
+      } catch {
+        // Rejection belongs to reclamation; its queued request propagates the error.
+      }
+    }
+  };
+  pendingAuthorizations.set(databasePath, service);
+  try {
+    return await run(authorize);
+  } finally {
+    pendingAuthorizations.delete(databasePath);
+  }
+}
+
+/** Retry only write admission; never replay an append or its synchronous callbacks. */
+export function runSqliteTranscriptWriteTransaction<T>(
+  operation: Parameters<typeof runOpenClawAgentWriteTransaction<T>>[0],
+  options: Parameters<typeof runOpenClawAgentWriteTransaction>[1],
+  transactionOptions?: Parameters<typeof runOpenClawAgentWriteTransaction>[2],
+): T {
+  const database = openOpenClawAgentDatabase(options);
+  const service = pendingAuthorizations.get(database.path);
+  if (!service || database.db.isTransaction) {
+    return runOpenClawAgentWriteTransaction(operation, options, transactionOptions);
+  }
+  const busyTimeoutMs = readSqliteBusyTimeout(database.db);
+  const deadline = performance.now() + busyTimeoutMs;
+  let entered = false;
+  while (true) {
+    try {
+      return runWithSqliteBusyTimeout(
+        database.db,
+        Math.min(25, Math.max(0, Math.ceil(deadline - performance.now()))),
+        (restore) =>
+          runOpenClawAgentWriteTransaction(
+            (current) => {
+              entered = true;
+              restore();
+              return operation(current);
+            },
+            options,
+            transactionOptions,
+          ),
+        { lockFailureReporting: "suppress" },
+      );
+    } catch (error) {
+      if (entered || !isSqliteLockError(error) || performance.now() >= deadline) {
+        throw error;
+      }
+      service();
+      if (performance.now() >= deadline) {
+        throw error;
+      }
+    }
+  }
+}
 
 function rejectCommit(shared: Int32Array): void {
   Atomics.compareExchange(shared, 0, WAITING, REJECTED);
+  Atomics.compareExchange(shared, 0, REQUESTED, REJECTED);
   Atomics.compareExchange(shared, 0, APPROVED, REJECTED);
   Atomics.notify(shared, 0);
 }
@@ -25,8 +138,9 @@ export function waitForSqliteReclamationCommit(
   request: () => void,
 ): void {
   const shared = new Int32Array(buffer);
+  Atomics.store(shared, 0, REQUESTED);
   request();
-  Atomics.wait(shared, 0, WAITING, COMMIT_DECISION_TIMEOUT_MS);
+  Atomics.wait(shared, 0, REQUESTED, COMMIT_DECISION_TIMEOUT_MS);
   if (Atomics.compareExchange(shared, 0, APPROVED, COMMITTING) !== APPROVED) {
     rejectCommit(shared);
     throw new Error("SQLite session reclamation commit was not authorized");
@@ -43,7 +157,7 @@ export function markSqliteReclamationSettled(buffer: SharedArrayBuffer | undefin
 }
 
 /** Keep the live parent authority current until the Worker's transaction has settled. */
-export function authorizeSqliteReclamationCommit(
+function authorizeSqliteReclamationCommit(
   buffer: SharedArrayBuffer,
   databasePath: string,
   assertCurrent: () => void,
@@ -58,7 +172,7 @@ export function authorizeSqliteReclamationCommit(
     database = openNodeSqliteDatabase(databasePath);
     setSqliteBusyTimeout(database, COMMIT_DECISION_TIMEOUT_MS);
     assertCurrent();
-    if (Atomics.compareExchange(shared, 0, WAITING, APPROVED) !== WAITING) {
+    if (Atomics.compareExchange(shared, 0, REQUESTED, APPROVED) !== REQUESTED) {
       throw new Error("SQLite session reclamation commit checkpoint expired");
     }
     Atomics.notify(shared, 0);

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -1,7 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { afterEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
+  closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
@@ -16,6 +18,7 @@ import {
   appendTranscriptEventSync,
   replaceTranscriptEventsSync,
 } from "./session-accessor.sqlite-transcript-write.js";
+import { reclaimSqliteFreePages } from "./session-history-archive-pruning.js";
 
 const hooks = vi.hoisted(() => ({ beforeAuthorization: undefined as (() => void) | undefined }));
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
@@ -161,4 +164,21 @@ test("one reclamation pass leaves a large freelist for bounded later maintenance
       value: true,
     });
   }
+  const budgetBefore = freePages();
+  const databaseOptions = plan.databaseOptions;
+  const duringDrain = yieldToEventLoop().then(() => {
+    expect(budgetBefore - freePages()).toBeGreaterThan(0);
+    expect(budgetBefore - freePages()).toBeLessThanOrEqual(512);
+    expect(database.db.isTransaction).toBe(false);
+    closeOpenClawAgentDatabaseByPath(database.path);
+    for (const scope of scopes) {
+      expect(appendTranscriptEventSync(scope, { type: "budget-progress" })).toEqual({
+        ok: true,
+        value: true,
+      });
+    }
+  });
+  await Promise.all([reclaimSqliteFreePages(databaseOptions), duringDrain]);
+  const reopened = openOpenClawAgentDatabase(databaseOptions);
+  expect(Number(reopened.db.prepare("PRAGMA freelist_count").get()?.freelist_count)).toBe(0);
 });

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -1,0 +1,164 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { afterEach, expect, test, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { loadTranscriptEvents } from "./session-accessor.js";
+import { ensureSessionEntrySync } from "./session-accessor.sqlite-initial-entry.js";
+import {
+  createHistoryEvictionReclamationPlan,
+  runSqliteSessionReclamation,
+} from "./session-accessor.sqlite-reclamation.js";
+import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.js";
+import {
+  appendTranscriptEventSync,
+  replaceTranscriptEventsSync,
+} from "./session-accessor.sqlite-transcript-write.js";
+
+const hooks = vi.hoisted(() => ({ beforeAuthorization: undefined as (() => void) | undefined }));
+vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    runSqliteTranscriptArchiveWorkerOperation: (
+      params: Parameters<typeof actual.runSqliteTranscriptArchiveWorkerOperation>[0],
+    ) =>
+      actual.runSqliteTranscriptArchiveWorkerOperation({
+        ...params,
+        onCommitRequest: () => {
+          hooks.beforeAuthorization?.();
+          params.onCommitRequest?.();
+        },
+      }),
+  };
+});
+afterEach(() => {
+  hooks.beforeAuthorization = undefined;
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawAgentDatabasesForTest());
+
+function createFixture() {
+  const env = { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-reclamation-writers-") };
+  const options = { agentId: "main", env };
+  const scopes = ["parent", "child"].map((sessionId) => ({
+    agentId: options.agentId,
+    env,
+    sessionId,
+    sessionKey: `agent:main:${sessionId}`,
+  }));
+  for (const scope of scopes) {
+    ensureSessionEntrySync(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+  }
+  const database = openOpenClawAgentDatabase(options);
+  const databaseOptions = { ...options, path: database.path };
+  const plan = createHistoryEvictionReclamationPlan({
+    databaseOptions,
+    materializedPlans: [],
+    protectedSessionIds: new Set(scopes.map((scope) => scope.sessionId)),
+    sessionId: "already-removed-history",
+  });
+  return { database, databaseOptions, plan, scopes };
+}
+
+test.each([
+  { operation: "append", rejected: false },
+  { operation: "append", rejected: true },
+  { operation: "replace", rejected: false },
+  { operation: "replace", rejected: true },
+])(
+  "two synchronous transcript writers progress at reclamation ($operation, rejected: $rejected)",
+  async ({ operation, rejected }) => {
+    const { databaseOptions, plan, scopes } = createFixture();
+    const appends: unknown[] = [];
+    const appendErrors: unknown[] = [];
+    let commitChecks = 0;
+    const owner = new AsyncLocalStorage<string>();
+    hooks.beforeAuthorization = () =>
+      owner.run("transcript-writer", () => {
+        // The worker owns BEGIN IMMEDIATE and is waiting for the parent. Both sync
+        // runtimes must service that request before its queued handler can return.
+        for (const scope of scopes) {
+          try {
+            const event = { type: "session", id: scope.sessionId };
+            appends.push(
+              operation === "replace"
+                ? replaceTranscriptEventsSync(scope, [event])
+                : appendTranscriptEventSync(scope, event),
+            );
+          } catch (error) {
+            appendErrors.push(error);
+          }
+        }
+      });
+    const reclamation = owner.run("reclamation-owner", () =>
+      runExclusiveSqliteSessionWrite(databaseOptions, () =>
+        runSqliteSessionReclamation({
+          forceInProcess: false,
+          plan,
+          assertCommitAllowed: () => {
+            commitChecks += 1;
+            expect(owner.getStore()).toBe("reclamation-owner");
+            if (rejected) {
+              throw new Error("reclamation owner retired");
+            }
+          },
+        }),
+      ),
+    );
+    if (rejected) {
+      await expect(reclamation).rejects.toThrow("reclamation owner retired");
+    } else {
+      await expect(reclamation).resolves.toEqual({
+        kind: "history-eviction",
+        value: { archivedTranscripts: [], deleted: true },
+      });
+    }
+    expect(commitChecks).toBe(1);
+    expect(appendErrors).toEqual([]);
+    expect(appends).toEqual(
+      operation === "replace"
+        ? [true, true]
+        : [
+            { ok: true, value: true },
+            { ok: true, value: true },
+          ],
+    );
+    for (const scope of scopes) {
+      await expect(loadTranscriptEvents(scope)).resolves.toEqual([
+        { type: "session", id: scope.sessionId },
+      ]);
+    }
+  },
+  20_000,
+);
+
+test("one reclamation pass leaves a large freelist for bounded later maintenance", async () => {
+  const { database, plan, scopes } = createFixture();
+  // sqlite-allow-raw -- synthetic disposable pages exercise the real vacuum boundary.
+  database.db.exec(`CREATE TABLE reclamation_fixture (payload BLOB);
+    INSERT INTO reclamation_fixture VALUES (zeroblob(8388608));
+    DROP TABLE reclamation_fixture;`);
+  const freePages = () =>
+    Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count);
+  const before = freePages();
+  expect(before).toBeGreaterThan(512);
+
+  await expect(runSqliteSessionReclamation({ forceInProcess: false, plan })).resolves.toMatchObject(
+    { value: { deleted: true } },
+  );
+
+  const after = freePages();
+  expect(before - after).toBeGreaterThan(0);
+  expect(before - after).toBeLessThanOrEqual(512);
+  expect(after).toBeGreaterThan(0);
+  for (const scope of scopes) {
+    expect(appendTranscriptEventSync(scope, { type: "session", id: scope.sessionId })).toEqual({
+      ok: true,
+      value: true,
+    });
+  }
+});

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -40,7 +40,7 @@ import {
 } from "./session-accessor.sqlite-lifecycle-state.js";
 import type { SessionEntryRemovalPlan } from "./session-accessor.sqlite-lifecycle-types.js";
 import { deleteSessionDeliveryArtifacts } from "./session-accessor.sqlite-node-artifacts.js";
-import { authorizeSqliteReclamationCommit } from "./session-accessor.sqlite-reclamation-commit.js";
+import { withSqliteReclamationAuthorization } from "./session-accessor.sqlite-reclamation-commit.js";
 import { cloneSessionEntry, getSessionKysely } from "./session-accessor.sqlite-scope.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
@@ -288,42 +288,20 @@ export function reclaimSqliteSessionInTransaction(
     return { kind: plan.kind, value };
   }
 
-  if (plan.kind === "history-eviction") {
-    const value = runOpenClawAgentWriteTransaction((transactionDb) => {
-      callbacks.beforeMutation?.();
-      const archivedTranscripts = deleteMaterializedSessionStatePlans(
-        transactionDb,
-        plan.materializedPlans,
-        new Set(plan.protectedSessionIds),
-      );
-      const db = getSessionKysely(transactionDb.db);
-      const deleted =
-        executeSqliteQuerySync(
-          transactionDb.db,
-          db
-            .selectFrom("session_windows")
-            .select("session_id")
-            .where("session_id", "=", plan.sessionId),
-        ).rows.length === 0;
-      if (deleted) {
-        callbacks.onCommit?.(transactionDb);
-      }
-      return { archivedTranscripts: deleted ? archivedTranscripts : [], deleted };
-    }, plan.databaseOptions);
-    if (value.deleted) {
-      reclaimSqliteFreePagesBestEffort(plan.databaseOptions);
-    }
-    return { kind: plan.kind, value };
-  }
-
   const value = runOpenClawAgentWriteTransaction((transactionDb) => {
     callbacks.beforeMutation?.();
-    const snapshot = readLifecycleTargetSnapshot(transactionDb, plan.deleteParams.target);
-    if (
-      !sqliteLifecycleTargetSnapshotsEqual(plan.preparedTargetSnapshot, snapshot) ||
-      !shouldDeleteSqliteSessionEntryLifecycle(transactionDb, snapshot[0]?.entry, plan.deleteParams)
-    ) {
-      return { archivedTranscripts: [], deleted: false, expectedEntryMismatch: true as const };
+    if (plan.kind === "historical-generation") {
+      const snapshot = readLifecycleTargetSnapshot(transactionDb, plan.deleteParams.target);
+      if (
+        !sqliteLifecycleTargetSnapshotsEqual(plan.preparedTargetSnapshot, snapshot) ||
+        !shouldDeleteSqliteSessionEntryLifecycle(
+          transactionDb,
+          snapshot[0]?.entry,
+          plan.deleteParams,
+        )
+      ) {
+        return { archivedTranscripts: [], deleted: false, expectedEntryMismatch: true as const };
+      }
     }
     const archivedTranscripts = deleteMaterializedSessionStatePlans(
       transactionDb,
@@ -344,22 +322,17 @@ export function reclaimSqliteSessionInTransaction(
     }
     return { archivedTranscripts: deleted ? archivedTranscripts : [], deleted };
   }, plan.databaseOptions);
+  if (plan.kind === "history-eviction" && value.deleted) {
+    reclaimSqliteFreePagesBestEffort(plan.databaseOptions);
+  }
   return { kind: plan.kind, value };
 }
 
 function reclaimSqliteFreePagesBestEffort(databaseOptions: ReclamationDatabaseOptions): void {
   try {
     const database = openOpenClawAgentDatabase(databaseOptions);
-    database.walMaintenance.checkpoint();
-    const row = database.db /* sqlite-allow-raw: page accounting is exposed only via PRAGMA */
-      .prepare("PRAGMA freelist_count")
-      .get() as { freelist_count: number | bigint }; // SAFETY: fixed numeric PRAGMA column.
-    const freePages = Number(row.freelist_count);
-    if (Number.isSafeInteger(freePages) && freePages > 0) {
-      // sqlite-allow-raw -- incremental vacuum is a maintenance PRAGMA, not a data query.
-      database.db.exec(`PRAGMA incremental_vacuum(${freePages});`);
-    }
-    database.walMaintenance.checkpoint();
+    // sqlite-allow-raw -- PASSIVE never waits for readers; cap page release per pass.
+    database.db.exec("PRAGMA wal_checkpoint(PASSIVE); PRAGMA incremental_vacuum(512);");
   } catch {
     // Deletion is already durable. The next budget pass can reclaim pages.
   }
@@ -415,29 +388,23 @@ export async function runSqliteSessionReclamation(params: {
     ? new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
     : undefined;
   const recoveredCommitErrors: unknown[] = [];
-  const [workerResult] =
-    await runSqliteTranscriptArchiveWorkerOperation<SqliteSessionReclamationWorkerResult>({
-      expectedMessageType: "reclaimed",
-      onCommitRequest:
-        commitGate && assertCommitAllowed
-          ? () => {
-              recoveredCommitErrors.push(
-                ...authorizeSqliteReclamationCommit(
-                  commitGate,
-                  params.plan.databaseOptions.path,
-                  assertCommitAllowed,
-                ),
-              );
-            }
-          : undefined,
-      transferList: prepareReclamationWorkerTransferList(params.plan),
-      workerData: {
-        commitGate,
-        operation: "reclaim",
-        plan: params.plan,
-        type: "sqlite-transcript-archive-v2",
-      } satisfies SqliteSessionReclamationWorkerData,
-    });
+  const [workerResult] = await withSqliteReclamationAuthorization(
+    commitGate,
+    params.plan.databaseOptions.path,
+    assertCommitAllowed,
+    (authorize) =>
+      runSqliteTranscriptArchiveWorkerOperation<SqliteSessionReclamationWorkerResult>({
+        expectedMessageType: "reclaimed",
+        onCommitRequest: () => recoveredCommitErrors.push(...authorize()),
+        transferList: prepareReclamationWorkerTransferList(params.plan),
+        workerData: {
+          commitGate,
+          operation: "reclaim",
+          plan: params.plan,
+          type: "sqlite-transcript-archive-v2",
+        } satisfies SqliteSessionReclamationWorkerData,
+      }),
+  );
   if (!workerResult) {
     throw new Error("SQLite session reclamation Worker returned no result");
   }

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -29,6 +29,7 @@ import {
   readTranscriptSnapshot,
   type SqliteTranscriptSnapshotRow,
 } from "./session-accessor.sqlite-read.js";
+import { runSqliteTranscriptWriteTransaction } from "./session-accessor.sqlite-reclamation-commit.js";
 import {
   cloneSessionEntry,
   resolveSqliteTranscriptScope,
@@ -210,7 +211,7 @@ export function replaceTranscriptEventsSync(
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let replaced = false;
-  runOpenClawAgentWriteTransaction((database) => {
+  runSqliteTranscriptWriteTransaction((database) => {
     assertOwnedTranscriptWriteCommit(fencedScope);
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
     if (
@@ -326,7 +327,7 @@ export function appendTranscriptEventSync(
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let result: Result<boolean, TranscriptAppendRefusal> = ok(false);
-  runOpenClawAgentWriteTransaction((database) => {
+  runSqliteTranscriptWriteTransaction((database) => {
     options.beforeCommitInTransaction?.();
     assertOwnedTranscriptWriteCommit(fencedScope);
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
@@ -365,7 +366,7 @@ export function persistCompactionBoundaryWithSessionEntrySync(
 ): string {
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
-  return runOpenClawAgentWriteTransaction(
+  return runSqliteTranscriptWriteTransaction(
     (database) => {
       assertOwnedTranscriptWriteCommit(fencedScope);
       const firstAppendedSeq = readNextTranscriptSeq(database, resolved.sessionId);
@@ -460,7 +461,7 @@ export function appendTranscriptMessageSync<TMessage>(
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let result: Result<TranscriptMessageAppendResult<TMessage> | undefined, TranscriptAppendRefusal> =
     ok(undefined);
-  runOpenClawAgentWriteTransaction((database) => {
+  runSqliteTranscriptWriteTransaction((database) => {
     assertOwnedTranscriptWriteCommit(fencedScope);
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
     const refusal = resolveTranscriptAppendRefusal(fresh?.entry, resolved, fencedScope);

--- a/src/config/sessions/session-history-archive-pruning.ts
+++ b/src/config/sessions/session-history-archive-pruning.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { setImmediate } from "node:timers/promises";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import {
   openOpenClawAgentDatabase,
@@ -13,21 +14,34 @@ import {
 } from "./disk-budget.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
 
-export function reclaimSqliteFreePages(databaseOptions: OpenClawAgentDatabaseOptions): void {
-  // openclaw-agent-db.ts cache rule: LRU eviction closes idle handles across awaits.
-  const database = openOpenClawAgentDatabase(databaseOptions);
-  // Committed row deletion first lands in the WAL. TRUNCATE makes that shrink immediately;
-  // incremental vacuum can then return free tail pages from the main file without a rewrite.
-  database.walMaintenance.checkpoint();
-  // SAFETY: SQLite returns this fixed numeric column for PRAGMA freelist_count.
-  const row = database.db.prepare("PRAGMA freelist_count").get() as
-    | { freelist_count?: unknown }
-    | undefined;
-  const freePages = Number(row?.freelist_count ?? 0);
-  if (Number.isSafeInteger(freePages) && freePages > 0) {
-    database.db.exec(`PRAGMA incremental_vacuum(${freePages});`);
+export async function reclaimSqliteFreePages(
+  databaseOptions: OpenClawAgentDatabaseOptions,
+): Promise<void> {
+  let remaining: number | undefined;
+  while (remaining === undefined || remaining > 0) {
+    if (remaining !== undefined) {
+      await setImmediate();
+    }
+    // Reacquire after yielding: idle cached handles can be evicted between passes.
+    const database = openOpenClawAgentDatabase(databaseOptions);
+    database.walMaintenance.checkpoint();
+    // sqlite-allow-raw -- Physical budget decisions need current SQLite page accounting.
+    const freePages = () =>
+      Number(database.db.prepare("PRAGMA freelist_count").get()?.freelist_count ?? 0);
+    const before = freePages();
+    if (!Number.isSafeInteger(before) || before <= 0) {
+      return;
+    }
+    // Bound the entire drain to its initial freelist, even if other writers free more pages.
+    remaining = Math.min(remaining ?? before, before);
+    const pages = Math.min(512, remaining);
+    database.db.exec(`PRAGMA incremental_vacuum(${pages});`); // sqlite-allow-raw -- Bounded maintenance outside a transaction.
+    database.walMaintenance.checkpoint();
+    remaining -= pages;
+    if (freePages() >= before) {
+      return;
+    }
   }
-  database.walMaintenance.checkpoint();
 }
 
 export function hasCanonicalSessionTranscriptArchives(
@@ -141,7 +155,7 @@ async function pruneCanonicalSessionTranscriptArchivesToHighWater(params: {
           .where("generation", "=", row.generation),
       );
     }, params.databaseOptions);
-    reclaimSqliteFreePages(params.databaseOptions);
+    await reclaimSqliteFreePages(params.databaseOptions);
     usage = await measureSessionPhysicalDiskUsage(params.storePath);
   }
   return { removedFiles, usage };
@@ -153,13 +167,11 @@ export async function pruneAllSessionTranscriptArchivesToHighWater(params: {
   highWaterBytes: number;
   storePath: string;
 }): Promise<{ removedFiles: number; usage: SessionPhysicalDiskUsage }> {
-  let canonical = {
-    removedFiles: 0,
-    usage: await measureSessionPhysicalDiskUsage(params.storePath),
-  };
-  if (hasCanonicalSessionTranscriptArchives(params.databaseOptions)) {
-    canonical = await pruneCanonicalSessionTranscriptArchivesToHighWater(params);
-  }
+  // Reclaim committed free pages before pressure can destroy a retained archive.
+  await reclaimSqliteFreePages(params.databaseOptions);
+  const canonical = hasCanonicalSessionTranscriptArchives(params.databaseOptions)
+    ? await pruneCanonicalSessionTranscriptArchivesToHighWater(params)
+    : { removedFiles: 0, usage: await measureSessionPhysicalDiskUsage(params.storePath) };
   if (canonical.usage.totalBytes <= params.highWaterBytes) {
     return canonical;
   }

--- a/src/config/sessions/session-history-eviction.test.ts
+++ b/src/config/sessions/session-history-eviction.test.ts
@@ -210,61 +210,68 @@ describe("SQLite historical session disk budget", () => {
     },
   );
 
-  it("evicts the oldest historical session and stops after reaching high water", async () => {
-    const sessionKey = "agent:main:history-order";
-    await createHistoricalTranscript({
-      content: "oldest " + "x".repeat(64 * 1024),
-      nextSessionId: "newer-history",
-      sessionId: "oldest-history",
-      sessionKey,
-      updatedAt: 10,
-    });
-    await appendTranscriptMessage(
-      { sessionId: "newer-history", sessionKey, storePath },
-      { message: { role: "user", content: "newer " + "y".repeat(64 * 1024) } },
-    );
-    await resetSessionEntryLifecycle({
-      storePath,
-      target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
-      buildNextEntry: () => ({ sessionId: "live-history", updatedAt: 30 }),
-    });
-    setSessionUpdatedAt("newer-history", 20);
-    settlePhysicalUsage();
-    database().db.exec("ANALYZE; PRAGMA analysis_limit = 37;");
-    expect(
-      database()
-        .db.prepare("SELECT stat FROM sqlite_stat1 WHERE idx = ?")
-        .get("idx_agent_session_windows_updated_at"),
-    ).toEqual({ stat: expect.stringMatching(/^3\b/u) });
-    settlePhysicalUsage();
-    const before = await measureSessionPhysicalDiskUsage(storePath);
+  it.each([
+    { oldestBytes: 64 * 1024, reclaimBytes: 1 },
+    { oldestBytes: 8 * 1024 * 1024, reclaimBytes: 4 * 1024 * 1024 },
+  ])(
+    "evicts the oldest historical session and retains its archive after reclaiming $reclaimBytes bytes",
+    async ({ oldestBytes, reclaimBytes }) => {
+      const sessionKey = "agent:main:history-order";
+      await createHistoricalTranscript({
+        content: "oldest " + "x".repeat(oldestBytes),
+        nextSessionId: "newer-history",
+        sessionId: "oldest-history",
+        sessionKey,
+        updatedAt: 10,
+      });
+      await appendTranscriptMessage(
+        { sessionId: "newer-history", sessionKey, storePath },
+        { message: { role: "user", content: "newer " + "y".repeat(64 * 1024) } },
+      );
+      await resetSessionEntryLifecycle({
+        storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        buildNextEntry: () => ({ sessionId: "live-history", updatedAt: 30 }),
+      });
+      setSessionUpdatedAt("newer-history", 20);
+      settlePhysicalUsage();
+      database().db.exec("ANALYZE; PRAGMA analysis_limit = 37;");
+      expect(
+        database()
+          .db.prepare("SELECT stat FROM sqlite_stat1 WHERE idx = ?")
+          .get("idx_agent_session_windows_updated_at"),
+      ).toEqual({ stat: expect.stringMatching(/^3\b/u) });
+      settlePhysicalUsage();
+      const before = await measureSessionPhysicalDiskUsage(storePath);
+      const highWaterBytes = before.totalBytes - reclaimBytes;
 
-    const result = await enforceSqliteSessionHistoryDiskBudget({
-      storePath,
-      mode: "enforce",
-      maintenance: {
-        maxDiskBytes: before.totalBytes - 1,
-        highWaterBytes: before.totalBytes - 1,
-      },
-    });
+      const result = await enforceSqliteSessionHistoryDiskBudget({
+        storePath,
+        mode: "enforce",
+        maintenance: {
+          maxDiskBytes: before.totalBytes - 1,
+          highWaterBytes,
+        },
+      });
 
-    expect(result?.removedEntries).toBe(1);
-    expect(result?.totalBytesAfter).toBeLessThanOrEqual(before.totalBytes - 1);
-    expect(result?.totalBytesAfter).toBe(
-      (await measureSessionPhysicalDiskUsage(storePath)).totalBytes,
-    );
-    expect(sessionExists("oldest-history")).toBe(false);
-    expect(sessionExists("newer-history")).toBe(true);
-    expect(sessionExists("live-history")).toBe(true);
-    expect(readArchiveNames("oldest-history")).toHaveLength(1);
-    expect(readArchiveNames("newer-history")).toHaveLength(0);
-    expect(
-      database()
-        .db.prepare("SELECT stat FROM sqlite_stat1 WHERE idx = ?")
-        .get("idx_agent_session_windows_updated_at"),
-    ).toEqual({ stat: expect.stringMatching(/^3\b/u) });
-    expect(database().db.prepare("PRAGMA analysis_limit").get()).toEqual({ analysis_limit: 37 });
-  });
+      expect(result?.removedEntries).toBe(1);
+      expect(result?.totalBytesAfter).toBeLessThanOrEqual(highWaterBytes);
+      expect(result?.totalBytesAfter).toBe(
+        (await measureSessionPhysicalDiskUsage(storePath)).totalBytes,
+      );
+      expect(sessionExists("oldest-history")).toBe(false);
+      expect(sessionExists("newer-history")).toBe(true);
+      expect(sessionExists("live-history")).toBe(true);
+      expect(readArchiveNames("oldest-history")).toHaveLength(1);
+      expect(readArchiveNames("newer-history")).toHaveLength(0);
+      expect(
+        database()
+          .db.prepare("SELECT stat FROM sqlite_stat1 WHERE idx = ?")
+          .get("idx_agent_session_windows_updated_at"),
+      ).toEqual({ stat: expect.stringMatching(/^3\b/u) });
+      expect(database().db.prepare("PRAGMA analysis_limit").get()).toEqual({ analysis_limit: 37 });
+    },
+  );
 
   it("pages past protected archives to evict cap-created sessions under pressure", async () => {
     const capKey = "agent:main:explicit:cap-archived";

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -15,7 +15,6 @@ import {
   hasRetainedSessionTranscriptArchives,
   measureSessionPhysicalDiskUsage,
   type SessionDiskBudgetSweepResult,
-  type SessionPhysicalDiskUsage,
 } from "./disk-budget.js";
 import { publishSessionStateArchives } from "./session-accessor.sqlite-archive-store.js";
 import { materializeSessionStateDeletePlans } from "./session-accessor.sqlite-archive.js";
@@ -504,26 +503,15 @@ async function enforceSessionHistoryMaintenanceSerialized(
   });
   const databaseOptions = toDatabaseOptions(resolved);
   const archiveDirectory = resolveSqliteTranscriptArchiveDirectory(resolved);
-  let usage: SessionPhysicalDiskUsage = await runExclusiveSqliteSessionWrite(resolved, async () => {
-    reclaimSqliteFreePages(databaseOptions);
-    return await measureSessionPhysicalDiskUsage(params.storePath);
-  });
+  let { usage, removedFiles } = await runExclusiveSqliteSessionWrite(resolved, async () =>
+    pruneAllSessionTranscriptArchivesToHighWater({
+      archiveDirectory,
+      databaseOptions,
+      highWaterBytes,
+      storePath: params.storePath,
+    }),
+  );
   let removedEntries = 0;
-  let removedFiles = 0;
-  if (usage.totalBytes > highWaterBytes) {
-    // Archive pruning shares the SQLite writer queue so a concurrent
-    // reset/delete cannot race its archive file against the unlink pass.
-    const archiveSweep = await runExclusiveSqliteSessionWrite(resolved, async () =>
-      pruneAllSessionTranscriptArchivesToHighWater({
-        archiveDirectory,
-        databaseOptions,
-        highWaterBytes,
-        storePath: params.storePath,
-      }),
-    );
-    removedFiles = archiveSweep.removedFiles;
-    usage = archiveSweep.usage;
-  }
   const candidates = readHistoricalSessionIds({
     databaseOptions,
     preserveRecentMs: params.maintenance.preserveRecentMs,
@@ -684,7 +672,7 @@ async function enforceSessionHistoryMaintenanceSerialized(
         removedEntries += 1;
         await runExclusiveSqliteSessionWrite(resolved, async () => {
           try {
-            reclaimSqliteFreePages(databaseOptions);
+            await reclaimSqliteFreePages(databaseOptions);
           } catch {
             // The durable deletion succeeded; a later pass can reclaim pages.
           }

--- a/src/infra/sqlite-busy-timeout.test.ts
+++ b/src/infra/sqlite-busy-timeout.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { runWithSqliteBusyTimeout } from "./sqlite-busy-timeout.js";
+import { runWithSqliteBusyTimeout, shouldReportSqliteLockFailure } from "./sqlite-busy-timeout.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -30,6 +30,23 @@ describe("runWithSqliteBusyTimeout", () => {
       }),
     ).toThrow("operation failed");
     expect(database.prepare("PRAGMA busy_timeout").get()).toEqual({ timeout: 5000 });
+  });
+
+  it("restores timeout and lock reporting before the admitted operation finishes", () => {
+    database = new DatabaseSync(":memory:");
+    database.exec("PRAGMA busy_timeout = 5000");
+    runWithSqliteBusyTimeout(
+      database,
+      25,
+      (restore) => {
+        expect(shouldReportSqliteLockFailure(database!)).toBe(false);
+        restore();
+        expect(database!.prepare("PRAGMA busy_timeout").get()).toEqual({ timeout: 5000 });
+        expect(shouldReportSqliteLockFailure(database!)).toBe(true);
+      },
+      { lockFailureReporting: "suppress" },
+    );
+    expect(shouldReportSqliteLockFailure(database)).toBe(true);
   });
 
   it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(

--- a/src/infra/sqlite-busy-timeout.ts
+++ b/src/infra/sqlite-busy-timeout.ts
@@ -28,11 +28,11 @@ export function shouldReportSqliteLockFailure(database: DatabaseSync): boolean {
   return lockFailureReportingByDatabase.get(database) !== "suppress";
 }
 
-/** Run one synchronous operation with a temporary connection-local busy timeout. */
+/** Run with a temporary busy policy; restore early when write admission finishes. */
 export function runWithSqliteBusyTimeout<T>(
   database: DatabaseSync,
   busyTimeoutMs: number,
-  operation: () => T,
+  operation: (restore: () => void) => T,
   options: { lockFailureReporting?: SqliteLockFailureReporting } = {},
 ): T {
   const normalizedTimeoutMs = normalizeSqliteNonNegativeInteger(busyTimeoutMs, "busyTimeoutMs");
@@ -44,9 +44,7 @@ export function runWithSqliteBusyTimeout<T>(
   if (previousBusyTimeoutMs !== normalizedTimeoutMs) {
     setSqliteBusyTimeout(database, normalizedTimeoutMs);
   }
-  try {
-    return operation();
-  } finally {
+  const restore = () => {
     if (database.isOpen && previousBusyTimeoutMs !== normalizedTimeoutMs) {
       setSqliteBusyTimeout(database, previousBusyTimeoutMs);
     }
@@ -55,5 +53,10 @@ export function runWithSqliteBusyTimeout<T>(
     } else {
       lockFailureReportingByDatabase.delete(database);
     }
+  };
+  try {
+    return operation(restore);
+  } finally {
+    restore();
   }
 }


### PR DESCRIPTION
## Problem

Fixes an issue where concurrent Gateway runs fail with `database is locked` while session reclamation is committing. This was reported on the Team Gateway and reproduced with two synchronous transcript writers against an isolated SQLite store.

The reclamation worker holds `BEGIN IMMEDIATE` and waits for the parent's commit-authorization message handler. A synchronous transcript append on the parent waits in SQLite's native busy handler for that same writer lock, preventing the authorization handler from running. The existing settlement barrier cannot satisfy that event-loop dependency.

## Solution

Keep archive preparation, deletion, and COMMIT on the worker. Publish a distinct authorization-requested state in the existing shared memory. While reclamation is active, synchronous transcript writers use short admission attempts and service that pending request with the existing authority validator before retrying admission. The same admission path covers synchronous transcript replacement and compaction. Once the write transaction begins, its original busy timeout and diagnostics are restored; append callbacks and mutations are never replayed.

Reclamation performs a PASSIVE checkpoint and caps incremental vacuum at 512 pages per pass. Before pruning retained archives, the disk-budget owner drains its initially observed free pages in bounded units, yielding between them and reacquiring the connection after each yield. It retains physical checkpointing before pressure measurements so pending free pages do not cause unnecessary archive deletion. Duplicate history-deletion and initial sweep logic is consolidated while retaining existing snapshot and retention checks.

## Design

The parent registers an operation-scoped authorization service before starting the worker and removes it after the worker settles. The service captures the reclamation owner's async context: the admission checks depend on that context to distinguish the owner's own work from competing admissions. The synchronous append invokes the same live authority checks in that captured context, then grants or rejects the shared request.

There is no parent event-loop dependency between authorization and worker COMMIT. The existing synchronous settlement join remains: after granting approval, the parent must not allow queued owner retirement before COMMIT, rollback, or connection-close settlement, including abrupt worker exit. A later queued request returns the already recorded result or failure, so it cannot authorize twice. Authorization rejection belongs to reclamation; unrelated transcript writers can continue after rollback.

The budget drain is limited to its initial freelist, stops when SQLite makes no progress, and never holds a transaction across a yield. Budget measurements retain TRUNCATE checkpointing because PASSIVE alone leaves WAL allocation counted as disk pressure. Archive pruning starts only after this physical reclamation step; the existing archive-selection and retention rules are unchanged.

The original append admission deadline is checked before and after servicing. An already-consumed authorization still requires the safety join, which cannot be abandoned at that deadline. PASSIVE avoids waiting for readers but does not cap the number of WAL frames copied.

This cooperative design and the production LOC exception were explicitly approved by the maintainer on September 5, 2026.

## Impact

This fixes a reproduced production deadlock associated with Team Gateway runs failing with `database is locked`. The approved net +85 production lines implement the cooperative commit-authorization protocol: shared request publication, idempotent servicing from the parent's synchronous append path, and short admission attempts. They replace an event-loop dependency the old barrier could never satisfy; the settlement barrier itself remains for fencing.

Deletion atomicity, visibility, rollback, fencing, and thread ownership are unchanged. There is no schema change, configuration option, retention change, or dependency addition. Incremental vacuum work is now capped at 512 pages per pass. Nearby duplicate deletion and initial pressure-sweep logic offsets part of the additional protocol and bounded-drain code.

Deltas against task base `74b764e81d4b`:

- Production: **+209 −124 (net +85)**; explicitly approved exception.
- Tests: **+309 −82 (net +227)**, including the new owner-boundary regression.
- Documentation: **+20 −0**.

## Evidence

Failing-first: restored the candidate regression in the session-accessor suite, adjusted the schedule so both synchronous append calls run while the actual worker holds the write lock and awaits authorization, and ran it against unchanged production at the task base:

```text
node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-reclamation.test.ts

SQLite session reclamation commit checkpoint expired
expected 2051 to be less than or equal to 512
Test Files  1 failed (1)
     Tests  2 failed (2)
```

Initial focused proof, before extending replacement coverage:

```text
OPENCLAW_TEST_RECLAMATION_LOG=1 node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-reclamation.test.ts src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts src/config/sessions/session-accessor.sqlite-reclamation-admission-race.test.ts src/config/sessions/session-accessor.sqlite-deletion.test.ts src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts src/config/sessions/cleanup-service.fix-missing.test.ts src/infra/sqlite-busy-timeout.test.ts

Test Files  1 passed (1)
     Tests  7 passed (7)
Test Files  6 passed (6)
     Tests  55 passed (55)
[test] passed 2 Vitest shards
```

The additional synchronous replacement variant also failed with checkpoint expiry before its one-line admission fix. Both cooperative authorization outcomes (grant/rejection), owner-context preservation, abrupt worker exits, barrier failures, native rollback, admission races, and bounded real-page reclamation pass. The existing 100,000-event cleanup recorded a maximum heartbeat gap of **201.23 ms**, below its **500 ms** requirement.

Broader owner proof on the initial PR head, before the retention follow-up:

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-fs-cooperative-full OPENCLAW_TEST_RECLAMATION_LOG=1 node scripts/run-vitest.mjs src/config/sessions src/state src/agents/sessions

Tests  864 passed | 6 skipped
Tests  1518 passed
Tests  684 passed | 3 skipped
[test] passed 3 Vitest shards in 798.79s
```

Total: **3,066 passed, 9 skipped**, across **230 passing files and 2 skipped files**. The final 100,000-event cleanup measured **200.66 ms** maximum heartbeat gap. The final Codex autoreview is scoped-clean through P2. The initial changed-file gate found an authorizer export that had become test-only; it is now private, and the existing settlement/fault tests exercise the production authorization wrapper instead.

The final five-case reclamation regression also passed after a fixture-only lint cleanup.

A review found that simply capping the worker's vacuum could cause disk-budget pruning to destroy a still-retainable compressed archive. The extended existing budget regression reproduced this on the initial PR head: an 8 MiB compressible history needing 4 MiB of reclamation lost the archive (`expected length 1, received 0`). The corrected budget ordering retained it. A separate extension of the real-page test failed on the old budget helper (`1539` pages reclaimed before the first yield exceeded `512`), then passed with the bounded drain, including two synchronous writer appends and cache close/reopen across a yield. The retention and neighboring suites passed 33 tests; the bounded-drain and budget suites passed 24 tests. The follow-up broad rerun encountered an unchanged shared-state heartbeat startup failure: `state lease heartbeat did not become ready` under its one-second lease. It occurred before the maintenance callback ran; the worker, lease owner, test, and busy-timeout helper are byte-identical to the initial green CI head. Replaying the entire unchanged heartbeat file reproduced that one failure with ten passes under high host load. No timeout or assertion was changed. The session and agent-session portions were run separately:

```text
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.artifacts/vitest-fs-cooperative-retention-remaining OPENCLAW_TEST_RECLAMATION_LOG=1 node scripts/run-vitest.mjs src/config/sessions src/agents/sessions
Tests  1519 passed
Tests  684 passed | 3 skipped
[test] passed 2 Vitest shards in 495.87s
```

That is **2,203 passed, 3 skipped** on the retention-safe candidate. Its 100,000-event cleanup measured **115.50 ms** maximum heartbeat gap. The follow-up autoreview is scoped-clean through P2. `node scripts/check-changed.mjs` completed successfully again (exit 0), and `git diff --check` passed. `node scripts/check-changed.mjs` completed successfully (exit 0), including core/test typechecks, core lint, dead-export scans, database guards, and zero runtime import cycles. `git diff --check` passed. No Swift app lint lane was selected. No live Team validation was attempted; the coordinator owns that proof after landing. No UI changed.

### CI status: blocked by an unrelated main-branch test

Exact-head CI for `4d345bcc69b14443c6a8b27a97d7af8308de329c` completed with failure because of `src/agents/embedded-agent-runner/run/assistant-failure.test.ts:273`:

- [check-test-types-core-1](https://github.com/openclaw/openclaw/actions/runs/33998516047/job/101393214664): TS2339, `maybeRetryTransient` does not exist on the fixture's `failover` type.
- [checks-node-compact-large-9](https://github.com/openclaw/openclaw/actions/runs/33998516047/job/101393215773): the same assertion fails with `undefined is not a spy or a call to a spy`.

The assertion was added by [#139409](https://github.com/openclaw/openclaw/pull/139409), commit `c91b1eaab768dd8223a6176c1a24decf98ee1b9c`. It is already present in CI's base `0cebe40cf7cb939da0c5722a990eb10522d27d5a`; CI checked out merge `f758ddd9` for this head. This PR does not modify that file. The aggregate `openclaw/ci-gate` also failed. The final observed check rollup was 130 passed, 51 skipped, 3 failed, with none pending. The failure needs an upstream repair and a fresh CI run; it is not being folded into this storage change. ClawSweeper reviewed corrected head `4d345bcc69b14443c6a8b27a97d7af8308de329c` with no actionable findings and explicitly cleared the earlier archive-retention blocker.

## Deferred

Durable logical deletion with resumable, bounded physical cleanup remains a separate approval for deletion latency. This fix preserves the existing atomic deletion units; it does not claim a hard bound on cascading deletion cost.

Release-note: Fix transcript writes failing with database lock errors during concurrent session reclamation, and cap incremental vacuum work per pass.
