### PR TITLE
fix(feishu): stop dead-stream log flooding + non-streaming card fallback (#139443)

### DIFF
--- a/extensions/feishu/src/streaming-card-token.ts
+++ b/extensions/feishu/src/streaming-card-token.ts
@@ -1,0 +1,132 @@
+/**
+ * Feishu Card Kit token + API base resolution helpers.
+ * Extracted from streaming-card.ts to keep the card session manager under the file-size limit.
+ */
+
+import {
+  asDateTimestampMs,
+  resolveDateTimestampMs,
+  resolveExpiresAtMsFromDurationSeconds,
+} from "openclaw/plugin-sdk/number-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
+import { getFeishuUserAgent } from "./client.js";
+import { readFeishuJsonResponse } from "./json-response.js";
+import type { FeishuDomain } from "./types.js";
+
+export type Credentials = {
+  appId: string;
+  appSecret: string;
+  domain?: FeishuDomain;
+  httpTimeoutMs?: number;
+};
+
+export type FeishuStreamingFetch = typeof fetch;
+
+export type FeishuStreamingDeps = {
+  /** Override fetch for tests while preserving the real SSRF guard path. */
+  fetchImpl?: FeishuStreamingFetch;
+  /** Override hostname lookup for hermetic SSRF-guard tests. */
+  lookupFn?: LookupFn;
+};
+
+const FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS = 7200;
+
+// Token cache (keyed by domain + appId)
+const tokenCache = new Map<string, { token: string; expiresAt: number }>();
+
+export function resolveStreamingTokenExpiresAt(value: unknown, nowMs = Date.now()): number {
+  const now = resolveDateTimestampMs(nowMs);
+  if (typeof value === "number" && Number.isFinite(value) && value <= 0) {
+    return now;
+  }
+  return (
+    resolveExpiresAtMsFromDurationSeconds(value, { nowMs: now }) ??
+    resolveExpiresAtMsFromDurationSeconds(FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS, {
+      nowMs: now,
+    }) ??
+    now
+  );
+}
+
+export function resolveApiBase(domain?: FeishuDomain): string {
+  if (domain === "lark") {
+    return "https://open.larksuite.com/open-apis";
+  }
+  if (domain && domain !== "feishu" && domain.startsWith("http")) {
+    return `${domain.replace(/\/+$/, "")}/open-apis`;
+  }
+  return "https://open.feishu.cn/open-apis";
+}
+
+export function resolveAllowedHostnames(domain?: FeishuDomain): string[] {
+  if (domain === "lark") {
+    return ["open.larksuite.com"];
+  }
+  if (domain && domain !== "feishu" && domain.startsWith("http")) {
+    try {
+      return [new URL(domain).hostname];
+    } catch {
+      return [];
+    }
+  }
+  return ["open.feishu.cn"];
+}
+
+export function cancelUnreadResponseBody(response: Response): void {
+  // A rejected response leaves its body unread; start cancellation before the
+  // guarded dispatcher is released so the connection is not leaked. Do not
+  // await: debug capture can tee the stream and deadlock a waiter.
+  if (!response.bodyUsed) {
+    void response.body?.cancel().catch(() => undefined);
+  }
+}
+
+export async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise<string> {
+  const key = `${creds.domain ?? "feishu"}|${creds.appId}`;
+  const cached = tokenCache.get(key);
+  const rawNow = Date.now();
+  const hasValidClock = asDateTimestampMs(rawNow) !== undefined;
+  const now = resolveDateTimestampMs(rawNow);
+  const minUsableExpiresAt = resolveExpiresAtMsFromDurationSeconds(60, { nowMs: now }) ?? now;
+  if (cached && hasValidClock && cached.expiresAt > minUsableExpiresAt) {
+    return cached.token;
+  }
+
+  const { response, release } = await fetchWithSsrFGuard({
+    url: `${resolveApiBase(creds.domain)}/auth/v3/tenant_access_token/internal`,
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "User-Agent": getFeishuUserAgent() },
+      body: JSON.stringify({ app_id: creds.appId, app_secret: creds.appSecret }),
+    },
+    fetchImpl: deps?.fetchImpl,
+    lookupFn: deps?.lookupFn,
+    policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
+    auditContext: "feishu.streaming-card.token",
+    timeoutMs: creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
+  });
+  let data: {
+    code: number;
+    msg: string;
+    tenant_access_token?: string;
+    expire?: number;
+  };
+  try {
+    if (!response.ok) {
+      cancelUnreadResponseBody(response);
+      throw new Error(`Token request failed with HTTP ${response.status}`);
+    }
+    data = await readFeishuJsonResponse(response, "feishu.streaming-card.token");
+  } finally {
+    await release();
+  }
+  if (data.code !== 0 || !data.tenant_access_token) {
+    throw new Error(`Token error: ${data.msg}`);
+  }
+  tokenCache.set(key, {
+    token: data.tenant_access_token,
+    expiresAt: resolveStreamingTokenExpiresAt(data.expire, now),
+  });
+  return data.tenant_access_token;
+}

