### PR TITLE
fix(ui): show shimmer skeletons while loading Control UI

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -21,6 +21,8 @@ For unmatched HTTP paths, the app-shell fallback respects the request's `Accept`
 
 It speaks **directly to the Gateway WebSocket** on the same port.
 
+While the initial connection or a route loads, shimmer placeholders reserve the chat layout. They respect your theme and reduced-motion preference; Gateway startup progress remains visible when available.
+
 Closed Terminal, Browser, Desktop, and Home/Ask OpenClaw panels initialize when you open them rather than during initial navigation. Panels saved as open still restore after a reload.
 
 While you watch a running session, the Gateway shows the model's latest safe preamble immediately as the session headline. When a utility model is available, it can replace that headline with a richer compact status digest after enough activity accumulates. Chat carries the result in a **session rail**: its compact pill shows the live digest, while the expanded rail shows the assessment, plan progress, pull requests, elapsed time, and a read-only Side chat thread. The rail can expand once when a run becomes stuck or needs input, and done or failed runs keep a frozen “finished” time based on the final digest. On wide chat panes the expanded rail docks as a 400 px right column; on narrower and mobile layouts it remains an overlay.

--- a/ui/src/app/app-host.gateway-lineage.test.ts
+++ b/ui/src/app/app-host.gateway-lineage.test.ts
@@ -422,7 +422,7 @@ describe("Control UI Gateway target lineage", () => {
     const surface = renderGatewaySurface(gateway);
 
     expect(gateway.snapshot.phase).toBe("starting");
-    expect(surface).toContain('class="connect-splash"');
+    expect(surface).toContain('class="connect-splash connect-splash--skeleton"');
     expect(surface).toContain("Gateway starting…");
     expect(surface).not.toContain("<openclaw-login-gate");
   });
@@ -500,7 +500,7 @@ describe("Control UI Gateway target lineage", () => {
 
       const surface = renderGatewaySurface(gateway, documentView);
 
-      expect(surface).toContain('class="connect-splash"');
+      expect(surface).toContain('class="connect-splash connect-splash--skeleton"');
       expect(surface).toContain("Gateway starting…");
     },
   );

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -7,8 +7,8 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { RouteId } from "../app-routes.ts";
 import "../components/gateway-url-confirmation.ts";
 import "../components/github-link-hovercard-registration.ts";
-import "../components/openclaw-mascot.ts";
 import { renderLazyElementState, renderLazyViewError } from "../components/lazy-view-error.ts";
+import { renderConnectingSplash } from "../components/loading-skeleton.ts";
 import { installTitleTooltips } from "../components/tooltip-title.ts";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
