### PR TITLE
fix(test): make plugin state and QA checks portable to Bun

### DIFF
--- a/extensions/device-pair/doctor-contract-api.test.ts
+++ b/extensions/device-pair/doctor-contract-api.test.ts
@@ -91,7 +91,7 @@ describe("device-pair doctor notify migration", () => {
       subscribers.map(notifySubscriberStoreKey).toSorted(),
     );
     await expect(fs.access(sourcePath)).rejects.toThrow();
-    await expect(fs.access(`${sourcePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${sourcePath}.migrated`);
     await expect(migration.detectLegacyState(migrationParams())).resolves.toBeNull();
   });
 
@@ -193,7 +193,7 @@ describe("device-pair doctor notify migration", () => {
       expect.stringContaining("Archived Device Pair notify-state legacy source"),
     ]);
     await expect(fs.access(sourcePath)).rejects.toThrow();
-    await expect(fs.access(`${sourcePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${sourcePath}.migrated`);
     await expect(
       createDoctorContext(env)
         .openPluginStateKeyedStore<NotifySubscription>({
@@ -222,6 +222,6 @@ describe("device-pair doctor notify migration", () => {
       changes: [],
       warnings: [],
     });
-    await expect(fs.access(sourcePath)).resolves.toBeUndefined();
+    await fs.access(sourcePath);
   });
 });

--- a/extensions/msteams/doctor-contract-api.test.ts
+++ b/extensions/msteams/doctor-contract-api.test.ts
@@ -135,7 +135,7 @@ describe("msteams doctor state migration", () => {
       expect.stringContaining("Archived Microsoft Teams conversation legacy source"),
     ]);
     await expect(fs.access(filePath)).rejects.toThrow();
