### PR TITLE
improve: replace forced Gateway lifetime waits with real barriers

### DIFF
--- a/src/gateway/server-held-work.test-support.ts
+++ b/src/gateway/server-held-work.test-support.ts
@@ -1,0 +1,65 @@
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { expect, onTestFinished, vi } from "vitest";
+import { AsyncWorkScope } from "../shared/async-work-scope.js";
+import { createDeferredCore } from "../shared/deferred.js";
+
+/** Observe the exact work owner; connection scopes also join server-side transport release. */
+export async function observeHeldGatewayWorkDrain(getSignal?: () => AbortSignal | undefined) {
+  const connections = new Set<symbol>();
+  const entered = createDeferredCore();
+  let connectionSignal: AbortSignal | undefined;
+  let draining = false;
+  let drained = false;
+  const ready = () => {
+    if (draining && connections.size === 0) {
+      entered.resolve();
+    }
+  };
+  // oxlint-disable-next-line typescript/unbound-method -- Capture the native method before spying; every invocation binds its actual scope with .call(this).
+  const drain = AsyncWorkScope.prototype.drain;
+  const observation = vi.spyOn(AsyncWorkScope.prototype, "drain");
+  observation.mockImplementation(async function (this: AsyncWorkScope) {
+    if (this.signal !== (getSignal ? getSignal() : connectionSignal)) {
+      return await drain.call(this);
+    }
+    draining = true;
+    ready();
+    await drain.call(this);
+    drained = true;
+  });
+  onTestFinished(() => observation.mockRestore());
+
+  if (!getSignal) {
+    const kernelModule = await import("./server-kernel.js");
+    const createKernel = kernelModule.createGatewayKernel;
+    const factory = vi
+      .spyOn(kernelModule, "createGatewayKernel")
+      .mockImplementationOnce(async (...args) => {
+        const kernel = await createKernel(...args);
+        connectionSignal = kernel.connectionWork.signal;
+        const register = kernel.connectionWork.registerConnection.bind(kernel.connectionWork);
+        const registration = vi
+          .spyOn(kernel.connectionWork, "registerConnection")
+          .mockImplementation((close) => {
+            const key = Symbol("gateway connection");
+            connections.add(key);
+            const release = register(close);
+            return () => {
+              release();
+              connections.delete(key);
+              ready();
+            };
+          });
+        onTestFinished(() => registration.mockRestore());
+        return kernel;
+      });
+    onTestFinished(() => factory.mockRestore());
+  }
+
+  return async (closing: Promise<unknown>) => {
+    await Promise.race([entered.promise, closing]);
+    await nextTurn();
+    expect(draining, "Gateway close must enter the held work owner").toBe(true);
+    expect(drained, "Gateway work drain must remain pending while work is held").toBe(false);
+  };
+}

--- a/src/gateway/server.health-request-lifetime.test.ts
+++ b/src/gateway/server.health-request-lifetime.test.ts
@@ -8,6 +8,7 @@ import { resolveStateDir } from "../config/paths.js";
 import { getAsyncWorkSignal } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import type { HealthSummary } from "./health/types.js";
