### PR TITLE
fix(agents): keep isolated completion config and credentials together

### DIFF
--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -307,6 +307,10 @@ deadline controls, and one prepared `authorization`:
   snapshot restricted to the single profile selected for that call. Core owns
   automatic fallback order and invokes the harness separately for each candidate.
 
+Each new isolated completion uses the configuration and agent/workspace directories
+of its admitted runtime generation. Explicit model, auth-profile, and runtime
+selections remain fixed while that generation is prepared.
+
 Host-authorized calls must use the supplied model and credential without substitution.
 Bundled host-authorized harnesses share one host-prepared completion helper that
 preserves the exact route, deadline, sampling options, and empty tool surface.

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -1137,6 +1137,69 @@ describe("resolveModel", () => {
     expect(resolveBundledProviderStaticCatalogModelMock).not.toHaveBeenCalled();
   });
 
+  it.each(["clone", "provider", "model", "google"] as const)(
+    "keeps %s request transport ahead of another config's prepared inline facts",
+    async (projection) => {
+      const preparedConfig = makeProviderConfig("custom", {
+        api: "openai-completions",
+        baseUrl: "https://prepared.example/v1",
+        headers: { "X-Retired": "prepared" },
+        models: [{ id: "model-a", name: "Prepared model" }],
+      });
+      preparedSnapshotState.inlineProviderModels = buildInlineProviderModels(
+        preparedConfig.models?.providers ?? {},
+      );
+      const runtimeHooks = {
+        ...createRuntimeHooks(),
+        normalizeProviderTransportWithPlugin: () => undefined,
+      };
+      await resolveModelAsync("custom", "model-a", state.agentDir(), preparedConfig, {
+        runtimeHooks,
+      });
+      const cfg =
+        projection === "clone"
+          ? structuredClone(preparedConfig)
+          : makeProviderConfig("custom", {
+              api: projection === "google" ? "google-generative-ai" : "openai-responses",
+              baseUrl:
+                projection === "google"
+                  ? "https://generativelanguage.googleapis.com"
+                  : "https://request.example/v1",
+              models: [
+                {
+                  id: "model-a",
+                  name: "Requested model",
+                  ...(projection === "model"
+                    ? { api: "openai-completions", baseUrl: "https://model.example/v1" }
+                    : {}),
+                },
+              ],
+            });
+
+      const result = await resolveModelAsync("custom", "model-a", state.agentDir(), cfg, {
+        runtimeHooks,
+      });
+
+      expectRecordFields(expectResolvedModel(result), {
+        id: "model-a",
+        api:
+          projection === "google"
+            ? "google-generative-ai"
+            : projection === "provider"
+              ? "openai-responses"
+              : "openai-completions",
+        baseUrl:
+          projection === "google"
+            ? "https://generativelanguage.googleapis.com/v1beta"
+            : `https://${projection === "clone" ? "prepared" : projection === "model" ? "model" : "request"}.example/v1`,
+      });
+      expect(expectResolvedModel(result).headers?.["X-Retired"]).toBe(
+        projection === "clone" ? "prepared" : undefined,
+      );
+      expect(discoverModels).toHaveBeenCalledOnce();
+    },
+  );
+
   it("falls back when an opaque prepared handle has no model facts", async () => {
     const config = {};
     resolveBundledStaticCatalogModelMock.mockReturnValueOnce(

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -214,7 +214,11 @@ export async function resolveModelAsync(
       manifestAlias: normalizedRef.manifestAlias,
       workspaceDir,
       runtimeHooks,
-      preparedInlineProviderModels: preparedModelRuntime?.inlineProviderModels,
+      // Inline rows carry configured transport and headers; only their captured config can reuse them.
+      preparedInlineProviderModels:
+        cfg === preparedModelRuntime?.config
+          ? preparedModelRuntime?.inlineProviderModels
+          : undefined,
       getStaticCatalogModel: getManifestStaticCatalogModel,
     });
     if (explicitModel?.kind === "suppressed") {

--- a/src/agents/harness/isolated-completion.native-auth.test.ts
+++ b/src/agents/harness/isolated-completion.native-auth.test.ts
@@ -135,9 +135,10 @@ describe("runIsolatedCompletion native authorization", () => {
       text: "native result",
       owner: { kind: "harness", id: "codex" },
     });
-    expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(expect.any(Object), {
-      catalogMode: "static",
-    });
+    expect(mocks.acquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ catalogMode: "static" }),
+    );
     expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
     expect(runIsolatedCompletionV2).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/agents/isolated-completion.test-support.ts
+++ b/src/agents/isolated-completion.test-support.ts
@@ -163,6 +163,7 @@ export function resetIsolatedCompletionTestState(): void {
   vi.clearAllMocks();
   preparedModelRuntime = {
     config: {},
+    agentDir: "/tmp/agent",
     metadataSnapshot: createEmptyPluginMetadataSnapshot("/tmp/workspace"),
     pluginRegistry: createEmptyPluginRegistry(),
     workspaceDir: "/tmp/workspace",

--- a/src/agents/isolated-completion.test.ts
+++ b/src/agents/isolated-completion.test.ts
@@ -152,6 +152,115 @@ describe("runIsolatedCompletion", () => {
     },
   );
 
+  it.each([false, true])(
+    "captures call-owned choices and authority before admission (retired: %s)",
+    async (retired) => {
+      const entered = createDeferred();
+      const release = createDeferred();
+      const expired = new Error("The original completion owner retired.");
+      let current = true;
+      const dispatch = vi.fn(async () => ({
+        assistant: isolatedAssistant([{ type: "text", text: "done" }]),
+      }));
+      registerIsolatedHarness({ runIsolatedCompletionV2: dispatch });
+      mocks.acquireAgentRunPreparedModelRuntime.mockImplementationOnce(async () => {
+        entered.resolve();
+        await release.promise;
+        return { snapshot: preparedModelRuntime, release: releaseRuntimeLease };
+      });
+      const mutableRequest = {
+        ...isolatedRequest(),
+        authProfileId: "openai:original",
+        streamParams: { maxTokens: 21, temperature: 0.1 },
+        assertCurrent() {
+          if (!current) {
+            throw expired;
+          }
+        },
+      };
+      const completion = runIsolatedCompletion(mutableRequest);
+      try {
+        await entered.promise;
+        mutableRequest.model = "changed-model";
+        mutableRequest.authProfileId = "openai:changed";
+        mutableRequest.streamParams.maxTokens = 84;
+        mutableRequest.streamParams.temperature = 0.9;
+        mutableRequest.agentHarnessRuntimeOverride = "changed-runtime";
+        mutableRequest.assertCurrent = () => {};
+        current = !retired;
+        release.resolve();
+
+        if (retired) {
+          await expect(completion).rejects.toBe(expired);
+          expect(dispatch).not.toHaveBeenCalled();
+          expect(mocks.prepareSimpleCompletionModel).not.toHaveBeenCalled();
+        } else {
+          await expect(completion).resolves.toMatchObject({ text: "done" });
+          expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
+            expect.objectContaining({ modelId: "gpt-test", profileId: "openai:original" }),
+          );
+          expect(dispatch).toHaveBeenCalledOnce();
+          expect(dispatch).toHaveBeenCalledWith(
+            expect.objectContaining({ streamParams: { maxTokens: 21, temperature: 0.1 } }),
+          );
+        }
+        expect(releaseRuntimeLease).toHaveBeenCalledOnce();
+      } finally {
+        release.resolve();
+        await Promise.allSettled([completion]);
+      }
+    },
+  );
+
+  it.each(["host", "cli"])(
+    "uses admitted config and directories for a newly owned %s completion",
+    async (owner) => {
+      const config = { agents: { defaults: { workspace: "/tmp/admitted-workspace" } } };
+      Object.assign(preparedModelRuntime, {
+        config,
+        agentDir: "/tmp/admitted-agent",
+        workspaceDir: "/tmp/admitted-workspace",
+      });
+      if (owner === "cli") {
+        mocks.isCliRuntimeAliasForProvider.mockReturnValue(true);
+        mocks.runCliAgent.mockResolvedValue({ payloads: [{ text: "done" }] });
+      } else {
+        registerIsolatedHarness({
+          runIsolatedCompletionV2: async () => ({
+            assistant: isolatedAssistant([{ type: "text", text: "done" }]),
+          }),
+        });
+      }
+
+      await expect(runIsolatedCompletion(isolatedRequest())).resolves.toMatchObject({
+        text: "done",
+      });
+
+      const admitted = {
+        config,
+        agentDir: "/tmp/admitted-agent",
+        workspaceDir: "/tmp/admitted-workspace",
+      };
+      expect(mocks.ensureSelectedAgentHarnessPlugin).toHaveBeenCalledWith(
+        expect.objectContaining(admitted),
+      );
+      if (owner === "cli") {
+        expect(mocks.runCliAgent).toHaveBeenCalledWith(expect.objectContaining(admitted));
+      } else {
+        expect(mocks.prepareSimpleCompletionModel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cfg: config,
+            agentDir: admitted.agentDir,
+            workspaceDir: admitted.workspaceDir,
+            provider: "openai",
+            modelId: "gpt-test",
+          }),
+        );
+      }
+      expect(releaseRuntimeLease).toHaveBeenCalledOnce();
+    },
+  );
+
   it("passes one prepared route to the selected harness and returns text", async () => {
     const runIsolatedCompletionHarness = vi.fn(async () => ({
       assistant: isolatedAssistant([{ type: "text", text: '{"ok":true}' }]),

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -8,7 +8,6 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { ThinkLevel } from "../auto-reply/thinking.js";
-import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withTempWorkspace } from "../infra/private-temp-workspace.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
@@ -174,7 +173,7 @@ function hasCliSideEffectEvidence(result: {
 }
 
 async function runCliIsolatedCompletion(params: {
-  request: RunIsolatedCompletionParams;
+  request: RunIsolatedCompletionParams & { config: OpenClawConfig };
   provider: string;
   modelProvider: string;
   agentId: string;
@@ -187,7 +186,7 @@ async function runCliIsolatedCompletion(params: {
       const { runCliAgent } = await import("./cli-runner.runtime.js");
       params.request.assertCurrent?.();
       const sessionId = `isolated-completion-${randomUUID()}`;
-      const config = params.request.config ?? getRuntimeConfig();
+      const config = params.request.config;
       const preparedRunAdmission = prepareSystemAgentRunAdmission(
         config,
         sessionId,
@@ -397,61 +396,76 @@ async function prepareHostAuthorization(params: {
 
 /** Run one fresh, zero-tool completion through its selected runtime. */
 export async function runIsolatedCompletion(
-  request: RunIsolatedCompletionParams,
+  params: RunIsolatedCompletionParams,
 ): Promise<IsolatedCompletionResult> {
-  // Native callbacks may be retained; their authority ends with this completion.
+  // Snapshot caller choices and validators before admission yields; callbacks expire on close.
+  const input = {
+    ...params,
+    streamParams: params.streamParams && { ...params.streamParams },
+  };
   let closed = false;
   const assertCurrent = () => {
     if (closed) {
       throw new IsolatedCompletionError("runtime-unavailable", "Isolated completion has ended.");
     }
-    request.assertCurrent?.();
-    request.abortSignal?.throwIfAborted();
+    input.assertCurrent?.();
+    input.abortSignal?.throwIfAborted();
   };
   assertCurrent();
-  const config = request.config ?? {};
-  const agentId = request.agentId ?? resolveDefaultAgentId(config);
-  const agentDir = request.agentDir ?? resolveAgentDir(config, agentId);
-  const workspaceDir = request.workspaceDir ?? resolveAgentWorkspaceDir(config, agentId);
+  const requestConfig = input.config ?? {};
+  const agentId = input.agentId ?? resolveDefaultAgentId(requestConfig);
+  const requestAgentDir = input.agentDir ?? resolveAgentDir(requestConfig, agentId);
+  const requestedWorkspaceDir =
+    input.workspaceDir ?? resolveAgentWorkspaceDir(requestConfig, agentId);
   const canonicalProvider = resolveCliRuntimeCanonicalProvider({
-    runtime: request.provider,
-    config,
+    runtime: input.provider,
+    config: requestConfig,
     includeSetupRegistry: true,
   });
-  const provider = canonicalProvider ?? request.provider;
+  const provider = canonicalProvider ?? input.provider;
   // Canonicalizing a CLI model ref must not discard its explicit execution owner.
   const runtimeOverride =
-    request.agentHarnessRuntimeOverride ?? (canonicalProvider ? request.provider : undefined);
+    input.agentHarnessRuntimeOverride ?? (canonicalProvider ? input.provider : undefined);
   const lease = await acquireAgentRunPreparedModelRuntime(
     {
-      config,
+      config: requestConfig,
       agentId,
-      agentDir,
-      workspaceDir,
-      runtimePluginSelections: [
+      agentDir: requestAgentDir,
+      workspaceDir: requestedWorkspaceDir,
+      preserveWorkspaceDirOnRefresh: input.workspaceDir !== undefined,
+    },
+    {
+      catalogMode: "static",
+      abortSignal: input.abortSignal,
+      deriveRuntimePluginSelections: () => [
         {
           provider,
-          modelId: request.model,
+          modelId: input.model,
           ...(runtimeOverride ? { runtime: runtimeOverride } : {}),
           agentId,
         },
       ],
     },
-    { catalogMode: "static", abortSignal: request.abortSignal },
   );
-  const pluginRegistry = lease.snapshot.pluginRegistry;
   try {
     assertCurrent();
     const run = async (): Promise<IsolatedCompletionResult> => {
+      // A new admission owns config and directories; the caller keeps its explicit route and profile.
+      const context = {
+        config: lease.snapshot.config,
+        agentId,
+        agentDir: lease.snapshot.agentDir,
+        workspaceDir: lease.snapshot.workspaceDir ?? requestedWorkspaceDir,
+      };
+      const { config, agentDir, workspaceDir } = context;
+      const request = { ...input, ...context, assertCurrent };
       await ensureSelectedAgentHarnessPlugin({
         provider,
         modelId: request.model,
-        config,
-        agentId,
+        ...context,
         agentHarnessId: runtimeOverride,
         agentHarnessRuntimeOverride: runtimeOverride,
-        workspaceDir,
-        pluginRegistry,
+        pluginRegistry: lease.snapshot.pluginRegistry,
       });
       assertCurrent();
       const runtime =
@@ -461,18 +475,14 @@ export async function runIsolatedCompletion(
         request,
         provider,
         runtime,
-        agentId,
-        agentDir,
-        workspaceDir,
+        ...context,
       });
       if (cliOwner) {
         const completion = await runCliIsolatedCompletion({
-          request: { ...request, assertCurrent },
+          request,
           provider: cliOwner,
           modelProvider: provider,
-          agentId,
-          agentDir,
-          workspaceDir,
+          ...context,
         });
         return {
           text: completion.text,
@@ -494,10 +504,7 @@ export async function runIsolatedCompletion(
       const commonParams = {
         provider,
         modelId: request.model,
-        config,
-        agentId,
-        agentDir,
-        workspaceDir,
+        ...context,
         systemPrompt: request.systemPrompt,
         prompt: request.prompt,
         timeoutMs: request.timeoutMs,
@@ -545,10 +552,8 @@ export async function runIsolatedCompletion(
             modelId: runtimeModel.id,
             modelApi: runtimeModel.api,
             modelBaseUrl: runtimeModel.baseUrl,
-            config,
+            ...context,
             env: process.env,
-            agentDir,
-            workspaceDir,
             authProfileStore,
             sessionAuthProfileId: request.authProfileId,
             sessionAuthProfileSource: request.authProfileId ? "user" : undefined,
@@ -628,14 +633,11 @@ export async function runIsolatedCompletion(
               };
             } else {
               authorization = await prepareHostAuthorization({
-                config,
-                agentId,
-                agentDir,
+                ...context,
                 provider,
                 modelId: request.model,
                 authProfileId:
                   attempt?.kind === "profile" ? attempt.profileId : request.authProfileId,
-                workspaceDir,
                 preparedModelRuntime: lease.snapshot,
               });
               modelMaxTokens = authorization.model.maxTokens;
@@ -677,16 +679,12 @@ export async function runIsolatedCompletion(
         }
       } else {
         const authorization = await prepareHostAuthorization({
-          config,
-          agentId,
-          agentDir,
+          ...context,
           provider,
           modelId: request.model,
           authProfileId: request.authProfileId,
-          workspaceDir,
           preparedModelRuntime: lease.snapshot,
         });
-        assertCurrent();
         const harnessParams: AgentHarnessIsolatedCompletionParams = {
           ...commonParams,
           streamParams: clampIsolatedStreamParams(
@@ -717,7 +715,7 @@ export async function runIsolatedCompletion(
     };
     const result = await withPluginRuntimeGenerationScope(lease.snapshot, run);
     assertCurrent();
-    if (!result.text && request.outputTextPolicy !== "strict-visible") {
+    if (!result.text && input.outputTextPolicy !== "strict-visible") {
       throw new IsolatedCompletionError(
         "output-rejected",
         "Isolated completion returned empty output.",


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

After a configuration replacement, an isolated completion could acquire the new runtime generation but continue using the previous configuration and directories. A compiled reproduction sent the previous credential to the new provider endpoint. Utility completions, generated labels, and plugin callers share this owner.

An explicit request configuration could also inherit transport and headers from another configuration's prepared inline models. Mutable request objects could change a selected model, profile, or sampling parameters during preparation, or replace the validator and cancellation signal that belonged to the original call.

## Why This Change Was Made

Capture call-owned choices and original validation/cancellation references before the first await. Carry one context from the acquired runtime snapshot through CLI dispatch, harness selection, model materialization, and authorization. Explicit models, profiles, runtime selections, and workspace overrides remain selected; implicit runtime policy and directories come from the admitted configuration. The CLI path no longer falls back to unrelated ambient configuration.

The model resolver reuses configured inline facts only with the configuration that prepared them. A projected configuration uses the existing inline builder while retaining catalog, registry, and generation facts. This preserves per-model API precedence, Google URL normalization, and borrowed generations while removing retired configured headers from projected requests.

This focused owner repair was found while extracting #130706. Production LOC is net +2 after consolidating the existing paths; the remaining growth captures nested sampling values while preserving live validators, signals, and owner-managed configuration. Tests/support are +174 and docs +4. No configuration, dependency, storage, protocol, or public SDK surface is added.

## User Impact

New isolated completions use a coherent current endpoint, credential, runtime policy, and agent directory. Explicit choices remain fixed through asynchronous preparation. Borrowed completions remain on their retained generation; route projections receive their own transport and headers.

## Evidence

Verified commit: `8a5bda6278bf01e54241ecfe5e065b5c98eea4c6`, tree `7711008c73c4eb174bfa2a7e1cf2294438f5e1b3`. The touched files remain unchanged on the newer main baseline, and the candidate merges cleanly.

- Before the repair, compiled runtime requests reproduced the old-credential/new-endpoint mismatch, stale runtime/directories, projected transport/header leakage, and changes to model/profile/sampling or authority after invocation. Corresponding regression tests were demonstrated failing before the repair.
- The integrated candidate passes 274 focused tests across isolated completion, prepared runtime ownership, model/generation resolution, inline model normalization, native authorization, and model materialization. The native suite retains retired-model, API-sibling, profile-fallback, cancellation, and authority-closure coverage.
- Fresh independent review is scoped-clean through P2 on the integrated candidate.
- Full build passes, including all 53 native control-plane loads/doctor closures, 90 plugins, SDK declarations/exports, CLI import checks, and UI budgets.
- All 21 completed-build runtime controls pass: 14 owner/transport/header/runtime/directory cases and 7 model/profile/runtime/validator/cancellation/sampling-mutation cases. New requests use the current endpoint and credential together; retained requests stay on their original generation; revoked or aborted requests send no HTTP; sampling remains 21 tokens and temperature 0.1 despite later request mutation.
- The staged source tree and all 8,531 runtime files were identical before and after replay. Every probe process exited and its synthetic fixture directory was removed; proof receipts were retained.
- The complete changed gate passes: formatting/ratchets, core and test typechecks, unused-export scans, changed-file lint, and repository guards. No source edits were needed after integration.

The HTTP/harness reproductions use isolated synthetic credentials and local fixture endpoints through the actual built runtime. They are not authenticated external-provider or Codex-account tests. Explicit CLI binding replacement was also observed failing closed before dispatch; a synthetic third-party backend reached the unsupported isolated-capability boundary, so that control does not claim healthy CLI execution.
