### PR TITLE
fix(memory): split embedding batches rejected for an input array item cap

### DIFF
--- a/extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts
+++ b/extensions/memory-core/src/memory/generic-embedding-provider.integration.test.ts
@@ -1,6 +1,7 @@
 // Memory Core tests cover generic embedding provider.integration plugin behavior.
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
+import { DatabaseSync } from "node:sqlite";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   clearEmbeddingProviders,
@@ -9,6 +10,9 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createEmbeddingProvider } from "./embeddings.js";
+import type { IndexedMemoryChunk } from "./manager-chunk-writer.js";
+import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
+import type { MemorySemanticProviderGeneration } from "./manager-sync-ops.js";
 
 type CapturedRequest = {
   method: string | undefined;
@@ -34,7 +38,10 @@ async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknow
   return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
 }
 
-async function startEmbeddingServer(): Promise<TestServer> {
+async function startEmbeddingServer(options?: {
+  /** Returns a rejection for a request the provider should not have sent, or undefined to serve it. */
+  reject?: (inputCount: number) => { status: number; body: string } | undefined;
+}): Promise<TestServer> {
   const requests: CapturedRequest[] = [];
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
@@ -48,6 +55,12 @@ async function startEmbeddingServer(): Promise<TestServer> {
         });
         const input = body.input;
         const texts = Array.isArray(input) ? input : [input];
+        const rejection = options?.reject?.(texts.length);
+        if (rejection) {
+          res.writeHead(rejection.status, { "content-type": "application/json" });
+          res.end(rejection.body);
+          return;
+        }
         res.writeHead(200, { "content-type": "application/json" });
         res.end(
           JSON.stringify({
@@ -229,5 +242,132 @@ describe("memory-core generic embedding provider contract", () => {
       ),
     ).rejects.toThrow("Unknown memory embedding provider: openai");
     expect(server.requests).toHaveLength(0);
+  });
+});
+
+// Zhipu BigModel embedding-3 caps `input` at 64 items and rejects a larger array
+// with HTTP 400 code 1214. Memory batches are byte-budgeted, not item-counted, so
+// short chunks pack far more than 64 items into one request (issue #139040).
+const ZHIPU_INPUT_ARRAY_LIMIT = 64;
+const ZHIPU_REJECTION_BODY = JSON.stringify({
+  error: { code: "1214", message: "input array max 64" },
+});
+
+/**
+ * Drives the real Memory Core embedding owner. Only the collaborators that would
+ * open an index or acquire an external provider are supplied; the batching,
+ * splitting, retry classification, and timeout methods under test stay real.
+ */
+function createMemoryEmbeddingOwner(params: {
+  provider: NonNullable<Awaited<ReturnType<typeof createEmbeddingProvider>>["provider"]>;
+  providerRuntime: Awaited<ReturnType<typeof createEmbeddingProvider>>["runtime"];
+  database: DatabaseSync;
+}) {
+  return Object.assign(Object.create(MemoryManagerEmbeddingOps.prototype), {
+    provider: params.provider,
+    providerRuntime: params.providerRuntime,
+    // `db` is a getter over `publishedDatabase`; the cache lookup is disabled, so
+    // only the handle itself is needed to satisfy the owner's database context.
+    publishedDatabase: { db: params.database },
+    cache: { enabled: false },
+    settings: { sync: {} },
+    markLocalEmbeddingProviderDegraded: () => {},
+    withProviderUse: async <T>(_provider: unknown, run: () => Promise<T>) => await run(),
+  }) as {
+    embedChunksInBatches: (
+      chunks: IndexedMemoryChunk[],
+      generation: MemorySemanticProviderGeneration,
+    ) => Promise<number[][]>;
+  };
+}
+
+async function createMemoryEmbeddingOwnerForServer(baseUrl: string, database: DatabaseSync) {
+  const created = await createEmbeddingProvider(createMemoryEmbeddingOptions({ baseUrl }));
+  const provider = created.provider;
+  if (!provider) {
+    throw new Error("expected the OpenAI-compatible embedding provider to be created");
+  }
+  const generation: MemorySemanticProviderGeneration = {
+    kind: "semantic",
+    provider,
+    runtime: created.runtime,
+    database,
+    providerKey: "integration-proof",
+    identities: [],
+  };
+  return {
+    owner: createMemoryEmbeddingOwner({ provider, providerRuntime: created.runtime, database }),
+    generation,
+  };
+}
+
+// Unique text lengths make each vector identify its own input, because the
+// fixture server answers with `[text.length, indexWithinRequest + 0.5, 3]`.
+function distinctChunks(count: number): IndexedMemoryChunk[] {
+  return Array.from(
+    { length: count },
+    (_, index) =>
+      ({
+        text: "x".repeat(index + 1),
+        hash: `hash-${index}`,
+        startLine: index + 1,
+        endLine: index + 1,
+      }) as IndexedMemoryChunk,
+  );
+}
+
+describe("memory-core embedding batch recovery over real transport", () => {
+  it("halves an oversized batch until the provider input array limit is met", async () => {
+    const server = await startEmbeddingServer({
+      reject: (inputCount) =>
+        inputCount > ZHIPU_INPUT_ARRAY_LIMIT
+          ? { status: 400, body: ZHIPU_REJECTION_BODY }
+          : undefined,
+    });
+    const database = new DatabaseSync(":memory:");
+    const { owner, generation } = await createMemoryEmbeddingOwnerForServer(
+      server.baseUrl,
+      database,
+    );
+    const chunks = distinctChunks(100);
+
+    const embeddings = await owner.embedChunksInBatches(chunks, generation);
+
+    // The byte budget alone put all 100 short chunks in one request; recovery
+    // halved it until each request fit the 64-item cap.
+    expect(server.requests.map((request) => (request.body.input as unknown[]).length)).toEqual([
+      100, 50, 50,
+    ]);
+    // Vectors come back in input order across the split: the first component is
+    // each chunk's own unique length, ascending.
+    expect(embeddings).toEqual(
+      Array.from({ length: 100 }, (_, index) => [index + 1, (index % 50) + 0.5, 3]),
+    );
+    database.close();
+  });
+
+  it("does not split a generic provider rejection that names no numeric bound", async () => {
+    const server = await startEmbeddingServer({
+      reject: () => ({
+        status: 400,
+        body: JSON.stringify({
+          error: { code: "1214", message: "input array must contain strings" },
+        }),
+      }),
+    });
+    const database = new DatabaseSync(":memory:");
+    const { owner, generation } = await createMemoryEmbeddingOwnerForServer(
+      server.baseUrl,
+      database,
+    );
+
+    await expect(owner.embedChunksInBatches(distinctChunks(100), generation)).rejects.toMatchObject(
+      {
+        code: "MEMORY_EMBEDDING_OPERATION_FAILED",
+        operation: "batch",
+      },
+    );
+    expect(server.requests).toHaveLength(1);
+    database.close();
   });
 });

