### PR TITLE
fix: complete updates that migrate database schemas

### DIFF
--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -165,6 +165,12 @@ recovery stops and reports the error without retrying with weaker options. Repai
 the reported failure, rerun `openclaw update`, and check `openclaw gateway status --deep`.
 See [Failed update recovery](/gateway/restart-recovery#recovery-after-a-failed-update).
 
+When a target supports a newer database schema, its executable takes over before
+Doctor migrates state. That process completes plugin updates, restart verification,
+and the run report; the old updater stops accessing the database. If migration or
+finalization fails, keep the updated build installed and follow the reported
+recovery steps. Reinstalling older code alone cannot undo a database migration.
+
 On macOS, if Doctor reports an installed but unloaded and disabled Gateway
 LaunchAgent after an interrupted update, finish update verification or Doctor and
 triage first. Then use the printed `openclaw gateway start` command, preserving

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -52,6 +52,10 @@ export function createUpdateProgress(
     currentSpinner = null;
   };
   const refresh = () => {
+    // The target process owns this database once its Doctor can migrate it.
+    if (run?.transferred) {
+      return undefined;
+    }
     const record = run ? getUpdateRun(run.runId, { env: run.env }) : undefined;
     if (!record) {
       return undefined;

--- a/src/cli/update-cli/schema-preflight.ts
+++ b/src/cli/update-cli/schema-preflight.ts
@@ -1,3 +1,4 @@
+import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../../state/openclaw-agent-db-contract.js";
 import {
   OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
   preflightOpenClawDatabaseSchemas,
@@ -6,6 +7,17 @@ import {
   type OpenClawDatabaseSchemaPreflight,
 } from "../../state/openclaw-database-preflight.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../../state/openclaw-state-db-contract.js";
+
+export function requiresFreshUpdateFinalization(
+  schemaVersions: OpenClawSchemaVersions | undefined,
+): boolean {
+  return Boolean(
+    schemaVersions &&
+    (schemaVersions.state > OPENCLAW_STATE_SCHEMA_VERSION ||
+      schemaVersions.agent > OPENCLAW_AGENT_SCHEMA_VERSION),
+  );
+}
 
 export function formatSchemaRefusalLines(
   schemas: {

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -30,7 +30,7 @@ import { isJsonOutputModeActive } from "../json-output-mode.js";
 
 export type UpdateCommandOptions = {
   /** Internal orchestration context, shared across update phases and child processes. */
-  run?: { runId: string; env: NodeJS.ProcessEnv };
+  run?: { runId: string; env: NodeJS.ProcessEnv; transferred?: boolean };
   acceptCapabilities?: boolean;
   json?: boolean;
   restart?: boolean;

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -17,6 +17,7 @@ import {
   checkTargetDatabaseSchemas,
   formatSchemaRefusalLines,
   hasSchemaRefusal,
+  requiresFreshUpdateFinalization,
 } from "./schema-preflight.js";
 import {
   normalizeTag,
@@ -234,6 +235,7 @@ export async function executeMutableUpdate(params: {
     nodeRunner: params.packageUpdateNodeRunner,
     installEnv: params.packageInstallEnv,
     installTarget: params.packageInstallTarget,
+    deferDoctor: requiresFreshUpdateFinalization(params.packageTargetSchemaVersions),
   });
 
   let result: UpdateRunResult;

--- a/src/cli/update-cli/update-command-git.ts
+++ b/src/cli/update-cli/update-command-git.ts
@@ -23,6 +23,7 @@ import {
   checkTargetDatabaseSchemas,
   formatSchemaRefusalLines,
   hasSchemaRefusal,
+  requiresFreshUpdateFinalization,
 } from "./schema-preflight.js";
 import {
   DEFAULT_PACKAGE_NAME,
@@ -123,6 +124,7 @@ type BeforeGitMutation = (target: {
 }) => Promise<{
   allowGatewayServiceRepair?: boolean;
   allowGatewayActivation?: boolean;
+  deferDoctor?: boolean;
 } | void>;
 
 export function createBeforeGitMutation(params: {
@@ -169,9 +171,12 @@ export function createBeforeGitMutation(params: {
     }
     // A candidate checkout cannot own the service until its global exposure
     // succeeds. Finalization refreshes and activates the verified installation.
-    return params.switchToGit
-      ? { allowGatewayServiceRepair: false, allowGatewayActivation: false }
-      : resolvePreparedGatewayUpdatePolicy(preManagedServiceStop, params.shouldRestart);
+    return {
+      ...(params.switchToGit
+        ? { allowGatewayServiceRepair: false, allowGatewayActivation: false }
+        : resolvePreparedGatewayUpdatePolicy(preManagedServiceStop, params.shouldRestart)),
+      ...(requiresFreshUpdateFinalization(target.schemaVersions) ? { deferDoctor: true } : {}),
+    };
   };
 }
 

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -56,6 +56,7 @@ export type PackageInstallUpdateParams = {
   nodeRunner?: string;
   installEnv?: NodeJS.ProcessEnv;
   installTarget?: ResolvedGlobalInstallTarget;
+  deferDoctor?: boolean;
 };
 
 export async function runPackageInstallUpdate(
@@ -116,76 +117,82 @@ export async function runPackageInstallUpdate(
         ...stepParams,
         progress: params.progress,
       }),
-    postVerifyStep: async (verifiedPackageRoot) => {
-      const entryPath = await resolveGatewayInstallEntrypoint(verifiedPackageRoot);
-      if (!entryPath) {
-        return null;
-      }
-      const doctorEnv = resolveUpdateTargetEnv({
-        serviceEnv: params.managedServiceEnv,
-        invocationCwd: params.invocationCwd,
-      });
-      // Backup and Doctor must select the same installation before Doctor can rewrite it.
-      await createUpdateConfigSnapshot(doctorEnv);
-      const candidateHostVersion = await readPackageVersion(verifiedPackageRoot);
-      const doctorResultPath = createUpdatePostInstallDoctorResultPath();
-      // The candidate is live only behind the staged npm rollback boundary. Keep
-      // native service changes external until this verification passes and the
-      // outer update finalizer owns the successful refresh/restart.
-      const doctorPolicy = resolveUpdateDoctorExecutionPolicy({
-        targetVersion: candidateHostVersion,
-        allowGatewayServiceRepair: false,
-      });
-      const doctorArgv = [
-        params.nodeRunner ?? resolveNodeRunner(),
-        entryPath,
-        "doctor",
-        "--non-interactive",
-        ...(doctorPolicy.fix ? ["--fix"] : []),
-      ];
-      const doctorProgressInfo = {
-        name: `${CLI_NAME} doctor`,
-        command: doctorArgv.join(" "),
-        index: 0,
-        total: 0,
-      };
-      params.progress?.onStepStart?.(doctorProgressInfo);
-      const doctorStep = await runUpdateStep({
-        name: `${CLI_NAME} doctor`,
-        argv: doctorArgv,
-        cwd: verifiedPackageRoot,
-        env: {
-          ...doctorEnv,
-          ...buildUpdateDoctorEnv({
+    postVerifyStep: params.deferDoctor
+      ? undefined
+      : async (verifiedPackageRoot) => {
+          const entryPath = await resolveGatewayInstallEntrypoint(verifiedPackageRoot);
+          if (!entryPath) {
+            return null;
+          }
+          const doctorEnv = resolveUpdateTargetEnv({
+            serviceEnv: params.managedServiceEnv,
+            invocationCwd: params.invocationCwd,
+          });
+          // Backup and Doctor must select the same installation before Doctor can rewrite it.
+          await createUpdateConfigSnapshot(doctorEnv);
+          const candidateHostVersion = await readPackageVersion(verifiedPackageRoot);
+          const doctorResultPath = createUpdatePostInstallDoctorResultPath();
+          // The candidate is live only behind the staged npm rollback boundary. Keep
+          // native service changes external until this verification passes and the
+          // outer update finalizer owns the successful refresh/restart.
+          const doctorPolicy = resolveUpdateDoctorExecutionPolicy({
+            targetVersion: candidateHostVersion,
             allowGatewayServiceRepair: false,
-            allowGatewayActivation: false,
-            deferConfiguredPluginInstallRepair: true,
-            serviceRepairPolicy: doctorPolicy.serviceRepairPolicy,
-            compatibilityHostVersion: candidateHostVersion,
-          }),
-          [UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV]: doctorResultPath,
+          });
+          const doctorArgv = [
+            params.nodeRunner ?? resolveNodeRunner(),
+            entryPath,
+            "doctor",
+            "--non-interactive",
+            ...(doctorPolicy.fix ? ["--fix"] : []),
+          ];
+          const doctorProgressInfo = {
+            name: `${CLI_NAME} doctor`,
+            command: doctorArgv.join(" "),
+            index: 0,
+            total: 0,
+          };
+          params.progress?.onStepStart?.(doctorProgressInfo);
+          const doctorStep = await runUpdateStep({
+            name: `${CLI_NAME} doctor`,
+            argv: doctorArgv,
+            cwd: verifiedPackageRoot,
+            env: {
+              ...doctorEnv,
+              ...buildUpdateDoctorEnv({
+                allowGatewayServiceRepair: false,
+                allowGatewayActivation: false,
+                deferConfiguredPluginInstallRepair: true,
+                serviceRepairPolicy: doctorPolicy.serviceRepairPolicy,
+                compatibilityHostVersion: candidateHostVersion,
+              }),
+              [UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV]: doctorResultPath,
+            },
+            timeoutMs: params.timeoutMs,
+          });
+          const doctorResult = await consumeUpdatePostInstallDoctorResult(doctorResultPath);
+          const completedDoctorStep = markPackagePostInstallDoctorAdvisory(
+            doctorStep,
+            doctorResult,
+          );
+          params.progress?.onStepComplete?.({
+            ...doctorProgressInfo,
+            durationMs: completedDoctorStep.durationMs,
+            exitCode: completedDoctorStep.exitCode,
+            stdoutTail: completedDoctorStep.stdoutTail,
+            stderrTail: completedDoctorStep.stderrTail,
+            signal: completedDoctorStep.signal,
+            killed: completedDoctorStep.killed,
+            termination: completedDoctorStep.termination,
+            advisory: completedDoctorStep.advisory,
+          });
+          return completedDoctorStep;
         },
-        timeoutMs: params.timeoutMs,
-      });
-      const doctorResult = await consumeUpdatePostInstallDoctorResult(doctorResultPath);
-      const completedDoctorStep = markPackagePostInstallDoctorAdvisory(doctorStep, doctorResult);
-      params.progress?.onStepComplete?.({
-        ...doctorProgressInfo,
-        durationMs: completedDoctorStep.durationMs,
-        exitCode: completedDoctorStep.exitCode,
-        stdoutTail: completedDoctorStep.stdoutTail,
-        stderrTail: completedDoctorStep.stderrTail,
-        signal: completedDoctorStep.signal,
-        killed: completedDoctorStep.killed,
-        termination: completedDoctorStep.termination,
-        advisory: completedDoctorStep.advisory,
-      });
-      return completedDoctorStep;
-    },
   });
 
   return {
     status: packageUpdate.failedStep ? "error" : "ok",
+    ...(!packageUpdate.failedStep && params.deferDoctor ? { deferredDoctor: true as const } : {}),
     mode: installTarget.manager,
     root: packageUpdate.verifiedPackageRoot ?? params.root,
     reason: packageUpdate.failedStep ? packageUpdate.failedStep.name : undefined,

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -51,6 +51,7 @@ import {
   writeControlPlaneUpdateRestartSentinelBestEffort,
 } from "./update-command-result.js";
 import { completeUpdateCommandRun } from "./update-command-run.js";
+import { continueUpdateFinalizationInFreshProcess } from "./update-command-schema-handoff.js";
 import {
   resolveServiceRefreshEnv,
   stripGatewayServiceMarkerEnv,
@@ -76,7 +77,7 @@ import { resolveUpdateResultNextAction } from "./update-recovery-guidance.js";
 
 const CLI_NAME = resolveCliName();
 
-export async function finishUpdate(params: {
+export type FinishUpdateParams = {
   result: UpdateRunResult;
   failure?: { cause: unknown; detail: string };
   root: string;
@@ -97,7 +98,13 @@ export async function finishUpdate(params: {
   packageUpdateNodeRunner?: string;
   updateStepTimeoutMs: number;
   invocationCwd?: string;
-}): Promise<void> {
+};
+
+export async function finishUpdate(params: FinishUpdateParams): Promise<void> {
+  if (params.result.status === "ok" && params.result.deferredDoctor) {
+    await continueUpdateFinalizationInFreshProcess(params);
+    return;
+  }
   // Finalization owns the complete outcome, including recovery, restart, and completion work.
   const completedResult = (result: UpdateRunResult): UpdateRunResult => ({
     ...result,

--- a/src/cli/update-cli/update-command-schema-handoff.test-support.ts
+++ b/src/cli/update-cli/update-command-schema-handoff.test-support.ts
@@ -1,0 +1,230 @@
+import fs from "node:fs";
+import { createRequire, registerHooks, stripTypeScriptTypes } from "node:module";
+import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+import type { FinishUpdateParams } from "./update-command-post-update.js";
+
+const root = process.env.OPENCLAW_HOME!;
+const child = process.env.OPENCLAW_UPDATE_POST_CORE === "finalize";
+const scenario = process.env.HANDOFF_SCENARIO!;
+const reportPath = path.join(root, "parent-report.json");
+const entrypoint = path.join(root, "updated.mjs");
+const sourceUrl = (relative: string) => new URL(relative, import.meta.url).href;
+const schemaUrl = sourceUrl("../../state/openclaw-state-db-contract.ts");
+const contractSource = fs.readFileSync(new URL(schemaUrl), "utf8");
+const currentSchema = Number(/OPENCLAW_STATE_SCHEMA_VERSION = (\d+)/u.exec(contractSource)![1]);
+const nextSchema = currentSchema + 1;
+const snapshot: FinishUpdateParams["configSnapshot"] = {
+  path: path.join(root, "openclaw.json"),
+  exists: true,
+  raw: null,
+  valid: true,
+  config: { plugins: { enabled: false } },
+  runtimeConfig: { plugins: { enabled: false } },
+  sourceConfig: { plugins: { enabled: false } },
+  resolved: { plugins: { enabled: false } },
+  parsed: { plugins: { enabled: false } },
+  issues: [],
+  warnings: [],
+  legacyIssues: [],
+};
+const pluginUpdate = {
+  status: "ok",
+  changed: false,
+  warnings: [],
+  sync: { changed: false, switchedToBundled: [], switchedToNpm: [], warnings: [], errors: [] },
+  npm: { changed: false, outcomes: [] },
+  integrityDrifts: [],
+};
+const stubs = new Map<string, string>();
+function override(relative: string, source: string) {
+  const url = sourceUrl(relative);
+  stubs.set(url, `export * from ${JSON.stringify(`${url}?actual`)};\n${source}`);
+}
+override(
+  "../../daemon/gateway-entrypoint.ts",
+  `export const resolveGatewayInstallEntrypoint = async () => ${JSON.stringify(entrypoint)};`,
+);
+override(
+  "./shared.ts",
+  `export const resolveUpdateRoot = async () => ${JSON.stringify(root)}; export const tryWriteCompletionCache = async () => {};`,
+);
+override(
+  "../../config/config.ts",
+  `export const readConfigFileSnapshot = async () => (${JSON.stringify(snapshot)});`,
+);
+override(
+  "../../plugins/plugin-lifecycle-lease.ts",
+  "export const withPluginLifecycleLease = async (_options, run) => run();",
+);
+override(
+  "../../plugins/installed-plugin-index-records.ts",
+  "export const loadInstalledPluginIndexInstallRecords = async () => ({});",
+);
+override(
+  "./update-command-config.ts",
+  "export const persistRequestedUpdateChannel = async ({configSnapshot}) => configSnapshot; export const restoreDroppedPreUpdateChannels = snapshot => ({snapshot, changed:false});",
+);
+override(
+  "./update-command-plugins.ts",
+  `export const updatePluginsAfterCoreUpdate = async () => (${JSON.stringify(pluginUpdate)});`,
+);
+override(
+  "./update-command-post-core.ts",
+  `export const continuePostCoreUpdateInFreshProcess = async () => ({resumed:true, pluginUpdate:${JSON.stringify(pluginUpdate)}});`,
+);
+override(
+  "../../infra/update-triage.ts",
+  "export const prepareUpdateFailureTriage = async () => async () => {};",
+);
+override(
+  "./update-command-service.ts",
+  `
+export const resolveUpdatedGatewayRestartPort = async () => 19091;
+export const maybeRestartService = async () => true;
+export const tryInstallShellCompletion = async () => {};
+`,
+);
+override(
+  "./update-command-fresh-doctor.ts",
+  `
+import { DatabaseSync } from 'node:sqlite';
+import { resolveOpenClawStateSqlitePath } from ${JSON.stringify(sourceUrl("../../state/openclaw-state-db.paths.ts"))};
+export async function runUpdateFinalizationDoctorInFreshProcess() {
+  const db = new DatabaseSync(resolveOpenClawStateSqlitePath(process.env));
+  try { db.exec('PRAGMA user_version = ${nextSchema}; UPDATE schema_meta SET schema_version = ${nextSchema}'); } finally { db.close(); }
+  // Keep the real parent's 250ms observer alive across the migration.
+  await new Promise(resolve => setTimeout(resolve, 350));
+  ${scenario === "doctor-error" ? "throw new Error('Synthetic Doctor failure after migration');" : ""}
+}
+export const completePostCorePluginUpdate = async ({pluginUpdate}) => ({pluginUpdate, configSnapshot:${JSON.stringify(snapshot)}});
+`,
+);
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith(".") || specifier.startsWith("file:")) {
+      const url = new URL(specifier, context.parentURL);
+      if (!url.search) {
+        const replacement = stubs.get(url.href.replace(/\.js$/u, ".ts"));
+        if (replacement) {
+          return {
+            url: `data:text/javascript,${encodeURIComponent(replacement)}`,
+            shortCircuit: true,
+          };
+        }
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+  load(url, context, nextLoad) {
+    if (child && url === schemaUrl) {
+      return {
+        format: "module",
+        source: stripTypeScriptTypes(
+          contractSource.replace(
+            `OPENCLAW_STATE_SCHEMA_VERSION = ${currentSchema}`,
+            `OPENCLAW_STATE_SCHEMA_VERSION = ${nextSchema}`,
+          ),
+        ),
+        shortCircuit: true,
+      };
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const { continueUpdateFinalizationInFreshProcess, resumeUpdateFinalization } =
+  await import("./update-command-schema-handoff.js");
+if (child) {
+  try {
+    await resumeUpdateFinalization();
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    process.disconnect?.();
+  }
+} else {
+  const require = createRequire(import.meta.url);
+  fs.writeFileSync(
+    entrypoint,
+    `import { register } from ${JSON.stringify(pathToFileURL(require.resolve("tsx/esm/api")).href)}; register({tsconfig:${JSON.stringify(fileURLToPath(new URL("../../../tsconfig.json", import.meta.url)))}}); await import(${JSON.stringify(import.meta.url)});\n`,
+  );
+  fs.writeFileSync(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "openclaw", type: "module", version: "2026.9.2" }),
+  );
+  const { createUpdateRun } = await import("../../infra/update-run-ledger.js");
+  const { createUpdateProgress } = await import("./progress.js");
+  const { closeOpenClawStateDatabaseForTest } = await import("../../state/openclaw-state-db.js");
+  const run = {
+    runId: createUpdateRun({ trigger: "cli" }, { env: process.env }).runId,
+    env: process.env,
+    transferred: false,
+  };
+  const progress = createUpdateProgress(true, run);
+  const recoveryEvents: Array<{ event: string; safe: boolean }> = [];
+  const params: FinishUpdateParams = {
+    root,
+    result: {
+      status: "ok",
+      mode: "git",
+      root,
+      before: { sha: "before", version: "2026.9.2" },
+      after: { sha: "after", version: "2026.9.2" },
+      deferredDoctor: true,
+      steps: [],
+      durationMs: 0,
+    },
+    installKindChanged: false,
+    configSnapshot: snapshot,
+    requestedChannel: null,
+    storedChannel: null,
+    channel: "dev",
+    downgradeRisk: false,
+    shouldRestart: false,
+    opts: { yes: true, json: true, run },
+    preManagedServiceStop: {
+      stopped: false,
+      inspected: true,
+      runtimeInspected: true,
+      running: false,
+      serviceMutationAllowed: false,
+      windowsTaskAutoStartRecovery: {
+        beginMutation: () => {},
+        interrupted: () => false,
+        restore: async (safe = false) => {
+          recoveryEvents.push({ event: "restore", safe });
+        },
+        complete: (safe = true) => {
+          recoveryEvents.push({ event: "complete", safe });
+        },
+      },
+    },
+    controlPlaneUpdateSentinelMeta: null,
+    preUpdatePluginInstallRecords: {},
+    startedAt: Date.now(),
+    packageUpdateNodeRunner: process.execPath,
+    updateStepTimeoutMs: 30_000,
+  };
+  let outcome = "ok";
+  try {
+    await continueUpdateFinalizationInFreshProcess(params);
+  } catch (error) {
+    outcome = error instanceof Error ? error.message : String(error);
+  } finally {
+    progress.dispose();
+    closeOpenClawStateDatabaseForTest();
+  }
+  fs.writeFileSync(
+    reportPath,
+    JSON.stringify({
+      outcome,
+      runId: run.runId,
+      transferred: run.transferred,
+      recoveryEvents,
+      currentSchema,
+      nextSchema,
+    }),
+  );
+}

--- a/src/cli/update-cli/update-command-schema-handoff.test.ts
+++ b/src/cli/update-cli/update-command-schema-handoff.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { formatCliProcessFailure, runCliProcessChild } from "../cli-process-child.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const fixture = fileURLToPath(
+  new URL("./update-command-schema-handoff.test-support.ts", import.meta.url),
+);
+
+describe("update schema finalization process ownership", () => {
+  it.each(["success", "doctor-error"])(
+    "settles %s without old-process reads after migration",
+    async (scenario) => {
+      const root = tempDirs.make("openclaw-schema-handoff-");
+      const state = path.join(root, "state");
+      const env = {
+        ...process.env,
+        HOME: root,
+        USERPROFILE: root,
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: state,
+        OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+        OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+        OPENCLAW_UPDATE_POST_CORE: undefined,
+        OPENCLAW_UPDATE_RUN_HANDOFF: undefined,
+        HANDOFF_SCENARIO: scenario,
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        NO_COLOR: "1",
+      };
+      const result = await runCliProcessChild({ nodeArgs: ["--import", "tsx", fixture], env });
+      const failure = formatCliProcessFailure({ reason: scenario, ...result });
+      expect(result.code, failure).toBe(0);
+      expect(result.signal, failure).toBeNull();
+      const report = JSON.parse(await fs.readFile(path.join(root, "parent-report.json"), "utf8"));
+      expect(report.transferred).toBe(true);
+      expect(report.outcome, failure).toBe(
+        scenario === "success"
+          ? "ok"
+          : "Updated OpenClaw finalization failed; keep the updated build installed and inspect the update diagnostics.",
+      );
+      const db = new DatabaseSync(resolveOpenClawStateSqlitePath(env), { readOnly: true });
+      try {
+        expect(db.prepare("PRAGMA user_version").get()?.user_version).toBe(report.nextSchema);
+        const run = db
+          .prepare("SELECT status, steps_json FROM update_runs WHERE run_id = ?")
+          .get(report.runId);
+        expect(run?.status, failure).toBe(scenario === "success" ? "succeeded" : "failed");
+        expect(JSON.parse(String(run?.steps_json)), failure).toContainEqual(
+          expect.objectContaining({
+            step: "openclaw doctor",
+            status: scenario === "success" ? "completed" : "failed",
+          }),
+        );
+      } finally {
+        db.close();
+      }
+      expect(report.recoveryEvents, failure).toContainEqual({
+        event: scenario === "success" ? "restore" : "complete",
+        safe: scenario === "success",
+      });
+    },
+  );
+});

--- a/src/cli/update-cli/update-command-schema-handoff.ts
+++ b/src/cli/update-cli/update-command-schema-handoff.ts
@@ -1,0 +1,333 @@
+import { safeParseJsonRecord } from "@openclaw/normalization-core/json-coercion";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { getOneMessage, sendMessage } from "execa";
+import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { resolveManagedServiceUpdateFailureExitCode } from "../../infra/update-control-plane-sentinel.js";
+import { updateInstallRootsMatch } from "../../infra/update-install-root.js";
+import { POST_CORE_UPDATE_ENV } from "../../infra/update-post-core-context.js";
+import { spawnCommand } from "../../process/exec-spawn.js";
+import { createCommandTerminationController } from "../../process/exec-termination.js";
+import { registerSignalExitBarrier } from "../signal-exit-barrier.js";
+import { resolveNodeRunner, resolveUpdateRoot } from "./shared.js";
+import { createUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
+import { runUpdateFinalizationDoctorInFreshProcess } from "./update-command-fresh-doctor.js";
+import type { FinishUpdateParams } from "./update-command-post-update.js";
+import { UpdateCommandFailure } from "./update-command-result.js";
+import { createUpdateRunProgress } from "./update-command-run.js";
+import {
+  stripGatewayServiceMarkerEnv,
+  disableUpdatedPackageCompileCacheEnv,
+  withUpdateInProgressEnv,
+} from "./update-command-service-env.js";
+import { withUpdateFailureTriage } from "./update-command-triage.js";
+
+type FinalizationContext = Omit<FinishUpdateParams, "preManagedServiceStop" | "failure"> & {
+  preManagedServiceStop?: Omit<
+    NonNullable<FinishUpdateParams["preManagedServiceStop"]>,
+    "windowsTaskAutoStartRecovery"
+  >;
+  nativeRecovery: boolean;
+};
+
+/** The old runtime can supervise native compensation, but cannot reopen migrated state. */
+export async function continueUpdateFinalizationInFreshProcess(
+  params: FinishUpdateParams,
+): Promise<void> {
+  const root = params.result.root ?? params.root;
+  const entrypoint = await resolveGatewayInstallEntrypoint(root);
+  if (!entrypoint) {
+    throw new Error(
+      "Updated OpenClaw entrypoint is missing; keep the Gateway stopped and rebuild the target.",
+    );
+  }
+  const nativeRecovery = params.preManagedServiceStop?.windowsTaskAutoStartRecovery;
+  let stopState: FinalizationContext["preManagedServiceStop"];
+  if (params.preManagedServiceStop) {
+    const { windowsTaskAutoStartRecovery: _nativeRecovery, ...state } =
+      params.preManagedServiceStop;
+    stopState = state;
+  }
+  const { failure: _failure, preManagedServiceStop: _stopState, ...rest } = params;
+  const context: FinalizationContext = {
+    ...rest,
+    root,
+    opts: {
+      ...params.opts,
+      run: params.opts.run ? { ...params.opts.run, transferred: false } : undefined,
+    },
+    preManagedServiceStop: stopState,
+    nativeRecovery: Boolean(nativeRecovery),
+  };
+  const serializedContext = JSON.stringify(context);
+  // No state migration has run yet. Publishing ownership before spawn also disarms
+  // the parent's progress timer and its failure/disposal readers.
+  if (params.opts.run) {
+    createUpdateRunProgress(params.opts.run, {}).onStepStart?.({
+      name: "openclaw doctor",
+      command: "openclaw doctor --repair --non-interactive",
+      index: 0,
+      total: 1,
+    });
+    params.opts.run.transferred = true;
+  }
+  const cancelController = new AbortController();
+  const child = spawnCommand(
+    [
+      params.packageUpdateNodeRunner ?? resolveNodeRunner(),
+      entrypoint,
+      "update",
+      ...(params.opts.json ? ["--json"] : []),
+    ],
+    {
+      cwd: root,
+      baseEnv: stripGatewayServiceMarkerEnv(
+        disableUpdatedPackageCompileCacheEnv(params.ownedManagedUpdateEnv ?? process.env),
+      ),
+      env: {
+        [POST_CORE_UPDATE_ENV]: "finalize",
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_NO_RESPAWN: "1",
+      },
+      ipc: true,
+      ipcInput: { kind: "update-finalization", context: serializedContext },
+      cancelSignal: cancelController.signal,
+      detached: process.platform !== "win32",
+      buffer: false,
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+      reject: false,
+    },
+  );
+  let settled = false;
+  const termination = createCommandTerminationController({
+    child: child.nodeChildProcess,
+    cancelController,
+    processTree: { mode: "graceful" },
+    killGraceMs: 300,
+    isChildExited: () =>
+      child.nodeChildProcess.exitCode !== null || child.nodeChildProcess.signalCode !== null,
+    isCommandSettled: () => settled,
+  });
+  let interruptedExitCode: number | undefined;
+  const cancel = () => {
+    if (!termination.terminate()) {
+      cancelController.abort();
+    }
+  };
+  const onSigint = () => {
+    interruptedExitCode = 130;
+    cancel();
+  };
+  const onSigterm = () => {
+    interruptedExitCode = 143;
+    cancel();
+  };
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+  const unregisterBarrier = registerSignalExitBarrier(async () => {
+    cancel();
+    await child;
+    await termination.settle();
+  });
+  let completed = false;
+  const messages = (async () => {
+    for await (const message of child.getEachMessage()) {
+      if (!isRecord(message)) {
+        continue;
+      }
+      if (message.kind === "update-finalization-complete") {
+        completed = true;
+      } else if (message.kind === "update-autostart-restore") {
+        try {
+          if (interruptedExitCode || !nativeRecovery || nativeRecovery.interrupted()) {
+            throw new Error("The native update owner is no longer available.");
+          }
+          await nativeRecovery.restore(message.restartSafe === true);
+          await child.sendMessage({ kind: "update-autostart-restored" });
+        } catch (error) {
+          await child.sendMessage({
+            kind: "update-autostart-restored",
+            error: formatErrorMessage(error),
+          });
+        }
+      } else if (message.kind === "update-autostart-complete") {
+        nativeRecovery?.complete(message.restartSafe === true);
+      }
+    }
+  })();
+  try {
+    const [result] = await Promise.all([child, messages]);
+    if (!completed || result.exitCode !== 0) {
+      const failure = {
+        ...params.result,
+        status: "error" as const,
+        reason: "target-finalization-failed",
+        recovery: {
+          serviceRestartSafe: false as const,
+          reason: "state-migration-started" as const,
+        },
+      };
+      throw new UpdateCommandFailure(
+        failure,
+        interruptedExitCode ?? resolveManagedServiceUpdateFailureExitCode(failure),
+        "Updated OpenClaw finalization failed; keep the updated build installed and inspect the update diagnostics.",
+      );
+    }
+  } catch (error) {
+    termination.terminate();
+    await child;
+    throw error;
+  } finally {
+    settled = true;
+    await termination.settle();
+    unregisterBarrier();
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+    nativeRecovery?.complete(false);
+  }
+}
+
+/** Receive the private parent-owned continuation; service authority is rechecked by finishUpdate. */
+export async function resumeUpdateFinalization(): Promise<void> {
+  const { finishUpdate } = await import("./update-command-post-update.js");
+  delete process.env[POST_CORE_UPDATE_ENV];
+  if (!process.send) {
+    throw new Error("Update finalization requires its parent IPC channel.");
+  }
+  const message = await getOneMessage();
+  if (
+    !isRecord(message) ||
+    message.kind !== "update-finalization" ||
+    typeof message.context !== "string"
+  ) {
+    throw new Error("Missing update finalization context.");
+  }
+  const payload = safeParseJsonRecord(message.context);
+  if (
+    !payload ||
+    !isRecord(payload.result) ||
+    payload.result.status !== "ok" ||
+    payload.result.deferredDoctor !== true ||
+    !isRecord(payload.opts) ||
+    typeof payload.nativeRecovery !== "boolean"
+  ) {
+    throw new Error("Invalid update finalization continuation.");
+  }
+  // The envelope and deferred-success transition are checked above; native
+  // recovery functions are reconstructed over IPC below.
+  // SAFETY: this connected child receives the serializable DTO only from the typed parent above.
+  const context = payload as FinalizationContext;
+  const root = await resolveUpdateRoot();
+  if (
+    !context ||
+    typeof context.root !== "string" ||
+    !updateInstallRootsMatch(root, context.root)
+  ) {
+    throw new Error("Update finalization executable does not match the installed target.");
+  }
+  const params: FinishUpdateParams = { ...context };
+  const nativeCompletions: Promise<void>[] = [];
+  const nativeCompletionErrors: unknown[] = [];
+  if (context.nativeRecovery && params.preManagedServiceStop) {
+    params.preManagedServiceStop.windowsTaskAutoStartRecovery = {
+      beginMutation: () => {
+        throw new Error("Core mutation cannot resume during finalization.");
+      },
+      interrupted: () => !process.connected,
+      restore: async (restartSafe) => {
+        await sendMessage({ kind: "update-autostart-restore", restartSafe });
+        const reply = await getOneMessage();
+        if (!isRecord(reply) || reply.kind !== "update-autostart-restored" || reply.error) {
+          throw new Error(
+            isRecord(reply) && typeof reply.error === "string"
+              ? reply.error
+              : "Native update owner did not confirm autostart restoration.",
+          );
+        }
+      },
+      complete: (restartSafe = true) => {
+        nativeCompletions.push(
+          sendMessage({ kind: "update-autostart-complete", restartSafe }).catch(
+            (error: unknown) => {
+              nativeCompletionErrors.push(error);
+            },
+          ),
+        );
+      },
+    };
+  }
+  const { deferredDoctor: _deferredDoctor, ...result } = params.result;
+  params.result = result;
+  const target = { root, env: process.env };
+  try {
+    await withUpdateFailureTriage(
+      { ...params.opts, invocationCwd: params.invocationCwd },
+      target,
+      async () => {
+        await withUpdateInProgressEnv(params.invocationCwd, async () => {
+          const progress = params.opts.run
+            ? createUpdateRunProgress(params.opts.run, {})
+            : undefined;
+          const step = {
+            name: "openclaw doctor",
+            command: "openclaw doctor --repair --non-interactive",
+            index: 0,
+            total: 1,
+          };
+          const startedAt = Date.now();
+          try {
+            await createUpdateConfigSnapshot();
+            await runUpdateFinalizationDoctorInFreshProcess({
+              phase: "pre-plugin",
+              root,
+              yes: params.opts.yes === true,
+              json: params.opts.json === true,
+              timeoutMs: params.updateStepTimeoutMs,
+              nodeRunner: params.packageUpdateNodeRunner,
+            });
+          } catch (cause) {
+            params.result = {
+              ...result,
+              status: "error",
+              reason: "doctor-failed",
+              recovery: { serviceRestartSafe: false, reason: "state-migration-started" },
+            };
+            params.failure = { cause, detail: formatErrorMessage(cause) };
+          }
+          const doctorStep = {
+            ...step,
+            cwd: root,
+            durationMs: Date.now() - startedAt,
+            exitCode: params.failure ? 1 : 0,
+            ...(params.failure ? { stderrTail: params.failure.detail } : {}),
+          };
+          params.result.steps.push(doctorStep);
+          try {
+            progress?.onStepComplete?.(doctorStep);
+            await finishUpdate(params);
+          } catch (error) {
+            if (!params.failure || error instanceof UpdateCommandFailure) {
+              throw error;
+            }
+            throw new UpdateCommandFailure(
+              params.result,
+              resolveManagedServiceUpdateFailureExitCode(params.result),
+              `${params.failure.detail}\nUpdate failure reporting also failed: ${formatErrorMessage(error)}`,
+            );
+          }
+          await Promise.all(nativeCompletions);
+          if (nativeCompletionErrors.length > 0) {
+            throw nativeCompletionErrors[0];
+          }
+          await sendMessage({ kind: "update-finalization-complete" });
+        });
+      },
+    );
+  } finally {
+    // Drain failed deliveries without replacing the original finalization error.
+    // The parent retains native compensation ownership if IPC has disconnected.
+    await Promise.all(nativeCompletions);
+  }
+}

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -293,10 +293,11 @@ async function maybeSuspendWindowsTaskAutoStartForUpdate(params: {
     try {
       // Native preparation may abort before returning its recovery handle.
       // Persist that outcome before releasing the signal's process-exit gate.
-      if (finishUpdate && interrupted && updateRun && (restoreAllowed || restorationFailed)) {
+      const run = updateRun?.transferred ? undefined : updateRun;
+      if (finishUpdate && interrupted && run && (restoreAllowed || restorationFailed)) {
         const failed = restorationFailed || !restartSafe;
         finishUpdateRun(
-          updateRun.runId,
+          run.runId,
           {
             status: failed ? "failed" : "skipped",
             reason: restorationFailed
@@ -305,7 +306,7 @@ async function maybeSuspendWindowsTaskAutoStartForUpdate(params: {
                 ? "update-failed"
                 : "cancelled",
           },
-          { env: updateRun.env },
+          { env: run.env },
         );
       }
     } finally {

--- a/src/cli/update-cli/update-command-triage.ts
+++ b/src/cli/update-cli/update-command-triage.ts
@@ -18,7 +18,7 @@ import { UpdateCommandFailure } from "./update-command-result.js";
 export type UpdateTriageTarget = TriageTarget & { failureResult?: UpdateRunResult };
 
 export async function withUpdateFailureTriage(
-  opts: Pick<UpdateCommandOptions, "json" | "yes" | "dryRun"> & { invocationCwd?: string },
+  opts: Pick<UpdateCommandOptions, "json" | "yes" | "dryRun" | "run"> & { invocationCwd?: string },
   target: UpdateTriageTarget,
   run: () => Promise<void>,
 ): Promise<void> {
@@ -44,6 +44,7 @@ export async function withUpdateFailureTriage(
     if (
       (!reportedFailure || classifyUpdateOutcome(error.result) === "failed") &&
       !opts.dryRun &&
+      !opts.run?.transferred &&
       target.env[POST_CORE_UPDATE_ENV] !== "1"
     ) {
       const failure = reportedFailure

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -28,6 +28,7 @@ import {
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
 import { cleanupStaleManagedServiceUpdateHandoffs } from "../../infra/update-managed-service-handoff-cleanup.js";
+import { POST_CORE_UPDATE_ENV } from "../../infra/update-post-core-context.js";
 import { finishUpdateRun, recordUpdateRunPhase } from "../../infra/update-run-ledger.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
@@ -79,6 +80,11 @@ const CLI_NAME = resolveCliName();
 const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
 
 export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<void> {
+  if (process.env[POST_CORE_UPDATE_ENV] === "finalize") {
+    const { resumeUpdateFinalization } = await import("./update-command-schema-handoff.js");
+    await resumeUpdateFinalization();
+    return;
+  }
   const invocationCwd = tryResolveInvocationCwd();
   const recoveryState: UpdateCommandRecoveryState = {
     triageTarget: { env: resolveServiceRefreshEnv(process.env, invocationCwd) },
@@ -140,7 +146,7 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
             recoveryState.windowsTaskAutoStartRecovery?.complete();
           }
           if (failure) {
-            if (!prepared.postCoreUpdateResume) {
+            if (!prepared.postCoreUpdateResume && !run.transferred) {
               if (failure.error instanceof UpdateCommandFailure) {
                 completeUpdateCommandRun(failure.error.result, run);
               } else {

--- a/src/cli/update-cli/update-package-executor.test.ts
+++ b/src/cli/update-cli/update-package-executor.test.ts
@@ -33,7 +33,8 @@ vi.mock("../../runtime.js", () => ({
   defaultRuntime: { error: mocks.runtimeError },
 }));
 
-vi.mock("./schema-preflight.js", () => ({
+vi.mock("./schema-preflight.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./schema-preflight.js")>()),
   checkTargetDatabaseSchemas: mocks.checkTargetSchemas,
   formatSchemaRefusalLines: mocks.formatSchemaRefusalLines,
   hasSchemaRefusal: mocks.hasSchemaRefusal,

--- a/src/infra/update-runner-git-target.ts
+++ b/src/infra/update-runner-git-target.ts
@@ -49,6 +49,7 @@ export async function prepareGitMutation(params: {
 }): Promise<{
   allowGatewayServiceRepair?: boolean;
   allowGatewayActivation?: boolean;
+  deferDoctor?: boolean;
 }> {
   const target = await readGitTargetSchemaVersions(params);
   const preparation = await params.beforeGitMutation?.(

--- a/src/infra/update-runner-git.ts
+++ b/src/infra/update-runner-git.ts
@@ -103,6 +103,7 @@ export async function updateGitCheckout(params: {
   let mutationPrepared = false;
   let runtimeMutationStarted = false;
   let stateMigrationStarted = false;
+  let deferDoctor = false;
   let recovery = await verifyGitUpdateRecovery({ root: gitRoot, sha: beforeSha });
   const prepareMutation = async (revision: string) => {
     const preparation = await prepareGitMutation({
@@ -113,6 +114,7 @@ export async function updateGitCheckout(params: {
       beforeGitMutation: opts.beforeGitMutation,
     });
     mutationPrepared = true;
+    deferDoctor = preparation.deferDoctor === true;
     allowGatewayServiceRepair = preparation.allowGatewayServiceRepair ?? allowGatewayServiceRepair;
     allowGatewayActivation = preparation.allowGatewayActivation ?? allowGatewayActivation;
     recovery = { serviceRestartSafe: false, reason: "runtime-verification-failed" };
@@ -495,35 +497,38 @@ export async function updateGitCheckout(params: {
       });
       return await rollbackError("doctor-entry-missing");
     }
-    const doctorNodePath = await resolveStableNodePath(process.execPath);
-    const doctorTargetVersion = await readPackageVersion(gitRoot);
-    const doctorPolicy = resolveUpdateDoctorExecutionPolicy({
-      targetVersion: doctorTargetVersion,
-      allowGatewayServiceRepair,
-    });
-    stateMigrationStarted = true;
-    recovery = { serviceRestartSafe: false, reason: "state-migration-started" };
-    const doctorStep = await runStep(
-      step(
-        "openclaw doctor",
-        [
-          doctorNodePath,
-          doctorEntry,
-          "doctor",
-          "--non-interactive",
-          ...(doctorPolicy.fix ? ["--fix"] : []),
-        ],
-        gitRoot,
-        buildUpdateDoctorEnv({
-          allowGatewayServiceRepair,
-          allowGatewayActivation,
-          serviceRepairPolicy: doctorPolicy.serviceRepairPolicy,
-          deferConfiguredPluginInstallRepair: opts.deferConfiguredPluginInstallRepair,
-        }),
-      ),
-    );
-    if (doctorStep.exitCode !== 0) {
-      return await rollbackError("doctor-failed");
+    // A newer schema must be migrated only after the target owns finalization.
+    if (!deferDoctor) {
+      const doctorNodePath = await resolveStableNodePath(process.execPath);
+      const doctorTargetVersion = await readPackageVersion(gitRoot);
+      const doctorPolicy = resolveUpdateDoctorExecutionPolicy({
+        targetVersion: doctorTargetVersion,
+        allowGatewayServiceRepair,
+      });
+      stateMigrationStarted = true;
+      recovery = { serviceRestartSafe: false, reason: "state-migration-started" };
+      const doctorStep = await runStep(
+        step(
+          "openclaw doctor",
+          [
+            doctorNodePath,
+            doctorEntry,
+            "doctor",
+            "--non-interactive",
+            ...(doctorPolicy.fix ? ["--fix"] : []),
+          ],
+          gitRoot,
+          buildUpdateDoctorEnv({
+            allowGatewayServiceRepair,
+            allowGatewayActivation,
+            serviceRepairPolicy: doctorPolicy.serviceRepairPolicy,
+            deferConfiguredPluginInstallRepair: opts.deferConfiguredPluginInstallRepair,
+          }),
+        ),
+      );
+      if (doctorStep.exitCode !== 0) {
+        return await rollbackError("doctor-failed");
+      }
     }
 
     const uiHealth = await resolveControlUiAssetHealth({ root: gitRoot });
@@ -579,6 +584,7 @@ export async function updateGitCheckout(params: {
       status: "ok",
       mode: "git",
       root: gitRoot,
+      ...(deferDoctor ? { deferredDoctor: true as const } : {}),
       before: { sha: beforeSha, version: beforeVersion },
       after: {
         sha: afterShaStep.stdoutTail?.trim() ?? null,

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -38,6 +38,8 @@ export type UpdateRunResult = {
   steps: UpdateStepResult[];
   durationMs: number;
   recovery?: UpdateRecovery;
+  /** Target-owned finalization must run Doctor before activating this install. */
+  deferredDoctor?: true;
   postUpdate?: {
     plugins?: {
       status: "ok" | "warning" | "skipped" | "error";
@@ -129,6 +131,7 @@ export type UpdateRunnerOptions = {
   }) => Promise<{
     allowGatewayServiceRepair?: boolean;
     allowGatewayActivation?: boolean;
+    deferDoctor?: boolean;
   } | void>;
   timeoutMs?: number;
   runCommand?: CommandRunner;

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -2,11 +2,16 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { bundledDistPluginFile } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
+import { createUpdateRunProgress } from "../cli/update-cli/update-command-run.js";
 import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.js";
 import * as processExec from "../process/exec.js";
+import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
@@ -14,6 +19,7 @@ import { pathExists } from "../utils.js";
 import { resolveStableNodePath } from "./stable-node-path.js";
 import type { UpdateChannel } from "./update-channels.js";
 import type { DevUpdateTarget } from "./update-dev-target.js";
+import { createUpdateRun, getUpdateRun } from "./update-run-ledger.js";
 import { buildUpdateDoctorEnv } from "./update-runner-doctor.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
@@ -942,6 +948,65 @@ describe("runGatewayUpdate", () => {
     });
     expect(calls).toContain(fetchCommand);
     expect(calls.slice(calls.indexOf(fetchCommand) + 1)).toStrictEqual([]);
+  });
+
+  it("leaves a newer-schema Doctor to the fresh owner while recording update progress", async () => {
+    await setupGitPackageManagerFixture();
+    const env = { OPENCLAW_STATE_DIR: path.join(tempDir, "isolated-state") };
+    const statePath = resolveOpenClawStateSqlitePath(env);
+    const targetSchema = OPENCLAW_STATE_SCHEMA_VERSION + 1;
+    const run = createUpdateRun({ trigger: "cli" }, { env });
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const { runCommand } = createDevGitRunner({
+      onCommand(key) {
+        if (key === `git -C ${tempDir} show upstream123:package.json`) {
+          return {
+            stdout: JSON.stringify({
+              openclaw: { schemaVersions: { state: targetSchema, agent: 0 } },
+            }),
+          };
+        }
+        if (key === doctorCommand) {
+          // The updated Doctor changes the shared file before the old runner's
+          // completion callback records this step with its loaded schema code.
+          const db = new DatabaseSync(statePath);
+          try {
+            db.exec(`PRAGMA user_version = ${targetSchema}`);
+          } finally {
+            db.close();
+          }
+        }
+        return undefined;
+      },
+    });
+    try {
+      const result = await runGatewayUpdate({
+        cwd: tempDir,
+        channel: "dev",
+        timeoutMs: 5_000,
+        runCommand,
+        progress: createUpdateRunProgress({ runId: run.runId, env }, {}),
+        beforeGitMutation: async ({ schemaVersions }) => ({
+          deferDoctor: (schemaVersions?.state ?? 0) > OPENCLAW_STATE_SCHEMA_VERSION,
+        }),
+      });
+
+      expect(result, JSON.stringify(result)).toMatchObject({ status: "ok", deferredDoctor: true });
+      expect(getUpdateRun(run.runId, { env })?.steps).toContainEqual(
+        expect.objectContaining({ step: "build", status: "completed" }),
+      );
+      const db = new DatabaseSync(statePath, { readOnly: true });
+      try {
+        expect(db.prepare("PRAGMA user_version").get()?.user_version).toBe(
+          OPENCLAW_STATE_SCHEMA_VERSION,
+        );
+      } finally {
+        db.close();
+      }
+    } finally {
+      closeOpenClawStateDatabaseForTest();
+    }
   });
 
   it("does not fetch tags for dev updates", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw update` could finish installing a new build but leave their Gateway stopped when the update raises the database schema version. The initiating updater kept reading and writing the update ledger after the new Doctor migrated it, causing `SqliteSchemaVersionError` before restart and final reporting.

## Why This Change Was Made

For Git and package targets with a newer state or agent schema, defer Doctor until the installed target takes ownership of finalization over private IPC. The old updater stops ledger access before the child can migrate; the updated process owns Doctor, plugin convergence, service verification, and the final outcome. Native recovery remains with its original parent, including interruption cleanup.

Same-schema updates keep their existing flow. A post-migration failure retains the updated build and does not authorize an unsafe rollback or service restart. The update guide explains this recovery boundary.

## User Impact

Once the initiating updater includes this fix, future schema upgrades can complete without stranding the Gateway solely because the old updater cannot read the migrated ledger. An updater already running older code cannot gain this protection retroactively.

## Evidence

- Started from freshly fetched `origin/main` at `e927f02952b`; the defect was still present.
- Regression run against original production code fails with `SqliteSchemaVersionError` after a synthetic schema upgrade. The repaired runner passes all 137 update-runner cases.
- Two subprocess regressions use real SQLite and the real parent progress timer across migration: both successful finalization and Doctor failure after migration settle the ledger in the updated process.
- Existing plugin lifecycle tests pass (26 cases); package executor tests pass (7 cases).
- Existing native macOS handoff tests pass (6 cases). The sandbox-only failures reproduce on the original commit; native execution passes there and on the fix.
- Top-level CLI tests pass after focused reruns of three unchanged-result-shape assertions; final native cleanup and schema handoff tests pass (15 cases).
- Built CLI smoke routes the private continuation and rejects missing IPC before database creation.
- Independent autoreview found no P0/P1 issues.

`check:changed` passed, including core/test typechecks, lint, dead-export scans, and storage/import guards. `pnpm build` passed, including CLI bootstrap, native Doctor module loading, SDK declarations, and Control UI checks.

External services and the actual Doctor migration are simulated in the subprocess regression; this branch has not been deployed to a live Gateway.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>
