### PR TITLE
test(workshop): isolate marker casing fixture identities

### DIFF
--- a/src/skills/workshop/service-evaluation.test.ts
+++ b/src/skills/workshop/service-evaluation.test.ts
@@ -344,20 +344,24 @@ describe("Skill Workshop proposal evaluation", () => {
     expect((await inspectSkillProposal(proposal.record.id))?.record.evaluation).toBe(undefined);
   });
 
-  it.each(["skill.md", "SKILL.MD"])(
-    "preserves the target marker casing in evaluation bundles for %s",
-    async (skillFileName) => {
+  // Each row owns a distinct skill under the shared agent's Workshop root.
+  it.each([
+    { skillFileName: "skill.md", skillName: "existing-marker-lower" },
+    { skillFileName: "SKILL.MD", skillName: "existing-marker-upper" },
+  ])(
+    "preserves the target marker casing in evaluation bundles for $skillFileName",
+    async ({ skillFileName, skillName }) => {
       const workspaceDir = await tempDirs.make("openclaw-skill-evaluation-filename-");
-      const skillDir = await createOwnedSkill(workspaceDir, "existing-marker-case");
+      const skillDir = await createOwnedSkill(workspaceDir, skillName);
       const canonicalSkillFile = path.join(skillDir, "SKILL.md");
       await fs.writeFile(
         canonicalSkillFile,
-        "---\nname: existing-marker-case\ndescription: Existing skill\n---\n\n# Existing\n",
+        `---\nname: ${skillName}\ndescription: Existing skill\n---\n\n# Existing\n`,
       );
       const proposal = await proposeUpdateSkill({
         workspaceDir,
         agentId: "main",
-        skillName: "existing-marker-case",
+        skillName,
         content: "# Existing\n\nUpdated.\n",
       });
       const intermediateSkillFile = path.join(skillDir, "marker.tmp");


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The Workshop evaluation suite fails its second marker-casing case on case-insensitive filesystems because both rows create the same agent-owned skill. Distinct workspace directories no longer isolate that target.

## Why This Change Was Made

Give each row a distinct normalized skill identity and use it consistently for creation, frontmatter, and update. Preserve both marker filenames, rendered test names, rename steps, missing-canonical-marker behavior, and bundle assertions.

## User Impact

No production behavior changes. Both casing scenarios reach their intended assertions without colliding with each other. This adds four test lines and repairs one blocker found in the full-suite profiling run.

## Evidence

Original order reproduced one passing row and one failure at the existing-target guard. After the fixture repair, all 71 tests across evaluation, service, and lifecycle-hook suites pass. The full changed gate, formatting, diff check, deslop, and independent P2 review pass. No runtime speedup is claimed.
