### PR TITLE
fix(streaming): preserve assistant items and settled output

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2789,8 +2789,8 @@ src/gateway/node-pairing-ssh-verify.ts	1
 src/gateway/node-registry-private.ts	1
 src/gateway/node-registry.ts	5
 src/gateway/openai-agent-run-usage.ts	1
-src/gateway/openai-http.ts	28
-src/gateway/openresponses-http.ts	4
+src/gateway/openai-http.ts	27
+src/gateway/openresponses-http.ts	3
 src/gateway/operator-approval-snapshot.ts	4
 src/gateway/operator-approval-store.ts	8
 src/gateway/operator-scopes.ts	1

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2773,7 +2773,6 @@ src/gateway/health/collector.ts	3
 src/gateway/hooks-mapping.ts	2
 src/gateway/hooks.ts	1
 src/gateway/live-agent-probes.ts	1
-src/gateway/live-chat-projector.ts	1
 src/gateway/local-request-context.ts	2
 src/gateway/managed-image-attachments.ts	5
 src/gateway/mcp-app-operations.ts	3

--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -228,6 +228,8 @@ After receiving `tool_calls`, execute the requested function(s) and send a follo
 
 ## Streaming (SSE)
 
+Streaming preserves repeated content from separate assistant messages. If a correction cannot be represented by appending to text already sent, the stream reports an error rather than completing with inconsistent content.
+
 Set `stream: true` to receive Server-Sent Events:
 
 - `Content-Type: text/event-stream`

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -233,6 +233,8 @@ Security note: URL allowlists are enforced before fetch and on redirect hops. Al
 
 ## Streaming (SSE)
 
+Streaming preserves repeated content from separate assistant messages. If a correction cannot be represented by appending to text already sent, the stream emits `response.failed` rather than completing with inconsistent content.
+
 Set `stream: true` to receive Server-Sent Events:
 
 - `Content-Type: text/event-stream`

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -14,6 +14,48 @@ export type AssistantTextSnapshot = {
   scope?: { itemId: string; prefix: string };
 };
 
+/** A text-bearing empty result clears output; a missing text payload does not. */
+export function resolveAssistantResultText(result: unknown): string | undefined {
+  const payloads = asOptionalObjectRecord(result)?.payloads;
+  const texts = Array.isArray(payloads)
+    ? payloads.flatMap((payload) => {
+        const text = asOptionalObjectRecord(payload)?.text;
+        return typeof text === "string" ? [text] : [];
+      })
+    : [];
+  return texts.length > 0 ? texts.filter(Boolean).join("\n\n") : undefined;
+}
+
+/** Settled provisional output is run-wide; ordinary item streams keep their wire projection. */
+export function resolveAssistantTextCompletion(params: {
+  assistantText: AssistantTextSnapshot;
+  pending?: AssistantTextSnapshot;
+  resultText?: string;
+  streamedText: string;
+  fallbackText: string;
+}): string {
+  if (params.pending) {
+    return (
+      params.resultText ?? (params.pending.text || (params.streamedText ? "" : params.fallbackText))
+    );
+  }
+  return params.streamedText
+    ? params.assistantText.text
+    : (params.resultText ?? params.assistantText.text) || params.fallbackText;
+}
+
+/** Unkeyed held snapshots, including terminal echoes, describe the whole pending run. */
+export function mergePendingAssistantText(
+  previous: AssistantTextSnapshot,
+  input: AssistantTextInput,
+): AssistantTextSnapshot {
+  return mergeAssistantText(
+    previous,
+    !input.itemId && input.text !== undefined ? { ...input, replace: true } : input,
+    "append-only",
+  );
+}
+
 /** Preserve snapshot presence: an absent snapshot is not an empty item. */
 export function resolveAssistantTextInput(data: unknown): AssistantTextInput | undefined {
   const record = asOptionalObjectRecord(data);

--- a/src/gateway/agent-event-assistant-text.ts
+++ b/src/gateway/agent-event-assistant-text.ts
@@ -1,25 +1,78 @@
-// Gateway assistant-event text extractor.
-// Normalizes provider stream event shapes into a display text delta.
-import type { AgentEventPayload } from "../infra/agent-events.js";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 
-// Agent stream events may carry assistant text as either incremental delta or
-// full text, depending on provider/runtime. Gateway display paths normalize the
-// two shapes here before broadcasting.
-/** Extracts the assistant-visible text delta from an agent event payload. */
-export function resolveAssistantStreamDeltaText(evt: AgentEventPayload): string {
-  const delta = evt.data.delta;
-  const text = evt.data.text;
-  return typeof delta === "string" ? delta : typeof text === "string" ? text : "";
-}
+type AssistantTextInput = {
+  text?: string;
+  delta?: string;
+  itemId?: string;
+  replace?: boolean;
+  replaceable?: boolean;
+  managedMediaUrls?: string[];
+};
 
-export function isReplaceableAssistantStreamEvent(evt: AgentEventPayload): boolean {
-  return evt.data.replaceable === true;
-}
+export type AssistantTextSnapshot = {
+  text: string;
+  scope?: { itemId: string; prefix: string };
+};
 
-export function resolveAssistantStreamSnapshotText(evt: AgentEventPayload): string {
-  const text = evt.data.text;
-  if (typeof text === "string") {
-    return text;
+/** Preserve snapshot presence: an absent snapshot is not an empty item. */
+export function resolveAssistantTextInput(data: unknown): AssistantTextInput | undefined {
+  const record = asOptionalObjectRecord(data);
+  if (!record || (typeof record.text !== "string" && typeof record.delta !== "string")) {
+    return undefined;
   }
-  return resolveAssistantStreamDeltaText(evt);
+  return {
+    text: typeof record.text === "string" ? record.text : undefined,
+    delta: typeof record.delta === "string" ? record.delta : undefined,
+    itemId: typeof record.itemId === "string" && record.itemId ? record.itemId : undefined,
+    replace: record.replace === true,
+    replaceable: record.replaceable === true,
+    ...(Array.isArray(record.managedMediaUrls)
+      ? {
+          managedMediaUrls: record.managedMediaUrls.filter(
+            (url): url is string => typeof url === "string",
+          ),
+        }
+      : {}),
+  };
+}
+
+/** Merge item snapshots without imposing a transport's display or wire limit. */
+export function mergeAssistantText(
+  previous: AssistantTextSnapshot,
+  input: AssistantTextInput,
+  unkeyed: "live" | "append-only",
+): AssistantTextSnapshot {
+  const scope = !input.itemId
+    ? undefined
+    : previous.scope?.itemId === input.itemId
+      ? previous.scope
+      : {
+          itemId: input.itemId,
+          // Only provisional stream replacements discard earlier items.
+          prefix: input.replace && input.replaceable ? "" : previous.text,
+        };
+  let text: string;
+  if (scope && input.text !== undefined) {
+    text = scope.prefix + input.text;
+  } else if (input.text === undefined) {
+    text = previous.text + (input.delta ?? "");
+  } else if (unkeyed === "append-only") {
+    // Legacy HTTP snapshots recover held prefixes; non-prefix input remains
+    // incremental unless its producer explicitly marks a replacement.
+    text =
+      input.replace || input.text.startsWith(previous.text)
+        ? input.text
+        : previous.text + (input.delta ?? input.text);
+  } else if (
+    previous.text &&
+    input.text.length > previous.text.length &&
+    input.text.startsWith(previous.text)
+  ) {
+    text = input.text;
+  } else if (input.delta) {
+    text = previous.text + input.delta;
+  } else {
+    text = previous.text.startsWith(input.text) ? previous.text : input.text;
+  }
+  return { text, scope };
 }

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -1,6 +1,4 @@
 import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-// Gateway live chat projector.
-// Converts streaming assistant events into display-safe live chat text.
 import { stripInternalRuntimeContext } from "../agents/internal-runtime-context.js";
 import { splitTrailingDirective } from "../auto-reply/reply/streaming-directives.js";
 import {
@@ -11,6 +9,7 @@ import {
 import { isRelativeAssistantMediaReference, splitMediaFromOutput } from "../media/parse.js";
 import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
+import type { AssistantTextSnapshot } from "./agent-event-assistant-text.js";
 import { stripAssistantMediaDirectivesForDisplay } from "./chat-display-projection.helpers.js";
 import {
   isSuppressedControlReplyLeadFragment,
@@ -20,74 +19,14 @@ import {
 
 const MAX_LIVE_CHAT_BUFFER_CHARS = 500_000;
 
-/** Normalizes assistant event payloads that contain a snapshot, a delta, or both. */
-export function resolveAssistantLiveChatInput(data: unknown):
-  | {
-      text: string;
-      delta: string;
-      itemId?: string;
-      replaceStream: boolean;
-      managedMediaUrls?: string[];
-    }
-  | undefined {
-  if (!data || typeof data !== "object") {
-    return undefined;
-  }
-  const record = data as {
-    text?: unknown;
-    delta?: unknown;
-    itemId?: unknown;
-    replace?: unknown;
-    replaceable?: unknown;
-    managedMediaUrls?: unknown;
-  };
-  if (typeof record.text !== "string" && typeof record.delta !== "string") {
-    return undefined;
-  }
-  return {
-    text: typeof record.text === "string" ? record.text : "",
-    delta: typeof record.delta === "string" ? record.delta : "",
-    replaceStream: record.replace === true && record.replaceable === true,
-    ...(typeof record.itemId === "string" && record.itemId ? { itemId: record.itemId } : {}),
-    ...(Array.isArray(record.managedMediaUrls)
-      ? {
-          managedMediaUrls: record.managedMediaUrls.filter(
-            (url): url is string => typeof url === "string",
-          ),
-        }
-      : {}),
-  };
-}
-
-/** Merges assistant full-text and delta events into a capped live buffer. */
-export function resolveMergedAssistantText(params: {
-  previousText: string;
-  nextText: string;
-  nextDelta: string;
-  scope?: { prefix: string };
-}): string {
-  const { previousText, nextText, nextDelta, scope } = params;
-  let text: string;
-  if (scope) {
-    text = scope.prefix + nextText;
-  } else if (
-    previousText &&
-    nextText.length > previousText.length &&
-    nextText.startsWith(previousText)
-  ) {
-    text = nextText;
-  } else if (nextDelta) {
-    text = previousText + nextDelta;
-  } else {
-    text = previousText.startsWith(nextText) ? previousText : nextText;
-  }
+/** Cap live display text without letting later snapshots resurrect the retired prefix. */
+export function capLiveAssistantText(snapshot: AssistantTextSnapshot): string {
+  const { text, scope } = snapshot;
   const capped =
     text.length > MAX_LIVE_CHAT_BUFFER_CHARS
       ? sliceUtf16Safe(text, -MAX_LIVE_CHAT_BUFFER_CHARS)
       : text;
   if (scope) {
-    // Retire discarded prefix text with the active scope; a later shorter
-    // snapshot must not resurrect text that already fell out of the run cap.
     scope.prefix = sliceUtf16Safe(scope.prefix, text.length - capped.length);
   }
   return capped;

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2371,19 +2371,60 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(agentCommandMock).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves buffered leading content in cumulative assistant snapshots", async () => {
-    const expected = "<xiaohai-banli>milk tea</xiaohai-banli>";
+  it.each([
+    {
+      name: "buffered leading content in cumulative assistant snapshots",
+      events: [
+        {
+          text: "<xiaohai-banli>milk tea</xiaohai-banli>",
+          delta: "xiaohai-banli>milk tea</xiaohai-banli>",
+        },
+      ],
+      expected: "<xiaohai-banli>milk tea</xiaohai-banli>",
+    },
+    {
+      name: "identical snapshots from distinct assistant items",
+      events: [
+        { itemId: "answer-1", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo", delta: "Echo" },
+      ],
+      expected: "EchoEcho",
+    },
+    {
+      name: "replayed and growing snapshots across assistant items",
+      events: [
+        { itemId: "answer-1", text: "Echo", delta: "Echo" },
+        { itemId: "answer-1", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo!", delta: "!" },
+      ],
+      expected: "EchoEcho!",
+    },
+    {
+      name: "repeated delta-only text within an assistant item",
+      events: [
+        { itemId: "answer-1", delta: "Echo" },
+        { itemId: "answer-1", delta: "Echo" },
+      ],
+      expected: "EchoEcho",
+    },
+    {
+      name: "text beyond the live display cap",
+      events: [
+        { itemId: "answer-1", text: "x".repeat(500_001), delta: "x".repeat(500_001) },
+        { itemId: "answer-2", text: "tail", delta: "tail" },
+      ],
+      expected: `${"x".repeat(500_001)}tail`,
+    },
+  ])("preserves $name in official SDK assistant streams", async ({ events, expected }) => {
     agentCommandMock.mockClear();
     agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
       const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: {
-          text: expected,
-          delta: "xiaohai-banli>milk tea</xiaohai-banli>",
-        },
-      });
+      for (const data of events) {
+        emitAgentEvent({ runId, stream: "assistant", data });
+      }
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
       return { payloads: [{ text: expected }] };
     }) as never);
 
@@ -3506,46 +3547,72 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(idleRootCount));
   });
 
-  it("buffers replaceable assistant events for streaming chat completions", async () => {
-    const port = enabledPort;
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+  it.each([
+    {
+      name: "a completed replacement",
+      replacement: { text: "final answer", delta: "", replace: true },
+      finalText: "final answer",
+      expected: "final answer",
+    },
+    {
+      name: "an empty snapshot",
+      replacement: { text: "", delta: "" },
+      finalText: "",
+      expected: "No response from OpenClaw.",
+    },
+    {
+      name: "an empty replacement snapshot",
+      replacement: { text: "", delta: "", replace: true },
+      finalText: "",
+      expected: "No response from OpenClaw.",
+    },
+    {
+      name: "an empty delta without a snapshot",
+      replacement: { delta: "" },
+      finalText: "",
+      expected: "coordination draft",
+    },
+  ])(
+    "buffers replaceable assistant events through $name",
+    async ({ replacement, finalText, expected }) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { ...replacement, replaceable: true },
+        });
+        if (finalText) {
+          emitAgentEvent({ runId, stream: "assistant", data: { text: finalText } });
+        }
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        return { payloads: finalText ? [{ text: finalText }] : [] };
+      }) as never);
+
+      const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+        stream: true,
+        model: "openclaw",
+        messages: [{ role: "user", content: "hi" }],
       });
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: "final answer", delta: "", replace: true, replaceable: true },
-      });
-      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
-      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-      return { payloads: [{ text: "final answer" }] };
-    }) as never);
 
