### PR TITLE
test(gateway): observe native drain without a lint exception

### DIFF
--- a/src/gateway/server-held-work.test-support.ts
+++ b/src/gateway/server-held-work.test-support.ts
@@ -1,32 +1,12 @@
 import { setImmediate as nextTurn } from "node:timers/promises";
 import { expect, onTestFinished, vi } from "vitest";
 import { AsyncWorkScope } from "../shared/async-work-scope.js";
-import { createDeferredCore } from "../shared/deferred.js";
 
 /** Observe the exact work owner; connection scopes also join server-side transport release. */
 export async function observeHeldGatewayWorkDrain(getSignal?: () => AbortSignal | undefined) {
   const connections = new Set<symbol>();
-  const entered = createDeferredCore();
   let connectionSignal: AbortSignal | undefined;
-  let draining = false;
-  let drained = false;
-  const ready = () => {
-    if (draining && connections.size === 0) {
-      entered.resolve();
-    }
-  };
-  // oxlint-disable-next-line typescript/unbound-method -- Capture the native method before spying; every invocation binds its actual scope with .call(this).
-  const drain = AsyncWorkScope.prototype.drain;
   const observation = vi.spyOn(AsyncWorkScope.prototype, "drain");
-  observation.mockImplementation(async function (this: AsyncWorkScope) {
-    if (this.signal !== (getSignal ? getSignal() : connectionSignal)) {
-      return await drain.call(this);
-    }
-    draining = true;
-    ready();
-    await drain.call(this);
-    drained = true;
-  });
   onTestFinished(() => observation.mockRestore());
 
   if (!getSignal) {
@@ -47,7 +27,6 @@ export async function observeHeldGatewayWorkDrain(getSignal?: () => AbortSignal 
             return () => {
               release();
               connections.delete(key);
-              ready();
             };
           });
         onTestFinished(() => registration.mockRestore());
@@ -57,9 +36,28 @@ export async function observeHeldGatewayWorkDrain(getSignal?: () => AbortSignal 
   }
 
   return async (closing: Promise<unknown>) => {
-    await Promise.race([entered.promise, closing]);
+    let closed = false;
+    const onClosed = () => {
+      closed = true;
+    };
+    void closing.then(onClosed, onClosed);
+    let drainIndex = -1;
+    await vi.waitFor(
+      () => {
+        const signal = getSignal ? getSignal() : connectionSignal;
+        drainIndex = observation.mock.contexts.findIndex(
+          (scope) => scope instanceof AsyncWorkScope && scope.signal === signal,
+        );
+        expect(closed || (drainIndex >= 0 && connections.size === 0)).toBe(true);
+      },
+      { interval: 1, timeout: 10_000 },
+    );
     await nextTurn();
-    expect(draining, "Gateway close must enter the held work owner").toBe(true);
-    expect(drained, "Gateway work drain must remain pending while work is held").toBe(false);
+    expect(drainIndex, "Gateway close must enter the held work owner").toBeGreaterThanOrEqual(0);
+    expect(connections.size, "Gateway connections must release before held work").toBe(0);
+    expect(
+      observation.mock.settledResults[drainIndex]?.type,
+      "Gateway work drain must remain pending while work is held",
+    ).toBe("incomplete");
   };
 }


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The test helper introduced in #139483 uses an unbound-method lint suppression that the broader suppression-inventory check rejects. Local lifetime and changed-file checks had passed, so that validation gap was discovered in subsequent CI.

## Why This Change Was Made

Observe the native drain through a call-through spy instead of capturing and replacing its implementation. Select the exact owner by signal, wait for its drain and transport releases, and check the native promise remains pending while work is held. Stop waiting when close settles on either outcome. The bounded wait has no mandatory delay.

## User Impact

No production behavior changes. Lifetime coverage remains while the suppression disappears. The inventory/ratchet is unchanged; net two test-support lines removed.

## Evidence

All 15 lifetime tests and four unchanged suppression-inventory tests pass. A negative control omitting only the selected owner's join makes exactly five intended pending-drain checks fail, while the other ten cases pass. Final native code was restored and revalidated.

The full changed gate, including core test typing, dead-export scans and helper lint, passes. Deslop, diff check and independent P2 review pass. No new full-suite runtime claim.
