### PR TITLE
fix(matrix): accept the opt-in Bun runtime

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -643,7 +643,6 @@ extensions/matrix/src/matrix/actions/verification.ts	1
 extensions/matrix/src/matrix/client-bootstrap.ts	1
 extensions/matrix/src/matrix/client/config.ts	5
 extensions/matrix/src/matrix/client/logging.ts	3
-extensions/matrix/src/matrix/client/runtime.ts	1
 extensions/matrix/src/matrix/config-update.ts	4
 extensions/matrix/src/matrix/credentials-state.ts	2
 extensions/matrix/src/matrix/delivery-plan.ts	1

--- a/docs/channels/matrix.md
+++ b/docs/channels/matrix.md
@@ -8,6 +8,8 @@ title: "Matrix"
 
 Matrix is a downloadable channel plugin (`@openclaw/matrix`) built on the official `matrix-js-sdk`. It supports DMs, rooms, threads, media, reactions, polls, location, and E2EE.
 
+Node remains the recommended runtime. Matrix also accepts the [opt-in Bun runtime](/install/bun); E2EE requires the Matrix SDK's native crypto bindings to be available for your platform.
+
 ## Install
 
 ```bash

--- a/extensions/matrix/src/matrix/actions/client.test.ts
+++ b/extensions/matrix/src/matrix/actions/client.test.ts
@@ -15,7 +15,6 @@ const {
   getMatrixRuntimeMock,
   acquireSharedMatrixClientMock,
   sharedLeaseReleaseMock,
-  isBunRuntimeMock,
   resolveMatrixAuthContextMock,
 } = matrixClientResolverMocks;
 
@@ -27,7 +26,6 @@ vi.mock("../../runtime.js", () => ({
 
 vi.mock("../client.js", () => ({
   acquireSharedMatrixClient: acquireSharedMatrixClientMock,
-  isBunRuntime: () => isBunRuntimeMock(),
   resolveMatrixAuthContext: resolveMatrixAuthContextMock,
 }));
 

--- a/extensions/matrix/src/matrix/client-bootstrap.test.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.test.ts
@@ -11,7 +11,6 @@ const {
   getMatrixRuntimeMock,
   acquireSharedMatrixClientMock,
   sharedLeaseReleaseMock,
-  isBunRuntimeMock,
   resolveMatrixAuthContextMock,
 } = matrixClientResolverMocks;
 
@@ -23,7 +22,6 @@ vi.mock("../runtime.js", () => ({
 
 vi.mock("./client.js", () => ({
   acquireSharedMatrixClient: (...args: unknown[]) => acquireSharedMatrixClientMock(...args),
-  isBunRuntime: () => isBunRuntimeMock(),
   resolveMatrixAuthContext: resolveMatrixAuthContextMock,
 }));
 

--- a/extensions/matrix/src/matrix/client-bootstrap.ts
+++ b/extensions/matrix/src/matrix/client-bootstrap.ts
@@ -2,7 +2,6 @@ import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Matrix plugin module implements client bootstrap behavior.
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import type { CoreConfig } from "../types.js";
-import { isBunRuntime } from "./client/runtime.js";
 import type { SharedMatrixClientLease } from "./client/shared.js";
 import type { MatrixClient } from "./sdk.js";
 
@@ -40,12 +39,6 @@ async function ensureResolvedClientReadiness(params: {
   }
 }
 
-function ensureMatrixNodeRuntime() {
-  if (isBunRuntime()) {
-    throw new Error("Matrix support requires Node (bun runtime not supported)");
-  }
-}
-
 export async function resolveRuntimeMatrixClientWithReadiness(opts: {
   client?: MatrixClient;
   cfg?: CoreConfig;
@@ -53,7 +46,6 @@ export async function resolveRuntimeMatrixClientWithReadiness(opts: {
   accountId?: string | null;
   readiness?: MatrixRuntimeClientReadiness;
 }): Promise<ResolvedRuntimeMatrixClient> {
-  ensureMatrixNodeRuntime();
   if (opts.client) {
     await ensureResolvedClientReadiness({
       client: opts.client,

--- a/extensions/matrix/src/matrix/client-resolver.test-helpers.ts
+++ b/extensions/matrix/src/matrix/client-resolver.test-helpers.ts
@@ -9,7 +9,6 @@ type MatrixClientResolverMocks = {
   acquireSharedMatrixClientMock: Mock<(...args: unknown[]) => Promise<SharedMatrixClientLease>>;
   sharedLeaseReleaseMock: Mock<(...args: unknown[]) => Promise<void>>;
   sharedLeaseStartMock: Mock<(...args: unknown[]) => Promise<void>>;
-  isBunRuntimeMock: Mock<() => boolean>;
   resolveMatrixAuthContextMock: Mock<
     (params: { cfg: unknown; accountId?: string | null }) => unknown
   >;
@@ -21,7 +20,6 @@ export const matrixClientResolverMocks: MatrixClientResolverMocks = {
   acquireSharedMatrixClientMock: vi.fn(),
   sharedLeaseReleaseMock: vi.fn(),
   sharedLeaseStartMock: vi.fn(),
-  isBunRuntimeMock: vi.fn(() => false),
   resolveMatrixAuthContextMock: vi.fn(),
 };
 
@@ -81,7 +79,6 @@ export function primeMatrixClientResolverMocks(params?: {
     acquireSharedMatrixClientMock,
     sharedLeaseReleaseMock,
     sharedLeaseStartMock,
-    isBunRuntimeMock,
     resolveMatrixAuthContextMock,
   } = matrixClientResolverMocks;
 
@@ -104,7 +101,6 @@ export function primeMatrixClientResolverMocks(params?: {
       current: loadConfigMock,
     },
   });
-  isBunRuntimeMock.mockReturnValue(false);
   sharedLeaseReleaseMock.mockReset().mockResolvedValue(undefined);
   sharedLeaseStartMock.mockReset();
   resolveMatrixAuthContextMock.mockImplementation(

--- a/extensions/matrix/src/matrix/client.ts
+++ b/extensions/matrix/src/matrix/client.ts
@@ -1,6 +1,5 @@
 // Matrix plugin module implements client behavior.
 export type { MatrixAuth } from "./client/types.js";
-export { isBunRuntime } from "./client/runtime.js";
 export { getMatrixScopedEnvVarNames } from "../env-vars.js";
 export {
   backfillMatrixAuthDeviceIdAfterStartup,

--- a/extensions/matrix/src/matrix/client/runtime.ts
+++ b/extensions/matrix/src/matrix/client/runtime.ts
@@ -1,5 +1,0 @@
-// Matrix plugin module implements runtime behavior.
-export function isBunRuntime(): boolean {
-  const versions = process.versions as { bun?: string };
-  return typeof versions.bun === "string";
-}

--- a/extensions/matrix/src/matrix/monitor/index.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test-helpers.ts
@@ -282,7 +282,6 @@ vi.mock("../accounts.js", async () => {
 vi.mock("../client.js", () => ({
   acquireSharedMatrixClient: hoisted.acquireSharedMatrixClient,
   backfillMatrixAuthDeviceIdAfterStartup: hoisted.backfillMatrixAuthDeviceIdAfterStartup,
-  isBunRuntime: () => false,
   resolveMatrixAuth: vi.fn(async () => ({
     accountId: "default",
     homeserver: "https://matrix.example.org",

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -31,7 +31,6 @@ import { resolveConfiguredMatrixBotUserIds } from "../accounts.js";
 import {
   acquireSharedMatrixClient,
   backfillMatrixAuthDeviceIdAfterStartup,
-  isBunRuntime,
   resolveMatrixAuth,
   resolveMatrixAuthContext,
   type SharedMatrixClientLease,
@@ -102,9 +101,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   // Fast-cancel callers should not pay the full Matrix startup/import cost.
   if (opts.abortSignal?.aborted) {
     return;
-  }
-  if (isBunRuntime()) {
-    throw new Error("Matrix provider requires Node (bun runtime not supported)");
   }
   const core = getMatrixRuntime();
   let cfg = core.config.current() as CoreConfig;

--- a/extensions/matrix/src/matrix/probe.test.ts
+++ b/extensions/matrix/src/matrix/probe.test.ts
@@ -2,14 +2,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createMatrixClientMock = vi.fn();
-const isBunRuntimeMock = vi.fn(() => false);
 
 vi.mock("./probe.runtime.js", () => ({
   createMatrixClient: (...args: unknown[]) => createMatrixClientMock(...args),
-}));
-
-vi.mock("./client/runtime.js", () => ({
-  isBunRuntime: () => isBunRuntimeMock(),
 }));
 
 import { probeMatrix } from "./probe.js";
@@ -17,7 +12,6 @@ import { probeMatrix } from "./probe.js";
 describe("probeMatrix", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isBunRuntimeMock.mockReturnValue(false);
     createMatrixClientMock.mockResolvedValue({
       getUserId: vi.fn(async () => "@bot:example.org"),
     });

--- a/extensions/matrix/src/matrix/probe.ts
+++ b/extensions/matrix/src/matrix/probe.ts
@@ -6,7 +6,6 @@ import type { PinnedDispatcherPolicy } from "openclaw/plugin-sdk/ssrf-dispatcher
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { runChannelProbe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { isBunRuntime } from "./client/runtime.js";
 
 const loadMatrixProbeRuntimeDeps = createLazyRuntimeModule(() =>
   import("./probe.runtime.js").then((runtimeModule) => ({
@@ -39,9 +38,6 @@ export async function probeMatrix(params: {
         status: null,
         error: null,
       };
-      if (isBunRuntime()) {
-        return { ...result, error: "Matrix probe requires Node (bun runtime not supported)" };
-      }
       if (!params.homeserver?.trim()) {
         return { ...result, error: "missing homeserver" };
       }

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -29,6 +29,52 @@ describe("performMatrixRequest", () => {
     clearTestUndiciRuntimeDepsOverride();
   });
 
+  it("loads a profile through the real SDK default guarded fetch and closes the client", async () => {
+    const { MatrixClient } = await import("../sdk.js");
+    const { resolveRuntimeMatrixClientWithReadiness } = await import("../client-bootstrap.js");
+    const requests: Array<{ url: string | undefined; authorization: string | undefined }> = [];
+    const profile = { displayname: "Matrix loopback fixture" };
+    const server = http.createServer((request, response) => {
+      requests.push({ url: request.url, authorization: request.headers.authorization });
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify(profile));
+    });
+    let client: InstanceType<typeof MatrixClient> | undefined;
+    try {
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("expected loopback server address");
+      }
+      client = new MatrixClient(`http://127.0.0.1:${address.port}/matrix-proxy`, "fixture-token", {
+        encryption: false,
+        autoBootstrapCrypto: false,
+        ssrfPolicy: { allowPrivateNetwork: true },
+      });
+
+      const resolved = await resolveRuntimeMatrixClientWithReadiness({ client, readiness: "none" });
+      await expect(resolved.client.getUserProfile("@fixture:example.org")).resolves.toEqual(
+        profile,
+      );
+      expect(requests).toEqual([
+        {
+          url: "/matrix-proxy/_matrix/client/v3/profile/%40fixture%3Aexample.org",
+          authorization: "Bearer fixture-token",
+        },
+      ]);
+    } finally {
+      try {
+        await client?.stopWithoutPersist();
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    }
+  });
+
   it.each([
     {
       name: "a root homeserver",

--- a/extensions/matrix/src/matrix/send/client.test.ts
+++ b/extensions/matrix/src/matrix/send/client.test.ts
@@ -13,7 +13,6 @@ const {
   getMatrixRuntimeMock,
   acquireSharedMatrixClientMock,
   sharedLeaseReleaseMock,
-  isBunRuntimeMock,
   resolveMatrixAuthContextMock,
 } = matrixClientResolverMocks;
 
@@ -21,7 +20,6 @@ const TEST_CFG = {};
 
 vi.mock("../client.js", () => ({
   acquireSharedMatrixClient: (...args: unknown[]) => acquireSharedMatrixClientMock(...args),
-  isBunRuntime: () => isBunRuntimeMock(),
   resolveMatrixAuthContext: resolveMatrixAuthContextMock,
 }));
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix bootstrap, monitoring, and probe entry points reject the opt-in Bun runtime before using the Matrix SDK, even with the required runtime dependencies installed.

## Why This Change Was Made

Remove the blanket Bun rejection and its unused runtime detector and test mocks. The prerequisite installed-peer and standalone-bundle fixes are now on main through [#140411](https://github.com/openclaw/openclaw/pull/140411), with Proxyline 0.3.11 and Undici 8.10.2. This change uses the existing Matrix SDK, guarded transport, and lifecycle paths; it adds no alternate resolver or persistence implementation.

The regression goes through bootstrap with a supplied real SDK client, then loads a profile through the SDK's default guarded fetch against an owned loopback server. It checks the homeserver prefix, ordinary request-header propagation, returned profile, and client/server cleanup. The assertion baseline removes only the entry for the deleted detector file.

## User Impact

Matrix accepts the opt-in Bun runtime. **Node remains recommended**, and E2EE requires the Matrix SDK's native crypto bindings to be available on the operator's platform. The documentation states those limitations. Existing storage, migration, recovery, and configuration semantics are unchanged.

## Evidence

- On the pin-aligned baseline with the original rejection still present, the new real-SDK profile case passed on Node and failed on Bun at the runtime rejection before the profile request. After this change it passed on both runtimes.
- Representative proof on **Node 26.8.1 and Bun 1.4.2**: eight selected existing/new cases per runtime covering the real default SDK profile/bootstrap request, four real HTTP prefix cases, two SDK lifecycle cases, and one IndexedDB persistence case. All passed; every monitored process tree joined without a cap.
- An additional native attachment encrypt/decrypt round-trip passed on each runtime using the installed Matrix crypto bindings. This is a native crypto availability check, not a full live-room E2EE or all-platform claim.
- The complete 14-path changed-file gate passed, with no resource cap or surviving child processes. Fresh independent P0–P2 review passed with no actionable findings. The updated Matrix documentation passed targeted MDX validation.
- Full `pnpm build` passed in3m38s, including declarations and plugin outputs; all children joined. The final follow-up was a behavior-identical Promise-executor callback block to satisfy the void-return lint rule, with no assertion or timeout change; final gate/build/review cover that exact source. Required hosted checks must pass before landing.

Proof is deliberately representative. No full Matrix plugin suite, live homeserver account, broad authorization/transport policy matrix, or blanket Bun compatibility claim is made. The earlier draft's broader proof wording is superseded by this current source and evidence.
