### PR TITLE
fix(sessions): avoid pauses resolving sessions with saved prompts

### DIFF
--- a/src/gateway/sessions-resolve-projection.test.ts
+++ b/src/gateway/sessions-resolve-projection.test.ts
@@ -1,0 +1,150 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionsResolveParams } from "../../packages/gateway-protocol/src/index.js";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { roleClient, rolePolicyConfig } from "./session-sharing.test-utils.js";
+import { resolveSessionKeyFromResolveParams } from "./sessions-resolve.js";
+
+const scope = { agentId: "main", sessionKey: "agent:main:target" };
+const entry = { sessionId: "target-id", updatedAt: 1, label: "original" };
+const cfg: OpenClawConfig = {
+  agents: { ownership: "explicit", entries: { main: {} } },
+};
+const selectors: SessionsResolveParams[] = [
+  { key: scope.sessionKey, agentId: "main" },
+  { sessionId: entry.sessionId, agentId: "main" },
+  { sessionId: entry.sessionId },
+  { label: entry.label, agentId: "main" },
+];
+
+function resolve(p: SessionsResolveParams) {
+  return resolveSessionKeyFromResolveParams({ cfg, client: null, p });
+}
+
+const resolved = { ok: true, key: scope.sessionKey, agentId: "main" };
+
+describe("session resolution metadata", () => {
+  it.each(selectors)("resolves %j without decoding unrelated saved prompts", async (p) => {
+    await withOpenClawTestState({ label: "resolve-prompts" }, async () => {
+      replaceSessionEntrySync(scope, entry);
+      for (let index = 0; index < 3; index++) {
+        replaceSessionEntrySync(
+          { ...scope, sessionKey: `agent:main:sibling-${index}` },
+          {
+            sessionId: `sibling-${index}`,
+            updatedAt: 1,
+            skillsSnapshot: { prompt: "unrelated-resolve-prompt".repeat(1024), skills: [] },
+          },
+        );
+      }
+      const parse = vi.spyOn(JSON, "parse");
+      try {
+        expect(await resolve(p)).toEqual(resolved);
+        expect(
+          parse.mock.calls.filter(([json]) => json.includes("unrelated-resolve-prompt")),
+        ).toHaveLength(0);
+      } finally {
+        parse.mockRestore();
+      }
+    });
+  });
+
+  it("observes same-timestamp external and tracked label/visibility changes", async () => {
+    await withOpenClawTestState({ label: "resolve-freshness" }, async () => {
+      const client = roleClient("view", "resolve-viewer");
+      const roleCfg = { ...cfg, ...rolePolicyConfig() };
+      const visible = { ...entry, visibility: "shared" as const };
+      replaceSessionEntrySync(scope, visible);
+      const lookup = (p: SessionsResolveParams) =>
+        resolveSessionKeyFromResolveParams({ cfg: roleCfg, client, p });
+      for (let repeat = 0; repeat < 2; repeat++) {
+        expect(await lookup({ key: scope.sessionKey })).toEqual(resolved);
+        expect(await lookup({ label: entry.label })).toEqual(resolved);
+      }
+      const external = new DatabaseSync(openOpenClawAgentDatabase(scope).path);
+      try {
+        const hidden = { ...visible, label: "external", visibility: "draft" };
+        external
+          .prepare("UPDATE session_nodes SET entry_json = ?, label = ? WHERE session_key = ?")
+          .run(JSON.stringify(hidden), hidden.label, scope.sessionKey);
+        expect(await lookup({ key: scope.sessionKey, allowMissing: true })).toEqual({
+          ok: true,
+          missing: true,
+        });
+        expect(await lookup({ label: hidden.label, allowMissing: true })).toEqual({
+          ok: true,
+          missing: true,
+        });
+        expect(await lookup({ label: entry.label, allowMissing: true })).toEqual({
+          ok: true,
+          missing: true,
+        });
+        const tracked = { ...visible, label: "tracked" };
+        replaceSessionEntrySync(scope, tracked);
+        expect(await lookup({ key: scope.sessionKey })).toEqual(resolved);
+        expect(await lookup({ label: tracked.label })).toEqual(resolved);
+        expect(await lookup({ label: hidden.label, allowMissing: true })).toEqual({
+          ok: true,
+          missing: true,
+        });
+      } finally {
+        external.close();
+      }
+    });
+  });
+
+  it.each(["malformed", "nul", "mismatched-time", "mismatched-window"])(
+    "preserves warm and cold lookup outcomes for %s rows",
+    async (kind) => {
+      await withOpenClawTestState({ label: "resolve-corruption" }, async () => {
+        const siblingKey = "agent:main:sibling";
+        replaceSessionEntrySync(scope, entry);
+        replaceSessionEntrySync(
+          { ...scope, sessionKey: siblingKey },
+          { sessionId: "sibling", updatedAt: 1 },
+        );
+        expect(await resolve({ key: scope.sessionKey })).toEqual(resolved);
+        const database = openOpenClawAgentDatabase(scope).db;
+        if (kind === "malformed" || kind === "nul") {
+          database
+            .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+            .run(
+              kind === "malformed" ? "{" : JSON.stringify(entry) + "\0trailing",
+              scope.sessionKey,
+            );
+        } else if (kind === "mismatched-time") {
+          database
+            .prepare("UPDATE session_nodes SET updated_at = ? WHERE session_key = ?")
+            .run(2, scope.sessionKey);
+        } else {
+          database
+            .prepare("UPDATE session_nodes SET current_session_id = ? WHERE session_key = ?")
+            .run("different", scope.sessionKey);
+        }
+        expect(await resolve({ key: scope.sessionKey, allowMissing: true })).toEqual(
+          kind === "mismatched-window" ? resolved : { ok: true, missing: true },
+        );
+        expect(await resolve({ key: siblingKey })).toEqual({
+          ok: true,
+          key: siblingKey,
+          agentId: "main",
+        });
+        closeOpenClawAgentDatabasesForTest();
+        expect(await resolve({ key: scope.sessionKey, allowMissing: true })).toEqual({
+          ok: true,
+          missing: true,
+        });
+        expect(await resolve({ key: siblingKey, allowMissing: true })).toEqual({
+          ok: true,
+          missing: true,
+        });
+      });
+    },
+  );
+});

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -270,6 +270,7 @@ describe("resolveSessionKeyFromResolveParams", () => {
     expect(result).toEqual({ ok: true, key: "agent:main:target", agentId: "main" });
     expect(hoisted.loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledWith(cfg, {
       agentId: "main",
+      projection: "list",
     });
     expect(rowSpy).not.toHaveBeenCalled();
   });
@@ -621,6 +622,7 @@ describe("resolveSessionKeyFromResolveParams", () => {
 
     expect(hoisted.loadCombinedSessionStoreForGatewayMock).toHaveBeenCalledWith(cfg, {
       agentId: undefined,
+      projection: "list",
     });
     expect(result).toEqual({
       ok: false,

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -277,6 +277,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
       cfg,
       key,
       clone: false,
+      projection: "list",
       ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
     });
     const store = target.store;
@@ -311,7 +312,10 @@ export async function resolveSessionKeyFromResolveParams(params: {
         { agentId: string; entry: SessionEntry; key: string }
       >();
       for (const agentId of listAgentIds(cfg)) {
-        const loaded = loadCombinedSessionStoreForGatewayCore(cfg, { agentId });
+        const loaded = loadCombinedSessionStoreForGatewayCore(cfg, {
+          agentId,
+          projection: "list",
+        });
         const agentMatches = findVisibleSessionIdMatches({
           cfg,
           store: loaded.store,
@@ -370,7 +374,10 @@ export async function resolveSessionKeyFromResolveParams(params: {
         );
       }
     }
-    const { store } = loadCombinedSessionStoreForGatewayCore(cfg, { agentId: p.agentId });
+    const { store } = loadCombinedSessionStoreForGatewayCore(cfg, {
+      agentId: p.agentId,
+      projection: "list",
+    });
     const matches = findVisibleSessionIdMatches({ cfg, store, p, sessionId, entryFilter });
     const selection = resolveSessionIdMatchSelection(matches, sessionId);
     if (selection.kind === "none") {
@@ -454,6 +461,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
 
   const { store, targetsBySessionKey } = loadCombinedSessionStoreForGatewayCore(cfg, {
     agentId: p.agentId,
+    projection: "list",
   });
   const now = Date.now();
   // Keep list-discovery snapshot semantics without hydrating display rows.


### PR DESCRIPTION
Closes #139609

## What Problem This Solves

Fixes unnecessary pauses when resolving a session key, raw session ID, or label in stores containing large saved prompts. Those selectors previously decoded every saved prompt in the selected stores, including when a requested key was missing.

## Why This Change Was Made

The four remaining resolver load sites now request the existing metadata projection, matching short-ID and reference resolution. The projection omits saved skill snapshots and system-prompt reports; all fields used for selection, visibility, ownership and ACP handling remain available.

Existing loaders, alias resolution, read modes, filters and error handling are unchanged. No schema, index, new cache, configuration or public API is introduced.

## User Impact

Resolution avoids allocating unrelated saved prompt payloads. Canonical keys, ambiguity, exact-key versus discovery visibility, archived-session behavior and freshness after committed changes retain their existing contracts.

## Evidence

- Original-code regression: all four affected selectors decoded three unrelated prompt payloads; the candidate decodes zero with the same answers.
- 77 focused tests passed across resolver, real-store federation/ACP, and cache data-version coverage. New cases exercise same-timestamp external and tracked label/visibility changes, plus warm/cold malformed, NUL and identity/time mismatch outcomes.
- Paired synthetic helper benchmark: alternating original and candidate calls, nine warm and three cold pairs per selector at 100 and 500 rows, measuring wall time and process CPU without JSON instrumentation. Median CPU was lower in every measured group, and median wall time was lower in all warm groups. At 500 rows, warm label resolution used 93.2 → 59.3 ms CPU; scoped session-ID resolution used 101.1 → 64.8 ms CPU.
- Cold key wall time varied and was sometimes higher despite lower CPU. These helper measurements do not establish a universal or production end-to-end speedup; cold validation and metadata enumeration remain.

Independent review and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34004798188) passed on `fc48c8420f20817f33b21b514d77cf61e9ec8577`.

The final compiled Gateway proof passed 35 resolver calls and three supported metadata mutations using a verified synthetic trusted-proxy user with read-only scope. It covered key/ID/label selectors, aliases, ambiguity, archive/draft visibility, and mutation freshness. Actual pre-read checks covered all 107 stored rows; fresh-process durable readback preserved all 107 rows, including 100 sibling prompt objects and the target's saved prompt/report. Gateway and sockets shut down cleanly; both owned proof leases are closed.

<details>
<summary>Proof qualification and retained fixture failures</summary>

The final run reused the original compiled build. Source contents, file kinds and Git executable modes matched the build's source; compiled/runtime artifacts matched exactly, including permissions. Native source replay generated a different transport commit, recorded separately without restamping the original build identity. One public plugin manifest normalized from mode 0600 to 0644 (read bits only); raw old/new source-seal identity is not claimed. Both proof processes read/hash it, but a Gateway-PID-specific file-read audit was not retained.

Failed fixture runs remain preserved: V2's shared-token reader was intentionally owner-equivalent, and V4's ancient generic rows were subject to normal retention after visibility writes. The final V5 fixture uses a verified non-owner human and freshly timestamped generic rows, with all RPC/durable assertions and retention settings unchanged. These were proof corrections, not production fixes. Setup/transport refusals also remain recorded.

</details>