--- a/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.retry.test.ts
@@ -141,6 +141,12 @@ describe.each(["text", "structured"])("memory embedding batch retry boundary (%s
       () =>
         '{"error":{"message":"<400> InternalError.Algo.InvalidParameter: Value error, batch size is invalid, it should not be larger than 10.: input.contents","type":"InvalidParameter","code":"InvalidParameter"}}',
     ],
+    // Zhipu names the bound on the input array itself, with no adjacent
+    // `embeddings` token, under its generic 1214 invalid-parameter code.
+    [
+      "an explicit input array item cap",
+      () => '{"error":{"code":"1214","message":"input array max 10"}}',
+    ],
   ])(
     "splits provider errors with %s without retrying oversized requests",
     async (_label, error) => {

--- a/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.test.ts
@@ -215,6 +215,8 @@ describe("memory embedding policy", () => {
       "Embeddings API input limit exceeded: max 10, got 33. Request id: fixture-000597000",
       "embeddings max input length is 16",
       'HTTP 400: {"error":{"message":"<400> InternalError.Algo.InvalidParameter: Value error, batch size is invalid, it should not be larger than 10.: input.contents","type":"InvalidParameter","code":"InvalidParameter"}}',
+      // Zhipu embedding-3 caps `input` at 64 items under its generic 1214 code.
+      'openai-compatible embeddings failed: HTTP 400: {"error":{"code":"1214","message":"input array max 64"}}',
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(true);
       expect(isRetryableMemoryEmbeddingError(message)).toBe(false);
@@ -229,6 +231,9 @@ describe("memory embedding policy", () => {
       "batch size is invalid, it should not be larger than unknown; request id 12345",
       "batch size is invalid, it should not be smaller than 20",
       "input size is invalid, it should not be larger than 20",
+      // Code 1214 alone, an item index, or a bare limit phrase without a number stay terminal.
+      'HTTP 400: {"error":{"code":"1214","message":"input array element 3 must be a string"}}',
+      'HTTP 400: {"error":{"code":"1214","message":"input array exceeds the maximum length"}}',
     ]) {
       expect(isSplittableMemoryEmbeddingBatchError(message)).toBe(false);
     }

--- a/extensions/memory-core/src/memory/manager-embedding-policy.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-policy.ts
@@ -54,8 +54,17 @@ const RETRYABLE_MEMORY_EMBEDDING_SERVICE_ERROR_RE =
 const RETRYABLE_MEMORY_EMBEDDING_TRANSPORT_ERROR_RE =
   /(fetch failed|other side closed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|UND_ERR_|socket hang up|socket terminated|network error|read ECONN|timed out|connection (?:reset|refused|aborted|timed out)|EHOSTUNREACH|ENETUNREACH|ECONNABORTED|EAI_AGAIN)/i;
 
+// Rejections a smaller request can satisfy: oversized-payload/transport failures,
+// then the item-limit phrasings providers actually report, each of which must carry
+// an explicit number so a generic HTTP 400 stays terminal instead of burning a
+// doomed request per halved batch:
+//   - `Embeddings API input limit exceeded: max 10, got 33` (Volcengine/Ark)
+//   - `embeddings max input length is 16` (Qianfan)
+//   - `batch size is invalid, it should not be larger than 10` (DashScope)
+//   - `input array max 64` (Zhipu BigModel embedding-3, HTTP 400 code 1214; the
+//     limit wording is not adjacent to `embeddings`)
 const SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE =
-  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b|\bbatch size is invalid,?\s+it should not be larger than\s+\d+\b)/i;
+  /(request_headers_too_large|request header fields too large|other side closed|ECONNRESET|EPIPE|UND_ERR_SOCKET|socket hang up|socket terminated|read ECONN|connection (?:reset|aborted)|\bembeddings (?:api input limit exceeded:\s*max\s+\d+\s*,\s*got\s+\d+|max input length is\s+\d+)\b|\bbatch size is invalid,?\s+it should not be larger than\s+\d+\b|\binput array\b[^\n]{0,16}?\b(?:max(?:imum)?|limit|exceed(?:s|ed)?)\b\D{0,8}\d)/i;
 
 export function isSplittableMemoryEmbeddingBatchError(message: string): boolean {
   return SPLITTABLE_MEMORY_EMBEDDING_BATCH_ERROR_RE.test(message);


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/139040

## What Problem This Solves

Memory indexing stops when an embedding provider rejects an oversized request
with `input array max 64`, instead of splitting it into smaller batches.

## User Impact

Oversized requests can recover through the existing batch-splitting path while
per-item validation errors and token limits remain terminal. Vector ordering and
existing provider retry behavior are preserved. No configuration, schema,
persistent-storage or dependency change is required.

## Why This Change Was Made

The reported item-count rejection needs its own precise classification. The new
alternative requires a complete integer and message boundary; generic error code
`1214`, item/token limits, token suffixes and fractional counts do not qualify.
Existing Ark, Qianfan, DashScope and transport alternatives remain unchanged.

The contributor's work and both commits are preserved. The maintainer integration
updates the existing transport harness for current Memory Core candidate and
generation APIs, narrows the matcher, and extends the existing test tables.
Original implementation and HTTP-boundary coverage by @ylcn91.

## Evidence

Current candidate: `21e1e78f9a2f1c9a0ddb5beaf6d7ab91b0ddcaca`, integrating
`201f11afefdb19a9c75e9d3542bf7425c80df7a7` without rewriting contributor ancestry.
Independent source review found no actionable P0-P2 issues; diff checks passed.

Isolated AWS proof on this exact candidate passed:
https://crabbox.openclaw.ai/portal/runs/run_7f17ed57d156

- The original broad-matcher counterfactual produced 14 intended failures and
  7 passing controls, with 18 tests deliberately unselected. Four terminal HTTP
  cases made eight requests instead of one; ten retry cases called twice instead
  of once, including the numbered-element token-limit wording.
- Restored candidate: 84 owner tests passed, including ordered HTTP requests
  `[100, 50, 50]`, ordered vectors and one-request terminal errors.
- Relevant embedding, bridge and cache siblings: 26 passed. Both green phases
  had zero failures or skips.
- Formatting and selected changed checks passed, including production/test
  types, lint, dead-export and applicable boundary guards. Candidate hashes were
  unchanged, all process trees joined and no evidence was omitted.

Exact-head CI completed green:
https://github.com/openclaw/openclaw/actions/runs/34775024167
Merged through native squash admission as
`0afc02335308892d7efa3ccf7d981e912c6dd238`.

The earlier `3e0078f860ce960389dac2ffdfe4580c44e9bc79` attempt stopped at formatting
before runtime tests; this head adds only canonical import wrapping to that
reviewed integration. No contributor code, tests or configuration ran locally.

The HTTP server is synthetic and reproduces the reported rejection. This is not
a live Zhipu endpoint test, and no provider credentials are used. The issue's
separate scan-eligibility observation remains outside this repair.
