### PR TITLE
fix(subagents): use metadata projection in subagent list reader

### DIFF
--- a/src/agents/subagents/registry/subagent-list.metadata-read.test.ts
+++ b/src/agents/subagents/registry/subagent-list.metadata-read.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../config/config.js";
+import { replaceSessionEntrySync } from "../../../config/sessions/session-accessor.js";
+import { buildSubagentList } from "./subagent-list.js";
+import {
+  addSubagentRunForTests,
+  resetSubagentRegistryForTests,
+} from "./subagent-registry.test-helpers.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+let testWorkspaceDir = os.tmpdir();
+
+beforeAll(async () => {
+  testWorkspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-subagent-list-meta-"));
+});
+
+afterAll(async () => {
+  await fs.rm(testWorkspaceDir, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 50,
+  });
+});
+
+beforeEach(() => {
+  resetSubagentRegistryForTests();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("buildSubagentList metadata projection", () => {
+  it("does not decode unrelated saved prompts in a large session store", () => {
+    const run = {
+      runId: "run-meta",
+      childSessionKey: "agent:main:subagent:target",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "target task",
+      cleanup: "keep",
+      createdAt: 1000,
+      execution: { status: "running", startedAt: 1000 },
+    } satisfies SubagentRunRecord;
+    addSubagentRunForTests(run);
+
+    const storePath = path.join(testWorkspaceDir, "sessions-metadata-projection.json");
+    // Seed 20 unrelated sessions whose skillsSnapshot.prompt is a 4 KiB blob.
+    for (let i = 0; i < 20; i++) {
+      replaceSessionEntrySync(
+        { storePath, sessionKey: `agent:main:subagent:other-${i}` },
+        {
+          sessionId: `other-${i}`,
+          updatedAt: 1,
+          skillsSnapshot: {
+            prompt: `UNRELATED_PAYLOAD_${"x".repeat(4096)}`,
+            skills: [],
+          },
+        },
+      );
+    }
+    // Seed the one target session the list actually consumes.
+    replaceSessionEntrySync(
+      { storePath, sessionKey: "agent:main:subagent:target" },
+      {
+        sessionId: "target",
+        updatedAt: 2000,
+        model: "opencode/claude-opus-4-6",
+        inputTokens: 5,
+        outputTokens: 10,
+        totalTokens: 15,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+    );
+
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    } as OpenClawConfig;
+
+    const parse = vi.spyOn(JSON, "parse");
+    const list = buildSubagentList({
+      cfg,
+      runs: [run],
+      recentMinutes: 30,
+      taskMaxChars: 110,
+    });
+
+    // The target session must still appear in the active list.
+    expect(list.active[0]?.task).toBe("target task");
+
+    const unrelatedParses = parse.mock.calls.filter(
+      ([value]) => typeof value === "string" && value.includes("UNRELATED_PAYLOAD_"),
+    ).length;
+    expect(unrelatedParses).toBe(0);
+  });
+});

--- a/src/agents/subagents/registry/subagent-list.ts
+++ b/src/agents/subagents/registry/subagent-list.ts
@@ -77,7 +77,7 @@ function resolveSessionEntryForKey(params: {
   let store = params.cache.get(storePath);
   if (!store) {
     store = Object.fromEntries(
-      listSessionEntriesReadOnly({ storePath, clone: false }).map(({ sessionKey, entry }) => [
+      listSessionEntriesReadOnly({ storePath, clone: false, projection: "list" }).map(({ sessionKey, entry }) => [
         sessionKey,
         entry,
       ]),

--- a/src/agents/subagents/registry/subagent-list.ts
+++ b/src/agents/subagents/registry/subagent-list.ts
@@ -77,10 +77,9 @@ function resolveSessionEntryForKey(params: {
   let store = params.cache.get(storePath);
   if (!store) {
     store = Object.fromEntries(
-      listSessionEntriesReadOnly({ storePath, clone: false, projection: "list" }).map(({ sessionKey, entry }) => [
-        sessionKey,
-        entry,
-      ]),
+      listSessionEntriesReadOnly({ storePath, clone: false, projection: "list" }).map(
+        ({ sessionKey, entry }) => [sessionKey, entry],
+      ),
     );
     params.cache.set(storePath, store);
   }


### PR DESCRIPTION
## What Problem This Solves

Closes #139518.

The common subagent-list owner (`buildSubagentList` in `src/agents/subagents/registry/subagent-list.ts`) called `listSessionEntriesReadOnly` without a `projection`, so the accessor defaulted to the full projection and decoded every unrelated `skillsSnapshot.prompt` payload in a large session store — even though the list only consumes session metadata (model, tokens, task, status, etc.).

This path is shared by active-subagent prompt construction, the subagents list tool, and the `/subagents` command.

The recently merged #139450 selected `projection: "list"` for completion, depth, and inherited-policy readers but did not cover the common subagent-list reader. This PR closes that gap.

## Root Cause

`subagent-list.ts:80`:
```ts
listSessionEntriesReadOnly({ storePath, clone: false })  // ← no projection → full
```

The adjacent depth reader (`subagent-depth.ts:35`) already uses the metadata projection:
```ts
listSessionEntriesReadOnly({ agentId, storePath, clone: false, projection: "list" })
```

The `"list"` projection (`session-accessor.sqlite-status.ts`) strips `$.skillsSnapshot` and `$.systemPromptReport` from the JSON before decoding, keeping all metadata fields the list actually consumes.

## Fix

Add `projection: "list"` to the `listSessionEntriesReadOnly` call in `subagent-list.ts`:

```diff
- listSessionEntriesReadOnly({ storePath, clone: false })
+ listSessionEntriesReadOnly({ storePath, clone: false, projection: "list" })
```

One line. No behavior change for the list output — the list never accesses `skillsSnapshot` or `systemPromptReport`.

## Evidence

### Runtime proof — buildSubagentList before/after capture

The proof creates a session store with 500 entries (1 target with model/tokens/status, 499 unrelated entries with 200 KB `skillsSnapshot.prompt` blobs, ~97 MB total prompt data). It adds a subagent run for the target, then calls `buildSubagentList` directly and captures the full output.

The proof is run twice: **before** the fix (full projection, current main) and **after** the fix (list projection, this PR branch).

**Node v24.15.0, `--expose-gc` for accurate RSS.**

#### BEFORE fix (full projection, current main)

```
--- buildSubagentList output ---
  total:    1
  active:   1
  recent:   0

--- Active subagent[0] metadata ---
  runId:        run-proof
  sessionKey:   agent:main:subagent:target
  task:         target task — analyze session metadata
  label:        target task — analyze session metadata
  status:       running
  model:        opencode/claude-opus-4-6
  totalTokens:  15
  runtime:      20702d18h
  runtimeMs:    1788719212343
  pendingDescendants: 0

--- Rendered text output ---
active subagents:
1. target task — analyze session metadata (claude-opus-4-6, 20702d18h, tokens 15 (in 5 / out 10)) running

recent (last 30m):
(none)

--- Performance ---
  Elapsed:   189.30 ms
  RSS delta: 106.23 MB
```

#### AFTER fix (list projection, this PR)

```
--- buildSubagentList output ---
  total:    1
  active:   1
  recent:   0

--- Active subagent[0] metadata ---
  runId:        run-proof
  sessionKey:   agent:main:subagent:target
  task:         target task — analyze session metadata
  label:        target task — analyze session metadata
  status:       running
  model:        opencode/claude-opus-4-6
  totalTokens:  15
  runtime:      20702d18h
  runtimeMs:    1788719221123
  pendingDescendants: 0

--- Rendered text output ---
active subagents:
1. target task — analyze session metadata (claude-opus-4-6, 20702d18h, tokens 15 (in 5 / out 10)) running

recent (last 30m):
(none)

--- Performance ---
  Elapsed:   90.99 ms
  RSS delta: 0.36 MB
```

#### Output preservation — field-by-field comparison

| Field | Before (full) | After (list) | Match |
|-------|-------------|------------|-------|
| **model** | opencode/claude-opus-4-6 | opencode/claude-opus-4-6 | ✅ |
| **totalTokens** | 15 | 15 | ✅ |
| **task** | target task — analyze session metadata | target task — analyze session metadata | ✅ |
| **status** | running | running | ✅ |
| **label** | target task — analyze session metadata | target task — analyze session metadata | ✅ |
| **pendingDescendants** | 0 | 0 | ✅ |
| **rendered text** | `1. target task — analyze session metadata (claude-opus-4-6, 20702d18h, tokens 15 (in 5 / out 10)) running` | identical | ✅ |

#### Performance improvement

| Metric | Before (full) | After (list) | Improvement |
|--------|-------------|------------|-------------|
| **Elapsed** | 189.30 ms | 90.99 ms | 2.1x faster (98.31 ms saved) |
| **RSS delta** | 106.23 MB | 0.36 MB | 105.87 MB eliminated |

### Accessor-level runtime proof (supplemental)

A separate proof creates 500 session entries with 200 KB prompts (~98 MB total) and calls `listSessionEntriesReadOnly` directly with full vs list projection, closing/reopening the database between measurements:

```
--- BEFORE fix (full projection, default) ---
  Elapsed:   160.31 ms
  RSS delta: 104.06 MB
  Entries:   500

--- AFTER fix (projection: list) ---
  Elapsed:   71.50 ms
  RSS delta: 0.00 MB
  Entries:   500

--- Output preservation ---
  Session keys match:    YES
  Metadata fields match: YES
  Entry count match:     YES

Speedup: 2.2x faster with list projection
RSS reduction: 104.06 MB
```

### Test evidence

**Before** (issue report): `{"unrelatedParses":20}` — 20 unrelated 4 KiB prompt payloads decoded per list build.

**With the metadata projection** (issue report): `{"unrelatedParses":0}`.

**Test added** (`subagent-list.metadata-read.test.ts`): seeds 20 unrelated sessions with 4 KiB `skillsSnapshot.prompt` blobs, spies on `JSON.parse`, calls `buildSubagentList`, and asserts:
1. The target run still appears in `list.active[0]?.task` — metadata is preserved.
2. Zero `JSON.parse` calls touch `UNRELATED_PAYLOAD_` — unrelated prompts are not decoded.

This mirrors the metadata-read test from #139450 (`subagent-session-reconciliation.metadata-read.test.ts`).

## Compatibility

- Open PR #135480 touches the same list module for a distinct shared-working-directory advisory. Its `spawnedCwd` metadata is retained by the `"list"` projection, so the fixes are compatible.
- The `"list"` projection is already used by `subagent-depth.ts`, `subagent-session-reconciliation.ts`, and `attempt-history.ts` without issues.
