### PR TITLE
refactor(exec): share package argument scanning

### DIFF
--- a/src/infra/package-manager-exec-wrapper.ts
+++ b/src/infra/package-manager-exec-wrapper.ts
@@ -161,10 +161,14 @@ type PackageManagerContextOptions = PackageManagerOptions & {
   contextFlagOptions?: ReadonlySet<string>;
 };
 
-const NPM_EXEC_OPTIONS: PackageManagerContextOptions = {
+const NPM_DIRECT_EXEC_OPTIONS: PackageManagerOptions = {
   optionsWithValue: NPM_EXEC_OPTIONS_WITH_VALUE,
-  caseSensitiveOptionsWithValue: new Set(["-C"]),
   flagOptions: NPM_EXEC_FLAG_OPTIONS,
+};
+
+const NPM_EXEC_OPTIONS: PackageManagerContextOptions = {
+  ...NPM_DIRECT_EXEC_OPTIONS,
+  caseSensitiveOptionsWithValue: new Set(["-C"]),
   contextOptionsWithValue: NPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
   contextCaseSensitiveOptionsWithValue: new Set(["-C"]),
   contextFlagOptions: new Set(["--ws", "--workspaces"]),
@@ -177,6 +181,12 @@ const PNPM_EXEC_OPTIONS: PackageManagerContextOptions = {
   contextOptionsWithValue: PNPM_EXEC_CONTEXT_OPTIONS_WITH_VALUE,
   contextCaseSensitiveOptionsWithValue: PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE,
   contextFlagOptions: new Set(["--recursive", "--workspace-root", "-r", "-w"]),
+};
+
+// dlx keeps both -c and -C outside its allowed options, unlike leading pnpm options.
+const PNPM_DLX_OPTIONS: PackageManagerOptions = {
+  optionsWithValue: PNPM_EXEC_OPTIONS.optionsWithValue,
+  flagOptions: PNPM_FLAG_OPTIONS,
 };
 
 const YARN_EXEC_OPTIONS: PackageManagerContextOptions = {
@@ -199,6 +209,7 @@ function findFirstNonOptionIndex(
   argv: string[],
   startIdx: number,
   params: PackageManagerOptions,
+  terminator: "skip" | "stop" | "reject" = "skip",
 ): number | null {
   let idx = startIdx;
   while (idx < argv.length) {
@@ -208,6 +219,12 @@ function findFirstNonOptionIndex(
       continue;
     }
     if (token === "--") {
+      if (terminator === "reject") {
+        return null;
+      }
+      if (terminator === "stop") {
+        return idx + 1 < argv.length ? idx + 1 : null;
+      }
       idx += 1;
       continue;
     }
@@ -363,7 +380,7 @@ function unwrapPnpmExecInvocation(argv: string[]): string[] | null {
     return normalizedTail.length > 0 ? normalizedTail : null;
   }
   if (token === "dlx") {
-    return unwrapPnpmDlxInvocation(argv.slice(idx + 1));
+    return unwrapPackageExecArguments(argv, idx + 1, PNPM_DLX_OPTIONS, "stop");
   }
   if (token === "node") {
     const tail = argv.slice(idx + 1);
@@ -373,135 +390,26 @@ function unwrapPnpmExecInvocation(argv: string[]): string[] | null {
   return null;
 }
 
-function unwrapPnpmDlxInvocation(argv: string[]): string[] | null {
-  let idx = 0;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      const tail = argv.slice(idx + 1);
-      return tail.length > 0 ? tail : null;
-    }
-    if (!token.startsWith("-")) {
-      return argv.slice(idx);
-    }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (flag === "-c" || flag === "--shell-mode") {
-      return null;
-    }
-    if (PNPM_OPTIONS_WITH_VALUE.has(flag) || PNPM_DLX_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_CASE_SENSITIVE_OPTIONS_WITH_VALUE.has(parsedOption.name)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (PNPM_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return null;
-  }
-  return null;
-}
-
-function unwrapDirectPackageExecInvocation(argv: string[]): string[] | null {
-  let idx = 1;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (!token.startsWith("-")) {
-      return argv.slice(idx);
-    }
-    const flag = normalizeOptionFlag(token);
-    if (flag === "-c" || flag === "--call") {
-      return null;
-    }
-    if (NPM_EXEC_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (NPM_EXEC_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return null;
-  }
-  return null;
+function unwrapPackageExecArguments(
+  argv: string[],
+  startIdx: number,
+  params: PackageManagerOptions,
+  terminator: "stop" | "reject",
+): string[] | null {
+  const idx = findFirstNonOptionIndex(argv, startIdx, params, terminator);
+  return idx === null ? null : argv.slice(idx);
 }
 
 function unwrapNpmExecInvocation(argv: string[]): string[] | null {
-  let idx = 1;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (!token.startsWith("-")) {
-      if (!NPM_EXEC_SUBCOMMANDS.has(token)) {
-        return null;
-      }
-      idx += 1;
-      break;
-    }
-    const parsedOption = parseInlineOptionToken(token);
-    const flag = normalizeLowercaseStringOrEmpty(parsedOption.name);
-    if (NPM_EXEC_OPTIONS_WITH_VALUE.has(flag) || parsedOption.name === "-C") {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (NPM_EXEC_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
+  const idx = findFirstNonOptionIndex(argv, 1, NPM_EXEC_OPTIONS, "reject");
+  if (idx === null || !NPM_EXEC_SUBCOMMANDS.has(argv[idx]?.trim() ?? "")) {
     return null;
   }
-  if (idx >= argv.length) {
-    return null;
-  }
-  const tail = argv.slice(idx);
+  const tail = argv.slice(idx + 1);
   if (tail[0] === "--") {
     return tail.length > 1 ? tail.slice(1) : null;
   }
-  return unwrapDirectPackageExecInvocation(["npx", ...tail]);
-}
-
-function unwrapYarnDlxInvocation(argv: string[]): string[] | null {
-  let idx = 0;
-  while (idx < argv.length) {
-    const token = argv[idx]?.trim() ?? "";
-    if (!token) {
-      idx += 1;
-      continue;
-    }
-    if (token === "--") {
-      const tail = argv.slice(idx + 1);
-      return tail.length > 0 ? tail : null;
-    }
-    if (!token.startsWith("-")) {
-      return argv.slice(idx);
-    }
-    const flag = normalizeOptionFlag(token);
-    if (YARN_DLX_OPTIONS_WITH_VALUE.has(flag)) {
-      idx += token.includes("=") ? 1 : 2;
-      continue;
-    }
-    if (YARN_DLX_FLAG_OPTIONS.has(flag)) {
-      idx += 1;
-      continue;
-    }
-    return null;
-  }
-  return null;
+  return unwrapPackageExecArguments(argv, idx + 1, NPM_DIRECT_EXEC_OPTIONS, "reject");
 }
 
 function unwrapYarnExecInvocation(argv: string[]): string[] | null {
@@ -519,7 +427,7 @@ function unwrapYarnExecInvocation(argv: string[]): string[] | null {
     return normalizedTail.length > 0 ? normalizedTail : null;
   }
   if (token === "dlx") {
-    return unwrapYarnDlxInvocation(argv.slice(idx + 1));
+    return unwrapPackageExecArguments(argv, idx + 1, YARN_DLX_OPTIONS, "stop");
   }
   return null;
 }
@@ -548,7 +456,7 @@ export function resolveKnownPackageManagerExecInvocation(
     }
     case "npx":
     case "bunx": {
-      const unwrapped = unwrapDirectPackageExecInvocation(argv);
+      const unwrapped = unwrapPackageExecArguments(argv, 1, NPM_DIRECT_EXEC_OPTIONS, "reject");
       return unwrapped ? { kind: "unwrapped", argv: unwrapped } : { kind: "unsafe-exec" };
     }
     case "pnpm": {


### PR DESCRIPTION
Related: #135868, #139482

## What Problem This Solves

Maintainer-requested follow-up to #139482: four package-manager argument walkers still repeat the same option-consumption rules, making the differences at `--` harder to inspect and maintain.

This is the independent `clean-broad` companion lane for the #135868 split; it extracts no recovery-stage content.

## Why This Change Was Made

Use the existing private option scanner for the remaining npm/npx/bunx and pnpm/Yarn dlx paths, with explicit delimiter behavior. Keep the existing package-manager option profiles and command-specific extraction rules, including npm's exact first-tail delimiter handling.

The old pnpm dlx loop rejected both `-c` and `-C` before reaching its uppercase-C branch. Its new profile preserves that rejection; leading npm/pnpm still accept uppercase `-C`, and npx/bunx still reject it. No previously accepted option or approval behavior changes.

Production LOC: +34 / -126 (**net -92**), one file, 160 changed lines. The parser shrinks from 590 to 498 lines. Tests, tooling, and docs: +0 / -0.

## User Impact

No intended behavior change. Package-manager execution targets, reusable approval restrictions, literal argument tails, and mutable-script binding stay the same.

## Evidence

- The expanded temporary comparison against the original `v2026.9.2` parser checked **650,840** synthetic invocations, including short/empty argument tails, whitespace delimiters, `-c`/`-C`, unknown options, shell modes, value-taking flags and longer combinations. Classification, extracted argv and context decisions matched exactly.
- `node scripts/run-vitest.mjs src/infra/exec-approvals-allow-always.test.ts src/infra/exec-wrapper-trust-plan.test.ts src/node-host/invoke-system-run-plan.test.ts`: **178 tests passed** on Vitest 5. Existing tests remain unchanged.
- `git diff --check`: passed. No build required: imports, lazy boundaries and public signatures are unchanged.
- `node scripts/check-changed.mjs`: complete selected core/coreTests plan passed after rebasing onto main containing #139519.
- Independent Codex local and branch reviews through P2: scoped-clean. The rebase preserved the parser and lockfile; focused tests and the differential probe passed again on the fixed base.

Deletion rationale: remove four duplicate option-consumption loops and their one-use adapters. The retained scanner owns flag recognition and value consumption; each caller retains its existing delimiter policy. The unreachable pnpm dlx uppercase-C branch is replaced by the narrower profile that matches the old case-folded rejection. Public exports and supported upgrade contracts are unchanged.

ClawSweeper reviewed the published head and found no actionable correctness or security defects, before-merge requests, or rank-up moves. The first exact-head CI run was blocked by an unrelated unlisted lint suppression from main #139483, repaired by merged #139576. After rebasing onto that fix, all 178 boundary tests, all four unchanged suppression-inventory tests, the complete changed-file gate and exact-head CI run 34002842541 passed. The final freshness rebase preserves the exact parser and lockfile; exact-head CI run 34003527230 also passed for 3359f1427b3c0eb2996e6e58ebaf7f74467b3acd, which is MERGEABLE.
