### PR TITLE
fix(audit): preserve sequence range validation before numeric decoding

### DIFF
--- a/src/audit/audit-event-store.ts
+++ b/src/audit/audit-event-store.ts
@@ -624,17 +624,19 @@ export function recordAuditEvent(
   try {
     return runOpenClawStateWriteTransaction(({ db }) => {
       countCacheDatabase = db;
-      const insert = executeSqliteQuerySync(
+      // Read losslessly so Node's rowid decoding cannot preempt the safe-integer guard.
+      const insert = executeSqliteQueryTakeFirstSync(
         db,
         getAuditKysely(db)
           .insertInto("audit_events")
           .values(bindAuditEvent(db, input))
-          .onConflict((conflict) => conflict.column("source_id").doNothing()),
+          .onConflict((conflict) => conflict.column("source_id").doNothing())
+          .returning((eb) => eb.cast<string>("sequence", "text").as("sequence")),
       );
-      if (insert.insertId === undefined) {
+      if (insert === undefined) {
         return undefined;
       }
-      const insertedSequence = Number(insert.insertId);
+      const insertedSequence = Number(insert.sequence);
       if (!Number.isSafeInteger(insertedSequence) || insertedSequence < 1) {
         throw new Error("audit event sequence is outside the supported integer range");
       }

--- a/src/audit/audit-events.test.ts
+++ b/src/audit/audit-events.test.ts
@@ -261,7 +261,7 @@ describe("audit event persistence", () => {
     const database = createDatabaseOptions();
     const { db } = openOpenClawStateDatabase(database);
     db.prepare("INSERT INTO sqlite_sequence (name, seq) VALUES ('audit_events', ?)").run(
-      Number.MAX_SAFE_INTEGER,
+      BigInt(Number.MAX_SAFE_INTEGER),
     );
 
     expect(() => recordAuditEvent(auditInput(), database)).toThrow(


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Audit insertion can throw a native SQLite rowid-conversion error before its existing supported-integer-range check runs. The full-suite profiling run exposed this at the largest safe JavaScript integer boundary.

## Why This Change Was Made

Return the inserted sequence as SQLite text, then apply the existing Number conversion and safe-integer guard inside the same transaction. Preserve duplicate no-row handling, pruning, rereading, terminal binding, and rollback order. The regression fixture binds the high-water mark as an actual SQLite INTEGER.

## User Impact

Oversized audit sequences receive the existing domain-specific rejection with the insert rolled back. No schema, retention, collection, reader-scope, or generic SQLite decoding policy changes. Net two production lines added; test LOC is unchanged.

## Evidence

The original audit-owner test reproduced the native conversion failure with the INTEGER fixture. The unchanged named-error and zero-row rollback assertions pass after the repair. All 198 audit/writer-family cases and 12 transaction cases pass, including deduplication and retention behavior. Full changed checks, formatting/diff checks, deslop and fresh independent P2 review pass.

No runtime reduction is claimed; this repairs a correctness blocker for the campaign baseline.
