### PR TITLE
fix(ai): guard transcript-transform trim against missing ids (#137729)

### DIFF
--- a/packages/ai/src/transcript-transform.test.ts
+++ b/packages/ai/src/transcript-transform.test.ts
@@ -1,0 +1,155 @@
+import type { AssistantMessage, Message, Model, ToolCall } from "@openclaw/llm-core";
+import { describe, expect, it } from "vitest";
+import { transformMessages } from "./transcript-transform.js";
+
+const baseModel: Model = {
+  id: "test-model",
+  name: "test-model",
+  api: "openai-completions",
+  provider: "test",
+  baseUrl: "",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  maxTokens: 100,
+};
+
+function assistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "test",
+    model: "test-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+function otherModelAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+  return {
+    role: "assistant",
+    content,
+    api: "anthropic",
+    provider: "other",
+    model: "other-model",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "stop",
+    timestamp: 0,
+  };
+}
+
+describe("transcript-transform / #137729 unguarded trim", () => {
+  it("does not crash on an assistant content block without an id", () => {
+    // A runtime attachment block may carry no id even though the static union
+    // requires one; before the fix this crashed every subsequent turn.
+    const attachmentBlock = { type: "attachment", data: "x" } as unknown as ToolCall;
+    const message = assistantMessage([attachmentBlock]);
+
+    expect(() => transformMessages([message], baseModel)).not.toThrow();
+    const [out] = transformMessages([message], baseModel) as AssistantMessage[];
+    expect(out).toBeDefined();
+    const result = out as AssistantMessage;
+    expect((result.content[0] as { id?: string }).id).toBe("");
+  });
+
+  it("does not crash on a toolResult message without a toolCallId", () => {
+    const toolResult = {
+      role: "toolResult",
+      toolName: "t",
+      content: [],
+      isError: false,
+      timestamp: 0,
+    } as unknown as Message;
+
+    expect(() => transformMessages([toolResult], baseModel)).not.toThrow();
+  });
+
+  it("still trims tool call ids (regression)", () => {
+    const call: ToolCall = {
+      type: "toolCall",
+      id: "  call_1  ",
+      name: "t",
+      arguments: {},
+    };
+    const message = assistantMessage([call]);
+
+    const [out] = transformMessages([message], baseModel) as AssistantMessage[];
+    expect(out).toBeDefined();
+    const result = out as AssistantMessage;
+    expect((result.content[0] as ToolCall).id).toBe("call_1");
+  });
+
+  it("does not crash on an async toolCall with undefined id from another model", () => {
+    const asyncCall = {
+      type: "toolCall",
+      id: undefined,
+      name: "t",
+      arguments: {},
+      async: true,
+    } as unknown as ToolCall;
+    const message = otherModelAssistantMessage([asyncCall]);
+
+    expect(() => transformMessages([message], baseModel)).not.toThrow();
+  });
+
+  it("relocates async tool results with empty IDs beside their calls", () => {
+    // Async calls from a different model should have their delayed results
+    // relocated adjacent to the call, even when both IDs are empty strings.
+    // An intervening assistant turn ensures the fixture actually detects a
+    // skipped relocation — without it, the result would already be adjacent.
+    const asyncCall: ToolCall = {
+      type: "toolCall",
+      id: "",
+      name: "t",
+      arguments: {},
+      async: true,
+    };
+    const otherMessage = otherModelAssistantMessage([asyncCall]);
+    const interveningAssistant = assistantMessage([{ type: "text", text: "intervening turn" }]);
+    const toolResult: Message = {
+      role: "toolResult",
+      toolCallId: "",
+      toolName: "t",
+      content: [{ type: "text", text: "delayed result" }],
+      isError: false,
+      timestamp: 1,
+    } as unknown as Message;
+
+    const result = transformMessages([otherMessage, interveningAssistant, toolResult], baseModel);
+
+    // The toolResult should be relocated to appear immediately after the
+    // assistant message that made the async call, before the intervening turn.
+    expect(result[0]?.role).toBe("assistant");
+    expect(result[1]?.role).toBe("toolResult");
+    // Assert observable contents instead of reference identity — the transform
+    // may copy toolResult messages for non-vision models.
+    const relocatedResult = result[1] as unknown as {
+      toolCallId?: string;
+      toolName?: string;
+      content: Array<{ type: string; text?: string }>;
+      isError?: boolean;
+    };
+    expect(relocatedResult.toolCallId).toBe("");
+    expect(relocatedResult.toolName).toBe("t");
+    expect(relocatedResult.content[0]?.text).toContain("delayed result");
+    expect(relocatedResult.isError).toBe(false);
+    // The intervening assistant turn should follow the relocated result.
+    expect(result[2]?.role).toBe("assistant");
+  });
+});

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -83,7 +83,11 @@ function transformAssistant<TApi extends Api>(
       return sameModel ? block : { type: "text" as const, text: block.text };
     }
     // Pairing uses these IDs as shared keys, before model-specific normalization runs.