-    const res = await postChatCompletions(port, {
-      stream: true,
-      model: "openclaw",
-      messages: [{ role: "user", content: "hi" }],
-    });
-
-    expect(res.status).toBe(200);
-    const data = parseSseDataLines(await res.text());
-    const chunks = data
-      .filter((d) => d !== "[DONE]")
-      .map((d) => JSON.parse(d) as Record<string, unknown>);
-    const allContent = chunks
-      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
-      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
-      .filter((content): content is string => typeof content === "string")
-      .join("");
-
-    expect(allContent).toBe("final answer");
-    expect(allContent).not.toContain("coordination draft");
-  });
+      const content: string[] = [];
+      const finishReasons: Array<string | null> = [];
+      for await (const chunk of stream) {
+        for (const choice of chunk.choices) {
+          content.push(choice.delta.content ?? "");
+          finishReasons.push(choice.finish_reason);
+        }
+      }
+      expect(content.join("")).toBe(expected);
+      expect(finishReasons.at(-1)).toBe("stop");
+    },
+  );
 
   it("prefers final result text over buffered replaceable chat drafts", async () => {
     const port = enabledPort;

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -2389,6 +2389,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         { itemId: "answer-2", text: "Echo", delta: "Echo" },
       ],
       expected: "EchoEcho",
+      resultTexts: ["Echo", "Echo"],
     },
     {
       name: "replayed and growing snapshots across assistant items",
@@ -2417,76 +2418,120 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       ],
       expected: `${"x".repeat(500_001)}tail`,
     },
-  ])("preserves $name in official SDK assistant streams", async ({ events, expected }) => {
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      for (const data of events) {
-        emitAgentEvent({ runId, stream: "assistant", data });
-      }
-      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-      return { payloads: [{ text: expected }] };
-    }) as never);
-
-    const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
-      model: "openclaw",
-      messages: [{ role: "user", content: "Preserve the full snapshot." }],
-      stream: true,
-    });
-    const content: string[] = [];
-    const finishReasons: Array<string | null> = [];
-    for await (const chunk of stream) {
-      for (const choice of chunk.choices) {
-        if (typeof choice.delta.content === "string") {
-          content.push(choice.delta.content);
+  ])(
+    "preserves $name in official SDK assistant streams",
+    async ({ events, expected, resultTexts }) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+        for (const data of events) {
+          emitAgentEvent({ runId, stream: "assistant", data });
         }
-        finishReasons.push(choice.finish_reason);
-      }
-    }
-
-    expect(content.join("")).toBe(expected);
-    expect(finishReasons.at(-1)).toBe("stop");
-  });
-
-  it("flushes same-turn assistant microtasks before the SSE done frame", async () => {
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce(((opts: unknown) => {
-      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
-      const result = Promise.resolve({ payloads: [{ text: "start finish" }] });
-      void result.then(() => {
         emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-        void Promise.resolve().then(() => {
-          emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
-        });
+        return { payloads: (resultTexts ?? [expected]).map((text) => ({ text })) };
+      }) as never);
+
+      const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+        model: "openclaw",
+        messages: [{ role: "user", content: "Preserve the full snapshot." }],
+        stream: true,
       });
-      return result;
-    }) as never);
+      const content: string[] = [];
+      const finishReasons: Array<string | null> = [];
+      for await (const chunk of stream) {
+        for (const choice of chunk.choices) {
+          if (typeof choice.delta.content === "string") {
+            content.push(choice.delta.content);
+          }
+          finishReasons.push(choice.finish_reason);
+        }
+      }
 
-    const res = await postChatCompletions(enabledPort, {
-      stream: true,
-      model: "openclaw",
-      messages: [{ role: "user", content: "Finish the streamed response." }],
-    });
-    expect(res.status).toBe(200);
-    expect(res.headers.get("content-type")).toContain("text/event-stream");
+      expect(content.join("")).toBe(expected);
+      expect(finishReasons.at(-1)).toBe("stop");
+    },
+  );
 
-    const data = parseSseDataLines(await res.text());
-    expect(data.at(-1)).toBe("[DONE]");
-    const chunks = data
-      .filter((line) => line !== "[DONE]")
-      .map((line) => JSON.parse(line) as Record<string, unknown>);
-    const content = chunks
-      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
-      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
-      .filter((value): value is string => typeof value === "string")
-      .join("");
-    expect(content).toBe("start finish");
-    const finishChoice = chunks
-      .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
-      .at(-1);
-    expect(finishChoice?.finish_reason).toBe("stop");
-  });
+  it.each([false, true])(
+    "flushes same-turn assistant microtasks before the SSE done frame (held tools=%s)",
+    async (heldTools) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(((opts: unknown) => {
+        const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { delta: "start ", ...(heldTools ? { itemId: "answer-1" } : {}) },
+        });
+        const result = Promise.resolve({
+          payloads: heldTools ? [] : [{ text: "start finish" }],
+          ...(heldTools
+            ? {
+                meta: {
+                  stopReason: "tool_calls",
+                  pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: "{}" }],
+                },
+              }
+            : {}),
+        });
+        void result.then(() => {
+          emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+          void Promise.resolve().then(() => {
+            emitAgentEvent({
+              runId,
+              stream: "assistant",
+              data: heldTools
+                ? {
+                    itemId: "answer-2",
+                    text: "start finish",
+                    delta: "",
+                    replace: true,
+                    replaceable: true,
+                  }
+                : { delta: "finish" },
+            });
+          });
+        });
+        return result;
+      }) as never);
+
+      const res = await postChatCompletions(enabledPort, {
+        stream: true,
+        model: "openclaw",
+        messages: [{ role: "user", content: "Finish the streamed response." }],
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/event-stream");
+
+      const data = parseSseDataLines(await res.text());
+      expect(data.at(-1)).toBe("[DONE]");
+      const chunks = data
+        .filter((line) => line !== "[DONE]")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      const content = chunks
+        .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+        .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+        .filter((value): value is string => typeof value === "string")
+        .join("");
+      expect(content).toBe("start finish");
+      const finishChoice = chunks
+        .flatMap((chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [])
+        .at(-1);
+      expect(finishChoice?.finish_reason).toBe(heldTools ? "tool_calls" : "stop");
+      if (heldTools) {
+        const choices = chunks.flatMap(
+          (chunk) => (chunk.choices as Array<Record<string, unknown>> | undefined) ?? [],
+        );
+        const textIndex = choices.findLastIndex(
+          (choice) => typeof (choice.delta as { content?: unknown })?.content === "string",
+        );
+        const toolIndex = choices.findIndex((choice) =>
+          Array.isArray((choice.delta as { tool_calls?: unknown })?.tool_calls),
+        );
+        expect(toolIndex).toBeGreaterThan(textIndex);
+      }
+    },
+  );
 
   it.each([
     { name: "resolved", reject: false },
@@ -2574,48 +2619,121 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     { name: "rewritten", replacementText: "final answer" },
     { name: "shortened", replacementText: "dra" },
     { name: "cleared", replacementText: "" },
-  ])("fails an official SDK stream when streamed text is $name", async ({ replacementText }) => {
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string }).runId;
-      if (!runId) {
-        throw new Error("expected a streaming chat-completion run ID");
-      }
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: "draft answer", delta: "draft answer" },
-      });
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: replacementText, delta: "", replace: true, phase: "commentary" },
-      });
-      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-      return { payloads: [{ text: replacementText }] };
-    }) as never);
+    {
+      name: "replaced by a held provisional item",
+      previousText: "Echo",
+      replacementText: "Replacement",
+      replaceable: true,
+    },
+    {
+      name: "cleared by a held provisional item",
+      previousText: "Echo",
+      replacementText: "",
+      replaceable: true,
+    },
+    {
+      name: "rewritten then explicitly restored",
+      replacementText: "final answer",
+      recoveryText: "draft answer",
+    },
+    {
+      name: "cleared by an explicit empty final result",
+      previousText: "Echo",
+      replacementText: "Echo tail",
+      resultText: "",
+      replaceable: true,
+    },
+    {
+      name: "cleared by held output without a text-bearing result",
+      previousText: "Echo",
+      replacementText: "",
+      noResultText: true,
+      replaceable: true,
+    },
+    {
+      name: "replaced by a held item followed by its native terminal echo",
+      previousText: "Echo",
+      replacementText: "Replacement",
+      replaceable: true,
+      terminalEcho: true,
+    },
+  ])(
+    "fails an official SDK stream when streamed text is $name",
+    async ({
+      replacementText,
+      previousText = "draft answer",
+      replaceable,
+      recoveryText,
+      resultText,
+      noResultText,
+      terminalEcho,
+    }) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming chat-completion run ID");
+        }
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: {
+            text: previousText,
+            delta: previousText,
+            ...(replaceable ? { itemId: "answer-1" } : {}),
+          },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: {
+            text: replacementText,
+            delta: "",
+            replace: true,
+            ...(replaceable ? { itemId: "answer-2", replaceable: true } : { phase: "commentary" }),
+          },
+        });
+        if (recoveryText !== undefined) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { text: recoveryText, delta: "", replace: true },
+          });
+        }
+        if (terminalEcho) {
+          emitAgentEvent({ runId, stream: "assistant", data: { text: replacementText } });
+        }
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        return {
+          payloads: noResultText ? [] : [{ text: resultText ?? recoveryText ?? replacementText }],
+        };
+      }) as never);
 
-    const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
-      model: "openclaw",
-      messages: [{ role: "user", content: "Reject an incompatible replacement snapshot." }],
-      stream: true,
-    });
-    const deliveredContent: string[] = [];
-    await expect(async () => {
-      for await (const chunk of stream) {
-        for (const choice of chunk.choices) {
-          if (typeof choice.delta.content === "string") {
-            deliveredContent.push(choice.delta.content);
+      const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
+        model: "openclaw",
+        messages: [{ role: "user", content: "Reject an incompatible replacement snapshot." }],
+        stream: true,
+      });
+      const deliveredContent: string[] = [];
+      const finishReasons: Array<string | null> = [];
+      await expect(async () => {
+        for await (const chunk of stream) {
+          for (const choice of chunk.choices) {
+            if (typeof choice.delta.content === "string") {
+              deliveredContent.push(choice.delta.content);
+            }
+            finishReasons.push(choice.finish_reason);
           }
         }
-      }
-    }).rejects.toMatchObject({
-      message: "Assistant output cannot be represented as an append-only response stream.",
-      type: "api_error",
-    });
-    expect(deliveredContent).toEqual(["draft answer"]);
-    expect(agentCommandMock).toHaveBeenCalledTimes(1);
-  });
+      }).rejects.toMatchObject({
+        message: "Assistant output cannot be represented as an append-only response stream.",
+        type: "api_error",
+      });
+      expect(deliveredContent).toEqual([previousText]);
+      expect(finishReasons).not.toContain("stop");
+      expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each([
     {
@@ -2633,9 +2751,73 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       previousDelta: "final ",
       replacementDelta: "answer",
     },
+    {
+      name: "a held append-compatible replacement",
+      previousDelta: "Echo",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      replaceable: true,
+    },
+    {
+      name: "a corrected held replacement",
+      previousDelta: "Echo",
+      intermediateText: "Replacement",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      replaceable: true,
+    },
+    {
+      name: "a held draft recovered only by the authoritative final result",
+      previousDelta: "Echo",
+      replacementText: "Replacement",
+      replacementDelta: "",
+      resultText: "Echo tail",
+      replaceable: true,
+    },
+    {
+      name: "held text without a text-bearing final payload",
+      previousDelta: "Echo",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      noResultText: true,
+      replaceable: true,
+    },
+    {
+      name: "an initial held draft cleared by an explicit empty result",
+      replacementText: "Draft",
+      replacementDelta: "",
+      resultText: "",
+      replaceable: true,
+    },
+    {
+      name: "a held replacement completed by its native terminal echo",
+      previousDelta: "Echo",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      replaceable: true,
+      terminalEcho: true,
+    },
+    {
+      name: "an incompatible native echo recovered by the final result",
+      previousDelta: "Echo",
+      replacementText: "Replacement",
+      replacementDelta: "",
+      resultText: "Echo tail",
+      replaceable: true,
+      terminalEcho: true,
+    },
   ])(
     "keeps official SDK text consistent for $name",
-    async ({ previousDelta, replacementDelta }) => {
+    async ({
+      previousDelta,
+      replacementDelta,
+      replacementText = "final answer",
+      replaceable,
+      intermediateText,
+      resultText,
+      noResultText,
+      terminalEcho,
+    }) => {
       agentCommandMock.mockClear();
       agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
         const runId = (opts as { runId?: string }).runId;
@@ -2646,21 +2828,46 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           emitAgentEvent({
             runId,
             stream: "assistant",
-            data: { text: previousDelta, delta: previousDelta },
+            data: {
+              text: previousDelta,
+              delta: previousDelta,
+              ...(replaceable ? { itemId: "answer-1" } : {}),
+            },
+          });
+        }
+        if (intermediateText !== undefined) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: {
+              itemId: "answer-2",
+              text: intermediateText,
+              delta: "",
+              replace: true,
+              replaceable: true,
+            },
           });
         }
         emitAgentEvent({
           runId,
           stream: "assistant",
           data: {
-            text: "final answer",
+            text: replacementText,
             replace: true,
-            phase: "commentary",
+            ...(replaceable
+              ? {
+                  itemId: intermediateText === undefined ? "answer-2" : "answer-3",
+                  replaceable: true,
+                }
+              : { phase: "commentary" }),
             ...(replacementDelta === undefined ? {} : { delta: replacementDelta }),
           },
         });