@@ -48,20 +48,6 @@ function routeLocationHref(location: RouteLocation): string {
 
 function isRouteNotFound(result: ChatRouteData | RouteNotFound): result is RouteNotFound {
   return "type" in result && result.type === "notFound";
-}
-
-function renderConnectingSplash(status?: string) {
-  return html`
-    <main
-      class="connect-splash"
-      role="status"
-      aria-live="polite"
-      aria-label=${status ?? t("common.loading")}
-    >
-      <openclaw-mascot mood="thinking" .size=${120}></openclaw-mascot>
-      ${status ? html`<span class="connect-splash__status">${status}</span>` : nothing}
-    </main>
-  `;
 }
 
 export class OpenClawApp extends OpenClawLightDomElement {

--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -5,6 +5,7 @@ import { isSessionRouteId } from "../app-route-paths.ts";
 import { isRouteId, type RouteId } from "../app-routes.ts";
 import { icons } from "../components/icons.ts";
 import { renderLazyElementModal } from "../components/lazy-view-error.ts";
+import { renderConnectingSplash } from "../components/loading-skeleton.ts";
 import { renderNewSessionLink } from "../components/new-session-link.ts";
 import {
   renderLazySettingsSidebar,
@@ -171,9 +172,7 @@ export function renderApplicationShell(host: ShellViewHost) {
     return nothing;
   }
   if (host.routeState.routeId === undefined) {
-    return html`<main class="connect-splash" role="status" aria-label=${t("common.loading")}>
-      <openclaw-mascot mood="thinking" .size=${120}></openclaw-mascot>
-    </main>`;
+    return renderConnectingSplash();
   }
   const gatewaySnapshot = context.gateway.snapshot;
   const config = context.config.current;

--- a/ui/src/app/router-outlet.test.ts
+++ b/ui/src/app/router-outlet.test.ts
@@ -122,7 +122,7 @@ describe("openclaw-router-outlet", () => {
     router.stop();
   });
 
-  it("replaces the centered loading mascot with the resolved route", async () => {
+  it("replaces the loading skeleton with the resolved route", async () => {
     vi.useFakeTimers();
     const routeModule = deferred<TestModule>();
     const context = { label: "loaded" };
@@ -147,7 +147,10 @@ describe("openclaw-router-outlet", () => {
 
     const loadingState = outlet.querySelector('[role="status"]');
     expect(loadingState?.getAttribute("aria-label")).toBe("Loading…");
-    expect(loadingState?.querySelector("openclaw-mascot")?.getAttribute("mood")).toBe("thinking");
+    expect(loadingState?.querySelector(".loading-skeleton")?.getAttribute("aria-hidden")).toBe(
+      "true",
+    );
+    expect(loadingState?.getAttribute("aria-busy")).toBeNull();
     expect(loadingState?.textContent?.trim()).toBe("");
     expect(outlet.textContent).not.toContain("Loading panel");
 
@@ -159,7 +162,7 @@ describe("openclaw-router-outlet", () => {
 
     expect(outlet.querySelector('[data-testid="route-page"]')?.textContent).toBe("loaded");
     expect(outlet.querySelector('[role="status"]')).toBeNull();
-    expect(outlet.querySelector("openclaw-mascot")).toBeNull();
+    expect(outlet.querySelector(".loading-skeleton")).toBeNull();
     outlet.remove();
     router.stop();
   });

--- a/ui/src/components/loading-skeleton.ts
+++ b/ui/src/components/loading-skeleton.ts
@@ -1,0 +1,45 @@
+import { html, nothing } from "lit";
+import { t } from "../i18n/index.ts";
+
+export function renderLoadingSkeleton() {
+  return html`<div class="loading-skeleton" aria-hidden="true">
+    <div class="loading-skeleton__header">
+      <div class="skeleton loading-skeleton__avatar"></div>
+      <div class="skeleton skeleton-line loading-skeleton__title"></div>
+    </div>
+    <div class="loading-skeleton__messages">
+      <div class="loading-skeleton__message loading-skeleton__message--user">
+        <div class="skeleton skeleton-line"></div>
+        <div class="skeleton skeleton-line skeleton-line--medium"></div>
+      </div>
+      <div class="loading-skeleton__message">
+        <div class="skeleton loading-skeleton__avatar"></div>
+        <div class="skeleton skeleton-line"></div>
+        <div class="skeleton skeleton-line skeleton-line--long"></div>
+        <div class="skeleton skeleton-line skeleton-line--medium"></div>
+      </div>
+    </div>
+    <div class="skeleton loading-skeleton__composer"></div>
+  </div>`;
+}
+
+export function renderConnectingSplash(status?: string) {
+  return html`<main
+    class="connect-splash connect-splash--skeleton"
+    role="status"
+    aria-live="polite"
+    aria-label=${status ?? t("common.loading")}
+  >
+    <div class="connect-splash__layout" aria-hidden="true">
+      <aside class="connect-splash__sidebar">
+        <div class="skeleton loading-skeleton__avatar"></div>
+        <div class="skeleton connect-splash__new-session"></div>
+        ${[85, 65, 75, 55, 80, 60].map(
+          (width) => html`<div class="skeleton skeleton-line" style=${`width: ${width}%`}></div>`,
+        )}
+      </aside>
+      ${renderLoadingSkeleton()}
+    </div>
+    ${status ? html`<span class="connect-splash__status">${status}</span>` : nothing}
+  </main>`;
+}

--- a/ui/src/components/loading-state.ts
+++ b/ui/src/components/loading-state.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { t } from "../i18n/index.ts";
-import "./openclaw-mascot.ts";
+import { renderLoadingSkeleton } from "./loading-skeleton.ts";
 
 export function renderLoadingState() {
   return html`
@@ -10,7 +10,7 @@ export function renderLoadingState() {
       aria-live="polite"
       aria-label=${t("common.loading")}
     >
-      <openclaw-mascot mood="thinking" .size=${120}></openclaw-mascot>
+      ${renderLoadingSkeleton()}
     </section>
   `;
 }

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -174,26 +174,36 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await gateway.waitForRequest("connect");
     const splash = page.locator(".connect-splash");
     await splash.waitFor();
-    const mascot = splash.locator('openclaw-mascot[mood="thinking"]');
-    await mascot.waitFor();
-    const mascotBounds = await mascot.boundingBox();
-    expect(mascotBounds).not.toBeNull();
-    expect(
-      Math.abs((mascotBounds?.x ?? 0) + (mascotBounds?.width ?? 0) / 2 - viewport.width / 2),
-    ).toBeLessThanOrEqual(1);
-    expect(
-      Math.abs((mascotBounds?.y ?? 0) + (mascotBounds?.height ?? 0) / 2 - viewport.height / 2),
-    ).toBeLessThanOrEqual(1);
+    const skeleton = splash.locator(".loading-skeleton");
+    await skeleton.waitFor();
+    expect(await splash.getAttribute("aria-busy")).toBeNull();
+    expect(await splash.locator("openclaw-mascot").count()).toBe(0);
     expect(await page.getByText("Loading panel", { exact: true }).count()).toBe(0);
     expect(await page.locator("openclaw-app-sidebar").count()).toBe(0);
     expect(await page.locator("openclaw-login-gate").count()).toBe(0);
-    // Inspect the compositor output, not the mascot's already-painted backing canvas.
-    // This regression runs in memory even when optional artifact retention is off.
-    const proof = await takeProofScreenshot(page, "01-centered-connecting-mascot", [
-      mascot.locator("canvas"),
+    const proof = await takeProofScreenshot(page, "01-connecting-shimmer", [
+      skeleton.locator(".loading-skeleton__composer"),
     ]);
-    const painted = await proofContentPainted(page, proof, mascot);
-    expect(painted, "connecting proof must contain the centered mascot").toBe(true);
+    const painted = await proofContentPainted(page, proof, skeleton);
+    expect(painted, "connecting proof must contain the skeleton").toBe(true);
+    const highlight = skeleton.locator(".loading-skeleton__composer");
+    expect(
+      await highlight.evaluate((element) => getComputedStyle(element, "::after").animationName),
+    ).toBe("shimmer");
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    expect(await splash.locator(".connect-splash__sidebar").isVisible()).toBe(false);
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(
+      true,
+    );
+    expect(
+      await highlight.evaluate((element) =>
+        Number.parseFloat(getComputedStyle(element, "::after").animationDuration),
+      ),
+    ).toBeLessThanOrEqual(0.00001);
+    await captureProof(page, "01-mobile-reduced-motion", [highlight]);
+    await page.setViewportSize(viewport);
+    await page.emulateMedia({ reducedMotion: "no-preference" });
 
     await gateway.resolveDeferred("connect");
     await page.locator("openclaw-app-shell").waitFor();
@@ -206,7 +216,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     ]);
   });
 
-  it("centers the animated mascot until the chat route finishes loading", async () => {
+  it("shows a shimmer skeleton until the chat route finishes loading", async () => {
     const page = await createPage();
     let chatModuleRequested = false;
     let releaseChatModule!: () => void;
@@ -236,29 +246,13 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       expect((await loadingState.textContent())?.trim()).toBe("");
       expect(await page.getByText("Loading panel", { exact: true }).count()).toBe(0);
 
-      const mascot = loadingState.locator('openclaw-mascot[mood="thinking"]');
-      await mascot.waitFor();
-      const [loadingBounds, mascotBounds] = await Promise.all([
-        loadingState.boundingBox(),
-        mascot.boundingBox(),
+      const skeleton = loadingState.locator(".loading-skeleton");
+      await skeleton.waitFor();
+      expect(await loadingState.getAttribute("aria-busy")).toBeNull();
+      expect(await loadingState.locator("openclaw-mascot").count()).toBe(0);
+      await captureProof(page, "03-pending-chat-shimmer", [
+        skeleton.locator(".loading-skeleton__composer"),
       ]);
-      expect(loadingBounds).not.toBeNull();
-      expect(mascotBounds).not.toBeNull();
-      expect(
-        Math.abs(
-          (mascotBounds?.x ?? 0) +
-            (mascotBounds?.width ?? 0) / 2 -
-            ((loadingBounds?.x ?? 0) + (loadingBounds?.width ?? 0) / 2),
-        ),
-      ).toBeLessThanOrEqual(1);
-      expect(
-        Math.abs(
-          (mascotBounds?.y ?? 0) +
-            (mascotBounds?.height ?? 0) / 2 -
-            ((loadingBounds?.y ?? 0) + (loadingBounds?.height ?? 0) / 2),
-        ),
-      ).toBeLessThanOrEqual(1);
-      await captureProof(page, "03-centered-pending-chat-mascot", [mascot.locator("canvas")]);
 
       releaseChatModule();
       await page.locator("openclaw-chat-page").waitFor();
@@ -282,8 +276,8 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await page.locator(".connect-splash").waitFor();
     expect(await page.locator("openclaw-login-gate").count()).toBe(0);
     expect(await loginGateMounted()).toBe(false);
-    await captureProof(page, "05-credentialless-connecting-mascot", [
-      page.locator(".connect-splash openclaw-mascot canvas"),
+    await captureProof(page, "05-credentialless-connecting-shimmer", [
+      page.locator(".connect-splash .loading-skeleton__composer"),
     ]);
 
     await gateway.resolveDeferred("connect");
@@ -799,7 +793,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       .poll(async () => await splash.evaluate((element) => getComputedStyle(element).opacity))
       .toBe("1");
     await captureProof(page, "06-gateway-starting-progress", [
-      splash.locator("openclaw-mascot canvas"),
+      splash.locator(".loading-skeleton__composer"),
     ]);
 
     await expect

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -22,6 +22,115 @@
   font-size: 14px;
 }
 
+.connect-splash--skeleton {
+  position: relative;
+  align-items: stretch;
+}
+
+.connect-splash__layout {
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.connect-splash__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding: 28px 24px;
+  border-right: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.connect-splash__new-session {
+  height: 40px;
+  margin: 16px 0;
+}
+
+.connect-splash--skeleton .connect-splash__status {
+  position: absolute;
+  inset: auto 24px 12px;
+  margin: 0;
+  text-align: center;
+}
+
+.loading-skeleton {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: min(50dvh, 360px);
+  padding: 24px 32px 40px;
+}
+
+.loading-skeleton__header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.loading-skeleton__avatar {
+  flex: none;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+}
+
+.loading-skeleton__title {
+  width: 140px;
+}
+
+.loading-skeleton__messages {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 48px;
+  width: min(100%, 760px);
+  margin: 24px auto 0;
+}
+
+.loading-skeleton__message {
+  display: grid;
+  gap: 14px;
+  width: 85%;
+}
+
+.loading-skeleton__message--user {
+  align-self: flex-end;
+  width: 48%;
+}
+
+.loading-skeleton__composer {
+  flex: none;
+  width: min(100%, 760px);
+  height: 112px;
+  margin: auto auto 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+@media (max-width: 768px) {
+  .connect-splash__layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .connect-splash__sidebar {
+    display: none;
+  }
+
+  .loading-skeleton {
+    gap: 24px;
+    padding: 20px 20px 40px;
+  }
+}
+
 openclaw-session-owner-chip {
   display: inline-flex;
   flex: none;
@@ -1619,7 +1728,7 @@ select.input {
   color: var(--ok);
 }
 
-/* Pending routes share the native mascot without exposing transient panel text. */
+/* Pending routes reserve the content layout without exposing transient panel text. */
 .lazy-view-state--loading {
   display: grid;
   flex: 1 1 auto;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the Control UI or waiting for a chat route left users looking at a centered mascot on an otherwise empty page, with no indication of the layout being loaded.

## Why This Change Was Made

Use one shared shimmer skeleton for the initial connection and pending route content. The initial splash reserves sidebar, conversation, and composer space; pending routes reuse the content skeleton. Existing theme tokens and reduced-motion styling drive the animation, and Gateway startup status, authentication failures, and route transitions retain their existing behavior.

## User Impact

Loading feels consistent with the chat layout. Mobile hides the placeholder sidebar, and reduced-motion users see static placeholders. This changes presentation only; it does not render private session content before authentication.

## Evidence

- 26 focused routing and Gateway-lineage tests passed.
- All 13 initial-connect E2E tests passed; the configured-token case also passed with explicit shimmer, mobile overflow, and reduced-motion assertions.
- Production Control UI build and performance budgets passed.
- Changed-file typechecks, i18n, formatting, guards, and unused-export scans passed. The initial lint run found one `Number.parseFloat` convention violation in the new test; it was corrected, and the exact affected lint and style checks passed on rerun.
- Synthetic desktop and mobile captures were visually inspected. Browser relay access to the operator's live browser was unavailable, so this is deterministic local browser proof, not a live deployment claim.



Independent review identified and resolved a live-region accessibility issue: loading status is not permanently marked busy, so startup announcements remain available. The affected routing and three startup E2E cases passed again after that correction.

**Before: centered mascot**

![Before: centered mascot](https://github.com/user-attachments/assets/d9a324c3-a54d-4e77-a4e5-8205d3748113)

**After: desktop shimmer skeleton**

![After: desktop shimmer skeleton](https://github.com/user-attachments/assets/8d17c847-07fb-4a90-aec1-429736633f73)

**After: mobile with reduced motion**

![After: mobile with reduced motion](https://github.com/user-attachments/assets/69c6e5fd-be5f-4b7b-b530-5e2286e534bc)


Maintainer visual verification: the lead inspected the full original synthetic before/after/mobile PNGs locally; a separate proof worker also inspected the baseline capture. Each published image URL responds with HTTP 200 and `image/png`. The screenshot-fetch limitation reported by automated review does not represent missing visual verification.

CI recovery: the first run passed every UI unit, seven UI E2E, real-Gateway UI, and performance lane. Its two failures came from the same unrelated `assistant-failure.test.ts` assertion already fixed on main by #139519. The patch-identical rebase includes that fix. A subsequent unrelated test-report subprocess cleanup failure passed on its exact failed-job rerun, without changing the test or its strict cleanup assertion. [CI run 34000833195](https://github.com/openclaw/openclaw/actions/runs/34000833195) and the required aggregate gate are successful for `749f0e8475f8df30044e987bba1149dd8f82f9a0`.
