### PR TITLE
fix(apple): harden native state file permissions

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawNativeState/OpenClawNativeStateSQLite.swift
@@ -1,5 +1,8 @@
 import Foundation
 import SQLite3
+#if canImport(Darwin)
+import Darwin
+#endif
 
 public struct OpenClawNativeStateError: Error, LocalizedError, Sendable {
     public let message: String
@@ -504,14 +507,14 @@ public final class OpenClawNativeStateSQLite: @unchecked Sendable {
         #if os(iOS) || os(watchOS)
         attributes[.protectionKey] = FileProtectionType.completeUntilFirstUserAuthentication
         #endif
-        try fileManager.setAttributes(attributes, ofItemAtPath: url.path)
+        try self.setPrivateAttributes(attributes, atPath: url.path)
     }
 
     static func secureDatabaseFiles(
         _ databaseURL: URL,
         fileExists: (String) -> Bool = { FileManager.default.fileExists(atPath: $0) },
         setAttributes: ([FileAttributeKey: Any], String) throws -> Void = {
-            try FileManager.default.setAttributes($0, ofItemAtPath: $1)
+            try OpenClawNativeStateSQLite.setPrivateAttributes($0, atPath: $1)
         }) throws
     {
         for (url, isTransient) in [
@@ -532,6 +535,71 @@ public final class OpenClawNativeStateSQLite: @unchecked Sendable {
                 continue
             }
         }
+    }
+
+    private static func setPrivateAttributes(_ attributes: [FileAttributeKey: Any], atPath path: String) throws {
+        try FileManager.default.setAttributes(attributes, ofItemAtPath: path)
+        #if canImport(Darwin)
+        guard let security = filesec_init() else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        defer { filesec_free(security) }
+        // Do not open and close another database descriptor: that can release SQLite's POSIX locks.
+        var metadata = stat()
+        guard statx_np(path, &metadata, security) == 0 else {
+            if errno == ENOTSUP || errno == EOPNOTSUPP { return }
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        guard metadata.st_uid == geteuid() else { return }
+        var storedACL: acl_t?
+        guard filesec_get_property(security, FILESEC_ACL, &storedACL) == 0 else {
+            // Unlike a failed stat, a missing ACL property means the existing object has no ACL.
+            if errno == ENOENT || errno == ENOTSUP || errno == EOPNOTSUPP { return }
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        guard let acl = storedACL else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(EINVAL))
+        }
+        defer { acl_free(UnsafeMutableRawPointer(acl)) }
+        var flags: acl_flagset_t?
+        guard acl_get_flagset_np(UnsafeMutableRawPointer(acl), &flags) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        let hasFlags = acl_get_flag_np(flags, acl_flag_t(rawValue: .max))
+        guard hasFlags >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        // Empty ACLs can lose their ACL-level inheritance flags when persisted.
+        guard hasFlags == 0 else { return }
+
+        // Mixed ACLs can depend on allow-before-deny ordering, even for the owner.
+        var index: Int32 = 0
+        while true {
+            var entry: acl_entry_t?
+            guard acl_get_entry(acl, index, &entry) == 0 else {
+                guard errno == EINVAL else {
+                    throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+                }
+                break
+            }
+            var tag = ACL_UNDEFINED_TAG
+            guard acl_get_tag_type(entry, &tag) == 0 else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+            }
+            guard tag == ACL_EXTENDED_ALLOW else { return }
+            index += 1
+        }
+        guard index > 0 else { return }
+        for _ in 0..<index {
+            var entry: acl_entry_t?
+            guard acl_get_entry(acl, 0, &entry) == 0, acl_delete_entry(acl, entry) == 0 else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+            }
+        }
+        if acl_set_file(path, ACL_TYPE_EXTENDED, acl) != 0, errno != ENOTSUP, errno != EOPNOTSUPP {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        #endif
     }
 
     private static func isMissingFileError(_ error: Error) -> Bool {

--- a/apps/shared/OpenClawKit/Tests/OpenClawNativeStateTests/OpenClawNativeStateSQLiteTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawNativeStateTests/OpenClawNativeStateSQLiteTests.swift
@@ -1,6 +1,10 @@
 import Foundation
 import Testing
 @testable import OpenClawNativeState
+#if canImport(Darwin)
+import Darwin
+import Darwin.membership
+#endif
 
 struct OpenClawNativeStateSQLiteTests {
     @Test
@@ -110,8 +114,11 @@ struct OpenClawNativeStateSQLiteTests {
             "SELECT COUNT(*) FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%'") == 4)
     }
 
