### PR TITLE
fix(ui): send queued attachments with MIME parameters

### DIFF
--- a/ui/src/pages/chat/attachment-api.test.ts
+++ b/ui/src/pages/chat/attachment-api.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from "vitest";
+import { buildChatApiAttachments } from "./attachment-api.ts";
+
+it.each([
+  { mediaType: "text/plain;charset=utf-8", mimeType: "text/plain", type: "file" },
+  {
+    mediaType: "text/plain;charset=utf-8;name=notes%20copy.txt",
+    mimeType: "text/plain",
+    type: "file",
+  },
+  { mediaType: "image/png;name=preview.png", mimeType: "image/png", type: "image" },
+])(
+  "converts parameterized $mediaType data URLs into chat attachments",
+  ({ mediaType, mimeType, type }) => {
+    expect(
+      buildChatApiAttachments([
+        {
+          id: "parameterized-attachment",
+          dataUrl: `data:${mediaType};base64,bm90ZXM=`,
+          mimeType,
+          fileName: "attachment",
+        },
+      ]),
+    ).toEqual([{ type, mimeType, fileName: "attachment", content: "bm90ZXM=" }]);
+  },
+);

--- a/ui/src/pages/chat/attachment-api.ts
+++ b/ui/src/pages/chat/attachment-api.ts
@@ -4,7 +4,8 @@ import { generateUUID } from "../../lib/uuid.ts";
 import { getChatAttachmentDataUrl } from "./attachment-payload-store.ts";
 
 function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
-  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+  // FileReader data URLs may include MIME parameters; chat.send uses the bare media type.
+  const match = /^data:([^;,]+)(?:;[^;,=]+=[^;,]*)*;base64,(.+)$/.exec(dataUrl);
   if (!match) {
     return null;
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where sending a valid chat attachment could fail when its FileReader data URL included a MIME parameter, such as text/plain;charset=utf-8. Bun exposed this valid input in the existing chat tests.

## Why This Change Was Made

The attachment parser accepts media-type parameters before the base64 marker and passes the bare media type and unchanged encoded bytes to chat.send. Image classification remains based on that bare media type.

## User Impact

Text and image attachments with parameterized MIME data URLs can be sent through the existing chat flow.

## Evidence

- 388 focused tests pass on Node and 388 on true Bun.
- Three new regression cases failed before the repair and pass afterward, covering charset, multiple parameters, and image classification.
- Complete changed-file gate passed; independent P0–P2 review found no actionable findings.
- Synthetic browser proof follows the real file-input, offline queue, and reconnect flow. The baseline serves only the original parser expression through browser source interception; the repaired run uses the reviewed parser unchanged.
- Before: zero chat.send requests and a persisted attachment error. After: exactly one request with canonical text/plain and unchanged file bytes; the displayed reply is a mock Gateway receipt.
- The broader Bun compatibility campaign remains in progress.

Before: the valid parameterized text attachment remains **Not sent** after reconnect, with zero send requests.

![Before: queued text attachment remains not sent](https://github.com/user-attachments/assets/c8170877-c3a4-4c0d-9f42-4002c23b389a)

After: the same attachment sends once with unchanged bytes and canonical media type. The visible receipt is from the synthetic mock Gateway.

![After: queued text attachment is delivered](https://github.com/user-attachments/assets/8eae8783-0f52-4189-91b9-aebc95af2feb)
