### PR TITLE
fix(backup): exclude shared workspace files from state-only backups

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -258,7 +258,11 @@ Auth profiles and other per-agent runtime state live in
 `<stateDir>/agents/<agentId>/agent`, but a custom root remains authoritative
 whether it is outside the state directory, inside a workspace, or nested under
 an otherwise regenerable managed state root. `--no-include-workspace` omits
-ordinary workspace sources, not configured agent directories.
+ordinary workspace sources, including the shared base configured by
+`agents.defaults.workspace` when agents use subdirectories beneath it. Configured
+agent directories, the active config file, and credentials remain included even
+when nested in that base. A workspace path equal to or containing the state
+directory never excludes the state directory itself.
 
 `--only-config` skips state, agent, credentials-directory, workspace, and
 plugin-resource discovery and archives only the active config file path.

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -598,7 +598,9 @@ export async function resolveBackupPlanFromDisk(
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
   const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
-  const configuredWorkspaceBase = discoverySnapshot.config.agents?.defaults?.workspace?.trim();
+  const configuredWorkspace = discoverySnapshot.config.agents?.defaults?.workspace;
+  const configuredWorkspaceBase =
+    typeof configuredWorkspace === "string" ? configuredWorkspace.trim() : undefined;
   if (!includeWorkspace && configuredWorkspaceBase) {
     // Agent discovery can return base/<id>, leaving shared scratch files in
     // the base. Exclude that base too without widening full backups or cleanup.

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -598,6 +598,12 @@ export async function resolveBackupPlanFromDisk(
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
   const discoveredWorkspaceDirs = cleanupPlan.workspaceDirs;
+  const configuredWorkspaceBase = discoverySnapshot.config.agents?.defaults?.workspace?.trim();
+  if (!includeWorkspace && configuredWorkspaceBase) {
+    // Agent discovery can return base/<id>, leaving shared scratch files in
+    // the base. Exclude that base too without widening full backups or cleanup.
+    discoveredWorkspaceDirs.push(resolveUserPath(configuredWorkspaceBase));
+  }
   const pluginInventory = unresolvedOwnership
     ? undefined
     : resolveActivatedPluginBackupInventory({

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -91,11 +91,14 @@ describe("backup commands", () => {
     await tempHome.restore();
   });
 
-  async function withInvalidWorkspaceBackupConfig<T>(fn: (runtime: RuntimeEnv) => Promise<T>) {
+  async function withInvalidWorkspaceBackupConfig<T>(
+    configRaw: string,
+    fn: (runtime: RuntimeEnv) => Promise<T>,
+  ) {
     const stateDir = path.join(tempHome.home, ".openclaw");
     const configPath = path.join(tempHome.home, "custom-config.json");
     await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({}), "utf8");
-    await fs.writeFile(configPath, '{"agents": { defaults: { workspace: ', "utf8");
+    await fs.writeFile(configPath, configRaw, "utf8");
 
     const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH"]);
     setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
@@ -578,8 +581,23 @@ describe("backup commands", () => {
     expect(await fs.readFile(existingArchive, "utf8")).toBe("already here");
   });
 
-  it("handles invalid config according to backup scope", async () => {
-    await withInvalidWorkspaceBackupConfig(async (runtime) => {
+  it.each([
+    { label: "malformed JSON", configRaw: '{"agents": { defaults: { workspace: ' },
+    {
+      label: "a non-string workspace base",
+      configRaw: JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          defaults: { workspace: 123 },
+          entries: {
+            main: { workspace: "/fixture/main" },
+            helper: { workspace: "/fixture/helper" },
+          },
+        },
+      }),
+    },
+  ])("handles invalid config with $label according to backup scope", async ({ configRaw }) => {
+    await withInvalidWorkspaceBackupConfig(configRaw, async (runtime) => {
       await expect(backupCreateCommand(runtime, { dryRun: true })).rejects.toThrow(
         /--no-include-workspace/i,
       );

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -930,51 +930,86 @@ describe("createBackupArchive", () => {
     },
   );
 
-  it("omits a nested workspace absolute symlink without dropping a nested agent root", async () => {
-    if (process.platform === "win32") {
-      return;
-    }
+  it.each(["legacy workspace", "shared workspace base"] as const)(
+    "omits a %s absolute symlink without dropping nested state owners",
+    async (layout) => {
+      if (process.platform === "win32") {
+        return;
+      }
 
-    await withOpenClawTestState(
-      {
-        layout: "state-only",
-        prefix: "openclaw-backup-nested-workspace-symlink-",
-        scenario: "minimal",
-      },
-      async (state) => {
-        const nestedWorkspace = state.statePath("workspace");
-        const agentDir = path.join(nestedWorkspace, "custom-agent");
-        const outsideTarget = state.path("outside-build");
-        await fs.mkdir(nestedWorkspace, { recursive: true });
-        await fs.mkdir(agentDir, { recursive: true });
-        await fs.mkdir(outsideTarget, { recursive: true });
-        await fs.writeFile(path.join(nestedWorkspace, "notes.md"), "workspace notes\n", "utf8");
-        await fs.writeFile(path.join(agentDir, "durable-agent-state.json"), "{}\n", "utf8");
-        await fs.symlink(outsideTarget, path.join(nestedWorkspace, ".build"), "dir");
-        await state.writeConfig({
-          agents: {
-            defaults: { workspace: nestedWorkspace },
-            entries: { main: { default: true, agentDir } },
-          },
-        });
+      await withOpenClawTestState(
+        {
+          layout: "state-only",
+          prefix: "openclaw-backup-nested-workspace-symlink-",
+          scenario: "minimal",
+          env: { OPENCLAW_OAUTH_DIR: undefined },
+        },
+        async (state) => {
+          const nestedWorkspace = state.statePath("workspace");
+          const agentDir = path.join(nestedWorkspace, "custom-agent");
+          const configPath = path.join(nestedWorkspace, "config", "openclaw.json");
+          const oauthDir = path.join(nestedWorkspace, "credentials");
+          const outsideTarget = state.path("outside-build");
+          await fs.mkdir(agentDir, { recursive: true });
+          await fs.mkdir(path.dirname(configPath), { recursive: true });
+          await fs.mkdir(oauthDir, { recursive: true });
+          await fs.mkdir(outsideTarget, { recursive: true });
+          await fs.writeFile(path.join(nestedWorkspace, "notes.md"), "workspace notes\n", "utf8");
+          await fs.writeFile(path.join(agentDir, "durable-agent-state.json"), "{}\n", "utf8");
+          await fs.writeFile(path.join(oauthDir, "credentials.json"), "{}\n", "utf8");
+          await fs.writeFile(
+            path.join(path.dirname(configPath), "scratch.txt"),
+            "omit me\n",
+            "utf8",
+          );
+          await fs.symlink(outsideTarget, path.join(nestedWorkspace, ".build"), "dir");
+          await fs.writeFile(
+            configPath,
+            JSON.stringify({
+              agents: {
+                ...(layout === "shared workspace base" ? { ownership: "explicit" } : {}),
+                defaults: { workspace: nestedWorkspace },
+                entries:
+                  layout === "legacy workspace"
+                    ? { main: { default: true, agentDir } }
+                    : { main: { agentDir }, helper: { workspace: state.path("helper-workspace") } },
+              },
+            }),
+            "utf8",
+          );
+          state.envVars.OPENCLAW_CONFIG_PATH = configPath;
+          state.envVars.OPENCLAW_OAUTH_DIR = oauthDir;
+          state.applyEnv();
 
-        const archive = await createBackupArchive({
-          output: state.path("backup.tar.gz"),
-          includeWorkspace: false,
-          nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
-        });
-        const entries = await listArchiveEntries(archive.archivePath);
+          const archive = await createBackupArchive({
+            output: state.path("backup.tar.gz"),
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 8, 1, 12, 0, 0),
+          });
+          const entries = await listArchiveEntries(archive.archivePath);
 
-        expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
-        expect(entries.some((entry) => entry.includes("/workspace/.build"))).toBe(false);
-        expect(entries.some((entry) => entry.endsWith("/workspace/notes.md"))).toBe(false);
-        expect(
-          entries.some((entry) => entry.endsWith("/custom-agent/durable-agent-state.json")),
-        ).toBe(true);
-        await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({ ok: true });
-      },
-    );
-  });
+          expect(archive.assets.map((asset) => asset.kind)).not.toContain("workspace");
+          expect(entries.some((entry) => entry.includes("/workspace/.build"))).toBe(false);
+          expect(entries.some((entry) => entry.endsWith("/workspace/notes.md"))).toBe(false);
+          expect(entries.some((entry) => entry.endsWith("/workspace/config/scratch.txt"))).toBe(
+            false,
+          );
+          expect(entries.some((entry) => entry.endsWith("/workspace/config/openclaw.json"))).toBe(
+            true,
+          );
+          expect(
+            entries.some((entry) => entry.endsWith("/workspace/credentials/credentials.json")),
+          ).toBe(true);
+          expect(
+            entries.some((entry) => entry.endsWith("/custom-agent/durable-agent-state.json")),
+          ).toBe(true);
+          await expect(verifyBackupArchive(archive.archivePath)).resolves.toMatchObject({
+            ok: true,
+          });
+        },
+      );
+    },
+  );
 
   it("omits an absolute workspace-root symlink under the state directory", async () => {
     if (process.platform === "win32") {
@@ -1034,7 +1069,9 @@ describe("createBackupArchive", () => {
           await fs.writeFile(nestedState, '{"nested":true}\n', "utf8");
           await state.writeConfig({
             agents: {
+              ownership: "explicit",
               defaults: { workspace: resolveWorkspace(state) },
+              entries: { main: {}, helper: { workspace: state.path("helper-workspace") } },
             },
           });
 


### PR DESCRIPTION
Closes #139549

## What Problem This Solves

Fixes an issue where users creating a state-only backup with `--no-include-workspace` still archive files directly beneath a shared workspace base. When agents use subdirectories such as `workspace/main`, an external symlink in a sibling scratch directory can abort the backup even though workspace content was excluded.

## Why This Change Was Made

Include the configured `agents.defaults.workspace` base in backup exclusion discovery, using the existing traversal policy to preserve nested agent state, active configuration, and credentials. Full-backup selection, destructive cleanup, and archive symlink containment retain their existing behavior.

Validate the workspace base's type before trimming it so partial backups remain available when configuration is structurally invalid.

## User Impact

Operators can create and verify state-only backups without relocating scratch files from the shared workspace base. Separately owned state remains backed up, including when it is nested beneath that base.

## Evidence

- Reproduced with the installed OpenClaw 2026.9.2 CLI using synthetic, isolated Linux state; configuration and reproduction steps are in #139549.
- Extended the existing real-archive regression table. On pre-fix source, the shared-base case fails with `Archive symbolic link target must be relative`; the legacy-workspace case and both state-root overlap cases pass (1 failed, 3 passed).
- The archive fixture checks excluded workspace files and preservation of nested agent state, the active config, and credentials, then verifies the archive.
- Targeted formatting and `git diff --check` passed.
- On initial PR head `33dc35faf7`, all 137 tests passed across `src/infra/backup-create.test.ts`, `src/commands/backup.test.ts`, and `src/commands/backup-shared.test.ts` using `node scripts/run-vitest.mjs`. This includes the full archive suite, credential symlinks, and SQLite snapshot/restore cases.
- The edited docs page passed MDX validation, and required autoreview completed with no actionable findings. The local changed-file gate passed the preliminary guards through package patch checks; remaining broad type/lint gates are delegated to PR CI because the full type graph exceeds this host’s practical memory budget.
- Review follow-up: the numeric-workspace recovery case failed before the string guard, while malformed JSON passed. After the guard, all 26 command/planning tests and four real-archive exclusion/overlap cases passed. Renewed autoreview found no actionable issues.

- Built CLI proof passed for head `eb6328184234d4e12bdffaac8cd409a311151953`, using the [successful CI build](https://github.com/openclaw/openclaw/actions/runs/34005627733/job/101412262554) and its [runtime artifact](https://github.com/openclaw/openclaw/actions/runs/34005627733/artifacts/9980864694). The artifact metadata and isolated checkout both identify tested merge `7643f588736aba49d4c99336bbb1b975bb21e5bc`. Ran the built launcher on Node 26.8.1 with fresh synthetic state, two explicit agents, a shared workspace base, an absolute scratch symlink, and nested state/config/credentials. Creation and verification both exited 0. Reading the resulting archive confirmed the excluded scratch content was absent and all three retained files matched their original bytes. No live Gateway or operator state was used.

<details>
<summary>After-fix CLI output and archive checks (synthetic paths normalized)</summary>

```text
Child environment keys: NODE_DISABLE_COMPILE_CACHE, OPENCLAW_CONFIG_PATH, OPENCLAW_HOME, OPENCLAW_OAUTH_DIR, OPENCLAW_STATE_DIR, PATH
$ node <checkout>/openclaw.mjs backup create --no-include-workspace --output <fixture>/backup.tar.gz --json
create: exit=0
{
  "createdAt": "2026-09-06T02:13:29.107Z",
  "archiveRoot": "2026-09-06T04-13-29.107+02-00-openclaw-backup",
  "archivePath": "<fixture>/backup.tar.gz",
  "dryRun": false,
  "includeWorkspace": false,
  "onlyConfig": false,
  "verified": false,
  "assets": [
    {
      "kind": "state",
      "sourcePath": "<fixture>/state",
      "displayPath": "<fixture>/state",
      "archivePath": "2026-09-06T04-13-29.107+02-00-openclaw-backup/payload/posix<fixture>/state"
    }
  ],
  "agentRoots": [
    {
      "agentId": "main",
      "sourcePath": "<fixture>/state/workspace/agent-state"
    },
    {
      "agentId": "helper",
      "sourcePath": "<fixture>/state/agents/helper/agent"
    }
  ],
  "skipped": [
    {
      "kind": "agent",
      "sourcePath": "<fixture>/state/workspace/agent-state",
      "displayPath": "<fixture>/state/workspace/agent-state",
      "reason": "covered",
      "coveredBy": "<fixture>/state"
    }
  ],
  "skippedVolatileCount": 0
}
$ node <checkout>/openclaw.mjs backup verify <fixture>/backup.tar.gz --json
verify: exit=0
{
  "ok": true,
  "archivePath": "<fixture>/backup.tar.gz",
  "archiveRoot": "2026-09-06T04-13-29.107+02-00-openclaw-backup",
  "createdAt": "2026-09-06T02:13:29.107Z",
  "runtimeVersion": "2026.9.2",
  "assetCount": 1,
  "entryCount": 9,
  "symlinkCount": 0
}
PASS omitted /workspace/notes.txt
PASS omitted /workspace/.build
PASS omitted /outside-build/sentinel.txt
PASS retained exact bytes /state/workspace/active-config/openclaw.json
PASS retained exact bytes /state/workspace/credentials/fixture.json
PASS retained exact bytes /state/workspace/agent-state/durable.txt
PASS built CLI created and verified the state-only archive
Synthetic fixture and proof outputs retained at <fixture>
```

</details>
