### PR TITLE
fix(gateway): restart inside a marker-less LaunchAgent no longer kills its caller

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -140,6 +140,8 @@ openclaw gateway restart --wait 30s
 
 On Windows, a plain restart launched from a Gateway service process, including an agent's shell command, automatically uses the safe restart path. The running Gateway owns the deferred Scheduled Task handoff, so stopping its process tree cannot kill the caller before relaunch. This requires a reachable Gateway; the command acknowledges the restart request, not successor health. Use `openclaw gateway status` afterward to verify recovery.
 
+On macOS, when `openclaw gateway restart`, `stop`, `install`, or `uninstall` runs inside the managed LaunchAgent's process tree, including an agent's shell command, OpenClaw detects that from launchd's service environment or, when a hand-written plist omits those variables, from process ancestry against the PID launchd reports for the job. Restart hands off to a detached helper so `kickstart -k` cannot kill the caller. Stop, install, and uninstall refuse and ask you to run the command from an external shell.
+
 External terminals without Gateway-service markers, externally supervised Gateways, node services, and non-Windows callers keep their existing routing. Explicit `--force`, `--wait`, `--preserve-definition`, or `--skip-deferral` also retain their existing behavior and validation; they do not implicitly enable `--safe`.
 
 <Warning>

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -81,6 +81,7 @@ vi.mock("../../daemon/launchd-exec.js", async (importOriginal) => ({
 }));
 vi.mock("../../daemon/launchd-current-service.js", () => ({
   isCurrentProcessLaunchdServiceLabel: () => mocks.inLaunchd,
+  isCurrentProcessInsideLaunchdService: async () => mocks.inLaunchd,
 }));
 vi.mock("../../daemon/launchd-restart-handoff.js", () => ({
   scheduleDetachedLaunchdRestartHandoff: mocks.handoff,

--- a/src/daemon/launchd-current-service.ts
+++ b/src/daemon/launchd-current-service.ts
@@ -1,5 +1,7 @@
-/** Detects whether the current process is running inside a launchd service label. */
+/** Detects launchd service membership from environment markers or process ancestry. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getSelfAndAncestorPidsSync } from "../infra/restart-stale-pids.js";
+import { probeLaunchAgentState, resolveLaunchAgentGuiDomain } from "./launchd-runtime.js";
 
 /** Checks whether the current process appears to be running under the requested launchd label. */
 export function isCurrentProcessLaunchdServiceLabel(
@@ -30,4 +32,25 @@ export function isCurrentProcessLaunchdServiceLabel(
     normalizeOptionalString(env.OPENCLAW_SERVICE_MARKER) === "openclaw" &&
     Boolean(normalizeOptionalString(env.OPENCLAW_SERVICE_KIND))
   );
+}
+
+/**
+ * Env markers are the fast path. A hand-written plist can omit them, so the PID
+ * launchd reports for the job is checked against the caller's ancestry instead.
+ * The detached update helper's recovery CLI inherits OPENCLAW_LAUNCHD_LABEL but
+ * descends from no running Gateway, so it stays on the synchronous path.
+ */
+export async function isCurrentProcessInsideLaunchdService(
+  label: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<boolean> {
+  if (isCurrentProcessLaunchdServiceLabel(label, env)) {
+    return true;
+  }
+  // Probe failures resolve to "unknown"; only a running job has a PID to be inside.
+  const probe = await probeLaunchAgentState(`${resolveLaunchAgentGuiDomain()}/${label}`);
+  if (probe.state !== "running" || probe.runtime.pid === undefined) {
+    return false;
+  }
+  return getSelfAndAncestorPidsSync().has(probe.runtime.pid);
 }

--- a/src/daemon/launchd-install.ts
+++ b/src/daemon/launchd-install.ts
@@ -3,7 +3,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveLegacyGatewayLaunchAgentLabels } from "./constants.js";
-import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
+import { isCurrentProcessInsideLaunchdService } from "./launchd-current-service.js";
 import {
   execLaunchctl,
   formatLaunchctlResultDetail,
@@ -40,7 +40,7 @@ export async function uninstallLaunchAgent({
   env,
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
-  assertExternalLaunchAgentMutation(env, "uninstall");
+  await assertExternalLaunchAgentMutation(env, "uninstall");
   const domain = resolveLaunchAgentGuiDomain();
   const label = resolveLaunchAgentLabel(env);
   const plistPath = resolveLaunchAgentPlistPath(env);
@@ -91,22 +91,27 @@ function createLaunchAgentRemovalError(error: unknown): Error {
     `LaunchAgent removal failed${code ? ` (${code})` : ""}. Check permissions and retry.`,
   );
 }
-function currentGatewayLaunchAgentLabel(
+async function currentGatewayLaunchAgentLabel(
   targetEnv: Record<string, string | undefined>,
-): string | undefined {
+): Promise<string | undefined> {
   const configuredCurrentLabel = process.env.OPENCLAW_LAUNCHD_LABEL?.trim();
   const candidates = new Set([
     resolveLaunchAgentLabel(targetEnv),
     ...(configuredCurrentLabel ? [assertValidLaunchAgentLabel(configuredCurrentLabel)] : []),
   ]);
-  return [...candidates].find((label) => isCurrentProcessLaunchdServiceLabel(label, process.env));
+  for (const label of candidates) {
+    if (await isCurrentProcessInsideLaunchdService(label, process.env)) {
+      return label;
+    }
+  }
+  return undefined;
 }
 
-function assertExternalLaunchAgentMutation(
+async function assertExternalLaunchAgentMutation(
   env: Record<string, string | undefined>,
   action: "install" | "uninstall",
-): void {
-  const currentLabel = currentGatewayLaunchAgentLabel(env);
+): Promise<void> {
+  const currentLabel = await currentGatewayLaunchAgentLabel(env);
   if (!currentLabel) {
     return;
   }
@@ -352,7 +357,7 @@ async function activateLaunchAgent(params: {
 export async function installLaunchAgent(
   args: GatewayServiceInstallArgs,
 ): Promise<{ plistPath: string }> {
-  assertExternalLaunchAgentMutation(args.env, "install");
+  await assertExternalLaunchAgentMutation(args.env, "install");
   const targetPlistPath = resolveLaunchAgentPlistPath(args.env);
   const previousContents = await readExistingLaunchAgentPlist(targetPlistPath);
   const label = resolveLaunchAgentLabel(args.env);

--- a/src/daemon/launchd-lifecycle.ts
+++ b/src/daemon/launchd-lifecycle.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { formatPortDiagnostics } from "../infra/ports-format.js";
 import { inspectPortUsage } from "../infra/ports-inspect.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
-import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
+import { isCurrentProcessInsideLaunchdService } from "./launchd-current-service.js";
 import {
   execLaunchctl,
   formatLaunchctlResultDetail,
@@ -253,7 +253,7 @@ export async function restartLaunchAgent({
   const reportMutation = createGatewayLifecycleMutationReporter(onMutation);
   await assertNoSystemLaunchDaemonOwnership(label);
 
-  const detached = isCurrentProcessLaunchdServiceLabel(label);
+  const detached = await isCurrentProcessInsideLaunchdService(label);
   if (!detached) {
     const { port: cleanupPort, probeHosts } = await resolveLaunchAgentGatewayContext(serviceEnv);
     if (cleanupPort !== null) {

--- a/src/daemon/launchd-stop.ts
+++ b/src/daemon/launchd-stop.ts
@@ -4,7 +4,7 @@ import { inspectPortUsage } from "../infra/ports-inspect.js";
 import { probePortUsage } from "../infra/ports-probe.js";
 import { cleanStaleGatewayProcessesSync } from "../infra/restart-stale-pids.js";
 import { sleep } from "../utils.js";
-import { isCurrentProcessLaunchdServiceLabel } from "./launchd-current-service.js";
+import { isCurrentProcessInsideLaunchdService } from "./launchd-current-service.js";
 import {
   execLaunchctl,
   formatLaunchctlResultDetail,
@@ -89,7 +89,7 @@ export async function stopLaunchAgent({
   const serviceTarget = `${domain}/${label}`;
   const reportMutation = createGatewayLifecycleMutationReporter(onMutation);
 
-  if (isCurrentProcessLaunchdServiceLabel(label, process.env)) {
+  if (await isCurrentProcessInsideLaunchdService(label, process.env)) {
     throw new Error(
       `Refusing to stop LaunchAgent ${label} from inside the same launchd service; run this command from an external shell.`,
     );
@@ -170,7 +170,7 @@ export async function parkCurrentLaunchAgentForMaintenance(
   const serviceEnv = params.env ?? (process.env as GatewayServiceEnv);
   const domain = resolveLaunchAgentGuiDomain();
   const label = resolveLaunchAgentLabel(serviceEnv);
-  if (!isCurrentProcessLaunchdServiceLabel(label, process.env)) {
+  if (!(await isCurrentProcessInsideLaunchdService(label, process.env))) {
     return false;
   }
   const serviceTarget = `${domain}/${label}`;

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -107,6 +107,7 @@ type CleanStaleGatewayProcessesOptions = {
 const cleanStaleGatewayProcessesSync = vi.hoisted(() =>
   vi.fn<(port?: number, options?: CleanStaleGatewayProcessesOptions) => number[]>(() => []),
 );
+const getSelfAndAncestorPidsSync = vi.hoisted(() => vi.fn<() => Set<number>>());
 const launchctlSpawnSync = vi.hoisted(() => vi.fn());
 const inspectPortUsage = vi.hoisted(() =>
   vi.fn<typeof import("../infra/ports-inspect.js").inspectPortUsage>(async () => ({
@@ -566,6 +567,7 @@ vi.mock("./launchd-system.js", () => ({
 }));
 
 vi.mock("../infra/restart-stale-pids.js", () => ({
+  getSelfAndAncestorPidsSync,
   cleanStaleGatewayProcessesSync: (port?: number, options?: CleanStaleGatewayProcessesOptions) =>
     options === undefined
       ? cleanStaleGatewayProcessesSync(port)
@@ -726,6 +728,8 @@ beforeEach(() => {
     return { ...result, status: result.code, error: undefined };
   });
   cleanStaleGatewayProcessesSync.mockReset();
+  getSelfAndAncestorPidsSync.mockReset();
+  getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid]));
   cleanStaleGatewayProcessesSync.mockImplementation((_port, options) => {
     state.cleanupProtectedPids.push(options?.resolveProtectedPid?.() ?? options?.protectedPid);
     return [];
@@ -756,6 +760,182 @@ beforeEach(() => {
     serviceTarget: `system/${label}`,
   }));
   vi.clearAllMocks();
+});
+
+describe("launchd process ancestry guards", () => {
+  it.each([true, false])(
+    "restarts without env markers with a Gateway ancestor: %s",
+    async (inside) => {
+      const env = createDefaultLaunchdEnv();
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      const serviceId = `${domain}/ai.openclaw.gateway`;
+      if (inside) {
+        getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
+      }
+
+      const result = await withProcessEnv(
+        {
+          LAUNCH_JOB_LABEL: undefined,
+          LAUNCH_JOB_NAME: undefined,
+          XPC_SERVICE_NAME: undefined,
+          OPENCLAW_SERVICE_MARKER: undefined,
+          OPENCLAW_SERVICE_KIND: undefined,
+          OPENCLAW_LAUNCHD_LABEL: undefined,
+        },
+        async () => restartLaunchAgent(launchAgentControlFixture(env)),
+      );
+
+      expect(getSelfAndAncestorPidsSync).toHaveBeenCalledOnce();
+      if (inside) {
+        expect(result).toEqual({ outcome: "scheduled" });
+        expect(
+          launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff,
+        ).toHaveBeenCalledWith({
+          env,
+          mode: "kickstart",
+          waitForPid: process.pid,
+        });
+        expect(state.launchctlCalls).toStrictEqual([["print", serviceId]]);
+        expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
+      } else {
+        expect(result).toEqual({ outcome: "completed" });
+        expect(
+          launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff,
+        ).not.toHaveBeenCalled();
+        expect(state.launchctlCalls).toStrictEqual([
+          ["print", serviceId],
+          ["enable", serviceId],
+          ["kickstart", "-k", serviceId],
+        ]);
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "refuses stop without env markers with a Gateway ancestor (disable: %s)",
+    async (disable) => {
+      const env = createDefaultLaunchdEnv();
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
+
+      await withProcessEnv(
+        {
+          LAUNCH_JOB_LABEL: undefined,
+          LAUNCH_JOB_NAME: undefined,
+          XPC_SERVICE_NAME: undefined,
+          OPENCLAW_SERVICE_MARKER: undefined,
+          OPENCLAW_SERVICE_KIND: undefined,
+          OPENCLAW_LAUNCHD_LABEL: undefined,
+        },
+        async () => {
+          await expect(
+            stopLaunchAgent(launchAgentControlFixture(env, { disable })),
+          ).rejects.toThrow(
+            "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
+          );
+        },
+      );
+
+      expect(state.launchctlCalls).toEqual([["print", `${domain}/ai.openclaw.gateway`]]);
+    },
+  );
+
+  it("parks without env markers when the Gateway is an ancestor", async () => {
+    const env = createDefaultLaunchdEnv();
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_LAUNCHD_LABEL: undefined,
+      },
+      async () => {
+        await expect(parkCurrentLaunchAgentForMaintenance({ env })).resolves.toBe(true);
+      },
+    );
+
+    expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
+      ["disable", serviceId],
+    ]);
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark).toHaveBeenCalledWith({
+      env,
+      waitForPid: process.pid,
+    });
+  });
+
+  it.each(["install", "uninstall"] as const)(
+    "refuses %s without env markers with a Gateway ancestor",
+    async (action) => {
+      const env = createDefaultLaunchdEnv();
+      const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+      const serviceId = `${domain}/ai.openclaw.gateway`;
+      state.serviceStates.set(serviceId, "running");
+      getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
+
+      await withProcessEnv(
+        {
+          LAUNCH_JOB_LABEL: undefined,
+          LAUNCH_JOB_NAME: undefined,
+          XPC_SERVICE_NAME: undefined,
+          OPENCLAW_SERVICE_MARKER: undefined,
+          OPENCLAW_SERVICE_KIND: undefined,
+          OPENCLAW_LAUNCHD_LABEL: undefined,
+        },
+        async () => {
+          await expect(
+            action === "install"
+              ? installLaunchAgent(defaultLaunchAgentFixture(env))
+              : uninstallLaunchAgent(launchAgentControlFixture(env)),
+          ).rejects.toThrow(
+            `Refusing to ${action} LaunchAgent ai.openclaw.gateway from inside ai.openclaw.gateway`,
+          );
+        },
+      );
+
+      expect(state.fileWrites).toEqual([]);
+      expect(state.launchctlCalls).toEqual([["print", serviceId]]);
+    },
+  );
+
+  it("refuses install from a legacy Gateway ancestor after probing the target first", async () => {
+    const env = createDefaultLaunchdEnv();
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+    const legacyServiceId = `${domain}/ai.openclaw.legacy-gateway`;
+    state.serviceStates.set(serviceId, "not-loaded");
+    state.serviceStates.set(legacyServiceId, "running");
+    getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
+
+    await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.legacy-gateway",
+      },
+      async () => {
+        await expect(installLaunchAgent(defaultLaunchAgentFixture(env))).rejects.toThrow(
+          "Refusing to install LaunchAgent ai.openclaw.gateway from inside ai.openclaw.legacy-gateway",
+        );
+      },
+    );
+
+    expect(state.fileWrites).toEqual([]);
+    expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
+      ["print", legacyServiceId],
+    ]);
+    expect(getSelfAndAncestorPidsSync).toHaveBeenCalledOnce();
+  });
 });
 
 describe("launchd runtime parsing", () => {
@@ -1781,7 +1961,8 @@ describe("launchd install", () => {
     );
 
     expect(state.fileWrites).toEqual([]);
-    expect(state.launchctlCalls).toEqual([]);
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    expect(state.launchctlCalls).toEqual([["print", `${domain}/ai.openclaw.gateway`]]);
   });
 
   it("restores an external legacy-label owner when canonical bootstrap fails", async () => {
@@ -1813,6 +1994,7 @@ describe("launchd install", () => {
     expect(state.serviceLoaded).toBe(true);
     expect(state.serviceRunning).toBe(true);
     expect(launchctlCommandNames()).toEqual([
+      "print",
       "print",
       "print",
       "bootout",
@@ -1852,7 +2034,8 @@ describe("launchd install", () => {
     });
     state.files.set(plistPath, previous);
     state.printError = "launchctl print permission denied";
-    state.printFailuresRemaining = 1;
+    // Both the membership probe and the supervision snapshot are denied.
+    state.printFailuresRemaining = 2;
 
     await expect(
       installLaunchAgent({
@@ -1864,7 +2047,7 @@ describe("launchd install", () => {
 
     expect(state.files.get(plistPath)).toBe(previous);
     expect(state.fileWrites).toEqual([]);
-    expect(launchctlCommandNames()).toEqual(["print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print"]);
   });
 
   it("aborts before mutation when launchd has the only copy of the prior definition", async () => {
@@ -1883,7 +2066,7 @@ describe("launchd install", () => {
     expect(state.serviceLoaded).toBe(true);
     expect(state.serviceRunning).toBe(true);
     expect(state.fileWrites).toEqual([]);
-    expect(launchctlCommandNames()).toEqual(["print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print"]);
   });
 
   it("keeps a previously unloaded LaunchAgent unloaded after failed reinstall", async () => {
@@ -1910,7 +2093,7 @@ describe("launchd install", () => {
     expect(state.files.get(plistPath)).toBe(previous);
     expect(state.serviceLoaded).toBe(false);
     expect(state.serviceRunning).toBe(false);
-    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootstrap", "print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print", "enable", "bootstrap", "print"]);
   });
 
   it("removes generated artifacts after a failed fresh install", async () => {
@@ -1936,13 +2119,14 @@ describe("launchd install", () => {
     expect(state.files.has(plistPath)).toBe(false);
     expect(state.files.has(envFilePath)).toBe(false);
     expect(state.files.has(wrapperPath)).toBe(false);
-    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootstrap", "print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print", "enable", "bootstrap", "print"]);
   });
 
   it("fails closed when rollback cannot determine the replacement state", async () => {
     const env = createDefaultLaunchdEnv();
     const plistPath = resolveLaunchAgentPlistPath(env);
-    state.printNotLoadedRemaining = 1;
+    // Membership and the prior snapshot see absence; rollback sees the error.
+    state.printNotLoadedRemaining = 2;
     state.printError = "launchctl print permission denied";
     state.printFailuresRemaining = 1;
     state.bootstrapError = "Operation not permitted";
@@ -1961,7 +2145,7 @@ describe("launchd install", () => {
     expect((error as Error).cause).toBeInstanceOf(Error);
     expect(((error as Error).cause as Error).message).toContain("could not determine whether");
     expect(state.files.has(plistPath)).toBe(true);
-    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootstrap", "print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print", "enable", "bootstrap", "print"]);
   });
 
   it("restores the exact prior plist and supervision after external bootstrap failure", async () => {
@@ -2010,6 +2194,7 @@ describe("launchd install", () => {
     expect(state.serviceRunning).toBe(true);
     expect(launchctlCommandNames()).toEqual([
       "print",
+      "print",
       "bootout",
       "unload",
       "enable",
@@ -2035,7 +2220,7 @@ describe("launchd install", () => {
     await expect(stageLaunchAgent(args)).rejects.toThrow("system ownership blocked: loaded");
 
     expect(state.fileWrites).toEqual([]);
-    expect(launchctlCommandNames()).toEqual(["print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print"]);
   });
 
   it("rolls back a post-publication ownership race before activation", async () => {
@@ -2055,7 +2240,7 @@ describe("launchd install", () => {
 
     expect(launchdSystemState.assertNoSystemLaunchDaemonOwnership).toHaveBeenCalledTimes(3);
     expect(state.files.has(resolveLaunchAgentPlistPath(env))).toBe(false);
-    expect(launchctlCommandNames()).toEqual(["print"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print"]);
   });
 
   it("restores the previous plist when staged publication loses ownership", async () => {
@@ -2113,7 +2298,7 @@ describe("launchd install", () => {
         (c) => c[0] === "kickstart" && c[2] === serviceId,
       );
       expect(installKickstartIndex).toBe(-1);
-      expect(launchctlCommandNames()).toEqual(["print", "enable", "bootstrap"]);
+      expect(launchctlCommandNames()).toEqual(["print", "print", "enable", "bootstrap"]);
     },
   );
 
@@ -2140,7 +2325,7 @@ describe("launchd install", () => {
       "launchctl bootout failed during LaunchAgent install: Boot-out failed: 5: Input/output error",
     );
 
-    expect(launchctlCommandNames()).toEqual(["print", "bootout", "print", "bootout"]);
+    expect(launchctlCommandNames()).toEqual(["print", "print", "bootout", "print", "bootout"]);
   });
 
   it("writes a version-free node service description", async () => {
@@ -2496,7 +2681,10 @@ describe("launchd install", () => {
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
-    expect(state.launchctlCalls).toEqual([["bootout", serviceId]]);
+    expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
+      ["bootout", serviceId],
+    ]);
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -2555,7 +2743,9 @@ describe("launchd install", () => {
       },
     );
 
-    expect(state.launchctlCalls).toEqual([]);
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    expect(state.launchctlCalls).toEqual([["print", `${domain}/ai.openclaw.gateway`]]);
+    expect(getSelfAndAncestorPidsSync).toHaveBeenCalledOnce();
     expect(
       launchdRestartHandoffState.scheduleDetachedLaunchdMaintenancePark,
     ).not.toHaveBeenCalled();
@@ -2633,7 +2823,10 @@ describe("launchd install", () => {
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/com.example.openclaw.gateway`;
-    expect(state.launchctlCalls).toEqual([["bootout", serviceId]]);
+    expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
+      ["bootout", serviceId],
+    ]);
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -2797,6 +2990,7 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
     expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
       ["disable", serviceId],
       ["stop", "ai.openclaw.gateway"],
       ["print", serviceId],
@@ -2851,6 +3045,7 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
     expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
       ["disable", serviceId],
       ["stop", "ai.openclaw.gateway"],
       ["print", serviceId],
@@ -2961,7 +3156,7 @@ describe("launchd install", () => {
     const stdout = capturePassThroughOutput((text) => (output += text));
     let output = "";
     state.printError = "launchctl print permission denied";
-    state.printFailuresRemaining = 10;
+    state.printFailuresRemaining = 11;
 
     await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
 
@@ -2973,7 +3168,7 @@ describe("launchd install", () => {
   it("throws when launchctl print cannot confirm stop and bootout also fails (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     state.printError = "launchctl print permission denied";
-    state.printFailuresRemaining = 10;
+    state.printFailuresRemaining = 11;
     state.bootoutError = "launchctl bootout permission denied";
 
     await expect(
@@ -3060,6 +3255,7 @@ describe("launchd install", () => {
       }),
     );
     expect(state.launchctlCalls).toEqual([
+      ["print", serviceId],
       ["print", serviceId],
       ["enable", serviceId],
       ["kickstart", "-k", serviceId],
@@ -3193,7 +3389,14 @@ describe("launchd install", () => {
     expect(plist).toContain("<key>StandardInPath</key>");
     expect(plist).toContain("<string>/dev/null</string>");
     expect(plist).toContain("<string>/Users/test/Library/Logs/openclaw/gateway.log</string>");
-    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "print",
+      "enable",
+      "bootout",
+      "enable",
+      "bootstrap",
+    ]);
     expect(launchctlCommandNames()).not.toContain("kickstart");
     expect(onMutation.mock.calls).toEqual([
       [{ mode: "enable" }],
@@ -3319,7 +3522,14 @@ describe("launchd install", () => {
       restartLaunchAgent({ env, stdout: new PassThrough(), onMutation }),
     ).resolves.toEqual({ outcome: "completed" });
 
-    expect(launchctlCommandNames()).toEqual(["print", "enable", "bootout", "enable", "bootstrap"]);
+    expect(launchctlCommandNames()).toEqual([
+      "print",
+      "print",
+      "enable",
+      "bootout",
+      "enable",
+      "bootstrap",
+    ]);
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootout" });
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
   });
@@ -3351,6 +3561,7 @@ describe("launchd install", () => {
       }
 
       expect(launchctlCommandNames()).toEqual([
+        "print",
         "print",
         "enable",
         "bootout",
@@ -3501,6 +3712,7 @@ describe("launchd install", () => {
       expect(state.launchctlCalls).toEqual([
         ["print", serviceId],
         ["print", serviceId],
+        ["print", serviceId],
         ["enable", serviceId],
         ["kickstart", "-k", serviceId],
       ]);
@@ -3562,6 +3774,7 @@ describe("launchd install", () => {
         probeHosts: ["127.0.0.1"],
       });
       expect(state.launchctlCalls).toEqual([
+        ["print", serviceId],
         ["print", serviceId],
         ["print", serviceId],
       ]);
@@ -3648,7 +3861,7 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     state.kickstartError = "Input/output error";
     state.kickstartFailuresRemaining = 1;
-    state.printNotLoadedRemaining = 1;
+    state.printNotLoadedRemaining = 2;
 
     await expectRestartLaunchAgentKickstartFailure(env);
 
@@ -3756,6 +3969,7 @@ describe("launchd install", () => {
     expect(result).toEqual({ outcome: "completed" });
     expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).not.toHaveBeenCalled();
     expect(launchctlCommandNames()).toEqual([
+      "print",
       "enable",
       "kickstart",
       "enable",
@@ -3764,6 +3978,35 @@ describe("launchd install", () => {
     ]);
     expect(state.kickstartFailuresRemaining).toBe(0);
     expect(state.serviceLoaded).toBe(true);
+    expect(getSelfAndAncestorPidsSync).not.toHaveBeenCalled();
+  });
+
+  it("restarts a KeepAlive-relaunched LaunchAgent synchronously for a detached update helper", async () => {
+    const env = createDefaultLaunchdEnv();
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const serviceId = `${domain}/ai.openclaw.gateway`;
+
+    const result = await withProcessEnv(
+      {
+        LAUNCH_JOB_LABEL: undefined,
+        LAUNCH_JOB_NAME: undefined,
+        XPC_SERVICE_NAME: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+        OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.gateway",
+      },
+      async () => restartLaunchAgent(launchAgentControlFixture(env, { preserveDefinition: true })),
+    );
+
+    expect(result).toEqual({ outcome: "completed" });
+    expect(launchdRestartHandoffState.scheduleDetachedLaunchdRestartHandoff).not.toHaveBeenCalled();
+    expect(getSelfAndAncestorPidsSync).toHaveBeenCalledOnce();
+    expect(state.launchctlCalls).toStrictEqual([
+      ["print", serviceId],
+      ["enable", serviceId],
+      ["kickstart", "-k", serviceId],
+    ]);
+    expect(state.fileWrites).toEqual([]);
   });
 
   it("does not hand restart off for unrelated inherited XPC service names", async () => {

--- a/src/infra/update-managed-service-handoff-command.test-support.ts
+++ b/src/infra/update-managed-service-handoff-command.test-support.ts
@@ -68,7 +68,7 @@ export function createManagedServiceCommandFixture(params: {
               `const { register } = await import(${JSON.stringify(pathToFileURL(createRequire(import.meta.url).resolve("tsx/esm/api")).href)});`,
               // The recovery command runs from the helper's temp dir; name the repo tsconfig for path aliases.
               `register({ tsconfig: ${JSON.stringify(fileURLToPath(new URL("../../tsconfig.json", import.meta.url)))} });`,
-              `const { isCurrentProcessLaunchdServiceLabel } = await import(${JSON.stringify(new URL("../daemon/launchd-current-service.ts", import.meta.url).href)});`,
+              `const { isCurrentProcessInsideLaunchdService } = await import(${JSON.stringify(new URL("../daemon/launchd-current-service.ts", import.meta.url).href)});`,
             ]
           : []),
         `const fs = require("node:fs");`,
@@ -77,7 +77,7 @@ export function createManagedServiceCommandFixture(params: {
         `state.guardedRestart = process.argv.slice(1);`,
         ...(checksServiceIdentity
           ? [
-              `state.recoveryInsideService = isCurrentProcessLaunchdServiceLabel("ai.openclaw.gateway", process.env);`,
+              `state.recoveryInsideService = await isCurrentProcessInsideLaunchdService("ai.openclaw.gateway", process.env);`,
               `state.recoveryEnv = Object.fromEntries(["LAUNCH_JOB_LABEL", "LAUNCH_JOB_NAME", "XPC_SERVICE_NAME", "OPENCLAW_SERVICE_MARKER", "OPENCLAW_SERVICE_KIND", "OPENCLAW_LAUNCHD_LABEL"].map((key) => [key, process.env[key]]));`,
               // Reproduce the old CLI's early success while its detached restart waits for exit.
               `if (state.recoveryInsideService) {`,


### PR DESCRIPTION
Related: #139393

## What Problem This Solves

Fixes an issue where operators running `openclaw gateway restart` from inside a macOS LaunchAgent defined by a hand-written plist (one that sets `OPENCLAW_LAUNCHD_LABEL` but neither `OPENCLAW_SERVICE_MARKER`/`OPENCLAW_SERVICE_KIND` nor launchd's `LAUNCH_JOB_LABEL`/`LAUNCH_JOB_NAME`/`XPC_SERVICE_NAME`), including from an agent's shell command, would have the CLI run `launchctl kickstart -k` synchronously and kill its own caller; KeepAlive then relaunched the gateway with the restart command's outcome lost. `gateway stop`, `install`, and `uninstall` from the same position were likewise not refused. This is the tradeoff ClawSweeper flagged on #139393, which had removed the configured-label-only fallback because the detached update helper's recovery CLI inherited that label and was misdetected as in-service.

## Why This Change Was Made

In-service identity now has a second signal: the new async `isCurrentProcessInsideLaunchdService` keeps the environment check as the fast path, then reads the PID launchd reports for the job (the same `launchctl print` probe `readLaunchAgentRuntime` is built on) and treats the caller as inside the service when that PID is in `getSelfAndAncestorPidsSync()`, the way the update CLI's ancestry block already works. Restart (after the system-LaunchDaemon ownership assertion), stop, maintenance park, and the install/uninstall guard use it. The ancestry walk only runs once a running PID is known. The detached update helper's recovery command inherits `OPENCLAW_LAUNCHD_LABEL` but is reparented to launchd once the gateway exits, so no running gateway PID is in its ancestry and it stays on the synchronous path. The update-job label check intentionally keeps the env-only rule. No new config, option, or retry; production delta is +28 lines.

## User Impact

Restart from inside any managed LaunchAgent, marker-less or not, hands off to the detached helper instead of killing itself; stop, install, and uninstall refuse with the existing "run this command from an external shell" guidance. Managed-update recovery after a failed update is unchanged and still restores the service synchronously with health proof. One extra read-only `launchctl print` runs before these lifecycle commands. `docs/cli/gateway.md` documents the macOS behavior.

## Evidence

- `pnpm test src/daemon/launchd.test.ts src/daemon/launchd-current-service.test.ts src/infra/update-managed-service-handoff-lifecycle.test.ts`: launchd 180 passed (8 new ancestry-guard cases: restart handoff vs synchronous, stop refusal with and without `--disable`, park, install/uninstall refusal, legacy-label candidate, KeepAlive-relaunched service during helper recovery), current-service 4 passed, lifecycle 137 passed in the worker run. Two later lifecycle runs each dropped one variant of "transfers update ownership before CLI disconnect" at its 1 s `vi.waitFor` under host load averages of 150-250; the failing variant alternated (systemd, then launchd), that helper imports none of the changed modules, and a focused rerun of all four variants passed.
- Fail-without-fix: with the detector reduced to the env-only check, all 8 new cases fail for the intended reason (no handoff scheduled, no refusal, ancestry never consulted).
- The lifecycle recovery fixture now runs the real combined detector against the rig's fake launchctl and still reports `recoveryInsideService: false` with `service-restore` exit 0 ("restores launchd through a synchronous installed-CLI restart when the helper inherits only the configured label").
- Sibling suites: update-command-service integration 94 passed (its module mock gained the new export), handoff command/restart-handoff/launchd-recovery/install-helpers/lifecycle 141 passed, update-cli/run.option-collisions/infra-runtime/gateway-processes 495 passed.
- `node scripts/check-changed.mjs`: 37 stages passed including lint and both typecheck lanes; oxfmt, docs format check, and `git diff --check` clean. Codex autoreview (P0/P1): scoped-clean.