--- a/extensions/feishu/src/streaming-card-token.ts
+++ b/extensions/feishu/src/streaming-card-token.ts
@@ -35,7 +35,7 @@ const FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS = 7200;
 // Token cache (keyed by domain + appId)
 const tokenCache = new Map<string, { token: string; expiresAt: number }>();
 
-export function resolveStreamingTokenExpiresAt(value: unknown, nowMs = Date.now()): number {
+function resolveStreamingTokenExpiresAt(value: unknown, nowMs = Date.now()): number {
   const now = resolveDateTimestampMs(nowMs);
   if (typeof value === "number" && Number.isFinite(value) && value <= 0) {
     return now;

--- a/extensions/feishu/src/streaming-card.dead-stream.test.ts
+++ b/extensions/feishu/src/streaming-card.dead-stream.test.ts
@@ -50,6 +50,7 @@ type StreamingSessionState = {
   currentText: string;
   sentText: string;
   hasNote: boolean;
+  header?: { title: string; template?: string };
 };
 
 function setStreamingSessionInternals(
@@ -278,5 +279,116 @@ describe("FeishuStreamingSession dead-stream handling", () => {
     expect(updateBodies).toHaveLength(1); // still 1 — no retry flood
 
     expect(log).toHaveBeenCalledWith(expect.stringContaining("Streaming card stream is dead"));
+  });
+
+  it("preserves the card header in the non-streaming fallback content", async () => {
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      return jsonResponse({ code: 300309, msg: "streaming mode is closed" });
+    });
+    const log = vi.fn();
+    const patchMock = vi.fn().mockResolvedValue({ code: 0, msg: "ok" });
+    const client = {
+      im: { message: { patch: patchMock } },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+    const session = new FeishuStreamingSession(
+      client,
+      { appId: "app_header", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_header",
+        messageId: "om_header",
+        sequence: 1,
+        currentText: "partial",
+        sentText: "partial",
+        hasNote: false,
+        header: { title: "Agent Run", template: "green" },
+      },
+    });
+    (session as unknown as { streamDead: boolean }).streamDead = true;
+
+    await session.closeWithResult("final text");
+
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    const fallbackContent = JSON.parse(patchMock.mock.calls[0][0].data.content as string);
+    expect(fallbackContent.header).toEqual({
+      title: { tag: "plain_text", content: "Agent Run" },
+      template: "green",
+    });
+    expect(fallbackContent.body.elements[0].content).toBe("final text");
+  });
+
+  it("retries via non-streaming fallback when the final write first detects expiration", async () => {
+    let updateCallCount = 0;
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (
+        url.pathname.includes("/elements/content/content") ||
+        url.pathname.includes("/elements/content")
+      ) {
+        updateCallCount += 1;
+        // The final write detects stream expiration (300309)
+        return jsonResponse({ code: 300309, msg: "streaming mode is closed" });
+      }
+      // CardKit settings PATCH (close streaming mode) — should also fail
+      if (url.pathname.includes("/settings")) {
+        return jsonResponse({ code: 300309, msg: "streaming mode is closed" });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+    const log = vi.fn();
+    const patchMock = vi.fn().mockResolvedValue({ code: 0, msg: "ok" });
+    const client = {
+      im: { message: { patch: patchMock } },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+    const session = new FeishuStreamingSession(
+      client,
+      { appId: "app_final_expire", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_final_expire",
+        messageId: "om_final_expire",
+        sequence: 1,
+        currentText: "partial text",
+        sentText: "partial text",
+        hasNote: false,
+      },
+    });
+    // Stream is NOT dead yet — it will die during the final write
+    (session as unknown as { streamDead: boolean }).streamDead = false;
+
+    const result = await session.closeWithResult("final answer");
+
+    // The final update attempted a streaming patch and got 300309
+    expect(updateCallCount).toBeGreaterThanOrEqual(1);
+    // After 300309, streamDead is set and the non-streaming fallback is retried
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock).toHaveBeenCalledWith({
+      path: { message_id: "om_final_expire" },
+      data: { content: expect.stringContaining("final answer") },
+    });
+    // The final answer should be visible via the fallback
+    expect(result.visibleReplySent).toBe(true);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("non-streaming fallback"));
   });
 });

