### PR TITLE
fix(ci): unblock PR checks by rebalancing services test roots

### DIFF
--- a/test/tsconfig/tsconfig.core.test.infra.json
+++ b/test/tsconfig/tsconfig.core.test.infra.json
@@ -5,6 +5,8 @@
   },
   "include": [
     "../../src/infra/**/*.test.ts",
-    "../../src/infra/**/*.test.tsx"
+    "../../src/infra/**/*.test.tsx",
+    "../../src/logging/**/*.test.ts",
+    "../../src/logging/**/*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.services.json
+++ b/test/tsconfig/tsconfig.core.test.services.json
@@ -12,8 +12,6 @@
     "../../src/plugin-sdk/**/*.test.tsx",
     "../../src/skills/**/*.test.ts",
     "../../src/skills/**/*.test.tsx",
-    "../../src/logging/**/*.test.ts",
-    "../../src/logging/**/*.test.tsx",
     "../../src/secrets/**/*.test.ts",
     "../../src/secrets/**/*.test.tsx",
     "../../src/shared/**/*.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where every open PR inherits a failing core test typecheck boundary from `main`. `origin/main` is currently red on `check-additional-boundaries`: the `services` shard has 721 test roots, exceeding its 720-root typecheck memory bound. Main CI run [34006539935](https://github.com/openclaw/openclaw/actions/runs/34006539935) fails that job and the aggregate CI gate.

This unblocks every open PR in the repo from this inherited failure, since PR CI builds the merge commit and inherits the failure from `main`.

## Why This Change Was Made

Move the 44 `src/logging` test roots from `services` to `infra`, leaving 677 and 680 roots respectively. The existing 720-root memory bound and exactly-once coverage remain enforced; only the two shard include lists change.

## User Impact

Developers can validate and land PRs without this unrelated failure inherited from `main`. There is no runtime behavior change.

## Evidence

The compiler-resolved boundary check passes: every canonical core test root is assigned exactly once, all shards stay at or below 720 roots, and core graphs exclude bundled plugin files.

| Shard | Test roots after rebalance | Headroom to 720 |
| --- | ---: | ---: |
| agents-root | 720 | 0 |
| agents-other | 647 | 73 |
| agents-tools | 143 | 577 |
| gateway-root | 694 | 26 |
| gateway-other | 513 | 207 |
| infra | 680 | 40 |
| commands | 531 | 189 |
| plugins-platform | 676 | 44 |
| config-cli | 653 | 67 |
| messaging | 572 | 148 |
| services | 677 | 43 |
| other | 689 | 31 |
| ui-pages | 488 | 232 |
| ui-e2e | 389 | 331 |
| ui-other | 460 | 260 |
| packages | 403 | 317 |

**Follow-up worth attention:** `agents-root` measured exactly 720, at the cap. The next test file added under that shard's roots will break `main` the same way. Rebalancing it is intentionally outside this fix.

- `pnpm check:changed` with isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`: passed (exit 0).
- `node --import ./scripts/tsx.mjs scripts/check-tsgo-core-boundary.mts`: passed.
- Both affected shard typechecks and the three guard suites passed during the implementation proof.
- Independent Codex autoreview of both the local patch and committed branch: scoped-clean, no accepted/actionable findings at the default P0 threshold; both exited 0.

Exact-head CI run [34007189986](https://github.com/openclaw/openclaw/actions/runs/34007189986) completed successfully for `e682430fe5e747761df5e7c5efa06ebf6e9393e3`, including `check-additional-boundaries`, all three test-typecheck jobs, and `openclaw/ci-gate`. No reruns were needed. [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139645#issuecomment-5556458792) found no actionable patch defects or pre-merge requirements.

The workflow linter was intentionally skipped: no `.github/` workflow file changes in this PR. Its earlier local failure, `No matching distribution found for pre-commit==4.6.2`, is a pre-existing local-environment issue outside this patch; no dependency pin or workaround was changed.
