### PR TITLE
refactor(test): reuse Google speech request guards

### DIFF
--- a/extensions/google/speech-provider.test.ts
+++ b/extensions/google/speech-provider.test.ts
@@ -1,7 +1,7 @@
-// Google tests cover speech provider plugin behavior.
 import {
   getProviderHttpMocks,
   installProviderHttpMockCleanup,
+  requireFirstPostJsonRecordRequest as requireFirstRecordArg,
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -90,25 +90,6 @@ function expectRecordFields(value: unknown, expected: Record<string, unknown>) {
     expect(actual[key]).toEqual(expectedValue);
   }
   return actual;
-}
-
-function requireFirstMockArg(mock: ReturnType<typeof vi.fn>, label: string): unknown {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`Expected ${label}`);
-  }
-  return call[0];
-}
-
-function requireFirstRecordArg(
-  mock: ReturnType<typeof vi.fn>,
-  label: string,
-): Record<string, unknown> {
-  const value = requireFirstMockArg(mock, label);
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`Expected ${label}`);
-  }
-  return value as Record<string, unknown>;
 }
 
 describe("Google speech provider", () => {


### PR DESCRIPTION
## What Problem This Solves

Google speech tests carry local copies of the first-call and record guards already provided by their existing HTTP test fixture. The copies add maintenance without independent coverage.

## Why This Change Was Made

Import the shared record reader under the existing local name and delete the two duplicate functions and narrative header comment. The reader returns the original argument by identity, including the transcoder options record. All field assertions and mock cleanup hooks remain unchanged. Helper-only error messages use the shared capitalization and record suffix; no asserted provider error changes.

## User Impact

Production behavior is unchanged. All 23 speech cases remain, including PCM/WAV/Opus handling, request headers, prompt text, base64 validation, retries, bounded response cleanup, telephony, and configured private-network behavior. Test code is reduced by 19 lines; the separate realtime suite is unchanged.

## Evidence

The same native speech-test command passed 23/23 before and after the cleanup. All test bodies and field assertions are unchanged, and the emitted verbose case rows match.

The normal configured [Linux changed-check run](https://github.com/openclaw/openclaw/actions/runs/34006326450) passed all 19 checks. Its delegated command exited 0; the one-shot Testbox completed and its temporary source capsule was removed.

Independent Codex review found no actionable findings through P2. The applied source matches the reviewed candidate. Transport and transcoding remain mocked at the suite's existing boundaries.

The earlier exact-head CI run failed only the shared services test-root boundary and its dependent aggregate. This mechanical refresh incorporates the already-landed fix in #139645 via main `11303cff99a1600338f0375b1a71189fcb44f150`. The reviewed test patch and all relevant owner code are unchanged; fresh exact-head CI is required before landing.
