### PR TITLE
fix: speed up model filtering and preserve async tool results

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -50,7 +50,7 @@ TUI, REST, or SSE clients.
 
 ## Where this runs
 
-All transcript hygiene is centralized in the embedded runner:
+The embedded runner selects and applies transcript policy:
 
 - Policy selection: `src/agents/transcript-policy.ts`
   (`resolveTranscriptPolicy`, keyed on `provider`, `modelApi`, and `modelId`)
@@ -107,6 +107,12 @@ extras are dropped and missing occurrences receive synthetic error results.
 
 Implementation: `sanitizeToolUseResultPairing` in
 `src/agents/session-transcript-repair.ts`
+
+When switching models, provider replay moves delayed asynchronous tool results
+next to their originating call before removing the source model's async metadata.
+Call and result IDs are trimmed before matching, so surrounding whitespace does
+not turn a real result into a synthetic missing-result error. This projection
+runs in `packages/ai/src/transcript-transform.ts` and leaves stored history intact.
 
 ---
 

--- a/packages/ai/src/providers/transform-messages.test.ts
+++ b/packages/ai/src/providers/transform-messages.test.ts
@@ -139,14 +139,22 @@ describe("transformMessages", () => {
     expect(projected[2]).toBe(metadata);
   });
 
-  it("pairs trimmed replay tool call and result ids without synthesizing an error", () => {
-    const messages = [
-      {
+  it.each([
+    ["synchronous call", false, " call_1 ", "call_1"],
+    ["synchronous result", false, "call_1", " call_1 "],
+    ["asynchronous call", true, " call_1 ", "call_1"],
+    ["asynchronous result", true, "call_1", " call_1 "],
+  ] as const)(
+    "pairs padded %s ids without synthesizing an error",
+    (_name, async, id, toolCallId) => {
+      const assistant: Extract<Message, { role: "assistant" }> = {
         role: "assistant",
-        content: [{ type: "toolCall", id: " call_1 ", name: "lookup", arguments: {} }],
+        content: [
+          { type: "toolCall", id, name: "lookup", arguments: {}, ...(async ? { async } : {}) },
+        ],
         api: model.api,
         provider: model.provider,
-        model: model.id,
+        model: async ? "source-model" : model.id,
         usage: {
           input: 0,
           output: 0,
@@ -157,57 +165,40 @@ describe("transformMessages", () => {
         },
         stopReason: "toolUse",
         timestamp: 1,
-      },
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "lookup",
-        content: [{ type: "text", text: "actual result" }],
-        isError: false,
-        timestamp: 2,
-      },
-    ] as Message[];
-
-    const transformed = transformMessages(messages, model);
-
-    expect(transformed).toHaveLength(2);
-    expect(transformed[0]?.content).toEqual([
-      { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
-    ]);
-    expect(transformed[1]).toMatchObject({ role: "toolResult", toolCallId: "call_1" });
-
-    const transformedPaddedResult = transformMessages(
-      [
-        {
-          role: "assistant",
-          content: [{ type: "toolCall", id: "call_2", name: "lookup", arguments: {} }],
-          api: model.api,
-          provider: model.provider,
-          model: model.id,
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
-          stopReason: "toolUse",
-          timestamp: 3,
-        },
+      };
+      const messages: Message[] = [
+        assistant,
+        ...(async
+          ? [{ ...assistant, content: [{ type: "text" as const, text: "later answer" }] }]
+          : []),
         {
           role: "toolResult",
-          toolCallId: " call_2 ",
+          toolCallId,
           toolName: "lookup",
           content: [{ type: "text", text: "actual result" }],
           isError: false,
-          timestamp: 4,
+          timestamp: 2,
         },
-      ] as Message[],
-      model,
-    );
+      ];
+      const original = structuredClone(messages);
 
-    expect(transformedPaddedResult).toHaveLength(2);
-    expect(transformedPaddedResult[1]).toMatchObject({ role: "toolResult", toolCallId: "call_2" });
-  });
+      const transformed = transformMessages(messages, model);
+
+      expect(transformed.map((message) => message.role)).toEqual([
+        "assistant",
+        "toolResult",
+        ...(async ? ["assistant"] : []),
+      ]);
+      expect(transformed[0]?.content).toEqual([
+        { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
+      ]);
+      expect(transformed[1]).toMatchObject({
+        role: "toolResult",
+        toolCallId: "call_1",
+        isError: false,
+        content: [{ type: "text", text: "actual result" }],
+      });
+      expect(messages).toEqual(original);
+    },
+  );
 });

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -34,26 +34,6 @@ function replaceImagesWithPlaceholder(
   return result;
 }
 
-function downgradeUnsupportedImages<TApi extends Api>(
-  messages: Message[],
-  model: Model<TApi>,
-): Message[] {
-  if (model.input.includes("image")) {
-    return messages;
-  }
-
-  return messages.map((message) => {
-    if (message.role === "assistant" || typeof message.content === "string") {
-      return message;
-    }
-    const placeholder =
-      message.role === "user"
-        ? NON_VISION_USER_IMAGE_PLACEHOLDER
-        : NON_VISION_TOOL_IMAGE_PLACEHOLDER;
-    return { ...message, content: replaceImagesWithPlaceholder(message.content, placeholder) };
-  });
-}
-
 function transformAssistant<TApi extends Api>(
   message: AssistantMessage,
   model: Model<TApi>,
@@ -102,12 +82,12 @@ function transformAssistant<TApi extends Api>(
     if (block.type === "text") {
       return sameModel ? block : { type: "text" as const, text: block.text };
     }
-    const { thoughtSignature: _, async: _async, ...unsigned } = block;
     // Pairing uses these IDs as shared keys, before model-specific normalization runs.
     const trimmedId = block.id.trim();
     if (sameModel) {
       return trimmedId === block.id ? block : Object.assign({}, block, { id: trimmedId });
     }
+    const { thoughtSignature: _, async: _async, ...unsigned } = block;
     const id = normalizeToolCallId?.(trimmedId, model, message) ?? trimmedId;
     if (id !== trimmedId) {
       toolCallIdMap.set(trimmedId, id);
@@ -136,21 +116,23 @@ export function transformMessages<TApi extends Api>(
         message.model === model.id;
       for (const block of message.content ?? []) {
         if (block.type === "toolCall") {
+          const id = block.id.trim();
           if (block.async && !sameModel) {
-            asyncOwners.set(block.id, message);
+            asyncOwners.set(id, message);
           } else {
-            asyncOwners.delete(block.id);
+            asyncOwners.delete(id);
           }
         }
       }
     } else if (message.role === "toolResult") {
-      const owner = asyncOwners.get(message.toolCallId);
+      const id = message.toolCallId.trim();
+      const owner = asyncOwners.get(id);
       if (owner) {
         const results = relocated.get(owner) ?? [];
         results.push(message);
         relocated.set(owner, results);
         movedResults.add(message);
-        asyncOwners.delete(message.toolCallId);
+        asyncOwners.delete(id);
       }
     }
   }
@@ -162,21 +144,7 @@ export function transformMessages<TApi extends Api>(
             : [message, ...(message.role === "assistant" ? (relocated.get(message) ?? []) : [])],
         )
       : messages;
-  const normalized = source.map((message) =>
-    message.content == null ? Object.assign({}, message, { content: [] }) : message,
-  );
-  const transformed = downgradeUnsupportedImages(normalized, model).map((message) => {
-    if (message.role === "assistant") {
-      return transformAssistant(message, model, toolCallIdMap, normalizeToolCallId);
-    }
-    if (message.role !== "toolResult") {
-      return message;
-    }
-    const trimmedId = message.toolCallId.trim();
-    const toolCallId = toolCallIdMap.get(trimmedId) ?? trimmedId;
-    return toolCallId === message.toolCallId ? message : Object.assign({}, message, { toolCallId });
-  });
-
+  const supportsImages = model.input.includes("image");
   const result: Message[] = [];
   const pendingAsyncCalls = new Map<string, ToolCall>();
   let pendingToolCalls: ToolCall[] = [];
@@ -198,8 +166,12 @@ export function transformMessages<TApi extends Api>(
     existingToolResultIds = new Set();
   };
 
-  for (const message of transformed) {
+  for (let message of source) {
+    if (message.content == null) {
+      message = { ...message, content: [] };
+    }
     if (message.role === "assistant") {
+      message = transformAssistant(message, model, toolCallIdMap, normalizeToolCallId);
       flushToolCalls();
       if (message.stopReason === "error" || message.stopReason === "aborted") {
         continue;
@@ -214,11 +186,29 @@ export function transformMessages<TApi extends Api>(
         }
         return true;
       });
-    } else if (message.role === "toolResult") {
-      existingToolResultIds.add(message.toolCallId);
-      pendingAsyncCalls.delete(message.toolCallId);
     } else {
-      flushToolCalls();
+      if (!supportsImages && typeof message.content !== "string") {
+        message = {
+          ...message,
+          content: replaceImagesWithPlaceholder(
+            message.content,
+            message.role === "user"
+              ? NON_VISION_USER_IMAGE_PLACEHOLDER
+              : NON_VISION_TOOL_IMAGE_PLACEHOLDER,
+          ),
+        };
+      }
+      if (message.role === "toolResult") {
+        const trimmedId = message.toolCallId.trim();
+        const toolCallId = toolCallIdMap.get(trimmedId) ?? trimmedId;
+        if (toolCallId !== message.toolCallId) {
+          message = { ...message, toolCallId };
+        }
+        existingToolResultIds.add(toolCallId);
+        pendingAsyncCalls.delete(toolCallId);
+      } else {
+        flushToolCalls();
+      }
     }
     result.push(message);
   }

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -88,6 +88,11 @@ describe("createReasoningTagTextPartitioner", () => {
       expected: { text: "a\r\n    ", thinking: "x" },
     },
     {
+      name: "a whitespace-only CRLF blank line starts a new indented code block",
+      input: "a\r\n \t\r\n    <think>x</think>",
+      expected: { text: "a\r\n \t\r\n    <think>x</think>", thinking: "" },
+    },
+    {
       name: "compaction retains context for a following empty list item",
       input: "    `\n\n-\n      <think>x</think>",
       expected: { text: "    `\n\n-\n      ", thinking: "x" },

--- a/packages/markdown-core/src/reasoning-tags.ts
+++ b/packages/markdown-core/src/reasoning-tags.ts
@@ -24,7 +24,22 @@ export {
 export type { ReasoningTagTextDelta } from "./reasoning-tag-parser.js";
 
 const MARKDOWN_CONTAINER_LINE_RE = /^(?: {0,3}(?:>|[-+*][\t ]|\d{1,9}[.)][\t ]))/mu;
-const BLANK_BOUNDARY_RE = /(?:\r\n|\r(?!\n)|\n)[\t ]*(?:\r\n|\r(?!\n)|\n)$/u;
+
+function endsBlankBlock(text: string): boolean {
+  let cursor = text.length - 1;
+  if (text[cursor] === "\n") {
+    cursor -= text[cursor - 1] === "\r" ? 2 : 1;
+  } else if (text[cursor] === "\r") {
+    cursor -= 1;
+  } else {
+    return false;
+  }
+  // Walk only the final blank line; a forward suffix regex rescans growing paragraphs.
+  while (text[cursor] === " " || text[cursor] === "\t") {
+    cursor -= 1;
+  }
+  return text[cursor] === "\n" || text[cursor] === "\r";
+}
 
 type PendingTagProbe = {
   nameResolved: boolean;
@@ -91,6 +106,7 @@ export interface ReasoningTagTextPartitioner {
 export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner {
   const reduction: ReductionState = { depth: 0, visibleEver: false };
   let source = "";
+  let endedBlankBlock = false;
   let blockStart = 0;
   let emitted = 0;
   let holdStart: number | undefined;
@@ -108,6 +124,7 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
 
   const compactCommittedSource = (retainStart: number) => {
     source = source.slice(retainStart);
+    endedBlankBlock = endsBlankBlock(source);
     blockStart = source.length;
     emitted = source.length;
     holdStart = undefined;
@@ -380,7 +397,7 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
       !final &&
       reduction.depth === 0 &&
       emitted === source.length &&
-      BLANK_BOUNDARY_RE.test(source) &&
+      endedBlankBlock &&
       !MARKDOWN_CONTAINER_LINE_RE.test(source.slice(blockRetainStart ?? 0)) &&
       !blockCodeSpans?.some(([, spanEnd]) => spanEnd === source.length)
     ) {
@@ -391,12 +408,14 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
     return true;
   };
 
-  const consume = (chunk: string, strict: boolean, final: boolean) => {
+  const consume = (appended: string, strict: boolean, final: boolean) => {
     strictMode ||= strict;
-    const previousLength = source.length;
-    const previousEndedBlankBlock = BLANK_BOUNDARY_RE.test(source);
-    source += chunk;
-    const appended = source.slice(previousLength);
+    const previousEndedBlankBlock = endedBlankBlock;
+    source += appended;
+    if (appended) {
+      endedBlankBlock =
+        (appended.endsWith("\n") || appended.endsWith("\r")) && endsBlankBlock(source);
+    }
     const appendedBlock = appended.replace(/^(?:\r\n|\r|\n)+/u, "");
     const appendedStartsTopLevelBlock =
       previousEndedBlankBlock &&
@@ -443,7 +462,7 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
                   ? 2
                   : 1),
             ) === -1);
-        const completedBlankBlock = BLANK_BOUNDARY_RE.test(source);
+        const completedBlankBlock = endedBlankBlock;
         const retainedContainerContext = MARKDOWN_CONTAINER_LINE_RE.test(
           source.slice(nonFinalRetainStart),
         );
@@ -498,9 +517,7 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
             heldBacktick && heldCodeSpan === undefined && completedBlankBlock;
           if ((!heldBacktick && !heldInOpenEndedCode) || stableCode || stableNonDelimiter) {
             let processEnd = source.length;
-            if (stableNonDelimiter) {
-              processEnd = source.length;
-            } else if (mayCloseTopLevelBlock) {
+            if (stableNonDelimiter || mayCloseTopLevelBlock) {
               processEnd = source.length;
             } else if (stableCode && heldCodeSpan) {
               processEnd = heldCodeSpan[1];
@@ -536,7 +553,7 @@ export function createReasoningTagTextPartitioner(): ReasoningTagTextPartitioner
         holdStart === undefined &&
         reduction.depth === 0 &&
         emitted === source.length &&
-        BLANK_BOUNDARY_RE.test(source) &&
+        endedBlankBlock &&
         (!MARKDOWN_CONTAINER_LINE_RE.test(source.slice(nonFinalRetainStart)) ||
           appendedStartsTopLevelBlock) &&
         nonFinalFullParses < 1

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -144,32 +144,12 @@ export function extractAssistantTextForPhase(
   const entry = message as { text?: unknown; content?: unknown; phase?: unknown };
   const messagePhase = normalizeAssistantPhase(entry.phase);
   const phase = options?.phase;
-  const shouldIncludeContent = (resolvedPhase?: AssistantPhase) => {
-    if (phase) {
-      return resolvedPhase === phase;
-    }
-    return resolvedPhase === undefined;
-  };
   const sanitizeText = options?.sanitizeText;
   const joinWith = options?.joinWith ?? "\n";
   const sanitizeBlockText = (text: string) => (sanitizeText ? sanitizeText(text) : text);
-  const normalizeJoinedText = (text: string) => {
-    const normalized = text.trim();
-    return normalized || undefined;
-  };
-
-  if (typeof entry.text === "string") {
-    if (!shouldIncludeContent(messagePhase)) {
-      return undefined;
-    }
-    return normalizeJoinedText(sanitizeBlockText(entry.text));
-  }
-
-  if (typeof entry.content === "string") {
-    if (!shouldIncludeContent(messagePhase)) {
-      return undefined;
-    }
-    return normalizeJoinedText(sanitizeBlockText(entry.content));
+  const inlineText = typeof entry.text === "string" ? entry.text : entry.content;
+  if (typeof inlineText === "string") {
+    return messagePhase === phase ? sanitizeBlockText(inlineText).trim() || undefined : undefined;
   }
 
   if (!Array.isArray(entry.content)) {
@@ -192,30 +172,26 @@ export function extractAssistantTextForPhase(
     return undefined;
   }
 
-  const parts = entry.content
-    .map((block) => {
-      if (!block || typeof block !== "object") {
-        return null;
-      }
-      const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
-      if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
-        return null;
-      }
-      const signature = parseAssistantTextSignature(record);
-      const resolvedPhase =
-        signature?.phase ?? (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
-      if (!shouldIncludeContent(resolvedPhase)) {
-        return null;
-      }
+  const parts: string[] = [];
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; text?: unknown; textSignature?: unknown };
+    if (!isAssistantTextContentBlockType(record.type) || typeof record.text !== "string") {
+      continue;
+    }
+    const resolvedPhase =
+      parseAssistantTextSignature(record)?.phase ??
+      (hasExplicitPhasedTextBlocks ? undefined : messagePhase);
+    if (resolvedPhase === phase) {
       const sanitized = sanitizeBlockText(record.text);
-      return sanitized.trim() ? sanitized : null;
-    })
-    .filter((value): value is string => typeof value === "string");
-
-  if (parts.length === 0) {
-    return undefined;
+      if (sanitized.trim()) {
+        parts.push(sanitized);
+      }
+    }
   }
-  return normalizeJoinedText(parts.join(joinWith));
+  return parts.join(joinWith).trim() || undefined;
 }
 
 /** Returns user-visible assistant text, preferring final answers over legacy unphased text. */

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -232,6 +232,15 @@ describe("stripAssistantInternalScaffolding", () => {
         expected: "prefix\n\nsuffix",
       },
       {
+        title: "preserves escaped quote state across repeated apparent closing tags",
+        prefix: "prefix",
+        openMarker: "<tool_call>",
+        payload: JSON.stringify({ html: '"</tool_call>', tail: "</tool_call> still hidden" }),
+        closeMarker: "</tool_call>",
+        suffix: "suffix",
+        expected: "prefix\n\nsuffix",
+      },
+      {
         title: "strips Gemma-style <function> with newlines between parameters (#67093)",
         prefix: "Let me check that.",
         openMarker: '<function name="read">',
@@ -418,6 +427,15 @@ describe("stripAssistantInternalScaffolding", () => {
         'Use <function> declarations. <parameter name="path">/tmp</parameter>',
         "Use <function> declarations. /tmp",
       );
+      expectVisibleText(
+        '<schema><other data="</schema>"><parameter name="path">/tmp</parameter>',
+        '<schema><other data="</schema>">/tmp',
+      );
+      expectVisibleText(
+        '`<schema data="` <parameter>x</parameter> "></schema>',
+        '`<schema data="` x "></schema>',
+      );
+      expectVisibleText("<schema>`</schema>`<parameter>x</parameter>", "<schema>`</schema>`x");
     });
 
     it("preserves XML-style explanations after lone <tool_call> tags", () => {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -54,35 +54,28 @@ const NESTED_JSON_TOOL_CALL_PAYLOAD_START_RE = /^\s*(?:\r?\n\s*)?<(?:function_ca
 
 type ToolCallPayloadKind = "json" | "xml" | null;
 
-function endsInsideQuotedString(text: string, start: number, end: number): boolean {
+function createQuotedStringScanner(text: string, start: number): (end: number) => boolean {
   let quoteChar: "'" | '"' | null = null;
   let isEscaped = false;
-
-  for (let idx = start; idx < end; idx += 1) {
-    const char = text[idx];
-    if (quoteChar === null) {
-      if (char === '"' || char === "'") {
-        quoteChar = char;
+  // Candidate closing tags share one monotonic scan through their payload.
+  let cursor = start;
+  return (end) => {
+    for (; cursor < end; cursor += 1) {
+      const char = text[cursor];
+      if (quoteChar === null) {
+        if (char === '"' || char === "'") {
+          quoteChar = char;
+        }
+      } else if (isEscaped) {
+        isEscaped = false;
+      } else if (char === "\\") {
+        isEscaped = true;
+      } else if (char === quoteChar) {
+        quoteChar = null;
       }
-      continue;
     }
-
-    if (isEscaped) {
-      isEscaped = false;
-      continue;
-    }
-
-    if (char === "\\") {
-      isEscaped = true;
-      continue;
-    }
-
-    if (char === quoteChar) {
-      quoteChar = null;
-    }
-  }
-
-  return quoteChar !== null;
+    return quoteChar !== null;
+  };
 }
 
 interface ParsedToolCallTag {
@@ -252,27 +245,36 @@ function parseToolCallTagAt(text: string, start: number): ParsedToolCallTag | nu
   return tag && TOOL_CALL_TAG_NAMES.has(tag.tagName) ? tag : null;
 }
 
-function hasMatchingXmlCloseTag(text: string, start: number, tagName: string): boolean {
-  let depth = 1;
-  for (let idx = start; idx < text.length; idx += 1) {
-    if (text[idx] !== "<") {
+function scanXmlTags(text: string, codeRegions: ReturnType<typeof findCodeRegions>) {
+  type Tag = ParsedToolCallTag & { start: number; hasMatchingClose: boolean };
+  const tags: Tag[] = [];
+  const openTags = new Map<string, Tag[]>();
+  for (let start = text.indexOf("<"); start !== -1; start = text.indexOf("<", start + 1)) {
+    if (isInsideCode(start, codeRegions)) {
       continue;
     }
-    const tag = parseXmlTagAt(text, idx);
-    if (!tag || tag.tagName !== tagName || tag.isTruncated) {
+    const parsed = parseXmlTagAt(text, start);
+    if (!parsed || parsed.isTruncated) {
       continue;
     }
+    const tag: Tag = { ...parsed, start, hasMatchingClose: false };
+    tags.push(tag);
+    const parents = openTags.get(tag.tagName);
     if (tag.isClose) {
-      depth -= 1;
-      if (depth === 0) {
-        return true;
+      const opening = parents?.pop();
+      if (opening) {
+        opening.hasMatchingClose = true;
       }
     } else if (!tag.isSelfClosing) {
-      depth += 1;
+      if (parents) {
+        parents.push(tag);
+      } else {
+        openTags.set(tag.tagName, [tag]);
+      }
     }
-    idx = Math.max(idx, tag.end - 1);
+    start = tag.end - 1;
   }
-  return false;
+  return tags;
 }
 
 function isDanglingFunctionParameterParent(text: string, tag: ParsedToolCallTag): boolean {
@@ -313,14 +315,8 @@ function unwrapStandaloneParameterTags(text: string): string {
   let result = "";
   let lastIndex = 0;
 
-  for (let idx = 0; idx < text.length; idx += 1) {
-    if (text[idx] !== "<" || isInsideCode(idx, codeRegions)) {
-      continue;
-    }
-    const tag = parseXmlTagAt(text, idx);
-    if (!tag || tag.isTruncated) {
-      continue;
-    }
+  for (const tag of scanXmlTags(text, codeRegions)) {
+    const idx = tag.start;
 
     if (tag.isClose) {
       const openIndex = openTags.findLastIndex((entry) => entry.name === tag.tagName);
@@ -343,10 +339,7 @@ function unwrapStandaloneParameterTags(text: string): string {
         result += text.slice(lastIndex, idx);
         lastIndex = tag.end;
       }
-    } else if (
-      hasMatchingXmlCloseTag(text, tag.end, tag.tagName) ||
-      isDanglingFunctionParameterParent(text, tag)
-    ) {
+    } else if (tag.hasMatchingClose || isDanglingFunctionParameterParent(text, tag)) {
       const unwrap = tag.tagName === "parameter" && openTags.length === 0;
       let trimBoundaryLineBreaks = false;
       if (unwrap) {
@@ -360,7 +353,6 @@ function unwrapStandaloneParameterTags(text: string): string {
       }
       openTags.push({ name: tag.tagName, unwrap, trimBoundaryLineBreaks });
     }
-    idx = Math.max(idx, tag.end - 1);
   }
 
   return result + text.slice(lastIndex);
@@ -381,9 +373,7 @@ export function stripToolCallXmlTags(
   const codeRegions = findCodeRegions(text);
   let result = "";
   let lastIndex = 0;
-  let inToolCallBlock = false;
-  let toolCallBlockContentStart = 0;
-  let toolCallBlockNeedsQuoteBalance = false;
+  let isInsidePayloadQuote: ((end: number) => boolean) | undefined;
   let toolCallBlockStart = 0;
   let toolCallBlockTagName: string | null = null;
   let lastStrippedToolCallBlockEnd: number | null = null;
@@ -393,7 +383,7 @@ export function stripToolCallXmlTags(
     if (text[idx] !== "<") {
       continue;
     }
-    if (!inToolCallBlock && isInsideCode(idx, codeRegions)) {
+    if (toolCallBlockTagName === null && isInsideCode(idx, codeRegions)) {
       continue;
     }
 
@@ -402,7 +392,7 @@ export function stripToolCallXmlTags(
       continue;
     }
 
-    if (!inToolCallBlock) {
+    if (toolCallBlockTagName === null) {
       result += text.slice(lastIndex, idx);
       if (tag.isClose) {
         if (tag.isTruncated) {
@@ -466,11 +456,11 @@ export function stripToolCallXmlTags(
             isLineStartAt(result, result.length) &&
             isLineEndAfter(text, tag.end)));
       if ((payloadKind && shouldStripStandaloneFunction) || shouldStripStandaloneResult) {
-        inToolCallBlock = true;
-        toolCallBlockContentStart = tag.end;
-        toolCallBlockNeedsQuoteBalance =
+        isInsidePayloadQuote =
           payloadKind === "json" ||
-          (payloadKind === "xml" && startsWithNestedJsonToolCallPayload(text, payloadStart));
+          (payloadKind === "xml" && startsWithNestedJsonToolCallPayload(text, payloadStart))
+            ? createQuotedStringScanner(text, tag.end)
+            : undefined;
         toolCallBlockStart = idx;
         toolCallBlockTagName = tag.tagName;
         if (tag.isTruncated) {
@@ -491,23 +481,18 @@ export function stripToolCallXmlTags(
       tag.isClose &&
       (tag.tagName === toolCallBlockTagName ||
         (toolCallBlockTagName === "tool_result" && tag.tagName === "tool_call")) &&
-      (!toolCallBlockNeedsQuoteBalance ||
-        !endsInsideQuotedString(text, toolCallBlockContentStart, idx))
+      !isInsidePayloadQuote?.(idx)
     ) {
-      const closedBlockTagName = toolCallBlockTagName;
-      inToolCallBlock = false;
-      toolCallBlockNeedsQuoteBalance = false;
+      isInsidePayloadQuote = undefined;
       toolCallBlockTagName = null;
-      if (closedBlockTagName) {
-        lastStrippedToolCallBlockEnd = tag.end;
-      }
+      lastStrippedToolCallBlockEnd = tag.end;
     }
 
     lastIndex = tag.end;
     idx = Math.max(idx, tag.end - 1);
   }
 
-  if (!inToolCallBlock) {
+  if (toolCallBlockTagName === null) {
     result += text.slice(lastIndex);
   } else if (toolCallBlockTagName === "function") {
     result += text.slice(toolCallBlockStart);


### PR DESCRIPTION
Closes #139515

## What Problem This Solves

Long model replies repeatedly rescan growing paragraphs and XML payloads, making filtering increasingly expensive. Switching models can also produce a false `No result provided` for a delayed async tool result when only one side of the call/result ID contains surrounding whitespace.

Related: #123120, whose native append evidence and queued-redaction protections remain intact. Thanks to @nierob-cmd for the original reasoning-stream performance investigation.

## Why This Change Was Made

Replay normalization, media projection, model conversion, and result pairing now share one traversal after async relocation, using consistently trimmed ownership keys. Streaming parsing carries blank-boundary state, XML matching uses one quote-aware tag scan, and quoted-payload filtering advances a single cursor. Shared phase extraction drops redundant wrappers and intermediate arrays.

Production is **−32 lines**; tests are **+14 lines**. Native append ownership, empty final-answer behavior, Markdown code examples, and stored transcript contents are preserved. The XML parser also stops treating closing tags inside attributes or code as real parent boundaries.

## User Impact

Long replies spend less CPU time filtering text, and real async tool results survive cross-model replay without invented failures. Literal code examples stay visible and tool payloads remain suppressed.

## Evidence

- Twelve focused test files passed across five Vitest groups, including native thinking lifetime, incremental/buffered Bedrock redaction, replay pairing, chunk boundaries, XML, phases, and text projection.
- Full `check:changed` passed, including production/test typechecks, lint, export scans, import cycles, and selected repository guards.
- Deterministic comparisons: 488,281 suffix cases, 36,804 per-chunk/final parser comparisons, 5,000 XML parity inputs, and 21,834 assistant-phase cases. Async padded-ID and malformed XML cases were reproduced on the original code before repair.
- Two authenticated OpenAI `gpt-4.1-mini` Completions runs exercised the native provider, agent loop, and subscription. Both sent one real delayed tool result, no synthetic failure, preserved a fenced `<think>` example, and delivered the final marker. The complete-patch run produced 374 text deltas and 373 visible events from one HTTP 200 request. [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33992440235); delegated command exit code was zero and the lease was stopped.
- Two independent Codex P0–P2 reviews, including a fresh pre-commit review, found no actionable defects.

Synthetic timings on macOS / Node 26.8.1, against main at cfe5477908b9a2bc6b189fe8f503d87b8ed08eee:

| Operation | Before | After |
| --- | ---: | ---: |
| 10,000 same-model tool messages, paired batch medians | 5.51 ms | 4.53 ms |
| 10,000 text-only media replay messages, paired batch medians | 1.495 ms | 1.436 ms |
| 256 KiB paragraph in 32-byte chunks, strict parser, median of three | 417.5 ms | 50.9 ms |
| Same paragraph, visible parser, median of three | 1078.7 ms | 247.1 ms |
| 2,000 nested XML wrappers | 278 ms | 1.4 ms |
| 2,000 quoted closing tags | 62.2 ms | 0.36 ms |

Strict-parser peak process RSS decreased from 244.9 to 136.4 MiB; visible-parser peak RSS was essentially unchanged. These are synthetic operation measurements, not provider latency or retained-heap claims. Visible streaming still has growing-string costs; this does not claim the entire pipeline is linear.

### Initial integration CI

[Run 33999384119](https://github.com/openclaw/openclaw/actions/runs/33999384119) failed in two shards because the merge baseline contains a stale assertion in `assistant-failure.test.ts`: it checks `fixture.input.failover.maybeRetryTransient`, which is absent from the fixture/controller surface. The type shard reports TS2339 and the test shard reports that `undefined` is not a spy. This file is unchanged by this PR. The same repair landed on main in #139519 (d5c988086f3). This PR was rebased onto corrected main; `git range-diff` confirmed the eight-file patch is unchanged. [Refreshed integration CI 34000328006](https://github.com/openclaw/openclaw/actions/runs/34000328006) passed on rebased head `387904859a65859601a35dd802f03aa114013f30`. Native prepare and merge verified that exact head; landed as `75c7f919326d1bcc81e5e216346ccd03189a3e05`.
