### PR TITLE
fix(heartbeat): keep sibling agents on their cadence when one agent sets heartbeat to 0m

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -141,7 +141,8 @@ Outside heartbeats, stray `HEARTBEAT_OK` at the start/end of a message is stripp
 ### Scope and precedence
 
 - `agents.defaults.heartbeat` sets global heartbeat behavior.
-- `agents.entries.*.heartbeat` merges on top; if any agent has a `heartbeat` block, **only those agents** run heartbeats.
+- `agents.entries.*.heartbeat` merges on top; if any agent has a `heartbeat` block that keeps a cadence, **only those agents** run heartbeats.
+- A per-agent block whose merged cadence is `0m` is an opt-out, not an enrollment selector: it disables that agent only, and its siblings keep the cadence they inherit from `agents.defaults.heartbeat`.
 - Ambient ownership resolves through `agents.defaults.heartbeat.agentId`, `agents.defaults.systemAgent.agentId`, the legacy default owner, then the sole agent; when no per-agent or default heartbeat block applies and that chain leaves a multi-agent roster ownerless, heartbeats stay disabled and emit validation and Gateway warnings.
 - `channels.defaults.heartbeatVisibility` sets visibility defaults for all channels.
 - `channels.<channel>.heartbeatVisibility` overrides channel defaults.
@@ -149,7 +150,9 @@ Outside heartbeats, stray `HEARTBEAT_OK` at the start/end of a message is stripp
 
 ### Per-agent heartbeats
 
-If any `agents.entries.*` entry includes a `heartbeat` block, **only those agents** run heartbeats. The per-agent block merges on top of `agents.defaults.heartbeat` (so you can set shared defaults once and override per agent).
+If any `agents.entries.*` entry includes a `heartbeat` block that keeps a cadence, **only those agents** run heartbeats. The per-agent block merges on top of `agents.defaults.heartbeat` (so you can set shared defaults once and override per agent).
+
+Entries that only disable the cadence (`heartbeat: { every: "0m" }`) do not select the enrolled set. Disabling one agent leaves every other agent on its inherited cadence, and the disabled agent keeps its monitor row (disabled) and scratch.
 
 Example: two agents, only the second agent runs heartbeats.
 

