### PR TITLE
fix: preserve targeted test selection under Bun

### DIFF
--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -2,7 +2,6 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import { matchesVitestCliSelection } from "../../test/vitest/vitest.pattern-file.ts";
 import { fullSuiteVitestShards } from "../../test/vitest/vitest.test-shards.mjs";
 import { runManagedCommand } from "./managed-child-process.mts";
 import { resolveRepoRoot } from "./repo-root.mjs";
@@ -12,10 +11,14 @@ const VITEST_PRETEST_BUILD_MODES = ["private-qa", "runtime"] as const;
 export type VitestPretestBuildMode = (typeof VITEST_PRETEST_BUILD_MODES)[number];
 type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
 
-type TestSelection = {
+export type VitestRuntimeTestSelection = {
   configs?: readonly string[];
   includePatterns?: readonly string[] | null;
-  cli?: { args: string[]; dir: string; env: NodeJS.ProcessEnv };
+  matchesFile?: (
+    file: string,
+    included: boolean,
+    includePatterns: readonly string[] | null | undefined,
+  ) => boolean;
 };
 
 // These tests consume built runtime artifacts. Prepare their strongest
@@ -95,16 +98,12 @@ function includesRuntimeConfig(configs: readonly string[] | undefined, config: s
   );
 }
 