+        if (terminalEcho) {
+          emitAgentEvent({ runId, stream: "assistant", data: { text: replacementText } });
+        }
         emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-        return { payloads: [{ text: "final answer" }] };
+        return { payloads: noResultText ? [] : [{ text: resultText ?? replacementText }] };
       }) as never);
 
       const stream = await createOpenAiChatClient(enabledPort).chat.completions.create({
@@ -2678,7 +2885,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           finishReasons.push(choice.finish_reason);
         }
       }
-      expect(deliveredContent.join("")).toBe("final answer");
+      expect(deliveredContent.join("")).toBe(resultText ?? replacementText);
       expect(finishReasons.at(-1)).toBe("stop");
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
     },
@@ -2705,6 +2912,20 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         payloads: [],
         expected: "Working...",
       },
+      {
+        name: "an explicit empty final payload",
+        provisional: "Working...",
+        payloads: [{ text: "" }],
+        expected: "",
+      },
+      {
+        name: "the finalized held replacement",
+        provisional: "Working...",
+        replacement: "Done.",
+        replaceable: true,
+        payloads: [{ text: "Final tool prose." }],
+        expected: "Final tool prose.",
+      },
     ].flatMap((scenario) => (["required", "pinned"] as const).map((mode) => ({ scenario, mode }))),
   )("uses $scenario.name for $mode tool-stream terminal commentary", async ({ scenario, mode }) => {
     agentCommandMock.mockClear();
@@ -2719,7 +2940,13 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         emitAgentEvent({
           runId,
           stream: "assistant",
-          data: { text: scenario.replacement, delta: "", replace: true, phase: "final_answer" },
+          data: {
+            text: scenario.replacement,
+            delta: "",
+            replace: true,
+            phase: "final_answer",
+            ...(scenario.replaceable ? { itemId: "held-item", replaceable: true } : {}),
+          },
         });
       }
       return {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -38,9 +38,9 @@ import { bindGatewayContextResolver } from "../plugins/runtime/gateway-request-s
 import { retainGatewayRootWorkAdmissionContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
-  isReplaceableAssistantStreamEvent,
-  resolveAssistantStreamDeltaText,
-  resolveAssistantStreamSnapshotText,
+  mergeAssistantText,
+  resolveAssistantTextInput,
+  type AssistantTextSnapshot,
 } from "./agent-event-assistant-text.js";
 import {
   buildAgentMessageFromConversationEntries,
@@ -1150,6 +1150,7 @@ export async function handleOpenAiHttpRequest(
   let wroteStopChunk = false;
   let sawAssistantDelta = false;
   let streamedAssistantText = "";
+  let assistantText: AssistantTextSnapshot = { text: "" };
   let bufferedReplaceableAssistantContent = "";
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
@@ -1215,57 +1216,41 @@ export async function handleOpenAiHttpRequest(
     }
 
     if (evt.stream === "assistant") {
-      const text = evt.data?.text;
-      const replace = evt.data?.replace === true;
-      if (replace && typeof text === "string") {
-        bufferedReplaceableAssistantContent = text;
+      const input = resolveAssistantTextInput(evt.data);
+      if (!input) {
+        return;
       }
-
-      if (isReplaceableAssistantStreamEvent(evt)) {
-        const snapshot = resolveAssistantStreamSnapshotText(evt);
-        if (snapshot) {
+      if (input.replace && input.text !== undefined) {
+        bufferedReplaceableAssistantContent = input.text;
+      }
+      if (input.replaceable) {
+        const snapshot = input.text ?? (input.delta || undefined);
+        if (snapshot !== undefined) {
           bufferedReplaceableAssistantContent = snapshot;
         }
         return;
       }
 
-      // SSE deltas cannot retract bytes already delivered to the OpenAI client.
-      if (
-        replace &&
-        typeof text === "string" &&
-        !toolChoiceConstraint &&
-        !text.startsWith(streamedAssistantText)
-      ) {
+      assistantText = mergeAssistantText(assistantText, input, "append-only");
+      // Hold prose until the run proves the requested client-tool call exists.
+      if (toolChoiceConstraint) {
+        return;
+      }
+      // SSE cannot retract bytes already delivered, even for an item correction.
+      if (!assistantText.text.startsWith(streamedAssistantText)) {
         terminalStreamError ??= {
           message: "Assistant output cannot be represented as an append-only response stream.",
           type: "api_error",
         };
         return;
       }
-
-      // Snapshots include prefixes held during tag-boundary filtering; the raw
-      // delta alone can omit a literal leading less-than.
-      const content =
-        typeof text === "string" && text.startsWith(streamedAssistantText)
-          ? text.slice(streamedAssistantText.length)
-          : resolveAssistantStreamDeltaText(evt);
+      const content = assistantText.text.slice(streamedAssistantText.length);
       if (!content) {
         return;
       }
-      streamedAssistantText += content;
-
-      // Hold prose until the run proves the requested client-tool call exists.
-      // If the provider ignores `tool_choice`, no partial text should leak
-      // before the stream fails with an OpenAI-compatible error payload.
-      if (toolChoiceConstraint) {
-        return;
-      }
-
+      streamedAssistantText = assistantText.text;
       sawAssistantDelta = true;
-      writeAssistantContentChunk(res, {
-        ...streamIdentity,
-        content,
-      });
+      writeAssistantContentChunk(res, { ...streamIdentity, content });
       return;
     }
 
@@ -1370,7 +1355,7 @@ export async function handleOpenAiHttpRequest(
           // Final payloads own held prose; snapshots may replace provisional deltas.
           const commentary =
             resolveAgentResponseText(result) ||
-            streamedAssistantText ||
+            assistantText.text ||
             bufferedReplaceableAssistantContent;
           if (commentary) {
             sawAssistantDelta = true;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -39,6 +39,9 @@ import { retainGatewayRootWorkAdmissionContinuation } from "../process/gateway-w
 import { defaultRuntime } from "../runtime.js";
 import {
   mergeAssistantText,
+  mergePendingAssistantText,
+  resolveAssistantResultText,
+  resolveAssistantTextCompletion,
   resolveAssistantTextInput,
   type AssistantTextSnapshot,
 } from "./agent-event-assistant-text.js";
@@ -707,17 +710,6 @@ function buildAgentPrompt(
   };
 }
 
-function resolveAgentResponseText(result: unknown): string {
-  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
-  if (!Array.isArray(payloads) || payloads.length === 0) {
-    return "";
-  }
-  return payloads
-    .map((p) => (typeof p.text === "string" ? p.text : ""))
-    .filter(Boolean)
-    .join("\n\n");
-}
-
 type PendingToolCall = {
   id?: unknown;
   name?: unknown;
@@ -1081,7 +1073,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
-        const commentary = resolveAgentResponseText(result);
+        const commentary = resolveAssistantResultText(result) ?? "";
         sendJson(res, 200, {
           id: runId,
           object: "chat.completion",
@@ -1106,7 +1098,7 @@ export async function handleOpenAiHttpRequest(
         });
         return true;
       }
-      const content = resolveAgentResponseText(result) || "No response from OpenClaw.";
+      const content = resolveAssistantResultText(result) || "No response from OpenClaw.";
 
       sendJson(res, 200, {
         id: runId,
@@ -1148,14 +1140,14 @@ export async function handleOpenAiHttpRequest(
   setSseHeaders(res);
 
   let wroteStopChunk = false;
-  let sawAssistantDelta = false;
   let streamedAssistantText = "";
   let assistantText: AssistantTextSnapshot = { text: "" };
-  let bufferedReplaceableAssistantContent = "";
+  let pendingAssistantText: AssistantTextSnapshot | undefined;
+  let finalResultText: string | undefined;
+  let finalToolCalls: ReturnType<typeof resolveStopReasonAndPendingToolCalls>["pendingToolCalls"];
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
   let finalizeScheduled = false;
-  let finalizeFinishReason: "stop" | "tool_calls" = "stop";
   let resultResolved = false;
   let closed = false;
   let observedTerminalLifecycle = false;
@@ -1184,11 +1176,39 @@ export async function handleOpenAiHttpRequest(
         finishStreamWithError(terminalStreamError);
         return;
       }
+      const text = resolveAssistantTextCompletion({
+        assistantText,
+        pending: pendingAssistantText,
+        resultText: finalResultText,
+        streamedText: streamedAssistantText,
+        fallbackText: finalToolCalls ? "" : "No response from OpenClaw.",
+      });
+      if (!text.startsWith(streamedAssistantText)) {
+        finishStreamWithError({
+          message: "Assistant output cannot be represented as an append-only response stream.",
+          type: "api_error",
+        });
+        return;
+      }
+      const content = text.slice(streamedAssistantText.length);
+      if (content) {
+        writeAssistantContentChunk(res, { ...streamIdentity, content });
+      }
+      streamedAssistantText = text;
+      if (finalToolCalls) {
+        writeAssistantToolCallsIncrementalChunks(res, {
+          ...streamIdentity,
+          toolCalls: finalToolCalls,
+        });
+      }
       closed = true;
       stopWatchingDisconnect();
       unsubscribe();
       if (!wroteStopChunk) {
-        writeAssistantFinishChunk(res, { ...streamIdentity, finishReason: finalizeFinishReason });
+        writeAssistantFinishChunk(res, {
+          ...streamIdentity,
+          finishReason: finalToolCalls ? "tool_calls" : "stop",
+        });
         wroteStopChunk = true;
       }
       if (streamIncludeUsage && finalUsage) {
@@ -1199,10 +1219,7 @@ export async function handleOpenAiHttpRequest(
     });
   };
 
-  const requestFinalize = (finishReason: "stop" | "tool_calls" = "stop") => {
-    if (!finalizeRequested || finishReason === "tool_calls") {
-      finalizeFinishReason = finishReason;
-    }
+  const requestFinalize = () => {
     finalizeRequested = true;
     maybeFinalize();
   };
@@ -1220,14 +1237,13 @@ export async function handleOpenAiHttpRequest(
       if (!input) {
         return;
       }
-      if (input.replace && input.text !== undefined) {
-        bufferedReplaceableAssistantContent = input.text;
-      }
-      if (input.replaceable) {
-        const snapshot = input.text ?? (input.delta || undefined);
-        if (snapshot !== undefined) {
-          bufferedReplaceableAssistantContent = snapshot;
-        }
+      // Once a provisional replacement begins, even its terminal text echo
+      // stays held until the run result selects the authoritative output.
+      if (input.replaceable || pendingAssistantText) {
+        pendingAssistantText = mergePendingAssistantText(
+          pendingAssistantText ?? assistantText,
+          input,
+        );
         return;
       }
 
@@ -1249,7 +1265,6 @@ export async function handleOpenAiHttpRequest(
         return;
       }
       streamedAssistantText = assistantText.text;
-      sawAssistantDelta = true;
       writeAssistantContentChunk(res, { ...streamIdentity, content });
       return;
     }
@@ -1350,41 +1365,9 @@ export async function handleOpenAiHttpRequest(
         return;
       }
 
-      if (stopReason === "tool_calls" && pendingToolCalls && pendingToolCalls.length > 0) {
-        if (!sawAssistantDelta) {
-          // Final payloads own held prose; snapshots may replace provisional deltas.
-          const commentary =
-            resolveAgentResponseText(result) ||
-            assistantText.text ||
-            bufferedReplaceableAssistantContent;
-          if (commentary) {
-            sawAssistantDelta = true;
-            writeAssistantContentChunk(res, {
-              ...streamIdentity,
-              content: commentary,
-            });
-          }
-        }
-        writeAssistantToolCallsIncrementalChunks(res, {
-          ...streamIdentity,
-          toolCalls: pendingToolCalls,
-        });
-        requestFinalize("tool_calls");
-        return;
-      }
-
-      if (!sawAssistantDelta) {
-        const content =
-          resolveAgentResponseText(result) ||
-          bufferedReplaceableAssistantContent ||
-          "No response from OpenClaw.";
-
-        sawAssistantDelta = true;
-        writeAssistantContentChunk(res, {
-          ...streamIdentity,
-          content,
-        });
-      }
+      finalResultText = resolveAssistantResultText(result);
+      finalToolCalls =
+        stopReason === "tool_calls" && pendingToolCalls?.length ? pendingToolCalls : undefined;
       requestFinalize();
     } catch (err) {
       resultResolved = true;

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -454,6 +454,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         { itemId: "answer-2", text: "Echo", delta: "Echo" },
       ],
       expected: "EchoEcho",
+      resultTexts: ["Echo", "Echo"],
     },
     {
       name: "replayed and growing snapshots across assistant items",
@@ -482,47 +483,90 @@ describe("OpenResponses HTTP API (e2e)", () => {
       ],
       expected: `${"x".repeat(500_001)}tail`,
     },
-  ])("preserves $name in official SDK assistant streams", async ({ events, expected }) => {
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string }).runId;
-      if (!runId) {
-        throw new Error("expected a streaming response run ID");
-      }
-      for (const data of events) {
-        emitAgentEvent({ runId, stream: "assistant", data });
-      }
-      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-      return { payloads: [{ text: expected }] };
-    }) as never);
+  ])(
+    "preserves $name in official SDK assistant streams",
+    async ({ events, expected, resultTexts }) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        for (const data of events) {
+          emitAgentEvent({ runId, stream: "assistant", data });
+        }
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        return { payloads: (resultTexts ?? [expected]).map((text) => ({ text })) };
+      }) as never);
 
-    const client = new OpenAI({
-      apiKey: "test",
-      baseURL: `http://127.0.0.1:${enabledPort}/v1`,
-      defaultHeaders: { "x-openclaw-scopes": "operator.write" },
-      maxRetries: 0,
-    });
-    const stream = client.responses.stream({
-      model: "openclaw",
-      input: "Preserve the complete assistant snapshot.",
-    });
-    const deltas: string[] = [];
-    stream.on("response.output_text.delta", (event) => deltas.push(event.delta));
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      const stream = client.responses.stream({
+        model: "openclaw",
+        input: "Preserve the complete assistant snapshot.",
+      });
+      const deltas: string[] = [];
+      stream.on("response.output_text.delta", (event) => deltas.push(event.delta));
 
-    const response = await stream.finalResponse();
-    expect({ deltas: deltas.join(""), outputText: response.output_text }).toEqual({
-      deltas: expected,
-      outputText: expected,
-    });
-  });
+      const response = await stream.finalResponse();
+      expect({ deltas: deltas.join(""), outputText: response.output_text }).toEqual({
+        deltas: expected,
+        outputText: expected,
+      });
+    },
+  );
 
   it.each([
     { name: "rewritten", replacementText: "final answer" },
     { name: "shortened", replacementText: "dra" },
     { name: "cleared", replacementText: "" },
+    {
+      name: "replaced by a held provisional item",
+      previousText: "Echo",
+      replacementText: "Replacement",
+      replaceable: true,
+    },
+    {
+      name: "cleared by a held provisional item",
+      previousText: "Echo",
+      replacementText: "",
+      replaceable: true,
+    },
+    {
+      name: "cleared by an explicit empty final result",
+      previousText: "Echo",
+      replacementText: "Echo tail",
+      resultText: "",
+      replaceable: true,
+    },
+    {
+      name: "cleared by held output without a text-bearing result",
+      previousText: "Echo",
+      replacementText: "",
+      noResultText: true,
+      replaceable: true,
+    },
+    {
+      name: "replaced by a held item followed by its native terminal echo",
+      previousText: "Echo",
+      replacementText: "Replacement",
+      replaceable: true,
+      terminalEcho: true,
+    },
   ])(
     "fails an official SDK Responses stream when streamed text is $name",
-    async ({ replacementText }) => {
+    async ({
+      replacementText,
+      previousText = "draft answer",
+      replaceable,
+      resultText,
+      noResultText,
+      terminalEcho,
+    }) => {
       agentCommandMock.mockClear();
       agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
         const runId = (opts as { runId?: string }).runId;
@@ -532,16 +576,29 @@ describe("OpenResponses HTTP API (e2e)", () => {
         emitAgentEvent({
           runId,
           stream: "assistant",
-          data: { text: "draft answer", delta: "draft answer" },
+          data: {
+            text: previousText,
+            delta: previousText,
+            ...(replaceable ? { itemId: "answer-1" } : {}),
+          },
         });
         emitAgentEvent({
           runId,
           stream: "assistant",
-          data: { text: replacementText, replace: true, phase: "commentary" },
+          data: {
+            text: replacementText,
+            replace: true,
+            ...(replaceable
+              ? { itemId: "answer-2", delta: "", replaceable: true }
+              : { phase: "commentary" }),
+          },
         });
+        if (terminalEcho) {
+          emitAgentEvent({ runId, stream: "assistant", data: { text: replacementText } });
+        }
         emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
         return {
-          payloads: [{ text: replacementText }],
+          payloads: noResultText ? [] : [{ text: resultText ?? replacementText }],
           meta: { agentMeta: { usage: { input: 11, output: 7, total: 18 } } },
         };
       }) as never);
@@ -585,7 +642,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
         }
       }
 
