### PR TITLE
fix(ci): board widget e2e clicks are silently swallowed before the frame accepts input

### DIFF
--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -12,6 +12,7 @@ import { getGatewayE2ePortBlock } from "../../../src/gateway/test-helpers.e2e.js
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
+  clickBoardWidgetControl,
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
   installMockGateway,
@@ -227,12 +228,7 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
         .poll(() => outer.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
       expect(await outer.getAttribute("inert")).toBeNull();
-      const refresh = widgetFrame.getByText("Refresh data");
-      // Chromium can target the outer iframe just after reveal despite passing
-      // actionability checks. Await native pointer entry before the single click.
-      await refresh.hover();
-      await expect.poll(() => refresh.evaluate((element) => element.matches(":hover"))).toBe(true);
-      await refresh.click();
+      await clickBoardWidgetControl(page, widgetFrame.getByText("Refresh data"));
       await expect.poll(async () => (await gateway.getRequests("board.event")).length).toBe(1);
       expect((await gateway.getRequests("board.event"))[0]?.params).toMatchObject({
         ticket: "ticket",

--- a/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
+++ b/ui/src/e2e/chat-widget-sandbox.e2e.test.ts
@@ -15,6 +15,7 @@ import {
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import {
+  clickBoardWidgetControl,
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
   defaultControlUiFeatureMethods,
@@ -390,7 +391,7 @@ suite.define(() => {
           expect(await note.inputValue()).toBe("State survives rerenders");
           expect(await gateway.getRequests("canvas.document.view")).toHaveLength(1);
 
-          await board.getByRole("button", { name: "Record state" }).click();
+          await clickBoardWidgetControl(page, board.getByRole("button", { name: "Record state" }));
           await board.getByText("State recorded", { exact: true }).waitFor();
           expect((await gateway.getRequests("board.event"))[0]?.params).toEqual({
             ticket: "ticket",

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -210,6 +210,36 @@ export async function waitForControlUiRoute(page: Page, target: ControlUiRouteTa
 }
 
 /**
+ * Click a control inside a board widget document once pointer events reach it.
+ *
+ * Board widget frames stay `inert` and transparent until the sandbox reports
+ * the document rendered, and Linux Chromium keeps routing pointer events to the
+ * outer iframe element instead of into the revealed cross-origin document until
+ * that reveal reaches its compositor. Playwright's actionability checks read the
+ * DOM, and its hit-target interceptor reports a click that reached no frame as
+ * delivered, so a click issued in that window is a silent no-op. Hover until the
+ * widget document itself observes the pointer, then click; a control that never
+ * observes it fails loudly instead.
+ */
+export async function clickBoardWidgetControl(page: Page, control: Locator): Promise<void> {
+  const deadline = Date.now() + controlUiE2eWaitTimeoutMs;
+  for (;;) {
+    // Leave and re-enter: a stationary pointer keeps the browser's stale
+    // routing decision, while a fresh move re-runs hit testing.
+    await page.mouse.move(0, 0);
+    await control.hover();
+    if (await control.evaluate((element) => element.matches(":hover"))) {
+      break;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("Board widget control never received pointer events.");
+    }
+    await page.waitForTimeout(100);
+  }
+  await control.click();
+}
+
+/**
  * Wait for the settled in-app confirmation modal. Control UI routes destructive
  * confirms through `showConfirmDialog`, so no native browser dialog ever fires;
  * waiting for full opacity keeps the click from landing mid-animation.


### PR DESCRIPTION
## What Problem This Solves

Resolves a flake where the Control UI dashboard A2UI e2e test failed in `checks-ui-e2e` on unrelated PRs and passed on rerun. Seen 2026-09-05 on #139371, #139355 (run 33993524339), and #139384 (run 33996683994): `expected +0 to be 1` polling for the `board.event` request after clicking the widget's "Refresh data" button, with the failing variant alternating between dark and light. Each failing test was as fast as its passing sibling (~0.6–1.1 s before the poll), so it is an ordering race, not a slow-runner timeout.

## Why This Change Was Made

Since #139076 (landed the same morning) a board widget's outer iframe stays `inert` with `opacity: 0` behind a skeleton until the sandbox proxy reports `sandbox-resource-loaded`, and the frame is revealed two animation frames later. The test polled only for the renderer's custom element inside the widget document, which is defined by the bundle script *before* the inner document's `load` event fires, so the click routinely runs while the outer frame is still inert.

On the CI Chromium (the runner image's `/usr/bin/chromium-browser`, Chromium 151, selected because the Playwright browser cache restores only ~2 MB) the parent document hit-tests the inert iframe element as the target: `elementsFromPoint` returns the iframe, so Playwright's actionability checks pass, and the real `pointerdown`/`mousedown`/`click` are dispatched to the iframe element in the top document and never enter the widget. Playwright's hit-target interceptor reports "done" when no event reaches the target frame, so the click is a silent no-op and no `board.event` is ever sent. Even after `inert`/opacity are cleared, Linux keeps routing pointer events to the outer element until the compositor catches up. macOS Chromium skips inert nodes in `elementsFromPoint`, so Playwright waits there instead, which is why this never reproduces locally.

#139506 (landed while this was in flight) already waits for the outer frame's reveal and performs one hover with a `:hover` poll before the click. That converts the silent no-op into a loud failure, but a single hover cannot recover: when the first pointer move is routed to the outer iframe element, nothing re-dispatches it, so the widget document never reports `:hover` and the poll times out (its own evidence notes a hover-only candidate still failed pointer entry).

This PR moves that wait into the shared harness as `clickBoardWidgetControl(page, control)`: hover, verify the widget document reports `:hover`, and retry with a leave/re-enter pointer move (which forces fresh hit testing) until it does, bounded by `controlUiE2eWaitTimeoutMs`, then click. It keeps #139506's reveal assertions in the A2UI test and applies the helper to the sibling board widget click in `chat-widget-sandbox.e2e.test.ts`, which takes the same reveal path. No timeouts were raised and no assertions weakened.

## User Impact

No product change. The Control UI e2e harness gains `clickBoardWidgetControl`, which every test that clicks into a board widget frame should use; on the CI browser a click that never reaches the widget now retries until the widget observes the pointer and fails loudly at the wait deadline instead of passing the click and timing out on a later assertion.

## Evidence

Reproduction and proof ran on a Blacksmith Testbox through `scripts/crabbox-wrapper.mjs` (Linux, system Chromium 151, the CI browser), using a scratch copy of the test with `repeats: 40` per variant and failure diagnostics.

Before, pre-#139506 test ([Testbox run 34003022453](https://github.com/openclaw/openclaw/actions/runs/34003022453)): 9 silent-click failures across 80 iterations. Every failure recorded `inert:true, opacity:0` on the outer frame at click time, with the top document receiving `pointerdown`/`mousedown`/`click` targeted at `IFRAME.board-widget__frame` and the proxy frame receiving nothing. A minimal cross-origin-frame script on the same box lost 300/300 clicks issued immediately after clearing `inert`/`opacity:0` (DOM check already reported the iframe as the hit target), and 99/100 on fresh pages.

After, helper on the pre-#139506 test ([Testbox run 34005414551](https://github.com/openclaw/openclaw/actions/runs/34005414551)): 0 failures across the same 80 iterations (40 dark + 40 light, ~0.8 s each), and the hover-verified variant of the minimal script lost 0/300 clicks on the same browser.

Local (macOS, Chrome for Testing): 0 failures in 250 iterations before or after, matching the platform difference above.

Head-to-head on one Testbox ([run 34005936572](https://github.com/openclaw/openclaw/actions/runs/34005936572)), 40 repeats per variant each: current `main` (#139506's single hover) failed the light variant once with `expected false to be true` on its `:hover` poll, the loud form of the same routing race; this branch's helper passed 80/80.

Locally on the rebased tree: `pnpm tsgo:core:test`, `board-a2ui.e2e.test.ts`, and `chat-widget-sandbox.e2e.test.ts` pass; `node scripts/check-changed.mjs` passes; Codex autoreview (P0–P2) reported no actionable findings.
