### PR TITLE
fix(process): require cleanup evidence before releasing owned work

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -91,6 +91,12 @@ and Gateway shutdown wait for the cleanup owner separately; when that owner repo
 uncertainty, they report failure instead of treating the timeout as proof that the
 command has stopped.
 
+For owned POSIX process groups, cleanup also waits for the operating system to
+confirm that the group has disappeared after graceful shutdown. A completed
+command or closed output pipe alone does not establish that its descendants have
+stopped. Forced termination without confirmed cleanup remains uncertain. Local
+TUI shell shutdown uses the same cleanup owner for its own commands.
+
 ## process tool
 
 Actions:

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -2712,7 +2712,7 @@ describe("short-term promotion", () => {
     vi.spyOn(process, "kill").mockImplementation(() => true);
     vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath) => {
       if (String(filePath) === `/proc/${ownerPid}/status`) {
-        return `Name:\tmemory worker\nState:\tZ (zombie)\nPid:\t${ownerPid}\n`;
+        return `Name:\tmemory worker\nState:\tZ (zombie)\nPid:\t${ownerPid}\nThreads:\t1\n`;
       }
       throw new Error(`unexpected read: ${String(filePath)}`);
     });

--- a/src/agents/cli-runner/execute.pending-cancellation.test.ts
+++ b/src/agents/cli-runner/execute.pending-cancellation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { createProcessAdapterEvents } from "../../process/supervisor/adapters/process-events.js";
 import { createProcessSupervisor } from "../../process/supervisor/supervisor.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
 import * as failoverErrors from "../failover-error.js";
@@ -35,11 +36,23 @@ type TestAdapter = ChildAdapter & {
 
 function createTestAdapter(): TestAdapter {
   const exit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const events = createProcessAdapterEvents();
+  let settled = false;
+  const settle: TestAdapter["settle"] = (code, signal = null) => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    events.emitExit(code, signal);
+    exit.resolve({ code, signal });
+  };
   let stdoutListener: ((chunk: string) => void) | undefined;
   let stderrListener: ((chunk: string) => void) | undefined;
   const adapter: TestAdapter = {
     pid: 1234,
     supportsRawOutput: false,
+    onExit: events.onExit,
+    onError: events.onError,
     onStdout: (listener) => {
       stdoutListener = listener;
     },
@@ -48,12 +61,12 @@ function createTestAdapter(): TestAdapter {
     },
     wait: async () => await exit.promise,
     kill: vi.fn((signal?: NodeJS.Signals) => {
-      exit.resolve({ code: null, signal: signal ?? "SIGTERM" });
+      settle(null, signal ?? "SIGTERM");
     }),
-    dispose: vi.fn(),
+    dispose: vi.fn(() => events.clear()),
     emitStdout: (chunk) => stdoutListener?.(chunk),
     emitStderr: (chunk) => stderrListener?.(chunk),
-    settle: (code, signal = null) => exit.resolve({ code, signal }),
+    settle,
   };
   return adapter;
 }