-    await expect(fs.access(`${filePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${filePath}.migrated`);
     const store = context.openPluginStateKeyedStore<StoredConversationReference>({
       namespace: MSTEAMS_CONVERSATIONS_NAMESPACE,
       maxEntries: 2000,
@@ -221,7 +221,7 @@ describe("msteams doctor state migration", () => {
     ).resolves.toMatchObject({
       votes: { "user-new": ["1"] },
     });
-    await expect(fs.access(`${filePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${filePath}.migrated`);
     const source = await fs.readFile(`${filePath}.migrated`, "utf8");
     const beforeRerun = await voteBucketStore.entries();
     await fs.writeFile(filePath, source);
@@ -279,7 +279,7 @@ describe("msteams doctor state migration", () => {
     ).resolves.toEqual(token);
     expect(result.changes.join("\n")).not.toContain(token.token);
     expect(result.warnings.join("\n")).not.toContain(token.token);
-    await expect(fs.access(`${filePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${filePath}.migrated`);
   });
 
   it.each([
@@ -419,7 +419,7 @@ describe("msteams doctor state migration", () => {
       overflowPolicy: "reject-new",
     });
     await expect(store.lookup(MSTEAMS_DELEGATED_TOKEN_KEY)).resolves.toEqual(token);
-    await expect(fs.access(`${filePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${filePath}.migrated`);
   });
 
   it("does not register a doctor migration for pending-upload cache files", () => {
@@ -498,8 +498,8 @@ describe("msteams doctor state migration", () => {
     expect(result.warnings).toEqual([]);
     await expect(fs.access(encodedSourcePath)).rejects.toThrow();
     await expect(fs.access(sanitizedSourcePath)).rejects.toThrow();
-    await expect(fs.access(`${encodedSourcePath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${sanitizedSourcePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${encodedSourcePath}.migrated`);
+    await fs.access(`${sanitizedSourcePath}.migrated`);
 
     const store = context.openPluginStateKeyedStore({
       namespace: "feedback-learnings",

--- a/extensions/msteams/src/conversation-store-state.test.ts
+++ b/extensions/msteams/src/conversation-store-state.test.ts
@@ -83,9 +83,7 @@ describe("msteams conversation store (plugin state)", () => {
       "19:legacy@thread.tacv2",
       "19:new@thread.tacv2",
     ]);
-    await expect(
-      fs.promises.access(path.join(stateDir, "state", "openclaw.sqlite")),
-    ).resolves.toBeUndefined();
+    await fs.promises.access(path.join(stateDir, "state", "openclaw.sqlite"));
   });
 
   it("ignores a stale legacy JSON file at runtime", async () => {
@@ -126,7 +124,7 @@ describe("msteams conversation store (plugin state)", () => {
 
     const store = createMSTeamsConversationStoreState({ env });
     await expect(store.get("conv-current")).resolves.toEqual(ref);
-    await expect(fs.promises.access(filePath)).resolves.toBeUndefined();
+    await fs.promises.access(filePath);
   });
 
   it("hashes external conversation ids before using plugin-state keys", async () => {

--- a/extensions/msteams/src/pending-uploads-fs.test.ts
+++ b/extensions/msteams/src/pending-uploads-fs.test.ts
@@ -109,9 +109,7 @@ describe("msteams pending uploads (fs-backed)", () => {
     // Confirm SQLite-backed plugin state was created instead of a new JSON store.
     const storePath = path.join(stateDir, "msteams-pending-uploads.json");
     await expect(fs.promises.access(storePath)).rejects.toThrow();
-    await expect(
-      fs.promises.access(path.join(stateDir, "state", "openclaw.sqlite")),
-    ).resolves.toBeUndefined();
+    await fs.promises.access(path.join(stateDir, "state", "openclaw.sqlite"));
 
     // Second "process": reader using the same state dir
     const reader = await getPendingUploadFs("upload-x", { env });
@@ -233,7 +231,7 @@ describe("msteams pending uploads (fs-backed)", () => {
     );
 
     expect(await getPendingUploadFs("cached", { env })).toBeUndefined();
-    await expect(fs.promises.access(storePath)).resolves.toBeUndefined();
+    await fs.promises.access(storePath);
   });
 });
 

--- a/extensions/msteams/src/polls.test.ts
+++ b/extensions/msteams/src/polls.test.ts
@@ -131,7 +131,7 @@ describe("state poll store", () => {
 
     const store = createMSTeamsPollStoreState({ stateDir });
     await expect(store.getPoll("poll-legacy")).resolves.toBeNull();
-    await expect(fs.promises.access(filePath)).resolves.toBeUndefined();
+    await fs.promises.access(filePath);
 
     await store.createPoll({
       id: "poll-new",
@@ -142,9 +142,7 @@ describe("state poll store", () => {
       votes: {},
     });
     await expect(store.getPoll("poll-new")).resolves.toMatchObject({ id: "poll-new" });
-    await expect(
-      fs.promises.access(path.join(stateDir, "state", "openclaw.sqlite")),
-    ).resolves.toBeUndefined();
+    await fs.promises.access(path.join(stateDir, "state", "openclaw.sqlite"));
   });
 
   it("hashes external poll ids before using plugin-state keys", async () => {

--- a/extensions/msteams/src/sso-token-store.test.ts
+++ b/extensions/msteams/src/sso-token-store.test.ts
@@ -46,9 +46,7 @@ describe("msteams sso token store (plugin state)", () => {
     expect(await store.get(second)).toEqual(second);
 
     await expect(fs.access(storePath)).rejects.toThrow();
-    await expect(
-      fs.access(path.join(stateDir, "state", "openclaw.sqlite")),
-    ).resolves.toBeUndefined();
+    await fs.access(path.join(stateDir, "state", "openclaw.sqlite"));
   });
 
   it("ignores legacy flat-key token files at runtime", async () => {
@@ -81,7 +79,7 @@ describe("msteams sso token store (plugin state)", () => {
         userId: "user-1",
       }),
     ).toBeNull();
-    await expect(fs.access(storePath)).resolves.toBeUndefined();
+    await fs.access(storePath);
   });
 
   it("keeps plugin-state keys bounded for long Teams identifiers", async () => {

--- a/extensions/qa-lab/src/suite-launch.runtime.test.ts
+++ b/extensions/qa-lab/src/suite-launch.runtime.test.ts
@@ -725,7 +725,7 @@ describe("qa suite runtime launcher", () => {
         }),
       ]),
     );
-    await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
+    await fs.access(result.result.reportPath);
   });
 
   it("preserves completed partitions when a retryable channel fails twice", async () => {
@@ -788,7 +788,7 @@ describe("qa suite runtime launcher", () => {
         }),
       ]),
     );
-    await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
+    await fs.access(result.result.reportPath);
   });
 
   it("records an exhausted fail-fast partition without starting later partitions", async () => {
@@ -844,7 +844,7 @@ describe("qa suite runtime launcher", () => {
       { test: { id: "whatsapp-status-command" }, result: { status: "fail" } },
     ]);
     expect(result.observedCells).toEqual([]);
-    await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
+    await fs.access(result.result.reportPath);
   });
 
   it("attributes an exhausted fail-fast retry to the later scenario that actually started", async () => {
@@ -913,7 +913,7 @@ describe("qa suite runtime launcher", () => {
         },
       },
     ]);
-    await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
+    await fs.access(result.result.reportPath);
   });
 
   it("runs distinct pluggable-driver channels within the global concurrency budget", async () => {
@@ -1357,8 +1357,8 @@ describe("qa suite runtime launcher", () => {
         writeEvidenceFile: false,
       }),
     );
-    await expect(fs.access(path.join(outputDir, "qa-suite-summary.json"))).resolves.toBeUndefined();
-    await expect(fs.access(path.join(outputDir, "qa-evidence.json"))).resolves.toBeUndefined();
+    await fs.access(path.join(outputDir, "qa-suite-summary.json"));
+    await fs.access(path.join(outputDir, "qa-evidence.json"));
     await expect(fs.access(path.join(outputDir, "flow", "qa-evidence.json"))).rejects.toMatchObject(
       {
         code: "ENOENT",
@@ -2560,8 +2560,8 @@ describe("qa suite runtime launcher", () => {
       counts: { failed: number; passed: number; total: number };
     };
     expect(summary.counts).toMatchObject({ total: 2, passed: 1, failed: 1 });
-    await expect(fs.access(result.result.evidencePath)).resolves.toBeUndefined();
-    await expect(fs.access(result.result.reportPath)).resolves.toBeUndefined();
+    await fs.access(result.result.evidencePath);
+    await fs.access(result.result.reportPath);
   });
 
   it("reuses unavailable channel credential evidence across serial partitions", async () => {

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -614,8 +614,8 @@ describe("qa suite", () => {
 
       expect(artifacts.evidence?.kind).toBe(QA_EVIDENCE_SUMMARY_KIND);
       await expect(fs.access(artifacts.evidencePath)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.access(artifacts.reportPath)).resolves.toBeUndefined();
-      await expect(fs.access(artifacts.summaryPath)).resolves.toBeUndefined();
+      await fs.access(artifacts.reportPath);
+      await fs.access(artifacts.summaryPath);
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });
     }

--- a/extensions/qa-lab/src/test-file-scenario-runner.native.test.ts
+++ b/extensions/qa-lab/src/test-file-scenario-runner.native.test.ts
@@ -238,7 +238,7 @@ describe("qa test file scenario runner", () => {
       result: {
         status: "fail",
         failure: {
-          reason: "node exited with 1",
+          reason: `${path.basename(process.execPath)} exited with 1`,
         },
       },
     });
@@ -452,7 +452,7 @@ describe("qa test file scenario runner", () => {
 
       const firstRun = await runQaTestFileScenarios(runParams);
       expect(firstRun.results[0]).toMatchObject({ status: "pass" });
-      await expect(fs.access(reportPath)).resolves.toBeUndefined();
+      await fs.access(reportPath);
 
       writeReport = false;
       const secondRun = await runQaTestFileScenarios(runParams);

--- a/extensions/voice-call/doctor-contract-api.test.ts
+++ b/extensions/voice-call/doctor-contract-api.test.ts
@@ -220,7 +220,7 @@ describe("voice-call doctor state migration", () => {
       expect.stringContaining("Archived Voice Call call-log legacy source"),
     ]);
     await expect(fs.access(sourcePath)).rejects.toThrow();
-    await expect(fs.access(`${sourcePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${sourcePath}.migrated`);
 
     const restored = loadActiveCallsFromStore(storePath);
     expect(restored.activeCalls.get("call-doctor")?.providerCallId).toBe("provider-doctor");
@@ -420,7 +420,7 @@ describe("voice-call doctor state migration", () => {
       "Skipped malformed Voice Call call-log line 2",
       "Left Voice Call call-log source in place because migration was incomplete",
     ]);
-    await expect(fs.access(sourcePath)).resolves.toBeUndefined();
+    await fs.access(sourcePath);
     await expect(fs.access(`${sourcePath}.migrated`)).rejects.toThrow();
     expect(loadActiveCallsFromStore(storePath).activeCalls.has("call-valid")).toBe(true);
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes failures in plugin migration, state, and QA tests when they run under Bun and successful file-access checks return a different value from Node. QA's native process test also assumed the executable was always named node.

## Why This Change Was Made

The tests now await successful file access directly, so missing or inaccessible files still fail while the resolved value is irrelevant. The native failure expectation derives the executable basename from the active runtime. Substantive migration, stored-state, and failure assertions remain intact.

## User Impact

Developers can validate these existing behaviors under both runtimes without test-only assumptions about success return values or executable names. Production behavior is unchanged.

## Evidence

- 180 focused tests pass on Node and 180 on true Bun.
- Complete expanded changed-file gate and final refinement gate passed.
- Independent P0–P2 review found no actionable findings.
- Ten test files changed, with no production changes. Full Bun compatibility remains an ongoing campaign.
