### PR TITLE
fix(macos): prevent dashboard fixture loopback timeouts

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixture.swift
@@ -7,47 +7,14 @@ import Security
 final class DashboardHTTPFixture {
     static let html = "<!doctype html><html><head><title>Dashboard fixture</title></head><body>Ready</body></html>"
 
-    private struct Client {
-        let connection: NWConnection
-        let timeout: DispatchWorkItem
-        var request = Data()
-    }
-
-    private let listener: NWListener
-    private let responseHTML: String
-    private let contentSecurityPolicy: String
-    private let beforeResponse: (@MainActor () async -> Void)?
-    private let requestHandler: (@MainActor (String) -> String?)?
-    private var clients: [UUID: Client] = [:]
-    private var stopped = false
+    private let server: DashboardHTTPFixtureServer
     nonisolated let port: UInt16
     nonisolated let usesTLS: Bool
 
-    private init(
-        listener: NWListener,
-        port: UInt16,
-        html: String,
-        contentSecurityPolicy: String,
-        beforeResponse: (@MainActor () async -> Void)?,
-        usesTLS: Bool,
-        requestHandler: (@MainActor (String) -> String?)?)
-    {
-        self.responseHTML = html
-        self.contentSecurityPolicy = contentSecurityPolicy
-        self.beforeResponse = beforeResponse
-        self.requestHandler = requestHandler
-        self.usesTLS = usesTLS
-        self.listener = listener
+    private init(server: DashboardHTTPFixtureServer, port: UInt16, usesTLS: Bool) {
+        self.server = server
         self.port = port
-        self.listener.newConnectionHandler = { [weak self] connection in
-            MainActor.assumeIsolated {
-                guard let self else {
-                    connection.cancel()
-                    return
-                }
-                self.accept(connection)
-            }
-        }
+        self.usesTLS = usesTLS
     }
 
     static func start(
@@ -67,8 +34,13 @@ final class DashboardHTTPFixture {
         }
         parameters.requiredLocalEndpoint = .hostPort(host: "127.0.0.1", port: .any)
         let listener = try NWListener(using: parameters, on: .any)
-        listener.newConnectionHandler = { $0.cancel() }
-        listener.start(queue: .main)
+        let server = DashboardHTTPFixtureServer(
+            listener: listener,
+            html: html,
+            contentSecurityPolicy: contentSecurityPolicy,
+            beforeResponse: beforeResponse,
+            requestHandler: requestHandler)
+        server.start()
         do {
             let deadline = ContinuousClock.now + .seconds(5)
             while true {
@@ -79,13 +51,9 @@ final class DashboardHTTPFixture {
                         throw URLError(.cannotFindHost)
                     }
                     return DashboardHTTPFixture(
-                        listener: listener,
+                        server: server,
                         port: port.rawValue,
-                        html: html,
-                        contentSecurityPolicy: contentSecurityPolicy,
-                        beforeResponse: beforeResponse,
-                        usesTLS: tlsIdentity != nil,
-                        requestHandler: requestHandler)
+                        usesTLS: tlsIdentity != nil)
                 case let .failed(error):
                     throw error
                 case .cancelled:
@@ -100,7 +68,7 @@ final class DashboardHTTPFixture {
                 }
             }
         } catch {
-            listener.cancel()
+            server.stop()
             throw error
         }
     }
@@ -114,11 +82,62 @@ final class DashboardHTTPFixture {
     }
 
     func stop() {
-        guard !self.stopped else { return }
-        self.stopped = true
-        self.listener.cancel()
-        for id in Array(self.clients.keys) {
-            self.close(id)
+        self.server.stop()
+    }
+}
+
+/// All mutable transport state belongs to queue; UI tests may block the main actor.
+private final class DashboardHTTPFixtureServer: @unchecked Sendable {
+    private struct Client {
+        let connection: NWConnection
+        let timeout: DispatchWorkItem
+        var request = Data()
+        var responseTask: Task<Void, Never>?
+    }
+
+    private let queue = DispatchQueue(label: "DashboardHTTPFixture")
+    private let listener: NWListener
+    private let responseHTML: String
+    private let contentSecurityPolicy: String
+    private let beforeResponse: (@MainActor () async -> Void)?
+    private let requestHandler: (@MainActor (String) -> String?)?
+    private var clients: [UUID: Client] = [:]
+    private var stopped = false
+
+    init(
+        listener: NWListener,
+        html: String,
+        contentSecurityPolicy: String,
+        beforeResponse: (@MainActor () async -> Void)?,
+        requestHandler: (@MainActor (String) -> String?)?)
+    {
+        self.listener = listener
+        self.responseHTML = html
+        self.contentSecurityPolicy = contentSecurityPolicy
+        self.beforeResponse = beforeResponse
+        self.requestHandler = requestHandler
+        // Network.framework requires the connection handler before listener.start.
+        self.listener.newConnectionHandler = { [weak self] connection in
+            guard let self else {
+                connection.cancel()
+                return
+            }
+            self.accept(connection)
+        }
+    }
+
+    func start() {
+        self.listener.start(queue: self.queue)
+    }
+
+    func stop() {
+        self.queue.sync {
+            guard !self.stopped else { return }
+            self.stopped = true
+            self.listener.cancel()
+            for id in Array(self.clients.keys) {
+                self.close(id)
+            }
         }
     }
 
@@ -128,12 +147,10 @@ final class DashboardHTTPFixture {
             return
         }
         let id = UUID()
-        let timeout = DispatchWorkItem { [weak self] in
-            MainActor.assumeIsolated { self?.close(id) }
-        }
+        let timeout = DispatchWorkItem { [weak self] in self?.close(id) }
         self.clients[id] = Client(connection: connection, timeout: timeout)
-        connection.start(queue: .main)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: timeout)
+        connection.start(queue: self.queue)
+        self.queue.asyncAfter(deadline: .now() + 5, execute: timeout)
         self.receive(id)
     }
 