@@ -442,7 +455,7 @@ describe("local CLI pending process cancellation", () => {
     const second = executePreparedCliRun(
       createRunContext({ runId: "cli-queue-aborted", signal: controller.signal }),
     );
-    const secondOutcome = Promise.allSettled([second]);
+    const secondRejected = expect(second).rejects.toMatchObject({ name: "AbortError" });
     controller.abort();
     firstPreparation.resolve();
 
@@ -450,9 +463,7 @@ describe("local CLI pending process cancellation", () => {
     firstAdapter.emitStdout("first");
     firstAdapter.settle(0);
     await expect(first).resolves.toMatchObject({ text: "first" });
-    await expect(secondOutcome).resolves.toEqual([
-      { status: "rejected", reason: expect.objectContaining({ name: "AbortError" }) },
-    ]);
+    await secondRejected;
     expect(createChildAdapterMock).toHaveBeenCalledOnce();
     expect(supervisor.getRecord("cli-queue-aborted")).toBeUndefined();
   });

--- a/src/agents/cli-runner/execute.test-support.ts
+++ b/src/agents/cli-runner/execute.test-support.ts
@@ -44,6 +44,9 @@ setCliRunnerExecuteTestDeps({
   getProcessSupervisor: () => {
     const activeRuns = new Map<string, Awaited<ReturnType<SupervisorSpawnFn>>>();
     return {
+      acquireScopeCleanup: vi.fn(() => {
+        throw new Error("CLI execution fixture does not own a cleanup scope");
+      }),
       spawn: async (params: Parameters<SupervisorSpawnFn>[0]) => {
         let stdoutDelivered = false;
         let stderrDelivered = false;

--- a/src/gateway/cron-stream-output.test.ts
+++ b/src/gateway/cron-stream-output.test.ts
@@ -11,6 +11,7 @@ import {
   createCronStreamWatcherFixture,
   createWatchers,
   exitResult,
+  fakeSupervisor,
   job,
   settle,
 } from "./cron-stream-watchers.test-helpers.js";
@@ -220,10 +221,8 @@ describe("cron stream output", () => {
       return run;
     });
     const supervisor = {
+      ...fakeSupervisor().supervisor,
       spawn,
-      cancel: vi.fn(),
-      cancelScope: vi.fn(),
-      getRecord: vi.fn(),
     } satisfies ProcessSupervisor;
     const fireBatch = vi.fn(async () => "fired" as const);
     const watchers = createWatchers({

--- a/src/gateway/cron-stream-watchers.test-helpers.ts
+++ b/src/gateway/cron-stream-watchers.test-helpers.ts
@@ -81,6 +81,9 @@ export function fakeSupervisor() {
     return run;
   });
   const supervisor = {
+    acquireScopeCleanup: vi.fn(() => {
+      throw new Error("Cron stream fixture does not own a cleanup scope");
+    }),
     spawn,
     cancel: vi.fn(),
     cancelScope: vi.fn(),

--- a/src/gateway/cron-stream-watchers.test.ts
+++ b/src/gateway/cron-stream-watchers.test.ts
@@ -2,12 +2,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { CronJob } from "../cron/types.js";
 import { createProcessSupervisor } from "../process/supervisor/supervisor.js";
-import type { ManagedRun, ProcessSupervisor, RunExit } from "../process/supervisor/types.js";
+import type {
+  ManagedRun,
+  ProcessSupervisor,
+  RunExit,
+  SpawnInput,
+} from "../process/supervisor/types.js";
 import { resolveStreamStopReason } from "./cron-stream-watchers.js";
 import {
   createCronStreamWatcherFixture,
   createWatchers,
   exitResult,
+  fakeSupervisor,
   job,
   settle,
 } from "./cron-stream-watchers.test-helpers.js";
@@ -138,11 +144,9 @@ describe("cron stream watchers", () => {
       } satisfies ManagedRun;
     });
     const supervisor = {
+      ...fakeSupervisor().supervisor,
       spawn,
-      cancel: vi.fn(),
-      cancelScope: vi.fn(),
-      getRecord: vi.fn(),
-    } as unknown as ProcessSupervisor;
+    } satisfies ProcessSupervisor;
     const watchers = createWatchers({
       getProcessSupervisor: () => supervisor,
       minIntervalMs: 1,
@@ -169,7 +173,10 @@ describe("cron stream watchers", () => {
   it("continues reconciling after a stubborn schedule replacement fails", async () => {
     vi.useFakeTimers();
     const cancels: Record<string, ReturnType<typeof vi.fn>> = {};
-    const spawn = vi.fn(async (input: { sessionId: string; argv: string[] }) => {
+    const spawn = vi.fn(async (input: SpawnInput) => {
+      if (input.mode !== "child") {
+        throw new Error("Expected an argv-based stream source");
+      }
       const jobId = input.sessionId.replace("cron-stream:", "");
       const stubborn = jobId === "stubborn-job" && input.argv[0] === "stream-source";
       const { promise: wait, resolve: resolveWait } = createDeferred<RunExit>();
@@ -188,11 +195,9 @@ describe("cron stream watchers", () => {
       } satisfies ManagedRun;
     });
     const supervisor = {
+      ...fakeSupervisor().supervisor,
       spawn,
-      cancel: vi.fn(),
-      cancelScope: vi.fn(),
-      getRecord: vi.fn(),
-    } as unknown as ProcessSupervisor;
+    } satisfies ProcessSupervisor;
     const watchers = createWatchers({
       getProcessSupervisor: () => supervisor,
       minIntervalMs: 1,
@@ -258,10 +263,8 @@ describe("cron stream watchers", () => {
       } satisfies ManagedRun;
     });
     const supervisor = {
+      ...fakeSupervisor().supervisor,
       spawn,
-      cancel: vi.fn(),
-      cancelScope: vi.fn(),
-      getRecord: vi.fn(),
     } satisfies ProcessSupervisor;
     const recordFailure = vi.fn(async () => {});
     const watchers = createWatchers({
@@ -436,10 +439,8 @@ describe("cron stream watchers", () => {
         wait: () => wait,
       };
       const supervisor = {
+        ...fakeSupervisor().supervisor,
         spawn: vi.fn(async () => await spawned),
-        cancel: vi.fn(),
-        cancelScope: vi.fn(),
-        getRecord: vi.fn(),
       } satisfies ProcessSupervisor;
       const watchers = createWatchers({
         getProcessSupervisor: () => supervisor,

--- a/src/gateway/desktop/managed-linux.test.ts
+++ b/src/gateway/desktop/managed-linux.test.ts
@@ -41,6 +41,9 @@ function createFakeSupervisor() {
     scopeKey?: string;
   }> = [];
   const supervisor: ProcessSupervisor = {
+    acquireScopeCleanup() {
+      throw new Error("Desktop fixture does not own a cleanup scope");
+    },
     async spawn(input) {
       inputs.push(input);
       let settle!: (exit: RunExit) => void;

--- a/src/infra/session-cost-usage-cache.sqlite.test.ts
+++ b/src/infra/session-cost-usage-cache.sqlite.test.ts
@@ -80,7 +80,7 @@ describe("session cost usage SQLite cache", () => {
       vi.spyOn(process, "kill").mockImplementation(() => true);
       vi.spyOn(fs, "readFileSync").mockImplementation((filePath) => {
         expect(String(filePath)).toBe(`/proc/${zombiePid}/status`);
-        return `Name:\tworker\nState:\tZ (zombie)\nPid:\t${zombiePid}\n`;
+        return `Name:\tworker\nState:\tZ (zombie)\nPid:\t${zombiePid}\nThreads:\t1\n`;
       });
 
       expect(isSessionCostUsageRefreshRunning(agentId, database.path)).toBe(false);

--- a/src/infra/windows-diagnostic-env.test.ts
+++ b/src/infra/windows-diagnostic-env.test.ts
@@ -100,7 +100,7 @@ async function withWindowsDiagnostics(
         status = 1;
       } else if (script.includes("Get-NetTCPConnection")) {
         stdout = "424242";
-      } else if (script.includes("CreationDate")) {
+      } else if (script.includes("CreationDate") || script.includes(".StartTime")) {
         stdout =
           command === "wmic.exe"
             ? "CreationDate=20260903000000.000000+000"

--- a/src/infra/windows-process-start.test.ts
+++ b/src/infra/windows-process-start.test.ts
@@ -34,6 +34,40 @@ describe("readWindowsProcessStartTimeSync", () => {
     expect(spawnSyncMock.mock.calls[1]?.[0]).toBe(getWindowsWmicExePath());
   });
 
+  it("projects supplied native context with Windows key precedence for both queries", () => {
+    const env = {
+      SYSTEMROOT: "D:\\Native",
+      SystemRoot: "E:\\Ignored",
+      WINDIR: "F:\\Ignored",
+      PATH: "native-path",
+      PSModuleAnalysisCachePath: "D:\\NativeCache",
+      DIAGNOSTIC_NEUTRAL_CANARY: "synthetic",
+      NODE_OPTIONS: "--synthetic-injection-must-not-be-inherited",
+    };
+    spawnSyncMock.mockReturnValueOnce({ status: 1, stdout: "" }).mockReturnValueOnce({
+      status: 0,
+      stdout: Buffer.from("CreationDate=20260713092049.123456+120\r\n"),
+    });
+    expect(readWindowsProcessStartTimeSync(456, 1000, env)).toBe(
+      Date.parse("2026-07-13T07:20:49.123Z"),
+    );
+    expect(spawnSyncMock.mock.calls[0]?.[0]).toBe(
+      "D:\\Native\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+    );
+    expect(spawnSyncMock.mock.calls[1]?.[0]).toBe("D:\\Native\\System32\\wbem\\wmic.exe");
+    for (const call of spawnSyncMock.mock.calls) {
+      expect(call[2].env).toEqual({
+        SYSTEMROOT: "D:\\Native",
+        WINDIR: "F:\\Ignored",
+        PATH: "native-path",
+        PSModuleAnalysisCachePath: "D:\\NativeCache",
+      });
+      expect(call[2].timeout).toBeLessThanOrEqual(1000);
+    }
+    expect(env.SystemRoot).toBe("E:\\Ignored");
+    expect(env.DIAGNOSTIC_NEUTRAL_CANARY).toBe("synthetic");
+  });
+
   it("does not start WMIC once PowerShell has spent the whole budget", () => {
     vi.useFakeTimers();
     try {

--- a/src/infra/windows-process-start.ts
+++ b/src/infra/windows-process-start.ts
@@ -1,14 +1,16 @@
 // Reads PID-reuse-safe Windows process start identities without workspace imports.
 import { spawnSync } from "node:child_process";
 import path from "node:path";
-import { resolveDiagnosticProcessEnv } from "./process-env.ts";
+import { resolveDiagnosticProcessEnv, resolveEnvironmentValue } from "./process-env.ts";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
 const DEFAULT_PROCESS_START_TIMEOUT_MS = 10_000;
 const DEFAULT_WINDOWS_SYSTEM_ROOT = "C:\\Windows";
 
-function windowsSystemRoot(): string {
-  const configured = process.env.SystemRoot ?? process.env.WINDIR;
+function windowsSystemRoot(env: NodeJS.ProcessEnv): string {
+  const configured =
+    resolveEnvironmentValue(env, "SystemRoot", "win32") ??
+    resolveEnvironmentValue(env, "WINDIR", "win32");
   if (!configured) {
     return DEFAULT_WINDOWS_SYSTEM_ROOT;
   }
@@ -18,9 +20,9 @@ function windowsSystemRoot(): string {
     : DEFAULT_WINDOWS_SYSTEM_ROOT;
 }
 
-function windowsPowerShellPath(): string {
+function windowsPowerShellPath(env: NodeJS.ProcessEnv): string {
   return path.win32.join(
-    windowsSystemRoot(),
+    windowsSystemRoot(env),
     "System32",
     "WindowsPowerShell",
     "v1.0",
@@ -28,8 +30,8 @@ function windowsPowerShellPath(): string {
   );
 }
 
-function windowsWmicPath(): string {
-  return path.win32.join(windowsSystemRoot(), "System32", "wbem", "wmic.exe");
+function windowsWmicPath(env: NodeJS.ProcessEnv): string {
+  return path.win32.join(windowsSystemRoot(env), "System32", "wbem", "wmic.exe");
 }
 
 export function decodeWindowsProcessOutput(output: Buffer | string): string {
@@ -79,6 +81,7 @@ function parseWindowsProcessStartTime(raw: Buffer | string): number | null {
 export function readWindowsProcessStartTimeSync(
   pid: number,
   timeoutMs = DEFAULT_PROCESS_START_TIMEOUT_MS,
+  env: NodeJS.ProcessEnv = process.env,
 ): number | null {
   if (!Number.isInteger(pid) || pid <= 0) {
     return null;
@@ -87,16 +90,18 @@ export function readWindowsProcessStartTimeSync(
   // still keep their smaller end-to-end budget.
   const deadline = Date.now() + timeoutMs;
   const powershell = spawnSync(
-    windowsPowerShellPath(),
+    windowsPowerShellPath(env),
     [
       "-NoProfile",
       "-NonInteractive",
       "-Command",
-      `$process = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}" -ErrorAction Stop; [Console]::Out.Write($process.CreationDate.ToUniversalTime().ToString("o"))`,
+      // Read the kernel timestamp without CIM module discovery consuming the
+      // caller's short ownership-query budget. Dispose the opened process handle.
+      `$process = [System.Diagnostics.Process]::GetProcessById(${pid}); try { [Console]::Out.Write($process.StartTime.ToUniversalTime().ToString("o")) } finally { $process.Dispose() }`,
     ],
     {
-      env: resolveDiagnosticProcessEnv(),
       encoding: "utf8",
+      env: resolveDiagnosticProcessEnv(env, "win32"),
       timeout: Math.min(timeoutMs, DEFAULT_TIMEOUT_MS),
       windowsHide: true,
     },
@@ -112,10 +117,10 @@ export function readWindowsProcessStartTimeSync(
     return null;
   }
   const wmic = spawnSync(
-    windowsWmicPath(),
+    windowsWmicPath(env),
     ["process", "where", `ProcessId=${pid}`, "get", "CreationDate", "/value"],
     {
-      env: resolveDiagnosticProcessEnv(),
+      env: resolveDiagnosticProcessEnv(env, "win32"),
       timeout: remainingMs,
       windowsHide: true,
       stdio: ["ignore", "pipe", "ignore"],

--- a/src/process/exec-result.ts
+++ b/src/process/exec-result.ts
@@ -9,6 +9,8 @@ export type SpawnResult = {
   code: number | null;
   signal: NodeJS.Signals | null;
   killed: boolean;
+  /** Completion of this invocation's cleanup; never an escaped-descendant inventory. */
+  cleanup?: "normal" | "cooperative" | "forced" | "uncertain";
   termination: "exit" | "timeout" | "no-output-timeout" | "signal";
   noOutputTimedOut?: boolean;
   outputLimitExceeded?: boolean;

--- a/src/process/exec-runner.ts
+++ b/src/process/exec-runner.ts
@@ -65,7 +65,7 @@ export type CommandOptions = {
   maxPreservedOutputLines?: number;
   preserveOutputLine?: PreserveOutputLine;
   killProcessTree?: boolean;
-  /** Signal used when terminating the direct child; tree termination owns its own grace policy. */
+  /** Initial signal for direct-child and graceful process-group cancellation. */
   killSignal?: NodeJS.Signals | number;
   /** Grace between graceful termination and the force-kill fallback. */
   killGraceMs?: number;
@@ -123,6 +123,7 @@ async function runCommandWithOutputEncoding(
       signal: null,
       killed: false,
       termination: "signal",
+      cleanup: "normal",
       noOutputTimedOut: false,
     };
   }
@@ -198,6 +199,7 @@ async function runCommandWithOutputEncoding(
     isChildExited: () => childExited,
     isCommandSettled: () => commandSettled,
     killGraceMs: resolvedKillGraceMs,
+    killSignal,
   });
 
   const clearNoOutputTimer = () => {
@@ -387,12 +389,18 @@ async function runCommandWithOutputEncoding(
     signal?.removeEventListener("abort", onAbort);
     releaseOutput();
   });
-  await terminationController.settle();
+  let cleanup = await terminationController.settle();
+  const resolvedSignal = result.signal ?? childExitState?.signal ?? nodeChild.signalCode ?? null;
+  if (cleanup !== "forced" && resolvedSignal) {
+    cleanup = "uncertain";
+  }
   if (terminatingOutputError) {
-    throw terminatingOutputError;
+    throw Object.assign(terminatingOutputError, { cleanup });
   }
   if (outputObserverError !== undefined) {
-    throw toErrorObject(outputObserverError, "Command output observer failed");
+    throw Object.assign(toErrorObject(outputObserverError, "Command output observer failed"), {
+      cleanup,
+    });
   }
   // Patched Node can report null/null after a cmd.exe shim exits. Execa turns
   // that into a cause-less failure; preserve the shim fallback only post-spawn.
@@ -440,13 +448,20 @@ async function runCommandWithOutputEncoding(
     )
   ) {
     const error = createSanitizedCommandError(result);
+    Object.assign(error, {
+      cleanup:
+        typeof nodeChild.pid === "number"
+          ? cleanup === "normal"
+            ? "uncertain"
+            : cleanup
+          : "normal",
+    });
     if (outputErrorStream) {
       Object.assign(error, { outputErrorStream });
     }
     throw error;
   }
 
-  const resolvedSignal = result.signal ?? childExitState?.signal ?? nodeChild.signalCode ?? null;
   const resolvedCode = resolveProcessExitCode({
     explicitCode: result.exitCode ?? childExitState?.code,
     childExitCode: nodeChild.exitCode,
@@ -511,6 +526,7 @@ async function runCommandWithOutputEncoding(
     code: normalizedCode,
     signal: resolvedSignal,
     killed: nodeChild.killed,
+    cleanup,
     termination: termination === "output-limit" ? "signal" : termination,
     noOutputTimedOut: termination === "no-output-timeout",
     outputLimitExceeded: termination === "output-limit" || undefined,

--- a/src/process/exec-termination.ts
+++ b/src/process/exec-termination.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
+import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import { COMMAND_PROCESS_TREE_KILL_GRACE_MS, spawnCommand } from "./exec-spawn.js";
 import { killProcessTree as terminateProcessTree } from "./kill-tree.js";
 
@@ -18,10 +19,19 @@ export function createCommandTerminationController(params: {
   env?: NodeJS.ProcessEnv;
   processTree?: { mode: "graceful" } | { mode: "force" };
   killGraceMs: number;
+  killSignal?: NodeJS.Signals | number;
   isChildExited: () => boolean;
   isCommandSettled: () => boolean;
-}): { terminate: () => boolean; settle: () => Promise<void> } {
-  let processTreeSettleAt: number | undefined;
+}): {
+  terminate: () => boolean;
+  settle: () => Promise<"normal" | "cooperative" | "forced" | "uncertain">;
+} {
+  let processTreeSettlement: Promise<void> | undefined;
+  let cleanup: "normal" | "cooperative" | "forced" | "uncertain" = "normal";
+  const originalStart =
+    params.processTree && params.child.pid && process.platform !== "win32"
+      ? getFileLockProcessStartTime(params.child.pid)
+      : null;
   let windowsTerminationPromise: Promise<void> | undefined;
 
   const isDirectChildAlive = () =>
@@ -80,18 +90,65 @@ export function createCommandTerminationController(params: {
     }
     if (params.processTree && typeof childPid === "number") {
       const force = params.processTree.mode === "force";
-      if (!force) {
-        processTreeSettleAt ??= Date.now() + params.killGraceMs;
-      }
       if (process.platform === "win32") {
         startWindowsTermination(childPid, !force);
         return true;
       }
-      terminateProcessTree(childPid, {
-        ...(force ? { force: true } : { graceMs: params.killGraceMs }),
-        detached: true,
+      if (force) {
+        cleanup = "forced";
+        terminateProcessTree(childPid, { force: true, detached: true });
+        return false;
+      }
+      if (processTreeSettlement) {
+        return true;
+      }
+      cleanup = "cooperative";
+      const groupAlive = () => {
+        try {
+          process.kill(-childPid, 0);
+          return true;
+        } catch (error) {
+          // SAFETY: Node's kill error carries errno; only ESRCH certifies absence.
+          return (error as NodeJS.ErrnoException).code !== "ESRCH";
+        }
+      };
+      try {
+        process.kill(-childPid, params.killSignal ?? "SIGTERM");
+      } catch (error) {
+        // SAFETY: Node's kill error carries errno; every non-ESRCH result stays uncertain.
+        if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+          cleanup = "uncertain";
+        }
+      }
+      processTreeSettlement = new Promise<void>((resolve) => {
+        const deadline = Date.now() + params.killGraceMs;
+        const check = () => {
+          if (!groupAlive()) {
+            resolve();
+            return;
+          }
+          if (Date.now() < deadline) {
+            setTimeout(check, Math.min(25, deadline - Date.now()));
+            return;
+          }
+          // Never signal a recycled group leader. A forced fallback cannot certify
+          // cleanup of independently detached descendants of this invocation.
+          const start = getFileLockProcessStartTime(childPid);
+          if (start !== null && start !== originalStart) {
+            cleanup = "uncertain";
+            if (isDirectChildAlive()) {
+              params.cancelController.abort();
+            }
+            resolve();
+            return;
+          }
+          cleanup = "forced";
+          terminateProcessTree(childPid, { force: true, detached: true });
+          resolve();
+        };
+        check();
       });
-      return false;
+      return true;
     }
     if (!directChildAlive) {
       return false;
@@ -103,29 +160,13 @@ export function createCommandTerminationController(params: {
     return false;
   };
 
-  const settle = async (): Promise<void> => {
+  const settle = async (): Promise<"normal" | "cooperative" | "forced" | "uncertain"> => {
     if (windowsTerminationPromise) {
       await windowsTerminationPromise;
+      return "forced";
     }
-    if (
-      params.processTree?.mode !== "graceful" ||
-      processTreeSettleAt === undefined ||
-      typeof params.child.pid !== "number"
-    ) {
-      return;
-    }
-    // A direct child can exit before its descendants finish the graceful
-    // signal. Keep the wrapper pending through that grace window, then ensure
-    // the detached group cannot outlive the completed command result.
-    const remainingMs = Math.max(0, processTreeSettleAt - Date.now());
-    if (remainingMs > 0) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, remainingMs);
-      });
-    }
-    if (process.platform !== "win32") {
-      terminateProcessTree(params.child.pid, { force: true, detached: true });
-    }
+    await processTreeSettlement;
+    return cleanup;
   };
 
   return { terminate, settle };

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -34,6 +34,43 @@ describe("runCommandWithTimeout", () => {
     ).toBe(false);
   });
 
+  it.skipIf(process.platform === "win32").each(["normal", "cooperative", "forced"] as const)(
+    "reports invocation cleanup and honors the initial SIGINT signal: %s",
+    async (mode) => {
+      const controller = new AbortController();
+      let ready!: () => void;
+      const started = new Promise<void>((resolve) => {
+        ready = resolve;
+      });
+      const program =
+        mode === "normal"
+          ? "process.stdout.write('ready'); process.exitCode=17;"
+          : `const timer=setInterval(()=>{},1000); process.on('SIGINT',()=>{${mode === "cooperative" ? "clearInterval(timer);process.stdout.write('interrupted');process.exitCode=17;" : ""}}); process.stdout.write('ready');`;
+      const running = runCommandWithTimeout([process.execPath, "-e", program], {
+        signal: controller.signal,
+        killProcessTree: true,
+        killSignal: "SIGINT",
+        killGraceMs: 100,
+        timeoutMs: 5000,
+        onOutputChunk: () => {
+          ready();
+        },
+      });
+      await started;
+      if (mode !== "normal") {
+        controller.abort();
+      }
+      const result = await running;
+      expect(result.cleanup).toBe(mode);
+      if (mode !== "forced") {
+        expect(result.code).toBe(17);
+      }
+      if (mode === "cooperative") {
+        expect(result.stdout).toContain("interrupted");
+      }
+    },
+  );
+
   it("merges custom env with base env and drops undefined values", () => {
     const resolved = resolveCommandEnv({
       argv: ["node", "script.js"],

--- a/src/process/pipe-output.test.ts
+++ b/src/process/pipe-output.test.ts
@@ -52,17 +52,18 @@ it.each(["close", "error", "finish", "unpipe"])(
     });
     const dispose = pipeProcessOutput(source, destination, () => {});
     try {
-      source.end(Buffer.alloc(1024));
+      source.write(Buffer.alloc(1024));
       expect(source.isPaused()).toBe(true);
+      source.end(Buffer.alloc(1024));
       if (ending === "finish") {
         destination.end();
+        finishWrite?.();
+        finishWrite = undefined;
       } else if (ending === "unpipe") {
         source.unpipe(destination);
       } else {
         destination.destroy(ending === "error" ? new Error("destination failed") : undefined);
       }
-      finishWrite?.();
-      finishWrite = undefined;
       await new Promise<void>((resolve) => {
         setImmediate(resolve);
       });

--- a/src/process/pipe-output.test.ts
+++ b/src/process/pipe-output.test.ts
@@ -1,0 +1,77 @@
+import { PassThrough, Writable } from "node:stream";
+import { expect, it, vi } from "vitest";
+import { pipeProcessOutput } from "./pipe-output.js";
+
+it.each(["dispose", "destination close", "destination error", "source close"])(
+  "releases destination listeners after %s without owning the destination lifetime",
+  async (ending) => {
+    const source = new PassThrough();
+    const destination = new PassThrough();
+    const reportError = vi.fn();
+    const dispose = pipeProcessOutput(source, destination, reportError);
+    source.write("diagnostic");
+    expect(destination.read()?.toString()).toBe("diagnostic");
+    const failure = new Error("diagnostic destination failed");
+    if (ending === "dispose") {
+      dispose();
+    } else if (ending === "destination close") {
+      destination.destroy();
+    } else if (ending === "destination error") {
+      destination.destroy(failure);
+    } else {
+      source.destroy();
+    }
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(destination.listenerCount("drain")).toBe(0);
+    expect(destination.listenerCount("error")).toBe(0);
+    expect(destination.listenerCount("close")).toBe(0);
+    expect(reportError.mock.calls).toEqual(ending === "destination error" ? [[failure]] : []);
+    if (ending === "dispose" || ending === "source close") {
+      expect(destination.destroyed).toBe(false);
+      expect(destination.writableEnded).toBe(false);
+    }
+    dispose();
+    source.destroy();
+    destination.destroy();
+  },
+);
+
+it.each(["close", "error", "finish", "unpipe"])(
+  "drains a backpressured source after destination %s",
+  async (ending) => {
+    const source = new PassThrough({ highWaterMark: 8 });
+    let finishWrite: (() => void) | undefined;
+    const destination = new Writable({
+      autoDestroy: false,
+      highWaterMark: 8,
+      write(_chunk, _encoding, callback) {
+        finishWrite = callback;
+      },
+    });
+    const dispose = pipeProcessOutput(source, destination, () => {});
+    try {
+      source.end(Buffer.alloc(1024));
+      expect(source.isPaused()).toBe(true);
+      if (ending === "finish") {
+        destination.end();
+      } else if (ending === "unpipe") {
+        source.unpipe(destination);
+      } else {
+        destination.destroy(ending === "error" ? new Error("destination failed") : undefined);
+      }
+      finishWrite?.();
+      finishWrite = undefined;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(source.readableEnded).toBe(true);
+    } finally {
+      finishWrite?.();
+      dispose();
+      source.destroy();
+      destination.destroy();
+    }
+  },
+);

--- a/src/process/pipe-output.ts
+++ b/src/process/pipe-output.ts
@@ -1,0 +1,31 @@
+import type { Readable, Writable } from "node:stream";
+
+/** Keep native backpressure while leaving the caller's diagnostic destination open. */
+export function pipeProcessOutput(
+  source: Readable,
+  destination: Writable,
+  reportError: (error: Error) => void,
+): () => void {
+  const cleanup = () => {
+    source.off("close", cleanup);
+    destination.off("unpipe", onUnpipe);
+    destination.off("error", onError);
+    source.unpipe(destination);
+    source.resume();
+  };
+  const onUnpipe = (stream: Readable) => {
+    if (stream === source) {
+      // Node's pipe error handler still needs our error listener after unpipe.
+      queueMicrotask(cleanup);
+    }
+  };
+  const onError = (error: Error) => {
+    cleanup();
+    reportError(error);
+  };
+  source.once("close", cleanup);
+  destination.on("unpipe", onUnpipe);
+  destination.on("error", onError);
+  source.pipe(destination, { end: false });
+  return cleanup;
+}

--- a/src/process/supervisor/adapters/child.events.test.ts
+++ b/src/process/supervisor/adapters/child.events.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createChildAdapter } from "./child.js";
+import { createStubChild } from "./child.test-support.js";
+
+const { spawnWithFallback } = vi.hoisted(() => ({ spawnWithFallback: vi.fn() }));
+vi.mock("../../spawn-utils.js", () => ({ spawnWithFallback }));
+
+beforeEach(() => {
+  vi.stubEnv("OPENCLAW_SERVICE_MARKER", "");
+  spawnWithFallback.mockReset();
+});
+afterEach(() => vi.unstubAllEnvs());
+
+it("reports actual root exit synchronously while output remains open", async () => {
+  const stub = createStubChild();
+  spawnWithFallback.mockResolvedValue({ child: stub.child, usedFallback: false });
+  const adapter = await createChildAdapter({ argv: ["synthetic-child"], stdinMode: "pipe-open" });
+  const onExit = vi.fn();
+  adapter.onExit(onExit);
+  stub.emitExit(1);
+  expect(onExit).toHaveBeenCalledExactlyOnceWith(1, null);
+  const late = vi.fn();
+  adapter.onExit(late);
+  expect(late).toHaveBeenCalledExactlyOnceWith(1, null);
+  const settled = vi.fn();
+  void adapter.wait().then(settled);
+  await Promise.resolve();
+  expect(settled).not.toHaveBeenCalled();
+  stub.emitClose(1);
+  await adapter.wait();
+  adapter.dispose();
+});
+
+it.each(["process", "stdin", "stdout", "stderr"] as const)(
+  "retains startup %s errors and forwards live errors",
+  async (source) => {
+    const stub = createStubChild();
+    spawnWithFallback.mockResolvedValue({ child: stub.child, usedFallback: false });
+    const adapter = await createChildAdapter({ argv: ["synthetic-child"], stdinMode: "pipe-open" });
+    const emitter = source === "process" ? stub.child : stub.child[source]!;
+    const early = new Error("startup transport failure");
+    emitter.emit("error", early);
+    emitter.emit("error", new Error("duplicate startup failure"));
+    const onError = vi.fn();
+    adapter.onError(onError);
+    expect(onError).toHaveBeenCalledExactlyOnceWith(early, source);
+    const live = new Error("live transport failure");
+    emitter.emit("error", live);
+    expect(onError).toHaveBeenLastCalledWith(live, source);
+    stub.emitExit(0);
+    stub.emitClose(0);
+    await adapter.wait();
+    adapter.dispose();
+  },
+);

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { setTimeout as realDelay } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { waitForPidFile } from "../../../../test/helpers/process-wait.js";
-import { withTestTimeout } from "../../../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import { killPidIfAlive } from "../../../test-utils/process-tree.js";
 import { createProcessSupervisor } from "../supervisor.js";
@@ -230,6 +230,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     `;
     const supervisor = createProcessSupervisor();
     const runId = "service-secret-construction";
+    const cleanupScope = supervisor.acquireScopeCleanup(runId, { requireProcessTree: true });
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const pendingRun = supervisor.spawn({
       runId,
@@ -262,7 +263,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
         reason: "overall-timeout",
         timedOut: true,
       });
-      await expect(supervisor.waitForScope(runId)).rejects.toThrow("cleanup identity lost");
+      await expect(cleanupScope()).rejects.toThrow("cleanup identity lost");
       await expect(run.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
       await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
       // TERM must still reach the command after failed cleanup joins. Dedicated
@@ -373,6 +374,55 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     expect(receivedBytes).toBe(outputBytes);
   });
 
+  it("drains backpressured output before closing after cancellation at root exit", async () => {
+    const outputBytes = 256 * 1024;
+    const adapter = await createChildAdapter({
+      ownProcessTree: true,
+      argv: [
+        process.execPath,
+        "-e",
+        `process.stdout.write(Buffer.alloc(${outputBytes}, 120), () => process.exit(23));`,
+      ],
+      stdinMode: "pipe-closed",
+    });
+    activePids.add(adapter.pid!);
+    let receivedBytes = 0;
+    let subscribed = false;
+    const subscribe = () => {
+      if (subscribed) {
+        return;
+      }
+      subscribed = true;
+      adapter.onStdout((chunk) => {
+        receivedBytes += Buffer.byteLength(chunk);
+      });
+    };
+    const rootExit = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+    adapter.onExit((code, signal) => {
+      adapter.kill("SIGTERM");
+      rootExit.resolve({ code, signal });
+    });
+    // Small native pipe buffers can block the root's final write. Release that
+    // pressure within the TERM budget; larger buffers exercise exit before drain.
+    const releaseBlockedRoot = setTimeout(subscribe, 1_000);
+    try {
+      await expect(rootExit.promise).resolves.toEqual({ code: 23, signal: null });
+      clearTimeout(releaseBlockedRoot);
+      // Give cleanup the opportunity to close while forwarding is backpressured.
+      await Promise.race([adapter.waitForExtinction!(), realDelay(200)]);
+      subscribe();
+      await expect(adapter.wait()).resolves.toEqual({ code: 23, signal: null });
+      await adapter.waitForExtinction!();
+      expect(receivedBytes).toBe(outputBytes);
+    } finally {
+      clearTimeout(releaseBlockedRoot);
+      subscribe();
+      adapter.kill("SIGKILL");
+      await adapter.waitForExtinction!();
+      adapter.dispose();
+    }
+  });
+
   it("revalidates and escalates when the group ignores SIGTERM", async () => {
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     const adapter = await createChildAdapter({
@@ -393,7 +443,8 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     activePids.add(descendantPid);
 
     adapter.kill("SIGTERM");
-    await adapter.wait();
+    await expect(adapter.wait()).rejects.toThrow("cleanup identity lost");
+    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
@@ -442,6 +493,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     activePids.add(descendantPid);
 
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    await expect(adapter.waitForExtinction?.()).resolves.toBeUndefined();
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
   });
 
@@ -577,7 +629,44 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
       adapter.kill("SIGKILL");
     }
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
     await waitFor(() => !isAlive(rootPid) && !isAlive(descendantPid));
+  });
+
+  it("keeps cleanup uncertain when an escaped group retains the lineage descriptor", async () => {
+    const descendantScript = `process.send("ready"); setInterval(() => {}, 1000);`;
+    const rootScript = `
+      const { spawn } = require("node:child_process");
+      const child = spawn(process.execPath, ["-e", ${JSON.stringify(descendantScript)}], {
+        detached: true,
+        stdio: ["ignore", "ignore", "ignore", 3, "ipc"],
+      });
+      child.once("message", () => {
+        process.stdout.write(process.pid + " " + child.pid + "\\n", () => {
+          child.disconnect();
+          process.exit(0);
+        });
+      });
+    `;
+    const adapter = await createChildAdapter({
+      ownProcessTree: true,
+      argv: [process.execPath, "-e", rootScript],
+      stdinMode: "pipe-closed",
+    });
+    let output = "";
+    adapter.onStdout((chunk) => {
+      output += chunk;
+    });
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    const [rootPid, descendantPid] = parsePidPair(output);
+    activePids.add(rootPid);
+    activePids.add(descendantPid);
+    adapter.kill("SIGTERM");
+    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
+    expect(isAlive(descendantPid)).toBe(true);
+    killPidIfAlive(descendantPid);
+    await waitFor(() => !isAlive(descendantPid));
+    adapter.dispose();
   });
 
   it("preserves split UTF-8 sequences on service stdout and stderr", async () => {
@@ -735,7 +824,8 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     const rootPid = Number.parseInt(output, 10);
     activePids.add(rootPid);
 
-    await adapter.wait();
+    await expect(adapter.wait()).rejects.toThrow("cleanup identity lost");
+    await expect(adapter.waitForExtinction?.()).rejects.toThrow("cleanup identity lost");
     await waitFor(() => !isAlive(rootPid));
   });
 

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -1,5 +1,6 @@
 // Child process adapter wraps spawned child processes for the supervisor.
 import type { ChildProcessWithoutNullStreams, SpawnOptions } from "node:child_process";
+import type { Writable } from "node:stream";
 import { toErrorObject } from "../../../infra/errors.js";
 import {
   resolveWindowsExecutablePath,
@@ -9,6 +10,7 @@ import { createDeferredCore } from "../../../shared/deferred.js";
 import { onDecodedOutput } from "../../decoded-output.js";
 import { signalProcessTree } from "../../kill-tree.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
+import { pipeProcessOutput } from "../../pipe-output.js";
 import { prepareSecretInputStdio, type SpawnStdioEntry } from "../../spawn-secret-input.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
 import {
@@ -25,6 +27,7 @@ import type {
 } from "../types.js";
 import { createManagedChildStdin } from "./child-stdin.js";
 import { toStringEnv } from "./env.js";
+import { createProcessAdapterEvents } from "./process-events.js";
 
 const FORCE_KILL_WAIT_FALLBACK_MS = 4000;
 const FORCED_WINDOWS_CLOSE_SETTLE_MS = 250;
@@ -73,7 +76,8 @@ function resolveChildInvocation(params: {
   };
 }
 
-type ChildAdapter = SpawnProcessAdapter<NodeJS.Signals | null>;
+type ChildAdapter = SpawnProcessAdapter<NodeJS.Signals | null> &
+  Required<Pick<SpawnProcessAdapter<NodeJS.Signals | null>, "onExit" | "onError">>;
 type WorkerChildAdapter = ChildAdapter & {
   closeStartGate?: () => void;
   openStartGate?: () => Promise<void>;
@@ -81,11 +85,11 @@ type WorkerChildAdapter = ChildAdapter & {
 
 const WORKER_START_MESSAGE = { type: "openclaw-worker-start-v1" } as const;
 
-function isServiceManagedRuntime(): boolean {
-  return Boolean(process.env.OPENCLAW_SERVICE_MARKER?.trim());
-}
-
 type ChildAdapterInput = ProcessAdapterConstruction & {
+  /** Retain a local tree owner independently of Gateway service markers. */
+  ownProcessTree?: true;
+  /** Preserve an owner-materialized Windows shell invocation without parsing it again. */
+  windowsShell?: true;
   /** Own a separately signalable tree whose private IPC channel gates worker startup. */
   ownedWorker?: true;
   /** Preserve the supplied environment exactly by skipping environment-mutating spawn wrappers. */
@@ -98,6 +102,7 @@ type ChildAdapterInput = ProcessAdapterConstruction & {
   input?: string;
   stdinMode?: "inherit" | "pipe-open" | "pipe-closed";
   secretInput?: SpawnSecretInput;
+  stderrDestination?: Writable;
 } & (
     | { argv: string[]; anchoredShellCommand?: never }
     | { argv?: never; anchoredShellCommand: string }
@@ -116,15 +121,23 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
       oomScoreWrapperSelected: false,
       abortSignal: params.abortSignal,
       onSpawnCleanup: params.onSpawnCleanup,
+      stderrDestination: params.stderrDestination,
     });
   }
 
   const baseEnv = params.env ? toStringEnv(params.env) : undefined;
-  const invocation = resolveChildInvocation({
-    argv: params.argv,
-    env: baseEnv,
-    windowsVerbatimArguments: params.windowsVerbatimArguments,
-  });
+  const windowsShell = process.platform === "win32" && params.windowsShell === true;
+  const invocation = windowsShell
+    ? {
+        command: params.argv[0]!,
+        args: params.argv.slice(1),
+        windowsVerbatimArguments: params.windowsVerbatimArguments,
+      }
+    : resolveChildInvocation({
+        argv: params.argv,
+        env: baseEnv,
+        windowsVerbatimArguments: params.windowsVerbatimArguments,
+      });
   const argv0 = invocation.command === params.argv[0] ? params.argv0 : undefined;
   const preparedSpawn = params.exactEnv
     ? { command: invocation.command, args: invocation.args, argv0, env: baseEnv, wrapped: false }
@@ -135,7 +148,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   if (
     process.platform !== "win32" &&
     params.ownedWorker === undefined &&
-    isServiceManagedRuntime()
+    (params.ownProcessTree === true || process.env.OPENCLAW_SERVICE_MARKER?.trim())
   ) {
     return await createServiceChildRelayAdapter({
       assertCurrent: params.assertCurrent,
@@ -150,14 +163,13 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
       oomScoreWrapperSelected: preparedSpawn.wrapped,
       abortSignal: params.abortSignal,
       onSpawnCleanup: params.onSpawnCleanup,
+      stderrDestination: params.stderrDestination,
     });
   }
 
   // A detached POSIX child is still a descendant in the service cgroup/job, but
   // owns a process group that can be killed without touching the node host.
-  const useDetached =
-    process.platform !== "win32" &&
-    (params.ownedWorker !== undefined || !isServiceManagedRuntime());
+  const useDetached = process.platform !== "win32";
 
   const stdio: SpawnStdioEntry[] = [stdinMode === "inherit" ? "inherit" : "pipe", "pipe", "pipe"];
   using secretDelivery = prepareSecretInputStdio(stdio, params.secretInput);
@@ -173,6 +185,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     detached: useDetached,
     windowsHide: true,
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    ...(windowsShell ? { shell: true } : {}),
   };
 
   const assertCurrent = () => {
@@ -189,6 +202,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   });
 
   const child = spawned.child as ChildProcessWithoutNullStreams;
+  const events = createProcessAdapterEvents();
   if (params.onWorkerMessage) {
     child.on("message", (message) => {
       try {
@@ -212,12 +226,19 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   };
   // Pipe errors can arrive before output subscribers attach. Close remains
   // responsible for decoder flush and Windows drain completion.
-  const ignoreOutputStreamError = () => {};
-  child.stdout.on("error", ignoreOutputStreamError);
-  child.stderr.on("error", ignoreOutputStreamError);
+  child.stdout.on("error", (error) => events.emitError(error, "stdout"));
+  child.stderr.on("error", (error) => events.emitError(error, "stderr"));
+  child.stdin?.on("error", (error) => events.emitError(error, "stdin"));
   const childStdin = spawned.child.stdin;
   const stdin = createManagedChildStdin(childStdin);
   const outputUnsubscribers: Array<() => void> = [];
+  if (params.stderrDestination) {
+    outputUnsubscribers.push(
+      pipeProcessOutput(child.stderr, params.stderrDestination, (error) =>
+        events.emitError(error, "stderr"),
+      ),
+    );
+  }
   const onStdout: ChildAdapter["onStdout"] = (listener, onRaw) => {
     outputUnsubscribers.push(onDecodedOutput(child.stdout, listener, onRaw));
   };
@@ -381,9 +402,15 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   });
 
   // Worker IPC failures close authority; ordinary post-spawn errors are nonterminal.
-  child.on("error", params.ownedWorker ? rejectPendingWait : () => {});
+  child.on("error", (error) => {
+    events.emitError(error, "process");
+    if (params.ownedWorker) {
+      rejectPendingWait(error);
+    }
+  });
   child.once("exit", (code, signal) => {
     childExitState = { code, signal };
+    events.emitExit(code, signal);
     scheduleForcedWindowsCloseSettlement();
     maybeSettleAfterExit();
   });
@@ -473,6 +500,7 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     child.stdout.destroy();
     child.stderr.destroy();
     child.removeAllListeners();
+    events.clear();
   };
 
   params.onSpawnCleanup?.(cleanup.promise);
@@ -538,6 +566,8 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
     supportsRawOutput: true,
     onStdout,
     onStderr,
+    onExit: events.onExit,
+    onError: events.onError,
     wait,
     kill,
     dispose,

--- a/src/process/supervisor/adapters/process-events.ts
+++ b/src/process/supervisor/adapters/process-events.ts
@@ -1,0 +1,51 @@
+import type { SpawnProcessAdapter } from "../types.js";
+
+type ProcessEvents = Required<
+  Pick<SpawnProcessAdapter<NodeJS.Signals | null>, "onExit" | "onError">
+>;
+type ErrorListener = Parameters<ProcessEvents["onError"]>[0];
+
+/** Preserve terminal facts and startup errors until the transport owner subscribes. */
+export function createProcessAdapterEvents() {
+  let exit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+  const exitListeners = new Set<Parameters<ProcessEvents["onExit"]>[0]>();
+  const errorListeners = new Set<ErrorListener>();
+  const pendingErrors = new Map<Parameters<ErrorListener>[1], Error>();
+  return {
+    onExit: (listener: Parameters<ProcessEvents["onExit"]>[0]) => {
+      exitListeners.add(listener);
+      if (exit) {
+        listener(exit.code, exit.signal);
+      }
+    },
+    onError: (listener: ErrorListener) => {
+      errorListeners.add(listener);
+      for (const [source, error] of pendingErrors) {
+        listener(error, source);
+      }
+      pendingErrors.clear();
+    },
+    emitExit: (code: number | null, signal: NodeJS.Signals | null) => {
+      exit = { code, signal };
+      for (const listener of exitListeners) {
+        listener(code, signal);
+      }
+    },
+    emitError: (error: Error, source: Parameters<ErrorListener>[1]) => {
+      if (errorListeners.size === 0) {
+        if (!pendingErrors.has(source)) {
+          pendingErrors.set(source, error);
+        }
+      } else {
+        for (const listener of errorListeners) {
+          listener(error, source);
+        }
+      }
+    },
+    clear: () => {
+      exitListeners.clear();
+      errorListeners.clear();
+      pendingErrors.clear();
+    },
+  };
+}

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -3,6 +3,7 @@ import { Socket } from "node:net";
 import { pipeline, type Readable } from "node:stream";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
+import { hasLiveOwnedProcessGroupMembers } from "./service-child-group-ownership.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorMessage,
@@ -91,12 +92,13 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     state = "closed";
-    await send({ type: "closing", reason });
     if (hardKill) {
-      // The live anchor is the sole authority: PID/PGID never leave this process as a kill target.
+      // Killing the observer cannot confirm descendant death. Missing closure
+      // leaves the host's existing ownership receipt uncertain.
       process.kill(0, "SIGKILL");
       return;
     }
+    await send({ type: "closing", reason });
     control?.end(() => process.exit(0));
   };
 
@@ -124,6 +126,7 @@ export function runServiceChildGroupAnchor(): void {
     }
     state = "closing";
     forceCleanup = signal === "SIGKILL";
+    const cleanupDeadline = Date.now() + GRACEFUL_CANCEL_TIMEOUT_MS;
     const termGraceDone = delay(GRACEFUL_CANCEL_TIMEOUT_MS);
     if (!forceCleanup) {
       // The anchor catches its own signal while every command-group member receives it.
@@ -141,7 +144,7 @@ export function runServiceChildGroupAnchor(): void {
     if (state !== "closing" || !start) {
       return;
     }
-    if (lineageClosed && rootExit && !forceCleanup) {
+    if (rootExit && !forceCleanup) {
       // Output can outlive lineage and the root. It may preserve the authentic root
       // result only within the existing TERM grace, and KILL must wake this wait.
       await Promise.race([rootSettledDone.promise, termGraceDone, forceCleanupRequested.promise]);
@@ -149,8 +152,27 @@ export function runServiceChildGroupAnchor(): void {
         return;
       }
     }
-    // Lineage EOF records descriptor closure, not group extinction. Once cleanup owns the
-    // group, only the live in-group anchor may finish it after the TERM grace boundary.
+    for (;;) {
+      // Process and control events can change these facts during the awaited observation.
+      if (forceCleanup || !rootExit || !stdoutDrained || !stderrDrained || !lineageClosed) {
+        break;
+      }
+      const remainingMs = cleanupDeadline - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+      // This census only schedules retirement or escalation; it cannot certify closure.
+      // The outside-group host must observe kernel group disappearance after we exit.
+      if (hasLiveOwnedProcessGroupMembers(remainingMs) === false) {
+        await closeAuthority(reason, false);
+        return;
+      }
+      const nextObservationMs = Math.min(100, cleanupDeadline - Date.now());
+      if (nextObservationMs <= 0) {
+        break;
+      }
+      await Promise.race([delay(nextObservationMs), forceCleanupRequested.promise]);
+    }
     await closeAuthority(reason, true);
   };
 
@@ -268,7 +290,7 @@ export function runServiceChildGroupAnchor(): void {
       await rootResultDelivery;
       rootSettledDone.resolve();
       if (lineageClosed && state === "active") {
-        await closeAuthority("lineage-closed", false);
+        await requestCleanup("lineage-lost");
       }
     };
     // Output EOF is independent of lineage EOF. Pipeline closes each forwarded stream

--- a/src/process/supervisor/service-child-group-ownership.test.ts
+++ b/src/process/supervisor/service-child-group-ownership.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
+const { census, definitelyDead } = vi.hoisted(() => ({
+  census: vi.fn(),
+  definitelyDead: vi.fn(),
+}));
+vi.mock("node:child_process", () => ({ spawnSync: census }));
+vi.mock("../../shared/pid-alive.js", () => ({ isPidDefinitelyDead: definitelyDead }));
+import { hasLiveOwnedProcessGroupMembers } from "./service-child-group-ownership.js";
+
+beforeEach(() => {
+  census.mockReset();
+  definitelyDead.mockReset().mockReturnValue(false);
+  mockProcessPlatform("linux");
+});
+afterEach(() => vi.restoreAllMocks());
+
+it.each([
+  { state: "S", expected: true },
+  { state: "D", expected: true },
+  { state: "U", expected: true },
+  { state: "Z", expected: true },
+  { state: "Z+", expected: true },
+  { state: "Zl", expected: true },
+  { state: "Zsl", expected: true },
+  { state: "Zl+", expected: true },
+])("observes a $state descendant as live=$expected", ({ state, expected }) => {
+  census.mockReturnValue({
+    status: 0,
+    stdout: `${process.pid} ${process.pid} S\n${process.pid + 1} ${process.pid} ${state}\n`,
+  });
+  expect(hasLiveOwnedProcessGroupMembers()).toBe(expected);
+});
+
+it("allows retirement only after the shared check confirms a Linux zombie's threads exited", () => {
+  census.mockReturnValue({
+    status: 0,
+    stdout: `${process.pid} ${process.pid} S\n${process.pid + 1} ${process.pid} Z\n`,
+  });
+  definitelyDead.mockReturnValue(true);
+  expect(hasLiveOwnedProcessGroupMembers()).toBe(false);
+});
+
+it.each([
+  { status: 1, stdout: "" },
+  { status: 0, stdout: "malformed census" },
+  { status: 0, stdout: "" },
+  { status: 0, stdout: `${process.pid} ${process.pid + 1} S\n` },
+])("keeps failed or missing group ownership uncertain (%j)", (result) => {
+  census.mockReturnValue(result);
+  expect(hasLiveOwnedProcessGroupMembers()).toBeUndefined();
+});
+
+it.each([false, true])("excludes only its exact inspector PID (other group member=%s)", (other) => {
+  census.mockReturnValue({
+    pid: process.pid + 1,
+    status: 0,
+    stdout: `${process.pid} ${process.pid} S\n${process.pid + 1} ${process.pid} R\n${process.pid + 2} ${other ? process.pid : process.pid + 2} S\n`,
+  });
+  expect(hasLiveOwnedProcessGroupMembers()).toBe(other);
+});

--- a/src/process/supervisor/service-child-group-ownership.ts
+++ b/src/process/supervisor/service-child-group-ownership.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import { isPidDefinitelyDead } from "../../shared/pid-alive.js";
+
+/** Advisory retirement timing only; the host owns kernel group-disappearance proof. */
+export function hasLiveOwnedProcessGroupMembers(timeoutMs = 1_000): boolean | undefined {
+  const census = spawnSync("/bin/ps", ["-A", "-o", "pid=,pgid=,stat="], {
+    encoding: "utf8",
+    timeout: Math.max(1, Math.min(1_000, timeoutMs)),
+    maxBuffer: 4 * 1024 * 1024,
+  });
+  if (census.error || census.status !== 0) {
+    return undefined;
+  }
+  let observedOwner = false;
+  for (const line of census.stdout.split("\n")) {
+    if (!line.trim()) {
+      continue;
+    }
+    const match = /^\s*(\d+)\s+(\d+)\s+(\S+)\s*$/.exec(line);
+    if (!match) {
+      return undefined;
+    }
+    const pid = Number(match[1]);
+    const pgid = Number(match[2]);
+    const state = match[3]!;
+    if (pid === process.pid) {
+      if (pgid !== process.pid) {
+        return undefined;
+      }
+      observedOwner = true;
+    } else if (
+      pid !== census.pid &&
+      pgid === process.pid &&
+      // BusyBox omits procps's thread marker; use the shared Linux thread check.
+      (!state.startsWith("Z") || (process.platform === "linux" && !isPidDefinitelyDead(pid)))
+    ) {
+      return true;
+    }
+  }
+  return observedOwner ? false : undefined;
+}

--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -37,6 +37,9 @@ afterEach(async () => {
 
 async function createRelay(platform: "linux" | "win32") {
   platformMock = mockProcessPlatform(platform);
+  const groupProbe = vi.spyOn(process, "kill").mockImplementation(() => {
+    throw Object.assign(new Error("synthetic missing process group"), { code: "ESRCH" });
+  });
   const stub = createStubChild();
   stub.child.unref = vi.fn();
   const cancellations: Array<(error: Error) => void> = [];
@@ -92,8 +95,7 @@ async function createRelay(platform: "linux" | "win32") {
       return true;
     });
   }
-  const completeRoot = () => {
-    emit({ type: "root-result", code: 0, signal: null });
+  const endOutput = () => {
     if (platform === "win32") {
       emit({ type: "output-end", stream: "stdout" });
       emit({ type: "output-end", stream: "stderr" });
@@ -101,6 +103,10 @@ async function createRelay(platform: "linux" | "win32") {
       stub.child.stdout?.emit("end");
       stub.child.stderr?.emit("end");
     }
+  };
+  const completeRoot = () => {
+    emit({ type: "root-result", code: 0, signal: null });
+    endOutput();
   };
   const close = () => {
     control.destroy();
@@ -118,10 +124,12 @@ async function createRelay(platform: "linux" | "win32") {
     cancellations,
     emit,
     completeRoot,
+    endOutput,
     close,
     floodControl,
     controlEncoding,
     killSpy,
+    groupProbe,
   };
 }
 
@@ -227,6 +235,7 @@ it.each(["linux", "win32"] as const)(
     mocks.spawn.mockReturnValue(stub.child);
     const supervisor = createProcessSupervisor();
     const scopeKey = "scope:rejected-construction";
+    const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
     const pending = supervisor.spawn({
       runId: "rejected-construction",
       mode: "anchored-shell",
@@ -239,7 +248,7 @@ it.each(["linux", "win32"] as const)(
     supervisor.cancel("rejected-construction");
     const run = await pending;
     await expect(run.wait()).resolves.toMatchObject({ reason: "manual-cancel" });
-    const outcomes = Promise.allSettled([supervisor.waitForScope(scopeKey), supervisor.shutdown()]);
+    const outcomes = Promise.allSettled([cleanupScope(), supervisor.shutdown()]);
     control.destroy();
     stub.disconnectMock();
     stub.emitExit(null, "SIGKILL");
@@ -252,7 +261,7 @@ it.each(["linux", "win32"] as const)(
         }),
       });
     }
-    await expect(supervisor.waitForScope(scopeKey)).rejects.toThrow("cleanup identity lost");
+    await expect(cleanupScope()).rejects.toThrow("cleanup identity lost");
     await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
   },
 );
@@ -346,6 +355,46 @@ it("bounds the newline search before inspecting an oversized control frame", asy
 });
 
 describe.each(["linux", "win32"] as const)("service closing authority (%s)", (platform) => {
+  it.each([false, true])(
+    "keeps root knowledge independent of failed extinction (root observed=%s)",
+    async (rootObserved) => {
+      const { adapter, completeRoot, close } = await createRelay(platform);
+      adapter.kill("SIGTERM");
+      if (rootObserved) {
+        completeRoot();
+      }
+      await nextTurn();
+      close();
+      await expect(adapter.waitForExtinction()).rejects.toThrow("cleanup identity lost");
+      if (rootObserved) {
+        await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+      } else {
+        await expect(adapter.wait()).rejects.toThrow("cleanup identity lost");
+      }
+    },
+  );
+
+  it("publishes root exit before output drain and replays it to late observers", async () => {
+    const { adapter, emit, completeRoot, close } = await createRelay(platform);
+    const onExit = vi.fn();
+    adapter.onExit(onExit);
+    emit({ type: "root-result", code: 0, signal: null });
+    // POSIX stream delivery is asynchronous; the observer itself runs within
+    // the root-result handler, independently of output completion.
+    if (platform === "linux") {
+      await nextTurn();
+    }
+    expect(onExit).toHaveBeenCalledExactlyOnceWith(0, null);
+    const lateExit = vi.fn();
+    adapter.onExit(lateExit);
+    expect(lateExit).toHaveBeenCalledExactlyOnceWith(0, null);
+    completeRoot();
+    await adapter.wait();
+    emit({ type: "closing", reason: "lineage-closed" });
+    close();
+    await adapter.waitForExtinction();
+  });
+
   it.each(["after receipt", "before receipt"])(
     "preserves confirmed extinction when cancellation starts %s",
     async (order) => {
@@ -377,6 +426,8 @@ describe.each(["linux", "win32"] as const)("service closing authority (%s)", (pl
     "rejects %s without an authoritative closing receipt",
     async (fault) => {
       const { adapter, cancellations, completeRoot, close } = await createRelay(platform);
+      const onError = vi.fn();
+      adapter.onError(onError);
       completeRoot();
       const rejected = expect(adapter.waitForExtinction()).rejects.toThrow(
         "service child cleanup identity lost",
@@ -388,6 +439,69 @@ describe.each(["linux", "win32"] as const)("service closing authority (%s)", (pl
         close();
       }
       await rejected;
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("cleanup identity lost") }),
+        "process",
+      );
     },
   );
+});
+
+it("drains output after losing cleanup authority without erasing the observed root", async () => {
+  const { adapter, emit, endOutput, close } = await createRelay("linux");
+  adapter.kill("SIGTERM");
+  emit({ type: "root-result", code: 23, signal: null });
+  await nextTurn();
+  const root = adapter.wait();
+  const settled = vi.fn();
+  void root.then(settled, settled);
+  close();
+  await expect(adapter.waitForExtinction()).rejects.toThrow("cleanup identity lost");
+  expect(settled).not.toHaveBeenCalled();
+  endOutput();
+  await expect(root).resolves.toEqual({ code: 23, signal: null });
+});
+
+it.each(["EPERM", "EIO", "still present"])(
+  "keeps graceful cleanup uncertain when the kernel group is %s",
+  async (failure) => {
+    const { adapter, completeRoot, emit, close, groupProbe } = await createRelay("linux");
+    groupProbe.mockImplementation(() => {
+      if (failure === "still present") {
+        return true;
+      }
+      throw Object.assign(new Error(`synthetic ${failure}`), { code: failure });
+    });
+    completeRoot();
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    emit({ type: "closing", reason: "lineage-closed" });
+    await nextTurn();
+    // Exhaust the bounded observation window without waiting on real process time.
+    vi.spyOn(Date, "now").mockReturnValueOnce(10_000).mockReturnValue(15_000);
+    close();
+    await expect(adapter.waitForExtinction()).rejects.toThrow("owned process group");
+    await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+    expect(groupProbe).toHaveBeenCalledWith(-1235, 0);
+    expect(groupProbe.mock.calls.every(([, signal]) => signal === 0)).toBe(true);
+  },
+);
+
+it("retains extinction ownership until the kernel group disappears", async () => {
+  const { adapter, completeRoot, emit, close, groupProbe } = await createRelay("linux");
+  groupProbe.mockReturnValueOnce(true);
+  completeRoot();
+  await adapter.wait();
+  const settled = vi.fn();
+  const extinction = adapter.waitForExtinction().then(settled);
+  emit({ type: "closing", reason: "lineage-closed" });
+  await nextTurn();
+  expect(groupProbe).not.toHaveBeenCalled();
+  close();
+  await nextTurn();
+  expect(settled).not.toHaveBeenCalled();
+  await extinction;
+  expect(groupProbe.mock.calls).toEqual([
+    [-1235, 0],
+    [-1235, 0],
+  ]);
 });

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -1,7 +1,8 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import type { Duplex, Readable } from "node:stream";
+import type { Duplex, Readable, Writable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
+import { setTimeout as delay } from "node:timers/promises";
 import { toErrorObject } from "../../infra/errors.js";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import {
@@ -10,9 +11,12 @@ import {
 } from "../../infra/runtime-worker-url.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { onDecodedOutput } from "../decoded-output.js";
+import { pipeProcessOutput } from "../pipe-output.js";
 import { prepareSecretInputStdio } from "../spawn-secret-input.js";
 import { createManagedChildStdin } from "./adapters/child-stdin.js";
 import { toStringEnv } from "./adapters/env.js";
+import { createProcessAdapterEvents } from "./adapters/process-events.js";
+import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorMessage,
@@ -24,7 +28,7 @@ import type { ProcessAdapterConstruction, SpawnProcessAdapter, SpawnSecretInput 
 
 type ServiceChildRelayAdapter = SpawnProcessAdapter<NodeJS.Signals | null> & {
   waitForExtinction: () => Promise<void>;
-};
+} & Required<Pick<SpawnProcessAdapter<NodeJS.Signals | null>, "onExit" | "onError">>;
 type AuthorityState = "starting" | "active" | "closing" | "closed" | "identity-lost";
 type StdioEntry = "ignore" | "inherit" | "ipc" | "pipe" | number;
 
@@ -48,7 +52,7 @@ function reserveStdioEntry(stdio: StdioEntry[], value: StdioEntry): number {
   return fd;
 }
 
-function createOutputRelay(stream?: Readable) {
+function createOutputRelay(stream?: Readable, piped = false) {
   const listeners = new Set<(chunk: string) => void>();
   const rawListeners = new Set<(chunk: Buffer) => void>();
   const pending: Array<string | Buffer> = [];
@@ -63,7 +67,7 @@ function createOutputRelay(stream?: Readable) {
     }
   };
   const activate = (keepOutput: boolean) => {
-    if (active) {
+    if (active || piped) {
       return;
     }
     active = true;
@@ -97,7 +101,9 @@ function createOutputRelay(stream?: Readable) {
     ended = true;
   };
   if (stream) {
-    onDecodedOutput(stream, push, push);
+    if (!piped) {
+      onDecodedOutput(stream, push, push);
+    }
     stream.once("end", end);
     stream.once("close", end);
   }
@@ -134,6 +140,7 @@ export async function createServiceChildRelayAdapter(
     stdinMode: "inherit" | "pipe-open" | "pipe-closed";
     input?: string;
     secretInput?: SpawnSecretInput;
+    stderrDestination?: Writable;
     oomScoreWrapperSelected: boolean;
     windowsShellCommand?: string;
   },
@@ -183,12 +190,24 @@ export async function createServiceChildRelayAdapter(
     throw error;
   }
   const stdoutRelay = createOutputRelay(child.stdout ?? undefined);
-  const stderrRelay = createOutputRelay(child.stderr ?? undefined);
-  child.stdout?.on("error", () => {});
-  child.stderr?.on("error", () => {});
+  const stderrRelay = createOutputRelay(
+    child.stderr ?? undefined,
+    Boolean(params.stderrDestination),
+  );
+  const events = createProcessAdapterEvents();
+  const unpipeStderr =
+    child.stderr && params.stderrDestination
+      ? pipeProcessOutput(child.stderr, params.stderrDestination, (error) =>
+          events.emitError(error, "stderr"),
+        )
+      : undefined;
+  child.stdout?.on("error", (error) => events.emitError(error, "stdout"));
+  child.stderr?.on("error", (error) => events.emitError(error, "stderr"));
+  child.stdin?.on("error", (error) => events.emitError(error, "stdin"));
 
   let state: AuthorityState = "starting";
   let commandPid: number | undefined;
+  let anchorPid: number | undefined;
   let outboundSequence = 0;
   let inboundSequence = 0;
   let rootResult: { code: number | null; signal: NodeJS.Signals | null } | undefined;
@@ -213,7 +232,9 @@ export async function createServiceChildRelayAdapter(
   let startupErrorAckDelivery: Promise<void> | undefined;
 
   const settleWait = () => {
-    const error = waitError ?? resultError;
+    // Authority loss cannot erase an already observed root result. Output must
+    // still drain, while the independent extinction join keeps the failure.
+    const error = resultError ?? (rootResult ? undefined : waitError);
     if (error) {
       resultCompletion.reject(error);
       return;
@@ -221,7 +242,7 @@ export async function createServiceChildRelayAdapter(
     if (!rootResult || !stdoutRelay.ended || !stderrRelay.ended) {
       return;
     }
-    if (requestedSignal && state !== "closed") {
+    if (requestedSignal && state !== "closed" && state !== "identity-lost") {
       return;
     }
     resultCompletion.resolve(rootResult);
@@ -240,6 +261,7 @@ export async function createServiceChildRelayAdapter(
     }
     state = "identity-lost";
     waitError = new Error(`service child cleanup identity lost: ${message}`);
+    events.emitError(waitError, "process");
     if (!commandPid) {
       startup.reject(waitError);
     }
@@ -295,6 +317,9 @@ export async function createServiceChildRelayAdapter(
   };
 
   const finishAuthorityClose = (missingReceiptError: string) => {
+    if (state === "closed" || state === "identity-lost") {
+      return;
+    }
     if (!closingReceipt) {
       loseIdentity(missingReceiptError);
       return;
@@ -307,6 +332,42 @@ export async function createServiceChildRelayAdapter(
     extinctionCompletion.resolve();
   };
 
+  const finishPosixAuthority = async (missingReceiptError: string) => {
+    if (state === "closed" || state === "identity-lost") {
+      return;
+    }
+    if (!closingReceipt || !anchorPid) {
+      loseIdentity(missingReceiptError);
+      return;
+    }
+    // Only kernel group disappearance certifies closure. The anchor's census is
+    // advisory: hidden or concurrently forked members can be absent from ps.
+    const deadline = Date.now() + GRACEFUL_CANCEL_TIMEOUT_MS;
+    for (;;) {
+      try {
+        // Observation only: signalling a retired numeric PGID could hit a reused group.
+        process.kill(-anchorPid, 0);
+      } catch (error) {
+        // SAFETY: process.kill throws Node system errors; only the exact ESRCH code certifies absence.
+        if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+          finishAuthorityClose(missingReceiptError);
+        } else {
+          loseIdentity("owned process group disappearance could not be confirmed");
+        }
+        return;
+      }
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        loseIdentity("owned process group remained after its anchor closed");
+        return;
+      }
+      await delay(Math.min(100, remainingMs));
+      if (state !== "closing") {
+        return;
+      }
+    }
+  };
+
   const handleAnchorMessage = (message: ServiceChildAnchorMessage) => {
     if (message.generation !== generation || message.sequence <= inboundSequence) {
       loseIdentity("stale anchor generation or sequence");
@@ -317,11 +378,13 @@ export async function createServiceChildRelayAdapter(
       // Ready is not construction-complete: secret delivery can still be
       // blocked. Keep abort protection until the adapter returns.
       commandPid = message.commandPid;
+      anchorPid = message.anchorPid;
       state = "active";
       startup.resolve();
     } else if (message.type === "root-result") {
-      if (!resultError) {
-        rootResult ??= { code: message.code, signal: message.signal };
+      if (!resultError && !rootResult) {
+        rootResult = { code: message.code, signal: message.signal };
+        events.emitExit(message.code, message.signal);
       }
       settleWait();
     } else if (message.type === "result-error") {
@@ -409,7 +472,7 @@ export async function createServiceChildRelayAdapter(
       }
     });
     control.once("close", () => {
-      finishAuthorityClose(
+      void finishPosixAuthority(
         childError?.message ??
           controlError?.message ??
           "anchor channel closed without a matching closing receipt",
@@ -446,6 +509,7 @@ export async function createServiceChildRelayAdapter(
   child.once("error", (error) => {
     // The direct control pipe may still contain the anchor's authoritative closing receipt.
     childError ??= error;
+    events.emitError(error, "process");
   });
   const finishWindowsAuthority = () => {
     if (!useWindowsJobAnchor || !childDisconnected || !childExited) {
@@ -516,6 +580,7 @@ export async function createServiceChildRelayAdapter(
     }
   } catch (error) {
     stdoutRelay.drain();
+    unpipeStderr?.();
     stderrRelay.drain();
     child.kill("SIGKILL");
     throw error;
@@ -552,6 +617,8 @@ export async function createServiceChildRelayAdapter(
     supportsRawOutput: !useWindowsJobAnchor,
     onStdout: stdoutRelay.subscribe,
     onStderr: stderrRelay.subscribe,
+    onExit: events.onExit,
+    onError: events.onError,
     wait: async () => {
       // A caller may intentionally ignore one stream; wait still owns draining it.
       stdoutRelay.drain();
@@ -562,8 +629,13 @@ export async function createServiceChildRelayAdapter(
     waitForExtinction: async () => await extinctionCompletion.promise,
     kill,
     dispose: () => {
+      if (unpipeStderr) {
+        unpipeStderr();
+        child.stderr?.destroy();
+      }
       stdoutRelay.clear();
       stderrRelay.clear();
+      events.clear();
     },
   };
 }

--- a/src/process/supervisor/supervisor.anchored-shell.real.test.ts
+++ b/src/process/supervisor/supervisor.anchored-shell.real.test.ts
@@ -23,7 +23,9 @@ afterEach(async () => {
   activePids.clear();
 });
 
-async function createDescendantScope() {
+async function createDescendantScope(
+  options: { inheritLineage?: boolean; oneShot?: boolean; ignoreTerm?: boolean } = {},
+) {
   const cwd = tempDirs.make("openclaw-anchored-shell-");
   const descendantPath = path.join(cwd, "descendant.cjs");
   const descendantPidPath = path.join(cwd, "descendant.pid");
@@ -33,6 +35,7 @@ async function createDescendantScope() {
     descendantPath,
     `
       const { existsSync, writeFileSync } = require("node:fs");
+      ${options.ignoreTerm ? 'process.on("SIGTERM", () => {});' : ""}
       const releaseTimer = setInterval(() => {
         if (existsSync(process.argv[2])) {
           clearInterval(releaseTimer);
@@ -93,19 +96,29 @@ async function createDescendantScope() {
       `
         const { spawn } = require("node:child_process");
         const child = spawn(process.execPath, [${JSON.stringify(descendantPath)}, ${JSON.stringify(releasePath)}, ${JSON.stringify(descendantPidPath)}], {
-          stdio: ["ignore", "ignore", "ignore", 3],
+          stdio: ${JSON.stringify(options.inheritLineage === false ? ["ignore", "ignore", "ignore"] : ["ignore", "ignore", "ignore", 3])},
         });
         child.unref();
-        ${fragmentedOutputFixture()}
+        const ready = setInterval(() => {
+          if (!require("node:fs").existsSync(${JSON.stringify(descendantPidPath)})) return;
+          clearInterval(ready);
+          ${fragmentedOutputFixture()}
+        }, 10);
       `,
       "utf8",
     );
   }
   const supervisor = createProcessSupervisor();
   const scopeKey = `anchored-shell:${cwd}`;
+  const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
   const run = await supervisor.spawn({
-    mode: "anchored-shell",
-    command: "node root.cjs",
+    ...(options.oneShot
+      ? {
+          mode: "child" as const,
+          argv: [process.execPath, rootPath],
+          stdinMode: "pipe-closed" as const,
+        }
+      : { mode: "anchored-shell" as const, command: "node root.cjs" }),
     sessionId: "anchored-shell-real",
     backendId: "anchored-shell-real",
     scopeKey,
@@ -123,6 +136,7 @@ async function createDescendantScope() {
     run,
     supervisor,
     scopeKey,
+    cleanup,
     readPid: () => waitForPidFile(descendantPidPath, 5_000),
     release: () => writeFile(releasePath, "", "utf8"),
   };
@@ -152,6 +166,38 @@ async function expectPending(promise: Promise<void>) {
 }
 
 describe("supervisor anchored shell real process ownership", () => {
+  it.skipIf(process.platform === "win32").each([
+    { oneShot: false, ignoreTerm: false },
+    { oneShot: true, ignoreTerm: false },
+    { oneShot: true, ignoreTerm: true },
+  ])(
+    "observes children that closed inherited descriptors (oneShot=$oneShot, ignores TERM=$ignoreTerm)",
+    async ({ oneShot, ignoreTerm }) => {
+      const fixture = await createDescendantScope({ inheritLineage: false, oneShot, ignoreTerm });
+      const pid = await fixture.readPid();
+      activePids.add(pid);
+      try {
+        await expect(fixture.run.wait()).resolves.toMatchObject({ exitCode: 0, exitSignal: null });
+        const cleanup = fixture.cleanup();
+        if (ignoreTerm) {
+          await expect(cleanup).rejects.toThrow("cleanup identity lost");
+        } else {
+          await cleanup;
+          expect(isProcessAlive(pid)).toBe(false);
+        }
+        await waitForDead(pid, 5_000);
+      } finally {
+        await fixture.release();
+        killPidIfAlive(pid);
+        await waitForDead(pid, 5_000);
+        if (ignoreTerm) {
+          await expect(fixture.supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
+        } else {
+          await fixture.supervisor.shutdown();
+        }
+      }
+    },
+  );
   it.each(["inherited", "replacement", "empty"] as const)(
     "completes an otherwise idle host with %s command environment",
     async (environment) => {
@@ -347,7 +393,7 @@ describe("supervisor anchored shell real process ownership", () => {
     { name: "cancels retained descendants idempotently", cancel: true },
     { name: "releases ownership after descendants exit naturally", cancel: false },
   ])("$name after root settlement and fragmented output flush", async ({ cancel }) => {
-    const { run, supervisor, scopeKey, readPid, release } = await createDescendantScope();
+    const { run, supervisor, scopeKey, cleanup, readPid, release } = await createDescendantScope();
     const result = await run.wait();
     const decoder = createWindowsOutputDecoder();
     const finalTail = decoder.decode(Buffer.from([0xe2, 0x82])) + decoder.flush();
@@ -372,11 +418,7 @@ describe("supervisor anchored shell real process ownership", () => {
     } else {
       await release();
     }
-    await Promise.all([
-      run.waitForExtinction!(),
-      supervisor.waitForScope(scopeKey),
-      supervisor.waitForScope(scopeKey),
-    ]);
+    await Promise.all([run.waitForExtinction!(), cleanup(), cleanup()]);
     expect(supervisor.getRecord(run.runId)).toMatchObject({
       state: "exited",
       terminationReason: "exit",

--- a/src/process/supervisor/supervisor.scope-extinction.test.ts
+++ b/src/process/supervisor/supervisor.scope-extinction.test.ts
@@ -52,7 +52,7 @@ describe("process supervisor scope extinction", () => {
     });
 
     expect(run.waitForExtinction).toBeUndefined();
-    const drain = supervisor.waitForScope("scope:ordinary-child");
+    const drain = run.wait();
     const drained = vi.fn();
     void drain.then(drained);
     await Promise.resolve();
@@ -60,8 +60,107 @@ describe("process supervisor scope extinction", () => {
 
     adapter.settle(0);
     await expect(run.wait()).resolves.toMatchObject({ reason: "exit", exitCode: 0 });
-    await expect(drain).resolves.toBeUndefined();
+    await expect(drain).resolves.toMatchObject({ exitCode: 0 });
     expect(adapter.disposeMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { failed: false, acquired: true },
+    { failed: true, acquired: true },
+    { failed: true, acquired: false },
+  ])(
+    "retains extinction until its scope joins (failed=$failed, acquired=$acquired)",
+    async ({ failed, acquired }) => {
+      const extinction = createDeferred();
+      const adapter = Object.assign(createStubChildAdapter(), {
+        waitForExtinction: () => extinction.promise,
+      });
+      createChildAdapterMock.mockResolvedValue(adapter);
+      const supervisor = createProcessSupervisor();
+      const scopeKey = "scope:one-shot-late-join";
+      const cleanup = acquired
+        ? supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true })
+        : () => supervisor.waitForScope!(scopeKey);
+      const run = await spawnChild(supervisor, {
+        sessionId: scopeKey,
+        scopeKey,
+        argv: createSilentIdleArgv(),
+      });
+      adapter.settle(0);
+      await expect(run.wait()).resolves.toMatchObject({ exitCode: 0 });
+      if (failed) {
+        extinction.reject(new Error("cleanup identity lost"));
+        await expect(run.waitForExtinction!()).rejects.toThrow("cleanup identity lost");
+        await expect(cleanup()).rejects.toThrow("cleanup identity lost");
+        await expect(cleanup()).rejects.toThrow("cleanup identity lost");
+      } else {
+        extinction.resolve();
+        await run.waitForExtinction!();
+        await expect(cleanup()).resolves.toBeUndefined();
+      }
+      // The released owner must neither poison a new run nor retain the old admission.
+      if (acquired) {
+        await expect(
+          supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true })(),
+        ).resolves.toBeUndefined();
+      }
+      if (failed) {
+        await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
+      } else {
+        await supervisor.shutdown();
+      }
+    },
+  );
+
+  it.each(["child", "pty", "external"] as const)(
+    "keeps %s execution available but reports unsupported one-shot cleanup",
+    async (mode) => {
+      const adapter = createStubChildAdapter();
+      createChildAdapterMock.mockResolvedValue(adapter);
+      createPtyAdapterMock.mockResolvedValue(adapter);
+      const supervisor = createProcessSupervisor();
+      const scopeKey = `scope:unsupported-${mode}`;
+      const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+      const run = await supervisor.spawn({
+        mode: mode === "pty" ? "pty" : "child",
+        argv: createSilentIdleArgv(),
+        backendId: "test",
+        sessionId: scopeKey,
+        scopeKey,
+        ...(mode === "external" ? { cleanupOwnership: "external" as const } : {}),
+      });
+      adapter.emitStdout("tool execution remains available");
+      adapter.settle(0);
+      await expect(run.wait()).resolves.toMatchObject({
+        exitCode: 0,
+        stdout: "tool execution remains available",
+      });
+      await expect(cleanup()).rejects.toThrow("cannot confirm owned execution-tree settlement");
+      await supervisor.shutdown();
+    },
+  );
+
+  it("allows graceful descendant cleanup after a one-shot root result", async () => {
+    const extinction = createDeferred();
+    const adapter = Object.assign(createStubChildAdapter(), {
+      waitForExtinction: () => extinction.promise,
+    });
+    createChildAdapterMock.mockResolvedValue(adapter);
+    const supervisor = createProcessSupervisor();
+    const scopeKey = "scope:graceful-one-shot";
+    const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+    const run = await spawnChild(supervisor, {
+      sessionId: scopeKey,
+      scopeKey,
+      argv: createSilentIdleArgv(),
+    });
+    adapter.settle(0);
+    await run.wait();
+    const closing = cleanup();
+    expect(adapter.killMock).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+    extinction.resolve();
+    await closing;
+    await supervisor.shutdown();
   });
 
   it.each(["scope", "shutdown"] as const)(
@@ -76,6 +175,7 @@ describe("process supervisor scope extinction", () => {
       createChildAdapterMock.mockReturnValueOnce(startup.promise);
       const supervisor = createProcessSupervisor();
       const scopeKey = "scope:timed-out-construction";
+      const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: false });
       const pending = spawnChild(supervisor, {
         sessionId: "timed-out-construction",
         scopeKey,
@@ -86,7 +186,7 @@ describe("process supervisor scope extinction", () => {
         await vi.advanceTimersByTimeAsync(25);
         const run = await pending;
         await expect(run.wait()).resolves.toMatchObject({ reason: "overall-timeout" });
-        const drain = join === "scope" ? supervisor.waitForScope(scopeKey) : supervisor.shutdown();
+        const drain = join === "scope" ? cleanupScope() : supervisor.shutdown();
         const drained = vi.fn();
         void drain.then(drained, drained);
         await vi.advanceTimersByTimeAsync(0);
@@ -108,6 +208,7 @@ describe("process supervisor scope extinction", () => {
         extinction.resolve();
         await pending;
         await supervisor.shutdown();
+        await cleanupScope();
       }
     },
   );
@@ -196,6 +297,9 @@ describe("process supervisor scope extinction", () => {
       createChildAdapterMock.mockReturnValueOnce(startup.promise).mockResolvedValueOnce(sibling);
 
       const supervisor = createProcessSupervisor();
+      const cleanupScope = supervisor.acquireScopeCleanup("scope:failed-drain", {
+        requireProcessTree: false,
+      });
       const sharedId = reuseRunId ? { runId: "same-agent-run" } : {};
       const firstPending = spawnChild(supervisor, {
         ...sharedId,
@@ -210,7 +314,7 @@ describe("process supervisor scope extinction", () => {
         argv: createSilentIdleArgv(),
       });
       supervisor.cancelScope("scope:failed-drain");
-      const drain = supervisor.waitForScope("scope:failed-drain");
+      const drain = cleanupScope();
       startup.resolve(first);
       const firstRun = await firstPending;
       expect(first.killMock).toHaveBeenCalledWith("SIGKILL");

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -27,7 +27,16 @@ type OwnedRun = {
   cancel?: (reason: TerminationReason) => void;
   pending?: Promise<ManagedRun>;
   waitForExtinction?: () => Promise<void>;
+  cleanupOwners: ScopeCleanupOwner[];
 };
+
+type ScopeCleanupOwner = { requireProcessTree: boolean; failure?: { error: unknown } };
+
+function recordScopeCleanupFailure(owner: OwnedRun, error: unknown): void {
+  for (const cleanupOwner of owner.cleanupOwners) {
+    cleanupOwner.failure ??= { error };
+  }
+}
 
 type StartingScope = {
   runs: Set<Promise<ManagedRun>>;
@@ -95,15 +104,16 @@ function resolveElapsedTimeoutReason(params: {
 
 export function createProcessSupervisor(): ProcessSupervisor & {
   shutdown: () => Promise<void>;
-  waitForScope: (scopeKey: string) => Promise<void>;
 } {
   const registry = createRunRegistry();
   // Retries share a run ID while an older command can still own descendants.
   // Keep each admission until its own cleanup completes.
   const ownedRuns = new Set<OwnedRun>();
+  const scopeCleanupOwners = new Map<string, Set<ScopeCleanupOwner>>();
   const startingScopes = new Map<string, StartingScope>();
   let shuttingDown = false;
   let shutdownPromise: Promise<void> | null = null;
+  let cleanupFailure: { error: unknown } | undefined;
 
   const cancelOwner = (current: OwnedRun, reason: TerminationReason) => {
     if (current.cancel) {
@@ -155,7 +165,6 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         if (!current.waitForExtinction) {
           return [];
         }
-        // Failed cleanup remains owned for later joins, but each drain observes it once.
         observed.add(current);
         return [current.waitForExtinction()];
       });
@@ -173,7 +182,33 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         .find((result): result is PromiseRejectedResult => result.status === "rejected");
     }
   };
-  const waitForScope = (scopeKey: string): Promise<void> => waitForRuns(scopeKey);
+  const acquireScopeCleanup = (
+    scopeKey: string,
+    options: { requireProcessTree: boolean },
+  ): (() => Promise<void>) => {
+    const cleanupOwner: ScopeCleanupOwner = { requireProcessTree: options.requireProcessTree };
+    const owners = scopeCleanupOwners.get(scopeKey) ?? new Set<ScopeCleanupOwner>();
+    owners.add(cleanupOwner);
+    scopeCleanupOwners.set(scopeKey, owners);
+    let closing: Promise<void> | undefined;
+    return () =>
+      (closing ??= (async () => {
+        try {
+          cancelScope(scopeKey);
+          await waitForRuns(scopeKey);
+        } catch (error) {
+          cleanupOwner.failure ??= { error };
+        } finally {
+          owners.delete(cleanupOwner);
+          if (owners.size === 0) {
+            scopeCleanupOwners.delete(scopeKey);
+          }
+        }
+        if (cleanupOwner.failure) {
+          throw cleanupOwner.failure.error;
+        }
+      })());
+  };
 
   const startRun = async (input: SpawnInput, owner: OwnedRun): Promise<ManagedRun> => {
     // A queued replacement must still own authority before stopping the surviving run.
@@ -359,6 +394,10 @@ export function createProcessSupervisor(): ProcessSupervisor & {
               })
             : createChildAdapter({
                 assertCurrent: input.assertCurrent,
+                ...(owner.cleanupOwners.some((scope) => scope.requireProcessTree) &&
+                input.cleanupOwnership !== "external"
+                  ? { ownProcessTree: true as const }
+                  : {}),
                 argv: input.argv,
                 argv0: input.argv0,
                 cwd: input.cwd,
@@ -375,6 +414,17 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         .then(
           async (started) => {
             ownedAdapter = started;
+            if (input.cleanupOwnership === "external" || !started.waitForExtinction) {
+              for (const scope of owner.cleanupOwners) {
+                if (scope.requireProcessTree) {
+                  scope.failure ??= {
+                    error: new Error(
+                      "process cleanup cannot confirm owned execution-tree settlement",
+                    ),
+                  };
+                }
+              }
+            }
             if (constructionAbort.signal.aborted) {
               started.kill("SIGKILL");
               // Drain a late adapter's output without reopening the terminal result.
@@ -401,7 +451,16 @@ export function createProcessSupervisor(): ProcessSupervisor & {
           ownedRuns.delete(owner);
           cleanup.resolve();
         },
-        (error: unknown) => cleanup.reject(error),
+        (error: unknown) => {
+          recordScopeCleanupFailure(owner, error);
+          cleanupFailure ??= { error };
+          // Legacy late scope joins still read this owner; acquired scopes retain
+          // the failure separately and can release the adapter's runtime graph.
+          if (owner.cleanupOwners.length > 0) {
+            ownedRuns.delete(owner);
+          }
+          cleanup.reject(error);
+        },
       );
       let adapter: Awaited<typeof adapterPromise>;
       try {
@@ -436,11 +495,15 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       };
 
       cancelAdapter = (reason: TerminationReason) => {
-        if (cleanupSettled || (cancelRequested && !(resultSettled && forceKillTimer))) {
+        const requireProcessTree = owner.cleanupOwners.some((scope) => scope.requireProcessTree);
+        if (
+          cleanupSettled ||
+          (cancelRequested && (requireProcessTree || !(resultSettled && forceKillTimer)))
+        ) {
           return;
         }
         cancelRequested = true;
-        if (resultSettled) {
+        if (resultSettled && !requireProcessTree) {
           if (forceKillTimer) {
             clearTimeout(forceKillTimer);
             forceKillTimer = null;
@@ -578,7 +641,11 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     }
     const scopeKey = normalizeOptionalString(input.scopeKey);
     const runId = normalizeOptionalString(input.runId) ?? crypto.randomUUID();
-    const owner: OwnedRun = { runId, scopeKey };
+    const owner: OwnedRun = {
+      runId,
+      scopeKey,
+      cleanupOwners: scopeKey ? [...(scopeCleanupOwners.get(scopeKey) ?? [])] : [],
+    };
     // Reserve cancellation before either adapter startup or a replacement
     // fence, so stopping a run cannot silently leave a late child alive.
     ownedRuns.add(owner);
@@ -638,15 +705,19 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         // must keep the process-wide supervisor fenced for operator recovery.
         await waitForRuns(null, true);
       }
+      if (cleanupFailure) {
+        throw cleanupFailure.error;
+      }
     }));
   };
 
   return {
+    acquireScopeCleanup,
     spawn,
     cancel,
     cancelScope,
+    waitForScope: (scopeKey: string) => waitForRuns(scopeKey),
     shutdown,
-    waitForScope,
     getRecord: (runId: string) => registry.get(runId),
   };
 }

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -44,7 +44,7 @@ export type ManagedRun = {
   startedAtMs: number;
   stdin?: ManagedRunStdin;
   wait: () => Promise<RunExit>;
-  /** The root result may settle before its independently owned descendants exit. */
+  /** Join the adapter's native ownership boundary; deliberately detached outsiders are excluded. */
   waitForExtinction?: () => Promise<void>;
   cancel: (reason?: TerminationReason) => void;
   /** Stop every decoded, raw, captured, and output-clock update for this run. */
@@ -81,6 +81,10 @@ export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
   supportsRawOutput: boolean;
   onStdout: (listener: (chunk: string) => void, onRaw?: (chunk: Buffer) => void) => void;
   onStderr: (listener: (chunk: string) => void, onRaw?: (chunk: Buffer) => void) => void;
+  onExit?: (listener: (code: number | null, signal: WaitSignal) => void) => void;
+  onError?: (
+    listener: (error: Error, source: "process" | "stdin" | "stdout" | "stderr") => void,
+  ) => void;
   wait: () => Promise<{ code: number | null; signal: WaitSignal }>;
   waitForExtinction?: () => Promise<void>;
   kill: (signal?: NodeJS.Signals) => void;
@@ -88,6 +92,8 @@ export type SpawnProcessAdapter<WaitSignal = NodeJS.Signals | number | null> = {
 };
 
 type SpawnBaseInput = {
+  /** The local subprocess transports execution owned outside its local process tree. */
+  cleanupOwnership?: "external";
   /** Revalidate the caller at deferred spawn and private-input delivery boundaries. */
   assertCurrent?: () => void;
   runId?: string;
@@ -140,6 +146,11 @@ type SpawnAnchoredShellInput = SpawnBaseInput & {
 export type SpawnInput = SpawnChildInput | SpawnPtyInput | SpawnAnchoredShellInput;
 
 export interface ProcessSupervisor {
+  /** Register before spawning; close caller admission before joining this exact cleanup owner. */
+  acquireScopeCleanup(
+    scopeKey: string,
+    options: { requireProcessTree: boolean },
+  ): () => Promise<void>;
   spawn(input: SpawnInput): Promise<ManagedRun>;
   cancel(runId: string, reason?: TerminationReason): void;
   cancelScope(scopeKey: string, reason?: TerminationReason): void;

--- a/src/shared/pid-alive.test.ts
+++ b/src/shared/pid-alive.test.ts
@@ -65,22 +65,6 @@ describe("isPidAlive", () => {
     expect(process["kill"]).toHaveBeenCalledWith(42, 0);
   });
 
-  it("returns false for Linux zombies even when probing reports EPERM", async () => {
-    const error = Object.assign(new Error("permission denied"), { code: "EPERM" });
-    vi.spyOn(process, "kill").mockImplementation(() => {
-      throw error;
-    });
-    mockProcReads({
-      "/proc/42/status": "Name:\tnode\nUmask:\t0022\nState:\tZ (zombie)\nTgid:\t42\nPid:\t42\n",
-    });
-
-    await withMockedPlatform("linux", async () => {
-      expect(isPidAlive(42)).toBe(false);
-    });
-
-    expect(process["kill"]).toHaveBeenCalledWith(42, 0);
-  });
-
   it("returns false when process probing reports ESRCH", () => {
     const error = Object.assign(new Error("missing process"), { code: "ESRCH" });
     vi.spyOn(process, "kill").mockImplementation(() => {
@@ -89,17 +73,6 @@ describe("isPidAlive", () => {
 
     expect(isPidAlive(42)).toBe(false);
     expect(process["kill"]).toHaveBeenCalledWith(42, 0);
-  });
-
-  it("returns false for zombie processes on Linux", async () => {
-    const zombiePid = process.pid;
-
-    mockProcReads({
-      [`/proc/${zombiePid}/status`]: `Name:\tnode\nUmask:\t0022\nState:\tZ (zombie)\nTgid:\t${zombiePid}\nPid:\t${zombiePid}\n`,
-    });
-    await withMockedPlatform("linux", async () => {
-      expect(isPidAlive(zombiePid)).toBe(false);
-    });
   });
 
   it("treats unreadable linux proc status as non-zombie when kill succeeds", async () => {
@@ -146,18 +119,6 @@ describe("isPidDefinitelyDead", () => {
     expect(process["kill"]).toHaveBeenCalledWith(42, 0);
   });
 
-  it("returns true for zombie processes on Linux", async () => {
-    const zombiePid = process.pid;
-    vi.spyOn(process, "kill").mockImplementation(() => true);
-    mockProcReads({
-      [`/proc/${zombiePid}/status`]: `Name:\tnode\nUmask:\t0022\nState:\tZ (zombie)\nTgid:\t${zombiePid}\nPid:\t${zombiePid}\n`,
-    });
-
-    await withMockedPlatform("linux", async () => {
-      expect(isPidDefinitelyDead(zombiePid)).toBe(true);
-    });
-  });
-
   it("returns false for live non-zombie processes", async () => {
     const livePid = process.pid;
     vi.spyOn(process, "kill").mockImplementation(() => true);
@@ -169,6 +130,32 @@ describe("isPidDefinitelyDead", () => {
       expect(isPidDefinitelyDead(livePid)).toBe(false);
     });
   });
+});
+
+describe.each(["success", "EPERM"])("Linux process liveness (probe=%s)", (probe) => {
+  it.each([
+    { state: "S", threads: "1", dead: false },
+    { state: "Z", threads: "1", dead: true },
+    { state: "Z", threads: "2", dead: false },
+    { state: "Z", threads: "", dead: false },
+  ])(
+    "requires exited threads (state=$state, threads=$threads)",
+    async ({ state, threads, dead }) => {
+      vi.spyOn(process, "kill").mockImplementation(() => {
+        if (probe === "EPERM") {
+          throw Object.assign(new Error("permission denied"), { code: "EPERM" });
+        }
+        return true;
+      });
+      mockProcReads({
+        "/proc/42/status": `Name:\tnode\nState:\t${state}\n${threads ? `Threads:\t${threads}\n` : ""}`,
+      });
+      await withMockedPlatform("linux", async () => {
+        expect(isPidAlive(42)).toBe(!dead);
+        expect(isPidDefinitelyDead(42)).toBe(dead && probe !== "EPERM");
+      });
+    },
+  );
 });
 
 describe("process start times", () => {
@@ -239,7 +226,6 @@ describe("process start times", () => {
     return withMockedPlatform("win32", async () => {
       expect(getProcessStartTime(42)).toBeNull();
       expect(getFileLockProcessStartTime(42)).toBe(1_752_000_000_123);
-      expect(readWindowsProcessStartTimeSyncMock).toHaveBeenCalledWith(42);
     });
   });
 

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -14,7 +14,7 @@ function isValidPid(pid: number): boolean {
 }
 
 /**
- * Check if a process is a zombie on Linux by reading /proc/<pid>/status.
+ * Check if every thread has exited by reading Linux /proc/<pid>/status.
  * Returns false on non-Linux platforms or if the proc file can't be read.
  */
 function isZombieProcess(pid: number): boolean {
@@ -24,7 +24,9 @@ function isZombieProcess(pid: number): boolean {
   try {
     const status = fsSync.readFileSync(`/proc/${pid}/status`, "utf8");
     const stateMatch = status.match(/^State:\s+(\S)/m);
-    return stateMatch?.[1] === "Z";
+    // pthread_exit can leave a zombie leader with live workers; missing thread
+    // evidence must not revoke a live process's locks or cleanup obligations.
+    return stateMatch?.[1] === "Z" && /^Threads:[ \t]+1[ \t]*$/m.test(status);
   } catch {
     return false;
   }
@@ -61,12 +63,12 @@ export function isPidDefinitelyDead(pid: number): boolean {
   return isZombieProcess(pid);
 }
 
-function getDarwinProcessStartTime(pid: number): number | null {
+function getDarwinProcessStartTime(pid: number, env: NodeJS.ProcessEnv): number | null {
   try {
     const startedAt = childProcess
       .execFileSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], {
         encoding: "utf8",
-        env: { ...resolveDiagnosticProcessEnv(), LC_ALL: "C", TZ: "UTC" },
+        env: { ...resolveDiagnosticProcessEnv(env), LC_ALL: "C", TZ: "UTC" },
         stdio: ["ignore", "pipe", "ignore"],
         timeout: PROCESS_START_TIMEOUT_MS,
         killSignal: "SIGKILL",
@@ -105,7 +107,11 @@ export function getProcessStartTime(pid: number): number | null {
 }
 
 /** Read a cross-platform process identity for filesystem lock ownership. */
-export function getFileLockProcessStartTime(pid: number): number | null {
+export function getFileLockProcessStartTime(
+  pid: number,
+  env: NodeJS.ProcessEnv = process.env,
+  windowsTimeoutMs?: number,
+): number | null {
   if (!isValidPid(pid)) {
     return null;
   }
@@ -115,9 +121,9 @@ export function getFileLockProcessStartTime(pid: number): number | null {
   }
   const startTime =
     process.platform === "darwin"
-      ? getDarwinProcessStartTime(pid)
+      ? getDarwinProcessStartTime(pid, env)
       : process.platform === "win32"
-        ? readWindowsProcessStartTimeSync(pid)
+        ? readWindowsProcessStartTimeSync(pid, windowsTimeoutMs, env)
         : getProcessStartTime(pid);
   if (isSelf && startTime !== null) {
     selfStartTime = startTime;

--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -13,7 +13,23 @@ vi.mock("../process/supervisor/index.js", () => ({
   getProcessSupervisor: vi.fn(),
 }));
 
-type ShellSupervisor = ReturnType<typeof getProcessSupervisor>;
+function createShellSupervisor(spawn = vi.fn<ProcessSupervisor["spawn"]>()) {
+  const cleanupScope = vi.fn(async (_scopeKey: string) => {});
+  const cancelScope = vi.fn<ProcessSupervisor["cancelScope"]>();
+  const supervisor = {
+    spawn,
+    cancel: vi.fn<ProcessSupervisor["cancel"]>(),
+    cancelScope,
+    acquireScopeCleanup: vi.fn<ProcessSupervisor["acquireScopeCleanup"]>((scopeKey) => async () => {
+      cancelScope(scopeKey);
+      await cleanupScope(scopeKey);
+    }),
+    getRecord: vi.fn<ProcessSupervisor["getRecord"]>(),
+  } satisfies ProcessSupervisor;
+  return { supervisor, cleanupScope };
+}
+
+type ShellSupervisor = ReturnType<typeof createShellSupervisor>["supervisor"];
 
 const createSelector = () => {
   const selector = {
@@ -37,8 +53,8 @@ function createOverlayHandle(): OverlayHandle {
 }
 
 function createShellHarness(params?: {
-  spawn?: ProcessSupervisor["spawn"];
-  supervisor?: ShellSupervisor;
+  spawn?: ShellSupervisor["spawn"];
+  supervisor?: ReturnType<typeof createShellSupervisor>;
   getCwd?: () => string | undefined;
   env?: Record<string, string>;
   maxOutputChars?: number;
@@ -58,15 +74,7 @@ function createShellHarness(params?: {
     lastSelector = createSelector();
     return lastSelector;
   });
-  const supervisor =
-    params?.supervisor ??
-    ({
-      spawn: params?.spawn ?? vi.fn(),
-      cancel: vi.fn(),
-      cancelScope: vi.fn(),
-      waitForScope: vi.fn(async () => {}),
-      getRecord: vi.fn(),
-    } satisfies ShellSupervisor);
+  const { supervisor, cleanupScope } = params?.supervisor ?? createShellSupervisor(params?.spawn);
   vi.mocked(getProcessSupervisor).mockReturnValue(supervisor);
   const { runLocalShellLine, shutdown } = createLocalShellRunner({
     chatLog,
@@ -85,6 +93,7 @@ function createShellHarness(params?: {
     closeOverlay,
     createSelectorSpy,
     supervisor,
+    cleanupScope,
     runLocalShellLine,
     shutdown,
     getLastSelector: () => lastSelector,
@@ -92,7 +101,7 @@ function createShellHarness(params?: {
 }
 
 function createSettlingSpawn(params: { stdout?: string[]; stderr?: string[]; error?: Error }) {
-  return vi.fn(async (input: SpawnInput) => {
+  return vi.fn<ProcessSupervisor["spawn"]>(async (input: SpawnInput) => {
     const exit: RunExit = {
       reason: "exit",
       exitCode: 0,
@@ -243,6 +252,10 @@ describe("createLocalShellRunner", () => {
 
   it("fences a pending approval when shutdown begins", async () => {
     const harness = createShellHarness();
+    expect(harness.supervisor.acquireScopeCleanup).toHaveBeenCalledExactlyOnceWith(
+      expect.any(String),
+      { requireProcessTree: true },
+    );
     const run = harness.runLocalShellLine("!echo late");
     const selector = harness.getLastSelector();
 
@@ -252,7 +265,7 @@ describe("createLocalShellRunner", () => {
 
     expect(harness.supervisor.spawn).not.toHaveBeenCalled();
     expect(harness.supervisor.cancelScope).toHaveBeenCalledOnce();
-    expect(harness.supervisor.waitForScope).toHaveBeenCalledWith(
+    expect(harness.cleanupScope).toHaveBeenCalledWith(
       vi.mocked(harness.supervisor.cancelScope).mock.calls[0]?.[0],
     );
     expect(harness.closeOverlay).toHaveBeenCalledWith(harness.overlayHandle);
@@ -261,7 +274,7 @@ describe("createLocalShellRunner", () => {
   it("keeps another TUI instance's settled command scope alive during shutdown", async () => {
     const spawn = createSettlingSpawn({});
     const first = createShellHarness({ spawn });
-    const second = createShellHarness({ supervisor: first.supervisor });
+    const second = createShellHarness({ supervisor: first });
 
     for (const harness of [first, second]) {
       const run = harness.runLocalShellLine("!echo alive");
@@ -285,7 +298,7 @@ describe("createLocalShellRunner", () => {
 
     expect(first.supervisor.cancelScope).toHaveBeenCalledOnce();
     expect(first.supervisor.cancelScope).toHaveBeenCalledWith(firstScope);
-    expect(first.supervisor.waitForScope).toHaveBeenCalledWith(firstScope);
+    expect(first.cleanupScope).toHaveBeenCalledWith(firstScope);
     expect(liveScopes).toEqual(new Set([secondScope]));
   });
 });

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -35,11 +35,8 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
   let shutdownPromise: Promise<void> | undefined;
   let cancelPendingApproval: (() => void) | undefined;
   const supervisor = getProcessSupervisor();
-  const waitForScope = supervisor.waitForScope;
-  if (!waitForScope) {
-    throw new Error("process supervisor must support scope extinction before running local shells");
-  }
   const scopeKey = `tui-local:${randomUUID()}`;
+  const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
   const createSelector = deps.createSelector ?? createSearchableSelectList;
   const getCwd = deps.getCwd ?? tryProcessCwd;
   const env = deps.env ?? process.env;
@@ -180,8 +177,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
     (shutdownPromise ??= (async () => {
       closing = true;
       cancelPendingApproval?.();
-      supervisor.cancelScope(scopeKey);
-      await waitForScope(scopeKey);
+      await cleanupScope();
     })());
 
   return { runLocalShellLine, shutdown };

--- a/test/helpers/process-wait.test.ts
+++ b/test/helpers/process-wait.test.ts
@@ -81,7 +81,7 @@ it("stops waiting when a Linux process is a zombie", async () => {
   vi.spyOn(process, "kill").mockImplementation(() => true);
   vi.spyOn(fsSync, "readFileSync").mockImplementation((filePath) => {
     if (String(filePath) === "/proc/42/status") {
-      return "Name:\tworker\nState:\tZ (zombie)\nPid:\t42\n";
+      return "Name:\tworker\nState:\tZ (zombie)\nPid:\t42\nThreads:\t1\n";
     }
     throw new Error(`unexpected read: ${String(filePath)}`);
   });


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Fixes an issue where supervised commands could finish while descendant cleanup remained unconfirmed. A closed control channel or completed command could be mistaken for completed cleanup, allowing shutdown or a later owner to proceed without reliable evidence.

This is Stage 3, part 1 of the #135868 split: the process foundation for the cleanup-certification concern. The dependent PR carries the remaining agent, Codex, MCP/LSP, and Gateway lifetime consumers.

## Why This Change Was Made

The process owner preserves command results separately from cleanup. An owned POSIX group requires graceful anchor retirement followed by kernel-confirmed group disappearance; forced or lost cleanup remains uncertain. Acquired cleanup scopes retain failures after adapter retirement, and existing late scope joins retain their failure evidence during the staged caller migration.

Local TUI shell shutdown now acquires that cleanup owner before launching commands. Shared process adapters preserve output drainage, including when a diagnostic destination closes, errors, finishes, or explicitly detaches. Linux zombie leaders with live threads remain live; Windows process-start queries preserve their captured diagnostic environment and budget.

## User Impact

Completed output remains available even when cleanup fails, and cleanup uncertainty prevents an unsafe successful shutdown. TUI shutdown owns only its own shell scope. This foundation does not enable automatic repair; that remains with the final #135868 stage.

## Evidence

- Five process suites / 90 tests passed on macOS after rebase, covering descendants after root exit, closed inherited descriptors, graceful and forced termination, output backpressure, and independent cleanup settlement.
- Focused process, PID, CLI cancellation/background-work/capture, Gateway stream/desktop, TUI, and memory-promotion suites passed. Additional fixture corrections preserve realistic single-thread zombie data without changing those subsystems' production behavior.
- Independent committed-branch Codex review through P2 is scoped-clean after addressing legacy-join failure retention and diagnostic drainage findings. Original-code regression replay failed for the intended group/PID/pipe/scope defects; the repaired candidate passed all 22 selected cases.
- The full changed-check plan and `pnpm build` passed on an isolated Linux Testbox with exit 0: https://github.com/openclaw/openclaw/actions/runs/33998094034. The one-shot lease completed and was stopped; its backing workflow may show cancellation during expected lease cleanup. Final exact-head CI passed: https://github.com/openclaw/openclaw/actions/runs/34000991966.

Judged LOC for this foundation: production +500/-105 (net +395), tests +743/-109 (net +634), docs +6, tooling 0. Production growth establishes native extinction evidence, retained cleanup failures, and shared process events. The existing PID-reader API carries the new optional arguments, and duplicate test-supervisor setups were consolidated; the stdio factory travels with its actual consumers in the dependent PR.

Windows utility execution and Linux thread-state edge cases use fixtures; native Windows execution was not run. POSIX group ownership excludes deliberately detached processes outside that group.

### Review follow-through

ClawSweeper found no actionable source defect. Its conservative-cleanup concern is the intended Stage 3 contract: a root exit or forced signal alone cannot release owned work. Public helper additions stay optional and invocation-scoped; they do not certify deliberately escaped descendants. The reported data-model concern does not apply: `pid-alive.ts` changes an OS liveness observation and optional diagnostic arguments, with no schema, stored shape, or migration change. Native Windows validation is deferred as the optional rank-up move; this PR records fixture coverage and the native execution gap explicitly.

The first exact-head CI run exposed an unrelated stale transient-retry assertion in `assistant-failure.test.ts`. Main fixed it in #139519; this branch was rebased onto that repair without changing its patch.
