### PR TITLE
fix(gateway): deliver upgrade rejection responses under Bun

### DIFF
--- a/src/gateway/server-http-upgrades.ts
+++ b/src/gateway/server-http-upgrades.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, Server as HttpServer } from "node:http";
+import type { Duplex } from "node:stream";
 import type { WebSocketServer } from "ws";
 import { getRuntimeConfig } from "../config/io.js";
 import {
@@ -38,7 +39,7 @@ import {
   type ResolvePluginNodeCapabilityRoute,
 } from "./server-http-plugin-auth.js";
 import type { GatewayRequestContext } from "./server-methods/types.js";
-import { writeGatewayUpgradeServiceUnavailable } from "./server/http-work-admission.js";
+import { rejectGatewayUpgradeServiceUnavailable } from "./server/http-work-admission.js";
 import { resolvePluginRoutePathContext } from "./server/plugins-http/path-context.js";
 import type { PluginRoutePathContext } from "./server/plugins-http/path-context.js";
 import type { PreauthConnectionBudget } from "./server/preauth-connection-budget.js";
@@ -65,10 +66,7 @@ const getPluginRouteRuntimeScopesModule = createLazyRuntimeModule(
   () => import("./server/plugin-route-runtime-scopes.js"),
 );
 
-function writeUpgradeAuthFailure(
-  socket: { write: (chunk: string) => void },
-  auth: GatewayAuthResult,
-) {
+function rejectUpgradeAuth(socket: Pick<Duplex, "end" | "destroy">, auth: GatewayAuthResult) {
   if (auth.rateLimited) {
     const retryAfterSeconds =
       auth.retryAfterMs && auth.retryAfterMs > 0 ? Math.ceil(auth.retryAfterMs / 1000) : undefined;
@@ -78,7 +76,7 @@ function writeUpgradeAuthFailure(
         type: "rate_limited",
       },
     });
-    socket.write(
+    socket.end(
       [
         "HTTP/1.1 429 Too Many Requests",
         ...(retryAfterSeconds ? [`Retry-After: ${retryAfterSeconds}`] : []),
@@ -88,6 +86,7 @@ function writeUpgradeAuthFailure(
         "",
         body,
       ].join("\r\n"),
+      () => socket.destroy(),
     );
     return;
   }
@@ -98,7 +97,7 @@ function writeUpgradeAuthFailure(
         type: PROXY_ATTRIBUTION_REQUIRED_REASON,
       },
     });
-    socket.write(
+    socket.end(
       [
         "HTTP/1.1 403 Forbidden",
         "Content-Type: application/json; charset=utf-8",
@@ -107,10 +106,11 @@ function writeUpgradeAuthFailure(
         "",
         body,
       ].join("\r\n"),
+      () => socket.destroy(),
     );
     return;
   }
-  socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+  socket.end("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n", () => socket.destroy());
 }
 
 function handleBudgetedGatewayWebSocketUpgrade(params: {
@@ -138,18 +138,15 @@ function handleBudgetedGatewayWebSocketUpgrade(params: {
       (getGatewaySuspendAdmissionPhase() !== "draining" &&
         getGatewaySuspendAdmissionPhase() !== "prepared"))
   ) {
-    writeGatewayUpgradeServiceUnavailable(socket, `${ingressName} websocket admission closed`);
-    socket.destroy();
+    rejectGatewayUpgradeServiceUnavailable(socket, `${ingressName} websocket admission closed`);
     return;
   }
   if (wss.listenerCount("connection") === 0) {
-    writeGatewayUpgradeServiceUnavailable(socket, `${ingressName} websocket handlers unavailable`);
-    socket.destroy();
+    rejectGatewayUpgradeServiceUnavailable(socket, `${ingressName} websocket handlers unavailable`);
     return;
   }
   if (!preauthConnectionBudget.acquire(preauthBudgetKey)) {
-    writeGatewayUpgradeServiceUnavailable(socket, "Too many unauthenticated sockets");
-    socket.destroy();
+    rejectGatewayUpgradeServiceUnavailable(socket, "Too many unauthenticated sockets");
     return;
   }
 
@@ -247,13 +244,11 @@ export function attachGatewayUpgradeHandler(opts: {
         ingressAttribution.kind === "unattributable-proxy"
       ) {
         opts.reportUnattributableProxy?.(ingressAttribution);
-        writeUpgradeAuthFailure(socket, { ok: false, reason: ingressAttribution.reason });
-        socket.destroy();
+        rejectUpgradeAuth(socket, { ok: false, reason: ingressAttribution.reason });
         return;
       }
       if (originalWorkerGatewayRoute === "worker" && !workerIngressEnabled) {
-        writeGatewayUpgradeServiceUnavailable(socket, "Worker websocket ingress unavailable");
-        socket.destroy();
+        rejectGatewayUpgradeServiceUnavailable(socket, "Worker websocket ingress unavailable");
         return;
       }
       if (originalWorkerGatewayRoute === "worker") {
@@ -262,13 +257,12 @@ export function attachGatewayUpgradeHandler(opts: {
           AUTH_RATE_LIMIT_SCOPE_WORKER_ADMISSION,
         );
         if (rateCheck && !rateCheck.allowed) {
-          writeUpgradeAuthFailure(socket, {
+          rejectUpgradeAuth(socket, {
             ok: false,
             reason: "rate_limited",
             rateLimited: true,
             retryAfterMs: rateCheck.retryAfterMs,
           });
-          socket.destroy();
           return;
         }
         try {
@@ -294,14 +288,12 @@ export function attachGatewayUpgradeHandler(opts: {
         return;
       }
       if (originalWorkerGatewayRoute !== "outside") {
-        socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
-        socket.destroy();
+        socket.end("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n", () => socket.destroy());
         return;
       }
       const scopedNodeCapability = normalizePluginNodeCapabilityScopedUrl(req.url ?? "/");
       if (scopedNodeCapability.malformedScopedPath) {
-        writeUpgradeAuthFailure(socket, { ok: false, reason: "unauthorized" });
-        socket.destroy();
+        rejectUpgradeAuth(socket, { ok: false, reason: "unauthorized" });
         return;
       }
       if (scopedNodeCapability.rewrittenUrl) {
@@ -312,16 +304,14 @@ export function attachGatewayUpgradeHandler(opts: {
       const pathContext = resolvePluginRoutePathContext(requestPath);
       const workerGatewayRoute = classifyWorkerGatewayPath(requestPath);
       if (workerGatewayRoute !== "outside") {
-        socket.write("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n");
-        socket.destroy();
+        socket.end("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n", () => socket.destroy());
         return;
       }
       const nodeCapability = resolvePluginNodeCapabilityRoute?.(pathContext);
       if (ingressAttribution.kind === "unattributable-proxy") {
         opts.reportUnattributableProxy?.(ingressAttribution);
         if (nodeCapability || !opts.isPluginAuthenticatedRoute?.(pathContext)) {
-          writeUpgradeAuthFailure(socket, { ok: false, reason: ingressAttribution.reason });
-          socket.destroy();
+          rejectUpgradeAuth(socket, { ok: false, reason: ingressAttribution.reason });
           return;
         }
       }
@@ -341,8 +331,7 @@ export function attachGatewayUpgradeHandler(opts: {
           rateLimiter,
         });
         if (!ok.ok) {
-          writeUpgradeAuthFailure(socket, ok);
-          socket.destroy();
+          rejectUpgradeAuth(socket, ok);
           return;
         }
       }
@@ -367,8 +356,7 @@ export function attachGatewayUpgradeHandler(opts: {
             cfg: configSnapshot,
           });
           if (!authCheck.ok) {
-            writeUpgradeAuthFailure(socket, authCheck.authResult);
-            socket.destroy();
+            rejectUpgradeAuth(socket, authCheck.authResult);
             return;
           }
           pluginGatewayAuthSatisfied = true;
@@ -392,22 +380,19 @@ export function attachGatewayUpgradeHandler(opts: {
         }
       }
       if (ingressAttribution.kind === "unattributable-proxy") {
-        writeUpgradeAuthFailure(socket, { ok: false, reason: ingressAttribution.reason });
-        socket.destroy();
+        rejectUpgradeAuth(socket, { ok: false, reason: ingressAttribution.reason });
         return;
       }
       if (requestPath === "/desktop/observe") {
         if (!opts.desktopSessionRegistry) {
-          writeGatewayUpgradeServiceUnavailable(socket, "desktop observe unavailable");
-          socket.destroy();
+          rejectGatewayUpgradeServiceUnavailable(socket, "desktop observe unavailable");
           return;
         }
         // Desktop observers are long-lived Gateway sockets, so they obey the same
         // suspension/restart admission boundary as core upgrades. Without this a
         // drained Gateway would keep accepting new desktop streams.
         if (isGatewayWorkAdmissionClosed()) {
-          writeGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
-          socket.destroy();
+          rejectGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
           return;
         }
         const { handleDesktopObserveUpgrade } = await import("./desktop/observe-bridge.js");
@@ -420,13 +405,11 @@ export function attachGatewayUpgradeHandler(opts: {
         const context = opts.getGatewayRequestContext?.();
         if (!opts.nodeDesktopStreamBroker || !context) {
           const feature = requestPath === NODE_DESKTOP_ATTACH_PATH ? "desktop" : "portal";
-          writeGatewayUpgradeServiceUnavailable(socket, `node ${feature} attach unavailable`);
-          socket.destroy();
+          rejectGatewayUpgradeServiceUnavailable(socket, `node ${feature} attach unavailable`);
           return;
         }
         if (isGatewayWorkAdmissionClosed()) {
-          writeGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
-          socket.destroy();
+          rejectGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
           return;
         }
         await opts.nodeDesktopStreamBroker.handleUpgrade(req, socket, head, context.nodeRegistry);

--- a/src/gateway/server-http.rejection-transport.test.ts
+++ b/src/gateway/server-http.rejection-transport.test.ts
@@ -27,7 +27,7 @@ describe("Gateway closing connection admission", () => {
         return true;
       },
     });
-    const wss = new WebSocketServer({ noServer: true });
+    const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PREAUTH_PAYLOAD_BYTES });
     attachGatewayUpgradeHandler({
       httpServer: server,
       wss,

--- a/src/gateway/server-http.rejection-transport.test.ts
+++ b/src/gateway/server-http.rejection-transport.test.ts
@@ -1,5 +1,5 @@
 import { once } from "node:events";
-import type { ServerResponse } from "node:http";
+import { Agent, request, type ServerResponse } from "node:http";
 import { connect } from "node:net";
 import type { Duplex } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
@@ -13,6 +13,73 @@ import { createPreauthConnectionBudget } from "./server/preauth-connection-budge
 vi.mock("../config/io.js", () => ({ getRuntimeConfig: () => ({}) }));
 
 describe("Gateway closing connection admission", () => {
+  it("delivers an upgrade rejection after an ordinary response on a reused connection", async () => {
+    const clients = new Set<never>();
+    const resolvedAuth = { mode: "none" as const, allowTailscale: false };
+    const server = createGatewayHttpServer({
+      clients,
+      controlUiEnabled: false,
+      controlUiBasePath: "",
+      resolvedAuth,
+      getRuntimeConfig: () => ({}),
+      handleHooksRequest: async (_req, res) => {
+        res.end("ready");
+        return true;
+      },
+    });
+    const wss = new WebSocketServer({ noServer: true });
+    attachGatewayUpgradeHandler({
+      httpServer: server,
+      wss,
+      clients,
+      resolvedAuth,
+      preauthConnectionBudget: createPreauthConnectionBudget(),
+    });
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing listener");
+    }
+    const readResponse = (upgrade: boolean) =>
+      new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+        const req = request(
+          {
+            host: "127.0.0.1",
+            port: address.port,
+            path: "/socket",
+            agent,
+            headers: upgrade ? { connection: "Upgrade", upgrade: "websocket" } : {},
+          },
+          (res) => {
+            const chunks: Buffer[] = [];
+            res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+            res.once("error", reject);
+            res.once("end", () =>
+              resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString() }),
+            );
+          },
+        );
+        req.once("error", reject);
+        req.end();
+      });
+    try {
+      await expect(readResponse(false)).resolves.toEqual({ status: 200, body: "ready" });
+      await expect(readResponse(true)).resolves.toEqual({
+        status: 503,
+        body: "Gateway websocket handlers unavailable",
+      });
+    } finally {
+      agent.destroy();
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      wss.close();
+    }
+  });
+
   it("contains browser socket errors while plugin upgrade routing is pending", async () => {
     const routing = createDeferredCore<Duplex>();
     const releaseRouting = createDeferredCore();

--- a/src/gateway/server-plugin-subagent-runtime.test.ts
+++ b/src/gateway/server-plugin-subagent-runtime.test.ts
@@ -499,7 +499,10 @@ describe("plugin background completions", () => {
       await started.promise;
       const second = complete(runtime);
       await vi.waitFor(() => expect(getBackgroundWorkSnapshot().queuedCount).toBe(1));
-      const rejected = expect(first).rejects.toThrow(/caller cancelled|timeout/u);
+      const rejected =
+        reason === "timeout"
+          ? expect(first).rejects.toMatchObject({ name: "TimeoutError" })
+          : expect(first).rejects.toThrow("caller cancelled");
       if (reason === "caller cancellation") {
         controller.abort(new Error("caller cancelled"));
       }

--- a/src/gateway/server/http-work-admission.ts
+++ b/src/gateway/server/http-work-admission.ts
@@ -55,17 +55,19 @@ export async function runWithGatewayHttpWorkAdmission(
   );
 }
 
-export function writeGatewayUpgradeServiceUnavailable(
-  socket: Pick<Duplex, "write">,
+export function rejectGatewayUpgradeServiceUnavailable(
+  socket: Pick<Duplex, "end" | "destroy">,
   body: string,
 ): void {
-  socket.write(
+  // Reused HTTP sockets can buffer upgrade writes; destroy only after flushing.
+  socket.end(
     "HTTP/1.1 503 Service Unavailable\r\n" +
       "Connection: close\r\n" +
       "Content-Type: text/plain; charset=utf-8\r\n" +
       `Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n` +
       "\r\n" +
       body,
+    () => socket.destroy(),
   );
 }
 
@@ -77,8 +79,7 @@ export async function runWithGatewayUpgradeWorkAdmission(
   return await runWithGatewayBoundaryWorkAdmission(
     "http:upgrade",
     () => {
-      writeGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
-      socket.destroy();
+      rejectGatewayUpgradeServiceUnavailable(socket, "Gateway websocket admission closed");
     },
     run,
   );

--- a/src/gateway/server/plugins-http.suspension-admission.test.ts
+++ b/src/gateway/server/plugins-http.suspension-admission.test.ts
@@ -88,6 +88,11 @@ function createMockUpgradeSocket() {
     write(chunk: string) {
       socket.chunks.push(chunk);
     },
+    end(chunk: string, callback?: () => void) {
+      socket.write(chunk);
+      callback?.();
+      return socket;
+    },
     destroy() {
       socket.destroyed = true;
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Gateway clients could receive a connection reset instead of the HTTP rejection response when attempting a WebSocket upgrade on a reused connection under Bun.

## Why This Change Was Made

Upgrade rejection helpers now own shutdown: they end the response and destroy the socket only after its buffered bytes finish writing. Existing admission decisions, status codes, headers, and response bodies stay intact. The background completion timeout assertion also checks the standard TimeoutError identity instead of runtime-specific wording.

## User Impact

Clients receive the intended rejection and explanation when WebSocket admission is unavailable or authentication fails.

## Evidence

- Node: 72 focused tests passed.
- Bun: 23 timeout tests, 7 Tailscale tests, and the new ordinary keep-alive upgrade rejection regression passed.
- Full changed-file gate passed; independent P0–P2 review found no actionable findings.
- The added regression protects delivery of a 503 response after an ordinary request reuses the same connection.
- Hosted checks exposed two fixture omissions: the new server now uses the existing payload limit, and the sibling suspension-admission mock records end(response) before its completion callback. Both targeted benign 503 cases pass under Node and true Bun; final changed checks and independent review pass.
- This is a bounded compatibility fix. Twelve existing Bun transport cases remain failing outside the repaired path; the full Bun suite is not green.
