### PR TITLE
fix(update): restore service refresh from npm 2026.9.1

### DIFF
--- a/scripts/e2e/lib/update-first-hop-package-fixtures.mjs
+++ b/scripts/e2e/lib/update-first-hop-package-fixtures.mjs
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const LEGACY_UPDATE_COMPAT_CHUNKS = ["shared-DTaQo6Hi.js", "shared-Y6bNiw2w.js"];
+export const LEGACY_UPDATE_COMPAT_CHUNKS = [
+  "shared-DTaQo6Hi.js",
+  "shared-Y6bNiw2w.js",
+  "shared-DFJEouXv.js",
+];
 export const FUTURE_FIXTURE_VERSION = "2026.9.99-first-hop.0";
 
 function readJson(filePath) {

--- a/scripts/runtime-postbuild.mts
+++ b/scripts/runtime-postbuild.mts
@@ -192,7 +192,7 @@ const LEGACY_PLUGIN_INSTALL_RUNTIME_COMPAT_ALIASES = [
   aliasFileName: PLUGIN_INSTALL_RUNTIME_ALIAS.aliasFileName,
   sourceIncludes: LEGACY_PLUGIN_INSTALL_RUNTIME_MARKERS,
 }));
-/** Compatibility chunks kept for live gateways loading old CLI exit modules. */
+/** Compatibility chunks for old updater and CLI exit modules after package replacement. */
 const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
   // v2026.8.2, the exact d413210 build, and v2026.9.1 load these after replacing dist/.
   // Remove only after the source artifacts fall outside the supported upgrade window.

--- a/scripts/runtime-postbuild.mts
+++ b/scripts/runtime-postbuild.mts
@@ -194,14 +194,18 @@ const LEGACY_PLUGIN_INSTALL_RUNTIME_COMPAT_ALIASES = [
 }));
 /** Compatibility chunks kept for live gateways loading old CLI exit modules. */
 const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
