### PR TITLE
fix(claws): show owned cron jobs once in removal previews

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -420,6 +420,8 @@ openclaw claws remove incident-triage \
 ```
 
 The default removes eligible managed state and releases referenced state.
+Eligible Claw-owned schedules appear once as removal actions; other attached
+schedules remain blockers.
 Modified files and resources with another current owner are retained or
 blocked. Cleanup choices are part of the plan digest; `--yes` never broadens
 them. Globally installed plugins are retained while this Claw's reference is

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -434,23 +434,51 @@ describe("Claw status and remove", () => {
     );
   });
 
-  it("does not treat Claw-owned cron jobs as external agent blockers", async () => {
-    const current = await addFixture({ withCron: true });
-    seedAttachedCronJob(current.env, {
-      id: "scheduler-daily",
-      name: "Claw job",
-      schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
-    });
+  it.each([false, true])(
+    "keeps Claw-owned cron removal actions consistent (independent jobs=%s)",
+    async (withIndependentJobs) => {
+      const current = await addFixture({ withCron: true });
+      seedAttachedCronJob(current.env, {
+        id: "scheduler-daily",
+        name: "Claw job",
+        schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      });
+      if (withIndependentJobs) {
+        for (const id of ["z-operator-job", "a-operator-job"]) {
+          seedAttachedCronJob(current.env, {
+            id,
+            name: "Operator job",
+            schedule: { kind: "every", everyMs: 60_000 },
+          });
+        }
+      }
 
-    const plan = await buildClawRemovePlan("worker", {
-      env: current.env,
-      config: current.getConfig(),
-    });
-
-    expect(plan.blockers).not.toContainEqual(
-      expect.objectContaining({ code: "agent_job_attached" }),
-    );
-  });
+      const plan = await buildClawRemovePlan("worker", {
+        env: current.env,
+        config: current.getConfig(),
+      });
+      const independentIds = withIndependentJobs ? ["a-operator-job", "z-operator-job"] : [];
+      expect(plan.blockers).toEqual(
+        independentIds.map((id) => ({
+          code: "agent_job_attached",
+          message: expect.stringContaining(JSON.stringify(id)),
+        })),
+      );
+      expect(plan.actions.filter((action) => action.kind === "scheduledJob")).toEqual(
+        independentIds.map((id) =>
+          expect.objectContaining({ id, action: "retain", blocked: true }),
+        ),
+      );
+      expect(plan.actions.filter((action) => action.kind === "cronJob")).toEqual([
+        expect.objectContaining({
+          id: "daily-report",
+          target: "scheduler-daily",
+          action: "remove",
+          blocked: false,
+        }),
+      ]);
+    },
+  );
 
   it("removes the agent and unchanged files but only releases package refs", async () => {
     const current = await addFixture({ withFile: true });

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -172,12 +172,6 @@ export async function buildClawRemovePlan(
         .filter((cron) => cron.status !== "removed" && cron.schedulerJobId)
         .map((cron) => cron.schedulerJobId),
     );
-    for (const job of attachedJobs.filter((candidate) => !ownedSchedulerJobIds.has(candidate.id))) {
-      blockers.push({
-        code: "agent_job_attached",
-        message: `Cron job ${JSON.stringify(job.id)} still references agent ${JSON.stringify(record.install.agentId)}; reassign or remove it first.`,
-      });
-    }
     actions.push({
       kind: "agent",
       id: record.install.agentId,
@@ -267,7 +261,11 @@ export async function buildClawRemovePlan(
         ? { reason: "Session directory contains state owned by another agent." }
         : {}),
     });
-    for (const job of attachedJobs) {
+    for (const job of attachedJobs.filter((candidate) => !ownedSchedulerJobIds.has(candidate.id))) {
+      blockers.push({
+        code: "agent_job_attached",
+        message: `Cron job ${JSON.stringify(job.id)} still references agent ${JSON.stringify(record.install.agentId)}; reassign or remove it first.`,
+      });
       actions.push({
         kind: "scheduledJob",
         id: job.id,


### PR DESCRIPTION
Claw removal previews listed the same owned cron job as both retained operator work and a scheduled removal. The blocker check already recognized the recorded ownership; the separate retained-action loop did not. Generate both blockers and retained actions through that existing filter, keeping the single owned removal action. The complete apply function and typed database inventory remain byte-identical, and the removal docs describe the corrected preview.

The mismatch dates to #102383: that change added Claw cron removal and excluded recorded scheduler IDs from blockers while leaving retained actions unfiltered.

Both owned-only and mixed-inventory regression cases fail before the fix. Afterward, all 76 lifecycle, cron and CLI tests, the full changed-file gate, qaRuntime build and normal UI build pass.

A real isolated Gateway and nine public CLI invocations verify JSON and human previews: the owned schedule appears once, two independent jobs and the Workshop monitor remain ordered blockers, and both output modes report ten actions. Preview exits of 1 are expected because those blockers remain. Complete cron/provenance snapshots and config bytes are unchanged; source and executed bundle identities match before and after. The Gateway exited cleanly and synthetic state was removed. This is preview proof; no removal apply, provider execution or scheduled job was run.

Production is two lines smaller; tests grow by 28 lines and docs by two. The separate system-monitor cleanup policy is unchanged.
