### PR TITLE
refactor(ios): reuse shared integer conversion

### DIFF
--- a/apps/ios/Sources/Design/AgentAutomationModels.swift
+++ b/apps/ios/Sources/Design/AgentAutomationModels.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Observation
+import OpenClawKit
 import OpenClawProtocol
 
 enum AgentAutomationScheduleDraft: Equatable {
@@ -224,12 +225,7 @@ enum AgentAutomationValue {
     }
 
     static func int(_ value: AnyCodable?) -> Int? {
-        switch value?.value {
-        case let value as Int: value
-        case let value as Double where value.isFinite: Int(value)
-        case let value as String: Int(value)
-        default: nil
-        }
+        value?.intValue ?? value?.stringValue.flatMap { Int($0) }
     }
 
     static func strings(_ value: AnyCodable?) -> [String]? {

--- a/apps/ios/Sources/Design/AgentProModels.swift
+++ b/apps/ios/Sources/Design/AgentProModels.swift
@@ -17,12 +17,7 @@ struct AgentOverviewRefreshGate {
 
 enum AgentProValueReader {
     static func intValue(_ value: AnyCodable?) -> Int? {
-        switch value?.value {
-        case let int as Int: int
-        case let double as Double where double.isFinite: Int(double)
-        case let string as String: Int(string)
-        default: nil
-        }
+        value?.intValue ?? value?.stringValue.flatMap { Int($0) }
     }
 
     static func doubleValue(_ value: AnyCodable?) -> Double? {

--- a/apps/ios/Tests/AgentAutomationModelsTests.swift
+++ b/apps/ios/Tests/AgentAutomationModelsTests.swift
@@ -5,15 +5,36 @@ import Testing
 
 struct AgentAutomationModelsTests {
     @Test func `draft decodes editable gateway fields`() throws {
-        let draft = try #require(AgentAutomationDraft(job: Self.job()))
+        let cases: [(schedule: String, expected: AgentAutomationScheduleDraft)] = [
+            (
+                #"{"kind":"every","everyMs":86400000,"anchorMs":1783468800000}"#,
+                .every(everyMs: "86400000", anchorMs: "1783468800000")),
+            (
+                #"{"kind":"every","everyMs":"86400000","anchorMs":"1783468800000"}"#,
+                .every(everyMs: "86400000", anchorMs: "1783468800000")),
+            (#"{"kind":"every","everyMs":86400000}"#, .every(everyMs: "86400000", anchorMs: "")),
+            (
+                #"{"kind":"cron","expr":"0 9 * * *","staggerMs":300000}"#,
+                .cron(expression: "0 9 * * *", timezone: "", staggerMs: "300000")),
+            (
+                #"{"kind":"cron","expr":"0 9 * * *","staggerMs":"300000"}"#,
+                .cron(expression: "0 9 * * *", timezone: "", staggerMs: "300000")),
+            (
+                #"{"kind":"cron","expr":"0 9 * * *"}"#,
+                .cron(expression: "0 9 * * *", timezone: "", staggerMs: "")),
+        ]
+        for testCase in cases {
+            let schedule = try JSONDecoder().decode(AnyCodable.self, from: Data(testCase.schedule.utf8))
+            let draft = try #require(AgentAutomationDraft(job: Self.job(schedule: schedule)))
 
-        #expect(draft.name == "Release briefing")
-        #expect(draft.sessionTarget == "isolated")
-        #expect(draft.schedule == .every(everyMs: "86400000", anchorMs: "1783468800000"))
-        #expect(draft.payload == .agentTurn(
-            message: "Summarize release readiness.",
-            model: "openai/gpt-5.2",
-            thinking: ""))
+            #expect(draft.name == "Release briefing")
+            #expect(draft.sessionTarget == "isolated")
+            #expect(draft.schedule == testCase.expected)
+            #expect(draft.payload == .agentTurn(
+                message: "Summarize release readiness.",
+                model: "openai/gpt-5.2",
+                thinking: ""))
+        }
     }
 
     @Test func `update includes exact revision and only normalized changes`() throws {

--- a/apps/ios/Tests/RootTabsPresentationTests.swift
+++ b/apps/ios/Tests/RootTabsPresentationTests.swift
@@ -214,6 +214,19 @@ struct RootTabsPresentationTests {
         })
     }
 
+    @Test func `usage summary preserves numeric and string counts with missing totals`() throws {
+        let cases: [(json: String, expected: Int?)] = [
+            (#"{"totals":{"totalTokens":1200}}"#, 1200),
+            (#"{"totals":{"totalTokens":"1200"}}"#, 1200),
+            (#"{"totals":{}}"#, nil),
+            (#"{}"#, nil),
+        ]
+        for testCase in cases {
+            let summary = try JSONDecoder().decode(CostUsageSummaryLite.self, from: Data(testCase.json.utf8))
+            #expect(summary.totalTokens == testCase.expected)
+        }
+    }
+
     @Test func `iOS usage requests device calendar days`() throws {
         let cases: [(timeZoneID: String, timestamp: TimeInterval, expectedOffset: String)] = [
             ("America/Los_Angeles", 1_769_000_000, "UTC-8"),


### PR DESCRIPTION
## What Problem This Solves

Automation schedules and usage totals had separate copies of numeric-to-integer conversion, despite an existing shared accessor. Both copies also converted finite floating-point values through a non-failable initializer.

## Why This Change Was Made

Use `AnyCodable.intValue` in both model readers and retain their small raw integer-string adapters. Numeric conversion stays with its existing shared owner; automation and usage retain their own model and missing-value handling. The two duplicate numeric switches are removed, reducing production code by nine lines.

## User Impact

Ordinary integer values, integer strings and absent optional values keep their existing behavior. The numeric policy change is explicit: fractional numeric values now yield no value instead of being truncated. Current and stable cron schemas require integers, and the usage producer normalizes token counts before aggregation. Historical Gateway versions and arbitrary old caches are not claimed to be exhaustively compatible.

The shared accessor, Gateway schema, configuration and persistence behavior are unchanged. No visual layout changes.

## Evidence

- Full signed iOS app/test build passed with Xcode 26.6, including the normal embedded Watch dependency. Host and test bundle signatures were verified before launch.
- Fresh test enumeration selected exactly four model methods, and authoritative results show **4 passed, zero failures and zero skips**. They cover six decoded schedule rows, four decoded usage rows, and existing update/no-op behavior. The rows are not counted as separate tests.
- **All 13 changed-file checks passed**, alongside scoped formatting and strict source lint. The initial test-table wrapping finding was fixed with the pinned formatter; no production or assertion change was needed.
- Independent peer and both managed source-review passes found no actionable defect. They explicitly considered the accepted numeric-policy narrowing and preserved string handling.

Proof used one new iPhone 17/iOS 26.5 simulator with ad-hoc-signed products. The simulator is deleted; existing simulator and operator state were preserved. Coverage is ordinary model behavior, not a crash or out-of-range reproduction.

Four files: **production +3/−12 (−9), tests +43/−9 (+34)**. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34002844351) passed: nine jobs succeeded, 24 were skipped, and none failed. The latest exact-head ClawSweeper review has no actionable findings or rank-up requests.
