### PR TITLE
test(reports): deduplicate native process census setup

### DIFF
--- a/test/scripts/test-report-utils.test.ts
+++ b/test/scripts/test-report-utils.test.ts
@@ -105,10 +105,6 @@ describe("scripts/test-report-utils runVitestJsonReport", () => {
     signal,
     onTestFinished,
   }) => {
-    // Keep Linux process-group verification real while this case runs native children.
-    const { spawnSync } =
-      await vi.importActual<typeof import("node:child_process")>("node:child_process");
-    spawnSyncMock.mockImplementation(spawnSync);
     const lifetime = createFixtureLifetime();
     onTestFinished(() => lifetime.cleanup());
     await lifetime.run(async () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Native process census setup is now duplicated inside the real subprocess-report case and its shared beforeEach. The original missing-census issue was independently fixed by #139496 and centralized by #139491 while this PR was being validated.

## Why This Change Was Made

Remove only the redundant per-case restoration. The shared beforeEach still restores native spawnSync before every case, and report-only unit cases retain their explicit mock implementations. No production cleanup, deadline or signal policy changes.

## User Impact

The real subprocess proof keeps its native Linux census with one setup owner. Four test lines removed; no scenarios or assertions removed.

## Evidence

The full report-utils, managed-child-process and run-node-script suites pass 94 tests, with one existing Linux-only case skipped on macOS. Root-test types, script and changed-file lint, deslop, diff check and fresh independent P2 review pass.

The complete local changed gate is currently blocked by an unrelated services test-graph inventory count of 721 against its 720 cap. This removal changes no roots; no cap or ignore was changed. Required CI must pass before landing.
