### PR TITLE
fix(qa): stop replaying committed requests after lost responses

### DIFF
--- a/config/knip.all-exports.config.ts
+++ b/config/knip.all-exports.config.ts
@@ -44,6 +44,8 @@ const ROOT_TEST_ENTRY_GLOBS = [
   "src/infra/exec-host.native.test-support.ts!",
   // The Windows CLI lifetime test launches this isolated probe by path.
   "test/helpers/openclaw-test-instance.cli.test-support.mjs!",
+  // The public QA Gateway child launches this transport proxy by path.
+  "test/fixtures/qa-gateway-rpc-proxy.mjs!",
   // Vitest loads these by configuration or module alias rather than imports.
   "test/setup*.ts!",
   "test/non-isolated-runner.ts!",

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1136,6 +1136,11 @@ timeouts, cancellations, and stream faults, retain bounded, redacted stderr and
 stdout captured through shutdown. Packaged plugin setup errors distinguish
 `update repair --help` from `update repair`.
 
+Gateway RPC calls wait for reconnection only while the request is unsent. Once
+sent, a lost connection is reported to the scenario without replaying the
+request: the Gateway may already have committed it. Scenario code must inspect
+the resulting state before deciding whether an interrupted action is safe to retry.
+
 Transport adapters drain their driver work in
 `cleanup()` and release Gateway-backed credentials in
 `cleanupAfterGatewayStop()`. The suite runs that second phase only when no

--- a/extensions/qa-lab/src/gateway-child-readiness.ts
+++ b/extensions/qa-lab/src/gateway-child-readiness.ts
@@ -9,7 +9,6 @@ import {
   type QaChildFailure,
   throwQaGatewayChildFailure,
 } from "./gateway-child-process.js";
-import { formatQaGatewayLogsForError } from "./gateway-log-redaction.js";
 
 export const QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS = 5;
 const QA_GATEWAY_CHILD_RESTART_BOUNDARY_TIMEOUT_MS = 90_000;
@@ -59,69 +58,6 @@ export function resolveQaGatewayStartupRetry(params: {
     migrationConvergenceRestartUsed:
       params.migrationConvergenceRestartUsed || kind === "migration-convergence-restart",
   };
-}
-
-function isRetryableGatewayCallError(details: string): boolean {
-  // The persistent QA client exposes preformatted close errors plus child logs,
-  // not the typed transport errors produced by one-shot gateway calls.
-  return (
-    details.includes("handshake timeout") ||
-    details.includes("gateway closed (1000") ||
-    details.includes("gateway closed (1012)") ||
-    details.includes("gateway closed (1006") ||
-    details.includes("abnormal closure") ||
-    details.includes("service restart")
-  );
-}
-
-export async function callQaGatewayWithRetry<T>(params: {
-  deadlineMs?: number;
-  logs: () => string;
-  request: (options: { deadlineMs?: number; timeoutMs: number }) => Promise<T>;
-  throwChildFailure: () => void;
-  timeoutMs: number;
-  waitForReady: (timeoutMs: number) => Promise<void>;
-}) {
-  const remainingMs = () =>
-    params.deadlineMs === undefined ? undefined : params.deadlineMs - Date.now();
-  const deadlineError = () =>
-    new Error(`gateway call deadline exceeded${formatQaGatewayLogsForError(params.logs())}`);
-  let lastDetails = "";
-  for (let attempt = 1; attempt <= 3; attempt += 1) {
-    params.throwChildFailure();
-    const requestRemainingMs = remainingMs();
-    if (requestRemainingMs !== undefined && requestRemainingMs <= 0) {
-      throw deadlineError();
-    }
-    try {
-      return await params.request({
-        ...(params.deadlineMs === undefined ? {} : { deadlineMs: params.deadlineMs }),
-        timeoutMs:
-          requestRemainingMs === undefined
-            ? params.timeoutMs
-            : Math.min(params.timeoutMs, requestRemainingMs),
-      });
-    } catch (error) {
-      params.throwChildFailure();
-      const details = formatErrorMessage(error);
-      lastDetails = details;
-      if (attempt >= 3 || !isRetryableGatewayCallError(details)) {
-        throw new Error(`${details}${formatQaGatewayLogsForError(params.logs())}`, {
-          cause: error,
-        });
-      }
-      const readinessRemainingMs = remainingMs();
-      if (readinessRemainingMs !== undefined && readinessRemainingMs <= 0) {
-        throw deadlineError();
-      }
-      await params.waitForReady(
-        readinessRemainingMs === undefined
-          ? Math.max(10_000, params.timeoutMs)
-          : Math.min(Math.max(10_000, params.timeoutMs), readinessRemainingMs),
-      );
-    }
-  }
-  throw new Error(`${lastDetails}${formatQaGatewayLogsForError(params.logs())}`);
 }
 
 async function fetchLocalGatewayHealth(params: {

--- a/extensions/qa-lab/src/gateway-child.test.ts
+++ b/extensions/qa-lab/src/gateway-child.test.ts
@@ -33,7 +33,6 @@ import {
   throwQaGatewayChildFailure,
 } from "./gateway-child-process.js";
 import {
-  callQaGatewayWithRetry,
   isRetryableRpcStartupError,
   resolveQaGatewayStartupRetry,
   waitForGatewayReady,
@@ -1202,56 +1201,6 @@ describe("buildQaRuntimeEnv", () => {
       expect(env.OPENCLAW_LIVE_GEMINI_KEY).toBeUndefined();
     },
   );
-
-  it("preserves relative gateway retry timeouts without an absolute deadline", async () => {
-    const request = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("gateway closed (1012 service restart)"))
-      .mockResolvedValueOnce({ ok: true });
-    const waitForReady = vi.fn(async () => {});
-
-    await expect(
-      callQaGatewayWithRetry({
-        logs: () => "qa logs",
-        request,
-        throwChildFailure: vi.fn(),
-        timeoutMs: 2_000,
-        waitForReady,
-      }),
-    ).resolves.toEqual({ ok: true });
-
-    expect(request).toHaveBeenNthCalledWith(1, { timeoutMs: 2_000 });
-    expect(request).toHaveBeenNthCalledWith(2, { timeoutMs: 2_000 });
-    expect(waitForReady).toHaveBeenCalledWith(10_000);
-  });
-
-  it("bounds near-expiry restart recovery by the absolute deadline", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    const request = vi.fn(async () => {
-      vi.setSystemTime(9_995);
-      throw new Error("gateway closed (1012 service restart)");
-    });
-    const waitForReady = vi.fn(async (timeoutMs: number) => {
-      vi.setSystemTime(Date.now() + timeoutMs);
-    });
-
-    await expect(
-      callQaGatewayWithRetry({
-        deadlineMs: 10_000,
-        logs: () => "qa logs",
-        request,
-        throwChildFailure: vi.fn(),
-        timeoutMs: 20_000,
-        waitForReady,
-      }),
-    ).rejects.toThrow("gateway call deadline exceeded");
-
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(request).toHaveBeenCalledWith({ deadlineMs: 10_000, timeoutMs: 10_000 });
-    expect(waitForReady).toHaveBeenCalledWith(5);
-    expect(Date.now()).toBe(10_000);
-  });
 
   it("waits for a fresh in-process restart boundary after the current log offset", async () => {
     let logs = "old restart mode: in-process restart\n";

--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -11,7 +11,6 @@ import {
   type QaChildFailure,
 } from "./gateway-child-process.js";
 import {
-  callQaGatewayWithRetry,
   isRetryableRpcStartupError,
   QA_GATEWAY_CHILD_STARTUP_MAX_ATTEMPTS,
   resolveQaGatewayStartupRetry,
@@ -320,26 +319,14 @@ async function startOwnedGatewayChild(
       rpcParams?: unknown,
       opts?: { deadlineMs?: number; expectFinal?: boolean; timeoutMs?: number },
     ) {
-      const timeoutMs = opts?.timeoutMs ?? 20_000;
-      return await callQaGatewayWithRetry({
-        deadlineMs: opts?.deadlineMs,
-        logs,
-        request: async (requestOptions) =>
-          await requireRpcClient().request(method, rpcParams, {
-            ...opts,
-            ...requestOptions,
-          }),
-        throwChildFailure: throwActiveChildFailure,
-        timeoutMs,
-        waitForReady: async (readinessTimeoutMs) =>
-          await waitForGatewayReady({
-            baseUrl,
-            logs,
-            child: active.child,
-            getChildFailure,
-            timeoutMs: readinessTimeoutMs,
-          }),
-      });
+      throwActiveChildFailure();
+      try {
+        // The RPC client owns unsent reconnects; replaying a sent call can repeat committed work.
+        return await requireRpcClient().request(method, rpcParams, opts);
+      } catch (error) {
+        throwActiveChildFailure();
+        throw error;
+      }
     },
     async stop(opts?: QaGatewayStopOptions) {
       const result = await lifetime.stop(opts);

--- a/src/gateway/server.qa-lab-rpc-replay.test.ts
+++ b/src/gateway/server.qa-lab-rpc-replay.test.ts
@@ -1,0 +1,301 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveRelativeBundledPluginPublicModuleId } from "../test-utils/bundled-plugin-public-surface.js";
+import {
+  connectOk,
+  getGatewayTestPort,
+  installGatewayTestHooks,
+  rpcReq,
+  startTestGatewayServer,
+  testState,
+  trackConnectChallengeNonce,
+} from "./test-helpers.js";
+
+// The public artifact crosses the plugin boundary without importing its compiler graph.
+type QaGatewayFixture = {
+  baseUrl: string;
+  pid: number | null;
+  call(
+    method: string,
+    params?: unknown,
+    options?: { timeoutMs?: number; deadlineMs?: number },
+  ): Promise<unknown>;
+};
+type QaGatewayFixtureOwner = {
+  start(params: {
+    repoRoot: string;
+    providerMode: "mock-openai";
+    controlUiEnabled: boolean;
+    transportBaseUrl: string;
+    command: {
+      executablePath: string;
+      argsPrefix: string[];
+      tempParentDir: string;
+      usePackagedPlugins: boolean;
+    };
+    onListening: (context: { token: string }) => Promise<void>;
+  }): Promise<QaGatewayFixture>;
+  stop(): Promise<{ process: string; errors: unknown[] }>;
+};
+
+const qaModule = resolveRelativeBundledPluginPublicModuleId({
+  fromModuleUrl: import.meta.url,
+  pluginId: "qa-lab",
+  artifactBasename: "api.js",
+});
+const { createQaGatewayChild } = (await import(qaModule)) as {
+  createQaGatewayChild: () => QaGatewayFixtureOwner;
+};
+installGatewayTestHooks({ scope: "suite" });
+
+type ProxyEvent = {
+  sequence: number;
+  kind: string;
+  connection?: number;
+  requestId?: string;
+  key?: string;
+  labelCollision?: boolean;
+};
+type ProxySnapshot = { events: ProxyEvent[]; held: boolean; pid: number };
+type CreateOutcome = { kind: "returned"; key: string } | { kind: "rejected"; message: string };
+const dirs = createTempDirTracker();
+const evidence: Array<Record<string, unknown>> = [];
+const owner = createQaGatewayChild();
+let child: Awaited<ReturnType<typeof owner.start>>;
+let backend: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
+let observer: WebSocket | undefined;
+let recordPath: string;
+let childPid: number | null;
+let stopped = false;
+let token: string;
+
+async function control(action = "snapshot"): Promise<ProxySnapshot> {
+  const response = await fetch(`${child.baseUrl}/__fixture`, {
+    method: "POST",
+    headers: { "x-qa-fixture-token": token, "content-type": "application/json" },
+    body: JSON.stringify({ action }),
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) {
+    throw new Error(`proxy control failed: ${response.status}`);
+  }
+  return (await response.json()) as ProxySnapshot;
+}
+
+async function create(
+  params: { label?: string; displayName?: string },
+  deadlineMs?: number,
+): Promise<CreateOutcome> {
+  try {
+    const value = await child.call("sessions.create", params, { timeoutMs: 10_000, deadlineMs });
+    if (!value || typeof value !== "object" || !("key" in value) || typeof value.key !== "string") {
+      throw new Error("sessions.create returned no key");
+    }
+    return { kind: "returned", key: value.key };
+  } catch (error) {
+    return { kind: "rejected", message: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function verifyCommittedRows(events: ProxyEvent[]) {
+  const keys = events
+    .filter((event) => event.kind === "mutation-success")
+    .map((event) => event.key);
+  for (const key of keys) {
+    expect(typeof key).toBe("string");
+    const read = await rpcReq<{ session: { key: string } | null }>(observer!, "sessions.describe", {
+      key,
+    });
+    expect(read.ok).toBe(true);
+    expect(read.payload?.session?.key).toBe(key);
+  }
+  return keys;
+}
+
+async function holdReconnect() {
+  await control("hold-reconnect");
+  await vi.waitFor(async () => expect((await control()).held).toBe(true), { timeout: 10_000 });
+}
+
+beforeAll(async () => {
+  vi.stubEnv("OPENCLAW_QA_LIVE_ANTHROPIC_SETUP_TOKEN", undefined);
+  vi.stubEnv("OPENCLAW_LIVE_SETUP_TOKEN_VALUE", undefined);
+  const root = dirs.make("qa-rpc-replay-");
+  recordPath = path.join(root, "proxy-events.jsonl");
+  const backendPort = await getGatewayTestPort();
+  child = await owner.start({
+    repoRoot: process.cwd(),
+    providerMode: "mock-openai",
+    controlUiEnabled: false,
+    transportBaseUrl: "http://127.0.0.1:1",
+    command: {
+      executablePath: process.execPath,
+      argsPrefix: [
+        path.resolve("test/fixtures/qa-gateway-rpc-proxy.mjs"),
+        String(backendPort),
+        process.cwd(),
+        recordPath,
+      ],
+      tempParentDir: root,
+      usePackagedPlugins: true,
+    },
+    onListening: async (context) => {
+      token = context.token;
+      testState.gatewayAuth = { mode: "token", token };
+      vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", token);
+      backend = await startTestGatewayServer(backendPort, { auth: { mode: "token", token } });
+    },
+  });
+  childPid = child.pid;
+  observer = new WebSocket(`ws://127.0.0.1:${backendPort}`);
+  trackConnectChallengeNonce(observer);
+  await once(observer, "open");
+  await connectOk(observer, { token, scopes: ["operator.admin"] });
+  // Family loading is fixture preparation, not the RPC's behavior deadline.
+  await rpcReq(observer, "sessions.create", { displayName: "QA replay setup" }, 30_000);
+  await rpcReq(observer, "sessions.describe", { key: "main" }, 30_000);
+}, 180_000);
+
+beforeEach(async () => {
+  testState.gatewayAuth = { mode: "token", token };
+  vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", token);
+  await control("reset");
+});
+
+afterAll(async () => {
+  const cleanupErrors: unknown[] = [];
+  try {
+    const result = await owner.stop();
+    stopped = result.process === "confirmed-stopped";
+    cleanupErrors.push(...result.errors);
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  if (observer && observer.readyState !== WebSocket.CLOSED) {
+    const closed = once(observer, "close");
+    observer.terminate();
+    await closed;
+  }
+  try {
+    await backend?.close();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  const finalEvents = recordPath
+    ? (await fs.readFile(recordPath, "utf8").catch(() => ""))
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line))
+    : [];
+  dirs.cleanup();
+  const output = path.resolve(".artifacts/qa-rpc-replay");
+  await fs.mkdir(output, { recursive: true });
+  await fs.writeFile(
+    path.join(output, "before.json"),
+    JSON.stringify(
+      {
+        evidence,
+        cleanup: {
+          stopped,
+          childPid,
+          remainingTempDirs: dirs.dirs.size,
+          errors: cleanupErrors.map(String),
+          finalEvents,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  vi.unstubAllEnvs();
+  expect(cleanupErrors).toEqual([]);
+  expect(stopped).toBe(true);
+}, 30_000);
+
+describe("QA child RPC mutation dispatch", () => {
+  it("creates once without a connection fault", async () => {
+    const outcome = await create({ displayName: "QA replay no fault" });
+    const snapshot = await control();
+    const keys = await verifyCommittedRows(snapshot.events);
+    evidence.push({ case: "no-fault", outcome, events: snapshot.events, keys });
+    expect(outcome.kind).toBe("returned");
+    expect(snapshot.events.filter((event) => event.kind === "mutation-request")).toHaveLength(1);
+    expect(keys).toHaveLength(1);
+  });
+
+  it.each(["label", "displayName"] as const)(
+    "does not replay a committed %s create after losing its response",
+    async (field) => {
+      await control("drop-response");
+      const outcome = await create({ [field]: `QA replay lost response ${field}` });
+      const snapshot = await control();
+      const keys = await verifyCommittedRows(snapshot.events);
+      evidence.push({ case: `sent-${field}`, outcome, events: snapshot.events, keys });
+      expect(snapshot.events.filter((event) => event.kind === "response-dropped")).toHaveLength(1);
+      expect(child.pid).toBe(childPid);
+      expect
+        .soft(snapshot.events.filter((event) => event.kind === "mutation-request"))
+        .toHaveLength(1);
+      expect.soft(keys).toHaveLength(1);
+      expect.soft(outcome.kind).toBe("rejected");
+      if (outcome.kind === "rejected") {
+        expect.soft(outcome.message).toContain("gateway closed (1006");
+        expect.soft(outcome.message).not.toContain("label already in use");
+      }
+    },
+  );
+
+  it("waits for reconnect Hello before sending an unsent mutation once", async () => {
+    await holdReconnect();
+    const pending = create({ displayName: "QA replay unsent" });
+    await setImmediate();
+    expect((await control()).events.some((event) => event.kind === "mutation-request")).toBe(false);
+    await control("release-hello");
+    const outcome = await pending;
+    const snapshot = await control();
+    const keys = await verifyCommittedRows(snapshot.events);
+    evidence.push({ case: "unsent-reconnect", outcome, events: snapshot.events, keys });
+    const sent = snapshot.events.filter((event) => event.kind === "mutation-request");
+    const release = snapshot.events.find((event) => event.kind === "hello-released");
+    expect(outcome.kind).toBe("returned");
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.sequence).toBeGreaterThan(release!.sequence);
+    expect(keys).toHaveLength(1);
+  });
+
+  it("does not send an expired mutation after reconnect completes", async () => {
+    await holdReconnect();
+    const outcome = await create({ displayName: "QA replay expired" }, Date.now() + 250);
+    await control("release-hello");
+    await child.call("health", {}, { timeoutMs: 10_000 });
+    const snapshot = await control();
+    evidence.push({ case: "expired-unsent", outcome, events: snapshot.events });
+    expect(outcome.kind).toBe("rejected");
+    if (outcome.kind === "rejected") {
+      expect(outcome.message).toContain("deadline exceeded");
+    }
+    expect(snapshot.events.some((event) => event.kind === "mutation-request")).toBe(false);
+  });
+
+  it("settles a pending unsent mutation when its child owner stops", async () => {
+    await holdReconnect();
+    const pending = create({ displayName: "QA replay stopped" });
+    const result = await owner.stop();
+    const outcome = await pending;
+    const events: ProxyEvent[] = (await fs.readFile(recordPath, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    evidence.push({ case: "stop-unsent", outcome, events, process: result.process });
+    expect(result).toEqual({ process: "confirmed-stopped", errors: [] });
+    expect(outcome.kind).toBe("rejected");
+    expect(events.some((event) => event.kind === "mutation-request")).toBe(false);
+  });
+});

--- a/src/gateway/server.qa-lab-rpc-replay.test.ts
+++ b/src/gateway/server.qa-lab-rpc-replay.test.ts
@@ -5,7 +5,6 @@ import { setImmediate } from "node:timers/promises";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { resolveRelativeBundledPluginPublicModuleId } from "../test-utils/bundled-plugin-public-surface.js";
 import {
   connectOk,
   getGatewayTestPort,
@@ -43,11 +42,7 @@ type QaGatewayFixtureOwner = {
   stop(): Promise<{ process: string; errors: unknown[] }>;
 };
 
-const qaModule = resolveRelativeBundledPluginPublicModuleId({
-  fromModuleUrl: import.meta.url,
-  pluginId: "qa-lab",
-  artifactBasename: "api.js",
-});
+const qaModule = "../../extensions/qa-lab/api.js";
 const { createQaGatewayChild } = (await import(qaModule)) as {
   createQaGatewayChild: () => QaGatewayFixtureOwner;
 };

--- a/test/fixtures/qa-gateway-rpc-proxy.mjs
+++ b/test/fixtures/qa-gateway-rpc-proxy.mjs
@@ -1,0 +1,183 @@
+import { appendFileSync, writeFileSync } from "node:fs";
+import { createServer, request } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const [backendPort, repoRoot, recordPath, command, ...args] = process.argv.slice(2);
+if (command === "models") {
+  for await (const chunk of process.stdin) {
+    // The packaged-bootstrap fixture consumes synthetic auth without retaining it.
+    void chunk;
+  }
+} else if (command === "update") {
+  if (args.includes("--help")) {
+    process.stdout.write("--accept-capabilities\n");
+  }
+} else if (command === "gateway") {
+  const { WebSocket, WebSocketServer } = createRequire(path.join(repoRoot, "package.json"))("ws");
+  const peers = new Set();
+  let events = [];
+  let sequence = 0;
+  let connection = 0;
+  let dropResponse = false;
+  let holdHello = false;
+  let held;
+  const record = (kind, facts = {}) => {
+    if (events.length >= 256) {
+      throw new Error("proxy evidence limit exceeded");
+    }
+    const event = { sequence: ++sequence, kind, ...facts };
+    events.push(event);
+    appendFileSync(recordPath, `${JSON.stringify(event)}\n`);
+  };
+  writeFileSync(recordPath, "");
+  const server = createServer((req, res) => {
+    if (req.url === "/__fixture") {
+      if (req.headers["x-qa-fixture-token"] !== process.env.OPENCLAW_GATEWAY_TOKEN) {
+        res.writeHead(403).end();
+        return;
+      }
+      void (async () => {
+        let text = "";
+        for await (const chunk of req) {
+          text += chunk;
+          if (text.length > 1024) {
+            throw new Error("fixture control limit exceeded");
+          }
+        }
+        const action = text ? JSON.parse(text).action : "snapshot";
+        if (action === "reset") {
+          events = [];
+          sequence = 0;
+          dropResponse = false;
+          writeFileSync(recordPath, "");
+        } else if (action === "drop-response") {
+          dropResponse = true;
+        } else if (action === "hold-reconnect") {
+          holdHello = true;
+          for (const peer of peers) {
+            peer.front.terminate();
+            peer.back.terminate();
+          }
+        } else if (action === "release-hello") {
+          if (!held) {
+            throw new Error("no held hello");
+          }
+          record("hello-released", { connection: held.connection });
+          const releasing = held;
+          held = undefined;
+          for (const raw of releasing.frames) {
+            releasing.front.send(raw);
+          }
+        } else if (action !== "snapshot") {
+          throw new Error("unknown fixture action");
+        }
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ events, held: Boolean(held), pid: process.pid }));
+      })().catch(() => res.writeHead(500).end("fixture control failed"));
+      return;
+    }
+    const upstream = request(
+      { hostname: "127.0.0.1", port: Number(backendPort), path: req.url, method: req.method },
+      (response) => {
+        res.writeHead(response.statusCode ?? 503, response.headers);
+        response.pipe(res);
+      },
+    );
+    upstream.on("error", () => res.writeHead(503).end());
+    req.pipe(upstream);
+  });
+  const sockets = new WebSocketServer({ server });
+  sockets.on("connection", (front) => {
+    const id = ++connection;
+    const back = new WebSocket(`ws://127.0.0.1:${backendPort}`);
+    const peer = { front, back };
+    peers.add(peer);
+    const methods = new Map();
+    const pending = [];
+    front.on("message", (raw) => {
+      const frame = JSON.parse(raw.toString());
+      if (frame.type === "req") {
+        methods.set(frame.id, frame.method);
+        if (frame.method === "sessions.create") {
+          record("mutation-request", { connection: id, requestId: frame.id });
+        }
+      }
+      if (back.readyState === WebSocket.OPEN) {
+        back.send(raw);
+      } else {
+        pending.push(raw);
+      }
+    });
+    back.on("open", () => {
+      for (const raw of pending.splice(0)) {
+        back.send(raw);
+      }
+    });
+    back.on("message", (raw) => {
+      const frame = JSON.parse(raw.toString());
+      const method = methods.get(frame.id);
+      if (frame.type === "res" && method === "sessions.create") {
+        record(frame.ok ? "mutation-success" : "mutation-error", {
+          connection: id,
+          requestId: frame.id,
+          ...(frame.ok
+            ? { key: frame.payload?.key }
+            : {
+                labelCollision: frame.error?.message?.startsWith("label already in use") === true,
+              }),
+        });
+        if (frame.ok && dropResponse) {
+          // A successful real response proves commit before the only injected loss.
+          dropResponse = false;
+          record("response-dropped", {
+            connection: id,
+            requestId: frame.id,
+            key: frame.payload?.key,
+          });
+          front.terminate();
+          back.terminate();
+          return;
+        }
+      }
+      if (frame.type === "res" && method === "connect" && frame.ok && holdHello) {
+        holdHello = false;
+        held = { connection: id, front, frames: [raw] };
+        record("hello-held", { connection: id });
+        return;
+      }
+      if (held?.front === front) {
+        if (held.frames.length >= 128) {
+          throw new Error("held frame limit exceeded");
+        }
+        held.frames.push(raw);
+      } else if (front.readyState === WebSocket.OPEN) {
+        front.send(raw);
+      }
+    });
+    front.on("close", () => {
+      back.terminate();
+      peers.delete(peer);
+      if (held?.front === front) {
+        held = undefined;
+      }
+    });
+    back.on("close", () => front.terminate());
+    front.on("error", () => back.terminate());
+    back.on("error", () => front.terminate());
+  });
+  const stop = () => {
+    for (const peer of peers) {
+      peer.front.terminate();
+      peer.back.terminate();
+    }
+    server.closeAllConnections();
+    sockets.close(() => server.close(() => process.exit(0)));
+  };
+  process.once("SIGTERM", stop);
+  process.once("SIGINT", stop);
+  setTimeout(stop, 240_000).unref();
+  server.listen(Number(args[args.indexOf("--port") + 1]), "127.0.0.1");
+} else {
+  throw new Error("unexpected proxy fixture command");
+}

--- a/test/tsconfig/tsconfig.core.test.infra.json
+++ b/test/tsconfig/tsconfig.core.test.infra.json
@@ -5,6 +5,8 @@
   },
   "include": [
     "../../src/infra/**/*.test.ts",
-    "../../src/infra/**/*.test.tsx"
+    "../../src/infra/**/*.test.tsx",
+    "../../src/logging/**/*.test.ts",
+    "../../src/logging/**/*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.services.json
+++ b/test/tsconfig/tsconfig.core.test.services.json
@@ -12,8 +12,6 @@
     "../../src/plugin-sdk/**/*.test.tsx",
     "../../src/skills/**/*.test.ts",
     "../../src/skills/**/*.test.tsx",
-    "../../src/logging/**/*.test.ts",
-    "../../src/logging/**/*.test.tsx",
     "../../src/secrets/**/*.test.ts",
     "../../src/secrets/**/*.test.tsx",
     "../../src/shared/**/*.test.ts",


### PR DESCRIPTION
Closes #139642

## What Problem This Solves

Fixes an issue where QA Lab workflows repeated an already-committed Gateway mutation after losing its response. A labeled session creation returned a misleading label-collision error; display-name-only creation silently produced two sessions and returned the second key.

## Why This Change Was Made

The persistent RPC client already records whether each request was sent and safely waits only for unsent reconnects. The Gateway child wrapped that client in another connection-error retry loop, discarding the dispatch guarantee. Delegate directly to the existing client and retain the child's pre-call and error-time lifecycle checks. Remove the duplicate retry classifier/loop and its implementation-coupled unit tests. Startup readiness retries and explicit scenario/config reconciliation remain with their existing owners.

Production shrinks by 77 lines. No configuration, protocol, schema, authentication, or stored representation changes are introduced. The new fixture stays under test/fixtures and exercises the plugin through its public artifact without adding a production test seam.

## User Impact

An interrupted sent call reports the original failure without repeating work. Safe unsent reconnection, deadlines, stopping, and explicit config recovery remain intact. QA authors can inspect the resulting state before choosing a safe retry.

## Evidence

Before: the public QA child, real persistent client/protocol, token-authenticated Gateway, and actual session store produce two failing committed-response-loss cases with four controls passing. The loopback proxy drops a successful response only after it has been observed, establishing commit before disconnection; a separate direct observer verifies the stored keys. After: all six same cases pass, with one mutation request and one committed row for each interrupted create. No model inference or external message is used.

Sibling validation passed 149 tests, with one Linux-only test skipped on macOS, across child/RPC lifecycle and explicit scenario/config recovery. The fixture-path smoke passed. Required type programs, doctor contracts, unused-export scans, targeted lint, and all structural guards passed after test-only dependency/type/style corrections. Managed complete-candidate P0–P2 review is scoped-clean.

The clean committed candidate `b994aa031c68f8ee902d8c28c2bf4371828444b8` passed the private-QA sourcePerformance runtime/metadata build in 69.7 seconds. This is source QA runtime proof, not full SDK/package acceptance. Core tests describe the minimal public fixture interface locally so the plugin compiler graph stays outside the core type programs; runtime still loads the real public artifact. Captured before/after observations and cleanup checks remain preserved.


```json
{
  "before": {"sentLabel": {"requests": 2, "rows": 1, "result": "label collision"}, "sentDisplayName": {"requests": 2, "rows": 2, "result": "second key"}, "passingControls": 4},
  "after": {"sentLabel": {"requests": 1, "rows": 1, "result": "original transport error"}, "sentDisplayName": {"requests": 1, "rows": 1, "result": "original transport error"}, "passingCases": 6},
  "cleanup": {"stopped": true, "remainingTempDirs": 0}
}
```

Current-main compatibility: the two production owners and persistent RPC client are unchanged at `80a89859228398650f6bd11205d0abe5c3979b00`. Prior client protections in #121677/#121809 are retained; this removes the outer wrapper that defeated their sent-request guarantee. Exact-head hosted CI remains required before landing.


Final reviewed head: `bf04808aa01eaf56d7553fe81386fb2dd940f85a`. The first CI run found three test/integration issues: the spawned proxy needed an explicit Knip entry; the regression used a core-forbidden public-surface resolver helper; and two unrelated main additions had pushed the services type graph to 721 roots against its 720 limit. The test now imports the documented public QA artifact directly. The existing logging family moves to the infrastructure type graph, leaving all roots covered exactly once and preserving the limit, graph count, and runtime test routing. No tests or limits were removed.

The corrected public-entry path passes all six real Gateway cases plus ten boundary tests. Production and full-tree unused-file scans, both rebalanced type graphs, and the complete 21-check correction scope passed. A fresh full-candidate managed P0–P2 review is scoped-clean. Production is unchanged from the recorded built/runtime-tested candidate; the later commit contains only test and test-configuration corrections. The suite-level temporary state is deliberately retained across cases and removed after stopping its Gateway/child, so the warning-only suggestion to clean it after each case is not applied.


### Maintainer resolution of the compatibility note

Accept the documented sent-call behavior recommended by the final ClawSweeper review. The existing fallible `call()` interface keeps its parameters and result shape; connection loss can already reject it. Its persistent client explicitly distinguishes sent requests from safe unsent reconnects. Repeating a request whose effect may have committed violates that owner guarantee and can duplicate non-idempotent work, so the outer blind replay is removed.

QA Lab is a private repository QA plugin (`extensions/qa-lab/package.json`, `private: true`), excluded from standard package outputs by the root package manifest and built through the explicit private-QA path. The callable `api.js` used by this test is a plugin boundary, not a new published SDK contract. Custom source scenarios receive the original interruption and reconcile observed state before retrying; the docs now state this. Existing startup and explicit config/scenario recovery remain, with149 sibling tests and the six real transport cases covering those boundaries. Universal custom-scenario proof is not claimed. Retaining a transparent sent-call retry would preserve the demonstrated data-duplication defect.
