### PR TITLE
fix(cli): reject explicitly blank Gateway ports

### DIFF
--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -32,6 +32,8 @@ Tail Gateway file logs over RPC. Works in remote mode.
 
 Passing `--url` skips auto-applied config credentials; include `--token` explicitly if the target Gateway requires auth.
 
+`--port` requires an integer from `1` to `65535`; empty or whitespace-only values are invalid. Omit the option to use the configured or environment target.
+
 ## Examples
 
 ```bash

--- a/src/cli/gateway-port-option.test.ts
+++ b/src/cli/gateway-port-option.test.ts
@@ -10,12 +10,15 @@ describe("parseGatewayPortOption", () => {
 
   it("treats absent values as no override", () => {
     expect(parseGatewayPortOption(undefined)).toBeUndefined();
-    expect(parseGatewayPortOption("")).toBeUndefined();
+    expect(parseGatewayPortOption(null)).toBeUndefined();
   });
 
-  it.each(["0", "65536", "1e4", "18789ms"])("rejects invalid port value %s", (value) => {
-    expect(() => parseGatewayPortOption(value)).toThrow(
-      "--port must be an integer between 1 and 65535.",
-    );
-  });
+  it.each(["", " \t ", "0", "65536", "1e4", "18789ms"])(
+    "rejects invalid port value %j",
+    (value) => {
+      expect(() => parseGatewayPortOption(value)).toThrow(
+        "--port must be an integer between 1 and 65535.",
+      );
+    },
+  );
 });

--- a/src/cli/gateway-port-option.test.ts
+++ b/src/cli/gateway-port-option.test.ts
@@ -3,9 +3,15 @@ import { describe, expect, it } from "vitest";
 import { parseGatewayPortOption } from "./gateway-port-option.js";
 
 describe("parseGatewayPortOption", () => {
-  it("accepts TCP port values", () => {
-    expect(parseGatewayPortOption("18789")).toBe(18789);
-    expect(parseGatewayPortOption(65_535)).toBe(65_535);
+  it.each([
+    ["1", 1],
+    ["18789", 18_789],
+    [" \t18789 ", 18_789],
+    [1e4, 10_000],
+    [65_535, 65_535],
+    [18_789n, 18_789],
+  ])("accepts TCP port value %s", (value, expected) => {
+    expect(parseGatewayPortOption(value)).toBe(expected);
   });
 
   it("treats absent values as no override", () => {
@@ -13,8 +19,8 @@ describe("parseGatewayPortOption", () => {
     expect(parseGatewayPortOption(null)).toBeUndefined();
   });
 
-  it.each(["", " \t ", "0", "65536", "1e4", "18789ms"])(
-    "rejects invalid port value %j",
+  it.each(["", " \t ", "0", "65536", "1e4", "18789ms", 1.5, 65_536n])(
+    "rejects invalid port value %s",
     (value) => {
       expect(() => parseGatewayPortOption(value)).toThrow(
         "--port must be an integer between 1 and 65535.",

--- a/src/cli/gateway-port-option.ts
+++ b/src/cli/gateway-port-option.ts
@@ -15,10 +15,6 @@ export function parseGatewayPortOption(raw: unknown, flagName = "--port"): numbe
       : typeof raw === "number" || typeof raw === "bigint"
         ? String(raw)
         : "";
-  if (!value) {
-    return undefined;
-  }
-
   const parsed = parseStrictPositiveInteger(value);
   if (parsed === undefined || parsed > MAX_TCP_PORT) {
     throw new Error(`${flagName} must be an integer between 1 and ${MAX_TCP_PORT}.`);

--- a/src/cli/gateway-port-option.ts
+++ b/src/cli/gateway-port-option.ts
@@ -9,13 +9,7 @@ export function parseGatewayPortOption(raw: unknown, flagName = "--port"): numbe
     return undefined;
   }
 
-  const value =
-    typeof raw === "string"
-      ? raw.trim()
-      : typeof raw === "number" || typeof raw === "bigint"
-        ? String(raw)
-        : "";
-  const parsed = parseStrictPositiveInteger(value);
+  const parsed = parseStrictPositiveInteger(typeof raw === "bigint" ? String(raw) : raw);
   if (parsed === undefined || parsed > MAX_TCP_PORT) {
     throw new Error(`${flagName} must be an integer between 1 and ${MAX_TCP_PORT}.`);
   }

--- a/src/cli/gateway-rpc.runtime.test.ts
+++ b/src/cli/gateway-rpc.runtime.test.ts
@@ -116,16 +116,21 @@ describe("callGatewayFromCliRuntime", () => {
     );
   });
 
-  it("rejects combining --url and --port before opening a Gateway connection", async () => {
-    await expect(
-      callGatewayFromCliRuntime("cron.status", {
-        url: "ws://127.0.0.1:19083",
-        port: "19083",
-      }),
-    ).rejects.toThrow("Use either --url or --port, not both.");
+  it.each([
+    { opts: { port: "" }, error: "--port must be an integer between 1 and 65535." },
+    { opts: { port: " \t " }, error: "--port must be an integer between 1 and 65535." },
+    {
+      opts: { url: "ws://127.0.0.1:19083", port: "19083" },
+      error: "Use either --url or --port, not both.",
+    },
+  ])(
+    "rejects invalid target $opts before opening a Gateway connection",
+    async ({ opts, error }) => {
+      await expect(callGatewayFromCliRuntime("cron.status", opts)).rejects.toThrow(error);
 
-    expect(callGatewayMock).not.toHaveBeenCalled();
-  });
+      expect(callGatewayMock).not.toHaveBeenCalled();
+    },
+  );
 
   it.each([
     { name: "token", auth: { token: "test-gateway-token" } },

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -210,7 +210,7 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardOptions().gatewayPort).toBe(18789);
   });
 
-  it.each(["not-a-port", "70000"])(
+  it.each(["", " \t ", "not-a-port", "70000"])(
     "rejects invalid --gateway-port %s before onboarding dispatch",
     async (gatewayPort) => {
       await runCli(["onboard", "--gateway-port", gatewayPort]);

--- a/src/cli/program/register.setup.test.ts
+++ b/src/cli/program/register.setup.test.ts
@@ -484,7 +484,7 @@ describe("registerSetupCommand", () => {
     },
   );
 
-  it.each(["not-a-port", "70000"])(
+  it.each(["", " \t ", "not-a-port", "70000"])(
     "rejects invalid --gateway-port %s before onboarding dispatch",
     async (gatewayPort) => {
       await runCli(["setup", "--gateway-port", gatewayPort]);


### PR DESCRIPTION
Closes #138613.

Passing an empty shell variable to `--port` previously selected the configured or environment Gateway instead of reporting an invalid argument. The shared parser now rejects empty and whitespace-only values before connecting. The same validation applies to `--gateway-port` during setup and onboarding.

The rewrite reuses the canonical integer parser and removes duplicated normalization. Omitted options, valid numeric and bigint inputs, and the separate environment-default rules retain their behavior. Scripts that used a blank CLI value to request defaults must omit the option instead; the CLI reference now says this explicitly.

Production LOC: +1/-11 (net -10). Tests: +34/-20 (net +14). Documentation: +2.

Validation at `f86c674b1454e7e8f0454338a79daec3477f1bdf`:

- Eight intended baseline assertion failures across the parser, RPC, setup, and onboarding owners; all 199 candidate owner/sibling tests pass without skips, suite errors, or unhandled errors.
- Thirteen before/after cases through the supported `pnpm openclaw logs` launcher and two synthetic loopback peers. Blank values previously fetched from the configured peer; afterward they return the exact local error with zero connections. Omission, environment port/URL, valid explicit override, numeric syntax, URL conflicts, and text output controls retain their behavior.
- Baseline and candidate builds pass. Error output is verified as one JSON failure document; successful log output remains NDJSON. All six published source files and the full patch match the hosted candidate exactly.
- Fresh automated source review, a separate read-only CLI review, and independent source/observed-proof verification are clean. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34020010576) is green.

[Hosted completion evidence](https://github.com/steipete/openclaw/actions/runs/34034282400) includes the preserved baseline receipts and new raw CLI captures. Earlier attempts stopped in proof orchestration or report parsing; completed evidence was retained and only unfinished cases were run afterward. The production patch stayed unchanged throughout. This is real CLI/transport proof against synthetic peers; no existing Gateway was changed.

Thanks to @TurboTheTurtle (Andy Ye) for the original fix and registered-command evidence, and @vincentkoc for the report.
