### PR TITLE
fix(ci): synchronize cloud retries and board widget input

### DIFF
--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -217,7 +217,16 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
         .toBe(true);
       const widgetFrame = outerFrame!.childFrames()[0]!;
       await widgetFrame.getByText("A2UI board widget").waitFor();
-      await widgetFrame.getByText("Refresh data").click();
+      await expect
+        .poll(() => outer.evaluate((element) => getComputedStyle(element).opacity))
+        .toBe("1");
+      expect(await outer.getAttribute("inert")).toBeNull();
+      const refresh = widgetFrame.getByText("Refresh data");
+      // Chromium can target the outer iframe just after reveal despite passing
+      // actionability checks. Await native pointer entry before the single click.
+      await refresh.hover();
+      await expect.poll(() => refresh.evaluate((element) => element.matches(":hover"))).toBe(true);
+      await refresh.click();
       await expect.poll(async () => (await gateway.getRequests("board.event")).length).toBe(1);
       expect((await gateway.getRequests("board.event"))[0]?.params).toMatchObject({
         ticket: "ticket",

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -112,6 +112,7 @@ suite.define(() => {
         : {}),
     });
     const page = await context.newPage();
+    await page.clock.install();
     const runtimeLoad = createDeferred();
     let runtimeRequested = false;
     await page.route(SESSION_PLACEMENT_STARTUP_RUNTIME_REQUEST, async (route) => {
@@ -380,10 +381,11 @@ suite.define(() => {
         await page.keyboard.press("Escape");
       }
 
-      await page.clock.install();
-      await gateway.setMethodResponse("environments.list", {
-        __mockError: { code: "UNAVAILABLE", message: "profile catalog remains unavailable" },
-      });
+      const profileCatalogError = {
+        code: "UNAVAILABLE",
+        message: "profile catalog remains unavailable",
+      };
+      await gateway.setMethodResponse("environments.list", { __mockError: profileCatalogError });
       await gateway.deferNext("environments.list");
       const requestsBeforePersistentFailure = (await gateway.getRequests("environments.list"))
         .length;
@@ -398,15 +400,19 @@ suite.define(() => {
           await takeControlUiViewportScreenshot(page, page.locator(".shell"), [startButton]),
         );
       }
-      await gateway.rejectDeferred("environments.list", {
-        code: "UNAVAILABLE",
-        message: "profile catalog remains unavailable",
-      });
+      await gateway.rejectDeferred("environments.list", profileCatalogError);
 
+      // A recorded request is not a processed failure. Let the page settle and
+      // schedule its next retry before advancing the clock.
+      await expect.poll(() => startButton.isDisabled()).toBe(false);
       for (const delayMs of CLOUD_PROFILE_RETRY_DELAYS_MS) {
+        await gateway.deferNext("environments.list");
         const requestsBeforeRetry = (await gateway.getRequests("environments.list")).length;
         await page.clock.fastForward(delayMs + 1);
         await gateway.waitForRequest("environments.list", { after: requestsBeforeRetry });
+        await expect.poll(() => startButton.isDisabled()).toBe(true);
+        await gateway.rejectDeferred("environments.list", profileCatalogError);
+        await expect.poll(() => startButton.isDisabled()).toBe(false);
       }
       await page.clock.resume();
       expect(await gateway.getRequests("environments.list")).toHaveLength(


### PR DESCRIPTION
## What Problem This Solves

Fixes intermittent CI failures in cloud-session retry and dashboard widget interaction proof. The cloud test could advance virtual time before the previous failure response scheduled its next retry. The board test could click an inner widget while Chromium was still routing input to its outer iframe.

Observed on main in [the cloud retry job](https://github.com/openclaw/openclaw/actions/runs/33994163511/job/101381925493) and [the board interaction job](https://github.com/openclaw/openclaw/actions/runs/34001319748/job/101400675353), and again in this PR's first board shard.

## Why This Change Was Made

Install the Playwright clock before application timers are created. Use the existing deferred Gateway fixture to settle each failed cloud-profile response and observe the Start button's pending-to-settled transition before advancing the next retry.

For board interaction, wait for the outer iframe's existing visible, non-inert state and native pointer entry into the inner Refresh control before the single click. This follows the existing fullscreen test's reveal boundary and retains the real browser input path.

## User Impact

More reliable CI proof of cloud retry limits, dispatch-before-send ordering, and dashboard widget actions in both themes. Product code, retry delays, timeouts, shards, and all four original scenarios are unchanged. Production LOC delta: zero; test delta: +24/-9 across the two existing files.

## Evidence

- A temporary 100 ms delay delivering cloud mock errors reproduced the missing-request timeout. Response synchronization passed both original scenarios under the same delay; the final two scenarios passed after removing the diagnostic.
- An earlier hover-only board candidate still failed native pointer entry. Waiting for the existing outer reveal boundary plus pointer entry passed both original theme cases and 12 temporary alternating-theme repetitions. The repetition was removed from the final source.
- Original retry counts/delays, placement, attachments, dispatch/send order, single board event, action payload, and scrollbar assertions remain intact.
- Managed Codex autoreview through P2 found no actionable issues in the combined change.
