### PR TITLE
fix(cron): preserve current-session delivery intent

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -419,6 +419,8 @@ If the bound conversation is an external channel, OpenClaw also performs its nor
 
 When the bound conversation has no external channel route — WebChat/Control UI conversations, or a gateway with no channel plugins configured — the session commit alone completes delivery and the run succeeds without attempting an external send. If the conversation does name an external route that cannot be resolved at run time, the committed result stays in the conversation and the run records the resolution failure as its delivery error: a delivery failure, not a turn failure.
 
+For current agent-turn jobs, configuring unrelated external channels does not change this behavior. An explicit delivery channel, recipient, account, or thread still uses normal channel resolution.
+
 <Warning>
   Every outbound automation webhook uses the strict SSRF guard. Loopback,
   private/internal, link-local, and other special-use targets are refused by

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -419,7 +419,7 @@ If the bound conversation is an external channel, OpenClaw also performs its nor
 
 When the bound conversation has no external channel route — WebChat/Control UI conversations, or a gateway with no channel plugins configured — the session commit alone completes delivery and the run succeeds without attempting an external send. If the conversation does name an external route that cannot be resolved at run time, the committed result stays in the conversation and the run records the resolution failure as its delivery error: a delivery failure, not a turn failure.
 
-For current agent-turn jobs, configuring unrelated external channels does not change this behavior. An explicit delivery channel, recipient, account, or thread still uses normal channel resolution.
+For current agent-turn jobs, configuring unrelated external channels does not change this behavior. An explicit delivery channel, recipient, account, or thread still uses normal channel resolution. If that resolution fails, the report remains in the conversation and the run records the delivery error, even when no external channel could be selected.
 
 <Warning>
   Every outbound automation webhook uses the strict SSRF guard. Loopback,

--- a/src/cli/cron-cli/cron-suppression.gateway.test.ts
+++ b/src/cli/cron-cli/cron-suppression.gateway.test.ts
@@ -5,6 +5,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isRich, theme } from "../../../packages/terminal-core/src/theme.js";
+import { resolveCronDeliveryPlan } from "../../cron/delivery-plan.js";
 import { dispatchCronDelivery } from "../../cron/isolated-agent/delivery-dispatch.js";
 import { CronService, type CronEvent } from "../../cron/service.js";
 import { createNoopLogger } from "../../cron/service.test-harness.js";
