### PR TITLE
perf(tui): prepare highlight patterns once per query

### DIFF
--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -204,19 +204,24 @@ describe("SearchableSelectList", () => {
     expectNoMatchesForQuery(list, "32m");
   });
 
-  it("does not corrupt ANSI sequences when highlighting multiple tokens", () => {
-    const items = [{ value: "gpt-model", label: "gpt-model" }];
-    const list = new SearchableSelectList(items, 5, ansiHighlightTheme);
+  it.each(["gpt m", "gpt GPT m", "  GPT  m  "])(
+    "does not corrupt ANSI sequences when highlighting query %j",
+    (query) => {
+      const items = [{ value: "gpt-model", label: "gpt-model" }];
+      const list = new SearchableSelectList(items, 5, ansiHighlightTheme);
 
-    typeInput(list, "gpt m");
+      typeInput(list, query);
 
-    const renderedLine = list.render(80).find((line) => stripAnsi(line).includes("gpt-model"));
-    if (!renderedLine) {
-      throw new Error("expected rendered gpt-model line");
-    }
-    const highlightOpens = renderedLine.split("\u001b[31m").length - 1;
-    expect(highlightOpens).toBe(2);
-  });
+      const rendered = list.render(80);
+      const renderedLine = rendered.find((line) => stripAnsi(line).includes("gpt-model"));
+      if (!renderedLine) {
+        throw new Error("expected rendered gpt-model line");
+      }
+      const highlightOpens = renderedLine.split("\u001b[31m").length - 1;
+      expect(highlightOpens).toBe(2);
+      expect(list.render(80)).toEqual(rendered);
+    },
+  );
 
   it("filters items when typing", () => {
     const list = new SearchableSelectList(testItems, 5, mockTheme);
@@ -330,20 +335,24 @@ describe("SearchableSelectList", () => {
     expect(output).toContain("*gpt*");
   });
 
-  it("discards compiled regexes from previous searches", () => {
-    const queryLength = 300;
-    const label = "a".repeat(queryLength);
-    const list = new SearchableSelectList([{ value: "match", label }], 5, mockTheme);
+  it("renders the current query during selection callbacks after clearing and replacing it", () => {
+    const list = new SearchableSelectList(
+      [{ value: "match", label: "alpha beta", description: "alpha beta description" }],
+      5,
+      ansiHighlightTheme,
+    );
+    list.handleInput("alpha");
+    list.render(80);
+    const frames: string[] = [];
+    list.onSelectionChange = () => frames.push(list.render(80).join("\n"));
 
-    for (let index = 0; index < queryLength; index += 1) {
-      list.handleInput("a");
-      list.render(queryLength + 10);
-    }
+    list.handleInput("\u0015");
+    list.handleInput("beta");
 
-    const regexCache = (list as unknown as { regexCache: Map<string, RegExp> }).regexCache;
-    expect(regexCache.size).toBe(1);
-    expect(regexCache.has(label)).toBe(true);
-    expect(list.render(queryLength + 10).join("\n")).toContain(`*${label}*`);
+    expect(frames).toHaveLength(2);
+    expect(frames[0]).not.toContain("\u001b[31m");
+    expect(frames[1]?.split("alpha \u001b[31mbeta\u001b[0m")).toHaveLength(3);
+    expect(list.render(80).join("\n")).toBe(frames[1]);
   });
 
   it("shows no match message when filter yields no results", () => {

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -45,7 +45,7 @@ export class SearchableSelectList implements Component, Focusable {
   private maxVisible: number;
   private theme: SearchableSelectListTheme;
   private searchInput: Input;
-  private regexCache = new Map<string, RegExp>();
+  private highlightPatterns?: RegExp[];
 
   onSelect?: (item: SearchableSelectItem) => void;
   onCancel?: () => void;
@@ -72,15 +72,6 @@ export class SearchableSelectList implements Component, Focusable {
 
   set focused(value: boolean) {
     this.searchInput.focused = value;
-  }
-
-  private getCachedRegex(pattern: string): RegExp {
-    let regex = this.regexCache.get(pattern);
-    if (!regex) {
-      regex = new RegExp(this.escapeRegex(pattern), "gi");
-      this.regexCache.set(pattern, regex);
-    }
-    return regex;
   }
 
   private updateFilter() {
@@ -186,20 +177,13 @@ export class SearchableSelectList implements Component, Focusable {
     return parts;
   }
 
-  private highlightMatch(text: string, query: string): string {
-    const tokens = query
-      .trim()
-      .split(/\s+/)
-      .map((token) => normalizeLowercaseStringOrEmpty(token))
-      .filter((token) => token.length > 0);
-    if (tokens.length === 0) {
+  private highlightMatch(text: string, patterns: RegExp[]): string {
+    if (patterns.length === 0) {
       return text;
     }
 
-    const uniqueTokens = uniqueStrings(tokens).toSorted((a, b) => b.length - a.length);
     let parts = this.splitAnsiParts(text);
-    for (const token of uniqueTokens) {
-      const regex = this.getCachedRegex(token);
+    for (const regex of patterns) {
       const nextParts: Array<{ text: string; isAnsi: boolean }> = [];
       for (const part of parts) {
         if (part.isAnsi) {
@@ -248,6 +232,16 @@ export class SearchableSelectList implements Component, Focusable {
       return lines;
     }
 
+    // One query owns these patterns; a render keeps its snapshot through theme callbacks.
+    const patterns = (this.highlightPatterns ??= uniqueStrings(
+      query
+        .split(/\s+/)
+        .map((token) => normalizeLowercaseStringOrEmpty(token))
+        .filter((token) => token.length > 0),
+    )
+      .toSorted((a, b) => b.length - a.length)
+      .map((token) => new RegExp(this.escapeRegex(token), "gi")));
+
     // Calculate visible range with scrolling
     const startIndex = Math.max(
       0,
@@ -266,7 +260,7 @@ export class SearchableSelectList implements Component, Focusable {
       }
       const isSelected = i === this.selectedIndex;
       lines.push(
-        truncateToWidth(this.renderItemLine(item, isSelected, safeWidth, query), safeWidth, ""),
+        truncateToWidth(this.renderItemLine(item, isSelected, safeWidth, patterns), safeWidth, ""),
       );
     }
 
@@ -283,7 +277,7 @@ export class SearchableSelectList implements Component, Focusable {
     item: SearchableSelectItem,
     isSelected: boolean,
     width: number,
-    query: string,
+    patterns: RegExp[],
   ): string {
     const prefix = isSelected ? "→ " : "  ";
     const prefixWidth = prefix.length;
@@ -297,7 +291,7 @@ export class SearchableSelectList implements Component, Focusable {
       const descriptionLayout = this.getDescriptionLayout(width, prefixWidth);
       if (descriptionLayout) {
         const truncatedValue = truncateToWidth(displayValue, descriptionLayout.maxValueWidth, "");
-        const valueText = this.highlightMatch(truncatedValue, query);
+        const valueText = this.highlightMatch(truncatedValue, patterns);
 
         const usedByValue = visibleWidth(valueText);
         const remainingWidth = descriptionLayout.availableWidth - usedByValue;
@@ -307,7 +301,7 @@ export class SearchableSelectList implements Component, Focusable {
           const spacing = " ".repeat(descriptionLayout.spacingWidth);
           const truncatedDesc = truncateToWidth(description, descriptionWidth, "");
           // Highlight plain text first, then apply theme styling to avoid corrupting ANSI codes
-          const highlightedDesc = this.highlightMatch(truncatedDesc, query);
+          const highlightedDesc = this.highlightMatch(truncatedDesc, patterns);
           const descText = isSelected ? highlightedDesc : this.theme.description(highlightedDesc);
           const line = `${prefix}${valueText}${spacing}${descText}`;
           return isSelected ? this.theme.selectedText(line) : line;
@@ -317,7 +311,7 @@ export class SearchableSelectList implements Component, Focusable {
 
     const maxWidth = width - prefixWidth - 2;
     const truncatedValue = truncateToWidth(displayValue, maxWidth, "");
-    const valueText = this.highlightMatch(truncatedValue, query);
+    const valueText = this.highlightMatch(truncatedValue, patterns);
     const line = `${prefix}${valueText}`;
     return isSelected ? this.theme.selectedText(line) : line;
   }
@@ -383,7 +377,7 @@ export class SearchableSelectList implements Component, Focusable {
 
     if (prevValue !== newValue) {
       // Only current-query patterns are reusable; retaining older edits grows without bound.
-      this.regexCache.clear();
+      this.highlightPatterns = undefined;
       this.updateFilter();
     }
   }


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated highlight preparation when searchable TUI pickers redraw the same query across labels and descriptions. Regex reuse still left token trimming, normalization, deduplication, and ordering repeated for each highlighted field.

## Why This Change Was Made

`src/tui/components/searchable-select-list.ts` prepares literal patterns once for the current query and carries that array through each render, replacing the regex Map/getter. Query invalidation remains before filtering because selection callbacks can synchronously render. A render retains its own pattern snapshot through callbacks; no-match returns still precede lazy preparation and empty-query preparation caches an empty array.

Model, agent, and context-mode selectors share this owner; the session picker retains its separate path. Normalization, ANSI partition/replacement order, theme calls, clipping, and input handling remain unchanged. Production: +20/-26 lines (net -6); tests: +36/-27 (net +9). Tests replace private-Map inspection with current-query behavior during synchronous callbacks and broaden existing ANSI coverage to duplicate/case/whitespace queries and repeat renders.

## User Impact

Searchable pickers repeat less preparation while preserving exact highlights, selection, editing, cancellation, and rendered output. Only current-query patterns remain cached; no retained-heap improvement is claimed.

## Evidence

The exact-source proof preserves 486 complete output/input/callback outcomes across real Pi Input, production/plain/ANSI themes, widths 0–160, Unicode, overlapping/literal tokens, paste, navigation, deletion, kill/yank, undo, cancellation, and rendering inside callbacks. The saved baseline rewrites only imports to identical dependencies; reversing those edits verifies original source bytes and unchanged outcomes.

A nine-row wide render formerly prepared 18 times: 1,800 preparations across 100 redraws. The candidate prepares once cold and zero times on redraw. Cold regex counts remain 0/1/2 for empty/single/multi-token queries; no-match controls prepare and construct nothing in either version. After 300 progressive edits and requested GCs, a WeakRef probe finds exactly the current regex reachable in both versions—a narrow lifetime check, not total retained heap.

Node 26.8.1/macOS arm64 cumulative samples over 1,500 renders:

| Case | Sampled bytes before → after | Median ms before → after |
| --- | ---: | ---: |
| Empty, wide | 445,775,832 → 437,938,272 | 268.22 → 250.29 |
| Duplicate/multiple tokens, wide | 703,042,744 → 650,505,544 | 480.68 → 472.11 |
| One token, narrow | 341,718,272 → 328,514,056 | 245.22 → 237.04 |
| No-match control | 54,181,568 → 54,082,520 | 30.03 → 29.61 |

The 512-byte sampler includes collected objects; timing has three separate batches per case. One shared-host process pair does not establish whole-TUI/Gateway latency, RSS, or retained-heap savings. The small no-match difference is variation, not removed work.

```sh
node scripts/run-vitest.mjs src/tui/components/searchable-select-list.test.ts src/tui/components/filterable-select-list.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-picker-cancel-pty.e2e.test.ts -t /models
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/tui/components/searchable-select-list.ts src/tui/components/searchable-select-list.test.ts
```

Component suites pass 71 tests. Real `runTui`/PTY with a fake backend passes four cancellation cases before/after, with four session cases deliberately unselected. Eight captured no-match-picker/chat frames match exactly; matching-highlight bytes come from the component proof. The first PTY filter selected nothing and is excluded. PTY proof covers input/terminal behavior, not Gateway/provider transport.

Illustrations below render previously captured output; they are not live screenshots or additional runtime runs. The PTY capture omitted colors, so its palette is neutral. The component capture preserves recorded ANSI styling, with illustrative font/background. Source-frame hashes are printed in the images.

| Captured evidence | Before | After |
| --- | --- | --- |
| Component matching highlights | ![Recorded component highlights before](https://github.com/user-attachments/assets/c41f15cd-f81b-42d5-84fc-647a64ca1bde) | ![Recorded component highlights after](https://github.com/user-attachments/assets/e816fc04-80b6-4bc9-9d2d-91ca659cb89e) |
| Actual PTY no-match picker | ![Recorded PTY no-match frame before](https://github.com/user-attachments/assets/d3718b2e-6fce-465f-ba0b-f12c8d991b39) | ![Recorded PTY no-match frame after](https://github.com/user-attachments/assets/184ddb82-3763-49b0-beca-531e55f033e7) |
| Actual PTY after cancel | ![Recorded PTY returned-chat frame before](https://github.com/user-attachments/assets/185ec862-65c7-4f89-9dc7-0a3e0d2021ef) | ![Recorded PTY returned-chat frame after](https://github.com/user-attachments/assets/c6e12a0b-0ced-4cc3-b003-c5775dc36bc5) |

Typed lint, formatting, diff checks, and changed-plan classification pass; P2 review records no actionable findings. Broad local gates remain unrun; required exact-head hosted CI/native landing gates remain mandatory.
