### PR TITLE
fix(test): close shared HTTP fixtures reliably under Bun

### DIFF
--- a/extensions/a2a/src/http.test.ts
+++ b/extensions/a2a/src/http.test.ts
@@ -1,11 +1,12 @@
 import { EventEmitter } from "node:events";
-import { createServer, type ServerResponse } from "node:http";
+import type { ServerResponse } from "node:http";
 import { VERSION } from "openclaw/plugin-sdk/cli-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   createMockIncomingRequest,
   createMockServerResponse,
   postRawWebhook,
+  withServer,
 } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createA2aHttpHandler } from "./http.js";
@@ -309,97 +310,71 @@ describe("A2A HTTP authentication and request limits", () => {
 
   it("delivers HTTP 413 over the wire and closes for request bodies above 1 MiB", async () => {
     const harness = await startHttpHarness();
-    const server = createServer((req, res) => {
-      void harness.handler(req, res);
-    });
-    try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          server.removeListener("error", reject);
-          resolve();
+    await withServer(
+      (req, res) => {
+        void harness.handler(req, res);
+      },
+      async (baseUrl) => {
+        // Declared and sent in one write: the shape whose rejection used to race the flush.
+        const result = await postRawWebhook({
+          url: `${baseUrl}/a2a/v1`,
+          body: "x".repeat(1024 * 1024 + 1),
+          headers: {
+            "content-type": "application/json",
+            authorization: "Bearer alpha-secret",
+          },
         });
-      });
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected the A2A test server to have a TCP address");
-      }
 
-      // Declared and sent in one write: the shape whose rejection used to race the flush.
-      const result = await postRawWebhook({
-        url: `http://127.0.0.1:${address.port}/a2a/v1`,
-        body: "x".repeat(1024 * 1024 + 1),
-        headers: {
-          "content-type": "application/json",
-          authorization: "Bearer alpha-secret",
-        },
-      });
-
-      expect(result.statusLine).toBe("HTTP/1.1 413 Payload Too Large");
-      expect(result.headers.connection).toBe("close");
-      expect(JSON.parse(result.body)).toEqual({
-        error: "Request body exceeds the 1 MiB limit",
-      });
-      expect(result.closedByServer).toBe(true);
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+        expect(result.statusLine).toBe("HTTP/1.1 413 Payload Too Large");
+        expect(result.headers.connection).toBe("close");
+        expect(JSON.parse(result.body)).toEqual({
+          error: "Request body exceeds the 1 MiB limit",
+        });
+        expect(result.closedByServer).toBe(true);
+      },
+    );
   });
 
   it("delivers the JSON-RPC timeout response before closing a partial upload", async () => {
-    vi.useFakeTimers();
     const harness = await startHttpHarness();
-    const server = createServer((req, res) => {
-      void harness.handler(req, res);
-    });
-    try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          server.removeListener("error", reject);
-          resolve();
-        });
-      });
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected the A2A test server to have a TCP address");
-      }
-      const requestReceived = new Promise<void>((resolve) => {
-        server.once("connection", (socket) => socket.once("data", () => resolve()));
-      });
-      const resultPromise = postRawWebhook({
-        url: `http://127.0.0.1:${address.port}/a2a/v1`,
-        body: "{",
-        contentLength: 2,
-        idleTimeoutMs: 60_000,
-        headers: {
-          "content-type": "application/json",
-          authorization: "Bearer alpha-secret",
-        },
-      });
+    const requestReceived = Promise.withResolvers<void>();
+    await withServer(
+      (req, res) => {
+        void harness.handler(req, res);
+        // Observe after the body reader is installed; Bun's socket wrapper omits raw data events.
+        req.once("data", () => requestReceived.resolve());
+      },
+      async (baseUrl) => {
+        vi.useFakeTimers();
+        try {
+          const resultPromise = postRawWebhook({
+            url: `${baseUrl}/a2a/v1`,
+            body: "{",
+            contentLength: 2,
+            idleTimeoutMs: 60_000,
+            headers: {
+              "content-type": "application/json",
+              authorization: "Bearer alpha-secret",
+            },
+          });
 
-      await requestReceived;
-      await vi.advanceTimersByTimeAsync(31_000);
-      const result = await resultPromise;
+          await requestReceived.promise;
+          await vi.advanceTimersByTimeAsync(31_000);
+          const result = await resultPromise;
 
-      expect(result.statusLine).toBe("HTTP/1.1 200 OK");
-      expect(result.headers.connection).toBe("close");
-      expect(JSON.parse(result.body)).toEqual({
-        jsonrpc: "2.0",
-        id: null,
-        error: { code: -32000, message: "Request body could not be read" },
-      });
-      expect(result.closedByServer).toBe(true);
-    } finally {
-      vi.useRealTimers();
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+          expect(result.statusLine).toBe("HTTP/1.1 200 OK");
+          expect(result.headers.connection).toBe("close");
+          expect(JSON.parse(result.body)).toEqual({
+            jsonrpc: "2.0",
+            id: null,
+            error: { code: -32000, message: "Request body could not be read" },
+          });
+          expect(result.closedByServer).toBe(true);
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    );
   });
 
   it("rejects oversized batches with one bounded error", async () => {

--- a/extensions/a2a/src/http.test.ts
+++ b/extensions/a2a/src/http.test.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import type { ServerResponse } from "node:http";
 import { VERSION } from "openclaw/plugin-sdk/cli-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import {
   createMockIncomingRequest,
   createMockServerResponse,
@@ -337,7 +338,7 @@ describe("A2A HTTP authentication and request limits", () => {
 
   it("delivers the JSON-RPC timeout response before closing a partial upload", async () => {
     const harness = await startHttpHarness();
-    const requestReceived = Promise.withResolvers<void>();
+    const requestReceived = createDeferred<void>();
     await withServer(
       (req, res) => {
         void harness.handler(req, res);

--- a/extensions/azure-speech/tts.test.ts
+++ b/extensions/azure-speech/tts.test.ts
@@ -1,6 +1,5 @@
 // Azure Speech tests cover tts plugin behavior.
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { installPinnedHostnameTestHooks } from "openclaw/plugin-sdk/test-media-understanding";
 import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -260,39 +259,31 @@ describe("azure speech tts", () => {
     const socketClosed = new Promise<boolean>((resolve) => {
       notifySocketClosed = resolve;
     });
-    const server = createServer((request, response) => {
-      request.socket.once("close", () => notifySocketClosed?.(true));
-      response.writeHead(200, { "content-type": "application/json" });
-      // Headers land, then the body never ends: only an explicit cancel closes this.
-      response.write('{"error":"still streaming');
-    });
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
+    await withServer(
+      (request, response) => {
+        request.socket.once("close", () => notifySocketClosed?.(true));
+        response.writeHead(200, { "content-type": "application/json" });
+        // Headers land, then the body never ends: only an explicit cancel closes this.
+        response.write('{"error":"still streaming');
+      },
+      async (baseUrl) => {
+        await expect(
+          azureSpeechTTS({
+            text: "hello",
+            apiKey: "fixture-value",
+            endpoint: baseUrl,
+            voice: "en-US-JennyNeural",
+            lang: "en-US",
+            timeoutMs: 5_000,
+          }),
+        ).rejects.toThrow("Azure Speech TTS API error: malformed audio response");
 
-    try {
-      const { port } = server.address() as AddressInfo;
-      await expect(
-        azureSpeechTTS({
-          text: "hello",
-          apiKey: "fixture-value",
-          endpoint: `http://127.0.0.1:${port}`,
-          voice: "en-US-JennyNeural",
-          lang: "en-US",
-          timeoutMs: 5_000,
-        }),
-      ).rejects.toThrow("Azure Speech TTS API error: malformed audio response");
-
-      await expect(
-        withTimeout(socketClosed, 250, {
-          message: "Azure Speech malformed-response socket did not close",
-        }),
-      ).resolves.toBe(true);
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+        await expect(
+          withTimeout(socketClosed, 250, {
+            message: "Azure Speech malformed-response socket did not close",
+          }),
+        ).resolves.toBe(true);
+      },
+    );
   });
 });

--- a/extensions/azure-speech/voices-timeout.test.ts
+++ b/extensions/azure-speech/voices-timeout.test.ts
@@ -1,31 +1,9 @@
 // Azure Speech voice list timeout integration proof.
 // A loopback server accepts the connection but never responds so this exercises
 // the real fetch abort path without depending on Azure latency.
-import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { listAzureSpeechVoices } from "./tts.js";
-
-async function listenLocal(server: Server): Promise<number> {
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  return (server.address() as AddressInfo).port;
-}
-
-async function closeServer(server: Server): Promise<void> {
-  server.closeAllConnections();
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-}
 
 describe("listAzureSpeechVoices timeout", () => {
   const originalFetch = globalThis.fetch;
@@ -42,48 +20,48 @@ describe("listAzureSpeechVoices timeout", () => {
     const requestReceived = new Promise<void>((resolve) => {
       notifyRequest = resolve;
     });
-    const server = createServer((_request, _response) => {
-      requestCount += 1;
-      notifyRequest();
-    });
+    await withServer(
+      (_request, _response) => {
+        requestCount += 1;
+        notifyRequest();
+      },
+      async (baseUrl) => {
+        vi.stubGlobal(
+          "fetch",
+          vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+            requestSignal = init?.signal ?? undefined;
+            if (!requestSignal) {
+              throw new Error("guarded fetch did not pass an abort signal");
+            }
+            return await originalFetch(`${baseUrl}/cognitiveservices/voices/list`, {
+              ...init,
+              signal: AbortSignal.any([requestSignal, cleanupController.signal]),
+            });
+          }) as unknown as typeof globalThis.fetch,
+        );
 
-    const port = await listenLocal(server);
-
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
-        requestSignal = init?.signal ?? undefined;
-        if (!requestSignal) {
-          throw new Error("guarded fetch did not pass an abort signal");
-        }
-        return await originalFetch(`http://127.0.0.1:${port}/cognitiveservices/voices/list`, {
-          ...init,
-          signal: AbortSignal.any([requestSignal, cleanupController.signal]),
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        const request = listAzureSpeechVoices({
+          apiKey: "not-a-real",
+          baseUrl: "https://custom.example.com",
+          timeoutMs: 100,
         });
-      }) as unknown as typeof globalThis.fetch,
+        try {
+          // Measure the request deadline after cold SDK imports and socket setup finish.
+          await Promise.race([requestReceived, request]);
+          expect(requestCount).toBe(1);
+          await vi.advanceTimersByTimeAsync(99);
+          expect(requestSignal?.aborted).toBe(false);
+          await vi.advanceTimersByTimeAsync(1);
+          expect(requestSignal?.aborted).toBe(true);
+          await expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
+        } finally {
+          // Abort independently of the production deadline, then settle before global/socket cleanup.
+          cleanupController.abort();
+          await request.catch(() => undefined);
+          vi.useRealTimers();
+        }
+      },
     );
-
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-    const request = listAzureSpeechVoices({
-      apiKey: "not-a-real",
-      baseUrl: "https://custom.example.com",
-      timeoutMs: 100,
-    });
-    try {
-      // Measure the request deadline after cold SDK imports and socket setup finish.
-      await Promise.race([requestReceived, request]);
-      expect(requestCount).toBe(1);
-      await vi.advanceTimersByTimeAsync(99);
-      expect(requestSignal?.aborted).toBe(false);
-      await vi.advanceTimersByTimeAsync(1);
-      expect(requestSignal?.aborted).toBe(true);
-      await expect(request).rejects.toThrow(/aborted|timeout|timed out/i);
-    } finally {
-      // Abort independently of the production deadline, then settle before global/socket cleanup.
-      cleanupController.abort();
-      await request.catch(() => undefined);
-      vi.useRealTimers();
-      await closeServer(server);
-    }
   });
 });

--- a/extensions/discord/src/send.webhook.chunk-limit.test.ts
+++ b/extensions/discord/src/send.webhook.chunk-limit.test.ts
@@ -1,6 +1,5 @@
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { chunkDiscordTextWithMode } from "./chunk.js";
 import { maybeSendBindingMessage } from "./monitor/thread-bindings.discord-api.js";
@@ -23,42 +22,38 @@ async function withWebhookServer(
   run: (contents: string[]) => Promise<void>,
 ) {
   const contents: string[] = [];
-  const server = createServer((request, response) => {
-    let body = "";
-    request.setEncoding("utf8");
-    request.on("data", (part: string) => {
-      body += part;
-    });
-    request.on("end", () => {
-      const { content } = JSON.parse(body) as { content: string };
-      contents.push(content);
-      const next = reply(content, contents.length);
-      response.writeHead(next.status ?? 200, { "content-type": "application/json" });
-      response.end(JSON.stringify(next.body));
-    });
-  });
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address() as AddressInfo;
-  const realFetch = globalThis.fetch.bind(globalThis);
-  const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
-    const original =
-      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    const target = new URL(original);
-    target.protocol = "http:";
-    target.host = `127.0.0.1:${address.port}`;
-    return realFetch(target, init);
-  });
-  try {
-    await run(contents);
-  } finally {
-    fetchSpy.mockRestore();
-    server.closeAllConnections();
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
+  await withServer(
+    (request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (part: string) => {
+        body += part;
+      });
+      request.on("end", () => {
+        const { content } = JSON.parse(body) as { content: string };
+        contents.push(content);
+        const next = reply(content, contents.length);
+        response.writeHead(next.status ?? 200, { "content-type": "application/json" });
+        response.end(JSON.stringify(next.body));
+      });
+    },
+    async (baseUrl) => {
+      const realFetch = globalThis.fetch.bind(globalThis);
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+        const original =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        const target = new URL(original);
+        target.protocol = "http:";
+        target.host = new URL(baseUrl).host;
+        return realFetch(target, init);
+      });
+      try {
+        await run(contents);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    },
+  );
 }
 
 const cfg: OpenClawConfig = { channels: { discord: { token: "Bot test-token" } } };

--- a/extensions/llama-cpp/src/external-server/discovery.test.ts
+++ b/extensions/llama-cpp/src/external-server/discovery.test.ts
@@ -1,6 +1,5 @@
-import { once } from "node:events";
-import { createServer } from "node:http";
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverLlamaServer } from "./discovery.js";
 
@@ -99,37 +98,26 @@ describe("llama-server discovery projection", () => {
     );
     discoverRowsMock.mockImplementation(actual.discoverOpenAICompatibleLocalModels);
     const requests: string[] = [];
-    const server = createServer((request, response) => {
-      requests.push(request.url ?? "");
-      if (request.url === "/models") {
-        response.end(body);
-      } else if (request.url === "/v1/models") {
-        response.setHeader("Content-Type", "application/json");
-        response.end(JSON.stringify({ data: [{ id: "local-model", object: "model" }] }));
-      } else {
-        response.end("{}");
-      }
-    });
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected a listening TCP server");
-      }
-      await expect(
-        discoverLlamaServer({ baseUrl: `http://127.0.0.1:${address.port}`, cacheTtlMs: 0 }),
-      ).resolves.toMatchObject({
-        kind: "success",
-        models: [{ config: { id: "local-model" } }],
-      });
-      expect(requests).toEqual(["/health", "/models", "/v1/models", "/props"]);
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+    await withServer(
+      (request, response) => {
+        requests.push(request.url ?? "");
+        if (request.url === "/models") {
+          response.end(body);
+        } else if (request.url === "/v1/models") {
+          response.setHeader("Content-Type", "application/json");
+          response.end(JSON.stringify({ data: [{ id: "local-model", object: "model" }] }));
+        } else {
+          response.end("{}");
+        }
+      },
+      async (baseUrl) => {
+        await expect(discoverLlamaServer({ baseUrl, cacheTtlMs: 0 })).resolves.toMatchObject({
+          kind: "success",
+          models: [{ config: { id: "local-model" } }],
+        });
+        expect(requests).toEqual(["/health", "/models", "/v1/models", "/props"]);
+      },
+    );
   });
 
   it.each([
@@ -143,45 +131,35 @@ describe("llama-server discovery projection", () => {
     discoverRowsMock.mockImplementation(actual.discoverOpenAICompatibleLocalModels);
     let modelId = "anonymous-model";
     const modelRequests: Array<string | undefined> = [];
-    const server = createServer((request, response) => {
-      response.setHeader("Content-Type", "application/json");
-      if (request.url === "/models") {
-        modelRequests.push(request.headers.authorization);
-        response.end(JSON.stringify({ data: [{ id: modelId, status: { value: "unloaded" } }] }));
-      } else {
-        response.end("{}");
-      }
-    });
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected a listening TCP server");
-      }
-      const baseUrl = `http://127.0.0.1:${address.port}`;
-      await expect(discoverLlamaServer({ baseUrl })).resolves.toMatchObject({
-        kind: "success",
-        models: [{ config: { id: "anonymous-model" } }],
-      });
-      modelId = "fresh-model";
-      await expect(discoverLlamaServer({ baseUrl, ...access })).resolves.toMatchObject({
-        kind: "success",
-        models: [{ config: { id: "fresh-model" } }],
-      });
-      await expect(discoverLlamaServer({ baseUrl })).resolves.toMatchObject({
-        kind: "success",
-        models: [{ config: { id: "anonymous-model" } }],
-      });
-      expect(modelRequests).toEqual([
-        undefined,
-        "cacheTtlMs" in access ? undefined : "Bearer endpoint-key",
-      ]);
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+    await withServer(
+      (request, response) => {
+        response.setHeader("Content-Type", "application/json");
+        if (request.url === "/models") {
+          modelRequests.push(request.headers.authorization);
+          response.end(JSON.stringify({ data: [{ id: modelId, status: { value: "unloaded" } }] }));
+        } else {
+          response.end("{}");
+        }
+      },
+      async (baseUrl) => {
+        await expect(discoverLlamaServer({ baseUrl })).resolves.toMatchObject({
+          kind: "success",
+          models: [{ config: { id: "anonymous-model" } }],
+        });
+        modelId = "fresh-model";
+        await expect(discoverLlamaServer({ baseUrl, ...access })).resolves.toMatchObject({
+          kind: "success",
+          models: [{ config: { id: "fresh-model" } }],
+        });
+        await expect(discoverLlamaServer({ baseUrl })).resolves.toMatchObject({
+          kind: "success",
+          models: [{ config: { id: "anonymous-model" } }],
+        });
+        expect(modelRequests).toEqual([
+          undefined,
+          "cacheTtlMs" in access ? undefined : "Bearer endpoint-key",
+        ]);
+      },
+    );
   });
 });