-  // v2026.8.2 and the exact d413210 build load these after replacing dist/.
-  // Remove only after both source artifacts fall outside the supported upgrade window.
+  // v2026.8.2, the exact d413210 build, and v2026.9.1 load these after replacing dist/.
+  // Remove only after the source artifacts fall outside the supported upgrade window.
   {
     dest: "dist/shared-Y6bNiw2w.js",
     contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
   },
   {
     dest: "dist/shared-DTaQo6Hi.js",
+    contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
+  },
+  {
+    dest: "dist/shared-DFJEouXv.js",
     contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
   },
   {

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -54,6 +54,7 @@ const DIST_CHANNEL_CATALOG = "dist/channel-catalog.json";
 const DIST_BUILD_INFO = "dist/build-info.json";
 const DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT = "dist/shared-Y6bNiw2w.js";
 const DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT = "dist/shared-DTaQo6Hi.js";
+const DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1 = "dist/shared-DFJEouXv.js";
 const DIST_LEGACY_CLI_EXIT_COMPAT = "dist/memory-state-CcqRgDZU.js";
 const DIST_LEGACY_CLI_EXIT_COMPAT_ALT = "dist/memory-state-DwGdReW4.js";
 const DIST_STABLE_ROOT_RUNTIME_SOURCE = "dist/model-catalog.runtime-AbCd1234.js";
@@ -171,6 +172,7 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
     [DIST_BUILD_INFO]: '{"buildId":"test-build"}\n',
     [DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT]: "export function resolveNodeRunner() {}\n",
     [DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT]: "export function resolveNodeRunner() {}\n",
+    [DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1]: "export function resolveNodeRunner() {}\n",
     [DIST_LEGACY_CLI_EXIT_COMPAT]: "export function hasMemoryRuntime() { return false; }\n",
     [DIST_LEGACY_CLI_EXIT_COMPAT_ALT]: "export function hasMemoryRuntime() { return false; }\n",
     [DIST_OPENCLAW_ALIAS_PACKAGE]:
@@ -185,6 +187,7 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
       DIST_PLUGIN_SDK_CORE,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT,
+      DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1,
       DIST_LEGACY_CLI_EXIT_COMPAT,
       DIST_LEGACY_CLI_EXIT_COMPAT_ALT,
       DIST_OPENCLAW_ALIAS_PACKAGE,
@@ -2029,6 +2032,7 @@ describe("run-node script", () => {
       DIST_BUILD_INFO,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT,
+      DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1,
       DIST_LEGACY_CLI_EXIT_COMPAT,
       DIST_STABLE_ROOT_RUNTIME_ALIAS,
       DIST_LEGACY_ROOT_RUNTIME_COMPAT,

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -1128,7 +1128,7 @@ describe("runtime postbuild static assets", () => {
     }
   });
 
-  it.each(["shared-Y6bNiw2w.js", "shared-DTaQo6Hi.js"])(
+  it.each(["shared-Y6bNiw2w.js", "shared-DTaQo6Hi.js", "shared-DFJEouXv.js"])(
     "preserves the old updater node-runner ABI through %s",
     async (chunk) => {
       const rootDir = createTempDir("openclaw-runtime-postbuild-");


### PR DESCRIPTION
Related: #139383

## What Problem This Solves

Fixes an issue where users updating an npm-installed Gateway from 2026.9.1 could be left with the service stopped after the new package installed successfully. The reported macOS update failed during service refresh and left the app stuck on “Updating…”, requiring a manual Gateway start.

## Why This Change Was Made

The already-running 2026.9.1 updater still lazily imports `shared-DFJEouXv.js` after replacing its package files; installing the eager-import fix from #138781 cannot change that old process. Emit this exact filename through the existing compatibility bridge, preserving its `resolveNodeRunner()` export and keeping the existing upgrade fixtures aligned with the supported compatibility window.

## User Impact

Upgrades from the published 2026.9.1 npm package can proceed past this missing-module failure to refresh the Gateway service. This addresses the frozen updater dependency behind the reported incident; the broader app recovery behavior remains tracked in #139383.

## Evidence

- Inspected the unmodified `openclaw@2026.9.1` npm archive: `update-command-service-maintenance-CxFxUV1H.js` imports `shared-DFJEouXv.js` and calls its named `resolveNodeRunner()` export without arguments. The existing bridge preserves the original executable selection behavior.
- Before the fix, the new ABI case failed with `ERR_MODULE_NOT_FOUND` for `shared-DFJEouXv.js`; the two existing compatibility cases passed (1 failed, 2 passed, 40 unselected).
- After the fix, all 138 tests passed across `runtime-postbuild.test.ts`, `update-first-hop-package-fixtures.test.ts`, and `run-node.test.ts` (46 tooling tests and 92 infra tests). Coverage includes importing the bridge and detecting a missing required output.
- Formatting, `git diff --check`, and required autoreview passed. [The complete PR CI gate passed](https://github.com/openclaw/openclaw/actions/runs/34005714668/job/101413208978) for current head `6b4ab193ef2386294f8c856b0f50997f7a9cd79a`.
- A full installed 2026.9.1 upgrade reproduced the failure without the compatibility facades and succeeded with this exact PR candidate. The real Gateway reported the intended candidate version/build and passed health checks before a further update succeeded.

<details>
<summary>Packaged upgrade commands, results, and provenance</summary>

The frozen npm 2026.9.1 first-hop package proof passed on the exact PR head
`6b4ab193ef2386294f8c856b0f50997f7a9cd79a`:
[successful hosted run](https://github.com/TheCrazyLex/openclaw/actions/runs/34006836461),
[evidence artifact](https://github.com/TheCrazyLex/openclaw/actions/runs/34006836461/artifacts/9981368581).

The canonical packer built the candidate before the task-only instrumentation
was applied. The published 2026.9.1 tarball SHA-256 was verified as
`1bfcac877d53f1e41b69d15c24e081895b2f07d6ff2ffdfe0bf8a7336ab00e59`.
The existing Docker harness removes all legacy facades for its negative and
future fixtures. The negative reproduced missing `shared-DFJEouXv.js`; the
repaired first hop and later fixture hop both succeeded.

| Observed case | CLI exit | Package result | Managed Gateway |
| --- | ---: | --- | --- |
| Frozen 2026.9.1 → candidate without facades | 1 | `error`, `restart-unhealthy`; missing `shared-DFJEouXv.js` | inactive |
| Frozen 2026.9.1 → exact bridge candidate | 0 | `ok`, 2026.9.1 → 2026.9.2 | active; PID 1904 → 3405 |
| Bridge candidate → future fixture without facades | 0 | `ok`, 2026.9.2 → 2026.9.99-first-hop.0 | active; PID 3405 → 5305 |

Actual first-hop CLI output and selected JSON fields, captured **before** the
future hop (JSON below is projected from the full artifact):

```text
$ openclaw --version
OpenClaw 2026.9.2 (6b4ab19)

$ openclaw health --json --timeout 10000
{ "ok": true }

$ openclaw gateway status --json
{
  "rpc": {
    "ok": true,
    "server": {
      "version": "2026.9.2",
      "buildId": "2026.9.2-6b4ab193ef23-2026-09-06T02-35-36.378Z"
    }
  }
}
```

The live server version and build ID match the candidate tarball. Installed
build metadata matches each selected tarball, and all three transaction-residue
captures are empty. This uses the repository's existing systemctl shim with
real installed Linux CLI/updater/Gateway processes in Docker; it does not claim
native systemd, launchd, or macOS service-manager coverage.

The frozen 2026.9.1 updater also emits a schema-15/schema-16 health-state
bookkeeping warning in both controls. That warning is retained in the artifact;
the repaired hop exits 0 and the new Gateway passes the real health/version
checks above.

</details>
