### PR TITLE
fix(sessions): avoid pauses decoding unrelated prompts during creation

### DIFF
--- a/src/config/sessions/incognito-session-transcript.test.ts
+++ b/src/config/sessions/incognito-session-transcript.test.ts
@@ -74,9 +74,10 @@ describe("session creation scope", () => {
 
       const created = await createSessionEntryWithTranscript(
         scope,
-        ({ existingEntry, sessionEntries }) => {
+        ({ existingEntry, targetEntry, isLabelInUse }) => {
           expect(existingEntry).toBeUndefined();
-          expect(sessionEntries).toEqual({});
+          expect(targetEntry).toBeUndefined();
+          expect(isLabelInUse("unused")).toBe(false);
           return { ok: true, entry };
         },
         { cwd: state.workspaceDir },
@@ -110,10 +111,10 @@ describe("session creation scope", () => {
 
       const updated = { ...entry, label: "recreated", updatedAt: 2 };
       await expect(
-        createSessionEntryWithTranscript(scope, ({ existingEntry, sessionEntries }) => {
+        createSessionEntryWithTranscript(scope, ({ existingEntry, targetEntry, isLabelInUse }) => {
           expect(existingEntry).toMatchObject(entry);
-          expect(Object.keys(sessionEntries)).toEqual([key]);
-          expect(sessionEntries[key]).toMatchObject(entry);
+          expect(targetEntry).toMatchObject(entry);
+          expect(isLabelInUse("recreated")).toBe(false);
           return { ok: true, entry: updated };
         }),
       ).resolves.toMatchObject({ ok: true, sessionFile: key });

--- a/src/config/sessions/session-accessor.creation-snapshot.test.ts
+++ b/src/config/sessions/session-accessor.creation-snapshot.test.ts
@@ -95,7 +95,9 @@ describe("session creation snapshot", () => {
         { ...scope, sessionKey: sibling },
         { sessionId: "sibling", updatedAt: 1, label: "taken" },
       );
-      if (cold) closeOpenClawAgentDatabasesForTest();
+      if (cold) {
+        closeOpenClawAgentDatabasesForTest();
+      }
       const result = await createSessionEntryWithTranscript(
         { ...scope, sessionKey: "AGENT:MAIN:MATRIX:GROUP:!Room:example.org" },
         (context) => {
@@ -225,7 +227,9 @@ describe("session creation snapshot", () => {
     });
     const target = mixed.entries.get(scope.sessionKey);
     expect(target?.skillsSnapshot?.prompt).toBe("saved target");
-    if (!target) throw new Error("Missing target");
+    if (!target) {
+      throw new Error("Missing target");
+    }
     target.label = "caller mutation";
     const metadata = readSessionEntryCache(database, options).entries.get(scope.sessionKey);
     expect(metadata?.label).toBe("original");

--- a/src/config/sessions/session-accessor.creation-snapshot.test.ts
+++ b/src/config/sessions/session-accessor.creation-snapshot.test.ts
@@ -1,0 +1,234 @@
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir, cleanupTempDirs } from "../../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  createSessionEntryWithTranscript,
+  assignSessionOwner,
+  recordSessionParticipant,
+  listSessionEntriesCore,
+  loadSessionEntry,
+  replaceSessionEntrySync,
+} from "./session-accessor.js";
+import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("session creation snapshot", () => {
+  it("prepares and adopts a complete target without decoding sibling saved prompts", async () => {
+    const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "creation-snapshot-") };
+    const scope = { agentId: "main", env, sessionKey: "agent:main:target" };
+    const target = {
+      sessionId: "target",
+      updatedAt: 1,
+      skillsSnapshot: { prompt: "target-saved-prompt", skills: [] },
+      systemPromptReport: {
+        source: "run" as const,
+        generatedAt: 1,
+        systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+        injectedWorkspaceFiles: [],
+        skills: { promptChars: 0, entries: [] },
+        tools: { listChars: 0, schemaChars: 0, entries: [] },
+      },
+    };
+    replaceSessionEntrySync(scope, target);
+    for (let index = 0; index < 3; index++) {
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: `agent:main:sibling-${index}` },
+        {
+          sessionId: `sibling-${index}`,
+          updatedAt: 1,
+          skillsSnapshot: { prompt: "unrelated-saved-prompt".repeat(1024), skills: [] },
+        },
+      );
+    }
+    assignSessionOwner(scope, {
+      owner: { type: "human", id: "owner" },
+      assignedBy: { type: "system", id: "fixture" },
+      assignedAt: 1,
+    });
+    recordSessionParticipant(scope, { identity: { type: "agent", id: "peer" }, promptedAt: 1 });
+    const parse = vi.spyOn(JSON, "parse");
+    const created = await createSessionEntryWithTranscript(scope, ({ existingEntry }) => {
+      const siblingPayloadReads = parse.mock.calls.filter(([json]) =>
+        json.includes("unrelated-saved-prompt"),
+      ).length;
+      parse.mockRestore();
+      expect(existingEntry).toMatchObject(target);
+      expect(siblingPayloadReads).toBe(0);
+      return { ok: true, entry: { ...existingEntry!, label: "adopted" } };
+    });
+    expect(created).toMatchObject({ ok: true, entry: { ...target, label: "adopted" } });
+    expect(loadSessionEntry(scope)).toMatchObject({
+      ...target,
+      label: "adopted",
+      owner: { actor: { type: "human", id: "owner" } },
+      participants: [{ identity: { type: "agent", id: "peer" } }],
+      participantCount: 1,
+    });
+  });
+  it.each([false, true])(
+    "preserves normalized and opaque target identities (cold=%s)",
+    async (cold) => {
+      const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "creation-identities-") };
+      const scope = { agentId: "main", env };
+      const key = "agent:main:matrix:group:!Room:example.org";
+      const sibling = "agent:main:matrix:group:!room:example.org";
+      const entry = {
+        sessionId: "target",
+        updatedAt: 1,
+        label: "own",
+        skillsSnapshot: { prompt: "preserved target", skills: [] },
+      };
+      replaceSessionEntrySync({ ...scope, sessionKey: key }, entry);
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: sibling },
+        { sessionId: "sibling", updatedAt: 1, label: "taken" },
+      );
+      if (cold) closeOpenClawAgentDatabasesForTest();
+      const result = await createSessionEntryWithTranscript(
+        { ...scope, sessionKey: "AGENT:MAIN:MATRIX:GROUP:!Room:example.org" },
+        (context) => {
+          expect(context.existingEntry).toMatchObject(entry);
+          expect(context.targetEntry).toMatchObject(entry);
+          expect(context.isLabelInUse("own")).toBe(false);
+          expect(context.isLabelInUse("taken")).toBe(true);
+          return { ok: false, error: "inspection complete" };
+        },
+      );
+      expect(result).toMatchObject({ ok: false, phase: "entry" });
+      expect(loadSessionEntry({ ...scope, sessionKey: sibling })?.sessionId).toBe("sibling");
+    },
+  );
+
+  it.each(["malformed", "mismatched-window", "mismatched-time", "nul"])(
+    "preserves warm listing behavior for a %s target",
+    async (kind) => {
+      const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "creation-warm-rows-") };
+      const scope = { agentId: "main", env, sessionKey: "agent:main:target" };
+      const entry = {
+        sessionId: "target",
+        updatedAt: 1,
+        label: "target",
+        skillsSnapshot: { prompt: "saved target", skills: [] },
+      };
+      replaceSessionEntrySync(scope, entry);
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: "agent:main:sibling" },
+        { sessionId: "sibling", updatedAt: 1, label: "taken" },
+      );
+      listSessionEntriesCore(scope);
+      const db = openOpenClawAgentDatabase(scope).db;
+      if (kind === "malformed" || kind === "nul") {
+        db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?").run(
+          kind === "malformed" ? "{" : JSON.stringify(entry) + "\0trailing",
+          scope.sessionKey,
+        );
+      } else if (kind === "mismatched-window") {
+        db.prepare("UPDATE session_nodes SET current_session_id = ? WHERE session_key = ?").run(
+          "different",
+          scope.sessionKey,
+        );
+      } else {
+        db.prepare("UPDATE session_nodes SET updated_at = ? WHERE session_key = ?").run(
+          2,
+          scope.sessionKey,
+        );
+      }
+      const expected = listSessionEntriesCore(scope).find(
+        (row) => row.sessionKey === scope.sessionKey,
+      )?.entry;
+      await createSessionEntryWithTranscript(scope, (context) => {
+        expect(context.existingEntry).toEqual(expected);
+        expect(context.targetEntry).toEqual(expected);
+        expect(context.isLabelInUse("taken")).toBe(true);
+        return { ok: false, error: "inspection complete" };
+      });
+      closeOpenClawAgentDatabasesForTest();
+      await expect(
+        createSessionEntryWithTranscript(scope, () => ({ ok: false, error: "unreachable" })),
+      ).rejects.toThrow("openclaw doctor --fix");
+    },
+  );
+
+  it("keeps the target and sibling labels on one snapshot across an external commit and callback await", async () => {
+    const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "creation-concurrent-snapshot-") };
+    const scope = { agentId: "main", env, sessionKey: "agent:main:a-target" };
+    const entry = {
+      sessionId: "target",
+      updatedAt: 1,
+      skillsSnapshot: { prompt: "snapshot-target-marker", skills: [] },
+    };
+    const sibling = { sessionId: "sibling", updatedAt: 1, label: "old label" };
+    replaceSessionEntrySync(scope, entry);
+    replaceSessionEntrySync({ ...scope, sessionKey: "agent:main:z-sibling" }, sibling);
+    listSessionEntriesCore(scope);
+    const external = new DatabaseSync(openOpenClawAgentDatabase(scope).path);
+    const parse = JSON.parse;
+    let changed = false;
+    vi.spyOn(JSON, "parse").mockImplementation((value, ...rest) => {
+      const result = parse(value, ...rest);
+      if (!changed && value.includes("snapshot-target-marker")) {
+        changed = true;
+        const update = external.prepare(
+          "UPDATE session_nodes SET entry_json = ? WHERE session_key = ?",
+        );
+        external.exec("BEGIN");
+        update.run(
+          JSON.stringify({ ...entry, skillsSnapshot: { prompt: "new target", skills: [] } }),
+          scope.sessionKey,
+        );
+        update.run(JSON.stringify({ ...sibling, label: "new label" }), "agent:main:z-sibling");
+        external.exec("COMMIT");
+      }
+      return result;
+    });
+    try {
+      await createSessionEntryWithTranscript(scope, async (context) => {
+        await Promise.resolve();
+        expect(changed).toBe(true);
+        expect(context.targetEntry).toMatchObject(entry);
+        expect(context.isLabelInUse("old label")).toBe(true);
+        expect(context.isLabelInUse("new label")).toBe(false);
+        return { ok: false, error: "inspection complete" };
+      });
+    } finally {
+      external.close();
+    }
+    expect(loadSessionEntry(scope)?.skillsSnapshot?.prompt).toBe("new target");
+  });
+  it("keeps selective full payloads detached from the metadata cache", () => {
+    const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "creation-cache-") };
+    const scope = { agentId: "main", env, sessionKey: "agent:main:target" };
+    replaceSessionEntrySync(scope, {
+      sessionId: "target",
+      updatedAt: 1,
+      label: "original",
+      skillsSnapshot: { prompt: "saved target", skills: [] },
+    });
+    const database = openOpenClawAgentDatabase(scope);
+    const options = { cache: true, projection: "list" as const };
+    readSessionEntryCache(database, options);
+    const mixed = readSessionEntryCache(database, {
+      ...options,
+      fullEntryKeys: [scope.sessionKey],
+    });
+    const target = mixed.entries.get(scope.sessionKey);
+    expect(target?.skillsSnapshot?.prompt).toBe("saved target");
+    if (!target) throw new Error("Missing target");
+    target.label = "caller mutation";
+    const metadata = readSessionEntryCache(database, options).entries.get(scope.sessionKey);
+    expect(metadata?.label).toBe("original");
+    expect(metadata).not.toHaveProperty("skillsSnapshot");
+  });
+});

