### PR TITLE
fix(ui): avoid refetching unrelated catalog hosts

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-state.ts
+++ b/ui/src/components/app-sidebar-session-catalog-state.ts
@@ -113,6 +113,7 @@ export async function refetchExpandedSessionCatalogPages(params: {
                 {
                   agentId: params.agentId,
                   catalogId: catalog.id,
+                  hostIds: [host.hostId],
                   cursors: { [host.hostId]: nextCursor },
                 },
               );

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -276,6 +276,7 @@ export async function loadMoreSessionCatalog(
     const result = await client.request<SessionsCatalogListResult>("sessions.catalog.list", {
       agentId,
       catalogId,
+      hostIds: Object.keys(cursors),
       cursors,
     });
     if (!isCurrentSessionCatalogRequest(owner, catalogId, client, generation, revision)) {

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -495,6 +495,10 @@ suite.define(() => {
   it("auto-loads older chat without moving the viewport and disables paired-node continuation", async () => {
     const page = await suite.browser.newPage();
     await page.clock.install();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+      : undefined;
     const catalogResponse = (threadId: string, name: string, nextCursor?: string) => ({
       catalogs: [
         {
@@ -525,6 +529,22 @@ suite.define(() => {
         },
       ],
     });
+    const firstCatalogPage = catalogResponse(
+      "remote-thread",
+      "Remote architecture review",
+      "catalog-page-2",
+    );
+    const firstHost = firstCatalogPage.catalogs[0]!.hosts[0]!;
+    firstCatalogPage.catalogs[0]!.hosts.push({
+      ...firstHost,
+      hostId: "node:exhausted",
+      nodeId: "exhausted",
+      label: "Exhausted host",
+      nextCursor: undefined,
+      sessions: [
+        { ...firstHost.sessions[0]!, threadId: "retained-thread", name: "Retained remote session" },
+      ],
+    });
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.catalog.list"],
       methodResponses: {
@@ -540,11 +560,7 @@ suite.define(() => {
             },
             {
               match: {},
-              response: catalogResponse(
-                "remote-thread",
-                "Remote architecture review",
-                "catalog-page-2",
-              ),
+              response: firstCatalogPage,
             },
           ],
         },
@@ -581,11 +597,27 @@ suite.define(() => {
     await page.goto(`${suite.server.baseUrl}chat`);
     await expandCodingSection(page);
     const catalog = page.locator('[data-session-section="catalog:claude"]');
+    await catalog.getByRole("link", { name: "Retained remote session", exact: true }).waitFor();
+    const initialCatalogRequest = (await gateway.getRequests("sessions.catalog.list"))[0]?.params;
+    expect(initialCatalogRequest).toMatchObject({ agentId: "main", limitPerHost: 40 });
+    expect(initialCatalogRequest).not.toHaveProperty("hostIds");
+    if (artifactDir) {
+      await page.screenshot({ path: path.join(artifactDir, "catalog-initial-discovery.png") });
+    }
     await page.locator('[data-session-catalog-load-more="claude"]').click();
     await catalog.getByRole("link", { name: "Older remote review", exact: true }).waitFor();
+    await catalog.getByRole("link", { name: "Retained remote session", exact: true }).waitFor();
+    if (artifactDir) {
+      await page.screenshot({ path: path.join(artifactDir, "catalog-after-pagination.png") });
+      await writeFile(
+        path.join(artifactDir, "catalog-pagination-requests.json"),
+        JSON.stringify(await gateway.getRequests("sessions.catalog.list"), null, 2),
+      );
+    }
     expect((await gateway.getRequests("sessions.catalog.list")).at(-1)?.params).toEqual({
       agentId: "main",
       catalogId: "claude",
+      hostIds: ["node:devbox"],
       cursors: { "node:devbox": "catalog-page-2" },
     });
     const catalogRequestCount = (await gateway.getRequests("sessions.catalog.list")).length;
@@ -597,6 +629,24 @@ suite.define(() => {
     await expect
       .poll(async () => (await gateway.getRequests("sessions.catalog.list")).length)
       .toBeGreaterThanOrEqual(catalogRequestCount + 1);
+    const catalogPageMatch = {
+      catalogId: "claude",
+      cursors: { "node:devbox": "catalog-page-2" },
+    };
+    await expect
+      .poll(
+        async () => (await gateway.getRequests("sessions.catalog.list", catalogPageMatch)).length,
+      )
+      .toBeGreaterThanOrEqual(2);
+    for (const request of await gateway.getRequests("sessions.catalog.list", catalogPageMatch)) {
+      expect(request.params).toEqual({
+        agentId: "main",
+        catalogId: "claude",
+        hostIds: ["node:devbox"],
+        cursors: { "node:devbox": "catalog-page-2" },
+      });
+    }
+    await catalog.getByRole("link", { name: "Retained remote session", exact: true }).waitFor();
     await catalog.getByRole("link", { name: "Older remote review", exact: true }).waitFor();
     const remote = catalog.getByRole("link", { name: /^Remote architecture review$/ });
     await remote.hover();
@@ -652,10 +702,6 @@ suite.define(() => {
     await expect
       .poll(() => page.getByText("This session is on a paired device and is view-only.").count())
       .toBe(1);
-    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    const artifactDir = artifactRoot
-      ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
-      : undefined;
     const expectCenteredLayout = async (screenshotName: string) => {
       const [workbenchBox, threadBox, composerBox] = await Promise.all([
         catalogPane.locator(".chat-workbench").boundingBox(),

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -5,6 +5,10 @@ import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  hostGroupedNativeCatalogs,
+  resumableClaudeCatalog,
+} from "./claude-sessions.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureTopVisibleVirtualRow,
@@ -20,80 +24,6 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
-
-function resumableClaudeCatalog() {
-  return {
-    catalogs: [
-      {
-        id: "claude",
-        label: "Claude Code",
-        capabilities: { continueSession: true, archive: false },
-        hosts: [
-          {
-            hostId: "gateway:local",
-            label: "Local Mac",
-            kind: "local",
-            connected: true,
-            sessions: [
-              {
-                threadId: "claude-terminal-session",
-                name: "Native Claude terminal",
-                status: "stored",
-                source: "claude-cli",
-                archived: false,
-                canContinue: true,
-                canArchive: false,
-                canOpenTerminal: true,
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  };
-}
-
-function hostGroupedNativeCatalogs() {
-  const catalog = (id: "claude" | "codex", label: string) => ({
-    id,
-    label,
-    capabilities: { continueSession: true, archive: false },
-    hosts: [
-      {
-        hostId: "gateway:local",
-        label: "Gateway Mac",
-        kind: "gateway",
-        connected: true,
-        sessions: [
-          {
-            threadId: `${id}-local`,
-            name: `${label} local plan`,
-            status: "stored",
-            canContinue: true,
-            canArchive: false,
-          },
-        ],
-      },
-      {
-        hostId: "node:build",
-        label: "Build Node",
-        kind: "node",
-        connected: true,
-        nodeId: "build",
-        sessions: [
-          {
-            threadId: `${id}-remote`,
-            name: `${label} remote review`,
-            status: "stored",
-            canContinue: false,
-            canArchive: false,
-          },
-        ],
-      },
-    ],
-  });
-  return { catalogs: [catalog("claude", "Claude Code"), catalog("codex", "Codex")] };
-}
 
 async function catalogHeaderAffordances(header: Locator) {
   return header.evaluate((element) => {

--- a/ui/src/e2e/claude-sessions.test-support.ts
+++ b/ui/src/e2e/claude-sessions.test-support.ts
@@ -1,0 +1,73 @@
+export function resumableClaudeCatalog() {
+  return {
+    catalogs: [
+      {
+        id: "claude",
+        label: "Claude Code",
+        capabilities: { continueSession: true, archive: false },
+        hosts: [
+          {
+            hostId: "gateway:local",
+            label: "Local Mac",
+            kind: "local",
+            connected: true,
+            sessions: [
+              {
+                threadId: "claude-terminal-session",
+                name: "Native Claude terminal",
+                status: "stored",
+                source: "claude-cli",
+                archived: false,
+                canContinue: true,
+                canArchive: false,
+                canOpenTerminal: true,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function hostGroupedNativeCatalogs() {
+  const catalog = (id: "claude" | "codex", label: string) => ({
+    id,
+    label,
+    capabilities: { continueSession: true, archive: false },
+    hosts: [
+      {
+        hostId: "gateway:local",
+        label: "Gateway Mac",
+        kind: "gateway",
+        connected: true,
+        sessions: [
+          {
+            threadId: `${id}-local`,
+            name: `${label} local plan`,
+            status: "stored",
+            canContinue: true,
+            canArchive: false,
+          },
+        ],
+      },
+      {
+        hostId: "node:build",
+        label: "Build Node",
+        kind: "node",
+        connected: true,
+        nodeId: "build",
+        sessions: [
+          {
+            threadId: `${id}-remote`,
+            name: `${label} remote review`,
+            status: "stored",
+            canContinue: false,
+            canArchive: false,
+          },
+        ],
+      },
+    ],
+  });
+  return { catalogs: [catalog("claude", "Claude Code"), catalog("codex", "Codex")] };
+}

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-compat.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-compat.ts
@@ -274,6 +274,7 @@ describe("AppSidebar session catalog pagination", () => {
       expect(request).toHaveBeenNthCalledWith(3, "sessions.catalog.list", {
         agentId: "main",
         catalogId: "codex",
+        hostIds: ["gateway:local"],
         cursors: { "gateway:local": "page-2" },
       });
       expect(section()?.querySelector('[data-session-catalog-error="codex"]')).toBeNull();

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-page-hosts.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-page-hosts.ts
@@ -1,0 +1,205 @@
+import { expect, it, vi } from "vitest";
+import type {
+  SessionCatalogHost,
+  SessionsCatalogHostEvent,
+  SessionsCatalogListResult,
+} from "../../../../packages/gateway-protocol/src/index.ts";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
+import {
+  catalogPage,
+  createGatewayHarness,
+  createSessions,
+  deferred,
+  mountSidebar,
+} from "../app-sidebar.ts";
+
+export function registerCatalogPageHostTests() {
+  it("pages only cursor hosts and preserves exhausted hosts through the next poll refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      const exhaustedHost: SessionCatalogHost = {
+        ...catalogPage([{ threadId: "exhausted", name: "Retained remote session" }]).catalogs[0]!
+          .hosts[0]!,
+        hostId: "node:exhausted",
+        label: "Exhausted host",
+        kind: "node",
+        connected: false,
+        error: { code: "NODE_OFFLINE", message: "Remote host unavailable" },
+      };
+      const firstPage = catalogPage([{ threadId: "thread-1", name: "Newest" }], "page-2");
+      const refreshedFirstPage = catalogPage(
+        [{ threadId: "thread-1", name: "Newest refreshed" }],
+        "page-2",
+      );
+      for (const page of [firstPage, refreshedFirstPage]) {
+        page.catalogs[0]!.hosts.push(exhaustedHost);
+      }
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(
+          catalogPage([{ threadId: "thread-2", name: "Stale title" }], "page-3"),
+        )
+        .mockResolvedValueOnce(refreshedFirstPage)
+        .mockResolvedValueOnce(
+          catalogPage([{ threadId: "thread-2", name: "Current title" }], "page-3"),
+        )
+        .mockResolvedValueOnce(catalogPage([{ threadId: "thread-3", name: "Oldest" }]));
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      const catalogRows = () =>
+        sidebar.querySelectorAll('[data-session-section="catalog:codex"] [data-session-key]');
+      const loadMore = () =>
+        sidebar.querySelector<HTMLButtonElement>('[data-session-catalog-load-more="codex"]');
+      const retainedHost = () =>
+        sidebar.sessionData.sessionCatalogs[0]?.hosts.find(
+          (host) => host.hostId === exhaustedHost.hostId,
+        );
+      expect(request).toHaveBeenNthCalledWith(1, "sessions.catalog.list", {
+        agentId: "main",
+        limitPerHost: 40,
+        progressId: expect.any(String),
+      });
+      expect(catalogRows()).toHaveLength(2);
+      loadMore()?.click();
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(request).toHaveBeenNthCalledWith(2, "sessions.catalog.list", {
+        agentId: "main",
+        catalogId: "codex",
+        hostIds: ["gateway:local"],
+        cursors: { "gateway:local": "page-2" },
+      });
+      expect(catalogRows()).toHaveLength(3);
+      expect(sidebar.textContent).toContain("Stale title");
+      expect(sidebar.textContent).toContain("Retained remote session");
+      expect(retainedHost()).toEqual(exhaustedHost);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await sidebar.updateComplete;
+      expect(request).toHaveBeenNthCalledWith(3, "sessions.catalog.list", {
+        agentId: "main",
+        limitPerHost: 40,
+        progressId: expect.any(String),
+      });
+      expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
+        agentId: "main",
+        catalogId: "codex",
+        hostIds: ["gateway:local"],
+        cursors: { "gateway:local": "page-2" },
+      });
+      expect(catalogRows()).toHaveLength(3);
+      expect(sidebar.textContent).toContain("Newest refreshed");
+      expect(sidebar.textContent).toContain("Current title");
+      expect(sidebar.textContent).not.toContain("Stale title");
+      expect(retainedHost()).toEqual(exhaustedHost);
+
+      loadMore()?.click();
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+      expect(request).toHaveBeenNthCalledWith(5, "sessions.catalog.list", {
+        agentId: "main",
+        catalogId: "codex",
+        hostIds: ["gateway:local"],
+        cursors: { "gateway:local": "page-3" },
+      });
+      expect(catalogRows()).toHaveLength(4);
+      expect(sidebar.textContent).toContain("Oldest");
+      expect(retainedHost()).toEqual(exhaustedHost);
+      expect(loadMore()).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps a progressive host update that arrives during expanded-page refetch", async () => {
+    vi.useFakeTimers();
+    try {
+      const pageOne = catalogPage([{ threadId: "thread-1", name: "Newest" }], "page-2");
+      const pageTwo = catalogPage([{ threadId: "thread-2", name: "Older" }]);
+      const pendingRefetch = deferred<SessionsCatalogListResult>();
+      const request = vi
+        .fn()
+        .mockResolvedValueOnce(pageOne)
+        .mockResolvedValueOnce(pageTwo)
+        .mockResolvedValueOnce(pageOne)
+        .mockReturnValueOnce(pendingRefetch.promise)
+        .mockResolvedValue(pageOne);
+      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+      gateway.publish({
+        hello: {
+          features: { methods: ["sessions.catalog.list"] },
+        } as ApplicationGatewaySnapshot["hello"],
+      });
+      const { sidebar } = await mountSidebar(
+        gateway.gateway,
+        createSessions("main", ["agent:main:main"]),
+      );
+      sidebar.connected = true;
+      await sidebar.updateComplete;
+      await vi.advanceTimersByTimeAsync(0);
+
+      sidebar.querySelector<HTMLButtonElement>('[data-session-catalog-load-more="codex"]')?.click();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(request).toHaveBeenCalledTimes(4);
+
+      const progressId = (request.mock.calls[2]?.[1] as { progressId?: string })?.progressId;
+      const catalog = pageOne.catalogs[0];
+      const host = catalog?.hosts[0];
+      if (!progressId || !catalog || !host) {
+        throw new Error("expanded progressive fixture is incomplete");
+      }
+      const progressiveHost = { ...host, hostId: "gateway:progressive" };
+      gateway.publishEvent("sessions.catalog.host", {
+        progressId,
+        agentId: "main",
+        catalog: {
+          ...catalog,
+          hosts: [progressiveHost],
+        },
+      } satisfies SessionsCatalogHostEvent);
+      await sidebar.updateComplete;
+      expect(
+        sidebar.querySelector('[data-session-catalog-host="gateway:progressive"]'),
+      ).not.toBeNull();
+
+      pendingRefetch.resolve(pageTwo);
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+
+      expect(
+        sidebar.querySelector('[data-session-catalog-host="gateway:progressive"]'),
+      ).not.toBeNull();
+      expect(request).toHaveBeenCalledTimes(4);
+      expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
+        agentId: "main",
+        catalogId: "codex",
+        hostIds: ["gateway:local"],
+        cursors: { "gateway:local": "page-2" },
+      });
+      expect(
+        sidebar.sessionData.sessionCatalogs[0]?.hosts.find(
+          (candidate) => candidate.hostId === progressiveHost.hostId,
+        ),
+      ).toEqual(progressiveHost);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+}

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
+  SessionCatalogHost,
   SessionsCatalogHostEvent,
   SessionsCatalogListResult,
 } from "../../../../packages/gateway-protocol/src/index.ts";
@@ -288,18 +289,33 @@ describe("AppSidebar session catalog pagination", () => {
     },
   );
 
-  it("appends host pages and keeps them through the next poll refresh", async () => {
+  it("pages only cursor hosts and preserves exhausted hosts through the next poll refresh", async () => {
     vi.useFakeTimers();
     try {
+      const exhaustedHost: SessionCatalogHost = {
+        ...catalogPage([{ threadId: "exhausted", name: "Retained remote session" }]).catalogs[0]!
+          .hosts[0]!,
+        hostId: "node:exhausted",
+        label: "Exhausted host",
+        kind: "node",
+        connected: false,
+        error: { code: "NODE_OFFLINE", message: "Remote host unavailable" },
+      };
+      const firstPage = catalogPage([{ threadId: "thread-1", name: "Newest" }], "page-2");
+      const refreshedFirstPage = catalogPage(
+        [{ threadId: "thread-1", name: "Newest refreshed" }],
+        "page-2",
+      );
+      for (const page of [firstPage, refreshedFirstPage]) {
+        page.catalogs[0]!.hosts.push(exhaustedHost);
+      }
       const request = vi
         .fn()
-        .mockResolvedValueOnce(catalogPage([{ threadId: "thread-1", name: "Newest" }], "page-2"))
+        .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(
           catalogPage([{ threadId: "thread-2", name: "Stale title" }], "page-3"),
         )
-        .mockResolvedValueOnce(
-          catalogPage([{ threadId: "thread-1", name: "Newest refreshed" }], "page-2"),
-        )
+        .mockResolvedValueOnce(refreshedFirstPage)
         .mockResolvedValueOnce(
           catalogPage([{ threadId: "thread-2", name: "Current title" }], "page-3"),
         )
@@ -323,7 +339,16 @@ describe("AppSidebar session catalog pagination", () => {
         sidebar.querySelectorAll('[data-session-section="catalog:codex"] [data-session-key]');
       const loadMore = () =>
         sidebar.querySelector<HTMLButtonElement>('[data-session-catalog-load-more="codex"]');
-      expect(catalogRows()).toHaveLength(1);
+      const retainedHost = () =>
+        sidebar.sessionData.sessionCatalogs[0]?.hosts.find(
+          (host) => host.hostId === exhaustedHost.hostId,
+        );
+      expect(request).toHaveBeenNthCalledWith(1, "sessions.catalog.list", {
+        agentId: "main",
+        limitPerHost: 40,
+        progressId: expect.any(String),
+      });
+      expect(catalogRows()).toHaveLength(2);
       loadMore()?.click();
       await vi.advanceTimersByTimeAsync(0);
       await sidebar.updateComplete;
@@ -331,10 +356,13 @@ describe("AppSidebar session catalog pagination", () => {
       expect(request).toHaveBeenNthCalledWith(2, "sessions.catalog.list", {
         agentId: "main",
         catalogId: "codex",
+        hostIds: ["gateway:local"],
         cursors: { "gateway:local": "page-2" },
       });
-      expect(catalogRows()).toHaveLength(2);
+      expect(catalogRows()).toHaveLength(3);
       expect(sidebar.textContent).toContain("Stale title");
+      expect(sidebar.textContent).toContain("Retained remote session");
+      expect(retainedHost()).toEqual(exhaustedHost);
 
       await vi.advanceTimersByTimeAsync(30_000);
       await sidebar.updateComplete;
@@ -346,12 +374,14 @@ describe("AppSidebar session catalog pagination", () => {
       expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
         agentId: "main",
         catalogId: "codex",
+        hostIds: ["gateway:local"],
         cursors: { "gateway:local": "page-2" },
       });
-      expect(catalogRows()).toHaveLength(2);
+      expect(catalogRows()).toHaveLength(3);
       expect(sidebar.textContent).toContain("Newest refreshed");
       expect(sidebar.textContent).toContain("Current title");
       expect(sidebar.textContent).not.toContain("Stale title");
+      expect(retainedHost()).toEqual(exhaustedHost);
 
       loadMore()?.click();
       await vi.advanceTimersByTimeAsync(0);
@@ -359,10 +389,12 @@ describe("AppSidebar session catalog pagination", () => {
       expect(request).toHaveBeenNthCalledWith(5, "sessions.catalog.list", {
         agentId: "main",
         catalogId: "codex",
+        hostIds: ["gateway:local"],
         cursors: { "gateway:local": "page-3" },
       });
-      expect(catalogRows()).toHaveLength(3);
+      expect(catalogRows()).toHaveLength(4);
       expect(sidebar.textContent).toContain("Oldest");
+      expect(retainedHost()).toEqual(exhaustedHost);
       expect(loadMore()).toBeNull();
     } finally {
       vi.useRealTimers();
@@ -407,12 +439,13 @@ describe("AppSidebar session catalog pagination", () => {
       if (!progressId || !catalog || !host) {
         throw new Error("expanded progressive fixture is incomplete");
       }
+      const progressiveHost = { ...host, hostId: "gateway:progressive" };
       gateway.publishEvent("sessions.catalog.host", {
         progressId,
         agentId: "main",
         catalog: {
           ...catalog,
-          hosts: [{ ...host, hostId: "gateway:progressive" }],
+          hosts: [progressiveHost],
         },
       } satisfies SessionsCatalogHostEvent);
       await sidebar.updateComplete;
@@ -428,6 +461,17 @@ describe("AppSidebar session catalog pagination", () => {
         sidebar.querySelector('[data-session-catalog-host="gateway:progressive"]'),
       ).not.toBeNull();
       expect(request).toHaveBeenCalledTimes(4);
+      expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
+        agentId: "main",
+        catalogId: "codex",
+        hostIds: ["gateway:local"],
+        cursors: { "gateway:local": "page-2" },
+      });
+      expect(
+        sidebar.sessionData.sessionCatalogs[0]?.hosts.find(
+          (candidate) => candidate.hostId === progressiveHost.hostId,
+        ),
+      ).toEqual(progressiveHost);
     } finally {
       vi.useRealTimers();
     }
@@ -481,6 +525,7 @@ describe("AppSidebar session catalog pagination", () => {
       expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
         agentId: "main",
         catalogId: "codex",
+        hostIds: ["gateway:local"],
         cursors: { "gateway:local": "replacement-page" },
       });
       expect(sidebar.textContent).toContain("Replacement");

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-pages.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import type {
-  SessionCatalogHost,
-  SessionsCatalogHostEvent,
-  SessionsCatalogListResult,
-} from "../../../../packages/gateway-protocol/src/index.ts";
+import type { SessionsCatalogListResult } from "../../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import {
@@ -15,6 +11,7 @@ import {
   mountSidebar,
   TWO_AGENTS,
 } from "../app-sidebar.ts";
+import { registerCatalogPageHostTests } from "./catalog-page-hosts.ts";
 import "../../components/app-sidebar.ts";
 
 describe("AppSidebar session catalog pagination", () => {
@@ -289,193 +286,7 @@ describe("AppSidebar session catalog pagination", () => {
     },
   );
 
-  it("pages only cursor hosts and preserves exhausted hosts through the next poll refresh", async () => {
-    vi.useFakeTimers();
-    try {
-      const exhaustedHost: SessionCatalogHost = {
-        ...catalogPage([{ threadId: "exhausted", name: "Retained remote session" }]).catalogs[0]!
-          .hosts[0]!,
-        hostId: "node:exhausted",
-        label: "Exhausted host",
-        kind: "node",
-        connected: false,
-        error: { code: "NODE_OFFLINE", message: "Remote host unavailable" },
-      };
-      const firstPage = catalogPage([{ threadId: "thread-1", name: "Newest" }], "page-2");
-      const refreshedFirstPage = catalogPage(
-        [{ threadId: "thread-1", name: "Newest refreshed" }],
-        "page-2",
-      );
-      for (const page of [firstPage, refreshedFirstPage]) {
-        page.catalogs[0]!.hosts.push(exhaustedHost);
-      }
-      const request = vi
-        .fn()
-        .mockResolvedValueOnce(firstPage)
-        .mockResolvedValueOnce(
-          catalogPage([{ threadId: "thread-2", name: "Stale title" }], "page-3"),
-        )
-        .mockResolvedValueOnce(refreshedFirstPage)
-        .mockResolvedValueOnce(
-          catalogPage([{ threadId: "thread-2", name: "Current title" }], "page-3"),
-        )
-        .mockResolvedValueOnce(catalogPage([{ threadId: "thread-3", name: "Oldest" }]));
-      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
-      gateway.publish({
-        hello: {
-          features: { methods: ["sessions.catalog.list"] },
-        } as ApplicationGatewaySnapshot["hello"],
-      });
-      const { sidebar } = await mountSidebar(
-        gateway.gateway,
-        createSessions("main", ["agent:main:main"]),
-      );
-      sidebar.connected = true;
-      await sidebar.updateComplete;
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-
-      const catalogRows = () =>
-        sidebar.querySelectorAll('[data-session-section="catalog:codex"] [data-session-key]');
-      const loadMore = () =>
-        sidebar.querySelector<HTMLButtonElement>('[data-session-catalog-load-more="codex"]');
-      const retainedHost = () =>
-        sidebar.sessionData.sessionCatalogs[0]?.hosts.find(
-          (host) => host.hostId === exhaustedHost.hostId,
-        );
-      expect(request).toHaveBeenNthCalledWith(1, "sessions.catalog.list", {
-        agentId: "main",
-        limitPerHost: 40,
-        progressId: expect.any(String),
-      });
-      expect(catalogRows()).toHaveLength(2);
-      loadMore()?.click();
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-
-      expect(request).toHaveBeenNthCalledWith(2, "sessions.catalog.list", {
-        agentId: "main",
-        catalogId: "codex",
-        hostIds: ["gateway:local"],
-        cursors: { "gateway:local": "page-2" },
-      });
-      expect(catalogRows()).toHaveLength(3);
-      expect(sidebar.textContent).toContain("Stale title");
-      expect(sidebar.textContent).toContain("Retained remote session");
-      expect(retainedHost()).toEqual(exhaustedHost);
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      await sidebar.updateComplete;
-      expect(request).toHaveBeenNthCalledWith(3, "sessions.catalog.list", {
-        agentId: "main",
-        limitPerHost: 40,
-        progressId: expect.any(String),
-      });
-      expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
-        agentId: "main",
-        catalogId: "codex",
-        hostIds: ["gateway:local"],
-        cursors: { "gateway:local": "page-2" },
-      });
-      expect(catalogRows()).toHaveLength(3);
-      expect(sidebar.textContent).toContain("Newest refreshed");
-      expect(sidebar.textContent).toContain("Current title");
-      expect(sidebar.textContent).not.toContain("Stale title");
-      expect(retainedHost()).toEqual(exhaustedHost);
-
-      loadMore()?.click();
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-      expect(request).toHaveBeenNthCalledWith(5, "sessions.catalog.list", {
-        agentId: "main",
-        catalogId: "codex",
-        hostIds: ["gateway:local"],
-        cursors: { "gateway:local": "page-3" },
-      });
-      expect(catalogRows()).toHaveLength(4);
-      expect(sidebar.textContent).toContain("Oldest");
-      expect(retainedHost()).toEqual(exhaustedHost);
-      expect(loadMore()).toBeNull();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it("keeps a progressive host update that arrives during expanded-page refetch", async () => {
-    vi.useFakeTimers();
-    try {
-      const pageOne = catalogPage([{ threadId: "thread-1", name: "Newest" }], "page-2");
-      const pageTwo = catalogPage([{ threadId: "thread-2", name: "Older" }]);
-      const pendingRefetch = deferred<SessionsCatalogListResult>();
-      const request = vi
-        .fn()
-        .mockResolvedValueOnce(pageOne)
-        .mockResolvedValueOnce(pageTwo)
-        .mockResolvedValueOnce(pageOne)
-        .mockReturnValueOnce(pendingRefetch.promise)
-        .mockResolvedValue(pageOne);
-      const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
-      gateway.publish({
-        hello: {
-          features: { methods: ["sessions.catalog.list"] },
-        } as ApplicationGatewaySnapshot["hello"],
-      });
-      const { sidebar } = await mountSidebar(
-        gateway.gateway,
-        createSessions("main", ["agent:main:main"]),
-      );
-      sidebar.connected = true;
-      await sidebar.updateComplete;
-      await vi.advanceTimersByTimeAsync(0);
-
-      sidebar.querySelector<HTMLButtonElement>('[data-session-catalog-load-more="codex"]')?.click();
-      await vi.advanceTimersByTimeAsync(0);
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(request).toHaveBeenCalledTimes(4);
-
-      const progressId = (request.mock.calls[2]?.[1] as { progressId?: string })?.progressId;
-      const catalog = pageOne.catalogs[0];
-      const host = catalog?.hosts[0];
-      if (!progressId || !catalog || !host) {
-        throw new Error("expanded progressive fixture is incomplete");
-      }
-      const progressiveHost = { ...host, hostId: "gateway:progressive" };
-      gateway.publishEvent("sessions.catalog.host", {
-        progressId,
-        agentId: "main",
-        catalog: {
-          ...catalog,
-          hosts: [progressiveHost],
-        },
-      } satisfies SessionsCatalogHostEvent);
-      await sidebar.updateComplete;
-      expect(
-        sidebar.querySelector('[data-session-catalog-host="gateway:progressive"]'),
-      ).not.toBeNull();
-
-      pendingRefetch.resolve(pageTwo);
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-
-      expect(
-        sidebar.querySelector('[data-session-catalog-host="gateway:progressive"]'),
-      ).not.toBeNull();
-      expect(request).toHaveBeenCalledTimes(4);
-      expect(request).toHaveBeenNthCalledWith(4, "sessions.catalog.list", {
-        agentId: "main",
-        catalogId: "codex",
-        hostIds: ["gateway:local"],
-        cursors: { "gateway:local": "page-2" },
-      });
-      expect(
-        sidebar.sessionData.sessionCatalogs[0]?.hosts.find(
-          (candidate) => candidate.hostId === progressiveHost.hostId,
-        ),
-      ).toEqual(progressiveHost);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+  registerCatalogPageHostTests();
 
   it("discards a load-more response after a poll replaces its cursor", async () => {
     vi.useFakeTimers();


### PR DESCRIPTION
## What Problem This Solves

Loading more catalog sessions, or refreshing an expanded catalog, also queried unrelated hosts whose results the sidebar discarded. A slow unrelated host could delay pagination.

## Why This Change Was Made

Both continuation callers now pass the existing `hostIds` filter for the cursors they consume. Initial discovery still lists all hosts, and page sizes, provider behavior, authorization, and caching remain unchanged.

The test cleanup moves existing host cases and pure browser fixtures into test-support modules, preserving assertions, execution order, and browser ownership while keeping the files within lint limits.

## User Impact

Catalog pagination avoids unnecessary host enumeration while retaining other hosts’ rows, cursors, errors, and progressive updates.

## Evidence

Validated exact head `578ab3dd986e4a05f316f2adfa0daa62df31721c` against baseline `e915ac8ec5be772f0b566ab4560f21618910b264` in isolated Linux checkouts with the same pinned dependencies:

- Baseline with the new coverage: four component assertions and one compiled-browser assertion fail solely because `hostIds` is absent.
- Candidate: all **333 sidebar cases and seven compiled-browser cases pass**, with no skips. Coverage includes initial all-host discovery, manual pagination, expanded-page replay, retained exhausted/offline hosts, progressive updates, and transcript scrolling.
- Complete seven-file changed gate passes, including core/UI types, guards, formatting, lint, dead-export checks, and Stylelint. Source checks and all owned command groups close cleanly.
- Fresh independent P0–P2 review found no actionable issues. [Exact-head CI is green](https://github.com/openclaw/openclaw/actions/runs/34005848817), including all seven UI E2E shards.

The screenshots below use synthetic data and show the paged and exhausted hosts retained in both versions. The browser request capture confirms continuation now includes `hostIds: ["node:devbox"]`; initial discovery remains unscoped. Browser proof uses a mock Gateway transport with the real compiled UI. No measured production speedup is claimed.

Production change: two request fields; no new protocol, configuration, dependency, or persistence surface.

![Before the fix: paged and exhausted host rows remain visible](https://github.com/user-attachments/assets/f099644b-0032-41d6-9975-356762c83ca3)

![After the fix: the same paged and exhausted host rows remain visible](https://github.com/user-attachments/assets/8a9dbd72-30d0-4fcf-9ebc-34df6af3b3c5)