### PR TITLE
refactor(models): share selector reference traversal

### DIFF
--- a/packages/model-catalog-core/src/configured-model-refs.test.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.test.ts
@@ -9,12 +9,21 @@ import {
 describe("configured model refs", () => {
   it("lists raw refs from one model selector without normalizing them", () => {
     expect(listModelRefsFromConfigValue("  openai/gpt-5.5  ")).toEqual(["  openai/gpt-5.5  "]);
-    expect(
-      listModelRefsFromConfigValue({
-        primary: " primary/model ",
-        fallbacks: ["", "fallback/model", 42, "fallback/model"],
-      }),
-    ).toEqual([" primary/model ", "", "fallback/model", "fallback/model"]);
+    const selector = Object.freeze({
+      primary: " primary/model ",
+      fallbacks: Object.freeze(["", "fallback/model", 42, "fallback/model"]),
+    });
+    expect(listModelRefsFromConfigValue(selector)).toEqual([
+      " primary/model ",
+      "",
+      "fallback/model",
+      "fallback/model",
+    ]);
+    expect(collectConfiguredModelRefs({ agents: { defaults: { model: selector } } })).toEqual([
+      { path: "agents.defaults.model.primary", value: "primary/model" },
+      { path: "agents.defaults.model.fallbacks.1", value: "fallback/model" },
+      { path: "agents.defaults.model.fallbacks.3", value: "fallback/model" },
+    ]);
     expect(listModelRefsFromConfigValue(["openai/gpt-5.5"])).toEqual([]);
     expect(listModelRefsFromConfigValue({ primary: 42, fallbacks: "openai/gpt-5.5" })).toEqual([]);
   });

--- a/packages/model-catalog-core/src/configured-model-refs.ts
+++ b/packages/model-catalog-core/src/configured-model-refs.ts
@@ -16,25 +16,35 @@ export const AGENT_MODEL_CONFIG_KEYS = [
   "pdfModel",
 ] as const;
 
-/** List raw refs from one string or primary/fallback model selector. */
-export function listModelRefsFromConfigValue(value: unknown): string[] {
+/** Visit raw selector refs without changing values, order, or fallback indices. */
+export function visitModelSelectorRefs(
+  value: unknown,
+  path: string,
+  visit: (path: string, value: string, role: "primary" | "fallback") => void,
+): void {
   if (typeof value === "string") {
-    return [value];
+    visit(path, value, "primary");
+    return;
   }
   if (!isRecord(value)) {
-    return [];
+    return;
   }
-  const refs: string[] = [];
   if (typeof value.primary === "string") {
-    refs.push(value.primary);
+    visit(`${path}.primary`, value.primary, "primary");
   }
   if (Array.isArray(value.fallbacks)) {
-    for (const fallback of value.fallbacks) {
+    for (const [index, fallback] of value.fallbacks.entries()) {
       if (typeof fallback === "string") {
-        refs.push(fallback);
+        visit(`${path}.fallbacks.${index}`, fallback, "fallback");
       }
     }
   }
+}
+
+/** List raw refs from one string or primary/fallback model selector. */
+export function listModelRefsFromConfigValue(value: unknown): string[] {
+  const refs: string[] = [];
+  visitModelSelectorRefs(value, "", (_path, ref) => refs.push(ref));
   return refs;
 }
 
@@ -49,21 +59,8 @@ export function collectConfiguredModelRefs(
       refs.push({ path, value: value.trim() });
     }
   };
-  const collectModelConfig = (path: string, value: unknown) => {
-    if (typeof value === "string") {
-      pushModelRef(path, value);
-      return;
-    }
-    if (!isRecord(value)) {
-      return;
-    }
-    pushModelRef(`${path}.primary`, value.primary);
-    if (Array.isArray(value.fallbacks)) {
-      for (const [index, entry] of value.fallbacks.entries()) {
-        pushModelRef(`${path}.fallbacks.${index}`, entry);
-      }
-    }
-  };
+  const collectModelConfig = (path: string, value: unknown) =>
+    visitModelSelectorRefs(value, path, pushModelRef);
   const collectFromAgent = (path: string, agent: unknown, includeEntrySelectors = false) => {
     if (!isRecord(agent)) {
       return;

--- a/src/commands/doctor/shared/codex-route-model-slots.ts
+++ b/src/commands/doctor/shared/codex-route-model-slots.ts
@@ -1,3 +1,7 @@
+import {
+  listModelRefsFromConfigValue,
+  visitModelSelectorRefs,
+} from "@openclaw/model-catalog-core/configured-model-refs";
 import { asOptionalRecord as asMutableRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalLowercaseString as normalizeString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -42,19 +46,17 @@ export function collectStringModelSlot(params: {
   value: unknown;
   runtime?: string;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
-}): boolean {
+}): void {
   if (typeof params.value !== "string") {
-    return false;
+    return;
   }
-  return Boolean(
-    recordCodexModelHit({
-      hits: params.hits,
-      path: params.path,
-      model: params.value.trim(),
-      runtime: params.runtime,
-      blockedModelIdentities: params.blockedModelIdentities,
-    }),
-  );
+  recordCodexModelHit({
+    hits: params.hits,
+    path: params.path,
+    model: params.value.trim(),
+    runtime: params.runtime,
+    blockedModelIdentities: params.blockedModelIdentities,
+  });
 }
 
 export function collectModelConfigSlot(params: {
@@ -63,49 +65,19 @@ export function collectModelConfigSlot(params: {
   value: unknown;
   runtime?: string;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
-}): boolean {
-  if (typeof params.value === "string") {
-    return collectStringModelSlot(params);
-  }
-  const record = asMutableRecord(params.value);
-  if (!record) {
-    return false;
-  }
-  const rewrotePrimary = collectStringModelSlot({
-    hits: params.hits,
-    path: `${params.path}.primary`,
-    value: record.primary,
-    runtime: params.runtime,
-    blockedModelIdentities: params.blockedModelIdentities,
+}): void {
+  visitModelSelectorRefs(params.value, params.path, (path, value, role) => {
+    collectStringModelSlot({
+      ...params,
+      path,
+      value,
+      runtime: role === "primary" ? params.runtime : undefined,
+    });
   });
-  if (Array.isArray(record.fallbacks)) {
-    for (const [index, entry] of record.fallbacks.entries()) {
-      collectStringModelSlot({
-        hits: params.hits,
-        path: `${params.path}.fallbacks.${index}`,
-        value: entry,
-        blockedModelIdentities: params.blockedModelIdentities,
-      });
-    }
-  }
-  return rewrotePrimary;
 }
 
 export function modelConfigContainsRef(value: unknown, modelRef: string): boolean {
-  if (typeof value === "string") {
-    return value.trim() === modelRef;
-  }
-  const record = asMutableRecord(value);
-  if (!record) {
-    return false;
-  }
-  if (typeof record.primary === "string" && record.primary.trim() === modelRef) {
-    return true;
-  }
-  return (
-    Array.isArray(record.fallbacks) &&
-    record.fallbacks.some((entry) => typeof entry === "string" && entry.trim() === modelRef)
-  );
+  return listModelRefsFromConfigValue(value).some((ref) => ref.trim() === modelRef);
 }
 
 export function collectModelConfigRefs(params: {
@@ -113,24 +85,9 @@ export function collectModelConfigRefs(params: {
   path: string;
   value: unknown;
 }): void {
-  if (typeof params.value === "string") {
-    collectStringModelConfigRef(params);
-    return;
-  }
-  const record = asMutableRecord(params.value);
-  if (!record) {
-    return;
-  }
-  if (typeof record.primary === "string" && record.primary.trim()) {
-    params.refs.push({ path: `${params.path}.primary`, modelRef: record.primary.trim() });
-  }
-  if (Array.isArray(record.fallbacks)) {
-    for (const [index, entry] of record.fallbacks.entries()) {
-      if (typeof entry === "string" && entry.trim()) {
-        params.refs.push({ path: `${params.path}.fallbacks.${index}`, modelRef: entry.trim() });
-      }
-    }
-  }
+  visitModelSelectorRefs(params.value, params.path, (path, value) =>
+    collectStringModelConfigRef({ ...params, path, value }),
+  );
 }
 
 export function collectStringModelConfigRef(params: {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested follow-up to #139523. Five readers repeated the scalar/primary/fallback traversal for model selectors. Keeping those copies aligned made model discovery and Doctor repair harder to maintain.

## Why This Change Was Made

One read-only visitor in the private model-catalog package now owns selector traversal. Callers retain their field inventories, trimming rules and primary-only runtime attribution. The cleanup also removes unused boolean bookkeeping from Doctor collectors. Existing mutation helpers keep their current behavior and ownership.

## User Impact

No behavior change intended. Raw values, blank and duplicate ordering, original fallback indices, model inventories and migration behavior are preserved. No operator configuration, provider policy, stored representation, schema, protocol or dependency change.

## Evidence

- Current-main owner/sibling run: 252 tests across five files passed through `node scripts/run-vitest.mjs`. Coverage includes model-catalog readers, Doctor warnings/migrations, startup providers and harness routing.
- The existing selector fixture is frozen and now checks both raw output and trimmed collector paths with blank/non-string index gaps and duplicates.
- Full local changed-file gate passed. Final branch autoreview at `ac0fe5a99108ffe0216f9cbc655bcc3afb6d5817` is scoped-clean P0–P2.
- Patch-identical rebase onto the existing CI repair #139576; 155 post-rebase tests passed (19 selector, 132 Doctor, four inventory guards). The initial CI failure came from the inherited suppression in #139483; no inventory exception was added.
- Exact-head CI: [34003001204](https://github.com/openclaw/openclaw/actions/runs/34003001204), **GREEN**.
- First follow-up Blacksmith Testbox run [34002124939](https://github.com/openclaw/openclaw/actions/runs/34002124939) passed at `5ef586738dcd386c387e2a5ed9e78b841f448e57`: two baseline HTTP400 calls, two guarded failures with zero inference requests, typed history/actionable notices, persisted Doctor clear, and success on the unchanged default. Lease stopped.
- Fresh exact-head Blacksmith Testbox [34002934680](https://github.com/openclaw/openclaw/actions/runs/34002934680), lease `tbx_01m1t3xamzynmp61kddhz8eddv`, passed on verified source `ac0fe5a99108ffe0216f9cbc655bcc3afb6d5817`. Candidate and baseline full builds passed; source/tree identities were verified before and after execution. The native run exited 0. A later portal synchronization timeout did not affect the command or verdict.
- ClawSweeper compatibility follow-through: this diff changes read traversal only. Mutation helpers, existing serialized references, schema and persistence owners are unchanged. The 132 Doctor cases cover migration/pin/inheritance behavior, and the Gateway proof exercises repair persistence and restart. No data-model migration or operator action is added.
- Real ChatGPT-account proof was unavailable during the parent fix because the existing CI token needed refresh; no authenticated provider request is claimed. Shared notice rendering is covered by the real Gateway with a synthetic capture channel; no Telegram adapter changed.

`git diff --numstat`: production **+45/−91 (net −46)**; tests **+15/−6 (net +9)**. Three files, no generated or dependency changes.


Final live-proof transcript (synthetic HTTP provider and capture channel, real public CLI and isolated Gateway; free ports and task-owned state):

```text
source: ac0fe5a99108ffe0216f9cbc655bcc3afb6d5817
baseline: 3383007573b010e3fb1387315eebca2853c4bf78
provider: blacksmith-testbox
lease: tbx_01m1t3xamzynmp61kddhz8eddv
baseline cron run x2: HTTP 400, two inference requests
candidate cron run x2: model_not_found recorded, two remedy notices, zero inference requests
openclaw doctor --fix: retired override cleared; agent default unchanged
restart isolated Gateway; run same cron job: ok, OPENCLAW_RETIRED_MODEL_RECOVERED
source/tree identities after run: verified
native command exit: 0
```

```json
{"status":"pass","candidateSha":"ac0fe5a99108ffe0216f9cbc655bcc3afb6d5817","beforeProviderRequests":2,"guardedRuns":2,"guardedProviderRequests":0,"failureCode":"model_not_found","deliveredRemedyNotices":2,"overrideCleared":true,"agentDefaultUnchanged":true,"recoveredStatus":"ok","sourceIdentityVerifiedAfterRun":true}
```

This completes the requested separate refactor pass. No additional refactor is needed in these reader paths. Related bug/reporters remain credited in #139523 and #139235 (@alessi0p on X and Séraphin on Discord).
