### PR TITLE
fix(gateway): reclaim no longer mistakes an unreadable workspace conflict for none

### DIFF
--- a/src/gateway/server-worker-placement-startup-cleanup.test.ts
+++ b/src/gateway/server-worker-placement-startup-cleanup.test.ts
@@ -75,7 +75,7 @@ describe("worker placement startup cleanup ownership", () => {
       workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
       resolveWorkspacePath,
       reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => undefined,
+      resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
     });
     const starting = recovery.reconcile("startup");
     let sweeping: Promise<void> | undefined;

--- a/src/gateway/server.sessions.worker-original-order.test.ts
+++ b/src/gateway/server.sessions.worker-original-order.test.ts
@@ -423,7 +423,7 @@ test("preserves ordered fallback through restart, workspace sync, and safe sessi
     runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
     resolveWorkspacePath: async () => localWorkspace,
     reportWorkspaceResultConflict: async () => {},
-    resolveWorkspaceResultConflict: async () => undefined,
+    resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
   });
 
   const active = await dispatch.dispatch({

--- a/src/gateway/worker-environments/placement-dispatch-conflict-lookup.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-conflict-lookup.test.ts
@@ -1,7 +1,6 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -27,6 +26,8 @@ vi.mock("../../logging/subsystem.js", async (importOriginal) => {
   };
 });
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
 describe("worker placement dispatch conflict lookup", () => {
   let root: string;
   let database: OpenClawStateDatabase;
@@ -38,14 +39,13 @@ describe("worker placement dispatch conflict lookup", () => {
 
   beforeEach(async () => {
     workerPlacementWarn.mockClear();
-    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-dispatch-"));
+    root = tempDirs.make("openclaw-dispatch-");
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     closeOpenClawStateDatabaseForTest();
-    await fs.rm(root, { recursive: true, force: true });
   });
 
   it("reclaims an unchanged worker with unknown conflict state without silently clearing its report", async () => {

--- a/src/gateway/worker-environments/placement-dispatch-conflict-lookup.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-conflict-lookup.test.ts
@@ -1,0 +1,122 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
+import { MANIFEST_REF, type PlacementStore, REQUEST } from "./placement-dispatch-test-fixtures.js";
+import { createHarness as createPlacementHarness } from "./placement-dispatch-test-harness.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import type { WorkspaceResultConflictLookup } from "./workspace-conflicts.js";
+
+const { workerPlacementWarn } = vi.hoisted(() => ({ workerPlacementWarn: vi.fn() }));
+
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-placement"
+        ? { ...logger, warn: workerPlacementWarn }
+        : logger;
+    },
+  };
+});
+
+describe("worker placement dispatch conflict lookup", () => {
+  let root: string;
+  let database: OpenClawStateDatabase;
+  let placementStore: PlacementStore;
+  const createTestHarness = (
+    options: Parameters<typeof createPlacementHarness>[1] = {},
+    store: PlacementStore = placementStore,
+  ) => createPlacementHarness(store, { workspacePath: path.join(root, "workspace"), ...options });
+
+  beforeEach(async () => {
+    workerPlacementWarn.mockClear();
+    root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-dispatch-"));
+    database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
+    placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
+  });
+
+  afterEach(async () => {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("reclaims an unchanged worker with unknown conflict state without silently clearing its report", async () => {
+    const harness = createTestHarness({
+      priorWorkspaceResultConflictLookup: { kind: "unknown", reason: "malformed-report" },
+      reconcileChanged: false,
+      reconcileCommitsManifest: false,
+    });
+    await harness.service.dispatch(REQUEST);
+
+    await expect(harness.service.reclaim(REQUEST)).resolves.toMatchObject({
+      state: "reclaimed",
+      workspaceBaseManifestRef: MANIFEST_REF,
+      turnClaim: null,
+    });
+
+    expect(harness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+    expect(workerPlacementWarn).toHaveBeenCalledExactlyOnceWith(
+      `Cloud workspace conflict state unknown sessionId=${REQUEST.sessionId} reason=malformed-report; preserving prior conflict state`,
+    );
+  });
+
+  it.each<WorkspaceResultConflictLookup>([
+    { kind: "absent" },
+    { kind: "unknown", reason: "malformed-report" },
+  ])(
+    "reclaims a previous-instance pending result with $kind conflict state without clearing unseen reports",
+    async (lookup) => {
+      const originalHarness = createTestHarness();
+      const active = originalHarness.placements.seedActive(2);
+      if (active.state !== "active") {
+        throw new Error("active placement fixture was not active");
+      }
+      const claim = placementStore.claimTurn({
+        ...REQUEST,
+        claimId: "restarted-turn-claim",
+        runId: "restarted-turn-run",
+        owner: {
+          kind: "worker",
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+      });
+      placementStore.markWorkspaceResultPending(claim);
+
+      const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+      const restartedHarness = createTestHarness(
+        { priorWorkspaceResultConflictLookup: lookup },
+        restartedStore,
+      );
+      restartedHarness.markEnvironmentOwnerEpoch(2);
+      await restartedHarness.service.reconcile();
+
+      expect(restartedHarness.placements.current()).toMatchObject({
+        state: "reclaimed",
+        turnClaim: null,
+        workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
+      });
+      expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+      expect(restartedHarness.environments.destroy).toHaveBeenCalledOnce();
+      expect(restartedHarness.log).not.toContain("workspace:resume");
+      expect(restartedHarness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
+      if (lookup.kind === "unknown") {
+        expect(workerPlacementWarn).toHaveBeenCalledExactlyOnceWith(
+          `Cloud workspace conflict state unknown sessionId=${REQUEST.sessionId} reason=malformed-report; preserving prior conflict state`,
+        );
+      } else {
+        expect(workerPlacementWarn).not.toHaveBeenCalled();
+      }
+    },
+  );
+});

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -1,3 +1,4 @@
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   isCurrentActiveWorkerEnvironment,
   workerDisappearanceError,
@@ -17,6 +18,7 @@ import { boundedWorkerError } from "./worker-error.js";
 import type {
   WorkerWorkspaceRecoveryFailureReport,
   WorkerWorkspaceResultConflict,
+  WorkspaceResultConflictLookup,
 } from "./workspace-conflicts.js";
 import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
 import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
@@ -60,11 +62,39 @@ export type PlacementRecoveryDeps = {
     sessionId: string;
     sessionKey: string;
     agentId: string;
-  }) => Promise<WorkerWorkspaceResultConflict | undefined>;
+  }) => Promise<WorkspaceResultConflictLookup>;
   recoverPlacementMoves?: (environmentId?: string) => Promise<Set<string>>;
   prepareAcceptedWorkspacePublication?: (claim: WorkerSessionTurnClaim) => Promise<void>;
   publishAcceptedWorkspace?: (claim: WorkerSessionTurnClaim) => Promise<void>;
 };
+
+const log = createSubsystemLogger("gateway/worker-placement");
+
+export async function resolvePriorWorkspaceResultConflict(
+  resolve: PlacementRecoveryDeps["resolveWorkspaceResultConflict"],
+  placement: {
+    sessionId: string;
+    sessionKey: string;
+    agentId: string;
+    workspaceResultConflict?: WorkerWorkspaceResultConflict;
+  },
+): Promise<WorkerWorkspaceResultConflict | undefined> {
+  if (placement.workspaceResultConflict) {
+    return placement.workspaceResultConflict;
+  }
+  const lookup = await resolve(placement);
+  if (lookup.kind === "conflict") {
+    return lookup.conflict;
+  }
+  if (lookup.kind === "unknown") {
+    log.warn(
+      `Cloud workspace conflict state unknown sessionId=${boundedWorkerError(placement.sessionId, 128)} reason=${lookup.reason}; preserving prior conflict state`,
+    );
+    // Undefined means no prior knowledge to finalizeWorkspaceResultConflicts: it cannot
+    // clear the retained report or delete its unseen staged ref. The warning signals this.
+  }
+  return undefined;
+}
 
 type WorkerOwnedPendingPlacement = Extract<
   WorkerDispatchPlacement,
@@ -181,8 +211,10 @@ export async function recoverPendingWorkspaceResults(
         continue;
       }
       const localPath = await deps.resolveWorkspacePath(active);
-      const priorWorkspaceResultConflict =
-        active.workspaceResultConflict ?? (await deps.resolveWorkspaceResultConflict(active));
+      const priorWorkspaceResultConflict = await resolvePriorWorkspaceResultConflict(
+        deps.resolveWorkspaceResultConflict,
+        active,
+      );
       const canonicalStagedResultRef = workerWorkspaceResultRef(turnClaim.claimId);
       let stagedResultRef = pending.stagedResultRef;
       if (

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -23,6 +23,21 @@ import { createWorkerPlacementMoveService } from "./placement-move-service.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { prepareSessionWorkerPlacementStop } from "./session-placement-lifecycle.js";
 
+const { workerPlacementWarn } = vi.hoisted(() => ({ workerPlacementWarn: vi.fn() }));
+
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-placement"
+        ? { ...logger, warn: workerPlacementWarn }
+        : logger;
+    },
+  };
+});
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("worker placement dispatch reclaim", () => {
@@ -31,6 +46,7 @@ describe("worker placement dispatch reclaim", () => {
   let placementStore: PlacementStore;
 
   beforeEach(async () => {
+    workerPlacementWarn.mockClear();
     root = tempDirs.make("openclaw-dispatch-");
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
@@ -609,6 +625,28 @@ describe("worker placement dispatch reclaim", () => {
     expect(harness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
     expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
     expect(harness.environments.destroy).toHaveBeenCalledOnce();
+  });
+
+  it("reclaims an unchanged worker with unknown conflict state without silently clearing its report", async () => {
+    const harness = createHarness(placementStore, {
+      priorWorkspaceResultConflictLookup: { kind: "unknown", reason: "malformed-report" },
+      reconcileChanged: false,
+      reconcileCommitsManifest: false,
+    });
+    await harness.service.dispatch(REQUEST);
+
+    await expect(harness.service.reclaim(REQUEST)).resolves.toMatchObject({
+      state: "reclaimed",
+      workspaceBaseManifestRef: MANIFEST_REF,
+      turnClaim: null,
+    });
+
+    expect(harness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
+    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+    expect(workerPlacementWarn).toHaveBeenCalledExactlyOnceWith(
+      `Cloud workspace conflict state unknown sessionId=${REQUEST.sessionId} reason=malformed-report; preserving prior conflict state`,
+    );
   });
 
   it("retires only the exact unclaimed safe placement generation", () => {

--- a/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch-reclaim.test.ts
@@ -23,21 +23,6 @@ import { createWorkerPlacementMoveService } from "./placement-move-service.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { prepareSessionWorkerPlacementStop } from "./session-placement-lifecycle.js";
 
-const { workerPlacementWarn } = vi.hoisted(() => ({ workerPlacementWarn: vi.fn() }));
-
-vi.mock("../../logging/subsystem.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
-  return {
-    ...actual,
-    createSubsystemLogger: (subsystem: string) => {
-      const logger = actual.createSubsystemLogger(subsystem);
-      return subsystem === "gateway/worker-placement"
-        ? { ...logger, warn: workerPlacementWarn }
-        : logger;
-    },
-  };
-});
-
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("worker placement dispatch reclaim", () => {
@@ -46,7 +31,6 @@ describe("worker placement dispatch reclaim", () => {
   let placementStore: PlacementStore;
 
   beforeEach(async () => {
-    workerPlacementWarn.mockClear();
     root = tempDirs.make("openclaw-dispatch-");
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
@@ -625,28 +609,6 @@ describe("worker placement dispatch reclaim", () => {
     expect(harness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
     expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
     expect(harness.environments.destroy).toHaveBeenCalledOnce();
-  });
-
-  it("reclaims an unchanged worker with unknown conflict state without silently clearing its report", async () => {
-    const harness = createHarness(placementStore, {
-      priorWorkspaceResultConflictLookup: { kind: "unknown", reason: "malformed-report" },
-      reconcileChanged: false,
-      reconcileCommitsManifest: false,
-    });
-    await harness.service.dispatch(REQUEST);
-
-    await expect(harness.service.reclaim(REQUEST)).resolves.toMatchObject({
-      state: "reclaimed",
-      workspaceBaseManifestRef: MANIFEST_REF,
-      turnClaim: null,
-    });
-
-    expect(harness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
-    expect(placementStore.listPendingWorkspaceResults()).toEqual([]);
-    expect(harness.environments.destroy).toHaveBeenCalledOnce();
-    expect(workerPlacementWarn).toHaveBeenCalledExactlyOnceWith(
-      `Cloud workspace conflict state unknown sessionId=${REQUEST.sessionId} reason=malformed-report; preserving prior conflict state`,
-    );
   });
 
   it("retires only the exact unclaimed safe placement generation", () => {

--- a/src/gateway/worker-environments/placement-dispatch-test-harness.ts
+++ b/src/gateway/worker-environments/placement-dispatch-test-harness.ts
@@ -22,7 +22,11 @@ import { completeReclaimedWorkspaceTeardown } from "./placement-teardown.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type { WorkerTunnelHandle } from "./tunnel.js";
-import type { WorkerWorkspaceRecoveryFailureReport } from "./workspace-conflicts.js";
+import {
+  projectWorkspaceResultConflict,
+  type WorkerWorkspaceRecoveryFailureReport,
+  type WorkspaceResultConflictLookup,
+} from "./workspace-conflicts.js";
 import {
   createWorkerWorkspaceOperationCoordinator,
   type WorkerWorkspaceOperationCoordinator,
@@ -57,6 +61,7 @@ export function createHarness(
     resumeFails?: boolean;
     workspacePath?: string;
     priorWorkspaceResultConflict?: { paths: string[]; stagedResultRef: string };
+    priorWorkspaceResultConflictLookup?: WorkspaceResultConflictLookup;
     reconcileConflictPaths?: string[];
     workspaceOperations?: WorkerWorkspaceOperationCoordinator;
     destroyFailureState?: "draining" | "destroying";
@@ -500,7 +505,18 @@ export function createHarness(
     },
     reportWorkspaceResultConflict,
     reportWorkspaceResultRecoveryFailure,
-    resolveWorkspaceResultConflict: vi.fn(async () => options.priorWorkspaceResultConflict),
+    resolveWorkspaceResultConflict: vi.fn(async (): Promise<WorkspaceResultConflictLookup> => {
+      const conflict = options.priorWorkspaceResultConflict;
+      return (
+        options.priorWorkspaceResultConflictLookup ??
+        (conflict
+          ? {
+              kind: "conflict",
+              conflict: projectWorkspaceResultConflict(conflict.paths, conflict.stagedResultRef),
+            }
+          : { kind: "absent" })
+      );
+    }),
     ...(options.prepareAcceptedWorkspacePublication
       ? { prepareAcceptedWorkspacePublication: options.prepareAcceptedWorkspacePublication }
       : {}),
@@ -593,5 +609,5 @@ export const createRecoveryService = (
     runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
     resolveWorkspacePath: async () => "/gateway/workspace",
     reportWorkspaceResultConflict: async () => {},
-    resolveWorkspaceResultConflict: async () => undefined,
+    resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
   });

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -18,22 +18,6 @@ import {
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { deriveEnvironmentIntent } from "./service-contract.js";
-import type { WorkspaceResultConflictLookup } from "./workspace-conflicts.js";
-
-const { workerPlacementWarn } = vi.hoisted(() => ({ workerPlacementWarn: vi.fn() }));
-
-vi.mock("../../logging/subsystem.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
-  return {
-    ...actual,
-    createSubsystemLogger: (subsystem: string) => {
-      const logger = actual.createSubsystemLogger(subsystem);
-      return subsystem === "gateway/worker-placement"
-        ? { ...logger, warn: workerPlacementWarn }
-        : logger;
-    },
-  };
-});
 
 describe("worker placement dispatch", () => {
   let root: string;
@@ -45,7 +29,6 @@ describe("worker placement dispatch", () => {
   ) => createHarness(store, { workspacePath: path.join(root, "workspace"), ...options });
 
   beforeEach(async () => {
-    workerPlacementWarn.mockClear();
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-dispatch-"));
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
@@ -242,56 +225,6 @@ describe("worker placement dispatch", () => {
     ]);
     expect(harness.environments.destroy).not.toHaveBeenCalled();
   });
-
-  it.each<WorkspaceResultConflictLookup>([
-    { kind: "absent" },
-    { kind: "unknown", reason: "malformed-report" },
-  ])(
-    "reclaims a previous-instance pending result with $kind conflict state without clearing unseen reports",
-    async (lookup) => {
-      const originalHarness = createTestHarness();
-      const active = originalHarness.placements.seedActive(2);
-      if (active.state !== "active") {
-        throw new Error("active placement fixture was not active");
-      }
-      const claim = placementStore.claimTurn({
-        ...REQUEST,
-        claimId: "restarted-turn-claim",
-        runId: "restarted-turn-run",
-        owner: {
-          kind: "worker",
-          environmentId: active.environmentId,
-          ownerEpoch: active.activeOwnerEpoch,
-        },
-      });
-      placementStore.markWorkspaceResultPending(claim);
-
-      const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
-      const restartedHarness = createTestHarness(
-        { priorWorkspaceResultConflictLookup: lookup },
-        restartedStore,
-      );
-      restartedHarness.markEnvironmentOwnerEpoch(2);
-      await restartedHarness.service.reconcile();
-
-      expect(restartedHarness.placements.current()).toMatchObject({
-        state: "reclaimed",
-        turnClaim: null,
-        workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
-      });
-      expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
-      expect(restartedHarness.environments.destroy).toHaveBeenCalledOnce();
-      expect(restartedHarness.log).not.toContain("workspace:resume");
-      expect(restartedHarness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
-      if (lookup.kind === "unknown") {
-        expect(workerPlacementWarn).toHaveBeenCalledExactlyOnceWith(
-          `Cloud workspace conflict state unknown sessionId=${REQUEST.sessionId} reason=malformed-report; preserving prior conflict state`,
-        );
-      } else {
-        expect(workerPlacementWarn).not.toHaveBeenCalled();
-      }
-    },
-  );
 
   it("keeps a previous-instance pending result fenced when another session is attached", async () => {
     const originalHarness = createTestHarness();

--- a/src/gateway/worker-environments/placement-dispatch.test.ts
+++ b/src/gateway/worker-environments/placement-dispatch.test.ts
@@ -18,6 +18,22 @@ import {
 import { createHarness } from "./placement-dispatch-test-harness.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { deriveEnvironmentIntent } from "./service-contract.js";
+import type { WorkspaceResultConflictLookup } from "./workspace-conflicts.js";
+
+const { workerPlacementWarn } = vi.hoisted(() => ({ workerPlacementWarn: vi.fn() }));
+
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-placement"
+        ? { ...logger, warn: workerPlacementWarn }
+        : logger;
+    },
+  };
+});
 
 describe("worker placement dispatch", () => {
   let root: string;
@@ -29,6 +45,7 @@ describe("worker placement dispatch", () => {
   ) => createHarness(store, { workspacePath: path.join(root, "workspace"), ...options });
 
   beforeEach(async () => {
+    workerPlacementWarn.mockClear();
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-dispatch-"));
     database = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: root } });
     placementStore = createWorkerSessionPlacementStore({ database, now: () => 1_000 });
@@ -226,38 +243,55 @@ describe("worker placement dispatch", () => {
     expect(harness.environments.destroy).not.toHaveBeenCalled();
   });
 
-  it("destroys and reclaims a pending result owned by a previous gateway instance", async () => {
-    const originalHarness = createTestHarness();
-    const active = originalHarness.placements.seedActive(2);
-    if (active.state !== "active") {
-      throw new Error("active placement fixture was not active");
-    }
-    const claim = placementStore.claimTurn({
-      ...REQUEST,
-      claimId: "restarted-turn-claim",
-      runId: "restarted-turn-run",
-      owner: {
-        kind: "worker",
-        environmentId: active.environmentId,
-        ownerEpoch: active.activeOwnerEpoch,
-      },
-    });
-    placementStore.markWorkspaceResultPending(claim);
+  it.each<WorkspaceResultConflictLookup>([
+    { kind: "absent" },
+    { kind: "unknown", reason: "malformed-report" },
+  ])(
+    "reclaims a previous-instance pending result with $kind conflict state without clearing unseen reports",
+    async (lookup) => {
+      const originalHarness = createTestHarness();
+      const active = originalHarness.placements.seedActive(2);
+      if (active.state !== "active") {
+        throw new Error("active placement fixture was not active");
+      }
+      const claim = placementStore.claimTurn({
+        ...REQUEST,
+        claimId: "restarted-turn-claim",
+        runId: "restarted-turn-run",
+        owner: {
+          kind: "worker",
+          environmentId: active.environmentId,
+          ownerEpoch: active.activeOwnerEpoch,
+        },
+      });
+      placementStore.markWorkspaceResultPending(claim);
 
-    const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
-    const restartedHarness = createTestHarness({}, restartedStore);
-    restartedHarness.markEnvironmentOwnerEpoch(2);
-    await restartedHarness.service.reconcile();
+      const restartedStore = createWorkerSessionPlacementStore({ database, now: () => 2_000 });
+      const restartedHarness = createTestHarness(
+        { priorWorkspaceResultConflictLookup: lookup },
+        restartedStore,
+      );
+      restartedHarness.markEnvironmentOwnerEpoch(2);
+      await restartedHarness.service.reconcile();
 
-    expect(restartedHarness.placements.current()).toMatchObject({
-      state: "reclaimed",
-      turnClaim: null,
-      workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
-    });
-    expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
-    expect(restartedHarness.environments.destroy).toHaveBeenCalledOnce();
-    expect(restartedHarness.log).not.toContain("workspace:resume");
-  });
+      expect(restartedHarness.placements.current()).toMatchObject({
+        state: "reclaimed",
+        turnClaim: null,
+        workspaceBaseManifestRef: restartedHarness.reconciledManifestRef,
+      });
+      expect(restartedStore.listPendingWorkspaceResults()).toEqual([]);
+      expect(restartedHarness.environments.destroy).toHaveBeenCalledOnce();
+      expect(restartedHarness.log).not.toContain("workspace:resume");
+      expect(restartedHarness.reportWorkspaceResultConflict).not.toHaveBeenCalled();
+      if (lookup.kind === "unknown") {
+        expect(workerPlacementWarn).toHaveBeenCalledExactlyOnceWith(
+          `Cloud workspace conflict state unknown sessionId=${REQUEST.sessionId} reason=malformed-report; preserving prior conflict state`,
+        );
+      } else {
+        expect(workerPlacementWarn).not.toHaveBeenCalled();
+      }
+    },
+  );
 
   it("keeps a previous-instance pending result fenced when another session is attached", async () => {
     const originalHarness = createTestHarness();

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -10,6 +10,7 @@ import {
   type WorkerDispatchPlacement,
   type WorkerDispatchPlacementStore,
 } from "./placement-dispatch-failure.js";
+import { resolvePriorWorkspaceResultConflict } from "./placement-dispatch-pending-results.js";
 import { createPlacementRecoveryActions } from "./placement-dispatch-recovery.js";
 import {
   createWorkerPlacementDispatchStartup,
@@ -49,7 +50,7 @@ import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-life
 import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
 import type {
   WorkerWorkspaceRecoveryFailureReport,
-  WorkerWorkspaceResultConflict,
+  WorkspaceResultConflictLookup,
 } from "./workspace-conflicts.js";
 import {
   verifyReconciledWorkspaceFinal,
@@ -112,7 +113,7 @@ type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
     sessionId: string;
     sessionKey: string;
     agentId: string;
-  }) => Promise<WorkerWorkspaceResultConflict | undefined>;
+  }) => Promise<WorkspaceResultConflictLookup>;
   prepareAcceptedWorkspacePublication?: (
     claim: import("./placement-store.js").WorkerSessionTurnClaim,
   ) => Promise<void>;
@@ -475,13 +476,10 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
                 if (conflictPaths.length > 0 && !recordedStagedResultRef) {
                   throw new Error("Cloud worker stop conflict has no staged result reference");
                 }
-                const priorWorkspaceResultConflict =
-                  current.workspaceResultConflict ??
-                  (await options.resolveWorkspaceResultConflict({
-                    sessionId: current.sessionId,
-                    sessionKey: current.sessionKey,
-                    agentId: current.agentId,
-                  }));
+                const priorWorkspaceResultConflict = await resolvePriorWorkspaceResultConflict(
+                  options.resolveWorkspaceResultConflict,
+                  current,
+                );
                 reauthorize?.();
                 const finalized = await finalizeWorkspaceResultConflicts({
                   placements,

--- a/src/gateway/worker-environments/placement-targeted-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-targeted-recovery.test.ts
@@ -51,7 +51,7 @@ function createDispatch(
       runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
       resolveWorkspacePath: async () => support.testState.root,
       reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => undefined,
+      resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
     }),
     (_request, run) => run(),
   );

--- a/src/gateway/worker-environments/provider-bootstrap.test.ts
+++ b/src/gateway/worker-environments/provider-bootstrap.test.ts
@@ -246,7 +246,7 @@ describe("worker environment service", () => {
       runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
       resolveWorkspacePath: async () => "/gateway/workspace",
       reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => undefined,
+      resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
     });
 
     await expect(

--- a/src/gateway/worker-environments/provider-provisioning.replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.replay.test.ts
@@ -293,7 +293,7 @@ describe("worker environment service provision replay", () => {
       runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
       resolveWorkspacePath: async () => "/gateway/workspace",
       reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => undefined,
+      resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
       onActivated,
     });
     const uninstallReconcileGuard = restarted.installReconcileEnvironmentGuard(

--- a/src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts
+++ b/src/gateway/worker-environments/provider-provisioning.shutdown-replay.test.ts
@@ -143,7 +143,7 @@ describe("worker node provisioning shutdown replay", () => {
         runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
         resolveWorkspacePath: async () => "/gateway/workspace",
         reportWorkspaceResultConflict: async () => {},
-        resolveWorkspaceResultConflict: async () => undefined,
+        resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
       });
     const firstDispatch = createDispatch(first);
     const uninstallFirstGuard = first.installReconcileEnvironmentGuard(

--- a/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-failure-recovery.test.ts
@@ -453,7 +453,7 @@ describe("worker turn launcher failure recovery", () => {
       workspaceOperations,
       resolveWorkspacePath: async () => root,
       reportWorkspaceResultConflict: async () => {},
-      resolveWorkspaceResultConflict: async () => undefined,
+      resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
     });
     const provider = createWorkerSessionTurnPlacementProvider({
       environments,

--- a/src/gateway/worker-environments/worker-turn-launcher-reconcile-error.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-reconcile-error.test.ts
@@ -90,7 +90,7 @@ describe("worker turn recovery after environment reconciliation errors", () => {
         runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
         resolveWorkspacePath: async () => root,
         reportWorkspaceResultConflict: async () => {},
-        resolveWorkspaceResultConflict: async () => undefined,
+        resolveWorkspaceResultConflict: async () => ({ kind: "absent" }),
       }),
       (_request, run) => run(),
     );

--- a/src/gateway/worker-environments/workspace-conflicts.ts
+++ b/src/gateway/worker-environments/workspace-conflicts.ts
@@ -8,7 +8,7 @@ export type WorkspaceResultConflictLookup =
   | { kind: "absent" }
   | { kind: "conflict"; conflict: Required<WorkerWorkspaceResultConflict> }
   | { kind: "unknown"; reason: WorkspaceResultConflictUnknownReason };
-export type WorkspaceResultConflictUnknownReason = "malformed-report" | "session-unavailable";
+type WorkspaceResultConflictUnknownReason = "malformed-report" | "session-unavailable";
 
 export type WorkerWorkspaceRecoveryFailureReport = {
   sessionId: string;

--- a/src/gateway/worker-environments/workspace-conflicts.ts
+++ b/src/gateway/worker-environments/workspace-conflicts.ts
@@ -4,6 +4,12 @@ export type WorkerWorkspaceResultConflict = {
   totalCount?: number;
 };
 
+export type WorkspaceResultConflictLookup =
+  | { kind: "absent" }
+  | { kind: "conflict"; conflict: Required<WorkerWorkspaceResultConflict> }
+  | { kind: "unknown"; reason: WorkspaceResultConflictUnknownReason };
+export type WorkspaceResultConflictUnknownReason = "malformed-report" | "session-unavailable";
+
 export type WorkerWorkspaceRecoveryFailureReport = {
   sessionId: string;
   sessionKey: string;

--- a/src/gateway/worker-workspace-conflict-transcript.ts
+++ b/src/gateway/worker-workspace-conflict-transcript.ts
@@ -1,4 +1,4 @@
-import type { Result } from "@openclaw/normalization-core/result";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { getRuntimeConfig } from "../config/config.js";
 import {
   appendSessionTranscriptReport,
@@ -13,6 +13,7 @@ import {
   WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
   WORKSPACE_RECOVERY_FAILURE_TRANSCRIPT_TYPE,
   type WorkerWorkspaceRecoveryFailureReport,
+  type WorkspaceResultConflictLookup,
 } from "./worker-environments/workspace-conflicts.js";
 
 export function createWorkerWorkspaceConflictTranscriptHandlers(
@@ -26,7 +27,7 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
     run: (target: SessionTranscriptWriteScope) => Promise<Result<T, unknown>>,
     missingMessage?: string,
     strictIdentity = false,
-  ): Promise<T | undefined> {
+  ): Promise<Result<T, "session-unavailable">> {
     const runtime = await loadSessionRuntime();
     const target = runtime.resolveGatewaySessionStoreTargetWithStore({
       cfg: getRuntimeConfig(),
@@ -35,11 +36,11 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
       clone: false,
       exactRead: true,
     });
-    const lostSession = () => {
+    const lostSession = (): Result<T, "session-unavailable"> => {
       if (missingMessage) {
         throw new Error(`${missingMessage} lost session ${identity.sessionId}`);
       }
-      return undefined;
+      return err("session-unavailable");
     };
     const entry = runtime.resolveCanonicalSessionEntryFromStoreKeys(target.store, target.storeKeys);
     if (
@@ -55,7 +56,7 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
       sessionKey: target.canonicalKey,
       storePath: target.storePath,
     });
-    return result.ok ? result.value : lostSession();
+    return result.ok ? ok(result.value) : lostSession();
   }
 
   return {
@@ -63,15 +64,19 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
       sessionId: string;
       sessionKey: string;
       agentId: string;
-    }) => {
-      const transcriptEntry = await withWorkerTranscript(identity, (target) =>
+    }): Promise<WorkspaceResultConflictLookup> => {
+      const result = await withWorkerTranscript(identity, (target) =>
         readLatestSessionTranscriptReport(target, [
           WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
           WORKSPACE_CONFLICT_CLEARED_TRANSCRIPT_TYPE,
         ]),
       );
+      if (!result.ok) {
+        return { kind: "unknown", reason: result.error };
+      }
+      const transcriptEntry = result.value;
       if (transcriptEntry?.customType !== WORKSPACE_CONFLICT_TRANSCRIPT_TYPE) {
-        return undefined;
+        return { kind: "absent" };
       }
       const details = transcriptEntry.details as
         | { paths?: unknown; stagedResultRef?: unknown; totalCount?: unknown }
@@ -88,13 +93,16 @@ export function createWorkerWorkspaceConflictTranscriptHandlers(
             (details.totalCount as number) >= details.paths.length)) &&
         /^refs\/openclaw\/worker-results\/[A-Za-z0-9-]+$/u.test(details.stagedResultRef)
       ) {
-        return projectWorkspaceResultConflict(
-          details.paths,
-          details.stagedResultRef,
-          details.totalCount as number | undefined,
-        );
+        return {
+          kind: "conflict",
+          conflict: projectWorkspaceResultConflict(
+            details.paths,
+            details.stagedResultRef,
+            details.totalCount as number | undefined,
+          ),
+        };
       }
-      return undefined;
+      return { kind: "unknown", reason: "malformed-report" };
     },
     reportWorkspaceResultConflict: async (
       conflict: { sessionId: string; sessionKey: string; agentId: string } & (

--- a/src/gateway/worker-workspace-recovery-transcript.test.ts
+++ b/src/gateway/worker-workspace-recovery-transcript.test.ts
@@ -100,13 +100,16 @@ describe("worker workspace recovery transcript reporting", () => {
         ]);
         const handlers = createWorkerWorkspaceConflictTranscriptHandlers(loadSessionRuntime);
         expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual(
-          navigation === "reset" ? undefined : conflict,
+          navigation === "reset" ? { kind: "absent" } : { kind: "conflict", conflict },
         );
         await handlers.reportWorkspaceResultConflict({ ...IDENTITY, ...conflict });
-        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual(conflict);
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual({
+          kind: "conflict",
+          conflict,
+        });
         await handlers.reportWorkspaceResultConflict({ ...IDENTITY, cleared: true });
         await handlers.reportWorkspaceResultConflict({ ...IDENTITY, cleared: true });
-        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toBeUndefined();
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual({ kind: "absent" });
         const reports = (await loadTranscriptEvents(IDENTITY)).filter(
           (event) => isRecord(event) && event.type === "custom_message",
         );
@@ -118,6 +121,58 @@ describe("worker workspace recovery transcript reporting", () => {
       });
     },
   );
+  it.each([
+    { label: "invalid staged ref", paths: ["edited.ts"], stagedResultRef: "refs/heads/main" },
+    { label: "empty paths", paths: [], stagedResultRef: "refs/openclaw/worker-results/result-1" },
+  ])(
+    "reports $label as unknown instead of treating a retained conflict as absent",
+    async (details) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        await upsertSessionEntryCore(IDENTITY, { sessionId: IDENTITY.sessionId, updatedAt: 1 });
+        await replaceTranscriptEvents(IDENTITY, [
+          { type: "session", id: IDENTITY.sessionId, version: CURRENT_SESSION_VERSION },
+          {
+            type: "custom_message",
+            id: "malformed-conflict",
+            parentId: null,
+            customType: WORKSPACE_CONFLICT_TRANSCRIPT_TYPE,
+            content: "Conflict",
+            display: true,
+            details: {
+              paths: details.paths,
+              stagedResultRef: details.stagedResultRef,
+              totalCount: 1,
+            },
+          },
+        ]);
+        const handlers = createWorkerWorkspaceConflictTranscriptHandlers(loadSessionRuntime);
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual({
+          kind: "unknown",
+          reason: "malformed-report",
+        });
+      });
+    },
+  );
+
+  it.each(["missing", "rebound"])(
+    "reports a %s session as unavailable instead of treating its conflict as absent",
+    async (sessionState) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        if (sessionState === "rebound") {
+          await upsertSessionEntryCore(IDENTITY, {
+            sessionId: "replacement-workspace-session",
+            updatedAt: 1,
+          });
+        }
+        const handlers = createWorkerWorkspaceConflictTranscriptHandlers(loadSessionRuntime);
+        expect(await handlers.resolveWorkspaceResultConflict(IDENTITY)).toEqual({
+          kind: "unknown",
+          reason: "session-unavailable",
+        });
+      });
+    },
+  );
+
   it("records historical recovery failures while preserving the live pending-result owner", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       await upsertSessionEntryCore(REQUEST, { sessionId: REQUEST.sessionId, updatedAt: 1 });


### PR DESCRIPTION
Related: #139437

## What Problem This Solves

Resolves a problem where cloud worker reclaim and pending-result recovery could not tell a verified "no retained conflict" apart from "could not read the conflict state". The transcript reader returned nothing in three different situations: the latest report was absent or cleared, the retained conflict report had malformed details, or the canonical session was missing or rebound. Callers treated all three as "no prior conflict", so an unreadable retained conflict was silently indistinguishable from a clean workspace, and an operator had no signal that anything was off.

## Why This Change Was Made

The reader now returns an explicit lookup: `absent`, `conflict` with the projected conflict, or `unknown` with a reason (`malformed-report` or `session-unavailable`). Session loss is carried through the reader's `Result` instead of being flattened, so a refusal from the transcript accessor is no longer read as absence. Both placement callers (the stop/reclaim path and startup pending-result recovery) go through one shared helper: `absent` and `conflict` behave exactly as before, while `unknown` emits one bounded `gateway/worker-placement` warning and hands the finalizer no prior knowledge. That is the correct preservation behavior: `finalizeWorkspaceResultConflicts` neither clears a report nor deletes a staged ref it was not shown, so the retained transcript report and its staged result survive untouched. Placement state machines, reclaim eligibility, and the finalizer are unchanged. This closes the follow-up noted while landing #139437.

## User Impact

No change to reclaim outcomes or to sessions with a readable conflict. When a retained conflict cannot be read, the Gateway log now shows one warning naming the session and reason instead of silently proceeding as if no conflict existed. No configuration or schema changes.

## Evidence

**Reader contract tests** (`src/gateway/worker-workspace-recovery-transcript.test.ts`): the existing navigation table now asserts the `conflict`/`absent` arms; new tables cover a retained report with an invalid staged ref or empty paths (`unknown`/`malformed-report`) and a missing or rebound canonical session entry (`unknown`/`session-unavailable`). These fail on the pre-change reader, which returned `undefined` for every case.

**Placement caller tests**: `placement-dispatch-reclaim.test.ts` reclaims an unchanged worker whose lookup is `unknown` and asserts the placement completes, no conflict report or clear is emitted, the pending result is settled, and exactly one bounded warning names the session and reason. `placement-dispatch.test.ts` extends the previous-instance pending-result fixture into an `absent`/`unknown` table with the same assertions, so startup recovery is covered too. Logging is observed through a partial subsystem-logger mock, the pattern already used in `event-web-push.test.ts`; no production seam was added.

Full placement-dispatch family plus every touched suite:

```sh
node scripts/run-vitest.mjs src/gateway/worker-environments/placement-dispatch*.test.ts src/gateway/worker-environments/worker-turn-launcher*.test.ts src/gateway/worker-environments/provider-provisioning*.test.ts src/gateway/worker-environments/provider-bootstrap.test.ts src/gateway/worker-environments/placement-targeted-recovery.test.ts src/gateway/server-worker-placement-startup-cleanup.test.ts src/gateway/server.sessions.worker-original-order.test.ts src/gateway/worker-workspace-recovery-transcript.test.ts
```

```text
 Test Files  30 passed (30)
      Tests  499 passed (499)
   Duration  195.90s (tests 66%, transform 25%, import 7%, worker 1%)
[test] passed 1 Vitest shard in 212.63s
```

`node scripts/check-changed.mjs`: all lanes ok on the rebased head, including typecheck core tests (the original base carried a pre-existing typecheck failure in an unrelated agents test, already fixed on main by #139519, so the branch was rebased onto it). The dead export lane first flagged the new reason type as exported but only used in its own file; the second commit makes it file-local, and the lane reruns clean (0 entries on the script, production, and full-tree scans).

Codex autoreview (local mode, P1 threshold): scoped-clean, no accepted or actionable findings.

Diff: production +70 / -26 across four files; tests and test support +186 / -44, most of it mechanical stub updates from `undefined` to `{ kind: "absent" }`.

**CI follow-up on the first head.** The first CI run failed `check-lint-core-1` because the new tests pushed `placement-dispatch-reclaim.test.ts` and `placement-dispatch.test.ts` over the oxlint `max-lines` limit, and `checks-node-compact-small-19` failed on the lint-suppressions allowlist for `server-held-work.test-support.ts`, a main-side file already fixed by #139593. The branch is rebased onto current main, and the two placement tests now live in their own suite, `placement-dispatch-conflict-lookup.test.ts` (127 lines), so both original suites are back at or below their main line counts. The previous-instance pending-result test that the table replaced moved with it as the `absent` row. The move is patch-identical apart from the relocation, and the three placement suites pass together.
