### PR TITLE
fix(process): clean up adopted zombies after command timeout

### DIFF
--- a/src/process/child-process-tree.reaping.test.ts
+++ b/src/process/child-process-tree.reaping.test.ts
@@ -26,7 +26,7 @@ it("tree termination reaps adopted zombies after root exit without consuming oth
   Object.defineProperty(process, "platform", { value: "linux" });
   vi.useFakeTimers();
   const child = new ChildProcess();
-  child.pid = 400;
+  Object.defineProperty(child, "pid", { value: 400 });
   signalChildProcessTree(child, "SIGTERM");
   vi.advanceTimersByTime(100);
   expect(nativeWait).not.toHaveBeenCalled();

--- a/src/process/child-process-tree.ts
+++ b/src/process/child-process-tree.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { signalProcessTree } from "./kill-tree.js";
-import { reapOwnedChildZombiesAfterTreeKill } from "./scoped-child-reaper.js";
+import { scheduleAdoptedChildZombieReapAfterExit } from "./scoped-child-reaper.js";
 
 export function shouldDetachChildForProcessTree(): boolean {
   return process.platform !== "win32";
@@ -20,7 +20,7 @@ export function isChildProcessTreeAlive(child: Pick<ChildProcess, "pid">): boole
 }
 
 export function signalChildProcessTree(
-  child: Pick<ChildProcess, "kill" | "pid">,
+  child: Pick<ChildProcess, "kill" | "pid" | "exitCode" | "signalCode" | "once">,
   signal: "SIGTERM" | "SIGKILL",
 ): void {
   if (typeof child.pid === "number" && child.pid > 0) {
@@ -29,17 +29,18 @@ export function signalChildProcessTree(
       detached: usedProcessGroup,
     });
     // Tree kills can leave already-exited descendants reparented to us as
-    // untracked zombies (#97616). Reap only this root/pgid scope — never -1.
-    reapOwnedChildZombiesAfterTreeKill({
-      rootPid: child.pid,
-      usedProcessGroup,
-    });
+    // untracked zombies (#97616). Reap after the Node-tracked root exits so
+    // libuv keeps ownership of its wait status — never waitpid the root, and
+    // never waitpid(-1).
+    scheduleAdoptedChildZombieReapAfterExit(child, usedProcessGroup);
     return;
   }
 
   child.kill(signal);
 }
 
