### PR TITLE
test(gateway): preserve held-work close failures

### DIFF
--- a/src/gateway/server-held-work.test-support.ts
+++ b/src/gateway/server-held-work.test-support.ts
@@ -52,9 +52,10 @@ export async function observeHeldGatewayWorkDrain(getSignal?: () => AbortSignal 
       },
       { interval: 1, timeout: 10_000 },
     );
-    await nextTurn();
+    await Promise.race([closing, nextTurn()]);
     expect(drainIndex, "Gateway close must enter the held work owner").toBeGreaterThanOrEqual(0);
     expect(connections.size, "Gateway connections must release before held work").toBe(0);
+    expect(closed, "Gateway close must remain pending while work is held").toBe(false);
     expect(
       observation.mock.settledResults[drainIndex]?.type,
       "Gateway work drain must remain pending while work is held",


### PR DESCRIPTION
Related: #139576

## What Problem This Solves

Resolves a problem where the Gateway lifetime test observer could report work as held after public close had already completed, or replace a native close rejection with an assertion error.

## Why This Change Was Made

Race the original closing promise at the final observation boundary and require public close to remain pending. Keep the existing bounded entry wait, native drain observation, connection-release checks, and cleanup ownership unchanged.

## User Impact

No production behavior changes. Developers get an accurate failure at the held-work boundary and retain the original close error. The change is one net test-support line; no baseline or timeout changes.

## Evidence

Six temporary controls exercise the real AsyncWorkScope and Vitest spy contract. On current main, early public close and rejection identity fail (two failures, four passes); the candidate passes all six. Scoped type-aware lint and independent P0–P2 review pass. The controls are retained proof, with no new maintained test file or production seam.

All four existing Gateway lifetime callers and their work-scope owner are byte-identical to the previously passed 15-case real-Gateway batches. Exact-head CI remains required before landing. No user-facing UI, provider API, storage, or runtime change is made.
