### PR TITLE
fix: open agent state on SQLite builds without extensions

### DIFF
--- a/docs/install/bun.md
+++ b/docs/install/bun.md
@@ -64,6 +64,14 @@ bun pm trust baileys protobufjs
 
 ## Caveats
 
+On macOS, Bun uses Apple's system SQLite, which omits native extension loading.
+OpenClaw can open ordinary agent databases without extension loading when that
+library meets the WAL safety floor. Operations that require extensions, including `sqlite-vec`, need an
+extension-capable SQLite library. Use Node, or preload a compatible SQLite
+library with Bun's [custom SQLite setup](https://bun.sh/docs/runtime/sqlite#loadextension)
+before opening any database. OpenClaw does not select a different SQLite library
+automatically.
+
 Some package scripts hardcode `pnpm` internally (for example `check:docs`, `ui:*`, `protocol:check`). Running them via `bun run` still shells out to `pnpm`, so just run those via `pnpm` directly.
 
 ## Related

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -10,13 +10,19 @@ import {
 
 const originalPrepare = Reflect.get(DatabaseSync.prototype, "prepare") as DatabaseSync["prepare"];
 
-async function loadNodeSqliteWithVersion(version: string) {
+async function loadNodeSqliteWithVersion(version: string, extensionLoadingOmitted?: number) {
   vi.spyOn(DatabaseSync.prototype, "prepare").mockImplementation(
     function (this: DatabaseSync, sql) {
       if (sql === "SELECT sqlite_version() AS version") {
         return {
           get: () => ({ version }),
         } as unknown as StatementSync;
+      }
+      if (
+        extensionLoadingOmitted !== undefined &&
+        sql === "SELECT sqlite_compileoption_used('OMIT_LOAD_EXTENSION') AS omitted"
+      ) {
+        return { get: () => ({ omitted: extensionLoadingOmitted }) } as unknown as StatementSync;
       }
       return originalPrepare.call(this, sql);
     },
@@ -149,6 +155,17 @@ describe("node SQLite safety", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  it.each([0, 1])(
+    "detects the loaded library's extension capability (omitted=%s)",
+    async (omitted) => {
+      const { supportsNodeSqliteExtensionLoading } = await loadNodeSqliteWithVersion(
+        "3.51.3",
+        omitted,
+      );
+      expect(supportsNodeSqliteExtensionLoading()).toBe(omitted === 0);
+    },
+  );
 
   it.each(["3.51.3", "3.51.4", "3.52.0", "4.0.0", "3.50.7", "3.50.8", "3.44.6"])(
     "accepts patched SQLite %s",

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -9,6 +9,7 @@ import { installProcessWarningFilter } from "./warning-filter.js";
 
 const require = createRequire(import.meta.url);
 let validatedSqliteModule: typeof import("node:sqlite") | undefined;
+let extensionLoadingSupported = false;
 
 type NodeSqliteDatabaseOptions = ConstructorParameters<
   typeof import("node:sqlite").DatabaseSync
@@ -76,6 +77,10 @@ function assertSafeSqliteRuntime(sqlite: typeof import("node:sqlite")): void {
       | undefined;
     const version = typeof row?.version === "string" ? row.version : "unknown";
     assertSqliteWalResetSafeVersion(version, process.versions.node);
+    const capabilities = database
+      .prepare("SELECT sqlite_compileoption_used('OMIT_LOAD_EXTENSION') AS omitted")
+      .get();
+    extensionLoadingSupported = capabilities?.omitted === 0;
     validatedSqliteModule = sqlite;
   } finally {
     database.close();
@@ -97,6 +102,12 @@ export function requireNodeSqlite(): typeof import("node:sqlite") {
       cause: err,
     });
   }
+}
+
+/** Whether the loaded SQLite library supports native extensions. */
+export function supportsNodeSqliteExtensionLoading(): boolean {
+  requireNodeSqlite();
+  return extensionLoadingSupported;
 }
 
 /** Open node:sqlite through OpenClaw's runtime and filesystem-location boundary. */

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -16,6 +16,7 @@ import {
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
+import * as nodeSqlite from "../infra/node-sqlite.js";
 import { listOpenFileDescriptorsForPath } from "../infra/open-file-descriptors.test-support.js";
 import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
@@ -58,6 +59,7 @@ import {
   settleOpenClawAgentDatabaseWorkerClose,
   withAgentDatabaseMaintenanceLease,
 } from "./openclaw-agent-db.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -846,6 +848,29 @@ afterEach(() => {
 });
 
 describe("openclaw agent database", () => {
+  it.each([false, true])(
+    "keeps agent state writable without SQLite extension support (incognito=%s)",
+    (incognito) => {
+      const options = { agentId: "worker-1", env: { OPENCLAW_STATE_DIR: createTempStateDir() } };
+      const capability = vi
+        .spyOn(nodeSqlite, "supportsNodeSqliteExtensionLoading")
+        .mockReturnValue(false);
+      try {
+        const { db } = openOpenClawAgentDatabase({
+          ...options,
+          ...(incognito ? { path: resolveIncognitoOpenClawAgentSqlitePath(options) } : {}),
+        });
+        db.prepare("UPDATE schema_meta SET updated_at = ? WHERE meta_key = 'primary'").run(123);
+        expect(
+          db.prepare("SELECT updated_at FROM schema_meta WHERE meta_key = 'primary'").get(),
+        ).toEqual({ updated_at: 123 });
+        expect(() => db.enableLoadExtension(true)).toThrow();
+      } finally {
+        capability.mockRestore();
+      }
+    },
+  );
+
   it("uses the canonical state schema for deletion journal reads and updates", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -5,7 +5,10 @@ import type { DatabaseSync } from "node:sqlite";
 import { resolveStateDir } from "../config/paths.js";
 import { isGatewayExternallySupervised } from "../infra/gateway-supervision.js";
 import { enableNodeSqliteKyselyStatementCache } from "../infra/kysely-sync.js";
-import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import {
+  openNodeSqliteDatabase,
+  supportsNodeSqliteExtensionLoading,
+} from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
 import { assertSqliteIntegrityInWorker } from "../infra/sqlite-integrity-worker.js";
@@ -342,6 +345,7 @@ function* openOpenClawAgentDatabaseSteps(
     revokePendingAgentDatabaseOpen(pathname);
   }
   const cached = cache.databases.get(pathname);
+  const allowExtension = !process.permission && supportsNodeSqliteExtensionLoading();
   if (incognito) {
     // The sentinel has no reachable durable owner, so doctor cannot safely migrate a collision.
     // Refuse operator-created state instead of silently shadowing it with volatile writes.
@@ -355,7 +359,7 @@ function* openOpenClawAgentDatabaseSteps(
     }
     // After the collision probe, this sentinel is only a cache key: SQLite opens :memory:,
     // and no directory, lease, registry row, WAL sidecar, or file write may be created.
-    const db = openNodeSqliteDatabase(":memory:", { allowExtension: !process.permission });
+    const db = openNodeSqliteDatabase(":memory:", { allowExtension });
     db.enableLoadExtension(false);
     configureSqlitePreSchemaPragmas(db, {
       busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -434,9 +438,9 @@ function* openOpenClawAgentDatabaseSteps(
     // Free a slot before constructing the new handle: under real descriptor
     // pressure the 65th open would otherwise fail before eviction could run.
     evictLruAgentDatabaseHandles();
-    // Node's permission model forbids extension-capable constructors. Otherwise,
-    // trusted borrowers load native extensions only in synchronous sections.
-    const db = openNodeSqliteDatabase(pathname, { allowExtension: !process.permission });
+    // Ordinary agent state also works with SQLite builds that omit extensions.
+    // Trusted borrowers may enable them only when both the runtime and permissions allow it.
+    const db = openNodeSqliteDatabase(pathname, { allowExtension });
     db.enableLoadExtension(false);
     enableNodeSqliteKyselyStatementCache(db);
     openedDb = db;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Bun on macOS could not open ordinary agent state because the system SQLite library does not support native extension loading.

## Why This Change Was Made

Detect the loaded SQLite library's extension capability once during runtime validation. Persistent and incognito agent database owners request extension support only when the runtime supports it and permissions allow it. Explicitly extension-required operations remain strict, and extension loading remains disabled by default.

## User Impact

Agent databases can open on SQLite builds without extensions. Native vector extensions still require an extension-capable library. No schema, persistence, migration, or permission policy changes.

## Evidence

- Original owner failed both new persistent/incognito regression cases; repaired owner passes.
- Node: 161 tests passed, with four platform cases skipped.
- Bun with Homebrew SQLite: 33 targeted tests passed.
- Stock macOS Bun: all 209 original Gateway agent-event tests passed.
- Full changed-file checks, lint, formatting, and independent review through P2 passed.
- Apple's separate read-only WAL-sidecar behavior remains an external runtime limitation; the full Bun campaign is ongoing.
