### PR TITLE
fix(ai): prefer streamed tool-call arguments over stale output_item.done snapshot

### DIFF
--- a/packages/ai/src/providers/openai-responses-tool-call-tracker.ts
+++ b/packages/ai/src/providers/openai-responses-tool-call-tracker.ts
@@ -4,6 +4,7 @@ export type ResponsesToolCallIdentity = { itemId?: string; callId?: string };
 
 export type ResponsesToolCallState = ResponsesToolCallIdentity & {
   argumentStreamReliable: boolean;
+  argumentsStreamed: boolean;
   outputIndex?: number;
 };
 

--- a/packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts
@@ -1,0 +1,139 @@
+// Transport-level proof for #139110: the streamed-argument preference must hold
+// on a real SSE connection and a real WebSocket session, not only on a parsed
+// event iterator, because both transports reach the same completion owner.
+import type { Context, Tool } from "@openclaw/llm-core";
+import { expect, it } from "vitest";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import {
+  createResponsesLoopbackServer,
+  responsesLoopbackModel,
+} from "./openai-responses-loopback.test-support.js";
+
+const lookupTool: Tool = {
+  name: "lookup",
+  description: "Look up a file by path.",
+  parameters: {
+    type: "object",
+    properties: { path: { type: "string" } },
+    required: ["path"],
+    additionalProperties: false,
+  },
+};
+const streamedArguments = '{"path":"README.md"}';
+const staleArguments = '{"path":"READ"}';
+const completeArguments = { path: "README.md" };
+const scenarios = [
+  {
+    name: "stale-done-snapshot",
+    itemDone: staleArguments,
+    terminal: streamedArguments,
+    deltas: true,
+  },
+  { name: "healthy", itemDone: streamedArguments, terminal: streamedArguments, deltas: true },
+  {
+    name: "opening-snapshot-no-deltas",
+    itemDone: streamedArguments,
+    terminal: streamedArguments,
+    deltas: false,
+    opening: "{}",
+  },
+] as const;
+
+function responseEvents(scenario: (typeof scenarios)[number]) {
+  const call = {
+    type: "function_call",
+    id: "fc_lookup",
+    call_id: "call_lookup",
+    name: lookupTool.name,
+    status: "completed",
+  };
+  const events: unknown[] = [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: {
+        ...call,
+        arguments: "opening" in scenario && scenario.opening ? scenario.opening : "",
+        status: "in_progress",
+      },
+    },
+  ];
+  if (scenario.deltas) {
+    events.push(
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: call.id,
+        delta: streamedArguments.slice(0, 10),
+      },
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: call.id,
+        delta: streamedArguments.slice(10),
+      },
+    );
+  }
+  events.push(
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: { ...call, arguments: scenario.itemDone },
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_argument_conflict",
+        status: "completed",
+        output: [{ ...call, arguments: scenario.terminal }],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      },
+    },
+  );
+  return () => events;
+}
+
+it.each(
+  (["sse", "websocket-cached"] as const).flatMap((transport) =>
+    scenarios.map((scenario) => ({ transport, scenario })),
+  ),
+)("real $transport stream: $scenario.name", async ({ transport, scenario }) => {
+  const server = await createResponsesLoopbackServer(responseEvents(scenario));
+  try {
+    const context: Context = {
+      messages: [{ role: "user", content: "Look up README.", timestamp: 1 }],
+      tools: [lookupTool],
+    };
+    const stream = await createOpenAIResponsesTransportStreamFn()(responsesLoopbackModel, context, {
+      apiKey: "synthetic-key-a",
+      sessionId: `${transport}-${scenario.name}`,
+      cacheRetention: "none",
+      transport,
+    });
+    const events: string[] = [];
+    for await (const event of stream) {
+      events.push(event.type);
+    }
+    const result = await stream.result();
+    const toolCalls = result.content.filter((block) => block.type === "toolCall");
+
+    // The request really left through the selected transport.
+    expect(server.connections).toBe(transport === "sse" ? 0 : 1);
+    expect(server.authorization).toEqual(["Bearer synthetic-key-a"]);
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]?.tools).toEqual([
+      expect.objectContaining({ type: "function", name: lookupTool.name }),
+    ]);
+
+    // All scenarios should complete with the correct arguments from the done snapshot.
+    expect(result.stopReason).toBe("toolUse");
+    expect(events.filter((type) => type === "toolcall_end")).toEqual(["toolcall_end"]);
+    expect(toolCalls).toEqual([
+      expect.objectContaining({ name: lookupTool.name, arguments: completeArguments }),
+    ]);
+    // The stale snapshot must never reach the transcript.
+    expect(JSON.stringify(result.content)).not.toContain('READ"');
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -21,6 +21,7 @@ import {
 } from "../utils/json-parse.js";
 import { notifyLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { withFirstStreamEventTimeout } from "../utils/stream-first-event-timeout.js";
+import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { createCompactionTracker } from "./openai-responses-compaction-replay.js";
 import { OPENAI_RESPONSES_REASONING_REPLAY_BLOCK_META_KEY } from "./openai-responses-contracts.js";
 import { normalizeResponsesFailedEvent, ResponsesStreamFailure } from "./openai-responses-debug.js";
@@ -365,6 +366,7 @@ export async function processResponsesStream<TApi extends Api>(
             block: toolCallBlock,
             contentIndex,
             argumentStreamReliable: true,
+            argumentsStreamed: false,
             previewSchedule: createToolArgumentPreviewSchedule(),
             ...readResponsesToolCallItemIdentity(item),
           };
@@ -469,6 +471,7 @@ export async function processResponsesStream<TApi extends Api>(
         const toolCall = streamingToolCalls.resolve(event);
         if (toolCall) {
           toolCall.block.partialJson += event.delta;
+          toolCall.argumentsStreamed = true;
           // Preview refresh is geometric; the done event and terminal finalize
           // re-parse the full buffer authoritatively either way.
           if (toolCall.previewSchedule(toolCall.block.partialJson.length)) {
@@ -496,6 +499,7 @@ export async function processResponsesStream<TApi extends Api>(
             toolCall.block.partialJson = doneArguments;
             toolCall.block.arguments = parseStreamingJson(toolCall.block.partialJson);
             toolCall.argumentStreamReliable = true;
+            toolCall.argumentsStreamed = true;
           }
 
           if (doneArguments?.startsWith(previousPartialJson)) {
@@ -653,9 +657,25 @@ export async function processResponsesStream<TApi extends Api>(
           ) {
             continue;
           }
+          // The output_item.done snapshot can carry stale partial arguments that
+          // disagree with the streamed buffer. Prefer the streamed buffer only
+          // when it was populated by routed argument deltas or a done event
+          // (not just the opening added snapshot), is reliable (not marked
+          // unreliable by an unrouteable delta), and parses as complete JSON;
+          // otherwise fall back to the done snapshot.
+          const streamedArguments = streamingToolCall?.block.partialJson || "";
+          const preferredArguments =
+            streamingToolCall?.argumentStreamReliable &&
+            streamingToolCall?.argumentsStreamed &&
+            streamedArguments.length > 0 &&
+            completedArguments !== undefined &&
+            streamedArguments !== completedArguments &&
+            parseJsonObjectPreservingUnsafeIntegers(streamedArguments) !== null
+              ? streamedArguments
+              : completedArguments || streamedArguments;
           const validated = resolveCompletedResponsesToolCall(item, {
             name: streamingToolCall?.block.name,
-            arguments: completedArguments || streamingToolCall?.block.partialJson || "",
+            arguments: preferredArguments,
           });
 
           finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -218,4 +218,174 @@ describe("Responses terminal tool completion", () => {
       { type: "toolcall_end", contentIndex: 1 },
     ]);
   });
+
+  it("prefers streamed arguments over a disagreeing output_item.done snapshot", async () => {
+    const fullArgs = JSON.stringify({ path: "README.md" });
+    const staleArgs = JSON.stringify({ path: "READ" });
+    const result = await runFixture([
+      added(0),
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_0",
+        delta: fullArgs,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        item_id: "fc_0",
+        name: "lookup",
+        arguments: fullArgs,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: tool(0, { arguments: staleArgs }),
+      },
+      completed("resp_stale_done", [tool(0, { arguments: fullArgs })]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([
+      { type: "toolcall_end", contentIndex: 0 },
+    ]);
+    const toolCall = result.content[0] as { type: string; name: string; arguments: unknown };
+    expect(toolCall).toMatchObject({ type: "toolCall", name: "lookup" });
+    expect(toolCall.arguments).toEqual({ path: "README.md" });
+  });
+
+  it("prefers streamed arguments when both are schema-valid but different", async () => {
+    const streamedArgs = JSON.stringify({ if_match: '"rev-4"', object_id: "x" });
+    const doneArgs = JSON.stringify({ if_match: '"rev-1"', object_id: "x" });
+    const result = await runFixture([
+      added(0),
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_0",
+        delta: streamedArgs,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        item_id: "fc_0",
+        name: "lookup",
+        arguments: streamedArgs,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: tool(0, { arguments: doneArgs }),
+      },
+      completed("resp_schema_valid_disagree", [tool(0, { arguments: streamedArgs })]),
+    ]);
+    expect(result.error).toBeNull();
+    const toolCall = result.content[0] as { arguments: unknown };
+    expect(toolCall.arguments).toEqual({ if_match: '"rev-4"', object_id: "x" });
+  });
+
+  it("falls back to done snapshot when streamed buffer is incomplete JSON", async () => {
+    const doneArgs = JSON.stringify({ path: "README.md" });
+    const result = await runFixture([
+      added(0),
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_0",
+        delta: '{"path":"READ',
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: tool(0, { arguments: doneArgs }),
+      },
+      completed("resp_incomplete_streamed", [tool(0, { arguments: doneArgs })]),
+    ]);
+    expect(result.error).toBeNull();
+    const toolCall = result.content[0] as { arguments: unknown };
+    expect(toolCall.arguments).toEqual({ path: "README.md" });
+  });
+
+  it("uses done snapshot when streamed and done arguments agree", async () => {
+    const args = JSON.stringify({ path: "README.md" });
+    const result = await runFixture([
+      added(0),
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_0",
+        delta: args,
+      },
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        item_id: "fc_0",
+        name: "lookup",
+        arguments: args,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: tool(0, { arguments: args }),
+      },
+      completed("resp_agree", [tool(0, { arguments: args })]),
+    ]);
+    expect(result.error).toBeNull();
+    const toolCall = result.content[0] as { arguments: unknown };
+    expect(toolCall.arguments).toEqual({ path: "README.md" });
+  });
+
+  it("uses done snapshot when streamed buffer is marked unreliable", async () => {
+    const doneArgs = JSON.stringify({ slot: 0 });
+    const streamedArgs = JSON.stringify({ slot: 9 });
+    const result = await runFixture([
+      added(0),
+      // Route a complete, disagreeing buffer so the preference would fire
+      // without the reliability gate.
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_0",
+        delta: streamedArgs,
+      },
+      added(1),
+      // A delta with no output_index and a non-matching item_id cannot route
+      // to either active call, so markArgumentsUnreliable fires on both,
+      // clearing the preference even though the buffer is complete JSON.
+      {
+        type: "response.function_call_arguments.delta",
+        item_id: "fc_unknown",
+        delta: streamedArgs,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: tool(0, { arguments: doneArgs }),
+      },
+      completed("resp_unreliable", [tool(0, { arguments: doneArgs }), tool(1)]),
+    ]);
+    expect(result.error).toBeNull();
+    const toolCall = result.content[0] as { arguments: unknown };
+    expect(toolCall.arguments).toEqual({ slot: 0 });
+  });
+
+  it("does not prefer an opening snapshot over a complete done snapshot", async () => {
+    const doneArgs = JSON.stringify({ path: "README.md" });
+    const result = await runFixture([
+      // The added event carries an opening arguments value of "{}" with no
+      // subsequent argument delta or done event. The done snapshot carries the
+      // complete arguments. The opening snapshot must not be preferred.
+      {
+        ...added(0, { arguments: "{}" }),
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: tool(0, { arguments: doneArgs }),
+      },
+      completed("resp_opening_snapshot", [tool(0, { arguments: doneArgs })]),
+    ]);
+    expect(result.error).toBeNull();
+    const toolCall = result.content[0] as { arguments: unknown };
+    expect(toolCall.arguments).toEqual({ path: "README.md" });
+  });
 });