--- a/src/commands/doctor-heartbeat-scratch-migration.test.ts
+++ b/src/commands/doctor-heartbeat-scratch-migration.test.ts
@@ -197,9 +197,12 @@ describe("HEARTBEAT.md cron scratch migration", () => {
 
   it("leaves a shared workspace file untouched when only a disabled agent is enrolled", async () => {
     const fixture = await createFixture();
+    // No ambient heartbeat owner: the "0m" entry is the only enrolled agent.
+    // With `agents.defaults.heartbeat` set, the sibling agent inherits that
+    // cadence and owns the migration (covered by the next case).
     const cfg = {
       agents: {
-        defaults: { heartbeat: { every: "30m" }, workspace: fixture.workspace },
+        defaults: { workspace: fixture.workspace },
         list: [
           { id: "main", workspace: fixture.workspace },
           { id: "ollama", workspace: fixture.workspace, heartbeat: { every: "0m" } },

--- a/src/infra/heartbeat-agent-resolution.test.ts
+++ b/src/infra/heartbeat-agent-resolution.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveHeartbeatMonitorPlan } from "../cron/heartbeat-monitor.js";
 import { tryResolveAmbientHeartbeatAgentId } from "./heartbeat-agent-resolution.js";
 import { isHeartbeatOwnerUnresolved, resolveHeartbeatAgents } from "./heartbeat-config.js";
-import { isHeartbeatEnabledForAgent } from "./heartbeat-summary.js";
+import {
+  isHeartbeatEnabledForAgent,
+  resolveHeartbeatSummaryForAgent,
+} from "./heartbeat-summary.js";
 
 describe("tryResolveAmbientHeartbeatAgentId", () => {
   it.each([
@@ -141,5 +145,81 @@ describe("resolveHeartbeatAgents", () => {
     for (const agentId of Object.keys(cfg.agents?.entries ?? {})) {
       expect(isHeartbeatEnabledForAgent(cfg, agentId)).toBe(expectedAgentIds.includes(agentId));
     }
+  });
+});
+
+describe("per-agent heartbeat opt-out", () => {
+  const disabledCodexConfig = {
+    agents: {
+      ownership: "explicit",
+      entries: { main: {}, codex: { heartbeat: { every: "0m" } }, dorami: {} },
+      defaults: {
+        heartbeat: { every: "55m" },
+        systemAgent: { agentId: "main" },
+      },
+    },
+  } as OpenClawConfig;
+
+  it("disables only the opted-out agent and keeps siblings on the inherited cadence", () => {
+    expect(resolveHeartbeatAgents(disabledCodexConfig).map((agent) => agent.agentId)).toEqual([
+      "main",
+      "codex",
+      "dorami",
+    ]);
+    for (const agentId of ["main", "dorami"]) {
+      expect(resolveHeartbeatSummaryForAgent(disabledCodexConfig, agentId)).toMatchObject({
+        enabled: true,
+        every: "55m",
+      });
+    }
+    expect(resolveHeartbeatSummaryForAgent(disabledCodexConfig, "codex")).toMatchObject({
+      enabled: false,
+      every: "disabled",
+      everyMs: null,
+    });
+  });
+
+  it("keeps the monitor row of the opted-out agent while its siblings keep theirs", () => {
+    const plan = resolveHeartbeatMonitorPlan(disabledCodexConfig, []);
+    expect(
+      plan.changes.map((change) => ({
+        kind: change.kind,
+        agentId: change.agentId,
+        enabled: change.kind === "create" ? change.input.enabled : undefined,
+      })),
+    ).toEqual([
+      { kind: "create", agentId: "main", enabled: true },
+      { kind: "create", agentId: "codex", enabled: false },
+      { kind: "create", agentId: "dorami", enabled: true },
+    ]);
+  });
+
+  it("still enrolls only opted-in agents when one per-agent block sets a cadence", () => {
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: {},
+          codex: { heartbeat: { every: "0m" } },
+          ops: { heartbeat: { every: "1h" } },
+        },
+        defaults: { heartbeat: { every: "55m" } },
+      },
+    } as OpenClawConfig;
+    expect(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId)).toEqual(["codex", "ops"]);
+    expect(isHeartbeatEnabledForAgent(cfg, "main")).toBe(false);
+  });
+
+  it("keeps the ambient owner enrolled when the only heartbeat block is an opt-out", () => {
+    const cfg = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: {}, codex: { heartbeat: { every: "0m" } } },
+        defaults: { systemAgent: { agentId: "main" } },
+      },
+    } as OpenClawConfig;
+    expect(resolveHeartbeatAgents(cfg).map((agent) => agent.agentId)).toEqual(["main", "codex"]);
+    expect(resolveHeartbeatSummaryForAgent(cfg, "main").enabled).toBe(true);
+    expect(resolveHeartbeatSummaryForAgent(cfg, "codex").enabled).toBe(false);
   });
 });

--- a/src/infra/heartbeat-config.ts
+++ b/src/infra/heartbeat-config.ts
@@ -54,16 +54,8 @@ export function resolveHeartbeatIntervalMs(
   }
 }
 