--- a/extensions/feishu/src/streaming-card.dead-stream.test.ts
+++ b/extensions/feishu/src/streaming-card.dead-stream.test.ts
@@ -1,0 +1,282 @@
+// Tests for dead-stream detection and non-streaming fallback in FeishuStreamingSession.
+// Covers issue #139443: after a 200850 idle timeout, 300309 "streaming mode is closed"
+// floods logs with ~978 consecutive retries. The fix marks the stream dead after the
+// first 300309 and falls back to im.message.patch (non-streaming) at close.
+
+import type { LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
+import { FeishuStreamingFinalizationError, FeishuStreamingSession } from "./streaming-card.js";
+
+type FeishuStreamingFetch = typeof fetch;
+
+const HERMETIC_PUBLIC_LOOKUP_ADDRESS = "93.184.216.34";
+
+const hermeticPublicLookup: LookupFn = async () => [
+  { address: HERMETIC_PUBLIC_LOOKUP_ADDRESS, family: 4 },
+];
+
+type StreamingFetchDeps = {
+  fetchImpl: FeishuStreamingFetch;
+  lookupFn: LookupFn;
+};
+
+function createMemoryFetch(
+  handler: (url: URL, body: string) => Response | Promise<Response>,
+): StreamingFetchDeps {
+  return {
+    fetchImpl: withFetchPreconnect(
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(input instanceof Request ? input.url : input.toString());
+        const body = typeof init?.body === "string" ? init.body : "";
+        return await handler(url, body);
+      }),
+    ) as FeishuStreamingFetch,
+    lookupFn: hermeticPublicLookup,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type StreamingSessionState = {
+  cardId: string;
+  messageId: string;
+  sequence: number;
+  currentText: string;
+  sentText: string;
+  hasNote: boolean;
+};
+
+function setStreamingSessionInternals(
+  session: FeishuStreamingSession,
+  values: {
+    state: StreamingSessionState;
+    lastUpdateTime?: number;
+  },
+): void {
+  const internals = session as unknown as {
+    state: StreamingSessionState;
+    lastUpdateTime: number;
+  };
+  internals.state = values.state;
+  if (values.lastUpdateTime !== undefined) {
+    internals.lastUpdateTime = values.lastUpdateTime;
+  }
+}
+
+describe("FeishuStreamingSession dead-stream handling", () => {
+  it("marks the stream dead after a 300309 update error and skips further updates", async () => {
+    const updateBodies: string[] = [];
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.includes("/elements/content/content")) {
+        updateBodies.push(body);
+        // First update: return 300309 to simulate dead stream
+        return jsonResponse({ code: 300309, msg: "streaming mode is closed" });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+    const log = vi.fn();
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_dead_stream", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_dead_stream",
+        messageId: "om_dead_stream",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 0,
+    });
+
+    // First update — should get 300309 and mark stream dead
+    await session.update("hello world");
+    expect(updateBodies).toHaveLength(1);
+
+    // Second update — should be skipped (stream is dead)
+    await session.update("hello world again");
+    await session.update("hello world third time");
+
+    // Still only 1 update attempt — no log flooding
+    expect(updateBodies).toHaveLength(1);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Streaming card stream is dead"));
+  });
+
+  it("falls back to im.message.patch at close when stream is dead", async () => {
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      // All streaming API calls return 300309
+      return jsonResponse({ code: 300309, msg: "streaming mode is closed" });
+    });
+    const log = vi.fn();
+
+    // Mock the Feishu SDK client with im.message.patch
+    const patchMock = vi.fn().mockResolvedValue({ code: 0, msg: "ok" });
+    const client = {
+      im: {
+        message: {
+          patch: patchMock,
+        },
+      },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+
+    const session = new FeishuStreamingSession(
+      client,
+      { appId: "app_dead_close", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_dead_close",
+        messageId: "om_dead_close",
+        sequence: 1,
+        currentText: "partial text",
+        sentText: "partial text",
+        hasNote: true,
+      },
+    });
+
+    // Simulate stream already dead (from a prior 300309 during updates)
+    (session as unknown as { streamDead: boolean }).streamDead = true;
+
+    const result = await session.closeWithResult("final answer text", {
+      note: "model/provider info",
+    });
+
+    // Should have used im.message.patch as fallback
+    expect(patchMock).toHaveBeenCalledTimes(1);
+    expect(patchMock).toHaveBeenCalledWith({
+      path: { message_id: "om_dead_close" },
+      data: {
+        content: expect.stringContaining("final answer text"),
+      },
+    });
+
+    // Should report visible content sent
+    expect(result.visibleReplySent).toBe(true);
+    expect(result.content).toBe("final answer text");
+
+    // Should log the non-streaming fallback
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("non-streaming fallback"));
+  });
+
+  it("throws FeishuStreamingFinalizationError when non-streaming fallback also fails", async () => {
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      return jsonResponse({ code: 300309, msg: "streaming mode is closed" });
+    });
+    const log = vi.fn();
+
+    const patchMock = vi.fn().mockResolvedValue({ code: 94003, msg: "message not found" });
+    const client = {
+      im: {
+        message: {
+          patch: patchMock,
+        },
+      },
+    } as unknown as ConstructorParameters<typeof FeishuStreamingSession>[0];
+
+    const session = new FeishuStreamingSession(
+      client,
+      { appId: "app_dead_fallback_fail", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_dead_fallback_fail",
+        messageId: "om_dead_fallback_fail",
+        sequence: 1,
+        currentText: "partial",
+        sentText: "partial",
+        hasNote: false,
+      },
+    });
+
+    (session as unknown as { streamDead: boolean }).streamDead = true;
+
+    const error = await session.closeWithResult("final text").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(FeishuStreamingFinalizationError);
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Non-streaming card fallback failed"));
+  });
+
+  it("marks stream dead after a 200850 idle timeout on update", async () => {
+    const updateBodies: string[] = [];
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({
+          code: 0,
+          msg: "ok",
+          tenant_access_token: "token",
+          expire: 7200,
+        });
+      }
+      if (url.pathname.includes("/elements/content/content")) {
+        updateBodies.push(body);
+        return jsonResponse({ code: 200850, msg: "card streaming timeout" });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+    const log = vi.fn();
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId: "app_idle_timeout", appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_idle_timeout",
+        messageId: "om_idle_timeout",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 0,
+    });
+
+    await session.update("hello extended");
+    // Only one update attempt — stream is now dead
+    expect(updateBodies).toHaveLength(1);
+
+    await session.update("hello extended again");
+    expect(updateBodies).toHaveLength(1); // still 1 — no retry flood
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Streaming card stream is dead"));
+  });
+});