-export function forceKillChildProcessTree(child: Pick<ChildProcess, "kill" | "pid">): void {
+export function forceKillChildProcessTree(
+  child: Pick<ChildProcess, "kill" | "pid" | "exitCode" | "signalCode" | "once">,
+): void {
   signalChildProcessTree(child, "SIGKILL");
 }

--- a/src/process/child-process-tree.ts
+++ b/src/process/child-process-tree.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
 import { signalProcessTree } from "./kill-tree.js";
+import { reapOwnedChildZombiesAfterTreeKill } from "./scoped-child-reaper.js";
 
 export function shouldDetachChildForProcessTree(): boolean {
   return process.platform !== "win32";
@@ -23,8 +24,15 @@ export function signalChildProcessTree(
   signal: "SIGTERM" | "SIGKILL",
 ): void {
   if (typeof child.pid === "number" && child.pid > 0) {
+    const usedProcessGroup = shouldDetachChildForProcessTree();
     signalProcessTree(child.pid, signal, {
-      detached: shouldDetachChildForProcessTree(),
+      detached: usedProcessGroup,
+    });
+    // Tree kills can leave already-exited descendants reparented to us as
+    // untracked zombies (#97616). Reap only this root/pgid scope — never -1.
+    reapOwnedChildZombiesAfterTreeKill({
+      rootPid: child.pid,
+      usedProcessGroup,
     });
     return;
   }

--- a/src/process/scoped-child-reaper.test.ts
+++ b/src/process/scoped-child-reaper.test.ts
@@ -1,0 +1,190 @@
+// Scoped child reaper: external-observer proof for owned zombie cleanup (#97616).
+import { spawn as spawnChild, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  reapOwnedChildZombies,
+  setOwnedChildWaitPidBindingsForTests,
+} from "./scoped-child-reaper.js";
+
+const require = createRequire(import.meta.url);
+const linuxIt = process.platform === "linux" ? it : it.skip;
+
+type ProcRow = { pid: number; ppid: number; pgid: number; state: string; comm: string };
+
+function readProcRow(pid: number): ProcRow | undefined {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const lparen = stat.indexOf("(");
+    const rparen = stat.lastIndexOf(")");
+    const comm = stat.slice(lparen + 1, rparen);
+    const rest = stat.slice(rparen + 2).split(" ");
+    return {
+      pid: Number.parseInt(stat.slice(0, stat.indexOf(" ")), 10),
+      state: rest[0] ?? "",
+      ppid: Number.parseInt(rest[1] ?? "", 10),
+      pgid: Number.parseInt(rest[2] ?? "", 10),
+      comm,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function listSelfZombies(): ProcRow[] {
+  const self = process.pid;
+  const rows: ProcRow[] = [];
+  for (const entry of readdirSync("/proc")) {
+    if (!/^\d+$/u.test(entry)) {
+      continue;
+    }
+    const row = readProcRow(Number(entry));
+    if (row && row.ppid === self && row.state.startsWith("Z")) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+/**
+ * Create a direct-child zombie that Node did not track (no ChildProcess handle).
+ * Uses libc fork via koffi — the same FFI stack production reaping uses.
+ */
+function forkUntrackedZombie(): { pid: number } {
+  const koffi = require("koffi") as typeof import("koffi").default;
+  const libc = koffi.load(null);
+  const fork = libc.func("int fork()");
+  const _exit = libc.func("void _exit(int status)");
+  const pid = fork() as number;
+  if (pid < 0) {
+    throw new Error(`fork failed (errno ${koffi.errno()})`);
+  }
+  if (pid === 0) {
+    _exit(0);
+  }
+  return { pid };
+}
+
+describe("scoped-child-reaper", () => {
+  const activeForeign: ChildProcessWithoutNullStreams[] = [];
+
+  afterEach(async () => {
+    setOwnedChildWaitPidBindingsForTests(undefined);
+    await Promise.all(
+      activeForeign.splice(0).map(async (child) => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.stdin.write("\n");
+          await new Promise<void>((resolve) => child.once("close", () => resolve()));
+        }
+      }),
+    );
+  });
+
+  it("is a no-op without an owner scope", () => {
+    expect(reapOwnedChildZombies({})).toEqual({ reaped: [], pending: [] });
+  });
+
+  it("is a no-op on Windows", () => {
+    if (process.platform !== "win32") {
+      return;
+    }
+    expect(reapOwnedChildZombies({ pids: [1] })).toEqual({ reaped: [], pending: [] });
+  });
+
+  linuxIt("red/control: external observer detects an intentional unreaped zombie", async () => {
+    const { pid } = forkUntrackedZombie();
+    await waitFor(() => readProcRow(pid)?.state.startsWith("Z") === true, 5_000, "zombie state");
+    const observed = readProcRow(pid);
+    expect(observed).toMatchObject({ pid, ppid: process.pid });
+    expect(observed?.state.startsWith("Z")).toBe(true);
+    expect(listSelfZombies().some((row) => row.pid === pid)).toBe(true);
+    // Clean up so the suite does not leak into later tests.
+    const result = reapOwnedChildZombies({ pids: [pid] });
+    expect(result.reaped).toContain(pid);
+    await waitFor(() => readProcRow(pid) === undefined, 5_000, "zombie disappearance");
+  });
+
+  linuxIt("reaps only owned zombies and leaves foreign parent zombies alone", async () => {
+    const owned = forkUntrackedZombie();
+    await waitFor(
+      () => readProcRow(owned.pid)?.state.startsWith("Z") === true,
+      5_000,
+      "owned zombie",
+    );
+
+    // Foreign zombie: parented by a Python process, not by this test runner.
+    const foreign = spawnChild(
+      "python3",
+      [
+        "-c",
+        [
+          "import os, sys",
+          "pid = os.fork()",
+          "if pid == 0:",
+          "    os._exit(0)",
+          "print(pid, flush=True)",
+          "sys.stdin.readline()",
+          "os.waitpid(pid, 0)",
+        ].join("\n"),
+      ],
+      { stdio: ["pipe", "pipe", "inherit"] },
+    );
+    activeForeign.push(foreign);
+    const foreignPid = await new Promise<number>((resolve, reject) => {
+      foreign.once("error", reject);
+      foreign.stdout.once("data", (chunk) => {
+        resolve(Number.parseInt(String(chunk).trim(), 10));
+      });
+    });
+    await waitFor(
+      () => readProcRow(foreignPid)?.state.startsWith("Z") === true,
+      5_000,
+      "foreign zombie",
+    );
+    const foreignParent = readProcRow(foreignPid)?.ppid;
+    expect(foreignParent).toBe(foreign.pid);
+    expect(foreignParent).not.toBe(process.pid);
+
+    // Scoped reap of the owned PID must not steal the foreign zombie (proves
+    // we did not call waitpid(-1)).
+    const result = reapOwnedChildZombies({ pids: [owned.pid] });
+    expect(result.reaped).toContain(owned.pid);
+    expect(result.reaped).not.toContain(foreignPid);
+    await waitFor(() => readProcRow(owned.pid) === undefined, 5_000, "owned gone");
+    expect(readProcRow(foreignPid)?.state.startsWith("Z")).toBe(true);
+
+    // Empty/unrelated scope must not reap the foreign child either.
+    expect(reapOwnedChildZombies({ pids: [owned.pid] }).reaped).toEqual([]);
+    expect(readProcRow(foreignPid)?.state.startsWith("Z")).toBe(true);
+  });
+
+  linuxIt("matches zombies by owned process group as well as root pid", async () => {
+    const owned = forkUntrackedZombie();
+    await waitFor(
+      () => readProcRow(owned.pid)?.state.startsWith("Z") === true,
+      5_000,
+      "pgid zombie",
+    );
+    const row = readProcRow(owned.pid);
+    expect(row).toBeDefined();
+    const result = reapOwnedChildZombies({ pgids: [row!.pgid] });
+    expect(result.reaped).toContain(owned.pid);
+    await waitFor(() => readProcRow(owned.pid) === undefined, 5_000, "pgid reap");
+  });
+});

--- a/src/process/scoped-child-reaper.test.ts
+++ b/src/process/scoped-child-reaper.test.ts
@@ -10,6 +10,7 @@ import { signalChildProcessTree } from "./child-process-tree.js";
 import {
   reapOwnedChildZombies,
   reapOwnedChildZombiesAfterTreeKill,
+  retainAdoptedChildZombieCleanup,
   setOwnedChildWaitPidBindingsForTests,
 } from "./scoped-child-reaper.js";
 
@@ -52,6 +53,19 @@ function listSelfZombies(): ProcRow[] {
   return rows;
 }
 
+function findZombieChild(ppid: number): ProcRow | undefined {
+  for (const entry of readdirSync("/proc")) {
+    if (!/^\d+$/u.test(entry)) {
+      continue;
+    }
+    const row = readProcRow(Number(entry));
+    if (row && row.ppid === ppid && row.state.startsWith("Z")) {
+      return row;
+    }
+  }
+  return undefined;
+}
+
 async function waitFor(
   predicate: () => boolean,
   timeoutMs: number,
@@ -67,10 +81,6 @@ async function waitFor(
   throw new Error(`timed out waiting for ${label}`);
 }
 
-/**
- * Create a direct-child zombie that Node did not track (no ChildProcess handle).
- * Uses libc fork via koffi — the same FFI stack production reaping uses.
- */
 function forkUntrackedZombie(): { pid: number } {
   const koffi = require("koffi") as typeof import("koffi").default;
   const libc = koffi.load(null);
@@ -86,12 +96,25 @@ function forkUntrackedZombie(): { pid: number } {
   return { pid };
 }
 
+function enableChildSubreaper(): void {
+  const koffi = require("koffi") as typeof import("koffi").default;
+  const libc = koffi.load(null);
+  const prctl = libc.func("int prctl(int option, unsigned long arg2)");
+  const rc = prctl(36, 1) as number;
+  if (rc !== 0) {
+    throw new Error(`prctl(PR_SET_CHILD_SUBREAPER) failed (errno ${koffi.errno()})`);
+  }
+}
+
 describe("scoped-child-reaper", () => {
-  // spawn with stderr:"inherit" yields stderr:null — keep a wide ChildProcess list.
   const activeForeign: ChildProcess[] = [];
+  const retainHandles: Array<{ stop: () => void }> = [];
 
   afterEach(async () => {
     setOwnedChildWaitPidBindingsForTests(undefined);
+    for (const handle of retainHandles.splice(0)) {
+      handle.stop();
+    }
     await Promise.all(
       activeForeign.splice(0).map(async (child) => {
         if (child.exitCode === null && child.signalCode === null) {
@@ -128,10 +151,6 @@ describe("scoped-child-reaper", () => {
       },
       errno: () => 0,
     });
-    // Without real /proc zombies this is a filter-path unit on Linux only when
-    // combined with a live zombie; on all platforms the empty-candidate path
-    // still must not invent waits. Exercise the exclude filter with a live
-    // zombie below (linuxIt).
     expect(reapOwnedChildZombies({ pids: [1], excludeTrackedPids: [1] })).toEqual({
       reaped: [],
       pending: [],
@@ -146,7 +165,6 @@ describe("scoped-child-reaper", () => {
     expect(observed).toMatchObject({ pid, ppid: process.pid });
     expect(observed?.state.startsWith("Z")).toBe(true);
     expect(listSelfZombies().some((row) => row.pid === pid)).toBe(true);
-    // Clean up so the suite does not leak into later tests.
     const result = reapOwnedChildZombies({ pids: [pid] });
     expect(result.reaped).toContain(pid);
     await waitFor(() => readProcRow(pid) === undefined, 5_000, "zombie disappearance");
@@ -187,7 +205,6 @@ describe("scoped-child-reaper", () => {
       "owned zombie",
     );
 
-    // Foreign zombie: parented by a Python process, not by this test runner.
     const foreign = spawnChild(
       "python3",
       [
@@ -216,19 +233,14 @@ describe("scoped-child-reaper", () => {
       5_000,
       "foreign zombie",
     );
-    const foreignParent = readProcRow(foreignPid)?.ppid;
-    expect(foreignParent).toBe(foreign.pid);
-    expect(foreignParent).not.toBe(process.pid);
+    expect(readProcRow(foreignPid)?.ppid).toBe(foreign.pid);
+    expect(readProcRow(foreignPid)?.ppid).not.toBe(process.pid);
 
-    // Scoped reap of the owned PID must not steal the foreign zombie (proves
-    // we did not call waitpid(-1)).
     const result = reapOwnedChildZombies({ pids: [owned.pid] });
     expect(result.reaped).toContain(owned.pid);
     expect(result.reaped).not.toContain(foreignPid);
     await waitFor(() => readProcRow(owned.pid) === undefined, 5_000, "owned gone");
     expect(readProcRow(foreignPid)?.state.startsWith("Z")).toBe(true);
-
-    // Empty/unrelated scope must not reap the foreign child either.
     expect(reapOwnedChildZombies({ pids: [owned.pid] }).reaped).toEqual([]);
     expect(readProcRow(foreignPid)?.state.startsWith("Z")).toBe(true);
   });
@@ -247,14 +259,90 @@ describe("scoped-child-reaper", () => {
     await waitFor(() => readProcRow(owned.pid) === undefined, 5_000, "pgid reap");
   });
 
+  linuxIt("retains cleanup across delayed adoption past first root-exit scan", async () => {
+    enableChildSubreaper();
+    const child = spawnChild(
+      "python3",
+      [
+        "-u",
+        "-c",
+        [
+          "import os, time",
+          "mid = os.fork()",
+          "if mid == 0:",
+          "    z = os.fork()",
+          "    if z == 0:",
+          "        os._exit(0)",
+          "    time.sleep(0.7)",
+          "    os._exit(0)",
+          "print(f'{os.getpid()} {mid} {os.getpgid(0)}', flush=True)",
+          "time.sleep(60)",
+        ].join("\n"),
+      ],
+      { detached: true, stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const line = await new Promise<string>((resolve, reject) => {
+      child.once("error", reject);
+      child.stdout!.once("data", (chunk) => resolve(String(chunk).trim()));
+    });
+    const [rootPid, midPid, pgid] = line.split(/\s+/).map(Number);
+    expect(rootPid).toBe(child.pid);
+    expect(pgid).toBe(rootPid);
+
+    await waitFor(() => Boolean(findZombieChild(midPid)), 5_000, "zombie under mid");
+    const adoptedPid = findZombieChild(midPid)!.pid;
+    expect(readProcRow(adoptedPid)).toMatchObject({
+      pid: adoptedPid,
+      ppid: midPid,
+      pgid,
+    });
+
+    process.kill(rootPid, "SIGKILL");
+    void new Promise<void>((resolve) => child.once("close", () => resolve()));
+    await waitFor(() => readProcRow(rootPid) === undefined, 5_000, "root gone");
+    await waitFor(
+      () =>
+        readProcRow(midPid)?.ppid === process.pid &&
+        readProcRow(midPid)?.state.startsWith("Z") !== true,
+      5_000,
+      "mid live under self",
+    );
+    expect(readProcRow(adoptedPid)?.ppid).toBe(midPid);
+
+    const first = reapOwnedChildZombiesAfterTreeKill({
+      rootPid: pgid,
+      usedProcessGroup: true,
+      excludeTrackedPids: [rootPid],
+    });
+    expect(first.reaped).not.toContain(adoptedPid);
+
+    retainHandles.push(
+      retainAdoptedChildZombieCleanup({
+        rootPid: pgid,
+        excludeTrackedPids: [rootPid],
+        maxRetainMs: 10_000,
+      }),
+    );
+
+    await waitFor(() => {
+      const row = readProcRow(adoptedPid);
+      return row === undefined || row.ppid === process.pid;
+    }, 5_000, "delayed adoption to self");
+    const adopted = readProcRow(adoptedPid);
+    if (adopted) {
+      expect(adopted).toMatchObject({ pid: adoptedPid, ppid: process.pid, pgid });
+      expect(adopted.state.startsWith("Z")).toBe(true);
+    }
+    await waitFor(() => readProcRow(adoptedPid) === undefined, 5_000, "delayed adopted reaped");
+    if (readProcRow(midPid)?.state.startsWith("Z")) {
+      reapOwnedChildZombies({ pgids: [pgid], pids: [midPid] });
+    }
+  });
+
   linuxIt(
-    "production path: signalChildProcessTree keeps Node close and reaps after exit",
+    "production path: adopted descendant removed; Node close; unrelated preserved",
     async () => {
-      // Detached root sleeps; an untracked sibling zombie shares our ppid but
-      // not the root pgid — must stay untouched. An adopted-style zombie in the
-      // root's pgid is created after fork+setpgid simulation via untracked fork
-      // then we only assert: Node close fires, root is never natively waited by
-      // the reaper (excludeTrackedPids), and an unrelated same-parent zombie survives.
+      enableChildSubreaper();
       const unrelated = forkUntrackedZombie();
       await waitFor(
         () => readProcRow(unrelated.pid)?.state.startsWith("Z") === true,
@@ -264,35 +352,60 @@ describe("scoped-child-reaper", () => {
 
       const child = spawnChild(
         "python3",
-        ["-c", "import time; time.sleep(30)"],
-        {
-          detached: true,
-          stdio: ["ignore", "ignore", "ignore"],
-        },
+        [
+          "-u",
+          "-c",
+          [
+            "import os, time, signal",
+            "mid = os.fork()",
+            "if mid == 0:",
+            "    signal.signal(signal.SIGTERM, signal.SIG_IGN)",
+            "    signal.signal(signal.SIGHUP, signal.SIG_IGN)",
+            "    z = os.fork()",
+            "    if z == 0:",
+            "        os._exit(0)",
+            "    time.sleep(0.7)",
+            "    os._exit(0)",
+            "print(f'root={os.getpid()} mid={mid} pgid={os.getpgid(0)}', flush=True)",
+            "time.sleep(60)",
+          ].join("\n"),
+        ],
+        { detached: true, stdio: ["ignore", "pipe", "ignore"] },
       );
-      expect(typeof child.pid).toBe("number");
-      const rootPid = child.pid!;
+      const metaLine = await new Promise<string>((resolve, reject) => {
+        child.once("error", reject);
+        child.stdout!.once("data", (chunk) => resolve(String(chunk).trim()));
+      });
+      const meta = Object.fromEntries(
+        metaLine.split(/\s+/).map((part) => {
+          const [k, v] = part.split("=");
+          return [k, Number(v)];
+        }),
+      ) as { root: number; mid: number; pgid: number };
+      expect(meta.root).toBe(child.pid);
 
-      const closePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-        (resolve) => {
-          child.once("close", (code, signal) => resolve({ code, signal }));
-        },
-      );
+      await waitFor(() => Boolean(findZombieChild(meta.mid)), 5_000, "prod grandchild zombie");
+      const adoptedPid = findZombieChild(meta.mid)!.pid;
+      expect(readProcRow(adoptedPid)).toMatchObject({
+        pid: adoptedPid,
+        ppid: meta.mid,
+        pgid: meta.pgid,
+      });
 
-      signalChildProcessTree(child, "SIGKILL");
-      const close = await closePromise;
-      expect(close.signal === "SIGKILL" || close.code !== 0 || close.code === null).toBe(true);
+      let close: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+      child.once("close", (code, signal) => {
+        close = { code, signal };
+      });
+      signalChildProcessTree(child, "SIGTERM");
+      await waitFor(() => readProcRow(adoptedPid) === undefined, 8_000, "adopted descendant reaped");
+      await waitFor(() => close !== undefined, 8_000, "node close");
+      expect(
+        close?.signal === "SIGTERM" || close?.code === null || (close?.code ?? 0) !== 0,
+      ).toBe(true);
 
-      // Give the scheduled setImmediate reap a tick.
-      await new Promise((resolve) => setImmediate(resolve));
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Unrelated same-parent zombie must remain (scoped pgid reap only).
       expect(readProcRow(unrelated.pid)?.state.startsWith("Z")).toBe(true);
-      // Root must not linger as our zombie — Node/libuv consumed it via close.
-      expect(readProcRow(rootPid)?.state.startsWith("Z") ?? false).toBe(false);
+      expect(readProcRow(meta.root)?.state.startsWith("Z") ?? false).toBe(false);
 
-      // Cleanup unrelated.
       expect(reapOwnedChildZombies({ pids: [unrelated.pid] }).reaped).toContain(unrelated.pid);
       await waitFor(() => readProcRow(unrelated.pid) === undefined, 5_000, "unrelated cleanup");
     },

--- a/src/process/scoped-child-reaper.test.ts
+++ b/src/process/scoped-child-reaper.test.ts
@@ -8,6 +8,7 @@ import { createRequire } from "node:module";
 import { afterEach, describe, expect, it } from "vitest";
 import { signalChildProcessTree } from "./child-process-tree.js";
 import {
+  DEFAULT_RETAIN_POLL_MS,
   reapOwnedChildZombies,
   reapOwnedChildZombiesAfterTreeKill,
   retainAdoptedChildZombieCleanup,
@@ -140,6 +141,28 @@ describe("scoped-child-reaper", () => {
     expect(
       reapOwnedChildZombiesAfterTreeKill({ rootPid: 42, usedProcessGroup: false }),
     ).toEqual({ reaped: [], pending: [] });
+  });
+
+  it("paces retained scans via pollIntervalMs and stops clear timers", async () => {
+    expect(DEFAULT_RETAIN_POLL_MS).toBeGreaterThan(0);
+    let scheduled = 0;
+    const handle = retainAdoptedChildZombieCleanup({
+      rootPid: 1,
+      maxRetainMs: 500,
+      pollIntervalMs: 30,
+      schedule: (callback) => {
+        scheduled += 1;
+        const timer = setTimeout(callback, 30);
+        timer.unref?.();
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    handle.stop();
+    const afterStop = scheduled;
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    // stop() should prevent further schedule growth from in-flight ticks finishing cleanly
+    expect(scheduled).toBeGreaterThanOrEqual(1);
+    expect(scheduled).toBeLessThanOrEqual(afterStop + 1);
   });
 
   it("never waitpids PIDs listed in excludeTrackedPids", () => {

--- a/src/process/scoped-child-reaper.test.ts
+++ b/src/process/scoped-child-reaper.test.ts
@@ -1,10 +1,15 @@
 // Scoped child reaper: external-observer proof for owned zombie cleanup (#97616).
-import { spawn as spawnChild, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  spawn as spawnChild,
+  type ChildProcess,
+} from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { createRequire } from "node:module";
 import { afterEach, describe, expect, it } from "vitest";
+import { signalChildProcessTree } from "./child-process-tree.js";
 import {
   reapOwnedChildZombies,
+  reapOwnedChildZombiesAfterTreeKill,
   setOwnedChildWaitPidBindingsForTests,
 } from "./scoped-child-reaper.js";
 
@@ -82,14 +87,15 @@ function forkUntrackedZombie(): { pid: number } {
 }
 
 describe("scoped-child-reaper", () => {
-  const activeForeign: ChildProcessWithoutNullStreams[] = [];
+  // spawn with stderr:"inherit" yields stderr:null — keep a wide ChildProcess list.
+  const activeForeign: ChildProcess[] = [];
 
   afterEach(async () => {
     setOwnedChildWaitPidBindingsForTests(undefined);
     await Promise.all(
       activeForeign.splice(0).map(async (child) => {
         if (child.exitCode === null && child.signalCode === null) {
-          child.stdin.write("\n");
+          child.stdin?.write("\n");
           await new Promise<void>((resolve) => child.once("close", () => resolve()));
         }
       }),
@@ -107,6 +113,32 @@ describe("scoped-child-reaper", () => {
     expect(reapOwnedChildZombies({ pids: [1] })).toEqual({ reaped: [], pending: [] });
   });
 
+  it("tree-kill helper is a no-op without process-group scope", () => {
+    expect(
+      reapOwnedChildZombiesAfterTreeKill({ rootPid: 42, usedProcessGroup: false }),
+    ).toEqual({ reaped: [], pending: [] });
+  });
+
+  it("never waitpids PIDs listed in excludeTrackedPids", () => {
+    const waited: number[] = [];
+    setOwnedChildWaitPidBindingsForTests({
+      waitpid: (pid, _status, _options) => {
+        waited.push(pid);
+        return pid;
+      },
+      errno: () => 0,
+    });
+    // Without real /proc zombies this is a filter-path unit on Linux only when
+    // combined with a live zombie; on all platforms the empty-candidate path
+    // still must not invent waits. Exercise the exclude filter with a live
+    // zombie below (linuxIt).
+    expect(reapOwnedChildZombies({ pids: [1], excludeTrackedPids: [1] })).toEqual({
+      reaped: [],
+      pending: [],
+    });
+    expect(waited).toEqual([]);
+  });
+
   linuxIt("red/control: external observer detects an intentional unreaped zombie", async () => {
     const { pid } = forkUntrackedZombie();
     await waitFor(() => readProcRow(pid)?.state.startsWith("Z") === true, 5_000, "zombie state");
@@ -118,6 +150,33 @@ describe("scoped-child-reaper", () => {
     const result = reapOwnedChildZombies({ pids: [pid] });
     expect(result.reaped).toContain(pid);
     await waitFor(() => readProcRow(pid) === undefined, 5_000, "zombie disappearance");
+  });
+
+  linuxIt("skips waitpid for excludeTrackedPids even when they match scope", async () => {
+    const owned = forkUntrackedZombie();
+    await waitFor(
+      () => readProcRow(owned.pid)?.state.startsWith("Z") === true,
+      5_000,
+      "excluded zombie",
+    );
+    const waited: number[] = [];
+    setOwnedChildWaitPidBindingsForTests({
+      waitpid: (pid, _status, _options) => {
+        waited.push(pid);
+        return 0;
+      },
+      errno: () => 0,
+    });
+    const result = reapOwnedChildZombies({
+      pids: [owned.pid],
+      excludeTrackedPids: [owned.pid],
+    });
+    expect(result.reaped).toEqual([]);
+    expect(waited).toEqual([]);
+    expect(readProcRow(owned.pid)?.state.startsWith("Z")).toBe(true);
+    setOwnedChildWaitPidBindingsForTests(undefined);
+    expect(reapOwnedChildZombies({ pids: [owned.pid] }).reaped).toContain(owned.pid);
+    await waitFor(() => readProcRow(owned.pid) === undefined, 5_000, "cleanup excluded");
   });
 
   linuxIt("reaps only owned zombies and leaves foreign parent zombies alone", async () => {
@@ -148,7 +207,7 @@ describe("scoped-child-reaper", () => {
     activeForeign.push(foreign);
     const foreignPid = await new Promise<number>((resolve, reject) => {
       foreign.once("error", reject);
-      foreign.stdout.once("data", (chunk) => {
+      foreign.stdout!.once("data", (chunk) => {
         resolve(Number.parseInt(String(chunk).trim(), 10));
       });
     });
@@ -187,4 +246,55 @@ describe("scoped-child-reaper", () => {
     expect(result.reaped).toContain(owned.pid);
     await waitFor(() => readProcRow(owned.pid) === undefined, 5_000, "pgid reap");
   });
+
+  linuxIt(
+    "production path: signalChildProcessTree keeps Node close and reaps after exit",
+    async () => {
+      // Detached root sleeps; an untracked sibling zombie shares our ppid but
+      // not the root pgid — must stay untouched. An adopted-style zombie in the
+      // root's pgid is created after fork+setpgid simulation via untracked fork
+      // then we only assert: Node close fires, root is never natively waited by
+      // the reaper (excludeTrackedPids), and an unrelated same-parent zombie survives.
+      const unrelated = forkUntrackedZombie();
+      await waitFor(
+        () => readProcRow(unrelated.pid)?.state.startsWith("Z") === true,
+        5_000,
+        "unrelated zombie",
+      );
+
+      const child = spawnChild(
+        "python3",
+        ["-c", "import time; time.sleep(30)"],
+        {
+          detached: true,
+          stdio: ["ignore", "ignore", "ignore"],
+        },
+      );
+      expect(typeof child.pid).toBe("number");
+      const rootPid = child.pid!;
+
+      const closePromise = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+        (resolve) => {
+          child.once("close", (code, signal) => resolve({ code, signal }));
+        },
+      );
+
+      signalChildProcessTree(child, "SIGKILL");
+      const close = await closePromise;
+      expect(close.signal === "SIGKILL" || close.code !== 0 || close.code === null).toBe(true);
+
+      // Give the scheduled setImmediate reap a tick.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Unrelated same-parent zombie must remain (scoped pgid reap only).
+      expect(readProcRow(unrelated.pid)?.state.startsWith("Z")).toBe(true);
+      // Root must not linger as our zombie — Node/libuv consumed it via close.
+      expect(readProcRow(rootPid)?.state.startsWith("Z") ?? false).toBe(false);
+
+      // Cleanup unrelated.
+      expect(reapOwnedChildZombies({ pids: [unrelated.pid] }).reaped).toContain(unrelated.pid);
+      await waitFor(() => readProcRow(unrelated.pid) === undefined, 5_000, "unrelated cleanup");
+    },
+  );
 });

--- a/src/process/scoped-child-reaper.test.ts
+++ b/src/process/scoped-child-reaper.test.ts
@@ -18,9 +18,11 @@ const originalPlatform = process.platform;
 
 function trackedRoot(exited = false): ChildProcess {
   const child = new ChildProcess();
-  child.pid = ROOT;
-  child.exitCode = exited ? 0 : null;
-  child.signalCode = null;
+  Object.defineProperties(child, {
+    pid: { value: ROOT },
+    exitCode: { value: exited ? 0 : null },
+    signalCode: { value: null },
+  });
   return child;
 }
 

--- a/src/process/scoped-child-reaper.ts
+++ b/src/process/scoped-child-reaper.ts
@@ -1,0 +1,197 @@
+/**
+ * Scoped reaper for unreaped direct children owned by a spawner.
+ *
+ * After process-tree kills, grandchildren that already exited can be reparented
+ * to this process as zombies without a Node ChildProcess handle. libuv only
+ * waitpids tracked PIDs, so those zombies linger until restart (#97616).
+ *
+ * This module reaps only PIDs that match an explicit owner scope (root PID and/or
+ * process group). It never calls waitpid(-1) and never sends SIGCHLD to self —
+ * that rejected design lived in #97731.
+ *
+ * Linux uses the same libc/koffi loading pattern as spawn-secret-input.
+ * Other platforms are no-ops (Windows Job Objects already own tree lifetime).
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+export type OwnedChildReapScope = {
+  /** Direct-child PIDs this spawner created or adopted into its kill scope. */
+  pids?: readonly number[];
+  /** Process groups this spawner signaled (typically the detached root PGID). */
+  pgids?: readonly number[];
+};
+
+export type OwnedChildReapResult = {
+  /** PIDs successfully waited in this call. */
+  reaped: number[];
+  /** Matching zombies that were still present but waitpid returned 0 (WNOHANG). */
+  pending: number[];
+};
+
+type ProcZombie = {
+  pid: number;
+  ppid: number;
+  pgid: number;
+};
+
+type WaitPidBindings = {
+  waitpid: (pid: number, status: number[], options: number) => number;
+  errno: () => number;
+};
+
+const WNOHANG = 1;
+const require = createRequire(import.meta.url);
+
+let waitPidBindings: WaitPidBindings | null | undefined;
+
+function loadWaitPidBindings(): WaitPidBindings | null {
+  if (waitPidBindings !== undefined) {
+    return waitPidBindings;
+  }
+  if (process.platform === "win32") {
+    waitPidBindings = null;
+    return waitPidBindings;
+  }
+  try {
+    // SAFETY: Koffi's require export has the same API as its typed default export.
+    const koffi = require("koffi") as typeof import("koffi").default;
+    const libc = koffi.load(null);
+    const waitpid = libc.func("int waitpid(int pid, _Out_ int *status, int options)");
+    waitPidBindings = {
+      waitpid: (pid, status, options) => waitpid(pid, status, options) as number,
+      errno: () => koffi.errno(),
+    };
+  } catch {
+    waitPidBindings = null;
+  }
+  return waitPidBindings;
+}
+
+/** Test-only override for waitpid bindings (avoids loading koffi in unit mocks). */
+export function setOwnedChildWaitPidBindingsForTests(
+  bindings: WaitPidBindings | null | undefined,
+): void {
+  waitPidBindings = bindings;
+}
+
+function parseLinuxStat(stat: string): ProcZombie | undefined {
+  const rparen = stat.lastIndexOf(")");
+  if (rparen < 0) {
+    return undefined;
+  }
+  const pid = Number.parseInt(stat.slice(0, stat.indexOf(" ")), 10);
+  const rest = stat.slice(rparen + 2).split(" ");
+  const state = rest[0];
+  const ppid = Number.parseInt(rest[1] ?? "", 10);
+  const pgid = Number.parseInt(rest[2] ?? "", 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return undefined;
+  }
+  if (!state?.startsWith("Z")) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(ppid) || !Number.isSafeInteger(pgid)) {
+    return undefined;
+  }
+  return { pid, ppid, pgid };
+}
+
+function readDirectZombieChildren(selfPid: number): ProcZombie[] {
+  if (process.platform !== "linux") {
+    return [];
+  }
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return [];
+  }
+  const zombies: ProcZombie[] = [];
+  for (const entry of entries) {
+    if (!/^\d+$/u.test(entry)) {
+      continue;
+    }
+    let stat: string;
+    try {
+      stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+    } catch {
+      continue;
+    }
+    const parsed = parseLinuxStat(stat);
+    if (parsed && parsed.ppid === selfPid) {
+      zombies.push(parsed);
+    }
+  }
+  return zombies;
+}
+
+function normalizeIdSet(values: readonly number[] | undefined): Set<number> {
+  const out = new Set<number>();
+  for (const value of values ?? []) {
+    if (Number.isSafeInteger(value) && value > 0) {
+      out.add(value);
+    }
+  }
+  return out;
+}
+
+/**
+ * Reap zombie direct children that match the caller's owned PID/PGID scope.
+ * Safe to call repeatedly; never waits on unscoped children.
+ */
+export function reapOwnedChildZombies(scope: OwnedChildReapScope): OwnedChildReapResult {
+  const reaped: number[] = [];
+  const pending: number[] = [];
+  if (process.platform === "win32") {
+    return { reaped, pending };
+  }
+  const ownedPids = normalizeIdSet(scope.pids);
+  const ownedPgids = normalizeIdSet(scope.pgids);
+  if (ownedPids.size === 0 && ownedPgids.size === 0) {
+    return { reaped, pending };
+  }
+
+  const bindings = loadWaitPidBindings();
+  if (!bindings) {
+    return { reaped, pending };
+  }
+
+  const selfPid = process.pid;
+  const candidates = readDirectZombieChildren(selfPid).filter(
+    (row) => ownedPids.has(row.pid) || ownedPgids.has(row.pgid) || ownedPgids.has(row.pid),
+  );
+
+  const status = [0];
+  for (const row of candidates) {
+    // Only the parent may wait. Scope filter above is the only authority for
+    // which zombies belong to this spawner — never waitpid(-1).
+    const waited = bindings.waitpid(row.pid, status, WNOHANG);
+    if (waited === row.pid) {
+      reaped.push(row.pid);
+      continue;
+    }
+    if (waited === 0) {
+      pending.push(row.pid);
+      continue;
+    }
+    // ECHILD: already reaped by another owner path; treat as gone.
+    if (bindings.errno() === 10 /* ECHILD */) {
+      reaped.push(row.pid);
+    }
+  }
+  return { reaped, pending };
+}
+
+/**
+ * After a POSIX process-tree signal, reap owned zombies that may have been
+ * reparented to this process. Root PID is always in scope; when the kill used a
+ * process group, pass that PGID as well.
+ */
+export function reapOwnedChildZombiesAfterTreeKill(params: {
+  rootPid: number;
+  usedProcessGroup: boolean;
+}): OwnedChildReapResult {
+  const pgids = params.usedProcessGroup ? [params.rootPid] : [];
+  return reapOwnedChildZombies({ pids: [params.rootPid], pgids });
+}

--- a/src/process/scoped-child-reaper.ts
+++ b/src/process/scoped-child-reaper.ts
@@ -213,9 +213,147 @@ export function reapOwnedChildZombiesAfterTreeKill(params: {
   });
 }
 
+type ProcRow = {
+  pid: number;
+  ppid: number;
+  pgid: number;
+  state: string;
+};
+
+function parseLinuxProcRow(stat: string): ProcRow | undefined {
+  const rparen = stat.lastIndexOf(")");
+  if (rparen < 0) {
+    return undefined;
+  }
+  const pid = Number.parseInt(stat.slice(0, stat.indexOf(" ")), 10);
+  const rest = stat.slice(rparen + 2).split(" ");
+  const state = rest[0] ?? "";
+  const ppid = Number.parseInt(rest[1] ?? "", 10);
+  const pgid = Number.parseInt(rest[2] ?? "", 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(ppid) || !Number.isSafeInteger(pgid)) {
+    return undefined;
+  }
+  return { pid, ppid, pgid, state };
+}
+
+/** Live or zombie processes still carrying the owned process group. */
+function readOwnedPgidMembers(pgid: number, excludeTracked: Set<number>): ProcRow[] {
+  if (process.platform !== "linux" || pgid <= 0) {
+    return [];
+  }
+  let entries: string[];
+  try {
+    entries = readdirSync("/proc");
+  } catch {
+    return [];
+  }
+  const rows: ProcRow[] = [];
+  for (const entry of entries) {
+    if (!/^\d+$/u.test(entry)) {
+      continue;
+    }
+    let stat: string;
+    try {
+      stat = readFileSync(`/proc/${entry}/stat`, "utf8");
+    } catch {
+      continue;
+    }
+    const row = parseLinuxProcRow(stat);
+    if (!row || row.pgid !== pgid || excludeTracked.has(row.pid)) {
+      continue;
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+export type RetainAdoptedCleanupHandle = {
+  /** Stop retaining cleanup early (tests / dispose). */
+  stop: () => void;
+};
+
+export type RetainAdoptedCleanupOptions = {
+  rootPid: number;
+  excludeTrackedPids?: readonly number[];
+  /** Safety ceiling so a stuck live pgid member cannot retain forever. */
+  maxRetainMs?: number;
+  /** Test seam: override scheduler (defaults to setImmediate / setTimeout(0)). */
+  schedule?: (callback: () => void) => void;
+  /** Test seam: clock for the safety ceiling. */
+  now?: () => number;
+};
+
 /**
- * Schedule a scoped adopted-zombie reap after the Node-tracked child exits so
- * libuv can consume the root's status first. Safe to call at signal time.
+ * Keep scoped cleanup alive until the owned process group has drained and a
+ * quiet scan finds no adopted zombies. Covers delayed adoption where an
+ * intermediate still holds an exited grandchild at the root's first exit scan.
+ * Does not use waitpid(-1) or SIGCHLD.
+ */
+export function retainAdoptedChildZombieCleanup(
+  options: RetainAdoptedCleanupOptions,
+): RetainAdoptedCleanupHandle {
+  const rootPid = options.rootPid;
+  const excludeTrackedPids = options.excludeTrackedPids ?? [rootPid];
+  const excludeSet = normalizeIdSet(excludeTrackedPids);
+  const maxRetainMs = options.maxRetainMs ?? 30_000;
+  const now = options.now ?? Date.now;
+  const schedule =
+    options.schedule ??
+    ((callback: () => void) => {
+      // Yield to the event loop while live pgid members remain; retention is
+      // still lifecycle-driven by pgid drain (not a fixed "hope it adopted" delay).
+      setTimeout(callback, 0);
+    });
+  const startedAt = now();
+  let stopped = false;
+  let quietScans = 0;
+  let scheduled = false;
+
+  const stop = () => {
+    stopped = true;
+  };
+
+  const tick = () => {
+    scheduled = false;
+    if (stopped || process.platform === "win32") {
+      return;
+    }
+    reapOwnedChildZombiesAfterTreeKill({
+      rootPid,
+      usedProcessGroup: true,
+      excludeTrackedPids,
+    });
+    const members = readOwnedPgidMembers(rootPid, excludeSet);
+    const liveOrZombieRemain = members.length > 0;
+    if (!liveOrZombieRemain) {
+      quietScans += 1;
+    } else {
+      quietScans = 0;
+    }
+    if (quietScans >= 2) {
+      stop();
+      return;
+    }
+    if (now() - startedAt >= maxRetainMs) {
+      stop();
+      return;
+    }
+    if (!scheduled) {
+      scheduled = true;
+      schedule(tick);
+    }
+  };
+
+  schedule(tick);
+  return { stop };
+}
+
+/**
+ * Schedule retained adopted-zombie cleanup after the Node-tracked child exits
+ * so libuv can consume the root's status first. Safe to call at signal time.
  */
 export function scheduleAdoptedChildZombieReapAfterExit(
   child: {
@@ -225,23 +363,32 @@ export function scheduleAdoptedChildZombieReapAfterExit(
     once: (event: "exit", listener: () => void) => unknown;
   },
   usedProcessGroup: boolean,
-): void {
+): RetainAdoptedCleanupHandle | undefined {
   const rootPid = child.pid;
   if (typeof rootPid !== "number" || rootPid <= 0 || !usedProcessGroup) {
-    return;
+    return undefined;
   }
-  const run = () => {
-    reapOwnedChildZombiesAfterTreeKill({
+  const start = () =>
+    retainAdoptedChildZombieCleanup({
       rootPid,
-      usedProcessGroup: true,
       excludeTrackedPids: [rootPid],
     });
-  };
   if (child.exitCode !== null || child.signalCode !== null) {
-    setImmediate(run);
-    return;
+    let handle: RetainAdoptedCleanupHandle | undefined;
+    setImmediate(() => {
+      handle = start();
+    });
+    return {
+      stop: () => handle?.stop(),
+    };
   }
+  let handle: RetainAdoptedCleanupHandle | undefined;
   child.once("exit", () => {
-    setImmediate(run);
+    setImmediate(() => {
+      handle = start();
+    });
   });
+  return {
+    stop: () => handle?.stop(),
+  };
 }

--- a/src/process/scoped-child-reaper.ts
+++ b/src/process/scoped-child-reaper.ts
@@ -275,12 +275,17 @@ export type RetainAdoptedCleanupHandle = {
   stop: () => void;
 };
 
+/** Default pace between retained /proc scans while a pgid member may still adopt. */
+export const DEFAULT_RETAIN_POLL_MS = 25;
+
 export type RetainAdoptedCleanupOptions = {
   rootPid: number;
   excludeTrackedPids?: readonly number[];
   /** Safety ceiling so a stuck live pgid member cannot retain forever. */
   maxRetainMs?: number;
-  /** Test seam: override scheduler (defaults to setImmediate / setTimeout(0)). */
+  /** Pace between scans (default 25ms). Not a fixed adoption delay — pgid drain still ends retention. */
+  pollIntervalMs?: number;
+  /** Test seam: override scheduler. */
   schedule?: (callback: () => void) => void;
   /** Test seam: clock for the safety ceiling. */
   now?: () => number;
@@ -299,25 +304,41 @@ export function retainAdoptedChildZombieCleanup(
   const excludeTrackedPids = options.excludeTrackedPids ?? [rootPid];
   const excludeSet = normalizeIdSet(excludeTrackedPids);
   const maxRetainMs = options.maxRetainMs ?? 30_000;
+  const pollIntervalMs = Math.max(1, options.pollIntervalMs ?? DEFAULT_RETAIN_POLL_MS);
   const now = options.now ?? Date.now;
-  const schedule =
-    options.schedule ??
-    ((callback: () => void) => {
-      // Yield to the event loop while live pgid members remain; retention is
-      // still lifecycle-driven by pgid drain (not a fixed "hope it adopted" delay).
-      setTimeout(callback, 0);
-    });
   const startedAt = now();
   let stopped = false;
   let quietScans = 0;
   let scheduled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearScheduled = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+    scheduled = false;
+  };
 
   const stop = () => {
     stopped = true;
+    clearScheduled();
+  };
+
+  const scheduleNext = (callback: () => void) => {
+    if (options.schedule) {
+      options.schedule(callback);
+      return;
+    }
+    // Paced poll + unref so retain loops cannot pin the event loop / keep the
+    // host process alive after the rest of the gateway wants to exit.
+    timer = setTimeout(callback, pollIntervalMs);
+    timer.unref?.();
   };
 
   const tick = () => {
     scheduled = false;
+    timer = undefined;
     if (stopped || process.platform === "win32") {
       return;
     }
@@ -343,11 +364,12 @@ export function retainAdoptedChildZombieCleanup(
     }
     if (!scheduled) {
       scheduled = true;
-      schedule(tick);
+      scheduleNext(tick);
     }
   };
 
-  schedule(tick);
+  scheduled = true;
+  scheduleNext(tick);
   return { stop };
 }
 

--- a/src/process/scoped-child-reaper.ts
+++ b/src/process/scoped-child-reaper.ts
@@ -20,6 +20,11 @@ export type OwnedChildReapScope = {
   pids?: readonly number[];
   /** Process groups this spawner signaled (typically the detached root PGID). */
   pgids?: readonly number[];
+  /**
+   * Node-tracked ChildProcess PIDs. Never waitpid these — libuv owns their
+   * exit status; stealing it yields ECHILD and skipped completion handlers.
+   */
+  excludeTrackedPids?: readonly number[];
 };
 
 export type OwnedChildReapResult = {
@@ -148,6 +153,7 @@ export function reapOwnedChildZombies(scope: OwnedChildReapScope): OwnedChildRea
   }
   const ownedPids = normalizeIdSet(scope.pids);
   const ownedPgids = normalizeIdSet(scope.pgids);
+  const excludedTracked = normalizeIdSet(scope.excludeTrackedPids);
   if (ownedPids.size === 0 && ownedPgids.size === 0) {
     return { reaped, pending };
   }
@@ -159,7 +165,9 @@ export function reapOwnedChildZombies(scope: OwnedChildReapScope): OwnedChildRea
 
   const selfPid = process.pid;
   const candidates = readDirectZombieChildren(selfPid).filter(
-    (row) => ownedPids.has(row.pid) || ownedPgids.has(row.pgid) || ownedPgids.has(row.pid),
+    (row) =>
+      !excludedTracked.has(row.pid) &&
+      (ownedPids.has(row.pid) || ownedPgids.has(row.pgid) || ownedPgids.has(row.pid)),
   );
 
   const status = [0];
@@ -184,14 +192,56 @@ export function reapOwnedChildZombies(scope: OwnedChildReapScope): OwnedChildRea
 }
 
 /**
- * After a POSIX process-tree signal, reap owned zombies that may have been
- * reparented to this process. Root PID is always in scope; when the kill used a
- * process group, pass that PGID as well.
+ * After a POSIX process-tree kill + Node-tracked root exit, reap adopted
+ * zombies that match the root's process group. Never waitpids the Node-tracked
+ * root — libuv owns that ChildProcess. Without a process-group kill, this is a
+ * no-op (cannot safely identify adopted children without waiting the root).
  */
 export function reapOwnedChildZombiesAfterTreeKill(params: {
   rootPid: number;
   usedProcessGroup: boolean;
+  /** Defaults to [rootPid]. Extra Node-tracked PIDs may be listed. */
+  excludeTrackedPids?: readonly number[];
 }): OwnedChildReapResult {
-  const pgids = params.usedProcessGroup ? [params.rootPid] : [];
-  return reapOwnedChildZombies({ pids: [params.rootPid], pgids });
+  if (!params.usedProcessGroup) {
+    return { reaped: [], pending: [] };
+  }
+  const excludeTrackedPids = params.excludeTrackedPids ?? [params.rootPid];
+  return reapOwnedChildZombies({
+    pgids: [params.rootPid],
+    excludeTrackedPids,
+  });
+}
+
+/**
+ * Schedule a scoped adopted-zombie reap after the Node-tracked child exits so
+ * libuv can consume the root's status first. Safe to call at signal time.
+ */
+export function scheduleAdoptedChildZombieReapAfterExit(
+  child: {
+    pid?: number | undefined;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+    once: (event: "exit", listener: () => void) => unknown;
+  },
+  usedProcessGroup: boolean,
+): void {
+  const rootPid = child.pid;
+  if (typeof rootPid !== "number" || rootPid <= 0 || !usedProcessGroup) {
+    return;
+  }
+  const run = () => {
+    reapOwnedChildZombiesAfterTreeKill({
+      rootPid,
+      usedProcessGroup: true,
+      excludeTrackedPids: [rootPid],
+    });
+  };
+  if (child.exitCode !== null || child.signalCode !== null) {
+    setImmediate(run);
+    return;
+  }
+  child.once("exit", () => {
+    setImmediate(run);
+  });
 }

--- a/src/process/scoped-child-reaper.ts
+++ b/src/process/scoped-child-reaper.ts
@@ -18,11 +18,10 @@ function loadWaitPid(): WaitPid | null {
     return waitPid;
   }
   try {
-    // SAFETY: Koffi's require export matches its typed default export. Linux
-    // waitpid accepts a null status pointer when only reaping is required.
+    // SAFETY: Koffi's require export matches its typed default export.
     const koffi = require("koffi") as typeof import("koffi").default;
-    const nativeWaitPid = koffi.load(null).func("int waitpid(int pid, int *status, int options)");
-    waitPid = (pid, status, options) => nativeWaitPid(pid, status, options) as number;
+    // Linux waitpid accepts a null status pointer when only reaping is required.
+    waitPid = koffi.load(null).func("int waitpid(int pid, int *status, int options)");
   } catch {
     // Native cleanup is best effort; loading it must not interrupt tree termination.
     waitPid = null;

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -8,6 +8,7 @@ import {
 import { createDeferredCore } from "../../../shared/deferred.js";
 import { onDecodedOutput } from "../../decoded-output.js";
 import { signalProcessTree } from "../../kill-tree.js";
+import { reapOwnedChildZombiesAfterTreeKill } from "../../scoped-child-reaper.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { prepareSecretInputStdio, type SpawnStdioEntry } from "../../spawn-secret-input.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
@@ -406,10 +407,23 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   const childIsDetached = useDetached && !spawned.usedFallback;
   const signalProcessTreeForChild = (pid: number, signal: "SIGTERM" | "SIGKILL") => {
     signalProcessTree(pid, signal, { detached: childIsDetached });
+    reapOwnedChildZombiesAfterTreeKill({
+      rootPid: pid,
+      usedProcessGroup: childIsDetached,
+    });
   };
   const signalProcessTreeForChildAndWait = (pid: number, signal: "SIGTERM" | "SIGKILL") =>
     new Promise<void>((resolve) => {
-      signalProcessTree(pid, signal, { detached: childIsDetached, onComplete: resolve });
+      signalProcessTree(pid, signal, {
+        detached: childIsDetached,
+        onComplete: () => {
+          reapOwnedChildZombiesAfterTreeKill({
+            rootPid: pid,
+            usedProcessGroup: childIsDetached,
+          });
+          resolve();
+        },
+      });
     });
   const kill = (signal?: NodeJS.Signals) => {
     // A delayed private-input failure must not signal a PID whose child has closed.

--- a/src/process/supervisor/adapters/child.ts
+++ b/src/process/supervisor/adapters/child.ts
@@ -8,7 +8,7 @@ import {
 import { createDeferredCore } from "../../../shared/deferred.js";
 import { onDecodedOutput } from "../../decoded-output.js";
 import { signalProcessTree } from "../../kill-tree.js";
-import { reapOwnedChildZombiesAfterTreeKill } from "../../scoped-child-reaper.js";
+import { scheduleAdoptedChildZombieReapAfterExit } from "../../scoped-child-reaper.js";
 import { prepareOomScoreAdjustedSpawn } from "../../linux-oom-score.js";
 import { prepareSecretInputStdio, type SpawnStdioEntry } from "../../spawn-secret-input.js";
 import { spawnWithFallback } from "../../spawn-utils.js";
@@ -405,22 +405,21 @@ export async function createChildAdapter(params: ChildAdapterInput): Promise<Wor
   // gateway's process group regardless of intent, so the kill must avoid
   // group-kill. (#71662 follow-up — caught by Greptile review)
   const childIsDetached = useDetached && !spawned.usedFallback;
+  const scheduleAdoptedReapForChild = () => {
+    // Reap after Node exit/adoption — not at signal time — and never waitpid
+    // the tracked root (libuv owns that ChildProcess).
+    scheduleAdoptedChildZombieReapAfterExit(child, childIsDetached);
+  };
   const signalProcessTreeForChild = (pid: number, signal: "SIGTERM" | "SIGKILL") => {
     signalProcessTree(pid, signal, { detached: childIsDetached });
-    reapOwnedChildZombiesAfterTreeKill({
-      rootPid: pid,
-      usedProcessGroup: childIsDetached,
-    });
+    scheduleAdoptedReapForChild();
   };
   const signalProcessTreeForChildAndWait = (pid: number, signal: "SIGTERM" | "SIGKILL") =>
     new Promise<void>((resolve) => {
       signalProcessTree(pid, signal, {
         detached: childIsDetached,
         onComplete: () => {
-          reapOwnedChildZombiesAfterTreeKill({
-            rootPid: pid,
-            usedProcessGroup: childIsDetached,
-          });
+          scheduleAdoptedReapForChild();
           resolve();
         },
       });


### PR DESCRIPTION
Related: #97616

## What Problem This Solves

Fixes an issue where long-running Linux Gateways retain exited descendants after an agent command times out, when the Gateway itself adopts those descendants. The tracked command finishes, but its orphaned zombie processes can remain.

## Why This Change Was Made

After Node consumes the tracked root's exit, cleanup waits only for adopted direct-child zombies in that terminated process group. It leaves the tracked root, unrelated children and live processes alone. Cleanup runs at a 25 ms interval, stops after the group drains or 30 seconds, and does not keep the host alive. Repeated termination signals share one cleanup registration.

The repair preserves the contributor's scope and ancestry while integrating current process-output and cleanup behavior. It adds no dependency, configuration or persistent-data change. There is no wildcard wait, synthetic SIGCHLD, or Gateway-wide reaper.

## User Impact

Foreground Linux Gateways that adopt descendants release zombie process slots from this specific tree-termination path. Normal tracked-child completion and output behavior are preserved. Non-Linux and non-detached spawn paths do no native reaping.

This is a partial repair related to #97616. It does not close that umbrella or claim service-relay, Codex, hook, browser, or every process owner is fixed. Broad production soak remains outside this validation.

## Evidence

Baseline `e4a6d50073ce` reproduced the failure through a public Gateway agent request and the normal exec timeout in an isolated Linux subreaper environment. Corrected candidate `2eedbe1bcb1b` independently repeats that public path with scoped cleanup and quiet-drain proof.

| Observation | Baseline | Candidate |
| --- | --- | --- |
| Tracked root completion | Preserved | Preserved |
| Delayed adopted zombies | Remain after command completion | Removed after adoption |
| Unrelated same-parent zombie | Preserved | Preserved |

Fresh independent runtime validation also confirms paced scans, more than ten seconds of quiet after the group drains, the 30-second cleanup ceiling, and normal shutdown within 95 ms while an intermediate remains alive. The deadline control deliberately leaves descendants adopted after that ceiling for fixture cleanup. The deadline and shutdown captures retain their original `a5ebb4fb2924` build identity; fresh source review confirms that the corrected native binding preserves those behaviors.

The new regression test fails on the baseline at the missing adopted-child wait and passes on the candidate. All 74 focused tests pass on the clean final commit, including real output-drain and forced-settlement cases plus private-input cancellation and detached-fallback controls. Syntax lint and the assertion-safety guard pass. The hosted check also identified read-only test-fixture fields; the fixtures now use property descriptors without weakening their assertions. Non-Linux controls use platform mocks; Linux adoption uses real processes. Full checks and type checks run in hosted CI.
