### PR TITLE
fix(test): reset QA CLI exit state portably under Bun

### DIFF
--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -341,11 +341,11 @@ describe("qa cli runtime", () => {
       scenarioIds: ["channel-chat-baseline"],
     });
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     try {
       await run();
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   }
@@ -751,7 +751,7 @@ describe("qa cli runtime", () => {
 
   it("accepts a passing scenario with lower-level blocked and passing producer checks", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await writeSuiteSummary({
       run: { status: "completed" },
       counts: { total: 1, passed: 1, failed: 0, skipped: 0 },
@@ -764,15 +764,15 @@ describe("qa cli runtime", () => {
 
     try {
       await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("keeps a direct suite green for a real pass and a report-only optional tool skip", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     const optionalScenario = {
       name: "Runtime tool fixture — image_generate",
       status: "skip" as const,
@@ -788,9 +788,9 @@ describe("qa cli runtime", () => {
 
     try {
       await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -1114,7 +1114,7 @@ describe("qa cli runtime", () => {
     {
       label: "implicit profile membership",
       scenarioIds: undefined,
-      expectedExitCode: undefined,
+      expectedExitCode: 0,
       explicitScenarioSelection: false,
     },
     {
@@ -1127,7 +1127,7 @@ describe("qa cli runtime", () => {
     "keeps optional skips $label blocking semantics",
     async ({ scenarioIds, expectedExitCode, explicitScenarioSelection }) => {
       const priorExitCode = process.exitCode;
-      process.exitCode = undefined;
+      process.exitCode = 0;
       const optionalScenario = {
         name: "Runtime tool fixture — image_generate",
         status: "skip" as const,
@@ -1166,7 +1166,7 @@ describe("qa cli runtime", () => {
           explicitScenarioSelection,
         });
       } finally {
-        process.exitCode = priorExitCode;
+        process.exitCode = priorExitCode ?? 0;
       }
     },
   );
@@ -1931,7 +1931,7 @@ describe("qa cli runtime", () => {
 
   it("sets a failing exit code when the telegram summary reports failures", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await fs.writeFile(
       telegramSummaryPath,
       JSON.stringify({
@@ -1954,13 +1954,13 @@ describe("qa cli runtime", () => {
       });
       expect(process.exitCode).toBe(1);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("keeps telegram exit code clear when --allow-failures is set", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await fs.writeFile(
       telegramSummaryPath,
       JSON.stringify({
@@ -1989,9 +1989,9 @@ describe("qa cli runtime", () => {
         repoRoot: "/tmp/openclaw-repo",
         allowFailures: true,
       });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -2024,7 +2024,7 @@ describe("qa cli runtime", () => {
 
   it("sets a failing exit code when host suite scenarios fail", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await writeSuiteSummary({
       run: { status: "completed" },
       counts: { total: 1, passed: 0, failed: 1 },
@@ -2038,13 +2038,13 @@ describe("qa cli runtime", () => {
       });
       expect(process.exitCode).toBe(1);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("rejects a full host suite containing only report-only optional tool skips", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await writeSuiteSummary({
       run: { status: "completed" },
       counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
@@ -2062,15 +2062,15 @@ describe("qa cli runtime", () => {
       await expect(runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" })).rejects.toThrow(
         "did not include any executed scenarios",
       );
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("keeps full host suite exit code clear for a real pass and an optional tool skip", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     const optionalScenario = {
       name: "Runtime tool fixture — image_generate",
       status: "skip" as const,
@@ -2086,15 +2086,15 @@ describe("qa cli runtime", () => {
 
     try {
       await runQaSuiteCommand({ repoRoot: "/tmp/openclaw-repo" });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("keeps explicitly selected optional tool skips blocking", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await writeSuiteSummary({
       run: { status: "completed" },
       counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
@@ -2115,13 +2115,13 @@ describe("qa cli runtime", () => {
       });
       expect(process.exitCode).toBe(1);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("sets a failing exit code when host suite scenarios are skipped", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await writeSuiteSummary({
       run: { status: "completed" },
       counts: { total: 1, passed: 0, failed: 0, skipped: 1 },
@@ -2135,13 +2135,13 @@ describe("qa cli runtime", () => {
       });
       expect(process.exitCode).toBe(1);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
   it("keeps host suite exit code clear when --allow-failures is set", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await writeSuiteSummary({
       run: { status: "completed" },
       counts: { total: 1, passed: 0, failed: 1 },
@@ -2158,9 +2158,9 @@ describe("qa cli runtime", () => {
         repoRoot: "/tmp/openclaw-repo",
         allowFailures: true,
       });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -2224,7 +2224,7 @@ describe("qa cli runtime", () => {
 
   it("does not retry host suite runs for semantic failures", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
@@ -2259,7 +2259,7 @@ describe("qa cli runtime", () => {
       expect(runQaSuite).toHaveBeenCalledTimes(1);
       expect(process.exitCode).toBe(1);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -2322,7 +2322,7 @@ describe("qa cli runtime", () => {
 
   it("keeps parity preflight exit code clear when --allow-failures is set", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     await fs.writeFile(
       suiteSummaryPath,
       JSON.stringify({
@@ -2351,9 +2351,9 @@ describe("qa cli runtime", () => {
         preflight: true,
         allowFailures: true,
       });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -2546,7 +2546,7 @@ describe("qa cli runtime", () => {
   it("sets a failing exit code when the parity gate fails", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-parity-"));
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
 
     try {
       await fs.writeFile(
@@ -2574,7 +2574,7 @@ describe("qa cli runtime", () => {
 
       expect(process.exitCode).toBe(1);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   });
@@ -2582,7 +2582,7 @@ describe("qa cli runtime", () => {
   it("writes a runtime-axis parity report from one summary", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-runtime-parity-"));
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
 
     try {
       await fs.writeFile(
@@ -2640,7 +2640,7 @@ describe("qa cli runtime", () => {
         summary: "runtime-summary.json",
       });
 
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
       expect(stdoutWrite).toHaveBeenCalledWith(
         expect.stringContaining("QA runtime parity report:"),
       );
@@ -2648,7 +2648,7 @@ describe("qa cli runtime", () => {
         expect.stringContaining("QA runtime parity verdict: pass"),
       );
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   });
@@ -2656,7 +2656,7 @@ describe("qa cli runtime", () => {
   it("writes a runtime-axis token-efficiency report when requested", async () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-runtime-token-efficiency-"));
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
 
     try {
       await fs.writeFile(
@@ -2742,7 +2742,7 @@ describe("qa cli runtime", () => {
       ) as { aggregate?: { flaggedScenarios?: string[] } };
       expect(tokenSummary.aggregate?.flaggedScenarios).toEqual(["runtime-tool-fs-read"]);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   });
@@ -2800,7 +2800,7 @@ describe("qa cli runtime", () => {
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-tool-coverage-null-"));
     await fs.writeFile(path.join(repoRoot, "runtime-summary.json"), "null\n", "utf8");
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     try {
       await expect(
         runQaCoverageReportCommand({
@@ -2810,9 +2810,9 @@ describe("qa cli runtime", () => {
           json: true,
         }),
       ).rejects.toMatchObject({ code: "summary_not_completed" });
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   });
@@ -2866,6 +2866,7 @@ describe("qa cli runtime", () => {
 
   it("exits nonzero when tool coverage summary is missing a required runtime tool call", async () => {
     const priorExitCode = process.exitCode;
+    process.exitCode = 0;
     const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "qa-tool-coverage-"));
     try {
       await fs.writeFile(
@@ -2922,7 +2923,7 @@ describe("qa cli runtime", () => {
         "web_search missing successful codex tool call/result web_search",
       );
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
       await fs.rm(repoRoot, { recursive: true, force: true });
     }
   });
@@ -3003,15 +3004,15 @@ describe("qa cli runtime", () => {
 
   it("keeps a successful character eval exit status clear", async () => {
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     try {
       await runQaCharacterEvalCommand({ model: ["qa/candidate"] });
 
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
       expectWriteContains(stdoutWrite, "QA character eval report: /tmp/character-report.md");
       expectWriteContains(stdoutWrite, "QA character eval summary: /tmp/character-summary.json");
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -3036,7 +3037,7 @@ describe("qa cli runtime", () => {
       judgments: failure.judgments,
     });
     const priorExitCode = process.exitCode;
-    process.exitCode = undefined;
+    process.exitCode = 0;
     try {
       await runQaCharacterEvalCommand({ model: ["qa/candidate"] });
 
@@ -3045,7 +3046,7 @@ describe("qa cli runtime", () => {
       expectWriteContains(stdoutWrite, "QA character eval report: /tmp/character-report.md");
       expectWriteContains(stdoutWrite, "QA character eval summary: /tmp/character-summary.json");
     } finally {
-      process.exitCode = priorExitCode;
+      process.exitCode = priorExitCode ?? 0;
     }
   });
 
@@ -3291,7 +3292,7 @@ describe("qa cli runtime", () => {
           runner: "multipass",
           allowFailures: true,
         });
-        expect(process.exitCode).toBeUndefined();
+        expect(process.exitCode).toBe(0);
       },
     );
   });

--- a/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/cli.runtime.test.ts
@@ -80,7 +80,8 @@ describe("Telegram live QA scenario gate", () => {
 
   beforeEach(() => {
     previousExitCode = process.exitCode;
-    process.exitCode = undefined;
+    // Bun does not clear a previous failure when assigned undefined.
+    process.exitCode = 0;
     vi.clearAllMocks();
     delete process.env[SUT_COMMAND_ENV];
     tempRoot = mkdtempSync(path.join(tmpdir(), "openclaw-qa-telegram-gate-"));
@@ -94,7 +95,7 @@ describe("Telegram live QA scenario gate", () => {
   });
 
   afterEach(() => {
-    process.exitCode = previousExitCode;
+    process.exitCode = previousExitCode ?? 0;
     rmSync(tempRoot, { force: true, recursive: true });
   });
 
@@ -128,7 +129,7 @@ describe("Telegram live QA scenario gate", () => {
       providerMode: "mock-openai",
     });
 
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it("permits genuinely executed failed scenarios when failures are explicitly allowed", async () => {
@@ -139,7 +140,7 @@ describe("Telegram live QA scenario gate", () => {
       allowFailures: true,
     });
 
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it.each([
@@ -176,7 +177,7 @@ describe("Telegram live QA scenario gate", () => {
           allowFailures: true,
         }),
       ).rejects.toThrow(expected);
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     },
   );
 

--- a/src/cli/config-cli-path.test.ts
+++ b/src/cli/config-cli-path.test.ts
@@ -53,7 +53,10 @@ describe("parseConfigSetValue", () => {
 
   it("still reports JSON parse errors in strict JSON mode", () => {
     expect(() => parseConfigSetValue("not-json", true)).toThrow(
-      /(Unexpected token|Expected).*not-json/,
+      expect.objectContaining({
+        message: expect.stringContaining('Could not parse "not-json" as JSON for --strict-json.'),
+        cause: expect.any(SyntaxError),
+      }),
     );
   });
 

--- a/ui/src/e2e/phone-stale-build-recovery.test-support.test.ts
+++ b/ui/src/e2e/phone-stale-build-recovery.test-support.test.ts
@@ -51,7 +51,7 @@ describe("phone stale-build proof cleanup", () => {
     const server = await startPhoneProofServer("phone-proof-build");
     expect(server.baseUrl).toBe("http://127.0.0.1:3210/");
     const allocatedBuildDir = requireBuildDir(buildDir);
-    await expect(access(allocatedBuildDir)).resolves.toBeUndefined();
+    await access(allocatedBuildDir);
 
     await server.close();
 


### PR DESCRIPTION
## What Problem This Solves

Fixes runtime-specific failures in QA CLI and phone-cleanup tests under Bun. Assigning undefined does not reliably clear a previous process exit failure in Bun, and a successful file-access check can resolve to a different value from Node.

## Why This Change Was Made

The tests initialize success as exit code 0 and restore any captured nonzero status. Failure and scenario-selection assertions remain intact. The phone cleanup test awaits file accessibility directly without asserting its fulfillment value. The strict JSON test checks the existing OpenClaw error prefix and SyntaxError cause instead of V8-specific wording.

## User Impact

Developers can validate the same CLI outcomes and cleanup behavior under Node and Bun. Production code is unchanged.

## Evidence

- Both runtimes passed 161 general CLI cases, 16 synthetic Telegram CLI cases, and four unique phone-cleanup cases. The added config CLI correction passed all 21 cases on each runtime.
- Complete four-file changed gate and final full-candidate P0–P2 review passed.
- Node CLI and final Bun phone/Telegram runs used the supported disabled filesystem module cache after host startup I/O stalls. The interrupted cache-enabled Node attempts are not claimed as passes.
- No test timeout or assertion workaround was added. These are synthetic tests; no live Telegram service was used.
- The full Bun compatibility campaign remains in progress.
