### PR TITLE
fix: avoid slow incognito key checks in large session stores

### DIFF
--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -1057,7 +1057,15 @@ test("sessions.create keeps incognito rows process-local through list, spawn, re
   const { storePath } = await createSessionStoreDir();
   try {
     const durableParentKey = "main";
-    await writeSessionStore({ entries: { main: sessionStoreEntry("durable-parent") } });
+    const savedPrompt = "unrelated durable prompt for incognito existence checks";
+    await writeSessionStore({
+      entries: {
+        main: {
+          ...sessionStoreEntry("durable-parent"),
+          skillsSnapshot: { prompt: savedPrompt, skills: [] },
+        },
+      },
+    });
     const created = await directSessionReq<{
       key: string;
       entry: {
@@ -1268,18 +1276,24 @@ test("sessions.create keeps incognito rows process-local through list, spawn, re
         "INSERT INTO session_windows (session_id, session_key, session_scope, created_at, updated_at) VALUES ('durable-collision', ?, 'conversation', ?, ?)",
       )
       .run(durableCollisionKey, durableCollisionUpdatedAt, durableCollisionUpdatedAt);
-    const rejectedExplicitDashboard = await directSessionReq("sessions.create", {
-      agentId: "main",
-      key: durableCollisionKey,
-      incognito: true,
-    });
-    expect(rejectedExplicitDashboard).toMatchObject({
-      ok: false,
-      error: {
-        code: "INVALID_REQUEST",
-        message: "incognito is immutable and requires a new session key",
-      },
-    });
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      const rejectedExplicitDashboard = await directSessionReq("sessions.create", {
+        agentId: "main",
+        key: durableCollisionKey,
+        incognito: true,
+      });
+      expect(parse.mock.calls.some(([json]) => json.includes(savedPrompt))).toBe(false);
+      expect(rejectedExplicitDashboard).toMatchObject({
+        ok: false,
+        error: {
+          code: "INVALID_REQUEST",
+          message: "incognito is immutable and requires a new session key",
+        },
+      });
+    } finally {
+      parse.mockRestore();
+    }
   } finally {
     closeOpenClawAgentDatabasesForTest();
   }

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -506,6 +506,8 @@ export async function createGatewaySession(params: {
     const durableEntryExists = listSessionEntriesReadOnly({
       agentId,
       storePath: durableStorePath,
+      projection: "list",
+      clone: false,
     }).some(({ sessionKey }) => sessionKey === explicitTargetKey);
     if (durableEntryExists || loadGatewaySessionEntryReadOnly(explicitTargetKey).entry) {
       return {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where checking an explicit incognito session key performs unnecessary synchronous work as the durable session store grows.

## Why This Change Was Made

Use the existing metadata listing for the durable collision check and consume its keys synchronously without cloning entries. Keep the same durable-store scope, canonical validation, malformed-row handling, and separate process-local existence check.

## User Impact

Incognito key checks avoid decoding unrelated saved prompts. Collision rejection and incognito session lifecycle behavior stay unchanged. Listing still visits session metadata; this change adds no cache, schema, configuration, or public API.

## Evidence

A synthetic source-service probe with 100 and 1,000 unrelated saved prompts reduced prompt decodes from 100/1,000 to zero. All eight actual service response cases, including normalized aliases and durable/process-local collisions, matched the baseline. Both readers retained the same fresh-handle malformed-row error.

The existing incognito create/list/spawn/reset/delete test now also checks that collision detection does not parse an unrelated saved prompt. It failed for that assertion on the baseline and passes with this change. All 162 tests in the complete creation suite passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33999908226) succeeded, and the supplemental deprecated-API, database-first, media-helper, and runtime-sidecar audits passed. Independent review found no actionable issues.

A compiled Linux Node 26.7 Gateway using the reviewed source tree passed nine real RPC operations: normalized explicit creation, three process-local reuse aliases, another creation, listing, reset, deletion, and confirmation that the sessions were gone. All 1,000 unrelated durable prompts remained intact; no incognito session nodes or windows were written to disk. Source/build/process bindings, unchanged file hashes, and graceful process closure were independently verified.

The reader probe is not a whole-Gateway latency benchmark and does not use a live model provider. Warm legacy durable-collision and malformed-row cases are covered separately by the source-service proof. A duplicate local changed-check run was cancelled after exact-head CI coverage was verified; it is not reported as a passing local full run.