+import { observeHeldGatewayWorkDrain } from "./server-held-work.test-support.js";
 import {
   connectOk,
   createGatewaySuiteHarness,
@@ -33,6 +34,7 @@ describe("public Gateway close health lifetime", () => {
     const selectedRoots: string[] = [];
     const collections: Promise<HealthSummary>[] = [];
     let healthSignal: AbortSignal | undefined;
+    const expectHeldWork = await observeHeldGatewayWorkDrain(() => healthSignal);
     collect.mockClear();
     collect.mockImplementation((params) => {
       const collection = (async () => {
@@ -49,7 +51,6 @@ describe("public Gateway close health lifetime", () => {
     const clients: WebSocket[] = [];
     const closing: Promise<void>[] = [];
     const finishedAtClose: number[] = [];
-    let releaseTimer: ReturnType<typeof setTimeout> | undefined;
     const unblock = () => release.resolve();
     signal.addEventListener("abort", unblock, { once: true });
     try {
@@ -79,9 +80,6 @@ describe("public Gateway close health lifetime", () => {
         second,
         (frame) => frame.type === "event" && frame.event === "shutdown",
       );
-      // Early close releases immediately on the baseline; the bounded release
-      // also lets the repaired owner finish without leaving a blocked collector.
-      releaseTimer = setTimeout(unblock, 5_000);
       for (let index = 0; index < 2; index++) {
         closing.push(
           gateway.server.close({ reason: "health lifetime proof" }).then(() => {
@@ -96,12 +94,13 @@ describe("public Gateway close health lifetime", () => {
         );
       }
       expect((await shutdown).payload.reason).toBe("health lifetime proof");
+      await expectHeldWork(Promise.all(closing));
+      unblock();
       await Promise.all(closing);
       await Promise.all(collections);
       expect(finishedAtClose).toEqual([1, 1]);
       expect(selectedRoots).toEqual([initialRoot]);
     } finally {
-      clearTimeout(releaseTimer);
       unblock();
       // Join the original producer even when the baseline public close returns early.
       await Promise.allSettled(collections);

--- a/src/gateway/server.operator-observer-lifetime.test.ts
+++ b/src/gateway/server.operator-observer-lifetime.test.ts
@@ -14,6 +14,7 @@ import * as questionChannel from "../infra/question-channel-runtime.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { issueOperatorToken } from "./device-authz.test-helpers.js";
+import { observeHeldGatewayWorkDrain } from "./server-held-work.test-support.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
 import { resetTestPluginRegistry, setTestPluginRegistry } from "./test-helpers.plugin-registry.js";
 import {
@@ -240,6 +241,7 @@ describe("public Gateway close operator observer lifetime", () => {
     "retires $name before state release without changing the pairing decision",
     async ({ name, disconnected, read }, { signal }) => {
       const holdRead = read === "held-pending" || read === "held-absent";
+      const expectHeldWork = holdRead ? await observeHeldGatewayWorkDrain() : undefined;
       const entered = createDeferredCore();
       const releaseRead = createDeferredCore();
       const readPending = devicePairing.getPendingDevicePairing;
@@ -355,14 +357,14 @@ describe("public Gateway close operator observer lifetime", () => {
         }
         await nextTurn();
         expect(settled).toBe(false);
-        releaseTimer = setTimeout(() => {
-          if (holdRead) {
-            releaseRead.resolve();
-          } else if (!settled) {
-            emergencyRelease = true;
-            unblock();
-          }
-        }, 5_000);
+        if (!holdRead) {
+          releaseTimer = setTimeout(() => {
+            if (!settled) {
+              emergencyRelease = true;
+              unblock();
+            }
+          }, 5_000);
+        }
         if (read === "queued-wake") {
           // Queue a poll continuation before the synchronous close fence. The
           // notification itself is not a durable decision; pending state stays intact.
@@ -373,14 +375,14 @@ describe("public Gateway close operator observer lifetime", () => {
           .close({ reason: `scope observer lifetime proof: ${name}`, drainTimeoutMs: 0 })
           .then(() => {
             atClose = { observerSettled: settled, heldReadFinished };
-            // Early public close releases the original read immediately on a broken owner;
-            // a correct join stays blocked until the independently bounded gate release.
+            // Early public close releases the original read on a broken owner.
             releaseRead.resolve();
           });
-        if (holdRead) {
-          await nextTurn();
+        if (expectHeldWork) {
+          await expectHeldWork(closing);
           expect(atClose).toBeUndefined();
           expect(heldReadFinished).toBe(false);
+          releaseRead.resolve();
         }
         await closing;
         expect(emergencyRelease).toBe(false);

--- a/src/gateway/server.operator-presentation-lifetime.test.ts
+++ b/src/gateway/server.operator-presentation-lifetime.test.ts
@@ -1,7 +1,9 @@
 // Real Gateway proof: execute only on a machine with isolated SQLite coordination.
 import { describe, expect, it, vi } from "vitest";
+import { getAsyncWorkSignal } from "../shared/async-work-scope.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import * as approvalWebPush from "./approval-web-push.js";
+import { observeHeldGatewayWorkDrain } from "./server-held-work.test-support.js";
 import { createGatewaySuiteHarness, installGatewayTestHooks } from "./test-helpers.server.js";
 
 installGatewayTestHooks({ scope: "suite" });
@@ -12,6 +14,8 @@ describe("public Gateway close startup presentation lifetime", () => {
   it("starts without waiting for approval recovery but joins it before close returns", async ({
     signal,
   }) => {
+    let recoverySignal: AbortSignal | undefined;
+    const expectHeldWork = await observeHeldGatewayWorkDrain(() => recoverySignal);
     const release = createDeferredCore();
     const recoveries: Promise<void>[] = [];
     const restoreRecoveries: Array<() => void> = [];
@@ -25,6 +29,7 @@ describe("public Gateway close startup presentation lifetime", () => {
         const observation = vi
           .spyOn(delivery, "recoverTerminalDeliveries")
           .mockImplementation(() => {
+            recoverySignal = getAsyncWorkSignal();
             const work = (async () => {
               await release.promise;
               await recover();
@@ -40,7 +45,6 @@ describe("public Gateway close startup presentation lifetime", () => {
     signal.addEventListener("abort", unblock, { once: true });
     let startup: Promise<GatewayHarness> | undefined;
     let closing: Promise<void> | undefined;
-    let releaseTimer: ReturnType<typeof setTimeout> | undefined;
     let finishedAtClose: boolean | undefined;
     try {
       startup = createGatewaySuiteHarness({
@@ -51,21 +55,19 @@ describe("public Gateway close startup presentation lifetime", () => {
       expect(recoveries).toHaveLength(1);
       expect(recoveryFinished).toBe(false);
 
-      // A repaired close waits for the bounded release. A broken early close releases
-      // immediately, but cannot turn its captured completion ordering into a pass.
-      releaseTimer = setTimeout(unblock, 5_000);
       closing = gateway.server
         .close({ reason: "startup approval recovery lifetime proof" })
         .then(() => {
           finishedAtClose = recoveryFinished;
           unblock();
         });
+      await expectHeldWork(closing);
+      unblock();
       await closing;
       await Promise.all(recoveries);
       expect(finishedAtClose).toBe(true);
       expect(recoveryFinished).toBe(true);
     } finally {
-      clearTimeout(releaseTimer);
       unblock();
       const [started] = await Promise.allSettled([startup]);
       try {

--- a/src/gateway/server.request-lifetime.test.ts
+++ b/src/gateway/server.request-lifetime.test.ts
@@ -11,6 +11,7 @@ import { initializeGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import * as agentJobs from "./agent-turn/agent-job.js";
+import { observeHeldGatewayWorkDrain } from "./server-held-work.test-support.js";
 import {
   getTestPluginRegistry,
   resetTestPluginRegistry,
@@ -143,6 +144,7 @@ describe("public Gateway close request lifetime", () => {
   it("joins both handlers and concurrent close callers before fixture restoration", async ({
     signal,
   }) => {
+    const expectHeldWork = await observeHeldGatewayWorkDrain();
     const bothEntered = createDeferredCore();
     const release = createDeferredCore();
     const initialRoot = path.join(os.tmpdir(), "gateway-lifetime", "fixture");
@@ -169,7 +171,6 @@ describe("public Gateway close request lifetime", () => {
     let ws: WebSocket | undefined;
     const closing: Promise<void>[] = [];
     const finishedAtClose: number[] = [];
-    let releaseTimer: ReturnType<typeof setTimeout> | undefined;
     const unblock = () => release.resolve();
     signal.addEventListener("abort", unblock, { once: true });
     try {
@@ -197,9 +198,6 @@ describe("public Gateway close request lifetime", () => {
         (frame) => frame.type === "event" && frame.event === "shutdown",
       );
 
-      // The bounded release also lets the repaired join finish. Early close releases
-      // immediately, reproducing teardown -> late continuation on the broken owner.
-      releaseTimer = setTimeout(unblock, 5_000);
       for (let index = 0; index < 2; index++) {
         closing.push(
           gateway.server.close({ reason: "request lifetime proof" }).then(() => {
@@ -211,12 +209,13 @@ describe("public Gateway close request lifetime", () => {
         );
       }
       expect((await shutdown).payload.reason).toBe("request lifetime proof");
+      await expectHeldWork(Promise.all(closing));
+      unblock();
       await Promise.all(closing);
       await Promise.all(handlerRuns);
       expect(finishedAtClose).toEqual([2, 2]);
       expect(selectedRoots).toEqual([initialRoot, initialRoot]);
     } finally {
-      clearTimeout(releaseTimer);
       unblock();
       // Public close is deliberately insufficient on the baseline. Join our own
       // continuations before the Gateway fixture can restore process state.


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Five Gateway lifetime tests deliberately wait five seconds before releasing held work, although their contract is shutdown ordering rather than elapsed time. These waits add at least 25 seconds of intentional delay across the cases.

## Why This Change Was Made

Observe the actual work owner's drain and, for connection-owned work, server-side connection release. Assert that drain remains pending while the test holds work, then release its existing deferred. Health and startup presentation use their distinct owner signals. Delegate every real drain with its original receiver. Retain all final ordering, state-preservation, and pairing assertions, plus unrelated emergency timers.

## User Impact

No production behavior changes. The tests synchronize on actual lifecycle progress instead of fixed waits. A shared test-only observer adds 67 net test/support lines, offsetting the campaign's deletion total.

## Evidence

All 15 tests across four files pass. A test-support negative control that omits the selected pending-work join makes all five targeted cases fail specifically at the missing-join assertion; the final candidate restores exact delegation. Final complete changed checks, targeted lint, formatting, and independent P2 review pass.

The five target cases totaled 26.862 seconds before and 2.308 seconds after. Whole-run timing includes cold-import/cache and host-contention effects, so no aggregate speedup is claimed. Native method capture uses the existing narrowly documented lint exception pattern; every invocation explicitly binds the actual work scope.
