### PR TITLE
fix(gateway): keep assistant media policy consistent for Control UI

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1240,6 +1240,10 @@ workspace-only filesystem protection, also permits image previews outside that
 workspace. An explicit session permission mode takes precedence over the agent's
 filesystem setting.
 
+Sessions dispatched to a cloud worker cannot read Gateway-local file paths,
+even with Full Access. Dispatch also revokes pending local previews and downloads.
+Gateway-owned inbound uploads remain available.
+
 Full Access also preserves playback and downloads for existing attachments in
 the agent's configured workspace. It does not permit arbitrary outside
 non-image files.

--- a/src/gateway/assistant-media-policy.ts
+++ b/src/gateway/assistant-media-policy.ts
@@ -1,3 +1,4 @@
+import { isCloudWorkerPlacementState } from "../../packages/gateway-protocol/src/schema/session-placement-state.js";
 import { GATEWAY_OWNER_PROFILE_ID } from "../../packages/gateway-protocol/src/schema/users.js";
 import { resolveSessionPermissionCoreToolPolicy } from "../agents/session-permission-exec-mode.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../agents/tool-fs-policy.js";
@@ -14,6 +15,7 @@ import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { resolveRequestedSessionAgentId } from "./session-request-agent.js";
 import { createProfileSessionEntryFilter } from "./session-sharing.js";
 import { loadGatewaySessionEntryReadOnly } from "./session-utils.js";
