### PR TITLE
refactor(native): share session mutation request construction

### DIFF
--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -10,7 +10,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
     private let widgetGateway: GatewayNodeSession?
     let globalAgentId: String?
     let outboxGatewayID: String?
-    private let sessionMutationRequest: (@Sendable (OpenClawChatGatewayRequest) async throws -> Data)?
     private let mediaArtifactLoader: IOSMediaArtifactLoader?
 
     var outboxRequiresSessionRoutingContract: Bool {
@@ -22,7 +21,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         widgetGateway: GatewayNodeSession? = nil,
         globalAgentId: String? = nil,
         outboxGatewayID: String? = nil,
-        sessionMutationRequest: (@Sendable (OpenClawChatGatewayRequest) async throws -> Data)? = nil,
         mediaArtifactLoader: IOSMediaArtifactLoader? = nil)
     {
         self.gateway = gateway
@@ -30,7 +28,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         let normalized = globalAgentId?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         self.globalAgentId = normalized?.isEmpty == false ? normalized : nil
         self.outboxGatewayID = GatewayStableIdentifier.exact(outboxGatewayID)
-        self.sessionMutationRequest = sessionMutationRequest
         self.mediaArtifactLoader = mediaArtifactLoader
     }
 
@@ -109,32 +106,10 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             ifCurrentRoute: route)
         let transport = self
         return OpenClawChatSessionMutationRouteLease(
-            patchSession: { key, expectedID, expectedMarkedUnreadAt, label, category, color, pinned, archived, unread in
-                guard unread != false || unreadAckContract != nil else {
-                    throw OpenClawChatTransportSendError.notDispatched
-                }
-                let target = transport.sessionTarget(for: key)
-                let request = OpenClawChatGatewayRequests.patchSession(
-                    sessionKey: target.sessionKey,
-                    agentID: target.agentID,
-                    expectedSessionID: expectedID,
-                    label: label,
-                    category: category,
-                    color: color,
-                    pinned: pinned,
-                    archived: archived,
-                    unreadPatch: .routed(
-                        unread: unread,
-                        expectedMarkedUnreadAt: expectedMarkedUnreadAt,
-                        supportsReadContract: unreadAckContract == true))
-                _ = try await transport.requestSessionMutation(request, ifCurrentRoute: route)
-            },
-            deleteSession: { key in
-                let target = transport.sessionTarget(for: key)
-                let request = OpenClawChatGatewayRequests.deleteSession(
-                    sessionKey: target.sessionKey,
-                    agentID: target.agentID)
-                _ = try await transport.requestSessionMutation(request, ifCurrentRoute: route)
+            sessionTarget: { transport.sessionTarget(for: $0) },
+            unreadAckContract: unreadAckContract,
+            request: { request in
+                try await transport.requestSessionMutation(request, ifCurrentRoute: route)
             })
     }
 
@@ -210,13 +185,6 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             overrideAgentID: overrideAgentID)
     }
 
-    private func requestSessionMutation(_ request: OpenClawChatGatewayRequest) async throws -> Data {
-        if let sessionMutationRequest {
-            return try await sessionMutationRequest(request)
-        }
-        return try await self.gateway.request(request)
-    }
-
     private func requestSessionMutation(
         _ request: OpenClawChatGatewayRequest,
         ifCurrentRoute route: GatewayNodeSessionRoute) async throws -> Data
@@ -257,7 +225,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             parentSessionKey: parentSessionKey,
             worktree: worktree,
             worktreeBaseRef: worktreeBaseRef)
-        let res = try await requestSessionMutation(request)
+        let res = try await gateway.request(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: res)
     }
 
@@ -452,7 +420,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
                 ifCurrentRoute: settingsRoute,
                 distinguishPreDispatchRouteChange: true)
         } else {
-            try await self.requestSessionMutation(request)
+            try await self.gateway.request(request)
         }
         return try Self.decodeModelPatchResult(response)
     }
@@ -479,36 +447,18 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         archived: Bool? = nil,
         unread: Bool? = nil) async throws
     {
-        if let routeLease = await acquireSessionMutationRouteLease() {
-            try await routeLease.patchSession(
-                key: key,
-                expectedSessionID: expectedSessionID,
-                label: label,
-                category: category,
-                color: color,
-                pinned: pinned,
-                archived: archived,
-                unread: unread)
-            return
-        }
-        guard self.sessionMutationRequest != nil else {
+        guard let routeLease = await acquireSessionMutationRouteLease() else {
             throw OpenClawChatTransportSendError.notDispatched
         }
-        let target = self.sessionTarget(for: key)
-        let request = OpenClawChatGatewayRequests.patchSession(
-            sessionKey: target.sessionKey,
-            agentID: target.agentID,
+        try await routeLease.patchSession(
+            key: key,
             expectedSessionID: expectedSessionID,
             label: label,
             category: category,
             color: color,
             pinned: pinned,
             archived: archived,
-            unreadPatch: .routed(
-                unread: unread,
-                expectedMarkedUnreadAt: nil,
-                supportsReadContract: false))
-        _ = try await self.requestSessionMutation(request)
+            unread: unread)
     }
 
     func deleteSession(key: String) async throws {
@@ -516,7 +466,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         let request = OpenClawChatGatewayRequests.deleteSession(
             sessionKey: target.sessionKey,
             agentID: target.agentID)
-        _ = try await self.requestSessionMutation(request)
+        _ = try await self.gateway.request(request)
     }
 
     func forkSession(parentKey: String) async throws -> String {
@@ -530,7 +480,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             parentSessionKey: target.sessionKey,
             agentID: childAgentID,
             fromLastCompleted: fromLastCompleted)
-        let response = try await requestSessionMutation(request)
+        let response = try await gateway.request(request)
         return try JSONDecoder().decode(OpenClawChatCreateSessionResponse.self, from: response).key
     }
 
