### PR TITLE
fix(qa): give hot-reload maintenance proofs their own budgets

### DIFF
--- a/extensions/discord/src/voice/voice-wav-lifetime.test.ts
+++ b/extensions/discord/src/voice/voice-wav-lifetime.test.ts
@@ -5,11 +5,29 @@ import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, vi } from "vitest";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
-const workspace = vi.hoisted(() => ({ rootDir: "" }));
-vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("openclaw/plugin-sdk/temp-path")>()),
-  resolvePreferredOpenClawTmpDir: () => workspace.rootDir,
+const workspace = vi.hoisted(() => ({
+  rootDir: "",
+  afterWrite: undefined as (() => Promise<void>) | undefined,
 }));
+vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/temp-path")>();
+  return {
+    ...actual,
+    resolvePreferredOpenClawTmpDir: () => workspace.rootDir,
+    // The receive owner must observe leave before its awaited WAV write returns.
+    tempWorkspace: async (options: Parameters<typeof actual.tempWorkspace>[0]) => {
+      const temporary = await actual.tempWorkspace(options);
+      return {
+        ...temporary,
+        write: async (...args: Parameters<typeof temporary.write>) => {
+          const filePath = await temporary.write(...args);
+          await workspace.afterWrite?.();
+          return filePath;
+        },
+      };
+    },
+  };
+});
 
 defineDiscordVoiceTests(
   ({
@@ -25,6 +43,7 @@ defineDiscordVoiceTests(
     loggerWarnMock,
   }) => {
     beforeEach(async () => {
+      workspace.afterWrite = undefined;
       workspace.rootDir = await fs.realpath(
         await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-voice-wav-lifetime-")),
       );
@@ -110,13 +129,9 @@ defineDiscordVoiceTests(
       } else if (reason === "short audio") {
         decodeOpusStreamMock.mockReset().mockResolvedValueOnce(Buffer.alloc(960));
       } else if (reason === "left during write") {
-        const audio = await import("./audio.js");
-        const writeWav = audio.writeVoiceWavFile;
-        vi.spyOn(audio, "writeVoiceWavFile").mockImplementationOnce(async (pcm) => {
-          const wav = await writeWav(pcm);
+        workspace.afterWrite = async () => {
           await f.manager.leave({ guildId: "g1" });
-          return wav;
-        });
+        };
       }
       try {
         await handleSpeakingStart(f.manager, f.entry, "guest");
@@ -127,6 +142,10 @@ defineDiscordVoiceTests(
             { guildId: "g1", channelId: "1001" },
             { transcripts: { sessionId: "replacement", onUtterance: vi.fn() } },
           );
+        }
+        if (reason === "left during write") {
+          expect(f.manager.status()).toEqual([]);
+          expect(await fs.readdir(workspace.rootDir)).toEqual([]);
         }
         blocked.resolve();
         await f.entry.processingQueue;

--- a/qa/scenarios/config/gateway-config-hot-reload-attachment-retention.yaml
+++ b/qa/scenarios/config/gateway-config-hot-reload-attachment-retention.yaml
@@ -1,0 +1,31 @@
+title: Gateway attachment retention hot reload
+scenario:
+  id: gateway-config-hot-reload-attachment-retention
+  surface: gateway
+  coverage:
+    primary:
+      - gateway.config-reload-hot-apply
+      - gateway.config-reload-hot-reload
+    secondary:
+      - gateway.config-reload-lifecycle
+  objective: Prove attachment retention adopts a changed TTL on real initial or hourly maintenance without restarting the Gateway.
+  successCriteria:
+    - The Gateway starts with a 24-hour attachment TTL, then commits a hot change to two hours.
+    - Real initial or hourly maintenance deletes the three-hour-old attachment and preserves the fresh control file.
+    - The original Gateway PID, boot identity, and authenticated WebSocket survive the complete observation.
+  plugins: [qa-lab]
+  docsRefs: [docs/gateway/configuration.md]
+  codeRefs:
+    - test/e2e/qa-lab/runtime/gateway-config-hot-reload-attachment-retention.ts
+    - test/e2e/qa-lab/runtime/gateway-config-hot-reload-retention.ts
+    - src/gateway/server-maintenance.ts
+  execution:
+    kind: script
+    parallelSafe: false
+    path: test/e2e/qa-lab/runtime/gateway-config-hot-reload-attachment-retention.ts
+    config:
+      requiredProviderMode: mock-openai
+    args: [--output-dir, "${outputDir}"]
+    # The retained proof allows 70 minutes for initial/hourly maintenance, plus setup and cleanup.
+    timeoutMs: 4500000
+    summary: Requires a disposable Testbox with OPENCLAW_TESTBOX=1. Owns a real Gateway and synthetic attachment files through initial or hourly maintenance; allow up to 75 minutes. Model upstream is synthetic.

--- a/qa/scenarios/config/gateway-config-hot-reload-tab-cleanup.yaml
+++ b/qa/scenarios/config/gateway-config-hot-reload-tab-cleanup.yaml
@@ -1,0 +1,32 @@
+title: Gateway tab cleanup hot reload
+scenario:
+  id: gateway-config-hot-reload-tab-cleanup
+  surface: gateway
+  coverage:
+    primary:
+      - gateway.config-reload-hot-apply
+      - gateway.config-reload-hot-reload
+    secondary:
+      - gateway.config-reload-lifecycle
+  objective: Prove browser tab cleanup adopts disabled, enabled, and disabled policy on the production five-minute cadence without replacing its Gateway or external Chromium owner.
+  successCriteria:
+    - Nine Browser-tool-owned tabs survive a complete disabled sweep window.
+    - Enabling cleanup removes exactly the oldest tracked tab at the production eight-tab cap.
+    - Disabling cleanup again preserves nine tracked tabs through another complete sweep window.
+    - All phases preserve the Gateway PID, boot identity, and original authenticated WebSocket.
+    - The external Chromium PID, CDP connection, and unowned witness page survive every phase.
+  plugins: [qa-lab, browser]
+  docsRefs: [docs/gateway/configuration.md, docs/tools/browser.md]
+  codeRefs:
+    - test/e2e/qa-lab/runtime/gateway-config-hot-reload-tab-cleanup.ts
+    - extensions/browser/src/browser/session-tab-cleanup.ts
+  execution:
+    kind: script
+    parallelSafe: false
+    path: test/e2e/qa-lab/runtime/gateway-config-hot-reload-tab-cleanup.ts
+    config:
+      requiredProviderMode: mock-openai
+    args: [--output-dir, "${outputDir}"]
+    # 305s + up to 330s + 305s observations, plus Gateway/browser startup and cleanup.
+    timeoutMs: 1200000
+    summary: Requires a disposable Linux Testbox with OPENCLAW_TESTBOX=1 and Playwright Chromium. Owns a real Gateway and external browser for three sequential production-cadence cleanup phases; allow up to 20 minutes. Provider and widget HTTP upstreams are synthetic.

--- a/qa/scenarios/config/gateway-config-hot-reload.yaml
+++ b/qa/scenarios/config/gateway-config-hot-reload.yaml
@@ -32,4 +32,4 @@ scenario:
       requiredProviderMode: mock-openai
     args: [--output-dir, "${outputDir}"]
     timeoutMs: 900000
-    summary: Requires a disposable Linux Testbox with OPENCLAW_TESTBOX=1, Chromium, Xvfb, and sudo sshd. Real Gateway and browser behavior; simulated provider, GitHub, favicon, APNs, and node upstreams.
+    summary: Requires a disposable Linux Testbox with OPENCLAW_TESTBOX=1, Chromium, Xvfb, sudo sshd, and avahi-browse with its daemon. Real Gateway and browser behavior; simulated provider, GitHub, favicon, APNs, and node upstreams.

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-attachment-retention.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-attachment-retention.ts
@@ -1,0 +1,164 @@
+// The initial/hourly maintenance owner needs its own real-time QA budget.
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  createQaGatewayChild,
+  startQaMockOpenAiServer,
+  type QaGatewayChild,
+} from "../../../../extensions/qa-lab/api.js";
+import { runQaGatewayFixture, stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import {
+  connectHotReloadClient,
+  type HotReloadConnection,
+} from "./gateway-config-hot-reload-fixtures.js";
+import { startHotReloadAttachmentRetention } from "./gateway-config-hot-reload-retention.js";
+import { createQaScriptEvidenceWriter } from "./script-evidence.js";
+
+const SCENARIO_ID = "gateway-config-hot-reload-attachment-retention";
+const SOURCE_PATH = "test/e2e/qa-lab/runtime/gateway-config-hot-reload-attachment-retention.ts";
+const MODEL = "mock-openai/gpt-5.6-luna";
+
+async function runProof(repoRoot: string, appendLog: (text: string) => void) {
+  const owner = createQaGatewayChild();
+  let mock: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
+  let gateway: QaGatewayChild | undefined;
+  let connection: HotReloadConnection | undefined;
+  let retention: Awaited<ReturnType<typeof startHotReloadAttachmentRetention>> | undefined;
+  const evidence: Array<Record<string, unknown>> = [];
+  await runQaGatewayFixture(
+    async () => {
+      assert.equal(
+        process.env.OPENCLAW_TESTBOX,
+        "1",
+        "Retention proof requires a disposable Testbox",
+      );
+      mock = await startQaMockOpenAiServer();
+      gateway = await owner.start({
+        repoRoot,
+        useRepoCli: true,
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: [path.join(repoRoot, "dist/index.js")],
+          cwd: repoRoot,
+          usePackagedPlugins: true,
+        },
+        providerMode: "mock-openai",
+        primaryModel: MODEL,
+        providerBaseUrl: `${mock.baseUrl}/v1`,
+        transportBaseUrl: mock.baseUrl,
+        controlUiEnabled: false,
+        mutateConfig: (cfg) => ({
+          ...cfg,
+          attachments: { ...cfg.attachments, ttlHours: 24 },
+          gateway: { ...cfg.gateway, reload: { mode: "hybrid" } },
+        }),
+      });
+      const activeGateway = gateway;
+      const primary = (connection = await connectHotReloadClient(activeGateway));
+      const pid = activeGateway.pid;
+      const bootId = primary.bootId;
+      assert(pid && bootId, "Gateway must expose its boot and process identities");
+      const rpc = <T>(method: string, params: unknown = {}) =>
+        primary.client.request<T>(method, params, { timeoutMs: 40_000 });
+      const patch = async (change: unknown) => {
+        const snapshot = await rpc<{ hash: string }>("config.get");
+        const result = await rpc<{
+          sentinel: { payload: { stats: { requiresRestart: boolean } } };
+        }>("config.patch", { baseHash: snapshot.hash, raw: JSON.stringify(change) });
+        assert.equal(result.sentinel.payload.stats.requiresRestart, false);
+      };
+      const started = Date.now();
+      retention = await startHotReloadAttachmentRetention({
+        gateway: activeGateway,
+        patch,
+        appendLog,
+        verifyContinuity: async (prefix, observation) => {
+          assert.equal(activeGateway.pid, pid);
+          assert.equal((await rpc<{ pid: number }>("system.info")).pid, pid);
+          assert.equal(primary.hellos, 1, "Persistent WebSocket reconnected");
+          assert.equal(primary.closes, 0, "Persistent WebSocket closed");
+          const fresh = await connectHotReloadClient(activeGateway);
+          try {
+            assert.equal(fresh.bootId, bootId, "Gateway restarted inside the same PID");
+          } finally {
+            await fresh.client.stopAndWait({ timeoutMs: 2_000 });
+          }
+          evidence.push({
+            prefix,
+            observation,
+            elapsedMs: Date.now() - started,
+            pid,
+            bootId,
+            socketHellos: primary.hellos,
+            socketCloses: primary.closes,
+          });
+          appendLog(`PASS ${prefix}: ${observation}\n`);
+        },
+      });
+      await retention.completion;
+    },
+    () => retention?.stop(),
+    () => {
+      if (gateway) {
+        appendLog(gateway.logs());
+      }
+    },
+    () => connection?.client.stopAndWait({ timeoutMs: 2_000 }),
+    () => stopQaGatewayFixture(owner),
+    () => mock?.stop(),
+  );
+  return evidence;
+}
+
+async function main() {
+  const repoRoot = process.cwd();
+  const argv = process.argv.slice(2);
+  assert(
+    argv.length === 2 && argv[0] === "--output-dir" && argv[1],
+    "Usage: --output-dir <artifact directory>",
+  );
+  const outputDir = path.resolve(repoRoot, argv[1]);
+  const writer = createQaScriptEvidenceWriter({
+    artifactBase: outputDir,
+    logFileName: `${SCENARIO_ID}.log`,
+    primaryModel: MODEL,
+    providerMode: "mock-openai",
+    repoRoot,
+    target: {
+      id: SCENARIO_ID,
+      title: "Gateway attachment retention hot reload",
+      sourcePath: SOURCE_PATH,
+      docsRefs: ["docs/gateway/configuration.md"],
+      codeRefs: [SOURCE_PATH, "src/gateway/server-maintenance.ts"],
+    },
+  });
+  const started = Date.now();
+  try {
+    const evidence = await runProof(repoRoot, (text) => writer.appendLog(text));
+    await fs.mkdir(outputDir, { recursive: true });
+    const summaryPath = path.join(outputDir, `${SCENARIO_ID}.json`);
+    await fs.writeFile(summaryPath, `${JSON.stringify(evidence, null, 2)}\n`);
+    await writer.write({
+      status: "pass",
+      durationMs: Date.now() - started,
+      details:
+        "TTL 24h→2h adopted by real initial/hourly maintenance: expired file removed and fresh file preserved on the original Gateway PID, boot and WebSocket",
+      artifacts: [{ kind: "summary", filePath: summaryPath }],
+    });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    writer.appendLog(details);
+    await writer.write({ status: "fail", durationMs: Date.now() - started, details });
+    process.stderr.write(writer.logText());
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-browser.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-browser.ts
@@ -69,7 +69,9 @@ export async function proveHotReloadBrowserSettings({
         (label) => document.title.endsWith(` · ${label}`),
         environment.label,
       );
-      assert.equal(await page.locator(".control-ui-environment-stripe").count(), 1);
+      const stripe = page.locator(".control-ui-environment-stripe");
+      await stripe.waitFor({ state: "visible" });
+      assert.equal(await stripe.count(), 1);
       await page.screenshot({ path: path.join(outputDir, `environment-${environment.color}.png`) });
     }
     await verifyContinuity(

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-pairing.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-pairing.ts
@@ -263,7 +263,6 @@ for (const signal of ["SIGTERM", "SIGINT"]) process.on(signal, () => child.kill(
     async run(params: {
       gateway: QaGatewayChild;
       operator: GatewayClient;
-      patchConfig: (change: unknown, replacePaths?: string[]) => Promise<unknown>;
       existingNode: HotReloadConnection;
     }): Promise<string> {
       const url = new URL(params.gateway.wsUrl);
@@ -275,12 +274,6 @@ for (const signal of ["SIGTERM", "SIGINT"]) process.on(signal, () => child.kill(
           path: path.join(temporaryRoot, "state", "openclaw.sqlite"),
           identityKey: `hot-reload-${randomUUID()}`,
         });
-      const patchPairing = (pairing: GatewayNodePairingConfig) =>
-        params.patchConfig({ gateway: { nodes: { pairing } } }, [
-          "gateway.nodes.pairing.autoApproveCidrs",
-          // Replacing the SSH policy with false removes its nested CIDRs too.
-          "gateway.nodes.pairing.sshVerify.cidrs",
-        ]);
       const list = () => params.operator.request<PairingList>("device.pair.list", {});
       const expectPending = async (device: DeviceIdentity) => {
         const result = await list();
@@ -326,6 +319,33 @@ for (const signal of ["SIGTERM", "SIGINT"]) process.on(signal, () => child.kill(
         await expectPending(device);
       };
       try {
+        // Unrelated umbrella writes must not spend the held SSH proof's deadline
+        // waiting for their config-write rate-limit window to reset.
+        const configConnection = await connectHotReloadClient(params.gateway);
+        connections.push(configConnection);
+        const patchPairing = async (pairing: GatewayNodePairingConfig) => {
+          const { hash } = await configConnection.client.request<{ hash: string }>(
+            "config.get",
+            {},
+            { timeoutMs: 40_000 },
+          );
+          const result = await configConnection.client.request<{
+            sentinel: { payload: { stats: { requiresRestart: boolean } } };
+          }>(
+            "config.patch",
+            {
+              baseHash: hash,
+              raw: JSON.stringify({ gateway: { nodes: { pairing } } }),
+              replacePaths: [
+                "gateway.nodes.pairing.autoApproveCidrs",
+                // Replacing the SSH policy with false removes its nested CIDRs too.
+                "gateway.nodes.pairing.sshVerify.cidrs",
+              ],
+            },
+            { timeoutMs: 40_000 },
+          );
+          assert.equal(result.sentinel.payload.stats.requiresRestart, false);
+        };
         await patchPairing({
           autoApproveLocal: false,
           autoApproveCidrs: [`${address}/32`],

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-plugin-policy.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-plugin-policy.ts
@@ -1,12 +1,9 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { setTimeout as delay } from "node:timers/promises";
 import type { QaGatewayChild } from "../../../../extensions/qa-lab/api.js";
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import { loadOrCreateDeviceIdentity } from "../../../../src/infra/device-identity.js";
-import { runQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
-import { createHotReloadExternalBrowser } from "./gateway-config-hot-reload-external-browser.js";
 import {
   connectHotReloadClient,
   waitForHotReloadFact,
@@ -19,13 +16,8 @@ type ToolResult = {
   details: { targetId?: string; viewerUrl?: string; ok?: boolean };
 };
 type BrowserStatus = { pid: number | null; cdpUrl: string; running: boolean; attachOnly: boolean };
-type BrowserTabs = { tabs: Array<{ targetId: string; url: string }> };
 const CANVAS_ASSET = "/__openclaw__/a2ui/a2ui.bundle.js";
 const SESSION_KEY = "agent:qa:hot-reload-plugin";
-// These are the shipped cleanup cadence and cap, observed through real elapsed time and tabs.
-const SWEEP_MS = 5 * 60_000;
-const TAB_CAP = 8;
-const CLEANUP_PROFILE = "cleanup-proof";
 
 export async function proveHotReloadPluginPolicy({
   gateway,
@@ -38,8 +30,6 @@ export async function proveHotReloadPluginPolicy({
   http,
   proveGroup,
   verifyContinuity,
-  appendLog,
-  signal,
 }: {
   gateway: QaGatewayChild;
   unaffectedNode: HotReloadConnection | undefined;
@@ -51,15 +41,9 @@ export async function proveHotReloadPluginPolicy({
   http: (route: string, body?: unknown) => Promise<{ status: number; text: string }>;
   proveGroup: (prefix: string, run: () => Promise<void>) => Promise<void>;
   verifyContinuity: (prefix: string, observation: string) => Promise<void>;
-  appendLog: (text: string) => void;
-  signal: AbortSignal;
 }) {
   const initial = (await rpc<{ config: OpenClawConfig }>("config.get")).config;
   const observations: Array<Record<string, unknown>> = [];
-  const log = (text: string) => {
-    appendLog(`${text}\n`);
-    process.stdout.write(`${text}\n`);
-  };
   const tool = async (name: string, args: unknown, sessionKey = SESSION_KEY) => {
     const response = await http("/tools/invoke", { tool: name, sessionKey, args });
     assert.equal(response.status, 200, response.text);
@@ -290,115 +274,6 @@ export async function proveHotReloadPluginPolicy({
           "browser.snapshotDefaults",
         ]);
       }
-    });
-
-    await proveGroup("browser.tabCleanup", async () => {
-      const externalOwner = createHotReloadExternalBrowser(temporaryRoot);
-      const opened: string[] = [];
-      const ownedTabs = async () => {
-        const { tabs } = await browserRequest<BrowserTabs>("/tabs", CLEANUP_PROFILE);
-        return tabs
-          .filter((tab) => opened.includes(tab.targetId))
-          .map((tab) => tab.targetId)
-          .toSorted();
-      };
-      const openTab = async () => {
-        const result = await browser({
-          profile: CLEANUP_PROFILE,
-          action: "open",
-          url: `${fixtureBaseUrl}/widget?cleanup-proof=${opened.length}`,
-        });
-        assert(result.details.targetId);
-        opened.push(result.details.targetId);
-      };
-      await runQaGatewayFixture(
-        async () => {
-          const external = await externalOwner.start();
-          // Managed opens have a separate eight-page cap. An attached profile isolates
-          // the periodic policy while the Browser tool still owns every tracked tab.
-          await patch({
-            browser: {
-              tabCleanup: { enabled: false },
-              profiles: { [CLEANUP_PROFILE]: { cdpUrl: external.cdpUrl, attachOnly: true } },
-            },
-          });
-          for (let index = 0; index <= TAB_CAP; index += 1) {
-            await openTab();
-          }
-          const status = await browserRequest<BrowserStatus>("/", CLEANUP_PROFILE);
-          assert(status.running && status.attachOnly);
-          assert.equal(status.pid, null, "Gateway must not own the external Chromium process");
-          const expectedRetained = opened.slice(1).toSorted();
-          for (const [phase, enabled] of [false, true, false].entries()) {
-            await patch({ browser: { tabCleanup: { enabled } } });
-            if (phase === 2) {
-              await openTab();
-            }
-            const expected =
-              phase === 1 ? expectedRetained : opened.slice(phase === 2 ? 1 : 0).toSorted();
-            const started = Date.now();
-            let nextLog = started;
-            let retained: string[] = [];
-            log(
-              `Browser tab cleanup phase ${phase + 1}: enabled=${enabled}, observing real five-minute sweep`,
-            );
-            while (Date.now() - started < SWEEP_MS + 30_000) {
-              signal.throwIfAborted();
-              retained = await ownedTabs();
-              await external.verifyAlive();
-              if (enabled && retained.length === TAB_CAP) {
-                break;
-              }
-              if (!enabled) {
-                assert.deepEqual(retained, expected, "Disabled cleanup removed a tracked tab");
-                if (Date.now() - started >= SWEEP_MS + 5_000) {
-                  break;
-                }
-              }
-              if (Date.now() >= nextLog) {
-                log(
-                  `Browser tab cleanup phase ${phase + 1}: ${retained.length} tracked tabs after ${Math.floor((Date.now() - started) / 1_000)}s`,
-                );
-                nextLog = Date.now() + 30_000;
-              }
-              await delay(5_000, undefined, { signal });
-            }
-            assert.deepEqual(retained, expected);
-            observations.push({
-              prefix: "browser.tabCleanup",
-              enabled,
-              elapsedMs: Date.now() - started,
-              trackedTabs: retained.length,
-              browserPid: external.pid,
-            });
-            await verifyContinuity(
-              "browser.tabCleanup",
-              `Real sweep phase ${phase + 1}: enabled=${enabled}, ${retained.length} tracked tabs retained after ${Math.floor((Date.now() - started) / 1_000)}s; external Chromium PID, CDP connection and unowned witness page unchanged`,
-            );
-          }
-        },
-        async () => {
-          if (opened.length) {
-            for (const targetId of await ownedTabs()) {
-              await browser({ action: "close", targetId, profile: CLEANUP_PROFILE });
-            }
-          }
-        },
-        async () => {
-          await patch(
-            {
-              browser: {
-                tabCleanup: initial.browser?.tabCleanup ?? null,
-                profiles: {
-                  [CLEANUP_PROFILE]: initial.browser?.profiles?.[CLEANUP_PROFILE] ?? null,
-                },
-              },
-            },
-            ["browser.tabCleanup", `browser.profiles.${CLEANUP_PROFILE}`],
-          );
-        },
-        () => externalOwner.close(),
-      );
     });
   } finally {
     await fs.writeFile(

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-runtime.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-runtime.ts
@@ -34,7 +34,6 @@ import { proveHotReloadPluginPolicy } from "./gateway-config-hot-reload-plugin-p
 import { proveHotReloadPolicyAdmission } from "./gateway-config-hot-reload-policy-admission.js";
 import { proveHotReloadPolicy } from "./gateway-config-hot-reload-policy.js";
 import { proveHotReloadRequests } from "./gateway-config-hot-reload-requests.js";
-import { startHotReloadAttachmentRetention } from "./gateway-config-hot-reload-retention.js";
 import { proveHotReloadSecurity } from "./gateway-config-hot-reload-security.js";
 import { proveHotReloadServicePolicy } from "./gateway-config-hot-reload-service-policy.js";
 import { proveHotReloadTerminalDeferredRestart } from "./gateway-config-hot-reload-terminal-deferred.js";
@@ -71,9 +70,6 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
   let passedChecks = 0;
   let channels: Awaited<ReturnType<typeof proveHotReloadChannels>> | undefined;
   let security: Awaited<ReturnType<typeof proveHotReloadSecurity>> | undefined;
-  let retention: Awaited<ReturnType<typeof startHotReloadAttachmentRetention>> | undefined;
-  const pluginPolicyAbort = new AbortController();
-  let pluginPolicy: Promise<void> | undefined;
   await runQaGatewayFixture(
     async () => {
       await fs.access(path.join(repoRoot, "dist/control-ui/index.html"));
@@ -115,7 +111,6 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         },
         mutateConfig: (cfg) => ({
           ...cfg,
-          attachments: { ...cfg.attachments, ttlHours: 24 },
           agents: {
             ...cfg.agents,
             defaults: { ...cfg.agents?.defaults, utilityModel: MODEL },
@@ -306,13 +301,6 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         verifyContinuity,
         proveGroup,
       };
-      retention = await startHotReloadAttachmentRetention({
-        gateway: activeGateway,
-        patch,
-        verifyContinuity,
-        appendLog,
-      });
-      void retention.completion.catch(() => {});
       await proveGroup("heartbeat and Workshop monitors", async () => {
         for (const [every, mode] of [
           ["1h", "auto"],
@@ -521,7 +509,6 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         const pairingObservation = await pairingFixture.run({
           gateway: activeGateway,
           operator: primary.client,
-          patchConfig: patch,
           existingNode: node,
         });
         await verifyContinuity(
@@ -664,7 +651,7 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         proveGroup,
         verifyContinuity,
       });
-      pluginPolicy = proveHotReloadPluginPolicy({
+      await proveHotReloadPluginPolicy({
         gateway: activeGateway,
         unaffectedNode: node,
         temporaryRoot,
@@ -675,11 +662,7 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
         http,
         proveGroup,
         verifyContinuity,
-        appendLog,
-        signal: pluginPolicyAbort.signal,
       });
-      // Join this owner below; real cleanup intervals overlap independent Gateway fixtures.
-      void pluginPolicy.catch(() => {});
       channels = await proveHotReloadChannels({ repoRoot, outputDir, appendLog });
       failures.push(...channels.failures);
       security = await proveHotReloadSecurity({ repoRoot, outputDir, appendLog });
@@ -694,8 +677,6 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
       failures.push(...servicePolicy.failures);
       const otel = await proveHotReloadOtel({ repoRoot, outputDir, appendLog });
       failures.push(...otel.failures);
-      await pluginPolicy;
-      await proveGroup("attachments.ttlHours", () => retention!.completion);
       await checkContinuity();
       passedChecks =
         evidence.length +
@@ -759,11 +740,6 @@ async function runProof(repoRoot: string, outputDir: string, appendLog: (text: s
           "SSH remote identity command with real isolated sshd",
         ],
       };
-    },
-    async () => {
-      pluginPolicyAbort.abort();
-      await pluginPolicy?.catch(() => {});
-      await retention?.stop();
     },
     () => {
       if (gateway) {

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-tab-cleanup.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-tab-cleanup.ts
@@ -1,0 +1,296 @@
+// Real elapsed-time proof owns one Gateway and external Chromium across all three phases.
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { pathToFileURL } from "node:url";
+import { chromium } from "playwright";
+import {
+  createQaGatewayChild,
+  startQaMockOpenAiServer,
+  type QaGatewayChild,
+} from "../../../../extensions/qa-lab/api.js";
+import { runQaGatewayFixture, stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
+import { createHotReloadExternalBrowser } from "./gateway-config-hot-reload-external-browser.js";
+import {
+  connectHotReloadClient,
+  startHotReloadUpstreams,
+  type HotReloadConnection,
+} from "./gateway-config-hot-reload-fixtures.js";
+import { createQaScriptEvidenceWriter } from "./script-evidence.js";
+
+const SCENARIO_ID = "gateway-config-hot-reload-tab-cleanup";
+const SOURCE_PATH = "test/e2e/qa-lab/runtime/gateway-config-hot-reload-tab-cleanup.ts";
+const MODEL = "mock-openai/gpt-5.6-luna";
+const SESSION_KEY = "agent:qa:hot-reload-plugin";
+// Production cadence and cap: two disabled witnesses plus an enabled sweep can take 940s.
+const SWEEP_MS = 5 * 60_000;
+const TAB_CAP = 8;
+const CLEANUP_PROFILE = "cleanup-proof";
+type BrowserTabs = { tabs: Array<{ targetId: string; url: string }> };
+type BrowserStatus = { pid: number | null; running: boolean; attachOnly: boolean };
+type ToolResult = {
+  isError?: boolean;
+  details: { targetId?: string; ok?: boolean };
+};
+
+async function runProof(repoRoot: string, appendLog: (text: string) => void) {
+  const gatewayOwner = createQaGatewayChild();
+  let mockOwner: Awaited<ReturnType<typeof startQaMockOpenAiServer>> | undefined;
+  let fixtureOwner: Awaited<ReturnType<typeof startHotReloadUpstreams>> | undefined;
+  let temporaryRoot: string | undefined;
+  let externalOwner: ReturnType<typeof createHotReloadExternalBrowser> | undefined;
+  const observations: Array<Record<string, unknown>> = [];
+  let gateway: QaGatewayChild | undefined;
+  let primary: HotReloadConnection | undefined;
+  const log = (text: string) => {
+    appendLog(`${text}\n`);
+    process.stdout.write(`${text}\n`);
+  };
+  await runQaGatewayFixture(
+    async () => {
+      assert.equal(
+        process.env.OPENCLAW_TESTBOX,
+        "1",
+        "Tab cleanup proof requires a disposable Testbox",
+      );
+      temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tab-cleanup-reload-"));
+      const mock = (mockOwner = await startQaMockOpenAiServer());
+      const fixture = (fixtureOwner = await startHotReloadUpstreams(mock.baseUrl));
+      externalOwner = createHotReloadExternalBrowser(temporaryRoot);
+      const external = await externalOwner.start();
+      gateway = await gatewayOwner.start({
+        repoRoot,
+        useRepoCli: true,
+        command: {
+          executablePath: process.execPath,
+          argsPrefix: [path.join(repoRoot, "dist/index.js")],
+          cwd: repoRoot,
+          usePackagedPlugins: true,
+        },
+        providerMode: "mock-openai",
+        providerBaseUrl: `${mock.baseUrl}/v1`,
+        transportBaseUrl: fixture.baseUrl,
+        primaryModel: MODEL,
+        enabledPluginIds: ["browser"],
+        mutateConfig: (cfg) => ({
+          ...cfg,
+          agents: {
+            ...cfg.agents,
+            entries: {
+              ...cfg.agents?.entries,
+              qa: { ...cfg.agents?.entries?.qa, tools: { alsoAllow: ["browser"] } },
+            },
+          },
+          browser: {
+            enabled: true,
+            headless: true,
+            noSandbox: true,
+            executablePath: chromium.executablePath(),
+            ssrfPolicy: { allowedHostnames: [new URL(fixture.baseUrl).hostname] },
+            tabCleanup: { enabled: false },
+            // Managed opens have a separate eight-page cap. Attach-only isolates periodic cleanup.
+            profiles: { [CLEANUP_PROFILE]: { cdpUrl: external.cdpUrl, attachOnly: true } },
+          },
+          gateway: { ...cfg.gateway, reload: { mode: "hybrid" } },
+        }),
+      });
+      const activeGateway = gateway;
+      const connection = await connectHotReloadClient(activeGateway);
+      primary = connection;
+      const pid = activeGateway.pid;
+      const bootId = connection.bootId;
+      assert(pid && bootId, "Gateway must expose its boot and process identities");
+      const rpc = <T>(method: string, params: unknown = {}) =>
+        connection.client.request<T>(method, params, { timeoutMs: 40_000 });
+      const patch = async (enabled: boolean) => {
+        const snapshot = await rpc<{ hash: string }>("config.get");
+        const result = await rpc<
+          { noop: true } | { sentinel: { payload: { stats: { requiresRestart: boolean } } } }
+        >("config.patch", {
+          baseHash: snapshot.hash,
+          raw: JSON.stringify({ browser: { tabCleanup: { enabled } } }),
+        });
+        if ("noop" in result) {
+          assert.equal(result.noop, true);
+        } else {
+          assert.equal(result.sentinel.payload.stats.requiresRestart, false);
+        }
+      };
+      const browser = async (args: Record<string, unknown>) => {
+        const response = await fetch(`${activeGateway.baseUrl}/tools/invoke`, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${activeGateway.token}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            tool: "browser",
+            sessionKey: SESSION_KEY,
+            args: { target: "host", profile: CLEANUP_PROFILE, ...args },
+          }),
+          signal: AbortSignal.timeout(40_000),
+        });
+        const text = await response.text();
+        assert.equal(response.status, 200, text);
+        const { result } = JSON.parse(text) as { result: ToolResult };
+        assert.notEqual(result.isError, true, text);
+        assert.notEqual(result.details.ok, false, text);
+        return result;
+      };
+      const browserRequest = <T>(route: string) =>
+        rpc<T>("browser.request", {
+          target: "host",
+          method: "GET",
+          path: route,
+          query: { profile: CLEANUP_PROFILE },
+          timeoutMs: 30_000,
+        });
+      const opened: string[] = [];
+      const ownedTabs = async () => {
+        const { tabs } = await browserRequest<BrowserTabs>("/tabs");
+        return tabs
+          .filter((tab) => opened.includes(tab.targetId))
+          .map((tab) => tab.targetId)
+          .toSorted();
+      };
+      const openTab = async () => {
+        const result = await browser({
+          action: "open",
+          url: `${fixture.baseUrl}/widget?cleanup-proof=${opened.length}`,
+        });
+        assert(result.details.targetId);
+        opened.push(result.details.targetId);
+      };
+      for (let index = 0; index <= TAB_CAP; index += 1) {
+        await openTab();
+      }
+      const status = await browserRequest<BrowserStatus>("/");
+      assert(status.running && status.attachOnly);
+      assert.equal(status.pid, null, "Gateway must not own the external Chromium process");
+      const expectedRetained = opened.slice(1).toSorted();
+      for (const [phase, enabled] of [false, true, false].entries()) {
+        await patch(enabled);
+        if (phase === 2) {
+          await openTab();
+        }
+        const expected =
+          phase === 1 ? expectedRetained : opened.slice(phase === 2 ? 1 : 0).toSorted();
+        const started = Date.now();
+        let nextLog = started;
+        let retained: string[] = [];
+        log(
+          `Browser tab cleanup phase ${phase + 1}: enabled=${enabled}, observing real five-minute sweep`,
+        );
+        while (Date.now() - started < SWEEP_MS + 30_000) {
+          retained = await ownedTabs();
+          await external.verifyAlive();
+          if (enabled && retained.length === TAB_CAP) {
+            break;
+          }
+          if (!enabled) {
+            assert.deepEqual(retained, expected, "Disabled cleanup removed a tracked tab");
+            if (Date.now() - started >= SWEEP_MS + 5_000) {
+              break;
+            }
+          }
+          if (Date.now() >= nextLog) {
+            log(
+              `Browser tab cleanup phase ${phase + 1}: ${retained.length} tracked tabs after ${Math.floor((Date.now() - started) / 1_000)}s`,
+            );
+            nextLog = Date.now() + 30_000;
+          }
+          await delay(5_000);
+        }
+        assert.deepEqual(retained, expected);
+        assert.equal(activeGateway.pid, pid);
+        assert.equal(connection.hellos, 1, "Persistent WebSocket reconnected");
+        assert.equal(connection.closes, 0, "Persistent WebSocket closed");
+        await rpc("health");
+        const fresh = await connectHotReloadClient(activeGateway);
+        try {
+          assert.equal(fresh.bootId, bootId, "Gateway restarted inside the same PID");
+        } finally {
+          await fresh.client.stopAndWait({ timeoutMs: 2_000 });
+        }
+        observations.push({
+          enabled,
+          elapsedMs: Date.now() - started,
+          trackedTabs: retained.length,
+          browserPid: external.pid,
+          gatewayPid: pid,
+          bootId,
+          socketHellos: connection.hellos,
+          socketCloses: connection.closes,
+        });
+        log(
+          `PASS browser.tabCleanup phase ${phase + 1}: enabled=${enabled}, ${retained.length} tracked tabs; Gateway boot/socket, external Chromium PID, CDP connection and unowned witness page unchanged`,
+        );
+      }
+    },
+    () => {
+      if (gateway) {
+        appendLog(gateway.logs());
+      }
+    },
+    () => primary?.client.stopAndWait({ timeoutMs: 2_000 }),
+    () => stopQaGatewayFixture(gatewayOwner),
+    () => externalOwner?.close(),
+    () => fixtureOwner?.close(),
+    () => mockOwner?.stop(),
+    () => temporaryRoot && fs.rm(temporaryRoot, { recursive: true, force: true }),
+  );
+  return observations;
+}
+
+async function main() {
+  const repoRoot = process.cwd();
+  const argv = process.argv.slice(2);
+  assert(
+    argv.length === 2 && argv[0] === "--output-dir" && argv[1],
+    "Usage: --output-dir <artifact directory>",
+  );
+  const outputDir = path.resolve(repoRoot, argv[1]);
+  const writer = createQaScriptEvidenceWriter({
+    artifactBase: outputDir,
+    logFileName: `${SCENARIO_ID}.log`,
+    primaryModel: MODEL,
+    providerMode: "mock-openai",
+    repoRoot,
+    target: {
+      id: SCENARIO_ID,
+      title: "Gateway tab cleanup hot reload",
+      sourcePath: SOURCE_PATH,
+      docsRefs: ["docs/gateway/configuration.md", "docs/tools/browser.md"],
+      codeRefs: [SOURCE_PATH, "extensions/browser/src/browser/session-tab-cleanup.ts"],
+    },
+  });
+  const started = Date.now();
+  try {
+    const observations = await runProof(repoRoot, (text) => writer.appendLog(text));
+    await fs.mkdir(outputDir, { recursive: true });
+    const summaryPath = path.join(outputDir, `${SCENARIO_ID}.json`);
+    await fs.writeFile(summaryPath, `${JSON.stringify(observations, null, 2)}\n`);
+    await writer.write({
+      status: "pass",
+      durationMs: Date.now() - started,
+      details:
+        "Disabled→enabled→disabled cleanup retained 9→8→9 tracked tabs on the real five-minute cadence with one Gateway boot/socket and one external Chromium owner",
+      artifacts: [{ kind: "summary", filePath: summaryPath }],
+    });
+  } catch (error) {
+    const details = error instanceof Error ? error.message : String(error);
+    writer.appendLog(details);
+    await writer.write({ status: "fail", durationMs: Date.now() - started, details });
+    process.stderr.write(writer.logText());
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`${String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/e2e/qa-lab/runtime/gateway-config-hot-reload-terminal-deferred.ts
+++ b/test/e2e/qa-lab/runtime/gateway-config-hot-reload-terminal-deferred.ts
@@ -153,7 +153,7 @@ export async function proveHotReloadTerminalDeferredRestart({
         );
         assert.equal(preflight.safe, false);
         assert(preflight.counts.embeddedRuns > 0, "The held response must own an active agent run");
-        const restart = await patch({ gateway: { controlUi: { enabled: false } } });
+        const restart = await patch({ gateway: { controlUi: { basePath: "/deferred-reload" } } });
         assert.equal(restart.sentinel.payload.stats.requiresRestart, true);
         await waitForHotReloadFact("startup-only change deferred for active work", () =>
           gateway
@@ -161,7 +161,7 @@ export async function proveHotReloadTerminalDeferredRestart({
             .split("\n")
             .some(
               (line) =>
-                line.includes("gateway.controlUi.enabled") && line.includes("deferring until"),
+                line.includes("gateway.controlUi.basePath") && line.includes("deferring until"),
             )
             ? true
             : undefined,
@@ -237,8 +237,9 @@ export async function proveHotReloadTerminalDeferredRestart({
           ),
         );
         assert.equal((await fetch(`${gateway.baseUrl}/chat/qa`)).status, 404);
+        assert.equal((await fetch(`${gateway.baseUrl}/deferred-reload/chat/qa`)).status, 200);
         startupOnlyControl = {
-          prefix: "gateway.controlUi.enabled (deferred)",
+          prefix: "gateway.controlUi.basePath (deferred)",
           originalBootId: bootId,
           replacementBootId: connection.bootId,
         };


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

The config hot-reload QA umbrella could not reliably finish within its 15-minute budget. Browser tab cleanup needs two 305-second disabled witnesses plus an enabled sweep, and attachment retention can wait an hour for actual maintenance. Their timing could exhaust the umbrella before its remaining checks finished.

## Why This Change Was Made

Give the existing browser and retention proofs separate scenarios with 20-minute and 75-minute budgets, preserving real cadences, ownership, controls, and cleanup. Remove their background bookkeeping from the 15-minute umbrella.

The umbrella now waits for the asynchronous environment stripe and uses the startup-owned Control UI base path for its deferred-restart check. The SSH fixture owns an authenticated config connection so unrelated traffic cannot consume its write budget; the actual rate limit, SSH deadlines, policy rejection checks, and existing-node continuity remain intact. Avahi is declared for the existing mDNS proof.

## User Impact

No product runtime behavior changes. Maintainers can run the long maintenance checks independently and obtain a complete hot-reload result within each scenario's stated budget.

## Evidence

Real Gateways and synthetic upstreams ran on disposable Blacksmith Testboxes:

- [Gateway umbrella](https://github.com/openclaw/openclaw/actions/runs/33997339986): 75 checks, zero failures, 601,779 ms. Covers SSH revocation, deferred terminal restart, real mDNS, OTel, and UI behavior.
- Browser cleanup: 936,487 ms; exact 9→8→9 retained tabs, unchanged Gateway boot/socket and external Chromium PID, CDP endpoint, and witness page.
- [Attachment retention](https://github.com/openclaw/openclaw/actions/runs/33997340150): the real hourly sweep removed the three-hour-old file after 3,600,259 ms, preserved the fresh control, and retained the Gateway PID/boot/socket.

Those maintenance receipts belong to tree `f237699cbdc7f6965b367dbff85b903742823755`; the original final umbrella belongs to `846028056d9f31d44ad6f5c5ef319a4a1cd1c7f1`. Their five proof leases are stopped. These are not relabeled as runs of the integrated tree.

Integration onto #139509 preserves its new heartbeat/Workshop monitor assertions byte-for-byte. Twenty-two maintenance fixture, production owner, config, and lockfile blobs match the original long proofs; relevant package dependency/runtime contracts also match. The surrounding Gateway changed, so a [fresh combined umbrella](https://github.com/openclaw/openclaw/actions/runs/34002106040) ran on integrated tree `76ac4eb4d7c625deb7a92b708bcf9cea8485f774`: **76 checks, zero failures, 599,153 ms**. Real config.patch writes changed persisted heartbeat/Workshop cadence and enablement on the same Gateway boot/PID; the startup-only basePath control closed the original socket and replaced the boot as expected. All six proof leases are stopped and independently verified completed.

The integrated candidate passed 86 catalog/script-evidence tests, root-test types, semantic lint, formatting, and fresh managed P2 review with no actionable findings. Prior complete changed checks also passed. The integrated clean Linux build, Control UI sidecars, and performance checks passed. A portal-sync warning occurred after successful execution; both native and wrapper exit codes are zero and all terminal JSON/log evidence was captured.

Production runtime LOC: 0. QA catalog: +63; tests/support: +353. Added support gives each existing duration-sensitive proof an independent scenario and cleanup owner. No product config, persistence, protocol, dependency, or public API surface is added.

The first CI run failed on a newly landed main test-support lint suppression. Main independently repaired it in #139576 (`e927f02952b`); this PR retains that canonical implementation and drops the redundant local helper commit. The QA scenario patch rebased mechanically onto `ae12ad058cd219dddccac1d14eb8c006d04a7e8f`, and all ten QA file blobs remain byte-identical to the live-tested head. No held-work helper change is introduced by this PR.

The live receipt remains attributed to its actual `73feb7375307fc5ee96dd071d0e99d864afd9299` head and `76ac4eb4d7c625deb7a92b708bcf9cea8485f774` tree. Final CI must pass before native landing.

The next CI run exposed a transient Discord WAV-lifetime fixture failure. This PR now schedules its “leave during write” case through the existing pre-import temporary-workspace mock, after real WAV bytes are written and before the receive owner resumes. It preserves all original checks and also verifies the manager and WAV directory are already closed before queued processing is released. Removing the production ownership guard made the stronger cleanup assertion fail; production source is unchanged.

The final fixture passed all 3,390 Discord tests across 247 files on Linux, its focused seven cases, changed-file checks, and fresh P2 review. The precise transient late-spy/module-identity cause did not recur and remains inferred. Targeted lint passed in an independently installed, non-nested checkout of the identical source tree after the nested checkout resolved an ancestor qrcode manifest; no guard was bypassed. [Linux proof](https://github.com/openclaw/openclaw/actions/runs/34005156527), tree `0c1b00911a8f64bb18ce55e451b9e6b2f613fe59`. The proof lease is stopped and independently verified completed.
