### PR TITLE
fix(anthropic): prevent duplicate questions from overwriting answers

### DIFF
--- a/extensions/anthropic/cli-user-input.test.ts
+++ b/extensions/anthropic/cli-user-input.test.ts
@@ -49,7 +49,7 @@ const input = {
       multiSelect: true,
     },
   ],
-};
+} as const;
 
 describe("Claude CLI user input adapter", () => {
   it("maps Claude questions and answers while deduplicating the CLI callbacks", async () => {
@@ -128,44 +128,60 @@ describe("Claude CLI user input adapter", () => {
     });
   });
 
-  it("guides a malformed question retry without replaying the rejected call", async () => {
-    const requestUserInput = vi.fn(async () => ({
-      status: "answered" as const,
-      answers: { question_1: ["Vitest"], question_2: ["Unit tests"] },
-    }));
-    const authorizer = createClaudeCliUserInputAuthorizer(createContext(requestUserInput));
-    const signal = new AbortController().signal;
-    const rejected = {
-      behavior: "deny",
-      message:
-        "OpenClaw rejected malformed Claude user questions: questions[0].header must be at most 12 characters. Correct the invalid field and retry AskUserQuestion.",
-    };
+  it.each([
+    {
+      name: "oversized header",
+      questions: [{ ...input.questions[0], header: "Too long for Claude" }],
+      failure: "questions[0].header must be at most 12 characters",
+    },
+    {
+      name: "duplicate question text with distinct headers and options",
+      questions: [
+        input.questions[0],
+        { ...input.questions[1], question: input.questions[0].question },
+      ],
+      failure: "questions[1].question must be unique within the request",
+    },
+  ])(
+    "guides a retry for $name without replaying the rejected call",
+    async ({ questions, failure }) => {
+      const requestUserInput = vi.fn(async () => ({
+        status: "answered" as const,
+        answers: { question_1: ["Vitest"], question_2: ["Unit tests"] },
+      }));
+      const authorizer = createClaudeCliUserInputAuthorizer(createContext(requestUserInput));
+      const signal = new AbortController().signal;
+      const rejected = {
+        behavior: "deny",
+        message: `OpenClaw rejected malformed Claude user questions: ${failure}. Correct the invalid field and retry AskUserQuestion.`,
+      };
 
-    await expect(
-      authorizer.authorize({
-        input: { questions: [{ ...input.questions[0], header: "Too long for Claude" }] },
-        signal,
-        toolUseId: "rejected-question",
-      }),
-    ).resolves.toEqual(rejected);
-    await expect(
-      authorizer.authorize({ input, signal, toolUseId: "rejected-question" }),
-    ).resolves.toEqual(rejected);
-    expect(requestUserInput).not.toHaveBeenCalled();
+      await expect(
+        authorizer.authorize({
+          input: { questions },
+          signal,
+          toolUseId: "rejected-question",
+        }),
+      ).resolves.toEqual(rejected);
+      await expect(
+        authorizer.authorize({ input, signal, toolUseId: "rejected-question" }),
+      ).resolves.toEqual(rejected);
+      expect(requestUserInput).not.toHaveBeenCalled();
 
-    await expect(
-      authorizer.authorize({ input, signal, toolUseId: "corrected-question" }),
-    ).resolves.toMatchObject({
-      behavior: "allow",
-      updatedInput: {
-        answers: {
-          "Which test runner should we use?": "Vitest",
-          "Which proof should we collect?": "Unit tests",
+      await expect(
+        authorizer.authorize({ input, signal, toolUseId: "corrected-question" }),
+      ).resolves.toMatchObject({
+        behavior: "allow",
+        updatedInput: {
+          answers: {
+            "Which test runner should we use?": "Vitest",
+            "Which proof should we collect?": "Unit tests",
+          },
         },
-      },
-    });
-    expect(requestUserInput).toHaveBeenCalledOnce();
-  });
+      });
+      expect(requestUserInput).toHaveBeenCalledOnce();
+    },
+  );
 
   it.each([
     ["missing questions array", {}, "questions must be an array of 1 to 4 questions"],

--- a/extensions/anthropic/cli-user-input.ts
+++ b/extensions/anthropic/cli-user-input.ts
@@ -81,6 +81,10 @@ function readClaudeUserInputQuestions(input: Record<string, unknown>): ParsedQue
     if (!question.ok) {
       return { ok: false, failure: `${questionPath}.question ${question.failure}` };
     }
+    // Claude keys answers by the exact question text, not the header or question ID.
+    if (questions.some((existing) => existing.question === question.text)) {
+      return { ok: false, failure: `${questionPath}.question must be unique within the request` };
+    }
     const header = readBoundedText(rawQuestion.header, 12);
     if (!header.ok) {
       return { ok: false, failure: `${questionPath}.header ${header.failure}` };


### PR DESCRIPTION
Related to #128932.

The adapter rejects duplicate question text before prompting, using the existing correction-and-retry response. Direct adapter calls previously overwrote the first answer because Claude answers are keyed by question text.

Native CLI verification did not establish that this defect is reachable: installed Claude Code 2.1.205 rejects duplicates before the OpenClaw authorizer on both the unpatched baseline and this PR. This remains unproven as a user-facing fix and should not be merged on the strength of the direct adapter tests alone.

All 563 Anthropic plugin tests, the final 11 adapter tests, and changed-file checks passed. Independent adapter validation and Codex autoreview passed. Those checks establish the adapter behavior, not native reachability.

<details>
<summary>Captured native CLI comparison and limitation</summary>

Captured the actual installed Claude Code 2.1.205 process through the production `executeClaudeCli` at `362777ef5ff8231254df467ed9a3fe6fb8e2ba7b`, using a scripted loopback Anthropic endpoint and synthetic user answers. No external model or Gateway was used.

```text
Duplicate AskUserQuestion: two "Which option?" questions with distinct headers/options
requestUserInput calls before retry: 0
Actual CLI tool_result sent in the next provider request:
  InputValidationError: Question texts must be unique, option labels must be unique within each question
Denial source: Claude Code native schema validation, before the OpenClaw authorizer

Corrected AskUserQuestion: "Which color?" and "Which travel modes?" (multiselect)
requestUserInput calls: 1
Actual CLI tool_result sent in the following provider request:
  Your questions have been answered: "Which color?"="Green", "Which travel modes?"="Bike, Train". You can now continue with these answers in mind.
```

The installed CLI already enforces unique question text before OpenClaw receives the request. This capture verifies the corrected native answer round-trip, but it does **not** establish a patch-specific live defect or attribute the duplicate rejection to this PR. The direct adapter regression proof and this native integration capture prove different layers; native reproduction of the reported defect remains unestablished.

The identical fixture also completed against unpatched baseline `07843c22c58811b245fd41219cac45d6b5926434`: zero duplicate prompts, the same native validation error, one corrected prompt, and the same two answers in the subsequent provider request. There is no observable before/after distinction on Claude Code 2.1.205.

</details>
