### PR TITLE
fix(test): shut down HTTP fixtures consistently under Bun

### DIFF
--- a/extensions/browser/src/browser/cdp.helpers.transport.test.ts
+++ b/extensions/browser/src/browser/cdp.helpers.transport.test.ts
@@ -63,9 +63,11 @@ async function startAuthenticatedCdpServer(params: {
     sockets,
     authorizations,
     close: async () => {
-      server.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
+        for (const socket of sockets) {
+          socket.destroy();
+        }
       });
     },
   };

--- a/extensions/qa-channel/src/bus-client.test.ts
+++ b/extensions/qa-channel/src/bus-client.test.ts
@@ -1,5 +1,6 @@
 // Qa Channel tests cover bus client plugin behavior.
 import { createServer, type Server } from "node:http";
+import type { Socket } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildQaTarget,
@@ -41,27 +42,20 @@ async function startJsonServer(
     res.end(response.body);
   });
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => resolve());
-  });
-
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("test server failed to bind");
-  }
+  const { port, stop } = await listenLoopbackServer(server);
 
   return {
-    baseUrl: `http://127.0.0.1:${address.port}`,
-    async stop() {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    },
+    baseUrl: `http://127.0.0.1:${port}`,
+    stop,
   };
 }
 
-async function listenLoopbackServer(server: Server): Promise<number> {
+async function listenLoopbackServer(server: Server) {
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(0, "127.0.0.1", () => {
@@ -73,7 +67,16 @@ async function listenLoopbackServer(server: Server): Promise<number> {
   if (!address || typeof address === "string") {
     throw new Error("test server failed to bind");
   }
-  return address.port;
+  return {
+    port: address.port,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        for (const socket of sockets) {
+          socket.destroy();
+        }
+      }),
+  };
 }
 
 function createOversizedJsonServer(pathname: string): { server: Server; closed: Promise<number> } {
@@ -158,9 +161,12 @@ describe("qa-bus client", () => {
   const stops: Array<() => Promise<void>> = [];
 
   afterEach(async () => {
-    await Promise.all(stops.splice(0).map((stop) => stop()));
-    guardedFetchCalls.length = 0;
-    vi.restoreAllMocks();
+    try {
+      await Promise.all(stops.splice(0).map((stop) => stop()));
+    } finally {
+      guardedFetchCalls.length = 0;
+      vi.restoreAllMocks();
+    }
   });
 
   it("roundtrips explicit group targets", () => {
@@ -235,13 +241,8 @@ describe("qa-bus client", () => {
 
   it("bounds oversized poll responses and closes the stream early", async () => {
     const oversized = createOversizedJsonServer("/v1/poll");
-    const port = await listenLoopbackServer(oversized.server);
-    stops.push(async () => {
-      oversized.server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        oversized.server.close((error) => (error ? reject(error) : resolve()));
-      });
-    });
+    const { port, stop } = await listenLoopbackServer(oversized.server);
+    stops.push(stop);
 
     await expect(
       pollQaBus({
@@ -261,26 +262,12 @@ describe("qa-bus client", () => {
       // Keep the request open so the client abort path owns the outcome.
     });
 
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => resolve());
-    });
-
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("test server failed to bind");
-    }
-
-    stops.push(async () => {
-      server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    });
+    const { port, stop } = await listenLoopbackServer(server);
+    stops.push(stop);
 
     const abort = new AbortController();
     const request = pollQaBus({
-      baseUrl: `http://127.0.0.1:${address.port}`,
+      baseUrl: `http://127.0.0.1:${port}`,
       accountId: "acct-a",
       cursor: 0,
       acknowledgedCursor: 0,
@@ -302,13 +289,8 @@ describe("qa-bus client", () => {
     const server = createServer((_req, _res) => {
       // Accept the request without returning headers so the client deadline owns the outcome.
     });
-    const port = await listenLoopbackServer(server);
-    stops.push(async () => {
-      server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    });
+    const { port, stop } = await listenLoopbackServer(server);
+    stops.push(stop);
 
     const realAbortSignalTimeout = AbortSignal.timeout.bind(AbortSignal);
     const timeoutSpy = vi
@@ -339,13 +321,8 @@ describe("qa-bus client", () => {
       });
       res.write('{"message":', markBodyStarted);
     });
-    const port = await listenLoopbackServer(server);
-    stops.push(async () => {
-      server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    });
+    const { port, stop } = await listenLoopbackServer(server);
+    stops.push(stop);
 
     const timeout = new AbortController();
     const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValueOnce(timeout.signal);
@@ -416,13 +393,8 @@ describe("qa-bus client", () => {
 
   it("bounds oversized qa-bus state responses", async () => {
     const oversized = createOversizedJsonServer("/v1/state");
-    const port = await listenLoopbackServer(oversized.server);
-    stops.push(async () => {
-      oversized.server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        oversized.server.close((error) => (error ? reject(error) : resolve()));
-      });
-    });
+    const { port, stop } = await listenLoopbackServer(oversized.server);
+    stops.push(stop);
 
     await expect(getQaBusState(`http://127.0.0.1:${port}`)).rejects.toThrow(
       "qa-channel.bus-state: JSON response exceeds 16777216 bytes",

--- a/test/e2e/qa-lab/runtime/otel-test-support.test.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.test.ts
@@ -1,5 +1,38 @@
+import { once } from "node:events";
+import { request } from "node:http";
 import { describe, expect, test } from "vitest";
-import { type CapturedSpan, createRecentTraceSummary } from "./otel-test-support.js";
+import {
+  type CapturedSpan,
+  createRecentTraceSummary,
+  startLocalOtlpReceiver,
+} from "./otel-test-support.js";
+
+test("closes an OTLP receiver with an unfinished request body", async () => {
+  const receiver = startLocalOtlpReceiver();
+  const port = await receiver.listen();
+  const client = request({
+    hostname: "127.0.0.1",
+    port,
+    path: "/v1/traces",
+    method: "POST",
+    headers: { expect: "100-continue", "content-length": "100" },
+  });
+  const clientError = new Promise<Error>((resolve) => {
+    client.once("error", resolve);
+  });
+  try {
+    const accepted = once(client, "continue");
+    client.flushHeaders();
+    await accepted;
+
+    await receiver.close();
+    await expect(clientError).resolves.toMatchObject({ code: "ECONNRESET" });
+    await receiver.close();
+  } finally {
+    client.destroy();
+    await receiver.close();
+  }
+});
 
 function span(traceId: string, name: string): CapturedSpan {
   return { attributes: {}, name, parent: false, traceId };

--- a/test/e2e/qa-lab/runtime/otel-test-support.ts
+++ b/test/e2e/qa-lab/runtime/otel-test-support.ts
@@ -675,16 +675,6 @@ function decodeLogRequest(body: Buffer): CapturedLogRecord[] {
   return records;
 }
 
-function closeLocalOtlpReceiverConnections(
-  server: ReturnType<typeof createServer>,
-  sockets: Set<Socket>,
-): void {
-  for (const socket of sockets) {
-    socket.destroy();
-  }
-  server.closeAllConnections();
-}
-
 export function startLocalOtlpReceiver(
   disallowedBodyNeedles: string[] = [],
   captureHeaderNames: string[] = [],
@@ -811,9 +801,11 @@ export function startLocalOtlpReceiver(
     },
     async close(): Promise<void> {
       closePromise ??= new Promise<void>((resolve, reject) => {
-        closeLocalOtlpReceiverConnections(server, sockets);
         server.close((error) => (error ? reject(error) : resolve()));
-        closeLocalOtlpReceiverConnections(server, sockets);
+        // Stop accepting first, then abort owned requests without stopping Bun's listener twice.
+        for (const socket of sockets) {
+          socket.destroy();
+        }
       });
       await closePromise;
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes test-fixture shutdown failures and lingering HTTP connections under Bun when browser transport, QA bus, and OTLP receiver tests stop their local servers.

## Why This Change Was Made

Each fixture stops accepting requests before destroying its tracked sockets. This avoids depending on runtime-specific closeAllConnections behavior and lets unfinished requests terminate. The OTLP receiver retains idempotent close behavior, and QA bus cleanup restores mocks even if shutdown fails.

## User Impact

Developers can run the covered HTTP fixture tests under Node and Bun with deterministic cleanup. Production behavior is unchanged.

## Evidence

- Six focused files, 134 tests: all pass on Node and true Bun.
- The added unfinished-request shutdown regression failed before the fix with ERR_SERVER_NOT_RUNNING and passes afterward.
- Complete changed-file gate passed; independent P0–P2 review found no actionable findings.
- Four files changed, 78 lines added and 79 removed. Full repository Bun compatibility remains an ongoing campaign.