@@ -543,7 +493,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             sessionKey: target.sessionKey,
             agentID: target.agentID,
             entryId: entryId)
-        let response = try await requestSessionMutation(request)
+        let response = try await gateway.request(request)
         return try JSONDecoder().decode(OpenClawChatRewindResponse.self, from: response)
     }
 
@@ -556,7 +506,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             sessionKey: target.sessionKey,
             agentID: target.agentID,
             entryId: entryId)
-        let response = try await requestSessionMutation(request)
+        let response = try await gateway.request(request)
         return try JSONDecoder().decode(OpenClawChatForkAtMessageResponse.self, from: response)
     }
 
@@ -578,7 +528,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
             sessionKey: target.sessionKey,
             agentID: agentID ?? target.agentID,
             leafEntryId: leafEntryId)
-        _ = try await self.requestSessionMutation(request)
+        _ = try await self.gateway.request(request)
     }
 
     func setActiveSessionKey(_ sessionKey: String) async throws {

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -102,24 +102,76 @@ struct IOSGatewayChatTransportTests {
         }
     }
 
+    private struct RecordedRequest: Decodable, Sendable {
+        let id: String
+        let method: String
+        let params: [String: AnyCodable]
+    }
+
     private actor RequestRecorder {
-        private var requests: [OpenClawChatGatewayRequest] = []
+        private var requests: [RecordedRequest] = []
 
-        func record(_ request: OpenClawChatGatewayRequest) -> Data {
+        func record(_ data: Data) throws -> RecordedRequest {
+            let request = try JSONDecoder().decode(RecordedRequest.self, from: data)
             self.requests.append(request)
-            if request.method == "sessions.create" {
-                return Data(#"{"key":"forked"}"#.utf8)
-            }
-            return Data(#"{"entry":{}}"#.utf8)
+            return request
         }
 
-        func record(_ request: OpenClawChatGatewayRequest, response: Data) -> Data {
-            self.requests.append(request)
-            return response
-        }
-
-        func all() -> [OpenClawChatGatewayRequest] {
+        func all() -> [RecordedRequest] {
             self.requests
+        }
+    }
+
+    private func withSessionTransport(
+        unreadAckAdvertisement: Bool? = true,
+        _ run: (IOSGatewayChatTransport, RequestRecorder) async throws -> Void) async throws
+    {
+        let recorder = RequestRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0 else { return }
+                let data: Data = switch message {
+                case let .data(value): value
+                case let .string(value): Data(value.utf8)
+                @unknown default: throw URLError(.cannotParseResponse)
+                }
+                let request = try await recorder.record(data)
+                let payload = request.method == "sessions.create" ? #"{"key":"forked"}"# : #"{"entry":{}}"#
+                socket.emitReceiveSuccess(.data(Data(
+                    #"{"type":"res","id":"\#(request.id)","ok":true,"payload":\#(payload)}"#.utf8)))
+            }, receiveHook: { socket, receiveIndex in
+                if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
+                let hello = GatewayWebSocketTestSupport.connectOkData(
+                    id: socket.snapshotConnectRequestID() ?? "connect",
+                    methods: ["sessions.patch", "sessions.delete", "sessions.create"],
+                    capabilities: unreadAckAdvertisement == true ? ["session-unread-ack-contract"] : [])
+                guard unreadAckAdvertisement == nil else { return .data(hello) }
+                var frame = try #require(JSONSerialization.jsonObject(with: hello) as? [String: Any])
+                var payload = try #require(frame["payload"] as? [String: Any])
+                var features = try #require(payload["features"] as? [String: Any])
+                features.removeValue(forKey: "capabilities")
+                payload["features"] = features
+                frame["payload"] = payload
+                return try .data(JSONSerialization.data(withJSONObject: frame))
+            })
+        })
+        let gateway = GatewayNodeSession()
+        var options = GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions
+        options.allowStoredDeviceAuth = false
+        do {
+            try await gateway.connect(
+                url: #require(URL(string: "ws://session-transport-test.invalid")),
+                credentials: .init(),
+                connectOptions: options,
+                sessionBox: WebSocketSessionBox(session: session),
+                onConnected: {},
+                onDisconnected: { _ in },
+                onInvoke: { BridgeInvokeResponse(id: $0.id, ok: true) })
+            try await run(IOSGatewayChatTransport(gateway: gateway, globalAgentId: " Reviewer "), recorder)
+            await gateway.disconnect()
+        } catch {
+            await gateway.disconnect()
+            throw error
         }
     }
 
@@ -345,176 +397,186 @@ struct IOSGatewayChatTransportTests {
     }
 
     @Test func `session mutations dispatch normalized selected agent targets`() async throws {
-        let recorder = RequestRecorder()
-        let transport = IOSGatewayChatTransport(
-            gateway: GatewayNodeSession(),
-            globalAgentId: " Reviewer ",
-            sessionMutationRequest: { request in
-                await recorder.record(request)
-            })
+        try await self.withSessionTransport { transport, recorder in
+            for key in ["Matrix:Channel:Room", "global", "agent:ops:main"] {
+                try await transport.patchSession(key: key, pinned: true)
+                try await transport.deleteSession(key: key)
+                _ = try await transport.forkSession(parentKey: key, fromLastCompleted: false)
+            }
 
-        for key in ["Matrix:Channel:Room", "global", "agent:ops:main"] {
-            try await transport.patchSession(key: key, pinned: true)
-            try await transport.deleteSession(key: key)
-            _ = try await transport.forkSession(parentKey: key, fromLastCompleted: false)
-        }
+            let requests = await recorder.all()
+            #expect(requests.map(\.method) == Array(
+                repeating: ["sessions.patch", "sessions.delete", "sessions.create"],
+                count: 3).flatMap(\.self))
 
-        let requests = await recorder.all()
-        #expect(requests.map(\.method) == Array(
-            repeating: ["sessions.patch", "sessions.delete", "sessions.create"],
-            count: 3).flatMap(\.self))
-        #expect(requests.map(\.timeoutMs) == Array(
-            repeating: [15000, 600_000, 15000],
-            count: 3).flatMap(\.self))
+            for (offset, expectedKey, expectedMutationAgentID, expectedForkAgentID) in [
+                (0, "agent:reviewer:Matrix:Channel:Room", nil, "reviewer"),
+                (3, "global", "reviewer", "reviewer"),
+                (6, "agent:ops:main", nil, "ops"),
+            ] as [(Int, String, String?, String?)] {
+                let patch = requests[offset].params
+                #expect(patch["key"]?.value as? String == expectedKey)
+                #expect(patch["agentId"]?.value as? String == expectedMutationAgentID)
+                #expect(patch["pinned"]?.value as? Bool == true)
 
-        for (offset, expectedKey, expectedMutationAgentID, expectedForkAgentID) in [
-            (0, "agent:reviewer:Matrix:Channel:Room", nil, "reviewer"),
-            (3, "global", "reviewer", "reviewer"),
-            (6, "agent:ops:main", nil, "ops"),
-        ] as [(Int, String, String?, String?)] {
-            let patch = requests[offset].params
-            #expect(patch["key"]?.value as? String == expectedKey)
-            #expect(patch["agentId"]?.value as? String == expectedMutationAgentID)
-            #expect(patch["pinned"]?.value as? Bool == true)
+                let delete = requests[offset + 1].params
+                #expect(delete["key"]?.value as? String == expectedKey)
+                #expect(delete["agentId"]?.value as? String == expectedMutationAgentID)
+                #expect(delete["deleteTranscript"]?.value as? Bool == true)
 
-            let delete = requests[offset + 1].params
-            #expect(delete["key"]?.value as? String == expectedKey)
-            #expect(delete["agentId"]?.value as? String == expectedMutationAgentID)
-            #expect(delete["deleteTranscript"]?.value as? Bool == true)
-
-            let fork = requests[offset + 2].params
-            #expect(fork["parentSessionKey"]?.value as? String == expectedKey)
-            #expect(fork["agentId"]?.value as? String == expectedForkAgentID)
-            #expect(fork["fork"]?.value as? Bool == true)
+                let fork = requests[offset + 2].params
+                #expect(fork["parentSessionKey"]?.value as? String == expectedKey)
+                #expect(fork["agentId"]?.value as? String == expectedForkAgentID)
+                #expect(fork["fork"]?.value as? Bool == true)
+            }
         }
     }
 
     @Test func `archive and restore carry the observed session identity`() async throws {
-        let recorder = RequestRecorder()
-        let transport = IOSGatewayChatTransport(
-            gateway: GatewayNodeSession(),
-            globalAgentId: " Reviewer ",
-            sessionMutationRequest: { request in
-                await recorder.record(request)
-            })
+        try await self.withSessionTransport { transport, recorder in
+            try await transport.patchSession(
+                key: "global",
+                expectedSessionID: " session-a ",
+                archived: true)
+            try await transport.patchSession(
+                key: "global",
+                expectedSessionID: "session-a",
+                archived: false)
 
-        try await transport.patchSession(
-            key: "global",
-            expectedSessionID: " session-a ",
-            archived: true)
-        try await transport.patchSession(
-            key: "global",
-            expectedSessionID: "session-a",
-            archived: false)
-
-        let requests = await recorder.all()
-        #expect(requests.map(\.method) == ["sessions.patch", "sessions.patch"])
-        #expect(requests.map(\.timeoutMs) == [600_000, 15000])
-        #expect(requests.allSatisfy { $0.params["key"]?.value as? String == "global" })
-        #expect(requests.allSatisfy { $0.params["agentId"]?.value as? String == "reviewer" })
-        #expect(requests.allSatisfy { $0.params["expectedSessionId"]?.value as? String == "session-a" })
-        #expect(requests[0].params["archived"]?.value as? Bool == true)
-        #expect(requests[1].params["archived"]?.value as? Bool == false)
+            let requests = await recorder.all()
+            #expect(requests.map(\.method) == ["sessions.patch", "sessions.patch"])
+            #expect(requests.allSatisfy { $0.params["key"]?.value as? String == "global" })
+            #expect(requests.allSatisfy { $0.params["agentId"]?.value as? String == "reviewer" })
+            #expect(requests.allSatisfy { $0.params["expectedSessionId"]?.value as? String == "session-a" })
+            #expect(requests[0].params["archived"]?.value as? Bool == true)
+            #expect(requests[1].params["archived"]?.value as? Bool == false)
+        }
     }
 
     @Test func `thinking changes dispatch through selected agent session target`() async throws {
-        let recorder = RequestRecorder()
-        let transport = IOSGatewayChatTransport(
-            gateway: GatewayNodeSession(),
-            globalAgentId: " Reviewer ",
-            sessionMutationRequest: { request in
-                await recorder.record(request)
-            })
+        try await self.withSessionTransport { transport, recorder in
+            try await transport.setSessionThinking(sessionKey: "global", thinkingLevel: "high")
 
-        try await transport.setSessionThinking(sessionKey: "global", thinkingLevel: "high")
-
-        let request = try #require(await recorder.all().first)
-        #expect(request.method == "sessions.patch")
-        #expect(request.params["key"]?.value as? String == "global")
-        #expect(request.params["agentId"]?.value as? String == "reviewer")
-        #expect(request.params["thinkingLevel"]?.value as? String == "high")
+            let request = try #require(await recorder.all().first)
+            #expect(request.method == "sessions.patch")
+            #expect(request.params["key"]?.value as? String == "global")
+            #expect(request.params["agentId"]?.value as? String == "reviewer")
+            #expect(request.params["thinkingLevel"]?.value as? String == "high")
+        }
     }
 
     @Test func `advanced session creation forwards agent worktree and base ref`() async throws {
-        let recorder = RequestRecorder()
-        let transport = IOSGatewayChatTransport(
-            gateway: GatewayNodeSession(),
-            globalAgentId: " Reviewer ",
-            sessionMutationRequest: { request in
-                await recorder.record(request)
-            })
+        try await self.withSessionTransport { transport, recorder in
+            let created = try await transport.createSession(
+                key: "agent:builder:ios-new",
+                label: "Build",
+                agentID: " Builder ",
+                parentSessionKey: "agent:builder:main",
+                worktree: true,
+                worktreeBaseRef: " origin/release ")
 
-        let created = try await transport.createSession(
-            key: "agent:builder:ios-new",
-            label: "Build",
-            agentID: " Builder ",
-            parentSessionKey: "agent:builder:main",
-            worktree: true,
-            worktreeBaseRef: " origin/release ")
-
-        #expect(created.key == "forked")
-        let request = try #require(await recorder.all().first)
-        #expect(request.method == "sessions.create")
-        #expect(request.params["key"]?.value as? String == "agent:builder:ios-new")
-        #expect(request.params["label"]?.value as? String == "Build")
-        #expect(request.params["agentId"]?.value as? String == "builder")
-        #expect(request.params["parentSessionKey"]?.value as? String == "agent:builder:main")
-        #expect(request.params["worktree"]?.value as? Bool == true)
-        #expect(request.params["worktreeBaseRef"]?.value as? String == "origin/release")
+            #expect(created.key == "forked")
+            let request = try #require(await recorder.all().first)
+            #expect(request.method == "sessions.create")
+            #expect(request.params["key"]?.value as? String == "agent:builder:ios-new")
+            #expect(request.params["label"]?.value as? String == "Build")
+            #expect(request.params["agentId"]?.value as? String == "builder")
+            #expect(request.params["parentSessionKey"]?.value as? String == "agent:builder:main")
+            #expect(request.params["worktree"]?.value as? Bool == true)
+            #expect(request.params["worktreeBaseRef"]?.value as? String == "origin/release")
+        }
     }
 
     @Test func `verbosity patches preserve set and clear values`() async throws {
-        let recorder = RequestRecorder()
-        let transport = IOSGatewayChatTransport(
-            gateway: GatewayNodeSession(),
-            globalAgentId: " Reviewer ",
-            sessionMutationRequest: { request in
-                await recorder.record(request)
-            })
+        try await self.withSessionTransport { transport, recorder in
+            _ = try await transport.patchSessionSettings(
+                sessionKey: "global",
+                agentID: nil,
+                patch: OpenClawChatSessionSettingsPatch(verboseLevel: .some("full")))
+            _ = try await transport.patchSessionSettings(
+                sessionKey: "global",
+                agentID: nil,
+                patch: OpenClawChatSessionSettingsPatch(verboseLevel: .some(nil)))
 
-        _ = try await transport.patchSessionSettings(
-            sessionKey: "global",
-            agentID: nil,
-            patch: OpenClawChatSessionSettingsPatch(verboseLevel: .some("full")))
-        _ = try await transport.patchSessionSettings(
-            sessionKey: "global",
-            agentID: nil,
-            patch: OpenClawChatSessionSettingsPatch(verboseLevel: .some(nil)))
-
-        let requests = await recorder.all()
-        #expect(requests.count == 2)
-        #expect(requests.allSatisfy { $0.method == "sessions.patch" })
-        #expect(requests.allSatisfy { $0.params["key"]?.value as? String == "global" })
-        #expect(requests.allSatisfy { $0.params["agentId"]?.value as? String == "reviewer" })
-        #expect(requests[0].params["verboseLevel"]?.value as? String == "full")
-        #expect(requests[1].params["verboseLevel"]?.value is NSNull)
-        #expect(requests.allSatisfy { $0.params["model"] == nil })
-        #expect(requests.allSatisfy { $0.params["thinkingLevel"] == nil })
+            let requests = await recorder.all()
+            #expect(requests.count == 2)
+            #expect(requests.allSatisfy { $0.method == "sessions.patch" })
+            #expect(requests.allSatisfy { $0.params["key"]?.value as? String == "global" })
+            #expect(requests.allSatisfy { $0.params["agentId"]?.value as? String == "reviewer" })
+            #expect(requests[0].params["verboseLevel"]?.value as? String == "full")
+            #expect(requests[1].params["verboseLevel"]?.value is NSNull)
+            #expect(requests.allSatisfy { $0.params["model"] == nil })
+            #expect(requests.allSatisfy { $0.params["thinkingLevel"] == nil })
+        }
     }
 
     @Test func `fast mode patches preserve boolean and explicit null`() async throws {
-        let recorder = RequestRecorder()
-        let transport = IOSGatewayChatTransport(
-            gateway: GatewayNodeSession(),
-            globalAgentId: " Reviewer ",
-            sessionMutationRequest: { request in
-                await recorder.record(request)
-            })
+        try await self.withSessionTransport { transport, recorder in
+            _ = try await transport.patchSessionSettings(
+                sessionKey: "global",
+                agentID: nil,
+                patch: OpenClawChatSessionSettingsPatch(fastMode: .some(.on)))
+            _ = try await transport.patchSessionSettings(
+                sessionKey: "global",
+                agentID: nil,
+                patch: OpenClawChatSessionSettingsPatch(fastMode: .some(nil)))
 
-        _ = try await transport.patchSessionSettings(
-            sessionKey: "global",
-            agentID: nil,
-            patch: OpenClawChatSessionSettingsPatch(fastMode: .some(.on)))
-        _ = try await transport.patchSessionSettings(
-            sessionKey: "global",
-            agentID: nil,
-            patch: OpenClawChatSessionSettingsPatch(fastMode: .some(nil)))
+            let requests = await recorder.all()
+            #expect(requests.count == 2)
+            #expect(requests[0].params["fastMode"]?.value as? Bool == true)
+            #expect(requests[1].params["fastMode"]?.value is NSNull)
+            #expect(requests.allSatisfy { $0.params["verboseLevel"] == nil })
+        }
+    }
 
