### PR TITLE
perf(browser): reuse parent links when finding role-tree roots

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -448,7 +448,6 @@ function buildRoleTree(nodes: RawAXNode[]): { tree: RoleTreeNode[]; roots: numbe
     });
   }
 
-  const childIndexes = new Set<number>();
   for (let index = 0; index < tree.length; index += 1) {
     for (const childId of tree[index]?.raw.childIds ?? []) {
       const childIndex = byId.get(childId);
@@ -457,11 +456,12 @@ function buildRoleTree(nodes: RawAXNode[]): { tree: RoleTreeNode[]; roots: numbe
       }
       tree[index]?.children.push(childIndex);
       expectDefined(tree[childIndex], "CDP child node index").parent = index;
-      childIndexes.add(childIndex);
     }
   }
 
-  const roots = tree.map((_node, index) => index).filter((index) => !childIndexes.has(index));
+  const roots = tree
+    .map((_node, index) => index)
+    .filter((index) => tree[index]?.parent === undefined);
   const stack = roots.map((index) => ({ index, depth: 0 }));
   while (stack.length) {
     const current = stack.pop();


### PR DESCRIPTION
## What Problem This Solves

Resolves duplicate root-membership storage while CDP role snapshots build large accessibility trees. The builder recorded each linked child's parent and also inserted its index into a Set used only to find roots, before output caps could reduce the returned snapshot.

## Why This Change Was Made

`buildRoleTree` in `extensions/browser/src/browser/cdp.ts` uses its already-computed internal parent index to select roots and removes the temporary Set. The strict `parent === undefined` check preserves parent index zero. Locally resolved child linkage remains authoritative; external parent IDs are not introduced into the decision.

`snapshotRoleViaCdp` reaches this owner through `buildCdpRoleSnapshot`, which also uses it for iframe recursion before rendering/finalization. Raw ARIA has a separate root heuristic; Playwright and Chrome MCP formatters do not consume this internal tree. Reusing existing metadata avoids another index/helper while preserving input ordering, missing IDs, repeated edges, shared children, root fallback, refs, limits, and traversal.

Production: +3/-3 lines (net zero); maintained tests/support: +0/-0. No public seam, dependency, configuration, or lifecycle state is added.

## User Impact

CDP role-tree construction allocates less temporary membership storage while preserving returned snapshot text and metadata. This owner-level reduction does not establish browser actionability or general snapshot latency.

## Evidence

The temporary proof invokes the actual `snapshotRoleViaCdp` and finalizer while replacing only CDP socket responses with deterministic synthetic data. All 80 complete observations match, including ordered requests, refs/stats/truncation, empty/missing/duplicate IDs, parent zero, wide/deep trees, interactive/compact/delta options, iframe recursion, and URL enrichment. Inputs remain unchanged. This is synthetic CDP boundary proof, not a Chromium or Gateway run.

A separate exact-source AST extraction compares all owner fields and raw-node reference identities across 504 cases: empty input, three rootless cycles, and 500 deterministic DAGs. Rootless cases exercise the builder fallback without downstream rendering; reachable cycles outside the CDP tree contract were not executed.

Node 26.8.1/macOS arm64 profiling uses frozen synthetic trees, three warmups, then 12 captures per size. Interactive output capped at 100 characters still requires full tree construction, and complete output hashes match.

| Linked children | Sampled Set.add bytes before → after | Total owner sampled bytes before → after | Median profiled ms before → after |
| --- | ---: | ---: | ---: |
| 20,000 | 15,740,000 → 0 | 155,412,432 → 138,726,552 | 8.54 → 6.86 |
| 100,000 | 62,907,920 → 0 | 729,415,272 → 667,071,664 | 44.07 → 37.37 |

The 4 KiB sampler includes collected objects. Removed named Set samples are the primary evidence; owner totals have sampling variance, and zero Set samples do not mean zero total allocation. Baseline constructor samples also include 4,200 bytes at the larger size. Shared host load and profiling limit timing interpretation. No retained heap, RSS, peak memory, or whole-Gateway savings are claimed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/browser/cdp.internal.test.ts extensions/browser/src/browser/cdp.test.ts extensions/browser/src/browser/pw-role-snapshot.test.ts
node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/browser/src/browser/cdp.ts
```

All 114 tests across three files pass, including local WebSocket CDP transport and sibling/finalizer behavior. Typed lint, formatting, diff checks, and changed-plan classification pass; P2 review records no actionable findings. The NodeList patch composes in either order; the additional real-browser composition proof below passes. Broad extension checks remain for the native/hosted gates; required exact-head hosted CI/native landing gates remain mandatory.

A separate real-Chromium check exercised the frozen combined browser changes through the actual built snapshot/ref/action owners. A genuine 393-node AX tree produced document-bound refs; clicks selected the first and second identically named buttons, a cursor-promoted control, then the second Playwright ref, giving exact visible events `["first", "second", "cursor", "second"]`. Hidden controls remained absent, disabled clicks remained rejected, and marker cleanup matched. Four snapshot texts and complete Playwright role/AI/capped objects were identical. CDP comparison normalized only browser-issued node/frame IDs; raw IDs were used for the actual clicks. This is behavior proof on synthetic browser content, separate from the allocation measurements and without a Gateway or Chrome MCP server.

| Real-browser outcome | Before | Combined changes |
| --- | --- | --- |
| Final selected button | ![Synthetic browser outcome before](https://github.com/user-attachments/assets/aa7b6616-62b5-428a-8feb-d2c4f5d37002) | ![Synthetic browser outcome after](https://github.com/user-attachments/assets/1575c570-5d27-4081-82d1-9cf91de81c8e) |