+import { resolveSessionWorkerPlacementContext } from "./session-worker-placement-context.js";
 import { resolveSessionWorkspaceRoots } from "./session-workspace-roots.js";
 
 export type AssistantMediaSession = {
@@ -125,9 +127,15 @@ export function resolveAssistantMediaPolicy(params: {
   if (sessionRoot && !localRoots.includes(sessionRoot)) {
     localRoots.push(sessionRoot);
   }
+  // Cloud placement owns its filesystem independently of the session exec-node setting.
+  const placement = session
+    ? resolveSessionWorkerPlacementContext()
+        .workerSessionPlacementService?.getMany([session.sessionId])
+        .get(session.sessionId)
+    : undefined;
   return {
     session,
-    remote: Boolean(entry?.execNode),
+    remote: Boolean(entry?.execNode) || isCloudWorkerPlacementState(placement?.state),
     localRoots,
     workspaceOnly,
     reader,

--- a/src/gateway/control-ui-assistant-media-policy.test.ts
+++ b/src/gateway/control-ui-assistant-media-policy.test.ts
@@ -18,9 +18,15 @@ import { makeMockHttpResponse } from "./test-http-response.js";
 const state = vi.hoisted(() => ({
   loaded: vi.fn(),
   auth: vi.fn(),
+  placements: vi.fn(),
 }));
 vi.mock("./session-utils.js", () => ({ loadGatewaySessionEntryReadOnly: state.loaded }));
 vi.mock("./http-utils.js", () => ({ authorizeControlUiReadRequestOrReply: state.auth }));
+vi.mock("./session-worker-placement-context.js", () => ({
+  resolveSessionWorkerPlacementContext: () => ({
+    workerSessionPlacementService: { getMany: state.placements },
+  }),
+}));
 const PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
   "base64",
@@ -40,6 +46,7 @@ let entry: {
 const sessionKey = "agent:main:dashboard:media";
 
 beforeEach(async () => {
+  state.placements.mockReset().mockReturnValue(new Map());
   temp = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "assistant-image-policy-")));
   project = path.join(temp, "project");
   await fs.mkdir(project);
@@ -481,6 +488,68 @@ describe("assistant image session policy", () => {
         });
         try {
           const denied = await request(source, { ticket, bytes: operation === "bytes" });
+          expect(denied.res.statusCode).toBe(404);
+          expect(denied.bytes).not.toEqual(PNG);
+        } finally {
+          openSpy.mockRestore();
+        }
+      });
+    },
+  );
+
+  it.each(["metadata", "bytes"] as const)(
+    "withdraws Gateway-local media after cloud dispatch during %s preparation",
+    async (operation) => {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(temp, "placement-state") }, async () => {
+        const { createWorkerSessionPlacementStore } =
+          await import("./worker-environments/placement-store.js");
+        const placements = createWorkerSessionPlacementStore();
+        state.placements.mockImplementation((sessionIds: readonly string[]) =>
+          placements.getMany(sessionIds),
+        );
+        entry.permissionMode = "full";
+        const source = path.join(temp, "gateway-only.png");
+        await fs.writeFile(source, PNG);
+        const ticket = String((await request(source)).payload!.mediaTicket);
+        const openFile = fs.open;
+        let dispatched = false;
+        const openSpy = vi.spyOn(fs, "open").mockImplementation(async (filePath, flags, mode) => {
+          const file = await openFile(filePath, flags, mode);
+          if (filePath === source && !dispatched) {
+            dispatched = true;
+            let placement = placements.startDispatch({
+              sessionId: entry.sessionId,
+              sessionKey,
+              agentId: "main",
+              executionMode: "worker-turn",
+            });
+            for (const [to, patch] of [
+              ["provisioning", { environmentId: "media-worker" }],
+              ["syncing", { workerBundleHash: "a".repeat(64) }],
+              [
+                "starting",
+                {
+                  workspaceBaseManifestRef: `sha256:${"b".repeat(64)}`,
+                  remoteWorkspaceDir: "/remote/workspace",
+                },
+              ],
+              ["active", { activeOwnerEpoch: 1 }],
+            ] as const) {
+              placement = placements.transition({
+                sessionId: entry.sessionId,
+                from: placement.state,
+                to,
+                expectedGeneration: placement.generation,
+                patch,
+              });
+            }
+          }
+          return file;
+        });
+        try {
+          const denied = await request(source, { ticket, bytes: operation === "bytes" });
+          expect(dispatched).toBe(true);
+          expect(entry.execNode).toBeUndefined();
           expect(denied.res.statusCode).toBe(404);
           expect(denied.bytes).not.toEqual(PNG);
         } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Control UI could preview or download a Gateway-local file after its session moved to a cloud worker. Cloud placement does not require an exec-node setting, so Full Access sessions could retain the wrong filesystem access during media preparation.

## Why This Change Was Made

The assistant-media policy now reads the session's canonical worker placement and uses the shared cloud-state classifier. The existing response-boundary policy recheck withdraws pending metadata and byte reads when dispatch changes filesystem ownership. Gateway-owned inbound uploads retain their existing behavior.

This is side-gateway stage 3 of the #135868 split, extracting the independent assistant-media fix from concern F (decision brief §1 and §5). Delegated-run authority tests and Gateway startup/cleanup changes remain with the runtime cleanup stage.

## User Impact

Cloud sessions no longer interpret file paths as paths on the Gateway host. Session permissions and media tickets continue to enforce the current filesystem owner.

## Evidence

- Before the fix: both cloud-dispatch regressions returned HTTP 200 instead of 404; 30 existing policy tests passed. The tests use real files and a real placement store, transitioning to active cloud placement during metadata or byte preparation.
- After the fix: 96 tests passed across five suites, including the real isolated Gateway HTTP route and session-file neighbors. The integration runtime build and its postbuild checks also passed.
- Independent Codex review: no actionable P0/P1 findings. The full changed-file check passed before the final main refresh, including core/test types, lint, guards, and all three Knip scans (zero unused exports). The final policy-only rerun passed 32/32 after rebasing.
- Production: +9/-1 (net +8), carrying missing filesystem-owner information through existing policy. Tests: +69/-0, 14 fewer lines than the source concern. Docs: +4/-0. Across the three side-gateway patches, production is net -2.

The prior exact-head CI failure was caused by the unrelated storage-failure fixture added in #139409. Main repaired it in #139519/#139531. This branch has been rebased onto those repairs; 125 tests across six suites passed, including the formerly failing assistant-failure and native-report suites plus media/session-file coverage. The full changed-file check passed again with no skips, and fresh Codex branch review is scoped-clean at P0/P1. Final exact-head CI is green on `1f0426f7f133f13bf5e9ded777ecc7978d4f37bf` ([run 34010453092](https://github.com/openclaw/openclaw/actions/runs/34010453092)). ClawSweeper reviewed the unchanged patch on the previous head with no introduced correctness or security findings ([review](https://github.com/openclaw/openclaw/pull/139503#issuecomment-5555509733)). Its requested merge-risk decision is addressed by retaining the recommended, documented isolation boundary: cloud sessions lose accidental Gateway-local path previews/downloads, while Gateway-owned inbound uploads remain available. This intentional correction is the concern F behavior extracted from #135868; no additional rank-up change was requested.