-        let requests = await recorder.all()
-        #expect(requests.count == 2)
-        #expect(requests[0].params["fastMode"]?.value as? Bool == true)
-        #expect(requests[1].params["fastMode"]?.value is NSNull)
-        #expect(requests.allSatisfy { $0.params["verboseLevel"] == nil })
+    @Test(arguments: [true, false, nil] as [Bool?])
+    func `session mutation leases preserve advertised and omitted read capabilities`(
+        unreadAckAdvertisement: Bool?) async throws
+    {
+        try await self.withSessionTransport(unreadAckAdvertisement: unreadAckAdvertisement) { transport, recorder in
+            let lease = try #require(await transport.acquireSessionMutationRouteLease())
+            try await lease.patchSession(
+                key: "global",
+                label: nil,
+                category: nil,
+                pinned: true,
+                archived: nil,
+                unread: nil)
+            try await lease.patchSession(
+                key: "global",
+                label: nil,
+                category: nil,
+                pinned: nil,
+                archived: nil,
+                unread: true)
+            for marker in [nil, .some(nil), .some(1234.5)] as [Double??] {
+                try await lease.patchSession(
+                    key: "global",
+                    expectedMarkedUnreadAt: marker,
+                    label: nil,
+                    category: nil,
+                    pinned: nil,
+                    archived: nil,
+                    unread: false)
+            }
+
+            let requests = await recorder.all()
+            try #require(requests.count == 5)
+            #expect(requests.allSatisfy { $0.method == "sessions.patch" })
+            #expect(requests.allSatisfy { $0.params["key"]?.value as? String == "global" })
+            #expect(requests.allSatisfy { $0.params["agentId"]?.value as? String == "reviewer" })
+            #expect(requests[0].params["pinned"]?.value as? Bool == true)
+            #expect(requests[0].params["unread"] == nil)
+            #expect(requests[1].params["unread"]?.value as? Bool == true)
+            if unreadAckAdvertisement == true {
+                #expect(requests[2].params["expectedMarkedUnreadAt"] == nil)
+                #expect(requests[3].params["expectedMarkedUnreadAt"]?.value is NSNull)
+                #expect(requests[4].params["expectedMarkedUnreadAt"]?.value as? Double == 1234.5)
+            } else {
+                #expect(requests.allSatisfy { $0.params["expectedMarkedUnreadAt"] == nil })
+            }
+            #expect(requests.dropFirst(2).allSatisfy { $0.params["unread"]?.value as? Bool == false })
+        }
     }
 
     @Test func `requests fail fast when gateway not connected`() async {

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -79,36 +79,10 @@ extension MacGatewayChatTransport {
             ifCurrentServerLease: serverLease)
         let transport = self
         return OpenClawChatSessionMutationRouteLease(
-            patchSession: { key, expectedID, expectedMarkedUnreadAt, label, category, color, pinned, archived, unread in
-                guard unread != false || unreadAckContract != nil else {
-                    throw OpenClawChatTransportSendError.notDispatched
-                }
-                let target = transport.sessionTarget(for: key)
-                let request = OpenClawChatGatewayRequests.patchSession(
-                    sessionKey: target.sessionKey,
-                    agentID: target.agentID,
-                    expectedSessionID: expectedID,
-                    label: label,
-                    category: category,
-                    color: color,
-                    pinned: pinned,
-                    archived: archived,
-                    unreadPatch: .routed(
-                        unread: unread,
-                        expectedMarkedUnreadAt: expectedMarkedUnreadAt,
-                        supportsReadContract: unreadAckContract == true))
-                _ = try await self.connection.request(
-                    method: request.method,
-                    params: request.params,
-                    timeoutMs: request.timeoutMs,
-                    ifCurrentServerLease: serverLease)
-            },
-            deleteSession: { key in
-                let target = transport.sessionTarget(for: key)
-                let request = OpenClawChatGatewayRequests.deleteSession(
-                    sessionKey: target.sessionKey,
-                    agentID: target.agentID)
-                _ = try await self.connection.request(
+            sessionTarget: { transport.sessionTarget(for: $0) },
+            unreadAckContract: unreadAckContract,
+            request: { request in
+                try await self.connection.request(
                     method: request.method,
                     params: request.params,
                     timeoutMs: request.timeoutMs,

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
@@ -6,21 +6,21 @@ import Testing
 @testable import OpenClaw
 
 struct MacGatewayChatTransportMappingTests {
-    private actor ProgressRequestRecorder {
-        var params: [Data] = []
+    private actor RequestRecorder {
+        var payloads: [Data] = []
 
         func append(_ data: Data) {
-            self.params.append(data)
+            self.payloads.append(data)
         }
 
         func snapshot() -> [Data] {
-            self.params
+            self.payloads
         }
     }
 
     @Test(arguments: [false, true, nil] as [Bool?])
     func `progress requests negotiate owner scope on the connected server`(supportsOwner: Bool?) async throws {
-        let recorder = ProgressRequestRecorder()
+        let recorder = RequestRecorder()
         let socketSession = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
                 guard sendIndex > 0 else { return }
@@ -88,6 +88,76 @@ struct MacGatewayChatTransportMappingTests {
                 ["sessionKey": "agent:research:global"],
                 ["sessionKey": "global", "agentId": "research"],
             ] : [["sessionKey": "agent:research:global"]]))
+            await gateway.shutdown()
+        } catch {
+            await gateway.shutdown()
+            throw error
+        }
+    }
+
+    @Test func `mutation lease resolves the current global agent for each request`() async throws {
+        let recorder = RequestRecorder()
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
+                guard sendIndex > 0 else { return }
+                let id = try #require(GatewayWebSocketTestSupport.requestID(from: message))
+                if GatewayWebSocketTestSupport.requestMethod(from: message)?.hasPrefix("sessions.") == true {
+                    let data: Data = switch message {
+                    case let .data(value): value
+                    case let .string(value): Data(value.utf8)
+                    @unknown default: throw URLError(.cannotParseResponse)
+                    }
+                    await recorder.append(data)
+                }
+                socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+            }, receiveHook: { socket, receiveIndex in
+                if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
+                return .data(GatewayWebSocketTestSupport.connectOkData(
+                    id: socket.snapshotConnectRequestID() ?? "connect",
+                    methods: ["sessions.patch", "sessions.delete"],
+                    capabilities: ["session-unread-ack-contract"]))
+            })
+        })
+        let gateway = GatewayConnection(
+            configProvider: { (url: URL(string: "ws://127.0.0.1:1")!, token: nil, password: nil) },
+            sessionBox: WebSocketSessionBox(session: session))
+        do {
+            _ = try await gateway.request(method: "health", params: nil)
+            let transport = MacGatewayChatTransport(connection: gateway, defaultGlobalAgentID: "agent-a")
+            let lease = try #require(await transport.acquireSessionMutationRouteLease())
+            try await lease.patchSession(
+                key: "global",
+                label: nil,
+                category: nil,
+                pinned: true,
+                archived: nil,
+                unread: nil)
+            let observerTransport = transport
+            observerTransport.updateDefaultGlobalAgentID(" Agent-B ")
+            try await lease.patchSession(
+                key: "global",
+                label: nil,
+                category: nil,
+                color: .some(nil),
+                pinned: nil,
+                archived: nil,
+                unread: nil)
+            try await lease.deleteSession(key: "agent:agent-b:work")
+
+            let frames = try await recorder.snapshot().map {
+                try #require(JSONSerialization.jsonObject(with: $0) as? [String: Any])
+            }
+            let methods = frames.map { $0["method"] as? String }
+            try #require(methods == ["sessions.patch", "sessions.patch", "sessions.delete"])
+            let params = try frames.map { try #require($0["params"] as? [String: Any]) }
+            #expect(params[0]["key"] as? String == "global")
+            #expect(params[0]["agentId"] as? String == "agent-a")
+            #expect(params[1]["key"] as? String == "global")
+            #expect(params[1]["agentId"] as? String == "agent-b")
+            #expect(params[1]["color"] is NSNull)
+            #expect(params[2]["key"] as? String == "agent:agent-b:work")
+            #expect(params[2]["agentId"] == nil)
+            #expect(params[2]["deleteTranscript"] as? Bool == true)
             await gateway.shutdown()
         } catch {
             await gateway.shutdown()

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatTransport.swift
@@ -405,6 +405,41 @@ public struct OpenClawChatSessionMutationRouteLease: Sendable {
         self.deleteSessionImpl = deleteSession
     }
 
+    /// The caller binds requests to its captured connection. Resolve targets at
+    /// invocation time because transport copies can share mutable agent routing.
+    public init(
+        sessionTarget: @escaping @Sendable (String) -> OpenClawChatSessionTarget,
+        unreadAckContract: Bool?,
+        request: @escaping @Sendable (OpenClawChatGatewayRequest) async throws -> Data)
+    {
+        self.init(
+            patchSession: { key, expectedID, expectedMarkedUnreadAt, label, category, color, pinned, archived, unread in
+                guard unread != false || unreadAckContract != nil else {
+                    throw OpenClawChatTransportSendError.notDispatched
+                }
+                let target = sessionTarget(key)
+                _ = try await request(OpenClawChatGatewayRequests.patchSession(
+                    sessionKey: target.sessionKey,
+                    agentID: target.agentID,
+                    expectedSessionID: expectedID,
+                    label: label,
+                    category: category,
+                    color: color,
+                    pinned: pinned,
+                    archived: archived,
+                    unreadPatch: .routed(
+                        unread: unread,
+                        expectedMarkedUnreadAt: expectedMarkedUnreadAt,
+                        supportsReadContract: unreadAckContract == true)))
+            },
+            deleteSession: { key in
+                let target = sessionTarget(key)
+                _ = try await request(OpenClawChatGatewayRequests.deleteSession(
+                    sessionKey: target.sessionKey,
+                    agentID: target.agentID))
+            })
+    }
+
     public func patchSession(
         key: String,
         expectedSessionID: String? = nil,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayRequestTests.swift
@@ -478,6 +478,108 @@ struct ChatGatewayRequestTests {
         #expect(delete.params["name"]?.value as? String == "Personal")
     }
 
+    private actor MutationRequestRecorder {
+        var requests: [OpenClawChatGatewayRequest] = []
+
+        func send(_ request: OpenClawChatGatewayRequest) -> Data {
+            self.requests.append(request)
+            return Data()
+        }
+    }
+
+    @Test func `gateway mutation lease forwards nullable fields and request timeouts`() async throws {
+        let recorder = MutationRequestRecorder()
+        let lease = OpenClawChatSessionMutationRouteLease(
+            sessionTarget: {
+                OpenClawChatSessionTarget.resolve(
+                    $0,
+                    selectedAgentID: "reviewer",
+                    policy: .scopeBareKeysToSelectedAgent)
+            },
+            unreadAckContract: true,
+            request: { await recorder.send($0) })
+        try await lease.patchSession(
+            key: "work",
+            expectedSessionID: " session-a ",
+            label: .some(nil),
+            category: .some("Work"),
+            color: .some("blue"),
+            pinned: false,
+            archived: nil,
+            unread: nil)
+        try await lease.patchSession(
+            key: "work",
+            expectedSessionID: "session-a",
+            label: nil,
+            category: nil,
+            color: .some(nil),
+            pinned: nil,
+            archived: true,
+            unread: nil)
+        try await lease.deleteSession(key: "work")
+
+        let requests = await recorder.requests
+        try #require(requests.map(\.method) == ["sessions.patch", "sessions.patch", "sessions.delete"])
+        #expect(requests.map(\.timeoutMs) == [15000, 600_000, 600_000])
+        #expect(requests[0].params == [
+            "key": AnyCodable("agent:reviewer:work"),
+            "expectedSessionId": AnyCodable("session-a"),
+            "label": AnyCodable(NSNull()),
+            "category": AnyCodable("Work"),
+            "color": AnyCodable("blue"),
+            "pinned": AnyCodable(false),
+        ])
+        #expect(requests[1].params == [
+            "key": AnyCodable("agent:reviewer:work"),
+            "expectedSessionId": AnyCodable("session-a"),
+            "color": AnyCodable(NSNull()),
+            "archived": AnyCodable(true),
+        ])
+        #expect(requests[2].params == [
+            "key": AnyCodable("agent:reviewer:work"),
+            "deleteTranscript": AnyCodable(true),
+        ])
+    }
+
+    @Test func `unknown captured read capability only blocks read mutations`() async throws {
+        let recorder = MutationRequestRecorder()
+        let lease = OpenClawChatSessionMutationRouteLease(
+            sessionTarget: { OpenClawChatSessionTarget(sessionKey: $0, agentID: nil) },
+            unreadAckContract: nil,
+            request: { await recorder.send($0) })
+        try await lease.patchSession(
+            key: "agent:reviewer:work",
+            label: nil,
+            category: nil,
+            pinned: true,
+            archived: nil,
+            unread: nil)
+        try await lease.patchSession(
+            key: "agent:reviewer:work",
+            label: nil,
+            category: nil,
+            pinned: nil,
+            archived: nil,
+            unread: true)
+        await #expect(throws: OpenClawChatTransportSendError.self) {
+            try await lease.patchSession(
+                key: "agent:reviewer:work",
+                expectedMarkedUnreadAt: .some(nil),
+                label: nil,
+                category: nil,
+                pinned: nil,
+                archived: nil,
+                unread: false)
+        }
+        let requests = await recorder.requests
+        try #require(requests.count == 2)
+        #expect(requests.allSatisfy { $0.method == "sessions.patch" })
+        #expect(requests[0].params["pinned"]?.value as? Bool == true)
+        #expect(requests[0].params["unread"] == nil)
+        #expect(requests[1].params["unread"]?.value as? Bool == true)
+        #expect(requests.allSatisfy { $0.params["expectedMarkedUnreadAt"] == nil })
+    }
+
     @Test func `rename clear archive delete and fork use session mutation contracts`() {
         let rename = OpenClawChatGatewayRequests.patchSession(
             sessionKey: "agent:main:child",
@@ -521,6 +623,7 @@ struct ChatGatewayRequestTests {
         #expect(restore.params["expectedSessionId"]?.value as? String == "session-child")
         #expect(restore.timeoutMs == 15000)
         #expect(fork.method == "sessions.create")
+        #expect(fork.timeoutMs == 15000)
         #expect(fork.params["parentSessionKey"]?.value as? String == "agent:main:child")
         #expect(fork.params["fork"]?.value as? Bool == true)
     }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

macOS and iOS duplicated request construction for session edits and deletion. The iOS tests also used an internal transport shortcut that could bypass the connected Gateway path, leaving the real adapter wiring outside those assertions.

## Why This Change Was Made

Move that construction into a request-based initializer on the existing `OpenClawChatSessionMutationRouteLease`. Platform callbacks retain their captured physical Gateway route and request checks, while session targets are resolved when each mutation is invoked so shared routing changes remain visible.

Remove the internal iOS `sessionMutationRequest` injection, which had six test callers and no production caller. Those tests now use the existing connected `GatewayNodeSession` and synthetic WebSocket fixtures. The original public closure initializer and non-Gateway adapter remain supported.

## User Impact

Session edits and deletion retain their platform-specific targeting, expected-session identity, nullable fields, unread capability behavior and request timeouts. macOS continues to resolve changes to shared selected-agent routing at invocation time. No new workflow, visual layout, Gateway schema, configuration or persistent-store behavior is introduced.

Six files: **production +54/−95 (−41), tests +403/−168 (+235)**. Test churn includes reindentation of six retained cases as they move into connected fixtures with joined cleanup.

## Evidence

- **iOS runtime:** full signed app/test build passed, followed by exactly **28 `IOSGatewayChatTransportTests` methods / 34 argument invocations**, with zero failures or skips. The migrated cases inspect actual encoded requests through the connected adapter. `LocalFixtureChatTransportTests` was not selected. Proof used a new iPhone 17/iOS 26.5 simulator and verified host/test-bundle signatures; the simulator was deleted and existing devices were preserved.
- **Disposable shared/Mac runtime:** [CI run 34006971262](https://github.com/openclaw/openclaw/actions/runs/34006971262) independently ran OpenClawKit: 1,657 tests / 124 suites, including explicit passes for `ChatGatewayRequestTests`, `ChatViewModelUnreadTests` and `ChatViewModelSessionActionTests`. The Mac default invocation reported 2,054 tests / 223 suites and explicitly passed `MacGatewayChatTransportMappingTests`; it logged three skips. The health-render fixture later passed separately (1 test / 1 suite); the response-loss and embedded-socket proof tests remain skipped. The named isolation invocation passed separately (2 tests / 1 suite). These are separate reported totals, not a combined unique-test count. The exact Mac job checked out `e702a8b2b341930df846432b1f1b451ab11a55b2`, parents `8ffe7768940e9f1d25035d62aa74dd341a7344c1` and committed candidate `1befcacb8d6a812eee949764d39d03490e4ef4e4`.
- **Checks:** scoped pinned formatting and strict production lint passed. All **14 canonical changed-file stages passed**, including **1,110 Node/Vitest tests across 21 files**. Those tooling tests do not substitute for native Swift execution.
- **Review:** independent review and all **five managed source-review passes** are clean for the corrected candidate. The independent P2 fixture finding was accepted and fixed: omitted hello capability advertisements normalize to known unsupported behavior, so connected empty/omitted cases use legacy read payloads. A separate shared-constructor test covers genuinely unknown captured support. Production capability policy was unchanged; the original finding and correction remain recorded.
- **Provenance:** validation is bound to frozen patch `d1a63c769acb5e583402aa36e16ba6042219b334618843fa097c91a328163fe7` over `ec40f39a8e7b6cbde65958956c15fb6e2b1bd68f`. All six source hashes and 3,766 tracked build/source inputs remained unchanged through final validation. The interrupted pre-correction compile is not counted as a pass or compiler failure.

**Complete exact-head CI:** [run 34006971262](https://github.com/openclaw/openclaw/actions/runs/34006971262) completed successfully with **20 passed jobs, 21 skipped, 0 failures and 0 pending**; the canonical CI observer returned GREEN with rollup SUCCESS. [The current Claw review](https://github.com/openclaw/openclaw/pull/139641#issuecomment-5556426442), refreshed 2026-09-06T03:13:21.327Z for the exact committed head, has no actionable findings or before-merge items. No Mac app or Swift test ran on the operator desktop, and connected fixtures are not a live external-Gateway test.
