### PR TITLE
refactor(skills): share pending proposal creation

### DIFF
--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -31,10 +31,6 @@ import { readWritableWorkshopSkill } from "./workspace-skill-read.js";
 
 export class SkillProposalStaleTargetError extends Error {}
 
-function proposalStoreOptions(env?: NodeJS.ProcessEnv) {
-  return env ? { env } : {};
-}
-
 export function normalizeProposalOrigin(
   origin: SkillProposalOrigin | undefined,
 ): SkillProposalOrigin | undefined {
@@ -274,7 +270,7 @@ async function createPendingSkillProposal(
       type: "created",
       actor: input.eventActor,
     }),
-    store: { ...proposalStoreOptions(input.env), agentId },
+    store: { ...(input.env ? { env: input.env } : {}), agentId },
   });
   await dispatchSkillProposalChanged({
     event,

--- a/src/skills/workshop/service-propose.ts
+++ b/src/skills/workshop/service-propose.ts
@@ -1,5 +1,4 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import {
   readWorkspaceSkillFile,
@@ -29,11 +28,6 @@ import {
   type SkillProposalUpdateInput,
 } from "./types.js";
 import { readWritableWorkshopSkill } from "./workspace-skill-read.js";
-
-type SkillWorkshopWorkspaceOptions = {
-  config: OpenClawConfig;
-  agentId?: string;
-};
 
 export class SkillProposalStaleTargetError extends Error {}
 
@@ -103,51 +97,16 @@ export async function proposeCreateSkill(
     throw new Error(`Skill already exists at ${target.skillFile}.`);
   }
 
-  const now = new Date().toISOString();
-  const prepared = prepareSkillProposalDraft({
-    name: target.skillKey,
-    description,
-    content: input.content,
-    date: now,
-    maxSkillBytes: config.maxSkillBytes,
-    supportFiles: input.supportFiles,
-    secretScanMetadata: [{ file: "skill-name", content: name }],
-    goal: input.goal,
-    evidence: input.evidence,
-  });
-  if (!prepared.ok) {
-    throw prepared.error.cause;
-  }
-  const {
-    content: proposalContent,
-    draftHash,
-    evidence,
-    goal,
-    scan,
-    supportFiles,
-  } = prepared.value;
-  const id = createSkillProposalId(name);
-  const origin = normalizeProposalOrigin({
-    ...input.origin,
-    agentId: input.origin?.agentId ?? input.agentId,
-  });
-  const originRunProvenance = mergeProposalOriginRunProvenance(undefined, origin);
-  const record: SkillProposalRecord = {
-    schema: SKILL_WORKSHOP_SCHEMA,
-    id,
+  return await createPendingSkillProposal(input, {
+    config,
+    agentId,
     kind: "create",
-    status: "pending",
-    title: `Create ${name}`,
-    description,
-    createdAt: now,
-    updatedAt: now,
-    createdBy: input.createdBy ?? "skill-workshop",
-    ...(input.autonomousCapture ? { autonomousCapture: true as const } : {}),
-    ...(origin ? { origin } : {}),
-    ...originRunProvenance,
-    proposedVersion: "v1",
-    draftFile: createSkillProposalGenerationDraftFile(),
-    draftHash,
+    draft: {
+      name: target.skillKey,
+      description,
+      content: input.content,
+      secretScanMetadata: [{ file: "skill-name", content: name }],
+    },
     target: {
       skillName: name,
       skillKey: target.skillKey,
@@ -155,33 +114,7 @@ export async function proposeCreateSkill(
       skillFile: target.skillFile,
       source: "openclaw-workshop",
     },
-    scan,
-    ...(supportFiles.length > 0
-      ? { supportFiles: await buildSupportFileMetadata(supportFiles) }
-      : {}),
-    ...(goal ? { goal } : {}),
-    ...(evidence ? { evidence } : {}),
-  };
-  const event = await writeSkillProposal({
-    record,
-    content: proposalContent,
-    supportFiles,
-    ownerAgentId: agentId,
-    maxPending: config.maxPending,
-    event: createSkillProposalEvent({
-      record,
-      type: "created",
-      actor: input.eventActor,
-    }),
-    store: { ...proposalStoreOptions(input.env), agentId },
   });
-  await dispatchSkillProposalChanged({
-    event,
-    record,
-    workspaceDir: input.workspaceDir,
-    ...(input.agentId ? { agentId: input.agentId } : {}),
-  });
-  return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
 }
 
 export function composeSkillBodyPatch(
@@ -217,7 +150,7 @@ export function findUniqueSkillPatchSpan(
 }
 
 export async function proposeUpdateSkill(
-  input: SkillProposalUpdateInput & SkillWorkshopWorkspaceOptions,
+  input: SkillProposalUpdateInput,
 ): Promise<SkillProposalReadResult> {
   const skillName = normalizeRequired(input.skillName, "Skill name");
   const config = resolveSkillWorkshopConfig(input.config);
@@ -247,12 +180,44 @@ export async function proposeUpdateSkill(
   }
   const description = resolveUpdateProposalDescription(input.description, target.description);
 
+  return await createPendingSkillProposal(input, {
+    config,
+    agentId,
+    kind: "update",
+    draft: {
+      name: target.skillName,
+      description,
+      content: draftContent,
+      fallbackFrontmatterContent: currentContent,
+    },
+    target: {
+      skillName: target.skillName,
+      skillKey: target.skillKey,
+      skillDir: target.baseDir,
+      skillFile: target.skillFile,
+      source: "openclaw-workshop",
+      currentContentHash: hashSkillProposalContent(currentContent),
+    },
+  });
+}
+
+async function createPendingSkillProposal(
+  input: SkillProposalCreateInput | SkillProposalUpdateInput,
+  params: {
+    config: ReturnType<typeof resolveSkillWorkshopConfig>;
+    agentId: string;
+    kind: SkillProposalRecord["kind"];
+    target: SkillProposalRecord["target"];
+    draft: Pick<
+      Parameters<typeof prepareSkillProposalDraft>[0],
+      "name" | "description" | "content" | "fallbackFrontmatterContent" | "secretScanMetadata"
+    >;
+  },
+): Promise<SkillProposalReadResult> {
+  const { config, agentId, kind, target, draft } = params;
   const now = new Date().toISOString();
   const prepared = prepareSkillProposalDraft({
-    name: target.skillName,
-    description,
-    content: draftContent,
-    fallbackFrontmatterContent: currentContent,
+    ...draft,
     date: now,
     maxSkillBytes: config.maxSkillBytes,
     supportFiles: input.supportFiles,
@@ -262,15 +227,8 @@ export async function proposeUpdateSkill(
   if (!prepared.ok) {
     throw prepared.error.cause;
   }
-  const {
-    content: proposalContent,
-    draftHash,
-    evidence,
-    goal,
-    scan,
-    supportFiles,
-  } = prepared.value;
-  const id = createSkillProposalId(target.skillKey);
+  const { content, draftHash, evidence, goal, scan, supportFiles } = prepared.value;
+  const id = createSkillProposalId(kind === "create" ? target.skillName : target.skillKey);
   const origin = normalizeProposalOrigin({
     ...input.origin,
     agentId: input.origin?.agentId ?? input.agentId,
@@ -279,10 +237,10 @@ export async function proposeUpdateSkill(
   const record: SkillProposalRecord = {
     schema: SKILL_WORKSHOP_SCHEMA,
     id,
-    kind: "update",
+    kind,
     status: "pending",
-    title: `Update ${target.skillName}`,
-    description,
+    title: `${kind === "create" ? "Create" : "Update"} ${target.skillName}`,
+    description: draft.description,
     createdAt: now,
     updatedAt: now,
     createdBy: input.createdBy ?? "skill-workshop",
@@ -292,24 +250,22 @@ export async function proposeUpdateSkill(
     proposedVersion: "v1",
     draftFile: createSkillProposalGenerationDraftFile(),
     draftHash,
-    target: {
-      skillName: target.skillName,
-      skillKey: target.skillKey,
-      skillDir: target.baseDir,
-      skillFile: target.skillFile,
-      source: "openclaw-workshop",
-      currentContentHash: hashSkillProposalContent(currentContent),
-    },
+    target,
     scan,
     ...(supportFiles.length > 0
-      ? { supportFiles: await buildSupportFileMetadata(supportFiles, target.baseDir) }
+      ? {
+          supportFiles: await buildSupportFileMetadata(
+            supportFiles,
+            kind === "update" ? target.skillDir : undefined,
+          ),
+        }
       : {}),
     ...(goal ? { goal } : {}),
     ...(evidence ? { evidence } : {}),
   };
   const event = await writeSkillProposal({
     record,
-    content: proposalContent,
+    content,
     supportFiles,
     ownerAgentId: agentId,
     maxPending: config.maxPending,
@@ -326,7 +282,7 @@ export async function proposeUpdateSkill(
     workspaceDir: input.workspaceDir,
     ...(input.agentId ? { agentId: input.agentId } : {}),
   });
-  return { record, revisionHash: hashSkillProposalRevision(record), content: proposalContent };
+  return { record, revisionHash: hashSkillProposalRevision(record), content };
 }
 
 function requireWorkshopAgentId(agentId: string | undefined): string {


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Skill Workshop's create and update paths repeat pending-proposal construction and publication, requiring changes to draft handling, provenance or event delivery to be made in two places.

This is an independent clean-broad companion to the #135868 split. It extracts no recovery-stage content.

## Why This Change Was Made

Share one private pending-proposal operation after each entry point has validated and resolved its target. Keep the create/update differences explicit: draft names and ID seeds, create-only name scanning, update frontmatter and content hashes, and support-file baselines. The existing store still owns generation publication and the SQLite transaction; hook dispatch still follows the committed write.

Remove the now-single-use store-options wrapper and the redundant workspace-options type intersection. The existing update input already declares the same configuration and agent fields.

Production LOC: +61 / -109 (**net -48**), one file, 170 changed lines; 371 → 323 lines. Tests, tooling and docs are unchanged.

## User Impact

No intended behavior change. Create and update continue returning pending proposals, preserving canonical skill identity, agent ownership, provenance and stale-target protection. Live skills still change only through apply.

## Evidence

- `node scripts/run-vitest.mjs src/skills/workshop/service.test.ts src/skills/workshop/service-evaluation.test.ts src/skills/workshop/service-lifecycle-hooks.test.ts src/agents/tools/skill-workshop-tool.skill-identity.test.ts src/agents/tools/skill-workshop-tool.review.test.ts`: all **86 unchanged tests passed** on the completed patch.
- The identity suite protects canonical names that differ from metadata keys, including the behavior fixed by #136495. The review suite changes the live skill during budget reservation and verifies stale rejection with a refunded budget.
- `node scripts/check-changed.mjs`: complete core/coreTests plan passed, including the selected UI-page type graph, all export scans, lint and architecture guards. Independent Codex local and branch reviews through P2 are scoped-clean.
- No build required: no runtime import, lazy boundary, package output or public SDK surface changed.

Deletion evidence: both original public entry points built the same pending record, merged run provenance, wrote through the same store and dispatched the same created event. Both now use that one private operation. The removed type repeats fields already present on SkillProposalUpdateInput; the removed store-options wrapper had only one remaining caller. No compatibility contract, migration, schema, test or baseline is removed.

ClawSweeper reviewed the published consolidation and found no actionable correctness/security findings, before-merge requests or rank-up moves. Exact-head CI run 34005259092 passed at 625ed41d1bcc8dbb036df116316a8356cefff1ed. The required final freshness rebase preserved the source and lockfile; exact-head CI run 34005740375 also passed for 197ca473694d175aec30f94a6a46f465e999b65b. ClawSweeper reviewed that final head without findings or rank-up requests.
