### PR TITLE
test(gateway): share HTTP authority scenarios

### DIFF
--- a/src/gateway/http-authority.test-support.ts
+++ b/src/gateway/http-authority.test-support.ts
@@ -1,0 +1,151 @@
+import { expect } from "vitest";
+import { resetConfigRuntimeState, type GatewayAuthConfig } from "../config/config.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import type { GatewayServer } from "./server.js";
+import { agentCommandMock, getGatewayTestPort, testState } from "./test-helpers.js";
+
+type OwnerIdentityRequests = {
+  post: (stream: boolean | undefined, headers: Record<string, string>) => Promise<Response>;
+  consume: (response: Response, stream: boolean) => Promise<unknown>;
+  senderIsOwner: () => unknown;
+};
+
+export async function expectDeclaredHttpOwnerIdentity(params: OwnerIdentityRequests) {
+  for (const stream of [false, true]) {
+    for (const { scopes, senderIsOwner } of [
+      { scopes: "operator.write", senderIsOwner: false },
+      { scopes: "operator.admin, operator.write", senderIsOwner: true },
+    ]) {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+      const response = await params.post(stream, {
+        "x-openclaw-scopes": scopes,
+        "x-openclaw-sender-is-owner": "true",
+      });
+      expect(response.status).toBe(200);
+      await params.consume(response, stream);
+      expect(agentCommandMock).toHaveBeenCalledTimes(1);
+      expect(params.senderIsOwner()).toBe(senderIsOwner);
+    }
+  }
+}
+
+export async function expectSharedSecretHttpOwnerIdentity(params: OwnerIdentityRequests) {
+  for (const stream of [false, true]) {
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+    const response = await params.post(stream, {
+      authorization: "Bearer secret",
+      "x-openclaw-scopes": "operator.approvals",
+      "x-openclaw-sender-is-owner": "false",
+    });
+    expect(response.status).toBe(200);
+    await params.consume(response, stream);
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    expect(params.senderIsOwner()).toBe(true);
+  }
+  agentCommandMock.mockClear();
+  const unauthorized = await params.post(undefined, {
+    authorization: "Bearer wrong",
+    "x-openclaw-sender-is-owner": "true",
+  });
+  expect(unauthorized.status).toBe(401);
+  await params.consume(unauthorized, false);
+  expect(agentCommandMock).not.toHaveBeenCalled();
+}
+
+export async function expectHttpForeignSessionAuthority(params: {
+  authMethod: "trusted-proxy" | "token";
+  ownerEmail: string;
+  sessionKey: string;
+  sessionId: string;
+  closeReason: string;
+  startServer: (port: number, auth: GatewayAuthConfig) => Promise<GatewayServer>;
+  writeGatewayConfig: (config: Record<string, unknown>) => Promise<void>;
+  post: (port: number, headers: Record<string, string>) => Promise<Response>;
+}) {
+  const sharedSecretOwner = params.authMethod === "token";
+  await withEnvAsync(
+    { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_GATEWAY_PASSWORD: undefined },
+    async () => {
+      const port = await getGatewayTestPort();
+      let server: GatewayServer | undefined;
+      const previousGatewayAuth = testState.gatewayAuth;
+      const trustedProxyAuth = {
+        mode: "trusted-proxy" as const,
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+          requiredHeaders: ["x-forwarded-proto"],
+          allowLoopback: true,
+        },
+      };
+      const requestAuth = sharedSecretOwner
+        ? { mode: "token" as const, token: "owner-secret" }
+        : trustedProxyAuth;
+      testState.gatewayAuth = requestAuth;
+      try {
+        await params.writeGatewayConfig({
+          gateway: {
+            auth: requestAuth,
+            trustedProxies: ["127.0.0.1"],
+            roles: {
+              default: "guest",
+              definitions: {
+                guest: {
+                  agents: sharedSecretOwner ? [] : "*",
+                  scopes: ["operator.write"],
+                  sessions: { others: "view" },
+                },
+              },
+            },
+          },
+        });
+        resetConfigRuntimeState();
+        server = await params.startServer(port, requestAuth);
+
+        const owner = ensureProfileForEmail(params.ownerEmail);
+        const sessionKey = params.sessionKey;
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: params.sessionId,
+            updatedAt: 1,
+            visibility: "shared",
+            createdVia: "operator",
+            createdActor: { type: "human", source: "profile", id: owner.id },
+          },
+        );
+
+        agentCommandMock.mockClear();
+        agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
+        const response = await params.post(port, {
+          ...(sharedSecretOwner
+            ? { authorization: "Bearer owner-secret" }
+            : {
+                "x-forwarded-for": "198.51.100.42",
+                "x-forwarded-proto": "https",
+                "x-forwarded-user": "guest@example.test",
+              }),
+          "x-openclaw-session-key": sessionKey,
+        });
+
+        expect(response.status).toBe(sharedSecretOwner ? 200 : 403);
+        if (sharedSecretOwner) {
+          expect(agentCommandMock).toHaveBeenCalledOnce();
+        } else {
+          expect(await response.json()).toMatchObject({
+            error: { type: "forbidden", message: expect.stringContaining("session is shared") },
+          });
+          expect(agentCommandMock).not.toHaveBeenCalled();
+        }
+      } finally {
+        await server?.close({ reason: params.closeReason });
+        testState.gatewayAuth = previousGatewayAuth;
+        await params.writeGatewayConfig({});
+        resetConfigRuntimeState();
+      }
+    },
+  );
+}

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -34,8 +34,12 @@ import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
 } from "../process/gateway-work-admission.js";