-      expect(deltas).toEqual(["draft answer"]);
+      expect(deltas).toEqual([previousText]);
       expect(failures).toEqual([
         {
           status: "failed",
@@ -617,9 +674,88 @@ describe("OpenResponses HTTP API (e2e)", () => {
       replacementDelta: "answer",
       expectedDeltas: "final answer",
     },
+    {
+      name: "a held append-compatible replacement",
+      previousDelta: "Echo",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      replaceable: true,
+      expectedDeltas: "Echo tail",
+    },
+    {
+      name: "a corrected held replacement",
+      previousDelta: "Echo",
+      intermediateText: "Replacement",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      replaceable: true,
+      expectedDeltas: "Echo tail",
+    },
+    {
+      name: "an explicit non-provisional recovery",
+      previousDelta: "final ",
+      intermediateText: "incompatible correction",
+      replacementDelta: "answer",
+      expectedDeltas: "final answer",
+    },
+    {
+      name: "a held draft recovered only by the authoritative final result",
+      previousDelta: "Echo",
+      replacementText: "Replacement",
+      replacementDelta: "",
+      resultText: "Echo tail",
+      expectedDeltas: "Echo tail",
+      replaceable: true,
+    },
+    {
+      name: "held text without a text-bearing final payload",
+      previousDelta: "Echo",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      noResultText: true,
+      expectedDeltas: "Echo tail",
+      replaceable: true,
+    },
+    {
+      name: "an initial held draft cleared by an explicit empty result",
+      replacementText: "Draft",
+      replacementDelta: "",
+      resultText: "",
+      expectedDeltas: "",
+      replaceable: true,
+    },
+    {
+      name: "a held replacement completed by its native terminal echo",
+      previousDelta: "Echo",
+      replacementText: "Echo tail",
+      replacementDelta: "",
+      expectedDeltas: "Echo tail",
+      replaceable: true,
+      terminalEcho: true,
+    },
+    {
+      name: "an incompatible native echo recovered by the final result",
+      previousDelta: "Echo",
+      replacementText: "Replacement",
+      replacementDelta: "",
+      resultText: "Echo tail",
+      expectedDeltas: "Echo tail",
+      replaceable: true,
+      terminalEcho: true,
+    },
   ])(
     "keeps official SDK Responses text consistent for $name",
-    async ({ previousDelta, replacementDelta, expectedDeltas }) => {
+    async ({
+      previousDelta,
+      replacementDelta,
+      expectedDeltas,
+      replacementText = "final answer",
+      replaceable,
+      intermediateText,
+      resultText,
+      noResultText,
+      terminalEcho,
+    }) => {
       agentCommandMock.mockClear();
       agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
         const runId = (opts as { runId?: string }).runId;
@@ -630,21 +766,45 @@ describe("OpenResponses HTTP API (e2e)", () => {
           emitAgentEvent({
             runId,
             stream: "assistant",
-            data: { text: previousDelta, delta: previousDelta },
+            data: {
+              text: previousDelta,
+              delta: previousDelta,
+              ...(replaceable ? { itemId: "answer-1" } : {}),
+            },
+          });
+        }
+        if (intermediateText !== undefined) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: {
+              text: intermediateText,
+              delta: "",
+              replace: true,
+              ...(replaceable ? { itemId: "answer-2", replaceable: true } : {}),
+            },
           });
         }
         emitAgentEvent({
           runId,
           stream: "assistant",
           data: {
-            text: "final answer",
+            text: replacementText,
             replace: true,
-            phase: "commentary",
+            ...(replaceable
+              ? {
+                  itemId: intermediateText === undefined ? "answer-2" : "answer-3",
+                  replaceable: true,
+                }
+              : { phase: "commentary" }),
             ...(replacementDelta === undefined ? {} : { delta: replacementDelta }),
           },
         });
+        if (terminalEcho) {
+          emitAgentEvent({ runId, stream: "assistant", data: { text: replacementText } });
+        }
         emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-        return { payloads: [{ text: "final answer" }] };
+        return { payloads: noResultText ? [] : [{ text: resultText ?? replacementText }] };
       }) as never);
 
       const client = new OpenAI({
@@ -679,8 +839,8 @@ describe("OpenResponses HTTP API (e2e)", () => {
       }
 
       expect(deltas.join("")).toBe(expectedDeltas);
-      expect(doneTexts).toEqual(["final answer"]);
-      expect(completedTexts).toEqual(["final answer"]);
+      expect(doneTexts).toEqual([resultText ?? replacementText]);
+      expect(completedTexts).toEqual([resultText ?? replacementText]);
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
     },
   );
@@ -1603,87 +1763,156 @@ describe("OpenResponses HTTP API (e2e)", () => {
     });
   });
 
-  it("flushes same-turn assistant microtasks before completing an official SDK stream", async () => {
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce(((opts: unknown) => {
-      const runId = (opts as { runId?: string }).runId;
-      if (!runId) {
-        throw new Error("expected a streaming response run ID");
-      }
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
-      const result = Promise.resolve({ payloads: [{ text: "start finish!" }] });
-      void result.then(() => {
-        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-        void Promise.resolve().then(() => {
-          emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
+  it.each([false, true])(
+    "flushes same-turn assistant microtasks before completing an official SDK stream (held tools=%s)",
+    async (heldTools) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(((opts: unknown) => {
+        const runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { delta: "start ", ...(heldTools ? { itemId: "answer-1" } : {}) },
+        });
+        const result = Promise.resolve({
+          payloads: heldTools ? [] : [{ text: "start finish!" }],
+          ...(heldTools
+            ? {
+                meta: {
+                  stopReason: "tool_calls",
+                  pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: "{}" }],
+                },
+              }
+            : {}),
+        });
+        void result.then(() => {
+          emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
           void Promise.resolve().then(() => {
-            emitAgentEvent({ runId, stream: "assistant", data: { delta: "!" } });
+            emitAgentEvent({
+              runId,
+              stream: "assistant",
+              data: heldTools
+                ? {
+                    itemId: "answer-2",
+                    text: "start finish",
+                    delta: "",
+                    replace: true,
+                    replaceable: true,
+                  }
+                : { delta: "finish" },
+            });
+            void Promise.resolve().then(() => {
+              emitAgentEvent({
+                runId,
+                stream: "assistant",
+                data: heldTools
+                  ? { itemId: "answer-2", text: "start finish!", delta: "!", replaceable: true }
+                  : { delta: "!" },
+              });
+            });
           });
         });
-      });
-      return result;
-    }) as never);
+        return result;
+      }) as never);
 
-    const client = new OpenAI({
-      apiKey: "test",
-      baseURL: `http://127.0.0.1:${enabledPort}/v1`,
-      defaultHeaders: { "x-openclaw-scopes": "operator.write" },
-      maxRetries: 0,
-    });
-    const stream = client.responses.stream({
-      model: "openclaw",
-      input: "Finish the streamed response.",
-    });
-    const deltas: string[] = [];
-    stream.on("response.output_text.delta", (event) => {
-      deltas.push(event.delta);
-    });
-
-    const response = await stream.finalResponse();
-    expect(deltas.join("")).toBe("start finish!");
-    expect(response.status).toBe("completed");
-    expect(response.output_text).toBe("start finish!");
-    expect(agentCommandMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("flushes post-lifecycle assistant microtasks after usage is already available", async () => {
-    let unsubscribe = () => {};
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce(((opts: unknown) => {
-      const runId = (opts as { runId?: string }).runId;
-      if (!runId) {
-        throw new Error("expected a streaming response run ID");
-      }
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
-      unsubscribe = onAgentEvent((event) => {
-        if (event.runId !== runId || event.stream !== "lifecycle" || event.data?.phase !== "end") {
-          return;
-        }
-        unsubscribe();
-        void Promise.resolve().then(() => {
-          emitAgentEvent({ runId, stream: "assistant", data: { delta: "finish" } });
-        });
-      });
-      return Promise.resolve({ payloads: [{ text: "start finish" }] });
-    }) as never);
-
-    try {
       const client = new OpenAI({
         apiKey: "test",
         baseURL: `http://127.0.0.1:${enabledPort}/v1`,
         defaultHeaders: { "x-openclaw-scopes": "operator.write" },
         maxRetries: 0,
       });
-      const response = await client.responses
-        .stream({ model: "openclaw", input: "Flush the final assistant microtask." })
-        .finalResponse();
+      const stream = client.responses.stream({
+        model: "openclaw",
+        input: "Finish the streamed response.",
+      });
+      const deltas: string[] = [];
+      stream.on("response.output_text.delta", (event) => {
+        deltas.push(event.delta);
+      });
 
-      expect(response.output_text).toBe("start finish");
+      const response = await stream.finalResponse();
+      expect(deltas.join("")).toBe("start finish!");
+      expect(response.status).toBe("completed");
+      expect(response.output_text).toBe("start finish!");
+      expect(response.output.map((item) => item.type)).toEqual(
+        heldTools ? ["message", "function_call"] : ["message"],
+      );
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
-    } finally {
-      unsubscribe();
-    }
-  });
+    },
+  );
+
+  it.each([false, true])(
+    "flushes result-following assistant microtasks before finalization (recovery=%s)",
+    async (recovery) => {
+      const completion = createDeferred<{ payloads: Array<{ text: string }> }>();
+      const created = createDeferred();
+      let runId: string | undefined;
+      let lateEventEmitted = false;
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(((opts: unknown) => {
+        runId = (opts as { runId?: string }).runId;
+        if (!runId) {
+          throw new Error("expected a streaming response run ID");
+        }
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "start " } });
+        if (recovery) {
+          emitAgentEvent({
+            runId,
+            stream: "assistant",
+            data: { text: "incompatible correction", replace: true },
+          });
+        }
+        return completion.promise;
+      }) as never);
+
+      try {
+        const client = new OpenAI({
+          apiKey: "test",
+          baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+          defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+          maxRetries: 0,
+        });
+        const stream = client.responses.stream({
+          model: "openclaw",
+          input: "Flush the final assistant microtask.",
+        });
+        stream.on("response.created", () => created.resolve());
+        const deltas: string[] = [];
+        stream.on("response.output_text.delta", (event) => deltas.push(event.delta));
+        await created.promise;
+        if (!runId) {
+          throw new Error("expected an admitted streaming response run");
+        }
+        const activeRunId = runId;
+        // Register the producer's completion work after the HTTP consumer is
+        // awaiting the result. Its queued recovery must survive that continuation.
+        void completion.promise.then(() => {
+          emitAgentEvent({ runId: activeRunId, stream: "lifecycle", data: { phase: "end" } });
+          queueMicrotask(() => {
+            lateEventEmitted = true;
+            emitAgentEvent({
+              runId: activeRunId,
+              stream: "assistant",
+              data: recovery ? { text: "start finish", replace: true } : { delta: "finish" },
+            });
+          });
+        });
+        completion.resolve({ payloads: [{ text: "start finish" }] });
+        const response = await stream.finalResponse();
+
+        expect(lateEventEmitted).toBe(true);
+        expect(response.status).toBe("completed");
+        expect(deltas.join("")).toBe("start finish");
+        expect(response.output_text).toBe("start finish");
+        expect(agentCommandMock).toHaveBeenCalledTimes(1);
+      } finally {
+        completion.resolve({ payloads: [{ text: "start finish" }] });
+      }
+    },
+  );
 
   it("fails conflicting assistant replacements queued after lifecycle completion", async () => {
     let unsubscribe = () => {};
@@ -2835,44 +3064,75 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(text).toContain("[DONE]");
   });
 
