### PR TITLE
perf(skills): detach cached metadata from source strings

### DIFF
--- a/src/skills/loading/frontmatter.ts
+++ b/src/skills/loading/frontmatter.ts
@@ -28,7 +28,9 @@ export function parseSkillFrontmatter(content: string): ParsedSkillFrontmatter {
   if (issue) {
     throw new Error(`invalid frontmatter: ${issue.code}: ${issue.message}`);
   }
-  return parsed.frontmatter;
+  // Cached metadata must not retain the discarded SKILL.md through parser slices.
+  // The normalized record contains only strings; copy its keys and values together.
+  return structuredClone(parsed.frontmatter);
 }
 
 const BREW_FORMULA_PATTERN = /^[A-Za-z0-9][A-Za-z0-9@+._/-]*$/;

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -55,7 +55,10 @@ function humanizeSkillIdentifier(value: string): string {
 export function resolveSkillDisplayName(content: string, fallbackName: string): string {
   const body = content.replace(SKILL_FRONTMATTER_BLOCK, "");
   const heading = body.match(SKILL_TITLE_HEADING)?.[1]?.trim();
-  return heading || humanizeSkillIdentifier(fallbackName) || fallbackName;
+  const displayName = heading || humanizeSkillIdentifier(fallbackName) || fallbackName;
+  // A captured heading can retain the whole skill body in metadata caches.
+  // Copy UTF-16 code units without changing lone surrogates.
+  return Buffer.from(displayName, "utf16le").toString("utf16le");
 }
 
 function truncateSkillDescription(description: string, maxChars: number): string {


### PR DESCRIPTION
## What Problem This Solves

Resolves retained skill source bodies in the measured Node workspace-cache workload. Short display titles and frontmatter values can remain sliced strings backed by the full SKILL.md, even after loading deliberately drops content from cached entries. Limiting cache entries alone does not remove that backing storage.

## Why This Change Was Made

The shared metadata producers copy their finalized results: `src/skills/loading/frontmatter.ts` applies native `structuredClone` to the normalized string record, and `src/skills/loading/skill-contract.ts` copies the display title through lossless UTF-16LE encoding/decoding. Parser validation/recovery, key order, fallback titles, and every string code unit remain unchanged; no universal string/key-identity guarantee is introduced.

Workspace caching, pinned library selection, and session resource loading share these producers. A cache-only repair would miss siblings; copying headings alone would miss frontmatter. An initial JSON roundtrip passed values but failed the existing prefer-structured-clone lint rule; the final native clone has fresh proof without suppression. Production: +7/-2 lines (net +5); tests/support: +0/-0. Those lines establish metadata ownership without cloning complete entries/files or adding a cache, parser, or fallback.

## User Impact

Cached local skill metadata retains fewer source-body strings in the measured Node cohorts while preserving titles, metadata, prompts, pins, refresh behavior, and cache-hit entry identity. Remote skills deliberately retain content and have no claimed memory reduction. Small metadata copies add transient work on cache misses.

## Evidence

The real exported workspace loader loads 100 synthetic 240,000-byte files, advances the real watcher snapshot, and loads a second generation under existing limits. Files/results leave scope, files are removed, and three explicit GCs separated by event-loop turns precede heap inspection.

In each independently run large cohort—heading plus metadata, frontmatter without H1, and heading with tiny/reconstructed metadata—the baseline cache payload retains 200 marked source bodies totaling 48,003,200 string self-bytes; the final Node candidate retains zero. Full entries/prompts and cache-hit entry identity match. The 512-byte control preserves outputs; the large-body classifier intentionally does not measure its small strings.

After 65 normal empty-snapshot insertions, neither arm retains a marked body through cache payloads. One baseline body remains engine-global in two cohorts through regexp last-match state. Earlier graph analyses incorrectly labeled that cache ownership; final v3 follows payload edges while excluding prototypes, runtime shapes, functions, and contexts. It preserves all 200 direct retained-entry paths and zero after eviction, without changing the cache or snapshots.

Whole-process heap deltas are noisy as warmed imports release memory; external memory remains 4,983,782 bytes at retained endpoints and ArrayBuffers near 2.31 MB. The attributed result is 200 source bodies → zero in these Node 26.8.1 cohorts, not universal engine/key detachment, Bun heap behavior, zero allocation, latency, RSS, or leak freedom. Bun was not executed.

All 131,390 full value results match, covering every UTF-16 code unit, YAML variants, parser errors, and policy/manifest projections. A real library/session proof preserves six pin/cache/revision/refresh/resource-replacement boundaries with a 900,429-byte fixture; normalized metadata/prompt bytes match. This sibling proof measures behavior, not heap or latency.

```sh
node scripts/run-vitest.mjs src/skills/loading/frontmatter.test.ts src/skills/loading/skill-contract.test.ts src/skills/loading/workspace-skill-loader.test.ts src/skills/loading/session.test.ts src/skills/runtime/remote-skills.test.ts src/skills/library/service.test.ts
node node_modules/oxlint/bin/oxlint --type-aware src/skills/loading/frontmatter.ts src/skills/loading/skill-contract.ts
```

All 84 tests across six files pass before/after. Final formatting, exact-file typed lint, and changed-plan classification pass. Independent P2 review recorded no actionable findings. Broad integration/build checks remain separate; required exact-head hosted CI/native landing gates remain mandatory.

Current-context composition at main `3dff8818ef42872cecc3899b41dffd95942fe70f` preserves the upstream pure `decodeSkillXml` and `compactSkillsPromptForContext` helpers and every previously reviewed producer statement. Independent static assessment confirms the original clean P2 remains applicable to this producer-copy change. The expected composed `skill-contract.ts` SHA-256 is `bae17b2bf0dd717ab51bb1e9a49634e2e0518c715050fff731fa84da3af3feef`. This adds no current-main runtime/heap experiment or Bun heap claim; the original measured Node cache cohorts remain the performance evidence.