-import { ensureProfileForEmail } from "../state/user-profiles.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import {
+  expectDeclaredHttpOwnerIdentity,
+  expectHttpForeignSessionAuthority,
+  expectSharedSecretHttpOwnerIdentity,
+} from "./http-authority.test-support.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommandMock,
@@ -3817,132 +3821,43 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
   });
 
   it("preserves declared owner identity for streaming and non-streaming private callers", async () => {
-    for (const stream of [false, true]) {
-      for (const { scopes, senderIsOwner } of [
-        { scopes: "operator.write", senderIsOwner: false },
-        { scopes: "operator.admin, operator.write", senderIsOwner: true },
-      ]) {
-        agentCommandMock.mockClear();
-        agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-
-        const res = await postChatCompletions(
+    await expectDeclaredHttpOwnerIdentity({
+      post: (stream, headers) =>
+        postChatCompletions(
           enabledPort,
-          {
-            stream,
-            model: "openclaw",
-            messages: [{ role: "user", content: "hi" }],
-          },
-          {
-            "x-openclaw-scopes": scopes,
-            "x-openclaw-sender-is-owner": "true",
-          },
-        );
-
-        expect(res.status).toBe(200);
-        await res.text();
-        expect(agentCommandMock).toHaveBeenCalledTimes(1);
-        expect(firstAgentCommandOptions()?.senderIsOwner).toBe(senderIsOwner);
-      }
-    }
+          { stream, model: "openclaw", messages: [{ role: "user", content: "hi" }] },
+          headers,
+        ),
+      consume: (response) => response.text(),
+      senderIsOwner: () => firstAgentCommandOptions()?.senderIsOwner,
+    });
   });
 
   it.each(["trusted-proxy", "token"] as const)(
     "preserves %s authority when mutating another operator session",
     async (authMethod) => {
-      const sharedSecretOwner = authMethod === "token";
-      await withEnvAsync(
-        { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_GATEWAY_PASSWORD: undefined },
-        async () => {
-          const port = await getGatewayTestPort();
-          let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
-          const previousGatewayAuth = testState.gatewayAuth;
-          const trustedProxyAuth = {
-            mode: "trusted-proxy" as const,
-            trustedProxy: {
-              userHeader: "x-forwarded-user",
-              requiredHeaders: ["x-forwarded-proto"],
-              allowLoopback: true,
-            },
-          };
-          const requestAuth = sharedSecretOwner
-            ? { mode: "token" as const, token: "owner-secret" }
-            : trustedProxyAuth;
-          testState.gatewayAuth = requestAuth;
-          try {
-            await writeGatewayConfig({
-              gateway: {
-                auth: requestAuth,
-                trustedProxies: ["127.0.0.1"],
-                roles: {
-                  default: "guest",
-                  definitions: {
-                    guest: {
-                      agents: sharedSecretOwner ? [] : "*",
-                      scopes: ["operator.write"],
-                      sessions: { others: "view" },
-                    },
-                  },
-                },
-              },
-            });
-            resetConfigRuntimeState();
-            server = await startGatewayServer(port, {
-              host: "127.0.0.1",
-              auth: requestAuth,
-              controlUiEnabled: false,
-              openAiChatCompletionsEnabled: true,
-            });
-
-            const owner = ensureProfileForEmail("session-owner@example.test");
-            const sessionKey = "agent:main:foreign-openai-http";
-            await upsertSessionEntryCore(
-              { agentId: "main", sessionKey },
-              {
-                sessionId: "foreign-openai-http",
-                updatedAt: 1,
-                visibility: "shared",
-                createdVia: "operator",
-                createdActor: { type: "human", source: "profile", id: owner.id },
-              },
-            );
-
-            agentCommandMock.mockClear();
-            agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-            const response = await postChatCompletions(
-              port,
-              {
-                model: "openclaw",
-                messages: [{ role: "user", content: "mutate foreign session" }],
-              },
-              {
-                ...(sharedSecretOwner
-                  ? { authorization: "Bearer owner-secret" }
-                  : {
-                      "x-forwarded-for": "198.51.100.42",
-                      "x-forwarded-proto": "https",
-                      "x-forwarded-user": "guest@example.test",
-                    }),
-                "x-openclaw-session-key": sessionKey,
-              },
-            );
-
-            expect(response.status).toBe(sharedSecretOwner ? 200 : 403);
-            if (sharedSecretOwner) {
-              expect(agentCommandMock).toHaveBeenCalledOnce();
-            } else {
-              expect(await response.json()).toMatchObject({
-                error: { type: "forbidden", message: expect.stringContaining("session is shared") },
-              });
-              expect(agentCommandMock).not.toHaveBeenCalled();
-            }
-          } finally {
-            await server?.close({ reason: "openai operator role session sharing test done" });
-            testState.gatewayAuth = previousGatewayAuth;
-            await writeGatewayConfig({});
-            resetConfigRuntimeState();
-          }
+      await expectHttpForeignSessionAuthority({
+        authMethod,
+        ownerEmail: "session-owner@example.test",
+        sessionKey: "agent:main:foreign-openai-http",
+        sessionId: "foreign-openai-http",
+        closeReason: "openai operator role session sharing test done",
+        startServer: async (port, auth) => {
+          return await startGatewayServer(port, {
+            host: "127.0.0.1",
+            auth,
+            controlUiEnabled: false,
+            openAiChatCompletionsEnabled: true,
+          });
         },
-      );
+        writeGatewayConfig,
+        post: (port, headers) =>
+          postChatCompletions(
+            port,
+            { model: "openclaw", messages: [{ role: "user", content: "mutate foreign session" }] },
+            headers,
+          ),
+      });
     },
   );
 
@@ -4087,39 +4002,20 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       const port = await getGatewayTestPort();
       const server = await startSharedSecretServer(port, mode);
       try {
-        for (const stream of [false, true]) {
-          agentCommandMock.mockClear();
-          agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-
-          const res = await postChatCompletions(
-            port,
-            {
-              stream,
-              model: "openclaw",
-              messages: [{ role: "user", content: "hi" }],
-            },
-            {
-              authorization: "Bearer secret",
-              "x-openclaw-scopes": "operator.approvals",
-              "x-openclaw-sender-is-owner": "false",
-            },
-          );
-
-          expect(res.status).toBe(200);
-          await res.text();
-          expect(agentCommandMock).toHaveBeenCalledTimes(1);
-          expect(firstAgentCommandOptions()?.senderIsOwner).toBe(true);
-        }
-
-        agentCommandMock.mockClear();
-        const unauthorized = await postChatCompletions(
-          port,
-          { model: "openclaw", messages: [{ role: "user", content: "hi" }] },
-          { authorization: "Bearer wrong", "x-openclaw-sender-is-owner": "true" },
-        );
-        expect(unauthorized.status).toBe(401);
-        await unauthorized.text();
-        expect(agentCommandMock).not.toHaveBeenCalled();
+        await expectSharedSecretHttpOwnerIdentity({
+          post: (stream, headers) =>
+            postChatCompletions(
+              port,
+              {
+                ...(stream === undefined ? {} : { stream }),
+                model: "openclaw",
+                messages: [{ role: "user", content: "hi" }],
+              },
+              headers,
+            ),
+          consume: (response) => response.text(),
+          senderIsOwner: () => firstAgentCommandOptions()?.senderIsOwner,
+        });
       } finally {
         await server.close({ reason: `openai ${mode} auth owner test done` });
       }

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -29,9 +29,13 @@ import {
   getActiveGatewayRootWorkCount,
   isGatewaySubordinateWorkAdmissionClosed,
 } from "../process/gateway-work-admission.js";
-import { ensureProfileForEmail } from "../state/user-profiles.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
+import {
+  expectDeclaredHttpOwnerIdentity,
+  expectHttpForeignSessionAuthority,
+  expectSharedSecretHttpOwnerIdentity,
+} from "./http-authority.test-support.js";
 import type { ResponseResource } from "./open-responses.schema.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
@@ -2156,132 +2160,45 @@ describe("OpenResponses HTTP API (e2e)", () => {
   );
 
   it("preserves declared owner identity for streaming and non-streaming private callers", async () => {
-    const port = enabledPort;
-    for (const stream of [false, true]) {
-      for (const { scopes, senderIsOwner } of [
-        { scopes: "operator.write", senderIsOwner: false },
-        { scopes: "operator.admin, operator.write", senderIsOwner: true },
-      ]) {
-        agentCommandMock.mockClear();
-        agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-
-        const res = await postResponses(
-          port,
-          { stream, model: "openclaw", input: "hi" },
-          {
-            "x-openclaw-scopes": scopes,
-            "x-openclaw-sender-is-owner": "true",
-          },
-        );
-
-        expect(res.status).toBe(200);
-        const body = await res.text();
+    await expectDeclaredHttpOwnerIdentity({
+      post: (stream, headers) =>
+        postResponses(enabledPort, { stream, model: "openclaw", input: "hi" }, headers),
+      consume: async (response, stream) => {
+        const body = await response.text();
         if (stream) {
           expect(parseSseEvents(body).map((event) => event.event)).toContain("response.completed");
         }
-        expect(agentCommandMock).toHaveBeenCalledTimes(1);
-        expect(firstAgentOpts().senderIsOwner).toBe(senderIsOwner);
-      }
-    }
+      },
+      senderIsOwner: () => firstAgentOpts().senderIsOwner,
+    });
   });
 
   it.each(["trusted-proxy", "token"] as const)(
     "preserves %s authority when mutating another operator response session",
     async (authMethod) => {
-      const sharedSecretOwner = authMethod === "token";
-      await withEnvAsync(
-        { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_GATEWAY_PASSWORD: undefined },
-        async () => {
-          const port = await getGatewayTestPort();
+      await expectHttpForeignSessionAuthority({
+        authMethod,
+        ownerEmail: "response-owner@example.test",
+        sessionKey: "agent:main:foreign-openresponses-http",
+        sessionId: "foreign-openresponses-http",
+        closeReason: "openresponses operator role session sharing test done",
+        startServer: async (port, auth) => {
           const { startGatewayServer } = await import("./server.js");
-          let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
-          const previousGatewayAuth = testState.gatewayAuth;
-          const trustedProxyAuth = {
-            mode: "trusted-proxy" as const,
-            trustedProxy: {
-              userHeader: "x-forwarded-user",
-              requiredHeaders: ["x-forwarded-proto"],
-              allowLoopback: true,
-            },
-          };
-          const requestAuth = sharedSecretOwner
-            ? { mode: "token" as const, token: "owner-secret" }
-            : trustedProxyAuth;
-          testState.gatewayAuth = requestAuth;
-          try {
-            await writeGatewayConfig({
-              gateway: {
-                auth: requestAuth,
-                trustedProxies: ["127.0.0.1"],
-                roles: {
-                  default: "guest",
-                  definitions: {
-                    guest: {
-                      agents: sharedSecretOwner ? [] : "*",
-                      scopes: ["operator.write"],
-                      sessions: { others: "view" },
-                    },
-                  },
-                },
-              },
-            });
-            resetConfigRuntimeState();
-            server = await startGatewayServer(port, {
-              host: "127.0.0.1",
-              auth: requestAuth,
-              controlUiEnabled: false,
-              openResponsesEnabled: true,
-            });
-
-            const owner = ensureProfileForEmail("response-owner@example.test");
-            const sessionKey = "agent:main:foreign-openresponses-http";
-            await upsertSessionEntryCore(
-              { agentId: "main", sessionKey },
-              {
-                sessionId: "foreign-openresponses-http",
-                updatedAt: 1,
-                visibility: "shared",
-                createdVia: "operator",
-                createdActor: { type: "human", source: "profile", id: owner.id },
-              },
-            );
-
-            agentCommandMock.mockClear();
-            agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-            const response = await postResponses(
-              port,
-              { model: "openclaw", input: "mutate foreign response session" },
-              {
-                ...(sharedSecretOwner
-                  ? { authorization: "Bearer owner-secret" }
-                  : {
-                      "x-forwarded-for": "198.51.100.42",
-                      "x-forwarded-proto": "https",
-                      "x-forwarded-user": "guest@example.test",
-                    }),
-                "x-openclaw-session-key": sessionKey,
-              },
-            );
-
-            expect(response.status).toBe(sharedSecretOwner ? 200 : 403);
-            if (sharedSecretOwner) {
-              expect(agentCommandMock).toHaveBeenCalledOnce();
-            } else {
-              expect(await response.json()).toMatchObject({
-                error: { type: "forbidden", message: expect.stringContaining("session is shared") },
-              });
-              expect(agentCommandMock).not.toHaveBeenCalled();
-            }
-          } finally {
-            await server?.close({
-              reason: "openresponses operator role session sharing test done",
-            });
-            testState.gatewayAuth = previousGatewayAuth;
-            await writeGatewayConfig({});
-            resetConfigRuntimeState();
-          }
+          return await startGatewayServer(port, {
+            host: "127.0.0.1",
+            auth,
+            controlUiEnabled: false,
+            openResponsesEnabled: true,
+          });
         },
-      );
+        writeGatewayConfig,
+        post: (port, headers) =>
+          postResponses(
+            port,
+            { model: "openclaw", input: "mutate foreign response session" },
+            headers,
+          ),
+      });
     },
   );
 
@@ -2474,35 +2391,16 @@ describe("OpenResponses HTTP API (e2e)", () => {
       const port = await getGatewayTestPort();
       const server = await startSharedSecretServer(port, mode);
       try {
-        for (const stream of [false, true]) {
-          agentCommandMock.mockClear();
-          agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "hello" }] } as never);
-
-          const res = await postResponses(
-            port,
-            { stream, model: "openclaw", input: "hi" },
-            {
-              authorization: "Bearer secret",
-              "x-openclaw-scopes": "operator.approvals",
-              "x-openclaw-sender-is-owner": "false",
-            },
-          );
-
-          expect(res.status).toBe(200);
-          await ensureResponseConsumed(res);
-          expect(agentCommandMock).toHaveBeenCalledTimes(1);
-          expect(firstAgentOpts().senderIsOwner).toBe(true);
-        }
-
-        agentCommandMock.mockClear();
-        const unauthorized = await postResponses(
-          port,
-          { model: "openclaw", input: "hi" },
-          { authorization: "Bearer wrong", "x-openclaw-sender-is-owner": "true" },
-        );
-        expect(unauthorized.status).toBe(401);
-        await ensureResponseConsumed(unauthorized);
-        expect(agentCommandMock).not.toHaveBeenCalled();
+        await expectSharedSecretHttpOwnerIdentity({
+          post: (stream, headers) =>
+            postResponses(
+              port,
+              { ...(stream === undefined ? {} : { stream }), model: "openclaw", input: "hi" },
+              headers,
+            ),
+          consume: ensureResponseConsumed,
+          senderIsOwner: () => firstAgentOpts().senderIsOwner,
+        });
       } finally {
         await server.close({ reason: `openresponses ${mode} auth owner test done` });
       }


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Chat Completions and OpenResponses tests duplicate three authority scenarios, including the same server/configuration lifetime and ownership assertions.

## Why This Change Was Made

Share those narrowly defined scenario bodies while keeping endpoint request adapters, payloads, streaming completion checks and distinct identities explicit. Preserve all 10 named invocations and 24 internal requests. The separate trusted-proxy tests, including additional Alice/Bob continuation coverage, remain byte-identical.

## User Impact

No production behavior or authorization expectations change. Net 55 test/support lines removed: tests -206, support +151. The shared support owns the repeated configuration/server cleanup sequence.

## Evidence

Both complete endpoint suites pass 159/159 before and after through the normal nonisolated route, with identical per-file full case/status inventories. Exact scenario mapping retains headers, status, mock sequencing, owner assertions, auth restoration and cleanup. The facade import timing was inspected: suite setup already loads it, it captures no auth/config at module evaluation, and actual startup remains after configuration preparation.

The full changed gate, diff check, deslop and independent P2 review pass. Review explicitly considered the modest savings versus helper indirection. Assertion time was 8.229s before and 8.535s after; no runtime improvement is claimed.
