### PR TITLE
fix(update): avoid stuck history after upgrades from older releases

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -560,7 +560,8 @@ vi.mock("../runtime.js", async (importOriginal) => ({
 vi.mock("../commands/triage.js", () => ({ triageCommand }));
 
 const { runGatewayUpdate } = await import("../infra/update-runner.js");
-const { getUpdateRun, listUpdateRuns } = await import("../infra/update-run-ledger.js");
+const { createUpdateRun, getUpdateRun, listUpdateRuns } =
+  await import("../infra/update-run-ledger.js");
 // Real recovery dependencies need the initialized runtime and child-process mocks.
 const { runUpdateFailureTriage } = await import("../infra/update-triage.js");
 const { resolveOpenClawPackageRoot } = await import("../infra/openclaw-root.js");
@@ -3759,23 +3760,42 @@ describe("update-cli", () => {
     );
   });
 
-  it("post-core resume children exit after writing a plugin update result", async () => {
-    const resultDir = createCaseDir("openclaw-post-core-result");
-    const resultPath = path.join(resultDir, "plugins.json");
-    await fs.mkdir(resultDir, { recursive: true });
+  it.each([false, true])(
+    "post-core resume children preserve parent run ownership (inherited run: %s)",
+    async (inheritRun) => {
+      const resultDir = createCaseDir("openclaw-post-core-result");
+      const resultPath = path.join(resultDir, "plugins.json");
+      await fs.mkdir(resultDir, { recursive: true });
+      const env = { ...process.env, OPENCLAW_STATE_DIR: resultDir };
+      const parentRun = inheritRun
+        ? createUpdateRun(
+            {
+              trigger: "cli",
+              target: { channel: "stable", version: "2026.9.2" },
+              before: { version: "2026.9.1" },
+            },
+            { env },
+          )
+        : undefined;
 
-    await runPostCoreCommand(
-      { restart: false },
-      { OPENCLAW_UPDATE_POST_CORE_RESULT_PATH: resultPath },
-    );
+      await runPostCoreCommand(
+        { restart: false },
+        {
+          OPENCLAW_STATE_DIR: resultDir,
+          OPENCLAW_UPDATE_POST_CORE_RESULT_PATH: resultPath,
+          OPENCLAW_UPDATE_RUN_ID: parentRun?.runId,
+        },
+      );
 
-    const result = JSON.parse(await fs.readFile(resultPath, "utf-8")) as {
-      status?: string;
-    };
-    expect(result.status).toBe("ok");
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
-    expectNoSideEffects(runGatewayUpdate, spawn);
-  });
+      const result = JSON.parse(await fs.readFile(resultPath, "utf-8")) as {
+        status?: string;
+      };
+      expect(result.status).toBe("ok");
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+      expectNoSideEffects(runGatewayUpdate, spawn);
+      expect(listUpdateRuns({}, { env })).toEqual(parentRun ? [parentRun] : []);
+    },
+  );
 
   it("post-core resume mode uses the parent install records snapshot for missing payload warnings", async () => {
     const resultDir = createCaseDir("openclaw-post-core-records");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -19,6 +19,7 @@ import {
   resolveExtendedStablePackage,
   resolveNpmChannelTag,
 } from "../../infra/update-check.js";
+import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
 import {
   canResolveRegistryVersionForPackageTarget,
   createGlobalInstallEnv,
@@ -87,15 +88,20 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
   const prepared = await withUpdateInProgressEnv(invocationCwd, () =>
     prepareUpdateCommand(inputOpts),
   );
-  const run = await admitUpdateCommandRun({
-    opts: inputOpts,
-    root: prepared.servicePlan?.rootRedirect?.root ?? prepared.discoveredRoot,
-    invocationCwd,
-  });
+  // Parents predating the run ledger cannot finish a row invented by their
+  // post-core child, which is already running the updated package version.
+  const run =
+    prepared.postCoreUpdateResume && !process.env[UPDATE_RUN_ID_ENV]?.trim()
+      ? undefined
+      : await admitUpdateCommandRun({
+          opts: inputOpts,
+          root: prepared.servicePlan?.rootRedirect?.root ?? prepared.discoveredRoot,
+          invocationCwd,
+        });
   const opts = { ...inputOpts, run };
   prepared.controlPlaneUpdateSentinelMeta = {
     ...prepared.controlPlaneUpdateSentinelMeta,
-    runId: run.runId,
+    runId: run?.runId,
   };
   recoveryState.triageTarget.root = prepared.discoveredRoot;
   const presentation = createUpdateProgress(!opts.json && !prepared.postCoreUpdateResume, run);
@@ -140,7 +146,7 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
             recoveryState.windowsTaskAutoStartRecovery?.complete();
           }
           if (failure) {
-            if (!prepared.postCoreUpdateResume) {
+            if (run && !prepared.postCoreUpdateResume) {
               if (failure.error instanceof UpdateCommandFailure) {
                 completeUpdateCommandRun(failure.error.result, run);
               } else {


### PR DESCRIPTION
Related: #139284

## What Problem This Solves

Fixes an issue where users upgrading from 2026.9.1 can finish plugin finalization but retain a permanently running update-history entry. The entry also reports the newly installed version as the starting version, obscuring what actually happened during the upgrade.

## Why This Change Was Made

The older updater starts finalization in the new package without passing a run ID. Skip new-run admission for that legacy continuation: its parent cannot finish a ledger entry it never created. Modern continuations still reuse their parent's run through the existing admission path. This prevents new orphan records without adding history recovery or changing the ledger schema.

## User Impact

Upgrades from parents predating the ledger no longer invent a running history entry during finalization. Modern updates retain their original version, target, and parent-owned completion behavior.

## Evidence

- Extended the existing post-core CLI test into a two-case table, using its established mocked external boundaries and a real isolated update ledger. It checks successful plugin-result output and the complete retained ledger state for both legacy and modern handoffs.
- Before the production change, the legacy case failed with an extra `requested / running` row, `before.version: 2026.9.2`, and an empty target. The inherited-run case passed and retained the original `2026.9.1` starting version and target. The focused regression run had 1 failed, 1 passed, and 361 unselected tests.
- After the fix, all 380 tests passed in `src/cli/update-cli.test.ts` and `src/cli/update-cli/update-command-post-core.test.ts` using `node scripts/run-vitest.mjs`, including both ownership cases, normal update phases, rejected preflights, and post-core failures.
- Targeted formatting, `git diff --check`, and required autoreview passed. [The PR CI gate passed](https://github.com/openclaw/openclaw/actions/runs/34004865581/job/101410803833) for head `825ffb9a8f21a33a1dda292d28a4d40fbbdda794`.
- Installed-updater proof passed for both ownership paths: a published pre-ledger parent completed finalization without creating a row; a modern parent completed its single inherited row with the original before version and target retained. Both installed Gateways passed real health and version checks.

<details>
<summary>Installed legacy and modern handoff proof</summary>

[Successful hosted run](https://github.com/TheCrazyLex/openclaw/actions/runs/34007924027).

[Full evidence artifact](https://github.com/TheCrazyLex/openclaw/actions/runs/34007924027/artifacts/9981708879).

Exact product head: `825ffb9a8f21a33a1dda292d28a4d40fbbdda794`.
Proof branch head: `b732aefcbad385ed9b197ba1a2ecb3461bb66424`.

| Actual installed update | CLI result / plugin finalization | All retained history | Live Gateway |
| --- | --- | --- | --- |
| Published 2026.8.2 → exact candidate 2026.9.2 | `ok / ok`, exit 0 | Zero rows; no invented run ID | Health and status RPC pass; version 2026.9.2, build identifies 825ffb9a8f21 |
| Candidate 2026.9.2 → existing future fixture 2026.9.99-first-hop.0 | `ok / ok`, exit 0 | Exactly one `succeeded / finished` row; parent result ID matches retained ID; original before/target preserved | Health and status RPC pass; version 2026.9.99-first-hop.0 |

The modern row ID is `cc2e18a5-a6d8-4036-8e34-7fbd36284ec4`. Its before version is `2026.9.2`, after version is `2026.9.99-first-hop.0`, and target remains `{channel: stable, tag: /tmp/openclaw-update-first-hop-future.tgz, kind: package}`. Every retained step is completed, including post-update verification. There are no other rows, unfinished runs, or transaction residues. All three successive service process IDs differ.

The first-hop missing-bridge negative control also reproduced its expected failure (exit 1, `shared-Y6bNiw2w.js`). That is the existing compatibility-control case; the failed-first ledger regression remains the separately recorded CLI/SQLite test.

Package checksums:

- Published 2026.8.2 SHA-256: `20e9c2f16742dfcebfb21504e51067d31e000a19577126ff4fab117e5e87dbe2`.
- Canonically packed exact candidate SHA-256: `d485c26afe341492e5b95d4a3016428c6bacd9579ddf005a3c5ebf6d53b0d8a1`.
- Uploaded artifact digest from GitHub: `sha256:37d531d231c60b1a22a8090822ab9f20f0bc0bff5bbbbdef323d144e78603302`.

The product was packed before harness instrumentation. Installed build-info matches the selected package at each hop, and the first live RPC observation was recorded before the future hop replaced the candidate. History observation opened the existing SQLite database read-only and read all rows; no fixture admission, terminalization, or manual history mutation was used.

Scope: this uses the existing isolated Docker updater harness, including its systemd-control shim, with real installed CLI binaries, package replacement, Gateway processes, and RPC calls. Published 2026.8.2 supplies the pre-ledger parent contract through an already-supported compatibility bridge; the future fixture is derived from the candidate by the existing fixture generator. It is not a native systemd-host or macOS proof, and no operator Gateway or private configuration was used.

Actual observation summaries from the run:

```json
{
  "stage": "positive-first",
  "before": "2026.8.2",
  "after": "2026.9.2",
  "finalization": "ok",
  "historyRows": 0,
  "runId": null,
  "gatewayVersion": "2026.9.2",
  "gatewayHealthy": true
}
{
  "stage": "positive-second",
  "before": "2026.9.2",
  "after": "2026.9.99-first-hop.0",
  "finalization": "ok",
  "historyRows": 1,
  "runId": "cc2e18a5-a6d8-4036-8e34-7fbd36284ec4",
  "gatewayVersion": "2026.9.99-first-hop.0",
  "gatewayHealthy": true
}
```

</details>

## Maintainer update

- Verified the shipped `v2026.9.1` post-core spawn contract: it supplies post-core context without an update run ID, so the original defect mechanism is valid.
- Current main already contains the repair in #139660, merged as `53b3ac0831350ad868cb0ca25daf691bbbd8e1f4`, including Alex Naidis's co-author credit. Post-core children now return before top-level run admission, and the existing two-case regression checks successful plugin output and unchanged complete ledger contents with and without a forwarded parent run.
- Both current-main ownership cases passed on `b4ce0df975fab5f1a5bc234ad9643c6de40c9eb0` in the combined run `node scripts/run-vitest.mjs src/cli/update-cli.test.ts -t 'finishes the admitted run|restored-generation completion|does not reopen the ledger after migrated|post-core resume children' --reporter=dot` (4 passed; the two expected initialization failures belong to #139288). There is no red-on-current-main result for this already-fixed defect.
- Fresh Codex autoreview of the original branch against its merge base found no actionable P0–P2 findings. The bounded exact-head CI watcher confirmed [run 34004865581](https://github.com/openclaw/openclaw/actions/runs/34004865581) is green for `825ffb9a8f21a33a1dda292d28a4d40fbbdda794`; this is the existing run, not new CI.
- No branch rewrite or redundant production change was pushed. Leaving this PR open for the landing lead's disposition; the original evidence above remains historical evidence for the contributor's patch.
