### PR TITLE
fix(lint): add server-held-work.test-support to lint-suppressions allowlist

### DIFF
--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -220,6 +220,8 @@ describe("production lint suppressions", () => {
         "src/commands/backup-restore.ts|preserve-caught-error|1",
         // Intl.Collator.compare is a getter returning a bound function.
         "src/cron/service/list-page-sort.ts|typescript/unbound-method|1",
+        // Capture the native method before spying; every invocation binds its actual scope with .call(this).
+        "src/gateway/server-held-work.test-support.ts|typescript/unbound-method|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
## What Problem This Solves

PR #139483 (merged to main at commit `13e1b10f78`) added `src/gateway/server-held-work.test-support.ts` with a `typescript/unbound-method` suppression (`// oxlint-disable-next-line typescript/unbound-method`) but did not add the entry to the lint-suppressions allowlist in `test/scripts/lint-suppressions.test.ts`.

This breaks the `keeps the intentional production suppression tail on an explicit allowlist` test for **all** PRs merging against the latest main. The test expects 67 entries but receives 68 — the extra entry is `src/gateway/server-held-work.test-support.ts|typescript/unbound-method|1`.

## Root Cause

The lint-suppressions test (`test/scripts/lint-suppressions.test.ts:187`) maintains an explicit allowlist of production code lint suppressions. When PR #139483 added the new test-support file with an `oxlint-disable-next-line typescript/unbound-method` comment, it should have also added the corresponding entry to the allowlist. The entry was omitted.

## Fix

Add the missing entry to the allowlist, alphabetically placed between `list-page-sort.ts` (the previous `unbound-method` entry) and `test-helpers.server.ts` (the next `gateway` entry):

```
// Capture the native method before spying; every invocation binds its actual scope with .call(this).
"src/gateway/server-held-work.test-support.ts|typescript/unbound-method|1",
```

The comment matches the rationale in the source file's `oxlint-disable-next-line` comment.

## Evidence

The allowlist had 67 entries; the actual lint output has 68. The diff from the failing test:

```
+   "src/gateway/server-held-work.test-support.ts|typescript/unbound-method|1",
```

After this fix, the allowlist has 68 entries matching the 68 actual suppressions. The test passes.
