### PR TITLE
fix(scripts): name the next step when boundary preparation fails

### DIFF
--- a/scripts/lib/compiler-input-snapshot.mts
+++ b/scripts/lib/compiler-input-snapshot.mts
@@ -288,13 +288,28 @@ export class CompilerInputSnapshot {
     outputRoot?: string,
   ) {
     const signature = this.signature(config, args, inputs, outputRoot);
-    if (
-      before.namespace(outputRoot) !== this.namespace(outputRoot) ||
-      before.toolchain() !== this.toolchain() ||
-      JSON.stringify(before.config(config)) !== JSON.stringify(this.config(config)) ||
-      before.config(config).files.some((file) => before.hash(file) !== this.hash(file))
-    ) {
-      throw new Error("Boundary configuration or resolution topology changed during compilation");
+    // Same comparisons, same order, same short-circuit; `find` only records which
+    // one flipped so the failure names the moving part instead of the whole fence.
+    const comparisons: [string, () => boolean][] = [
+      [
+        "package resolution topology",
+        () => before.namespace(outputRoot) !== this.namespace(outputRoot),
+      ],
+      ["toolchain inputs", () => before.toolchain() !== this.toolchain()],
+      [
+        `parsed configuration of ${config}`,
+        () => JSON.stringify(before.config(config)) !== JSON.stringify(this.config(config)),
+      ],
+      [
+        `config file bytes of ${config}`,
+        () => before.config(config).files.some((file) => before.hash(file) !== this.hash(file)),
+      ],
+    ];
+    const changed = comparisons.find(([, differs]) => differs())?.[0];
+    if (changed) {
+      throw new Error(
+        `Boundary ${changed} changed during compilation. Another build, lint, or typecheck usually wrote into this checkout or the node_modules it shares (linked worktrees share the primary checkout's node_modules); run those serially and retry.`,
+      );
     }
     for (const file of [...inputs, ...this.config(config).files, ...this.toolInputs()]) {
       const current = this.read(file);

--- a/scripts/lib/compiler-input-snapshot.mts
+++ b/scripts/lib/compiler-input-snapshot.mts
@@ -308,7 +308,7 @@ export class CompilerInputSnapshot {
     const changed = comparisons.find(([, differs]) => differs())?.[0];
     if (changed) {
       throw new Error(
-        `Boundary ${changed} changed during compilation. Another build, lint, or typecheck usually wrote into this checkout or the node_modules it shares (linked worktrees share the primary checkout's node_modules); run those serially and retry.`,
+        `Boundary ${changed} changed during compilation. Another build, lint, or typecheck usually wrote into this checkout's inputs while this one ran; run those serially and retry.`,
       );
     }
     for (const file of [...inputs, ...this.config(config).files, ...this.toolInputs()]) {

--- a/scripts/run-oxlint.mts
+++ b/scripts/run-oxlint.mts
@@ -238,7 +238,9 @@ async function prepareExtensionPackageBoundaryArtifacts(env: NodeJS.ProcessEnv) 
   });
 
   if (status !== 0) {
-    throw new Error(`prepare-extension-package-boundary-artifacts failed with exit code ${status}`);
+    throw new Error(
+      `prepare-extension-package-boundary-artifacts failed with exit code ${status}. If dependencies changed (rebase or branch switch), run pnpm install and retry.`,
+    );
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Two repo script failures stop at "what happened" and never say what to do next.

1. `scripts/lib/compiler-input-snapshot.mts` `seal()` guards four independent
   comparisons behind one `||` chain and throws a single constant:

   ```
   Boundary configuration or resolution topology changed during compilation
   ```

   The message does not say which of the four (package resolution topology,
   toolchain inputs, parsed config, config-file bytes) moved, and does not name
   the usual cause. The sibling check ten lines below already names its input
   (`Boundary input changed during compilation: ${file}`), so the inconsistency
   is inside one function.

2. `scripts/run-oxlint.mts` re-raises a bare exit code when the extension package
   boundary artifacts cannot be prepared:

   ```
   prepare-extension-package-boundary-artifacts failed with exit code 3
   ```

   In practice this is stale `node_modules` after a rebase or branch switch, but
   the operator is left to guess.

## Why This Change Was Made

Root `AGENTS.md`, Product Judgment: "Failure messages explain the next useful
step." Both messages are terminal errors an operator hits during a normal
`pnpm build` / `pnpm lint` and neither points anywhere.

For (1) the practical cause is concurrency: another build, lint, or typecheck
writing into the same checkout — or into the `node_modules` a linked worktree
shares with the primary checkout — flips one of these inputs mid-compile. Naming
the flipped comparison turns a dead end into a decision: a topology or toolchain
flip means a concurrent writer, a config flip means an edited `tsconfig`.

## User Impact

Contributors and CI operators who hit either failure get the moving part and the
recovery in the message itself instead of reading `seal()` to find out which of
four comparisons fired, or guessing that a boundary-artifact failure means
"install dependencies".

No behavior change: the same conditions throw at the same points, in the same
order, with the same short-circuit. Only the text changed.

## Evidence

### (1) `seal()` — provoked through the real function

A throwaway harness built a temp root, took a `before` snapshot, mutated one
input, then called `seal()` on a fresh snapshot — once per comparison
(`node --import ./scripts/tsx.mjs <harness>.mts`).

Before (`git show HEAD:scripts/lib/compiler-input-snapshot.mts`), all four
mutations produce the same sentence:

```
topology:      Boundary configuration or resolution topology changed during compilation
toolchain:     Boundary configuration or resolution topology changed during compilation
parsed config: Boundary configuration or resolution topology changed during compilation
config bytes:  Boundary configuration or resolution topology changed during compilation
```

After:

```
topology:      Boundary package resolution topology changed during compilation. Another build, lint, or typecheck usually wrote into this checkout's inputs while this one ran; run those serially and retry.
toolchain:     Boundary toolchain inputs changed during compilation. Another build, ...
parsed config: Boundary parsed configuration of tsconfig.json changed during compilation. Another build, ...
config bytes:  Boundary config file bytes of tsconfig.json changed during compilation. Another build, ...
```

Each mutation is the minimal one that reaches exactly its comparison: a new
`.json` file in the root (topology digest is over names), a byte change to a
declared toolchain file, a `compilerOptions` change (parsed config), and a
trailing-newline change (parsed config identical, bytes differ).

### (2) `run-oxlint.mts` — provoked through the real wrapper

`scripts/prepare-extension-package-boundary-artifacts.mts` was temporarily
prefixed with `process.exit(3);` and restored afterwards, then:

```
node --import ./scripts/tsx.mjs scripts/run-oxlint.mts src/index.ts
```

Before:

```
Error: prepare-extension-package-boundary-artifacts failed with exit code 3
```

After:

```
Error: prepare-extension-package-boundary-artifacts failed with exit code 3. If dependencies changed (rebase or branch switch), run pnpm install and retry.
```

### Checks

- `node scripts/run-vitest.mjs run test/scripts/run-oxlint.test.ts test/scripts/build-artifact-cache.test.ts test/scripts/native-declaration-boundary.test.ts`
  — 3 files, 116 passed, 3 skipped.
- `node_modules/.bin/oxfmt --check` and `node_modules/.bin/oxlint -c .oxlintrc.json`
  on both changed files: clean.
- `git diff --check`: clean.

No test was added: no existing test asserts either message, and a message-only
change does not warrant a new assertion whose only content is the string.

## Compatibility

Scripts-only, developer-facing text. No public API, config, schema, or CI
contract changes. The `seal()` guard evaluates the same four comparisons in the
same order and still short-circuits on the first one that differs.
