### PR TITLE
fix(ai): reject conflicting Responses tool-call argument snapshots

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts
@@ -1,0 +1,131 @@
+// Transport-level proof for #139110: the argument reconciliation must hold on a
+// real SSE connection and a real WebSocket session, not only on a parsed event
+// iterator, because both transports reach the same completion owner.
+import type { Context, Tool } from "@openclaw/llm-core";
+import { expect, it } from "vitest";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import {
+  createResponsesLoopbackServer,
+  responsesLoopbackModel,
+} from "./openai-responses-loopback.test-support.js";
+
+const updateTool: Tool = {
+  name: "update_record",
+  description: "Update a record behind an ETag precondition.",
+  parameters: {
+    type: "object",
+    properties: { object_id: { type: "string" }, if_match: { type: "string" } },
+    required: ["object_id", "if_match"],
+    additionalProperties: false,
+  },
+};
+const streamedArguments = '{"object_id":"x","if_match":"\\"rev-4\\""}';
+const staleArguments = '{"object_id":"x","if_match":"\\"rev-"}';
+const completeArguments = { object_id: "x", if_match: '"rev-4"' };
+const scenarios = [
+  { name: "conflicting", itemDone: staleArguments, terminal: streamedArguments },
+  { name: "healthy", itemDone: streamedArguments, terminal: streamedArguments },
+  { name: "item-done without arguments", itemDone: undefined, terminal: undefined },
+] as const;
+
+function responseEvents(scenario: (typeof scenarios)[number]) {
+  const call = {
+    type: "function_call",
+    id: "fc_update",
+    call_id: "call_update",
+    name: updateTool.name,
+    status: "completed",
+  };
+  const withArguments = (value: string | undefined) =>
+    value === undefined ? call : { ...call, arguments: value };
+  return () => [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...call, arguments: "", status: "in_progress" },
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      output_index: 0,
+      item_id: call.id,
+      delta: streamedArguments.slice(0, 18),
+    },
+    {
+      type: "response.function_call_arguments.delta",
+      output_index: 0,
+      item_id: call.id,
+      delta: streamedArguments.slice(18),
+    },
+    {
+      type: "response.output_item.done",
+      output_index: 0,
+      item: withArguments(scenario.itemDone),
+    },
+    {
+      type: "response.completed",
+      response: {
+        id: "resp_argument_conflict",
+        status: "completed",
+        output: [withArguments(scenario.terminal)],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      },
+    },
+  ];
+}
+
+it.each(
+  (["sse", "websocket-cached"] as const).flatMap((transport) =>
+    scenarios.map((scenario) => ({ transport, scenario })),
+  ),
+)("real $transport stream: $scenario.name", async ({ transport, scenario }) => {
+  const server = await createResponsesLoopbackServer(responseEvents(scenario));
+  try {
+    const context: Context = {
+      messages: [{ role: "user", content: "Update record x.", timestamp: 1 }],
+      tools: [updateTool],
+    };
+    const stream = await createOpenAIResponsesTransportStreamFn()(responsesLoopbackModel, context, {
+      apiKey: "synthetic-key-a",
+      sessionId: `${transport}-${scenario.name}`,
+      cacheRetention: "none",
+      transport,
+    });
+    const events: string[] = [];
+    for await (const event of stream) {
+      events.push(event.type);
+    }
+    const result = await stream.result();
+    const toolCalls = result.content.filter((block) => block.type === "toolCall");
+
+    // The request really left through the selected transport.
+    expect(server.connections).toBe(transport === "sse" ? 0 : 1);
+    expect(server.authorization).toEqual(["Bearer synthetic-key-a"]);
+    expect(server.requests).toHaveLength(1);
+    expect(server.requests[0]?.tools).toEqual([
+      expect.objectContaining({ type: "function", name: updateTool.name }),
+    ]);
+
+    if (scenario.name === "conflicting") {
+      expect(events).not.toContain("toolcall_end");
+      expect(events).toContain("error");
+      expect(result.stopReason).toBe("error");
+      expect(result.errorMessage).toBe(
+        "Responses stream completed tool call with conflicting arguments",
+      );
+      // The started block stays unfinished with no arguments: the stale snapshot
+      // never reaches the transcript, and no toolcall_end authorizes execution.
+      expect(toolCalls).toEqual([
+        expect.objectContaining({ name: updateTool.name, arguments: {} }),
+      ]);
+      expect(JSON.stringify(result.content)).not.toContain("rev-");
+      return;
+    }
+    expect(result.stopReason).toBe("toolUse");
+    expect(events.filter((type) => type === "toolcall_end")).toEqual(["toolcall_end"]);
+    expect(toolCalls).toEqual([
+      expect.objectContaining({ name: updateTool.name, arguments: completeArguments }),
+    ]);
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -282,7 +282,10 @@ export async function processResponsesStream<TApi extends Api>(
       if (tracked && !state) {
         throw new Error("Responses stream completed with unresolved tool calls");
       }
-      const validated = resolveCompletedResponsesToolCall(item, { name: state?.block.name });
+      const validated = resolveCompletedResponsesToolCall(item, {
+        name: state?.block.name,
+        arguments: state?.argumentStreamReliable ? state.block.partialJson : undefined,
+      });
       if (state) {
         recovered.push(state);
       }
@@ -655,7 +658,9 @@ export async function processResponsesStream<TApi extends Api>(
           }
           const validated = resolveCompletedResponsesToolCall(item, {
             name: streamingToolCall?.block.name,
-            arguments: completedArguments || streamingToolCall?.block.partialJson || "",
+            arguments: streamingToolCall?.argumentStreamReliable
+              ? streamingToolCall.block.partialJson
+              : undefined,
           });
 
           finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -477,7 +477,10 @@ export async function processResponsesStream<TApi extends Api>(
       } else if (event.type === "response.function_call_arguments.delta") {
         const toolCall = streamingToolCalls.resolve(event);
         if (toolCall) {
-          toolCall.argumentsStreamed = true;
+          // A keepalive delta contributes no bytes, so it leaves the buffer as
+          // the opening snapshot, which must stay a fallback rather than a
+          // streamed encoding that can conflict with the completion snapshot.
+          toolCall.argumentsStreamed ||= event.delta.length > 0;
           toolCall.block.partialJson += event.delta;
           // Preview refresh is geometric; the done event and terminal finalize
           // re-parse the full buffer authoritatively either way.

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -62,6 +62,10 @@ export async function processResponsesStream<TApi extends Api>(
   type StreamingToolCallState = ResponsesToolCallState & {
     block: StreamingToolCallBlock;
     contentIndex: number;
+    // Set once an argument delta or done event lands on this call. The opening
+    // item snapshot seeds partialJson too, so this is what separates a streamed
+    // encoding from a snapshot the terminal item may legitimately replace.
+    argumentsStreamed: boolean;
     // Preview refresh schedule for streamed arguments; done/terminal parses stay authoritative.
     previewSchedule: ToolArgumentPreviewSchedule;
   };
@@ -284,7 +288,10 @@ export async function processResponsesStream<TApi extends Api>(
       }
       const validated = resolveCompletedResponsesToolCall(item, {
         name: state?.block.name,
-        arguments: state?.argumentStreamReliable ? state.block.partialJson : undefined,
+        arguments:
+          state?.argumentStreamReliable && state.argumentsStreamed
+            ? state.block.partialJson
+            : undefined,
       });
       if (state) {
         recovered.push(state);
@@ -368,6 +375,7 @@ export async function processResponsesStream<TApi extends Api>(
             block: toolCallBlock,
             contentIndex,
             argumentStreamReliable: true,
+            argumentsStreamed: false,
             previewSchedule: createToolArgumentPreviewSchedule(),
             ...readResponsesToolCallItemIdentity(item),
           };
@@ -471,6 +479,7 @@ export async function processResponsesStream<TApi extends Api>(
       } else if (event.type === "response.function_call_arguments.delta") {
         const toolCall = streamingToolCalls.resolve(event);
         if (toolCall) {
+          toolCall.argumentsStreamed = true;
           toolCall.block.partialJson += event.delta;
           // Preview refresh is geometric; the done event and terminal finalize
           // re-parse the full buffer authoritatively either way.
@@ -499,6 +508,7 @@ export async function processResponsesStream<TApi extends Api>(
             toolCall.block.partialJson = doneArguments;
             toolCall.block.arguments = parseStreamingJson(toolCall.block.partialJson);
             toolCall.argumentStreamReliable = true;
+            toolCall.argumentsStreamed = true;
           }
 
           if (doneArguments?.startsWith(previousPartialJson)) {
@@ -658,9 +668,10 @@ export async function processResponsesStream<TApi extends Api>(
           }
           const validated = resolveCompletedResponsesToolCall(item, {
             name: streamingToolCall?.block.name,
-            arguments: streamingToolCall?.argumentStreamReliable
-              ? streamingToolCall.block.partialJson
-              : undefined,
+            arguments:
+              streamingToolCall?.argumentStreamReliable && streamingToolCall.argumentsStreamed
+                ? streamingToolCall.block.partialJson
+                : undefined,
           });
 
           finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);

--- a/packages/ai/src/transports/openai-responses-stream-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-internal.ts
@@ -63,8 +63,8 @@ export async function processResponsesStream<TApi extends Api>(
     block: StreamingToolCallBlock;
     contentIndex: number;
     // Set once an argument delta or done event lands on this call. The opening
-    // item snapshot seeds partialJson too, so this is what separates a streamed
-    // encoding from a snapshot the terminal item may legitimately replace.
+    // item snapshot seeds partialJson too; only a streamed buffer may conflict
+    // with the completion snapshot, an opening snapshot merely backs it up.
     argumentsStreamed: boolean;
     // Preview refresh schedule for streamed arguments; done/terminal parses stay authoritative.
     previewSchedule: ToolArgumentPreviewSchedule;
@@ -288,10 +288,8 @@ export async function processResponsesStream<TApi extends Api>(
       }
       const validated = resolveCompletedResponsesToolCall(item, {
         name: state?.block.name,
-        arguments:
-          state?.argumentStreamReliable && state.argumentsStreamed
-            ? state.block.partialJson
-            : undefined,
+        arguments: state?.argumentStreamReliable ? state.block.partialJson : undefined,
+        argumentsStreamed: state?.argumentsStreamed,
       });
       if (state) {
         recovered.push(state);
@@ -668,10 +666,10 @@ export async function processResponsesStream<TApi extends Api>(
           }
           const validated = resolveCompletedResponsesToolCall(item, {
             name: streamingToolCall?.block.name,
-            arguments:
-              streamingToolCall?.argumentStreamReliable && streamingToolCall.argumentsStreamed
-                ? streamingToolCall.block.partialJson
-                : undefined,
+            arguments: streamingToolCall?.argumentStreamReliable
+              ? streamingToolCall.block.partialJson
+              : undefined,
+            argumentsStreamed: streamingToolCall?.argumentsStreamed,
           });
 
           finalizeToolCall(item, readResponsesOutputIndex(event), streamingToolCall, validated);

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -87,7 +87,7 @@ export function resolveResponsesToolCallId(
 
 export function resolveCompletedResponsesToolCall(
   item: Extract<ResponseOutputItem, { type: "function_call" }>,
-  streamed?: { name?: string; arguments?: string },
+  streamed?: { name?: string; arguments?: string; argumentsStreamed?: boolean },
 ): Pick<ToolCall, "name" | "arguments"> {
   if (item.status && item.status !== "completed") {
     throw new IncompleteToolCallError(
@@ -109,7 +109,10 @@ export function resolveCompletedResponsesToolCall(
   // terminal snapshot must decode to the same object. A buffer that is not yet
   // a complete JSON object is an incomplete stream the snapshot legitimately
   // repairs, but two complete disagreeing encodings have no authoritative side,
-  // so the call fails closed instead of authorizing a stale snapshot.
+  // so the call fails closed instead of authorizing a stale snapshot. A buffer
+  // seeded only by the opening item snapshot was never streamed: it still
+  // stands in when the completion carries no arguments, but the completion
+  // snapshot may replace it without a conflict.
   const streamedArguments = parseJsonObjectPreservingUnsafeIntegers(streamed?.arguments);
   if (streamedArguments && !item.arguments) {
     return { name, arguments: streamedArguments };
@@ -118,7 +121,11 @@ export function resolveCompletedResponsesToolCall(
     item.arguments,
     "Responses stream completed tool call with invalid JSON arguments",
   );
-  if (streamedArguments && !isDeepStrictEqual(streamedArguments, argumentsValue)) {
+  if (
+    streamedArguments &&
+    streamed?.argumentsStreamed &&
+    !isDeepStrictEqual(streamedArguments, argumentsValue)
+  ) {
     throw new Error("Responses stream completed tool call with conflicting arguments");
   }
   return { name, arguments: argumentsValue };

--- a/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-internal.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
 import type {
   ResponseCreateParamsStreaming,
   ResponseOutputItem,
@@ -23,6 +24,7 @@ import type {
   ToolCall,
   Usage,
 } from "../types.js";
+import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { captureOpenAIResponsesCompaction } from "./openai-responses-compaction-replay.js";
 import {
   OPENAI_RESPONSES_COMPACTION_REPLAY_TYPE,
@@ -103,10 +105,22 @@ export function resolveCompletedResponsesToolCall(
   if (!name) {
     throw new Error("Responses stream completed tool call without a function name");
   }
+  // One call, one argument encoding: the accumulated delta buffer and each
+  // terminal snapshot must decode to the same object. A buffer that is not yet
+  // a complete JSON object is an incomplete stream the snapshot legitimately
+  // repairs, but two complete disagreeing encodings have no authoritative side,
+  // so the call fails closed instead of authorizing a stale snapshot.
+  const streamedArguments = parseJsonObjectPreservingUnsafeIntegers(streamed?.arguments);
+  if (streamedArguments && !item.arguments) {
+    return { name, arguments: streamedArguments };
+  }
   const argumentsValue = parseTerminalToolCallArguments(
-    streamed?.arguments ?? item.arguments,
+    item.arguments,
     "Responses stream completed tool call with invalid JSON arguments",
   );
+  if (streamedArguments && !isDeepStrictEqual(streamedArguments, argumentsValue)) {
+    throw new Error("Responses stream completed tool call with conflicting arguments");
+  }
   return { name, arguments: argumentsValue };
 }
 

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -179,6 +179,61 @@ describe("Responses terminal tool completion", () => {
     expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
   });
 
+  it.each([
+    ["an item-done", true],
+    ["a terminal", false],
+  ])(
+    "rejects %s snapshot that disagrees with complete streamed arguments",
+    async (_name, hasItemDone) => {
+      const streamed = '{"object_id":"x","if_match":"\\"rev-4\\"","object":{"data":{"kept":true}}}';
+      const stale = '{"object_id":"x","if_match":"\\"rev-","object":{"data":{}}}';
+      const result = await runFixture([
+        added(0),
+        {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_0",
+          delta: streamed,
+        },
+        ...(hasItemDone
+          ? [
+              {
+                type: "response.output_item.done",
+                output_index: 0,
+                item: tool(0, { arguments: stale }),
+              },
+            ]
+          : []),
+        completed("resp_argument_conflict", [
+          tool(0, { arguments: hasItemDone ? streamed : stale }),
+        ]),
+      ]);
+      expect(result.error).toBe("Responses stream completed tool call with conflicting arguments");
+      expect(result.events.filter((event) => event.type === "toolcall_end")).toEqual([]);
+    },
+  );
+
+  it("keeps the snapshot authoritative after an unrouteable argument frame", async () => {
+    const result = await runFixture([
+      added(0),
+      {
+        type: "response.function_call_arguments.delta",
+        output_index: 0,
+        item_id: "fc_0",
+        delta: '{"slot":9}',
+      },
+      added(1),
+      { type: "response.function_call_arguments.delta", delta: '{"unrouteable":true}' },
+      { type: "response.output_item.done", output_index: 0, item: tool(0) },
+      { type: "response.output_item.done", output_index: 1, item: tool(1) },
+      completed("resp_unreliable_arguments", [tool(0), tool(1)]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(
+      result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+    ).toEqual([{ slot: 0 }, { slot: 1 }]);
+  });
+
   it("never completes active tools from an incomplete response", async () => {
     const result = await runFixture([
       added(0),

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -234,6 +234,31 @@ describe("Responses terminal tool completion", () => {
     ).toEqual([{ slot: 0 }, { slot: 1 }]);
   });
 
+  it("completes a snapshot-only call whose opening snapshot is an empty object", async () => {
+    // No argument events: the terminal item, not the seeded opening snapshot,
+    // is the only argument encoding this call ever streamed.
+    const result = await runFixture([
+      added(0, { arguments: "{}" }),
+      { type: "response.output_item.done", output_index: 0, item: tool(0) },
+      completed("resp_opening_snapshot_done", [tool(0)]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(
+      result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+    ).toEqual([{ slot: 0 }]);
+  });
+
+  it("recovers a snapshot-only call from the terminal response after an empty-object opening", async () => {
+    const result = await runFixture([
+      added(0, { arguments: "{}" }),
+      completed("resp_opening_snapshot_terminal", [tool(0)]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(
+      result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+    ).toEqual([{ slot: 0 }]);
+  });
+
   it("never completes active tools from an incomplete response", async () => {
     const result = await runFixture([
       added(0),

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -282,6 +282,32 @@ describe("Responses terminal tool completion", () => {
     ).toEqual([{ slot: 0 }]);
   });
 
+  it.each([
+    ["an item-done", true],
+    ["a terminal", false],
+  ])(
+    "lets %s snapshot replace an opening snapshot a keepalive delta never changed",
+    async (_name, hasItemDone) => {
+      const result = await runFixture([
+        added(0, { arguments: JSON.stringify({ slot: 9 }) }),
+        {
+          type: "response.function_call_arguments.delta",
+          output_index: 0,
+          item_id: "fc_0",
+          delta: "",
+        },
+        ...(hasItemDone
+          ? [{ type: "response.output_item.done", output_index: 0, item: tool(0) }]
+          : []),
+        completed("resp_empty_delta_opening_snapshot", [tool(0)]),
+      ]);
+      expect(result.error).toBeNull();
+      expect(
+        result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+      ).toEqual([{ slot: 0 }]);
+    },
+  );
+
   it("never completes active tools from an incomplete response", async () => {
     const result = await runFixture([
       added(0),

--- a/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
@@ -259,6 +259,29 @@ describe("Responses terminal tool completion", () => {
     ).toEqual([{ slot: 0 }]);
   });
 
+  it("uses complete opening arguments when the done item carries none", async () => {
+    const result = await runFixture([
+      added(0, { arguments: JSON.stringify({ slot: 0 }) }),
+      { type: "response.output_item.done", output_index: 0, item: tool(0, { arguments: "" }) },
+      completed("resp_opening_arguments_done", [tool(0, { arguments: "" })]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(
+      result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+    ).toEqual([{ slot: 0 }]);
+  });
+
+  it("uses complete opening arguments when the terminal item carries none", async () => {
+    const result = await runFixture([
+      added(0, { arguments: JSON.stringify({ slot: 0 }) }),
+      completed("resp_opening_arguments_terminal", [tool(0, { arguments: "" })]),
+    ]);
+    expect(result.error).toBeNull();
+    expect(
+      result.content.map((block) => (block.type === "toolCall" ? block.arguments : null)),
+    ).toEqual([{ slot: 0 }]);
+  });
+
   it("never completes active tools from an incomplete response", async () => {
     const result = await runFixture([
       added(0),


### PR DESCRIPTION
## What Problem This Solves

On the OpenAI Responses stream, a syntactically valid but stale
`response.output_item.done.item.arguments` snapshot silently overrode the complete arguments
already accumulated from `response.function_call_arguments.delta`/`.done`. The call was finalized
and emitted as an executable `toolcall_end` with the stale arguments, and because the output
position was already marked completed, the correct snapshot in `response.completed` could never
repair it.

The reporter saw an intended `{"if_match":"\"rev-4\""}` reach local tool validation as
`{"if_match":"\"rev-"}`. Schema validation caught it that time; a stale snapshot that still
satisfies the target schema would have crossed the execution boundary with wrong arguments.

Fixes #139110.

## Why This Change Was Made

Root cause: argument snapshots were never reconciled, only ranked.

- The `response.output_item.done` branch in
  `packages/ai/src/transports/openai-responses-stream-internal.ts` (now `:659-664`) collapsed both
  sources into `completedArguments || streamingToolCall?.block.partialJson || ""`, so any non-empty
  item-done snapshot won unconditionally; `finalizeToolCall(...)` then emitted `toolcall_end` and
  marked the position completed.
- The completed-position skips at `openai-responses-stream-internal.ts:274` and `:638`, and at
  `openai-responses-stream-terminal-internal.ts:271` and `:305`, then bypass that position, so the
  later `response.completed` snapshot could not correct the decision.
- `resolveCompletedResponsesToolCall` at
  `packages/ai/src/transports/openai-responses-stream-terminal-internal.ts:85` already rejects an
  identity conflict (streamed vs. completed function name) but had no equivalent check for
  arguments, and `prepareTerminalToolCalls` never passed it the streamed buffer at all — so the
  same silent override existed on the `response.completed` recovery path.

The repair keeps one owner. `resolveCompletedResponsesToolCall` — the single classifier both the
item-done path and the terminal-recovery path already route through, and therefore shared by the
HTTP/SSE and the native WebSocket transports — now reconciles the two encodings
(`openai-responses-stream-terminal-internal.ts:103-119`):

- a streamed buffer that is not yet a complete JSON object is an incomplete stream that the
  snapshot legitimately repairs (unchanged behavior from #108461);
- a snapshot that is absent or empty leaves the complete streamed buffer authoritative
  (unchanged behavior);
- a buffer marked unreliable by an unrouteable argument frame is not compared at all, because
  the tracker's documented invariant says only a full snapshot can recover such a call;
- two complete but disagreeing encodings have no authoritative side, so the stream fails closed
  with `Responses stream completed tool call with conflicting arguments` instead of finalizing
  either one. The error carries no argument values.

Both call sites now pass the streamed buffer
(`openai-responses-stream-internal.ts:287` and `:661`), so the terminal path gets the same check.

## User Impact

- A provider stream that disagrees with itself about tool arguments now fails the turn visibly
  instead of executing a tool with stale or truncated arguments. This is the same fail-closed
  shape already used for changed tool identities and malformed terminal JSON.
- No change for healthy streams: when the delta buffer, `function_call_arguments.done`,
  `output_item.done`, and `response.completed` agree — the normal case, including the reporter's
  live WebSocket control — the call completes exactly as before.
- Existing recovery paths are preserved: missing item-done events, truncated or dropped argument
  frames, item-done events without an `arguments` field, rotated item ids, and unrouteable
  argument frames all still recover.

## Evidence

Pre-fix, on `origin/main` @ `67e8e2da4b1` with only the new tests applied:

```
$ node scripts/run-vitest.mjs run packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts
 × ... > rejects an item-done snapshot that disagrees with complete streamed arguments
 × ... > rejects a terminal snapshot that disagrees with complete streamed arguments
AssertionError: expected null to be 'Responses stream completed tool call …'
- Expected: "Responses stream completed tool call with conflicting arguments"
+ Received: null
      Tests  2 failed | 25 passed (27)
```

A probe on the same pre-fix fixtures shows the reported symptom directly — the stale snapshot is
what reaches the tool:

```
+   "error": null,
+   "finalized": [ { "if_match": "\"rev-", "object": { "data": {} }, "object_id": "x" } ],
+   "toolcallEnds": 1,
```

Post-fix, every test file covering the changed modules, in full:

```
$ node scripts/run-vitest.mjs run \
    packages/ai/src/providers/openai-responses-shared.test.ts \
    packages/ai/src/providers/openai-chatgpt-responses.test.ts \
    packages/ai/src/providers/openai-chatgpt-responses.tools.test.ts \
    packages/ai/src/providers/openai-chatgpt-responses-streaming.test.ts \
    packages/ai/src/transports/openai-responses-compaction-replay.test.ts \
    packages/ai/src/transports/openai-responses-stream-activity.test.ts \
    packages/ai/src/transports/openai-responses-stream-parity.test.ts \
    packages/ai/src/transports/openai-responses-stream-terminal-recovery.test.ts \
    packages/ai/src/transports/openai-responses-stream-terminal-tools.test.ts \
    packages/ai/src/transports/openai-responses-websocket.test.ts \
    packages/ai/src/transports/openai-responses-async-replay.test.ts \
    src/agents/openai-transport-stream.base.test.ts \
    src/agents/openai-transport-stream.incomplete-output.test.ts \
    src/agents/openai-transport-stream.streaming.test.ts
 Test Files  11 passed (11) / 2 passed (2) / 1 passed (1)
      Tests  308 + 48 + 15 passed (371)
[test] passed 3 Vitest shards in 27.92s
```

```
$ node_modules/.bin/oxfmt --check <3 changed files>   # All matched files use the correct format.
$ node_modules/.bin/oxlint -c .oxlintrc.json <3 changed files>   # exit 0
$ git diff --check                                    # exit 0
$ node scripts/check-changed.mjs                       # 15/16 lanes ok
```

`check:changed`'s `typecheck core tests` lane fails on
`src/agents/embedded-agent-runner/run/assistant-failure.test.ts(273,35): error TS2339` — a
pre-existing failure on `origin/main`, reproduced on the same worktree with this change reverted,
in a file this change does not touch.

Each production edit was also individually reverted to confirm it is load-bearing: dropping the
reliability gate fails `keeps the snapshot authoritative after an unrouteable argument frame`;
dropping the snapshot-less branch fails four existing `openai-responses-shared.test.ts` recovery
tests; dropping the terminal buffer pass-through fails the terminal half of the new regression
test.

Proof gap: no live provider run. A healthy provider does not emit the conflicting sequence (the
issue's own live control confirms all four encodings agree), so the deterministic fixture drives
the reported event order through the real parser both transports share.

### Evidence (real transport)

The checks above drive the parser directly, so the same three cases were re-run over real
connections through the actual Responses client
(`createOpenAIResponsesTransportStreamFn` → real `openai` SDK → loopback server), reusing the
repository's existing `createResponsesLoopbackServer` harness
(`packages/ai/src/transports/openai-responses-loopback.test-support.ts`): a real HTTP server
answering `POST /v1/responses` with `text/event-stream`, and a real `ws` WebSocket server on the
same port. Only the destination host is redirected; the SDK, the request bytes, the SSE framing,
and the WebSocket session are real. New file:
`packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts`
(3 scenarios × `sse` + `websocket-cached`).

```
$ node scripts/run-vitest.mjs run \
    packages/ai/src/transports/openai-responses-client.tool-argument-conflict.integration.test.ts
 ✓ real sse stream: conflicting 138ms
 ✓ real sse stream: healthy 15ms
 ✓ real sse stream: item-done without arguments 11ms
 ✓ real websocket-cached stream: conflicting 19ms
 ✓ real websocket-cached stream: healthy 10ms
 ✓ real websocket-cached stream: item-done without arguments 12ms
 Test Files  1 passed (1)   Tests  6 passed (6)
```

Provider-visible frames and client outcome per case (captured from the loopback server and the
client stream; `request.type: response.create` only appears on the WebSocket session, and
`server.connections` is `0` for SSE and `1` for WebSocket, so each case really used its transport):

```
--- sse / conflicting            (and identically: websocket-cached / conflicting)
  item_done.arguments          : "{\"object_id\":\"x\",\"if_match\":\"\\\"rev-\"}"
  completed.output[0].arguments: "{\"object_id\":\"x\",\"if_match\":\"\\\"rev-4\\\"\"}"
  client events      : ['start','toolcall_start','toolcall_delta','toolcall_delta','error']
  stopReason         : error | errorMessage: Responses stream completed tool call with conflicting arguments
  toolCalls          : [{"type":"toolCall","id":"call_update|fc_update","name":"update_record","arguments":{}}]

--- sse / healthy                (and identically: websocket-cached / healthy)
  item_done.arguments          : "{\"object_id\":\"x\",\"if_match\":\"\\\"rev-4\\\"\"}"
  client events      : ['start','toolcall_start','toolcall_delta','toolcall_delta','toolcall_end','done']
  stopReason         : toolUse
  toolCalls          : [{… "arguments":{"object_id":"x","if_match":"\"rev-4\""}}]

--- sse / item-done without arguments   (and identically: websocket-cached)
  item_done.arguments          : null      completed.output[0].arguments: null
  client events      : ['start','toolcall_start','toolcall_delta','toolcall_delta','toolcall_end','done']
  stopReason         : toolUse
  toolCalls          : [{… "arguments":{"object_id":"x","if_match":"\"rev-4\""}}]
```

The same file run against this PR's parent commit (production files restored with
`git checkout HEAD~1 -- <2 files>`) fails on both transports for the reported reason:

```
 FAIL  real sse stream: conflicting
 FAIL  real websocket-cached stream: conflicting
AssertionError: expected [ 'start', 'toolcall_start', …(4) ] to not include 'toolcall_end'
```

and a probe on the parent commit shows what the pre-fix code delivered over each real connection:

```
  stopReason  : toolUse
  events      : ['start','toolcall_start','toolcall_delta','toolcall_delta','toolcall_end','done']
  toolCalls   : [{"type":"toolCall","id":"call_update|fc_update","name":"update_record",
                  "arguments":{"if_match":"\"rev-","object_id":"x"}}]        # transport: sse
                                                                             # and: websocket-cached
```

The three pre-existing suites that share this loopback harness still pass alongside it
(`openai-responses-client.continuation.integration.test.ts`,
`openai-responses-client.tools-change.integration.test.ts`,
`openai-responses-steering.integration.test.ts`): 6 files, 194 tests, exit 0.

Not covered by these runs: the agent loop itself was not exercised end to end (no
`openclaw agent exec` against a mock provider), and no real OpenAI endpoint was contacted. What the
transport runs do establish is that no `toolcall_end` is emitted and the turn ends
`stopReason: "error"`; mid-stream tool execution is gated on a `toolcall_end` event
(`packages/agent-core/src/agent-stream-response.ts:302`) and the agent loop returns before
collecting `remainingToolCalls` when `stopReason === "error"`
(`packages/agent-core/src/agent-loop.ts:374-384`), so the conflicted call cannot reach execution.

## Relationship to #139534

#139534 (opened while this branch was being prepared) repairs the same `output_item.done` branch by preferring the streamed buffer whenever it parses as a complete object and differs from the snapshot. Applying its production patch to a clean `origin/main` checkout and running this PR's `openai-responses-stream-terminal-tools.test.ts` gives `Tests 3 failed | 24 passed (27)`:

- `keeps the snapshot authoritative after an unrouteable argument frame`: `expected [ { slot: 9 }, { slot: 1 } ] to deeply equal [ { slot: 0 }, { slot: 1 } ]`. After an argument frame the tracker cannot route, `argumentStreamReliable` is false and only a full snapshot may recover the call (the tracker's documented invariant); #139534 checks only that the buffer parses, so it finalizes the unreliable `{"slot":9}` buffer over the authoritative snapshot.
- The two `rejects ... snapshot that disagrees with complete streamed arguments` cases fail by design difference: #139534 picks the buffer, this PR fails closed as #139110 asks ("must not prefer an earlier disagreeing snapshot"; either retain until a terminal snapshot reconciles, or fail closed). Two complete encodings that disagree have no authoritative side in the frames OpenClaw sees; the healthy live control in the issue shows they agree, so the conflict itself is the signal.
- #139534 leaves `prepareTerminalToolCalls` unchanged, so a call finalized from `response.completed` without an item-done event still takes the terminal snapshot without comparing it to the streamed buffer; this PR routes both paths through the one shared classifier.

## Compatibility

No config, schema, storage, or public API change. The only behavior change is on a stream that
contradicts itself about a tool call's arguments: previously a silent wrong-argument completion,
now a stream error. Agreeing streams and every existing recovery path are unchanged, as covered
by the 371 tests above.

## ClawSweeper review rounds after the rebase

**[P1] Preserve recovery when only an opening argument snapshot exists** (fixed in `f6038fc`). `argumentsStreamed` provenance was added to the streaming tool-call state so a buffer seeded only by `response.output_item.added` is never treated as a streamed encoding. Covered in `openai-responses-stream-terminal-tools.test.ts` by `completes a snapshot-only call whose opening snapshot is an empty object` and `recovers a snapshot-only call from the terminal response after an empty-object opening`.

**[P2] Preserve complete opening arguments when completion provides none** (fixed in `d63e0af`). `resolveCompletedResponsesToolCall` now separates comparison eligibility from fallback availability: a complete buffer stands in whenever the completion item carries no arguments, while only a buffer an argument event actually produced is eligible for the conflict comparison. Both call sites (`output_item.done` and `prepareTerminalToolCalls`) pass the same provenance. Covered by `uses complete opening arguments when the done item carries none` and `uses complete opening arguments when the terminal item carries none`. This also closes a pre-existing gap on the terminal path: before this PR, a `response.completed` item with empty or absent `arguments` threw `invalid JSON arguments` even when the buffer was complete.

**Self-review follow-up** (fixed in `82d88b7`). A `response.function_call_arguments.delta` with an empty delta string contributes no bytes but still marked the call as streamed, so an opening snapshot could conflict with a disagreeing completion snapshot. `adaptResponsesStream` admits `delta: ""`, and OpenClaw's own OpenResponses server emits `output_item.added` with complete arguments, so the combination is reachable. `argumentsStreamed` is now set only by a delta that changes the buffer. Covered by `lets an item-done snapshot replace an opening snapshot a keepalive delta never changed` and `lets a terminal snapshot replace an opening snapshot a keepalive delta never changed`. Each pair above fails on the head before its fix and passes after; all 30 non-live `openai-responses*` transport files pass (479 tests).

## Compatibility decision for maintainers

Before this PR, when a stream produced two complete but disagreeing argument encodings for one call, the later snapshot won unconditionally: `output_item.done` overrode the accumulated delta buffer, and `response.completed` overrode it on the recovery path. The call was finalized and emitted as an executable `toolcall_end`, so the disagreement was never visible and, once the output position was marked completed, never correctable. With this PR the turn ends with `Responses stream completed tool call with conflicting arguments` and no `toolcall_end` is emitted.

Unchanged: disagreement where one side is not a complete JSON object (an incomplete buffer is still repaired by the snapshot), an absent or empty snapshot (the buffer stays authoritative), and a buffer marked unreliable by an unrouteable argument frame (never compared). The case for failing closed: neither complete encoding is independently authoritative in the frames OpenClaw sees, the healthy live control in #139110 shows all four encodings agreeing, so the disagreement itself is the only signal available, and picking either side can hand wrong arguments across the execution boundary. The cost: a provider that today completes despite contradicting itself will now fail the turn, including cases where a later terminal snapshot would have agreed with the streamed buffer.

The alternative, deferred terminal reconciliation, would keep those turns alive by withholding finalization until `response.completed` and resolving two-of-three agreement. It requires holding tool calls past `output_item.done` (delaying mid-stream tool execution for every call, not just conflicted ones), a new precedence contract for when the terminal event never arrives or is itself the outlier, and rework of the completed-position skips in both stream files. #139534 takes a third route, preferring the streamed buffer, which drops the unreliable-buffer invariant that only a full snapshot may recover a call after an unrouteable argument frame. Happy to switch to whichever the owners prefer.