-    const trimmedId = block.id.trim();
+    // Runtime content blocks (e.g. attachment blocks) may carry no id even though
+    // the static union requires one; guard the trim so a missing id does not crash
+    // every subsequent turn in the session (see #137729).
+    // SAFETY: ToolCall.id is statically a required string, but runtime attachment blocks bypass the union and carry no id.
+    const trimmedId = (block as { id?: string }).id?.trim() ?? "";
     if (sameModel) {
       return trimmedId === block.id ? block : Object.assign({}, block, { id: trimmedId });
     }
@@ -116,7 +120,8 @@ export function transformMessages<TApi extends Api>(
         message.model === model.id;
       for (const block of message.content ?? []) {
         if (block.type === "toolCall") {
-          const id = block.id.trim();
+          // SAFETY: same guard as transformAssistant — runtime blocks may omit id (#137729).
+          const id = (block as { id?: string }).id?.trim() ?? "";
           if (block.async && !sameModel) {
             asyncOwners.set(id, message);
           } else {

--- a/packages/ai/src/transcript-transform.ts
+++ b/packages/ai/src/transcript-transform.ts
@@ -130,7 +130,9 @@ export function transformMessages<TApi extends Api>(
         }
       }
     } else if (message.role === "toolResult") {
-      const id = message.toolCallId.trim();
+      // SAFETY: toolCallId is statically required, but runtime toolResult messages
+      // may omit it; guard the trim so a missing id does not crash (#137729).
+      const id = (message.toolCallId ?? "").trim();
       const owner = asyncOwners.get(id);
       if (owner) {
         const results = relocated.get(owner) ?? [];
@@ -204,7 +206,8 @@ export function transformMessages<TApi extends Api>(
         };
       }
       if (message.role === "toolResult") {
-        const trimmedId = message.toolCallId.trim();
+        // SAFETY: same guard as the first pass — runtime toolResult may omit toolCallId (#137729).
+        const trimmedId = (message.toolCallId ?? "").trim();
         const toolCallId = toolCallIdMap.get(trimmedId) ?? trimmedId;
         if (toolCallId !== message.toolCallId) {
           message = { ...message, toolCallId };

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes #137729 — runtime content blocks (e.g. attachment blocks) may carry no `id` even though the static union requires one; the unguarded `.trim()` call crashes every subsequent turn in the session.

## Root Cause

`packages/ai/src/transcript-transform.ts` calls `block.id.trim()` in two places (`transformAssistant` line ~86 and `transformToolResult` line ~107). Runtime attachment blocks bypass the static `ToolCall` union and carry `id: undefined`, causing `TypeError: Cannot read properties of undefined (reading 'trim')`.

## Fix

Guard the `id` access with optional chaining: `(block as { id?: string }).id?.trim() ?? ""`.

## Additional fix (pre-existing main type drift)

Commit `f172f136` (#139753) renamed `ChatDisplayProjectionResult` properties from `streamErrorFallbackPending`/`streamErrorFallbackRepaired` to `assistantErrorPending`/`assistantErrorRecoveryObserved`, but did not update the test added by `883d4d65` (#139715) in `src/gateway/session-history-state.test.ts`. This caused a pre-existing `TS2353` type error on main that blocks all PRs triggering `check-test-types-core-2`. This PR includes the trivial 2-line property rename to unblock CI.

## Evidence

### Test results (local, 5/5 pass)
```
Test Files  1 passed (1)
Tests  5 passed (5)
```

### Tests added
1. `does not crash on an assistant content block without an id` — attachment block with no `id` doesn't crash
2. `does not crash on a toolResult message without a toolCallId` — toolResult with no `toolCallId` doesn't crash
3. `still trims tool call ids (regression)` — existing trimming behavior preserved
4. `does not crash on an async toolCall with undefined id from another model` — async cross-model call with no `id` doesn't crash
5. `relocates async tool results with empty IDs beside their calls` — asserts result contents (identifier, payload, error state) instead of reference identity; inserts an intervening assistant turn so the fixture actually detects a skipped relocation

## Bot review findings addressed
- **P2** `toBe(toolResult)` reference equality → replaced with content assertions (toolCallId, toolName, content text, isError)
- **P2** Fixture supplies already-adjacent result → inserted intervening assistant turn between call and result


<!-- rebase-trigger: 58b628103f45b761 -->