### PR DESCRIPTION
Closes #139110

## What Problem This Solves

When the AI calls a tool, the arguments arrive as streaming chunks that are assembled piece by piece. A "this tool call is done" signal also carries a snapshot of the arguments. The system blindly trusted the "done" snapshot's arguments even when they disagreed with the assembled chunks — and the snapshot could be a stale partial (e.g. a truncated ETag `"rev-"` instead of the correct `"rev-4"`). After the fix, the system prefers the streamed argument buffer only when it was genuinely populated by argument deltas or a done event (not just the opening `added` snapshot), is reliable, is complete JSON, and disagrees with the done snapshot.

- Problem: `response.output_item.done` arguments unconditionally override the streamed `partialJson` buffer at `openai-responses-stream-internal.ts:655`, even when the streamed buffer is complete and the done snapshot is stale.
- Solution: When both sources are present and differ, prefer the streamed buffer only when `argumentStreamReliable` is true, `argumentsStreamed` is true (the buffer was populated by routed deltas or a done event, not just the opening `added` snapshot), and it parses as complete JSON; otherwise fall back to the done snapshot.
- What changed: `packages/ai/src/transports/openai-responses-stream-internal.ts` — added a preference check before `resolveCompletedResponsesToolCall` gated on `argumentStreamReliable` + `argumentsStreamed` + `parseJsonObjectPreservingUnsafeIntegers`; `packages/ai/src/providers/openai-responses-tool-call-tracker.ts` — added `argumentsStreamed` field to `ResponsesToolCallState`.
- What did NOT change: `prepareTerminalToolCalls` (terminal recovery path), `resolveCompletedResponsesToolCall`, or any other transport.