-export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
-  const explicitAgents = listAgentEntries(cfg).filter((entry) => entry.heartbeat);
-  if (explicitAgents.length > 0) {
-    return explicitAgents
-      .map((entry) => {
-        const agentId = normalizeAgentId(entry.id);
-        return { agentId, heartbeat: resolveHeartbeatConfig(cfg, agentId) };
-      })
-      .filter((agent) => agent.agentId);
-  }
+/** Enrollment owned by `agents.defaults.heartbeat` and the ambient owner chain. */
+function resolveAmbientHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   const configuredAgentId = normalizeOptionalString(cfg.agents?.defaults?.heartbeat?.agentId);
   if (configuredAgentId) {
     const agentId = normalizeAgentId(configuredAgentId);
@@ -77,6 +69,35 @@ export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   }
   const agentId = tryResolveAmbientHeartbeatAgentId(cfg);
   return agentId ? [{ agentId, heartbeat: resolveHeartbeatConfig(cfg, agentId) }] : [];
+}
+
+export function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
+  const explicitAgents = listAgentEntries(cfg)
+    .filter((entry) => entry.heartbeat)
+    .map((entry) => {
+      const agentId = normalizeAgentId(entry.id);
+      return { agentId, heartbeat: resolveHeartbeatConfig(cfg, agentId) };
+    })
+    .filter((agent) => agent.agentId);
+  // A per-agent block selects the enrolled agents, but a block whose merged
+  // cadence is disabled ("0m") is an opt-out, not an enrollment selector.
+  // Without this check, disabling one agent would silently unenroll every
+  // sibling that inherits `agents.defaults.heartbeat`.
+  const optsInSomeAgent = explicitAgents.some(
+    (agent) => resolveHeartbeatIntervalMs(cfg, undefined, agent.heartbeat) !== null,
+  );
+  if (optsInSomeAgent) {
+    return explicitAgents;
+  }
+  // Keep the opted-out agents enrolled with their disabled cadence so their
+  // monitor row and scratch are retained for re-enabling.
+  const agents = new Map(resolveAmbientHeartbeatAgents(cfg).map((agent) => [agent.agentId, agent]));
+  for (const agent of explicitAgents) {
+    if (!agents.has(agent.agentId)) {
+      agents.set(agent.agentId, agent);
+    }
+  }
+  return [...agents.values()];
 }
 
 export function isHeartbeatOwnerUnresolved(cfg: OpenClawConfig): boolean {


### PR DESCRIPTION
Related: #119005

## What Problem This Solves

Fixes an issue where operators who disable one agent's heartbeat with `agents.entries.<id>.heartbeat.every: "0m"` would silently lose heartbeats for **every** agent, not just that one.

Observed on 2026.9.2 (macOS, gateway in LaunchAgent mode) with three agents (`main`, `codex`, `dorami`), `agents.ownership: "explicit"`, `agents.defaults.systemAgent.agentId: "main"`, and `agents.defaults.heartbeat.every: "55m"`:

1. All three agents run a 55m heartbeat; `openclaw cron list --all` shows `heartbeat:main`, `heartbeat:codex`, `heartbeat:dorami`.
2. `openclaw config set agents.entries.codex.heartbeat.every '"0m"' --strict-json` with the gateway running.
3. The gateway logs, under subsystem `gateway/heartbeat`, `config change detected; evaluating reload (agents.entries.codex.heartbeat)` and immediately `heartbeat: disabled  {"enabled": false}`.
4. `openclaw status` shows `Heartbeat: disabled (main), disabled (codex), disabled (dorami)`.
5. `openclaw cron list --all` lists only the `heartbeat:codex` monitor job (disabled); the `heartbeat:main` and `heartbeat:dorami` monitor jobs are gone. This survives a full gateway restart.
6. `openclaw config unset agents.entries.codex.heartbeat` restores all three 55m heartbeats immediately.

`docs/gateway/heartbeat.md` documents `0m` as disabling the recurring cadence and says a `0m` agent keeps its monitor row (disabled) and scratch, so the expected result is that only `codex` stops.

## Why This Change Was Made

`resolveHeartbeatAgents` (`src/infra/heartbeat-config.ts`) treated *any* per-agent `heartbeat` block as the enrollment selector, so a block that only disables the cadence was read as an opt-in for that agent and an opt-out for everyone else — the `agents.defaults.heartbeat` broadcast branch below it was never reached. Scheduler enablement, the monitor-job plan, the status projection, and the Doctor migrations all derive from this one resolver, which is why a single `0m` entry silenced the fleet and removed the sibling monitor rows.

The resolver now uses per-agent blocks as the enrollment selector only when at least one of them resolves to a non-zero cadence. A disable-only block leaves ambient/default enrollment intact, and the opted-out agent stays enrolled with a disabled cadence so its monitor row and scratch are retained for re-enabling. The documented explicit-enrollment contract is unchanged whenever any per-agent block actually sets a cadence: `{ ops: { every: "1h" }, codex: { every: "0m" } }` still enrolls only `ops`.

Docs (`docs/gateway/heartbeat.md`) now state that a disable-only block is an opt-out rather than an enrollment selector.

Non-goal: no change to event-driven wakes, cadence parsing, or the monitor schedule/retention rules.

## User Impact

Operators can disable one agent's recurring heartbeat with `0m` and keep every other agent on its inherited cadence, with the sibling monitor jobs intact. The disabled agent still keeps its (disabled) monitor row and scratch, so re-enabling the cadence restores it unchanged.

## Evidence

Regression tests added in `src/infra/heartbeat-agent-resolution.test.ts` cover the reported config end to end (enrollment, `openclaw status` summaries, and the monitor-job plan). They fail on the pre-fix resolver:

```
FAIL src/infra/heartbeat-agent-resolution.test.ts > per-agent heartbeat opt-out >
  disables only the opted-out agent and keeps siblings on the inherited cadence
AssertionError: expected [ 'codex' ] to deeply equal [ 'main', 'codex', 'dorami' ]
FAIL ... > keeps the monitor row of the opted-out agent while its siblings keep theirs
FAIL ... > keeps the ambient owner enrolled when the only heartbeat block is an opt-out
Test Files  1 failed (1)
     Tests  3 failed | 14 passed (17)
```

After the fix, the heartbeat resolver, monitor, scheduler, Doctor, gateway cron, and status lanes pass:

```
node scripts/run-vitest.mjs \
  src/infra/heartbeat-agent-resolution.test.ts src/cron/heartbeat-monitor.test.ts \
  src/infra/heartbeat-runner.scheduler.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts \
  src/commands/doctor-heartbeat-scratch-migration.test.ts src/commands/doctor-heartbeat-task-migration.test.ts \
  src/commands/doctor-heartbeat-session-target.test.ts src/commands/doctor-heartbeat-cadence-migration.test.ts \
  src/commands/doctor/shared/default-agent-role-materialization.test.ts src/gateway/server-cron.test.ts
[test] passed 5 Vitest shards in 40.34s   (10 files, 304 tests)

node scripts/run-vitest.mjs \
  src/gateway/server-cron-heartbeat-jobs.test.ts src/gateway/server-runtime-services.test.ts \
  src/status/summary.read-only.test.ts src/commands/status.summary.test.ts \
  src/gateway/health/collector.legacy-owner.test.ts src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
[test] passed 4 Vitest shards in 40.93s   (6 files, 149 tests)
```

One existing expectation was updated rather than relaxed: `doctor-heartbeat-scratch-migration.test.ts` had a case named "leaves a shared workspace file untouched when only a disabled agent is enrolled" whose config also set `agents.defaults.heartbeat.every: "30m"`, so under the corrected semantics its sibling `main` is enrolled and owns the migration (already covered by the adjacent "copies into enabled scratch while retaining a file shared with a disabled agent" case). The config now drops the ambient cadence so the disabled agent really is the only enrolled one, preserving the invariant that case protects (#133389).

`node scripts/check-changed.mjs` passes (exit 0: format, lint, typecheck lanes, dead-code and repository guards). Proof gap: no live gateway run — the reported repro comes from the reporter's LaunchAgent gateway, and the fix is proven at the resolver/monitor-plan boundary that produced the observed log line, status row, and cron rows.
