### PR TITLE
fix(ui): keep Swarm outcomes visible after completion

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6105,21 +6105,25 @@ public struct SessionsPreviewParams: Codable, Sendable {
 
 public struct SessionsDescribeParams: Codable, Sendable {
     public let key: String
+    public let agentid: String?
     public let includederivedtitles: Bool?
     public let includelastmessage: Bool?
 
     public init(
         key: String,
+        agentid: String? = nil,
         includederivedtitles: Bool? = nil,
         includelastmessage: Bool? = nil)
     {
         self.key = key
+        self.agentid = agentid
         self.includederivedtitles = includederivedtitles
         self.includelastmessage = includelastmessage
     }
 
     private enum CodingKeys: String, CodingKey {
         case key
+        case agentid = "agentId"
         case includederivedtitles = "includeDerivedTitles"
         case includelastmessage = "includeLastMessage"
     }
@@ -6607,6 +6611,7 @@ public struct SessionRow: Codable, Sendable {
     public let subagentrole: AnyCodable?
     public let subagentcontrolscope: AnyCodable?
     public let swarmgroupid: String?
+    public let swarm: [String: AnyCodable]?
     public let worktree: [String: AnyCodable]?
     public let execnode: String?
     public let execcwd: String?
@@ -6686,6 +6691,7 @@ public struct SessionRow: Codable, Sendable {
         subagentrole: AnyCodable? = nil,
         subagentcontrolscope: AnyCodable? = nil,
         swarmgroupid: String? = nil,
+        swarm: [String: AnyCodable]? = nil,
         worktree: [String: AnyCodable]? = nil,
         execnode: String? = nil,
         execcwd: String? = nil,
@@ -6764,6 +6770,7 @@ public struct SessionRow: Codable, Sendable {
         self.subagentrole = subagentrole
         self.subagentcontrolscope = subagentcontrolscope
         self.swarmgroupid = swarmgroupid
+        self.swarm = swarm
         self.worktree = worktree
         self.execnode = execnode
         self.execcwd = execcwd
@@ -6844,6 +6851,7 @@ public struct SessionRow: Codable, Sendable {
         case subagentrole = "subagentRole"
         case subagentcontrolscope = "subagentControlScope"
         case swarmgroupid = "swarmGroupId"
+        case swarm
         case worktree
         case execnode = "execNode"
         case execcwd = "execCwd"

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3890,7 +3890,6 @@ ui/src/lib/sessions/grouping.ts	4
 ui/src/lib/sessions/index.ts	1
 ui/src/lib/sessions/reconcile.ts	10
 ui/src/lib/sessions/session-key.ts	4
-ui/src/lib/sessions/swarm-activity.ts	1
 ui/src/lib/skills/index.ts	1
 ui/src/lit/stream-auto-follow-controller.ts	1
 ui/src/lit/subscriptions-controller.ts	1
@@ -3954,7 +3953,6 @@ ui/src/pages/chat/components/chat-session-sharing.ts	1
 ui/src/pages/chat/components/chat-session-workspace.ts	1
 ui/src/pages/chat/components/chat-sidebar-editor-menu.ts	2
 ui/src/pages/chat/components/chat-sidebar-region.runtime.ts	2
-ui/src/pages/chat/components/chat-swarm-progress.ts	2
 ui/src/pages/chat/components/chat-task-suggestions.ts	1
 ui/src/pages/chat/components/chat-thread-interactions.ts	3
 ui/src/pages/chat/components/chat-voice-activity.ts	1

--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -364,25 +364,33 @@ Keep the parent session open in Chat while a swarm is active. The Control UI and
 native Android, iOS, and macOS chat surfaces show a compact Swarm progress widget
 between the transcript and composer.
 
-In the Control UI, each active collector group appears as a card with a completion
-count and phase progress segments. Hover over a card or focus it with the keyboard
-to reveal a list of child names, status icons, and run durations.
+In the Control UI, cards show queued, running, completed, and failed counts with
+visible status markers. Click or tap **Child details**, or activate it with the
+keyboard, to expand available child names, status icons, and run durations. The
+view shows up to four active groups plus the latest completed group, with an
+explicit count when more groups are active. Each card displays at most 64 markers
+and 64 child details; its counts include every accepted group member.
 
-Native Android, iOS, and macOS chat surfaces show phase-grouped grids of child
-status markers, capped at 256 markers per phase with an overflow count for additional
-children. Accessible labels identify each child and its queued, running, done, or
-failed status.
+The latest completed group's counts remain visible after the children finish,
+including when the parent fails before writing its final response. These are
+child outcomes, not confirmation that the parent produced a synthesis. Counts
+come from retained collector records, so reloading the page or cleaning up a
+child session does not reduce the reported total. They expire with the existing
+collector retention policy; this is not a permanent execution archive.
 
-All clients present killed and timed-out children as failed. Each group leaves the
-widget when none of its children are queued or running, and the widget disappears
-when no active groups remain.
+Native Android, iOS, and macOS chat surfaces still show active-only phase-grouped
+grids, capped at 256 markers per phase with an overflow count. Accessible labels
+identify each child's status. All clients present killed and timed-out children
+as failed. Native groups leave the widget when none of their children are queued
+or running; the native widget disappears when no active groups remain.
 
 The session sidebar keeps the normal parent/child tree. Expand the parent row to
 inspect a collector child or open its transcript without losing the swarm hierarchy.
 
-Collector results remain waitable until their group is archived. After every
-member reaches its retention deadline, OpenClaw archives the group's children
-as a batch so completed swarms do not remain in the live session tree.
+Delete-mode collectors can clean up their child sessions immediately after
+completion while retaining their waitable results. Those collector records remain
+available until the group is archived after every member reaches its retention
+deadline. Retained child sessions are archived as a batch at that point.
 
 ## Stop a Swarm
 

--- a/packages/gateway-protocol/src/schema/sessions-row.ts
+++ b/packages/gateway-protocol/src/schema/sessions-row.ts
@@ -61,6 +61,35 @@ export const SessionOwnerSchema = closedObject({
   assignedAt: Type.Optional(Type.Number({ minimum: 0 })),
 });
 
+const SessionSwarmSummarySchema = closedObject({
+  groups: Type.Array(
+    closedObject({
+      groupId: NonEmptyString,
+      createdAt: Type.Number({ minimum: 0 }),
+      children: Type.Optional(
+        Type.Array(
+          closedObject({
+            sessionKey: NonEmptyString,
+            status: Type.Union([
+              Type.Literal("queued"),
+              Type.Literal("running"),
+              Type.Literal("done"),
+              Type.Literal("failed"),
+            ]),
+          }),
+          { maxItems: 64 },
+        ),
+      ),
+      queued: Type.Integer({ minimum: 0 }),
+      running: Type.Integer({ minimum: 0 }),
+      done: Type.Integer({ minimum: 0 }),
+      failed: Type.Integer({ minimum: 0 }),
+    }),
+    { maxItems: 5 },
+  ),
+  otherActiveGroups: Type.Integer({ minimum: 0 }),
+});
+
 /** Stable Gateway session row fields; mutation envelopes may add null tombstones. */
 export const SessionRowSchema = Type.Object(
   {
@@ -122,6 +151,8 @@ export const SessionRowSchema = Type.Object(
       Type.Union([Type.Literal("children"), Type.Literal("none")]),
     ),
     swarmGroupId: Type.Optional(Type.String()),
+    /** Requester-owned execution counts; never child content or parent synthesis status. */
+    swarm: Type.Optional(SessionSwarmSummarySchema),
     worktree: Type.Optional(
       Type.Object({
         id: Type.String(),

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -446,6 +446,7 @@ export const SessionsPreviewParamsSchema = closedObject({
 /** Describes one session and optional derived title/last-message previews. */
 export const SessionsDescribeParamsSchema = closedObject({
   key: NonEmptyString,
+  agentId: Type.Optional(NonEmptyString),
   includeDerivedTitles: Type.Optional(Type.Boolean()),
   includeLastMessage: Type.Optional(Type.Boolean()),
 });

--- a/src/agents/subagents/registry/subagent-registry-queries.ts
+++ b/src/agents/subagents/registry/subagent-registry-queries.ts
@@ -98,6 +98,7 @@ export type SubagentRunReadIndex<T extends SubagentRunReadRecord = SubagentRunRe
   hasDescendantRunAwaitingSettle(rootSessionKey: string, excludeRunId?: string): boolean;
   listDescendantRunsForRequester(rootSessionKey: string): T[];
   runsByControllerSessionKey: ReadonlyMap<string, readonly T[]>;
+  swarmRunsByRequesterSessionKey: ReadonlyMap<string, readonly T[]>;
 };
 
 export type LatestSubagentRunReadIndex = {
@@ -146,6 +147,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
   const latestSnapshotEndedByChildSessionKey = new Map<string, T>();
   const latestRunsByChildSessionKey = new Map<string, T>();
   const runsByControllerSessionKey = new Map<string, T[]>();
+  const swarmRunsByRequesterSessionKey = new Map<string, T[]>();
   const latestRunByRequesterAndChildSessionKey = new Map<string, Map<string, T>>();
   const activeDescendantCountBySessionKey = new Map<string, number>();
   const pendingDescendantCountBySessionKey = new Map<string, number>();
@@ -159,6 +161,12 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
   }
 
   for (const [, entry] of runs.entries()) {
+    if (entry.collect && entry.groupId && entry.swarmRequesterSessionKey) {
+      const requester = entry.swarmRequesterSessionKey;
+      const members = swarmRunsByRequesterSessionKey.get(requester) ?? [];
+      members.push(entry);
+      swarmRunsByRequesterSessionKey.set(requester, members);
+    }
     const childSessionKey = entry.childSessionKey.trim();
     const controllerSessionKey = resolveControllerSessionKey(entry);
     if (controllerSessionKey) {
@@ -319,6 +327,7 @@ export function buildSubagentRunReadIndexFromRuns<T extends SubagentRunReadRecor
     hasDescendantRunAwaitingSettle,
     listDescendantRunsForRequester,
     runsByControllerSessionKey,
+    swarmRunsByRequesterSessionKey,
   };
 }
 

--- a/src/agents/subagents/registry/subagent-registry-state.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-state.test.ts
@@ -1,6 +1,10 @@
 // Subagent registry state tests cover hot read caching over the persisted SQLite snapshot.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  onSessionLifecycleEvent,
+  type SessionLifecycleEvent,
+} from "../../../sessions/session-lifecycle-events.js";
+import {
   clearSubagentRunsReadCacheForTest,
   getSubagentSessionListRunsSnapshotForRead,
   getSubagentRunsSnapshotForChildSession,
@@ -8,6 +12,9 @@ import {
   getSubagentRunsSnapshotForRead,
   onSubagentRegistryPersisted,
   persistSubagentRunsToDisk,
+  persistSubagentRunsToDiskOrThrow,
+  publishSubagentRunsAfterAtomicStore,
+  restoreSubagentRunsFromDisk,
 } from "./subagent-registry-state.js";
 import type { SubagentRunReadRecord, SubagentRunRecord } from "./subagent-registry.types.js";
 
@@ -325,5 +332,173 @@ describe("subagent registry state read cache", () => {
       new Map(),
     );
     expect(mocks.loadSubagentRunsForControllerFromSqlite).toHaveBeenCalledOnce();
+  });
+
+  it("invalidates the strict collector parent after each committed lifecycle transition", () => {
+    const run: SubagentRunRecord = {
+      ...createRun("cross-agent"),
+      childSessionKey: "agent:research:subagent:child",
+      collect: true,
+      swarmRequesterSessionKey: "global",
+      requesterAgentId: "ops",
+      groupId: "opaque-group",
+      execution: { status: "queued" as const },
+    };
+    const runs = new Map([[run.runId, run]]);
+    const observed: Array<{ event: SessionLifecycleEvent; stored?: SubagentRunRecord }> = [];
+    const unsubscribe = onSessionLifecycleEvent((event) => {
+      observed.push({ event, stored: getSubagentRunsSnapshotForRead(new Map()).get(run.runId) });
+    });
+    try {
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      run.execution = { status: "running", startedAt: 2 };
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      run.execution = { status: "terminal", endedAt: 3, outcome: { status: "ok" } };
+      run.collectorCompletion = { status: "done", structured: { private: "child result" } };
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      run.task = "unrelated bookkeeping";
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      runs.delete(run.runId);
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      expect(observed.map(({ event }) => event)).toEqual(
+        Array.from({ length: 4 }, () => ({
+          sessionKey: "global",
+          agentId: "ops",
+          reason: "swarm",
+        })),
+      );
+      expect(
+        observed.map(
+          ({ stored }) => stored?.collectorCompletion?.status ?? stored?.execution.status,
+        ),
+      ).toEqual(["queued", "running", "done", undefined]);
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it.each([false, true])(
+    "does not advance collector notifications on failed writes (strict=%s)",
+    (strict) => {
+      const run: SubagentRunRecord = {
+        ...createRun("retry"),
+        collect: true,
+        swarmRequesterSessionKey: "agent:ops:parent",
+        requesterAgentId: "ops",
+        groupId: "batch",
+      };
+      const runs = new Map([[run.runId, run]]);
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      const received = vi.fn();
+      const unsubscribe = onSessionLifecycleEvent(received);
+      try {
+        run.collectorCompletion = { status: "failed" };
+        mocks.saveSubagentRegistryChangesToSqlite.mockImplementationOnce(() => {
+          throw new Error("disk unavailable");
+        });
+        if (strict) {
+          expect(() => persistSubagentRunsToDiskOrThrow(runs, [run.runId])).toThrow(
+            "disk unavailable",
+          );
+        } else {
+          persistSubagentRunsToDisk(runs, [run.runId]);
+        }
+        expect(received).not.toHaveBeenCalled();
+        persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+        expect(received).toHaveBeenCalledExactlyOnceWith({
+          sessionKey: "agent:ops:parent",
+          agentId: "ops",
+          reason: "swarm",
+        });
+      } finally {
+        unsubscribe();
+      }
+    },
+  );
+
+  it("invalidates archived cold-restored groups once per exact parent", () => {
+    const rows = ["a", "b"].map((runId) => {
+      const run = createRun(runId);
+      run.collect = true;
+      run.swarmRequesterSessionKey = "global";
+      run.requesterAgentId = "ops";
+      run.groupId = "batch";
+      run.collectorCompletion = { status: "done" };
+      return run;
+    });
+    mocks.loadSubagentRegistryFromSqlite.mockReturnValue(
+      new Map(rows.map((row) => [row.runId, row])),
+    );
+    const runs = new Map<string, SubagentRunRecord>();
+    const received = vi.fn();
+    const unsubscribe = onSessionLifecycleEvent(received);
+    try {
+      restoreSubagentRunsFromDisk({ runs });
+      expect(received).not.toHaveBeenCalled();
+      runs.clear();
+      persistSubagentRunsToDiskOrThrow(
+        runs,
+        rows.map((row) => row.runId),
+      );
+      expect(received).toHaveBeenCalledExactlyOnceWith({
+        sessionKey: "global",
+        agentId: "ops",
+        reason: "swarm",
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("defers atomic collector notifications until all owner snapshots are published", () => {
+    const run: SubagentRunRecord = {
+      ...createRun("atomic"),
+      collect: true,
+      swarmRequesterSessionKey: "agent:ops:parent",
+      requesterAgentId: "ops",
+      groupId: "batch",
+    };
+    const received = vi.fn();
+    const unsubscribe = onSessionLifecycleEvent(received);
+    try {
+      const deferred: Array<() => void> = [];
+      publishSubagentRunsAfterAtomicStore(new Map([[run.runId, run]]), [run.runId], deferred);
+      expect(received).not.toHaveBeenCalled();
+      expect(getSubagentRunsSnapshotForRead(new Map()).get(run.runId)?.groupId).toBe("batch");
+      for (const publish of deferred) {
+        publish();
+      }
+      expect(received).toHaveBeenCalledExactlyOnceWith({
+        sessionKey: "agent:ops:parent",
+        agentId: "ops",
+        reason: "swarm",
+      });
+    } finally {
+      unsubscribe();
+    }
+  });
+
+  it("does not infer collector parent ownership from requester or group strings", () => {
+    const base = { ...createRun("missing"), collect: true, groupId: "swarm:agent:ops:parent:run" };
+    const rows: SubagentRunRecord[] = [
+      base,
+      { ...base, runId: "no-agent", swarmRequesterSessionKey: "agent:ops:parent" },
+      { ...base, runId: "no-key", requesterAgentId: "ops" },
+      {
+        ...base,
+        runId: "ordinary",
+        collect: false,
+        swarmRequesterSessionKey: "agent:ops:parent",
+        requesterAgentId: "ops",
+      },
+    ];
+    const received = vi.fn();
+    const unsubscribe = onSessionLifecycleEvent(received);
+    try {
+      persistSubagentRunsToDiskOrThrow(new Map(rows.map((row) => [row.runId, row])));
+      expect(received).not.toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+    }
   });
 });

--- a/src/agents/subagents/registry/subagent-registry-state.ts
+++ b/src/agents/subagents/registry/subagent-registry-state.ts
@@ -1,4 +1,8 @@
 import { isVitestRuntimeEnv } from "../../../infra/env.js";
+import {
+  emitSessionLifecycleEvent,
+  type SessionLifecycleEvent,
+} from "../../../sessions/session-lifecycle-events.js";
 import { subagentRuns } from "./subagent-registry-memory.js";
 /**
  * Subagent registry state persistence bridge.
@@ -40,6 +44,68 @@ const persistedSubagentSessionListRunsReadCache: SubagentRunsCache<SubagentRunRe
   project: projectSubagentRunForSessionList,
 };
 
+// Read caches deliberately advance on failed best-effort writes. Keep notification facts
+// commit-owned so a successful retry still refreshes the parent, including after archive.
+const committedSwarmNotifications = new Map<
+  string,
+  { event: SessionLifecycleEvent; signature: string }
+>();
+
+function swarmNotification(entry: SubagentRunRecord | undefined) {
+  if (
+    !entry?.collect ||
+    !entry.swarmRequesterSessionKey ||
+    !entry.requesterAgentId ||
+    !entry.groupId
+  ) {
+    return undefined;
+  }
+  return {
+    event: {
+      sessionKey: entry.swarmRequesterSessionKey,
+      agentId: entry.requesterAgentId,
+      reason: "swarm",
+    },
+    // Compare the summary's raw inputs, never child results, labels or error text.
+    signature: JSON.stringify([
+      entry.swarmRequesterSessionKey,
+      entry.requesterAgentId,
+      entry.groupId,
+      entry.createdAt,
+      entry.childSessionKey,
+      entry.execution.status,
+      entry.collectorCompletion?.status,
+    ]),
+  };
+}
+
+function updateCommittedSwarmNotifications(
+  runs: Map<string, SubagentRunRecord>,
+  changedRunIds?: readonly string[],
+): SessionLifecycleEvent[] {
+  const events = new Map<string, SessionLifecycleEvent>();
+  const ids = changedRunIds ?? new Set([...committedSwarmNotifications.keys(), ...runs.keys()]);
+  for (const runId of ids) {
+    const previous = committedSwarmNotifications.get(runId);
+    const next = swarmNotification(runs.get(runId));
+    if (previous?.signature === next?.signature) {
+      continue;
+    }
+    if (next) {
+      committedSwarmNotifications.set(runId, next);
+    } else {
+      committedSwarmNotifications.delete(runId);
+    }
+    for (const notification of [previous, next]) {
+      if (notification) {
+        const event = notification.event;
+        events.set(JSON.stringify([event.sessionKey, event.agentId]), event);
+      }
+    }
+  }
+  return [...events.values()];
+}
+
 type SubagentRegistryPersistListener = () => void;
 
 const SUBAGENT_REGISTRY_PERSIST_LISTENERS = new Set<SubagentRegistryPersistListener>();
@@ -68,6 +134,16 @@ function projectSubagentRunForSessionList(entry: SubagentRunRecord): SubagentRun
     childSessionKey: entry.childSessionKey,
     ...(entry.controllerSessionKey ? { controllerSessionKey: entry.controllerSessionKey } : {}),
     requesterSessionKey: entry.requesterSessionKey,
+    ...(entry.collect
+      ? {
+          collect: true,
+          groupId: entry.groupId,
+          swarmRequesterSessionKey: entry.swarmRequesterSessionKey,
+        }
+      : {}),
+    ...(entry.collectorCompletion
+      ? { collectorCompletion: { status: entry.collectorCompletion.status } }
+      : {}),
     ...(entry.requesterAgentId ? { requesterAgentId: entry.requesterAgentId } : {}),
     ...(entry.model ? { model: entry.model } : {}),
     ...(entry.generation !== undefined ? { generation: entry.generation } : {}),
@@ -148,7 +224,11 @@ export function publishSubagentRunsAfterAtomicStore(
   deferredObserverEvents: Array<() => void>,
 ): void {
   rememberPersistedSubagentRunsSnapshot(runs, changedRunIds);
-  deferredObserverEvents.push(() => emitSubagentRegistryPersisted());
+  const events = updateCommittedSwarmNotifications(runs, changedRunIds);
+  deferredObserverEvents.push(() => {
+    emitSubagentRegistryPersisted();
+    events.forEach(emitSessionLifecycleEvent);
+  });
 }
 
 function shouldReadPersistedSubagentRuns(): boolean {
@@ -180,6 +260,7 @@ function loadPersistedSubagentRunsForRead<T extends SubagentRunReadRecord>(
 }
 
 export function clearSubagentRunsReadCacheForTest(): void {
+  committedSwarmNotifications.clear();
   persistedSubagentRunsReadCache.snapshot = undefined;
   persistedSubagentSessionListRunsReadCache.snapshot = undefined;
 }
@@ -189,12 +270,14 @@ function persistSubagentRuns(
   changedRunIds: readonly string[] | undefined,
   strict: boolean,
 ): void {
+  let committed = false;
   try {
     if (changedRunIds) {
       saveSubagentRegistryChangesToSqlite(runs, changedRunIds);
     } else {
       saveSubagentRegistryToSqlite(runs);
     }
+    committed = true;
   } catch (error) {
     if (strict) {
       throw error;
@@ -202,7 +285,9 @@ function persistSubagentRuns(
   }
   // In-process readers must observe the authoritative memory snapshot before the wake.
   rememberPersistedSubagentRunsSnapshot(runs, changedRunIds);
+  const events = committed ? updateCommittedSwarmNotifications(runs, changedRunIds) : [];
   emitSubagentRegistryPersisted();
+  events.forEach(emitSessionLifecycleEvent);
 }
 
 export function persistSubagentRunsToDisk(
@@ -238,6 +323,12 @@ export function restoreSubagentRunsFromDisk(params: {
       continue;
     }
     params.runs.set(runId, entry);
+    const notification = swarmNotification(entry);
+    if (notification) {
+      committedSwarmNotifications.set(runId, notification);
+    } else {
+      committedSwarmNotifications.delete(runId);
+    }
     subagentRuns.commitOwnership(entry);
     added += 1;
   }

--- a/src/agents/subagents/registry/subagent-registry-task-replacement.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-task-replacement.test.ts
@@ -22,6 +22,7 @@ import {
   getAgentRunContextOwnership,
   getAgentRunContextOwnerStatus,
 } from "../../../infra/agent-run-registry.js";
+import { onSessionLifecycleEvent } from "../../../sessions/session-lifecycle-events.js";
 import { openOpenClawStateDatabase } from "../../../state/openclaw-state-db.js";
 import { reloadTaskRuntimeStateFromStore } from "../../../tasks/runtime-internal.js";
 import { failFlow, getTaskFlowById } from "../../../tasks/task-flow-registry.js";
@@ -294,6 +295,17 @@ it.each(["successor", "task activation", "flow activation"] as const)(
     const flowId = terminalTask.parentFlowId!;
     expect(terminalTask.status).toBe("failed");
     expect(getTaskFlowById(flowId)?.status).toBe("failed");
+    previous.collect = true;
+    previous.swarmRequesterSessionKey = "agent:main:main";
+    previous.requesterAgentId = "main";
+    previous.groupId = "rollback-group";
+    persistSubagentRunsToDiskOrThrow(subagentRuns, [previous.runId]);
+    const parentEvents = vi.fn();
+    const unsubscribe = onSessionLifecycleEvent((event) => {
+      if (event.reason === "swarm") {
+        parentEvents(event);
+      }
+    });
     const database = openOpenClawStateDatabase().db;
     const triggerName = `reject_replacement_${
       rejectedWrite === "successor" ? "run" : rejectedWrite === "task activation" ? "task" : "flow"
@@ -329,7 +341,9 @@ it.each(["successor", "task activation", "flow activation"] as const)(
         .toBe(false);
     } finally {
       database.exec(`DROP TRIGGER ${triggerName}`);
+      unsubscribe();
     }
+    expect(parentEvents).not.toHaveBeenCalled();
     expect.soft(subagentRuns.get(previous.runId)).toBe(previous);
     expect.soft(subagentRuns.has("rollback-successor")).toBe(false);
     expect.soft(loadSubagentRegistryFromSqlite().has("rollback-successor")).toBe(false);

--- a/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.steer-restart.test.ts
@@ -100,7 +100,7 @@ const announceSpy = vi.fn(
   async (_params: unknown): Promise<"delivered" | "retryable"> => "delivered",
 );
 const runSubagentEndedHookMock = vi.fn(async (_eventValue?: unknown, _ctx?: unknown) => {});
-const emitSessionLifecycleEventMock = vi.fn();
+const emitSessionLifecycleEventMock = vi.hoisted(() => vi.fn());
 const removeInternalSessionEffectsSessionMock = vi.fn(async (_target?: unknown) => {});
 
 function countMatching<T>(items: readonly T[], predicate: (item: T) => boolean) {

--- a/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
+++ b/src/agents/subagents/registry/subagent-registry.store.sqlite.ts
@@ -41,6 +41,10 @@ type SubagentRunReadSqliteRow = Pick<
   delivery_status: string | null;
   delivery_suspended_at: number | null;
   requester_agent_id: string | null;
+  collect: number | null;
+  group_id: string | null;
+  swarm_requester_session_key: string | null;
+  collector_status: NonNullable<SubagentRunRecord["collectorCompletion"]>["status"] | null;
 };
 type CanonicalSubagentRunRecord = SubagentRunRecord &
   Required<Pick<SubagentRunRecord, "completion" | "delivery">>;
@@ -265,6 +269,14 @@ function readSubagentSessionListRows(): SubagentRunReadSqliteRow[] {
         "requester_session_key",
         "created_at",
         subagentPayloadJsonValue<string | null>("$.model").as("model"),
+        subagentPayloadJsonValue<number | null>("$.collect").as("collect"),
+        subagentPayloadJsonValue<string | null>("$.groupId").as("group_id"),
+        subagentPayloadJsonValue<string | null>("$.swarmRequesterSessionKey").as(
+          "swarm_requester_session_key",
+        ),
+        subagentPayloadJsonValue<string | null>("$.collectorCompletion.status").as(
+          "collector_status",
+        ),
         subagentPayloadJsonValue<number | null>("$.runTimeoutSeconds").as("run_timeout_seconds"),
         subagentPayloadJsonValue<SubagentRunRecord["execution"]["status"]>("$.execution.status").as(
           "execution_status",
@@ -319,6 +331,10 @@ function rowToSubagentRunReadRecord(row: SubagentRunReadSqliteRow): SubagentRunR
       controllerSessionKey: row.controller_session_key?.trim() || undefined,
       requesterSessionKey,
       requesterAgentId: row.requester_agent_id?.trim() || undefined,
+      collect: row.collect === 1 ? true : undefined,
+      groupId: row.group_id || undefined,
+      swarmRequesterSessionKey: row.swarm_requester_session_key || undefined,
+      collectorCompletion: row.collector_status ? { status: row.collector_status } : undefined,
       model: row.model || undefined,
       generation: normalizeFiniteNumber(row.generation),
       createdAt: row.created_at,

--- a/src/agents/subagents/registry/subagent-registry.types.ts
+++ b/src/agents/subagents/registry/subagent-registry.types.ts
@@ -320,6 +320,9 @@ export type SubagentRunRecord = {
 export type SubagentRunReadRecord = Pick<
   SubagentRunRecord,
   | "runId"
+  | "collect"
+  | "groupId"
+  | "swarmRequesterSessionKey"
   | "childSessionKey"
   | "controllerSessionKey"
   | "requesterSessionKey"
@@ -335,4 +338,5 @@ export type SubagentRunReadRecord = Pick<
   | "delivery"
 > & {
   execution: Pick<SubagentExecutionState, "status" | "startedAt" | "endedAt" | "outcome">;
+  collectorCompletion?: Pick<SwarmCollectorCompletion, "status">;
 };

--- a/src/gateway/server-broadcast.board.test.ts
+++ b/src/gateway/server-broadcast.board.test.ts
@@ -4,12 +4,18 @@ import {
   GATEWAY_CLIENT_CAPS,
   GATEWAY_CLIENT_IDS,
 } from "../../packages/gateway-protocol/src/client-info.js";
+import {
+  persistSubagentRunsToDiskOrThrow,
+  clearSubagentRunsReadCacheForTest,
+} from "../agents/subagents/registry/subagent-registry-state.js";
+import type { SubagentRunRecord } from "../agents/subagents/registry/subagent-registry.types.js";
 import { setRuntimeConfigSnapshot } from "../config/io.js";
 import {
   deleteSessionEntryLifecycle,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { onSessionLifecycleEvent } from "../sessions/session-lifecycle-events.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { boardStore } from "./board-store.js";
 import { progressCardStore } from "./progress-card-store.js";
@@ -22,6 +28,7 @@ import { createBoardHandlers } from "./server-methods/board.js";
 import { createProgressCardHandlers } from "./server-methods/progress-card.js";
 import { flushPendingSessionsChangedEvents } from "./server-methods/session-change-event.js";
 import type { GatewayRequestContext, RespondFn } from "./server-methods/types.js";
+import { createLifecycleEventBroadcastHandler } from "./server-session-events.js";
 import { GatewayClientRegistry } from "./server/client-registry.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { createSessionObserverAudience } from "./session-observer-audience.js";
@@ -797,5 +804,123 @@ describe("collaboration event scope guards", () => {
     expect(reader.socket.events).toEqual(["session.typing"]);
     expect(unrelated.socket.events).toEqual([]);
     expect(canReceiveSessionEvent).toHaveBeenCalledTimes(4);
+  });
+});
+
+it("delivers committed collector updates to a parent-only cross-agent viewer", async () => {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    const cfg: OpenClawConfig = {
+      ...rolePolicyConfig(),
+      agents: { ownership: "explicit", entries: { ops: {}, research: {} } },
+    };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    clearSubagentRunsReadCacheForTest();
+    const peers = ["parent-viewer", "child-viewer"].map((name) => {
+      const peer = makeClient(name, "operator", ["operator.read"]);
+      Object.assign(peer.client, roleClient("view", name));
+      return peer;
+    });
+    const parent = { sessionKey: "global", agentId: "ops" };
+    const child = { sessionKey: "agent:research:subagent:collector", agentId: "research" };
+    for (const [index, target] of [parent, child].entries()) {
+      await upsertSessionEntryCore(target, {
+        sessionId: peers[index]!.client.connId,
+        updatedAt: 1,
+        visibility: "draft",
+        createdActor: {
+          type: "human",
+          source: "profile",
+          id: peers[index]!.client.authenticatedUserProfile!.profileId,
+        },
+      });
+    }
+    invalidateSessionSharingSnapshot();
+    expect(
+      canReceiveSessionEventForClient({
+        cfg,
+        client: peers[0]!.client,
+        sessionKeys: [child.sessionKey],
+        agentId: child.agentId,
+        event: "sessions.changed",
+      }),
+    ).toBe(false);
+    const { broadcastToConnIds } = createGatewayBroadcaster({
+      clients: new GatewayClientRegistry(peers.map(({ client }) => client)),
+      canReceiveSessionEvent: (client, sessionKeys, agentId, event, payload) =>
+        canReceiveSessionEventForClient({ cfg, client, sessionKeys, agentId, event, payload }),
+    });
+    const unsubscribe = onSessionLifecycleEvent(
+      createLifecycleEventBroadcastHandler({
+        broadcastToConnIds,
+        sessionEventSubscribers: {
+          getAll: () => new Set(peers.map(({ client }) => client.connId)),
+        },
+        chatAbortControllers: new Map([
+          [
+            "parent-run",
+            {
+              controller: new AbortController(),
+              sessionId: "parent-viewer",
+              sessionKey: parent.sessionKey,
+              agentId: parent.agentId,
+              startedAtMs: 1,
+              expiresAtMs: Date.now() + 60_000,
+              projectSessionActive: true,
+              executionStarted: true,
+            },
+          ],
+        ]),
+      }),
+    );
+    const run: SubagentRunRecord = {
+      runId: "collector",
+      childSessionKey: child.sessionKey,
+      requesterSessionKey: "agent:research:private-delivery",
+      requesterDisplayKey: "private child",
+      swarmRequesterSessionKey: parent.sessionKey,
+      requesterAgentId: parent.agentId,
+      collect: true,
+      groupId: "opaque-batch",
+      createdAt: 1,
+      cleanup: "keep",
+      task: "child-private task",
+      execution: { status: "queued" },
+      completion: { required: false },
+      delivery: { status: "not_required" },
+    };
+    const runs = new Map([[run.runId, run]]);
+    try {
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      run.execution = { status: "running", startedAt: 2 };
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      run.execution = { status: "terminal", endedAt: 3, outcome: { status: "error" } };
+      run.collectorCompletion = {
+        status: "failed",
+        structured: { private: "child-private result" },
+      };
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      runs.clear();
+      persistSubagentRunsToDiskOrThrow(runs, [run.runId]);
+      expect(peers[0]!.socket.events).toEqual(Array(4).fill("sessions.changed"));
+      expect(peers[1]!.socket.events).toEqual([]);
+      for (const [raw] of peers[0]!.socket.send.mock.calls) {
+        const event = JSON.parse(raw);
+        expect(event.payload).toMatchObject({
+          sessionKey: "global",
+          agentId: "ops",
+          reason: "swarm",
+          status: "running",
+          hasActiveRun: true,
+          activeRunIds: ["parent-run"],
+        });
+        expect(event.payload).not.toHaveProperty("phase");
+        expect(raw).not.toContain("child-private");
+        expect(raw).not.toContain(child.sessionKey);
+      }
+    } finally {
+      unsubscribe();
+      clearSubagentRunsReadCacheForTest();
+      invalidateSessionSharingSnapshot();
+    }
   });
 });

--- a/src/gateway/server-methods/sessions-read-by-key.ts
+++ b/src/gateway/server-methods/sessions-read-by-key.ts
@@ -1,9 +1,10 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { validateSessionsDescribeParams } from "../../../packages/gateway-protocol/src/index.js";
 import { hasOperatorBoundary } from "../operator-role-policy.js";
-import { resolveRequestedSessionAgentId as resolveRequestedGlobalAgentId } from "../session-request-agent.js";
+import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { createSessionListEntryFilter } from "../session-sharing.js";
 import { readRecentSessionMessagesWithStatsAsync } from "../session-transcript-readers.js";
+import { buildSessionListRowMetadataContext } from "../session-utils-projection.js";
 import { buildGatewaySessionRow } from "../session-utils.js";
 import { readSessionPlacementFields } from "./session-placement-read-projection.js";
 import { loadSessionEntriesForTarget, requireSessionKey } from "./sessions-shared.js";
@@ -29,7 +30,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
       return;
     }
     const cfg = context.getRuntimeConfig();
-    const requestedAgent = resolveRequestedGlobalAgentId(cfg, key);
+    const requestedAgent = resolveRequestedSessionAgentId(cfg, key, params.agentId);
     if (!requestedAgent.ok) {
       respond(false, undefined, requestedAgent.error);
       return;
@@ -54,6 +55,8 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
       includeDerivedTitles: params.includeDerivedTitles,
       includeLastMessage: params.includeLastMessage,
       transcriptUsageMaxBytes: 64 * 1024,
+      rowContext: buildSessionListRowMetadataContext({ now: Date.now() }),
+      includeSwarmChildren: true,
     });
     Object.assign(row, readSessionPlacementFields(context, row.sessionId));
     respond(true, { session: row });
@@ -76,7 +79,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
         : 200;
 
     const cfg = context.getRuntimeConfig();
-    const requestedAgent = resolveRequestedGlobalAgentId(
+    const requestedAgent = resolveRequestedSessionAgentId(
       cfg,
       key,
       normalizeOptionalString(p.agentId),
@@ -111,7 +114,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
       },
     );
     const currentCfg = context.getRuntimeConfig();
-    const currentRequestedAgent = resolveRequestedGlobalAgentId(
+    const currentRequestedAgent = resolveRequestedSessionAgentId(
       currentCfg,
       key,
       normalizeOptionalString(p.agentId),

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -414,10 +414,12 @@ test("sessions.describe retains each global row owner from a qualified main alia
     ["main", "main"],
     ["work", "workspace"],
     ["main", "workspace"],
+    ["work", "global"],
   ]) {
-    const described = await directSessionReq("sessions.describe", {
-      key: `agent:${agentId}:${alias}`,
-    });
+    const described = await directSessionReq(
+      "sessions.describe",
+      alias === "global" ? { key: "global", agentId } : { key: `agent:${agentId}:${alias}` },
+    );
     expect(described).toMatchObject({
       ok: true,
       payload: {
@@ -430,6 +432,12 @@ test("sessions.describe retains each global row owner from a qualified main alia
       },
     });
   }
+  expect(
+    await directSessionReq("sessions.describe", { key: "agent:main:workspace", agentId: "work" }),
+  ).toMatchObject({
+    ok: false,
+    error: { code: "INVALID_REQUEST" },
+  });
 });
 
 test("sessions.describe reads a pre-existing store after its agent is removed from config", async () => {

--- a/src/gateway/server-session-events.ts
+++ b/src/gateway/server-session-events.ts
@@ -453,7 +453,10 @@ export function createLifecycleEventBroadcastHandler(params: {
       );
       return;
     }
-    const sessionRow = loadGatewaySessionRow(event.sessionKey, { agentId: routingAgentId });
+    const sessionRow = loadGatewaySessionRow(event.sessionKey, {
+      agentId: routingAgentId,
+      ...(event.reason === "swarm" ? { includeSwarmSummary: true } : {}),
+    });
     const activeRunState =
       sessionRow && (sessionRow.key !== "global" || routingAgentId)
         ? resolveVisibleActiveSessionRunState({

--- a/src/gateway/server-session-lifecycle-events.test.ts
+++ b/src/gateway/server-session-lifecycle-events.test.ts
@@ -46,6 +46,35 @@ describe("createLifecycleEventBroadcastHandler", () => {
     expect(loadGatewaySessionRowMock).not.toHaveBeenCalled();
   });
 
+  it.each(["swarm", "run-capacity"])(
+    "prepares collector counts only for a committed parent invalidation (%s)",
+    (reason) => {
+      const broadcastToConnIds = vi.fn();
+      loadGatewaySessionRowMock.mockImplementation((_key, options) => ({
+        ...sessionRow,
+        ...(options?.includeSwarmSummary ? { swarm: undefined } : {}),
+      }));
+      const handler = createLifecycleEventBroadcastHandler({
+        broadcastToConnIds,
+        sessionEventSubscribers: { getAll: () => new Set(["observer"]) },
+        chatAbortControllers: new Map(),
+      });
+
+      handler({ sessionKey: sessionRow.key, agentId: "main", reason });
+
+      expect(loadGatewaySessionRowMock).toHaveBeenCalledExactlyOnceWith(sessionRow.key, {
+        agentId: "main",
+        ...(reason === "swarm" ? { includeSwarmSummary: true } : {}),
+      });
+      const payload = broadcastToConnIds.mock.calls[0]?.[1];
+      if (reason === "swarm") {
+        expect(payload).toHaveProperty("swarm", null);
+      } else {
+        expect(payload).not.toHaveProperty("swarm");
+      }
+    },
+  );
+
   it.each(["phase", "log"] as const)("projects swarm %s payload fields", (kind) => {
     const broadcastToConnIds = vi.fn();
     const handler = createLifecycleEventBroadcastHandler({

--- a/src/gateway/session-event-payload.ts
+++ b/src/gateway/session-event-payload.ts
@@ -23,6 +23,8 @@ export function buildGatewaySessionEventFields(params: {
 }): Record<string, unknown> {
   const { sessionRow } = params;
   const omitUnscopedGlobalGoal = sessionRow.key === "global" && !params.agentId;
+  const omitUnscopedSwarm =
+    (sessionRow.key === "global" || sessionRow.key === "unknown") && !params.agentId;
   return {
     updatedAt: sessionRow.updatedAt ?? undefined,
     sessionId: sessionRow.sessionId,
@@ -53,6 +55,16 @@ export function buildGatewaySessionEventFields(params: {
     spawnedBy: sessionRow.spawnedBy,
     controlOwnerSessionKey: sessionRow.controlOwnerSessionKey ?? null,
     swarmGroupId: sessionRow.swarmGroupId,
+    ...(!Object.hasOwn(sessionRow, "swarm") || omitUnscopedSwarm
+      ? {}
+      : {
+          swarm: sessionRow.swarm
+            ? {
+                ...sessionRow.swarm,
+                groups: sessionRow.swarm.groups.map(({ children: _children, ...counts }) => counts),
+              }
+            : null,
+        }),
     spawnedWorkspaceDir: sessionRow.spawnedWorkspaceDir,
     spawnedCwd: sessionRow.spawnedCwd,
     permissionMode: sessionRow.permissionMode ?? null,
@@ -212,6 +224,9 @@ export function buildGatewaySessionSnapshot(params: {
     : undefined;
   if (session && sessionRow.key === "global" && !params.agentId) {
     delete session.goal;
+  }
+  if (session && (sessionRow.key === "global" || sessionRow.key === "unknown") && !params.agentId) {
+    delete session.swarm;
   }
   return {
     ...(session ? { session } : {}),

--- a/src/gateway/session-swarm-summary.test.ts
+++ b/src/gateway/session-swarm-summary.test.ts
@@ -119,7 +119,7 @@ describe("parent Swarm outcome projection", () => {
     });
     expect(
       buildGatewaySessionEventFields({
-        sessionRow: { key: parent, kind: "direct", swarm: detailed },
+        sessionRow: { key: parent, kind: "direct", updatedAt: 0, swarm: detailed },
       }).swarm,
     ).toEqual(summary);
   });
@@ -230,24 +230,28 @@ describe("parent Swarm outcome projection", () => {
         includeChildren: true,
       });
       expect(
-        buildGatewaySessionEventFields({ sessionRow: { key: parent, kind: "direct" } }),
+        buildGatewaySessionEventFields({
+          sessionRow: { key: parent, kind: "direct", updatedAt: 0 },
+        }),
       ).not.toHaveProperty("swarm");
       expect(
         buildGatewaySessionEventFields({
-          sessionRow: { key: parent, kind: "direct", swarm: undefined },
+          sessionRow: { key: parent, kind: "direct", updatedAt: 0, swarm: undefined },
         }),
       ).toHaveProperty("swarm", null);
       expect(
         buildGatewaySessionEventFields({
-          sessionRow: { key, kind: "global", swarm },
+          sessionRow: { key, kind: "global", updatedAt: 0, swarm },
           agentId: "main",
         }),
       ).toMatchObject({ swarm: { groups: [{ done: 1, failed: 0 }] } });
       expect(
-        buildGatewaySessionEventFields({ sessionRow: { key, kind: "global", swarm } }),
+        buildGatewaySessionEventFields({
+          sessionRow: { key, kind: "global", updatedAt: 0, swarm },
+        }),
       ).not.toHaveProperty("swarm");
       const snapshot = buildGatewaySessionSnapshot({
-        sessionRow: { key, kind: "global", swarm },
+        sessionRow: { key, kind: "global", updatedAt: 0, swarm },
         includeSession: true,
       });
       expect(snapshot).not.toHaveProperty("swarm");

--- a/src/gateway/session-swarm-summary.test.ts
+++ b/src/gateway/session-swarm-summary.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearSubagentRunsReadCacheForTest } from "../agents/subagents/registry/subagent-registry-state.js";
+import { saveSubagentRegistryToSqlite } from "../agents/subagents/registry/subagent-registry.store.sqlite.js";
+import type { SubagentRunRecord } from "../agents/subagents/registry/subagent-registry.types.js";
+import {
+  resolveInternalSessionKey,
+  resolveMainSessionAlias,
+} from "../agents/tools/sessions-resolution.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import {
+  buildGatewaySessionSnapshot,
+  buildGatewaySessionEventFields,
+} from "./session-event-payload.js";
+import { listSessionFixture } from "./session-list.test-support.js";
+import { resolveSessionStoreIdentity } from "./session-store-key.js";
+import { buildSessionSwarmSummary } from "./session-swarm-summary.js";
+
+const parent = "agent:main:dashboard:research";
+const groupId = `swarm:${parent}:turn`;
+const cfg = { agents: { entries: { main: {}, other: {} } } };
+
+function collector(index: number, overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    runId: `run-${index}`,
+    childSessionKey: `agent:main:subagent:${index}`,
+    requesterSessionKey: parent,
+    requesterAgentId: "main",
+    requesterDisplayKey: parent,
+    controllerSessionKey: parent,
+    swarmRequesterSessionKey: parent,
+    task: "Private child task text must not reach the summary",
+    cleanup: "delete",
+    collect: true,
+    groupId,
+    createdAt: 100 + index,
+    execution: { status: "terminal", startedAt: 200, endedAt: 300 },
+    completion: { required: false, resultText: "Private child result" },
+    delivery: { status: "not_required" },
+    collectorCompletion: { status: index < 25 ? "done" : "failed" },
+    ...overrides,
+  };
+}
+
+async function withCollectors(runs: SubagentRunRecord[], run: () => Promise<void>) {
+  await withStateDirEnv("session-swarm-summary-", async () => {
+    await withEnvAsync({ OPENCLAW_TEST_READ_SUBAGENT_RUNS_FROM_SQLITE: "1" }, async () => {
+      saveSubagentRegistryToSqlite(new Map(runs.map((entry) => [entry.runId, entry])));
+      await run();
+    });
+  });
+}
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  clearSubagentRunsReadCacheForTest();
+});
+
+describe("parent Swarm outcome projection", () => {
+  it("counts every retained collector after child sessions are deleted", async () => {
+    await withCollectors(
+      Array.from({ length: 30 }, (_, index) => collector(index)),
+      async () => {
+        const result = await listSessionFixture({
+          cfg,
+          storePath: "",
+          store: { [parent]: { sessionId: "parent", updatedAt: 400 } },
+          opts: {},
+        });
+        expect(result.sessions).toHaveLength(1);
+        expect(result.sessions[0]).toMatchObject({
+          swarm: {
+            groups: [{ groupId, createdAt: 100, queued: 0, running: 0, done: 25, failed: 5 }],
+            otherActiveGroups: 0,
+          },
+        });
+        expect(buildGatewaySessionEventFields({ sessionRow: result.sessions[0]! })).toMatchObject({
+          swarm: { groups: [{ done: 25, failed: 5 }] },
+        });
+        expect(JSON.stringify(result)).not.toContain("Private child");
+      },
+    );
+  });
+
+  it("does not expose a hidden parent's summary or borrow another parent's collectors", async () => {
+    await withCollectors([collector(0)], async () => {
+      const store = {
+        [parent]: { sessionId: "parent", updatedAt: 400 },
+        "agent:main:other": { sessionId: "other", updatedAt: 400 },
+      };
+      const result = await listSessionFixture({
+        cfg,
+        storePath: "",
+        store,
+        opts: {},
+        entryFilter: (key) => key !== parent,
+      });
+      expect(result.sessions).toHaveLength(1);
+      expect(JSON.stringify(result.sessions[0])).not.toContain('"swarm":');
+    });
+  });
+  it("keeps list payloads compact and selected-parent details bounded without losing totals", () => {
+    const runs = Array.from({ length: 300 }, (_, index) => collector(index));
+    runs.push(
+      collector(300, {
+        collectorCompletion: undefined,
+        execution: { status: "running", startedAt: 300 },
+      }),
+    );
+    const summary = buildSessionSwarmSummary(runs, parent, "main");
+    expect(summary?.groups[0]).toMatchObject({ running: 1, done: 25, failed: 275 });
+    expect(summary?.groups[0]).not.toHaveProperty("children");
+    const detailed = buildSessionSwarmSummary(runs, parent, "main", { includeChildren: true });
+    expect(detailed?.groups[0]?.children).toHaveLength(64);
+    expect(detailed?.groups[0]?.children?.[0]).toEqual({
+      sessionKey: "agent:main:subagent:300",
+      status: "running",
+    });
+    expect(
+      buildGatewaySessionEventFields({
+        sessionRow: { key: parent, kind: "direct", swarm: detailed },
+      }).swarm,
+    ).toEqual(summary);
+  });
+
+  it("separates global owners even when they reuse a custom group id", () => {
+    const runs = [
+      collector(0, {
+        requesterSessionKey: "global",
+        swarmRequesterSessionKey: "global",
+        groupId: "review",
+      }),
+      collector(25, {
+        requesterSessionKey: "global",
+        swarmRequesterSessionKey: "global",
+        requesterAgentId: "other",
+        groupId: "review",
+      }),
+    ];
+    expect(buildSessionSwarmSummary(runs, "global", "main")?.groups).toMatchObject([
+      { groupId: "review", done: 1, failed: 0 },
+    ]);
+    expect(
+      buildSessionSwarmSummary(runs, "global", "other", { includeChildren: true })?.groups,
+    ).toMatchObject([
+      {
+        groupId: "review",
+        done: 0,
+        failed: 1,
+        children: [{ sessionKey: "agent:main:subagent:25", status: "failed" }],
+      },
+    ]);
+  });
+
+  it.each(["main", "workspace", "global"])(
+    "joins admitted global-scope %s collectors to their owner row",
+    async (suffix) => {
+      const globalConfig = { ...cfg, session: { scope: "global" as const, mainKey: "workspace" } };
+      const admitted = resolveSessionStoreIdentity({
+        cfg: globalConfig,
+        sessionKey: `agent:other:${suffix}`,
+      });
+      const { alias, mainKey } = resolveMainSessionAlias(globalConfig);
+      const requesterKey = resolveInternalSessionKey({
+        key: admitted.canonicalKey,
+        alias,
+        mainKey,
+      });
+      expect(requesterKey).toBe(suffix === "global" ? "agent:other:global" : "global");
+      await withCollectors(
+        [
+          collector(0, {
+            swarmRequesterSessionKey: requesterKey,
+            requesterSessionKey: requesterKey,
+            requesterAgentId: admitted.agentId,
+          }),
+        ],
+        async () => {
+          const result = await listSessionFixture({
+            cfg: globalConfig,
+            storePath: "",
+            store: { [admitted.canonicalKey]: { sessionId: "global-owner", updatedAt: 400 } },
+            opts: { agentId: admitted.agentId, includeGlobal: true },
+          });
+          expect(result.sessions).toMatchObject([
+            { key: requesterKey, agentId: "other", swarm: { groups: [{ done: 1 }] } },
+          ]);
+        },
+      );
+    },
+  );
+
+  it("bounds active groups and keeps only the latest completed group", () => {
+    const runs = Array.from({ length: 8 }, (_, index) =>
+      collector(index, {
+        groupId: `group-${index}`,
+        ...(index < 6
+          ? { collectorCompletion: undefined, execution: { status: "queued" as const } }
+          : {}),
+      }),
+    );
+    const summary = buildSessionSwarmSummary(runs, parent, "main");
+    expect(summary?.groups.map((group) => group.groupId)).toEqual([
+      "group-5",
+      "group-4",
+      "group-3",
+      "group-2",
+      "group-7",
+    ]);
+    expect(summary?.otherActiveGroups).toBe(2);
+  });
+  it("does not infer missing collector ownership from completion routing", () => {
+    expect(
+      buildSessionSwarmSummary(
+        [collector(0, { swarmRequesterSessionKey: undefined })],
+        parent,
+        "main",
+      ),
+    ).toBeUndefined();
+    expect(
+      buildSessionSwarmSummary([collector(0, { requesterAgentId: undefined })], parent, "main"),
+    ).toBeUndefined();
+  });
+
+  it.each(["global", "unknown"])(
+    "clears computed counts but omits uncomputed and unscoped %s events",
+    (key) => {
+      const swarm = buildSessionSwarmSummary([collector(0)], parent, "main", {
+        includeChildren: true,
+      });
+      expect(
+        buildGatewaySessionEventFields({ sessionRow: { key: parent, kind: "direct" } }),
+      ).not.toHaveProperty("swarm");
+      expect(
+        buildGatewaySessionEventFields({
+          sessionRow: { key: parent, kind: "direct", swarm: undefined },
+        }),
+      ).toHaveProperty("swarm", null);
+      expect(
+        buildGatewaySessionEventFields({
+          sessionRow: { key, kind: "global", swarm },
+          agentId: "main",
+        }),
+      ).toMatchObject({ swarm: { groups: [{ done: 1, failed: 0 }] } });
+      expect(
+        buildGatewaySessionEventFields({ sessionRow: { key, kind: "global", swarm } }),
+      ).not.toHaveProperty("swarm");
+      const snapshot = buildGatewaySessionSnapshot({
+        sessionRow: { key, kind: "global", swarm },
+        includeSession: true,
+      });
+      expect(snapshot).not.toHaveProperty("swarm");
+      expect(snapshot.session).not.toHaveProperty("swarm");
+    },
+  );
+});

--- a/src/gateway/session-swarm-summary.ts
+++ b/src/gateway/session-swarm-summary.ts
@@ -1,0 +1,84 @@
+import type { SessionRow } from "../../packages/gateway-protocol/src/schema/sessions-row.js";
+import type { SubagentRunReadRecord } from "../agents/subagents/registry/subagent-registry.types.js";
+
+const MAX_ACTIVE_GROUPS = 4;
+type SwarmSummary = NonNullable<SessionRow["swarm"]>;
+type Member = NonNullable<SwarmSummary["groups"][number]["children"]>[number];
+const STATUS_RANK = { running: 0, queued: 1, failed: 2, done: 3 } as const;
+
+/** Counts requester-owned operations, including tombstones whose child sessions were deleted. */
+export function buildSessionSwarmSummary(
+  runs: readonly SubagentRunReadRecord[],
+  sessionKey: string,
+  agentId: string,
+  options: { includeChildren?: boolean } = {},
+): SwarmSummary | undefined {
+  const groups = new Map<string, SwarmSummary["groups"][number]>();
+  const members = options.includeChildren
+    ? new Map<string, Array<Member & { createdAt: number }>>()
+    : undefined;
+  for (const run of runs) {
+    const requester = run.swarmRequesterSessionKey;
+    if (
+      !run.collect ||
+      !run.groupId ||
+      requester !== sessionKey ||
+      run.requesterAgentId !== agentId
+    ) {
+      continue;
+    }
+    const group = groups.get(run.groupId) ?? {
+      groupId: run.groupId,
+      createdAt: run.createdAt,
+      queued: 0,
+      running: 0,
+      done: 0,
+      failed: 0,
+    };
+    group.createdAt = Math.min(group.createdAt, run.createdAt);
+    // Completion is frozen by the collector owner only after its result settles.
+    // A provider terminal event alone must not claim the collector has finished.
+    const completion = run.collectorCompletion?.status;
+    const status = completion
+      ? completion === "done"
+        ? "done"
+        : "failed"
+      : run.execution.status === "queued"
+        ? "queued"
+        : "running";
+    group[status] += 1;
+    groups.set(run.groupId, group);
+    if (members) {
+      const children = members.get(run.groupId) ?? [];
+      children.push({ sessionKey: run.childSessionKey, status, createdAt: run.createdAt });
+      members.set(run.groupId, children);
+    }
+  }
+  if (groups.size === 0) {
+    return undefined;
+  }
+  const ordered = [...groups.values()].toSorted(
+    (left, right) => right.createdAt - left.createdAt || left.groupId.localeCompare(right.groupId),
+  );
+  const active = ordered.filter((group) => group.queued + group.running > 0);
+  const terminal = ordered.find((group) => group.queued + group.running === 0);
+  const selected = [...active.slice(0, MAX_ACTIVE_GROUPS), ...(terminal ? [terminal] : [])];
+  if (members) {
+    // Only a selected-parent read carries member detail; ordinary rosters stay compact.
+    for (const group of selected) {
+      group.children = (members.get(group.groupId) ?? [])
+        .toSorted(
+          (left, right) =>
+            STATUS_RANK[left.status] - STATUS_RANK[right.status] ||
+            left.createdAt - right.createdAt ||
+            left.sessionKey.localeCompare(right.sessionKey),
+        )
+        .slice(0, 64)
+        .map(({ sessionKey: childKey, status }) => ({ sessionKey: childKey, status }));
+    }
+  }
+  return {
+    groups: selected,
+    otherActiveGroups: Math.max(0, active.length - MAX_ACTIVE_GROUPS),
+  };
+}

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -46,11 +46,13 @@ export function buildSingleRowStoreChildSessionsByKey(params: {
   store: Record<string, SessionEntry>;
   key: string;
   now: number;
+  subagentRuns?: SessionListRowContext["subagentRuns"];
 }): Map<string, string[]> {
   return buildStoreChildSessionIndex({
     store: params.store,
     keys: [params.key],
     now: params.now,
+    subagentRuns: params.subagentRuns,
     requireCurrentController: true,
   });
 }

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -41,6 +41,7 @@ import {
 } from "./session-identity-projection.js";
 import { isSessionPermissionChangePending } from "./session-permission-change.js";
 import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
+import { buildSessionSwarmSummary } from "./session-swarm-summary.js";
 import { readSessionTitleFieldsFromTranscript as readScopedSessionTitleFieldsFromTranscript } from "./session-transcript-title-reader.js";
 import type { SessionListRowContext } from "./session-utils-contracts.js";
 import {
@@ -95,6 +96,7 @@ export function buildGatewaySessionRow(params: {
   agentId: string;
   skipTranscriptUsageFallback?: boolean;
   lightweightListRow?: boolean;
+  includeSwarmChildren?: boolean;
 }): GatewaySessionRow {
   const { cfg, storePath, store, key, entry } = params;
   const lightweight = params.lightweightListRow === true;
@@ -331,8 +333,16 @@ export function buildGatewaySessionRow(params: {
   const pluginExtensions =
     !lightweight && entry ? projectPluginSessionExtensionsSync({ sessionKey: key, entry }) : [];
 
+  const swarm = buildSessionSwarmSummary(
+    rowContext?.subagentRuns.swarmRunsByRequesterSessionKey.get(key) ?? [],
+    key,
+    sessionAgentId,
+    { includeChildren: params.includeSwarmChildren },
+  );
   return {
     key,
+    // Presence records a completed registry projection; event merges may clear only that fact.
+    ...(rowContext ? { swarm } : {}),
     visibility: entry ? (entry.visibility ?? "shared") : undefined,
     incognito: entry?.incognito,
     spawnedBy: subagentOwner || entry?.spawnedBy,

--- a/src/gateway/session-utils-search.ts
+++ b/src/gateway/session-utils-search.ts
@@ -259,6 +259,7 @@ type LoadGatewaySessionRowOptions = {
   includeLastMessage?: boolean;
   now?: number;
   transcriptUsageMaxBytes?: number;
+  includeSwarmSummary?: boolean;
 };
 
 function loadGatewaySessionSnapshot(
@@ -278,10 +279,14 @@ function loadGatewaySessionSnapshot(
   if (!entry) {
     return { row: null };
   }
+  const rowContext = options?.includeSwarmSummary
+    ? buildSessionListRowMetadataContext({ now })
+    : undefined;
   const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
     store,
     key: canonicalKey,
     now,
+    subagentRuns: rowContext?.subagentRuns,
   });
   const lifecycleRunId = (entry as InternalSessionEntry).lifecycleRunId;
   return {
@@ -300,6 +305,8 @@ function loadGatewaySessionSnapshot(
       skipTranscriptUsageFallback: lightweight,
       lightweightListRow: lightweight,
       agentId,
+      // Event snapshots carry complete counts, while ordinary exact-row reads stay scoped.
+      rowContext,
     }),
   };
 }

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -36,6 +36,7 @@ const subagentRegistryReadMock = vi.hoisted(() => {
     }
     return {
       runsByControllerSessionKey,
+      swarmRunsByRequesterSessionKey: new Map(),
       getDisplaySubagentRun: vi.fn(
         (childSessionKey: string) => runsByChildSessionKey.get(childSessionKey) ?? null,
       ),

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -357,6 +357,10 @@ type SessionCompactionCheckpointPreview = Pick<
 >;
 
 export type GatewaySessionRow = SessionRow & {
+  /** Transient UI-owned Swarm note overlays, not persisted session fields. */
+  swarmPhase?: string;
+  swarmPhaseRank?: number;
+  swarmLog?: string;
   placement?: import("../../../packages/gateway-protocol/src/index.js").SessionPlacement;
   placementMove?: import("../../../packages/gateway-protocol/src/index.js").SessionPlacementMove;
   icon?: string;

--- a/ui/src/e2e/chat-swarm-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-swarm-lifecycle.e2e.test.ts
@@ -1,0 +1,177 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { chatSessionListResponse } from "./chat-flow.test-support.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI Swarm lifecycle",
+  startServerBeforeBrowser: true,
+});
+const sessionKey = "agent:main:dashboard:11111111-2222-4333-8444-555555555555";
+const groupId = `swarm:${sessionKey}:11111111-2222-4333-8444-666666666666`;
+
+suite.define(() => {
+  it.each([
+    { name: "desktop", width: 1440, height: 900, childAgent: "main" },
+    { name: "mobile", width: 390, height: 844, childAgent: "main" },
+    { name: "cross-agent", width: 1440, height: 900, childAgent: "worker" },
+  ])("keeps a thirty-child outcome visible after the parent fails on $name", async (viewport) => {
+    const proofDir = createControlUiE2eArtifactDir(`swarm-lifecycle-${viewport.name}`);
+    await suite.withPage({ viewport, hasTouch: viewport.name === "mobile" }, async ({ page }) => {
+      const now = Date.now();
+      const parent = {
+        key: sessionKey,
+        kind: "direct",
+        label: "Research comparison",
+        status: "running",
+        hasActiveRun: true,
+        updatedAt: now,
+        swarm: {
+          groups: [
+            {
+              groupId,
+              createdAt: now,
+              children: Array.from({ length: 30 }, (_, index) => ({
+                sessionKey: `agent:${viewport.childAgent}:subagent:research-${index}`,
+                status: index < 8 ? "running" : "queued",
+              })),
+              queued: 22,
+              running: 8,
+              done: 0,
+              failed: 0,
+            },
+          ],
+          otherActiveGroups: 0,
+        },
+      };
+      const children = Array.from({ length: 30 }, (_, index) => ({
+        key: `agent:${viewport.childAgent}:subagent:research-${index}`,
+        kind: "direct",
+        label: `Research lane ${index + 1}`,
+        parentSessionKey: sessionKey,
+        spawnedBy: sessionKey,
+        swarmGroupId: groupId,
+        status: index < 8 ? "running" : "queued",
+        hasActiveRun: true,
+        updatedAt: now,
+        ...(index < 8 ? { startedAt: now - 1_000 } : {}),
+      }));
+      // Keep children outside the sidebar page so only real child hydration can
+      // populate the chart. A whole-session fixture would hide a broken fetch.
+      const listResponse = (rows: typeof children, parentRow = parent) => ({
+        cases: [
+          { match: { spawnedBy: sessionKey }, response: chatSessionListResponse(rows) },
+          { match: {}, response: chatSessionListResponse([parentRow]) },
+        ],
+      });
+      const gateway = await installMockGateway(page, {
+        sessionKey,
+        sessions: [parent, ...children],
+        historyMessages: [
+          { role: "assistant", content: [{ type: "text", text: "Research is running." }] },
+        ],
+        methodResponses: {
+          "sessions.list": listResponse(children),
+          "sessions.describe": { session: parent },
+        },
+      });
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+      await gateway.waitForRequest("sessions.list", { match: { spawnedBy: sessionKey } });
+      const widget = page.locator('[data-test-id="chat-swarm"]');
+      await widget.waitFor();
+      await expect.poll(() => widget.locator(".chat-swarm__task").count()).toBe(30);
+      await expect
+        .poll(() => widget.locator(".chat-swarm__header").textContent())
+        .toContain("0 of 30");
+      expect(
+        await widget.evaluate((element) => {
+          const box = element.getBoundingClientRect();
+          return box.width > 0 && box.height > 0 && box.top >= 0 && box.bottom <= innerHeight;
+        }),
+      ).toBe(true);
+      await page.screenshot({ path: path.join(proofDir, "active.png"), animations: "disabled" });
+      const group = widget.locator("[data-swarm-group]");
+      if (viewport.name === "mobile") {
+        await group.locator("summary").tap();
+      } else {
+        await group.locator("summary").click();
+      }
+      await expect.poll(() => widget.locator(".chat-swarm__tasks").isVisible()).toBe(true);
+      await page.screenshot({
+        path: path.join(proofDir, "active-details.png"),
+        animations: "disabled",
+      });
+
+      const endedAt = now + 60_000;
+      const completed = children.map((row, index) =>
+        Object.assign(row, {
+          status: index < 25 ? "done" : "failed",
+          hasActiveRun: false,
+          updatedAt: endedAt,
+          startedAt: now,
+          endedAt,
+        }),
+      );
+      const failedParent = {
+        ...parent,
+        status: "failed",
+        hasActiveRun: false,
+        updatedAt: endedAt,
+        swarm: {
+          groups: [
+            {
+              groupId,
+              createdAt: now,
+              children: Array.from({ length: 30 }, (_, index) => ({
+                sessionKey: `agent:${viewport.childAgent}:subagent:research-${index}`,
+                status: index < 25 ? "done" : "failed",
+              })),
+              queued: 0,
+              running: 0,
+              done: 25,
+              failed: 5,
+            },
+          ],
+          otherActiveGroups: 0,
+        },
+      };
+      await gateway.setSessionsListResponse(
+        chatSessionListResponse([failedParent, ...completed.slice(18)]),
+      );
+      await gateway.setMethodResponse(
+        "sessions.list",
+        listResponse(completed.slice(18), failedParent),
+      );
+      await gateway.setMethodResponse("sessions.describe", { session: failedParent });
+      const reads = (await gateway.getRequests("sessions.list", { spawnedBy: sessionKey })).length;
+      await gateway.emitGatewayEvent("sessions.changed", {
+        sessionKey,
+        agentId: "main",
+        reason: "swarm",
+      });
+      await gateway.waitForRequest("sessions.list", {
+        after: reads,
+        match: { spawnedBy: sessionKey },
+      });
+      await expect.poll(() => widget.count()).toBe(1);
+      await expect
+        .poll(() => widget.locator(".chat-swarm__header").textContent())
+        .toContain("30 of 30");
+      expect(await widget.locator(".chat-swarm__marker--failed").count()).toBe(5);
+      expect(await widget.locator(".chat-swarm__marker--done").count()).toBe(25);
+      await page.screenshot({ path: path.join(proofDir, "terminal.png"), animations: "disabled" });
+      await page.reload();
+      await widget.waitFor();
+      await expect.poll(() => widget.count()).toBe(1);
+      await expect
+        .poll(() => widget.locator(".chat-swarm__header").textContent())
+        .toContain("30 of 30");
+      await page.screenshot({
+        path: path.join(proofDir, "terminal-reloaded.png"),
+        animations: "disabled",
+      });
+    });
+  });
+});

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -477,6 +477,7 @@ suite.define(() => {
           await takeControlUiViewportScreenshot(page, page.locator(".shell"), [startupStatus]),
         );
       }
+      await gateway.waitForRequest("sessions.describe", { match: { key: sessionKey } });
       const describeRequestsAfterNavigation = (await gateway.getRequests("sessions.describe"))
         .length;
       await expect.poll(() => page.url()).toContain(controlUiSessionPath(sessionKey));

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "../pages/new-session/cloud-profile-discovery.ts";
@@ -478,8 +479,6 @@ suite.define(() => {
         );
       }
       await gateway.waitForRequest("sessions.describe", { match: { key: sessionKey } });
-      const describeRequestsAfterNavigation = (await gateway.getRequests("sessions.describe"))
-        .length;
       await expect.poll(() => page.url()).toContain(controlUiSessionPath(sessionKey));
       await expect
         .poll(() => page.locator(".agent-chat__composer-combobox textarea").isDisabled())
@@ -536,11 +535,24 @@ suite.define(() => {
         ["starting", 4, "Starting…"],
       ] as const) {
         await publishPlacement(state, generation, label, state === "starting");
+        await page.clock.runFor(250);
         expect(await gateway.getRequests("sessions.send")).toHaveLength(0);
       }
-      expect(await gateway.getRequests("sessions.describe")).toHaveLength(
-        describeRequestsAfterNavigation,
-      );
+      // This single-page fixture pairs each Swarm child read with its parent read.
+      // Placement updates must not add an unpaired describe for the same session.
+      const parentReads = (await gateway.getRequests()).filter((request) => {
+        const params = asNullableRecord(request.params);
+        return (
+          (request.method === "sessions.describe" && params?.key === sessionKey) ||
+          (request.method === "sessions.list" && params?.spawnedBy === sessionKey)
+        );
+      });
+      for (let index = 0; index < parentReads.length; index += 2) {
+        expect(parentReads.slice(index, index + 2)).toMatchObject([
+          { method: "sessions.list", params: { spawnedBy: sessionKey } },
+          { method: "sessions.describe", params: { key: sessionKey } },
+        ]);
+      }
       const neutralRow = page.locator('[data-session-key="agent:cloud:neutral-e2e"] a');
       await neutralRow.waitFor();
       await neutralRow.click();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3159,6 +3159,12 @@ export const en: TranslationMap & {
       description: "Coordinate parallel subagents and collect their results.",
       defaultPhase: "Unphased",
       progress: "{complete} of {total}",
+      active: "{running} running · {queued} queued · {failed} failed",
+      finished: "{done} completed · {failed} failed",
+      childOutcome: "Child runs finished. Check the conversation for the final response.",
+      details: "Child details",
+      detailsUnavailable: "Child details are unavailable. Counts include all accepted workers.",
+      otherGroups: "{count} more active groups",
     },
     toolSearch: {
       title: "Tool Search for all models",

--- a/ui/src/lib/sessions/swarm-activity.ts
+++ b/ui/src/lib/sessions/swarm-activity.ts
@@ -8,12 +8,6 @@ const MAX_TRACKED_SWARM_GROUPS = 10_000;
 // supported lifetime membership ceiling rather than only the live-child cap.
 const MAX_TRACKED_SWARM_CHILDREN = 100_000;
 
-type SwarmDisplayCarrier = {
-  swarmPhaseRank?: number;
-  swarmLog?: string;
-  swarmPhase?: string;
-};
-
 function setBounded<K, V>(map: Map<K, V>, key: K, value: V, limit: number): void {
   map.delete(key);
   map.set(key, value);
@@ -105,19 +99,14 @@ export class SwarmActivityTracker {
     }
     let changed = false;
     const sessions = result.sessions.map((row): GatewaySessionRow => {
-      const carrier = row as GatewaySessionRow & SwarmDisplayCarrier;
-      const phase = this.phaseByChild.get(row.key) ?? carrier.swarmPhase;
+      const phase = this.phaseByChild.get(row.key) ?? row.swarmPhase;
       const groupId = row.swarmGroupId?.trim();
-      const log = (groupId ? this.latestLogByGroup.get(groupId) : undefined) ?? carrier.swarmLog;
+      const log = (groupId ? this.latestLogByGroup.get(groupId) : undefined) ?? row.swarmLog;
       const phaseRank =
         (phase && groupId
           ? this.phaseRankByGroupPhase.get(`${groupId}\u0000${phase}`)
-          : undefined) ?? carrier.swarmPhaseRank;
-      if (
-        phase === carrier.swarmPhase &&
-        log === carrier.swarmLog &&
-        phaseRank === carrier.swarmPhaseRank
-      ) {
+          : undefined) ?? row.swarmPhaseRank;
+      if (phase === row.swarmPhase && log === row.swarmLog && phaseRank === row.swarmPhaseRank) {
         return row;
       }
       changed = true;

--- a/ui/src/lib/sessions/swarm-roster.test.ts
+++ b/ui/src/lib/sessions/swarm-roster.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import type { SessionCapability, SessionListOptions } from "./index.ts";
 import {
@@ -11,11 +13,11 @@ import {
 function row(index: number): GatewaySessionRow {
   return {
     key: `agent:worker:subagent:${index}`,
-    kind: "other",
+    kind: "direct",
     updatedAt: index,
     spawnedBy: "agent:main:parent",
     swarmGroupId: "swarm:agent:main:parent:run-1",
-  } as unknown as GatewaySessionRow;
+  };
 }
 
 function result(rows: GatewaySessionRow[], offset: number, totalCount: number): SessionsListResult {
@@ -121,6 +123,7 @@ describe("SwarmRosterHydrator", () => {
 
     hydrator.update({
       sessions,
+      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
       currentRows: () => [row(0)],
@@ -130,6 +133,7 @@ describe("SwarmRosterHydrator", () => {
 
     hydrator.update({
       sessions,
+      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
       parentKey: "agent:main:parent",
       sourceEpoch: 2,
       currentRows: () => [],
@@ -154,6 +158,7 @@ describe("SwarmRosterHydrator", () => {
 
     const params = {
       sessions,
+      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
       currentRows: () => currentRows,
@@ -162,12 +167,18 @@ describe("SwarmRosterHydrator", () => {
     hydrator.update(params);
     await vi.runAllTimersAsync();
 
-    expect(hydrator.rows).toEqual([expect.objectContaining({ status: "done" })]);
+    expect(hydrator.rows.filter((entry) => entry.key !== "agent:main:parent")).toEqual([
+      expect.objectContaining({ status: "done" }),
+    ]);
     hydrator.update(params);
-    expect(hydrator.rows).toEqual([expect.objectContaining({ status: "done" })]);
+    expect(hydrator.rows.filter((entry) => entry.key !== "agent:main:parent")).toEqual([
+      expect.objectContaining({ status: "done" }),
+    ]);
     currentRows = [{ ...running, status: "failed" }];
     hydrator.update(params);
-    expect(hydrator.rows).toEqual([expect.objectContaining({ status: "failed" })]);
+    expect(hydrator.rows.filter((entry) => entry.key !== "agent:main:parent")).toEqual([
+      expect.objectContaining({ status: "failed" }),
+    ]);
     hydrator.dispose();
   });
 
@@ -185,6 +196,7 @@ describe("SwarmRosterHydrator", () => {
 
     hydrator.update({
       sessions,
+      readParent: async () => ({ key: "agent:main:parent", kind: "direct" as const }),
       parentKey: "agent:main:parent",
       sourceEpoch: 1,
       currentRows: () => [],
@@ -193,9 +205,155 @@ describe("SwarmRosterHydrator", () => {
     await vi.runAllTimersAsync();
 
     expect(list).toHaveBeenCalledTimes(4);
-    expect(hydrator.rows).toEqual([expect.objectContaining({ key: row(0).key })]);
+    expect(hydrator.rows.filter((entry) => entry.key !== "agent:main:parent")).toEqual([
+      expect.objectContaining({ key: row(0).key }),
+    ]);
     hydrator.dispose();
   });
+  it("fences an old global owner read and clears a denied parent without restoring stale page totals", async () => {
+    vi.useFakeTimers();
+    let release!: (row: GatewaySessionRow) => void;
+    const oldRead = new Promise<GatewaySessionRow>((resolve) => {
+      release = resolve;
+    });
+    const main: GatewaySessionRow = {
+      key: "global",
+      kind: "global",
+      agentId: "main",
+      label: "Old owner",
+    };
+    const other: GatewaySessionRow = {
+      key: "global",
+      kind: "global",
+      agentId: "other",
+      label: "Current owner",
+    };
+    let revision = 1;
+    const sessions = {
+      get canonicalListRevision() {
+        return revision;
+      },
+      list: vi.fn(async () => result([], 0, 0)),
+    } as unknown as SessionCapability;
+    const hydrator = new SwarmRosterHydrator();
+    const params = {
+      sessions,
+      parentKey: "global",
+      sourceEpoch: 1,
+      currentRows: () => [main],
+      onRows: () => {},
+    };
+    hydrator.update({ ...params, agentId: "main", readParent: () => oldRead });
+    await vi.advanceTimersByTimeAsync(250);
+    hydrator.update({ ...params, agentId: "other", readParent: async () => other });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(hydrator.rows).toEqual([other]);
+    release(main);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hydrator.rows).toEqual([other]);
+    revision += 1;
+    const denied = { ...params, agentId: "other", readParent: async () => null };
+    hydrator.update(denied);
+    await vi.advanceTimersByTimeAsync(250);
+    expect(hydrator.rows).toEqual([]);
+    hydrator.update(denied);
+    expect(hydrator.rows).toEqual([]);
+    hydrator.dispose();
+  });
+  it("publishes parent counts before slow optional children and retains them when that read fails", async () => {
+    vi.useFakeTimers();
+    let rejectChildren!: (error: Error) => void;
+    const childRead = new Promise<SessionsListResult>((_resolve, reject) => {
+      rejectChildren = reject;
+    });
+    const parent: GatewaySessionRow = {
+      key: "agent:main:parent",
+      kind: "direct",
+      swarm: {
+        groups: [{ groupId: "group", createdAt: 1, queued: 0, running: 0, done: 25, failed: 5 }],
+        otherActiveGroups: 0,
+      },
+    };
+    const sessions = {
+      canonicalListRevision: 1,
+      list: vi.fn(() => childRead),
+    } as unknown as SessionCapability;
+    const hydrator = new SwarmRosterHydrator();
+    hydrator.update({
+      sessions,
+      parentKey: parent.key,
+      sourceEpoch: 1,
+      readParent: async () => parent,
+      currentRows: () => [],
+      onRows: () => {},
+    });
+    await vi.advanceTimersByTimeAsync(250);
+    expect(hydrator.rows).toEqual([parent]);
+    rejectChildren(new Error("Child details temporarily unavailable"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(hydrator.rows).toEqual([parent]);
+    hydrator.dispose();
+  });
+  it.each(["missing", "denied"] as const)(
+    "does not restore a %s parent when an earlier child read finishes late",
+    async (outcome) => {
+      vi.useFakeTimers();
+      const children = createDeferred<SessionsListResult>();
+      const parent: GatewaySessionRow = {
+        key: "agent:main:parent",
+        kind: "direct",
+        swarm: {
+          groups: [{ groupId: "group", createdAt: 1, queued: 0, running: 1, done: 0, failed: 0 }],
+          otherActiveGroups: 0,
+        },
+      };
+      let revision = 1;
+      const sessions = {
+        get canonicalListRevision() {
+          return revision;
+        },
+        list: vi
+          .fn()
+          .mockReturnValueOnce(children.promise)
+          .mockResolvedValue(result([], 0, 0)),
+      } as unknown as SessionCapability;
+      const onRows = vi.fn();
+      const hydrator = new SwarmRosterHydrator();
+      const params = {
+        sessions,
+        parentKey: parent.key,
+        sourceEpoch: 1,
+        currentRows: () => [parent],
+        onRows,
+      };
+      try {
+        hydrator.update({ ...params, readParent: async () => parent });
+        await vi.advanceTimersByTimeAsync(250);
+        expect(hydrator.rows).toEqual([parent]);
+        revision += 1;
+        hydrator.update({
+          ...params,
+          readParent: async () => {
+            if (outcome === "denied") {
+              throw new GatewayRequestError({
+                code: "INVALID_REQUEST",
+                message: "Parent unavailable",
+              });
+            }
+            return null;
+          },
+        });
+        await vi.advanceTimersByTimeAsync(250);
+        expect(hydrator.rows).toEqual([]);
+        children.resolve(result([row(0)], 0, 1));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(hydrator.rows).toEqual([]);
+        expect(onRows).toHaveBeenLastCalledWith([]);
+      } finally {
+        hydrator.dispose();
+      }
+    },
+  );
 });
 
 describe("hydrateSwarmSessionRows", () => {
@@ -213,9 +371,9 @@ describe("hydrateSwarmSessionRows", () => {
     const currentRows: GatewaySessionRow[] = [
       {
         key: "agent:main:parent",
-        kind: "main",
+        kind: "direct",
         updatedAt: 2_000,
-      } as unknown as GatewaySessionRow,
+      },
       currentChild,
     ];
 

--- a/ui/src/lib/sessions/swarm-roster.ts
+++ b/ui/src/lib/sessions/swarm-roster.ts
@@ -1,8 +1,9 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import { GatewayRequestError } from "../../api/gateway.ts";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { fetchChildSessionRows } from "./child-session-data.ts";
 import type { SessionCapability } from "./index.ts";
-import { normalizeAgentId } from "./session-key.ts";
+import { normalizeAgentId, areUiSessionKeysEquivalent } from "./session-key.ts";
 
 const SWARM_SESSION_PAGE_SIZE = 10_000;
 
@@ -67,6 +68,8 @@ export async function hydrateSwarmSessionRows(params: {
 
 type SwarmHydrationParams = {
   sessions: SessionCapability;
+  agentId?: string;
+  readParent: () => Promise<GatewaySessionRow | null>;
   parentKey: string;
   sourceEpoch: number;
   currentRows: () => readonly GatewaySessionRow[];
@@ -84,11 +87,13 @@ export class SwarmRosterHydrator {
   private timer: ReturnType<typeof setTimeout> | null = null;
 
   update(params: SwarmHydrationParams): void {
-    const key = `${params.sourceEpoch}:${params.parentKey}`;
+    const key = `${params.sourceEpoch}:${params.agentId ?? ""}:${params.parentKey}`;
     if (this.key !== key) {
       this.reset(key);
     }
-    const currentRows = params.currentRows();
+    const currentRows = params
+      .currentRows()
+      .filter((row) => !areUiSessionKeysEquivalent(row.key, params.parentKey));
     const currentRowsByKey = new Map(currentRows.map((row) => [row.key, JSON.stringify(row)]));
     // A repeated page is not a new lifecycle observation. Reapplying it can
     // overwrite a newer child fetch whose persisted timestamp did not change.
@@ -116,47 +121,69 @@ export class SwarmRosterHydrator {
   }
 
   private hydrate(params: SwarmHydrationParams): void {
-    const generation = this.generation;
+    const generation = ++this.generation;
     const revision = params.sessions.canonicalListRevision;
-    const key = `${params.sourceEpoch}:${params.parentKey}`;
+    const key = `${params.sourceEpoch}:${params.agentId ?? ""}:${params.parentKey}`;
     const isCurrent = () => generation === this.generation && this.key === key;
-    const currentRowsAtStart = params.currentRows();
+    const currentRowsAtStart = params
+      .currentRows()
+      .filter((row) => !areUiSessionKeysEquivalent(row.key, params.parentKey));
     const currentRowsAtStartByKey = new Map(
       currentRowsAtStart.map((row) => [row.key, JSON.stringify(row)]),
     );
     let hydrated = false;
     let retrying = false;
     this.attempts += 1;
-    void hydrateSwarmSessionRows({
+    const scheduleRetry = () => {
+      retrying = true;
+      this.revision = -1;
+      const delayMs = Math.min(30_000, 1_000 * 2 ** Math.min(this.attempts - 1, 5));
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        if (isCurrent()) this.update(params);
+      }, delayMs);
+    };
+    // Counts belong to the parent read; optional child names must never hold them hostage.
+    const children = hydrateSwarmSessionRows({
       sessions: params.sessions,
       parentKey: params.parentKey,
       currentRows: currentRowsAtStart,
       isCurrent,
-    })
-      .then((rows) => {
-        if (!rows || !isCurrent()) {
-          return;
-        }
+    }).catch(() => null);
+    void params
+      .readParent()
+      .then((parent) => {
+        if (!isCurrent()) return;
         hydrated = true;
         this.revision = revision;
-        const changedCurrentRows = params
-          .currentRows()
-          .filter((row) => currentRowsAtStartByKey.get(row.key) !== JSON.stringify(row));
-        this.rows = mergeSwarmSessionRows(rows, changedCurrentRows);
+        this.rows = parent ? mergeSwarmSessionRows(this.rows, [parent]) : [];
         params.onRows(this.rows);
+        if (!parent) return;
+        void children.then((rows) => {
+          if (!isCurrent()) return;
+          const changedCurrentRows = params
+            .currentRows()
+            .filter(
+              (row) =>
+                !areUiSessionKeysEquivalent(row.key, params.parentKey) &&
+                currentRowsAtStartByKey.get(row.key) !== JSON.stringify(row),
+            );
+          this.rows = rows
+            ? mergeSwarmSessionRows(mergeSwarmSessionRows(rows, [parent]), changedCurrentRows)
+            : [parent];
+          params.onRows(this.rows);
+          if (!rows) scheduleRetry();
+        });
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (!isCurrent()) {
           return;
         }
-        retrying = true;
-        const retryDelayMs = Math.min(30_000, 1_000 * 2 ** Math.min(this.attempts - 1, 5));
-        this.timer = setTimeout(() => {
-          this.timer = null;
-          if (isCurrent()) {
-            this.update(params);
-          }
-        }, retryDelayMs);
+        if (error instanceof GatewayRequestError && error.code === "INVALID_REQUEST") {
+          this.rows = [];
+          params.onRows(this.rows);
+        }
+        scheduleRetry();
       })
       .finally(() => {
         if (!isCurrent()) {

--- a/ui/src/lib/sessions/swarm-roster.ts
+++ b/ui/src/lib/sessions/swarm-roster.ts
@@ -140,7 +140,9 @@ export class SwarmRosterHydrator {
       const delayMs = Math.min(30_000, 1_000 * 2 ** Math.min(this.attempts - 1, 5));
       this.timer = setTimeout(() => {
         this.timer = null;
-        if (isCurrent()) this.update(params);
+        if (isCurrent()) {
+          this.update(params);
+        }
       }, delayMs);
     };
     // Counts belong to the parent read; optional child names must never hold them hostage.
@@ -153,14 +155,20 @@ export class SwarmRosterHydrator {
     void params
       .readParent()
       .then((parent) => {
-        if (!isCurrent()) return;
+        if (!isCurrent()) {
+          return;
+        }
         hydrated = true;
         this.revision = revision;
         this.rows = parent ? mergeSwarmSessionRows(this.rows, [parent]) : [];
         params.onRows(this.rows);
-        if (!parent) return;
+        if (!parent) {
+          return;
+        }
         void children.then((rows) => {
-          if (!isCurrent()) return;
+          if (!isCurrent()) {
+            return;
+          }
           const changedCurrentRows = params
             .currentRows()
             .filter(
@@ -172,7 +180,9 @@ export class SwarmRosterHydrator {
             ? mergeSwarmSessionRows(mergeSwarmSessionRows(rows, [parent]), changedCurrentRows)
             : [parent];
           params.onRows(this.rows);
-          if (!rows) scheduleRetry();
+          if (!rows) {
+            scheduleRetry();
+          }
         });
       })
       .catch((error: unknown) => {

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -8,6 +8,7 @@ import {
   createGatewayRequestMock,
   createTestGatewayClient,
   type GatewayRequestMock,
+  type GatewayRequestHandler,
 } from "../../test-helpers/gateway-client.ts";
 import { sessionMutationGatewayHello } from "../../test-helpers/gateway-methods.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
@@ -54,7 +55,7 @@ export function createBrowserAnnotationAttachment(
 }
 
 export function findChatSendPayload(host: {
-  request: { mock: { calls: ReadonlyArray<readonly [string, unknown?]> } };
+  request: { mock: { calls: ReadonlyArray<Readonly<Parameters<GatewayRequestHandler>>> } };
 }): Record<string, unknown> {
   const call = host.request.mock.calls.find(([method]) => method === "chat.send");
   if (!call?.[1] || typeof call[1] !== "object") {

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -295,15 +295,7 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
       if (!state || this.isCurrentSessionArchived(state)) {
         return undefined;
       }
-      const identity = resolveUiConversationIdentity(state, state.sessionKey);
-      if (identity.agentId) {
-        return identity;
-      }
-      const session = getAcceptedChatHistorySession(state);
-      // Raw retained panes follow their accepted history owner, never the selected assistant.
-      return session && parseAgentSessionKey(session.key)
-        ? resolveUiConversationIdentity(state, session.key)
-        : undefined;
+      return this.resolveChatReadTarget();
     },
   });
   protected readonly questionPromptState = createQuestionPromptState(() => {
@@ -312,6 +304,23 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   });
   protected questionPrompts: QuestionPrompt[] = [];
   protected state: ChatPageHost | undefined;
+
+  protected resolveChatReadTarget(): ReturnType<typeof resolveUiConversationIdentity> | undefined {
+    const state = this.state;
+    if (!state) return undefined;
+    const identity = resolveUiConversationIdentity(state, state.sessionKey);
+    if (identity.agentId) {
+      return identity;
+    }
+    const session = getAcceptedChatHistorySession(state);
+    // Raw retained panes follow their accepted history owner, never the selected assistant.
+    if (session && parseAgentSessionKey(session.key)) {
+      return resolveUiConversationIdentity(state, session.key);
+    }
+    return session?.agentId && (session.key === "global" || session.key === "unknown")
+      ? { sessionKey: session.key, agentId: session.agentId }
+      : undefined;
+  }
 
   protected isCurrentSessionArchived(state: ChatPageHost): boolean {
     return (

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -307,7 +307,9 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
 
   protected resolveChatReadTarget(): ReturnType<typeof resolveUiConversationIdentity> | undefined {
     const state = this.state;
-    if (!state) return undefined;
+    if (!state) {
+      return undefined;
+    }
     const identity = resolveUiConversationIdentity(state, state.sessionKey);
     if (identity.agentId) {
       return identity;

--- a/ui/src/pages/chat/chat-pane-board.test.ts
+++ b/ui/src/pages/chat/chat-pane-board.test.ts
@@ -98,7 +98,9 @@ let theme: ReturnType<typeof createApplicationTheme>;
 
 function createTestPane(sessions: SessionCapability = {} as SessionCapability) {
   const pane = document.createElement("openclaw-chat-pane") as unknown as TestChatPane;
-  const client = {} as GatewayBrowserClient;
+  const client = {
+    request: vi.fn(async () => ({ session: { key: "agent:main:current", kind: "direct" } })),
+  } as unknown as GatewayBrowserClient;
   Object.defineProperty(pane, "isConnected", { configurable: true, value: true });
   pane.context = {
     theme,

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -1,6 +1,7 @@
 import { html, nothing } from "lit";
 import { guard } from "lit/directives/guard.js";
 import { GATEWAY_SERVER_CAPS } from "../../../../packages/gateway-protocol/src/index.js";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import { hasOperatorApprovalsAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { patchSettings } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
@@ -23,7 +24,6 @@ import {
   canonicalUiSessionKeyForPersistence,
   normalizeSessionKeyForUiComparison,
   parseAgentSessionKey,
-  resolveAgentIdFromSessionKey,
   resolveUiConversationIdentity,
 } from "../../lib/sessions/session-key.ts";
 import { ensureBoardViewElement, renderBoardSessionSurface } from "./board-session-surface.ts";
@@ -201,13 +201,23 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     if (!state || !this.presented) {
       return;
     }
-    const parentKey = this.resolveBoardSessionKey();
+    const target = this.resolveChatReadTarget();
+    if (!target) {
+      this.swarmHydrator?.dispose();
+      this.swarmHydrator = null;
+      return;
+    }
+    const { sessionKey: parentKey, agentId } = target;
+    const client = state.client;
+    if (!client) return;
     const sourceEpoch = state.connectionEpoch;
     const isCurrent = () =>
       this.state === state &&
       this.presented &&
+      state.client === client &&
       state.connectionEpoch === sourceEpoch &&
-      parentKey === this.resolveBoardSessionKey();
+      parentKey === this.resolveChatReadTarget()?.sessionKey &&
+      agentId === this.resolveChatReadTarget()?.agentId;
     void import("../../lib/sessions/swarm-roster.ts").then(
       ({ isSwarmEnabledInConfig, SwarmRosterHydrator }) => {
         if (!isCurrent()) {
@@ -215,10 +225,7 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
         }
         const enabled =
           state.connected &&
-          isSwarmEnabledInConfig(
-            this.context.runtimeConfig?.state.configSnapshot?.config,
-            resolveAgentIdFromSessionKey(parentKey),
-          );
+          isSwarmEnabledInConfig(this.context.runtimeConfig?.state.configSnapshot?.config, agentId);
         if (!enabled) {
           if (this.swarmHydrator) {
             this.swarmHydrator.dispose();
@@ -231,7 +238,15 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
         this.swarmHydrator.update({
           sessions: this.context.sessions,
           parentKey,
+          agentId,
           sourceEpoch,
+          readParent: () =>
+            client
+              .request<{ session: GatewaySessionRow | null }>("sessions.describe", {
+                key: parentKey,
+                ...(parseAgentSessionKey(parentKey) ? {} : { agentId }),
+              })
+              .then((result) => result.session),
           currentRows: () => (isCurrent() ? (state.sessionsResult?.sessions ?? []) : []),
           onRows: () => {
             if (isCurrent()) {

--- a/ui/src/pages/chat/chat-pane-board.ts
+++ b/ui/src/pages/chat/chat-pane-board.ts
@@ -209,7 +209,9 @@ export abstract class ChatPaneBoard extends ChatPaneHistory {
     }
     const { sessionKey: parentKey, agentId } = target;
     const client = state.client;
-    if (!client) return;
+    if (!client) {
+      return;
+    }
     const sourceEpoch = state.connectionEpoch;
     const isCurrent = () =>
       this.state === state &&

--- a/ui/src/pages/chat/chat-pane-identity.test.ts
+++ b/ui/src/pages/chat/chat-pane-identity.test.ts
@@ -196,7 +196,7 @@ describe("chat pane assistant identity snapshots", () => {
   });
 
   it("keeps a session-specific assistant identity across ordinary gateway snapshots", () => {
-    const client = {} as GatewayBrowserClient;
+    const client = createGatewayBrowserClientFixture();
     const { pane } = createTestChatPane({ client, sessions: {} as SessionCapability });
     const state = (pane as unknown as { state: ChatPageHost }).state;
     state.client = client;
@@ -212,8 +212,8 @@ describe("chat pane assistant identity snapshots", () => {
   });
 
   it("resets a session-specific identity when the logical connection changes", () => {
-    const client = {} as GatewayBrowserClient;
-    const nextClient = {} as GatewayBrowserClient;
+    const client = createGatewayBrowserClientFixture();
+    const nextClient = createGatewayBrowserClientFixture();
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
     state.assistantName = "Session Agent";
 

--- a/ui/src/pages/chat/chat-pane-progress-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-progress-history.test.ts
@@ -8,13 +8,19 @@ import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { SessionProgressCardController } from "../../components/session-progress-card-controller.ts";
-import type { SessionCapability } from "../../lib/sessions/index.ts";
 import { resolveUiConversationIdentity } from "../../lib/sessions/session-key.ts";
+import { createSessionsListResult } from "../../test-helpers/chat-model.ts";
+import type { GatewayRequestHandler } from "../../test-helpers/gateway-client.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import type { ChatHistoryResult } from "./chat-history-snapshot.ts";
 import { resetChatHistoryProjection } from "./chat-history-state.ts";
 import { loadChatHistory } from "./chat-history.ts";
-import { createTestChatPane, type TestChatPane } from "./chat-pane.test-support.ts";
+import {
+  createGatewayBrowserClientFixture,
+  createSessionCapabilityFixture,
+  createTestChatPane,
+  type TestChatPane,
+} from "./chat-pane.test-support.ts";
 
 const history: ChatHistoryResult = {
   sessionId: "research-notes",
@@ -37,9 +43,12 @@ function progressCard(revision = 1): ProgressCard {
   };
 }
 
-function createHistoryProgressPane(request: ReturnType<typeof vi.fn>) {
-  const client = { request } as unknown as GatewayBrowserClient;
-  const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
+function createHistoryProgressPane(
+  request: GatewayRequestHandler,
+  sessions = createSessionCapabilityFixture(),
+) {
+  const client = createGatewayBrowserClientFixture({ request });
+  const { pane, state } = createTestChatPane({ client, sessions });
   const hello = gatewayHelloForMethods(["chat.history", "progressCard.get", "progressCard.put"]);
   pane.context.gateway.snapshot.hello = hello;
   state.hello = hello;
@@ -132,7 +141,11 @@ describe("retained bare pane progress follows accepted history ownership", () =>
           ? { session }
           : { card: null },
     );
-    const { pane, state } = createHistoryProgressPane(request);
+    const sessions = createSessionCapabilityFixture({
+      canonicalListRevision: 1,
+      list: vi.fn(async () => createSessionsListResult({ omitSessionFromList: true })),
+    });
+    const { pane, state } = createHistoryProgressPane(request, sessions);
     pane.sessionKey = target.raw;
     state.sessionKey = target.raw;
     state.settings = {
@@ -140,12 +153,6 @@ describe("retained bare pane progress follows accepted history ownership", () =>
       sessionKey: target.raw,
       lastActiveSessionKey: target.raw,
     };
-    const sessions = {
-      canonicalListRevision: 1,
-      list: vi.fn(async () => ({ sessions: [] })),
-    } as unknown as SessionCapability;
-    pane.context.sessions = sessions;
-    state.sessions = sessions;
     const swarmPane = pane as TestChatPane & {
       refreshSwarmRoster: () => void;
       swarmHydrator?: { dispose: () => void; rows: GatewaySessionRow[] };

--- a/ui/src/pages/chat/chat-pane-progress-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-progress-history.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../../api/gateway.ts";
+import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import type { SessionProgressCardController } from "../../components/session-progress-card-controller.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
@@ -112,6 +113,53 @@ describe("retained bare pane progress follows accepted history ownership", () =>
       expectedRevision: 2,
     });
     expect(progress.card).toBeNull();
+  });
+
+  it.each([
+    { raw: "notes", canonical: "agent:research:notes", request: { key: "agent:research:notes" } },
+    { raw: "unknown", canonical: "unknown", request: { key: "unknown", agentId: "research" } },
+  ])("binds Swarm parent reads to accepted $raw history", async (target) => {
+    const session: GatewaySessionRow = {
+      ...expectDefined(history.sessionInfo, "accepted history session"),
+      key: target.canonical,
+      agentId: "research",
+      kind: "direct",
+    };
+    const request = vi.fn(async (method: string) =>
+      method === "chat.history"
+        ? { ...history, sessionInfo: session }
+        : method === "sessions.describe"
+          ? { session }
+          : { card: null },
+    );
+    const { pane, state } = createHistoryProgressPane(request);
+    pane.sessionKey = target.raw;
+    state.sessionKey = target.raw;
+    state.settings = {
+      ...state.settings,
+      sessionKey: target.raw,
+      lastActiveSessionKey: target.raw,
+    };
+    const sessions = {
+      canonicalListRevision: 1,
+      list: vi.fn(async () => ({ sessions: [] })),
+    } as unknown as SessionCapability;
+    pane.context.sessions = sessions;
+    state.sessions = sessions;
+    const swarmPane = pane as TestChatPane & {
+      refreshSwarmRoster: () => void;
+      swarmHydrator?: { dispose: () => void; rows: GatewaySessionRow[] };
+    };
+    onTestFinished(() => swarmPane.swarmHydrator?.dispose());
+    swarmPane.refreshSwarmRoster();
+    expect(request).not.toHaveBeenCalled();
+    await loadChatHistory(state, { deferBranches: true });
+    swarmPane.refreshSwarmRoster();
+    await vi.waitFor(() =>
+      expect(request).toHaveBeenCalledWith("sessions.describe", target.request),
+    );
+    await vi.waitFor(() => expect(swarmPane.swarmHydrator?.rows).toContainEqual(session));
+    expect(state.sessionKey).toBe(target.raw);
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -78,6 +78,7 @@ export class ChatPane extends ChatPaneLayoutRender {
     }
     void this.ensureTaskSuggestionCloudProfiles();
     const selectedSession = selectedChatSessionRow(state);
+    const swarmTarget = this.resolveChatReadTarget();
     const selectedSessionArchived = this.isCurrentSessionArchived(state);
     const mutationAccess = readChatPaneMutationAccess(
       this.context.gateway.snapshot,
@@ -506,7 +507,7 @@ export class ChatPane extends ChatPaneLayoutRender {
               (composerState.capabilityMenuView === "skills" ||
                 composerState.capabilityMenuView.startsWith("library:")),
           ),
-      swarmSessions: this.swarmHydrator?.rows ?? [],
+      swarm: swarmTarget ? { ...swarmTarget, sessions: this.swarmHydrator?.rows ?? [] } : undefined,
       sessionHost: {
         assistantAgentId: state.assistantAgentId,
         agentsList: state.agentsList,

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -29,6 +29,7 @@ import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import type { TaskSuggestionAcceptMode } from "../../lib/task-suggestion-acceptance.ts";
 import "./chat-pane.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import {
   gatewayHelloForMethods,
   SESSION_MUTATION_TEST_METHODS,
@@ -188,7 +189,15 @@ type GatewayBrowserClientFixtureOverrides = Omit<Partial<GatewayBrowserClient>, 
 export function createGatewayBrowserClientFixture(
   overrides: GatewayBrowserClientFixtureOverrides = {},
 ): GatewayBrowserClient {
-  return overrides as typeof overrides & GatewayBrowserClient;
+  const {
+    request = (method) => (method === "sessions.describe" ? { session: null } : {}),
+    ...properties
+  } = overrides;
+  const client = createTestGatewayClient(request);
+  for (const [key, value] of Object.entries(properties)) {
+    Object.defineProperty(client, key, { configurable: true, writable: true, value });
+  }
+  return client;
 }
 
 function withLivePreferences(context: Omit<ApplicationContext, "theme">): ApplicationContext {
@@ -344,7 +353,7 @@ export function createSessionContext(
     chatSubmissions: createChatSubmissions(),
     chatAttachmentHandoff: createChatAttachmentHandoff(),
     nativeChatDrafts: { subscribe: () => () => undefined },
-    placementStartup: { get: vi.fn(() => null), pause: vi.fn() },
+    placementStartup: { get: vi.fn(() => null), hasPendingTurn: () => false, pause: vi.fn() },
     sessions,
   } as unknown as Omit<ApplicationContext, "theme">);
 }
@@ -409,6 +418,7 @@ export function createTestChatPane(params: {
   pane.state = state;
   pane.connectedClient = params.client;
   pane.connectionGeneration = 4;
+  onTestFinished(() => pane.disconnectedCallback());
   return {
     pane,
     requestUpdate,

--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -29,7 +29,10 @@ import type { CatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
 import type { TaskSuggestionAcceptMode } from "../../lib/task-suggestion-acceptance.ts";
 import "./chat-pane.ts";
-import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import {
+  createTestGatewayClient,
+  type GatewayRequestHandler,
+} from "../../test-helpers/gateway-client.ts";
 import {
   gatewayHelloForMethods,
   SESSION_MUTATION_TEST_METHODS,
@@ -183,7 +186,7 @@ export type TestChatPane = HTMLElement & {
 };
 
 type GatewayBrowserClientFixtureOverrides = Omit<Partial<GatewayBrowserClient>, "request"> & {
-  request?: (method: string, params?: unknown) => unknown;
+  request?: GatewayRequestHandler;
 };
 
 export function createGatewayBrowserClientFixture(

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -8,6 +8,7 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { showToast } from "../../lib/toast.ts";
 import { createGatewayRequestMock } from "../../test-helpers/gateway-client.ts";
+import { settleLitElement } from "../../test-helpers/lit-settle.ts";
 import {
   installDialogPolyfill,
   submitInputDialog,
@@ -112,11 +113,11 @@ describe("chat pane retained presentation", () => {
     const lifecycle = pane as TestChatPane & { hasUpdated: boolean; render: () => unknown };
     lifecycle.render = () => null;
     ChatPaneBase.prototype.connectedCallback.call(lifecycle);
-    await lifecycle.updateComplete;
+    await settleLitElement(lifecycle);
     const performUpdate = vi.spyOn(lifecycle, "performUpdate");
 
     lifecycle.onPaneSessionChange = () => undefined;
-    await lifecycle.updateComplete;
+    await settleLitElement(lifecycle);
 
     expect(performUpdate).not.toHaveBeenCalled();
     ChatPaneBase.prototype.disconnectedCallback.call(lifecycle);

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -877,34 +877,58 @@ function createBackgroundTasks(
 }
 
 describe("chat Swarm progress", () => {
-  it("stays visible during an active run between the transcript and composer", () => {
-    const parentSessionKey = "agent:main:parent";
-    const container = renderChatView({
-      sessionKey: parentSessionKey,
-      canAbort: true,
-      showNewMessages: true,
-      swarmSessions: [
-        {
-          key: "agent:main:subagent:worker",
-          kind: "direct",
-          updatedAt: 1,
-          parentSessionKey,
-          swarmGroupId: "swarm:agent:main:parent:turn-42",
-          label: "Worker A",
-          status: "running",
+  it.each(["agent:main:parent", "parent"])(
+    "stays visible for %s between the transcript and composer",
+    (routeKey) => {
+      const parentSessionKey = "agent:main:parent";
+      const container = renderChatView({
+        sessionKey: routeKey,
+        canAbort: true,
+        showNewMessages: true,
+        swarm: {
+          sessionKey: parentSessionKey,
+          sessions: [
+            {
+              key: "agent:main:parent",
+              kind: "direct",
+              swarm: {
+                groups: [
+                  {
+                    groupId: "swarm:agent:main:parent:turn-42",
+                    createdAt: 1,
+                    children: [{ sessionKey: "agent:main:subagent:worker", status: "running" }],
+                    queued: 0,
+                    running: 1,
+                    done: 0,
+                    failed: 0,
+                  },
+                ],
+                otherActiveGroups: 0,
+              },
+            },
+            {
+              key: "agent:main:subagent:worker",
+              kind: "direct",
+              updatedAt: 1,
+              parentSessionKey,
+              swarmGroupId: "swarm:agent:main:parent:turn-42",
+              label: "Worker A",
+              status: "running",
+            },
+          ],
         },
-      ],
-    });
+      });
 
-    const widget = requireElement(container, "[data-test-id=chat-swarm]", "Swarm progress");
-    const shell = requireElement(container, ".agent-chat__composer-shell", "composer shell");
-    const scrollAnchor = widget.previousElementSibling;
-    expect(scrollAnchor?.classList.contains("chat-scroll-to-bottom-wrap")).toBe(true);
-    expect(scrollAnchor?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
-    expect(widget.parentElement).toBe(shell.parentElement);
-    expect(widget.compareDocumentPosition(shell)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-    expect(container.querySelector(".chat-swarm__task-name")?.textContent).toBe("Worker A");
-  });
+      const widget = requireElement(container, "[data-test-id=chat-swarm]", "Swarm progress");
+      const shell = requireElement(container, ".agent-chat__composer-shell", "composer shell");
+      const scrollAnchor = widget.previousElementSibling;
+      expect(scrollAnchor?.classList.contains("chat-scroll-to-bottom-wrap")).toBe(true);
+      expect(scrollAnchor?.previousElementSibling?.classList.contains("chat-thread")).toBe(true);
+      expect(widget.parentElement).toBe(shell.parentElement);
+      expect(widget.compareDocumentPosition(shell)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(container.querySelector(".chat-swarm__task-name")?.textContent).toBe("Worker A");
+    },
+  );
 });
 
 describe("inline approval card", () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -11,7 +11,6 @@ import type {
   ControlUiSessionBranch,
   ControlUiSessionPullRequest,
 } from "../../../../src/gateway/control-ui-contract.js";
-import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ExecApprovalDecision, ExecApprovalRequest } from "../../app/exec-approval.ts";
 import { renderExecApprovalCard } from "../../components/exec-approval-card.ts";
 import { icons } from "../../components/icons.ts";
@@ -90,7 +89,7 @@ export type ChatProps = Omit<
     ) => void | Promise<void>;
     workspaceConflict?: WorkspaceResultConflict;
     onDismissWorkspaceConflict?: () => void;
-    swarmSessions?: readonly GatewaySessionRow[];
+    swarm?: Parameters<typeof renderChatSwarmProgress>[0];
     focusMode?: boolean;
     chatMessageMaxWidth?: string | null;
     showNewMessages?: boolean;
@@ -430,10 +429,7 @@ export function renderChat(props: ChatProps) {
                     onResolve: (suggestion, resolution) =>
                       props.onResolveSessionSuggestion?.(suggestion, resolution),
                   })}
-                  ${renderChatSwarmProgress({
-                    sessions: props.swarmSessions ?? [],
-                    sessionKey: props.sessionKey,
-                  })}
+                  ${props.swarm ? renderChatSwarmProgress(props.swarm) : nothing}
                   <openclaw-plugin-contributions
                     .kind=${"composer"}
                     .sessionKey=${props.sessionKey}

--- a/ui/src/pages/chat/components/chat-swarm-progress.test.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.test.ts
@@ -2,6 +2,8 @@
 
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SubagentRunReadRecord } from "../../../../../src/agents/subagents/registry/subagent-registry.types.js";
+import { buildSessionSwarmSummary } from "../../../../../src/gateway/session-swarm-summary.js";
 import type { GatewaySessionRow } from "../../../api/types.ts";
 import { i18n } from "../../../i18n/index.ts";
 import { pt_BR } from "../../../i18n/locales/pt-BR.ts";
@@ -31,10 +33,43 @@ function session(overrides: Partial<SwarmTestSession>): SwarmTestSession {
   };
 }
 
+function withSummary(sessions: readonly GatewaySessionRow[]): GatewaySessionRow[] {
+  const runs: SubagentRunReadRecord[] = sessions
+    .filter((child) => child.swarmGroupId)
+    .map((child) => ({
+      runId: child.key,
+      childSessionKey: child.key,
+      requesterSessionKey: parentSessionKey,
+      requesterAgentId: "main",
+      swarmRequesterSessionKey: parentSessionKey,
+      collect: true,
+      groupId: child.swarmGroupId,
+      createdAt: child.updatedAt ?? 1,
+      execution: { status: child.status === "queued" ? "queued" : "running" },
+      ...(child.status === "done" ||
+      child.status === "failed" ||
+      child.status === "killed" ||
+      child.status === "timeout"
+        ? { collectorCompletion: { status: child.status } }
+        : {}),
+    }));
+  return [
+    {
+      key: parentSessionKey,
+      kind: "direct",
+      swarm: buildSessionSwarmSummary(runs, parentSessionKey, "main", { includeChildren: true }),
+    },
+    ...sessions,
+  ];
+}
+
 function renderProgress(sessions: readonly GatewaySessionRow[]) {
   const container = document.createElement("div");
   document.body.append(container);
-  render(renderChatSwarmProgress({ sessionKey: parentSessionKey, sessions }), container);
+  render(
+    renderChatSwarmProgress({ sessionKey: parentSessionKey, sessions: withSummary(sessions) }),
+    container,
+  );
   return container;
 }
 
@@ -82,11 +117,6 @@ describe("chat Swarm progress", () => {
       session({ key: "running", label: "Running child", status: "running" }),
       session({ key: "done", label: "Done child", status: "done" }),
       session({ key: "failed", label: "Timed out child", status: "timeout" }),
-      session({
-        key: "finished-group",
-        swarmGroupId: "swarm:agent:main:parent:finished",
-        status: "done",
-      }),
     ]);
 
     const group = container.querySelector("[data-swarm-group]");
@@ -148,10 +178,17 @@ describe("chat Swarm progress", () => {
         list: vi.fn(async () => ({ sessions: [hydrated], hasMore: false })),
       } as unknown as SessionCapability,
       parentKey: parentSessionKey,
+      readParent: async () => ({ key: parentSessionKey, kind: "direct" as const }),
       sourceEpoch: 1,
       currentRows: () => currentRows,
       onRows: (sessions: GatewaySessionRow[]) =>
-        render(renderChatSwarmProgress({ sessionKey: parentSessionKey, sessions }), container),
+        render(
+          renderChatSwarmProgress({
+            sessionKey: parentSessionKey,
+            sessions: withSummary(sessions),
+          }),
+          container,
+        ),
     };
     try {
       hydrator.update(params);
@@ -194,7 +231,7 @@ describe("chat Swarm progress", () => {
       session({ key: "running", status: "running" }),
     ]);
 
-    expect(container.querySelectorAll(".chat-swarm__task")).toHaveLength(256);
+    expect(container.querySelectorAll(".chat-swarm__task")).toHaveLength(64);
     expect(container.querySelector(".chat-swarm__task-icon--running")).not.toBeNull();
     expect(
       container.querySelector(".chat-swarm__header")?.textContent?.replace(/\s+/g, " "),
@@ -215,7 +252,7 @@ describe("chat Swarm progress", () => {
     expect(container.querySelector("[data-test-id=chat-swarm]")).toBeNull();
   });
 
-  it("keeps registry-active terminal workers completed and hides finished groups", () => {
+  it("keeps completed and failed child outcomes visible after the group finishes", () => {
     const running = session({ key: "running", status: "running" });
     const completed = session({ key: "completed", status: "done", hasActiveRun: true });
     const failed = session({ key: "failed", status: "failed", hasActiveRun: true });
@@ -226,10 +263,15 @@ describe("chat Swarm progress", () => {
     expect(container.querySelectorAll(".chat-swarm__task-icon--failed")).toHaveLength(1);
 
     render(
-      renderChatSwarmProgress({ sessionKey: parentSessionKey, sessions: [completed, failed] }),
+      renderChatSwarmProgress({
+        sessionKey: parentSessionKey,
+        sessions: withSummary([completed, failed]),
+      }),
       container,
     );
-    expect(container.querySelector("[data-test-id=chat-swarm]")).toBeNull();
+    expect(container.querySelector("[data-test-id=chat-swarm]")).not.toBeNull();
+    expect(container.textContent).toContain("1 completed · 1 failed");
+    expect(container.textContent).toContain("Check the conversation for the final response");
   });
 
   it("keeps tasks from every phase in the compact detail", () => {
@@ -318,4 +360,35 @@ describe("chat Swarm progress", () => {
       { label: "Done", duration: "7s" },
     ]);
   });
+  it.each(["global", "unknown"])(
+    "keeps raw %s owners separate from ordinary qualified keys",
+    (raw) => {
+      const makeParent = (key: string, agentId: string, done: number): GatewaySessionRow => ({
+        key,
+        agentId,
+        kind: "direct",
+        swarm: {
+          groups: [{ groupId: "custom", createdAt: 1, queued: 0, running: 0, done, failed: 0 }],
+          otherActiveGroups: 0,
+        },
+      });
+      const sessions = [
+        makeParent(raw, "main", 1),
+        makeParent(raw, "research", 2),
+        makeParent(`agent:main:${raw}`, "main", 3),
+      ];
+      const container = document.createElement("div");
+      document.body.append(container);
+      for (const target of [
+        { sessionKey: raw, agentId: "main", count: 1 },
+        { sessionKey: raw, agentId: "research", count: 2 },
+        { sessionKey: `agent:main:${raw}`, agentId: "main", count: 3 },
+      ]) {
+        render(renderChatSwarmProgress({ ...target, sessions }), container);
+        expect(container.textContent).toContain(`${target.count} of ${target.count}`);
+      }
+      render(renderChatSwarmProgress({ sessionKey: raw, sessions }), container);
+      expect(container.querySelector("[data-test-id=chat-swarm]")).toBeNull();
+    },
+  );
 });

--- a/ui/src/pages/chat/components/chat-swarm-progress.test.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.test.ts
@@ -46,12 +46,13 @@ function withSummary(sessions: readonly GatewaySessionRow[]): GatewaySessionRow[
       groupId: child.swarmGroupId,
       createdAt: child.updatedAt ?? 1,
       execution: { status: child.status === "queued" ? "queued" : "running" },
-      ...(child.status === "done" ||
-      child.status === "failed" ||
-      child.status === "killed" ||
-      child.status === "timeout"
-        ? { collectorCompletion: { status: child.status } }
-        : {}),
+      collectorCompletion:
+        child.status === "done" ||
+        child.status === "failed" ||
+        child.status === "killed" ||
+        child.status === "timeout"
+          ? { status: child.status }
+          : undefined,
     }));
   return [
     {

--- a/ui/src/pages/chat/components/chat-swarm-progress.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.ts
@@ -46,7 +46,9 @@ function collectSwarmTasks(
   for (const row of sessions) {
     const groupId = row.swarmGroupId?.trim();
     const status = groupId ? members.get(groupId)?.get(row.key) : undefined;
-    if (!status || !groupId) continue;
+    if (!status || !groupId) {
+      continue;
+    }
     const entries = byGroup.get(groupId) ?? [];
     entries.push({
       phaseRank: row.swarmPhaseRank ?? Number.MAX_SAFE_INTEGER,

--- a/ui/src/pages/chat/components/chat-swarm-progress.ts
+++ b/ui/src/pages/chat/components/chat-swarm-progress.ts
@@ -1,18 +1,13 @@
 import { html, nothing, type TemplateResult } from "lit";
-import { ref } from "lit/directives/ref.js";
+import { repeat } from "lit/directives/repeat.js";
 import type { GatewaySessionRow } from "../../../api/types.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatDurationCompact } from "../../../lib/format.ts";
 import { resolveSessionDisplayName } from "../../../lib/session-display.ts";
-import { isSessionRunActive } from "../../../lib/session-run-state.ts";
 import { areUiSessionKeysEquivalent } from "../../../lib/sessions/session-key.ts";
-import { replaceComposerPopoverAnchor } from "./chat-composer-dom.ts";
 
 type SwarmDotStatus = "queued" | "running" | "done" | "failed";
-
-const SWARM_DOT_STATUS_RANK = { running: 0, queued: 1, failed: 2, done: 3 } as const;
-const MAX_RENDERED_DOTS_PER_PHASE = 256;
 
 type SwarmDot = {
   key: string;
@@ -20,58 +15,6 @@ type SwarmDot = {
   status: SwarmDotStatus;
   duration: string;
 };
-
-type SwarmPhase = {
-  title?: string;
-  dots: SwarmDot[];
-};
-
-type SwarmGroup = {
-  groupId: string;
-  phases: SwarmPhase[];
-};
-
-type SwarmPhaseCarrier = {
-  swarmPhase?: unknown;
-  swarmPhaseRank?: unknown;
-};
-
-function swarmDotStatus(row: GatewaySessionRow): SwarmDotStatus | null {
-  if (row.status === "queued") {
-    return "queued";
-  }
-  if (isSessionRunActive(row)) {
-    return "running";
-  }
-  if (row.status === "done") {
-    return "done";
-  }
-  if (row.status === "failed" || row.status === "killed" || row.status === "timeout") {
-    return "failed";
-  }
-  return row.subagentRunState === "active" ? "queued" : null;
-}
-
-function swarmPhaseRank(row: GatewaySessionRow): number {
-  const rank = (row as GatewaySessionRow & SwarmPhaseCarrier).swarmPhaseRank;
-  return typeof rank === "number" && Number.isFinite(rank) ? rank : Number.MAX_SAFE_INTEGER;
-}
-
-function swarmPhase(row: GatewaySessionRow): string | undefined {
-  const phase = (row as GatewaySessionRow & SwarmPhaseCarrier).swarmPhase;
-  return typeof phase === "string" && phase.trim() ? phase.trim() : undefined;
-}
-
-function isSwarmChildForSession(row: GatewaySessionRow, sessionKey: string): boolean {
-  if (
-    (row.parentSessionKey && areUiSessionKeysEquivalent(row.parentSessionKey, sessionKey)) ||
-    (row.spawnedBy && areUiSessionKeysEquivalent(row.spawnedBy, sessionKey))
-  ) {
-    return true;
-  }
-  const owner = row.swarmGroupId?.split(":").slice(1, -1).join(":");
-  return Boolean(owner && areUiSessionKeysEquivalent(owner, sessionKey));
-}
 
 function swarmDuration(row: GatewaySessionRow, status: SwarmDotStatus): string {
   if (status === "queued") {
@@ -89,24 +32,24 @@ function swarmDuration(row: GatewaySessionRow, status: SwarmDotStatus): string {
   return formatDurationCompact(durationMs) ?? "—";
 }
 
-function collectActiveSwarmGroups(
+function collectSwarmTasks(
   sessions: readonly GatewaySessionRow[],
-  sessionKey: string,
-): SwarmGroup[] {
-  const byGroup = new Map<string, Array<{ phase?: string; phaseRank: number; dot: SwarmDot }>>();
+  groups: NonNullable<GatewaySessionRow["swarm"]>["groups"],
+): Map<string, SwarmDot[]> {
+  const byGroup = new Map<string, Array<{ phaseRank: number; dot: SwarmDot }>>();
+  const members = new Map(
+    groups.map((group) => [
+      group.groupId,
+      new Map((group.children ?? []).map((child) => [child.sessionKey, child.status])),
+    ]),
+  );
   for (const row of sessions) {
     const groupId = row.swarmGroupId?.trim();
-    if (!groupId || !isSwarmChildForSession(row, sessionKey)) {
-      continue;
-    }
-    const status = swarmDotStatus(row);
-    if (!status) {
-      continue;
-    }
+    const status = groupId ? members.get(groupId)?.get(row.key) : undefined;
+    if (!status || !groupId) continue;
     const entries = byGroup.get(groupId) ?? [];
     entries.push({
-      phase: swarmPhase(row),
-      phaseRank: swarmPhaseRank(row),
+      phaseRank: row.swarmPhaseRank ?? Number.MAX_SAFE_INTEGER,
       dot: {
         key: row.key,
         label: resolveSessionDisplayName(row.key, row, { includeSubagentPrefix: false }),
@@ -116,138 +59,95 @@ function collectActiveSwarmGroups(
     });
     byGroup.set(groupId, entries);
   }
-
-  return [...byGroup.entries()]
-    .map(([groupId, entries]) => {
-      const phases = new Map<string | undefined, { rank: number; dots: SwarmDot[] }>();
-      for (const entry of entries) {
-        const bucket = phases.get(entry.phase) ?? { rank: entry.phaseRank, dots: [] };
-        bucket.rank = Math.min(bucket.rank, entry.phaseRank);
-        bucket.dots.push(entry.dot);
-        phases.set(entry.phase, bucket);
-      }
-      return {
-        groupId,
-        phases: [...phases.entries()]
-          .toSorted((left, right) => left[1].rank - right[1].rank)
-          .map(([title, bucket]) => {
-            const visibleFirst =
-              bucket.dots.length > MAX_RENDERED_DOTS_PER_PHASE
-                ? bucket.dots.toSorted(
-                    (left, right) =>
-                      SWARM_DOT_STATUS_RANK[left.status] - SWARM_DOT_STATUS_RANK[right.status],
-                  )
-                : bucket.dots;
-            return {
-              title,
-              dots: visibleFirst,
-            };
-          }),
-      } satisfies SwarmGroup;
-    })
-    .filter((group) =>
-      group.phases.some((phase) =>
-        phase.dots.some((dot) => dot.status === "queued" || dot.status === "running"),
-      ),
-    )
-    .toSorted((left, right) => left.groupId.localeCompare(right.groupId));
+  return new Map(
+    [...byGroup].map(([groupId, entries]) => [
+      groupId,
+      entries.toSorted((left, right) => left.phaseRank - right.phaseRank).map((entry) => entry.dot),
+    ]),
+  );
 }
 
 export function renderChatSwarmProgress({
   sessions,
   sessionKey,
+  agentId,
 }: {
   sessions: readonly GatewaySessionRow[];
   sessionKey: string;
+  agentId?: string;
 }): TemplateResult | typeof nothing {
-  const groups = collectActiveSwarmGroups(sessions, sessionKey);
-  if (groups.length === 0) {
+  const summary = sessions.find(
+    (row) =>
+      areUiSessionKeysEquivalent(row.key, sessionKey) &&
+      ((sessionKey !== "global" && sessionKey !== "unknown") ||
+        Boolean(agentId && row.agentId === agentId)),
+  )?.swarm;
+  if (!summary?.groups.length) {
     return nothing;
   }
-  return html`
-    <aside
-      class="chat-swarm"
-      data-test-id="chat-swarm"
-      role="status"
-      aria-live="off"
-      aria-label=${t("labsPage.swarm.title")}
-    >
-      ${groups.map((group) => {
-        const allTasks = group.phases.flatMap((phase) => phase.dots);
-        // Group IDs identify the parent run, not the work; never use them as titles.
-        const label =
-          allTasks.length === 1 && allTasks[0] ? allTasks[0].label : t("labsPage.swarm.groupTitle");
-        const tasks = group.phases.flatMap((phase) =>
-          phase.dots.slice(0, MAX_RENDERED_DOTS_PER_PHASE),
-        );
-        const complete = allTasks.filter(
-          (task) => task.status === "done" || task.status === "failed",
-        ).length;
-        const hasFailure = allTasks.some((task) => task.status === "failed");
-        let popoverAnchor: HTMLElement | null = null;
-        return html`
-          <div
-            class="chat-swarm__group ${hasFailure ? "chat-swarm__group--failed" : ""}"
-            data-swarm-group=${group.groupId}
-            tabindex="0"
-            ${ref((element) => {
-              popoverAnchor = replaceComposerPopoverAnchor(popoverAnchor, element);
-            })}
-          >
+  const details = collectSwarmTasks(sessions, summary.groups);
+  return html` <aside
+    class="chat-swarm"
+    data-test-id="chat-swarm"
+    role="status"
+    aria-live="off"
+    aria-label=${t("labsPage.swarm.title")}
+  >
+    ${repeat(
+      summary.groups,
+      (group) => group.groupId,
+      (group) => {
+        const tasks = details.get(group.groupId) ?? [];
+        const total = group.queued + group.running + group.done + group.failed;
+        const complete = group.done + group.failed;
+        const terminal = complete === total;
+        const label = total === 1 && tasks[0] ? tasks[0].label : t("labsPage.swarm.groupTitle");
+        const counts = t(terminal ? "labsPage.swarm.finished" : "labsPage.swarm.active", {
+          running: String(group.running),
+          queued: String(group.queued),
+          done: String(group.done),
+          failed: String(group.failed),
+        });
+        // Counts come from the requester registry, not the surviving child-session page.
+        const markers = (["running", "queued", "failed", "done"] as const)
+          .flatMap((status) => Array.from({ length: Math.min(group[status], 64) }, () => status))
+          .slice(0, 64);
+        return html` <details
+          class="chat-swarm__group ${group.failed > 0 ? "chat-swarm__group--failed" : ""}"
+          data-swarm-group=${group.groupId}
+        >
+          <summary class="chat-swarm__summary">
             <div class="chat-swarm__header">
               <strong title=${label}>${label}</strong>
               <span
-                >${t("labsPage.swarm.progress", {
-                  complete: String(complete),
-                  total: String(allTasks.length),
-                })}</span
+                >${t("labsPage.swarm.progress", { complete: String(complete), total: String(total) })}</span
               >
             </div>
-            <div class="chat-swarm__progress" aria-hidden="true">
-              ${group.phases.map((phase) => {
-                const phaseProgress =
-                  phase.dots.length === 0
-                    ? 0
-                    : Math.round(
-                        (phase.dots.filter(
-                          (task) => task.status === "done" || task.status === "failed",
-                        ).length /
-                          phase.dots.length) *
-                          100,
-                      );
-                const phaseFailed = phase.dots.some((task) => task.status === "failed");
-                return html`<span class="chat-swarm__progress-segment">
-                  <span
-                    class=${phaseFailed ? "chat-swarm__progress-fill--failed" : ""}
-                    style=${`width:${phaseProgress}%`}
-                  ></span>
-                </span>`;
-              })}
+            <div class="chat-swarm__markers" role="img" aria-label=${counts}>
+              ${markers.map((status) => html`<span class=${`chat-swarm__marker chat-swarm__marker--${status}`} aria-hidden="true"></span>`)}
+              ${total > markers.length ? html`<span>+${total - markers.length}</span>` : nothing}
             </div>
-            <div class="chat-swarm__tasks" role="list">
-              ${tasks.map(
-                (task) => html`
-                  <div class="chat-swarm__task" role="listitem">
-                    <span class=${`chat-swarm__task-icon chat-swarm__task-icon--${task.status}`}>
-                      ${
-                        task.status === "done"
-                          ? icons.check
-                          : task.status === "failed"
-                            ? icons.alertTriangle
-                            : task.status === "running"
-                              ? icons.loader
-                              : icons.clock
-                      }
-                    </span>
-                    <span class="chat-swarm__task-name">${task.label}</span>
-                    <span class="chat-swarm__task-duration">${task.duration}</span>
-                  </div>
-                `,
-              )}
-            </div>
+            <div class="chat-swarm__counts">${counts}</div>
+            ${terminal ? html`<div class="chat-swarm__outcome">${t("labsPage.swarm.childOutcome")}</div>` : nothing}
+            <span class="chat-swarm__disclosure"
+              >${t("labsPage.swarm.details")} ${icons.chevronDown}</span
+            >
+          </summary>
+          <div class="chat-swarm__tasks" role="list">
+            ${tasks.length === 0 ? html`<div class="chat-swarm__outcome">${t("labsPage.swarm.detailsUnavailable")}</div>` : nothing}
+            ${tasks.map(
+              (task) => html` <div class="chat-swarm__task" role="listitem">
+                <span class=${`chat-swarm__task-icon chat-swarm__task-icon--${task.status}`}>
+                  ${task.status === "done" ? icons.check : task.status === "failed" ? icons.alertTriangle : task.status === "running" ? icons.loader : icons.clock}
+                </span>
+                <span class="chat-swarm__task-name">${task.label}</span>
+                <span class="chat-swarm__task-duration">${task.duration}</span>
+              </div>`,
+            )}
           </div>
-        `;
-      })}
-    </aside>
-  `;
+        </details>`;
+      },
+    )}
+    ${summary.otherActiveGroups > 0 ? html`<div class="chat-swarm__outcome">${t("labsPage.swarm.otherGroups", { count: String(summary.otherActiveGroups) })}</div>` : nothing}
+  </aside>`;
 }

--- a/ui/src/pages/model-setup/model-setup-activation.test.ts
+++ b/ui/src/pages/model-setup/model-setup-activation.test.ts
@@ -17,6 +17,7 @@ import {
   detection,
   mountPage,
 } from "./model-setup-first-run.test-support.ts";
+import { MODEL_SETUP_AUTH_START_TIMEOUT_MS } from "./state.ts";
 
 describe("ModelSetupPage first-run activation ownership", () => {
   beforeEach(async () => {
@@ -345,14 +346,19 @@ describe("ModelSetupPage first-run activation ownership", () => {
       await waitForFast(() =>
         expect(original.request).toHaveBeenCalledWith(
           "openclaw.setup.auth.start",
-          expect.anything(),
+          { sessionId: expect.any(String), agentId: "main", authChoice: "provider-login" },
+          { timeoutMs: null },
         ),
       );
       [...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button")]
         .find((button) => button.textContent?.trim() === "Cancel")!
         .click();
       await waitForFast(() =>
-        expect(original.request).toHaveBeenCalledWith("wizard.cancel", expect.anything()),
+        expect(original.request).toHaveBeenCalledWith(
+          "wizard.cancel",
+          { sessionId: expect.any(String) },
+          { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
+        ),
       );
       // Explicitly leaving first-run setup releases its intent. Re-entering is
       // a distinct attempt; the old cancellation acknowledgement is still pending.
@@ -760,14 +766,22 @@ describe("ModelSetupPage first-run activation ownership", () => {
       });
       page.querySelector<HTMLButtonElement>('[data-auth-choice="provider-login"] button')!.click();
       await waitForFast(() =>
-        expect(request).toHaveBeenCalledWith("openclaw.setup.auth.start", expect.anything()),
+        expect(request).toHaveBeenCalledWith(
+          "openclaw.setup.auth.start",
+          { sessionId: expect.any(String), agentId: "main", authChoice: "provider-login" },
+          { timeoutMs: null },
+        ),
       );
       const cancel = [
         ...page.querySelectorAll<HTMLButtonElement>("openclaw-modal-dialog button"),
       ].find((button) => button.textContent?.trim() === "Cancel")!;
       cancel.click();
       await waitForFast(() =>
-        expect(request).toHaveBeenCalledWith("wizard.cancel", expect.anything()),
+        expect(request).toHaveBeenCalledWith(
+          "wizard.cancel",
+          { sessionId: expect.any(String) },
+          { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
+        ),
       );
       await page.updateComplete;
       expect(page.querySelector("openclaw-modal-dialog")).toBeNull();

--- a/ui/src/pages/model-setup/model-setup-consent.test.ts
+++ b/ui/src/pages/model-setup/model-setup-consent.test.ts
@@ -9,6 +9,7 @@ import {
   detection,
   mountPage,
 } from "./model-setup-first-run.test-support.ts";
+import { MODEL_SETUP_AUTH_START_TIMEOUT_MS } from "./state.ts";
 
 describe("ModelSetupPage activation consent", () => {
   beforeEach(async () => {
@@ -115,7 +116,11 @@ describe("ModelSetupPage activation consent", () => {
         if (decision === "decline") {
           expect(answers.at(-1)).toEqual({ stepId: "consent", value: false });
         } else {
-          expect(request).toHaveBeenCalledWith("wizard.cancel", { sessionId: activeSession });
+          expect(request).toHaveBeenCalledWith(
+            "wizard.cancel",
+            { sessionId: activeSession },
+            { timeoutMs: MODEL_SETUP_AUTH_START_TIMEOUT_MS },
+          );
         }
       }
       expect(

--- a/ui/src/pages/model-setup/model-setup-first-run.test-support.ts
+++ b/ui/src/pages/model-setup/model-setup-first-run.test-support.ts
@@ -27,7 +27,8 @@ function mutableGatewaySnapshot(snapshot: ApplicationGateway["snapshot"]) {
 }
 
 export function createFirstRunContext(refreshError?: string, beforeRefresh?: () => Promise<void>) {
-  const request = vi.fn<(method: string, params?: unknown) => Promise<unknown>>();
+  const request =
+    vi.fn<(...args: Parameters<GatewayBrowserClient["request"]>) => Promise<unknown>>();
   const client = createTestGatewayClient(request);
   const listeners = new Set<(snapshot: ApplicationGateway["snapshot"]) => void>();
   const snapshot = {

--- a/ui/src/pages/model-setup/model-setup-first-run.test.ts
+++ b/ui/src/pages/model-setup/model-setup-first-run.test.ts
@@ -17,6 +17,7 @@ import {
   mountPage,
   requestParameters,
 } from "./model-setup-first-run.test-support.ts";
+import { MODEL_SETUP_VERIFY_TIMEOUT_MS } from "./state.ts";
 
 describe("ModelSetupPage first-run inference", () => {
   beforeEach(async () => {
@@ -512,7 +513,11 @@ describe("ModelSetupPage first-run inference", () => {
       }
       expect(original.request).toHaveBeenCalledOnce();
       expect(relaunched.request).toHaveBeenCalledOnce();
-      expect(relaunched.request).toHaveBeenCalledWith("openclaw.setup.verify", { agentId: "main" });
+      expect(relaunched.request).toHaveBeenCalledWith(
+        "openclaw.setup.verify",
+        { agentId: "main" },
+        { timeoutMs: MODEL_SETUP_VERIFY_TIMEOUT_MS, signal: expect.any(AbortSignal) },
+      );
     },
   );
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1996,64 +1996,72 @@ openclaw-chat-video-player {
   font-variant-numeric: tabular-nums;
 }
 
-.chat-swarm__progress {
+.chat-swarm__summary {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+}
+
+.chat-swarm__summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-swarm__markers {
   display: flex;
-  gap: 2px;
-  height: 2px;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
 }
 
-.chat-swarm__progress-segment {
-  position: relative;
-  flex: 1 1 0;
-  overflow: hidden;
+.chat-swarm__marker {
+  width: 9px;
+  height: 9px;
+  border: 1px solid var(--muted);
   border-radius: var(--radius-full);
-  background: color-mix(in srgb, var(--muted) 24%, transparent);
 }
 
-.chat-swarm__progress-segment > span {
-  display: block;
-  height: 100%;
-  border-radius: inherit;
-  background: var(--accent);
+.chat-swarm__marker--running {
+  border-color: var(--info);
+  background: var(--info);
 }
-
-.chat-swarm__progress-segment > .chat-swarm__progress-fill--failed {
+.chat-swarm__marker--done {
+  border-color: var(--ok);
+  background: var(--ok);
+}
+.chat-swarm__marker--failed {
+  border-color: var(--danger);
   background: var(--danger);
 }
 
-.chat-swarm__tasks {
-  position: absolute;
-  z-index: 20;
-  left: 0;
-  right: 0;
-  bottom: calc(100% + 8px);
-  display: grid;
-  gap: 2px;
-  max-height: var(--chat-composer-popover-max-height, calc(100dvh - 116px));
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  padding: 8px;
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  border-radius: calc(14px * var(--openclaw-corner-radius-scale));
-  corner-shape: superellipse(1.5);
-  background: var(--chat-composer-surface, var(--popover));
-  box-shadow: var(--shadow-md);
-  opacity: 0;
-  transform: translateY(8px) scale(0.95);
-  transform-origin: center bottom;
-  visibility: hidden;
-  transition:
-    opacity 100ms ease 300ms,
-    transform 100ms ease 300ms,
-    visibility 0ms linear 400ms;
+.chat-swarm__counts,
+.chat-swarm__outcome,
+.chat-swarm__disclosure {
+  color: var(--muted);
+  font-size: 12px;
 }
 
-.chat-swarm__group:is(:hover, :focus-within) .chat-swarm__tasks,
-.chat-swarm__tasks:hover {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-  visibility: visible;
-  transition-delay: 600ms, 600ms, 0ms;
+.chat-swarm__disclosure {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.chat-swarm__disclosure svg {
+  width: 12px;
+  height: 12px;
+}
+.chat-swarm__group[open] .chat-swarm__disclosure svg {
+  transform: rotate(180deg);
+}
+
+.chat-swarm__tasks {
+  display: grid;
+  gap: 2px;
+  max-height: min(240px, 30dvh);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  margin-top: 8px;
 }
 
 .chat-swarm__task {

--- a/ui/src/test-helpers/control-ui-plugin-action.ts
+++ b/ui/src/test-helpers/control-ui-plugin-action.ts
@@ -7,7 +7,7 @@ export function registerSessionPluginAction(
   action: ControlUiAction,
 ) {
   const lifetime = new AbortController();
-  const open = vi.fn();
+  const open = vi.fn<ControlUiHost["sessions"]["open"]>();
   const host = {
     signal: lifetime.signal,
     sessions: { open },

--- a/ui/src/test-helpers/gateway-client.test.ts
+++ b/ui/src/test-helpers/gateway-client.test.ts
@@ -1,0 +1,22 @@
+/* @vitest-environment jsdom */
+
+import { expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { createTestGatewayClient } from "./gateway-client.ts";
+
+const requests: Array<Parameters<GatewayBrowserClient["request"]>> = [
+  ["sessions.list"],
+  ["sessions.describe", { key: "agent:main:main" }],
+  ["sessions.describe", { key: "agent:main:main" }, undefined],
+  ["sessions.reclaim", { key: "agent:main:main" }, { timeoutMs: null }],
+];
+
+it.each(requests.map((args) => ({ args, arity: args.length })))(
+  "preserves the exact $arity-argument Gateway request tuple",
+  async ({ args }) => {
+    const request = vi.fn(async () => ({ ok: true }));
+    const client = createTestGatewayClient(request);
+    await expect(client.request(...args)).resolves.toEqual({ ok: true });
+    expect(request.mock.calls).toStrictEqual([args]);
+  },
+);

--- a/ui/src/test-helpers/gateway-client.ts
+++ b/ui/src/test-helpers/gateway-client.ts
@@ -1,7 +1,9 @@
 import { vi, type Mock } from "vitest";
 import { GatewayBrowserClient } from "../api/gateway.ts";
 
-export type GatewayRequestHandler = (method: string, params?: unknown) => unknown;
+export type GatewayRequestHandler = (
+  ...args: Parameters<GatewayBrowserClient["request"]>
+) => unknown;
 
 export type GatewayRequestMock = Mock<GatewayRequestHandler>;
 
@@ -19,7 +21,8 @@ export function createTestGatewayClient(request: GatewayRequestHandler): Gateway
     get: () => "test-recovery-scope",
   });
   Object.defineProperty(client, "recoveryScopeReady", { configurable: true, get: () => true });
-  client.request = async <T = unknown>(method: string, params?: unknown): Promise<T> =>
-    (await request(method, params)) as T;
+  client.request = async <T = unknown>(
+    ...args: Parameters<GatewayBrowserClient["request"]>
+  ): Promise<T> => (await request(...args)) as T;
   return client;
 }


### PR DESCRIPTION
Related: #139420

## What Problem This Solves

Fixes an issue where users watching a Swarm in the Control UI would lose its display when all children finished, even if the parent failed before producing a final response. Deleted child sessions could no longer supply the full outcome, parent-only viewers could miss cross-agent updates, and child details depended on hover.

## Why This Change Was Made

The existing collector registry now supplies a bounded summary for the authorized parent: up to four active groups and the most recent completed group. Counts include retained collectors after child-session cleanup; only a selected-parent read includes bounded member identities and statuses. Child names remain separate authorized reads. Completion counts come from frozen collector results and do not imply that the parent produced a synthesis.

The registry's existing commit boundary emits parent-scoped updates after successful changes, including archive removal. A small process-local committed snapshot prevents failed best-effort writes from suppressing a later successful notification. Atomic publication waits for owner snapshots; child completion never changes parent run status. Ordinary message and agent events retain scoped reads and omit uncomputed Swarm data.

Native details/summary replaces the hover-only display. The component loses obsolete phase wrappers, owner inference from group strings, and redundant marker-limit handling. Raw session keys follow the admitted owner; `sessions.describe` gains an optional `agentId` using the existing owner resolver, while qualified key-only callers remain valid.

## User Impact

Users can see queued, running, completed and failed totals, open child details with keyboard or touch, and reload without losing retained outcome counts. Missing child details do not hide successful parent counts. Removed or denied parents clear the display, and late responses cannot restore stale ownership.

Counts expire under the existing collector retention policy. Native app widgets retain their existing active-only behavior. There is no new configuration, dependency, database schema, stored representation, retention policy, or protocol-version change. Independent database contention and provider quota failures are separate from this display repair.

Production is net +247 lines (including brace-only formatting required by CI), including the committed-parent notification owner; the component is net -98 and activity tracking -11. The remaining growth supplies the retained read projection and lifecycle delivery, rather than an additional store or compatibility path. Generated Swift adds eight lines.

## Evidence

The integrated candidate passed 524 focused tests: 45 Gateway, 19 registry, 417 UI, 40 board, and three browser cases. Final reruns passed 32 summary/API tests, 19 registry tests, and three browser scenarios including literal mobile tap. Scoped lint, formatting and English verification passed. Two fixture copy lint findings and a redundant projection copy were repaired and rerun; the wire test still verifies JSON omission directly.

Original browser fixtures show the completed chart disappearing and mobile disclosure failing. Original registry tests fail at five missing-notification assertions. The candidate exercises real SQLite, parent-only versus child-only visibility, commit/retry/archive/rollback ordering, raw and qualified owners, retained totals, bounded payloads, and stale asynchronous responses. Browser fixtures cover desktop/mobile completion, cleanup, reload, and cross-agent child hydration.

Independent Codex reviews are scoped-clean through P2, including all request-option follow-ups. Generated Swift is byte-identical to the passed OpenClawProtocol build and four Codable round trips. Full UI and Gateway test types, CI-configured lint, and the shrinking assertion ratchet passed. Commit hooks preserved the verified source bytes. A patch-identical rebase picked up the separately landed main retry-test repair (#139519). [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34003172851) is green on `bbda1c9eddfe7301bb253551d7d59e7bc7eb3ddb`, including the native screenshot gates and the unchanged browser-job rerun.

Browser fixtures and recording-socket Gateway tests are synthetic boundary proof; live deployment evidence is reported separately. The attached before/after captures contain only inspected synthetic data. Manual remote changed-check attempts were either stopped before validation or failed the then-stale assertion baseline; none is counted as passing. The required hosted checks remain the landing gate.

![Before: the completed Swarm disappears](https://github.com/user-attachments/assets/6c88e90c-e74c-4684-aac6-207b82bd601a)

![After: all thirty outcomes remain visible after cleanup and reload](https://github.com/user-attachments/assets/4dd502ae-289a-4fb3-ba40-9f631dddd7d8)

![After: a mobile tap opens child details](https://github.com/user-attachments/assets/114d0902-8d2f-4666-9cb0-5848fba71bc2)

CI follow-up: the [initial run](https://github.com/openclaw/openclaw/actions/runs/33997731363) exposed incomplete async client fixtures, readonly-context construction, mock initialization order, and obsolete assertion-baseline entries. The [second run](https://github.com/openclaw/openclaw/actions/runs/33999131630) exposed a shared test adapter dropping the third request argument, incomplete backend row fixtures, and a cloud test counting legitimate Swarm reads as placement polling. These are repaired at their test owners without production fallbacks, forced clicks, longer timeouts, or disabling Swarm. The request-tuple regression failed before the fix; 290 helper/placement tests, 72 payload-reader tests, 11 summary tests, two final cloud browser cases, full UI/Gateway test types, and lint pass. The cloud guard still rejects unpaired parent describes, and the placement owner's independent no-polling assertion remains intact.

The unchanged sidebar pointer case and dependency-download HTTP 502 both passed their Linux jobs in the second run; no speculative source or dependency change was made for them.

The final shared-adapter follow-up strengthens model-setup assertions for retained start replies, bounded cancellation, and abortable verification. The broad canonical UI run passed 14,501 cases and failed two unchanged native-fixture scenarios at their 60-second outer limit; one was observed before fixture-body entry, and the managed process owner confirmed cleanup. Both scenarios passed unchanged on the combined source in a focused replay (56.47s and 49.02s), with joined worker cleanup verified. Their slow startup remains a separate harness follow-up; the full run is not counted as passing.

The separate main suppression-inventory failure from #139483 was resolved upstream by #139576. A required conflict refresh retains that exact main helper; this PR no longer changes it. All four Swarm and request-fixture commits remained patch-identical through the refresh. Additional held-drain observer controls are being handled separately.

The latest CI run exposed one dashboard A2UI action case receiving no event after a click. The original two-theme scenario passed locally; six instrumented local cases and two instrumented Linux cases also delivered exactly one event each. Linux tracing confirmed Playwright waited through the frame's inert loading state before delivering native input. No source repair is justified for that isolated failure yet; its original CI job passed unchanged on the exact-job rerun. The Linux Testbox was stopped and independently verified completed after retrieving its four owned trace/screenshot files. The separate pre-existing fixture initializer error in opaque frames is addressed independently in #139618.
