### PR TITLE
refactor(test): reuse DeepInfra HTTP request readers

### DIFF
--- a/extensions/deepinfra/image-generation-provider.test.ts
+++ b/extensions/deepinfra/image-generation-provider.test.ts
@@ -1,7 +1,8 @@
-// Deepinfra tests cover image generation provider plugin behavior.
 import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
+  requireFirstPostJsonRecordRequest,
+  requireFirstPostJsonRequest,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildDeepInfraImageGenerationProvider } from "./image-generation-provider.js";
@@ -14,22 +15,6 @@ const {
 } = getProviderHttpMocks();
 
 installProviderHttpMockCleanup();
-
-function requireFirstMockArg(mock: ReturnType<typeof vi.fn>, label: string): unknown {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label}`);
-  }
-  return call[0];
-}
-
-function requireFirstMockObjectArg(mock: ReturnType<typeof vi.fn>, label: string): object {
-  const value = requireFirstMockArg(mock, label);
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected ${label}`);
-  }
-  return value;
-}
 
 describe("deepinfra image generation provider", () => {
   beforeEach(() => {
@@ -102,7 +87,10 @@ describe("deepinfra image generation provider", () => {
       ],
     ]);
     expect(postJsonRequestMock).toHaveBeenCalledOnce();
-    const jsonRequest = requireFirstMockArg(postJsonRequestMock, "DeepInfra JSON image request");
+    const jsonRequest = requireFirstPostJsonRequest(
+      postJsonRequestMock,
+      "DeepInfra JSON image request",
+    );
     const jsonRequestHeaders = Reflect.get(jsonRequest ?? {}, "headers");
     expect(jsonRequestHeaders).toBeInstanceOf(Headers);
     expect(Object.fromEntries((jsonRequestHeaders as Headers).entries())).toEqual({
@@ -162,7 +150,7 @@ describe("deepinfra image generation provider", () => {
     });
 
     expect(postMultipartRequestMock).toHaveBeenCalledOnce();
-    const multipartRequest = requireFirstMockObjectArg(
+    const multipartRequest = requireFirstPostJsonRecordRequest(
       postMultipartRequestMock,
       "DeepInfra multipart image request",
     );


### PR DESCRIPTION
## What Problem This Solves

DeepInfra's image-provider tests duplicate two mock-request readers already exported by their existing provider HTTP test SDK import. Keeping separate copies adds maintenance without providing distinct coverage.

## Why This Change Was Made

Reuse the shared first-request and record-request readers, and remove the local copies and narrative file-header comment. Both readers return the original request object, so JSON headers, multipart FormData, and complete request-envelope assertions retain their existing meaning. The malformed-record helper diagnostic gains the shared “to be a record” suffix; no test or public error contract depends on that text.

## User Impact

No user-facing behavior changes. All three DeepInfra cases and all 24 assertions remain, including model and URL normalization, output formats, and generation-resource release. Production and shared test APIs are unchanged; test code is reduced by 12 lines.

## Evidence

Baseline and candidate each passed the same 31 cases across DeepInfra image generation, the shared image-provider owner, and Together video. All three native project invocations passed on their first attempts.

The normal configured [Linux changed-check run](https://github.com/openclaw/openclaw/actions/runs/34005660582) passed all 19 checks, including extension-test types and type-aware lint. Its delegated command exited 0, the one-shot Testbox stopped successfully, and the temporary source capsule was removed.

Independent Codex review found no actionable findings through P2. The applied source exactly matches the reviewed candidate; production and SDK files are unchanged.

The earlier exact-head CI run failed only the shared services test-root boundary and its dependent aggregate. This mechanical refresh incorporates the already-landed fix in #139645 via main `11303cff99a1600338f0375b1a71189fcb44f150`. The reviewed test patch and all relevant owner code are unchanged; fresh exact-head CI is required before landing.