-  it("emits the tool call when a streaming required tool_choice is satisfied", async () => {
-    const port = enabledPort;
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "Calling " } });
-      emitAgentEvent({ runId, stream: "assistant", data: { delta: "the tool." } });
-      return {
+  it.each(
+    [
+      {
+        name: "the final payload",
         payloads: [{ text: "Calling the tool." }],
-        meta: {
-          stopReason: "tool_calls",
-          pendingToolCalls: [{ id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' }],
-        },
-      };
-    }) as never);
+        expected: "Calling the tool.",
+      },
+      {
+        name: "missing final text",
+        payloads: [],
+        expected: "Calling the tool.",
+      },
+      {
+        name: "an explicit empty final payload",
+        payloads: [{ text: "" }],
+        expected: "",
+      },
+    ].flatMap((scenario) => (["required", "pinned"] as const).map((mode) => ({ scenario, mode }))),
+  )(
+    "uses $scenario.name for $mode response tool-stream terminal commentary",
+    async ({ scenario, mode }) => {
+      const port = enabledPort;
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "Calling " } });
+        emitAgentEvent({ runId, stream: "assistant", data: { delta: "the tool." } });
+        return {
+          payloads: scenario.payloads,
+          meta: {
+            stopReason: "tool_calls",
+            pendingToolCalls: [
+              { id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' },
+            ],
+          },
+        };
+      }) as never);
 
-    const res = await postResponses(port, {
-      stream: true,
-      model: "openclaw",
-      input: "check the weather",
-      tools: WEATHER_TOOL,
-      tool_choice: "required",
-    });
+      const res = await postResponses(port, {
+        stream: true,
+        model: "openclaw",
+        input: "check the weather",
+        tools: WEATHER_TOOL,
+        tool_choice: mode === "required" ? "required" : { type: "function", name: "get_weather" },
+      });
 
-    expect(res.status).toBe(200);
-    const events = parseSseEvents(await res.text());
-    const delta = findSseEvent(events, "response.output_text.delta");
-    expect((parseSseData(delta) as { delta?: string }).delta).toBe("Calling the tool.");
-    const completed = findSseEvent(events, "response.completed");
-    const response = (
-      parseSseData(completed) as {
-        response?: { status?: string; output?: Array<Record<string, unknown>> };
-      }
-    ).response;
-    expect(response?.status).toBe("completed");
-    expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
-    expect(response?.output?.[1]?.name).toBe("get_weather");
-  });
+      expect(res.status).toBe(200);
+      const events = parseSseEvents(await res.text());
+      const text = events
+        .filter((event) => event.event === "response.output_text.delta")
+        .map((event) => (parseSseData(event) as { delta?: string }).delta ?? "")
+        .join("");
+      expect(text).toBe(scenario.expected);
+      const done = findSseEvent(events, "response.output_text.done");
+      expect(parseSseData(done)).toMatchObject({ text: scenario.expected });
+      const completed = findSseEvent(events, "response.completed");
+      const response = (
+        parseSseData(completed) as {
+          response?: { status?: string; output?: Array<Record<string, unknown>> };
+        }
+      ).response;
+      expect(response?.status).toBe("completed");
+      expect(response?.output?.map((item) => item.type)).toEqual(["message", "function_call"]);
+      expect(response?.output?.[1]?.name).toBe("get_weather");
+      expect(response?.output?.[0]?.content).toEqual([
+        { type: "output_text", text: scenario.expected },
+      ]);
+    },
+  );
 
   it.each([
     { name: "an initial replacement", previousDelta: undefined, replacementDelta: undefined },

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -441,19 +441,58 @@ describe("OpenResponses HTTP API (e2e)", () => {
     },
   );
 
-  it("preserves buffered leading text in official SDK streaming snapshots", async () => {
-    const expected = "<tag>ok</tag>";
+  it.each([
+    {
+      name: "buffered leading text in cumulative assistant snapshots",
+      events: [{ text: "<tag>ok</tag>", delta: "tag>ok</tag>" }],
+      expected: "<tag>ok</tag>",
+    },
+    {
+      name: "identical snapshots from distinct assistant items",
+      events: [
+        { itemId: "answer-1", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo", delta: "Echo" },
+      ],
+      expected: "EchoEcho",
+    },
+    {
+      name: "replayed and growing snapshots across assistant items",
+      events: [
+        { itemId: "answer-1", text: "Echo", delta: "Echo" },
+        { itemId: "answer-1", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo", delta: "Echo" },
+        { itemId: "answer-2", text: "Echo!", delta: "!" },
+      ],
+      expected: "EchoEcho!",
+    },
+    {
+      name: "repeated delta-only text within an assistant item",
+      events: [
+        { itemId: "answer-1", delta: "Echo" },
+        { itemId: "answer-1", delta: "Echo" },
+      ],
+      expected: "EchoEcho",
+    },
+    {
+      name: "text beyond the live display cap",
+      events: [
+        { itemId: "answer-1", text: "x".repeat(500_001), delta: "x".repeat(500_001) },
+        { itemId: "answer-2", text: "tail", delta: "tail" },
+      ],
+      expected: `${"x".repeat(500_001)}tail`,
+    },
+  ])("preserves $name in official SDK assistant streams", async ({ events, expected }) => {
     agentCommandMock.mockClear();
     agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
       const runId = (opts as { runId?: string }).runId;
       if (!runId) {
         throw new Error("expected a streaming response run ID");
       }
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: expected, delta: "tag>ok</tag>" },
-      });
+      for (const data of events) {
+        emitAgentEvent({ runId, stream: "assistant", data });
+      }
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
       return { payloads: [{ text: expected }] };
     }) as never);
 
@@ -471,8 +510,10 @@ describe("OpenResponses HTTP API (e2e)", () => {
     stream.on("response.output_text.delta", (event) => deltas.push(event.delta));
 
     const response = await stream.finalResponse();
-    expect(deltas.join("")).toBe(expected);
-    expect(response.output_text).toBe(expected);
+    expect({ deltas: deltas.join(""), outputText: response.output_text }).toEqual({
+      deltas: expected,
+      outputText: expected,
+    });
   });
 
   it.each([
@@ -2908,49 +2949,75 @@ describe("OpenResponses HTTP API (e2e)", () => {
     },
   );
 
-  it("buffers replaceable assistant events for streaming responses", async () => {
-    const port = enabledPort;
-    agentCommandMock.mockClear();
-    agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
-      const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+  it.each([
+    {
+      name: "a completed replacement",
+      replacement: { text: "final answer", delta: "", replace: true },
+      finalText: "final answer",
+      expected: "final answer",
+    },
+    {
+      name: "an empty snapshot",
+      replacement: { text: "", delta: "" },
+      finalText: "",
+      expected: "No response from OpenClaw.",
+    },
+    {
+      name: "an empty replacement snapshot",
+      replacement: { text: "", delta: "", replace: true },
+      finalText: "",
+      expected: "No response from OpenClaw.",
+    },
+    {
+      name: "an empty delta without a snapshot",
+      replacement: { delta: "" },
+      finalText: "",
+      expected: "coordination draft",
+    },
+  ])(
+    "buffers replaceable assistant events through $name",
+    async ({ replacement, finalText, expected }) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
+        const runId = (opts as { runId?: string } | undefined)?.runId ?? "";
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { text: "coordination draft", delta: "coordination draft", replaceable: true },
+        });
+        emitAgentEvent({
+          runId,
+          stream: "assistant",
+          data: { ...replacement, replaceable: true },
+        });
+        if (finalText) {
+          emitAgentEvent({ runId, stream: "assistant", data: { text: finalText } });
+        }
+        emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+        return { payloads: finalText ? [{ text: finalText }] : [] };
+      }) as never);
+
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${enabledPort}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
       });
-      emitAgentEvent({
-        runId,
-        stream: "assistant",
-        data: { text: "final answer", delta: "", replace: true, replaceable: true },
+      const stream = client.responses.stream({
+        model: "openclaw",
+        input: "hi",
       });
-      emitAgentEvent({ runId, stream: "assistant", data: { text: "final answer" } });
-      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
-      return { payloads: [{ text: "final answer" }] };
-    }) as never);
+      const deltas: string[] = [];
+      stream.on("response.output_text.delta", (event) => deltas.push(event.delta));
 