--- a/src/config/sessions/session-accessor.entry-mutation.ts
+++ b/src/config/sessions/session-accessor.entry-mutation.ts
@@ -7,11 +7,10 @@ import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import {
   resolveAccessStorePath,
   loadSessionEntry,
-  listSessionEntriesCore,
   patchSessionEntryCore,
-  resolveSessionEntryFromStore,
 } from "./session-accessor.entry.js";
 import { applySessionEntryLifecycleMutation } from "./session-accessor.lifecycle.js";
+import { readSessionCreationSnapshot } from "./session-accessor.sqlite-creation-read.js";
 import {
   recordInboundSessionMeta,
   updateSessionLastRoute,
@@ -71,14 +70,11 @@ export async function createSessionEntryWithTranscript<TError = string>(
   const agentId = scope.agentId ?? resolveAgentIdFromSessionKey(scope.sessionKey);
   // The incognito sentinel is scoped to env; its path alone cannot identify the memory store.
   const storeScope = { agentId, env: scope.env, storePath };
-  const store = Object.fromEntries(
-    listSessionEntriesCore(storeScope).map(({ sessionKey, entry }) => [sessionKey, entry]),
-  );
-  const resolved = resolveSessionEntryFromStore({ store, sessionKey: scope.sessionKey });
-  const created = await createEntry({
-    existingEntry: resolved.existing ? { ...resolved.existing } : undefined,
-    sessionEntries: cloneSessionEntries(store),
+  const { normalizedKey, legacyKeys, ...context } = readSessionCreationSnapshot({
+    ...storeScope,
+    sessionKey: scope.sessionKey,
   });
+  const created = await createEntry(context);
   if (!created.ok) {
     return { ok: false, error: created.error, phase: "entry" };
   }
@@ -88,7 +84,7 @@ export async function createSessionEntryWithTranscript<TError = string>(
       {
         ...storeScope,
         sessionId: created.entry.sessionId,
-        sessionKey: resolved.normalizedKey,
+        sessionKey: normalizedKey,
       },
       createSessionTranscriptHeader({ cwd: options.cwd, sessionId: created.entry.sessionId }),
       options.commitGuard ? { beforeCommitInTransaction: options.commitGuard } : undefined,
@@ -107,12 +103,12 @@ export async function createSessionEntryWithTranscript<TError = string>(
   const entry = created.entry;
   await applySessionEntryLifecycleMutation({
     ...storeScope,
-    removals: resolved.legacyKeys.map((sessionKey) => ({ sessionKey })),
-    upserts: [{ sessionKey: resolved.normalizedKey, entry }],
+    removals: legacyKeys.map((sessionKey) => ({ sessionKey })),
+    upserts: [{ sessionKey: normalizedKey, entry }],
     skipMaintenance: true,
     ...(options.commitGuard ? { beforeCommitInTransaction: options.commitGuard } : {}),
   });
-  return { ok: true, entry, sessionFile: resolved.normalizedKey };
+  return { ok: true, entry, sessionFile: normalizedKey };
 }
 
 export function cloneSessionEntries(

--- a/src/config/sessions/session-accessor.sqlite-creation-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-creation-read.ts
@@ -1,0 +1,51 @@
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
+import { projectSessionEntriesForListing } from "./session-accessor.sqlite-entry.js";
+import { resolveSqliteScope, toDatabaseOptions } from "./session-accessor.sqlite-scope.js";
+import type {
+  SessionAccessScope,
+  SessionEntryCreateWithTranscriptContext,
+} from "./session-accessor.types.js";
+import {
+  collectSessionEntryLookupKeys,
+  normalizeStoreSessionKey,
+  resolveSessionEntryCandidates,
+} from "./store-entry.js";
+
+/** Owns the complete target payload and sibling-label facts before asynchronous preparation. */
+export function readSessionCreationSnapshot(
+  scope: SessionAccessScope,
+): SessionEntryCreateWithTranscriptContext & {
+  normalizedKey: string;
+  legacyKeys: string[];
+} {
+  const database = openOpenClawAgentDatabase(toDatabaseOptions(resolveSqliteScope(scope)));
+  // Listing validation rejects other structural aliases; these candidates retain
+  // complete payloads in the same SELECT that captures sibling label metadata.
+  const snapshot = readSessionEntryCache(database, {
+    cache: false,
+    projection: "list",
+    fullEntryKeys: [
+      normalizeStoreSessionKey(scope.sessionKey),
+      ...collectSessionEntryLookupKeys(database, scope.sessionKey),
+    ],
+  });
+  const entries = projectSessionEntriesForListing(snapshot);
+  const resolved = resolveSessionEntryCandidates({ entries, sessionKey: scope.sessionKey });
+  const targetEntry = entries.find(
+    ({ sessionKey }) => sessionKey === resolved.normalizedKey,
+  )?.entry;
+  const labels = new Set<string | undefined>();
+  for (const { sessionKey, entry } of entries) {
+    if (sessionKey !== resolved.normalizedKey) {
+      labels.add(entry.label);
+    }
+  }
+  return {
+    normalizedKey: resolved.normalizedKey,
+    legacyKeys: resolved.legacyKeys,
+    existingEntry: resolved.existing ? { ...resolved.existing.entry } : undefined,
+    targetEntry: targetEntry ? { ...targetEntry } : undefined,
+    isLabelInUse: (label) => labels.has(label),
+  };
+}

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -125,21 +125,29 @@ function loadSessionEntrySnapshot(
   database: SessionEntryCacheDatabase,
   projection: "full" | "list" = "list",
   prepared?: ValidatedSessionMetadata,
+  fullEntryKeys?: ReadonlySet<string>,
 ): SessionEntryCacheSnapshot {
   // Validation lends complete parsed facts only within this read. A concurrent external commit
   // requires the ordinary fresh SELECT, never a stale snapshot stamped with its newer version.
   const metadata =
-    prepared && prepared.dataVersion === readSqliteDataVersion(database.db) ? prepared : undefined;
+    !fullEntryKeys && prepared && prepared.dataVersion === readSqliteDataVersion(database.db)
+      ? prepared
+      : undefined;
   const parsedEntries = metadata?.entries ?? new Map<string, SessionEntry>();
   const keys = metadata?.keys ?? [];
   // Stream raw JSON so a full read never holds both serialized and parsed store-wide payloads.
   if (!metadata) {
     for (const row of iterateSqliteQuerySync(
       database.db,
-      selectSessionEntryRows(database, projection).select("updated_at").orderBy("session_key"),
+      selectSessionEntryRows(database, projection, fullEntryKeys ? [...fullEntryKeys] : [])
+        .select("updated_at")
+        .orderBy("session_key"),
     )) {
       keys.push(row.session_key);
-      const entry = parseSessionEntryJson(row, projection);
+      const entry = parseSessionEntryJson(
+        row,
+        fullEntryKeys?.has(row.session_key) ? "full" : projection,
+      );
       if (entry) {
         parsedEntries.set(row.session_key, entry);
       }
@@ -154,20 +162,32 @@ function loadSessionEntrySnapshot(
 
 export function readSessionEntryCache(
   database: SessionEntryCacheDatabase,
-  options: { cache: boolean; latest?: boolean; projection?: "full" | "list" },
+  options: {
+    cache: boolean;
+    latest?: boolean;
+    projection?: "full" | "list";
+    /** Uncached mixed snapshot: retain complete selected rows beside sibling metadata. */
+    fullEntryKeys?: readonly string[];
+  },
 ): SessionEntryCacheSnapshot {
   const prepared = assertCanonicalSqliteSessionKeysCurrent(
     database,
     undefined,
-    options.projection !== "full",
+    options.projection !== "full" && !options.fullEntryKeys,
   );
   if (
     !options.cache ||
+    options.fullEntryKeys ||
     options.latest ||
     options.projection === "full" ||
     database.db.isTransaction
   ) {
-    return loadSessionEntrySnapshot(database, options.projection, prepared);
+    return loadSessionEntrySnapshot(
+      database,
+      options.projection,
+      prepared,
+      options.fullEntryKeys ? new Set(options.fullEntryKeys) : undefined,
+    );
   }
   const validityToken = readCacheValidityToken(database.db);
   const cached = sessionEntryCaches.get(database.db);

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -27,7 +27,10 @@ import type {
   SessionEntryTargetPatchScope,
   SessionTranscriptReadScope,
 } from "./session-accessor.sqlite-contract.js";
-import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js";
+import {
+  readSessionEntryCache,
+  type SessionEntryCacheSnapshot,
+} from "./session-accessor.sqlite-entry-cache.js";
 import {
   assertLifecycleTargetSnapshotUnchanged,
   type SqliteLifecycleTargetSnapshot,
@@ -296,6 +299,14 @@ function listSqliteSessionEntriesFromDatabase(
     latest: scope.readConsistency === "latest",
     projection,
   });
+  return projectSessionEntriesForListing(snapshot, projection === "list" && scope.clone !== false);
+}
+
+/** Applies the listing visibility and canonical-key contract to an owned snapshot. */
+export function projectSessionEntriesForListing(
+  snapshot: SessionEntryCacheSnapshot,
+  cloneEntries = false,
+): SessionEntrySummary[] {
   return snapshot.keys.flatMap((sessionKey) => {
     if (isInternalSessionEffectsKey(sessionKey)) {
       return [];
@@ -314,7 +325,7 @@ function listSqliteSessionEntriesFromDatabase(
     return [
       {
         sessionKey,
-        entry: projection === "list" && scope.clone !== false ? cloneSessionEntry(entry) : entry,
+        entry: cloneEntries ? cloneSessionEntry(entry) : entry,
       },
     ];
   });

--- a/src/config/sessions/session-accessor.sqlite-status.ts
+++ b/src/config/sessions/session-accessor.sqlite-status.ts
@@ -38,11 +38,17 @@ export const sessionEntryMetadataJson =
 export function selectSessionEntryRows(
   database: Pick<OpenClawAgentDatabase, "db">,
   projection: "full" | "list",
+  fullEntryKeys: readonly string[] = [],
 ) {
+  const metadata = fullEntryKeys.length
+    ? /* kysely-allow-raw: one row snapshot preserves complete selected entries beside sibling metadata. */ sql<string>`CASE WHEN session_key IN ${sqliteStringSet(fullEntryKeys)} THEN entry_json ELSE ${sessionEntryMetadataJson.expression} END`.as(
+        "entry_json",
+      )
+    : sessionEntryMetadataJson;
   return getNodeSqliteKysely<SessionStatusDatabase>(database.db)
     .selectFrom("session_nodes")
     .select("session_key")
-    .select(projection === "full" ? "entry_json" : sessionEntryMetadataJson)
+    .select(projection === "full" ? "entry_json" : metadata)
     .$if(hasSqliteSessionOwnerColumns(database.db), (query) =>
       query.select([
         "owner_actor_type",

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -1392,16 +1392,21 @@ describe("session accessor seam", () => {
       storePath,
     };
 
-    const created = await createSessionEntryWithTranscript(scope, ({ sessionEntries }) => {
-      expect(sessionEntries).toEqual({});
-      return {
-        ok: true,
-        entry: {
-          sessionId: "session-1",
-          updatedAt: 10,
-        },
-      };
-    });
+    const created = await createSessionEntryWithTranscript(
+      scope,
+      ({ existingEntry, targetEntry, isLabelInUse }) => {
+        expect(existingEntry).toBeUndefined();
+        expect(targetEntry).toBeUndefined();
+        expect(isLabelInUse("unused")).toBe(false);
+        return {
+          ok: true,
+          entry: {
+            sessionId: "session-1",
+            updatedAt: 10,
+          },
+        };
+      },
+    );
 
     expect(created.ok).toBe(true);
     if (!created.ok) {

--- a/src/config/sessions/session-accessor.types.ts
+++ b/src/config/sessions/session-accessor.types.ts
@@ -844,8 +844,10 @@ export type RestoreSessionFromCompactionCheckpointParams = {
 export type SessionEntryCreateWithTranscriptContext = {
   /** Current entry under the requested key before creation, if any. */
   existingEntry?: SessionEntry;
-  /** Current entries snapshot for validation rules such as label uniqueness. */
-  sessionEntries: Record<string, SessionEntry>;
+  /** Exact normalized target from the same snapshot, distinct from an alias-resolved entry. */
+  targetEntry?: SessionEntry;
+  /** Detached sibling-label facts; excludes the exact normalized target only. */
+  isLabelInUse: (label: string) => boolean;
 };
 
 export type SessionEntryCreateWithTranscriptResult<TError = string> =

--- a/src/config/sessions/store-entry.ts
+++ b/src/config/sessions/store-entry.ts
@@ -186,7 +186,7 @@ type SessionEntryCandidate = {
   sessionKey: string;
 };
 
-function resolveSessionEntryCandidates(params: {
+export function resolveSessionEntryCandidates(params: {
   entries: readonly SessionEntryCandidate[];
   sessionKey: string;
 }): {

--- a/src/gateway/session-create-preparation.test.ts
+++ b/src/gateway/session-create-preparation.test.ts
@@ -18,7 +18,9 @@ describe("Gateway creation preparation", () => {
       expect(first.ok).toBe(true);
       const scope = { agentId: "main", sessionKey: "agent:main:target" };
       const initial = loadSessionEntry(scope);
-      if (!initial) throw new Error("Missing initial session");
+      if (!initial) {
+        throw new Error("Missing initial session");
+      }
       const saved = {
         ...initial,
         skillsSnapshot: { prompt: "Saved skill prompt", skills: [] },

--- a/src/gateway/session-create-preparation.test.ts
+++ b/src/gateway/session-create-preparation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { loadSessionEntry, replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createGatewaySession } from "./session-create-service.js";
+
+describe("Gateway creation preparation", () => {
+  it("retains the full adopted target while checking sibling labels", async () => {
+    await withOpenClawTestState({ label: "gateway-create-snapshot" }, async () => {
+      const create = (key: string, label: string) =>
+        createGatewaySession({
+          cfg: {},
+          key,
+          label,
+          commandSource: "test",
+          operatorRoleActor: { kind: "system" },
+        });
+      const first = await create("agent:main:target", "Original");
+      expect(first.ok).toBe(true);
+      const scope = { agentId: "main", sessionKey: "agent:main:target" };
+      const initial = loadSessionEntry(scope);
+      if (!initial) throw new Error("Missing initial session");
+      const saved = {
+        ...initial,
+        skillsSnapshot: { prompt: "Saved skill prompt", skills: [] },
+        systemPromptReport: {
+          source: "run" as const,
+          generatedAt: 1,
+          systemPrompt: { chars: 1, projectContextChars: 0, nonProjectContextChars: 1 },
+          injectedWorkspaceFiles: [],
+          skills: { promptChars: 0, entries: [] },
+          tools: { listChars: 0, schemaChars: 0, entries: [] },
+        },
+      };
+      replaceSessionEntrySync(scope, saved);
+      expect((await create("agent:main:sibling", "Taken")).ok).toBe(true);
+      expect(await create(scope.sessionKey, "Renamed")).toMatchObject({
+        ok: true,
+        entry: { sessionId: saved.sessionId, label: "Renamed" },
+      });
+      expect(loadSessionEntry(scope)).toMatchObject({
+        sessionId: saved.sessionId,
+        label: "Renamed",
+        skillsSnapshot: saved.skillsSnapshot,
+        systemPromptReport: saved.systemPromptReport,
+      });
+      expect(await create(scope.sessionKey, "Taken")).toMatchObject({
+        ok: false,
+        error: { message: "label already in use: Taken" },
+      });
+      expect(loadSessionEntry(scope)).toMatchObject({
+        sessionId: saved.sessionId,
+        label: "Renamed",
+        skillsSnapshot: saved.skillsSnapshot,
+        systemPromptReport: saved.systemPromptReport,
+      });
+    });
+  });
+});

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -1005,7 +1005,7 @@ export async function createGatewaySession(params: {
         sessionKey: target.canonicalKey,
         storePath: target.storePath,
       },
-      async ({ existingEntry, sessionEntries }) => {
+      async ({ existingEntry, targetEntry, isLabelInUse }) => {
         // This callback owns generated and explicit keys alike; no existing row
         // is the canonical signal that this request will actually create one.
         if (!existingEntry) {
@@ -1148,11 +1148,8 @@ export async function createGatewaySession(params: {
         }
         const patched = await projectSessionsPatchEntry({
           cfg: params.cfg,
-          existingEntry: sessionEntries[target.canonicalKey],
-          isLabelInUse: (label) =>
-            Object.entries(sessionEntries).some(
-              ([sessionKey, entry]) => sessionKey !== target.canonicalKey && entry.label === label,
-            ),
+          existingEntry: targetEntry,
+          isLabelInUse,
           storeKey: target.canonicalKey,
           agentId: target.agentId,
           preparedSessionRoot: sessionRoot,
@@ -1194,7 +1191,6 @@ export async function createGatewaySession(params: {
             ),
           };
         }
-        sessionEntries[target.canonicalKey] = patched.entry;
         const execNode = normalizeOptionalString(params.execNode);
         const execCwd = normalizeOptionalString(params.execCwd);
         const initialAgentHarnessId = params.initialEntry
@@ -1327,7 +1323,6 @@ export async function createGatewaySession(params: {
             : {}),
           ...(existingEntry === undefined && incognito ? { incognito: true as const } : {}),
         };
-        sessionEntries[target.canonicalKey] = initializedEntry;
         const initialized = { ...patched, entry: initializedEntry };
         const explicitParentSessionKey =
           canonicalParentSessionKey ?? normalizeOptionalString(initializedEntry.parentSessionKey);


### PR DESCRIPTION
Closes #139526

## What Problem This Solves

Fixes pauses when creating or adopting sessions in agent stores containing large saved prompts. Creation previously decoded every saved prompt in the store before invoking its preparation callback, including when that callback ignored the store.

## Why This Change Was Made

The existing snapshot owner now supports an uncached selective-full read: requested/canonical/folded target candidates retain their complete payloads while sibling rows use the established metadata projection. The same SQL row snapshot supplies target and label facts. Existing participant hydration remains its separate query; no transaction or broader consistency guarantee is introduced.

The internal callback receives its resolved existing entry, distinct exact target entry, and detached label predicate. Gateway adoption keeps its full original payload. Existing canonical-key, malformed-row, owner, participant, transcript/lifecycle and commit-guard behavior remain in place. The default SDK callback continues using the same creator without consuming snapshot context.

## User Impact

Creating a session avoids allocating unrelated saved prompt payloads. Adoption preserves saved skill snapshots and system-prompt reports; existing label rejection, incognito scope and guarded initialization behavior remain unchanged.

## Evidence

- The final regression failed with the original creator: three unrelated prompt JSON decodes instead of zero. The candidate passes and retains the full adopted target.
- Owner and Gateway tests cover cold/opaque keys, warm malformed/NUL/identity/time mismatches, cold validation rejection, owner/participant fields, an external SQLite commit during row iteration, post-await snapshot stability, cache isolation, and saved-payload retention through real Gateway creation/adoption.
- No schema, index, persisted projection, new cache, locking, transaction-boundary, public SDK or operator configuration change. Ordinary cached reads remain unchanged; selective creation snapshots are uncached.
- Existing readers offer uniform full or metadata projections; they cannot preserve selected complete targets and sibling metadata in one row snapshot. Additional production code implements selective complete-target snapshots and detached callback facts in the existing materialization owner. It replaces the full-store callback and removes unnecessary Gateway record assignments; no parallel parser or fallback reader is retained.

Compiled Gateway proof on source `36beea075b748e33da163d2173f7f760d180b06f` completed four token-authenticated `sessions.create` scenarios: new creation, full-target adoption, duplicate-label rejection, and structural-key normalization. A separate process verified saved target prompt/report hashes, the new session, absence of the rejected row, and all 100 unchanged siblings. Source/build/harness seals remained stable and the Gateway shut down cleanly. The isolated proof environment has been stopped.

The combined proof command exited 1 because an additional default-manager SDK probe attempted an internal module path absent from the compiled artifact. That constructor is not exported by the supported compiled SDK barrel; no SDK construction or provider turn ran. The completed Gateway phases are qualified separately, and source-level ignored-context preparation coverage remains separate evidence.

Initial CI found three missing brace pairs in the new tests. Commit `685ae5004823446963b1bc99152d5174da7c2063` fixes only those test blocks; targeted lint and independent review passed. All production files remain identical to the compiled proof. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34000571739) passed; native preparation verified its hosted gates on `685ae5004823446963b1bc99152d5174da7c2063`. Synthetic accessor/preparation measurements do not establish production end-to-end latency.
