### PR TITLE
refactor(exec): share package-manager option scans

### DIFF
--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -149,6 +149,48 @@ const YARN_BUILTIN_NON_EXEC_SUBCOMMANDS = new Set([
   "workspace",
 ]);
 
+type PackageManagerOptions = {
+  optionsWithValue: ReadonlySet<string>;
+  caseSensitiveOptionsWithValue?: ReadonlySet<string>;
+  flagOptions: ReadonlySet<string>;
+};
+
+type PackageManagerContextOptions = PackageManagerOptions & {
+  contextOptionsWithValue: ReadonlySet<string>;
+  contextCaseSensitiveOptionsWithValue?: ReadonlySet<string>;
+  contextFlagOptions?: ReadonlySet<string>;
+};
+
+const NPM_EXEC_OPTIONS: PackageManagerContextOptions = {
+  optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
+  caseSensitiveOptionsWithValue: new Set(["-C"]),
+  flagOptions: NPM_EXEC_FLAG_OPTIONS,
+  contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
+  contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
+  contextFlagOptions: new Set(["--ws", "--workspaces"]),
+};
+
+const PNPM_EXEC_OPTIONS: PackageManagerContextOptions = {
+  optionsWithValue: new Set([...PNPM_OPTIONS_WITH_VALUE, ...PNPM_DLX_OPTIONS_WITH_VALUE]),
+  caseSensitiveOptionsWithValue: PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
+  flagOptions: PNPM_FLAG_OPTIONS,
+  contextOptionsWithValue: PNPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
+  contextCaseSensitiveOptionsWithValue: PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
+  contextFlagOptions: new Set(["--recursive", "--workspace-root", "-r", "-w"]),
+};
+
+const YARN_EXEC_OPTIONS: PackageManagerContextOptions = {
+  optionsWithValue: new Set([...YARN_OPTIONS_WITH_VALUE, ...YARN_DLX_OPTIONS_WITH_VALUE]),
+  flagOptions: new Set([...YARN_FLAG_OPTIONS, ...YARN_DLX_FLAG_OPTIONS]),
+  contextOptionsWithValue: YARN_OPTIONS_WITH_VALUE,
+};
+
+const YARN_DLX_OPTIONS: PackageManagerContextOptions = {
+  optionsWithValue: YARN_DLX_OPTIONS_WITH_VALUE,
+  flagOptions: YARN_DLX_FLAG_OPTIONS,
+  contextOptionsWithValue: YARN_DLX_OPTIONS_WITH_VALUE,
+};
+
 function normalizeOptionFlag(token: string): string {
   return normalizeLowercaseStringOrEmpty(parseInlineOptionToken(token).name);
 }