@@ -145,29 +162,35 @@ final class DashboardHTTPFixture {
             minimumIncompleteLength: 1,
             maximumLength: 8192 - client.request.count)
         { [weak self] data, _, complete, error in
-            MainActor.assumeIsolated {
-                guard let self, var client = self.clients[id] else { return }
-                if let data { client.request.append(data) }
-                self.clients[id] = client
-                if client.request.range(of: Data("\r\n\r\n".utf8)) != nil {
-                    if let beforeResponse = self.beforeResponse {
-                        Task { @MainActor [weak self] in
-                            await beforeResponse()
-                            self?.respond(id)
-                        }
-                    } else {
-                        self.respond(id)
+            guard let self, var client = self.clients[id] else { return }
+            if let data { client.request.append(data) }
+            self.clients[id] = client
+            if client.request.range(of: Data("\r\n\r\n".utf8)) != nil {
+                if self.beforeResponse != nil || self.requestHandler != nil {
+                    let request = String(data: client.request, encoding: .utf8) ?? ""
+                    self.clients[id]?.responseTask = Task { @MainActor [
+                        weak self,
+                        beforeResponse = self.beforeResponse,
+                        requestHandler = self.requestHandler,
+                    ] in
+                        await beforeResponse?()
+                        // stop/timeout may have retired this client while the hook waited.
+                        guard !Task.isCancelled else { return }
+                        let response = requestHandler?(request)
+                        self?.queue.async { [weak self] in self?.respond(id, response: response) }
                     }
-                } else if error != nil || complete || client.request.count >= 8192 {
-                    self.close(id)
                 } else {
-                    self.receive(id)
+                    self.respond(id)
                 }
+            } else if error != nil || complete || client.request.count >= 8192 {
+                self.close(id)
+            } else {
+                self.receive(id)
             }
         }
     }
 
-    private func respond(_ id: UUID) {
+    private func respond(_ id: UUID, response: String? = nil) {
         guard let client = self.clients[id] else { return }
         let body = Data(self.responseHTML.utf8)
         // Existing callers stay inert; navigation tests explicitly opt into
@@ -180,16 +203,16 @@ final class DashboardHTTPFixture {
             "Content-Security-Policy: \(self.contentSecurityPolicy)",
             "Connection: close",
         ].joined(separator: "\r\n") + "\r\n\r\n"
-        let response = self.requestHandler?(String(data: client.request, encoding: .utf8) ?? "")
-            .map { Data($0.utf8) } ?? (Data(headers.utf8) + body)
-        client.connection.send(content: response, completion: .contentProcessed { [weak self] _ in
-            MainActor.assumeIsolated { self?.close(id) }
+        let content = response.map { Data($0.utf8) } ?? (Data(headers.utf8) + body)
+        client.connection.send(content: content, completion: .contentProcessed { [weak self] _ in
+            self?.close(id)
         })
     }
 
     private func close(_ id: UUID) {
         guard let client = self.clients.removeValue(forKey: id) else { return }
         client.timeout.cancel()
+        client.responseTask?.cancel()
         client.connection.cancel()
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixtureTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DashboardHTTPFixtureTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import Synchronization
 import Testing
 
 @MainActor
@@ -11,14 +12,7 @@ struct DashboardHTTPFixtureTests {
         defer { second.stop() }
         #expect(first.port != second.port)
 
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.urlCache = nil
-        configuration.httpCookieStorage = nil
-        configuration.urlCredentialStorage = nil
-        configuration.connectionProxyDictionary = [:]
-        configuration.timeoutIntervalForRequest = 2
-        configuration.timeoutIntervalForResource = 5
-        let session = URLSession(configuration: configuration)
+        let session = Self.makeSession()
         defer { session.invalidateAndCancel() }
 
         for fixture in [first, second] {
@@ -36,6 +30,48 @@ struct DashboardHTTPFixtureTests {
             #expect(http.value(forHTTPHeaderField: "Content-Security-Policy") == "default-src 'none'")
             #expect(http.value(forHTTPHeaderField: "Set-Cookie") == nil)
         }
+    }
+
+    @Test func `inert responses do not wait for the main actor`() async {
+        // The child owns the actor stall so parallel suites keep their deadlines.
+        await #expect(processExitsWith: .success) {
+            try await DashboardHTTPFixtureTests.checkResponseWithBlockedMainActor()
+        }
+    }
+
+    private static func checkResponseWithBlockedMainActor() async throws {
+        let fixture = try await DashboardHTTPFixture.start()
+        defer { fixture.stop() }
+        let session = Self.makeSession()
+        defer { session.invalidateAndCancel() }
+        try Self.receiveWhileBlockingMainActor(fixture: fixture, session: session)
+    }
+
+    private static func receiveWhileBlockingMainActor(fixture: DashboardHTTPFixture, session: URLSession) throws {
+        let completed = DispatchSemaphore(value: 0)
+        let servedHTML = Mutex(false)
+        let expectedBody = Data(DashboardHTTPFixture.html.utf8)
+        let task = session.dataTask(with: fixture.url()) { data, response, error in
+            servedHTML.withLock {
+                $0 = error == nil && (response as? HTTPURLResponse)?.statusCode == 200 && data == expectedBody
+            }
+            completed.signal()
+        }
+        task.resume()
+        // No actor suspension: accept/read/write must finish on the transport queue.
+        try #require(completed.wait(timeout: .now() + 5) == .success)
+        #expect(servedHTML.withLock { $0 })
+    }
+
+    private static func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        configuration.urlCredentialStorage = nil
+        configuration.connectionProxyDictionary = [:]
+        configuration.timeoutIntervalForRequest = 2
+        configuration.timeoutIntervalForResource = 5
+        return URLSession(configuration: configuration)
     }
 
     @Test func `stopping a fixture closes unfinished clients and releases its listener`() async throws {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `macos-swift (tests)` intermittently fails an unrelated PR because `DashboardHTTPFixtureTests` times out fetching inert loopback HTML. The reported failure is [run 33999463775, macos-swift (tests)](https://github.com/openclaw/openclaw/actions/runs/33999463775/job/101395703807) on #139522: the first URLSession request fails with `NSURLErrorDomain -1001` after 2.627 seconds; the suite reports one issue across 2,042 tests.

## Why This Change Was Made

The fixture already waits for `NWListener.State.ready`, starts its two listeners sequentially, uses distinct ephemeral ports, disables URLSession caches, and replies with `Connection: close`. The transport instead depends on the main queue for accepting connections, reading headers, sending responses, and cleanup. Parallel native tests can occupy that queue, including deliberate semaphore stalls in `TalkModeRuntimeSpeechTests`. A TCP handshake can complete while the application callbacks remain queued until after the two-second request deadline. The original log does not identify which callback was delayed.

The repair gives each fixture a private serial transport queue and installs its real connection handler before starting the listener, as Network.framework requires. Existing main-actor response hooks remain isolated there, with cancellation when their client closes. Startup still waits for `.ready`; request deadlines, assertions, connection limits, and header bounds remain unchanged.

## User Impact

Developers get reliable dashboard fixture HTTP responses even while other native tests occupy the main actor. This is test support only; shipped app behavior does not change.

## Evidence

- Adds a child-process regression that holds the main actor synchronously until a URLSession completion arrives, then requires HTTP 200 and the exact inert body. Its request timeout remains two seconds. The child prevents the deliberate stall from affecting parallel suites.
- Before repair: [run 34001430025](https://github.com/openclaw/openclaw/actions/runs/34001430025/job/101401003091) on `f4ae221bd18b2fee0c1c0ba14d5d444f22f07f07` failed only the new regression at its HTTP-success assertion (2,052 tests, one issue). Both existing fixture tests passed. This reproduces the main-queue dependency without relying on random suite scheduling.
- Local: full `swift build --package-path apps/macos --build-system native --build-tests` passed after generating the standard Apple Mermaid resources; changed-file checks, Swift formatting, native localization verification, and independent review passed.
- After repair: [run 34002395536, first attempt](https://github.com/openclaw/openclaw/actions/runs/34002395536/attempts/1) on `69680abe79042e58d84866ad9b44b9facf26d668` passed the complete `DashboardHTTPFixtureTests` suite, including the new blocked-main-actor regression. The only issue across 2,053 tests was the unchanged `PipeReadStreamTests` cleanup join timing out at line 39; it passed in the preceding run and does not use this fixture. The [same-head rerun passed](https://github.com/openclaw/openclaw/actions/runs/34002395536/attempts/2), including all 2,053 app tests, the two named-profile tests, 1,655 shared-kit tests, the original fixture tests, the new regression, and the pipe cleanup test. The required CI gate is green. No timeout or assertion changed; the pipe test remains a separate follow-up.
- Native tests are compiled only on the local operator desktop; execution is reserved for disposable macOS CI.
