### PR TITLE
fix(backup): state-only backup fails on files under a shared workspace base

### DIFF
--- a/src/commands/backup-shared.test.ts
+++ b/src/commands/backup-shared.test.ts
@@ -1,6 +1,8 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveRequiredBackupPath } from "./backup-shared.js";
+import { resolveBackupPlanFromDisk, resolveRequiredBackupPath } from "./backup-shared.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -33,5 +35,35 @@ describe("resolveRequiredBackupPath", () => {
   it("preserves absolute paths", () => {
     const absolute = path.resolve("absolute-backup");
     expect(resolveRequiredBackupPath(`  ${absolute}  `, "--scratch")).toBe(absolute);
+  });
+});
+
+describe("resolveBackupPlanFromDisk workspace exclusion", () => {
+  it("stops traversing the configured shared workspace base when workspace content is excluded", async () => {
+    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-base-"));
+    const stateDir = path.join(home, ".openclaw");
+    const sharedBase = path.join(stateDir, "workspace");
+    await fs.mkdir(path.join(sharedBase, "tmp"), { recursive: true });
+    await fs.mkdir(path.join(sharedBase, "main"), { recursive: true });
+    await fs.writeFile(path.join(sharedBase, "tmp", "scratch.txt"), "scratch", "utf8");
+    // Agents resolve to <base>/<agentId>, so nothing owns the base itself.
+    await fs.writeFile(
+      path.join(stateDir, "openclaw.json"),
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          defaults: { workspace: sharedBase },
+          entries: { main: {}, helper: { workspace: path.join(home, "helper-workspace") } },
+        },
+      }),
+      "utf8",
+    );
+    vi.stubEnv("OPENCLAW_HOME", home);
+
+    const plan = await resolveBackupPlanFromDisk({ includeWorkspace: false });
+
+    expect(plan.inventory.isTraversable(path.join(sharedBase, "tmp"))).toBe(false);
+    expect(plan.inventory.isIncluded(path.join(sharedBase, "tmp", "scratch.txt"))).toBe(false);
+    await fs.rm(home, { recursive: true, force: true });
   });
 });

