### PR TITLE
fix(browser): keep the node file name in saved proxy downloads

### DIFF
--- a/extensions/browser/src/browser/proxy-files.test.ts
+++ b/extensions/browser/src/browser/proxy-files.test.ts
@@ -1,6 +1,7 @@
 // Browser tests cover proxy files plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { extractOriginalFilename } from "openclaw/plugin-sdk/media-runtime";
 import { createTempHomeEnv, type TempHomeEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BROWSER_PROXY_MAX_FILE_BYTES } from "../browser-proxy-envelope.js";
@@ -37,6 +38,28 @@ describe("persistBrowserProxyResultFiles", () => {
       `${path.sep}.openclaw${path.sep}media${path.sep}browser${path.sep}`,
     );
     await expect(fs.readFile(savedPath ?? "", "utf8")).resolves.toBe("hello from browser proxy");
+  });
+
+  it.each([
+    { sourcePath: "/tmp/quarterly-report.pdf", expectedFilename: "quarterly-report.pdf" },
+    { sourcePath: "C:\\downloads\\quarterly-report.pdf", expectedFilename: "quarterly-report.pdf" },
+    { sourcePath: "/tmp/my <file>:test!.bin", expectedFilename: "my_filetest.pdf" },
+  ])("preserves a safe filename from $sourcePath", async ({ sourcePath, expectedFilename }) => {
+    const contents = "%PDF-1.7 browser proxy download";
+    const result = { download: { path: sourcePath, suggestedFilename: "website-title.pdf" } };
+    await persistBrowserProxyResultFiles(result, [
+      {
+        path: sourcePath,
+        base64: Buffer.from(contents).toString("base64"),
+        mimeType: "application/pdf",
+      },
+    ]);
+
+    const savedPath = result.download.path;
+    expect(path.dirname(savedPath)).toBe(path.join(tempHome.home, ".openclaw", "media", "browser"));
+    expect(extractOriginalFilename(savedPath)).toBe(expectedFilename);
+    expect(result.download.suggestedFilename).toBe("website-title.pdf");
+    await expect(fs.readFile(savedPath, "utf8")).resolves.toBe(contents);
   });
 
   it("persists legitimate empty browser proxy downloads", async () => {

--- a/extensions/browser/src/browser/proxy-files.ts
+++ b/extensions/browser/src/browser/proxy-files.ts
@@ -96,6 +96,7 @@ export async function persistBrowserProxyResultFiles(result: unknown, files: unk
       file.mimeType,
       "browser",
       BROWSER_PROXY_MAX_FILE_BYTES,
+      file.path,
     );
     mapping.set(file.path, saved.path);
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes #139557.

The Gateway discarded the validated node-side filename when saving files returned by a browser node. Downloads, screenshots, and annotated snapshots therefore became UUID-only media files even when a node filename was available.

## Why This Change Was Made

Pass the validated path as the media store's existing `originalFilename` argument. The store extracts and sanitizes the basename, resolves the extension, and writes its normal `<name>---<uuid>.<ext>` identifier. No new parser, storage format, or migration is added.

## User Impact

Browser-node files retain a safe, recoverable node-side name. Website `suggestedFilename` remains separate metadata: an automatic download can already have a generated node prefix, and an explicit output filename can differ from the website suggestion. This change preserves the node name within the existing store's filename bounds.

## Evidence

- **Before:** current main at `4da5d447f695`, running browser node → Gateway: a named 39-byte PDF was saved with a UUID-only basename. Node and saved-byte hashes matched.
- **After:** candidate `105e3f63aa55`, same real route: explicit and automatic downloads retain safe node names; saved bytes match; returned paths point to Gateway media files. Empty downloads, screenshots, and annotated snapshot images also pass.
- A clearly labeled synthetic attachment consumer using the published media filename API rendered the UUID before and the recovered node name after. This is not a full Control UI or external-channel display claim.
- Labeled synthetic node-envelope probes against the running Gateway reject malformed base64 and over-limit file counts, individual bytes, and aggregate bytes before writing. Exact limits of 256 files, 10 MiB per file, and 16 MiB total pass.
- The three new filename regressions fail on the original implementation. Candidate owner suites: **98 passed**; final changed regression suite: **21 passed**. Pinned formatting, owning TypeScript-aware lint, line/assertion guards, and the combined runtime/UI build pass.
- Fresh independent code review and all eight source-blind acceptance clauses passed. The validator repeated the same boundary inputs on baseline and candidate builds.

CI run [34006491665](https://github.com/openclaw/openclaw/actions/runs/34006491665) reports an unrelated services test-group limit failure: [#139592](https://github.com/openclaw/openclaw/pull/139592) added the test file that raised that group from 720 to 721 roots. Its parent diff and exact CI merge tree confirm the cause; this PR leaves the count unchanged. Landing still requires the complete CI result and guarded review.

AI-assisted repair and verification. Original contribution by @ruel225.

<details>
<summary>Redacted browser-node download output</summary>

These are captured browser.request results and matching filesystem observations. Only private path prefixes, the fixture URL, and browser target identities are redacted. The baseline requested `quarterly-report.pdf`; the candidate deliberately requested `candidate-quarterly.pdf` while keeping the website suggestion unchanged.

Before (`4da5d447f695`):

```json
{
  "browserResult": {
    "ok": true,
    "download": {
      "url": "<fixture-download-url>",
      "suggestedFilename": "quarterly-report.pdf",
      "path": "<gateway-browser-media>/92a94425-1c4e-46c3-bccd-989b0a082b92.pdf"
    }
  },
  "nodeFile": {
    "name": "quarterly-report.pdf",
    "path": "<node-downloads>/quarterly-report.pdf",
    "size": 39,
    "sha256": "4547e8c1e1654e67682c5f483017313fd02ab51081e5d5e5da40b24ab2d40485"
  },
  "gatewayFile": {
    "name": "92a94425-1c4e-46c3-bccd-989b0a082b92.pdf",
    "path": "<gateway-browser-media>/92a94425-1c4e-46c3-bccd-989b0a082b92.pdf",
    "size": 39,
    "sha256": "4547e8c1e1654e67682c5f483017313fd02ab51081e5d5e5da40b24ab2d40485"
  }
}
```

After (`105e3f63aa55`):

```json
{
  "browserResult": {
    "ok": true,
    "download": {
      "url": "<fixture-download-url>",
      "suggestedFilename": "quarterly-report.pdf",
      "path": "<gateway-browser-media>/candidate-quarterly---8518a609-06c4-48b7-9756-77bddb1b4f0b.pdf"
    }
  },
  "nodeFile": {
    "name": "candidate-quarterly.pdf",
    "path": "<node-downloads>/candidate-quarterly.pdf",
    "size": 39,
    "sha256": "4547e8c1e1654e67682c5f483017313fd02ab51081e5d5e5da40b24ab2d40485"
  },
  "gatewayFile": {
    "name": "candidate-quarterly---8518a609-06c4-48b7-9756-77bddb1b4f0b.pdf",
    "path": "<gateway-browser-media>/candidate-quarterly---8518a609-06c4-48b7-9756-77bddb1b4f0b.pdf",
    "size": 39,
    "sha256": "4547e8c1e1654e67682c5f483017313fd02ab51081e5d5e5da40b24ab2d40485"
  }
}
```

</details>
