### PR TITLE
test(memory): consolidate visibility fixtures without policy defaults

### DIFF
--- a/extensions/memory-core/src/session-search-reset-recall-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-reset-recall-visibility.test.ts
@@ -3,14 +3,12 @@ import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-ru
 import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
+import {
+  searchHit,
+  sessionEntry,
+  type TestSessionEntry,
+} from "./session-search-visibility.test-support.js";
 import { asOpenClawConfig } from "./tools.test-helpers.js";
-
-type TestSessionEntry = {
-  sessionId: string;
-  updatedAt: number;
-  sessionFile: string;
-  chatType?: "direct" | "group" | "channel";
-};
 
 let combinedSessionStore: Record<string, TestSessionEntry> = {};
 
@@ -62,24 +60,21 @@ describe("reset-generation session search visibility", () => {
     const sessionKey = "agent:main:telegram:direct:owner";
     const archiveName = `session-${"a".repeat(64)}.jsonl.reset.2026-08-11T08-00-00.000Z.zst`;
     combinedSessionStore = {
-      [sessionKey]: {
-        sessionId: "current-after-reset",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current-after-reset.jsonl",
-        chatType: "direct",
-      },
+      [sessionKey]: sessionEntry(
+        "current-after-reset",
+        2,
+        "/tmp/sessions/current-after-reset.jsonl",
+        { chatType: "direct" },
+      ),
     };
     vi.mocked(engineSessions.loadArchivedSessions).mockReturnValue([
       { archiveName, sessionId: archivedSessionId, sessionKey, createdAt: 1 },
     ]);
-    const hit: MemorySearchResult = {
-      path: `sessions/main/${archiveName}`,
-      source: "sessions",
-      score: 1,
-      snippet: "retained context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      `sessions/main/${archiveName}`,
+      "sessions",
+      "retained context",
+    );
 
     await expect(
       filterMemorySearchHitsBySessionVisibility({
@@ -109,24 +104,19 @@ describe("reset-generation session search visibility", () => {
     async ({ range, cutoff, kept }) => {
       const anchorSessionKey = "agent:main:telegram:direct:owner";
       combinedSessionStore = {
-        [anchorSessionKey]: {
-          sessionId: "current",
-          updatedAt: 2,
-          sessionFile: "/tmp/sessions/current.jsonl",
+        [anchorSessionKey]: sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
           chatType: "direct",
-        },
+        }),
       };
       vi.mocked(engineSessions.buildSessionEntry).mockResolvedValue(
         (cutoff === undefined ? {} : entryWithCutoff(cutoff)) as never,
       );
-      const hit: MemorySearchResult = {
-        path: "sessions/main/current.jsonl",
-        source: "sessions",
-        score: 1,
-        snippet: "short fact",
-        startLine: range[0],
-        endLine: range[1],
-      };
+      const hit: MemorySearchResult = searchHit(
+        "sessions/main/current.jsonl",
+        "sessions",
+        "short fact",
+        { startLine: range[0], endLine: range[1] },
+      );
 
       const filtered = await filterMemorySearchHitsBySessionVisibility({
         cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
@@ -144,33 +134,20 @@ describe("reset-generation session search visibility", () => {
   it("resolves the live anchor reset cutoff once per filter pass", async () => {
     const anchorSessionKey = "agent:main:telegram:direct:owner";
     combinedSessionStore = {
-      [anchorSessionKey]: {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      [anchorSessionKey]: sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
         chatType: "direct",
-      },
+      }),
     };
     vi.mocked(engineSessions.buildSessionEntry).mockResolvedValue(
       entryWithCutoff({ state: "valid", cutoffLine: 5 }) as never,
     );
     const hits: MemorySearchResult[] = [
-      {
-        path: "sessions/main/current.jsonl",
-        source: "sessions",
-        score: 1,
-        snippet: "first pre-reset chunk",
-        startLine: 1,
-        endLine: 2,
-      },
-      {
-        path: "sessions/main/current.jsonl",
-        source: "sessions",
+      searchHit("sessions/main/current.jsonl", "sessions", "first pre-reset chunk"),
+      searchHit("sessions/main/current.jsonl", "sessions", "second pre-reset chunk", {
         score: 0.9,
-        snippet: "second pre-reset chunk",
         startLine: 3,
         endLine: 4,
-      },
+      }),
     ];
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -198,21 +175,15 @@ describe("reset-generation session search visibility", () => {
     async (compressionSuffix) => {
       const anchorSessionKey = "agent:main:telegram:direct:owner";
       combinedSessionStore = {
-        [anchorSessionKey]: {
-          sessionId: "current",
-          updatedAt: 2,
-          sessionFile: "/tmp/sessions/current.jsonl",
+        [anchorSessionKey]: sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
           chatType: "direct",
-        },
+        }),
       };
-      const hit: MemorySearchResult = {
-        path: `sessions/main/current.jsonl.reset.2026-08-11T08-00-00.000Z${compressionSuffix}`,
-        source: "sessions",
-        score: 1,
-        snippet: "prior conversation context",
-        startLine: 1,
-        endLine: 2,
-      };
+      const hit: MemorySearchResult = searchHit(
+        `sessions/main/current.jsonl.reset.2026-08-11T08-00-00.000Z${compressionSuffix}`,
+        "sessions",
+        "prior conversation context",
+      );
 
       const filtered = await filterMemorySearchHitsBySessionVisibility({
         cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
@@ -257,31 +228,21 @@ describe("reset-generation session search visibility", () => {
     async ({ path, snippet, includeDeletedSource }) => {
       const anchorSessionKey = "agent:main:telegram:direct:owner";
       combinedSessionStore = {
-        [anchorSessionKey]: {
-          sessionId: "current",
-          updatedAt: 2,
-          sessionFile: "/tmp/sessions/current.jsonl",
+        [anchorSessionKey]: sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
           chatType: "direct",
-        },
+        }),
         ...(includeDeletedSource
           ? {
-              "agent:main:telegram:direct:deleted-source": {
-                sessionId: "deleted-source",
-                updatedAt: 1,
-                sessionFile: "/tmp/sessions/deleted-source.jsonl",
-                chatType: "direct" as const,
-              },
+              "agent:main:telegram:direct:deleted-source": sessionEntry(
+                "deleted-source",
+                1,
+                "/tmp/sessions/deleted-source.jsonl",
+                { chatType: "direct" as const },
+              ),
             }
           : {}),
       };
-      const hit: MemorySearchResult = {
-        path,
-        source: "sessions",
-        score: 1,
-        snippet,
-        startLine: 1,
-        endLine: 2,
-      };
+      const hit: MemorySearchResult = searchHit(path, "sessions", snippet);
 
       const filtered = await filterMemorySearchHitsBySessionVisibility({
         cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),

--- a/extensions/memory-core/src/session-search-visibility.cross-agent.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.cross-agent.test.ts
@@ -3,22 +3,15 @@ import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-ru
 import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
+import {
+  searchHit,
+  sessionEntry,
+  type TestSessionEntry,
+} from "./session-search-visibility.test-support.js";
 import { asOpenClawConfig } from "./tools.test-helpers.js";
 
-type TestSessionEntry = {
-  sessionId: string;
-  updatedAt: number;
-  sessionFile: string;
-  chatType?: "direct" | "group" | "channel";
-  origin?: { chatType?: "direct" | "group" | "channel" };
-};
-
 const crossAgentStore: Record<string, TestSessionEntry> = {
-  "agent:peer:only": {
-    sessionId: "w1",
-    updatedAt: 1,
-    sessionFile: "/tmp/sessions/w1.jsonl",
-  },
+  "agent:peer:only": sessionEntry("w1", 1, "/tmp/sessions/w1.jsonl"),
 };
 let combinedSessionStore: Record<string, TestSessionEntry> = crossAgentStore;
 
@@ -42,20 +35,9 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("keeps same-agent session hits when visibility=all and agent-to-agent is enabled", async () => {
     combinedSessionStore = {
-      "agent:main:only": {
-        sessionId: "w1",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/w1.jsonl",
-      },
+      "agent:main:only": sessionEntry("w1", 1, "/tmp/sessions/w1.jsonl"),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/w1.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/w1.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -73,20 +55,9 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("keeps built-in live SQLite session hits with agent-scoped logical paths", async () => {
     combinedSessionStore = {
-      "agent:main:only": {
-        sessionId: "w1",
-        updatedAt: 1,
-        sessionFile: "sqlite-session://main/w1",
-      },
+      "agent:main:only": sessionEntry("w1", 1, "sqlite-session://main/w1"),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/main/w1.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/main/w1.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -104,20 +75,9 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("keeps global-scope session hits for non-default agents", async () => {
     combinedSessionStore = {
-      global: {
-        sessionId: "w1",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/w1.jsonl",
-      },
+      global: sessionEntry("w1", 1, "/tmp/sessions/w1.jsonl"),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/w1.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/w1.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       session: { scope: "global" },
       tools: {
@@ -137,14 +97,7 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("does not keep cross-agent session hits outside the scoped store", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/w1.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/w1.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -162,14 +115,7 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("does not keep cross-agent session hits when a shared store returns out-of-scope keys", async () => {
     combinedSessionStore = crossAgentStore;
-    const hit: MemorySearchResult = {
-      path: "sessions/w1.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/w1.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -187,20 +133,9 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("does not keep owner-qualified cross-agent hits that collide with a scoped stem", async () => {
     combinedSessionStore = {
-      "agent:main:main": {
-        sessionId: "main",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/main.jsonl",
-      },
+      "agent:main:main": sessionEntry("main", 1, "/tmp/sessions/main.jsonl"),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/peer/main.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/peer/main.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -217,14 +152,7 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
   });
 
   it("denies cross-agent session hits when agent-to-agent is disabled", async () => {
-    const hit: MemorySearchResult = {
-      path: "sessions/w1.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/w1.jsonl", "sessions", "x");
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -242,14 +170,11 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("keeps same-agent deleted archive hits using owner metadata when the live store entry is gone", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/main/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/main/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
+      "sessions",
+      "x",
+    );
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "agent" },
@@ -268,14 +193,11 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("still denies cross-agent deleted archive hits resolved from owner metadata when a2a is disabled", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/peer/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/peer/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
+      "sessions",
+      "x",
+    );
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },
@@ -295,14 +217,11 @@ describe("filterMemorySearchHitsBySessionVisibility across agents", () => {
 
   it("does not keep cross-agent deleted archive hits outside the scoped store when a2a is allowed", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/peer/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/peer/deleted-stem.jsonl.deleted.2026-02-16T22-27-33.000Z",
+      "sessions",
+      "x",
+    );
     const cfg = asOpenClawConfig({
       tools: {
         sessions: { visibility: "all" },

--- a/extensions/memory-core/src/session-search-visibility.test-support.ts
+++ b/extensions/memory-core/src/session-search-visibility.test-support.ts
@@ -1,0 +1,29 @@
+import type { MemorySearchResult } from "openclaw/plugin-sdk/memory-core-host-runtime-files";
+import type { normalizeSessionDeliveryState } from "openclaw/plugin-sdk/session-store-runtime";
+
+export type TestSessionEntry = {
+  sessionId: string;
+  updatedAt: number;
+  sessionFile: string;
+  chatType?: "direct" | "group" | "channel";
+  delivery?: ReturnType<typeof normalizeSessionDeliveryState>;
+  origin?: { chatType?: "direct" | "group" | "channel" };
+};
+
+export function sessionEntry(
+  sessionId: string,
+  updatedAt: number,
+  sessionFile: string,
+  metadata?: Pick<TestSessionEntry, "chatType" | "delivery" | "origin">,
+): TestSessionEntry {
+  return { sessionId, updatedAt, sessionFile, ...metadata };
+}
+
+export function searchHit(
+  path: string,
+  source: MemorySearchResult["source"],
+  snippet: string,
+  details?: Partial<Pick<MemorySearchResult, "score" | "startLine" | "endLine">>,
+): MemorySearchResult {
+  return { path, source, score: 1, snippet, startLine: 1, endLine: 2, ...details };
+}

--- a/extensions/memory-core/src/session-search-visibility.test.ts
+++ b/extensions/memory-core/src/session-search-visibility.test.ts
@@ -5,23 +5,15 @@ import * as sessionTranscriptHit from "openclaw/plugin-sdk/session-transcript-hi
 import * as sessionVisibility from "openclaw/plugin-sdk/session-visibility";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { filterMemorySearchHitsBySessionVisibility } from "./session-search-visibility.js";
+import {
+  searchHit,
+  sessionEntry,
+  type TestSessionEntry,
+} from "./session-search-visibility.test-support.js";
 import { asOpenClawConfig } from "./tools.test-helpers.js";
 
-type TestSessionEntry = {
-  sessionId: string;
-  updatedAt: number;
-  sessionFile: string;
-  chatType?: "direct" | "group" | "channel";
-  delivery?: ReturnType<typeof normalizeSessionDeliveryState>;
-  origin?: { chatType?: "direct" | "group" | "channel" };
-};
-
 const crossAgentStore: Record<string, TestSessionEntry> = {
-  "agent:peer:only": {
-    sessionId: "w1",
-    updatedAt: 1,
-    sessionFile: "/tmp/sessions/w1.jsonl",
-  },
+  "agent:peer:only": sessionEntry("w1", 1, "/tmp/sessions/w1.jsonl"),
 };
 let combinedSessionStore: Record<string, TestSessionEntry> = crossAgentStore;
 
@@ -45,16 +37,7 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
   });
 
   it("drops sessions-sourced hits when requester key is missing (fail closed)", async () => {
-    const hits: MemorySearchResult[] = [
-      {
-        path: "sessions/u1.jsonl",
-        source: "sessions",
-        score: 1,
-        snippet: "x",
-        startLine: 1,
-        endLine: 2,
-      },
-    ];
+    const hits: MemorySearchResult[] = [searchHit("sessions/u1.jsonl", "sessions", "x")];
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "all" } } }),
       requesterSessionKey: undefined,
@@ -68,16 +51,7 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     "does not load session history for memory-only hits with recall corpus %s",
     async (corpus) => {
       const guard = vi.spyOn(sessionVisibility, "createSessionVisibilityGuard");
-      const hits: MemorySearchResult[] = [
-        {
-          path: "memory/foo.md",
-          source: "memory",
-          score: 1,
-          snippet: "x",
-          startLine: 1,
-          endLine: 2,
-        },
-      ];
+      const hits: MemorySearchResult[] = [searchHit("memory/foo.md", "memory", "x")];
       const filtered = await filterMemorySearchHitsBySessionVisibility({
         cfg: asOpenClawConfig({ tools: { sessions: { visibility: "all" } } }),
         requesterSessionKey: "agent:main:main",
@@ -101,35 +75,26 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     "applies %s visibility to unrelated same-agent recall from a voice requester",
     async (visibility) => {
       combinedSessionStore = {
-        "agent:main:voice:15550001111": {
-          sessionId: "voice",
-          updatedAt: 2,
-          sessionFile: "/tmp/sessions/voice.jsonl",
+        "agent:main:voice:15550001111": sessionEntry("voice", 2, "/tmp/sessions/voice.jsonl", {
           chatType: "direct",
-        },
-        "agent:main:telegram:direct:owner": {
-          sessionId: "private",
-          updatedAt: 1,
-          sessionFile: "/tmp/sessions/private.jsonl",
-          chatType: "direct",
-        },
+        }),
+        "agent:main:telegram:direct:owner": sessionEntry(
+          "private",
+          1,
+          "/tmp/sessions/private.jsonl",
+          { chatType: "direct" },
+        ),
       };
-      const memoryHit: MemorySearchResult = {
-        path: "memory/allowed.md",
-        source: "memory",
-        score: 1,
-        snippet: "Visible memory",
-        startLine: 1,
-        endLine: 2,
-      };
-      const sessionHit: MemorySearchResult = {
-        path: "sessions/private.jsonl",
-        source: "sessions",
-        score: 1,
-        snippet: "Private session secret",
-        startLine: 1,
-        endLine: 2,
-      };
+      const memoryHit: MemorySearchResult = searchHit(
+        "memory/allowed.md",
+        "memory",
+        "Visible memory",
+      );
+      const sessionHit: MemorySearchResult = searchHit(
+        "sessions/private.jsonl",
+        "sessions",
+        "Private session secret",
+      );
 
       const filtered = await filterMemorySearchHitsBySessionVisibility({
         cfg: asOpenClawConfig({ tools: { sessions: { visibility } } }),
@@ -145,27 +110,17 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("allows another same-agent private transcript through trusted conversation recall", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:webchat:direct:owner": sessionEntry("past", 1, "/tmp/sessions/past.jsonl", {
         chatType: "direct",
-      },
-      "agent:main:webchat:direct:owner": {
-        sessionId: "past",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/past.jsonl",
-        chatType: "direct",
-      },
+      }),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/past.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/past.jsonl", "sessions", "private context");
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: "agent:main:telegram:direct:owner",
@@ -184,27 +139,21 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
   it("allows an agent-scoped builtin hit for an Active Memory private requester", async () => {
     const anchorSessionKey = "agent:qa:qa-channel:direct:dm:remember-target";
     combinedSessionStore = {
-      [anchorSessionKey]: {
-        sessionId: "target-id",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/target-id.jsonl",
+      [anchorSessionKey]: sessionEntry("target-id", 2, "/tmp/sessions/target-id.jsonl", {
         chatType: "direct",
-      },
-      "agent:qa:qa-channel:direct:dm:remember-source": {
-        sessionId: "source-id",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/source-id.jsonl",
-        chatType: "direct",
-      },
+      }),
+      "agent:qa:qa-channel:direct:dm:remember-source": sessionEntry(
+        "source-id",
+        1,
+        "/tmp/sessions/source-id.jsonl",
+        { chatType: "direct" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/qa/source-id.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/qa/source-id.jsonl",
+      "sessions",
+      "private context",
+    );
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
@@ -225,38 +174,34 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
   it("allows recognized explicit private sessions with persisted direct metadata", async () => {
     const anchorSessionKey = "agent:main:explicit:laptop";
     combinedSessionStore = {
-      [anchorSessionKey]: {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      [anchorSessionKey]: sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
         delivery: normalizeSessionDeliveryState({
           context: { channel: "discord", to: "user:current" },
           origin: { provider: "discord", chatType: "direct", to: "user:current" },
         }),
-      },
-      "agent:main:explicit:phone:group:shadow": {
-        sessionId: "explicit-private",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/explicit-private.jsonl",
-        chatType: "direct",
-        delivery: normalizeSessionDeliveryState({
-          context: { channel: "discord", to: "user:explicit-private" },
-          origin: {
-            provider: "discord",
-            chatType: "direct",
-            to: "user:explicit-private",
-          },
-        }),
-      },
+      }),
+      "agent:main:explicit:phone:group:shadow": sessionEntry(
+        "explicit-private",
+        1,
+        "/tmp/sessions/explicit-private.jsonl",
+        {
+          chatType: "direct",
+          delivery: normalizeSessionDeliveryState({
+            context: { channel: "discord", to: "user:explicit-private" },
+            origin: {
+              provider: "discord",
+              chatType: "direct",
+              to: "user:explicit-private",
+            },
+          }),
+        },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/explicit-private.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/explicit-private.jsonl",
+      "sessions",
+      "private context",
+    );
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: `${anchorSessionKey}:active-memory:123456abcdef`,
@@ -274,33 +219,27 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies recall when the anchor transcript also has a shared group alias", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
-      "agent:main:telegram:group:team": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:telegram:group:team": sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
         chatType: "group",
-      },
-      "agent:main:qa-channel:direct:dm:friend": {
-        sessionId: "other-private",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/other-private.jsonl",
-        chatType: "direct",
-      },
+      }),
+      "agent:main:qa-channel:direct:dm:friend": sessionEntry(
+        "other-private",
+        1,
+        "/tmp/sessions/other-private.jsonl",
+        { chatType: "direct" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/main/current.jsonl.reset.2026-08-11T08-00-00.000Z",
-      source: "sessions",
-      score: 1,
-      snippet: "prior private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/main/current.jsonl.reset.2026-08-11T08-00-00.000Z",
+      "sessions",
+      "prior private context",
+    );
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: "agent:main:telegram:direct:owner",
@@ -318,27 +257,21 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies the shared global session as a recall source despite direct metadata", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      global: sessionEntry("global-shared", 1, "/tmp/sessions/global-shared.jsonl", {
         chatType: "direct",
-      },
-      global: {
-        sessionId: "global-shared",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/global-shared.jsonl",
-        chatType: "direct",
-      },
+      }),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/global-shared.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "shared global context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/global-shared.jsonl",
+      "sessions",
+      "shared global context",
+    );
     const cfg = asOpenClawConfig({
       session: { scope: "global" },
       tools: { sessions: { visibility: "self" } },
@@ -361,27 +294,21 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies recall anchored in the shared global session despite direct metadata", async () => {
     combinedSessionStore = {
-      "agent:main:global": {
-        sessionId: "global-shared",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/global-shared.jsonl",
+      "agent:main:global": sessionEntry("global-shared", 2, "/tmp/sessions/global-shared.jsonl", {
         chatType: "direct",
-      },
-      "agent:main:qa-channel:direct:dm:friend": {
-        sessionId: "other-private",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/other-private.jsonl",
-        chatType: "direct",
-      },
+      }),
+      "agent:main:qa-channel:direct:dm:friend": sessionEntry(
+        "other-private",
+        1,
+        "/tmp/sessions/other-private.jsonl",
+        { chatType: "direct" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/other-private.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/other-private.jsonl",
+      "sessions",
+      "private context",
+    );
     const cfg = asOpenClawConfig({
       session: { scope: "global" },
       tools: { sessions: { visibility: "self" } },
@@ -404,26 +331,23 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies a metadata-less generated explicit model-run transcript", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
-      "agent:main:explicit:model-run-probe": {
-        sessionId: "model-run-probe",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/model-run-probe.jsonl",
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:explicit:model-run-probe": sessionEntry(
+        "model-run-probe",
+        1,
+        "/tmp/sessions/model-run-probe.jsonl",
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/model-run-probe.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "internal model probe",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/model-run-probe.jsonl",
+      "sessions",
+      "internal model probe",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "self" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -451,27 +375,20 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     "denies another agent's $name private transcript during trusted conversation recall",
     async ({ path }) => {
       combinedSessionStore = {
-        "agent:main:telegram:direct:owner": {
-          sessionId: "current",
-          updatedAt: 2,
-          sessionFile: "/tmp/sessions/current.jsonl",
-          chatType: "direct",
-        },
-        "agent:peer:telegram:direct:owner": {
-          sessionId: "peer-private",
-          updatedAt: 1,
-          sessionFile: "/tmp/sessions/peer-private.jsonl",
-          chatType: "direct",
-        },
+        "agent:main:telegram:direct:owner": sessionEntry(
+          "current",
+          2,
+          "/tmp/sessions/current.jsonl",
+          { chatType: "direct" },
+        ),
+        "agent:peer:telegram:direct:owner": sessionEntry(
+          "peer-private",
+          1,
+          "/tmp/sessions/peer-private.jsonl",
+          { chatType: "direct" },
+        ),
       };
-      const hit: MemorySearchResult = {
-        path,
-        source: "sessions",
-        score: 1,
-        snippet: "other agent context",
-        startLine: 1,
-        endLine: 2,
-      };
+      const hit: MemorySearchResult = searchHit(path, "sessions", "other agent context");
       const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
 
       const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -492,26 +409,20 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies persisted Active Memory helper transcripts under explicit sessions", async () => {
     combinedSessionStore = {
-      "agent:main:explicit:laptop": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      "agent:main:explicit:laptop": sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
         chatType: "direct",
-      },
-      "agent:main:explicit:laptop:active-memory:abcdef123456": {
-        sessionId: "helper",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/helper.jsonl",
-      },
+      }),
+      "agent:main:explicit:laptop:active-memory:abcdef123456": sessionEntry(
+        "helper",
+        1,
+        "/tmp/sessions/helper.jsonl",
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/helper.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "internal helper transcript",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/helper.jsonl",
+      "sessions",
+      "internal helper transcript",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -531,21 +442,18 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("excludes the anchor transcript from trusted conversation recall", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/current.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "already in context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/current.jsonl",
+      "sessions",
+      "already in context",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -565,27 +473,24 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("excludes the anchor transcript when another private key aliases the same session", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
-      "agent:main:explicit:legacy-owner-alias": {
-        sessionId: "current",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:explicit:legacy-owner-alias": sessionEntry(
+        "current",
+        1,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/current.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "already in context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/current.jsonl",
+      "sessions",
+      "already in context",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -609,27 +514,24 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     { name: "unknown", chatType: undefined },
   ])("denies $name transcript hits from trusted conversation recall", async ({ chatType }) => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
-      [chatType ? "agent:main:telegram:group:family" : "agent:main:unknown-surface"]: {
-        sessionId: "candidate",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/candidate.jsonl",
-        ...(chatType ? { chatType } : {}),
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      [chatType ? "agent:main:telegram:group:family" : "agent:main:unknown-surface"]: sessionEntry(
+        "candidate",
+        1,
+        "/tmp/sessions/candidate.jsonl",
+        chatType ? { chatType } : {},
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/candidate.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "not private",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/candidate.jsonl",
+      "sessions",
+      "not private",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -649,33 +551,30 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("rejects a transcript when one alias is private and another alias is shared", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 3,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
-      "agent:main:telegram:direct:private-alias": {
-        sessionId: "candidate",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/candidate.jsonl",
-        chatType: "direct",
-      },
-      "agent:main:telegram:group:shared-alias": {
-        sessionId: "candidate",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/candidate.jsonl",
-        chatType: "group",
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        3,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:telegram:direct:private-alias": sessionEntry(
+        "candidate",
+        2,
+        "/tmp/sessions/candidate.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:telegram:group:shared-alias": sessionEntry(
+        "candidate",
+        1,
+        "/tmp/sessions/candidate.jsonl",
+        { chatType: "group" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/candidate.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "shared transcript",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/candidate.jsonl",
+      "sessions",
+      "shared transcript",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -695,26 +594,19 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies a metadata-less main transcript during trusted conversation recall", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
-      "agent:main:main": {
-        sessionId: "ambiguous-main",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/ambiguous-main.jsonl",
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
+      "agent:main:main": sessionEntry("ambiguous-main", 1, "/tmp/sessions/ambiguous-main.jsonl"),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/ambiguous-main.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "unknown conversation kind",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit(
+      "sessions/ambiguous-main.jsonl",
+      "sessions",
+      "unknown conversation kind",
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -734,27 +626,14 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("rejects a synthetic recall requester that does not start with the anchor key", async () => {
     combinedSessionStore = {
-      "agent:main:main": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
+      "agent:main:main": sessionEntry("current", 2, "/tmp/sessions/current.jsonl", {
         chatType: "direct",
-      },
-      "agent:main:webchat:direct:owner": {
-        sessionId: "past",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/past.jsonl",
+      }),
+      "agent:main:webchat:direct:owner": sessionEntry("past", 1, "/tmp/sessions/past.jsonl", {
         chatType: "direct",
-      },
+      }),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/past.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/past.jsonl", "sessions", "private context");
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -774,27 +653,17 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("denies trusted conversation recall when the anchor is shared, mismatched, or sandboxed", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:group:family": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "group",
-      },
-      "agent:main:webchat:direct:owner": {
-        sessionId: "past",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/past.jsonl",
+      "agent:main:telegram:group:family": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "group" },
+      ),
+      "agent:main:webchat:direct:owner": sessionEntry("past", 1, "/tmp/sessions/past.jsonl", {
         chatType: "direct",
-      },
+      }),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/past.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "private context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/past.jsonl", "sessions", "private context");
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "self" } } });
     const conversationRecall = {
       anchorSessionKey: "agent:main:telegram:group:family",
@@ -833,22 +702,17 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("preserves ordinary memory while denying unauthorized configured transcript recall", async () => {
     combinedSessionStore = {};
-    const memoryHit: MemorySearchResult = {
-      path: "MEMORY.md",
-      source: "memory",
-      score: 1,
-      snippet: "shared workspace memory",
-      startLine: 1,
-      endLine: 2,
-    };
-    const sessionHit: MemorySearchResult = {
-      path: "sessions/private.jsonl",
-      source: "sessions",
-      score: 0.9,
-      snippet: "private transcript",
-      startLine: 1,
-      endLine: 2,
-    };
+    const memoryHit: MemorySearchResult = searchHit(
+      "MEMORY.md",
+      "memory",
+      "shared workspace memory",
+    );
+    const sessionHit: MemorySearchResult = searchHit(
+      "sessions/private.jsonl",
+      "sessions",
+      "private transcript",
+      { score: 0.9 },
+    );
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -868,21 +732,14 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("restricts trusted sessions-only recall to transcript hits", async () => {
     combinedSessionStore = {
-      "agent:main:telegram:direct:owner": {
-        sessionId: "current",
-        updatedAt: 2,
-        sessionFile: "/tmp/sessions/current.jsonl",
-        chatType: "direct",
-      },
+      "agent:main:telegram:direct:owner": sessionEntry(
+        "current",
+        2,
+        "/tmp/sessions/current.jsonl",
+        { chatType: "direct" },
+      ),
     };
-    const hit: MemorySearchResult = {
-      path: "memory/private.md",
-      source: "memory",
-      score: 1,
-      snippet: "workspace memory",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("memory/private.md", "memory", "workspace memory");
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } });
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
@@ -903,22 +760,8 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
   it("loads the combined session store once per filter pass", async () => {
     const cfg = asOpenClawConfig({ tools: { sessions: { visibility: "all" } } });
     const hits: MemorySearchResult[] = [
-      {
-        path: "sessions/w1.jsonl",
-        source: "sessions",
-        score: 1,
-        snippet: "a",
-        startLine: 1,
-        endLine: 2,
-      },
-      {
-        path: "sessions/w1.jsonl",
-        source: "sessions",
-        score: 0.9,
-        snippet: "b",
-        startLine: 1,
-        endLine: 2,
-      },
+      searchHit("sessions/w1.jsonl", "sessions", "a"),
+      searchHit("sessions/w1.jsonl", "sessions", "b", { score: 0.9 }),
     ];
     await filterMemorySearchHitsBySessionVisibility({
       cfg,
@@ -939,21 +782,11 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
     "applies canonical-main tree visibility with sandboxed=$sandboxed",
     async ({ sandboxed, visible }) => {
       combinedSessionStore = {
-        "agent:main:slack:channel:team": {
-          sessionId: "team",
-          updatedAt: 1,
-          sessionFile: "/tmp/sessions/team.jsonl",
+        "agent:main:slack:channel:team": sessionEntry("team", 1, "/tmp/sessions/team.jsonl", {
           chatType: "channel",
-        },
+        }),
       };
-      const hit: MemorySearchResult = {
-        path: "sessions/team.jsonl",
-        source: "sessions",
-        score: 1,
-        snippet: "team context",
-        startLine: 1,
-        endLine: 2,
-      };
+      const hit: MemorySearchResult = searchHit("sessions/team.jsonl", "sessions", "team context");
 
       const filtered = await filterMemorySearchHitsBySessionVisibility({
         cfg: asOpenClawConfig({
@@ -971,21 +804,11 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("applies canonical global-main tree visibility in an explicit fleet", async () => {
     combinedSessionStore = {
-      "agent:main:slack:channel:team": {
-        sessionId: "team",
-        updatedAt: 1,
-        sessionFile: "/tmp/sessions/team.jsonl",
+      "agent:main:slack:channel:team": sessionEntry("team", 1, "/tmp/sessions/team.jsonl", {
         chatType: "channel",
-      },
+      }),
     };
-    const hit: MemorySearchResult = {
-      path: "sessions/team.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "team context",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/team.jsonl", "sessions", "team context");
 
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({
@@ -1008,14 +831,7 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("keeps same-agent live orphan transcript hits", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/main/live-orphan.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/main/live-orphan.jsonl", "sessions", "x");
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "agent" } } }),
       requesterSessionKey: "agent:main:main",
@@ -1027,14 +843,7 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("drops cross-agent live orphan transcript hits", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/peer/live-orphan.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/peer/live-orphan.jsonl", "sessions", "x");
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({
         tools: {
@@ -1051,14 +860,7 @@ describe("filterMemorySearchHitsBySessionVisibility", () => {
 
   it("does not treat a same-agent orphan filename as proven self-session lineage", async () => {
     combinedSessionStore = {};
-    const hit: MemorySearchResult = {
-      path: "sessions/main/main.jsonl",
-      source: "sessions",
-      score: 1,
-      snippet: "x",
-      startLine: 1,
-      endLine: 2,
-    };
+    const hit: MemorySearchResult = searchHit("sessions/main/main.jsonl", "sessions", "x");
     const filtered = await filterMemorySearchHitsBySessionVisibility({
       cfg: asOpenClawConfig({ tools: { sessions: { visibility: "self" } } }),
       requesterSessionKey: "agent:main:main",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three Memory Core visibility suites repeat session-entry and search-hit construction across otherwise distinct privacy and recall scenarios, adding fixture maintenance without independent behavioral proof.

## Why This Change Was Made

Use two neutral plugin-local constructors for 50 session entries and 46 search hits. Keep identity, timestamp, locator, path, source and snippet explicit. Preserve optional metadata exactly as supplied and retain score/range overrides. Visibility, authorization, requester, sandbox and recall configuration stay in each case.

## User Impact

No production behavior changes or scenarios removed. Sparse legacy metadata, conflicting aliases, SQLite/archive locators, non-default scores and reset-cutoff ranges remain covered. Net 289 test/support lines removed: tests -318, support +29.

## Evidence

All 58 fully expanded test identities match baseline and pass. A structural verifier expands the actual helper definitions back into the tests and confirms all 96 migrated fixture expressions and the remaining test program match the originals, ignoring only imports and the moved type declarations.

The final changed gate, formatting/diff checks, deslop and independent P2 review pass. An initial redundant-spread lint finding was fixed and all proof refreshed. Recorded wrapper times were 27.92s before and 7.57s after; transform/import warming dominates, so no attributable runtime reduction is claimed.