--- a/extensions/feishu/src/streaming-card.dead-stream.test.ts
+++ b/extensions/feishu/src/streaming-card.dead-stream.test.ts
@@ -320,7 +320,7 @@ describe("FeishuStreamingSession dead-stream handling", () => {
     await session.closeWithResult("final text");
 
     expect(patchMock).toHaveBeenCalledTimes(1);
-    const fallbackContent = JSON.parse(patchMock.mock.calls[0][0].data.content as string);
+    const fallbackContent = JSON.parse(patchMock.mock.calls[0]![0]!.data.content as string);
     expect(fallbackContent.header).toEqual({
       title: { tag: "plain_text", content: "Agent Run" },
       template: "green",

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -3,12 +3,7 @@
  */
 
 import type { Client } from "@larksuiteoapi/node-sdk";
-import {
-  asDateTimestampMs,
-  resolveDateTimestampMs,
-  resolveExpiresAtMsFromDurationSeconds,
-} from "openclaw/plugin-sdk/number-runtime";
-import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
@@ -16,14 +11,16 @@ import { requestFeishuApi } from "./comment-shared.js";
 import { readFeishuJsonResponse } from "./json-response.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import { resolveStreamingCardSendMode } from "./streaming-card-send-mode.js";
-import type { FeishuDomain } from "./types.js";
+import {
+  cancelUnreadResponseBody,
+  getToken,
+  resolveAllowedHostnames,
+  resolveApiBase,
+  type Credentials,
+  type FeishuStreamingDeps,
+  type FeishuStreamingFetch,
+} from "./streaming-card-token.js";
 
-type Credentials = {
-  appId: string;
-  appSecret: string;
-  domain?: FeishuDomain;
-  httpTimeoutMs?: number;
-};
 type CardState = {
   cardId: string;
   messageId?: string;
@@ -31,15 +28,6 @@ type CardState = {
   currentText: string;
   sentText: string;
   hasNote: boolean;
-};
-
-type FeishuStreamingFetch = typeof fetch;
-
-type FeishuStreamingDeps = {
-  /** Override fetch for tests while preserving the real SSRF guard path. */
-  fetchImpl?: FeishuStreamingFetch;
-  /** Override hostname lookup for hermetic SSRF-guard tests. */
-  lookupFn?: LookupFn;
 };
 
 type CardKitResponse = { code?: number; msg?: string };
@@ -85,56 +73,11 @@ type StreamingStartOptions = {
 
 const STREAMING_UPDATE_THROTTLE_MS = 160;
 const STREAMING_SIGNIFICANT_DELTA_CHARS = 18;
-const FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS = 7200;
 
-// Token cache (keyed by domain + appId)
-const tokenCache = new Map<string, { token: string; expiresAt: number }>();
-
-function resolveStreamingTokenExpiresAt(value: unknown, nowMs = Date.now()): number {
-  const now = resolveDateTimestampMs(nowMs);
-  if (typeof value === "number" && Number.isFinite(value) && value <= 0) {
-    return now;
-  }
-  return (
-    resolveExpiresAtMsFromDurationSeconds(value, { nowMs: now }) ??
-    resolveExpiresAtMsFromDurationSeconds(FEISHU_STREAMING_TOKEN_DEFAULT_LIFETIME_SECONDS, {
-      nowMs: now,
-    }) ??
-    now
-  );
-}
-
-function resolveApiBase(domain?: FeishuDomain): string {
-  if (domain === "lark") {
-    return "https://open.larksuite.com/open-apis";
-  }
-  if (domain && domain !== "feishu" && domain.startsWith("http")) {
-    return `${domain.replace(/\/+$/, "")}/open-apis`;
-  }
-  return "https://open.feishu.cn/open-apis";
-}
-
-function resolveAllowedHostnames(domain?: FeishuDomain): string[] {
-  if (domain === "lark") {
-    return ["open.larksuite.com"];
-  }
-  if (domain && domain !== "feishu" && domain.startsWith("http")) {
-    try {
-      return [new URL(domain).hostname];
-    } catch {
-      return [];
-    }
-  }
-  return ["open.feishu.cn"];
-}
-
-function cancelUnreadResponseBody(response: Response): void {
-  // A rejected response leaves its body unread; start cancellation before the
-  // guarded dispatcher is released so the connection is not leaked. Do not
-  // await: debug capture can tee the stream and deadlock a waiter.
-  if (!response.bodyUsed) {
-    void response.body?.cancel().catch(() => undefined);
-  }
+/** Detect a dead-stream error from a Card Kit response error message. */
+function isCardStreamClosedError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return /code=(200850|300309)/.test(msg);
 }
 
 async function assertSuccessfulCardKitResponse(
@@ -150,55 +93,6 @@ async function assertSuccessfulCardKitResponse(
   if (data.code !== 0) {
     throw new Error(`${action} failed: ${data.msg ?? "unknown error"} (code=${String(data.code)})`);
   }
-}
-
-async function getToken(creds: Credentials, deps?: FeishuStreamingDeps): Promise<string> {
-  const key = `${creds.domain ?? "feishu"}|${creds.appId}`;
-  const cached = tokenCache.get(key);
-  const rawNow = Date.now();
-  const hasValidClock = asDateTimestampMs(rawNow) !== undefined;
-  const now = resolveDateTimestampMs(rawNow);
-  const minUsableExpiresAt = resolveExpiresAtMsFromDurationSeconds(60, { nowMs: now }) ?? now;
-  if (cached && hasValidClock && cached.expiresAt > minUsableExpiresAt) {
-    return cached.token;
-  }
-
-  const { response, release } = await fetchWithSsrFGuard({
-    url: `${resolveApiBase(creds.domain)}/auth/v3/tenant_access_token/internal`,
-    init: {
-      method: "POST",
-      headers: { "Content-Type": "application/json", "User-Agent": getFeishuUserAgent() },
-      body: JSON.stringify({ app_id: creds.appId, app_secret: creds.appSecret }),
-    },
-    fetchImpl: deps?.fetchImpl,
-    lookupFn: deps?.lookupFn,
-    policy: { allowedHostnames: resolveAllowedHostnames(creds.domain) },
-    auditContext: "feishu.streaming-card.token",
-    timeoutMs: creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
-  });
-  let data: {
-    code: number;
-    msg: string;
-    tenant_access_token?: string;
-    expire?: number;
-  };
-  try {
-    if (!response.ok) {
-      cancelUnreadResponseBody(response);
-      throw new Error(`Token request failed with HTTP ${response.status}`);
-    }
-    data = await readFeishuJsonResponse(response, "feishu.streaming-card.token");
-  } finally {
-    await release();
-  }
-  if (data.code !== 0 || !data.tenant_access_token) {
-    throw new Error(`Token error: ${data.msg}`);
-  }
-  tokenCache.set(key, {
-    token: data.tenant_access_token,
-    expiresAt: resolveStreamingTokenExpiresAt(data.expire, now),
-  });
-  return data.tenant_access_token;
 }
 
 function truncateSummary(text: string, max = 50): string {
@@ -253,6 +147,10 @@ export class FeishuStreamingSession {
   private state: CardState | null = null;
   private queue: Promise<void> = Promise.resolve();
   private closed = false;
+  /** Set when a streaming API patch fails with a dead-stream code (200850/300309).
+   *  Further streaming patches are skipped to avoid log flooding; closeWithResult falls
+   *  back to the non-streaming message patch API. */
+  private streamDead = false;
   private log?: (msg: string) => void;
   private lastUpdateTime = 0;
   private pendingText: string | null = null;
@@ -449,6 +347,12 @@ export class FeishuStreamingSession {
       }
       return true;
     } catch (error) {
+      if (isCardStreamClosedError(error)) {
+        this.streamDead = true;
+        this.log?.(
+          `Streaming card stream is dead (cardId=${this.state.cardId}); skipping further streaming patches`,
+        );
+      }
       onError?.(error);
       return false;
     }
@@ -530,7 +434,7 @@ export class FeishuStreamingSession {
 
   private async flushPendingUpdate(): Promise<void> {
     this.queue = this.queue.then(async () => {
-      if (!this.state || this.closed) {
+      if (!this.state || this.closed || this.streamDead) {
         return;
       }
       const nextText = this.pendingText;
@@ -552,7 +456,7 @@ export class FeishuStreamingSession {
   }
 
   async update(text: string): Promise<void> {
-    if (!this.state || this.closed || !text) {
+    if (!this.state || this.closed || this.streamDead || !text) {
       return;
     }
     // The caller supplies the complete current card text. CardKit derives its own
@@ -572,7 +476,7 @@ export class FeishuStreamingSession {
   }
 
   private async updateNoteContent(note: string): Promise<void> {
-    if (!this.state || !this.state.hasNote) {
+    if (!this.state || !this.state.hasNote || this.streamDead) {
       return;
     }
     const apiBase = resolveApiBase(this.creds.domain);
@@ -612,7 +516,15 @@ export class FeishuStreamingSession {
           await release();
         }
       })
-      .catch((e: unknown) => this.log?.(`Note update failed: ${String(e)}`));
+      .catch((e: unknown) => {
+        if (isCardStreamClosedError(e)) {
+          this.streamDead = true;
+          this.log?.(
+            `Streaming card stream is dead after note update (cardId=${this.state?.cardId})`,
+          );
+        }
+        this.log?.(`Note update failed: ${String(e)}`);
+      });
   }
 
   async closeWithResult(
@@ -633,9 +545,50 @@ export class FeishuStreamingSession {
     let visibleContentSent = Boolean(this.state.sentText.trim());
     let finalWriteError: unknown;
 
-    // Only send final update if content differs from what's already displayed.
-    // An explicit empty final text clears a transient preview before closeout.
-    if ((text || finalText !== undefined) && text !== this.state.sentText) {
+    // When the streaming card's server-side stream is dead (200850 idle timeout →
+    // 300309 "streaming mode is closed"), all streaming API patches fail. Skip them
+    // and fall back to the non-streaming im.message.patch API to update the card
+    // content so the final text is not lost and logs are not flooded.
+    if (this.streamDead && this.state.messageId) {
+      const fallbackContent = JSON.stringify({
+        schema: "2.0",
+        body: {
+          elements: [
+            { tag: "markdown", content: text, element_id: "content" },
+            ...(this.state.hasNote && options?.note
+              ? [
+                  { tag: "hr" },
+                  {
+                    tag: "markdown",
+                    content: `<font color='grey'>${options.note}</font>`,
+                    element_id: "note",
+                  },
+                ]
+              : []),
+          ],
+        },
+      });
+      try {
+        const response = await this.client.im.message.patch({
+          path: { message_id: this.state.messageId },
+          data: { content: fallbackContent },
+        });
+        if (response.code !== undefined && response.code !== 0) {
+          throw new Error(`Non-streaming card fallback failed: ${response.msg ?? response.code}`);
+        }
+        this.state.sentText = text;
+        this.state.currentText = text;
+        visibleContentSent = Boolean(text.trim());
+        this.log?.(
+          `Closed streaming via non-streaming fallback: cardId=${this.state.cardId}, messageId=${this.state.messageId}`,
+        );
+      } catch (error: unknown) {
+        finalWriteError = error;
+        this.log?.(`Non-streaming card fallback failed: ${String(error)}`);
+      }
+    } else if ((text || finalText !== undefined) && text !== this.state.sentText) {
+      // Only send final update if content differs from what's already displayed.
+      // An explicit empty final text clears a transient preview before closeout.
       const sent = text.startsWith(this.state.sentText)
         ? await this.updateCardContent(text, (e) => {
             finalWriteError = e;
@@ -652,58 +605,62 @@ export class FeishuStreamingSession {
       }
     }
 
-    // Update note with final model/provider info
-    if (options?.note) {
+    // Update note with final model/provider info (skipped when stream is dead —
+    // note content is included in the non-streaming fallback above).
+    if (!this.streamDead && options?.note) {
       await this.updateNoteContent(options.note);
     }
 
-    // Close streaming mode
-    // A rejected final write must not advertise content that CardKit never accepted.
-    const acceptedText = this.state.sentText;
-    this.state.sequence += 1;
+    // Close streaming mode. When the stream is already dead, the server-side
+    // streaming mode is already closed, so this PATCH would fail with 300309 — skip it.
     let closeError: unknown;
-    try {
-      const { response, release } = await fetchWithSsrFGuard({
-        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
-        init: {
-          method: "PATCH",
-          headers: {
-            Authorization: `Bearer ${await getToken(this.creds, {
-              fetchImpl: this.fetchImpl,
-              lookupFn: this.lookupFn,
-            })}`,
-            "Content-Type": "application/json; charset=utf-8",
-            "User-Agent": getFeishuUserAgent(),
-          },
-          body: JSON.stringify({
-            settings: JSON.stringify({
-              config: {
-                streaming_mode: false,
-                summary: { content: truncateSummary(acceptedText) },
-              },
-            }),
-            sequence: this.state.sequence,
-            uuid: `c_${this.state.cardId}_${this.state.sequence}`,
-          }),
-        },
-        fetchImpl: this.fetchImpl,
-        lookupFn: this.lookupFn,
-        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-        auditContext: "feishu.streaming-card.close",
-        timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
-      });
+    if (!this.streamDead) {
+      // A rejected final write must not advertise content that CardKit never accepted.
+      const acceptedText = this.state.sentText;
+      this.state.sequence += 1;
       try {
-        await assertSuccessfulCardKitResponse(
-          response,
-          "feishu.streaming-card.close",
-          "Close streaming card",
-        );
-      } finally {
-        await release();
+        const { response, release } = await fetchWithSsrFGuard({
+          url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/settings`,
+          init: {
+            method: "PATCH",
+            headers: {
+              Authorization: `Bearer ${await getToken(this.creds, {
+                fetchImpl: this.fetchImpl,
+                lookupFn: this.lookupFn,
+              })}`,
+              "Content-Type": "application/json; charset=utf-8",
+              "User-Agent": getFeishuUserAgent(),
+            },
+            body: JSON.stringify({
+              settings: JSON.stringify({
+                config: {
+                  streaming_mode: false,
+                  summary: { content: truncateSummary(acceptedText) },
+                },
+              }),
+              sequence: this.state.sequence,
+              uuid: `c_${this.state.cardId}_${this.state.sequence}`,
+            }),
+          },
+          fetchImpl: this.fetchImpl,
+          lookupFn: this.lookupFn,
+          policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+          auditContext: "feishu.streaming-card.close",
+          timeoutMs: this.creds.httpTimeoutMs ?? FEISHU_HTTP_TIMEOUT_MS,
+        });
+        try {
+          await assertSuccessfulCardKitResponse(
+            response,
+            "feishu.streaming-card.close",
+            "Close streaming card",
+          );
+        } finally {
+          await release();
+        }
+      } catch (error: unknown) {
+        closeError = error;
+        this.log?.(`Close failed: ${String(error)}`);
       }
-    } catch (error: unknown) {
-      closeError = error;
-      this.log?.(`Close failed: ${String(error)}`);
     }
     const finalState = this.state;
     this.state = null;
@@ -728,14 +685,26 @@ export class FeishuStreamingSession {
     return result;
   }
 
-  async discard(): Promise<FeishuStreamingCloseResult> {
+  async close(finalText?: string, options?: { note?: string }): Promise<boolean> {
+    try {
+      return (await this.closeWithResult(finalText, options)).visibleReplySent;
+    } catch (error: unknown) {
+      if (error instanceof FeishuStreamingFinalizationError) {
+        return error.result.visibleReplySent;
+      }
+      throw error;
+    }
+  }
+
+  async discard(): Promise<void> {
     if (!this.state || this.closed) {
-      return { visibleReplySent: false };
+      return;
     }
     const { cardId, messageId } = this.state;
     if (!messageId) {
       // Accepted cards without a message receipt can still be cleared by card id.
-      return this.closeWithResult("");
+      await this.close("");
+      return;
     }
     this.closed = true;
     this.clearFlushTimer();
@@ -751,12 +720,10 @@ export class FeishuStreamingSession {
       this.state = null;
       this.pendingText = null;
       this.log?.(`Discarded streaming card: cardId=${cardId}`);
-      return { visibleReplySent: false };
     } catch (error) {
       this.log?.(`Discard failed: ${String(error)}`);
       this.closed = false;
-      // A rejected clear leaves accepted text visible; preserve its receipt and failure.
-      return this.closeWithResult("");
+      await this.close("");
     }
   }
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -28,6 +28,8 @@ type CardState = {
   currentText: string;
   sentText: string;
   hasNote: boolean;
+  /** Initial card header retained for non-streaming fallback replacement. */
+  header?: { title: string; template?: string };
 };
 
 type CardKitResponse = { code?: number; msg?: string };
@@ -298,6 +300,14 @@ export class FeishuStreamingSession {
       currentText: "",
       sentText: "",
       hasNote: Boolean(options?.note),
+      ...(options?.header
+        ? {
+            header: {
+              title: options.header.title,
+              template: resolveFeishuCardTemplate(options.header.template) ?? "blue",
+            },
+          }
+        : {}),
     };
     this.log?.(`Started streaming: cardId=${cardId}${messageId ? `, messageId=${messageId}` : ""}`);
   }
@@ -403,6 +413,12 @@ export class FeishuStreamingSession {
       }
       return true;
     } catch (error) {
+      if (isCardStreamClosedError(error)) {
+        this.streamDead = true;
+        this.log?.(
+          `Streaming card stream is dead (cardId=${this.state.cardId}); skipping further streaming patches`,
+        );
+      }
       onError?.(error);
       return false;
     }
@@ -549,9 +565,24 @@ export class FeishuStreamingSession {
     // 300309 "streaming mode is closed"), all streaming API patches fail. Skip them
     // and fall back to the non-streaming im.message.patch API to update the card
     // content so the final text is not lost and logs are not flooded.
-    if (this.streamDead && this.state.messageId) {
+    // When the streaming card's server-side stream is dead (200850 idle timeout →
+    // 300309 "streaming mode is closed"), all streaming API patches fail. Skip them
+    // and fall back to the non-streaming im.message.patch API to update the card
+    // content so the final text is not lost and logs are not flooded.
+    const applyNonStreamingFallback = async (): Promise<void> => {
+      if (!this.state?.messageId) {
+        return;
+      }
       const fallbackContent = JSON.stringify({
         schema: "2.0",
+        ...(this.state.header
+          ? {
+              header: {
+                title: { tag: "plain_text", content: this.state.header.title },
+                template: this.state.header.template ?? "blue",
+              },
+            }
+          : {}),
         body: {
           elements: [
             { tag: "markdown", content: text, element_id: "content" },
@@ -579,6 +610,8 @@ export class FeishuStreamingSession {
         this.state.sentText = text;
         this.state.currentText = text;
         visibleContentSent = Boolean(text.trim());
+        // Clear the prior write error — the fallback recovered the final content.
+        finalWriteError = undefined;
         this.log?.(
           `Closed streaming via non-streaming fallback: cardId=${this.state.cardId}, messageId=${this.state.messageId}`,
         );
@@ -586,6 +619,10 @@ export class FeishuStreamingSession {
         finalWriteError = error;
         this.log?.(`Non-streaming card fallback failed: ${String(error)}`);
       }
+    };
+
+    if (this.streamDead && this.state.messageId) {
+      await applyNonStreamingFallback();
     } else if ((text || finalText !== undefined) && text !== this.state.sentText) {
       // Only send final update if content differs from what's already displayed.
       // An explicit empty final text clears a transient preview before closeout.
@@ -602,6 +639,11 @@ export class FeishuStreamingSession {
       if (sent) {
         this.state.sentText = text;
         visibleContentSent = Boolean(text.trim());
+      }
+      // If the final write first detected stream expiration, retry via the
+      // non-streaming fallback so the final text replaces the stale partial.
+      if (this.streamDead && this.state.messageId && text !== this.state.sentText) {
+        await applyNonStreamingFallback();
       }
     }
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Client } from "@larksuiteoapi/node-sdk";
-import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
+import { fetchWithSsrFGuard, type LookupFn } from "openclaw/plugin-sdk/ssrf-runtime";
 import { sliceUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { FEISHU_HTTP_TIMEOUT_MS } from "./client-timeout.js";
 import { getFeishuUserAgent } from "./client.js";
@@ -696,15 +696,14 @@ export class FeishuStreamingSession {
     }
   }
 
-  async discard(): Promise<void> {
+  async discard(): Promise<FeishuStreamingCloseResult> {
     if (!this.state || this.closed) {
-      return;
+      return { visibleReplySent: false };
     }
     const { cardId, messageId } = this.state;
     if (!messageId) {
       // Accepted cards without a message receipt can still be cleared by card id.
-      await this.close("");
-      return;
+      return this.closeWithResult("");
     }
     this.closed = true;
     this.clearFlushTimer();
@@ -720,10 +719,12 @@ export class FeishuStreamingSession {
       this.state = null;
       this.pendingText = null;
       this.log?.(`Discarded streaming card: cardId=${cardId}`);
+      return { visibleReplySent: false };
     } catch (error) {
       this.log?.(`Discard failed: ${String(error)}`);
       this.closed = false;
-      await this.close("");
+      // A rejected clear leaves accepted text visible; preserve its receipt and failure.
+      return this.closeWithResult("");
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

When the Feishu streaming card's server-side stream dies (200850 idle timeout → 300309 "streaming mode is closed"), all streaming API patches fail. The original code logged failures without marking the stream terminal, causing ~978 consecutive retries that flood logs. The initial fix marked the stream dead after the first 300309 and fell back to `im.message.patch` (non-streaming) at close.

This update addresses two bot review findings:

1. **[P2] Apply recovery when the final write first detects expiration** — When the stream dies *during* the final write (not before `closeWithResult()`), the `streamDead` flag was set but the fallback was never revisited. Additionally, `replaceCardContent` didn't detect stream-dead errors at all. Fixed by: (a) adding `isCardStreamClosedError` detection to `replaceCardContent`, (b) retrying via the non-streaming fallback when the final write detects expiration, (c) clearing `finalWriteError` when the fallback recovers.

2. **[P2] Preserve the card header in the full-card fallback** — The fallback content only had `schema` and `body`, losing the original card's title and color. Fixed by retaining the initial header in session state during `start()` and including it in the replacement payload.

## Evidence

### Test verification

All 44 feishu streaming-card tests pass (38 error-release + 6 dead-stream), including 2 new tests:

1. **`preserves the card header in the non-streaming fallback content`** — Verifies the fallback content includes `header.title` and `header.template` matching the initial card header.

2. **`retries via non-streaming fallback when the final write first detects expiration`** — Sends a divergent final text (triggers `replaceCardContent`), which gets 300309. Asserts the fallback is called, the final text is visible, and no `FeishuStreamingFinalizationError` is thrown.

### Recovery path coverage

| Scenario | Before fix | After fix |
|---|---|---|
| Stream dead before close | Fallback applied | Fallback applied (unchanged) |
| Stream dies during `updateCardContent` | `streamDead` set, no retry | Fallback retried ✅ |
| Stream dies during `replaceCardContent` | `streamDead` NOT set, no retry, close PATCH fails | `streamDead` set + fallback retried ✅
