### PR TITLE
fix(voice-call): preserve WebSocket transport behavior under Bun

### DIFF
--- a/extensions/voice-call/src/media-stream.test.ts
+++ b/extensions/voice-call/src/media-stream.test.ts
@@ -11,7 +11,6 @@ import type {
 } from "openclaw/plugin-sdk/realtime-transcription";
 import { createTalkSessionController, type TalkEvent } from "openclaw/plugin-sdk/realtime-voice";
 import { describe, expect, it, vi } from "vitest";
-import { WebSocket } from "ws";
 import { MediaStreamHandler } from "./media-stream.js";
 import {
   connectWs,
@@ -19,6 +18,7 @@ import {
   waitForClose,
   withTimeout,
 } from "./websocket-test-support.js";
+import { WebSocket } from "./websocket.js";
 
 const createStubSession = (): RealtimeTranscriptionSession => ({
   connect: async () => {},

--- a/extensions/voice-call/src/media-stream.ts
+++ b/extensions/voice-call/src/media-stream.ts
@@ -24,8 +24,9 @@ import {
   type TalkSessionController,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { type RawData, WebSocket, WebSocketServer } from "ws";
+import type { RawData } from "ws";
 import { canonicalizeVoiceCallMediaBase64 } from "./media-base64.js";
+import { WebSocket, WebSocketServer } from "./websocket.js";
 
 /**
  * Configuration for the media stream handler.

--- a/extensions/voice-call/src/webhook/realtime-handler.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.test.ts
@@ -963,7 +963,8 @@ describe("RealtimeCallHandler path routing", () => {
       );
       await waitForRealtimeTest(() => expect(createBridge).toHaveBeenCalledTimes(1));
 
-      vi.useFakeTimers();
+      // Keep socket teardown callbacks real while controlling the reconnect grace.
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       const closed = waitForClose(ws);
       ws.terminate();
       expect(await closed).toEqual({ code: 1006, reason: "" });

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -29,12 +29,12 @@ import {
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
-import WebSocket, { WebSocketServer } from "ws";
 import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "../realtime-call-control.js";
 import type { CallRecord, EndReason, NormalizedEvent } from "../types.js";
 import type { WebhookResponsePayload } from "../webhook.types.js";
+import { WebSocket, WebSocketServer } from "../websocket.js";
 import { RealtimeAudioPacer } from "./realtime-audio-pacer.js";
 import type { StreamDisconnectLifecycle } from "./stream-disconnect-grace.js";
 import {

--- a/extensions/voice-call/src/websocket-test-support.ts
+++ b/extensions/voice-call/src/websocket-test-support.ts
@@ -1,7 +1,7 @@
 // Voice Call plugin module implements websocket test support behavior.
 import { once } from "node:events";
 import http from "node:http";
-import { WebSocket } from "ws";
+import { WebSocket } from "./websocket.js";
 
 export const withTimeout = async <T>(promise: Promise<T>, timeoutMs = 2000): Promise<T> => {
   let timer: ReturnType<typeof setTimeout> | null = null;

--- a/extensions/voice-call/src/websocket.ts
+++ b/extensions/voice-call/src/websocket.ts
@@ -1,0 +1,11 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// Load the installed receiver so Bun preserves ws frame limits and close behavior.
+const require = createRequire(import.meta.url);
+export const { WebSocket, WebSocketServer }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
+
+export type WebSocket = import("ws").WebSocket;
+export type WebSocketServer = import("ws").WebSocketServer;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the voice-call plugin running under Bun could use different WebSocket frame-limit and connection-close behavior from the installed dependency expected by its media and realtime handlers.

## Why This Change Was Made

A plugin-owned loader resolves the installed `ws` package from the voice-call plugin and shares its constructors across both server owners and their test clients. A reconnect-grace test controls only its timeout clock, leaving socket teardown callbacks real.

## User Impact

Voice-call media and realtime WebSocket connections preserve the installed transport's existing frame limits and close behavior on Bun.

## Evidence

- 123 focused tests pass on Node and 123 on true Bun.
- Full build and complete changed-file gate passed.
- Independent P0–P2 review found no actionable findings.
- This is a bounded compatibility repair; the repository-wide Bun campaign remains in progress.