@@ -156,11 +198,7 @@ function normalizeOptionFlag(token: string): string {
 function findFirstNonOptionIndex(
   argv: string[],
   startIdx: number,
-  params: {
-    optionsWithValue: ReadonlySet<string>;
-    caseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    flagOptions: ReadonlySet<string>;
-  },
+  params: PackageManagerOptions,
 ): number | null {
   let idx = startIdx;
   while (idx < argv.length) {
@@ -195,17 +233,11 @@ function findFirstNonOptionIndex(
   return null;
 }
 
-function hasLeadingContextOption(
+function hasContextOption(
   argv: string[],
   startIdx: number,
-  params: {
-    optionsWithValue: ReadonlySet<string>;
-    caseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    flagOptions: ReadonlySet<string>;
-    contextOptionsWithValue: ReadonlySet<string>;
-    contextCaseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    contextFlagOptions?: ReadonlySet<string>;
-  },
+  params: PackageManagerContextOptions,
+  scope: "leading" | "before-terminator" = "leading",
 ): boolean {
   let idx = startIdx;
   while (idx < argv.length) {
@@ -215,61 +247,16 @@ function hasLeadingContextOption(
       continue;
     }
     if (token === "--") {
+      if (scope === "before-terminator") {
+        return false;
+      }
       idx += 1;
       continue;
     }
     if (!token.startsWith("-")) {
-      return false;
-    }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (
-      params.contextCaseSensitiveOptionsWithValue?.has(parsedOption.name) ||
-      params.contextOptionsWithValue.has(flag) ||
-      params.contextFlagOptions?.has(flag)
-    ) {
-      return true;
-    }
-    if (params.caseSensitiveOptionsWithValue?.has(parsedOption.name)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (params.optionsWithValue.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (params.flagOptions.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return false;
-  }
-  return false;
-}
-
-function hasContextOptionBeforeTerminator(
-  argv: string[],
-  startIdx: number,
-  params: {
-    optionsWithValue: ReadonlySet<string>;
-    caseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    flagOptions: ReadonlySet<string>;
-    contextOptionsWithValue: ReadonlySet<string>;
-    contextCaseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    contextFlagOptions?: ReadonlySet<string>;
-  },
-): boolean {
-  let idx = startIdx;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      return false;
-    }
-    if (!token.startsWith("-")) {
+      if (scope === "leading") {
+        return false;
+      }
       idx += 1;
       continue;
     }
@@ -293,6 +280,9 @@ function hasContextOptionBeforeTerminator(
     if (params.flagOptions.has(flag)) {
       idx += 1;
       continue;
+    }
+    if (scope === "leading") {
+      return false;
     }
     idx += 1;
   }
@@ -303,89 +293,34 @@ export function hasKnownPackageManagerExecContextOptions(argv: string[]): boolea
   const executable = normalizePackageManagerExecToken(argv[0] ?? "");
   switch (executable) {
     case "npm": {
-      const leadingOptions = {
-        optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
-        caseSensitiveOptionsWithValue: new Set(["-C"]),
-        flagOptions: NPM_EXEC_FLAG_OPTIONS,
-      };
-      if (
-        hasLeadingContextOption(argv, 1, {
-          ...leadingOptions,
-          contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
-          contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
-          contextFlagOptions: new Set(["--ws", "--workspaces"]),
-        })
-      ) {
+      if (hasContextOption(argv, 1, NPM_EXEC_OPTIONS)) {
         return true;
       }
-      const subcommandIdx = findFirstNonOptionIndex(argv, 1, leadingOptions);
+      const subcommandIdx = findFirstNonOptionIndex(argv, 1, NPM_EXEC_OPTIONS);
+      // npm also consumes context options after the command, up to the first `--`.
       return subcommandIdx !== null && NPM_EXEC_SUBCOMMANDS.has(argv[subcommandIdx] ?? "")
-        ? hasContextOptionBeforeTerminator(argv, subcommandIdx + 1, {
-            optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
-            caseSensitiveOptionsWithValue: new Set(["-C"]),
-            flagOptions: NPM_EXEC_FLAG_OPTIONS,
-            contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
-            contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
-            contextFlagOptions: new Set(["--ws", "--workspaces"]),
-          })
+        ? hasContextOption(argv, subcommandIdx + 1, NPM_EXEC_OPTIONS, "before-terminator")
         : false;
     }
     case "npx":
     case "bunx":
-      return hasLeadingContextOption(argv, 1, {
-        optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
-        caseSensitiveOptionsWithValue: new Set(["-C"]),
-        flagOptions: NPM_EXEC_FLAG_OPTIONS,
-        contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
-        contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
-        contextFlagOptions: new Set(["--ws", "--workspaces"]),
-      });
+      return hasContextOption(argv, 1, NPM_EXEC_OPTIONS);
     case "pnpm": {
-      const leadingOptions = {
-        optionsWithValue: new Set([...PNPM_OPTIONS_WITH_VALUE, ...PNPM_DLX_OPTIONS_WITH_VALUE]),
-        caseSensitiveOptionsWithValue: PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
-        flagOptions: PNPM_FLAG_OPTIONS,
-      };
-      if (
-        hasLeadingContextOption(argv, 1, {
-          ...leadingOptions,
-          contextOptionsWithValue: PNPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
-          contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
-          contextFlagOptions: new Set(["--recursive", "--workspace-root", "-r", "-w"]),
-        })
-      ) {
+      if (hasContextOption(argv, 1, PNPM_EXEC_OPTIONS)) {
         return true;
       }
-      const subcommandIdx = findFirstNonOptionIndex(argv, 1, leadingOptions);
+      const subcommandIdx = findFirstNonOptionIndex(argv, 1, PNPM_EXEC_OPTIONS);
       return argv[subcommandIdx ?? -1] === "dlx"
-        ? hasLeadingContextOption(argv, (subcommandIdx ?? 0) + 1, {
-            ...leadingOptions,
-            contextOptionsWithValue: PNPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
-            contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
-            contextFlagOptions: new Set(["--recursive", "--workspace-root", "-r", "-w"]),
-          })
+        ? hasContextOption(argv, (subcommandIdx ?? 0) + 1, PNPM_EXEC_OPTIONS)
         : false;
     }
     case "yarn": {
-      const leadingOptions = {
-        optionsWithValue: new Set([...YARN_OPTIONS_WITH_VALUE, ...YARN_DLX_OPTIONS_WITH_VALUE]),
-        flagOptions: new Set([...YARN_FLAG_OPTIONS, ...YARN_DLX_FLAG_OPTIONS]),
-      };
-      if (
-        hasLeadingContextOption(argv, 1, {
-          ...leadingOptions,
-          contextOptionsWithValue: new Set(["--cwd"]),
-        })
-      ) {
+      if (hasContextOption(argv, 1, YARN_EXEC_OPTIONS)) {
         return true;
       }
-      const subcommandIdx = findFirstNonOptionIndex(argv, 1, leadingOptions);
+      const subcommandIdx = findFirstNonOptionIndex(argv, 1, YARN_EXEC_OPTIONS);
       return argv[subcommandIdx ?? -1] === "dlx"
-        ? hasLeadingContextOption(argv, (subcommandIdx ?? 0) + 1, {
-            optionsWithValue: YARN_DLX_OPTIONS_WITH_VALUE,
-            flagOptions: YARN_DLX_FLAG_OPTIONS,
-            contextOptionsWithValue: new Set(["--package", "-p"]),
-          })
+        ? hasContextOption(argv, (subcommandIdx ?? 0) + 1, YARN_DLX_OPTIONS)
         : false;
     }
     default:
@@ -407,68 +342,33 @@ type PackageManagerExecInvocation =
   | { kind: "unsafe-exec" }
   | { kind: "unwrapped"; argv: string[] };
 
-function firstSubcommandAfterOptions(
-  argv: string[],
-  params: {
-    optionsWithValue: ReadonlySet<string>;
-    caseSensitiveOptionsWithValue?: ReadonlySet<string>;
-    flagOptions: ReadonlySet<string>;
-  },
-): string | null {
+function firstSubcommandAfterOptions(argv: string[], params: PackageManagerOptions): string | null {
   const idx = findFirstNonOptionIndex(argv, 1, params);
   return idx === null ? null : normalizeLowercaseStringOrEmpty(argv[idx] ?? "");
 }
 
 function unwrapPnpmExecInvocation(argv: string[]): string[] | null {
-  let idx = 1;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      idx += 1;
-      continue;
-    }
-    if (!token.startsWith("-")) {
-      if (token === "exec") {
-        if (idx + 1 >= argv.length) {
-          return null;
-        }
-        const tail = argv.slice(idx + 1);
-        const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
-        const firstExecArg = normalizeOptionFlag(normalizedTail[0] ?? "");
-        if (firstExecArg === "-c" || firstExecArg === "--shell-mode") {
-          return null;
-        }
-        return normalizedTail.length > 0 ? normalizedTail : null;
-      }
-      if (token === "dlx") {
-        return unwrapPnpmDlxInvocation(argv.slice(idx + 1));
-      }
-      if (token === "node") {
-        const tail = argv.slice(idx + 1);
-        const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
-        return ["node", ...normalizedTail];
-      }
+  const idx = findFirstNonOptionIndex(argv, 1, PNPM_EXEC_OPTIONS);
+  if (idx === null) {
+    return null;
+  }
+  const token = argv[idx]?.trim();
+  if (token === "exec") {
+    const tail = argv.slice(idx + 1);
+    const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
+    const firstExecArg = normalizeOptionFlag(normalizedTail[0] ?? "");
+    if (firstExecArg === "-c" || firstExecArg === "--shell-mode") {
       return null;
     }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE.has(parsedOption.name)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return null;
+    return normalizedTail.length > 0 ? normalizedTail : null;
+  }
+  if (token === "dlx") {
+    return unwrapPnpmDlxInvocation(argv.slice(idx + 1));
+  }
+  if (token === "node") {
+    const tail = argv.slice(idx + 1);
+    const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
+    return ["node", ...normalizedTail];
   }
   return null;
 }
@@ -605,38 +505,21 @@ function unwrapYarnDlxInvocation(argv: string[]): string[] | null {
 }
 
 function unwrapYarnExecInvocation(argv: string[]): string[] | null {
-  let idx = 1;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      idx += 1;
-      continue;
-    }
-    if (!token.startsWith("-")) {
-      if (token === "exec") {
-        const tail = argv.slice(idx + 1);
-        const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
-        return normalizedTail.length > 0 ? normalizedTail : null;
-      }
-      if (token === "dlx") {
-        return unwrapYarnDlxInvocation(argv.slice(idx + 1));
-      }
-      return null;
-    }
-    const flag = normalizeOptionFlag(token);
-    if (YARN_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (YARN_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
+  const idx = findFirstNonOptionIndex(argv, 1, {
+    optionsWithValue: YARN_OPTIONS_WITH_VALUE,
+    flagOptions: YARN_FLAG_OPTIONS,
+  });
+  if (idx === null) {
     return null;
+  }
+  const token = argv[idx]?.trim();
+  if (token === "exec") {
+    const tail = argv.slice(idx + 1);
+    const normalizedTail = tail[0] === "--" ? tail.slice(1) : tail;
+    return normalizedTail.length > 0 ? normalizedTail : null;
+  }
+  if (token === "dlx") {
+    return unwrapYarnDlxInvocation(argv.slice(idx + 1));
   }
   return null;
 }
@@ -656,11 +539,7 @@ export function resolveKnownPackageManagerExecInvocation(
       if (unwrapped) {
         return { kind: "unwrapped", argv: unwrapped };
       }
-      const firstSubcommand = firstSubcommandAfterOptions(argv, {
-        optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
-        caseSensitiveOptionsWithValue: new Set(["-C"]),
-        flagOptions: NPM_EXEC_FLAG_OPTIONS,
-      });
+      const firstSubcommand = firstSubcommandAfterOptions(argv, NPM_EXEC_OPTIONS);
       return NPM_EXEC_SUBCOMMANDS.has(firstSubcommand ?? "")
         ? { kind: "unsafe-exec" }
         : firstSubcommand === null && containsSubcommandToken(argv.slice(1), NPM_EXEC_SUBCOMMANDS)
@@ -677,11 +556,7 @@ export function resolveKnownPackageManagerExecInvocation(
       if (unwrapped) {
         return { kind: "unwrapped", argv: unwrapped };
       }
-      const firstSubcommand = firstSubcommandAfterOptions(argv, {
-        optionsWithValue: new Set([...PNPM_OPTIONS_WITH_VALUE, ...PNPM_DLX_OPTIONS_WITH_VALUE]),
-        caseSensitiveOptionsWithValue: PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
-        flagOptions: PNPM_FLAG_OPTIONS,
-      });
+      const firstSubcommand = firstSubcommandAfterOptions(argv, PNPM_EXEC_OPTIONS);
       const detectedKnownExec = PNPM_EXEC_SUBCOMMANDS.has(firstSubcommand ?? "");
       const hiddenKnownExec =
         firstSubcommand === null && containsSubcommandToken(argv.slice(1), PNPM_EXEC_SUBCOMMANDS);
@@ -698,10 +573,7 @@ export function resolveKnownPackageManagerExecInvocation(
       if (unwrapped) {
         return { kind: "unwrapped", argv: unwrapped };
       }
-      const firstSubcommand = firstSubcommandAfterOptions(argv, {
-        optionsWithValue: new Set([...YARN_OPTIONS_WITH_VALUE, ...YARN_DLX_OPTIONS_WITH_VALUE]),
-        flagOptions: new Set([...YARN_FLAG_OPTIONS, ...YARN_DLX_FLAG_OPTIONS]),
-      });
+      const firstSubcommand = firstSubcommandAfterOptions(argv, YARN_EXEC_OPTIONS);
       const detectedKnownExec = YARN_EXEC_SUBCOMMANDS.has(firstSubcommand ?? "");
       const hiddenKnownExec =
         firstSubcommand === null && containsSubcommandToken(argv.slice(1), YARN_EXEC_SUBCOMMANDS);


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Maintainer-requested cleanup supporting the #135868 split: package-manager command analysis repeats option scanners and reconstructs the same option sets at several call sites. That duplication makes it harder to keep reusable exec approvals and mutable-script detection consistent.

This is the independent `clean-broad` companion lane; it extracts none of the numbered recovery stages.

## Why This Change Was Made

Share the existing option scanner with pnpm and Yarn command extraction, combine the two context-option scans with their distinct stopping rules, and prepare the unchanged package-manager option sets once. npm still detects context options after the command until `--`; leading scans still stop at the first command or unknown flag.

Production LOC: +103 / -231 (**net -128**), one file, 334 changed lines. Tests, tooling, and docs: +0 / -0. No compatibility path, public export, supported option, or approval rule is removed.

## User Impact

No intended behavior change. Existing package-manager commands retain the same execution target, reusable-approval restrictions, and mutable-file binding.

## Evidence

- The baseline parser is byte-identical to stable tag `v2026.9.2`. Its context restrictions come from #112946; these are retained.
- A temporary differential probe compared 543,008 synthetic invocations against that baseline, including npm/npx/bunx/pnpm/Yarn, Windows executable spellings, empty tokens, separators, unknown flags, value-taking options, shell modes, nested commands, and context options. Classification, unwrapped argv, and context decisions were identical.
- `node scripts/run-vitest.mjs src/infra/exec-approvals-allow-always.test.ts src/infra/exec-wrapper-trust-plan.test.ts src/node-host/invoke-system-run-plan.test.ts`: **178 tests passed**.
- `git diff --check`: passed. No build required: imports and packaging boundaries are unchanged.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33997768289) for `084f5176217b1ff993119c123a17ed4c987ba5e1`: passed; the CI watcher returned `GREEN`.
- Independent Codex local and branch reviews through P2: scoped-clean, no accepted/actionable findings.
- [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139482#issuecomment-5555364079) on `de402b243ab59884c908a5d855c15276d68ca863`: no findings and no before-merge or rank-up actions. The review confirmed the scanner stopping rules and read-only option-set consumers.
- `node scripts/check-changed.mjs`: passed the complete selected core/coreTests plan, including all type shards, three export scans, and architecture guards.

Deletion rationale: the removed walkers used the same token/value/unknown-option rules as the retained scanner; the context scans differed only at positional tokens, unknown flags, and the delimiter, now explicit in the scan scope. Existing owner-boundary tests remain intact. The exported pnpm option sets have only read-only production consumers in mutable-file operand detection.
