### PR TITLE
refactor: use consistent media factory test snapshots

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -368,7 +368,6 @@ src/agents/model-selection.test.ts
 src/agents/models.profiles.live.test.ts
 src/agents/openai-transport-stream.base.test.ts
 src/agents/openai-transport-stream.replay-and-tools.test.ts
-src/agents/openclaw-tools.media-factory-plan.test.ts
 src/agents/openclaw-tools.session-status.test.ts
 src/agents/openclaw-tools.sessions.test.ts
 src/agents/provider-attribution.test.ts

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -5,10 +5,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
-import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { finalizePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
@@ -142,28 +142,6 @@ function createComfyPlugin(
   });
 }
 
-function createInstalledPluginRecord(
-  plugin: PluginManifestRecord,
-  enabledPluginIds: string[],
-): InstalledPluginIndexRecord {
-  const enabled = plugin.origin === "bundled" || enabledPluginIds.includes(plugin.id);
-  return {
-    pluginId: plugin.id,
-    manifestPath: plugin.manifestPath,
-    manifestHash: `test-${plugin.id}`,
-    source: plugin.source,
-    rootDir: plugin.rootDir,
-    origin: plugin.origin,
-    enabled,
-    startup: {
-      sidecar: false,
-      memory: false,
-      agentHarnesses: [],
-    },
-    compat: [],
-  };
-}
-
 function legacyModelProviderConfig(provider: Record<string, unknown>): OpenClawConfig {
   return {
     models: {
@@ -177,54 +155,18 @@ function legacyModelProviderConfig(provider: Record<string, unknown>): OpenClawC
 function installSnapshot(
   config: OpenClawConfig,
   plugins: PluginManifestRecord[],
-  enabledPluginIds = plugins
-    .filter((plugin) => plugin.origin !== "bundled")
-    .map((plugin) => plugin.id),
   workspaceDir?: string,
 ) {
-  // Builds the current plugin metadata snapshot used by factory planning.
-  const index: PluginMetadataSnapshot["index"] = {
-    version: 1,
-    hostContractVersion: "test",
-    compatRegistryVersion: "test",
-    migrationVersion: 1,
-    policyHash: "test",
-    generatedAtMs: 0,
-    installRecords: {},
-    plugins: plugins.map((plugin) => createInstalledPluginRecord(plugin, enabledPluginIds)),
-    diagnostics: [],
-  };
-  const snapshot = {
-    policyHash: resolveInstalledPluginIndexPolicyHash(config),
+  const prepared = createPluginMetadataSnapshotFixture({ plugins });
+  const policyHash = resolveInstalledPluginIndexPolicyHash(config);
+  const index = { ...prepared.index, policyHash };
+  const snapshot = finalizePluginMetadataSnapshot({
+    ...prepared,
+    policyHash,
     ...(workspaceDir ? { workspaceDir } : {}),
     index,
     registryIndex: index,
-    registryDiagnostics: [],
-    manifestRegistry: { plugins, diagnostics: [] },
-    plugins,
-    diagnostics: [],
-    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
-    normalizePluginId: (id: string) => id,
-    owners: {
-      channels: new Map(),
-      channelConfigs: new Map(),
-      providers: new Map(),
-      modelCatalogProviders: new Map(),
-      cliBackends: new Map(),
-      setupProviders: new Map(),
-      commandAliases: new Map(),
-      contracts: new Map(),
-      modelIdNormalizationPolicies: new Map(),
-    },
-    metrics: {
-      registrySnapshotMs: 0,
-      manifestRegistryMs: 0,
-      ownerMapsMs: 0,
-      totalMs: 0,
-      indexPluginCount: 0,
-      manifestPluginCount: plugins.length,
-    },
-  } satisfies PluginMetadataSnapshot;
+  });
   setCurrentPluginMetadataSnapshot(snapshot, { config });
   return snapshot;
 }
@@ -427,7 +369,6 @@ describe("optional media tool factory planning", () => {
           setupProviders: [{ id: "image-owner", envVars: ["IMAGE_OWNER_API_KEY"] }],
         }),
       ],
-      undefined,
       "/workspace/a",
     );
     expect(getCurrentPluginMetadataSnapshot({ config })).toBeUndefined();
@@ -731,7 +672,7 @@ describe("optional media tool factory planning", () => {
       authStore: createAuthStore(["openai"]),
     });
     expect(plan.imageGenerate).toBe(true);
-    installSnapshot(config, plugins, undefined, process.cwd());
+    installSnapshot(config, plugins, process.cwd());
     expect(
       (
         await createOpenClawToolsForTest({
@@ -861,7 +802,7 @@ describe("optional media tool factory planning", () => {
         required: ["promptNodeId", "apiKey"],
       },
     ];
-    installSnapshot(config, [createComfyPlugin(configSignals)], undefined, workspaceDir);
+    installSnapshot(config, [createComfyPlugin(configSignals)], workspaceDir);
 
     expect(
       resolveOptionalMediaToolFactoryPlan({
@@ -947,7 +888,6 @@ describe("optional media tool factory planning", () => {
           setupProviders: [{ id: "media-owner", envVars: ["MEDIA_OWNER_API_KEY"] }],
         }),
       ],
-      undefined,
       workspaceDir,
     );
 
@@ -1105,4 +1045,3 @@ describe("optional media tool factory planning", () => {
     });
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Media factory tests manually assemble full plugin snapshots with inconsistent manifest-derived owner maps, counts, normalization, and snapshot/index hashes. The duplicated scaffold bypasses the preparation path used by real full snapshots.

## Why This Change Was Made

Use the existing canonical fixture and finalization owner for derived metadata and immutability. Preserve all scenario configs, auth inputs, manifests, workspace scope, and tool outcomes. Negative-policy cases intentionally retain optimistic enabled inventory hints to verify that current config still blocks factory creation; not every fixture policy field represents a freshly generated production index. Thin metadata and cold-loading behavior remain unchanged.

## User Impact

No production behavior changes. Remove 61 test lines and the now-obsolete max-lines baseline entry. The unused fixture enablement parameter and duplicate index-record constructor are gone.

## Evidence

All 28 original and final cases pass. Complete changed checks, formatting, and final P2 review pass. The exact shrink-only max-lines cleanup followed the lint guard detecting an unused suppression. The warm comparison was slightly slower (8.88 to 9.05 seconds), so no runtime improvement is claimed.
