### PR TITLE
test(cli): keep Unix socket fixtures within path limits

### DIFF
--- a/src/cli/connect-cli.test.ts
+++ b/src/cli/connect-cli.test.ts
@@ -178,7 +178,8 @@ describe("connect cli", () => {
   it.skipIf(process.platform === "win32")(
     "rejects a socket target without removing it",
     async () => {
-      const root = tempDirs.make("openclaw-connect-target-socket-");
+      // Keep the Unix socket below Darwin's path limit even under a long test TMPDIR.
+      const root = tempDirs.make("openclaw-connect-target-socket-", "/tmp");
       const targetFile = path.join(root, "setup-code.sock");
       const server = net.createServer();
       await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The connect CLI socket-refusal test fails during socket creation under a long temporary directory, before exercising the CLI's refusal behavior. The Unix socket pathname exceeds the platform limit.

## Why This Change Was Made

Use the existing tracked private temp-directory helper with the short /tmp root for this socket fixture. Retain the real server, CLI call, socket-preservation assertion, close-in-finally and directory cleanup.

## User Impact

No production behavior changes. The test now reaches its intended assertions even under nested runner temp paths. Net one added test line.

## Evidence

The original case reproduced EINVAL while binding a 249-byte pathname under a deterministic long TMPDIR. All 20 connect CLI cases pass after the repair under that same long parent. Full changed gate, formatting/diff check, deslop and independent P2 review pass. No runtime speedup claimed.