-export function resolveVitestRuntimeCliSelections(
-  config: string,
-  args: string[],
-  env: NodeJS.ProcessEnv,
-): TestSelection[] {
+export function resolveVitestRuntimeConfigScopes(config: string) {
   return runtimeConsumers.flatMap(({ configs, dir }) => {
     // Preserve the matched project scope; broad roots must not apply another
     // consumer's directory to scoped exclusions.
     const selected = configs.filter((candidate) => includesRuntimeConfig([config], candidate));
-    return selected.length ? [{ configs: selected, cli: { args, dir, env } }] : [];
+    return selected.length ? [{ configs: selected, dir }] : [];
   });
 }
 
@@ -129,27 +128,18 @@ export function mergeVitestPretestBuildModes(
 }
 
 export function resolveVitestPretestBuildMode(
-  selections: readonly TestSelection[],
+  selections: readonly VitestRuntimeTestSelection[],
 ): VitestPretestBuildMode | undefined {
   return mergeVitestPretestBuildModes(
     runtimeConsumers
       .filter(({ file, configs: consumerConfigs }) =>
-        selections.some(({ configs, includePatterns, cli }) => {
+        selections.some(({ configs, includePatterns, matchesFile }) => {
           const included = includePatterns
             ? includePatterns.some((pattern) => path.matchesGlob(file, pattern))
             : consumerConfigs.some((config) => includesRuntimeConfig(configs, config));
           // Only project the canonical consumers; config loading and test discovery
           // stay with Vitest. Include-file overrides still intersect emitted filters.
-          return cli
-            ? matchesVitestCliSelection(
-                file,
-                included ? [file] : [],
-                cli.args,
-                cli.dir,
-                cli.env,
-                includePatterns,
-              )
-            : included;
+          return matchesFile ? matchesFile(file, included, includePatterns) : included;
         }),
       )
       .map(({ mode }) => mode),
@@ -157,7 +147,7 @@ export function resolveVitestPretestBuildMode(
 }
 
 export async function prepareVitestRuntime(
-  selections: readonly TestSelection[],
+  selections: readonly VitestRuntimeTestSelection[],
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<number> {
   const mode = resolveVitestPretestBuildMode(selections);

--- a/scripts/lib/vitest-runtime-selection.mts
+++ b/scripts/lib/vitest-runtime-selection.mts
@@ -1,0 +1,18 @@
+import { matchesVitestCliSelection } from "../../test/vitest/vitest.pattern-file.ts";
+import {
+  resolveVitestRuntimeConfigScopes,
+  type VitestRuntimeTestSelection,
+} from "./vitest-build-prerequisites.mts";
+
+/** Bind installed CLI matching without adding runtime dependencies to CI planning. */
+export function resolveVitestRuntimeCliSelections(
+  config: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+): VitestRuntimeTestSelection[] {
+  return resolveVitestRuntimeConfigScopes(config).map(({ configs, dir }) => ({
+    configs,
+    matchesFile: (file, included, includePatterns) =>
+      matchesVitestCliSelection(file, included ? [file] : [], args, dir, env, includePatterns),
+  }));
+}

--- a/scripts/pr-lib/wrapper-components.txt
+++ b/scripts/pr-lib/wrapper-components.txt
@@ -25,6 +25,7 @@ scripts/lib/vitest-local-scheduling.mts
 scripts/lib/vitest-process-env.mts
 scripts/lib/vitest-process.mts
 scripts/lib/vitest-resource-ownership.mts
+scripts/lib/vitest-runtime-selection.mts
 scripts/lib/vitest-shard-metadata.mts
 scripts/lib/vitest-unhandled-errors.mts
 scripts/lib/vitest-worker-artifacts.mts

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -19,7 +19,6 @@ import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   prepareE2eVitestRuntime,
   resolveVitestCliEntry,
-  resolveVitestRuntimeCliSelections,
   prepareVitestRuntime,
 } from "./lib/vitest-build-prerequisites.mts";
 import {
@@ -47,6 +46,7 @@ import {
   runVitestCli,
   type exitVitestBySignal,
 } from "./lib/vitest-process.mts";
+import { resolveVitestRuntimeCliSelections } from "./lib/vitest-runtime-selection.mts";
 import {
   createVitestUnhandledErrorDetector,
   stripVitestAnsi,

--- a/scripts/test-extension-batch.mts
+++ b/scripts/test-extension-batch.mts
@@ -26,6 +26,7 @@ import type { VitestBatchRunParams } from "./lib/vitest-batch-runner.mts";
 import { prepareVitestRuntime } from "./lib/vitest-build-prerequisites.mts";
 import { resolveVitestHomeSelection } from "./lib/vitest-home-selection.mts";
 import { createVitestReportOwner, type VitestReportOutcome } from "./lib/vitest-report-owner.mts";
+import { resolveVitestRuntimeCliSelections } from "./lib/vitest-runtime-selection.mts";
 
 const FS_MODULE_CACHE_PATH_ENV_KEY = "OPENCLAW_VITEST_FS_MODULE_CACHE_PATH";
 const PARALLEL_ENV_KEY = "OPENCLAW_EXTENSION_BATCH_PARALLEL";
@@ -313,10 +314,9 @@ export async function runExtensionBatchPlan(
     // from the exact emitted chunks, including existing exact-exclude expansion.
     const preparationCode = await prepareVitestRuntime(
       preparedGroups.flatMap((group) =>
-        group.invocations.map(({ config, args, targets }) => ({
-          configs: [config],
-          cli: { args: [...args, ...targets], dir: "extensions", env },
-        })),
+        group.invocations.flatMap(({ config, args, targets }) =>
+          resolveVitestRuntimeCliSelections(config, [...args, ...targets], env),
+        ),
       ),
       env,
     );

--- a/scripts/test-projects-run.mts
+++ b/scripts/test-projects-run.mts
@@ -11,7 +11,6 @@ import {
   prepareE2eVitestRuntime,
   prepareVitestRuntime,
   resolveVitestCliEntry,
-  resolveVitestRuntimeCliSelections,
 } from "./lib/vitest-build-prerequisites.mts";
 import { createVitestCacheSlots } from "./lib/vitest-cache-slots.mts";
 import { hasNonRunVitestSubcommand } from "./lib/vitest-cli-mode.mts";
@@ -21,6 +20,7 @@ import { isCiLikeEnv, resolveLocalFullSuiteProfile } from "./lib/vitest-local-sc
 import { resolveVitestNodeArgs, resolveVitestProcessEnv } from "./lib/vitest-process-env.mts";
 import type { exitVitestBySignal } from "./lib/vitest-process.mts";
 import { createVitestReportOwner, type VitestReportOwner } from "./lib/vitest-report-owner.mts";
+import { resolveVitestRuntimeCliSelections } from "./lib/vitest-runtime-selection.mts";
 import {
   createShardTimingSample,
   readShardTimings,

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -31,7 +31,6 @@ import {
 import { codexExtensionTestRoots } from "../test/vitest/vitest.extension-codex-paths.mjs";
 import { matrixExtensionTestRoots } from "../test/vitest/vitest.extension-matrix-paths.mjs";
 import { telegramExtensionTestRoots } from "../test/vitest/vitest.extension-telegram-paths.mjs";
-import { narrowIncludePatternsForCli } from "../test/vitest/vitest.pattern-file.ts";
 import { resolveVitestFsModuleCacheRoot } from "../test/vitest/vitest.performance-config.ts";
 import {
   isPluginSdkLightTarget,
@@ -64,7 +63,6 @@ import {
   isBoundaryTestFile,
   isBundledPluginDependentUnitTestFile,
   isUnitConfigTestFile,
-  unitTestIncludePatterns,
 } from "../test/vitest/vitest.unit-paths.mjs";
 import {
   detectChangedLanes,
@@ -4018,20 +4016,14 @@ export function buildVitestRunPlans(
       kind === "default" &&
       useCliTargetArgs &&
       !watchMode &&
-      !options.env?.[INCLUDE_FILE_ENV_KEY]?.trim()
-        ? narrowIncludePatternsForCli(unitTestIncludePatterns, [
-            "node",
-            "vitest",
-            ...forwardedPlanArgs,
-          ])
+      !options.env?.[INCLUDE_FILE_ENV_KEY]?.trim() &&
+      grouped.every((targetArg) => !path.isAbsolute(targetArg))
+        ? uniqueOrdered(grouped.map((targetArg) => toRepoRelativeTarget(targetArg, cwd)))
         : null;
     // CI needs explicit selection metadata. Keep the CLI filters too: the unit
     // config and runner use them for exclude and empty-selection policy.
     const scopedUnitIncludes =
       unitCliIncludes?.length &&
-      grouped.every((targetArg) =>
-        unitCliIncludes.includes(toRepoRelativeTarget(targetArg, cwd)),
-      ) &&
       unitCliIncludes.every(
         (file) =>
           !isGlobTarget(file) && isUnitConfigTestFile(file) && isExistingFileTarget(file, cwd),
@@ -4484,7 +4476,7 @@ function filterPlansForContractIncludeFile(plans: VitestRunPlan[], env: NodeJS.P
 
 function expandVitestIncludePatterns(includePatterns: string[], cwd: string) {
   const candidateFiles = includePatterns.some(isGlobTarget)
-    ? listExplicitTestTargetFilesForCwd(cwd)
+    ? listExplicitTestTargetFilesForCwd(cwd).toSorted()
     : [];
   return uniqueOrdered(
     includePatterns.flatMap((pattern) => {

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -123,7 +123,7 @@ registerHooks({resolve(specifier, context, nextResolve) {
       // The JS shim creates another Node process; inject at the inherited dependency
       // boundary, and retain a bounded empty selection even if injection regresses.
       const result = spawnSync(
-        process.execPath,
+        process.versions.bun ? "node" : process.execPath,
         [
           nodePath.resolve(`scripts/run-vitest.${extension}`),
           "run",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -6,10 +6,8 @@ import path from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { listExtensionTestFilesForRoots } from "../../scripts/lib/extension-test-plan.mts";
 import { readTestSelectorSourceFacts } from "../../scripts/lib/test-selector-source-facts.mts";
-import {
-  resolveVitestPretestBuildMode,
-  resolveVitestRuntimeCliSelections,
-} from "../../scripts/lib/vitest-build-prerequisites.mts";
+import { resolveVitestPretestBuildMode } from "../../scripts/lib/vitest-build-prerequisites.mts";
+import { resolveVitestRuntimeCliSelections } from "../../scripts/lib/vitest-runtime-selection.mts";
 import { resolveShardTimingKey } from "../../scripts/lib/vitest-shard-metadata.mts";
 import {
   CHANNEL_CONTRACT_CONFIG_PATTERNS,
@@ -155,6 +153,22 @@ describe("test runtime prerequisites", () => {
       {},
     );
     expect(resolveVitestPretestBuildMode(selections)).toBe(expected);
+  });
+
+  it("projects invocation-owned include files when selecting prerequisites", () => {
+    const selections = resolveVitestRuntimeCliSelections(
+      "test/vitest/vitest.gateway-server.config.ts",
+      ["run"],
+      {},
+    );
+    for (const selection of selections) {
+      selection.includePatterns = ["src/gateway/server-request-context.test.ts"];
+    }
+    expect(resolveVitestPretestBuildMode(selections)).toBeUndefined();
+    for (const selection of selections) {
+      selection.includePatterns = ["src/gateway/server-sidecar-retention.test.ts"];
+    }
+    expect(resolveVitestPretestBuildMode(selections)).toBe("runtime");
   });
 
   it("combines private QA and runtime readers into one private build", () => {

--- a/test/vitest-scoped-config.test.ts
+++ b/test/vitest-scoped-config.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { minimatch } from "minimatch";
 import { BUNDLED_PLUGIN_TEST_GLOB, bundledPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
@@ -287,6 +288,12 @@ describe("createScopedVitestConfig", () => {
       includePattern: "extensions/**/*.test.ts",
       target: "extensions/browser/index.test.ts",
       expectedInclude: "browser/index.test.ts",
+    },
+    {
+      title: "keeps explicitly selected files owned by negative extglobs",
+      includePattern: "extensions/*/browser/**/!(*.browser).test.ts",
+      target: "extensions/example/browser/view.test.ts",
+      expectedInclude: "example/browser/view.test.ts",
     },
     {
       title: "narrows scoped includes to matching dot-prefixed CLI file filters",
@@ -1162,7 +1169,7 @@ describe("scoped vitest configs", () => {
       ["extensions/workboard/browser/native.browser.test.ts", false],
     ] as const) {
       expect(
-        testConfig.include?.some((pattern) => path.matchesGlob(file, pattern)),
+        testConfig.include?.some((pattern) => minimatch(file, pattern)),
         file,
       ).toBe(included);
     }

--- a/test/vitest/vitest.pattern-file.test.ts
+++ b/test/vitest/vitest.pattern-file.test.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   collectVitestExcludePatterns,
@@ -7,6 +11,35 @@ import {
 } from "./vitest.pattern-file.ts";
 
 describe("native CLI selection", () => {
+  it("plans Node CI test ownership before dependencies are installed", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-selection-preflight-"));
+    try {
+      for (const relative of [
+        "test/vitest/vitest.pattern-file.ts",
+        "scripts/lib/vitest-cli-mode.mts",
+      ]) {
+        const target = path.join(root, relative);
+        mkdirSync(path.dirname(target), { recursive: true });
+        copyFileSync(path.resolve(import.meta.dirname, "../..", relative), target);
+      }
+      writeFileSync(path.join(root, "package.json"), '{"type":"module"}');
+      const result = spawnSync(
+        process.versions.bun ? "node" : process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          `import { matchesVitestGlob } from './test/vitest/vitest.pattern-file.ts';
+           console.log(matchesVitestGlob('ui/src/example.test.ts', 'ui/src/**/!(*.browser).test.ts'));`,
+        ],
+        { cwd: root, encoding: "utf8", env: { ...process.env, NODE_OPTIONS: "", NODE_PATH: "" } },
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout.trim()).toBe("true");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     { file: "ui/src/pages/devices/capability-chips.test.ts", selected: true },
     { file: "ui/src/pages/devices/capability-chips.browser.test.ts", selected: false },

--- a/test/vitest/vitest.pattern-file.test.ts
+++ b/test/vitest/vitest.pattern-file.test.ts
@@ -7,6 +7,17 @@ import {
 } from "./vitest.pattern-file.ts";
 
 describe("native CLI selection", () => {
+  it.each([
+    { file: "ui/src/pages/devices/capability-chips.test.ts", selected: true },
+    { file: "ui/src/pages/devices/capability-chips.browser.test.ts", selected: false },
+  ])("preserves UI extglob ownership for $file", ({ file, selected }) => {
+    const include = ["ui/src/**/!(*.browser).test.ts"];
+    const expected = selected ? [file] : [];
+    expect(narrowIncludePatternsForCli(include, ["node", "vitest", "run", file])).toEqual(expected);
+    expect(intersectIncludePatterns(include, [file])).toEqual(expected);
+    expect(matchesVitestCliSelection(file, include, ["run", file], "", {})).toBe(selected);
+  });
+
   const file = "extensions/qa-lab/src/suite-process-lifecycle.test.ts";
   it.each([
     { args: ["--configLoader", "runner"], selected: true },

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -1,17 +1,24 @@
 // Vitest pattern file helper reads include and exclude patterns from files.
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
-import { Minimatch } from "minimatch";
+import type { Minimatch } from "minimatch";
 import { collectVitestFileFilters } from "../../scripts/lib/vitest-cli-mode.mts";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
+const require = createRequire(import.meta.url);
 const globMatchers = new Map<string, Minimatch>();
 
 export function matchesVitestGlob(value: string, pattern: string): boolean {
+  // CI plans tests before installing dependencies; keep Node's matcher dependency-free.
+  if (!process.versions.bun) {
+    return path.matchesGlob(value, pattern);
+  }
   let matcher = globMatchers.get(pattern);
   if (!matcher) {
     // Keep Node's path.matchesGlob semantics when Bun does not support extglobs.
-    matcher = new Minimatch(pattern, {
+    const { Minimatch: Matcher }: typeof import("minimatch") = require("minimatch");
+    matcher = new Matcher(pattern, {
       nocase: process.platform === "win32" || process.platform === "darwin",
       windowsPathsNoEscape: true,
       nonegate: true,

--- a/test/vitest/vitest.pattern-file.ts
+++ b/test/vitest/vitest.pattern-file.ts
@@ -1,9 +1,35 @@
 // Vitest pattern file helper reads include and exclude patterns from files.
 import fs from "node:fs";
 import path from "node:path";
+import { Minimatch } from "minimatch";
 import { collectVitestFileFilters } from "../../scripts/lib/vitest-cli-mode.mts";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
+const globMatchers = new Map<string, Minimatch>();
+
+export function matchesVitestGlob(value: string, pattern: string): boolean {
+  let matcher = globMatchers.get(pattern);
+  if (!matcher) {
+    // Keep Node's path.matchesGlob semantics when Bun does not support extglobs.
+    matcher = new Minimatch(pattern, {
+      nocase: process.platform === "win32" || process.platform === "darwin",
+      windowsPathsNoEscape: true,
+      nonegate: true,
+      nocomment: true,
+      optimizationLevel: 2,
+      platform: process.platform,
+      nocaseMagicOnly: true,
+    });
+    globMatchers.set(pattern, matcher);
+    if (globMatchers.size > 250) {
+      const oldest = globMatchers.keys().next().value;
+      if (oldest !== undefined) {
+        globMatchers.delete(oldest);
+      }
+    }
+  }
+  return matcher.match(value);
+}
 
 function normalizeCliPattern(value: string): string {
   let normalized = value
@@ -74,7 +100,7 @@ function literalPrefixForGlobPattern(value: string): string {
 }
 
 function patternsCouldOverlap(value: string, pattern: string): boolean {
-  if (path.matchesGlob(value, pattern) || path.matchesGlob(pattern, value)) {
+  if (matchesVitestGlob(value, pattern) || matchesVitestGlob(pattern, value)) {
     return true;
   }
 
@@ -103,7 +129,7 @@ function narrowIncludePatterns(
     const isLiteral = !/[?*[\]{}]/u.test(candidate);
     for (const laneScope of includePatterns) {
       if (isLiteral) {
-        if (path.matchesGlob(candidate, laneScope)) {
+        if (matchesVitestGlob(candidate, laneScope)) {
           narrowed.add(candidate);
         }
       } else if (patternsCouldOverlap(candidate, laneScope)) {
@@ -189,7 +215,7 @@ export function intersectIncludePatterns(
   for (const candidate of candidatePatterns) {
     if (!isPlainRepoRelativePath(candidate)) {
       if (literalIncludes) {
-        result.push(...includePatterns.filter((include) => path.matchesGlob(include, candidate)));
+        result.push(...includePatterns.filter((include) => matchesVitestGlob(include, candidate)));
         continue;
       }
       // Watch directory targets retain their glob so newly added tests appear.
@@ -204,7 +230,7 @@ export function intersectIncludePatterns(
     if (
       literalIncludes
         ? literalIncludes.has(candidate)
-        : includePatterns.some((include) => path.matchesGlob(candidate, include))
+        : includePatterns.some((include) => matchesVitestGlob(candidate, include))
     ) {
       result.push(candidate);
     }
@@ -317,10 +343,10 @@ export function matchesVitestCliSelection(
   const absoluteFile = path.resolve(repoRoot, file);
   if (
     !relativizeScopedPatterns(patterns, scopedDir).some((pattern) =>
-      path.matchesGlob(path.isAbsolute(pattern) ? absoluteFile : relativeFile, pattern),
+      matchesVitestGlob(path.isAbsolute(pattern) ? absoluteFile : relativeFile, pattern),
     ) ||
     collectVitestExcludePatterns(args).some((pattern) =>
-      path.matchesGlob(path.isAbsolute(pattern) ? absoluteFile : relativeFile, pattern),
+      matchesVitestGlob(path.isAbsolute(pattern) ? absoluteFile : relativeFile, pattern),
     )
   ) {
     return false;

--- a/test/vitest/vitest.scoped-config.ts
+++ b/test/vitest/vitest.scoped-config.ts
@@ -4,6 +4,7 @@ import { defineConfig, type ViteUserConfig } from "vitest/config";
 import {
   intersectIncludePatterns,
   loadPatternListFromEnv,
+  matchesVitestGlob,
   narrowIncludePatternsForCli,
   relativizeScopedPatterns,
 } from "./vitest.pattern-file.ts";
@@ -46,7 +47,7 @@ function includePatternIsFullyExcluded(includePattern: string, excludePattern: s
   const exclude = normalizePathPattern(excludePattern);
   return (
     include === exclude ||
-    path.matchesGlob(include, exclude) ||
+    matchesVitestGlob(include, exclude) ||
     directoryPatternCoversInclude(exclude, include)
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where targeted test selection under Bun interpreted advanced glob patterns differently from Node and could omit intended tests. CI preinstall planning must also remain usable without installed dependencies.

## Why This Change Was Made

Retain Node's native matcher and lazily use the existing Minimatch dependency under Bun. Separate installed runtime matching from dependency-free planning, bind invocation-specific filters through a narrow adapter, and preserve deterministic file inventory order. Relative existing unit-test paths can supply selection metadata without importing runtime matching into the planner.

## User Impact

Developers can use the maintained test commands under Bun with the intended glob semantics. Node CI planning still runs before dependency installation, and the preflight import-closure guard remains unchanged.

## Evidence

- Final focused suite passes 748 tests on Node and 748 on true Bun.
- The unchanged dependency-free import-closure guard passes. Actual planners run without node_modules and emit valid JSON for full, changed, and compact selections.
- UI discovery inventory matches across the before/after runs, with all existing scoped exceptions retained.
- Complete final nine-path correction gate passes after verified manual recovery of a stale task-owned artifact lock. Independent P0–P2 review is clean.
- Earlier focused matcher proof passed 118 tests on each runtime, including a regression that failed the original eager dependency import in an empty dependency tree.
- The final rebase is patch-identical. The full repository Bun compatibility campaign remains in progress.