-    @Test
-    func `vanished transient sidecar does not fail committed write cleanup`() throws {
+    @Test(arguments: [
+        NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError),
+        NSError(domain: NSPOSIXErrorDomain, code: Int(POSIXErrorCode.ENOENT.rawValue)),
+    ])
+    func `vanished transient sidecar does not fail committed write cleanup`(missing: NSError) throws {
         let databaseURL = URL(fileURLWithPath: "/tmp/openclaw-native-state.sqlite")
         var attemptedPaths: [String] = []
 
@@ -121,7 +128,7 @@ struct OpenClawNativeStateSQLiteTests {
             setAttributes: { _, path in
                 attemptedPaths.append(path)
                 if path.hasSuffix("-wal") {
-                    throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError)
+                    throw missing
                 }
             })
 
@@ -132,6 +139,228 @@ struct OpenClawNativeStateSQLiteTests {
             databaseURL.path + "-journal",
         ])
     }
+
+    #if canImport(Darwin)
+    @Test
+    func `new private state removes inherited grants without changing ancestors`() throws {
+        let ancestor = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: ancestor, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: ancestor) }
+        try self.installACL(at: ancestor)
+        let ancestorACL = try self.aclText(at: ancestor)
+        let sibling = ancestor.appendingPathComponent("unrelated")
+        try Data("unchanged".utf8).write(to: sibling)
+        let siblingACL = try self.aclText(at: sibling)
+
+        let parent = ancestor.appendingPathComponent("state")
+        let databaseURL = parent.appendingPathComponent("openclaw.sqlite")
+        let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+        try database.execute("PRAGMA journal_mode=WAL")
+        try database.withImmediateTransaction {
+            try database.ensureCanonicalTable(.deviceIdentities)
+        }
+
+        try self.expectPrivateMetadata(at: parent, mode: 0o700)
+        for suffix in ["", "-wal", "-shm"] {
+            try self.expectPrivateMetadata(at: URL(fileURLWithPath: databaseURL.path + suffix), mode: 0o600)
+        }
+        #expect(try self.aclText(at: ancestor) == ancestorACL)
+        #expect(try self.aclText(at: sibling) == siblingACL)
+    }
+
+    @Test(arguments: [false, true], ["WAL", "PERSIST"])
+    func `existing state removes explicit grants and preserves contents`(
+        createIfMissing: Bool,
+        journalMode: String) throws
+    {
+        let parent = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: parent) }
+        let databaseURL = parent.appendingPathComponent("openclaw.sqlite")
+        do {
+            let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+            try database.withImmediateTransaction {
+                try database.ensureCanonicalTable(.deviceIdentities)
+                try database.ensureCanonicalTable(.deviceAuthTokens)
+                try database.execute("""
+                INSERT INTO device_identities VALUES ('profile', 'device', 'public', 'private', 10, 20);
+                INSERT INTO device_auth_tokens VALUES ('device', 'operator', 'token', '["read"]', 30);
+                """)
+            }
+        }
+        try self.installACL(at: parent)
+        try self.installACL(at: databaseURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o750], ofItemAtPath: parent.path)
+        let parentACL = try self.aclText(at: parent)
+
+        let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL, createIfMissing: createIfMissing)
+        try self.expectPrivateMetadata(at: databaseURL, mode: 0o600)
+        try database.execute("PRAGMA journal_mode=\(journalMode)")
+        try database.withImmediateTransaction {
+            try database.execute("UPDATE device_identities SET updated_at_ms = 20")
+        }
+        let suffixes = journalMode == "WAL" ? ["", "-wal", "-shm"] : ["", "-journal"]
+        for suffix in suffixes {
+            try self.installACL(at: URL(fileURLWithPath: databaseURL.path + suffix))
+        }
+        try database.withImmediateTransaction {
+            try database.execute("UPDATE device_auth_tokens SET updated_at_ms = 30")
+        }
+        for suffix in suffixes {
+            try self.expectPrivateMetadata(at: URL(fileURLWithPath: databaseURL.path + suffix), mode: 0o600)
+        }
+        #expect(try database.scalarInt64("""
+        SELECT COUNT(*) FROM device_identities
+        WHERE identity_key = 'profile' AND device_id = 'device' AND public_key_pem = 'public'
+          AND private_key_pem = 'private' AND created_at_ms = 10 AND updated_at_ms = 20
+        """) == 1)
+        #expect(try database.scalarInt64("""
+        SELECT COUNT(*) FROM device_auth_tokens
+        WHERE device_id = 'device' AND role = 'operator' AND token = 'token'
+          AND scopes_json = '["read"]' AND updated_at_ms = 30
+        """) == 1)
+        #expect(try database.scalarInt64("PRAGMA user_version") == 0)
+        if createIfMissing {
+            try self.expectPrivateMetadata(at: parent, mode: 0o700)
+        } else {
+            #expect(try self.aclText(at: parent) == parentACL)
+            #expect(try FileManager.default.attributesOfItem(atPath: parent.path)[.posixPermissions] as? Int == 0o750)
+        }
+    }
+
+    @Test(arguments: [GrantPrincipal.owner, .group, .everyone])
+    func `mixed ACL preserves ordering and owner access`(principal: GrantPrincipal) throws {
+        try self.withDatabaseURL { database, databaseURL in
+            try database.withImmediateTransaction {
+                try database.ensureCanonicalTable(.deviceIdentities)
+            }
+            try self.installACL(
+                at: databaseURL,
+                tags: [ACL_EXTENDED_ALLOW, ACL_EXTENDED_DENY],
+                principal: principal)
+            let originalACL = try self.aclText(at: databaseURL)
+            let originalBytes = try Data(contentsOf: databaseURL)
+
+            try OpenClawNativeStateSQLite.secureDatabaseFiles(databaseURL)
+
+            #expect(try self.aclText(at: databaseURL) == originalACL)
+            #expect(try Data(contentsOf: databaseURL) == originalBytes)
+            try database.withImmediateTransaction {
+                try database.execute("""
+                INSERT INTO device_identities VALUES ('profile', 'device', 'public', 'private', 10, 20)
+                """)
+            }
+            #expect(try database.scalarInt64("SELECT COUNT(*) FROM device_identities") == 1)
+            #expect(try self.aclText(at: databaseURL) == originalACL)
+        }
+    }
+
+    @Test(arguments: [ACL_FLAG_NO_INHERIT, ACL_FLAG_DEFER_INHERIT])
+    func `flagged ACL remains unchanged`(flag: acl_flag_t) throws {
+        try self.withDatabaseURL { _, databaseURL in
+            try self.installACL(at: databaseURL, flag: flag)
+            let originalACL = try self.aclText(at: databaseURL)
+
+            try OpenClawNativeStateSQLite.secureDatabaseFiles(databaseURL)
+
+            #expect(try self.aclText(at: databaseURL) == originalACL)
+            guard let acl = acl_get_file(databaseURL.path, ACL_TYPE_EXTENDED) else { throw self.aclError() }
+            defer { acl_free(UnsafeMutableRawPointer(acl)) }
+            var flags: acl_flagset_t?
+            guard acl_get_flagset_np(UnsafeMutableRawPointer(acl), &flags) == 0 else { throw self.aclError() }
+            #expect(acl_get_flag_np(flags, flag) == 1)
+        }
+    }
+
+    enum GrantPrincipal: UInt8, Sendable {
+        case owner = 0x0A
+        case everyone = 0x0C
+        case group = 0x10
+    }
+
+    private func installACL(
+        at url: URL,
+        tags: [acl_tag_t] = [ACL_EXTENDED_ALLOW, ACL_EXTENDED_ALLOW],
+        principal: GrantPrincipal = .everyone,
+        flag: acl_flag_t? = nil) throws
+    {
+        var acl = acl_init(Int32(tags.count))
+        guard acl != nil else { throw self.aclError() }
+        defer { acl_free(UnsafeMutableRawPointer(acl!)) }
+        if let flag {
+            var flags: acl_flagset_t?
+            guard acl_get_flagset_np(UnsafeMutableRawPointer(acl!), &flags) == 0,
+                  acl_add_flag_np(flags, flag) == 0
+            else { throw self.aclError() }
+        }
+        for tag in tags {
+            // Darwin's well-known principals keep the fixture independent of local accounts.
+            var qualifier: uuid_t = (
+                0xAB, 0xCD, 0xEF, 0xAB, 0xCD, 0xEF, 0xAB, 0xCD,
+                0xEF, 0xAB, 0xCD, 0xEF, 0, 0, 0,
+                tag == ACL_EXTENDED_ALLOW ? principal.rawValue : GrantPrincipal.everyone.rawValue)
+            if tag == ACL_EXTENDED_ALLOW, principal == .owner || principal == .group {
+                let result = principal == .owner
+                    ? mbr_uid_to_uuid(geteuid(), &qualifier)
+                    : mbr_gid_to_uuid(getegid(), &qualifier)
+                guard result == 0 else { throw NSError(domain: NSPOSIXErrorDomain, code: Int(result)) }
+            }
+            var entry: acl_entry_t?
+            guard acl_create_entry(&acl, &entry) == 0,
+                  acl_set_tag_type(entry, tag) == 0,
+                  acl_set_qualifier(entry, &qualifier) == 0
+            else { throw self.aclError() }
+            var permissions: acl_permset_t?
+            guard acl_get_permset(entry, &permissions) == 0 else { throw self.aclError() }
+            for permission in tag == ACL_EXTENDED_ALLOW
+                ? [ACL_READ_DATA, ACL_WRITE_DATA, ACL_APPEND_DATA, ACL_EXECUTE, ACL_READ_ATTRIBUTES,
+                   ACL_WRITE_ATTRIBUTES, ACL_READ_EXTATTRIBUTES, ACL_WRITE_EXTATTRIBUTES, ACL_READ_SECURITY,
+                   ACL_WRITE_SECURITY]
+                : [ACL_READ_DATA]
+            {
+                guard acl_add_perm(permissions, permission) == 0 else { throw self.aclError() }
+            }
+            var flags: acl_flagset_t?
+            guard acl_get_flagset_np(UnsafeMutableRawPointer(entry), &flags) == 0,
+                  acl_add_flag_np(flags, ACL_ENTRY_FILE_INHERIT) == 0,
+                  acl_add_flag_np(flags, ACL_ENTRY_DIRECTORY_INHERIT) == 0
+            else { throw self.aclError() }
+        }
+        guard acl_set_file(url.path, ACL_TYPE_EXTENDED, acl) == 0 else { throw self.aclError() }
+    }
+
+    private func aclText(at url: URL) throws -> String {
+        guard let acl = acl_get_file(url.path, ACL_TYPE_EXTENDED) else { throw self.aclError() }
+        defer { acl_free(UnsafeMutableRawPointer(acl)) }
+        guard let text = acl_to_text(acl, nil) else { throw self.aclError() }
+        defer { acl_free(text) }
+        return String(cString: text)
+    }
+
+    private func expectPrivateMetadata(at url: URL, mode: Int) throws {
+        #expect(try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? Int == mode)
+        guard let acl = acl_get_file(url.path, ACL_TYPE_EXTENDED) else {
+            let code = errno
+            _ = try FileManager.default.attributesOfItem(atPath: url.path)
+            #expect(code == ENOENT)
+            return
+        }
+        defer { acl_free(UnsafeMutableRawPointer(acl)) }
+        var index: Int32 = 0
+        var entry: acl_entry_t?
+        while acl_get_entry(acl, index, &entry) == 0 {
+            var tag = ACL_UNDEFINED_TAG
+            guard acl_get_tag_type(entry, &tag) == 0 else { throw self.aclError() }
+            #expect(tag != ACL_EXTENDED_ALLOW)
+            index += 1
+        }
+        guard errno == EINVAL else { throw self.aclError() }
+        #expect(index == 0)
+    }
+
+    private func aclError() -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+    #endif
 
     @Test
     func `missing database or nonmissing sidecar failure remains fatal`() {
@@ -164,11 +393,17 @@ struct OpenClawNativeStateSQLiteTests {
     private func withDatabase(
         body: (OpenClawNativeStateSQLite) throws -> Void) throws
     {
+        try self.withDatabaseURL { database, _ in try body(database) }
+    }
+
+    private func withDatabaseURL(
+        body: (OpenClawNativeStateSQLite, URL) throws -> Void) throws
+    {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }
-        let database = try OpenClawNativeStateSQLite(
-            databaseURL: directory.appendingPathComponent("openclaw.sqlite", isDirectory: false))
-        try body(database)
+        let databaseURL = directory.appendingPathComponent("openclaw.sqlite", isDirectory: false)
+        let database = try OpenClawNativeStateSQLite(databaseURL: databaseURL)
+        try body(database, databaseURL)
     }
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

The branch is in `openclaw/openclaw`, not a contributor fork.

</details>

## What Problem This Solves

Resolves a problem where native Apple state files could retain extra access grants from inherited or explicit allow-only ACLs despite owner-only POSIX permissions.

## Why This Change Was Made

The existing SQLite metadata checkpoints now remove grants only from unflagged, allow-only ACLs on objects owned by the effective user. The direct database parent is included only when the existing create-if-missing path owns its preparation.

Mixed ACLs, unrecognized entries, ACL-level flags, and delegated ownership are left unchanged. Unsupported ACL operations retain the existing mode-only behavior. This is bounded metadata hardening, not comprehensive effective-access normalization or a guarantee for ownership-disabled/custom filesystems or concurrent pathname replacement.

SQLite schema, stored identifiers and values, profiles, migrations, transaction boundaries, locking, and Apple data-protection attributes are unchanged. The repair does not open and close another descriptor for the database.

## User Impact

Native state created or opened through the existing persistence owner sheds additional allow-only ACL grants at its existing permission checkpoints. Normal stores without ACLs continue to work, and opening an existing store without create-if-missing does not change its parent directory.

## Evidence

- Focused standalone macOS proof: 11 native tests / 18 cases pass with system Swift and SQLite. The test-source copy changes only temporary-directory roots to stay inside an OS sandbox; this is not a full package test run.
- The same tests against the original source fail only the new inherited/explicit allow-only ACL assertions.
- Coverage includes real WAL and persistent-journal sidecars, unchanged identity/token rows, parent scope, mixed owner/group ACL ordering, ACL-level flags, rollback, concurrent bootstrap, and transient sidecar errors.
- An additional isolated API-fault fixture passes 13 cases for unsupported ACL operations, delegated ownership, and fatal versus transient metadata errors. These are injected API outcomes, not claims of testing every filesystem.
- The standalone persistence owner typechecks and links for iOS.
- Independent review at the exact public head, fresh P2 autoreview, and the completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139623#issuecomment-5556284697) found no actionable issues.
- [Hosted CI for head `48b076e9139a0791cdaeb861ad118b5f2b258ad2`](https://github.com/openclaw/openclaw/actions/runs/34005630210) passed, including macOS Swift release/tests and iOS release/tests.
- The hosted full OpenClawKit run passed 1,659 tests in 124 suites, including native SQLite, identity, auth, bootstrap, migration, and execution-approval coverage. The macOS app run passed 2,053 tests in 223 suites. These are the normal PR merge-ref CI runs, separate from the standalone proof above.
