### PR TITLE
fix(process): start supervised commands under Bun

### DIFF
--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import { createReadStream, createWriteStream, type WriteStream } from "node:fs";
 import { Socket } from "node:net";
 import { pipeline, type Readable } from "node:stream";
 import { createDeferredCore } from "../../shared/deferred.js";
@@ -52,7 +54,7 @@ export function runServiceChildGroupAnchor(): void {
   let sequence = 0;
   let lastHostSequence = 0;
   let command: ChildProcess | undefined;
-  let control: Socket | undefined;
+  let control: Socket | WriteStream | undefined;
   let rootSettlementStarted = false;
   let rootResultDelivery: Promise<void> | undefined;
   let rootExit: { code: number | null; signal: NodeJS.Signals | null } | undefined;
@@ -199,10 +201,21 @@ export function runServiceChildGroupAnchor(): void {
       return;
     }
     start = next;
-    control = new Socket({ fd: start.controlFd, readable: true, writable: true });
-    control.setEncoding("utf8");
+    let controlInput: Readable;
+    if (process.versions.bun) {
+      // Bun cannot wrap a duplex inherited fd in Socket. The anchor process owns
+      // this shared descriptor until exit; neither stream may close the other direction.
+      controlInput = createReadStream("", { fd: start.controlFd, autoClose: false });
+      control = createWriteStream("", { fd: start.controlFd, autoClose: false });
+    } else {
+      // Node must use nonblocking socket IO: a pending fs read prevents process exit.
+      const socket = new Socket({ fd: start.controlFd, readable: true, writable: true });
+      controlInput = socket;
+      control = socket;
+    }
+    controlInput.setEncoding("utf8");
     let pending = "";
-    control.on("data", (chunk: string) => {
+    controlInput.on("data", (chunk: string) => {
       pending += chunk;
       for (;;) {
         const newline = pending.indexOf("\n");
@@ -219,16 +232,17 @@ export function runServiceChildGroupAnchor(): void {
         }
       }
     });
-    control.once("close", () => {
+    const onControlLoss = () => {
       if (state !== "closed") {
         void requestCleanup("parent-lost");
       }
-    });
-    control.once("error", () => {
-      if (state !== "closed") {
-        void requestCleanup("parent-lost");
-      }
-    });
+    };
+    controlInput.once("end", onControlLoss);
+    controlInput.once("close", onControlLoss);
+    controlInput.once("error", onControlLoss);
+    if (controlInput !== control) {
+      control.once("error", onControlLoss);
+    }
 
     const { stdio, lineageFd } = commandStdio(start);
     try {
@@ -240,6 +254,8 @@ export function runServiceChildGroupAnchor(): void {
         detached: false,
         windowsHide: true,
       });
+      // Failed Bun spawns have no stdio. Preserve the spawn error before checking lineage.
+      await once(command, "spawn");
     } catch (error) {
       await reportStartupFailure(error instanceof Error ? error.message : String(error));
       return;
@@ -314,17 +330,14 @@ export function runServiceChildGroupAnchor(): void {
         void reportStartupFailure(error.message);
       }
     });
-    command.once("spawn", () => {
-      if (!command?.pid || state !== "starting") {
-        return;
-      }
+    if (command.pid && state === "starting") {
       state = "active";
       void send({
         type: "ready",
         commandPid: command.pid,
         anchorPid: process.pid,
       });
-    });
+    }
     command.once("exit", (code, signal) => {
       rootExit = { code, signal };
       // The host gates public settlement on output EOF, so record the authentic root


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where supervised commands could fail to start under Bun because their inherited control channel could not be opened as a Node socket. Failed spawns could also lose the original startup error before it reached the caller.

## Why This Change Was Made

The child-group anchor uses separate non-owning read and write streams for Bun's inherited descriptor. Node retains its existing nonblocking socket path. The anchor waits for the spawn result before inspecting lineage descriptors, preserving errors such as ENOENT. Receipt handling and cleanup authority remain with their existing owners.

## User Impact

Bun can start and control the covered supervised commands, and startup failures retain the original error. Complete Bun supervisor compatibility is not claimed.

## Evidence

- Node lifecycle and relay tests: 42 passed.
- Bun receipt tests: 18 passed; construction and cancellation: 11 passed; Gateway close: 64 passed.
- Complete changed-file gate and independent P0–P2 review passed; exact-head hosted CI is green.
- Fresh classification runs at head 5ad6265e199 reproduce the two retained-output failures on Bun, while both cases pass on Node. Cancellation-group and split-UTF8 sibling cases pass on both runtimes.

## Remaining Bun Output-Lifetime Limitation

The still-failing cases are `settles the root result while retaining descendant cleanup ownership` and `flushes incomplete UTF-8 before exposing a root result with retained authority`. Both reach the existing five-second root-result wait and fail with `root result waited for descendant release`; their cleanup completes.

An independent probe contains no OpenClaw imports, control descriptor, descendants, or changed spawn ordering. It pipelines empty output or the exact three bytes `[88, 226, 130]` into process.stdout, reports successful pipeline completion, and stays alive until released on stdin. Node emits stdout EOF while that child is alive. Bun delivers the bytes and successful callback but emits no EOF during the pre-release observation; EOF arrives when the child exits. The result is the same with Node and Bun parents, and every probe child exits zero after release.

This isolates an existing Bun stdout-lifetime incompatibility from both changes in this PR. The unchanged anchor pipelines and host result-plus-EOF gate expose it once control startup works. The original unconditional Socket construction prevents a useful full pre-patch Bun lifecycle run; the standalone probe establishes independence instead of treating unchanged forwarding code as proof by itself.

The output limitation remains unresolved. No descriptor-close workaround, receipt change, EOF bypass, timeout relaxation, or output-forwarding change is included here.