--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -1,6 +1,6 @@
 // Openai tests cover speech provider plugin behavior.
-import { createServer } from "node:http";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildOpenAISpeechProvider } from "./speech-provider.js";
 
@@ -231,65 +231,49 @@ describe("buildOpenAISpeechProvider", () => {
           body: unknown;
         }
       | undefined;
-    const server = createServer((request, response) => {
-      const chunks: Buffer[] = [];
-      request.on("data", (chunk: Buffer) => chunks.push(chunk));
-      request.on("end", () => {
-        receivedRequest = {
-          method: request.method,
-          url: request.url,
-          body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
-        };
-        response.writeHead(200, { "content-type": "audio/mpeg" });
-        response.end(Buffer.from("snapshot-audio"));
-      });
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        server.removeListener("error", reject);
-        resolve();
-      });
-    });
+    await withServer(
+      (request, response) => {
+        const chunks: Buffer[] = [];
+        request.on("data", (chunk: Buffer) => chunks.push(chunk));
+        request.on("end", () => {
+          receivedRequest = {
+            method: request.method,
+            url: request.url,
+            body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
+          };
+          response.writeHead(200, { "content-type": "audio/mpeg" });
+          response.end(Buffer.from("snapshot-audio"));
+        });
+      },
+      async (baseUrl) => {
+        const result = await provider.synthesize({
+          text: "snapshot request",
+          cfg: {} as never,
+          providerConfig: {
+            apiKey: "sk-test",
+            baseUrl: `${baseUrl}/v1`,
+            model: OPENAI_TTS_SNAPSHOT,
+            voice: "alloy",
+            instructions: " Speak warmly ",
+          },
+          target: "audio-file",
+          timeoutMs: 1_000,
+        });
 
-    try {
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected a loopback server address");
-      }
-
-      const result = await provider.synthesize({
-        text: "snapshot request",
-        cfg: {} as never,
-        providerConfig: {
-          apiKey: "sk-test",
-          baseUrl: `http://127.0.0.1:${address.port}/v1`,
-          model: OPENAI_TTS_SNAPSHOT,
-          voice: "alloy",
-          instructions: " Speak warmly ",
-        },
-        target: "audio-file",
-        timeoutMs: 1_000,
-      });
-
-      expect(receivedRequest).toEqual({
-        method: "POST",
-        url: "/v1/audio/speech",
-        body: {
-          model: OPENAI_TTS_SNAPSHOT,
-          input: "snapshot request",
-          voice: "alloy",
-          response_format: "mp3",
-          instructions: "Speak warmly",
-        },
-      });
-      expect(result.audioBuffer).toEqual(Buffer.from("snapshot-audio"));
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+        expect(receivedRequest).toEqual({
+          method: "POST",
+          url: "/v1/audio/speech",
+          body: {
+            model: OPENAI_TTS_SNAPSHOT,
+            input: "snapshot request",
+            voice: "alloy",
+            response_format: "mp3",
+            instructions: "Speak warmly",
+          },
+        });
+        expect(result.audioBuffer).toEqual(Buffer.from("snapshot-audio"));
+      },
+    );
   });
 
   it("parses preferred-OpenAI speed directive within the supported range", () => {

--- a/extensions/openai/video-generation-provider.test.ts
+++ b/extensions/openai/video-generation-provider.test.ts
@@ -1,7 +1,5 @@
 // Openai tests cover video generation provider plugin behavior.
 import fs from "node:fs";
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -14,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-runtime-testing";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const {
@@ -396,74 +395,66 @@ describe("openai video generation provider", () => {
       const socketClosed = new Promise<boolean>((resolve) => {
         notifySocketClosed = resolve;
       });
-      const server = createServer((request, response) => {
-        request.socket.once("close", () => notifySocketClosed?.(true));
-        response.writeHead(200, { "content-type": "application/json" });
-        response.write('{"error":"still streaming');
-      });
-      await new Promise<void>((resolve) => {
-        server.listen(0, "127.0.0.1", resolve);
-      });
+      await withServer(
+        (request, response) => {
+          request.socket.once("close", () => notifySocketClosed?.(true));
+          response.writeHead(200, { "content-type": "application/json" });
+          response.write('{"error":"still streaming');
+        },
+        async (baseUrl) => {
+          postMultipartRequestMock.mockResolvedValueOnce({
+            response: streamedJsonResponse({ id: "vid_unread", status: "completed" }),
+            release: vi.fn(async () => {}),
+          });
+          const upstreamUrl = `${baseUrl}/videos/vid_unread/content`;
+          const downloadRelease = vi.fn(async () => {});
+          if (allowPrivateNetwork) {
+            fetchWithTimeoutGuardedMock.mockImplementationOnce(async () => ({
+              response: await fetch(upstreamUrl),
+              finalUrl: upstreamUrl,
+              release: downloadRelease,
+            }));
+          } else {
+            fetchWithTimeoutMock.mockImplementationOnce(async () => await fetch(upstreamUrl));
+          }
 
-      try {
-        postMultipartRequestMock.mockResolvedValueOnce({
-          response: streamedJsonResponse({ id: "vid_unread", status: "completed" }),
-          release: vi.fn(async () => {}),
-        });
-        const { port } = server.address() as AddressInfo;
-        const upstreamUrl = `http://127.0.0.1:${port}/videos/vid_unread/content`;
-        const downloadRelease = vi.fn(async () => {});
-        if (allowPrivateNetwork) {
-          fetchWithTimeoutGuardedMock.mockImplementationOnce(async () => ({
-            response: await fetch(upstreamUrl),
-            finalUrl: upstreamUrl,
-            release: downloadRelease,
-          }));
-        } else {
-          fetchWithTimeoutMock.mockImplementationOnce(async () => await fetch(upstreamUrl));
-        }
-
-        await expect(
-          buildOpenAIVideoGenerationProvider().generateVideo({
-            provider: "openai",
-            model: "sora-2",
-            prompt: "Reject an unending public video error response",
-            cfg: allowPrivateNetwork
-              ? {
-                  models: {
-                    providers: {
-                      openai: {
-                        baseUrl: `http://127.0.0.1:${port}/v1`,
-                        request: { allowPrivateNetwork: true },
-                        models: [],
+          await expect(
+            buildOpenAIVideoGenerationProvider().generateVideo({
+              provider: "openai",
+              model: "sora-2",
+              prompt: "Reject an unending public video error response",
+              cfg: allowPrivateNetwork
+                ? {
+                    models: {
+                      providers: {
+                        openai: {
+                          baseUrl: `${baseUrl}/v1`,
+                          request: { allowPrivateNetwork: true },
+                          models: [],
+                        },
                       },
                     },
-                  },
-                }
-              : {},
-          }),
-        ).rejects.toThrow("OpenAI generated video download: malformed video response");
-
-        await expect(
-          Promise.race([
-            socketClosed,
-            new Promise<boolean>((resolve) => {
-              setTimeout(() => resolve(false), 250);
+                  }
+                : {},
             }),
-          ]),
-        ).resolves.toBe(true);
-        if (allowPrivateNetwork) {
-          expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledOnce();
-          expect(downloadRelease).toHaveBeenCalledOnce();
-        } else {
-          expect(fetchWithTimeoutGuardedMock).not.toHaveBeenCalled();
-        }
-      } finally {
-        server.closeAllConnections();
-        await new Promise<void>((resolve, reject) => {
-          server.close((error) => (error ? reject(error) : resolve()));
-        });
-      }
+          ).rejects.toThrow("OpenAI generated video download: malformed video response");
+
+          await expect(
+            Promise.race([
+              socketClosed,
+              new Promise<boolean>((resolve) => {
+                setTimeout(() => resolve(false), 250);
+              }),
+            ]),
+          ).resolves.toBe(true);
+          if (allowPrivateNetwork) {
+            expect(fetchWithTimeoutGuardedMock).toHaveBeenCalledOnce();
+            expect(downloadRelease).toHaveBeenCalledOnce();
+          } else {
+            expect(fetchWithTimeoutGuardedMock).not.toHaveBeenCalled();
+          }
+        },
+      );
     },
   );
 

--- a/extensions/qa-lab/src/ignored-response-body.test.ts
+++ b/extensions/qa-lab/src/ignored-response-body.test.ts
@@ -1,5 +1,4 @@
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { discardIgnoredResponseBody, readQaJsonResponse } from "./ignored-response-body.js";
 
@@ -37,28 +36,20 @@ describe("readQaJsonResponse", () => {
     { name: "oversized", body: `{"padding":"${"x".repeat(1 << 20)}"}`, error: /exceeds 1048576/ },
     { name: "stalled", body: "[", error: /stalled for 5000ms/ },
   ])("bounds $name local provider responses and releases the request", async ({ body, error }) => {
-    const server = createServer((_request, response) => {
-      response.writeHead(200, { "content-type": "application/json" });
-      response.write(body);
-      if (body !== "[") {
-        response.end();
-      }
-    });
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const address = server.address() as AddressInfo;
-    const release = vi.fn(async () => {});
-
-    try {
-      const response = await fetch(`http://127.0.0.1:${address.port}`);
-      await expect(readQaJsonResponse(response, release, "qa response")).rejects.toThrow(error);
-      expect(release).toHaveBeenCalledOnce();
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((closeError) => (closeError ? reject(closeError) : resolve()));
-      });
-    }
+    await withServer(
+      (_request, response) => {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.write(body);
+        if (body !== "[") {
+          response.end();
+        }
+      },
+      async (baseUrl) => {
+        const release = vi.fn(async () => {});
+        const response = await fetch(baseUrl);
+        await expect(readQaJsonResponse(response, release, "qa response")).rejects.toThrow(error);
+        expect(release).toHaveBeenCalledOnce();
+      },
+    );
   });
 });

--- a/extensions/sms/src/webhook.boundary.test.ts
+++ b/extensions/sms/src/webhook.boundary.test.ts
@@ -1,10 +1,9 @@
 import { createHmac } from "node:crypto";
 import {
-  createServer,
   request,
   type ClientRequest,
   type IncomingHttpHeaders,
-  type Server,
+  type RequestListener,
 } from "node:http";
 import { createConnection } from "node:net";
 import {
@@ -13,6 +12,7 @@ import {
   resetPluginRuntimeStateForTest,
   setActivePluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { startSmsGatewayAccount } from "./gateway.js";
 import type { SmsChannelRuntime } from "./inbound.js";
@@ -63,21 +63,6 @@ function createAccount(): ResolvedSmsAccount {
     allowFrom: [],
     textChunkLimit: 1500,
   };
-}
-
-function listen(server: Server): Promise<number> {
-  return new Promise((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        reject(new Error("expected the SMS boundary server to have a TCP address"));
-        return;
-      }
-      resolve(address.port);
-    });
-  });
 }
 
 function readResponse(req: ClientRequest): Promise<HttpResult> {
@@ -179,13 +164,6 @@ function computeTwilioSignature(params: {
   return createHmac("sha1", params.account.authToken).update(input).digest("base64");
 }
 
-async function closeServer(server: Server): Promise<void> {
-  server.closeAllConnections();
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
-}
-
 describe("SMS webhook real route boundary", () => {
   afterEach(() => {
     enqueueSmsIngress.mockReset();
@@ -216,8 +194,7 @@ describe("SMS webhook real route boundary", () => {
 
     let receivedRequests = 0;
     let heldBodyReaders = 0;
-    let overflowRequestComplete: boolean | undefined;
-    const server = createServer((req, res) => {
+    const handler: RequestListener = (req, res) => {
       receivedRequests += 1;
       const requestNumber = receivedRequests;
       if (requestNumber <= 64) {
@@ -225,72 +202,70 @@ describe("SMS webhook real route boundary", () => {
           heldBodyReaders += 1;
         });
       }
-      void Promise.resolve(route.handler(req, res))
-        .then(() => {
-          if (requestNumber === 65) {
-            overflowRequestComplete = req.complete;
-          }
-        })
-        .catch((error: unknown) => {
-          if (!res.writableEnded) {
-            res.statusCode = 500;
-            res.end(error instanceof Error ? error.message : String(error));
-          }
-        });
-    });
+      void Promise.resolve(route.handler(req, res)).catch((error: unknown) => {
+        if (!res.writableEnded) {
+          res.statusCode = 500;
+          res.end(error instanceof Error ? error.message : String(error));
+        }
+      });
+    };
     const held: HeldRequest[] = [];
 
     try {
-      const port = await listen(server);
-      for (let index = 0; index < 64; index += 1) {
-        held.push(holdIncompletePost(port, index));
-      }
-      await vi.waitFor(
-        () => {
-          expect(receivedRequests).toBe(64);
-          expect(heldBodyReaders).toBe(64);
-        },
-        { timeout: 10_000 },
-      );
+      await withServer(handler, async (baseUrl) => {
+        const port = Number(new URL(baseUrl).port);
+        try {
+          for (let index = 0; index < 64; index += 1) {
+            held.push(holdIncompletePost(port, index));
+          }
+          await vi.waitFor(
+            () => {
+              expect(receivedRequests).toBe(64);
+              expect(heldBodyReaders).toBe(64);
+            },
+            { timeout: 10_000 },
+          );
 
-      const overflow = await sendIncompleteRawPost(port);
-      expect(overflow.response).toContain("HTTP/1.1 429 Too Many Requests\r\n");
-      expect(overflow.response).toMatch(/\r\nConnection: close\r\n/iu);
-      expect(overflow.response).toContain("\r\n\r\nRate limit exceeded");
-      expect(overflow.endedByServer).toBe(true);
-      await vi.waitFor(() => expect(overflowRequestComplete).toBe(false));
-      expect(enqueueSmsIngress).not.toHaveBeenCalled();
+          // Header-only input plus peer closure proves early rejection; Bun marks req.complete on response end.
+          const overflow = await sendIncompleteRawPost(port);
+          expect(overflow.response).toContain("HTTP/1.1 429 Too Many Requests\r\n");
+          expect(overflow.response).toMatch(/\r\nConnection: close\r\n/iu);
+          expect(overflow.response).toContain("\r\n\r\nRate limit exceeded");
+          expect(overflow.endedByServer).toBe(true);
+          expect(enqueueSmsIngress).not.toHaveBeenCalled();
 
-      for (const pending of held) {
-        pending.finish();
-      }
-      const released = await Promise.all(held.map((pending) => pending.result));
-      expect(released.every((result) => result.statusCode === 403)).toBe(true);
+          for (const pending of held) {
+            pending.finish();
+          }
+          const released = await Promise.all(held.map((pending) => pending.result));
+          expect(released.every((result) => result.statusCode === 403)).toBe(true);
 
-      const form = {
-        AccountSid: account.accountSid,
-        From: "+15551234567",
-        To: account.fromNumber,
-        Body: "boundary proof",
-        MessageSid: "SM00000000000000000000000000000985",
-      };
-      const body = new URLSearchParams(form).toString();
-      const admitted = await postForm({
-        port,
-        body,
-        signature: computeTwilioSignature({ account, form }),
+          const form = {
+            AccountSid: account.accountSid,
+            From: "+15551234567",
+            To: account.fromNumber,
+            Body: "boundary proof",
+            MessageSid: "SM00000000000000000000000000000985",
+          };
+          const body = new URLSearchParams(form).toString();
+          const admitted = await postForm({
+            port,
+            body,
+            signature: computeTwilioSignature({ account, form }),
+          });
+
+          expect(admitted.statusCode).toBe(200);
+          expect(admitted.headers["x-openclaw-delivery-accepted"]).toBe("durable");
+          expect(enqueueSmsIngress).toHaveBeenCalledOnce();
+          expect(enqueueSmsIngress).toHaveBeenCalledWith(form);
+        } finally {
+          for (const pending of held) {
+            pending.request.destroy();
+          }
+          await Promise.allSettled(held.map((pending) => pending.result));
+        }
       });
-
-      expect(admitted.statusCode).toBe(200);
-      expect(admitted.headers["x-openclaw-delivery-accepted"]).toBe("durable");
-      expect(enqueueSmsIngress).toHaveBeenCalledOnce();
-      expect(enqueueSmsIngress).toHaveBeenCalledWith(form);
     } finally {
-      for (const pending of held) {
-        pending.request.destroy();
-      }
-      await Promise.allSettled(held.map((pending) => pending.result));
-      await closeServer(server);
       abortController.abort();
       await lifecycle;
       if (previousRegistry) {

--- a/extensions/sms/src/webhook.wire.test.ts
+++ b/extensions/sms/src/webhook.wire.test.ts
@@ -1,6 +1,5 @@
 // Sms tests cover webhook responses as the sender receives them on the wire.
-import { createServer } from "node:http";
-import { postRawWebhook } from "openclaw/plugin-sdk/test-env";
+import { postRawWebhook, withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSmsWebhookHandler } from "./webhook.js";
 import {
@@ -43,104 +42,78 @@ describe("createSmsWebhookHandler over a real connection", () => {
       ingress: { enqueue: enqueueSmsIngress },
       delivery,
     });
-    const server = createServer((req, res) => {
-      void handler(req, res);
-    });
-    try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          server.removeListener("error", reject);
-          resolve();
+    await withServer(
+      (req, res) => {
+        void handler(req, res);
+      },
+      async (baseUrl) => {
+        // Declared and sent in one write: the shape whose rejection used to race the flush.
+        const result = await postRawWebhook({
+          url: `${baseUrl}/sms`,
+          body: "x".repeat(32 * 1024 + 1),
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "x-twilio-signature": "unused",
+          },
         });
-      });
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected the SMS webhook test server to have a TCP address");
-      }
 
-      // Declared and sent in one write: the shape whose rejection used to race the flush.
-      const result = await postRawWebhook({
-        url: `http://127.0.0.1:${address.port}/sms`,
-        body: "x".repeat(32 * 1024 + 1),
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          "x-twilio-signature": "unused",
-        },
-      });
-
-      expect(result.statusLine).toBe("HTTP/1.1 413 Payload Too Large");
-      expect(result.headers.connection).toBe("close");
-      expect(result.body).toBe("Payload too large");
-      expect(result.closedByServer).toBe(true);
-      expect(delivery.record).not.toHaveBeenCalled();
-      expect(enqueueSmsIngress).not.toHaveBeenCalled();
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+        expect(result.statusLine).toBe("HTTP/1.1 413 Payload Too Large");
+        expect(result.headers.connection).toBe("close");
+        expect(result.body).toBe("Payload too large");
+        expect(result.closedByServer).toBe(true);
+        expect(delivery.record).not.toHaveBeenCalled();
+        expect(enqueueSmsIngress).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("delivers a retryable 500 before closing a timed-out callback upload", async () => {
-    vi.useFakeTimers();
     const handler = createSmsWebhookHandler({
       cfg: {},
       account: createSmsTestAccount(),
       ingress: { enqueue: enqueueSmsIngress },
     });
     let routeError: unknown;
-    const server = createServer((req, res) => {
-      void handler(req, res).catch((error: unknown) => {
-        routeError = error;
-        res.statusCode = 500;
-        res.setHeader("content-type", "text/plain; charset=utf-8");
-        res.end("Internal Server Error");
-      });
-    });
-    try {
-      await new Promise<void>((resolve, reject) => {
-        server.once("error", reject);
-        server.listen(0, "127.0.0.1", () => {
-          server.removeListener("error", reject);
-          resolve();
+    const requestReceived = Promise.withResolvers<void>();
+    await withServer(
+      (req, res) => {
+        void handler(req, res).catch((error: unknown) => {
+          routeError = error;
+          res.statusCode = 500;
+          res.setHeader("content-type", "text/plain; charset=utf-8");
+          res.end("Internal Server Error");
         });
-      });
-      const address = server.address();
-      if (!address || typeof address === "string") {
-        throw new Error("expected the SMS webhook test server to have a TCP address");
-      }
-      const requestReceived = new Promise<void>((resolve) => {
-        server.once("connection", (socket) => socket.once("data", () => resolve()));
-      });
-      const resultPromise = postRawWebhook({
-        url: `http://127.0.0.1:${address.port}/sms`,
-        body: "x",
-        contentLength: 2,
-        idleTimeoutMs: 10_000,
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          "x-twilio-signature": "unused",
-        },
-      });
+        // Observe after the body reader is installed; Bun's socket wrapper omits raw data events.
+        req.once("data", () => requestReceived.resolve());
+      },
+      async (baseUrl) => {
+        vi.useFakeTimers();
+        try {
+          const resultPromise = postRawWebhook({
+            url: `${baseUrl}/sms`,
+            body: "x",
+            contentLength: 2,
+            idleTimeoutMs: 10_000,
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              "x-twilio-signature": "unused",
+            },
+          });
 
-      await requestReceived;
-      await vi.advanceTimersByTimeAsync(6_000);
-      const result = await resultPromise;
+          await requestReceived.promise;
+          await vi.advanceTimersByTimeAsync(6_000);
+          const result = await resultPromise;
 
-      expect(routeError).toBeUndefined();
-      expect(result.statusLine).toBe("HTTP/1.1 500 Internal Server Error");
-      expect(result.headers.connection).toBe("close");
-      expect(result.body).toBe("Internal Server Error");
-      expect(result.closedByServer).toBe(true);
-      expect(enqueueSmsIngress).not.toHaveBeenCalled();
-    } finally {
-      vi.useRealTimers();
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+          expect(routeError).toBeUndefined();
+          expect(result.statusLine).toBe("HTTP/1.1 500 Internal Server Error");
+          expect(result.headers.connection).toBe("close");
+          expect(result.body).toBe("Internal Server Error");
+          expect(result.closedByServer).toBe(true);
+          expect(enqueueSmsIngress).not.toHaveBeenCalled();
+        } finally {
+          vi.useRealTimers();
+        }
+      },
+    );
   });
 });

--- a/extensions/sms/src/webhook.wire.test.ts
+++ b/extensions/sms/src/webhook.wire.test.ts
@@ -1,4 +1,5 @@
 // Sms tests cover webhook responses as the sender receives them on the wire.
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { postRawWebhook, withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createSmsWebhookHandler } from "./webhook.js";
@@ -74,7 +75,7 @@ describe("createSmsWebhookHandler over a real connection", () => {
       ingress: { enqueue: enqueueSmsIngress },
     });
     let routeError: unknown;
-    const requestReceived = Promise.withResolvers<void>();
+    const requestReceived = createDeferred<void>();
     await withServer(
       (req, res) => {
         void handler(req, res).catch((error: unknown) => {

--- a/src/plugin-sdk/test-helpers/http-test-server.test.ts
+++ b/src/plugin-sdk/test-helpers/http-test-server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { withServer } from "./http-test-server.js";
 
 describe("withServer", () => {
@@ -7,7 +8,7 @@ describe("withServer", () => {
     { outcome: "throws", rejectCallback: true },
   ])("closes an active response when its callback $outcome", async ({ rejectCallback }) => {
     const callbackError = new Error("callback failed");
-    const started = Promise.withResolvers<void>();
+    const started = createDeferredCore();
     let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
     let streamEnded = false;
     const outcome = withServer(

--- a/src/plugin-sdk/test-helpers/http-test-server.test.ts
+++ b/src/plugin-sdk/test-helpers/http-test-server.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { withServer } from "./http-test-server.js";
+
+describe("withServer", () => {
+  it.each([
+    { outcome: "returns", rejectCallback: false },
+    { outcome: "throws", rejectCallback: true },
+  ])("closes an active response when its callback $outcome", async ({ rejectCallback }) => {
+    const callbackError = new Error("callback failed");
+    const started = Promise.withResolvers<void>();
+    let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+    let streamEnded = false;
+    const outcome = withServer(
+      (_request, response) => {
+        response.writeHead(200);
+        response.write("stream started");
+      },
+      async (baseUrl) => {
+        const response = await fetch(baseUrl);
+        reader = response.body!.getReader();
+        await reader.read();
+        void reader.read().then(
+          ({ done }) => {
+            streamEnded = done;
+          },
+          () => {
+            streamEnded = true;
+          },
+        );
+        started.resolve();
+        if (rejectCallback) {
+          throw callbackError;
+        }
+      },
+    ).then(
+      () => undefined,
+      (error: unknown) => {
+        started.reject(error);
+        return error;
+      },
+    );
+    try {
+      await started.promise;
+      await vi.waitFor(() => expect(streamEnded).toBe(true));
+      expect(await outcome).toBe(rejectCallback ? callbackError : undefined);
+    } finally {
+      await reader?.cancel().catch(() => undefined);
+      await outcome;
+    }
+  });
+});

--- a/src/plugin-sdk/test-helpers/http-test-server.ts
+++ b/src/plugin-sdk/test-helpers/http-test-server.ts
@@ -1,10 +1,15 @@
 // Plugin SDK test helper for temporary local HTTP servers.
 import { createServer, type RequestListener } from "node:http";
-import type { AddressInfo } from "node:net";
+import type { AddressInfo, Socket } from "node:net";
 
 /** Run an ephemeral loopback HTTP server for the duration of an async test callback. */
 export async function withServer(handler: RequestListener, fn: (baseUrl: string) => Promise<void>) {
   const server = createServer(handler);
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", () => resolve());
   });
@@ -15,11 +20,12 @@ export async function withServer(handler: RequestListener, fn: (baseUrl: string)
   try {
     await fn(`http://127.0.0.1:${address.port}`);
   } finally {
-    const closed = new Promise<void>((resolve) => {
-      server.close(() => resolve());
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+      // Bun clears its native handle in close(), so closeAllConnections cannot finish active streams.
+      for (const socket of sockets) {
+        socket.destroy();
+      }
     });
-    // Hanging-response tests must still release active sockets when their assertion fails.
-    server.closeAllConnections();
-    await closed;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes failures and hangs when shared local HTTP test fixtures shut down active response streams under Bun. Several plugin tests duplicated cleanup that relied on runtime-specific closeAllConnections behavior.

## Why This Change Was Made

The existing withServer test helper tracks its sockets, registers listener shutdown first, then destroys owned connections. The affected fixtures share that owner. Two request-arrival waits now observe IncomingMessage after the body reader is installed. Wire-level rejection and capacity-recovery checks remain; a request-complete bookkeeping observation that Bun reports differently was removed.

## User Impact

Developers can run the covered plugin and HTTP lifecycle tests consistently on Node and Bun. Production behavior and the existing fixture API remain unchanged.

## Evidence

- Initial wider Node run: 132 tests passed. The corresponding Bun run identified three remaining cases, all repaired and included in the final focused proof.
- Final focused scenarios: 39 tests passed on each runtime. The new benign withServer regression also passed two cases on each runtime after the portable deferred-helper correction.
- Complete changed-file gate passed across all 12 files and all four typecheck lanes; fresh staged full-candidate P0–P2 review is clean.
- ES2023 typechecking exposed three direct Promise.withResolvers calls; they now use the existing repository deferred helpers without compiler-setting changes.
- Final runs used the supported disabled filesystem module cache to avoid host startup I/O stalls. No timeout or protocol assertion was weakened.
- The full Bun compatibility campaign remains in progress.