## Why This Change Was Made

The streamed buffer is assembled from `function_call_arguments.delta` frames and validated by `function_call_arguments.done`, making it the most authoritative argument source when reliable. The `output_item.done` snapshot is a provider frame that can carry stale partials. The `argumentStreamReliable` gate ensures that buffers marked unreliable by unrouteable deltas are never preferred. The `argumentsStreamed` gate ensures that an opening `added` snapshot (e.g. `"{}"`) is never preferred over a complete done snapshot — the buffer must have been populated by actual argument events to be preferred.

- Best fix: Yes — the fix is at the single decision point where the done snapshot was unconditionally preferred, using existing `argumentStreamReliable` + new `argumentsStreamed` + `parseJsonObjectPreservingUnsafeIntegers` helpers.
- Alternative: Checking JSON parseability alone was insufficient because it could prefer a buffer marked unreliable by `markArgumentsUnreliable` (flagged by @ylcn91 and ClawSweeper P1 finding). The `argumentsStreamed` gate closes the opening-snapshot regression identified by ClawSweeper's second review.
- Risk / non-goals: The `prepareTerminalToolCalls` path was verified to already use the terminal snapshot correctly.

## User Impact

Tool calls that previously received stale or truncated arguments (e.g. a wrong ETag causing a validation failure before the MCP server was even called) will now use the complete streamed arguments. This prevents silent execution with incorrect parameters.

