### PR TITLE
perf(agents): stop error summary projection after the first line

### DIFF
--- a/src/agents/embedded-agent-tool-results.ts
+++ b/src/agents/embedded-agent-tool-results.ts
@@ -71,11 +71,7 @@ export function capLiveExecResult(result: unknown): unknown {
 }
 
 function normalizeToolErrorText(text: string): string | undefined {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const firstLine = trimmed.split(/\r?\n/)[0]?.trim() ?? "";
+  const firstLine = text.trimStart().split(/\r?\n/, 1)[0]?.trim();
   if (!firstLine) {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable allocation when a failed command supplies large multiline output for a short tool-error summary. Retained process output can approach 200,000 characters, but the summary needs only its first line after leading whitespace.

## Why This Change Was Made

`normalizeToolErrorText` in `src/agents/embedded-agent-tool-results.ts` trims the start, splits with a one-result limit, and trims that line. This removes the whole-string trim/blank guard and array of discarded lines while retaining the empty-result check and exact 400-character surrogate-safe cap/ellipsis.

Terminal tool events reach the completion owner, which sanitizes results before `extractToolErrorMessage` selects direct/nested errors or aggregate/reason fallbacks. Source precedence, error classification, partial progress, terminal projections, and Unicode slicing remain unchanged. The terminal-failure sibling already uses a one-result split; no new parser or caller-side workaround is needed.

Production: +1/-5 lines (net -4); tests/support: +0/-0. The summary owner absorbs the reduction without changing retained process output or diagnostic policy.

## User Impact

Multiline failed-command summaries create fewer temporary strings and arrays while returning the same bounded diagnostic. The change preserves leading-line rules, redaction, terminal-control suppression, and exact error text. Single-line inputs have no claimed allocation improvement.

## Evidence

The actual-source probe produces identical full serialized outputs across 10,377 deterministic cases in all three before and three after processes. Cases cover direct/nested fields, classification/fallback, LF/CRLF/lone CR, blank lines, Unicode separators/whitespace, cap boundaries, valid surrogate pairs, and lone surrogates; independent expected-value assertions cover the cap and leading-line rules.

Measured objects pass through the real `sanitizeToolResult` first. Construction, sanitization, imports, and warmup occur outside measurement; the measured interval calls the actual exported extractor and checks complete outputs. Node 26.8.1/macOS arm64 results:

| Cohort | Calls/run | Mean total sampled bytes before → after | Median ms before → after |
| --- | ---: | ---: | ---: |
| Multiline LF, 199,961 chars | 200 | 64,942,083 → 243,320 | 64.312 → 0.129 |
| Multiline CRLF, 199,989 chars | 200 | 63,955,429 → 83,669 | 58.591 → 0.145 |
| Single line, 25 chars | 10,000 | 3,227,469 → 3,240,459 | 4.667 → 3.906 |
| Single line, 200,000 chars | 200 | 237,048 → 259,091 | 1.777 → 1.646 |

Total sampled allocation falls 99.63%/99.87% for multiline LF/CRLF; owner-attributed samples fall about 99.91%. Controls increase 0.40%/9.30%, including approximately 22 KB for the long single line. The 1 KiB sampler includes collected objects. Runs are before-before-before/after-after-after, not randomized ABBA; timings describe amplified operations under shared load. Harness objects remain alive at GC endpoints, so no retained-heap, RSS, live-provider, or whole-Gateway improvement is claimed.

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.tools.test.ts
node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.handlers.tools.test.ts -t 'records timeout metadata for failed exec results|projects a structured diagnostic from the real terminal process|keeps child output out of the terminal diagnostic|omits full-verbosity process output containing terminal control characters'
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/embedded-agent-tool-results.ts
```

The helper suite passes 45 tests; completion-boundary selection passes five, with 181 intentionally unselected. These cover real process-result projection, timeout metadata, bounded redacted diagnostics, and terminal-control suppression without launching a command or Gateway. Typed lint, formatting, diff checks, and changed-plan classification pass. Broad local gates remain unrun. Independent P2 review recorded no actionable findings; required exact-head hosted CI/native landing gates remain mandatory.

The requested RSS reporting comes from the same six preserved benchmark runs above; no new benchmark or source change was needed. Each value is the median across three processes for that arm. RSS columns show start / end / after two requested GCs, in MiB (bytes / 1,048,576).

| Cohort | Median seconds, before → after | Baseline RSS, start / end / after GC | Candidate RSS, start / end / after GC |
| --- | ---: | ---: | ---: |
| Multiline LF, 200 calls | 0.064312 → 0.000129 | 119.84 / 158.91 / 158.88 | 128.12 / 128.91 / 128.91 |
| Multiline CRLF, 200 calls | 0.058591 → 0.000145 | 159.23 / 163.73 / 163.50 | 128.91 / 129.06 / 129.05 |
| Short single line, 10,000 calls | 0.004667 → 0.003906 | 163.50 / 163.55 / 163.30 | 129.05 / 129.53 / 129.62 |
| Long single line, 200 calls | 0.001777 → 0.001646 | 163.30 / 163.39 / 163.38 | 129.45 / 129.47 / 129.45 |

RSS start is recorded after warmup and two GCs, before starting the allocation profiler. RSS end is recorded after stopping the profiler and traversing its returned profile; the profile, fixtures and other harness objects remain alive at the post-GC endpoint. These are full-process endpoint measurements, not peak RSS or isolated retained ownership. All baseline processes ran before all candidate processes, and earlier cohorts affect later process state. The higher candidate starting RSS and single-line control allocation increases remain visible; these observations do not establish a causal RSS or whole-Gateway improvement.

This supplies the before/after seconds and RSS requested in the completed ClawSweeper review and its Rank-up move.

The first required CI attempt failed the session-delivery clock-jump integration test. The historical empty client-event observation remains unclassified. Supplementary proof on its exact merge `f2cec3afc39e4bdfc9fe9c65040270bd7e4a6424` and tree `04623ad867d58265cc6c4a70d3760ef61f86ac97` passed the unchanged focused test and the original 85-file, 1,312-test selection on Linux x64, Node 24.19.0 and pnpm 12.3.4 ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/34000553296)). A temporary passive observer recorded durable completion with zero retries and two actual peer/client events before the unchanged assertion; both sockets stayed open until teardown. All 18 source bindings were restored, commands joined, and both diagnostic leases completed. The first diagnostic attempt stopped before tests because of a command-envelope heredoc collision; the replacement changed only serialization of the identical payload. The observation can affect timing and does not reconstruct historical worker assignment or host load. No product code, repository test assertion, timeout or scheduler was changed; this evidence supported one standard failed-jobs CI retry at the unchanged PR head. Required CI and native landing gates still apply.
