### PR TITLE
chore(linux): enforce AppImage ABI floor

### DIFF
--- a/.github/workflows/linux-app.yml
+++ b/.github/workflows/linux-app.yml
@@ -88,6 +88,11 @@ jobs:
           cache-mode: restore
           install-bun: "false"
 
+      - name: Test packaged runtime ABI scanner
+        run: |
+          PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+            -s apps/linux/tests -p 'test_packaged_runtime_smoke.py'
+
       - name: Check Rust formatting
         working-directory: apps/linux/src-tauri
         run: cargo +stable fmt --check

--- a/apps/linux/tests/packaged_runtime_smoke.py
+++ b/apps/linux/tests/packaged_runtime_smoke.py
@@ -12,6 +12,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import re
 import shutil
 import signal
 import subprocess
@@ -63,6 +64,190 @@ FORBIDDEN_APPIMAGE_LIBRARY_PATTERNS = (
     "libwayland-egl.so*",
     "libwayland-server.so*",
 )
+
+ABI_LIMITS = {
+    "GLIBC": "2.35",
+    "GLIBCXX": "3.4.30",
+    # Keep the C++ and libgcc symbol ceilings paired to the GCC 12.1 runtime.
+    "CXXABI": "1.3.13",
+    "GCC": "12.0.0",
+}
+
+AMD64_ABI_ALLOWED_VARIANTS = {
+    "CXXABI": frozenset(("FLOAT128", "TM_1")),
+}
+
+
+def version_key(version):
+    return tuple(int(part) for part in version.split("."))
+
+
+def is_numeric_version(version):
+    return re.fullmatch(r"\d+(?:\.\d+)*", version) is not None
+
+
+def requirement_sort_key(version):
+    if is_numeric_version(version):
+        return (0, version_key(version), "")
+    return (1, (), version)
+
+
+def compare_versions(left, right):
+    left_parts = version_key(left)
+    right_parts = version_key(right)
+    length = max(len(left_parts), len(right_parts))
+    return (
+        left_parts + (0,) * (length - len(left_parts))
+        > right_parts + (0,) * (length - len(right_parts))
+    )
+
+
+def parse_version_needs(text, source):
+    requirements = {family: set() for family in ABI_LIMITS}
+    in_version_needs = False
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("Version needs section "):
+            in_version_needs = True
+            continue
+        if line.startswith("Version ") and " section " in line:
+            in_version_needs = False
+            continue
+        if not in_version_needs:
+            continue
+        match = re.search(r"\bName:\s*(\S+)", line)
+        if match is None:
+            continue
+        name = match.group(1)
+        family = None
+        for candidate in ABI_LIMITS:
+            prefix = f"{candidate}_"
+            if name.startswith(prefix):
+                family = candidate
+                version = name.removeprefix(prefix)
+                break
+        if family is None:
+            continue
+        if (
+            not is_numeric_version(version)
+            and version not in AMD64_ABI_ALLOWED_VARIANTS.get(family, ())
+        ):
+            raise RuntimeError(f"{source} requires unknown {family} version {name}")
+        requirements[family].add(version)
+    return {
+        family: sorted(versions, key=requirement_sort_key)
+        for family, versions in requirements.items()
+    }
+
+
+def is_regular_elf(path):
+    if path.is_symlink() or not path.is_file():
+        return False
+    with path.open("rb") as source:
+        return source.read(4) == b"\x7fELF"
+
+
+def read_abi_requirements(path, source, readelf):
+    result = subprocess.run(
+        [readelf, "--version-info", "--wide", str(path)],
+        env={**os.environ, "LC_ALL": "C"},
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        detail = result.stdout.strip().replace(str(path), source)
+        suffix = f": {detail}" if detail else ""
+        raise RuntimeError(
+            f"readelf failed for {source} with exit {result.returncode}{suffix}"
+        )
+    return parse_version_needs(result.stdout, source)
+
+
+def collect_abi_report(appimage, appdir, readelf=None):
+    readelf = readelf or shutil.which("readelf")
+    if readelf is None:
+        raise RuntimeError("readelf is required for AppImage ABI inspection")
+    if not is_regular_elf(appimage):
+        raise RuntimeError(f"{appimage.name} is not a regular ELF AppImage runtime")
+
+    candidates = [
+        {
+            "path": appimage,
+            "reportPath": appimage.name,
+            "source": "appimage-runtime",
+        }
+    ]
+    candidates.extend(
+        {
+            "path": path,
+            "reportPath": path.relative_to(appdir).as_posix(),
+            "source": "appdir",
+        }
+        for path in appdir.rglob("*")
+        if is_regular_elf(path)
+    )
+    files = []
+    for candidate in sorted(
+        candidates,
+        key=lambda item: (item["reportPath"], item["source"]),
+    ):
+        files.append(
+            {
+                "path": candidate["reportPath"],
+                "source": candidate["source"],
+                "requires": read_abi_requirements(
+                    candidate["path"],
+                    candidate["reportPath"],
+                    readelf,
+                ),
+            }
+        )
+
+    maximum_required = {}
+    for family in ABI_LIMITS:
+        versions = [
+            version
+            for entry in files
+            for version in entry["requires"][family]
+            if is_numeric_version(version)
+        ]
+        maximum_required[family] = (
+            max(versions, key=version_key) if versions else None
+        )
+    return {
+        "files": files,
+        "limits": ABI_LIMITS,
+        "maximumRequired": maximum_required,
+    }
+
+
+def write_abi_report(output, report):
+    (output / "abi.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def enforce_abi_limits(report):
+    violations = []
+    for entry in report["files"]:
+        for family, limit in ABI_LIMITS.items():
+            for version in entry["requires"][family]:
+                if not is_numeric_version(version):
+                    if version not in AMD64_ABI_ALLOWED_VARIANTS.get(family, ()):
+                        raise RuntimeError(
+                            f"{entry['path']} requires unknown {family} version "
+                            f"{family}_{version}"
+                        )
+                    continue
+                if compare_versions(version, limit):
+                    violations.append(
+                        f"{entry['path']} requires {family}_{version} (limit {family}_{limit})"
+                    )
+    if violations:
+        raise RuntimeError("AppImage ABI floor exceeded: " + "; ".join(violations))
 
 
 def write_command(output, name, command, *, cwd=None, env=None):
@@ -432,6 +617,10 @@ def main():
         for required in (apprun, binary):
             if not required.is_file():
                 raise RuntimeError(f"Missing packaged runtime file: {required.relative_to(appdir)}")
+
+        abi_report = collect_abi_report(appimage, appdir)
+        write_abi_report(output, abi_report)
+        enforce_abi_limits(abi_report)
 
         usr_lib = appdir / "usr/lib"
         forbidden_libraries = sorted(

--- a/apps/linux/tests/test_packaged_runtime_smoke.py
+++ b/apps/linux/tests/test_packaged_runtime_smoke.py
@@ -1,0 +1,256 @@
+import json
+from pathlib import Path
+import tempfile
+import textwrap
+import unittest
+
+import packaged_runtime_smoke as smoke
+
+
+def version_output(*, needs=(), definitions=()):
+    lines = [
+        "Version symbols section '.gnu.version' contains 1 entry:",
+        "  000:   0 (*local*)",
+        "Version needs section '.gnu.version_r' contains 1 entry:",
+        " Addr: 0x0  Offset: 0x0  Link: 0 (.dynstr)",
+        "  000000: Version: 1  File: libc.so.6  Cnt: 1",
+    ]
+    lines.extend(
+        f"  0x0010:   Name: {name}  Flags: none  Version: 2"
+        for name in needs
+    )
+    lines.extend(
+        [
+            "Version definition section '.gnu.version_d' contains 1 entry:",
+            " Addr: 0x0  Offset: 0x0  Link: 0 (.dynstr)",
+        ]
+    )
+    lines.extend(
+        f"  0x001c: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: {name}"
+        for name in definitions
+    )
+    return "\n".join(lines) + "\n"
+
+
+class PackagedRuntimeAbiTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.appdir = self.root / "squashfs-root"
+        self.appdir.mkdir()
+        self.readelf = self.root / "readelf"
+        self.readelf.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                from pathlib import Path
+                import sys
+
+                target = Path(sys.argv[-1])
+                if Path(f"{target}.readelf-error").exists():
+                    print(f"readelf: Error: {target}: synthetic failure")
+                    raise SystemExit(1)
+                print(Path(f"{target}.readelf").read_text(), end="")
+                """
+            )
+        )
+        self.readelf.chmod(0o755)
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_elf(self, path, output):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"\x7fELFsynthetic")
+        Path(f"{path}.readelf").write_text(output)
+        return path
+
+    def collect(self, appimage_output, appdir_outputs=()):
+        appimage = self.write_elf(
+            self.root / "OpenClaw.AppImage",
+            appimage_output,
+        )
+        for relative, output in appdir_outputs:
+            self.write_elf(self.appdir / relative, output)
+        return smoke.collect_abi_report(
+            appimage,
+            self.appdir,
+            readelf=str(self.readelf),
+        )
+
+    def test_exact_limits_pass(self):
+        report = self.collect(
+            version_output(
+                needs=(
+                    "GLIBC_2.35",
+                    "GLIBCXX_3.4.30",
+                    "CXXABI_1.3.13",
+                    "GCC_12.0.0",
+                )
+            ),
+        )
+
+        smoke.enforce_abi_limits(report)
+
+        self.assertEqual(
+            report["maximumRequired"],
+            {
+                "GLIBC": "2.35",
+                "GLIBCXX": "3.4.30",
+                "CXXABI": "1.3.13",
+                "GCC": "12.0.0",
+            },
+        )
+
+    def test_versions_above_limits_are_rejected_numerically(self):
+        for required in (
+            "GLIBC_2.36",
+            "GLIBCXX_3.4.31",
+            "CXXABI_1.3.14",
+            "GCC_13.0.0",
+        ):
+            with self.subTest(required=required):
+                report = self.collect(version_output(needs=(required,)))
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    rf"{required} .*limit ",
+                ):
+                    smoke.enforce_abi_limits(report)
+
+    def test_allowed_amd64_cxxabi_variants_pass_and_are_reported(self):
+        report = self.collect(
+            version_output(
+                needs=(
+                    "CXXABI_TM_1",
+                    "CXXABI_FLOAT128",
+                    "CXXABI_1.3.13",
+                )
+            ),
+        )
+
+        smoke.enforce_abi_limits(report)
+
+        self.assertEqual(
+            report["files"][0]["requires"]["CXXABI"],
+            ["1.3.13", "FLOAT128", "TM_1"],
+        )
+        self.assertEqual(report["maximumRequired"]["CXXABI"], "1.3.13")
+
+    def test_version_definitions_do_not_affect_requirements(self):
+        requirements = smoke.parse_version_needs(
+            version_output(
+                needs=("GLIBC_2.35",),
+                definitions=(
+                    "GLIBC_9.99",
+                    "GLIBCXX_99.0.0",
+                    "CXXABI_99.0.0",
+                    "GCC_99.0.0",
+                ),
+            ),
+            "usr/bin/openclaw-desktop",
+        )
+
+        self.assertEqual(
+            requirements,
+            {
+                "GLIBC": ["2.35"],
+                "GLIBCXX": [],
+                "CXXABI": [],
+                "GCC": [],
+            },
+        )
+
+    def test_report_includes_outer_runtime_and_sorts_relative_paths(self):
+        appimage = self.write_elf(
+            self.root / "OpenClaw.AppImage",
+            version_output(needs=("GLIBC_2.34",)),
+        )
+        self.write_elf(
+            self.appdir / "usr/lib/z.so",
+            version_output(needs=("GLIBCXX_3.4.29",)),
+        )
+        self.write_elf(
+            self.appdir / "usr/bin/a",
+            version_output(needs=("GLIBC_2.17",)),
+        )
+        (self.appdir / "usr/bin/not-elf").write_text("plain text")
+        (self.appdir / "usr/lib/z-link.so").symlink_to("z.so")
+        report = smoke.collect_abi_report(
+            appimage,
+            self.appdir,
+            readelf=str(self.readelf),
+        )
+
+        self.assertEqual(
+            [(entry["path"], entry["source"]) for entry in report["files"]],
+            [
+                ("OpenClaw.AppImage", "appimage-runtime"),
+                ("usr/bin/a", "appdir"),
+                ("usr/lib/z.so", "appdir"),
+            ],
+        )
+        self.assertNotIn(str(self.root), json.dumps(report))
+
+    def test_report_output_is_deterministic_and_written_before_rejection(self):
+        report = self.collect(
+            version_output(needs=("GLIBC_2.36",)),
+            (
+                (
+                    "usr/lib/libexample.so",
+                    version_output(needs=("GLIBC_2.17", "GLIBC_2.35")),
+                ),
+            ),
+        )
+        first = self.root / "first"
+        second = self.root / "second"
+        first.mkdir()
+        second.mkdir()
+
+        smoke.write_abi_report(first, report)
+        smoke.write_abi_report(second, report)
+        with self.assertRaisesRegex(RuntimeError, "AppImage ABI floor exceeded"):
+            smoke.enforce_abi_limits(report)
+
+        self.assertEqual(
+            (first / "abi.json").read_bytes(),
+            (second / "abi.json").read_bytes(),
+        )
+
+    def test_unknown_abi_variants_fail_closed(self):
+        for family, required in (
+            ("GLIBC", "GLIBC_ABI_DT_RELR"),
+            ("GLIBCXX", "GLIBCXX_DEBUG_MESSAGE_LENGTH"),
+            ("CXXABI", "CXXABI_FUTURE"),
+            ("CXXABI", "CXXABI_IEEE128_1.3.13"),
+            ("GCC", "GCC_PRIVATE"),
+        ):
+            with self.subTest(required=required):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    rf"unknown {family} version {required}",
+                ):
+                    smoke.parse_version_needs(
+                        version_output(needs=(required,)),
+                        "usr/lib/libc.so.6",
+                    )
+
+    def test_readelf_errors_fail_closed(self):
+        appimage = self.write_elf(
+            self.root / "OpenClaw.AppImage",
+            version_output(),
+        )
+        Path(f"{appimage}.readelf-error").touch()
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "readelf failed for OpenClaw.AppImage with exit 1",
+        ):
+            smoke.collect_abi_report(
+                appimage,
+                self.appdir,
+                readelf=str(self.readelf),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -17297,6 +17297,14 @@ it("pins simple release admission owners before selected checkout and preserves 
   expect(appImageTools).toMatch(/continuous[\s\S]*digest-pinned/u);
 
   const prLinux = parse(readFileSync(".github/workflows/linux-app.yml", "utf8"));
+  const abiScannerTest = expectDefined(
+    (prLinux.jobs.build.steps as WorkflowStep[]).find(
+      ({ name }) => name === "Test packaged runtime ABI scanner",
+    ),
+    "pull request AppImage ABI scanner test",
+  );
+  expect(abiScannerTest.run).toContain("python3 -m unittest discover");
+  expect(abiScannerTest.run).toContain("-s apps/linux/tests -p 'test_packaged_runtime_smoke.py'");
   const workflowContracts = [
     {
       job: prLinux.jobs.build,


### PR DESCRIPTION
## What Problem This Solves

Resolves a packaging gap where a dependency or build-host change could silently raise the published AMD64 AppImage's runtime ABI requirements above the documented Ubuntu 22.04 floor.

## Why This Change Was Made

The packaged-runtime smoke test now scans the outer AppImage runtime and every regular ELF in the extracted AppDir. It records only required ELF version nodes, writes deterministic `abi.json` evidence, and fails the build when `GLIBC`, `GLIBCXX`, `CXXABI`, or `GCC` requirements exceed the GCC 12.1 / Ubuntu 22.04 ceiling.

Known AMD64 GCC 12.1 C++ ABI variants are handled explicitly. Unknown version variants and `readelf` failures remain fail-closed. This does not claim RHEL/Rocky 9 support and does not change the AppImage build base or release process.

Architectural owner: the existing packaged-runtime smoke harness, which already validates the finalized AppImage payload.

Production LOC: `+0/-0`. Test and CI support: `+458/-0`.

## User Impact

Linux operators can rely on CI to prevent future AppImages from silently drifting above the documented runtime floor. There is no immediate runtime behavior change.

## Evidence

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s apps/linux/tests -p 'test_packaged_runtime_smoke.py'`: 8 passed
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts`: 453 passed, 2 skipped
- `git diff --check`: passed
- Independent P0-P2 autoreview: scoped clean
- GCC 12.1 ABI source verified for `GLIBCXX_3.4.30`, `CXXABI_1.3.13`, `CXXABI_TM_1`, `CXXABI_FLOAT128`, and `GCC_12.0.0`
