### PR TITLE
test(gateway): distinguish final CLI results from draft text

### DIFF
--- a/src/gateway/test-helpers.agent-results.test.ts
+++ b/src/gateway/test-helpers.agent-results.test.ts
@@ -22,7 +22,7 @@ describe("extractPayloadText", () => {
       JSON.stringify({
         type: "assistant",
         message: {
-          content: [{ type: "text", text: "CLI backend OK ABC123." }],
+          content: [{ type: "text", text: "CLI backend draft before completion." }],
         },
       }),
       JSON.stringify({


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The CLI stream-JSON extraction test gave the assistant draft and terminal result identical text, so it could not detect reversed precedence.

## Why This Change Was Made

Give the draft distinct text while keeping the existing terminal expected value and case. The extractor is unchanged.

## User Impact

The existing test now rejects a regression that returns draft text instead of the terminal CLI result. No new cases or production changes; test LOC is unchanged.

## Evidence

A task-local negative control reversing extractor precedence failed this case while the plain payload case still passed. The extractor was restored byte-for-byte. All 18 owner/sibling tests, full changed checks, formatting/diff checks, deslop and independent P2 review pass.
