### PR TITLE
fix(ci): keep native report cleanup observable on Linux

### DIFF
--- a/test/scripts/test-report-utils.test.ts
+++ b/test/scripts/test-report-utils.test.ts
@@ -103,6 +103,10 @@ describe("scripts/test-report-utils runVitestJsonReport", () => {
     signal,
     onTestFinished,
   }) => {
+    // Native child supervision needs the real Linux process-group census too.
+    const childProcess =
+      await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    spawnSyncMock.mockImplementation(childProcess.spawnSync);
     const lifetime = createFixtureLifetime();
     onTestFinished(() => lifetime.cleanup());
     await lifetime.run(async () => {


### PR DESCRIPTION
Related: #139377

## What Problem This Solves

Resolves a problem where Linux tooling CI rejects a successfully generated Vitest JSON report when exited tool descendants are still awaiting reaping. This caused `checks-node-compact-small-31` to fail after the report had already been written.

## Why This Change Was Made

The native report test shared a file-wide `spawnSync` mock with synthetic report tests. That mock also intercepted the real child supervisor's Linux `ps` census, preventing it from verifying process-group completion. Restore the real `spawnSync` implementation for the native subprocess case; the existing `beforeEach` reset preserves the synthetic cases' mocks.

Strict process-tree joining, report-content validation, and all seven test cases remain enforced. Production delta: **0 lines**. Test delta: **+4 lines**.

## User Impact

Developers get reliable native-report CI coverage on Linux while retaining checks for lingering child processes. There is no application behavior change.

## Evidence

- Original CI failure: [run 33998745633, compact-small-31](https://github.com/openclaw/openclaw/actions/runs/33998745633/job/101393820096): JSON report written, followed by `EPROCESSGROUP_CLEANUP_FAILED` at `test/scripts/test-report-utils.test.ts:143`.
- Controlled Linux reproduction uses the existing managed-child test's `PR_SET_CHILD_SUBREAPER` technique to hold naturally exited tooling descendants until supervision settles. Before the fix, the native report case fails after writing its report; six sibling cases pass and three descendants are subsequently reaped.
- With the four-line repair on base `67e8e2da4b10a7db00a36f39e77537ed3a2ea91a`, [Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34003017458) passed **7/7 cases** under the same held-reaping condition. The native report case took **1.093s**, the test shard took **2.27s**, and the subreaper verified **three successfully exited descendants**. Node **24.19.0**, Vitest **5.0.0**. The wrapper verified the frozen source and test-file digest before execution, returned exit **0**, and stopped the lease; independent status readback reports `completed`.
- macOS focused tests: **7/7 passed**. Changed checks, test-root typechecking, formatting, and `git diff --check` passed.
- Managed review through **P2**: scoped-clean, no accepted or actionable findings.

The Testbox backing Actions run may show cancellation during normal one-shot cleanup; its delegated command returned `runStatus: succeeded` and `exitCode: 0`. A later external runner-portal synchronization warning did not change the completed test or lease state.
