### PR TITLE
fix(types): keep test graphs within the existing root limit

### DIFF
--- a/test/tsconfig/tsconfig.core.test.infra.json
+++ b/test/tsconfig/tsconfig.core.test.infra.json
@@ -5,6 +5,8 @@
   },
   "include": [
     "../../src/infra/**/*.test.ts",
-    "../../src/infra/**/*.test.tsx"
+    "../../src/infra/**/*.test.tsx",
+    "../../src/logging/**/*.test.ts",
+    "../../src/logging/**/*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.services.json
+++ b/test/tsconfig/tsconfig.core.test.services.json
@@ -12,8 +12,6 @@
     "../../src/plugin-sdk/**/*.test.tsx",
     "../../src/skills/**/*.test.ts",
     "../../src/skills/**/*.test.tsx",
-    "../../src/logging/**/*.test.ts",
-    "../../src/logging/**/*.test.tsx",
     "../../src/secrets/**/*.test.ts",
     "../../src/secrets/**/*.test.tsx",
     "../../src/shared/**/*.test.ts",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the additional-boundaries CI check fails after the services test type graph reaches 721 roots, exceeding its existing 720-root limit.

## Why This Change Was Made

Move the complete 44-file logging test cohort to the existing infra type graph. Services falls from 721 to 677 roots and infra grows from 636 to 680. Compiler settings, ambient declarations, the 16-shard layout, and the 720-root limit stay unchanged.

## User Impact

Contributors regain a passing type-graph boundary check. This changes typechecking placement only; runtime tests and production behavior are unchanged. This batch contributes no test LOC removal or measured runtime gain to the campaign.

## Evidence

The installed compiler inventory confirms all 8,935 canonical test roots occur exactly once, with an identical root union before and after. Both affected native `run-tsgo` lanes and the complete planned `check-changed` gate pass. Formatting, `git diff --check`, deslop, and independent review pass.
