### PR TITLE
test(ui): scope dashboard settings setup to the top frame

### DIFF
--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -41,6 +41,10 @@ async function openDashboard(page: Page): Promise<void> {
   const settingsKey = controlUiBundledSettingsStorageKey(controlUi.baseUrl);
   await page.addInitScript(
     ({ key, storageKey }) => {
+      // Init scripts also run in opaque widget frames; only the dashboard owns settings.
+      if (window !== window.top) {
+        return;
+      }
       const settings = JSON.parse(localStorage.getItem(storageKey) ?? "{}") as Record<
         string,
         unknown
@@ -115,6 +119,8 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
       });
       contexts.add(context);
       const page = await context.newPage();
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(error.message));
       const origin = new URL(controlUi.baseUrl).origin;
       const rendererUrl = `${rendererOrigin}/__openclaw__/cap/canvas-proof/__openclaw__/a2ui/a2ui-v0.9.bundle.js`;
       const messages = [
@@ -274,6 +280,7 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
         scrollbar.thumbBackground,
       );
       expect(scrollbar.ratio).toBeLessThan(0.2);
+      expect(pageErrors).toEqual([]);
       if (scrollbarProofLabel) {
         const screenshotPath = path.resolve(
           createControlUiE2eArtifactDir("widget-scrollbar"),


### PR DESCRIPTION
Related: #139490

## What Problem This Solves

Resolves a problem where the dashboard A2UI browser fixture raises storage-access errors inside its sandboxed widget frames, even while its action and theme assertions pass.

## Why This Change Was Made

The settings preload now runs only in the top-level dashboard. Both existing theme scenarios also assert that no uncaught page errors occurred.

## User Impact

No production or visual behavior changes. The fixture initializes only the page that owns those settings and exposes future uncaught renderer errors. Existing action delivery, payload, and scrollbar checks remain intact; no timeout or dependency changes.

## Evidence

With only the new error assertion, both existing scenarios fail on three opaque-frame localStorage errors each. With the ownership guard, both pass with zero page errors and unchanged action/theme results. Scoped type-aware lint, formatting, diff checks, and independent P0–P2 review pass. The change adds seven test-only lines.

This fixes the demonstrated fixture errors; it does not claim to explain the separate, unreproduced missing-action CI failure. Exact-head CI is required before landing.
