### PR TITLE
improve(browser): reduce compact snapshot allocations

### DIFF
--- a/extensions/browser/src/browser/pw-role-snapshot.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.ts
@@ -269,21 +269,20 @@ function createRoleNameTracker() {
 
 type RoleNameTracker = ReturnType<typeof createRoleNameTracker>;
 
-function compactTree(tree: string) {
-  const lines = tree.split("\n");
+function compactTree(lines: readonly string[]) {
   const entries: Array<{ line: string; keep: boolean; hasRef: boolean; indent: number }> = [];
-  const stack: Array<{ entry: (typeof entries)[number]; indent: number }> = [];
+  const stack: (typeof entries)[number][] = [];
 
   const finishEntry = () => {
     const current = stack.pop();
     if (!current) {
       return;
     }
-    current.entry.keep ||= current.entry.hasRef;
-    if (current.entry.hasRef && stack.length > 0) {
+    current.keep ||= current.hasRef;
+    if (current.hasRef && stack.length > 0) {
       const parent = stack.at(-1);
       if (parent !== undefined) {
-        parent.entry.hasRef = true;
+        parent.hasRef = true;
       }
     }
   };
@@ -305,7 +304,7 @@ function compactTree(tree: string) {
       indent,
     };
     entries.push(entry);
-    stack.push({ entry, indent });
+    stack.push(entry);
   }
   while (stack.length > 0) {
     finishEntry();
@@ -473,9 +472,8 @@ export function buildRoleSnapshotFromAriaSnapshot(
     }
   }
 
-  const tree = result.join("\n") || "(empty)";
   return {
-    snapshot: options.compact ? compactTree(tree) : tree,
+    snapshot: options.compact ? compactTree(result) : result.join("\n") || "(empty)",
     refs,
   };
 }
@@ -544,9 +542,8 @@ export function buildRoleSnapshotFromAiSnapshot(
     out.push(line);
   }
 
-  const tree = out.join("\n") || "(empty)";
   return {
-    snapshot: options.compact ? compactTree(tree) : tree,
+    snapshot: options.compact ? compactTree(out) : out.join("\n") || "(empty)",
     refs,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Compact Playwright snapshots allocate a full intermediate snapshot string and split it back into lines before pruning the tree. Large non-interactive compact snapshots pay for those copies on every request.

## Why This Change Was Made

Pass each builder's existing line array directly to the private compactor and reuse its entry objects on the traversal stack. This removes the intermediate string, split array, and per-line wrapper objects while preserving snapshot text, ordering, ancestor propagation, and action refs.

## User Impact

Compact Playwright snapshots create fewer temporary allocations. The efficient interactive preset bypasses this compactor. No API or output changes are intended; production code is three lines smaller.

## Evidence

- All 52 existing role-snapshot tests pass.
- Selected changed checks pass, including extension and extension-test typechecks, guard tests, lint, dead-export scans, and import cycles.
- A synthetic before/after probe produced identical snapshots and refs in 112 cases across both builders.
- On a 6,000-line fixture, four ABBA allocation samples estimated 4.47% fewer temporary allocations. This is an owner-level synthetic result with two observations per variant, not a Gateway RSS measurement or a production guarantee.
- Independent source and measurement reviews found no actionable issues; isolated autoreview completed without findings in its selected scope.
