### PR TITLE
refactor: consolidate generic channel account tests

### DIFF
--- a/extensions/irc/src/accounts.test.ts
+++ b/extensions/irc/src/accounts.test.ts
@@ -11,10 +11,6 @@ function asConfig(value: unknown): CoreConfig {
 }
 
 describe("listIrcAccountIds", () => {
-  it("returns default when no accounts are configured", () => {
-    expect(listIrcAccountIds(asConfig({}))).toEqual(["default"]);
-  });
-
   it("normalizes, deduplicates, and sorts configured account ids", () => {
     const cfg = asConfig({
       channels: {
@@ -68,37 +64,6 @@ describe("resolveDefaultIrcAccountId", () => {
     });
 
     expect(resolveDefaultIrcAccountId(cfg)).toBe("ops-team");
-  });
-
-  it("falls back to default when configured defaultAccount is missing", () => {
-    const cfg = asConfig({
-      channels: {
-        irc: {
-          defaultAccount: "missing",
-          accounts: {
-            default: {},
-            work: {},
-          },
-        },
-      },
-    });
-
-    expect(resolveDefaultIrcAccountId(cfg)).toBe("default");
-  });
-
-  it("falls back to first sorted account when default is absent", () => {
-    const cfg = asConfig({
-      channels: {
-        irc: {
-          accounts: {
-            zzz: {},
-            aaa: {},
-          },
-        },
-      },
-    });
-
-    expect(resolveDefaultIrcAccountId(cfg)).toBe("aaa");
   });
 });
 

--- a/extensions/zalouser/src/accounts.test.ts
+++ b/extensions/zalouser/src/accounts.test.ts
@@ -1,5 +1,4 @@
 // Zalouser tests cover accounts plugin behavior.
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import {
@@ -33,26 +32,6 @@ describe("zalouser account resolution", () => {
     }
   });
 
-  it("returns default account id when no accounts are configured", () => {
-    expect(listZalouserAccountIds(asConfig({}))).toEqual([DEFAULT_ACCOUNT_ID]);
-  });
-
-  it("returns sorted configured account ids", () => {
-    const cfg = asConfig({
-      channels: {
-        zalouser: {
-          accounts: {
-            work: {},
-            personal: {},
-            default: {},
-          },
-        },
-      },
-    });
-
-    expect(listZalouserAccountIds(cfg)).toEqual(["default", "personal", "work"]);
-  });
-
   it("preserves top-level default account when named accounts are configured", () => {
     const cfg = asConfig({
       channels: {
@@ -84,37 +63,6 @@ describe("zalouser account resolution", () => {
     });
 
     expect(resolveDefaultZalouserAccountId(cfg)).toBe("work");
-  });
-
-  it("falls back to default account when configured defaultAccount is missing", () => {
-    const cfg = asConfig({
-      channels: {
-        zalouser: {
-          defaultAccount: "missing",
-          accounts: {
-            default: {},
-            work: {},
-          },
-        },
-      },
-    });
-
-    expect(resolveDefaultZalouserAccountId(cfg)).toBe("default");
-  });
-
-  it("falls back to first sorted configured account when default is absent", () => {
-    const cfg = asConfig({
-      channels: {
-        zalouser: {
-          accounts: {
-            zzz: {},
-            aaa: {},
-          },
-        },
-      },
-    });
-
-    expect(resolveDefaultZalouserAccountId(cfg)).toBe("aaa");
   });
 
   it("resolves sync account by merging base + account config", () => {

--- a/src/channels/plugins/account-helpers.test.ts
+++ b/src/channels/plugins/account-helpers.test.ts
@@ -226,7 +226,12 @@ describe("createAccountListHelpers", () => {
       },
       {
         name: 'returns "default" when present',
-        input: cfg({ default: {}, other: {} }),
+        input: cfg({ alpha: {}, default: {}, other: {} }),
+        expected: "default",
+      },
+      {
+        name: "falls back to the listed default when configured defaultAccount is missing",
+        input: cfg({ alpha: {}, default: {} }, "missing"),
         expected: "default",
       },
       {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

IRC and ZaloUser replay generic account-list/default-selection scenarios even though their exported functions are direct bindings from the shared account factory. The owner tests also use a listed default that already sorts first, which does not independently prove default precedence.

## Why This Change Was Made

Remove seven generic plugin replay cases and keep their behavior at the shared owner. Strengthen the owner table so `default` beats alphabetically earlier `alpha`, both normally and when a configured preference is missing. Preserve plugin-specific configured-default wiring, normalization, implicit root credentials/profile, account merging, and actual account resolution cases.

## User Impact

No production behavior changes. Test code shrinks by 82 net lines while the common selection contract gains more discriminating assertions.

## Evidence

The shared owner, IRC, and ZaloUser suites pass: 75 tests. Full changed checks, formatting, and independent P2 review pass. Both adapters expose direct factory bindings; custom resolver implementations in other plugins are outside this deletion. No aggregate speedup is claimed.
