### PR TITLE
test(sessions): assert off-thread reclamation instead of a wall-clock ceiling

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
@@ -20,6 +20,7 @@ import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target
 
 const archiveMaterializationHook = vi.hoisted(() => ({
   afterMaterialize: undefined as (() => void) | undefined,
+  workerOperations: [] as unknown[],
 }));
 
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
@@ -32,6 +33,16 @@ vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
       const result = await actual.materializeSessionStateDeletePlans(...args);
       archiveMaterializationHook.afterMaterialize?.();
       return result;
+    },
+    // Only session reclamation reaches this export from another module, so the
+    // recorded operations show whether the delete transaction left this thread.
+    runSqliteTranscriptArchiveWorkerOperation: (
+      params: Parameters<typeof actual.runSqliteTranscriptArchiveWorkerOperation>[0],
+    ) => {
+      archiveMaterializationHook.workerOperations.push(
+        (params.workerData as { operation?: unknown }).operation,
+      );
+      return actual.runSqliteTranscriptArchiveWorkerOperation(params);
     },
   };
 });
@@ -53,6 +64,7 @@ describe("SQLite lifecycle cleanup reclamation", () => {
 
   afterEach(() => {
     archiveMaterializationHook.afterMaterialize = undefined;
+    archiveMaterializationHook.workerOperations.length = 0;
     closeOpenClawAgentDatabasesForTest();
   });
 
@@ -251,9 +263,11 @@ describe("SQLite lifecycle cleanup reclamation", () => {
 
     const samples: number[] = [];
     let previous = 0;
+    let measuredFrom = 0;
     let heartbeat: ReturnType<typeof setInterval> | undefined;
     archiveMaterializationHook.afterMaterialize = () => {
-      previous = performance.now();
+      measuredFrom = performance.now();
+      previous = measuredFrom;
       heartbeat = setInterval(() => {
         const current = performance.now();
         samples.push(current - previous);
@@ -275,16 +289,31 @@ describe("SQLite lifecycle cleanup reclamation", () => {
         clearInterval(heartbeat);
       }
     }
+    const reclamationMs = performance.now() - measuredFrom;
 
     const maxGapMs = Math.max(...samples);
     if (process.env.OPENCLAW_TEST_RECLAMATION_LOG === "1") {
       process.stdout.write(
-        `${JSON.stringify({ owner: "lifecycle-cleanup", rows, maxGapMs, result })}\n`,
+        `${JSON.stringify({
+          owner: "lifecycle-cleanup",
+          rows,
+          maxGapMs,
+          reclamationMs,
+          workerOperations: archiveMaterializationHook.workerOperations,
+          result,
+        })}\n`,
       );
     }
     expect(result).toEqual({ removedEntries: 1, archivedTranscriptArtifacts: 1 });
     expect(samples.length).toBeGreaterThan(0);
-    expect(maxGapMs).toBeLessThan(500);
+    // #126035 moved this delete transaction and its commit off the event loop into
+    // the archive Worker, so own that structurally. A wall-clock ceiling cannot
+    // decide it: the two populations overlap, with on-thread reclamation of these
+    // rows measured at 341 ms on a 16-core host while the repaired path measured
+    // 525-624 ms on slower shared CI runners. The parent still blocks briefly on
+    // the commit barrier, so bound that against the window it overlaps.
+    expect(archiveMaterializationHook.workerOperations).toContain("reclaim");
+    expect(maxGapMs).toBeLessThan(reclamationMs / 2);
     expect(loadSessionEntry({ sessionKey, storePath })).toBeUndefined();
     expect(loadSessionEntry({ sessionKey: unrelatedKey, storePath })).toMatchObject({
       sessionId: unrelatedSessionId,

--- a/src/gateway/server.sessions.reclamation.test.ts
+++ b/src/gateway/server.sessions.reclamation.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import { performance } from "node:perf_hooks";
-import { afterEach, expect, test } from "vitest";
+import { afterEach, expect, test, vi } from "vitest";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -13,6 +13,25 @@ import {
   setupGatewaySessionsTestHarness,
 } from "./test/server-sessions.test-helpers.js";
 
+// Records every operation reaching the transcript-archive Worker so the test
+// can assert the delete transaction left the Gateway thread, the same way the
+// owner-level session-accessor.sqlite-cleanup-reclamation test does.
+const archiveWorkerOperations = vi.hoisted(() => [] as unknown[]);
+
+vi.mock("../config/sessions/session-accessor.sqlite-archive.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../config/sessions/session-accessor.sqlite-archive.js")>();
+  return {
+    ...actual,
+    runSqliteTranscriptArchiveWorkerOperation: (
+      params: Parameters<typeof actual.runSqliteTranscriptArchiveWorkerOperation>[0],
+    ) => {
+      archiveWorkerOperations.push((params.workerData as { operation?: unknown }).operation);
+      return actual.runSqliteTranscriptArchiveWorkerOperation(params);
+    },
+  };
+});
+
 const SESSION_ID = "phase3-reclamation-e2e";
 const SESSION_KEY = "discord:group:phase3-reclamation-e2e";
 const CANONICAL_SESSION_KEY = `agent:main:${SESSION_KEY}`;
@@ -24,6 +43,7 @@ const ROWS = 200_000;
 const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
 
 afterEach(() => {
+  archiveWorkerOperations.length = 0;
   closeOpenClawAgentDatabasesForTest();
   closeOpenClawStateDatabaseForTest();
 });
@@ -260,6 +280,7 @@ test("sessions.delete keeps the Gateway responsive while reclaiming a large sess
       `${JSON.stringify({
         deleteMs,
         maxGatewayGapMs,
+        archiveWorkerOperations,
         rows: ROWS,
         historicalCounts,
         targetCounts,
@@ -318,5 +339,9 @@ test("sessions.delete keeps the Gateway responsive while reclaiming a large sess
   ]);
   expect(archives.every((archive) => Number(archive.archive_bytes) > 0)).toBe(true);
   expect(samples.length).toBeGreaterThan(0);
-  expect(maxGatewayGapMs).toBeLessThan(500);
+  // The delete transaction must run in the archive Worker (#126035); a fixed
+  // 500 ms ceiling on the Gateway's longest stall tripped on slow CI runners with
+  // the repaired path (612 ms), so bound the stall against the delete it overlaps.
+  expect(archiveWorkerOperations).toContain("reclaim");
+  expect(maxGatewayGapMs).toBeLessThan(deleteMs / 2);
 }, 120_000);


### PR DESCRIPTION
## What Problem This Solves

`src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts` and its
Gateway sibling `src/gateway/server.sessions.reclamation.test.ts` guard the repair
from #126035 — the final SQLite delete transaction and its commit for
a large transcript run in the archive Worker, not on the event loop — with a
fixed ceiling on `performance.now()` deltas sampled by a 10 ms heartbeat:

```ts
expect(maxGapMs).toBeLessThan(500);
```

That constant fails in both directions.

**It does not fail on the defect it guards.** Restoring the pre-#126035 behavior
(`forceInProcess: true` in `session-accessor.sqlite-lifecycle.ts`, so the delete
and commit run on the event loop again) leaves the test green: the parent blocks
for 341.0 ms (unpinned) and 353.6 ms (two CPUs) on a 16-core Linux host, both
under 500 ms, and all four cases pass.

**It fails on correct code.** The same assertion has turned `openclaw/ci-gate`
red on unrelated pull requests:

| Value | Where |
| ---: | --- |
| 525.116 ms | #138126, run 33858096691 attempt 3; retried green with no code change |
| 583.537 ms | #137594, run 33882912206, job 101056327522 `checks-node-compact-small-11`, shard `core-runtime-config-hosted-2` |
| 624.38 ms | #137594, previous head `84c0584` |
| 612.8 ms | sibling `src/gateway/server.sessions.reclamation.test.ts:321`, run 33905404738, `checks-node-compact-small-8` |

The two populations overlap: 341–354 ms of genuinely on-thread commit sits below
500 ms, and 525–624 ms of correctly off-thread reclamation sits above it. No
millisecond constant separates them, so raising the number would only trade a
false red for a false green.

## Why This Change Was Made

The invariant is structural, so the test now states it structurally. #126035's
repair is "route the final reclamation transaction through the transcript archive
Worker" (`runSqliteSessionReclamation` in
`session-accessor.sqlite-reclamation.ts`); the parent keeps only archive
publication, notifications, caller authority and the short commit barrier in
`authorizeSqliteReclamationCommit`. An on-thread reclamation therefore never
dispatches the `reclaim` Worker operation — a fact that is the same on every host.

The file already mocks `session-accessor.sqlite-archive.js` to hook archive
materialization, and the sibling `session-accessor.sqlite-reclamation-admission-race.test.ts`
already wraps `runSqliteTranscriptArchiveWorkerOperation` the same way. This change
records the `workerData.operation` of every call that reaches that export and
asserts the run dispatched `"reclaim"`. Only `session-accessor.sqlite-reclamation.ts`
reaches this export from another module, so the record is exactly the reclamation
dispatch.

A plain Worker count would not have worked and was rejected on evidence: archive
publication starts its own Worker, so the on-thread run still reports one Worker
after materialization (measured) and would have passed a `> 0` assertion.

The Gateway sibling gets the same spy through `vi.mock` of the same module (the
in-process Gateway's `sessions.delete` reaches the same export) and asserts the
`reclaim` dispatch too.

The heartbeat stays at both sites, and its bound becomes relative to the window it
samples (`maxGapMs < reclamationMs / 2`; `maxGatewayGapMs < deleteMs / 2`). The parent legitimately blocks while the commit
barrier joins the Worker's writer lock; what must never happen is the parent
blocking for the delete itself. Measured: 1.2 % and 2.4 % of the window
off-thread, 28.6 % and 30.3 % on-thread, and about 21 % for the worst CI value
above — a bound at half the window is quiet on every one of them while still
catching a parent that stops serving for most of the operation.

Precedent for repairing a two-CPU CI failure in the test rather than the product:
#139176 (`subagent-spawn.authority.test.ts`, `vi.waitFor` tolerance raised with
the runner named) and #139291 (worker pool idle retirement bound to the pool's own
clock instead of whichever clock a neighbour test installed). This change follows
#139291's shape: measure the thing the invariant is about, not a proxy that the
runner also moves.

## User Impact

CI only; no runtime code changes. Fork and repository pull requests stop failing
`checks-node-compact-*` on an assertion unrelated to their change, and the guard
starts failing on the regression it exists for.

## Evidence

Base `origin/main` @ `67e8e2da4b1`. Host: 16-core Linux, Node 24.18.0.

### Negative proof (the assertion must fail when reclamation runs on-thread)

`src/config/sessions/session-accessor.sqlite-lifecycle.ts` temporarily changed to
`forceInProcess: true` (restored afterwards), which is exactly the pre-#126035
path:

```
node scripts/run-vitest.mjs run src/config/sessions/session-accessor.sqlite-cleanup-reclamation.test.ts
```

- Before this change: **passes** — `maxGapMs` 340.96, window 1193.35 ms,
  `Tests 4 passed (4)`. Pinned to two CPUs: `maxGapMs` 353.65, window 1167.95 ms,
  `Tests 4 passed (4)`.
- After this change: **fails** — `workerOperations: []`,
  `AssertionError: expected [] to include 'reclaim'`, `Tests 1 failed | 3 passed (4)`
  (`maxGapMs` 386.8 ms in that run, again under the old ceiling).

Gateway sibling, same `forceInProcess: true` edit:

- Before this change: **passes** by luck of the constant only — the on-thread run
  stalls the Gateway for 4252.5 ms (30 % of a 14.4 s delete), so the old ceiling did
  fail here; the problem at this site was the false red on correct code (612.8 ms).
- After this change: **fails** on the structural assertion —
  `archiveWorkerOperations: []`, `expected [] to include 'reclaim'`.

### Gateway sibling, unchanged product code

| Profile | `maxGatewayGapMs` | `deleteMs` | gap/delete | dispatched |
| --- | ---: | ---: | ---: | --- |
| Unpinned | 147.13 | 11542.98 | 1.3 % | (old assertion) |
| `taskset -c 4,5`, `CI=true`, 2 workers | 137.47 | 12040.06 | 1.1 % | (old assertion) |
| Unpinned, box under two pinned CI replays | 353.94 | 20702.35 | 1.7 % | `["reclaim","reclaim"]` |

The last row is a healthy run at 354 ms, which is how close the old 500 ms ceiling
sat to correct code on a loaded host.

### Repaired path, unchanged product code

Twelve runs across five profiles, all with the original 500 ms assertion and
`OPENCLAW_TEST_RECLAMATION_LOG=1`; every one is far from the ceiling, which is
why the failure could not be reproduced on this host:

| Profile | `maxGapMs` |
| --- | ---: |
| Unpinned, cold transform cache | 22.03 |
| `taskset -c 0,1`, `OPENCLAW_VITEST_MAX_WORKERS=2`, cold, ×3 | 100.74 / 67.70 / 21.82 |
| Same, plus four sibling SQLite suites in one invocation, `CI=true`, ×3 | 25.03 / 19.51 / 67.64 |
| Same, all 27 `session-accessor.sqlite-*` suites, `MemoryMax=7860M` | 36.15 |
| `systemd-run -p CPUQuota=100%` + `taskset -c 0,1`, cold | 41.98 |

Instrumented window measurements (same product code):

| Mode | `maxGapMs` | window | gap/window |
| --- | ---: | ---: | ---: |
| Worker (unpinned) | 26.85 | 2330.21 | 1.2 % |
| Worker (two CPUs) | 54.66 | 2296.10 | 2.4 % |
| On-thread (unpinned) | 340.96 | 1193.35 | 28.6 % |
| On-thread (two CPUs) | 353.65 | 1167.95 | 30.3 % |

Format and lint on both changed files pass; `git diff --check` is clean.


### Raw log excerpts

CI, correct code, the assertion this change removes (run 33882912206, job 101056327522, `checks-node-compact-small-11`, shard `core-runtime-config-hosted-2`, fetched with `gh run view --log-failed`):

```
2026-09-04T14:26:34.1130268Z [shard:core-runtime-config-hosted-2]    → expected 583.5366789999971 to be less than 500
2026-09-04T14:26:52.3641165Z [shard:core-runtime-config-hosted-2] AssertionError: expected 583.5366789999971 to be less than 500
```

On-thread reclamation (`forceInProcess: true`), original assertion, `OPENCLAW_TEST_RECLAMATION_LOG=1` — the guard passes on the regression:

```
{"owner":"lifecycle-cleanup","rows":100000,"maxGapMs":340.95632599999954,"reclamationMs":1193.3509639999975,"fixtureMs":303.40734800000064,"ticks":84,"result":{"removedEntries":1,"archivedTranscriptArtifacts":1}}
      Tests  4 passed (4)
{"owner":"lifecycle-cleanup","rows":100000,"maxGapMs":353.6469939999988,"reclamationMs":1167.9527659999985,"fixtureMs":306.84188800000265,"ticks":78,"result":{"removedEntries":1,"archivedTranscriptArtifacts":1}}
      Tests  4 passed (4)
```

On-thread reclamation, this change — the guard fails on the regression, twice on two separate runs:

```
{"owner":"lifecycle-cleanup","rows":100000,"maxGapMs":345.72338599999784,"reclamationMs":1175.474815999998,"workerOperations":[],"result":{"removedEntries":1,"archivedTranscriptArtifacts":1}}
AssertionError: expected [] to include 'reclaim'
      Tests  1 failed | 3 passed (4)
{"owner":"lifecycle-cleanup","rows":100000,"maxGapMs":386.81242300000304,"reclamationMs":1174.097396000001,"workerOperations":[],"result":{"removedEntries":1,"archivedTranscriptArtifacts":1}}
   → expected [] to include 'reclaim'
      Tests  1 failed | 3 passed (4)
```

Gateway sibling, on-thread reclamation, this change:

```
{"deleteMs":14358.252415000003,"maxGatewayGapMs":4252.510663000001,"archiveWorkerOperations":[],"rows":200000, ...}
AssertionError: expected [] to include 'reclaim'
      Tests  1 failed (1)
```

Correct code, this change:

```
{"owner":"lifecycle-cleanup","rows":100000,"maxGapMs":35.4006870000012,"reclamationMs":3661.2303070000016,"workerOperations":["reclaim"],"result":{"removedEntries":1,"archivedTranscriptArtifacts":1}}
      Tests  4 passed (4)
{"owner":"lifecycle-cleanup","rows":100000,"maxGapMs":26.616158000000723,"reclamationMs":2095.4379599999993,"workerOperations":["reclaim"],"result":{"removedEntries":1,"archivedTranscriptArtifacts":1}}   # taskset -c 4,5 CI=true OPENCLAW_VITEST_MAX_WORKERS=2
      Tests  4 passed (4)
{"deleteMs":20702.349219000003,"maxGatewayGapMs":353.9411949999994,"archiveWorkerOperations":["reclaim","reclaim"],"rows":200000, ...}
      Tests  1 passed (1)
```

## Compatibility

Test-only; no production lines change. Both cases keep their names, budgets,
its 100,000-row fixture, and every existing assertion about the result, the
removed entry, the preserved unrelated entry, the emptied transcript rows and the
published archive. `orphanTranscriptMinAgeMs` and the `now - 600_000` fixture
timestamps are logical time driven by the injected `nowMs` and are untouched. The
opt-in `OPENCLAW_TEST_RECLAMATION_LOG` line gains `reclamationMs` and
`workerOperations`.

## Follow-ups, not in this change

- The residual parent-thread stall itself is #112423, reduced by open PR #137908
  ("reduce delays when deleting sessions"). This change does not claim to fix or
  to hide it: the heartbeat number is still recorded on every run.

## Rebase onto `main` (`9a9b92322d7`)

Same two test files, same diff (+59/-5); no production change. The branch had fallen 703 commits behind, and `main` has since changed the reclamation owners this test guards (#139469 "prevent database lock failures during reclamation", #139689 "prevent cleanup failures during other database writes", #139974). Neither test file changed on `main`; both still carry `expect(...).toBeLessThan(500)`. Re-verified on the rebased head, Linux 16-core, Node v24.18.0, `node scripts/run-vitest.mjs run ...`:

- Positive: `session-accessor.sqlite-cleanup-reclamation.test.ts` 4 passed (4), `server.sessions.reclamation.test.ts` 1 passed (1).
- Negative (all three `forceInProcess: hasPreparedNativeSessionDeletion()` sites in `session-accessor.sqlite-lifecycle.ts` temporarily set to `true`, restored afterwards): the cleanup case fails with `AssertionError: expected [] to include 'reclaim'` (`Tests 1 failed | 3 passed (4)`), and the Gateway case fails with the same assertion (`Tests 1 failed (1)`). The structural guard still rejects on-thread reclamation on current `main`.

The open item on this PR is unchanged: acceptance of a standalone test repair under CONTRIBUTING.md is a maintainer decision.
