### PR TITLE
fix(ui): keep Logbook timestamps clear of the activity stripe

### DIFF
--- a/ui/src/pages/plugin/logbook-view.browser.test.ts
+++ b/ui/src/pages/plugin/logbook-view.browser.test.ts
@@ -1,0 +1,95 @@
+import { render } from "lit";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { page } from "vitest/browser";
+import { i18n } from "../../i18n/index.ts";
+import "../../styles/base.css";
+import { getLogbookState } from "./logbook-controller.ts";
+import { renderLogbook } from "./logbook-view.ts";
+
+let container: HTMLDivElement;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+});
+
+afterEach(() => {
+  render(null, container);
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+it.each([
+  { locale: "en", width: 1000, expected: "12:00 AM–12:10 AM" },
+  { locale: "de", width: 1000, expected: "00:00–00:10" },
+  { locale: "en", width: 769, expected: "12:00 AM–12:10 AM" },
+  { locale: "en", width: 768, expected: "12:00 AM–12:10 AM" },
+] as const)(
+  "keeps the $locale time range separate at $width px",
+  async ({ locale, width, expected }) => {
+    await page.viewport(width, 700);
+    vi.spyOn(i18n, "getLocale").mockReturnValue(locale);
+    const host = {};
+    const state = getLogbookState(host);
+    state.day = "2026-01-01";
+    state.status = {
+      captureEnabled: true,
+      capturePaused: false,
+      captureIntervalSeconds: 30,
+      analysisIntervalMinutes: 15,
+      retentionDays: 30,
+      pendingFrames: 0,
+      analysisRunning: false,
+      visionModelSource: "missing",
+      today: state.day,
+      todayCards: 1,
+      timeZone: "UTC",
+    };
+    state.timeline = {
+      day: state.day,
+      cards: [
+        {
+          id: 1,
+          day: state.day,
+          startMs: Date.UTC(2026, 0, 1, 0, 0),
+          endMs: Date.UTC(2026, 0, 1, 0, 10),
+          title: "Reviewing the synthetic example project and its implementation notes ".repeat(4),
+          summary: "Synthetic activity for timestamp layout validation.",
+          detail: "",
+          category: "Coding",
+          distractions: [],
+        },
+      ],
+      stats: { trackedMs: 0, distractionMs: 0, categories: [], apps: [] },
+    };
+    render(renderLogbook({ host, client: null, connected: false }), container);
+
+    const header = container.querySelector<HTMLElement>(".logbook-card__header")!;
+    const time = header.querySelector<HTMLElement>(".logbook-card__time")!;
+    const stripe = header.querySelector<HTMLElement>(".logbook-card__stripe")!;
+    const title = header.querySelector<HTMLElement>(".logbook-card__title")!;
+    const meta = header.querySelector<HTMLElement>(".logbook-card__meta")!;
+    expect(time.textContent?.trim()).toBe(expected);
+    if (width <= 768) {
+      expect(getComputedStyle(time).display).toBe("none");
+      expect(getComputedStyle(meta).display).toBe("none");
+    } else {
+      const range = document.createRange();
+      range.selectNodeContents(time);
+      expect(range.getBoundingClientRect().width).toBeGreaterThan(0);
+      expect(range.getBoundingClientRect().right).toBeLessThanOrEqual(
+        stripe.getBoundingClientRect().left,
+      );
+    }
+    expect(stripe.getBoundingClientRect().width).toBeGreaterThan(0);
+    expect(title.getBoundingClientRect().left).toBeGreaterThan(
+      stripe.getBoundingClientRect().right,
+    );
+    expect(title.getBoundingClientRect().right).toBeLessThanOrEqual(
+      header.getBoundingClientRect().right,
+    );
+    expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+    expect(getComputedStyle(title).textOverflow).toBe("ellipsis");
+    expect(getComputedStyle(title).overflow).toBe("hidden");
+  },
+);

--- a/ui/src/styles/logbook.css
+++ b/ui/src/styles/logbook.css
@@ -132,7 +132,7 @@
 
 .logbook-card__header {
   display: grid;
-  grid-template-columns: 92px 4px minmax(0, 1fr) auto;
+  grid-template-columns: max-content 4px minmax(0, 1fr) auto;
   gap: 10px;
   align-items: center;
   width: 100%;


### PR DESCRIPTION
Closes #139365.

## What Problem This Solves

Fixes an issue where Logbook readers using 12-hour clocks could see the end-time AM/PM marker overlap the activity stripe and title.

## Why This Change Was Made

The time column now sizes to its localized contents. Timestamp formatting, title truncation, and the existing compact-screen layout are preserved.

## User Impact

Both endpoints remain readable and separate from the activity heading. Category, application, duration, and capture-timezone formatting remain intact.

## Evidence

The contributor's four Chromium geometry cases pass on head `3f2bf28f16d9e53006f9310325d62e0c7334a514`, including English, German, and both sides of the 768px breakpoint. The existing capture-timezone test passes. Exact-head [CI run 34000442241](https://github.com/openclaw/openclaw/actions/runs/34000442241) is green, including UI typechecks and all UI browser checks. Focused formatting and lint checks pass.

Independent verification used the shipped Gateway and Control UI with synthetic Logbook data. Current main `4bb95eb02cede3b2677aa7274c4f574431531c92` reproduces the overlap: at 1280px, midnight text extends 16.8px past the stripe's start. The exact candidate has a 10px gap with both endpoints fully visible. The browser and capture host use different time zones; the displayed range follows the capture host.

A fresh source-blind browser pass accepted all ten observable requirements across 64 candidate captures: English and German, desktop and compact widths, collapsed and expanded rows, native 125%/150%/200% browser zoom, reload, day navigation, and no horizontal page scroll. Visible ranges retain a 10px gap. Source inspection separately confirms one row layout and the unchanged 768px compact policy.

The existing sanitized contributor captures were independently opened and visually inspected:

| Before | After |
| --- | --- |
| ![Timestamp overlaps the stripe](https://github.com/user-attachments/assets/ab9388cc-b3b0-4397-b7a5-fb0490fc7b73) | ![Both timestamps remain clear of the stripe](https://github.com/user-attachments/assets/5efd2c01-8580-43d6-a703-7d32254d08e2) |

Original fix by @TurboTheTurtle. Report and [supporting independent verification](https://github.com/openclaw/openclaw/pull/139539#issuecomment-5555755831) by @Colton-Harris.
