### PR TITLE
fix: preserve realtime transcription message limits under Bun

### DIFF
--- a/extensions/openai/realtime-transcription-provider.bounds.test.ts
+++ b/extensions/openai/realtime-transcription-provider.bounds.test.ts
@@ -54,6 +54,7 @@ vi.mock("ws", () => ({
 type FakeWebSocketInstance = InstanceType<typeof FakeWebSocket>;
 
 async function waitForFakeSocket(index = 0): Promise<FakeWebSocketInstance> {
+  await vi.dynamicImportSettled();
   let socket: FakeWebSocketInstance | undefined;
   await vi.waitFor(() => {
     socket = FakeWebSocket.instances[index];

--- a/extensions/openai/realtime-transcription-provider.test.ts
+++ b/extensions/openai/realtime-transcription-provider.test.ts
@@ -97,6 +97,7 @@ async function waitForFakeSocket(
   index = 0,
 ): Promise<FakeWebSocketInstance> {
   sessions.add(session);
+  await vi.dynamicImportSettled();
   const existing = FakeWebSocket.instances[index];
   if (existing) {
     return existing;

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -2,6 +2,7 @@
 import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { toErrorObject, toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import type WebSocket from "ws";
 import { RetrySupervisor } from "../../packages/retry/src/index.js";
@@ -15,9 +16,13 @@ import type {
 
 // The installed receiver enforces maxPayload; Bun's built-in ws adapter ignores it.
 const require = createRequire(import.meta.url);
-const { WebSocket: NpmWebSocket }: typeof import("ws") = require(
-  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
-);
+let webSocketConstructor: Promise<typeof WebSocket> | undefined;
+function loadWebSocket(): Promise<typeof WebSocket> {
+  return (webSocketConstructor ??= import(
+    pathToFileURL(path.join(path.dirname(require.resolve("ws/package.json")), "wrapper.mjs")).href
+  ).then((module: typeof import("ws")) => module.default));
+}
+const WEBSOCKET_OPEN = 1;
 
 // Generic websocket-backed realtime transcription session. Providers supply URL,
 // protocol messages, and audio framing while core owns reconnection and queues.
@@ -126,7 +131,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     if (this.closed || audio.byteLength === 0) {
       return;
     }
-    if (this.ws?.readyState === NpmWebSocket.OPEN && this.ready && this.transport) {
+    if (this.ws?.readyState === WEBSOCKET_OPEN && this.ready && this.transport) {
       this.options.sendAudio(audio, this.transport);
       return;
     }
@@ -147,7 +152,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     this.clearQueuedAudio();
     const socket = this.ws;
     const transport = this.transport;
-    if (!socket || socket.readyState !== NpmWebSocket.OPEN || !transport) {
+    if (!socket || socket.readyState !== WEBSOCKET_OPEN || !transport) {
       this.forceClose(socket);
       return;
     }
@@ -280,7 +285,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
             failConnect(error);
           }
         },
-        isOpen: () => ownsSocket() && socket?.readyState === NpmWebSocket.OPEN,
+        isOpen: () => ownsSocket() && socket?.readyState === WEBSOCKET_OPEN,
         isReady: () => ownsSocket() && this.ready,
         markReady: () => {
           if (ownsSocket()) {
@@ -303,8 +308,12 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
 
       void (async () => {
         let connection: { headers?: Record<string, string>; url: string };
+        let NpmWebSocket: typeof WebSocket;
         try {
-          connection = await this.resolveConnection();
+          [connection, NpmWebSocket] = await Promise.all([
+            this.resolveConnection(),
+            loadWebSocket(),
+          ]);
         } catch (error) {
           failConnect(toStringifiedError(error));
           return;
@@ -513,7 +522,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
       !socket ||
       generation !== this.connectionGeneration ||
       this.ws !== socket ||
-      socket.readyState !== NpmWebSocket.OPEN
+      socket.readyState !== WEBSOCKET_OPEN
     ) {
       return false;
     }

--- a/src/realtime-transcription/websocket-session.ts
+++ b/src/realtime-transcription/websocket-session.ts
@@ -1,7 +1,9 @@
 // Realtime transcription websocket session streams audio to transcription providers.
 import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { toErrorObject, toStringifiedError } from "@openclaw/normalization-core/error-coercion";
-import WebSocket from "ws";
+import type WebSocket from "ws";
 import { RetrySupervisor } from "../../packages/retry/src/index.js";
 import { sleepWithAbort } from "../infra/backoff.js";
 import { createDebugProxyWebSocketAgent, resolveDebugProxySettings } from "../proxy-capture/env.js";
@@ -10,6 +12,12 @@ import type {
   RealtimeTranscriptionSession,
   RealtimeTranscriptionSessionCallbacks,
 } from "./provider-types.js";
+
+// The installed receiver enforces maxPayload; Bun's built-in ws adapter ignores it.
+const require = createRequire(import.meta.url);
+const { WebSocket: NpmWebSocket }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
 
 // Generic websocket-backed realtime transcription session. Providers supply URL,
 // protocol messages, and audio framing while core owns reconnection and queues.
@@ -118,7 +126,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     if (this.closed || audio.byteLength === 0) {
       return;
     }
-    if (this.ws?.readyState === WebSocket.OPEN && this.ready && this.transport) {
+    if (this.ws?.readyState === NpmWebSocket.OPEN && this.ready && this.transport) {
       this.options.sendAudio(audio, this.transport);
       return;
     }
@@ -139,7 +147,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
     this.clearQueuedAudio();
     const socket = this.ws;
     const transport = this.transport;
-    if (!socket || socket.readyState !== WebSocket.OPEN || !transport) {
+    if (!socket || socket.readyState !== NpmWebSocket.OPEN || !transport) {
       this.forceClose(socket);
       return;
     }
@@ -272,7 +280,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
             failConnect(error);
           }
         },
-        isOpen: () => ownsSocket() && socket?.readyState === WebSocket.OPEN,
+        isOpen: () => ownsSocket() && socket?.readyState === NpmWebSocket.OPEN,
         isReady: () => ownsSocket() && this.ready,
         markReady: () => {
           if (ownsSocket()) {
@@ -311,7 +319,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
 
         this.currentUrl = connection.url;
         try {
-          socket = new WebSocket(this.currentUrl, {
+          socket = new NpmWebSocket(this.currentUrl, {
             headers: connection.headers,
             maxPayload: REALTIME_TRANSCRIPTION_WS_MAX_PAYLOAD_BYTES,
             ...(proxyAgent ? { agent: proxyAgent } : {}),
@@ -505,7 +513,7 @@ class WebSocketRealtimeTranscriptionSession<Event> implements RealtimeTranscript
       !socket ||
       generation !== this.connectionGeneration ||
       this.ws !== socket ||
-      socket.readyState !== WebSocket.OPEN
+      socket.readyState !== NpmWebSocket.OPEN
     ) {
       return false;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where realtime transcription running under Bun did not enforce the configured inbound WebSocket payload limit before provider parsing.

## Why This Change Was Made

Load the installed `ws` package explicitly through its ESM entry. Bun substitutes its built-in adapter for a bare `ws` import; selecting the installed dependency preserves the existing transport contract. The cached lazy import runs within the existing protected connection flow, with generation and closure checks before creating a socket.

## User Impact

Realtime transcription retains its existing inbound message bound under Bun. Provider APIs and reconnect behavior remain unchanged.

## Evidence

- 143 focused tests pass on Node and 143 pass on true Bun across transcription and provider coverage.
- Full build and complete changed-file gate pass.
- Independent P0–P2 review found no actionable findings.
- An initial CI failure exposed that direct CommonJS loading bypassed provider test interception. The final ESM loader and test synchronization repair that issue while preserving the installed receiver.
- The full Bun suite remains a separate ongoing compatibility campaign; this PR does not claim that every suite passes under Bun.
