### PR TITLE
refactor(test): simplify catalog guards and fix native report fixture

### DIFF
--- a/extensions/gmi/index.test.ts
+++ b/extensions/gmi/index.test.ts
@@ -3,19 +3,6 @@ import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-ru
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
-function requireCatalogProvider(
-  result:
-    | { provider: { baseUrl?: string; models?: Array<{ id: string }> } }
-    | { providers: Record<string, unknown> }
-    | null
-    | undefined,
-): { baseUrl?: string; models?: Array<{ id: string }> } {
-  if (!result || !("provider" in result)) {
-    throw new Error("single provider catalog result missing");
-  }
-  return result.provider;
-}
-
 describe("gmi provider plugin", () => {
   it("registers GMI Cloud as an OpenAI-compatible provider", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
@@ -31,8 +18,8 @@ describe("gmi provider plugin", () => {
       env: {},
       resolveProviderApiKey: () => ({}),
     } as never);
-    const catalogProvider = requireCatalogProvider(result);
-    expect(catalogProvider.baseUrl).toBe("https://api.gmi-serving.com/v1");
-    expect(catalogProvider.models?.map((model) => model.id)).toContain("openai/gpt-5.6-sol");
+    const catalogProvider = result && "provider" in result ? result.provider : undefined;
+    expect(catalogProvider?.baseUrl).toBe("https://api.gmi-serving.com/v1");
+    expect(catalogProvider?.models?.map((model) => model.id)).toContain("openai/gpt-5.6-sol");
   });
 });

--- a/extensions/novita/index.test.ts
+++ b/extensions/novita/index.test.ts
@@ -3,19 +3,6 @@ import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-ru
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
-function requireCatalogProvider(
-  result:
-    | { provider: { baseUrl?: string; models?: Array<{ id: string }> } }
-    | { providers: Record<string, unknown> }
-    | null
-    | undefined,
-): { baseUrl?: string; models?: Array<{ id: string }> } {
-  if (!result || !("provider" in result)) {
-    throw new Error("single provider catalog result missing");
-  }
-  return result.provider;
-}
-
 describe("novita provider plugin", () => {
   it("registers NovitaAI as an OpenAI-compatible provider", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
@@ -31,8 +18,8 @@ describe("novita provider plugin", () => {
       env: {},
       resolveProviderApiKey: () => ({}),
     } as never);
-    const catalogProvider = requireCatalogProvider(result);
-    expect(catalogProvider.baseUrl).toBe("https://api.novita.ai/openai/v1");
-    expect(catalogProvider.models?.map((model) => model.id)).toContain("deepseek/deepseek-v4-pro");
+    const catalogProvider = result && "provider" in result ? result.provider : undefined;
+    expect(catalogProvider?.baseUrl).toBe("https://api.novita.ai/openai/v1");
+    expect(catalogProvider?.models?.map((model) => model.id)).toContain("deepseek/deepseek-v4-pro");
   });
 });

--- a/test/scripts/test-report-utils.test.ts
+++ b/test/scripts/test-report-utils.test.ts
@@ -103,6 +103,10 @@ describe("scripts/test-report-utils runVitestJsonReport", () => {
     signal,
     onTestFinished,
   }) => {
+    // Keep Linux process-group verification real while this case runs native children.
+    const { spawnSync } =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    spawnSyncMock.mockImplementation(spawnSync);
     const lifetime = createFixtureLifetime();
     onTestFinished(() => lifetime.cleanup());
     await lifetime.run(async () => {


### PR DESCRIPTION
## What Problem This Solves

GMI and Novita catalog tests duplicate one-use result guards around useful registration assertions. A native report-utility test also leaves its process mock active while verifying real subprocess cleanup, which can turn valid Linux process observations into a cleanup failure.

## Why This Change Was Made

Project the catalog-result union inline while keeping the original positive assertions, complete model-array traversal, and credential-free catalog calls. The shared catalog helper would inject an auth resolver and change those inputs.

Restore actual `spawnSync` passthrough only in the native report case. Its suite-wide mock otherwise returns `undefined` after reset and intercepts the cleanup owner's Linux `ps -L` census. The real observer can distinguish exited threads awaiting reaping from surviving workers. The strict process-tree flag, timeout, fixture lifetime, empty child `PATH`, and every assertion remain unchanged; the mock-only cases still configure their own implementations.

## User Impact

No production, configuration, model-data or public-contract change. Both catalog cases and all 14 assertions remain, as do all seven report-utility cases. Three test files are +10/-32 lines, net -22; no production code changes.

## Evidence

- Catalog baseline and candidate each passed all 32 cases across the same five complete files and four native projects. Case identities and multiplicities match. The [initial Linux changed gate](https://github.com/openclaw/openclaw/actions/runs/33996372819) passed all 19 checks.
- [Hosted CI](https://github.com/openclaw/openclaw/actions/runs/33999396753/job/101395525186) exposed the report-fixture cleanup failure. Its original remaining process state is unknown. In a separate [controlled Linux proof](https://github.com/openclaw/openclaw/actions/runs/34000720773), the baseline failed one of seven cases: real all-thread observations showed only an exited descendant awaiting reaping before cleanup sent SIGKILL. The repaired case passed all seven tests with instrumentation, then all seven without it. Eight selected unchanged lifecycle controls also passed, including rejection of live descendants; 75 other controls were deliberately filtered.
- Both paired runs used the same resolved Node 24.19/pnpm 12.3.4 Linux defaults. A transparent external observer and subreaper were used only for the controlled diagnosis. The remote default heap configuration differed from the original CI job, so this is not presented as an identical-environment CI replay or a performance comparison.
- The [report-fixture changed gate](https://github.com/openclaw/openclaw/actions/runs/34001244011) passed all 15 checks, including test-root types and lint. Both proof leases completed, temporary sources were removed, and recorded children were absent. Independent Codex subagent review found no actionable P0–P2 findings in the final composition.
- The final three test afterimages match the reviewed and proved candidates after the current-main restack. Relevant provider/report/process owners, package pins, and test harnesses were unchanged; the only observed harness delta was an unrelated UI E2E configuration change.

An earlier CI run also exposed a retired assistant retry assertion. Main fixed that independently in #139519; this PR drops its temporary repair and contains no assistant-failure test change. The separate Gateway suppression fix is also already on main in #139576; no Gateway helper change is included here. These are registration and subprocess fixtures, not live provider API tests.
