### PR TITLE
refactor(sdk): keep helper types private

### DIFF
--- a/src/plugin-sdk/api-baseline.ts
+++ b/src/plugin-sdk/api-baseline.ts
@@ -22,7 +22,7 @@ export {
 } from "./api-baseline-normalization.js";
 
 /** Declaration kind recorded for each public SDK export in the API baseline. */
-export type PluginSdkApiExportKind =
+type PluginSdkApiExportKind =
   | "class"
   | "const"
   | "enum"
@@ -34,7 +34,7 @@ export type PluginSdkApiExportKind =
   | "variable";
 
 /** Repo source location for a public SDK declaration or module. */
-export type PluginSdkApiSourceLink = {
+type PluginSdkApiSourceLink = {
   /** Repo-relative source file path. */
   path: string;
 };
@@ -56,7 +56,7 @@ export type PluginSdkApiExport = {
 };
 
 /** API baseline record for one public SDK module/subpath. */
-export type PluginSdkApiModule = {
+type PluginSdkApiModule = {
   /** Documentation category used to group SDK entrypoints when documented. */
   category: PluginSdkDocCategory | null;
   /** Canonical public SDK entrypoint. */

--- a/src/plugin-sdk/api-diff.ts
+++ b/src/plugin-sdk/api-diff.ts
@@ -11,10 +11,7 @@ const REPORT_ITEM_LIMIT = 40;
 const REPORT_TEXT_LINE_LIMIT = 20;
 const REPORT_BYTE_LIMIT = 64 * 1024;
 
-export type PluginSdkApiExportSnapshot = Pick<
-  PluginSdkApiExport,
-  "closureHash" | "declaration" | "kind"
->;
+type PluginSdkApiExportSnapshot = Pick<PluginSdkApiExport, "closureHash" | "declaration" | "kind">;
 
 type PluginSdkApiDiffExport = Pick<
   PluginSdkApiExport,
@@ -32,13 +29,13 @@ export type PluginSdkApiDiffSurface = {
   modules: PluginSdkApiDiffModule[];
 };
 
-export type PluginSdkApiDeclarationChange = {
+type PluginSdkApiDeclarationChange = {
   after: string | null;
   before: string | null;
   name: string;
 };
 
-export type PluginSdkApiExportChange = {
+type PluginSdkApiExportChange = {
   after: PluginSdkApiExportSnapshot | null;
   before: PluginSdkApiExportSnapshot | null;
   change: "added" | "reachable" | "removed" | "signature";
@@ -48,13 +45,13 @@ export type PluginSdkApiExportChange = {
   importSpecifier: string;
 };
 
-export type PluginSdkApiEntrypointChange = {
+type PluginSdkApiEntrypointChange = {
   entrypoint: string;
   exportNames: string[];
   importSpecifier: string;
 };
 
-export type PluginSdkApiDiffPayload = {
+type PluginSdkApiDiffPayload = {
   entrypointsAdded: PluginSdkApiEntrypointChange[];
   entrypointsRemoved: PluginSdkApiEntrypointChange[];
   exports: PluginSdkApiExportChange[];

--- a/src/plugin-sdk/memory-core-bundled-runtime.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.ts
@@ -20,7 +20,7 @@ type EmbeddingProviderResult = {
   runtime?: MemoryEmbeddingProviderRuntime;
 };
 
-export type DreamingArtifactsAuditIssue = {
+type DreamingArtifactsAuditIssue = {
   severity: "warn" | "error";
   code:
     | "dreaming-session-corpus-unreadable"
@@ -42,7 +42,7 @@ export type DreamingArtifactsAuditSummary = {
   issues: DreamingArtifactsAuditIssue[];
 };
 
-export type ShortTermAuditIssue = {
+type ShortTermAuditIssue = {
   severity: "warn" | "error";
   code:
     | "recall-store-unreadable"
@@ -71,7 +71,7 @@ export type ShortTermAuditSummary = {
   issues: ShortTermAuditIssue[];
 };
 
-export type RepairShortTermPromotionArtifactsResult = {
+type RepairShortTermPromotionArtifactsResult = {
   changed: boolean;
   removedInvalidEntries: number;
   removedDanglingEntries?: number;
@@ -139,7 +139,7 @@ type GroundedRemPreviewResult = {
   files: GroundedRemFilePreview[];
 };
 
-export type ShortTermDreamingStatsEntry = {
+type ShortTermDreamingStatsEntry = {
   key: string;
   path: string;
   startLine: number;
@@ -156,7 +156,7 @@ export type ShortTermDreamingStatsEntry = {
   lastRecalledAt?: string;
 };
 
-export type ShortTermDreamingStats = {
+type ShortTermDreamingStats = {
   shortTermCount: number;
   recallSignalCount: number;
   dailySignalCount: number;
@@ -202,7 +202,7 @@ type ApiFacadeModule = {
   }) => Promise<{ dreamsPath: string; removed: number }>;
 };
 
-export type RepairDreamingArtifactsResult = {
+type RepairDreamingArtifactsResult = {
   changed: boolean;
   archiveDir?: string;
   archivedDreamsDiary: boolean;


### PR DESCRIPTION
## What Problem This Solves

Resolves a maintainer-requested SDK boundary cleanup where helper-only declaration types in Plugin SDK implementation modules were exported even though they are not supported public SDK contracts.

## Why This Change Was Made

The change keeps 14 helper-only type aliases local to `src/plugin-sdk/api-baseline.ts`, `src/plugin-sdk/api-diff.ts`, and `src/plugin-sdk/memory-core-bundled-runtime.ts`. It preserves the public aggregate types and runtime values, including `PluginSdkApiExport`, `PluginSdkApiBaseline`, `PluginSdkApiDiff`, `PluginSdkApiDiffSurface`, `DreamingArtifactsAuditSummary`, and `ShortTermAuditSummary`.

## User Impact

No runtime behavior changes. Plugin developers keep the documented/public SDK types, while unsupported internal helper shapes stop appearing as exported source-level implementation details.

## Evidence

- Frozen public `main` before publication: `e10007407d7ce25cf13d816123607993699dc6f3`.
- Patch identity before commit: `git diff --full-index --binary | shasum -a 256` -> `cd40292de50dc6015459a48de1a74f23c4331157ddf3823fe804b6b83a00ccb1`.
- Current-main source check: no external imports from the three `src/plugin-sdk/*` target modules for the 14 helper type names; package/entrypoint metadata does not expose these files as typed public SDK entrypoints.
- `git diff --check` passed.
- Fresh autoreview: scoped-clean, no accepted/actionable P0-P2 findings.
- Prior focused local proof on the same patch identity: 104 tests passed across the affected SDK files.

Hosted exact-head PR CI will provide the final merge gate after this draft is marked ready.
