### PR TITLE
improve(test): overlap independent proxy deadline checks

### DIFF
--- a/src/infra/net/fetch-guard.socks.test.ts
+++ b/src/infra/net/fetch-guard.socks.test.ts
@@ -210,7 +210,8 @@ describe("SOCKS proxy protocol boundaries", () => {
     },
   );
 
-  it.each([
+  // Each row owns its server, sockets, and dispatcher, so native deadline waits can overlap.
+  it.concurrent.each([
     { name: "fixed target", mode: "fixed", stall: "target", target: 100, proxy: 0 },
     { name: "environment target", mode: "environment", stall: "target", target: 100, proxy: 0 },
     {


### PR DESCRIPTION
## What Problem This Solves

The SOCKS proxy test file spends roughly 81 seconds running 60 cases. Seven independent deadline cases each wait through Undici's real ten-second default timeout, serially.

## Why This Change Was Made

Run only the existing deadline table concurrently. Each row owns its loopback server, sockets, and dispatcher and closes them in its own `finally`. Vitest's existing five-case concurrency limit bounds this group; its scheduler waits for the whole group before admitting the surrounding sequential tests that change global dispatchers or environment variables.

## User Impact

The same proxy coverage completes sooner in the same CI job. All 60 cases, native timeout values, error assertions, TLS-handshake checks, and cleanup remain. No production code, mock, runner, shard, timeout, or configuration changes.

## Evidence

Paired runs on the same Mac with Node 24.19.0, pnpm 12.3.4, Vitest 5.0.0, one worker, and separate fresh transform caches:

| Measurement | Before | After |
| --- | ---: | ---: |
| Test file | 81.404s | 22.620s |
| Complete command | 91.01s | 32.59s |
| CPU user + system | 8.06s | 6.34s |
| Peak RSS | 464.5 MB | 467.1 MB |

Both runs passed all 60 cases with identical names and results: 72% lower file time. [Exact-head Linux CI](https://github.com/openclaw/openclaw/actions/runs/34007665295/job/101417819951) also passed all 60 cases in a 24.61s invocation; each default-timeout row still took about 10.49s. The native default-timeout cases still wait ten seconds. Recent main CI independently measured this file at 81.17s and 81.19s ([first run](https://github.com/openclaw/openclaw/actions/runs/34005380592), [second run](https://github.com/openclaw/openclaw/actions/runs/34005546357)).

Installed Vitest scheduling and Undici timeout source were inspected. Managed Codex review through P2 found no actionable issues. Formatting and initial changed checks passed. The first full gate hit the unrelated main services partition overflow (721 roots against720). After rebasing onto the canonical #139645 partition repair, [required exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34009109027) passed26 jobs with20 conditional skips. The rebased patch is identical; no test root or cap changed here.

The separate changed-file Opengrep scan reports twelve pre-existing direct body reads outside the changed table. Those assertions read the fixed `PROXY_FIXTURE_PAYLOAD` from fixture-owned loopback servers in `src/test-fixtures/proxy-fixture.ts`; the fixture rejects other target hosts. The performance patch changes none of those reads. This is a named scanner-scope follow-up, with no rule, ignore, assertion, or production change in this PR.
