### PR TITLE
fix(agents): retain storage-failure retry and credential coverage

### DIFF
--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -269,9 +269,14 @@ describe("handleEmbeddedAssistantFailure", () => {
       action: "proceed",
       assistantProfileFailureReason: null,
       emptyErrorRetries: 0,
+      authRetryPending: false,
+      lastRetryFailoverReason: null,
     });
+    expect(fixture.input.maybeRefreshRuntimeAuthForAuthError).not.toHaveBeenCalled();
     expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
+    expect(fixture.input.failover.advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     expect(fixture.maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
+    expect(fixture.traceAttempts).toEqual([]);
   });
   beforeEach(() => {
     providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockReset();

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -290,6 +290,7 @@ describe("recoverEmbeddedRunAttempt", () => {
     ["the run timed out", { terminal: { kind: "timeout", phase: "prompt", source: "runtime" } }],
     ["the attempt yielded", { yieldDetected: true }],
     ["the assistant error is not transient", { errorMessage: "invalid request: bad schema" }],
+    ["Gateway storage is locked", { errorMessage: "database is locked", diagnostics: [] }],
     ["the provider requires authentication", { errorMessage: "401 unauthorized" }],
     [
       "the provider has exhausted its quota",
@@ -297,10 +298,15 @@ describe("recoverEmbeddedRunAttempt", () => {
     ],
     ["the continuation budget is spent", { retryAvailable: false }],
   ])("keeps the replay gate closed when %s", async (_label, scenario) => {
-    const { recovery, markOwnedTranscriptRetry, continueFromCurrentTranscript } =
-      await recoverAfterTransportDrop(scenario);
+    const {
+      recovery,
+      markOwnedTranscriptRetry,
+      continueFromCurrentTranscript,
+      failoverRetryController,
+    } = await recoverAfterTransportDrop(scenario);
 
     expect(recovery).toEqual({ action: "proceed" });
+    expect(failoverRetryController.transientRetryCount).toBe(0);
     expect(markOwnedTranscriptRetry).not.toHaveBeenCalled();
     expect(continueFromCurrentTranscript).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What Problem This Solves

Preserves meaningful no-retry and no-credential-rotation coverage for Gateway storage failures after the failover owner move. This maintainer-requested fix-forward began by repairing the red-main test introduced by #139409's rebase over #139410. While it was being validated, #139519 independently removed the stale assertion and cleared the immediate failure; this PR is rebased on that fix and adds the remaining behavioral coverage.

#139410 moved the fixture under the failover controller; #139397 subsequently moved transient retry handling into attempt recovery and removed that method from the assistant-failure input.

## Why This Change Was Made

Keep the storage-failure assertion at its current owner: require `action: "proceed"`, no profile failure reason, no retry state or trace, and no runtime auth refresh, credential rotation, or profile failure marking. Add a storage-lock case to the existing attempt-recovery table and check the real controller's retry count remains zero.

## User Impact

No production behavior changes. CI explicitly protects that a Gateway storage failure surfaces without replaying the run or rotating credentials, including at the current transient-retry owner.

## Evidence

- Reproduced the original failure before #139519: 22 tests passed, one failed at `assistant-failure.test.ts:273` with `undefined is not a spy or a call to a spy!`.
- Passed 95 tests across the assistant-failure, assistant-failure failover, failover-retry-controller, and attempt-recovery files.
- Passed all 880 tests across the 12 `src/agents/failover/*.test.ts` files.
- The requested `assistant-failover` selector no longer exists; `assistant-failure` includes the current `assistant-failure.failover.test.ts`. The failover directory selector also routes to an empty lane, so those files were run explicitly through the repository wrapper.
- `node scripts/check-changed.mjs` completed successfully, including core-test typechecking, repository guards, all dead-export scans, and changed-file lint.
- Codex autoreview: scoped-clean, no actionable P0–P2 findings.
- The rebase preserves byte-identical validated test files; the three relevant production owners are unchanged from the validated base.
- `git diff --check` passed.
