### PR TITLE
test(qa): make cleanup child logging deterministic

### DIFF
--- a/extensions/qa-lab/src/gateway-child-artifacts.test.ts
+++ b/extensions/qa-lab/src/gateway-child-artifacts.test.ts
@@ -51,6 +51,8 @@ describe("cleanupQaGatewayTempRoots", () => {
         USERPROFILE: home,
         OPENCLAW_HOME: home,
         OPENCLAW_STATE_DIR: path.join(home, "state"),
+        // Reserve stderr for errors; slow-open warnings depend on host load.
+        OPENCLAW_LOG_LEVEL: "error",
         XDG_CONFIG_HOME: path.join(home, "config"),
         XDG_CACHE_HOME: path.join(home, "cache"),
         XDG_DATA_HOME: path.join(home, "data"),


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The QA cleanup child test intermittently fails its empty-stderr assertion when host load triggers a legitimate slow-database-open warning, despite successful exit and correct cleanup.

## Why This Change Was Made

Set the synthetic child's existing logging policy explicitly to error. Keep captured output untouched and preserve the strict stderr, exit, target cleanup, sibling-store and lifecycle assertions.

## User Impact

No production behavior changes. Load-dependent warnings no longer fail this cleanup fixture, while error/fatal diagnostics still do. Net two added test lines.

## Evidence

Temporary instrumentation emitted the exact warning through the real subsystem logger: the unchanged case failed before the policy and passed afterward. An error-level negative control still failed the strict stderr check. All instrumentation was removed. Final cleanup and logging tests pass 12/12, as do the complete changed gate, formatting/diff check, deslop and independent P2 review. No runtime speedup claimed.
