### PR TITLE
perf(browser): avoid temporary NodeList copies in snapshots

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -552,7 +552,7 @@ async function findCursorInteractiveElements(
         const roles = new Set(["button","link","textbox","checkbox","radio","combobox","listbox","menuitem","menuitemcheckbox","menuitemradio","option","searchbox","slider","spinbutton","switch","tab","treeitem"]);
         const tags = new Set(["a","button","input","select","textarea","details","summary"]);
         document.querySelectorAll("[${attr}]").forEach((el) => el.removeAttribute("${attr}"));
-        for (const el of Array.from(document.body ? document.body.querySelectorAll("*") : [])) {
+        for (const el of document.body ? document.body.querySelectorAll("*") : []) {
           if (!(el instanceof HTMLElement) || el.closest("[hidden],[aria-hidden='true']")) continue;
           const tagName = el.tagName.toLowerCase();
           if (tags.has(tagName)) continue;

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -80,7 +80,7 @@ async function collectSnapshotUrls(page: Page): Promise<SnapshotUrlEntry[]> {
     .evaluate(() => {
       const seen = new Set<string>();
       const out: SnapshotUrlEntry[] = [];
-      for (const anchor of Array.from(document.querySelectorAll("a[href]"))) {
+      for (const anchor of document.querySelectorAll("a[href]")) {
         const href = anchor instanceof HTMLAnchorElement ? anchor.href : "";
         if (!href || seen.has(href)) {
           continue;

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -91,7 +91,7 @@ async function collectChromeMcpSnapshotUrls(
     fn: `() => {
       const seen = new Set();
       const out = [];
-      for (const anchor of Array.from(document.querySelectorAll("a[href]"))) {
+      for (const anchor of document.querySelectorAll("a[href]")) {
         const href = anchor.href || "";
         if (!href || seen.has(href)) continue;
         const text = (anchor.innerText || anchor.textContent || anchor.getAttribute("aria-label") || "")


### PR DESCRIPTION
## What Problem This Solves

Resolves avoidable allocation when browser snapshots scan large documents for cursor-interactive elements or collect link appendices. Each collector copied a complete NodeList into a temporary JavaScript array before iterating it, even when output stopped at 100 links.

## Why This Change Was Made

The collectors in `extensions/browser/src/browser/cdp.ts`, `pw-tools-core.snapshot.ts`, and `routes/agent.snapshot.ts` iterate their existing static NodeLists directly. Managed role snapshots reach the cursor collector through the CDP owner; Playwright and the existing-session route retain their respective URL collectors. Selectors, tree order, body fallback, exclusions, marker cleanup, URL deduplication/limits, and text precedence remain unchanged.

The native static iterable already provides the needed sequence, so no helper, compatibility fallback, or dependency is added. Returned arrays and Chromium's underlying NodeList allocation remain. Production: +3/-3 lines (net zero); maintained tests/support: +0/-0.

## User Impact

Snapshot collection avoids a page-sized intermediate array while preserving snapshot text, refs, metadata, URL ordering, bounds, target/session handling, and permission/network checks. This is collector allocation reduction, without a claimed end-to-end MCP-server speedup.

## Evidence

The harness extracts the exact three production page callbacks through the TypeScript AST and executes them in isolated Chromium 151.0.7922.34 through Playwright 1.62.1 on Node 26.8.1. Nine fixtures preserve complete results across empty/rich/bounded pages, hidden/native/editable controls, SVG anchors, labels, duplicates, Unicode, and zero geometry. Baseline calls each make one NodeList copy; candidates make none. A 50,008-match link fixture still returns at most 100 links, with identical cleanup and zero network requests.

A separate temporary harness invokes actual CDP role, Playwright role, and Playwright AI snapshot owners in real isolated Chromium. Five complete snapshot outputs, including capped variants, match byte-for-byte, alongside refs/stats, marker state, and request observations. The MCP-emitted page function runs in Chromium; no Chrome MCP server/session is launched.

Three samples per arm measure complete capture/cleanup sequences using a 4 KiB Chromium cumulative sampler including collected objects:

| Collector | Captures/sample | Sampled bytes before → after | Median ms before → after |
| --- | ---: | ---: | ---: |
| Playwright URLs, 50,000 links + controls | 24 | 80,889,320 → 45,034,712 | 449.7 → 362.5 |
| MCP URL function, same fixture | 24 | 79,296,588 → 40,994,460 | 501.8 → 376.7 |
| CDP cursor, 10,000 nodes + controls | 12 | 12,779,364 → 9,325,192 | 111.8 → 89.0 |

`Array.from`-attributed samples fall from 16,284,980 / 16,294,940 / 1,587,376 bytes to zero respectively. Baselines precede candidates under shared host load; timings are descriptive, not randomized latency estimates. No retained-heap, RSS, or whole-Gateway improvement is claimed.

```sh
OPENCLAW_BROWSER_SNAPSHOT_E2E=1 node scripts/run-vitest.mjs extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.test.ts extensions/browser/src/browser/cdp.internal.test.ts extensions/browser/src/browser/routes/agent.snapshot.test.ts
node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/browser/src/browser/cdp.ts extensions/browser/src/browser/pw-tools-core.snapshot.ts extensions/browser/src/browser/routes/agent.snapshot.ts
```

Maintained suites pass 55 tests, including three Chromium cases; the final run including the temporary owner harness passes 56. The harness was removed before freeze. Correct extension-project typed lint, formatting, diff checks, and changed-plan classification pass; P2 review records no actionable findings. The separate role-tree patch composes in either order; the additional real-browser composition proof below passes. Broad local extension gates were not run; required exact-head hosted CI/native landing gates remain mandatory.

A separate real-Chromium check exercised the frozen combined browser changes through the actual built snapshot/ref/action owners. A genuine 393-node AX tree produced document-bound refs; clicks selected the first and second identically named buttons, a cursor-promoted control, then the second Playwright ref, giving exact visible events `["first", "second", "cursor", "second"]`. Hidden controls remained absent, disabled clicks remained rejected, and marker cleanup matched. Four snapshot texts and complete Playwright role/AI/capped objects were identical. CDP comparison normalized only browser-issued node/frame IDs; raw IDs were used for the actual clicks. This is behavior proof on synthetic browser content, separate from the allocation measurements and without a Gateway or Chrome MCP server.

| Real-browser outcome | Before | Combined changes |
| --- | --- | --- |
| Final selected button | ![Synthetic browser outcome before](https://github.com/user-attachments/assets/d5ea595e-8c0a-4740-b145-df4137bb83a1) | ![Synthetic browser outcome after](https://github.com/user-attachments/assets/874f7a36-50a0-499e-b5b9-471adfe34184) |


The initial required core test-type job failed on main’s stale `maybeRetryTransient` test assertion. The exact CI merge and its main parent contain the same mismatch outside this browser patch. The branch is mechanically refreshed onto main after the separately landed [test repair #139519](https://github.com/openclaw/openclaw/pull/139519); all three reviewed browser source files remain byte-identical. Fresh exact-head required CI remains mandatory.
