### PR TITLE
test(config): consolidate redaction coverage

### DIFF
--- a/src/config/redact-snapshot.restore.test.ts
+++ b/src/config/redact-snapshot.restore.test.ts
@@ -1,6 +1,5 @@
 // Covers restoring redacted config snapshots into writable config values.
 
-import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { redactSnapshotTestHints as mainSchemaHints } from "../../test/helpers/config/redact-snapshot-test-hints.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
@@ -43,17 +42,6 @@ describe("restoreRedactedValues", () => {
     expect(result.gateway.auth.token).toBe("real-secret-token-value");
   });
 
-  it("preserves explicitly changed sensitive values", () => {
-    const incoming = {
-      gateway: { auth: { token: "new-token-value-from-user" } },
-    };
-    const original = {
-      gateway: { auth: { token: "old-token-value" } },
-    };
-    const result = restoreRedactedValues(incoming, original) as typeof incoming;
-    expect(result.gateway.auth.token).toBe("new-token-value-from-user");
-  });
-
   it("preserves non-sensitive fields unchanged", () => {
     const incoming = {
       ui: { seamColor: "#ff0000" },
@@ -63,7 +51,7 @@ describe("restoreRedactedValues", () => {
       ui: { seamColor: "#0088cc" },
       gateway: { port: 18789, auth: { token: "real-secret" } },
     };
-    const result = restoreRedactedValues(incoming, original) as typeof incoming;
+    const result = restoreRedactedValues(incoming, original);
     expect(result.ui.seamColor).toBe("#ff0000");
     expect(result.gateway.port).toBe(9999);
     expect(result.gateway.auth.token).toBe("real-secret");
@@ -90,7 +78,7 @@ describe("restoreRedactedValues", () => {
         },
       },
     };
-    const result = restoreRedactedValues(incoming, original) as typeof incoming;
+    const result = restoreRedactedValues(incoming, original);
     expect(result.channels.slack.accounts.ws1.botToken).toBe("original-ws1-token-value");
     expect(result.channels.slack.accounts.ws2.botToken).toBe("user-typed-new-token-value");
   });
@@ -220,16 +208,10 @@ describe("restoreRedactedValues", () => {
     };
     const snapshot = makeSnapshot(originalConfig);
     const redacted = redactConfigSnapshot(snapshot, hints);
-    const custom = (redacted.config as typeof originalConfig).custom as Record<string, string>;
-    expect(custom.myApiKey).toBe(REDACTED_SENTINEL);
-    expect(custom.displayName).toBe("My Bot");
-
-    const restored = restoreRedactedValues(
-      redacted.config,
-      snapshot.config,
-      hints,
-    ) as typeof originalConfig;
-    expect(restored).toEqual(originalConfig);
+    expect(redacted.config).toEqual({
+      custom: { myApiKey: REDACTED_SENTINEL, displayName: "My Bot" },
+    });
+    expect(restoreRedactedValues(redacted.config, snapshot.config, hints)).toEqual(originalConfig);
   });
 
   it("rejects sentinel literals even when uiHints mark the path non-sensitive", () => {
@@ -304,19 +286,11 @@ describe("restoreRedactedValues", () => {
         },
       },
     };
-    const result = restoreRedactedValues(incoming, original, hints) as typeof incoming;
-    expect(
-      expectDefined(
-        result.channels.slack.accounts[0],
-        "result.channels.slack.accounts[0] test invariant",
-      ).botToken,
-    ).toBe("original-token-first-account");
-    expect(
-      expectDefined(
-        result.channels.slack.accounts[1],
-        "result.channels.slack.accounts[1] test invariant",
-      ).botToken,
-    ).toBe("user-provided-new-token-value");
+    const result = restoreRedactedValues(incoming, original, hints);
+    expect(result.channels.slack.accounts).toEqual([
+      { botToken: "original-token-first-account" },
+      { botToken: "user-provided-new-token-value" },
+    ]);
   });
 
   describe.each([
@@ -344,33 +318,20 @@ describe("restoreRedactedValues", () => {
       expect(restored.accounts).toEqual(ids.map((id) => ({ id, token: `synthetic-${id}-token` })));
     });
 
-    it("keeps a unique owner's secret when an unidentified sibling is deleted", () => {
-      const previous = {
-        accounts: [
-          { token: "synthetic-unidentified-token" },
-          { id: "bravo", token: "synthetic-bravo-token" },
-        ],
-      };
-      const incoming = {
-        accounts: [{ id: "bravo", token: REDACTED_SENTINEL }],
-      };
-
-      expect(restoreRedactedValues(incoming, previous, hints).accounts).toEqual([
-        { id: "bravo", token: "synthetic-bravo-token" },
-      ]);
-    });
-
-    it("keeps a unique owner's secret when ambiguous sibling identities are deleted", () => {
-      const previous = {
-        accounts: [
+    it.each([
+      { kind: "unidentified", siblings: [{ token: "synthetic-unidentified-token" }] },
+      {
+        kind: "ambiguous",
+        siblings: [
           { id: "duplicate", token: "synthetic-first-duplicate-token" },
           { id: "duplicate", token: "synthetic-second-duplicate-token" },
-          { id: "bravo", token: "synthetic-bravo-token" },
         ],
+      },
+    ])("keeps a unique owner's secret when $kind siblings are deleted", ({ siblings }) => {
+      const previous = {
+        accounts: [...siblings, { id: "bravo", token: "synthetic-bravo-token" }],
       };
-      const incoming = {
-        accounts: [{ id: "bravo", token: REDACTED_SENTINEL }],
-      };
+      const incoming = { accounts: [{ id: "bravo", token: REDACTED_SENTINEL }] };
 
       expect(restoreRedactedValues(incoming, previous, hints).accounts).toEqual([
         { id: "bravo", token: "synthetic-bravo-token" },
@@ -458,81 +419,54 @@ describe("restoreRedactedValues", () => {
     it.each([
       {
         reason: "original identities are duplicated",
-        previous: [
-          { id: "duplicate", token: "synthetic-first-token" },
-          { id: "duplicate", token: "synthetic-second-token" },
-        ],
-        incoming: [
-          { id: "duplicate", token: REDACTED_SENTINEL },
-          { id: "duplicate", token: REDACTED_SENTINEL },
-        ],
+        previous: [{ id: "duplicate" }, { id: "duplicate" }],
+        incoming: [{ id: "duplicate" }, { id: "duplicate" }],
       },
       {
         reason: "incoming identities are duplicated",
-        previous: [
-          { id: "alpha", token: "synthetic-first-token" },
-          { id: "bravo", token: "synthetic-second-token" },
-        ],
-        incoming: [
-          { id: "alpha", token: REDACTED_SENTINEL },
-          { id: "alpha", token: REDACTED_SENTINEL },
-        ],
+        previous: [{ id: "alpha" }, { id: "bravo" }],
+        incoming: [{ id: "alpha" }, { id: "alpha" }],
       },
       {
         reason: "an original identity is missing",
-        previous: [
-          { id: "alpha", token: "synthetic-first-token" },
-          { token: "synthetic-second-token" },
-        ],
-        incoming: [{ id: "alpha", token: REDACTED_SENTINEL }, { token: REDACTED_SENTINEL }],
+        previous: [{ id: "alpha" }, {}],
+        incoming: [{ id: "alpha" }, {}],
       },
       {
         reason: "an incoming identity is missing",
-        previous: [
-          { id: "alpha", token: "synthetic-first-token" },
-          { id: "bravo", token: "synthetic-second-token" },
-        ],
-        incoming: [{ id: "alpha", token: REDACTED_SENTINEL }, { token: REDACTED_SENTINEL }],
+        previous: [{ id: "alpha" }, { id: "bravo" }],
+        incoming: [{ id: "alpha" }, {}],
       },
       {
         reason: "an identity is empty",
-        previous: [
-          { id: "", token: "synthetic-first-token" },
-          { id: "bravo", token: "synthetic-second-token" },
-        ],
-        incoming: [
-          { id: "", token: REDACTED_SENTINEL },
-          { id: "bravo", token: REDACTED_SENTINEL },
-        ],
+        previous: [{ id: "" }, { id: "bravo" }],
+        incoming: [{ id: "" }, { id: "bravo" }],
       },
       {
         reason: "an incoming identity is an unresolved environment placeholder",
-        previous: [
-          { id: "alpha", token: "synthetic-first-token" },
-          { id: "bravo", token: "synthetic-second-token" },
-        ],
-        incoming: [
-          { id: "${ACCOUNT_ID}", token: REDACTED_SENTINEL },
-          { id: "bravo", token: REDACTED_SENTINEL },
-        ],
+        previous: [{ id: "alpha" }, { id: "bravo" }],
+        incoming: [{ id: "${ACCOUNT_ID}" }, { id: "bravo" }],
       },
       {
         reason: "an incoming identity contains an inline environment placeholder",
-        previous: [
-          { id: "account-alpha", token: "synthetic-first-token" },
-          { id: "bravo", token: "synthetic-second-token" },
-        ],
-        incoming: [
-          { id: "account-${ACCOUNT_ID}", token: REDACTED_SENTINEL },
-          { id: "bravo", token: REDACTED_SENTINEL },
-        ],
+        previous: [{ id: "account-alpha" }, { id: "bravo" }],
+        incoming: [{ id: "account-${ACCOUNT_ID}" }, { id: "bravo" }],
       },
     ])("keeps positional restoration when $reason", ({ previous, incoming }) => {
-      const restored = restoreRedactedValues({ accounts: incoming }, { accounts: previous }, hints);
+      const restored = restoreRedactedValues(
+        { accounts: incoming.map((entry) => ({ ...entry, token: REDACTED_SENTINEL })) },
+        {
+          accounts: previous.map((entry, index) => ({
+            ...entry,
+            token: `synthetic-${index}-token`,
+          })),
+        },
+        hints,
+      );
 
       expect(restored.accounts.map((entry) => entry.token)).toEqual([
-        "synthetic-first-token",
-        "synthetic-second-token",
+        "synthetic-0-token",
+        "synthetic-1-token",
       ]);
     });
   });

--- a/src/gateway/config-get-response.test.ts
+++ b/src/gateway/config-get-response.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { REDACTED_SENTINEL, restoreRedactedValues } from "../config/redact-snapshot.js";
+import { makeSnapshot } from "../config/redact-snapshot.test-helpers.js";
 import { buildRuntimeConfigSchemaFromRegistry } from "../config/runtime-schema.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
@@ -49,30 +50,12 @@ function readConfigGetResponse(
 const activeWatcher = () => "active" as const;
 const disabledWatcher = () => "disabled" as const;
 
-function configSnapshot(sourceConfig: OpenClawConfig): ConfigFileSnapshot {
-  return {
-    path: "/tmp/openclaw.json",
-    exists: true,
-    raw: JSON.stringify(sourceConfig),
-    hash: "raw-1",
-    parsed: sourceConfig,
-    sourceConfig,
-    resolved: sourceConfig,
-    valid: true,
-    runtimeConfig: sourceConfig,
-    config: sourceConfig,
-    issues: [],
-    warnings: [],
-    legacyIssues: [],
-  } as ConfigFileSnapshot;
-}
-
 beforeEach(() => {
   invalidateConfigGetResponseCache();
   mocks.appliedConfigHash = "applied-1";
   mocks.pluginRegistryVersion = 1;
   mocks.readConfigFileSnapshot.mockReset();
-  mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot({ gateway: { port: 19_001 } }));
+  mocks.readConfigFileSnapshot.mockResolvedValue(makeSnapshot({ gateway: { port: 19_001 } }));
 });
 
 afterEach(() => {
@@ -147,7 +130,7 @@ describe("config.get response cache", () => {
     const secretPath = "plugins.entries.webhooks.config.routes.*.secret";
     expect(runtimeSchema.uiHints[secretPath]?.sensitive).toBe(true);
 
-    mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot(config));
+    mocks.readConfigFileSnapshot.mockResolvedValue(makeSnapshot(config));
     const response = await readConfigGetResponse({
       loadUiHints: () => runtimeSchema.uiHints,
     });
@@ -226,7 +209,7 @@ describe("config.get response cache", () => {
           },
         })),
       });
-      mocks.readConfigFileSnapshot.mockResolvedValue(configSnapshot(config));
+      mocks.readConfigFileSnapshot.mockResolvedValue(makeSnapshot(config));
       const response = await readConfigGetResponse({
         loadUiHints: () => buildRuntimeConfigSchemaFromRegistry(manifestRegistry, config).uiHints,
       });
@@ -301,42 +284,36 @@ describe("config.get response cache", () => {
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
   });
 
-  it("rebuilds when the active plugin metadata generation changes", async () => {
+  it.each([
+    {
+      reason: "the active plugin metadata generation changes",
+      invalidate: () => {
+        mocks.pluginRegistryVersion = 2;
+      },
+    },
+    {
+      reason: "the watcher or write path invalidates",
+      invalidate: invalidateConfigGetResponseCache,
+    },
+  ])("rebuilds when $reason", async ({ invalidate }) => {
     const loadUiHints = vi.fn(() => undefined);
     await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
 
-    mocks.pluginRegistryVersion = 2;
+    invalidate();
     await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
 
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
     expect(loadUiHints).toHaveBeenCalledTimes(2);
   });
 
-  it("rebuilds immediately after watcher or write-path invalidation", async () => {
-    const loadUiHints = vi.fn(() => undefined);
-    await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
-
-    invalidateConfigGetResponseCache();
-    await readConfigGetResponse({ getHotReloadStatus: activeWatcher, loadUiHints });
-
-    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
-  });
-
-  it("bypasses the cache when hot reload is disabled", async () => {
+  it.each([
+    { reason: "hot reload is disabled", getHotReloadStatus: disabledWatcher },
+    { reason: "no watcher status is available", getHotReloadStatus: undefined },
+  ])("bypasses the cache when $reason", async ({ getHotReloadStatus }) => {
     const loadUiHints = vi.fn(() => undefined);
 
-    await readConfigGetResponse({ getHotReloadStatus: disabledWatcher, loadUiHints });
-    await readConfigGetResponse({ getHotReloadStatus: disabledWatcher, loadUiHints });
-
-    expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
-    expect(loadUiHints).toHaveBeenCalledTimes(2);
-  });
-
-  it("bypasses the cache when no config watcher status is available", async () => {
-    const loadUiHints = vi.fn(() => undefined);
-
-    await readConfigGetResponse({ loadUiHints });
-    await readConfigGetResponse({ loadUiHints });
+    await readConfigGetResponse({ getHotReloadStatus, loadUiHints });
+    await readConfigGetResponse({ getHotReloadStatus, loadUiHints });
 
     expect(mocks.readConfigFileSnapshot).toHaveBeenCalledTimes(2);
     expect(loadUiHints).toHaveBeenCalledTimes(2);

--- a/src/system-agent/config-redaction.test.ts
+++ b/src/system-agent/config-redaction.test.ts
@@ -135,58 +135,29 @@ describe("isSystemAgentSensitiveConfigPathEmbedding", () => {
     ).toBe(true);
   });
 
-  it("redacts unknown-owner and sensitive descendant paths", () => {
-    expect(redactSystemAgentConfigPath("channels.missing.opaque.abcDEF123")).toBe(
-      "<redacted path>",
-    );
-    expect(redactSystemAgentConfigPath("plugins.entries.missing.config.opaque.abcDEF123")).toBe(
-      "<redacted path>",
-    );
-    expect(redactSystemAgentConfigPath("plugins.entries.codex.config.opaque=abcDEF123")).toBe(
-      "<redacted path>",
-    );
-    expect(redactSystemAgentConfigPath('channels.synology-chat["webhookUrl=abcDEF123"]')).toBe(
-      "<redacted path>",
-    );
-    expect(redactSystemAgentConfigPath('channels.synology-chat.accounts["prod=us"].enabled')).toBe(
-      'channels.synology-chat.accounts["prod=us"].enabled',
-    );
-    expect(
-      redactSystemAgentConfigPath(
-        'plugins.entries.codex.config.appServer.headers["Authorization=Bearer-abc"]',
-      ),
-    ).toBe("<redacted path>");
-    expect(
-      redactSystemAgentConfigPath(
-        "plugins.entries.codex.config.appServer.headers.AuthorizationabcDEF123",
-      ),
-    ).toBe("plugins.entries.codex.config.appServer.headers.AuthorizationabcDEF123");
-    expect(
-      redactSystemAgentConfigPath('plugins.entries.codex.config.appServer.headers["X-Test"]'),
-    ).toBe('plugins.entries.codex.config.appServer.headers["X-Test"]');
-    expect(
-      redactSystemAgentConfigPath('channels.synology-chat.accounts["token=prod"].enabled'),
-    ).toBe('channels.synology-chat.accounts["token=prod"].enabled');
-    expect(redactSystemAgentConfigPath('broadcast["token=prod"]')).toBe('broadcast["token=prod"]');
-    expect(redactSystemAgentConfigPath('session.identityLinks["token=prod"]')).toBe(
-      'session.identityLinks["token=prod"]',
-    );
-    expect(redactSystemAgentConfigPath('channels.modelByChannel["token=prod"].chat')).toBe(
-      'channels.modelByChannel["token=prod"].chat',
-    );
-    expect(
-      redactSystemAgentConfigPath(
-        'channels.telegram.groups["prod.guild"].topics["token=prod"].groupPolicy',
-      ),
-    ).toBe('channels.telegram.groups["prod.guild"].topics["token=prod"].groupPolicy');
-    expect(redactSystemAgentConfigPath('hooks.mappings["token=abcDEF123"].agentId')).toBe(
-      "<redacted path>",
-    );
-    expect(
-      redactSystemAgentConfigPath(
-        'channels.buzz.groups["gateway.auth.token=ACTUAL_GATEWAY_TOKEN"].enabled',
-      ),
-    ).toBe("<redacted path>");
+  it.each([
+    "channels.missing.opaque.abcDEF123",
+    "plugins.entries.missing.config.opaque.abcDEF123",
+    "plugins.entries.codex.config.opaque=abcDEF123",
+    'channels.synology-chat["webhookUrl=abcDEF123"]',
+    'plugins.entries.codex.config.appServer.headers["Authorization=Bearer-abc"]',
+    'hooks.mappings["token=abcDEF123"].agentId',
+    'channels.buzz.groups["gateway.auth.token=ACTUAL_GATEWAY_TOKEN"].enabled',
+  ])("redacts unknown-owner or secret-bearing path %s", (path) => {
+    expect(redactSystemAgentConfigPath(path)).toBe("<redacted path>");
+  });
+
+  it.each([
+    'channels.synology-chat.accounts["prod=us"].enabled',
+    "plugins.entries.codex.config.appServer.headers.AuthorizationabcDEF123",
+    'plugins.entries.codex.config.appServer.headers["X-Test"]',
+    'channels.synology-chat.accounts["token=prod"].enabled',
+    'broadcast["token=prod"]',
+    'session.identityLinks["token=prod"]',
+    'channels.modelByChannel["token=prod"].chat',
+    'channels.telegram.groups["prod.guild"].topics["token=prod"].groupPolicy',
+  ])("preserves schema-valid path %s", (path) => {
+    expect(redactSystemAgentConfigPath(path)).toBe(path);
   });
 });
 


### PR DESCRIPTION
Related: #135868, #139337

## What Problem This Solves

The config-redaction tests repeat fixture construction and assertion scaffolding, making their safety contracts harder to maintain. This is test-deslop stage 1 (config) of the maintainer-requested #135868 split campaign, covering the independent config concern F described in the decision brief (§1 and §5) and landed in #139337.

## Why This Change Was Made

Reuse the existing snapshot fixture, table-drive cache triggers and path-rendering cases, and share repeated token fields in array-identity fixtures. Remove one explicit-replacement test already covered by the retained nested-token test, and compare whole restored arrays instead of dereferencing them through assertion helpers.

Both owner-switching orders, return-to-first-config cache coverage, every public snapshot projection, URL declarations and round-trips, and SecretRef/array ownership behavior remain covered.

## User Impact

No runtime behavior changes. Tests are smaller by 118 lines: +93/-211 across three files (1,412 → 1,294 lines on the current base). Production, tooling, and docs are +0/-0. This contributes -118 to the original +94 campaign test tally, yielding -24 for that original scope. The separately added Crabbox-wrapper target (#139405, +412) makes the expanded tracked tally +388 before other lane changes.

## Evidence

All 128 focused cases in the three changed files passed after rebasing onto the graph repair (#139645), including the new Settings-save SecretRef regression from #139536. The rebase preserves that regression and uses the shared snapshot fixture. The paired full standard-directory runs used baseline `74ad6ba4f2e` with and without this test diff, the same 1,525 files, and repository test routing. Counts below include skipped cases; durations sum Vitest execution times. Cache and host load differed, so these timings are not a performance claim.

| Directory | Before: files / cases / seconds | After: files / cases / seconds |
| --- | ---: | ---: |
| `src/config` | 300 / 4,386 / 351.29 | 300 / 4,385 / 237.63 |
| `src/gateway` | 1,177 / 19,890 / 5,687.99 | 1,177 / 19,890 / 3,714.49 |
| `src/system-agent` | 48 / 897 / 1,160.26 | 48 / 911 / 608.15 |

The baseline had seven failed cases plus a suite-hook timeout in unchanged Gateway tests. The after-run had two failures in unchanged files: the large dirty-workspace clone timeout in `worker-environments/workspace-sync-tunnel.git.test.ts` (also failed before) and the public-clean startup fixture timeout in `server.startup-fixture-lifetime.test.ts` (passed before). No timeout, assertion, baseline, or expected-failure rule was weakened. These broad local failures remain documented proof limitations; exact-head CI gates landing.

The previous candidate passed the full changed-check plan and independent Codex review through P2. After main introduced the global 721/720 services-root failure, sibling PR #139645 rebalanced all logging roots into infra while preserving the cap and exactly-once coverage; its verified merge is 5b099995413589f41904cef1413c62239542aa7c. The refreshed candidate passed 128 focused cases. Fresh independent Codex branch review is scoped-clean through P2 (no actionable findings, confidence 0.95). The complete changed-check plan passed, including the compiler graph boundary, all consuming type graphs, formatting/lint, selected guards, and all three dead-export scans. This proof and the 128 focused cases ran on f54e58ba69d; the required pre-push refresh produced 88cc878f060 with byte-identical changed files and unchanged inspected owners. Exact-head CI [34008291524](https://github.com/openclaw/openclaw/actions/runs/34008291524) is green for 88cc878f060; the PR is MERGEABLE. Native Testbox-backed prepare completed successfully on the same unchanged head. The lockfile is unchanged.

Coverage retained for each consolidation:

| Removed or consolidated scaffolding | Remaining proof |
| --- | --- |
| Separate explicit sensitive-value replacement case | `src/config/redact-snapshot.restore.test.ts:60` preserves a user-supplied nested token while restoring its sibling. |
| Wildcard array dereference helpers | `src/config/redact-snapshot.restore.test.ts:265` compares both restored elements and their order. |
| Separate unidentified/ambiguous sibling fixtures | `src/config/redact-snapshot.restore.test.ts:330` retains both original sibling cases in both hint modes. |
| Repeated token fields in seven positional-restore fixtures | `src/config/redact-snapshot.restore.test.ts:455` retains every identity shape, including absent IDs, and independent expected token values. |
| Custom-hint casts and separate leaf assertions | `src/config/redact-snapshot.restore.test.ts:201` compares the full redacted object and restores the original config. |
| Fifteen repeated path-rendering assertions | `src/system-agent/config-redaction.test.ts:146` and `:159` retain every original input in redacted/preserved tables. |
| Local snapshot constructor | Existing `src/config/redact-snapshot.test-helpers.ts:20` supplies all projections; `src/gateway/config-get-response.test.ts:186` still checks every projection and raw secrecy. |
| Duplicate cache rebuild/bypass scaffolding | `src/gateway/config-get-response.test.ts:298` and `:312` retain all four triggers and filesystem/schema-work assertions. |

ClawSweeper [reviewed the current head 88cc878f060](https://github.com/openclaw/openclaw/pull/139626#issuecomment-5556314257) with no findings and no before-merge requirements. No rank-up changes were requested.