@@ -146,6 +147,7 @@ describe("cron CLI delivery suppression readback", () => {
                     error: new Error("fixture delivery route unavailable"),
                   }
                 : { ok: true, mode: "explicit", channel: "telegram", to: "123" },
+            deliveryPlan: resolveCronDeliveryPlan(job),
             deliveryRequested: phase !== "not-requested",
             undeliveredRunStatus: "ok",
             spawnOnlyHandoff: false,

--- a/src/cron/delivery-plan.ts
+++ b/src/cron/delivery-plan.ts
@@ -24,7 +24,9 @@ export type CronDeliveryPlan = {
 };
 
 /** Returns whether a delivery plan names a concrete channel, recipient, thread, or account. */
-export function hasExplicitCronDeliveryTarget(plan: CronDeliveryPlan): boolean {
+export function hasExplicitCronDeliveryTarget(
+  plan: Pick<CronDeliveryPlan, "channel" | "to" | "threadId" | "accountId">,
+): boolean {
   return Boolean(
     (plan.channel && plan.channel !== "last") || plan.to || plan.threadId != null || plan.accountId,
   );

--- a/src/cron/delivery-preview.current-origin.test.ts
+++ b/src/cron/delivery-preview.current-origin.test.ts
@@ -1,0 +1,153 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import {
+  normalizeSessionDeliveryState,
+  type DeliveryContext,
+} from "../utils/delivery-context.shared.js";
+import { resolveCronDeliveryPreview } from "./delivery-preview.js";
+import { makeCronJob } from "./delivery.test-helpers.js";
+import { resolveDeliveryTarget } from "./isolated-agent/delivery-target.js";
+import type { CronDelivery, CronJob } from "./types.js";
+
+afterEach(() => resetPluginRuntimeStateForTest());
+
+async function withCurrentOrigin(
+  options: {
+    surface?: string;
+    channelCount?: number;
+    delivery?: CronDelivery;
+    source?: DeliveryContext;
+  },
+  check: (fixture: { cfg: OpenClawConfig; job: CronJob }) => Promise<void>,
+) {
+  await withOpenClawTestState({ layout: "home" }, async (state) => {
+    setActivePluginRegistry(
+      createTestRegistry(
+        ["telegram", "discord"].slice(0, options.channelCount ?? 1).map((id) => ({
+          pluginId: id,
+          plugin: createChannelTestPluginBase({ id }),
+          source: "test",
+        })),
+      ),
+    );
+    const sessionKey = `agent:main:${options.surface ?? "dashboard"}:current-origin`;
+    const storePath = path.join(state.sessionsDir(), "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: { workspace: state.workspaceDir } } },
+      session: { store: storePath },
+    };
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey, storePath },
+      {
+        sessionId: "source-session",
+        updatedAt: 1,
+        delivery: normalizeSessionDeliveryState({
+          context:
+            options.source ?? (options.surface === "webchat" ? { channel: "webchat" } : undefined),
+        }),
+      },
+    );
+    const job = makeCronJob({
+      agentId: "main",
+      sessionTarget: "current",
+      sessionKey,
+      delivery: options.delivery ?? { mode: "announce" },
+    });
+    await check({ cfg, job });
+  });
+}
+
+describe("current cron delivery origin", () => {
+  it.each(
+    ["dashboard", "webchat"].flatMap((surface) =>
+      [0, 1, 2].map((channelCount) => ({ surface, channelCount })),
+    ),
+  )(
+    "keeps a $surface completion in its conversation with $channelCount unrelated channels",
+    async (options) => {
+      await withCurrentOrigin(options, async ({ cfg, job }) => {
+        expect(await resolveCronDeliveryPreview({ cfg, job })).toEqual({
+          label: "announce -> current session",
+          detail: "commits to this conversation (no external channel route)",
+        });
+      });
+    },
+  );
+
+  it.each([{ channel: "telegram" }, { to: "recipient" }, { accountId: "work" }, { threadId: 0 }])(
+    "retains explicit delivery coordinates %j",
+    async (coordinates) => {
+      await withCurrentOrigin(
+        { delivery: { mode: "announce", ...coordinates } },
+        async ({ cfg, job }) => {
+          const resolved = await resolveDeliveryTarget(cfg, "main", {
+            ...job.delivery,
+            sessionKey: job.sessionKey,
+            sessionTarget: job.sessionTarget,
+          });
+          expect(resolved.channel).toBe("telegram");
+          expect(resolved.ok).toBe("to" in coordinates);
+        },
+      );
+    },
+  );
+
+  it("preserves the explicit recipient, account, and thread", async () => {
+    const delivery = {
+      mode: "announce",
+      channel: "telegram",
+      to: "recipient",
+      accountId: "work",
+      threadId: "topic",
+    } as const;
+    await withCurrentOrigin({ delivery }, async ({ cfg, job }) => {
+      expect(
+        await resolveDeliveryTarget(cfg, "main", {
+          ...delivery,
+          sessionKey: job.sessionKey,
+          sessionTarget: job.sessionTarget,
+        }),
+      ).toMatchObject({
+        ok: true,
+        channel: "telegram",
+        to: "recipient",
+        accountId: "work",
+        threadId: "topic",
+      });
+    });
+  });
+
+  it("retains failure for an unavailable external source route", async () => {
+    await withCurrentOrigin(
+      { source: { channel: "unavailable-plugin", to: "recipient" } },
+      async ({ cfg, job }) => {
+        const resolved = await resolveDeliveryTarget(cfg, "main", {
+          ...job.delivery,
+          sessionKey: job.sessionKey,
+          sessionTarget: job.sessionTarget,
+        });
+        expect(resolved).toMatchObject({ ok: false, channel: "unavailable-plugin" });
+        expect((await resolveCronDeliveryPreview({ cfg, job })).detail).toContain(
+          "will fail-closed",
+        );
+      },
+    );
+  });
+
+  it.each([0, 1])(
+    "keeps command announcements on their channel path with %i channels",
+    async (channelCount) => {
+      await withCurrentOrigin({ channelCount }, async ({ cfg, job }) => {
+        job.payload = { kind: "command", argv: ["echo", "report"] };
+        const preview = await resolveCronDeliveryPreview({ cfg, job });
+        expect(preview.label).toBe("announce -> last");
+        expect(preview.detail).toContain("will fail-closed");
+      });
+    },
+  );
+});

--- a/src/cron/delivery-preview.current-origin.test.ts
+++ b/src/cron/delivery-preview.current-origin.test.ts
@@ -3,7 +3,11 @@ import { afterEach, describe, expect, it } from "vitest";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
-import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createDirectOutboundTestAdapter,
+  createTestRegistry,
+} from "../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   normalizeSessionDeliveryState,
@@ -30,7 +34,10 @@ async function withCurrentOrigin(
       createTestRegistry(
         ["telegram", "discord"].slice(0, options.channelCount ?? 1).map((id) => ({
           pluginId: id,
-          plugin: createChannelTestPluginBase({ id }),
+          plugin: {
+            ...createChannelTestPluginBase({ id }),
+            outbound: createDirectOutboundTestAdapter({ channel: id }),
+          },
           source: "test",
         })),
       ),
@@ -79,19 +86,34 @@ describe("current cron delivery origin", () => {
     },
   );
 
-  it.each([{ channel: "telegram" }, { to: "recipient" }, { accountId: "work" }, { threadId: 0 }])(
-    "retains explicit delivery coordinates %j",
-    async (coordinates) => {
+  it.each(
+    [{ channel: "telegram" }, { to: "recipient" }, { accountId: "work" }, { threadId: 0 }].flatMap(
+      (coordinates) =>
+        ("channel" in coordinates ? [1] : [0, 1, 2]).map((channelCount) => ({
+          coordinates,
+          channelCount,
+        })),
+    ),
+  )(
+    "retains explicit delivery coordinates $coordinates with $channelCount channels",
+    async ({ coordinates, channelCount }) => {
       await withCurrentOrigin(
-        { delivery: { mode: "announce", ...coordinates } },
+        { channelCount, delivery: { mode: "announce", ...coordinates } },
         async ({ cfg, job }) => {
           const resolved = await resolveDeliveryTarget(cfg, "main", {
             ...job.delivery,
             sessionKey: job.sessionKey,
             sessionTarget: job.sessionTarget,
           });
-          expect(resolved.channel).toBe("telegram");
-          expect(resolved.ok).toBe("to" in coordinates);
+          expect(resolved.channel).toBe(channelCount === 1 ? "telegram" : undefined);
+          expect(resolved.ok).toBe(channelCount === 1 && "to" in coordinates);
+          if (channelCount !== 1) {
+            const preview = await resolveCronDeliveryPreview({ cfg, job });
+            expect(preview.label).toBe(
+              "to" in coordinates ? "announce -> last:recipient" : "announce -> last",
+            );
+            expect(preview.detail).toContain("will fail-closed");
+          }
         },
       );
     },

--- a/src/cron/delivery-preview.test.ts
+++ b/src/cron/delivery-preview.test.ts
@@ -43,13 +43,11 @@ describe("resolveCronDeliveryPreview", () => {
     expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith(
       {},
       "avery",
-      {
+      expect.objectContaining({
         channel: "last",
-        to: undefined,
-        threadId: undefined,
-        accountId: undefined,
         sessionKey: "agent:avery:telegram:direct:direct-123",
-      },
+        sessionTarget: job.sessionTarget,
+      }),
       { dryRun: true },
     );
     expect(preview.detail).toBe(
@@ -87,13 +85,14 @@ describe("resolveCronDeliveryPreview", () => {
     expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith(
       {},
       "avery",
-      {
+      expect.objectContaining({
         channel: "topicchat",
         to: "room#42",
         threadId: 42,
         accountId: "ops",
         sessionKey: undefined,
-      },
+        sessionTarget: "isolated",
+      }),
       { dryRun: true },
     );
     expect(preview).toEqual({
@@ -164,13 +163,11 @@ describe("resolveCronDeliveryPreview", () => {
     expect(mocks.resolveDeliveryTarget).toHaveBeenCalledWith(
       {},
       "avery",
-      {
-        channel: "last",
-        to: undefined,
+      expect.objectContaining({
         threadId: 0,
-        accountId: undefined,
         sessionKey: undefined,
-      },
+        sessionTarget: "isolated",
+      }),
       { dryRun: true },
     );
     expect(preview).toEqual({

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -60,22 +60,22 @@ export async function resolveCronDeliveryPreview(params: {
   const requestedChannel = plan.channel ?? "last";
   const agentId =
     params.job.agentId?.trim() || params.defaultAgentId || resolveDefaultAgentId(params.cfg);
+  const sessionTarget =
+    params.job.payload.kind === "agentTurn" ? params.job.sessionTarget : undefined;
   const deliverySessionKey = resolveCronDeliverySessionKey(params.job);
   const resolved = await resolveDeliveryTarget(
     params.cfg,
     agentId,
     {
-      channel: requestedChannel,
-      to: plan.to,
-      threadId: plan.threadId,
-      accountId: plan.accountId,
+      ...plan,
+      sessionTarget,
       sessionKey: deliverySessionKey,
     },
     { dryRun: true },
   );
   if (!resolved.ok) {
     if (
-      params.job.sessionTarget === "current" &&
+      sessionTarget === "current" &&
       plan.mode === "announce" &&
       !resolvedDeliveryTargetsExternalChannel(resolved)
     ) {

--- a/src/cron/delivery-preview.ts
+++ b/src/cron/delivery-preview.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasExplicitCronDeliveryTarget, resolveCronDeliveryPlan } from "./delivery-plan.js";
 import {
   resolveDeliveryTarget,
-  resolvedDeliveryTargetsExternalChannel,
+  requiresExternalCronDelivery,
 } from "./isolated-agent/delivery-target.js";
 import { resolveCronDeliverySessionKey } from "./session-target.js";
 import type { CronDeliveryPreview, CronJob } from "./types.js";
@@ -77,7 +77,7 @@ export async function resolveCronDeliveryPreview(params: {
     if (
       sessionTarget === "current" &&
       plan.mode === "announce" &&
-      !resolvedDeliveryTargetsExternalChannel(resolved)
+      !requiresExternalCronDelivery(plan, resolved)
     ) {
       // Mirrors runtime: a current-target completion with no external channel
       // route commits durably to its own conversation instead of failing.

--- a/src/cron/isolated-agent/current-session-completion.test.ts
+++ b/src/cron/isolated-agent/current-session-completion.test.ts
@@ -26,6 +26,7 @@ import {
   withOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { makeCronJob } from "../delivery.test-helpers.js";
 import { createCliDeps } from "../isolated-agent.delivery.test-helpers.js";
 import { commitCurrentSessionCronCompletion } from "./current-session-completion.js";
@@ -55,11 +56,12 @@ async function createCompletionFixture(state: OpenClawTestState) {
     session: { store: scope.storePath },
   };
   const payload: ReplyPayload = { text: "Example report", mediaUrl: imagePath };
+  const job = makeCronJob({ id: "report-job", sessionTarget: "current", sessionKey });
   const params: DispatchCronDeliveryParams = {
     cfg,
     cfgWithAgentDefaults: cfg,
     deps: createCliDeps(),
-    job: makeCronJob({ id: "report-job", sessionTarget: "current", sessionKey }),
+    job,
     agentId: "main",
     agentSessionKey: "agent:main:cron:report-job",
     sourceSessionKey: sessionKey,
@@ -72,6 +74,7 @@ async function createCompletionFixture(state: OpenClawTestState) {
     runEndedAt: 2000,
     timeoutMs: 30000,
     resolvedDelivery: { ok: false, mode: "implicit", error: new Error("No external channel") },
+    deliveryPlan: resolveCronDeliveryPlan(job),
     deliveryRequested: true,
     undeliveredRunStatus: "ok",
     spawnOnlyHandoff: false,
@@ -122,6 +125,35 @@ async function createCompletionFixture(state: OpenClawTestState) {
       ),
   };
 }
+
+describe("current-session completion delivery", () => {
+  it.each([{ to: "recipient" }, { accountId: "work" }, { threadId: 0 }])(
+    "preserves the committed report and reports unresolved explicit intent %j",
+    async (coordinates) => {
+      await withOpenClawTestState({ layout: "state-only" }, async (state) => {
+        const fixture = await createCompletionFixture(state);
+        try {
+          fixture.params.job.delivery = { mode: "announce", ...coordinates };
+          fixture.params.deliveryPlan = resolveCronDeliveryPlan(fixture.params.job);
+          fixture.params.deliveryPayloads = [{ text: "Final report" }];
+          const completion = await fixture.commit();
+          const messages = await fixture.messages();
+          expect(messages).toHaveLength(1);
+          expect(readTranscriptEventMessage(messages[0])?.content).toEqual([
+            { type: "text", text: "Final report" },
+          ]);
+          expect(completion).toEqual({
+            ok: true,
+            requiresExternalDelivery: false,
+            deliveryError: "No external channel",
+          });
+        } finally {
+          fixture.unsubscribe();
+        }
+      });
+    },
+  );
+});
 
 describe("current-session completion media", () => {
   it.each(["ordinary", "promotion-failure"] as const)(

--- a/src/cron/isolated-agent/current-session-completion.ts
+++ b/src/cron/isolated-agent/current-session-completion.ts
@@ -24,7 +24,7 @@ import {
 } from "./delivery-dispatch-awareness.js";
 import { logCronDeliveryWarn } from "./delivery-dispatch-policy.js";
 import type { DispatchCronDeliveryParams } from "./delivery-dispatch-types.js";
-import { resolvedDeliveryTargetsExternalChannel } from "./delivery-target.js";
+import { requiresExternalCronDelivery } from "./delivery-target.js";
 
 type CurrentSessionCompletionResult =
   | { ok: false; reason: string }
@@ -114,12 +114,9 @@ export async function commitCurrentSessionCronCompletion(
   if (params.resolvedDelivery.ok) {
     return { ok: true, requiresExternalDelivery: true };
   }
-  // The completion is durably committed to the target conversation. When the
-  // failed resolution names an external channel route, that route still owed a
-  // send — report it as a delivery failure without failing the committed turn.
-  // With no external route (internal webchat/Control UI conversations, or a
-  // gateway with no channels configured), the commit IS the delivery.
-  if (resolvedDeliveryTargetsExternalChannel(params.resolvedDelivery)) {
+  // Committing the report cannot satisfy an explicit or remembered external
+  // destination; retain its error even when selection produced no channel.
+  if (requiresExternalCronDelivery(params.deliveryPlan, params.resolvedDelivery)) {
     return {
       ok: true,
       requiresExternalDelivery: false,

--- a/src/cron/isolated-agent/delivery-dispatch-types.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-types.ts
@@ -4,6 +4,7 @@ import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import type { SourceDeliveryOutcome } from "../../infra/outbound/source-delivery-plan.js";
+import type { CronDeliveryPlan } from "../delivery-plan.js";
 import type { CronJob, CronResolvedDeliveryState, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
@@ -28,6 +29,8 @@ export type DispatchCronDeliveryParams = {
   runEndedAt: number;
   timeoutMs: number;
   resolvedDelivery: DeliveryTargetResolution;
+  /** Preserve prepared intent instead of rereading job configuration after inference. */
+  deliveryPlan: CronDeliveryPlan;
   deliveryRequested: boolean;
   /** Finalizer-owned execution status if delivery cannot recover a presentation warning. */
   undeliveredRunStatus: "ok" | "error";

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -202,7 +202,9 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { logError } from "../../logger.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { resolveCronDeliveryPlan } from "../delivery-plan.js";
 import { withTempCronHome } from "../isolated-agent.test-harness.js";
+import type { CronDelivery } from "../types.js";
 import {
   dispatchCronDelivery,
   queueCronMessageToolDeliveryAwareness,
@@ -262,6 +264,10 @@ function makeBaseParams(overrides: {
     ...makeResolvedDelivery(),
     mode: overrides.resolvedDeliveryMode ?? "explicit",
   } satisfies Extract<DeliveryTargetResolution, { ok: true }>;
+  const delivery: CronDelivery = {
+    mode: "announce",
+    bestEffort: overrides.deliveryBestEffort,
+  };
   const runStartedAt = overrides.runStartedAt ?? Date.now();
   return {
     cfg: {} as never,
@@ -274,7 +280,7 @@ function makeBaseParams(overrides: {
       sessionKey:
         overrides.sessionTarget === "current" ? "agent:main:webchat:direct:owner" : undefined,
       deleteAfterRun: false,
-      delivery: { mode: "announce", bestEffort: overrides.deliveryBestEffort },
+      delivery,
       payload: { kind: "agentTurn", message: "hello" },
     } as never,
     agentId: "main",
@@ -293,6 +299,7 @@ function makeBaseParams(overrides: {
     runEndedAt: runStartedAt,
     timeoutMs: 30_000,
     resolvedDelivery,
+    deliveryPlan: resolveCronDeliveryPlan({ delivery }),
     deliveryRequested: overrides.deliveryRequested ?? true,
     undeliveredRunStatus: "ok",
     skipDelivery: undefined,

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -1,6 +1,5 @@
 /** Resolves isolated cron delivery requests into concrete outbound targets. */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { loadSessionEntryReadOnly } from "../../config/sessions/session-accessor.js";
@@ -18,6 +17,8 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../../utils/message-channel.js";
 import { resolveCronStoredDeliveryContext } from "../delivery-context.js";
+import { hasExplicitCronDeliveryTarget, type CronDeliveryPlan } from "../delivery-plan.js";
+import type { CronJob } from "../types.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 
 /** Result of resolving a cron job delivery request into a sendable outbound channel target. */
@@ -132,14 +133,8 @@ function shouldStripResolvedTargetProviderPrefix(target: ResolvedMessagingTarget
 export async function resolveDeliveryTarget(
   cfg: OpenClawConfig,
   agentId: string,
-  jobPayload: {
-    channel?: ChannelId;
-    to?: string;
-    threadId?: string | number;
-    /** Explicit accountId from job.delivery — overrides session-derived and binding-derived values. */
-    accountId?: string;
-    sessionKey?: string;
-  },
+  jobPayload: Pick<CronDeliveryPlan, "channel" | "to" | "threadId" | "accountId"> &
+    Partial<Pick<CronJob, "sessionKey" | "sessionTarget">>,
   options?: { dryRun?: boolean; inheritSessionThread?: boolean },
 ): Promise<DeliveryTargetResolution> {
   const requestedChannel = typeof jobPayload.channel === "string" ? jobPayload.channel : "last";
@@ -196,7 +191,12 @@ export async function resolveDeliveryTarget(
   if (!preliminary.channel) {
     if (preliminary.lastChannel) {
       fallbackChannel = preliminary.lastChannel;
-    } else {
+    } else if (
+      jobPayload.sessionTarget !== "current" ||
+      hasExplicitCronDeliveryTarget(jobPayload)
+    ) {
+      // Current jobs without an external source route complete in their own
+      // conversation; an unrelated configured channel cannot create a delivery obligation.
       try {
         const { resolveMessageChannelSelection } = await channelSelectionRuntimeLoader.load();
         const selection = await resolveMessageChannelSelection({ cfg });

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -41,16 +41,16 @@ export type DeliveryTargetResolution =
       error: Error;
     };
 
-/**
- * Returns whether a delivery resolution names an external channel route.
- * Registration is intentionally irrelevant: an unavailable plugin route still
- * owes delivery. Only webchat/Control UI and an absent route are satisfied by
- * the durable session commit alone.
- */
-export function resolvedDeliveryTargetsExternalChannel(
+// Explicit destinations remain owed when channel selection fails; remembered
+// external routes remain owed when their plugin is unavailable.
+export function requiresExternalCronDelivery(
+  plan: CronDeliveryPlan,
   resolution: DeliveryTargetResolution,
 ): boolean {
-  return resolution.channel !== undefined && resolution.channel !== INTERNAL_MESSAGE_CHANNEL;
+  return (
+    hasExplicitCronDeliveryTarget(plan) ||
+    (resolution.channel !== undefined && resolution.channel !== INTERNAL_MESSAGE_CHANNEL)
+  );
 }
 
 const targetsRuntimeLoader = createLazyImportLoader(

--- a/src/cron/isolated-agent/run-delivery-trace.ts
+++ b/src/cron/isolated-agent/run-delivery-trace.ts
@@ -274,16 +274,10 @@ export async function resolveCronDeliveryContext(params: {
   }
   const { resolveDeliveryTarget } = await loadCronDeliveryRuntime();
   const resolvedDelivery = await resolveDeliveryTarget(params.cfg, params.agentId, {
-    channel: deliveryPlan.channel ?? "last",
-    to: deliveryPlan.to,
-    threadId: deliveryPlan.threadId,
-    accountId: deliveryPlan.accountId,
-    // Resolve the job's own session identity (sessionTarget takes precedence over sessionKey, the
-    // same as delivery preview) so a session-scoped cron is not misread as keyless by the #91613
-    // keyless-inherited refusal inside resolveDeliveryTarget. The refusal itself now lives in the
-    // resolver (returns ok:false), so the delivery dispatch !ok gate, the failure-notification
-    // path, and the delivery preview all honor it uniformly (the dispatch gate refuses the send and
-    // never enqueues, so a restart has nothing to replay; the agent turn still runs before that).
+    ...deliveryPlan,
+    sessionTarget: params.job.payload.kind === "agentTurn" ? params.job.sessionTarget : undefined,
+    // Match preview's sessionTarget precedence: custom jobs resolve their own
+    // delivery session rather than the creator's last conversation.
     sessionKey: resolveCronDeliverySessionKey(params.job),
   });
   return {

--- a/src/cron/isolated-agent/run-finalize.ts
+++ b/src/cron/isolated-agent/run-finalize.ts
@@ -515,6 +515,7 @@ export async function finalizeCronRun(params: {
     runEndedAt: execution.runEndedAt,
     timeoutMs: prepared.timeoutMs,
     resolvedDelivery: prepared.resolvedDelivery,
+    deliveryPlan: prepared.deliveryPlan,
     deliveryRequested: prepared.deliveryRequested,
     undeliveredRunStatus: hasFatalErrorPayload || pendingPresentationWarningError ? "error" : "ok",
     skipDelivery: skipHeartbeatDelivery

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -24,7 +24,9 @@ import {
 } from "../config/sessions/session-accessor.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveCronDeliveryPlan } from "../cron/delivery-plan.js";
 import { dispatchCronDelivery } from "../cron/isolated-agent/delivery-dispatch.js";
+import type { CronJob } from "../cron/types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { claimAgentRunContext, clearAgentRunContext } from "../infra/agent-run-registry.js";
 import * as secureRandom from "../infra/secure-random.js";
@@ -1021,24 +1023,25 @@ describe("session.message websocket events", () => {
       });
       await rpcReq(webWs, "sessions.messages.subscribe", { key: sessionKey });
 
+      const job: CronJob = {
+        id: "job-webchat",
+        name: "Current WebChat completion",
+        sessionTarget: "current",
+        sessionKey,
+        wakeMode: "now",
+        enabled: true,
+        state: {},
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        schedule: { kind: "at", at: "2030-01-01T00:00:00.000Z" },
+        payload: { kind: "agentTurn", message: "Finish later" },
+      };
       const liveEventPromise = waitForSessionMessageEvent(webWs, sessionKey);
       const dispatched = await dispatchCronDelivery({
         cfg: { session: { store: storePath } },
         cfgWithAgentDefaults: { session: { store: storePath } },
         deps: {},
-        job: {
-          id: "job-webchat",
-          name: "Current WebChat completion",
-          sessionTarget: "current",
-          sessionKey,
-          wakeMode: "now",
-          enabled: true,
-          state: {},
-          createdAtMs: 1,
-          updatedAtMs: 1,
-          schedule: { kind: "at", at: "2030-01-01T00:00:00.000Z" },
-          payload: { kind: "agentTurn", message: "Finish later" },
-        },
+        job,
         agentId: "main",
         agentSessionKey: "cron:job-webchat",
         sourceSessionKey: sessionKey,
@@ -1059,6 +1062,7 @@ describe("session.message websocket events", () => {
           mode: "implicit",
           error: new Error("WebChat uses canonical session events"),
         },
+        deliveryPlan: resolveCronDeliveryPlan(job),
         deliveryRequested: true,
         undeliveredRunStatus: "ok",
         spawnOnlyHandoff: false,

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -220,6 +220,8 @@ describe("production lint suppressions", () => {
         "src/commands/backup-restore.ts|preserve-caught-error|1",
         // Intl.Collator.compare is a getter returning a bound function.
         "src/cron/service/list-page-sort.ts|typescript/unbound-method|1",
+        // Native drain is captured before spying and called with the actual scope as its receiver.
+        "src/gateway/server-held-work.test-support.ts|typescript/unbound-method|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -220,8 +220,6 @@ describe("production lint suppressions", () => {
         "src/commands/backup-restore.ts|preserve-caught-error|1",
         // Intl.Collator.compare is a getter returning a bound function.
         "src/cron/service/list-page-sort.ts|typescript/unbound-method|1",
-        // Native drain is captured before spying and called with the actual scope as its receiver.
-        "src/gateway/server-held-work.test-support.ts|typescript/unbound-method|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",

--- a/test/scripts/test-report-utils.test.ts
+++ b/test/scripts/test-report-utils.test.ts
@@ -94,9 +94,11 @@ describe("scripts/test-report-utils collectVitestAssertionDurations", () => {
 });
 
 describe("scripts/test-report-utils runVitestJsonReport", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
-    spawnSyncMock.mockReset();
+    const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    // Keep process-cleanup probes native; report-only cases override the implementation below.
+    spawnSyncMock.mockReset().mockImplementation(actual.spawnSync);
   });
 
   it("creates and reuses a native JSON report without a package-manager PATH", async ({


### PR DESCRIPTION
Closes #139488

## What Problem This Solves

Fixes incorrect delivery outcomes for current-session agent-turn automations. A dashboard/WebChat report could be marked **Not delivered** merely because an unrelated external channel was configured. Conversely, an explicitly requested destination could be silently treated as local delivery when no channel could be selected.

## Why This Change Was Made

The delivery resolver now receives the job's existing current-session intent, so it does not invent an external route from unrelated host configuration. A shared delivery-intent check combines the normalized plan with the resolved source route: an explicit or remembered external destination remains owed even when resolution fails. Preview and completion use the same check, and completion receives the plan prepared before inference rather than re-reading job configuration afterward.

The conversation report is committed in both cases. A local-only report completes delivery; an unresolved explicit external request retains its delivery error. Command announcements keep their strict external path. No configuration, schema, protocol, or stored representation changes are introduced. Production code shrinks by three lines.

## User Impact

Current-session reports finish successfully in their bound conversation when no external delivery was requested. Requested destinations remain visible as delivery failures if channel selection cannot resolve them. Preview and run history agree about the outcome, while the report remains available in chat.

## Evidence

The original real Gateway/dashboard before capture shows the report in chat but a false Telegram missing-target failure with one unrelated configured channel. The repair has storage/resolver coverage for dashboard and WebChat, zero/one/two configured channels, explicit channel/recipient/account/thread settings including thread zero, unavailable actual external routes, and command announcements.

Independent review exposed the explicit-destination side of the same invariant. Nine new cases failed before the correction; the three completion cases verified the durable report before failing on the omitted delivery error. The full final four-file test selection then passed 204 tests. Canonical core/services test types, targeted lint, formatting, and the runtime/metadata build passed.

The first CI run stalled in a recipient test because its metadata-only fake plugin triggered real plugin bootstrap. The fixture now uses the existing activated outbound adapter while retaining the same configured account and assertions. A cold call-through probe observed three bootstrap calls before and zero after; the original 20 cases passed with a fresh cache. No timeout, assertion, or production loader was weakened.

The runtime build uses `sourcePerformance`, not full SDK/package output. All external APIs in the real Gateway/browser proof are synthetic and local; no authenticated cloud-provider or real external-message claim is made. The original before proof used packaged-plugin staging; subsequent runtime proof uses supported source staging after an earlier package preflight hit its existing 120-second timeout before Gateway execution.


The runtime-validated production commit is `a3bef6a3b2cd1755287155dffa52be96a9758c9e`, rebased onto `61690da40bd436684311adec59d69bae3b0e383d` to inherit the unrelated upstream CI correction in #139519. The complete four-file selection passed 204 tests again on this clean head, as did canonical core/services type checks and the runtime/metadata build. Fresh managed P0–P2 review is scoped-clean. The seven production owners remain unchanged on fetched main `e284dad94f9c26cf91f0ce69a392890c7bb6de1e`.

This completes the no-external-route behavior of #131975 and preserves the opposite explicit-destination obligation. It is separate from creation-time capture of an explicitly selected channel in #138185.

![Before: report committed but falsely marked Not delivered](https://github.com/user-attachments/assets/deae475f-01ec-400b-9965-bb44bcb710e5)

Fresh real Gateway/dashboard flows on that exact built head verified both outcomes: route-less report with one unrelated Telegram channel → report retained, Delivered, completion succeeded; explicit recipient with zero channels → report retained, Not delivered, completion failed with the channel-resolution error. Each made one synthetic provider request and zero external sends. Both drivers verified their actual HOME, state, config, OAuth, XDG and announced log-file paths were inside their owned temporary roots.

![After: local current-session report is Delivered](https://github.com/user-attachments/assets/a9cdb472-71ac-4176-a3ca-ed253f14637a)

![After: unresolved explicit recipient retains the delivery error](https://github.com/user-attachments/assets/7608cae9-ac6a-4a4a-b361-a3b8f7ab908f)

https://github.com/user-attachments/assets/f47c4282-7c8b-4665-a36a-0af8cbd098b7

https://github.com/user-attachments/assets/2fb48a1e-3161-4c44-80ec-e51cdbdb58f6


Current head `6288cf4e58df835fbffbd7ee9858b737e6d32900` contains test-only CI corrections relative to the runtime-tested production commit above. Production is byte-identical. CI exposed two additional direct dispatcher fixtures in CLI suppression and Gateway background-completion coverage that needed the prepared plan. The complete caller audit covers all five construction owners. Those two files passed 31 tests and their owning type checks; the complete candidate passed managed P0–P2 review.

CI also caught an incoming-main lint-suppression inventory omission from #139483. While the temporary inventory correction was being validated, #139576 removed the suppression at its source. The final branch therefore leaves that inventory unchanged; the superseded entry was removed and that deletion independently reviewed. The original three fixture/guard checks totalled 35 passing tests, and current CI verifies composition with the upstream cleanup. No assertions, timeouts, production fallback, or helper behavior were weakened.


A later Linux CI failure occurred after the native JSON-report test had written its report but encountered strict process-group cleanup. Its broad `spawnSync` mock had been reset to return `undefined`, also affecting Linux process-inspection probes. The fixture now calls Node's actual implementation by default and retains the explicit report-unit overrides. All seven report-helper tests, root-test types, and selected static/lint checks passed, followed by scoped-clean P0–P2 review. Strict cleanup and its deadlines are unchanged. The historical group member was not recorded; no specific descendant is blamed. Exact-head CI supplies the remaining Linux proof.
