### PR TITLE
perf(test): reuse transforms within owned scheduler slots

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -302,6 +302,13 @@ existing temporary directories, Node or Vitest caches, or other global caches. S
 validators; it does not require `TSX_DISABLE_CACHE` in the invoking shell. Raw
 external `tsx` and `node --import tsx` invocations outside these launchers are unchanged.
 
+Parallel project runs on macOS and Linux reuse filesystem transforms within
+exclusive worker slots, with separate directories for each Vitest configuration.
+A slot stays owned through preflight, retries, and verified child/group completion;
+uncertain cleanup retires it. Explicit isolated cache paths, serial and watch runs,
+and Windows retain their existing cache ownership. Concurrent invocations still
+need separate cache roots.
+
 Control UI builds report size budgets without enforcing them. Run
 `pnpm ui:check-performance` after a build to enforce absolute budgets, or
 `pnpm ui:check-performance:base <base-commit-sha>` to build and compare both

--- a/scripts/lib/vitest-cache-slots.mts
+++ b/scripts/lib/vitest-cache-slots.mts
@@ -1,0 +1,49 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { VitestCacheAssignment } from "../test-projects.test-support.mts";
+
+type CacheSpec = {
+  config: string;
+  env: NodeJS.ProcessEnv;
+  watchMode: boolean;
+  cacheAssignment?: VitestCacheAssignment;
+};
+
+/** A slot remains borrowed through retries and the process owner's final join. */
+export function createVitestCacheSlots(concurrency: number, platform = process.platform) {
+  const available = Array.from({ length: concurrency }, (_, index) => index);
+  let nextSlot = concurrency;
+  return async <T extends CacheSpec, R extends { groupJoined: boolean }>(
+    spec: T,
+    run: (assigned: T) => Promise<R>,
+  ): Promise<R> => {
+    if (
+      concurrency <= 1 ||
+      platform === "win32" ||
+      spec.watchMode ||
+      spec.cacheAssignment?.kind !== "scheduler"
+    ) {
+      return run(spec);
+    }
+    const slot = available.pop() ?? nextSlot++;
+    const configKey = createHash("sha256").update(path.resolve(spec.config)).digest("hex");
+    const result = await run({
+      ...spec,
+      cacheAssignment: { ...spec.cacheAssignment, leased: true },
+      env: {
+        ...spec.env,
+        OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: path.join(
+          spec.cacheAssignment.root,
+          "slots",
+          String(slot),
+          configKey,
+        ),
+      },
+    });
+    // A rejection or child-only completion leaves this slot retired.
+    if (result.groupJoined) {
+      available.push(slot);
+    }
+    return result;
+  };
+}

--- a/scripts/lib/vitest-process.mts
+++ b/scripts/lib/vitest-process.mts
@@ -108,7 +108,7 @@ export function spawnOwnedVitestProcess(spec: {
           `[vitest] retained temporary namespace ${tempRoot}; descendant completion is unverified on this non-group launch. Stop the remaining writers before removing this exact directory.`,
         );
       }
