### PR TITLE
perf(prometheus): reduce temporary scrape allocations

### DIFF
--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -17,7 +17,7 @@ import { isInternalDiagnosticEventMetadata, redactSensitiveText } from "../api.j
 
 type LabelSet = Record<string, string>;
 
-type CounterSample = {
+type ScalarSample = {
   help: string;
   labels: LabelSet;
   value: number;
@@ -30,18 +30,6 @@ type HistogramSample = {
   help: string;
   labels: LabelSet;
   sum: number;
-};
-
-type GaugeSample = {
-  help: string;
-  labels: LabelSet;
-  value: number;
-};
-
-type MetricSnapshot = {
-  counters: Map<string, CounterSample>;
-  gauges: Map<string, GaugeSample>;
-  histograms: Map<string, HistogramSample>;
 };
 
 type PrometheusMetricStore = ReturnType<typeof createPrometheusMetricStore>;
@@ -64,7 +52,9 @@ function seconds(ms: number | undefined): number | undefined {
 }
 
 function sortedLabels(labels: LabelSet): [string, string][] {
-  return Object.entries(labels).toSorted(([left], [right]) => left.localeCompare(right));
+  const entries = Object.entries(labels);
+  entries.sort(([left], [right]) => left.localeCompare(right));
+  return entries;
 }
 
 function metricKey(name: string, labels: LabelSet): string {
@@ -79,12 +69,16 @@ function escapeLabelValue(value: string): string {
   return value.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
 }
 
+function formatLabelEntry([key, value]: [string, string]): string {
+  return `${key}="${escapeLabelValue(value)}"`;
+}
+
 function formatLabels(labels: LabelSet): string {
   const entries = sortedLabels(labels);
   if (entries.length === 0) {
     return "";
   }
-  return `{${entries.map(([key, value]) => `${key}="${escapeLabelValue(value)}"`).join(",")}}`;
+  return `{${entries.map(formatLabelEntry).join(",")}}`;
 }
 
 function formatPrometheusNumber(value: number): string {
@@ -95,8 +89,8 @@ function formatPrometheusNumber(value: number): string {
 }
 
 function createPrometheusMetricStore() {
-  const counters = new Map<string, CounterSample>();
-  const gauges = new Map<string, GaugeSample>();
+  const counters = new Map<string, ScalarSample>();
+  const gauges = new Map<string, ScalarSample>();
   const histograms = new Map<string, HistogramSample>();
   let droppedSeries = 0;
 
@@ -177,19 +171,22 @@ function createPrometheusMetricStore() {
     }
   };
 
-  const snapshot = (): MetricSnapshot => {
-    const counterSnapshot = new Map(counters);
+  const snapshot = () => {
+    const counterSnapshot = [...counters];
     if (droppedSeries > 0) {
-      counterSnapshot.set(metricKey(DROPPED_SERIES_COUNTER_NAME, {}), {
-        help: "Prometheus metric series dropped because the exporter series cap was reached.",
-        labels: {},
-        value: droppedSeries,
-      });
+      counterSnapshot.push([
+        metricKey(DROPPED_SERIES_COUNTER_NAME, {}),
+        {
+          help: "Prometheus metric series dropped because the exporter series cap was reached.",
+          labels: {},
+          value: droppedSeries,
+        },
+      ]);
     }
     return {
       counters: counterSnapshot,
-      gauges: new Map(gauges),
-      histograms: new Map(histograms),
+      gauges: [...gauges],
+      histograms: [...histograms],
     };
   };
 
@@ -231,46 +228,43 @@ function renderPrometheusMetrics(store: PrometheusMetricStore): string {
     lines.push(`# TYPE ${name} ${type}`);
   };
 
-  const counterEntries = [...snapshot.counters.entries()].toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  );
-  for (const [key, sample] of counterEntries) {
-    const name = key.split("|", 1)[0] ?? "";
-    emitHeader(name, "counter", sample.help);
-    lines.push(`${name}${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.value)}`);
+  for (const [type, entries] of [
+    ["counter", snapshot.counters],
+    ["gauge", snapshot.gauges],
+  ] as const) {
+    entries.sort(([left], [right]) => left.localeCompare(right));
+    for (const [key, sample] of entries) {
+      const name = key.split("|", 1)[0] ?? "";
+      emitHeader(name, type, sample.help);
+      lines.push(`${name}${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.value)}`);
+    }
   }
 
-  const gaugeEntries = [...snapshot.gauges.entries()].toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  );
-  for (const [key, sample] of gaugeEntries) {
-    const name = key.split("|", 1)[0] ?? "";
-    emitHeader(name, "gauge", sample.help);
-    lines.push(`${name}${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.value)}`);
-  }
-
-  const histogramEntries = [...snapshot.histograms.entries()].toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  );
-  for (const [key, sample] of histogramEntries) {
+  snapshot.histograms.sort(([left], [right]) => left.localeCompare(right));
+  for (const [key, sample] of snapshot.histograms) {
     const name = key.split("|", 1)[0] ?? "";
     emitHeader(name, "histogram", sample.help);
+    const labels = formatLabels(sample.labels);
+    const bucketLabels = sortedLabels({ ...sample.labels, le: "" });
+    const boundIndex = bucketLabels.findIndex(([labelKey]) => labelKey === "le");
+    const bucketFragments = bucketLabels.map(formatLabelEntry);
+    // Only the bound changes between buckets; reuse sorted, escaped labels within this scrape.
     for (let index = 0; index < sample.buckets.length; index += 1) {
       const bucket = sample.buckets[index];
       if (bucket === undefined) {
         continue;
       }
+      bucketFragments[boundIndex] = `le="${String(bucket)}"`;
       lines.push(
-        `${name}_bucket${formatLabels({ ...sample.labels, le: String(bucket) })} ${formatPrometheusNumber(sample.counts[index] ?? 0)}`,
+        `${name}_bucket{${bucketFragments.join(",")}} ${formatPrometheusNumber(sample.counts[index] ?? 0)}`,
       );
     }
+    bucketFragments[boundIndex] = 'le="+Inf"';
     lines.push(
-      `${name}_bucket${formatLabels({ ...sample.labels, le: "+Inf" })} ${formatPrometheusNumber(sample.count)}`,
+      `${name}_bucket{${bucketFragments.join(",")}} ${formatPrometheusNumber(sample.count)}`,
     );
-    lines.push(`${name}_sum${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.sum)}`);
-    lines.push(
-      `${name}_count${formatLabels(sample.labels)} ${formatPrometheusNumber(sample.count)}`,
-    );
+    lines.push(`${name}_sum${labels} ${formatPrometheusNumber(sample.sum)}`);
+    lines.push(`${name}_count${labels} ${formatPrometheusNumber(sample.count)}`);
   }
 
   lines.push("");


### PR DESCRIPTION
## What Problem This Solves

Resolves repeated copying and label formatting during Prometheus scrapes, especially near the exporter’s series cap. Rendering copied metric maps, expanded them into arrays, copied those arrays again for sorting, and repeatedly sorted/escaped histogram labels for buckets, sum, and count.

## Why This Change Was Made

`extensions/diagnostics-prometheus/src/service.ts` creates fresh scrape-local entry arrays directly from its canonical private maps, sorts those arrays, shares counter/gauge rendering, and reuses sorted/escaped histogram-label fragments within a scrape. Projection remains synchronous; the former map snapshots were shallow and did not isolate sample objects.

The current-main composition preserves the original optimization and main’s newly added `openclaw_gateway_build_info` gauge. That existing gauge reserves one slot in the same 2,048-sample cap, captures process identity and optional build ID once at enabled startup, and clears/repopulates on stop/restart. It still uses ordinary gauge rendering. Runtime identity remains with the service host’s lease-validated callback; the optimization changes neither identity lookup nor admission/retention.

Production remains +46/-52 lines (net -6); tests/support: +0/-0. No persistent cache, runtime state, dependency, or identity capability is added by this PR.

## User Impact

Scrapes allocate fewer temporary objects while preserving metric names, labels, escaping, buckets, privacy, cap/drop accounting, build identity, reset behavior, and HTTP metadata. Existing series continue updating after saturation, and the reserved build-info sample survives saturation.

## Evidence

The new sealed proof compares main `3dff8818ef42872cecc3899b41dffd95942fe70f` with that baseline plus the exact reviewed performance edits. **Eleven complete body pairs match byte-for-byte**, covering startup/restart, mixed metrics, stop/disabled diagnostics, RPC cap/update/overflow, model cap, process-only identity, and unavailable identity capability. The original four-run measurements remain historical; no original output is reused as current-composition proof.

The actual exporter receives synthetic events through the real diagnostic dispatcher. Controlled runtime identity preserves exact comparisons. The build-info sample appears once with value 1 and correctly ordered labels; process/build IDs stay confined to it. With the lifecycle counter and gauge admitted first, RPC drops remain 89 after existing-series updates and rise to 91 for two unseen samples; model drops are 2,154 in both arms.

**Six HTTP states per arm** exercise real local GET/HEAD/POST, including saturation and optional/disabled identity cases. GET/HEAD return 200, POST returns 405 with `Allow: GET, HEAD`, HEAD is empty, and Content-Length matches each GET body—including the 31,140-byte mixed response and zero-byte disabled response. All 12 servers close; stop removes subscriptions. Five enabled identity-bearing starts make five identity reads despite repeated scrapes; disabled startup makes none.

One fresh allocation observation per arm on Node 26.8.1/macOS arm64:

| Workload | Projections | Baseline sampled bytes | Composed sampled bytes |
| --- | ---: | ---: | ---: |
| Mixed | 300 | 237,514,760 | 82,368,456 |
| RPC cap | 25 | 1,801,207,000 | 431,546,848 |
| Model cap | 25 | 2,700,152,232 | 638,509,816 |

These 4 KiB cumulative V8 samples include collected objects after five warmups; imports, event seeding, and HTTP are excluded. The single shared-host pair is descriptive corroboration, not retained heap/RSS, statistical significance, whole-Gateway performance, or authentication/installation proof.

```sh
node scripts/run-vitest.mjs extensions/diagnostics-prometheus/src/service.test.ts extensions/diagnostics-prometheus/src/service.event-loop.test.ts extensions/diagnostics-prometheus/src/service.runtime-identity.test.ts src/plugins/services.runtime-identity.test.ts
node scripts/run-oxlint.mjs --tsconfig extensions/tsconfig.json extensions/diagnostics-prometheus/src/service.ts
```

Both arms pass **32 tests**: 31 plugin tests and one host lease/identity test. Candidate type-aware plugin lint and formatting pass. Independent P2 review of this composition records no actionable findings. Broad duplicate gates were not run; final exact-head required CI/native landing and applicable integration gates remain with publication.