-    const res = await postResponses(port, {
-      stream: true,
-      model: "openclaw",
-      input: "hi",
-    });
-
-    expect(res.status).toBe(200);
-    const events = parseSseEvents(await res.text());
-    const deltas = events
-      .filter((event) => event.event === "response.output_text.delta")
-      .map((event) => {
-        const parsed = JSON.parse(event.data) as { delta?: string };
-        return parsed.delta ?? "";
-      })
-      .join("");
-    const completed = JSON.parse(findSseEvent(events, "response.completed").data) as {
-      response?: { output?: Array<{ content?: Array<{ text?: string }> }> };
-    };
-
-    expect(deltas).toBe("final answer");
-    expect(completed.response?.output?.[0]?.content?.[0]?.text).toBe("final answer");
-    expect(deltas).not.toContain("coordination draft");
-  });
+      const response = await stream.finalResponse();
+      expect({ deltas: deltas.join(""), outputText: response.output_text }).toEqual({
+        deltas: expected,
+        outputText: expected,
+      });
+      expect(response.status).toBe("completed");
+    },
+  );
 
   it("prefers final result text over buffered replaceable response drafts", async () => {
     const port = enabledPort;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -41,9 +41,9 @@ import { bindGatewayContextResolver } from "../plugins/runtime/gateway-request-s
 import { retainGatewayRootWorkAdmissionContinuation } from "../process/gateway-work-admission.js";
 import { defaultRuntime } from "../runtime.js";
 import {
-  isReplaceableAssistantStreamEvent,
-  resolveAssistantStreamDeltaText,
-  resolveAssistantStreamSnapshotText,
+  mergeAssistantText,
+  resolveAssistantTextInput,
+  type AssistantTextSnapshot,
 } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -874,7 +874,7 @@ export async function handleOpenResponsesHttpRequest(
 
   setSseHeaders(res);
 
-  let accumulatedText = "";
+  let assistantText: AssistantTextSnapshot = { text: "" };
   let streamedAssistantText = "";
   let bufferedReplaceableAssistantContent = "";
   let sawAssistantDelta = false;
@@ -912,7 +912,7 @@ export async function handleOpenResponsesHttpRequest(
       }
       const usage = finalUsage;
       const finalText =
-        accumulatedText || bufferedReplaceableAssistantContent || finalizeRequested.text;
+        assistantText.text || bufferedReplaceableAssistantContent || finalizeRequested.text;
 
       closed = true;
       stopWatchingDisconnect();
@@ -1059,65 +1059,37 @@ export async function handleOpenResponsesHttpRequest(
     }
 
     if (evt.stream === "assistant") {
-      if (isReplaceableAssistantStreamEvent(evt)) {
-        const snapshot = resolveAssistantStreamSnapshotText(evt);
-        if (snapshot) {
+      const input = resolveAssistantTextInput(evt.data);
+      if (!input) {
+        return;
+      }
+      if (input.replaceable) {
+        const snapshot = input.text ?? (input.delta || undefined);
+        if (snapshot !== undefined) {
           bufferedReplaceableAssistantContent = snapshot;
         }
         return;
       }
 
-      const text = evt.data?.text;
-      const replace = evt.data?.replace === true;
-      if (replace && typeof text === "string") {
-        accumulatedText = text;
-        if (toolChoiceConstraint) {
-          return;
-        }
-        // Responses deltas can only append. A conflicting replacement must
-        // fail after usage resolves instead of claiming inconsistent success.
-        if (!text.startsWith(streamedAssistantText)) {
-          unrepresentableAssistantReplacement = true;
-          return;
-        }
-        unrepresentableAssistantReplacement = false;
-        const replacementDelta = text.slice(streamedAssistantText.length);
-        if (replacementDelta) {
-          sawAssistantDelta = true;
-          streamedAssistantText = text;
-          writeSseEvent(res, {
-            type: "response.output_text.delta",
-            item_id: outputItemId,
-            output_index: 0,
-            content_index: 0,
-            delta: replacementDelta,
-          });
-        }
+      assistantText = mergeAssistantText(assistantText, input, "append-only");
+      // Unconfirmed tool-choice prose may still be corrected before it is sent.
+      if (toolChoiceConstraint) {
         return;
       }
-
-      const content =
-        typeof text === "string" && text.startsWith(streamedAssistantText)
-          ? text.slice(streamedAssistantText.length)
-          : resolveAssistantStreamDeltaText(evt);
+      // Keep physical wire progress separate from a corrected item snapshot.
+      if (!assistantText.text.startsWith(streamedAssistantText)) {
+        unrepresentableAssistantReplacement = true;
+        return;
+      }
+      if (input.replace && input.text !== undefined) {
+        unrepresentableAssistantReplacement = false;
+      }
+      const content = assistantText.text.slice(streamedAssistantText.length);
       if (!content) {
         return;
       }
-      streamedAssistantText += content;
-
-      // Hold assistant prose until the tool-choice contract is confirmed. A
-      // `required`/pinned request must reject text-only turns, so streaming
-      // deltas now could leak output we may have to fail. Buffered text is
-      // still flushed as commentary if a matching tool call arrives, matching
-      // the openai-http.ts streaming buffer.
-      if (toolChoiceConstraint) {
-        accumulatedText += content;
-        return;
-      }
-
+      streamedAssistantText = assistantText.text;
       sawAssistantDelta = true;
-      accumulatedText += content;
-
       writeSseEvent(res, {
         type: "response.output_text.delta",
         item_id: outputItemId,
@@ -1132,7 +1104,7 @@ export async function handleOpenResponsesHttpRequest(
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
         const finalText =
-          accumulatedText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
+          assistantText.text || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
         const errorMessage =
           phase === "error" && typeof evt.data?.error === "string"
@@ -1237,7 +1209,7 @@ export async function handleOpenResponsesHttpRequest(
       ) {
         const usage = finalUsage ?? createEmptyUsage();
         const finalText =
-          accumulatedText || resultPayloadText || bufferedReplaceableAssistantContent;
+          assistantText.text || resultPayloadText || bufferedReplaceableAssistantContent;
 
         if (finalText && !sawAssistantDelta) {
           sawAssistantDelta = true;
@@ -1336,7 +1308,7 @@ export async function handleOpenResponsesHttpRequest(
         const content =
           resultPayloadText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
 
-        accumulatedText = content;
+        assistantText.text = content;
         sawAssistantDelta = true;
         if (finalizeStatus !== null) {
           finalizeRequested = { status: finalizeStatus, text: content };

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -42,6 +42,9 @@ import { retainGatewayRootWorkAdmissionContinuation } from "../process/gateway-w
 import { defaultRuntime } from "../runtime.js";
 import {
   mergeAssistantText,
+  mergePendingAssistantText,
+  resolveAssistantResultText,
+  resolveAssistantTextCompletion,
   resolveAssistantTextInput,
   type AssistantTextSnapshot,
 } from "./agent-event-assistant-text.js";
@@ -254,17 +257,6 @@ export const testing = {
 function writeSseEvent(res: ServerResponse, event: StreamingEvent) {
   res.write(`event: ${event.type}\n`);
   res.write(`data: ${JSON.stringify(event)}\n\n`);
-}
-
-function resolveResponsePayloadText(result: unknown): string {
-  const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
-  return Array.isArray(payloads)
-    ? payloads
-        .flatMap((payload) =>
-          typeof payload.text === "string" && payload.text ? [payload.text] : [],
-        )
-        .join("\n\n")
-    : "";
 }
 
 type ResolvedResponsesLimits = {
@@ -757,7 +749,7 @@ export async function handleOpenResponsesHttpRequest(
       if (readAgentRunTerminalOutcome(result) === "failed") {
         throw new Error("agent run failed");
       }
-      const assistantText = resolveResponsePayloadText(result);
+      const assistantText = resolveAssistantResultText(result);
       const usage = extractUsageFromResult(result);
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -876,17 +868,17 @@ export async function handleOpenResponsesHttpRequest(
 
   let assistantText: AssistantTextSnapshot = { text: "" };
   let streamedAssistantText = "";
-  let bufferedReplaceableAssistantContent = "";
-  let sawAssistantDelta = false;
+  let pendingAssistantText: AssistantTextSnapshot | undefined;
+  let finalResultText: string | undefined;
+  let finalToolCalls: PendingToolCall[] | undefined;
   let unrepresentableAssistantReplacement = false;
   let closed = false;
   let unsubscribe = () => {};
   let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
-  let finalizeStatus: ResponseResource["status"] | null = null;
-  let finalizeRequested: { status: ResponseResource["status"]; text: string } | null = null;
+  let finalizeRequested: { status: ResponseResource["status"]; errorMessage?: string } | null =
+    null;
   let finalizeScheduled = false;
-  let finalizeErrorMessage: string | undefined;
   let terminalLifecyclePhase: "end" | "error" = "end";
 
   const maybeFinalize = () => {
@@ -911,9 +903,28 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
       const usage = finalUsage;
-      const finalText =
-        assistantText.text || bufferedReplaceableAssistantContent || finalizeRequested.text;
-
+      const finalText = resolveAssistantTextCompletion({
+        assistantText,
+        pending: pendingAssistantText,
+        resultText: finalResultText,
+        streamedText: streamedAssistantText,
+        fallbackText: finalToolCalls ? "" : "No response from OpenClaw.",
+      });
+      if (!finalText.startsWith(streamedAssistantText)) {
+        finalizeUnrepresentableAssistantReplacement();
+        return;
+      }
+      const delta = finalText.slice(streamedAssistantText.length);
+      if (delta) {
+        writeSseEvent(res, {
+          type: "response.output_text.delta",
+          item_id: outputItemId,
+          output_index: 0,
+          content_index: 0,
+          delta,
+        });
+      }
+      streamedAssistantText = finalText;
       closed = true;
       stopWatchingDisconnect();
       unsubscribe();
@@ -937,7 +948,10 @@ export async function handleOpenResponsesHttpRequest(
       const completedItem = createAssistantOutputItem({
         id: outputItemId,
         text: finalText,
-        phase: finalizeRequested.status === "completed" ? "final_answer" : "commentary",
+        phase:
+          finalizeRequested.status === "completed" && !finalToolCalls
+            ? "final_answer"
+            : "commentary",
         status: "completed",
       });
 
@@ -947,17 +961,39 @@ export async function handleOpenResponsesHttpRequest(
         item: completedItem,
       });
 
+      const output: OutputItem[] = [completedItem];
+      for (const functionCall of finalToolCalls ?? []) {
+        const item = createFunctionCallOutputItem({
+          id: `call_${randomUUID()}`,
+          callId: functionCall.id,
+          name: functionCall.name,
+          arguments: functionCall.arguments,
+        });
+        const outputIndex = output.length;
+        writeSseEvent(res, {
+          type: "response.output_item.added",
+          output_index: outputIndex,
+          item,
+        });
+        const completedCall: OutputItem = { ...item, status: "completed" };
+        writeSseEvent(res, {
+          type: "response.output_item.done",
+          output_index: outputIndex,
+          item: completedCall,
+        });
+        output.push(completedCall);
+      }
       const finalResponse = createResponseResource({
         ...responseIdentity,
         model,
         status: finalizeRequested.status,
-        output: [completedItem],
+        output,
         usage,
         ...(finalizeRequested.status === "failed"
           ? {
               error: {
                 code: "server_error",
-                message: finalizeErrorMessage || "Agent run failed",
+                message: finalizeRequested.errorMessage || "Agent run failed",
               },
             }
           : {}),
@@ -973,17 +1009,11 @@ export async function handleOpenResponsesHttpRequest(
     });
   };
 
-  const requestFinalize = (
-    status: ResponseResource["status"],
-    text: string,
-    errorMessage?: string,
-  ) => {
+  const requestFinalize = (status: ResponseResource["status"], errorMessage?: string) => {
     if (finalizeRequested) {
       return;
     }
-    finalizeStatus = status;
-    finalizeErrorMessage = errorMessage;
-    finalizeRequested = { status, text };
+    finalizeRequested = { status, errorMessage };
     maybeFinalize();
   };
 
@@ -1063,10 +1093,20 @@ export async function handleOpenResponsesHttpRequest(
       if (!input) {
         return;
       }
-      if (input.replaceable) {
-        const snapshot = input.text ?? (input.delta || undefined);
-        if (snapshot !== undefined) {
-          bufferedReplaceableAssistantContent = snapshot;
+      // Once a provisional replacement begins, even its terminal text echo
+      // stays held until the run result selects the authoritative output.
+      if (input.replaceable || pendingAssistantText) {
+        pendingAssistantText = mergePendingAssistantText(
+          pendingAssistantText ?? assistantText,
+          input,
+        );
+        if (
+          !input.replaceable &&
+          input.replace &&
+          input.text !== undefined &&
+          pendingAssistantText.text.startsWith(streamedAssistantText)
+        ) {
+          unrepresentableAssistantReplacement = false;
         }
         return;
       }
@@ -1089,7 +1129,6 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
       streamedAssistantText = assistantText.text;
-      sawAssistantDelta = true;
       writeSseEvent(res, {
         type: "response.output_text.delta",
         item_id: outputItemId,
@@ -1103,14 +1142,12 @@ export async function handleOpenResponsesHttpRequest(
     if (evt.stream === "lifecycle") {
       const phase = evt.data?.phase;
       if (phase === "end" || phase === "error") {
-        const finalText =
-          assistantText.text || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
         const finalStatus = phase === "error" ? "failed" : "completed";
         const errorMessage =
           phase === "error" && typeof evt.data?.error === "string"
             ? evt.data.error.trim()
             : undefined;
-        requestFinalize(finalStatus, finalText, errorMessage);
+        requestFinalize(finalStatus, errorMessage);
       }
     }
   });
@@ -1169,15 +1206,10 @@ export async function handleOpenResponsesHttpRequest(
 
       finalUsage = extractUsageFromResult(result);
 
-      if (unrepresentableAssistantReplacement) {
-        finalizeUnrepresentableAssistantReplacement();
-        return;
-      }
-
       // Check for pending client tool calls BEFORE maybeFinalize() because the
       // lifecycle:end event may already have requested finalization.
       const resultAny = result as { meta?: unknown };
-      const resultPayloadText = resolveResponsePayloadText(result);
+      const resultPayloadText = resolveAssistantResultText(result);
       const meta = resultAny.meta;
       const { stopReason, pendingToolCalls } = resolveStopReasonAndPendingToolCalls(meta);
 
@@ -1201,128 +1233,9 @@ export async function handleOpenResponsesHttpRequest(
         return;
       }
 
-      if (
-        !closed &&
-        stopReason === "tool_calls" &&
-        pendingToolCalls &&
-        pendingToolCalls.length > 0
-      ) {
-        const usage = finalUsage ?? createEmptyUsage();
-        const finalText =
-          assistantText.text || resultPayloadText || bufferedReplaceableAssistantContent;
-
-        if (finalText && !sawAssistantDelta) {
-          sawAssistantDelta = true;
-          writeSseEvent(res, {
-            type: "response.output_text.delta",
-            item_id: outputItemId,
-            output_index: 0,
-            content_index: 0,
-            delta: finalText,
-          });
-        }
-        writeSseEvent(res, {
-          type: "response.output_text.done",
-          item_id: outputItemId,
-          output_index: 0,
-          content_index: 0,
-          text: finalText,
-        });
-        writeSseEvent(res, {
-          type: "response.content_part.done",
-          item_id: outputItemId,
-          output_index: 0,
-          content_index: 0,
-          part: { type: "output_text", text: finalText },
-        });
-
-        const completedItem = createAssistantOutputItem({
-          id: outputItemId,
-          text: finalText,
-          phase: "commentary",
-          status: "completed",
-        });
-        writeSseEvent(res, {
-          type: "response.output_item.done",
-          output_index: 0,
-          item: completedItem,
-        });
-
-        // Emit one `function_call` output item per pending call, preserving
-        // arrival order. `output_index` continues past the assistant
-        // message at index 0 so the SSE stream keeps a single, monotonic
-        // index per response. Pre-#52288 the streaming path read only
-        // `pendingToolCalls[0]` and hard-coded `output_index: 1`, so a turn
-        // with multiple client tool calls dropped every call past the
-        // first.
-        const functionCallItems: OutputItem[] = [];
-        let nextStreamOutputIndex = 1;
-        for (const functionCall of pendingToolCalls) {
-          const functionCallItemId = `call_${randomUUID()}`;
-          const functionCallItem = createFunctionCallOutputItem({
-            id: functionCallItemId,
-            callId: functionCall.id,
-            name: functionCall.name,
-            arguments: functionCall.arguments,
-          });
-          writeSseEvent(res, {
-            type: "response.output_item.added",
-            output_index: nextStreamOutputIndex,
-            item: functionCallItem,
-          });
-          const completedFunctionCallItem = createFunctionCallOutputItem({
-            id: functionCallItemId,
-            callId: functionCall.id,
-            name: functionCall.name,
-            arguments: functionCall.arguments,
-            status: "completed",
-          });
-          writeSseEvent(res, {
-            type: "response.output_item.done",
-            output_index: nextStreamOutputIndex,
-            item: completedFunctionCallItem,
-          });
-          functionCallItems.push(completedFunctionCallItem);
-          nextStreamOutputIndex += 1;
-        }
-
-        const completedResponse = createResponseResource({
-          ...responseIdentity,
-          model,
-          status: "completed",
-          output: [completedItem, ...functionCallItems],
-          usage,
-        });
-        closed = true;
-        stopWatchingDisconnect();
-        unsubscribe();
-        rememberResponseSession();
-        writeSseEvent(res, { type: "response.completed", response: completedResponse });
-        writeDone(res);
-        res.end();
-        return;
-      }
-
-      // Fallback: if no streaming deltas were received, send the full response as text
-      if (!sawAssistantDelta) {
-        const content =
-          resultPayloadText || bufferedReplaceableAssistantContent || "No response from OpenClaw.";
-
-        assistantText.text = content;
-        sawAssistantDelta = true;
-        if (finalizeStatus !== null) {
-          finalizeRequested = { status: finalizeStatus, text: content };
-        }
-
-        writeSseEvent(res, {
-          type: "response.output_text.delta",
-          item_id: outputItemId,
-          output_index: 0,
-          content_index: 0,
-          delta: content,
-        });
-      }
-
+      finalResultText = resultPayloadText;
+      finalToolCalls =
+        stopReason === "tool_calls" && pendingToolCalls?.length ? pendingToolCalls : undefined;
       maybeFinalize();
     } catch (err) {
       if (closed || abortController.signal.aborted) {
@@ -1361,7 +1274,7 @@ export async function handleOpenResponsesHttpRequest(
     } finally {
       releaseAgentRootWork?.();
       // Existing provider terminals must not be replaced or emitted twice.
-      if (finalizeStatus === null && (terminalLifecyclePhase === "error" || !closed)) {
+      if (finalizeRequested === null && (terminalLifecyclePhase === "error" || !closed)) {
         emitAgentEvent({
           runId: responseId,
           stream: "lifecycle",

--- a/src/gateway/openresponses-shape.ts
+++ b/src/gateway/openresponses-shape.ts
@@ -28,7 +28,7 @@ export function createFunctionCallOutputItem(params: {
   name: string;
   arguments: string;
   status?: "in_progress" | "completed";
-}): OutputItem {
+}): Extract<OutputItem, { type: "function_call" }> {
   return {
     type: "function_call",
     id: params.id,

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -2595,6 +2595,9 @@ describe("agent event handler", () => {
     },
     { itemId: "message-1", text: "Hi", flags: { replace: true }, expected: "EarlierHi" },
     { itemId: "message-1", text: "", flags: { replace: true }, expected: "Earlier" },
+    { itemId: "message-1", text: "", flags: {}, expected: "Earlier" },
+    { itemId: "message-1", flags: { delta: "Hello" }, expected: "EarlierHelloHello" },
+    { itemId: "message-2", flags: { delta: "Hello" }, expected: "HelloHello" },
   ])(
     "keeps item ownership across $itemId correction $text",
     ({ itemId, text, flags, expected }) => {
@@ -2629,7 +2632,7 @@ describe("agent event handler", () => {
         handler,
         "run-item-correction",
         "assistant",
-        { itemId, text, ...flags },
+        { itemId, ...(text === undefined ? {} : { text }), ...flags },
         {
           seq: itemId === "message-1" ? 3 : 2,
         },

--- a/src/gateway/server-chat.stream-text-merge.test.ts
+++ b/src/gateway/server-chat.stream-text-merge.test.ts
@@ -2,7 +2,8 @@
  * Tests chat stream text merging before gateway events reach clients.
  */
 import { describe, expect, it } from "vitest";
-import { resolveMergedAssistantText } from "./live-chat-projector.js";
+import { mergeAssistantText, type AssistantTextSnapshot } from "./agent-event-assistant-text.js";
+import { capLiveAssistantText } from "./live-chat-projector.js";
 
 const LIVE_CHAT_BUFFER_CHARS = 500_000;
 
@@ -29,95 +30,86 @@ describe("server chat stream text merge", () => {
       expected: "|||",
     },
   ])("appends incremental deltas without collapsing $name", ({ chunks, expected }) => {
-    const merged = chunks.reduce(
-      (previousText, nextDelta) =>
-        resolveMergedAssistantText({
-          previousText,
-          nextText: nextDelta,
-          nextDelta,
-        }),
-      "",
+    const merged = chunks.reduce<AssistantTextSnapshot>(
+      (previous, delta) => mergeAssistantText(previous, { text: delta, delta }, "live"),
+      { text: "" },
     );
 
-    expect(merged).toBe(expected);
+    expect(merged.text).toBe(expected);
   });
 
-  it("keeps cumulative snapshots from duplicating already-buffered text", () => {
-    expect(
-      resolveMergedAssistantText({
-        previousText: "Hello",
-        nextText: "Hello world",
-        nextDelta: " world",
-      }),
-    ).toBe("Hello world");
-  });
-
-  it("keeps non-prefix incremental segments after tool calls", () => {
-    expect(
-      resolveMergedAssistantText({
-        previousText: "Before tool call",
-        nextText: "After tool call",
-        nextDelta: "\nAfter tool call",
-      }),
-    ).toBe("Before tool call\nAfter tool call");
-  });
-
-  it("replaces prior live text when Codex assistant item switches with empty delta", () => {
-    const prior = "coordination draft";
-    const replacement = resolveMergedAssistantText({
-      previousText: prior,
-      nextText: "final answer",
-      nextDelta: "",
-    });
-
-    expect(replacement).toBe("final answer");
-    expect(replacement).not.toContain(prior);
-  });
-
-  it("would concatenate superseded text if replacement incorrectly included delta", () => {
-    const prior = "coordination draft";
-    const buggy = resolveMergedAssistantText({
-      previousText: prior,
-      nextText: "final ",
-      nextDelta: "final ",
-    });
-
-    expect(buggy).toBe("coordination draftfinal ");
+  it.each([
+    {
+      name: "growing cumulative snapshots",
+      previous: "Hello",
+      input: { text: "Hello world", delta: " world" },
+      live: "Hello world",
+      appendOnly: "Hello world",
+    },
+    {
+      name: "incremental segments after tool calls",
+      previous: "Before tool call",
+      input: { text: "After tool call", delta: "\nAfter tool call" },
+      live: "Before tool call\nAfter tool call",
+      appendOnly: "Before tool call\nAfter tool call",
+    },
+    {
+      name: "non-prefix snapshots with empty deltas",
+      previous: "coordination draft",
+      input: { text: "final answer", delta: "" },
+      live: "final answer",
+      appendOnly: "coordination draft",
+    },
+    {
+      name: "repeated text with an explicit delta",
+      previous: "Echo",
+      input: { text: "Echo", delta: "Echo" },
+      live: "EchoEcho",
+      appendOnly: "Echo",
+    },
+  ])("preserves legacy unkeyed handling of $name", ({ previous, input, live, appendOnly }) => {
+    expect(mergeAssistantText({ text: previous }, input, "live").text).toBe(live);
+    expect(mergeAssistantText({ text: previous }, input, "append-only").text).toBe(appendOnly);
   });
 
   it("caps merged live text while preserving the newest assistant output", () => {
-    const result = resolveMergedAssistantText({
-      previousText: "a".repeat(LIVE_CHAT_BUFFER_CHARS - 2),
-      nextText: "",
-      nextDelta: "bbbb",
-    });
+    const result = capLiveAssistantText(
+      mergeAssistantText(
+        { text: "a".repeat(LIVE_CHAT_BUFFER_CHARS - 2) },
+        { delta: "bbbb" },
+        "live",
+      ),
+    );
 
     expect(result).toHaveLength(LIVE_CHAT_BUFFER_CHARS);
     expect(result.endsWith("bbbb")).toBe(true);
   });
 
   it("does not resurrect a discarded scoped prefix after a shorter correction", () => {
-    const scope = { prefix: "x🚀keep" };
     const snapshot = "y".repeat(LIVE_CHAT_BUFFER_CHARS - 5);
-    const capped = resolveMergedAssistantText({
-      previousText: scope.prefix,
-      nextText: snapshot,
-      nextDelta: snapshot,
-      scope,
-    });
+    const merged = mergeAssistantText(
+      { text: "x🚀keep" },
+      { itemId: "answer", text: snapshot, delta: snapshot },
+      "live",
+    );
+    const capped = capLiveAssistantText(merged);
     expect(capped).toBe(`keep${snapshot}`);
     expect(
-      resolveMergedAssistantText({ previousText: capped, nextText: "!", nextDelta: "", scope }),
+      capLiveAssistantText(
+        mergeAssistantText(
+          { text: capped, scope: merged.scope },
+          { itemId: "answer", text: "!", delta: "" },
+          "live",
+        ),
+      ),
     ).toBe("keep!");
   });
 
   it("does not start the capped tail with the low half of a surrogate pair", () => {
     const safeTail = "y".repeat(LIVE_CHAT_BUFFER_CHARS - 1);
-    const result = resolveMergedAssistantText({
-      previousText: "",
-      nextText: `x🚀${safeTail}`,
-      nextDelta: "",
-    });
+    const result = capLiveAssistantText(
+      mergeAssistantText({ text: "" }, { text: `x🚀${safeTail}`, delta: "" }, "live"),
+    );
 
     expect(result).toBe(safeTail);
   });

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -39,10 +39,10 @@ import {
 } from "../sessions/session-key-utils.js";
 import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
+import { mergeAssistantText, resolveAssistantTextInput } from "./agent-event-assistant-text.js";
 import {
+  capLiveAssistantText,
   projectLiveAssistantBufferedText,
-  resolveAssistantLiveChatInput,
-  resolveMergedAssistantText,
   shouldSuppressAssistantEventForLiveChat,
 } from "./live-chat-projector.js";
 import type {
@@ -1023,7 +1023,7 @@ export function createAgentEventHandler({
     clientRunId: string,
     sourceRunId: string,
     seq: number,
-    input: NonNullable<ReturnType<typeof resolveAssistantLiveChatInput>>,
+    input: NonNullable<ReturnType<typeof resolveAssistantTextInput>>,
     opts?: { controlUiVisible?: boolean; isCurrent?: () => boolean },
   ) => {
     const run = chatRunState.getOrCreate(clientRunId);
@@ -1035,21 +1035,13 @@ export function createAgentEventHandler({
       delete run.bufferProjection;
     }
     const previousRawText = run.rawBuffer ?? "";
-    if (!input.itemId) {
-      delete run.assistantScope;
-    } else if (run.assistantScope?.itemId !== input.itemId) {
-      // Only provisional stream replacements discard prior text; bounded message snapshots retain it.
-      run.assistantScope = {
-        itemId: input.itemId,
-        prefix: input.replaceStream ? "" : previousRawText,
-      };
-    }
-    const mergedRawText = resolveMergedAssistantText({
-      previousText: previousRawText,
-      nextText: input.text,
-      nextDelta: input.delta,
-      scope: run.assistantScope,
-    });
+    const snapshot = mergeAssistantText(
+      { text: previousRawText, scope: run.assistantScope },
+      input,
+      "live",
+    );
+    run.assistantScope = snapshot.scope;
+    const mergedRawText = capLiveAssistantText(snapshot);
     if (!mergedRawText && !previousRawText) {
       return;
     }
@@ -1728,7 +1720,7 @@ export function createAgentEventHandler({
         );
       }
       const assistantLiveChatInput =
-        evt.stream === "assistant" ? resolveAssistantLiveChatInput(evt.data) : undefined;
+        evt.stream === "assistant" ? resolveAssistantTextInput(evt.data) : undefined;
       const suppressAssistant = shouldSuppressAssistantEventForLiveChat(evt.data);
       if (
         !isAborted &&

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -3431,7 +3431,82 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
-  it("marks local embedded replacement deltas", async () => {
+  it.each([
+    {
+      name: "unkeyed replacement snapshots",
+      updates: [{ text: "Hello world" }, { text: "Goodbye world" }],
+      expectedDeltas: [
+        { deltaText: "Hello world", replace: undefined },
+        { deltaText: "Goodbye world", replace: true },
+      ],
+      expectedText: "Goodbye world",
+    },
+    {
+      name: "identical snapshots from distinct assistant items",
+      updates: [
+        { itemId: "first", text: "Echo" },
+        { itemId: "second", text: "Echo" },
+      ],
+      expectedDeltas: [
+        { deltaText: "Echo", replace: undefined },
+        { deltaText: "Echo", replace: undefined },
+      ],
+      expectedText: "EchoEcho",
+    },
+    {
+      name: "a new assistant item extending an earlier item's text",
+      updates: [
+        { itemId: "first", text: "Echo", delta: "Echo" },
+        { itemId: "second", text: "Echo!", delta: "Echo!" },
+      ],
+      expectedDeltas: [
+        { deltaText: "Echo", replace: undefined },
+        { deltaText: "Echo!", replace: undefined },
+      ],
+      expectedText: "EchoEcho!",
+    },
+    {
+      name: "replayed and growing snapshots of one assistant item",
+      updates: [
+        { itemId: "answer", text: "Echo", delta: "Echo" },
+        { itemId: "answer", text: "Echo", delta: "Echo" },
+        { itemId: "answer", text: "Echo again", delta: " again" },
+      ],
+      expectedDeltas: [
+        { deltaText: "Echo", replace: undefined },
+        { deltaText: " again", replace: undefined },
+      ],
+      expectedText: "Echo again",
+    },
+    {
+      name: "item-scoped deltas without snapshots",
+      updates: [
+        { itemId: "first", delta: "Echo" },
+        { itemId: "first", delta: "Echo" },
+        { itemId: "second", delta: "!" },
+      ],
+      expectedDeltas: [
+        { deltaText: "Echo", replace: undefined },
+        { deltaText: "Echo", replace: undefined },
+        { deltaText: "!", replace: undefined },
+      ],
+      expectedText: "EchoEcho!",
+    },
+    {
+      name: "empty corrections that remove only the current assistant item",
+      updates: [
+        { itemId: "first", text: "Hello" },
+        { itemId: "second", text: " world" },
+        { itemId: "second", text: "" },
+      ],
+      expectedDeltas: [
+        { deltaText: "Hello", replace: undefined },
+        { deltaText: " world", replace: undefined },
+        { deltaText: "Hello", replace: true },
+      ],
+      expectedText: "Hello",
+    },
+  ])("projects local embedded $name", async ({ updates, expectedDeltas, expectedText }) => {
     const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
@@ -3441,18 +3516,11 @@ describe("EmbeddedTuiBackend", () => {
     backend.start();
     await sendMainChat(backend, "replace", "run-local-replace");
 
-    registeredListener?.({
-      runId: "run-local-replace",
-      stream: "assistant",
-      data: { text: "Hello world" },
-    });
-    registeredListener?.({
-      runId: "run-local-replace",
-      stream: "assistant",
-      data: { text: "Goodbye world" },
-    });
+    for (const data of updates) {
+      registeredListener?.({ runId: "run-local-replace", stream: "assistant", data });
+    }
 
-    pending.resolve({ payloads: [{ text: "Goodbye world" }], meta: {} });
+    pending.resolve({ payloads: [], meta: {} });
     await flushMicrotasks();
 
     const chatPayloads = events
@@ -3463,20 +3531,21 @@ describe("EmbeddedTuiBackend", () => {
             state?: string;
             deltaText?: string;
             replace?: boolean;
+            message?: { content?: Array<{ text?: string }> };
           },
       );
     expect(
       chatPayloads
         .filter((payload) => payload.state === "delta")
         .map((payload) => ({
-          state: payload.state,
           deltaText: payload.deltaText,
           replace: payload.replace,
         })),
-    ).toEqual([
-      { state: "delta", deltaText: "Hello world", replace: undefined },
-      { state: "delta", deltaText: "Goodbye world", replace: true },
-    ]);
+    ).toEqual(expectedDeltas);
+    expect(chatPayloads.at(-1)).toMatchObject({
+      state: "final",
+      message: { content: [{ text: expectedText }] },
+    });
   });
 
   it("keeps internal context private when local deltas split its delimiters", async () => {
@@ -3518,7 +3587,10 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
-  it("keeps a fallback response deliverable after a retryable lifecycle error", async () => {
+  it.each([
+    { name: "unkeyed fallback", itemId: undefined },
+    { name: "fallback reusing an assistant item ID", itemId: "answer" },
+  ])("keeps a $name deliverable after a retryable lifecycle error", async ({ itemId }) => {
     const pending = deferred<EmbeddedAgentResult>();
     agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
 
@@ -3528,6 +3600,14 @@ describe("EmbeddedTuiBackend", () => {
     backend.start();
     await sendMainChat(backend, "recover after timeout", "run-local-fallback");
 
+    if (itemId) {
+      for (const data of [
+        { itemId: "prefix", text: "Discarded attempt: " },
+        { itemId, text: "draft answer" },
+      ]) {
+        registeredListener?.({ runId: "run-local-fallback", stream: "assistant", data });
+      }
+    }
     registeredListener?.({
       runId: "run-local-fallback",
       stream: "lifecycle",
@@ -3554,7 +3634,14 @@ describe("EmbeddedTuiBackend", () => {
     registeredListener?.({
       runId: "run-local-fallback",
       stream: "assistant",
-      data: { text: "fallback answer", delta: "fallback answer" },
+      data: { itemId, text: "fallback answer", delta: "fallback answer" },
+    });
+    expect(events.at(-1)).toMatchObject({
+      event: "chat",
+      payload: {
+        state: "delta",
+        message: { content: [{ text: "fallback answer" }] },
+      },
     });
     registeredListener?.({
       runId: "run-local-fallback",
@@ -3583,9 +3670,15 @@ describe("EmbeddedTuiBackend", () => {
     { failureCount: 2, streamedText: "recovered answer", finalText: "recovered answer" },
     { failureCount: 1, streamedText: "outdated draft", finalText: "authoritative final answer" },
     { failureCount: 1, streamedText: undefined, finalText: "authoritative unstreamed answer" },
+    {
+      failureCount: 2,
+      streamedText: "recovered item answer",
+      finalText: "recovered item answer",
+      itemId: "answer",
+    },
   ])(
     "replaces $failureCount expired attempt failures with authoritative result '$finalText'",
-    async ({ failureCount, streamedText, finalText }) => {
+    async ({ failureCount, streamedText, finalText, itemId }) => {
       const pending = deferred<EmbeddedAgentResult>();
       agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
       const backend = new EmbeddedTuiBackend();
@@ -3595,6 +3688,14 @@ describe("EmbeddedTuiBackend", () => {
       backend.start();
       await sendMainChat(backend, "recover after a slow retry", runId);
       for (let attempt = 0; attempt < failureCount; attempt += 1) {
+        if (itemId) {
+          for (const data of [
+            { itemId: "prefix", text: `Discarded attempt ${attempt + 1}: ` },
+            { itemId, text: "draft answer" },
+          ]) {
+            registeredListener?.({ runId, stream: "assistant", data });
+          }
+        }
         registeredListener?.({
           runId,
           stream: "lifecycle",
@@ -3613,7 +3714,14 @@ describe("EmbeddedTuiBackend", () => {
         registeredListener?.({
           runId,
           stream: "assistant",
-          data: { text: streamedText, delta: streamedText },
+          data: { itemId, text: streamedText, delta: streamedText },
+        });
+        expect(events.at(-1)).toMatchObject({
+          event: "chat",
+          payload: {
+            state: "delta",
+            message: { content: [{ text: streamedText }] },
+          },
         });
       }
       registeredListener?.({

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -45,13 +45,17 @@ import { getRuntimeConfig, registerConfigWriteListener } from "../config/config.
 import type { SessionEntry } from "../config/sessions.js";
 import { applySessionPatchProjection } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  mergeAssistantText,
+  resolveAssistantTextInput,
+  type AssistantTextSnapshot,
+} from "../gateway/agent-event-assistant-text.js";
 import { isChatStopCommandText } from "../gateway/chat-abort.js";
 import { resolveEffectiveChatHistoryMaxChars } from "../gateway/chat-display-projection.js";
 import {
+  capLiveAssistantText,
   normalizeLiveAssistantBufferedText,
   projectLiveAssistantBufferedText,
-  resolveAssistantLiveChatInput,
-  resolveMergedAssistantText,
   shouldSuppressAssistantEventForLiveChat,
 } from "../gateway/live-chat-projector.js";
 import { getMaxChatHistoryMessagesBytes } from "../gateway/server-constants.js";
@@ -127,6 +131,7 @@ type LocalRunState = {
   agentId: string;
   controller: AbortController;
   buffer: string;
+  assistantScope?: AssistantTextSnapshot["scope"];
   managedMediaUrls: Set<string>;
   lastBroadcastText?: string;
   isBtw: boolean;
@@ -1325,7 +1330,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
 
     const assistantLiveChatInput =
-      evt.stream === "assistant" ? resolveAssistantLiveChatInput(evt.data) : undefined;
+      evt.stream === "assistant" ? resolveAssistantTextInput(evt.data) : undefined;
     if (
       assistantLiveChatInput &&
       !run.isBtw &&
@@ -1334,11 +1339,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
       for (const url of assistantLiveChatInput.managedMediaUrls ?? []) {
         run.managedMediaUrls.add(url);
       }
-      run.buffer = resolveMergedAssistantText({
-        previousText: run.buffer,
-        nextText: assistantLiveChatInput.text,
-        nextDelta: assistantLiveChatInput.delta,
-      });
+      const snapshot = mergeAssistantText(
+        { text: run.buffer, scope: run.assistantScope },
+        assistantLiveChatInput,
+        "live",
+      );
+      run.assistantScope = snapshot.scope;
+      run.buffer = capLiveAssistantText(snapshot);
       this.emitChatDelta(evt.runId, run);
       return;
     }
@@ -1361,6 +1368,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     run.finishing = false;
     if (phase === "error") {
       run.buffer = "";
+      delete run.assistantScope;
     }
     if (this.projectTerminalOutcome(evt.runId, run, evt.data)) {
       return;


### PR DESCRIPTION
Closes #139440

## What Problem This Solves

Streaming clients could lose repeated text from distinct assistant messages or successfully complete with an answer that the model had replaced. For example, separate `Echo` and `Echo!` items displayed only `Echo!` during streaming. In the real native HTTP path, a later selected `Replacement` answer produced the incorrect successful output `EchoReplacement`.

## Why This Change Was Made

A shared item-aware merger preserves message identity and distinguishes a missing snapshot from an explicitly empty one. Gateway WebSocket chat, local TUI, Chat Completions, and Responses use that owner; the existing UTF-16-safe live-display cap stays outside the uncapped HTTP merge.

HTTP completion now retains provisional output through the native terminal snapshot and selects the settled text at its existing deferred finalization boundary. A compatible suffix is emitted once; a final answer that would retract delivered bytes produces the existing explicit transport error. Normal and tool-call completion share the same selection. Required/pinned tool validation precedes held prose and tool frames. Explicit empty results cannot resurrect draft commentary, and queued compatible Responses recovery is observed before deciding failure. Chat's existing sticky non-provisional error behavior remains intact.

The change removes duplicated projection and completion paths: production +311/-424 (net **-113**), tests +1151/-427, docs +4, assertion baseline net -1. The function-call factory's return type now names the variant it actually creates. No configuration, protocol, schema, or stored representation changes.

## User Impact

Repeated content in separate assistant messages remains visible while streaming. HTTP consumers receive one consistent sequence of text, tool, and terminal frames. Unsupported retractions are reported explicitly instead of being presented as successful output.

## Evidence

Final commit: `f89d7761e94ca110bf6859a96d03f182417bd516`, based on `61690da40bd436684311adec59d69bae3b0e383d`. Complete final managed P0–P2 review is scoped-clean. The clean-head private-QA `sourcePerformance` build passed in 96.6 seconds; this builds runtime and metadata, rather than full SDK/package output.

The item repair had failing before regressions, 390 Gateway tests and 121 TUI tests, plus the inspected native TUI before/after captures below. Later terminal corrections had separate failing-before evidence: 8 failures for ignored held replacements, 4 failures for explicit empty tool commentary, and 1 queued-recovery ordering failure. The full HTTP selection passed 203 tests before the last two small corrections; those received 29 and 27 targeted owning controls, including ordinary empty/no-response behavior, missing results, tool choice, late events, unrecovered failures and sibling error policy. All 30 canonical changed checks passed before those final corrections, which also received their owning type/lint/format checks. A final full 211-test run is not claimed here; hosted CI covers the published head.

Real after-proof used the isolated Gateway, native Codex 0.153.4, and official OpenAI SDK 7.5.0 on the final built commit. Both APIs delivered only `Echo`, then an explicit append-only failure, with no successful completion. Each actual bus recorded the first item, the flagged provisional replacement, the unkeyed terminal `Replacement` snapshot, and native lifecycle end. Each made one local synthetic inference request and one genuine HTTP 426 fallback. Owned runtime paths were isolated, the Gateway exited 0, and owned processes/runtime directories were removed.

```json
{
  "source": "f89d7761e94ca110bf6859a96d03f182417bd516",
  "chat": {"sdkText": "Echo", "errorType": "api_error", "successfulCompletion": false},
  "responses": {"sdkText": "Echo", "event": "response.failed", "errorCode": "server_error", "successfulCompletion": false},
  "nativeSelectedText": "Replacement",
  "nativeRequests": 2,
  "cleanupVerified": true
}
```

The original after driver exited 1 because its Responses checker incorrectly expected `api_error`; the existing handler and official SDK require `server_error`. The raw captures and failed driver receipt remain unchanged. A separate verification, independently repeated against the original SDK/bus captures, confirms the behavior above; no additional inference or application change was used to correct the checker. This is real local Gateway/native-runtime/SDK evidence with a synthetic loopback provider, not authenticated cloud-model or package-acceptance proof.

The images below prove the earlier item-scoping correction. Subsequent changes concern HTTP terminal settlement; the item merger and TUI behavior shown remain unchanged. Both captures were inspected and contain synthetic content.

![Before: distinct Echo and Echo! items display only Echo! during streaming](https://github.com/user-attachments/assets/b1d8b045-3abb-46a0-b169-3087b13cbb45)

![After: both distinct assistant items remain visible during streaming](https://github.com/user-attachments/assets/214a3084-0f2f-4a84-a0ef-047c3360aaf1)