--- a/src/commands/backup-shared.test.ts
+++ b/src/commands/backup-shared.test.ts
@@ -1,8 +1,6 @@
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { resolveBackupPlanFromDisk, resolveRequiredBackupPath } from "./backup-shared.js";
+import { resolveRequiredBackupPath } from "./backup-shared.js";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -35,35 +33,5 @@ describe("resolveRequiredBackupPath", () => {
   it("preserves absolute paths", () => {
     const absolute = path.resolve("absolute-backup");
     expect(resolveRequiredBackupPath(`  ${absolute}  `, "--scratch")).toBe(absolute);
-  });
-});
-
-describe("resolveBackupPlanFromDisk workspace exclusion", () => {
-  it("stops traversing the configured shared workspace base when workspace content is excluded", async () => {
-    const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-base-"));
-    const stateDir = path.join(home, ".openclaw");
-    const sharedBase = path.join(stateDir, "workspace");
-    await fs.mkdir(path.join(sharedBase, "tmp"), { recursive: true });
-    await fs.mkdir(path.join(sharedBase, "main"), { recursive: true });
-    await fs.writeFile(path.join(sharedBase, "tmp", "scratch.txt"), "scratch", "utf8");
-    // Agents resolve to <base>/<agentId>, so nothing owns the base itself.
-    await fs.writeFile(
-      path.join(stateDir, "openclaw.json"),
-      JSON.stringify({
-        agents: {
-          ownership: "explicit",
-          defaults: { workspace: sharedBase },
-          entries: { main: {}, helper: { workspace: path.join(home, "helper-workspace") } },
-        },
-      }),
-      "utf8",
-    );
-    vi.stubEnv("OPENCLAW_HOME", home);
-
-    const plan = await resolveBackupPlanFromDisk({ includeWorkspace: false });
-
-    expect(plan.inventory.isTraversable(path.join(sharedBase, "tmp"))).toBe(false);
-    expect(plan.inventory.isIncluded(path.join(sharedBase, "tmp", "scratch.txt"))).toBe(false);
-    await fs.rm(home, { recursive: true, force: true });
   });
 });

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -597,15 +597,15 @@ export async function resolveBackupPlanFromDisk(
   const agentRoots = unresolvedOwnership
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
-  // Agents resolve to subdirectories of a shared base, so the base itself is never an
-  // effective agent workspace and would otherwise be traversed. When workspace content is
-  // excluded these paths are only ever the exclusion set, so adding the base skips its
-  // scratch contents without changing what an include-workspace archive collects.
-  const sharedWorkspaceBase = discoverySnapshot.config?.agents?.defaults?.workspace?.trim();
-  const discoveredWorkspaceDirs =
-    includeWorkspace || !sharedWorkspaceBase
-      ? cleanupPlan.workspaceDirs
-      : [...cleanupPlan.workspaceDirs, resolveUserPath(sharedWorkspaceBase)];
+  const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
+  // Effective agent workspaces can omit their shared base. Exclude it only here
+  // so full backups and destructive cleanup retain their existing selection.
+  if (!includeWorkspace && discoverySnapshot.valid) {
+    const sharedWorkspaceBase = discoverySnapshot.config.agents?.defaults?.workspace?.trim();
+    if (sharedWorkspaceBase) {
+      discoveredWorkspaceDirs.push(resolveUserPath(sharedWorkspaceBase));
+    }
+  }
   const pluginInventory = unresolvedOwnership
     ? undefined
     : resolveActivatedPluginBackupInventory({

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -597,7 +597,15 @@ export async function resolveBackupPlanFromDisk(
   const agentRoots = unresolvedOwnership
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
-  const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
+  // Agents resolve to subdirectories of a shared base, so the base itself is never an
+  // effective agent workspace and would otherwise be traversed. When workspace content is
+  // excluded these paths are only ever the exclusion set, so adding the base skips its
+  // scratch contents without changing what an include-workspace archive collects.
+  const sharedWorkspaceBase = discoverySnapshot.config?.agents?.defaults?.workspace?.trim();
+  const discoveredWorkspaceDirs =
+    includeWorkspace || !sharedWorkspaceBase
+      ? cleanupPlan.workspaceDirs
+      : [...cleanupPlan.workspaceDirs, resolveUserPath(sharedWorkspaceBase)];
   const pluginInventory = unresolvedOwnership
     ? undefined
     : resolveActivatedPluginBackupInventory({

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -91,11 +91,14 @@ describe("backup commands", () => {
     await tempHome.restore();
   });
 
-  async function withInvalidWorkspaceBackupConfig<T>(fn: (runtime: RuntimeEnv) => Promise<T>) {
+  async function withInvalidWorkspaceBackupConfig<T>(
+    raw: string,
+    fn: (runtime: RuntimeEnv) => Promise<T>,
+  ) {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const configPath = path.join(tempHome.home, "custom-config.json");
     await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
-    await fs.writeFile(configPath, '{"agents": { defaults: { workspace: ', "utf8");
+    await fs.writeFile(configPath, raw, "utf8");
 
     const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH"]);
     setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
@@ -578,27 +581,40 @@ describe("backup commands", () => {
     expect(await fs.readFile(existingArchive, "utf8")).toBe("already here");
   });
 
-  it("handles invalid config according to backup scope", async () => {
-    await withInvalidWorkspaceBackupConfig(async (runtime) => {
-      await expect(backupCreateCommand(runtime, { dryRun: true })).rejects.toThrow(
-        /--no-include-workspace/i,
-      );
+  it.each(["syntax", "workspace"])(
+    "handles invalid %s according to backup scope",
+    async (invalid) => {
+      const raw =
+        invalid === "syntax"
+          ? '{"agents": { defaults: { workspace: '
+          : JSON.stringify({
+              agents: {
+                ownership: "explicit",
+                defaults: { workspace: 42 },
+                entries: { main: { workspace: path.join(tempHome.home, "workspace") } },
+              },
+            });
+      await withInvalidWorkspaceBackupConfig(raw, async (runtime) => {
+        await expect(backupCreateCommand(runtime, { dryRun: true })).rejects.toThrow(
+          /--no-include-workspace/i,
+        );
 
-      const result = await backupCreateCommand(runtime, {
-        dryRun: true,
-        includeWorkspace: false,
+        const result = await backupCreateCommand(runtime, {
+          dryRun: true,
+          includeWorkspace: false,
+        });
+
+        expect(result.includeWorkspace).toBe(false);
+        expect(result.assets.map((asset) => asset.kind)).not.toContain("workspace");
+
+        const configOnly = await backupCreateCommand(runtime, {
+          dryRun: true,
+          onlyConfig: true,
+        });
+        expectOnlyAssetKind(configOnly.assets, "config");
       });
-
-      expect(result.includeWorkspace).toBe(false);
-      expect(result.assets.map((asset) => asset.kind)).not.toContain("workspace");
-
-      const configOnly = await backupCreateCommand(runtime, {
-        dryRun: true,
-        onlyConfig: true,
-      });
-      expectOnlyAssetKind(configOnly.assets, "config");
-    });
-  });
+    },
+  );
 
   it("discovers workspaces through the stable upgrade compatibility view", async () => {
     const stateDir = path.join(tempHome.home, ".openclaw");

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -930,51 +930,62 @@ describe("createBackupArchive", () => {
     },
   );
 
-  it("omits a nested workspace absolute symlink without dropping a nested agent root", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
+  it.each(["sole agent", "explicit roster"])(
+    "omits a nested workspace absolute symlink without dropping a nested agent root for %s",
+    async (roster) => {
+      if (process.platform === "win32") {
+        return;
+      }
 
-    await withOpenClawTestState(
-      {
-        layout: "state-only",
-        prefix: "openclaw-backup-nested-workspace-symlink-",
-        scenario: "minimal",
-      },
-      async (state) => {
-        const nestedWorkspace = state.statePath("workspace");
-        const agentDir = path.join(nestedWorkspace, "custom-agent");
-        const outsideTarget = state.path("outside-build");
-        await fs.mkdir(nestedWorkspace, { recursive: true });
-        await fs.mkdir(agentDir, { recursive: true });
-        await fs.mkdir(outsideTarget, { recursive: true });
-        await fs.writeFile(path.join(nestedWorkspace, "notes.md"), "workspace notes\n", "utf8");
-        await fs.writeFile(path.join(agentDir, "durable-agent-state.json"), "{}\n", "utf8");
-        await fs.symlink(outsideTarget, path.join(nestedWorkspace, ".build"), "dir");
-        await state.writeConfig({
-          agents: {
-            defaults: { workspace: nestedWorkspace },
-            entries: { main: { default: true, agentDir } },
-          },
-        });
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-nested-workspace-symlink-",
+          scenario: "minimal",
+        },
+        async (state) => {
+          const nestedWorkspace = state.statePath("workspace");
+          const agentDir = path.join(nestedWorkspace, "custom-agent");
+          const outsideTarget = state.path("outside-build");
+          await fs.mkdir(nestedWorkspace, { recursive: true });
+          await fs.mkdir(agentDir, { recursive: true });
+          await fs.mkdir(outsideTarget, { recursive: true });
+          await fs.writeFile(path.join(nestedWorkspace, "notes.md"), "workspace notes\n", "utf8");
+          await fs.writeFile(path.join(agentDir, "durable-agent-state.json"), "{}\n", "utf8");
+          await fs.symlink(outsideTarget, path.join(nestedWorkspace, ".build"), "dir");
+          await state.writeConfig({
+            agents: {
+              ownership: "explicit",
+              defaults: { workspace: nestedWorkspace },
+              entries: {
+                main: { agentDir },
+                ...(roster === "explicit roster"
+                  ? { helper: { workspace: state.path("helper-workspace") } }
+                  : {}),
+              },
+            },
+          });
 
-        const archive = await createBackupArchive({
-          output: state.path("backup.tar.gz"),
-          includeWorkspace: false,
-          nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
-        });
-        const entries = await listArchiveEntries(archive.archivePath);
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
+          });
+          const entries = await listArchiveEntries(archive.archivePath);
 
-        expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
-        expect(entries.some((entry) => entry.includes("/workspace/.build"))).toBe(false);
-        expect(entries.some((entry) => entry.endsWith("/workspace/notes.md"))).toBe(false);
-        expect(
-          entries.some((entry) => entry.endsWith("/custom-agent/durable-agent-state.json")),
-        ).toBe(true);
-        await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({ ok: true });
-      },
-    );
-  });
+          expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
+          expect(entries.some((entry) => entry.includes("/workspace/.build"))).toBe(false);
+          expect(entries.some((entry) => entry.endsWith("/workspace/notes.md"))).toBe(false);
+          expect(
+            entries.some((entry) => entry.endsWith("/custom-agent/durable-agent-state.json")),
+          ).toBe(true);
+          await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({
+            ok: true,
+          });
+        },
+      );
+    },
+  );
 
   it("omits an absolute workspace-root symlink under the state directory", async () => {
     if (process.platform === "win32") {


### PR DESCRIPTION
## What Problem This Solves

Fixes #139549.

`openclaw backup create --no-include-workspace --verify` can fail before writing an archive when an explicit multi-agent roster shares a workspace base containing an absolute symlink. Ordinary scratch files beneath that base also leak into state-only archives.

## Why This Change Was Made

State-only backup discovery now excludes the configured shared base as well as effective agent workspaces. It reads the base only from a valid configuration snapshot, preserving partial backups for invalid configurations. The existing inventory continues to preserve nested agent state, active configuration, and credentials.

Full-backup selection, destructive cleanup discovery, and archive link containment keep their existing behavior.

## User Impact

Operators can create a verified state-only backup without removing unrelated workspace files. Explicit nested owners remain included, and invalid configurations retain their recovery path.

## Evidence

- Current main `4da5d447f695def5c1d5ac9c81479710a46e45e1`: the real CLI rejects the shared-base absolute link, exits 1, and writes no archive. A separate link-free run includes unwanted scratch content.
- Repaired candidate: the same CLI completes with `verified: true`; extracted archives omit ordinary workspace content and retain state, active configuration, credentials, and nested agent state.
- Full-backup controls cover shared bases inside and outside the state directory. Included-state links remain rejected. Bases equal to or containing the state root retain ordinary state. Missing, syntax-invalid, and numeric-workspace configurations retain partial-backup behavior.
- Focused backup and cleanup tests: 164 passed. The archive regression fails on main at the link guard; the invalid-workspace regression fails on the original candidate at its unvalidated string operation.
- Formatting, maximum-line and assertion-safety checks passed. Independent source-blind CLI acceptance passed all nine contract observations and supplementary controls, with 57 archived fixture files matching their original bytes.

Original shared-base repair by @ayaangazali; maintainer validation and recovery correction are AI-assisted.
