### PR TITLE
fix(discord): retain voice input until transcription completes

### DIFF
--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -236,23 +236,16 @@ describe("createDiscordOpusPlaybackStream child stream errors", () => {
 
 describe("Discord voice WAV workspace ownership", () => {
   async function withVoiceWorkspace(
-    run: (params: { rootDir: string; timeoutSpy: ReturnType<typeof vi.spyOn> }) => Promise<void>,
+    run: (params: { rootDir: string }) => Promise<void>,
   ): Promise<void> {
     const rootDir = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discord-voice-workspace-")),
     );
     voiceWorkspaceFixture.rootDir = rootDir;
     voiceWorkspaceFixture.writeError = undefined;
-    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
-      await run({ rootDir, timeoutSpy });
+      await run({ rootDir });
     } finally {
-      for (const result of timeoutSpy.mock.results) {
-        if (result.type === "return") {
-          clearTimeout(result.value as ReturnType<typeof setTimeout>);
-        }
-      }
-      timeoutSpy.mockRestore();
       voiceWorkspaceFixture.rootDir = "";
       voiceWorkspaceFixture.writeError = undefined;
       await fs.rm(rootDir, { recursive: true, force: true });
@@ -260,28 +253,18 @@ describe("Discord voice WAV workspace ownership", () => {
   }
 
   it("owns partial WAV writes before surfacing their original failure", async () => {
-    await withVoiceWorkspace(async ({ rootDir, timeoutSpy }) => {
+    await withVoiceWorkspace(async ({ rootDir }) => {
       const writeError = Object.assign(new Error("disk full"), { code: "ENOSPC" });
       voiceWorkspaceFixture.writeError = writeError;
 
       await expect(writeVoiceWavFile(Buffer.alloc(960))).rejects.toBe(writeError);
 
-      const workspaces = await fs.readdir(rootDir);
-      expect(workspaces).toHaveLength(1);
-      expect(await fs.readFile(path.join(rootDir, workspaces[0]!, "segment.wav"))).toHaveLength(8);
-      const scheduledCleanup = timeoutSpy.mock.calls.find(
-        (call: Parameters<typeof setTimeout>) => call[1] === 30 * 60 * 1_000,
-      );
-      expect(scheduledCleanup).toBeDefined();
-
-      (scheduledCleanup![0] as () => void)();
-
-      await vi.waitFor(async () => expect(await fs.readdir(rootDir)).toEqual([]));
+      expect(await fs.readdir(rootDir)).toEqual([]);
     });
   });
 
-  it("retains successful WAV files until the existing scheduled cleanup runs", async () => {
-    await withVoiceWorkspace(async ({ rootDir, timeoutSpy }) => {
+  it("retains successful WAV files until their processing owner releases them", async () => {
+    await withVoiceWorkspace(async ({ rootDir }) => {
       const pcm = Buffer.alloc(960);
 
       const result = await writeVoiceWavFile(pcm);
@@ -289,15 +272,11 @@ describe("Discord voice WAV workspace ownership", () => {
       expect(path.basename(result.path)).toBe("segment.wav");
       expect((await fs.readFile(result.path)).subarray(0, 4).toString()).toBe("RIFF");
       expect(result.durationSeconds).toBe(960 / (4 * 48_000));
-      const scheduledCleanup = timeoutSpy.mock.calls.find(
-        (call: Parameters<typeof setTimeout>) => call[1] === 30 * 60 * 1_000,
-      );
-      expect(scheduledCleanup).toBeDefined();
       expect(await fs.readdir(rootDir)).toHaveLength(1);
 
-      (scheduledCleanup![0] as () => void)();
+      await result.cleanup();
 
-      await vi.waitFor(async () => expect(await fs.readdir(rootDir)).toEqual([]));
+      expect(await fs.readdir(rootDir)).toEqual([]);
     });
   });
 });

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -1,6 +1,5 @@
 // Discord plugin module implements audio behavior.
 import { spawn } from "node:child_process";
-import fs from "node:fs/promises";
 import { Transform, type Readable, type TransformCallback } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 import {
@@ -333,24 +332,20 @@ function estimateDurationSeconds(pcm: Buffer): number {
 
 export async function writeVoiceWavFile(
   pcm: Buffer,
-): Promise<{ path: string; durationSeconds: number }> {
+): Promise<{ path: string; durationSeconds: number; cleanup: () => Promise<void> }> {
   const workspace = await tempWorkspace({
     rootDir: resolvePreferredOpenClawTmpDir(),
     prefix: "discord-voice-",
   });
-  scheduleTempCleanup(workspace.dir);
-  const wav = buildWavBuffer(pcm);
-  const filePath = await workspace.write("segment.wav", wav);
-  return { path: filePath, durationSeconds: estimateDurationSeconds(pcm) };
-}
-
-function scheduleTempCleanup(tempDir: string, delayMs: number = 30 * 60 * 1000): void {
-  const timer = setTimeout(() => {
-    fs.rm(tempDir, { recursive: true, force: true }).catch((err: unknown) => {
-      if (shouldLogVerbose()) {
-        logVerbose(`discord voice: temp cleanup failed for ${tempDir}: ${formatErrorMessage(err)}`);
-      }
-    });
-  }, delayMs);
-  timer.unref();
+  try {
+    const filePath = await workspace.write("segment.wav", buildWavBuffer(pcm));
+    return {
+      path: filePath,
+      durationSeconds: estimateDurationSeconds(pcm),
+      cleanup: () => workspace[Symbol.asyncDispose](),
+    };
+  } catch (error) {
+    await workspace.cleanup();
+    throw error;
+  }
 }

--- a/extensions/discord/src/voice/voice-receive.ts
+++ b/extensions/discord/src/voice/voice-receive.ts
@@ -143,6 +143,7 @@ export class DiscordVoiceReceive {
     let streamAborted = false;
     let receiveFailureHandled = false;
     let receiveStreamEndHandled = false;
+    let pendingWavCleanup: (() => Promise<void>) | undefined;
     const handleStreamError = (err: unknown) => {
       const analysis = analyzeVoiceReceiveError(err);
       if (analysis.isAbortLike && !analysis.countsAsDecryptFailure) {
@@ -238,7 +239,8 @@ export class DiscordVoiceReceive {
         return;
       }
       this.resetDecryptFailureState(entry);
-      const { path: wavPath, durationSeconds } = await writeVoiceWavFile(pcm);
+      const { path: wavPath, durationSeconds, cleanup } = await writeVoiceWavFile(pcm);
+      pendingWavCleanup = cleanup;
       if (!this.params.isEntryCurrent(entry)) {
         return;
       }
@@ -252,8 +254,10 @@ export class DiscordVoiceReceive {
       logVoiceVerbose(
         `capture ready (${durationSeconds.toFixed(2)}s): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
       );
-      entry.processingQueue = entry.processingQueue
-        .then(async () => {
+      const previousProcessing = entry.processingQueue;
+      entry.processingQueue = (async () => {
+        try {
+          await previousProcessing;
           if (!this.params.isEntryCurrent(entry)) {
             return;
           }
@@ -261,10 +265,14 @@ export class DiscordVoiceReceive {
             return;
           }
           await this.processSegment({ entry, wavPath, userId, durationSeconds });
-        })
-        .catch((err: unknown) =>
-          logger.warn(`discord voice: processing failed: ${formatErrorMessage(err)}`),
-        );
+        } finally {
+          await cleanup();
+        }
+      })().catch((err: unknown) =>
+        logger.warn(`discord voice: processing failed: ${formatErrorMessage(err)}`),
+      );
+      // Processing owns the WAV until its queue work settles, even after this receive stream ends.
+      pendingWavCleanup = undefined;
     } catch (err) {
       if (!receiveFailureHandled) {
         this.handleReceiveError(entry, err);
@@ -277,6 +285,7 @@ export class DiscordVoiceReceive {
       if (finishedActiveCapture && stream && !stream.destroyed) {
         stream.destroy();
       }
+      await pendingWavCleanup?.();
     }
   }
 

--- a/extensions/discord/src/voice/voice-test-mocks.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-mocks.test-support.ts
@@ -1,3 +1,4 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import type { RealtimeVoiceAgentControlResult } from "openclaw/plugin-sdk/realtime-voice";
 import { vi, type Mock } from "vitest";
 const {
@@ -156,7 +157,9 @@ const {
       (...args: unknown[]) => Promise<string | undefined>
     >(async () => undefined),
     resolveVoiceIngressWithParticipantsMock: vi.fn() as Mock,
-    transcribeAudioFileMock: vi.fn(async () => ({ text: "hello from voice" })),
+    transcribeAudioFileMock: vi.fn<PluginRuntime["mediaUnderstanding"]["transcribeAudioFile"]>(
+      async () => ({ text: "hello from voice" }),
+    ),
     prepareTtsRequestMock: vi.fn(async ({ cfg, text }: { cfg: unknown; text: string }) => ({
       cfg,
       directives: {

--- a/extensions/discord/src/voice/voice-wav-lifetime.test.ts
+++ b/extensions/discord/src/voice/voice-wav-lifetime.test.ts
@@ -1,0 +1,147 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, vi } from "vitest";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+const workspace = vi.hoisted(() => ({ rootDir: "" }));
+vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/temp-path")>()),
+  resolvePreferredOpenClawTmpDir: () => workspace.rootDir,
+}));
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    createClientWithMember,
+    createManager,
+    makeVoiceConfig,
+    getSessionEntry,
+    handleSpeakingStart,
+    decodeOpusStreamMock,
+    transcribeAudioFileMock,
+    loggerWarnMock,
+  }) => {
+    beforeEach(async () => {
+      workspace.rootDir = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-wav-lifetime-")),
+      );
+    });
+    afterEach(async () => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+      await fs.rm(workspace.rootDir, { recursive: true, force: true });
+    });
+
+    async function fixture() {
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:guest"] }),
+        createClientWithMember("guest", "Guest", "1234"),
+      );
+      const sink = vi.fn();
+      await manager.join(
+        { guildId: "g1", channelId: "1001" },
+        { transcripts: { sessionId: "notes", onUtterance: sink } },
+      );
+      decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(192_000));
+      transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+        const wav = await fs.readFile(filePath);
+        expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
+        return { text: "Meeting notes" };
+      });
+      return { manager, entry: getSessionEntry(manager), sink };
+    }
+
+    it.each(["queued", "transcribing"] as const)(
+      "retains %s WAV input beyond thirty minutes and releases it after transcription",
+      async (phase) => {
+        const f = await fixture();
+        const blocked = createDeferred<void>();
+        const transcribing = createDeferred<void>();
+        if (phase === "queued") {
+          f.entry.processingQueue = blocked.promise;
+        } else {
+          transcribeAudioFileMock.mockImplementationOnce(async ({ filePath }) => {
+            transcribing.resolve();
+            await blocked.promise;
+            const wav = await fs.readFile(filePath);
+            expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
+            return { text: "Meeting notes" };
+          });
+        }
+        const removals = vi.spyOn(fs, "rm");
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        try {
+          await handleSpeakingStart(f.manager, f.entry, "guest");
+          if (phase === "transcribing") {
+            await transcribing.promise;
+          }
+          await vi.advanceTimersByTimeAsync(30 * 60 * 1_000 + 1);
+          await Promise.all(removals.mock.results.map((result) => result.value));
+          expect(await fs.readdir(workspace.rootDir)).toHaveLength(1);
+          blocked.resolve();
+          await f.entry.processingQueue;
+          expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ text: "Meeting notes" }),
+          );
+          expect(await fs.readdir(workspace.rootDir)).toEqual([]);
+        } finally {
+          blocked.resolve();
+          await f.entry.processingQueue;
+          await f.manager.destroy();
+        }
+      },
+    );
+
+    it.each([
+      "transcription failure",
+      "left channel",
+      "replaced capture",
+      "short audio",
+      "left during write",
+    ] as const)("releases WAV input after %s without waiting for a timer", async (reason) => {
+      const f = await fixture();
+      const blocked = createDeferred<void>();
+      f.entry.processingQueue = blocked.promise;
+      if (reason === "transcription failure") {
+        transcribeAudioFileMock.mockRejectedValueOnce(new Error("STT unavailable"));
+      } else if (reason === "short audio") {
+        decodeOpusStreamMock.mockReset().mockResolvedValueOnce(Buffer.alloc(960));
+      } else if (reason === "left during write") {
+        const audio = await import("./audio.js");
+        const writeWav = audio.writeVoiceWavFile;
+        vi.spyOn(audio, "writeVoiceWavFile").mockImplementationOnce(async (pcm) => {
+          const wav = await writeWav(pcm);
+          await f.manager.leave({ guildId: "g1" });
+          return wav;
+        });
+      }
+      try {
+        await handleSpeakingStart(f.manager, f.entry, "guest");
+        if (reason === "left channel") {
+          await f.manager.leave({ guildId: "g1" });
+        } else if (reason === "replaced capture") {
+          await f.manager.join(
+            { guildId: "g1", channelId: "1001" },
+            { transcripts: { sessionId: "replacement", onUtterance: vi.fn() } },
+          );
+        }
+        blocked.resolve();
+        await f.entry.processingQueue;
+        expect(f.sink).not.toHaveBeenCalled();
+        if (reason === "transcription failure") {
+          expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("STT unavailable"));
+        } else {
+          expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+        }
+        expect(await fs.readdir(workspace.rootDir)).toEqual([]);
+      } finally {
+        blocked.resolve();
+        await f.entry.processingQueue;
+        await f.manager.destroy();
+      }
+    });
+  },
+);


### PR DESCRIPTION
Related: #130860

## What Problem This Solves

Fixes an issue where Discord voice transcription could lose its temporary audio when it stayed queued or in progress for more than 30 minutes. Failed and discarded recordings also retained temporary workspace resources after they were no longer needed.

## Why This Change Was Made

WAV creation now returns the existing workspace's cleanup handle. The receiver retains ownership until it either discards the input or transfers it to the processing queue; queue completion releases the workspace on both success and failure.

This extracts the independent WAV lifetime repair from #130860. The shared transcription mock now uses the runtime method's real type so its file-consuming regressions are checked accurately.

## User Impact

Long-running and queued transcriptions keep valid audio until they finish. Short, stale, failed, and replaced captures release their temporary files promptly, along with the workspace's retained cleanup resources.

## Evidence

- Eight retention and cleanup regressions demonstrated failure on the original code and success with the fix, using real WAV files and filesystem cleanup.
- 71 focused tests passed for the final change across audio codec/WAV, receive, segment, and lifetime suites.
- Extension production/test typechecks, type-aware lint, and all changed-check guards passed, including dead exports, media download helpers, runtime sidecar loaders, and import cycles.
- Fresh independent P0–P2 review found no actionable findings.

The focused tests exercise the Discord service boundaries with synthetic data; the broader live Discord work remains with #130860.
