### PR TITLE
docs: fix session visibility scope in multi-agent example

### DIFF
--- a/docs/tools/multi-agent-sandbox-tools.md
+++ b/docs/tools/multi-agent-sandbox-tools.md
@@ -344,17 +344,27 @@ Legacy `agents.list` rosters and retired per-agent keys (such as `sandbox.perSes
 
   </Tab>
   <Tab title="Communication-only">
+    This complete configuration limits tool access for the `messenger` agent. Session visibility is a separate, global setting: `tools.sessions.visibility` applies to every agent on the Gateway and cannot be set under `agents.entries.*.tools`.
+
     ```json
     {
       "tools": {
-        "sessions": { "visibility": "tree" },
-        "allow": ["sessions_list", "sessions_send", "sessions_history", "session_status"],
-        "deny": ["exec", "write", "edit", "apply_patch", "read", "browser"]
+        "sessions": { "visibility": "tree" }
+      },
+      "agents": {
+        "entries": {
+          "messenger": {
+            "tools": {
+              "allow": ["sessions_list", "sessions_send", "sessions_history", "session_status"],
+              "deny": ["exec", "write", "edit", "apply_patch", "read", "browser"]
+            }
+          }
+        }
       }
     }
     ```
 
-    Session tools default to Gateway-wide visibility (`all`) with agent-to-agent messaging on; this profile narrows the agent to its own session tree. See [`tools.sessions`](/gateway/config-tools#tools-sessions) and [`tools.agentToAgent`](/gateway/config-tools#tools-agenttoagent).
+    Session tools default to Gateway-wide visibility (`all`) with agent-to-agent messaging on. Here, `tree` limits visibility to the current session and its spawned sessions; the canonical main session can also access all sessions belonging to its agent. See [`tools.sessions`](/gateway/config-tools#tools-sessions) and [`tools.agentToAgent`](/gateway/config-tools#tools-agenttoagent).
 
     `sessions_history` in this profile still returns a bounded, sanitized recall view rather than a raw transcript dump. Assistant recall strips thinking tags, `<relevant-memories>` scaffolding, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks), downgraded tool-call scaffolding, leaked ASCII/full-width model control tokens, and malformed MiniMax tool-call XML before redaction/truncation.
 


### PR DESCRIPTION
Closes #139438

## What Problem This Solves

Fixes an issue where users copying the Communication-only example into a per-agent tool policy receive `agents.entries.<id>.tools: Unrecognized key: "sessions"`. Applying the original example globally validates, but also applies its tool restrictions to every agent.

## Why This Change Was Made

Show a complete configuration with `tools.sessions.visibility` at global scope and the existing allow/deny lists under `agents.entries.messenger.tools`. Explain that session visibility applies to every agent on the Gateway and preserve the documented canonical-main-session exception for `tree` visibility.

## User Impact

Readers can configure the communication-only agent with a valid example and understand which settings affect other agents. Runtime behavior and the example's tool allow/deny lists are unchanged.

## Evidence

- Extracted the original JSON example and validated it under `agents.entries.messenger` with the current `OpenClawSchema`: rejected with `Unrecognized key: "sessions"`. The corrected complete example passes the same schema. Assertions also confirm that both tool lists are unchanged.
- `node scripts/check-docs-config-examples.mjs` passed.
- `node scripts/check-docs-mdx.mjs docs/tools/multi-agent-sandbox-tools.md` passed.
- `node_modules/.bin/oxfmt --check docs/tools/multi-agent-sandbox-tools.md` and `git diff --check` passed.
- `node scripts/docs-link-audit.mjs`, with `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` pointing to a current ClawHub checkout, checked 8,196 internal links with zero broken links.
- Independent repository `autoreview --mode local --max-priority P2` reported no actionable findings.

The additional `--anchors` audit found one unrelated broken anchor in imported ClawHub documentation: `clawhub/publishing.md:285` links to `/clawhub/cli#package-transfer-name`. No links in the changed page failed. Validation used Node 24.19.0 and the repository's pinned pnpm 12.3.4.
