### PR TITLE
refactor(auth): share legacy choice resolution across onboarding

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2389,7 +2389,6 @@ src/commands/agents.commands.identity.ts	1
 src/commands/agents.config.ts	1
 src/commands/agents.providers.ts	8
 src/commands/audit.ts	2
-src/commands/auth-choice-legacy.ts	2
 src/commands/auth-choice-options.ts	2
 src/commands/auth-choice-prompt.ts	1
 src/commands/auth-choice.apply.api-providers.ts	1

--- a/src/commands/auth-choice-legacy.test.ts
+++ b/src/commands/auth-choice-legacy.test.ts
@@ -25,11 +25,7 @@ vi.mock("../plugins/provider-auth-choices.js", () => ({
     manifestAuthChoices.find((choice) => choice.deprecatedChoiceIds?.includes(choiceId) === true),
 }));
 
-import {
-  formatDeprecatedNonInteractiveAuthChoiceError,
-  normalizeLegacyOnboardAuthChoice,
-  resolveDeprecatedAuthChoiceReplacement,
-} from "./auth-choice-legacy.js";
+import { resolveLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
 
 function authChoiceManifestEnv(): NodeJS.ProcessEnv {
   return {
@@ -41,23 +37,20 @@ function authChoiceManifestEnv(): NodeJS.ProcessEnv {
 
 describe("auth choice legacy aliases", () => {
   it("maps claude-cli to the new anthropic cli choice", () => {
-    const env = authChoiceManifestEnv();
-    expect(normalizeLegacyOnboardAuthChoice("claude-cli", { env })).toBe("anthropic-cli");
-    expect(resolveDeprecatedAuthChoiceReplacement("claude-cli", { env })).toEqual({
-      normalized: "anthropic-cli",
-      message: 'Auth choice "claude-cli" is deprecated; using Anthropic Claude CLI setup instead.',
+    expect(resolveLegacyOnboardAuthChoice("claude-cli", { env: authChoiceManifestEnv() })).toEqual({
+      authChoice: "anthropic-cli",
+      deprecated: {
+        message:
+          'Auth choice "claude-cli" is deprecated; using Anthropic Claude CLI setup instead.',
+        nonInteractiveError:
+          'Auth choice "claude-cli" is deprecated.\nUse "--auth-choice anthropic-cli".',
+      },
     });
-    expect(formatDeprecatedNonInteractiveAuthChoiceError("claude-cli", { env })).toBe(
-      'Auth choice "claude-cli" is deprecated.\nUse "--auth-choice anthropic-cli".',
-    );
   });
 
   it("does not keep retired Codex setup choices alive outside doctor", () => {
-    expect(normalizeLegacyOnboardAuthChoice("codex-cli", { env: authChoiceManifestEnv() })).toBe(
-      "codex-cli",
-    );
-    expect(
-      resolveDeprecatedAuthChoiceReplacement("codex-cli", { env: authChoiceManifestEnv() }),
-    ).toBeUndefined();
+    const result = resolveLegacyOnboardAuthChoice("codex-cli", { env: authChoiceManifestEnv() });
+    expect(result.authChoice).toBe("codex-cli");
+    expect(result.deprecated).toBeUndefined();
   });
 });

--- a/src/commands/auth-choice-legacy.ts
+++ b/src/commands/auth-choice-legacy.ts
@@ -5,105 +5,41 @@ import type { AuthChoice } from "./onboard-types.js";
 
 const LEGACY_REPLACEMENT_AUTH_CHOICES = new Set(["claude-cli"]);
 
-function resolveLegacyCliBackendChoice(
-  choice: string,
-  params?: {
-    config?: OpenClawConfig;
-    workspaceDir?: string;
-    env?: NodeJS.ProcessEnv;
-  },
-) {
-  if (!LEGACY_REPLACEMENT_AUTH_CHOICES.has(choice)) {
-    return undefined;
-  }
-  return resolveManifestDeprecatedProviderAuthChoice(choice, params);
-}
-
-function resolveReplacementLabel(choiceLabel: string): string {
-  return choiceLabel.trim() || "the replacement auth choice";
-}
-
-/** Map old onboard auth choices to their current provider-backed choices. */
-export function normalizeLegacyOnboardAuthChoice(
+/** Resolve a legacy choice and its diagnostics from one manifest generation. */
+export function resolveLegacyOnboardAuthChoice(
   authChoice: AuthChoice | undefined,
-  params?: {
-    config?: OpenClawConfig;
-    workspaceDir?: string;
-    env?: NodeJS.ProcessEnv;
-  },
-): AuthChoice | undefined {
-  if (authChoice === "oauth") {
-    // Pre-manifest spelling of Anthropic setup-token auth. Normalizing here is
-    // what keeps it out of the CLI choice lists: every onboard surface runs this
-    // first, so no downstream validator ever sees "oauth".
-    return "setup-token";
-  }
-  if (typeof authChoice === "string") {
-    const deprecatedChoice = resolveLegacyCliBackendChoice(authChoice, params);
-    if (deprecatedChoice) {
-      return deprecatedChoice.choiceId as AuthChoice;
-    }
-  }
-  return authChoice;
-}
-
-/** Return true when an auth choice is a deprecated provider alias. */
-export function isDeprecatedAuthChoice(
-  authChoice: AuthChoice | undefined,
-  params?: {
-    config?: OpenClawConfig;
-    workspaceDir?: string;
-    env?: NodeJS.ProcessEnv;
-  },
-): authChoice is AuthChoice {
-  return (
-    typeof authChoice === "string" && Boolean(resolveLegacyCliBackendChoice(authChoice, params))
-  );
-}
-
-/** Resolve the current replacement and warning text for a deprecated auth choice. */
-export function resolveDeprecatedAuthChoiceReplacement(
-  authChoice: AuthChoice,
   params?: {
     config?: OpenClawConfig;
     workspaceDir?: string;
     env?: NodeJS.ProcessEnv;
   },
 ):
+  | { authChoice: AuthChoice | undefined; deprecated?: undefined }
   | {
-      normalized: AuthChoice;
-      message: string;
-    }
-  | undefined {
-  if (typeof authChoice !== "string") {
-    return undefined;
+      authChoice: AuthChoice;
+      deprecated: { message: string; nonInteractiveError: string };
+    } {
+  if (authChoice === "oauth") {
+    // Pre-manifest spelling of Anthropic setup-token auth. Entry-point
+    // normalization keeps this alias out of the accepted CLI choice list.
+    return { authChoice: "setup-token" };
   }
-  const deprecatedChoice = resolveLegacyCliBackendChoice(authChoice, params);
+  if (typeof authChoice !== "string" || !LEGACY_REPLACEMENT_AUTH_CHOICES.has(authChoice)) {
+    return { authChoice };
+  }
+  const deprecatedChoice = resolveManifestDeprecatedProviderAuthChoice(authChoice, params);
   if (!deprecatedChoice) {
-    return undefined;
+    return { authChoice };
   }
-  const replacementLabel = resolveReplacementLabel(deprecatedChoice.choiceLabel);
+  const replacementLabel = deprecatedChoice.choiceLabel.trim() || "the replacement auth choice";
   return {
-    normalized: deprecatedChoice.choiceId as AuthChoice,
-    message: `Auth choice "${authChoice}" is deprecated; using ${replacementLabel} setup instead.`,
+    authChoice: deprecatedChoice.choiceId,
+    deprecated: {
+      message: `Auth choice "${authChoice}" is deprecated; using ${replacementLabel} setup instead.`,
+      nonInteractiveError: [
+        `Auth choice "${authChoice}" is deprecated.`,
+        `Use "--auth-choice ${deprecatedChoice.choiceId}".`,
+      ].join("\n"),
+    },
   };
-}
-
-/** Format the non-interactive error shown when a deprecated auth choice was supplied. */
-export function formatDeprecatedNonInteractiveAuthChoiceError(
-  authChoice: AuthChoice,
-  params?: {
-    config?: OpenClawConfig;
-    workspaceDir?: string;
-    env?: NodeJS.ProcessEnv;
-  },
-): string | undefined {
-  const replacement = resolveDeprecatedAuthChoiceReplacement(authChoice, params);
-  if (!replacement) {
-    return undefined;
-  }
-  return [
-    `Auth choice "${authChoice}" is deprecated.`,
-    `Use "--auth-choice ${replacement.normalized}".`,
-  ].join("\n");
 }

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -18,8 +18,8 @@ async function normalizeLegacyChoice(
   if (typeof authChoice !== "string") {
     return authChoice;
   }
-  const { normalizeLegacyOnboardAuthChoice } = await import("./auth-choice-legacy.js");
-  return normalizeLegacyOnboardAuthChoice(authChoice, params);
+  const { resolveLegacyOnboardAuthChoice } = await import("./auth-choice-legacy.js");
+  return resolveLegacyOnboardAuthChoice(authChoice, params).authChoice;
 }
 
 async function normalizeTokenProviderChoice(params: {

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -26,7 +26,11 @@ vi.mock("../api-keys.js", () => ({
   resolveNonInteractiveApiKey,
 }));
 
-const resolveManifestDeprecatedProviderAuthChoice = vi.hoisted(() => vi.fn(() => undefined));
+const resolveManifestDeprecatedProviderAuthChoice = vi.hoisted(() =>
+  vi.fn<
+    typeof import("../../../plugins/provider-auth-choices.js").resolveManifestDeprecatedProviderAuthChoice
+  >(() => undefined),
+);
 const resolveManifestProviderAuthChoices = vi.hoisted(() => vi.fn(() => []));
 vi.mock("../../../plugins/provider-auth-choices.js", () => ({
   resolveManifestDeprecatedProviderAuthChoice,
@@ -645,5 +649,86 @@ describe("applyNonInteractiveAuthChoice", () => {
     expect(result?.models?.providers?.["custom-models-custom-local"]?.models?.[0]?.input).toEqual([
       "text",
     ]);
+  });
+
+  it.each([
+    {
+      name: "warns before dispatching a manifest replacement",
+      authChoice: "claude-cli",
+      hasReplacement: true,
+      expectedError: undefined,
+    },
+    {
+      name: "keeps direct oauth as an unknown choice",
+      authChoice: "oauth",
+      hasReplacement: true,
+      expectedError:
+        'Unknown --auth-choice "oauth". Valid choices: custom-api-key, skip, demo-provider-api-key.',
+    },
+    {
+      name: "rejects the original alias when replacement metadata is missing",
+      authChoice: "claude-cli",
+      hasReplacement: false,
+      expectedError:
+        'Unknown --auth-choice "claude-cli". Valid choices: custom-api-key, skip, demo-provider-api-key.',
+    },
+  ])("$name", async ({ authChoice, hasReplacement, expectedError }) => {
+    const runtime = createRuntime();
+    const nextConfig: OpenClawConfig = { agents: { defaults: {} } };
+    const resolvedConfig: OpenClawConfig = { agents: { defaults: { workspace: "/tmp/resolved" } } };
+    const warning = 'Auth choice "claude-cli" is deprecated; using Fixture Provider setup instead.';
+    resolveManifestDeprecatedProviderAuthChoice.mockImplementation((choice, scope) =>
+      hasReplacement &&
+      choice === "claude-cli" &&
+      scope?.config === nextConfig &&
+      scope.workspaceDir === target.workspaceDir &&
+      scope.env === process.env
+        ? {
+            pluginId: "fixture-provider",
+            providerId: "fixture-provider",
+            methodId: "api-key",
+            choiceId: "demo-provider-api-key",
+            choiceLabel: "  Fixture Provider  ",
+            deprecatedChoiceIds: ["claude-cli"],
+          }
+        : undefined,
+    );
+    if (!expectedError) {
+      applyNonInteractivePluginProviderChoice.mockResolvedValueOnce(resolvedConfig as never);
+    }
+
+    const result = await applyNonInteractiveAuthChoice({
+      nextConfig,
+      authChoice,
+      opts: {},
+      runtime: runtime as never,
+      baseConfig: nextConfig,
+      target,
+    });
+
+    expect(writeWizardConfigFile).not.toHaveBeenCalled();
+    expect(resolveNonInteractiveApiKey).not.toHaveBeenCalled();
+    if (expectedError) {
+      expect(result).toBeNull();
+      expect(runtime.error).toHaveBeenCalledExactlyOnceWith(expectedError);
+      expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+      expect(runtime.log).not.toHaveBeenCalled();
+      expect(applyNonInteractivePluginProviderChoice).not.toHaveBeenCalled();
+      return;
+    }
+
+    expect(result).toBe(resolvedConfig);
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledExactlyOnceWith(warning);
+    expect(applyNonInteractivePluginProviderChoice).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ authChoice: "demo-provider-api-key", nextConfig, target }),
+    );
+    const warningOrder = runtime.log.mock.invocationCallOrder[0];
+    const dispatchOrder = applyNonInteractivePluginProviderChoice.mock.invocationCallOrder[0];
+    if (warningOrder === undefined || dispatchOrder === undefined) {
+      throw new Error("Expected legacy warning and plugin dispatch");
+    }
+    expect(warningOrder).toBeLessThan(dispatchOrder);
   });
 });

--- a/src/commands/onboard-non-interactive/local/auth-choice.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.ts
@@ -14,11 +14,7 @@ import { normalizeSecretInputModeInput } from "../../../plugins/provider-auth-in
 import { resolveDeprecatedProviderInstallCatalogEntry } from "../../../plugins/provider-install-catalog.js";
 import type { RuntimeEnv } from "../../../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../../../secrets/ref-contract.js";
-import {
-  formatDeprecatedNonInteractiveAuthChoiceError,
-  isDeprecatedAuthChoice,
-  resolveDeprecatedAuthChoiceReplacement,
-} from "../../auth-choice-legacy.js";
+import { resolveLegacyOnboardAuthChoice } from "../../auth-choice-legacy.js";
 import { formatAuthChoiceChoicesForCli } from "../../auth-choice-options.js";
 import { normalizeApiKeyTokenProviderAuthChoice } from "../../auth-choice.apply.api-providers.js";
 import type { OnboardingAgentTarget } from "../../onboard-agent-target.js";
@@ -127,35 +123,16 @@ export async function applyNonInteractiveAuthChoice(params: {
       ...(paramsLocal.metadata ? { metadata: paramsLocal.metadata } : {}),
     };
   };
-  if (
-    isDeprecatedAuthChoice(authChoice, {
-      config: nextConfig,
-      workspaceDir: params.target.workspaceDir,
-      env: process.env,
-    })
-  ) {
-    // Keep deprecated aliases out of the config by normalizing them before
-    // either plugin dispatch or built-in setup handling.
-    const replacement = resolveDeprecatedAuthChoiceReplacement(authChoice, {
-      config: nextConfig,
-      workspaceDir: params.target.workspaceDir,
-      env: process.env,
-    });
-    if (replacement) {
-      runtime.log(replacement.message);
-      authChoice = replacement.normalized;
-    } else {
-      rejectOnboardingOption(
-        opts,
-        runtime,
-        formatDeprecatedNonInteractiveAuthChoiceError(authChoice, {
-          config: nextConfig,
-          workspaceDir: params.target.workspaceDir,
-          env: process.env,
-        })!,
-      );
-      return null;
-    }
+  const legacyChoice = resolveLegacyOnboardAuthChoice(authChoice, {
+    config: nextConfig,
+    workspaceDir: params.target.workspaceDir,
+    env: process.env,
+  });
+  if (legacyChoice.deprecated) {
+    // Only provider aliases normalize here; the onboarding entry point owns
+    // the separate oauth spelling before local dispatch.
+    runtime.log(legacyChoice.deprecated.message);
+    authChoice = legacyChoice.authChoice;
   }
 
   const deprecatedChoice = resolveManifestDeprecatedProviderAuthChoice(authChoice as string, {

--- a/src/commands/onboard.test.ts
+++ b/src/commands/onboard.test.ts
@@ -3,11 +3,13 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as providerAuthChoices from "../plugins/provider-auth-choices.js";
 import type { ProviderAuthMethod, ProviderPlugin } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import * as nonInteractiveApiKeys from "./onboard-non-interactive/api-keys.js";
 import { setupWizardCommand } from "./onboard.js";
+import { createTestRuntime as makeRuntime } from "./test-runtime-config-helpers.js";
 
 type ConfigSnapshotStub = {
   exists: boolean;
@@ -120,12 +122,16 @@ vi.mock("./onboard-helpers.js", async (importOriginal) => ({
   handleReset: mocks.handleReset,
 }));
 
-function makeRuntime(): RuntimeEnv {
-  return {
-    log: vi.fn(),
-    error: vi.fn(),
-    exit: vi.fn() as unknown as RuntimeEnv["exit"],
-  };
+async function expectAuthPreflightError(
+  opts: Parameters<typeof setupWizardCommand>[0],
+  getMessage: () => string,
+): Promise<void> {
+  const runtime = makeRuntime();
+  const options = { reset: true, nonInteractive: true, acceptRisk: true, ...opts };
+  await setupWizardCommand(options, runtime);
+  expect(runtime.error).toHaveBeenCalledWith(getMessage());
+  expect(mocks.handleReset).not.toHaveBeenCalled();
+  expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
 }
 
 function expectResetCall(params: { scope: string; runtime: RuntimeEnv; workspace?: string }): void {
@@ -745,90 +751,33 @@ describe("setupWizardCommand", () => {
     expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
   });
 
-  it("validates dependent auth-choice options before reset", async () => {
-    const runtime = makeRuntime();
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
-        authChoice: "token",
-        token: "value",
-      },
-      runtime,
-    );
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Auth choice "token" requires --token-provider in non-interactive setup.',
-    );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-  });
-
-  it("validates a required setup token before reset", async () => {
-    const runtime = makeRuntime();
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
-        authChoice: "setup-token",
-        tokenProvider: "anthropic",
-      },
-      runtime,
-    );
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Auth choice "setup-token" requires --token in non-interactive setup.',
-    );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-  });
-
-  it("validates setup-token expiry before reset", async () => {
-    const runtime = makeRuntime();
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
+  it.each([
+    {
+      name: "validates dependent auth-choice options before reset",
+      opts: { authChoice: "token", token: "value" },
+      message: 'Auth choice "token" requires --token-provider in non-interactive setup.',
+    },
+    {
+      name: "validates a required setup token before reset",
+      opts: { authChoice: "setup-token", tokenProvider: "anthropic" },
+      message: 'Auth choice "setup-token" requires --token in non-interactive setup.',
+    },
+    {
+      name: "validates setup-token expiry before reset",
+      opts: {
         authChoice: "setup-token",
         tokenProvider: "anthropic",
         token: "test-token",
         tokenExpiresIn: "nope",
       },
-      runtime,
-    );
-
-    expect(runtime.error).toHaveBeenCalledWith("Invalid --token-expires-in: invalid duration");
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-  });
-
-  it("validates the token provider before reset", async () => {
-    const runtime = makeRuntime();
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
-        authChoice: "token",
-        tokenProvider: "typo",
-        token: "value",
-      },
-      runtime,
-    );
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Auth choice "token" was not matched to provider "typo".',
-    );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-  });
+      message: "Invalid --token-expires-in: invalid duration",
+    },
+    {
+      name: "validates the token provider before reset",
+      opts: { authChoice: "token", tokenProvider: "typo", token: "value" },
+      message: 'Auth choice "token" was not matched to provider "typo".',
+    },
+  ] as const)("$name", ({ opts, message }) => expectAuthPreflightError(opts, () => message));
 
   it.each([
     { agentName: "robby", agentId: "robby", scope: "config", reuseProfile: true },
@@ -880,26 +829,33 @@ describe("setupWizardCommand", () => {
     },
   );
 
-  it.each(localResetProviderCases)(
-    "validates $providerId exactly once before reset and non-interactive setup",
-    async ({ providerId, methodId }) => {
-      const runtime = makeRuntime();
-      const { runNonInteractive, validateNonInteractive } = mockLocalResetPreflight({
+  it.each(
+    [true, false].flatMap((validationResult) =>
+      localResetProviderCases.map(({ providerId, methodId }) => ({
         providerId,
         methodId,
-        validationResult: true,
-      });
-
+        validationResult,
+      })),
+    ),
+  )(
+    "preflights $providerId before reset and setup (accepted: $validationResult)",
+    async (params) => {
+      const { providerId, validationResult } = params;
+      const runtime = makeRuntime();
+      const { runNonInteractive, validateNonInteractive } = mockLocalResetPreflight(params);
       await setupWizardCommand(
-        {
-          reset: true,
-          nonInteractive: true,
-          acceptRisk: true,
-          authChoice: providerId,
-        },
+        { reset: true, nonInteractive: true, acceptRisk: true, authChoice: providerId },
         runtime,
       );
-
+      expect(runNonInteractive).not.toHaveBeenCalled();
+      expect(mocks.handleReset).toHaveBeenCalledTimes(validationResult ? 1 : 0);
+      expect(mocks.runNonInteractiveSetup).toHaveBeenCalledTimes(validationResult ? 1 : 0);
+      if (!validationResult) {
+        expect(validateNonInteractive).toHaveBeenCalledOnce();
+        expect(runtime.error).toHaveBeenCalledWith("Local provider preflight failed");
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        return;
+      }
       expect(validateNonInteractive).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
           authChoice: providerId,
@@ -909,10 +865,6 @@ describe("setupWizardCommand", () => {
           runtime,
         }),
       );
-      expect(mocks.handleReset).toHaveBeenCalledOnce();
-      expect(mocks.runNonInteractiveSetup).toHaveBeenCalledOnce();
-      expect(runNonInteractive).not.toHaveBeenCalled();
-
       const validationCall = validateNonInteractive.mock.invocationCallOrder.at(0);
       const resetCall = mocks.handleReset.mock.invocationCallOrder.at(0);
       const setupCall = mocks.runNonInteractiveSetup.mock.invocationCallOrder.at(0);
@@ -924,79 +876,22 @@ describe("setupWizardCommand", () => {
     },
   );
 
-  it.each(localResetProviderCases)(
-    "never resets or starts setup when $providerId validation fails",
-    async ({ providerId, methodId }) => {
-      const runtime = makeRuntime();
-      const { runNonInteractive, validateNonInteractive } = mockLocalResetPreflight({
-        providerId,
-        methodId,
-        validationResult: false,
-      });
-
-      await setupWizardCommand(
-        {
-          reset: true,
-          nonInteractive: true,
-          acceptRisk: true,
-          authChoice: providerId,
-        },
-        runtime,
-      );
-
-      expect(validateNonInteractive).toHaveBeenCalledOnce();
-      expect(runtime.error).toHaveBeenCalledWith("Local provider preflight failed");
-      expect(runtime.exit).toHaveBeenCalledWith(1);
-      expect(mocks.handleReset).not.toHaveBeenCalled();
-      expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
-      expect(runNonInteractive).not.toHaveBeenCalled();
-    },
-  );
-
   it("validates a provider-specific API key before reset", async () => {
-    const runtime = makeRuntime();
     vi.stubEnv("ANTHROPIC_API_KEY", "");
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
-        authChoice: "apiKey",
-        tokenProvider: "anthropic",
-        anthropicApiKey: "",
-      },
-      runtime,
+    await expectAuthPreflightError(
+      { authChoice: "apiKey", tokenProvider: "anthropic", anthropicApiKey: "" },
+      () =>
+        `Missing --anthropic-api-key (or ANTHROPIC_API_KEY in env). Export ANTHROPIC_API_KEY, pass --anthropic-api-key, or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
     );
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      `Missing --anthropic-api-key (or ANTHROPIC_API_KEY in env). Export ANTHROPIC_API_KEY, pass --anthropic-api-key, or run ${formatCliCommand("openclaw onboard")} for interactive setup.`,
-    );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
   });
 
   it("validates an inferred custom auth choice before reset", async () => {
-    const runtime = makeRuntime();
-
-    await setupWizardCommand(
-      {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
-        customBaseUrl: "https://example.com/v1",
-      },
-      runtime,
-    );
-
-    expect(runtime.error).toHaveBeenCalledWith(
+    await expectAuthPreflightError({ customBaseUrl: "https://example.com/v1" }, () =>
       [
         'Auth choice "custom-api-key" requires a base URL and model ID.',
         "Use --custom-base-url and --custom-model-id.",
       ].join("\n"),
     );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
   });
 
   it("rejects ambiguous interactive provider flags before reset", async () => {
@@ -1006,30 +901,20 @@ describe("setupWizardCommand", () => {
   });
 
   it("validates custom credential storage before reset", async () => {
-    const runtime = makeRuntime();
     vi.stubEnv("CUSTOM_API_KEY", "");
-
-    await setupWizardCommand(
+    await expectAuthPreflightError(
       {
-        reset: true,
-        nonInteractive: true,
-        acceptRisk: true,
         customBaseUrl: "https://example.com/v1",
         customModelId: "test-model",
         customApiKey: "test-token",
         secretInputMode: "ref",
       },
-      runtime,
+      () =>
+        [
+          "--custom-api-key cannot be used with --secret-input-mode ref unless CUSTOM_API_KEY is set in env.",
+          "Set CUSTOM_API_KEY in env and omit --custom-api-key, or use --secret-input-mode plaintext.",
+        ].join("\n"),
     );
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      [
-        "--custom-api-key cannot be used with --secret-input-mode ref unless CUSTOM_API_KEY is set in env.",
-        "Set CUSTOM_API_KEY in env and omit --custom-api-key, or use --secret-input-mode plaintext.",
-      ].join("\n"),
-    );
-    expect(mocks.handleReset).not.toHaveBeenCalled();
-    expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
   });
 
   it("rejects migration import before reset because provider input is not preplanned", async () => {
@@ -1138,5 +1023,101 @@ describe("setupWizardCommand", () => {
     expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
     expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
     expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "rejects a deprecated choice before non-interactive effects",
+      authChoice: "claude-cli",
+      hasReplacement: true,
+      nonInteractive: true,
+      expectedAuthChoice: "demo-provider-api-key",
+    },
+    {
+      name: "warns before interactive dispatch of the replacement",
+      authChoice: "claude-cli",
+      hasReplacement: true,
+      nonInteractive: false,
+      expectedAuthChoice: "demo-provider-api-key",
+    },
+    {
+      name: "normalizes oauth without a deprecation warning",
+      authChoice: "oauth",
+      hasReplacement: true,
+      nonInteractive: false,
+      expectedAuthChoice: "setup-token",
+    },
+    {
+      name: "keeps the original choice when replacement metadata is missing",
+      authChoice: "claude-cli",
+      hasReplacement: false,
+      nonInteractive: false,
+      expectedAuthChoice: "claude-cli",
+    },
+  ])("$name", async ({ authChoice, hasReplacement, nonInteractive, expectedAuthChoice }) => {
+    const runtime = makeRuntime();
+    const warning = 'Auth choice "claude-cli" is deprecated; using Fixture Provider setup instead.';
+    const manifest = vi
+      .spyOn(providerAuthChoices, "resolveManifestDeprecatedProviderAuthChoice")
+      .mockImplementation((choice) =>
+        hasReplacement && choice === "claude-cli"
+          ? {
+              pluginId: "fixture-provider",
+              providerId: "fixture-provider",
+              methodId: "api-key",
+              choiceId: "demo-provider-api-key",
+              choiceLabel: "  Fixture Provider  ",
+              deprecatedChoiceIds: ["claude-cli"],
+            }
+          : undefined,
+      );
+
+    try {
+      await setupWizardCommand(
+        nonInteractive
+          ? { authChoice, nonInteractive: true, json: true, reset: true }
+          : { authChoice, classic: true },
+        runtime,
+      );
+
+      expect(mocks.readConfigFileSnapshot).not.toHaveBeenCalled();
+      expect(mocks.handleReset).not.toHaveBeenCalled();
+      expect(mocks.runGuidedOnboarding).not.toHaveBeenCalled();
+      expect(mocks.runNonInteractiveSetup).not.toHaveBeenCalled();
+      if (nonInteractive) {
+        const message =
+          'Auth choice "claude-cli" is deprecated.\nUse "--auth-choice demo-provider-api-key".';
+        expect(runtime.error).toHaveBeenCalledExactlyOnceWith(message);
+        expect(runtime.log).toHaveBeenCalledExactlyOnceWith(
+          JSON.stringify({ ok: false, phase: "options", message }, null, 2),
+        );
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+        expect(mocks.withSetupMigrationTargetLock).not.toHaveBeenCalled();
+        expect(mocks.runInteractiveSetup).not.toHaveBeenCalled();
+        return;
+      }
+
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(mocks.runInteractiveSetup).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ authChoice: expectedAuthChoice, classic: true }),
+        runtime,
+      );
+      const logCalls = vi.mocked(runtime.log).mock.calls;
+      expect(logCalls.filter(([message]) => String(message).startsWith('Auth choice "'))).toEqual(
+        hasReplacement && authChoice === "claude-cli" ? [[warning]] : [],
+      );
+      if (hasReplacement && authChoice === "claude-cli") {
+        const warningIndex = logCalls.findIndex(([message]) => message === warning);
+        const warningOrder = vi.mocked(runtime.log).mock.invocationCallOrder[warningIndex];
+        const setupOrder = mocks.runInteractiveSetup.mock.invocationCallOrder[0];
+        if (warningOrder === undefined || setupOrder === undefined) {
+          throw new Error("Expected legacy warning and interactive dispatch");
+        }
+        expect(warningOrder).toBeLessThan(setupOrder);
+      }
+    } finally {
+      manifest.mockRestore();
+    }
   });
 });

--- a/src/commands/onboard.ts
+++ b/src/commands/onboard.ts
@@ -25,12 +25,7 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { t } from "../wizard/i18n/index.js";
 import { withSetupMigrationTargetLock } from "../wizard/setup.migration-snapshot.js";
-import {
-  formatDeprecatedNonInteractiveAuthChoiceError,
-  isDeprecatedAuthChoice,
-  normalizeLegacyOnboardAuthChoice,
-  resolveDeprecatedAuthChoiceReplacement,
-} from "./auth-choice-legacy.js";
+import { resolveLegacyOnboardAuthChoice } from "./auth-choice-legacy.js";
 import { formatAuthChoiceChoicesForCli } from "./auth-choice-options.js";
 import { GENERIC_PROVIDER_AUTH_CHOICES } from "./auth-choice-options.static.js";
 import { isGatewayDaemonRuntime } from "./daemon-runtime.js";
@@ -543,26 +538,18 @@ export async function setupWizardCommand(
   runtime: RuntimeEnv = defaultRuntime,
 ) {
   assertSupportedRuntime(runtime);
-  const originalAuthChoice = opts.authChoice;
-  const normalizedAuthChoice = normalizeLegacyOnboardAuthChoice(originalAuthChoice, {
-    env: process.env,
-  });
-  if (opts.nonInteractive && isDeprecatedAuthChoice(originalAuthChoice, { env: process.env })) {
+  const { authChoice: normalizedAuthChoice, deprecated } = resolveLegacyOnboardAuthChoice(
+    opts.authChoice,
+    { env: process.env },
+  );
+  if (opts.nonInteractive && deprecated) {
     // Non-interactive output must be deterministic; reject deprecated aliases
     // instead of printing prompts or compatibility guidance mid-flow.
-    rejectOption(
-      opts,
-      runtime,
-      formatDeprecatedNonInteractiveAuthChoiceError(originalAuthChoice, {
-        env: process.env,
-      })!,
-    );
+    rejectOption(opts, runtime, deprecated.nonInteractiveError);
     return;
   }
-  if (isDeprecatedAuthChoice(originalAuthChoice, { env: process.env })) {
-    runtime.log(
-      resolveDeprecatedAuthChoiceReplacement(originalAuthChoice, { env: process.env })!.message,
-    );
+  if (deprecated) {
+    runtime.log(deprecated.message);
   }
   const flow = opts.flow === "manual" ? ("advanced" as const) : opts.flow;
   const normalizedOpts =

--- a/src/plugins/provider-auth-choice-preference.ts
+++ b/src/plugins/provider-auth-choice-preference.ts
@@ -1,11 +1,7 @@
 /** Resolves preferred provider auth choices from config and plugin metadata. */
-import { normalizeLegacyOnboardAuthChoice } from "../commands/auth-choice-legacy.js";
+import { resolveLegacyOnboardAuthChoice } from "../commands/auth-choice-legacy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveManifestProviderAuthChoice } from "./provider-auth-choices.js";
-
-function normalizeLegacyAuthChoice(choice: string, env?: NodeJS.ProcessEnv): string {
-  return normalizeLegacyOnboardAuthChoice(choice, { env }) ?? choice;
-}
 
 export async function resolvePreferredProviderForAuthChoice(params: {
   choice: string;
@@ -14,7 +10,8 @@ export async function resolvePreferredProviderForAuthChoice(params: {
   env?: NodeJS.ProcessEnv;
   includeUntrustedWorkspacePlugins?: boolean;
 }): Promise<string | undefined> {
-  const choice = normalizeLegacyAuthChoice(params.choice, params.env) ?? params.choice;
+  const choice =
+    resolveLegacyOnboardAuthChoice(params.choice, { env: params.env }).authChoice ?? params.choice;
   const manifestResolved = resolveManifestProviderAuthChoice(choice, params);
   if (manifestResolved) {
     return manifestResolved.providerId;


### PR DESCRIPTION
## What Problem This Solves

Legacy authentication choices are normalized and described independently at several onboarding entry points. Repeated manifest lookups make it harder to keep the selected replacement, warning and non-interactive error consistent.

This is a behavior-preserving cleanup, not a claim that the existing aliases or onboarding flow are broken.

## Why This Change Was Made

One resolver returns the normalized choice and its deprecation diagnostics from the same manifest result. Onboarding, local non-interactive setup and provider preference selection consume it. The redundant wrappers and repeated-lookup branch are removed: **103 fewer production lines**, with no new configuration, public SDK, protocol or storage surface.

The existing `oauth` alias, provider-backed replacements, warning order and non-interactive rejection behavior remain intact. Onboarding tests are consolidated without dropping cases; the obsolete assertion-baseline entry is removed.

## User Impact

No intended user-visible behavior change. Existing authentication-choice spellings keep their current normalization or diagnostic behavior.

## Evidence

- All 125 focused cases passed: 95 onboarding cases and 30 legacy/local-auth cases. The eight changed code/test files remain byte-identical through the mechanical refresh.
- The original candidate tree passed the normal 16-phase build and all 30 required changed checks through the configured Linux Blacksmith Testbox. Its lease and temporary checkout were cleaned up. A later reporting-portal sync timed out; that warning is retained separately from the successful checks.
- Fresh built CLI checks confirmed the deprecated choice's exact non-interactive JSON error and classic warning/non-TTY rejection. These used isolated synthetic state and stopped before provider/setup dispatch, not before normal startup SQLite effects. One run retained a slow-transaction diagnostic. This is not successful provider authentication or database-reopen proof.
- Precommit and separate signed-commit Codex reviews found no actionable P0–P2 defects. The refreshed signed commit was independently reviewed against its new raw parent too.
- Initial PR CI failed on two shared-main issues: the services type-test shard exceeded its capacity, and a Discord cancellation fixture did not reliably intercept the write boundary. Canonical fixes [#139645](https://github.com/openclaw/openclaw/pull/139645) and [#139580](https://github.com/openclaw/openclaw/pull/139580) are now incorporated. No test limit was raised and no failure was waived.

Current signed head is `96d9243912118e60fd518b8fb567c918fc9fa84a`, based on `5b099995413589f41904cef1413c62239542aa7c`. The stable Auth patch is unchanged; the assertion baseline preserves upstream removals. Earlier build/CLI/check results belong to the original tested tree `80562b041d4d280a4972c0e2fe3939cb6a8ee20d`, not an execution of this rebased full tree. Native build stamps were not rewritten. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34009341731) completed successfully for this signed head. Landing remains gated on the native maintainer workflow.
