### PR TITLE
feat: expose garbage collection duration metrics

### DIFF
--- a/docs/gateway/opentelemetry.md
+++ b/docs/gateway/opentelemetry.md
@@ -603,6 +603,15 @@ see [Prometheus event-loop windows](/gateway/prometheus#event-loop-observation-w
 
 ### Diagnostics internals (memory, payloads, exporter health)
 
+- `openclaw.gc.duration_ms` (histogram, no attrs; elapsed GC duration for the hosting JavaScript isolate)
+
+GC duration uses Node.js performance entries and is exported only when metrics
+are enabled. It is not CPU time or a guaranteed stop-the-world pause. Observation
+starts when the existing diagnostics heartbeat sees an interested consumer;
+registration after startup can wait until its next 30-second tick, with no
+backfill. Diagnostics disable/shutdown disconnects immediately. See
+[GC duration coverage and correlation limits](/gateway/prometheus#garbage-collection-duration).
+
 - `openclaw.payload.large` (counter, attrs: `openclaw.payload.surface`, `openclaw.payload.action`, `openclaw.channel`, `openclaw.plugin`, `openclaw.reason`)
 - `openclaw.payload.large_bytes` (histogram, attrs: same as `openclaw.payload.large`)
 - `openclaw.memory.rss_bytes` / `openclaw.memory.heap_used_bytes` / `openclaw.memory.heap_total_bytes` / `openclaw.memory.external_bytes` / `openclaw.memory.array_buffers_bytes` (histograms, no attrs; process memory samples)

--- a/docs/gateway/prometheus.md
+++ b/docs/gateway/prometheus.md
@@ -94,6 +94,7 @@ For traces, logs, OTLP push, and OpenTelemetry GenAI semantic attributes, see [O
 | Metric                                               | Type      | Labels                                                                                    |
 | ---------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------- |
 | `openclaw_gateway_build_info`                        | gauge     | `process_instance_id`, optional `build_id`                                                |
+| `openclaw_gc_duration_seconds`                       | histogram | none                                                                                      |
 | `openclaw_gateway_rpc_requests_total`                | counter   | `method`                                                                                  |
 | `openclaw_gateway_rpc_first_response_seconds`        | histogram | `method`                                                                                  |
 | `openclaw_gateway_rpc_handler_seconds`               | histogram | `method`                                                                                  |
@@ -232,6 +233,29 @@ exporter's series cap, and process restarts can also lose observations. Watch
 the existing drop counters and the represented-duration counter when assessing
 coverage. Readiness decisions and persistent liveness-warning thresholds are unchanged.
 
+### Garbage collection duration
+
+`openclaw_gc_duration_seconds` records elapsed garbage collection (GC) duration
+reported by Node.js for the hosting JavaScript isolate. Each observation is one
+GC entry, not CPU time, allocated bytes, or a guaranteed stop-the-world pause.
+Compare its bucket counts with event-loop window maxima to investigate GC as a
+possible contributor to stalls; matching scrape intervals do not prove causality.
+
+Collection uses the existing diagnostics enablement and starts when the
+diagnostics heartbeat observes an interested consumer, such as a metrics exporter. A consumer added
+after heartbeat startup may wait until the next 30-second tick, or longer if the
+event loop is stalled. Entries preceding observer activation are not backfilled.
+Demand is checked when entries are delivered, so a brief consumer gap before the
+next heartbeat can still yield delayed observations. Losing the last
+consumer suppresses new exports; the observer disconnects at the next heartbeat.
+Disabling diagnostics or stopping the heartbeat disconnects it immediately.
+
+The histogram is absent until the first observation, so absence does not prove
+zero GC. Queue drops, the series cap, observation gaps and process restarts limit
+coverage. Diagnostics disable/re-enable preserves the exporter's existing
+counters; restarting the exporter resets them as usual. No extra timer, GC
+trigger, trace attribution or application payload is collected.
+
 ## Label policy
 
 <AccordionGroup>
@@ -306,6 +330,10 @@ increase(openclaw_gateway_event_loop_delay_max_seconds_count[5m])
 
 # Seconds represented by exported event-loop windows
 increase(openclaw_gateway_event_loop_observed_seconds_total[5m])
+
+# Observed GC entries whose elapsed duration exceeded one second
+increase(openclaw_gc_duration_seconds_count[5m])
+  - increase(openclaw_gc_duration_seconds_bucket{le="1"}[5m])
 ```
 
 <Tip>

--- a/extensions/diagnostics-otel/src/service-events.ts
+++ b/extensions/diagnostics-otel/src/service-events.ts
@@ -30,6 +30,7 @@ export function createDiagnosticsEventHandler(params: {
 }) {
   const { logger, recorders, recordLogRecord, recordSecurityEvent } = params;
   const {
+    recordGcDuration,
     recordGatewayEventLoopSample,
     recordGatewayRpc,
     recordModelUsage,
@@ -86,6 +87,9 @@ export function createDiagnosticsEventHandler(params: {
   ) => {
     try {
       switch (evt.type) {
+        case "diagnostic.gc":
+          recordGcDuration(evt, metadata);
+          return;
         case "gateway.event_loop.sample":
           recordGatewayEventLoopSample(evt, metadata);
           return;

--- a/extensions/diagnostics-otel/src/service-metrics.ts
+++ b/extensions/diagnostics-otel/src/service-metrics.ts
@@ -20,6 +20,11 @@ export function createDiagnosticsMetrics(
     meter.createHistogram(resolveMetricName(name), options);
 
   return {
+    gcDurationHistogram: createHistogram("openclaw.gc.duration_ms", {
+      unit: "ms",
+      description: "Elapsed garbage collection duration for the hosting JavaScript isolate",
+      advice: { explicitBucketBoundaries: AGENT_DURATION_MS_BUCKETS },
+    }),
     gatewayEventLoopDelayMaxHistogram: createHistogram("openclaw.gateway.event_loop.delay_max_ms", {
       unit: "ms",
       description: "Maximum event-loop delay per completed Gateway observation window",

--- a/extensions/diagnostics-otel/src/service-recorders-tools.ts
+++ b/extensions/diagnostics-otel/src/service-recorders-tools.ts
@@ -16,6 +16,7 @@ import type { TelemetryExporterDiagnosticEvent } from "./service-types.js";
 
 export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime) {
   const {
+    gcDurationHistogram,
     gatewayEventLoopDelayMaxHistogram,
     gatewayEventLoopObservedCounter,
     queueDepthHistogram,
@@ -272,6 +273,16 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
     span.end(evt.ts);
   };
 
+  const recordGcDuration = (
+    evt: Extract<DiagnosticEventPayload, { type: "diagnostic.gc" }>,
+    metadata: DiagnosticEventMetadata,
+  ) => {
+    if (!metadata.trusted && !isInternalDiagnosticEventMetadata(metadata)) {
+      return;
+    }
+    gcDurationHistogram.record(evt.durationMs, undefined, ROOT_CONTEXT);
+  };
+
   const recordGatewayEventLoopSample = (
     evt: Extract<DiagnosticEventPayload, { type: "gateway.event_loop.sample" }>,
     metadata: DiagnosticEventMetadata,
@@ -392,6 +403,7 @@ export function createToolAndSystemRecorders(runtime: DiagnosticsRecorderRuntime
   };
 
   return {
+    recordGcDuration,
     recordGatewayEventLoopSample,
     recordSkillUsed,
     recordToolExecutionStarted,

--- a/extensions/diagnostics-otel/src/service.event-loop.test.ts
+++ b/extensions/diagnostics-otel/src/service.event-loop.test.ts
@@ -27,7 +27,7 @@ test.each([
   { mode: "traces-only", metricsEnabled: false, traces: true, logs: false },
   { mode: "logs-only", metricsEnabled: false, traces: false, logs: true },
 ])(
-  "retains event-loop windows only as metrics with a preloaded SDK ($mode)",
+  "retains event-loop and GC durations only as metrics with a preloaded SDK ($mode)",
   async ({ metricsEnabled, traces, logs }) => {
     const receiver = await startOtlpReceiver();
     let meterProvider: MeterProvider | undefined;
@@ -43,9 +43,9 @@ test.each([
             exportIntervalMillis: 60_000,
           }),
         ],
-        views: [
-          {
-            instrumentName: "openclaw.gateway.event_loop.*",
+        views: ["openclaw.gateway.event_loop.*", "openclaw.gc.duration_ms"].map(
+          (instrumentName) => ({
+            instrumentName,
             attributesProcessors: [
               {
                 process(attributes, measurementContext) {
@@ -58,8 +58,8 @@ test.each([
                 },
               },
             ],
-          },
-        ],
+          }),
+        ),
       });
       metrics.disable();
       expect(metrics.setGlobalMeterProvider(meterProvider)).toBe(true);
@@ -75,7 +75,7 @@ test.each([
             ...bridge,
             onEvent(listener, filter) {
               return bridge.onEvent((event, metadata, privateData) => {
-                if (event.type === "gateway.event_loop.sample") {
+                if (event.type === "gateway.event_loop.sample" || event.type === "diagnostic.gc") {
                   deliveredSamples++;
                 }
                 listener(event, metadata, privateData);
@@ -99,7 +99,11 @@ test.each([
               .at(-1)
               ?.scopeMetrics.flatMap((scope) => scope.metrics) ?? []
           )
-            .filter((metric) => metric.descriptor.name.startsWith("openclaw.gateway.event_loop."))
+            .filter(
+              (metric) =>
+                metric.descriptor.name.startsWith("openclaw.gateway.event_loop.") ||
+                metric.descriptor.name === "openclaw.gc.duration_ms",
+            )
             .map(
               (metric) =>
                 [
@@ -125,6 +129,7 @@ test.each([
             intervalMs,
             delayMaxMs,
           });
+          emitInternalDiagnosticEventForTest({ type: "diagnostic.gc", durationMs: delayMaxMs });
           await waitForDiagnosticEventsDrained();
         });
         await meterProvider.forceFlush();
@@ -138,6 +143,10 @@ test.each([
               unit: "ms",
               points: [{ attributes: {}, value: totalMs }],
             },
+            "openclaw.gc.duration_ms": {
+              unit: "ms",
+              points: [{ attributes: {}, value: { count, sum } }],
+            },
           });
         } else {
           expect(sampleMetrics()).toEqual({});
@@ -149,6 +158,7 @@ test.each([
         intervalMs: 99_000,
         delayMaxMs: 99_000,
       });
+      emitDiagnosticEvent({ type: "diagnostic.gc", durationMs: 99_000 });
       await waitForDiagnosticEventsDrained();
       await meterProvider.forceFlush();
       expect(sampleMetrics()).toEqual(retained);
@@ -156,10 +166,10 @@ test.each([
         Object.values(sampleMetrics()).flatMap((metric) =>
           metric.points.map(({ attributes }) => attributes),
         ),
-      ).toEqual(metricsEnabled ? [{}, {}] : []);
-      expect(deliveredSamples).toBe(metricsEnabled ? 3 : 0);
+      ).toEqual(metricsEnabled ? [{}, {}, {}] : []);
+      expect(deliveredSamples).toBe(metricsEnabled ? 6 : 0);
       expect(observedParents).toEqual(
-        metricsEnabled ? [undefined, undefined, undefined, undefined] : [],
+        metricsEnabled ? [undefined, undefined, undefined, undefined, undefined, undefined] : [],
       );
       await stopStartedOtelServices();
       expect(sdk.exporter.getFinishedSpans()).toEqual([]);

--- a/extensions/diagnostics-otel/src/service.ts
+++ b/extensions/diagnostics-otel/src/service.ts
@@ -601,7 +601,7 @@ export function createDiagnosticsOtelService(): OpenClawPluginService {
         metricsActive
           ? undefined
           : tracesActive
-            ? { exclude: ["gateway.event_loop.sample"] }
+            ? { exclude: ["gateway.event_loop.sample", "diagnostic.gc"] }
             : { include: ["log.record", "security.event"] },
       );
       if (tracesActive) {

--- a/extensions/diagnostics-prometheus/src/service.event-loop.test.ts
+++ b/extensions/diagnostics-prometheus/src/service.event-loop.test.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import { describe, expect, it } from "vitest";
 import { baseEvent, createMetricsHarness, trusted, untrusted } from "./service.test-helpers.js";
 
-describe("diagnostics-prometheus event-loop metrics", () => {
+describe("diagnostics-prometheus runtime metrics", () => {
   it.each([false, true])(
     "caps series growth while retaining admitted event-loop windows (preseed=%s)",
     (preseed) => {
@@ -16,6 +16,7 @@ describe("diagnostics-prometheus event-loop metrics", () => {
       try {
         if (preseed) {
           metrics.record(sample, trusted);
+          metrics.record({ ...baseEvent(), type: "diagnostic.gc", durationMs: 20 }, trusted);
         }
         for (let index = 0; index < 2100; index += 1) {
           metrics.record(
@@ -43,13 +44,16 @@ describe("diagnostics-prometheus event-loop metrics", () => {
         const before = drops();
         expect(before).toBeGreaterThan(0);
         metrics.record(sample, trusted);
-        expect(drops()).toBe(before + (preseed ? 0 : 2));
+        metrics.record({ ...baseEvent(), type: "diagnostic.gc", durationMs: 20 }, trusted);
+        expect(drops()).toBe(before + (preseed ? 0 : 3));
         const rendered = metrics.render();
         if (preseed) {
           expect(rendered).toContain("openclaw_gateway_event_loop_delay_max_seconds_count 2");
           expect(rendered).toContain("openclaw_gateway_event_loop_observed_seconds_total 2");
+          expect(rendered).toContain("openclaw_gc_duration_seconds_count 2");
         } else {
           expect(rendered).not.toContain("openclaw_gateway_event_loop_");
+          expect(rendered).not.toContain("openclaw_gc_duration_seconds");
         }
       } finally {
         metrics.stop();
@@ -57,7 +61,7 @@ describe("diagnostics-prometheus event-loop metrics", () => {
     },
   );
 
-  it("retains event-loop windows across repeated HTTP scrapes without labels", async () => {
+  it("retains runtime durations across repeated HTTP scrapes without labels", async () => {
     const metrics = createMetricsHarness();
     const server = createServer((req, res) => {
       void metrics.handler(req, res);
@@ -80,14 +84,21 @@ describe("diagnostics-prometheus event-loop metrics", () => {
         { ...baseEvent(), type: "gateway.event_loop.sample", intervalMs: 2_000, delayMaxMs: 1_250 },
         trusted,
       );
+      metrics.record({ ...baseEvent(), type: "diagnostic.gc", durationMs: 1_250 }, trusted);
       const first = await scrape();
       expect(first).toContain("openclaw_gateway_event_loop_delay_max_seconds_count 1");
       expect(first).toContain("openclaw_gateway_event_loop_observed_seconds_total 2");
+      expect(first).toContain("openclaw_gc_duration_seconds_count 1");
       expect(await scrape()).toBe(first);
       metrics.record(
         { ...baseEvent(), type: "gateway.event_loop.sample", intervalMs: 8_000, delayMaxMs: 20 },
         Object.freeze({ trusted: false, internal: true }),
       );
+      metrics.record(
+        { ...baseEvent(), type: "diagnostic.gc", durationMs: 20 },
+        Object.freeze({ trusted: false, internal: true }),
+      );
+      metrics.record({ ...baseEvent(), type: "diagnostic.gc", durationMs: 99_000 }, untrusted);
       metrics.record(
         {
           ...baseEvent(),
@@ -104,6 +115,10 @@ describe("diagnostics-prometheus event-loop metrics", () => {
         "openclaw_gateway_event_loop_delay_max_seconds_count 2",
         "openclaw_gateway_event_loop_delay_max_seconds_sum 1.27",
         "openclaw_gateway_event_loop_observed_seconds_total 10",
+        'openclaw_gc_duration_seconds_bucket{le="1"} 1',
+        'openclaw_gc_duration_seconds_bucket{le="2.5"} 2',
+        "openclaw_gc_duration_seconds_count 2",
+        "openclaw_gc_duration_seconds_sum 1.27",
       ]) {
         expect(second).toContain(expected);
       }

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -540,6 +540,14 @@ function recordDiagnosticEvent(
   }
 
   switch (evt.type) {
+    case "diagnostic.gc":
+      store.histogram(
+        "openclaw_gc_duration_seconds",
+        "Elapsed garbage collection duration in seconds for the hosting JavaScript isolate.",
+        {},
+        seconds(evt.durationMs),
+      );
+      return;
     case "gateway.event_loop.sample":
       store.histogram(
         "openclaw_gateway_event_loop_delay_max_seconds",

--- a/src/infra/diagnostic-events.event-loop.test.ts
+++ b/src/infra/diagnostic-events.event-loop.test.ts
@@ -1,4 +1,4 @@
-// Covers the private event-loop sample stream and its bounded async queue.
+// Covers private runtime measurements and their bounded async queue.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   emitDiagnosticEvent,
@@ -21,39 +21,39 @@ describe("diagnostic-events", () => {
     vi.restoreAllMocks();
   });
 
-  it("drops sample windows under queue pressure while preserving lifecycle terminals", async () => {
-    const events: DiagnosticEventPayload[] = [];
-    onInternalDiagnosticEvent((event) => events.push(event));
-    for (let index = 0; index < 10_001; index += 1) {
-      emitInternalDiagnosticEvent({
-        type: "gateway.event_loop.sample",
-        intervalMs: 1_000,
-        delayMaxMs: 1_500,
+  it.each([
+    { type: "gateway.event_loop.sample", intervalMs: 1_000, delayMaxMs: 1_500 },
+    { type: "diagnostic.gc", durationMs: 1_500 },
+  ] as const)(
+    "drops $type under queue pressure while preserving lifecycle terminals",
+    async (sample) => {
+      const events: DiagnosticEventPayload[] = [];
+      onInternalDiagnosticEvent((event) => events.push(event));
+      for (let index = 0; index < 10_001; index += 1) {
+        emitInternalDiagnosticEvent(sample);
+      }
+      emitTrustedDiagnosticEvent({
+        type: "tool.execution.completed",
+        toolName: "exec",
+        durationMs: 1,
       });
-    }
-    emitTrustedDiagnosticEvent({
-      type: "tool.execution.completed",
-      toolName: "exec",
-      durationMs: 1,
-    });
-    expect(events).toHaveLength(0);
-    await waitForDiagnosticEventsDrained();
-    expect(events.filter((event) => event.type === "gateway.event_loop.sample")).toHaveLength(
-      9_999,
-    );
-    expect(events).toContainEqual(expect.objectContaining({ type: "tool.execution.completed" }));
-    expect(events).toContainEqual(
-      expect.objectContaining({
-        type: "diagnostic.async_queue.dropped",
-        droppedEvents: 2,
-        droppedUntrustedEvents: 2,
-        maxQueueLength: 10_000,
-        drainBatchSize: 100,
-      }),
-    );
-  });
+      expect(events).toHaveLength(0);
+      await waitForDiagnosticEventsDrained();
+      expect(events.filter((event) => event.type === sample.type)).toHaveLength(9_999);
+      expect(events).toContainEqual(expect.objectContaining({ type: "tool.execution.completed" }));
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "diagnostic.async_queue.dropped",
+          droppedEvents: 2,
+          droppedUntrustedEvents: 2,
+          maxQueueLength: 10_000,
+          drainBatchSize: 100,
+        }),
+      );
+    },
+  );
 
-  it("keeps log records and sample windows off the public diagnostic event stream", async () => {
+  it("keeps log records and runtime measurements off the public diagnostic event stream", async () => {
     const publicEvents: string[] = [];
     const internalEvents: string[] = [];
     onDiagnosticEvent((event) => {
@@ -73,11 +73,12 @@ describe("diagnostic-events", () => {
       intervalMs: 1_000,
       delayMaxMs: 1_500,
     });
+    emitInternalDiagnosticEvent({ type: "diagnostic.gc", durationMs: 25 });
 
     await new Promise<void>((resolve) => {
       setImmediate(resolve);
     });
     expect(publicEvents).toStrictEqual([]);
-    expect(internalEvents).toEqual(["log.record", "gateway.event_loop.sample"]);
+    expect(internalEvents).toEqual(["log.record", "gateway.event_loop.sample", "diagnostic.gc"]);
   });
 });

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -443,6 +443,11 @@ type DiagnosticGatewayEventLoopSampleEvent = DiagnosticBaseEvent & {
   delayMaxMs: number;
 };
 
+type DiagnosticGcEvent = DiagnosticBaseEvent & {
+  type: "diagnostic.gc";
+  durationMs: number;
+};
+
 export type DiagnosticHeartbeatEvent = DiagnosticBaseEvent & {
   type: "diagnostic.heartbeat";
   webhooks: {
@@ -859,6 +864,7 @@ export type DiagnosticEventPayload =
   | DiagnosticRunProgressEvent
   | DiagnosticRunExecutionPhaseEvent
   | DiagnosticGatewayEventLoopSampleEvent
+  | DiagnosticGcEvent
   | DiagnosticHeartbeatEvent
   | DiagnosticLivenessWarningEvent
   | DiagnosticPhaseCompletedEvent
@@ -1006,6 +1012,7 @@ const MAX_ASYNC_DIAGNOSTIC_EVENTS = 10_000;
 const MAX_ASYNC_DIAGNOSTIC_EVENTS_PER_TURN = 100;
 const DIAGNOSTIC_EVENTS_STATE_KEY = Symbol.for("openclaw.diagnosticEvents.state.v1");
 const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
+  "diagnostic.gc",
   "gateway.event_loop.sample",
   "gateway.rpc",
   "tool.execution.started",
@@ -1659,7 +1666,7 @@ export function onDiagnosticEvent(listener: (evt: DiagnosticEventPayload) => voi
       }
       listener(event);
     },
-    { exclude: ["log.record", "gateway.rpc", "gateway.event_loop.sample"] },
+    { exclude: ["log.record", "gateway.rpc", "gateway.event_loop.sample", "diagnostic.gc"] },
   );
 }
 

--- a/src/logging/diagnostic-gc.test.ts
+++ b/src/logging/diagnostic-gc.test.ts
@@ -1,0 +1,108 @@
+import { performance } from "node:perf_hooks";
+import { afterEach, expect, it, vi } from "vitest";
+import { hasInternalDiagnosticEventInterest } from "../infra/diagnostic-event-listener-presence.js";
+import {
+  onDiagnosticEvent,
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
+import { startDiagnosticHeartbeat, stopDiagnosticHeartbeat } from "./diagnostic.js";
+import { resetDiagnosticStateForTest } from "./diagnostic.test-support.js";
+
+const native = vi.hoisted(() => {
+  type Entry = { startTime: number; duration: number };
+  const observers: Observer[] = [];
+  class Observer {
+    static supportedEntryTypes = ["gc"];
+    observe = vi.fn();
+    disconnect = vi.fn();
+    constructor(private callback: (list: { getEntries: () => Entry[] }) => void) {
+      observers.push(this);
+    }
+    deliver(entries: Entry[]) {
+      this.callback({ getEntries: () => entries });
+    }
+  }
+  return { Observer, observers };
+});
+
+vi.mock("node:perf_hooks", async (original) => ({
+  ...(await original<typeof import("node:perf_hooks")>()),
+  PerformanceObserver: native.Observer,
+}));
+
+afterEach(() => {
+  resetDiagnosticStateForTest();
+  resetDiagnosticEventsForTest();
+  native.observers.length = 0;
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+it("owns demand, queued GC batches, and disable/re-enable through the existing heartbeat", async () => {
+  vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+  const now = vi.spyOn(performance, "now").mockReturnValue(100);
+  const durations: number[] = [];
+  const start = () => startDiagnosticHeartbeat({}, { sampleLiveness: () => null });
+  const publicUnsubscribe = onDiagnosticEvent(() => {});
+  let unsubscribe = () => {};
+  try {
+    setDiagnosticsEnabledForProcess(false);
+    start();
+    expect(native.observers).toHaveLength(0);
+    setDiagnosticsEnabledForProcess(true);
+    start();
+    expect(hasInternalDiagnosticEventInterest("diagnostic.gc")).toBe(false);
+    expect(native.observers).toHaveLength(0);
+
+    unsubscribe = onInternalDiagnosticEvent(
+      (event) => {
+        if (event.type === "diagnostic.gc") {
+          durations.push(event.durationMs);
+        }
+      },
+      { include: ["diagnostic.gc"] },
+    );
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(native.observers).toHaveLength(0);
+    await vi.advanceTimersByTimeAsync(1);
+    const first = native.observers[0]!;
+    expect(first.observe).toHaveBeenCalledExactlyOnceWith({ entryTypes: ["gc"] });
+    start();
+    expect(native.observers).toHaveLength(1);
+    first.deliver([
+      { startTime: 99, duration: 99 },
+      { startTime: 100, duration: 10 },
+      { startTime: 101, duration: 20 },
+    ]);
+    await waitForDiagnosticEventsDrained();
+    expect(durations).toEqual([10, 20]);
+
+    setDiagnosticsEnabledForProcess(false);
+    first.deliver([{ startTime: 150, duration: 99 }]);
+    stopDiagnosticHeartbeat();
+    expect(first.disconnect).toHaveBeenCalledTimes(1);
+    now.mockReturnValue(200);
+    setDiagnosticsEnabledForProcess(true);
+    start();
+    first.deliver([{ startTime: 201, duration: 99 }]);
+    native.observers[1]!.deliver([
+      { startTime: 199, duration: 99 },
+      { startTime: 200, duration: 30 },
+    ]);
+    await waitForDiagnosticEventsDrained();
+    expect(durations).toEqual([10, 20, 30]);
+
+    unsubscribe();
+    expect(hasInternalDiagnosticEventInterest("diagnostic.gc")).toBe(false);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(native.observers[1]!.disconnect).toHaveBeenCalledTimes(1);
+    stopDiagnosticHeartbeat();
+    expect(native.observers[1]!.disconnect).toHaveBeenCalledTimes(1);
+  } finally {
+    unsubscribe();
+    publicUnsubscribe();
+  }
+});

--- a/src/logging/diagnostic-gc.ts
+++ b/src/logging/diagnostic-gc.ts
@@ -1,0 +1,51 @@
+import { performance, PerformanceObserver } from "node:perf_hooks";
+import { hasInternalDiagnosticEventInterest } from "../infra/diagnostic-event-listener-presence.js";
+import {
+  areDiagnosticsEnabledForProcess,
+  emitInternalDiagnosticEvent,
+} from "../infra/diagnostic-events.js";
+import { runWithDiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
+
+let observer: PerformanceObserver | undefined;
+
+export function stopDiagnosticGcObserver(): void {
+  const current = observer;
+  observer = undefined;
+  current?.disconnect();
+}
+
+export function reconcileDiagnosticGcObserver(): void {
+  if (
+    !areDiagnosticsEnabledForProcess() ||
+    !hasInternalDiagnosticEventInterest("diagnostic.gc") ||
+    !PerformanceObserver.supportedEntryTypes.includes("gc")
+  ) {
+    stopDiagnosticGcObserver();
+    return;
+  }
+  if (observer) {
+    return;
+  }
+
+  const activatedAt = performance.now();
+  const current = new PerformanceObserver((list) => {
+    if (
+      observer !== current ||
+      !areDiagnosticsEnabledForProcess() ||
+      !hasInternalDiagnosticEventInterest("diagnostic.gc")
+    ) {
+      return;
+    }
+    runWithDiagnosticTraceContext(undefined, () => {
+      for (const entry of list.getEntries()) {
+        // Node can deliver a queued native GC entry to a replacement observer.
+        // Disconnect clears JS buffers, but does not cancel that native delivery.
+        if (entry.startTime >= activatedAt) {
+          emitInternalDiagnosticEvent({ type: "diagnostic.gc", durationMs: entry.duration });
+        }
+      }
+    });
+  });
+  observer = current;
+  current.observe({ entryTypes: ["gc"] });
+}

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -250,6 +250,7 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
   switch (event.type) {
     case "gateway.rpc":
     case "gateway.event_loop.sample":
+    case "diagnostic.gc":
       // High-volume measurements are exporter-only and excluded by the subscription.
       break;
     case "model.usage":
@@ -865,7 +866,15 @@ export function startDiagnosticStabilityRecorder(): void {
       }
       appendRecord(sanitizeDiagnosticEvent(event));
     },
-    { exclude: ["log.record", "telemetry.exporter", "gateway.rpc", "gateway.event_loop.sample"] },
+    {
+      exclude: [
+        "log.record",
+        "telemetry.exporter",
+        "gateway.rpc",
+        "gateway.event_loop.sample",
+        "diagnostic.gc",
+      ],
+    },
   );
 }
 

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -12,6 +12,7 @@ import {
   type DiagnosticLivenessWarningReason,
 } from "../infra/diagnostic-events.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { reconcileDiagnosticGcObserver, stopDiagnosticGcObserver } from "./diagnostic-gc.js";
 import { emitDiagnosticMemorySample, resetDiagnosticMemoryForTest } from "./diagnostic-memory.js";
 import {
   getCurrentDiagnosticPhase,
@@ -1124,6 +1125,7 @@ export function startDiagnosticHeartbeat(
   startDiagnosticRunActivityTracking();
   startDiagnosticStabilityRecorder();
   installDiagnosticStabilityFatalHook();
+  reconcileDiagnosticGcObserver();
   if (heartbeatInterval) {
     return;
   }
@@ -1136,6 +1138,8 @@ export function startDiagnosticHeartbeat(
     opts?.startupGraceMs != null && opts.startupGraceMs > 0 ? Date.now() + opts.startupGraceMs : 0;
   lastDiagnosticHeartbeatTickAt = Date.now();
   heartbeatInterval = setInterval(() => {
+    // Reuse this tick for exporter demand changes; GC collection never adds a timer.
+    reconcileDiagnosticGcObserver();
     let heartbeatConfig = config;
     if (!heartbeatConfig) {
       try {
@@ -1287,6 +1291,7 @@ export function startDiagnosticHeartbeat(
 }
 
 export function stopDiagnosticHeartbeat() {
+  stopDiagnosticGcObserver();
   if (heartbeatInterval) {
     clearInterval(heartbeatInterval);
     heartbeatInterval = null;


### PR DESCRIPTION
Closes #139547

## What Problem This Solves

Operators investigating intermittent event-loop stalls can see memory and delay metrics, but have no GC-duration distribution covering the gaps between short CPU profiles. Sampled GC frames cannot establish actual GC-entry counts or elapsed durations.

## Why This Change Was Made

The existing diagnostics heartbeat now owns one demand-driven Node GC observer. It reconciles demand at startup and on its existing 30-second tick, stops observation on diagnostics teardown, and fences stale callbacks and entries when observation restarts. A duration-only internal event uses the existing bounded diagnostic queue and the existing Prometheus and OpenTelemetry histogram implementations.

There is no new configuration, dependency, persistent store, public RPC, timer, or registry. Readiness/recovery policy and exporter counter-reset behavior are unchanged. The change adds about 101 production lines for the missing observation and both exporter adapters.

## User Impact

Metrics consumers gain `openclaw_gc_duration_seconds` and `openclaw.gc.duration_ms`. These measure elapsed GC duration for the hosting JavaScript isolate, not CPU time, allocation ownership, or guaranteed stop-the-world pauses. Bucket counts provide co-evidence when compared with event-loop windows; they do not establish request-level causality.

Collection can begin at the next heartbeat after a consumer registers, with no backfill before observer activation. Brief subscriber gaps, queue drops and series limits constrain coverage. Runtimes that do not advertise GC performance entries leave this observer inactive.

## Evidence

- Thirteen focused tests passed across diagnostic lifecycle, bounded queue/public-stream policy, Prometheus HTTP/cap behavior, and real OpenTelemetry SDK signal modes and trace isolation. The corrected lifecycle test also passed independently.
- Full local `pnpm build` passed. All four type lanes and Knip scans passed; two test-only lint findings were corrected and both lint scopes plus the affected canonical services test graph passed. Remaining runtime guards and the 753-page MDX check passed.
- Independent review through P2 is clean on the final change.
- Actual Node 26.7 component integration passed through real plugin registration, capability leases, diagnostic dispatch, Prometheus HTTP rendering, and OpenTelemetry SDK aggregation: matching counts/sums, cumulative disable/re-enable, stale-entry rejection and cleanup. This is component integration, not a compiled Gateway claim.
- Actual compiled Linux Gateway on Node 26.7 passed authenticated metrics and the real config-watcher hot-toggle flow. GC counts progressed 0 → 8 → 12, stayed at 12 through disable, and resumed to 17 after enable; the existing three-call RPC counter stayed unchanged. Source/build/runtime seals and exact process/listener identity stayed stable; the Gateway closed gracefully and the fixture was removed. This proves the Prometheus Gateway flow; the separate component run proves both-exporter parity.
- Controlled warmed Linux comparison completed: six alternating OFF/ON pairs, four CPU affinity, 3,276,800 allocations per run, both real exporters and four HTTP/flush cycles. ON exported 22 GC entries per run; OFF exported zero; both histograms agreed. Median paired CPU difference was +0.145 ms (+0.104% ratio), with individual differences −2.167 to +8.611 ms (ratios 0.986–1.055). Wall-time differences were −148.6 to +54.1 ms and RSS-growth differences −5.4 to +1.9 MiB. These are observed component-workload results, not a precise isolated observer cost or a production bound. All children joined without cleanup signals, and the test lease was stopped. The earlier noisy macOS result remains inconclusive.
- Native evidence is bound to `f00f29cb6374e1b274bc144133ebb6c5ca0f410c`. The current-main rebase preserves the identical GC patch; the only changed GC-owner file inherits main's already-landed Prometheus rendering allocation improvement (#139535). All thirteen combined lifecycle/exporter tests passed again on the refreshed head. Main also supplies the unrelated native-report test mock repair (#139496) for fresh CI.
- The new GC documentation anchor resolves through the publishing parser. A full optional anchor audit reports unrelated stale anchors in mirrored ClawHub validation docs; ordinary link checking found no broken routes.