-      return result;
+      return { ...result, groupJoined: verifiedGroup };
     } catch (error) {
       // A failed parent receipt can follow successful child disposal. Report
       // the still-owned ancestor, not a child directory already removed.

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -887,13 +887,13 @@ export function spawnWatchedVitestProcess({
     teardownNoOutputWatchdog();
   };
   const completion = Promise.all([childCompletion, forwardedOutput])
-    .then(async ([{ code, signal }]) => {
+    .then(async ([{ code, signal, groupJoined }]) => {
       await diagnosticsCompletion;
       const result = unhandledErrors.finish();
       if (result) {
         writeVitestUnhandledErrorSummary(result, env);
       }
-      return { code, signal: normalizeNodeSignal(signal) };
+      return { code, signal: normalizeNodeSignal(signal), groupJoined };
     })
     .finally(teardown);
 

--- a/scripts/test-projects-run.mts
+++ b/scripts/test-projects-run.mts
@@ -13,6 +13,7 @@ import {
   resolveVitestCliEntry,
   resolveVitestRuntimeCliSelections,
 } from "./lib/vitest-build-prerequisites.mts";
+import { createVitestCacheSlots } from "./lib/vitest-cache-slots.mts";
 import { hasNonRunVitestSubcommand } from "./lib/vitest-cli-mode.mts";
 import { parseVitestExecutionArgs } from "./lib/vitest-cli.mts";
 import { resolveVitestHomeSelection } from "./lib/vitest-home-selection.mts";
@@ -48,6 +49,7 @@ import {
   shouldRetryVitestNoOutputTimeout,
   type FailedVitestShard,
   type VitestRunSpec as BaseVitestRunSpec,
+  type VitestCacheAssignment,
   withRetryNoOutputTimeout,
   writeVitestIncludeFile,
 } from "./test-projects.test-support.mts";
@@ -56,14 +58,26 @@ type VitestRunSpec = BaseVitestRunSpec & {
   continueOnFailure?: boolean;
   reportIndex?: number;
   workerRun?: VitestWorkerRun;
+  cacheAssignment?: VitestCacheAssignment;
 };
 type VitestCommandOutcome = {
   code: number;
   noOutputTimedOut: boolean;
   signal: NodeJS.Signals | null;
+  groupJoined: boolean;
 };
 
 type ShardTiming = NonNullable<ReturnType<typeof createShardTimingSample>>;
+
+function assertCacheLeaseJoined(spec: VitestRunSpec, result: VitestCommandOutcome) {
+  if (
+    spec.cacheAssignment?.kind === "scheduler" &&
+    spec.cacheAssignment.leased &&
+    !result.groupJoined
+  ) {
+    throw new Error("Cannot continue a Vitest cache lease without verified group completion");
+  }
+}
 
 function printHelp() {
   console.log(`Usage: node --import tsx scripts/test-projects.mts [--changed <base>] [--watch] [targets...] [-- vitest-args...]
@@ -107,12 +121,13 @@ function runPnpmSpecCommand(
     });
 
     completion.then(
-      ({ code, signal }) => {
+      ({ code, signal, groupJoined }) => {
         const exitSignal = getForwardedSignal() ?? signal;
         resolve({
           code: exitSignal ? signalExitCode(exitSignal) : (code ?? 1),
           noOutputTimedOut,
           signal: exitSignal,
+          groupJoined,
         });
       },
       (error: unknown) => {
@@ -123,6 +138,7 @@ function runPnpmSpecCommand(
 }
 
 async function runVitestSpec(spec: VitestRunSpec, reports: VitestReportOwner) {
+  let preflightJoined = true;
   if (spec.includeFilePath && spec.includePatterns) {
     writeVitestIncludeFile(spec.includeFilePath, spec.includePatterns, {
       expandGlobs: !spec.watchMode,
@@ -137,15 +153,17 @@ async function runVitestSpec(spec: VitestRunSpec, reports: VitestReportOwner) {
         undefined,
         "tooling",
       );
+      preflightJoined = preflightResult.groupJoined;
       if (preflightResult.code !== 0 || preflightResult.signal) {
         return preflightResult;
       }
+      assertCacheLeaseJoined(spec, preflightResult);
     }
     const attempt = reports?.attempt(spec.reportIndex!, spec.pnpmArgs);
     try {
       const result = await runPnpmSpecCommand(spec, attempt?.args ?? spec.pnpmArgs, spec.workerRun);
       attempt?.complete(result);
-      return result;
+      return { ...result, groupJoined: preflightJoined && result.groupJoined };
     } catch (error) {
       attempt?.fail(error);
       throw error;
@@ -174,8 +192,11 @@ async function runLoggedVitestSpec(spec: VitestRunSpec, reports: VitestReportOwn
   const startedAt = performance.now();
   let result = await runVitestSpec(spec, reports);
   if (result.noOutputTimedOut && !spec.watchMode && shouldRetryVitestNoOutputTimeout(spec.env)) {
+    assertCacheLeaseJoined(spec, result);
     console.error(`[test] retrying ${spec.config} after no-output timeout`);
+    const firstJoined = result.groupJoined;
     result = await runVitestSpec(withRetryNoOutputTimeout(spec), reports);
+    result = { ...result, groupJoined: firstJoined && result.groupJoined };
   }
   const durationMs = performance.now() - startedAt;
   if (result.noOutputTimedOut && result.signal) {
@@ -228,6 +249,7 @@ async function runVitestSpecs(
   let stopScheduling = false;
   const failures: FailedVitestShard[] = [];
   const timings: ShardTiming[] = [];
+  const withCacheSlot = createVitestCacheSlots(concurrency);
   await pMap(
     specs,
     async (spec, index) => {
@@ -236,7 +258,7 @@ async function runVitestSpecs(
       }
       let result: Awaited<ReturnType<typeof runLoggedVitestSpec>>;
       try {
-        result = await runLoggedVitestSpec(spec, reports);
+        result = await withCacheSlot(spec, (assigned) => runLoggedVitestSpec(assigned, reports));
       } catch (error) {
         stopScheduling = true;
         throw error;

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -139,7 +139,16 @@ type ChangedTestTargetPlan = {
 };
 
 type ImportGraphOptions = { tooling?: boolean };
-type VitestSpecShape = Pick<VitestRunSpec, "config" | "env">;
+type VitestSpecShape = Pick<VitestRunSpec, "config" | "env"> & {
+  cacheAssignment?: VitestCacheAssignment;
+};
+export type VitestCacheAssignment =
+  | { kind: "scheduler"; root: string; leased?: true }
+  | { kind: "caller" };
+type CacheAssignedSpec<T> = Omit<T, "env"> & {
+  env: NodeJS.ProcessEnv;
+  cacheAssignment?: VitestCacheAssignment;
+};
 type WatchableVitestSpecShape = VitestSpecShape & Pick<VitestRunSpec, "watchMode">;
 type ImportGraph = {
   reverseImports: Map<string, string[]>;
@@ -4301,7 +4310,7 @@ function sanitizeVitestCachePathSegment(value: string) {
 export function applyParallelVitestCachePaths<T extends VitestSpecShape>(
   specs: T[],
   params: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
-): Array<Omit<T, "env"> & { env: NodeJS.ProcessEnv }> {
+): Array<CacheAssignedSpec<T>> {
   const baseEnv = params.env ?? process.env;
   const cwd = params.cwd ?? process.cwd();
   const configuredCacheRoot = baseEnv[FS_MODULE_CACHE_PATH_ENV_KEY]?.trim() || undefined;
@@ -4311,11 +4320,12 @@ export function applyParallelVitestCachePaths<T extends VitestSpecShape>(
   return specs.map((spec, index) => {
     const specCachePath = spec.env?.[FS_MODULE_CACHE_PATH_ENV_KEY]?.trim();
     if (specCachePath && specCachePath !== configuredCacheRoot) {
-      return spec;
+      return { ...spec, cacheAssignment: spec.cacheAssignment ?? { kind: "caller" } };
     }
     const cacheSegment = sanitizeVitestCachePathSegment(`${index}-${spec.config}`);
     return {
       ...spec,
+      cacheAssignment: { kind: "scheduler", root: cacheRoot },
       env: {
         ...spec.env,
         [FS_MODULE_CACHE_PATH_ENV_KEY]: path.join(cacheRoot, cacheSegment),
@@ -4327,7 +4337,7 @@ export function applyParallelVitestCachePaths<T extends VitestSpecShape>(
 export function applyDefaultMultiSpecVitestCachePaths<T extends WatchableVitestSpecShape>(
   specs: T[],
   params: { cwd?: string; env?: NodeJS.ProcessEnv } = {},
-): Array<Omit<T, "env"> & { env: NodeJS.ProcessEnv }> {
+): Array<CacheAssignedSpec<T>> {
   if (specs.length <= 1 || specs.some((spec) => spec.watchMode)) {
     return specs;
   }

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -761,7 +761,7 @@ process.exitCode = 1;
     };
     try {
       console.log(`${fault}: ${JSON.stringify({ result, ...evidence, stderr })}`);
-      expect(result, stderr).toEqual({ code: 1, signal: null });
+      expect(result, stderr).toEqual({ code: 1, signal: null, groupJoined: true });
       expect(existsSync(evidence.outerRoot), "outer runner did not remove its own namespace").toBe(
         false,
       );

--- a/test/scripts/ci-windows-process-census.test-support.ts
+++ b/test/scripts/ci-windows-process-census.test-support.ts
@@ -230,7 +230,12 @@ fs.rmSync(root, { recursive: true });
       child.stdout?.on("data", (data) => (stdout += String(data)));
       child.stderr?.on("data", (data) => (stderr += String(data)));
       const result = await completion;
-      expect(result, stdout + stderr).toEqual({ code: 0, signal: null });
+      // Simulated census faults do not revoke the outer process owner's actual join.
+      expect(result, stdout + stderr).toEqual({
+        code: 0,
+        signal: null,
+        groupJoined: process.platform !== "win32",
+      });
       expect(JSON.parse(stdout)).toMatchObject({ fault, accepted: fault === "ready" });
     },
     55_000,

--- a/test/scripts/run-vitest-progress.test.ts
+++ b/test/scripts/run-vitest-progress.test.ts
@@ -162,7 +162,7 @@ export default {
         const result = await watched.completion;
         // Vitest's logger handles SIGTERM and exits with 128 + 15, rather than
         // leaving Node to report a signal-only exit (as a bare silent child does).
-        expect(result, output).toEqual({ code: stall ? 143 : 0, signal: null });
+        expect(result, output).toEqual({ code: stall ? 143 : 0, signal: null, groupJoined: true });
         expect(casePassed(4)).toBe(!stall);
         expect(isProcessAlive(watched.child.pid!)).toBe(false);
         expect(isProcessAlive(workerPid!)).toBe(false);

--- a/test/scripts/run-vitest.test.ts
+++ b/test/scripts/run-vitest.test.ts
@@ -1154,7 +1154,7 @@ registerHooks({resolve(specifier, context, nextResolve) {
       expect(snapshot).toEqual({
         groupStopped: true,
         noOutputTimedOut: false,
-        result: { code: 0, signal: null },
+        result: { code: 0, signal: null, groupJoined: true },
       });
     } finally {
       lines.close();

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -10,7 +10,8 @@ import { createTempDirTracker, useAutoCleanupTempDirTracker } from "../helpers/t
 import { createToolingVitestConfig } from "../vitest/vitest.tooling.config.ts";
 
 const commands = vi.hoisted(() => ({ prepare: vi.fn(), prepareE2e: vi.fn(), reader: vi.fn() }));
-vi.mock("../../scripts/lib/managed-child-process.mts", () => ({
+vi.mock("../../scripts/lib/managed-child-process.mts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../scripts/lib/managed-child-process.mts")>()),
   runManagedCommand: commands.prepare,
 }));
 vi.mock("../../scripts/lib/vitest-build-prerequisites.mts", async (importOriginal) => ({
@@ -406,6 +407,185 @@ async function start(args: string[]) {
   startCount += 1;
   await import(entryUrl);
 }
+
+describe("parallel cache lease completion", () => {
+  it.each(["preflight", "retry"])(
+    "refuses a next process after an unverified %s completion",
+    async (phase) => {
+      vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
+      vi.stubEnv("OPENCLAW_VITEST_NO_OUTPUT_RETRY", "1");
+      const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
+      let preflights = 0;
+      let attempts = 0;
+      commands.reader.mockImplementation(({ pnpmArgs, onNoOutputTimeout }) => {
+        let groupJoined = true;
+        if (pnpmArgs.includes("scripts/ensure-playwright-chromium.mts")) {
+          preflights += 1;
+          groupJoined = phase !== "preflight";
+        } else if (pnpmArgs.includes("test/vitest/vitest.ui-e2e.config.ts")) {
+          attempts += 1;
+          groupJoined = false;
+          onNoOutputTimeout();
+        }
+        return {
+          completion: Promise.resolve({ code: 0, signal: null, groupJoined }),
+          getForwardedSignal: () => undefined,
+        };
+      });
+      await expect(
+        runTestProjects(async () => {}, [
+          "test/vitest/vitest.ui-e2e.config.ts",
+          "test/vitest/vitest.cli.config.ts",
+        ]),
+      ).rejects.toMatchObject({
+        errors: [
+          expect.objectContaining({
+            message: "Cannot continue a Vitest cache lease without verified group completion",
+          }),
+        ],
+      });
+      expect(preflights).toBe(1);
+      expect(attempts).toBe(phase === "preflight" ? 0 : 1);
+    },
+  );
+
+  it("holds one cache lease through preflight and a watchdog retry while its peer runs", async () => {
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
+    vi.stubEnv("OPENCLAW_VITEST_NO_OUTPUT_RETRY", "1");
+    const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
+    const firstPreflight = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+    const retryPreflight = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+    const peer = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+    const started = createDeferred();
+    const retryStarted = createDeferred();
+    const paths: string[] = [];
+    const uiPaths: string[] = [];
+    let peerPath: string | undefined;
+    let preflights = 0;
+    let attempts = 0;
+    const joined = { code: 0, signal: null, groupJoined: true };
+    commands.reader.mockImplementation(({ env, pnpmArgs, onNoOutputTimeout }) => {
+      const cache = env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH;
+      paths.push(cache);
+      let completion;
+      if (pnpmArgs.includes("scripts/ensure-playwright-chromium.mts")) {
+        uiPaths.push(cache);
+        preflights += 1;
+        completion = preflights === 1 ? firstPreflight.promise : retryPreflight.promise;
+        if (preflights === 2) {
+          retryStarted.resolve();
+        }
+      } else if (pnpmArgs.includes("test/vitest/vitest.ui-e2e.config.ts")) {
+        uiPaths.push(cache);
+        attempts += 1;
+        if (attempts === 1) {
+          onNoOutputTimeout();
+        }
+        completion = Promise.resolve(
+          attempts === 1 ? { code: 143, signal: "SIGTERM", groupJoined: true } : joined,
+        );
+      } else {
+        peerPath = cache;
+        completion = peer.promise;
+      }
+      if (paths.length === 2) {
+        started.resolve();
+      }
+      return { completion, getForwardedSignal: () => undefined };
+    });
+    const running = runTestProjects(async () => {}, [
+      "test/vitest/vitest.ui-e2e.config.ts",
+      "test/vitest/vitest.cli.config.ts",
+    ]);
+    try {
+      await withTestTimeout(started.promise, 5_000, "preflight and peer admission");
+      expect(new Set(paths).size).toBe(2);
+      firstPreflight.resolve(joined);
+      await withTestTimeout(retryStarted.promise, 5_000, "retry preflight admission");
+      expect(uiPaths).toHaveLength(3);
+      expect(new Set(uiPaths).size).toBe(1);
+      expect(uiPaths).not.toContain(peerPath);
+      expect(attempts).toBe(1);
+    } finally {
+      firstPreflight.resolve(joined);
+      retryPreflight.resolve(joined);
+      peer.resolve(joined);
+      await running;
+    }
+    expect(uiPaths).toHaveLength(4);
+    expect(new Set(uiPaths).size).toBe(1);
+    expect(attempts).toBe(2);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it.each(["failure", "signal", "rejection"])(
+    "joins admitted work after %s without confusing failure with cleanup",
+    async (outcome) => {
+      vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
+      const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
+      const first = createDeferred<{
+        code: number;
+        signal: NodeJS.Signals | null;
+        groupJoined: boolean;
+      }>();
+      const second = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+      const admitted = createDeferred();
+      const settled = { value: false };
+      commands.reader.mockImplementation(() => {
+        const index = commands.reader.mock.calls.length;
+        if (index === 2) {
+          admitted.resolve();
+        }
+        return {
+          completion:
+            index === 1
+              ? first.promise
+              : index === 2
+                ? second.promise
+                : Promise.resolve({ code: 0, signal: null, groupJoined: true }),
+          getForwardedSignal: () => undefined,
+        };
+      });
+      const running = runTestProjects(async () => {}, [
+        "test/vitest/vitest.unit-fast.config.ts",
+        "test/vitest/vitest.unit-fast-fake-timers.config.ts",
+        "test/vitest/vitest.cli.config.ts",
+      ]).finally(() => {
+        settled.value = true;
+      });
+      const checked = outcome === "rejection" ? expect(running).rejects.toThrow() : running;
+      try {
+        await withTestTimeout(
+          Promise.race([admitted.promise, running]),
+          5_000,
+          "scheduler admission",
+        );
+        expect(commands.reader).toHaveBeenCalledTimes(2);
+        if (outcome === "rejection") {
+          first.reject(new Error("unverified group completion"));
+        } else {
+          first.resolve({
+            code: 1,
+            signal: outcome === "signal" ? "SIGTERM" : null,
+            groupJoined: true,
+          });
+        }
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        expect(settled.value).toBe(false);
+        expect(commands.reader).toHaveBeenCalledTimes(outcome === "failure" ? 3 : 2);
+      } finally {
+        first.resolve({ code: 0, signal: null, groupJoined: true });
+        second.resolve({ code: 0, signal: null, groupJoined: true });
+        await checked;
+      }
+      if (outcome !== "rejection") {
+        expect(process.exitCode).toBe(outcome === "signal" ? 143 : 1);
+      }
+    },
+  );
+});
 
 function createPreparationGate<T>(prepare: typeof commands.prepare) {
   const started = createDeferred();

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -409,118 +409,145 @@ async function start(args: string[]) {
 }
 
 describe("parallel cache lease completion", () => {
-  it.each(["preflight", "retry"])(
-    "refuses a next process after an unverified %s completion",
-    async (phase) => {
+  it.each([
+    { platform: "linux", phase: "preflight" },
+    { platform: "linux", phase: "retry" },
+    { platform: "win32", phase: "preflight" },
+    { platform: "win32", phase: "retry" },
+  ] as const)(
+    "preserves $platform policy after an unverified $phase completion",
+    async ({ platform, phase }) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue(platform);
       vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
       vi.stubEnv("OPENCLAW_VITEST_NO_OUTPUT_RETRY", "1");
       const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
       let preflights = 0;
       let attempts = 0;
       commands.reader.mockImplementation(({ pnpmArgs, onNoOutputTimeout }) => {
-        let groupJoined = true;
+        let groupJoined = platform !== "win32";
+        let timedOut = false;
         if (pnpmArgs.includes("scripts/ensure-playwright-chromium.mts")) {
           preflights += 1;
-          groupJoined = phase !== "preflight";
+          groupJoined = platform !== "win32" && phase !== "preflight";
         } else if (pnpmArgs.includes("test/vitest/vitest.ui-e2e.config.ts")) {
           attempts += 1;
           groupJoined = false;
-          onNoOutputTimeout();
+          if (attempts === 1) {
+            timedOut = true;
+            onNoOutputTimeout();
+          }
         }
         return {
-          completion: Promise.resolve({ code: 0, signal: null, groupJoined }),
+          completion: Promise.resolve({ code: timedOut ? 143 : 0, signal: null, groupJoined }),
           getForwardedSignal: () => undefined,
         };
       });
-      await expect(
-        runTestProjects(async () => {}, [
-          "test/vitest/vitest.ui-e2e.config.ts",
-          "test/vitest/vitest.cli.config.ts",
-        ]),
-      ).rejects.toMatchObject({
-        errors: [
-          expect.objectContaining({
-            message: "Cannot continue a Vitest cache lease without verified group completion",
-          }),
-        ],
-      });
-      expect(preflights).toBe(1);
-      expect(attempts).toBe(phase === "preflight" ? 0 : 1);
+      const running = runTestProjects(async () => {}, [
+        "test/vitest/vitest.ui-e2e.config.ts",
+        "test/vitest/vitest.cli.config.ts",
+      ]);
+      if (platform === "win32") {
+        await expect(running).resolves.toBeUndefined();
+        expect(preflights).toBe(2);
+        expect(attempts).toBe(2);
+      } else {
+        await expect(running).rejects.toMatchObject({
+          errors: [
+            expect.objectContaining({
+              message: "Cannot continue a Vitest cache lease without verified group completion",
+            }),
+          ],
+        });
+        expect(preflights).toBe(1);
+        expect(attempts).toBe(phase === "preflight" ? 0 : 1);
+      }
     },
   );
 
-  it("holds one cache lease through preflight and a watchdog retry while its peer runs", async () => {
-    vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
-    vi.stubEnv("OPENCLAW_VITEST_NO_OUTPUT_RETRY", "1");
-    const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
-    const firstPreflight = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
-    const retryPreflight = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
-    const peer = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
-    const started = createDeferred();
-    const retryStarted = createDeferred();
-    const paths: string[] = [];
-    const uiPaths: string[] = [];
-    let peerPath: string | undefined;
-    let preflights = 0;
-    let attempts = 0;
-    const joined = { code: 0, signal: null, groupJoined: true };
-    commands.reader.mockImplementation(({ env, pnpmArgs, onNoOutputTimeout }) => {
-      const cache = env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH;
-      paths.push(cache);
-      let completion;
-      if (pnpmArgs.includes("scripts/ensure-playwright-chromium.mts")) {
-        uiPaths.push(cache);
-        preflights += 1;
-        completion = preflights === 1 ? firstPreflight.promise : retryPreflight.promise;
-        if (preflights === 2) {
-          retryStarted.resolve();
+  it.each(["linux", "win32"] as const)(
+    "preserves %s cache ownership through preflight and retry while its peer runs",
+    async (platform) => {
+      vi.spyOn(process, "platform", "get").mockReturnValue(platform);
+      const cacheRoot = tempDirs.make("cache-policy-");
+      vi.stubEnv("OPENCLAW_VITEST_FS_MODULE_CACHE_PATH", cacheRoot);
+      vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
+      vi.stubEnv("OPENCLAW_VITEST_NO_OUTPUT_RETRY", "1");
+      const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
+      const firstPreflight = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+      const retryPreflight = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+      const peer = createDeferred<{ code: number; signal: null; groupJoined: boolean }>();
+      const started = createDeferred();
+      const retryStarted = createDeferred();
+      const paths: string[] = [];
+      const uiPaths: string[] = [];
+      let peerPath: string | undefined;
+      let preflights = 0;
+      let attempts = 0;
+      const joined = { code: 0, signal: null, groupJoined: platform !== "win32" };
+      commands.reader.mockImplementation(({ env, pnpmArgs, onNoOutputTimeout }) => {
+        const cache = env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH;
+        paths.push(cache);
+        let completion;
+        if (pnpmArgs.includes("scripts/ensure-playwright-chromium.mts")) {
+          uiPaths.push(cache);
+          preflights += 1;
+          completion = preflights === 1 ? firstPreflight.promise : retryPreflight.promise;
+          if (preflights === 2) {
+            retryStarted.resolve();
+          }
+        } else if (pnpmArgs.includes("test/vitest/vitest.ui-e2e.config.ts")) {
+          uiPaths.push(cache);
+          attempts += 1;
+          if (attempts === 1) {
+            onNoOutputTimeout();
+          }
+          completion = Promise.resolve(
+            attempts === 1 ? { ...joined, code: 143, signal: "SIGTERM" } : joined,
+          );
+        } else {
+          peerPath = cache;
+          completion = peer.promise;
         }
-      } else if (pnpmArgs.includes("test/vitest/vitest.ui-e2e.config.ts")) {
-        uiPaths.push(cache);
-        attempts += 1;
-        if (attempts === 1) {
-          onNoOutputTimeout();
+        if (paths.length === 2) {
+          started.resolve();
         }
-        completion = Promise.resolve(
-          attempts === 1 ? { code: 143, signal: "SIGTERM", groupJoined: true } : joined,
-        );
-      } else {
-        peerPath = cache;
-        completion = peer.promise;
+        return { completion, getForwardedSignal: () => undefined };
+      });
+      const running = runTestProjects(async () => {}, [
+        "test/vitest/vitest.ui-e2e.config.ts",
+        "test/vitest/vitest.cli.config.ts",
+      ]);
+      try {
+        await withTestTimeout(started.promise, 5_000, "preflight and peer admission");
+        expect(new Set(paths).size).toBe(2);
+        for (const cache of paths) {
+          expect(path.relative(cacheRoot, cache).startsWith(`slots${path.sep}`)).toBe(
+            platform !== "win32",
+          );
+        }
+        firstPreflight.resolve(joined);
+        await withTestTimeout(retryStarted.promise, 5_000, "retry preflight admission");
+        expect(uiPaths).toHaveLength(3);
+        expect(new Set(uiPaths).size).toBe(1);
+        expect(uiPaths).not.toContain(peerPath);
+        expect(attempts).toBe(1);
+      } finally {
+        firstPreflight.resolve(joined);
+        retryPreflight.resolve(joined);
+        peer.resolve(joined);
+        await running;
       }
-      if (paths.length === 2) {
-        started.resolve();
-      }
-      return { completion, getForwardedSignal: () => undefined };
-    });
-    const running = runTestProjects(async () => {}, [
-      "test/vitest/vitest.ui-e2e.config.ts",
-      "test/vitest/vitest.cli.config.ts",
-    ]);
-    try {
-      await withTestTimeout(started.promise, 5_000, "preflight and peer admission");
-      expect(new Set(paths).size).toBe(2);
-      firstPreflight.resolve(joined);
-      await withTestTimeout(retryStarted.promise, 5_000, "retry preflight admission");
-      expect(uiPaths).toHaveLength(3);
+      expect(uiPaths).toHaveLength(4);
       expect(new Set(uiPaths).size).toBe(1);
-      expect(uiPaths).not.toContain(peerPath);
-      expect(attempts).toBe(1);
-    } finally {
-      firstPreflight.resolve(joined);
-      retryPreflight.resolve(joined);
-      peer.resolve(joined);
-      await running;
-    }
-    expect(uiPaths).toHaveLength(4);
-    expect(new Set(uiPaths).size).toBe(1);
-    expect(attempts).toBe(2);
-    expect(process.exitCode).toBeUndefined();
-  });
+      expect(attempts).toBe(2);
+      expect(process.exitCode).toBeUndefined();
+    },
+  );
 
   it.each(["failure", "signal", "rejection"])(
     "joins admitted work after %s without confusing failure with cleanup",
     async (outcome) => {
+      const groupJoined = process.platform !== "win32";
       vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
       const { runTestProjects } = await import("../../scripts/test-projects-run.mts");
       const first = createDeferred<{
@@ -542,7 +569,7 @@ describe("parallel cache lease completion", () => {
               ? first.promise
               : index === 2
                 ? second.promise
-                : Promise.resolve({ code: 0, signal: null, groupJoined: true }),
+                : Promise.resolve({ code: 0, signal: null, groupJoined }),
           getForwardedSignal: () => undefined,
         };
       });
@@ -567,7 +594,7 @@ describe("parallel cache lease completion", () => {
           first.resolve({
             code: 1,
             signal: outcome === "signal" ? "SIGTERM" : null,
-            groupJoined: true,
+            groupJoined,
           });
         }
         await new Promise<void>((resolve) => {
@@ -576,8 +603,8 @@ describe("parallel cache lease completion", () => {
         expect(settled.value).toBe(false);
         expect(commands.reader).toHaveBeenCalledTimes(outcome === "failure" ? 3 : 2);
       } finally {
-        first.resolve({ code: 0, signal: null, groupJoined: true });
-        second.resolve({ code: 0, signal: null, groupJoined: true });
+        first.resolve({ code: 0, signal: null, groupJoined });
+        second.resolve({ code: 0, signal: null, groupJoined });
         await checked;
       }
       if (outcome !== "rejection") {

--- a/test/scripts/vitest-cache-slots.test.ts
+++ b/test/scripts/vitest-cache-slots.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { createVitestCacheSlots } from "../../scripts/lib/vitest-cache-slots.mts";
+import type { VitestCacheAssignment } from "../../scripts/test-projects.test-support.mts";
+import { createDeferred } from "../helpers/promise.js";
+
+const spec = {
+  config: "test/vitest/vitest.tooling.config.ts",
+  env: { OPENCLAW_VITEST_FS_MODULE_CACHE_PATH: "/cache/original" },
+  watchMode: false,
+  cacheAssignment: { kind: "scheduler", root: "/cache" } satisfies VitestCacheAssignment,
+};
+const cachePath = (assigned: typeof spec) => assigned.env.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH;
+
+describe("Vitest cache slot ownership", () => {
+  it("holds concurrent leases until joined and reuses a failed command's completed slot", async () => {
+    const run = createVitestCacheSlots(2, "linux");
+    const first = createDeferred<{ groupJoined: boolean; code: number }>();
+    const second = createDeferred<{ groupJoined: boolean; code: number }>();
+    const paths: string[] = [];
+    const pending = [first, second].map((completion) =>
+      run(spec, (assigned) => {
+        paths.push(cachePath(assigned));
+        return completion.promise;
+      }),
+    );
+    expect(new Set(paths).size).toBe(2);
+    first.resolve({ groupJoined: true, code: 1 });
+    await expect(pending[0]).resolves.toMatchObject({ code: 1 });
+    await run(spec, async (assigned) => {
+      expect(cachePath(assigned)).toBe(paths[0]);
+      expect(cachePath(assigned)).not.toBe(paths[1]);
+      return { groupJoined: true };
+    });
+    await run({ ...spec, config: "test/vitest/vitest.cli.config.ts" }, async (assigned) => {
+      expect(paths).not.toContain(cachePath(assigned));
+      return { groupJoined: true };
+    });
+    second.resolve({ groupJoined: true, code: 0 });
+    await pending[1];
+  });
+
+  it.each(["child-only", "rejected"])(
+    "retires a %s lease without reusing its directory",
+    async (mode) => {
+      const run = createVitestCacheSlots(2, "linux");
+      let retired: string | undefined;
+      const attempt = run(spec, async (assigned) => {
+        retired = cachePath(assigned);
+        if (mode === "rejected") {
+          throw new Error("unverified descendants");
+        }
+        return { groupJoined: false };
+      });
+      if (mode === "rejected") {
+        await expect(attempt).rejects.toThrow("unverified descendants");
+      } else {
+        await attempt;
+      }
+      for (let index = 0; index < 3; index += 1) {
+        await run(spec, async (assigned) => {
+          expect(cachePath(assigned)).not.toBe(retired);
+          return { groupJoined: true };
+        });
+      }
+    },
+  );
+
+  it.each(["caller", "serial", "watch", "windows"])(
+    "preserves the %s cache owner",
+    async (mode) => {
+      const input = {
+        ...spec,
+        watchMode: mode === "watch",
+        cacheAssignment: mode === "caller" ? { kind: "caller" as const } : spec.cacheAssignment,
+      };
+      const run = createVitestCacheSlots(
+        mode === "serial" ? 1 : 2,
+        mode === "windows" ? "win32" : "linux",
+      );
+      await run(input, async (assigned) => {
+        expect(assigned).toBe(input);
+        return { groupJoined: false };
+      });
+    },
+  );
+});

--- a/test/scripts/vitest-process-cache.test.ts
+++ b/test/scripts/vitest-process-cache.test.ts
@@ -52,7 +52,10 @@ console.log(JSON.stringify({ namespace, output: result.stdout, cached: fs.exists
     child.stderr?.on("data", (chunk: Buffer) => {
       errorOutput += chunk.toString();
     });
-    expect((await completion).code, errorOutput).toBe(0);
+    expect(await completion, errorOutput).toMatchObject({
+      code: 0,
+      groupJoined: process.platform !== "win32",
+    });
     const observed = JSON.parse(output);
     expect(observed.output).toBe("42\n");
     expect(observed.cached).toBe(homeMode !== "tooling");


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Parallel local test runs repeatedly transform shared imports into one filesystem cache per shard. Hundreds of isolated shard caches consume disk and repeat work even when earlier writers have finished.

## Why This Change Was Made

Reuse scheduler-owned transforms in exclusive worker slots, separated by Vitest configuration. Keep a slot leased across preflight and watchdog retries until the actual process owner confirms group completion. Reject intermediate unverified completion and retire uncertain slots; join admitted peers before returning failures. Caller-isolated paths, serial/watch execution, and Windows retain their existing ownership.

## User Impact

Parallel macOS/Linux test runs can reuse completed transforms with fewer cache directories. No production application behavior, test selection, assertion, or coverage exclusions change. Concurrent invocations still require separate cache roots.

## Evidence

Final focused proof passed 297 tests after fixing an intermediate-completion gap found in review; the complete changed gate and fresh independent P2 review passed. Earlier broad focused proof passed 751 tests. Real scheduler/process-owner proof exercised preflight, a watchdog retry, and an overlapping peer; actual group completion receipts were observed and all child PIDs were gone afterward.

A bounded real Vitest diagnostic ran the same six Telegram files and 43 test identities/results with two slots: cold wall time 48.758s to 26.755s, warm 18.330s to 15.688s. Baseline used six cache leaves and candidate used two. Both sides used the same selection/configuration, disabled timing history, and no forwarded reporter flags. This single alternating cold/warm comparison is not full-suite acceptance or a claim of 30% aggregate improvement.

Net additions: 81 tooling lines, 301 test/support lines, seven documentation lines. Test growth counts against the campaign deletion target; ownership and failure cases justify the added proof.

CI also exposed 13 direct completion-receipt assertions that needed the new group-completion field. Those failures were reproduced locally; exact code/signal assertions remain and actual host-group semantics are now explicit. All 74 checkout cases, the final changed gate and fresh P2 review pass after that repair. A separate inherited suppression-inventory failure from #139483 is being corrected without changing its ratchet.

The progress/watchdog integration pair also needed the exact new receipt field. Both failures reproduced before editing; 179 owner/sibling tests and refreshed changed/P2 checks pass afterward. A complete direct-consumer and strict-result search found no remaining old-shape expectations for the changed receipt producers. Raw child-close contracts remain unchanged.

Review also caught a Windows-only assumption in the new lease tests. Both original failures reproduced with the repository platform spy. The final matrix verifies Linux rejection and unchanged Windows continuation, with platform-correct receipts and cache paths. Final proof:302 owner/sibling tests plus9 policy cases, changed gate and P2 pass. This is controlled platform-policy proof, not native Windows execution; no test was skipped to conceal the issue.