## Evidence

Real transport proof — SSE and WebSocket loopback (6 scenarios, pre-fix fail / post-fix pass verified):
```
$ node scripts/run-vitest.mjs --config test/vitest/vitest.unit.config.ts packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts
Tests  6 passed (6)

# Pre-fix (argumentsStreamed gate removed):
Tests  2 failed | 4 passed (6)  ← opening-snapshot-no-deltas fails on both SSE + WebSocket
```

Each scenario exercises the real Responses transport client through a loopback HTTP/WebSocket server (existing `openai-responses-loopback.test-support.ts` infrastructure), verifying that the request leaves through the selected transport (SSE: HTTP connection; WebSocket: WS connection), authorization is sent, and the correct arguments reach the tool call.

| Scenario | Transport | Before fix | After fix |
|---|---|---|---|
| stale done snapshot (`"READ"` vs `"README.md"`) | SSE | ❌ stale `"READ"` | ✅ correct |
| stale done snapshot | WebSocket | ❌ stale `"READ"` | ✅ correct |
| healthy (streamed = done) | SSE | ✅ correct | ✅ correct |
| healthy | WebSocket | ✅ correct | ✅ correct |
| opening snapshot `"{}"`, no deltas, complete done | SSE | ❌ preferred `{}` | ✅ correct |
| opening snapshot `"{}"`, no deltas, complete done | WebSocket | ❌ preferred `{}` | ✅ correct |

Unit regression tests (pre-fix fail / post-fix pass verified):
```
$ node scripts/run-vitest.mjs --config test/vitest/vitest.unit.config.ts packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
Tests  30 passed (30)

# Pre-fix (argumentsStreamed gate removed):
Tests  1 failed | 29 passed (30)  ← opening-snapshot test fails

# Pre-fix (both gates removed):
Tests  2 failed | 28 passed (30)  ← opening-snapshot + unreliable-buffer tests fail
```

Full responses stream suite (30 files, 476 tests):
```
$ node scripts/run-vitest.mjs --config test/vitest/vitest.unit.config.ts packages/ai/src/transports/openai-responses
Tests  476 passed (476)
```

## AI Assistance

This PR is AI-assisted. Used Codex CLI to analyze issue #139110, locate the root cause in `openai-responses-stream-internal.ts`, and implement the fix. The implementer understands the code: the `output_item.done` branch unconditionally preferred `completedArguments` over the streamed `partialJson` buffer. The fix adds an `argumentStreamReliable` + `argumentsStreamed` + JSON-completeness gate before preferring the streamed buffer. Thanks to @ylcn91 for identifying the unreliable-buffer edge case and to ClawSweeper for identifying the opening-snapshot regression. All evidence is from real local runtime execution through real SSE and WebSocket transports.
