### PR TITLE
fix(runtime): require cleanup evidence before releasing owned work

### DIFF
--- a/docs/cli/agent.md
+++ b/docs/cli/agent.md
@@ -26,7 +26,7 @@ openclaw agent exec --message-file task.md --cwd ./repo
 cat task.md | openclaw agent exec --message-file - --json
 ```
 
-By default, the command creates and later removes a temporary state directory, and it runs against your ordinary OpenClaw config, so configured providers, credentials, and `agentRuntime` harness selection apply exactly as they do elsewhere. `--cwd` defaults to the process working directory and is passed as both the agent workspace and tool working directory.
+By default, the command creates a temporary state directory and removes it after confirmed cleanup. It runs against your ordinary OpenClaw config, so configured providers, credentials, and `agentRuntime` harness selection apply exactly as they do elsewhere. `--cwd` defaults to the process working directory and is passed as both the agent workspace and tool working directory.
 
 Config is layered in three parts, entirely in memory: exec composes the run config and publishes it as this process's runtime config rather than writing a copy to disk. Exec defaults apply only where your config leaves a setting unset: workspace bootstrap files are skipped, the agent sandbox is off, the `coding` tool profile is selected, filesystem tools are restricted to `--cwd`, and exec runs under the full execution policy a headless turn needs. Anything your config sets wins over those defaults, so a configured sandbox, shell env, or tool profile is never downgraded, and exec host routing stays with the sandbox when your config enables one. The invocation itself always wins last: the run is scoped to `--cwd` and never bootstraps.
 
@@ -68,6 +68,10 @@ openclaw agent exec "Inspect this repository" \
 The timeout defaults to 600 seconds for `agent exec`; this does not change the existing embedded `agent --local` default. A successful run exits `0`, any model or result error exits `1`, and a timeout exits `2`. Failure includes `meta.error`, aborted runs, exhausted model fallbacks, an error stop reason, and any error payload.
 
 If cleanup fails after a run error or timeout, the original result and exit code are preserved and the cleanup failure is reported on stderr. A cleanup failure after a successful run exits `1`.
+
+Uncertain runtime cleanup preserves temporary state for inspection and keeps any
+acquired state lock until this process exits. Inspect the reported cleanup failure
+before retrying a run against retained state.
 
 Plain output writes only the final assistant text to stdout. Diagnostics use stderr. `--json` reserves stdout for this stable envelope:
 

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -394,6 +394,11 @@ If no MCP servers are enabled, OpenClaw still injects a strict config when a bac
 
 Session-scoped bundled MCP runtimes are cached for reuse within a session, then reaped after 10 minutes of idle time. One-shot embedded runs such as auth probes, slug generation, and active-memory recall request cleanup at run end so stdio children and Streamable HTTP/SSE streams do not outlive the run.
 
+A fresh CLI session must wait for its predecessor's cleanup. If cleanup fails or
+exceeds its deadline, OpenClaw refuses replacement, including from a later run.
+Check the cleanup error and the backend's remaining processes before retrying.
+Command output and process exit alone do not confirm that descendants stopped.
+
 For `claude-cli`, the installed Claude Code process uses its current native
 login. OpenClaw uses a non-secret route marker and never reads, persists,
 refreshes, selects, or forwards the native tokens.

--- a/extensions/codex/src/app-server/attempt-client-cleanup.test.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.test.ts
@@ -12,9 +12,14 @@ import { createClientHarness } from "./test-support.js";
 import { getCodexAppServerTurnRouter } from "./turn-router.js";
 
 describe("Codex app-server attempt client cleanup", () => {
-  it.each([true, false])(
-    "drains the full terminal inventory and accepts a concurrent exit (%s)",
-    async (terminated) => {
+  it.each([
+    { terminated: true, oneShot: false },
+    { terminated: false, oneShot: false },
+    { terminated: true, oneShot: true },
+    { terminated: false, oneShot: true },
+  ])(
+    "drains native terminals without claiming OS cleanup (terminated=$terminated, oneShot=$oneShot)",
+    async ({ terminated, oneShot }) => {
       const request = vi
         .fn()
         .mockResolvedValueOnce({
@@ -24,15 +29,29 @@ describe("Codex app-server attempt client cleanup", () => {
         .mockResolvedValueOnce({ terminated })
         .mockResolvedValueOnce({ terminated: true })
         .mockResolvedValueOnce({ data: [], nextCursor: null });
-      await expect(
-        terminateCodexBackgroundTerminals({ request } as never, "thread-1"),
-      ).resolves.toBeUndefined();
+      const cleanup = terminateCodexBackgroundTerminals({ request } as never, "thread-1", oneShot);
+      if (oneShot) {
+        await expect(cleanup).rejects.toThrow("Codex background-terminal cleanup");
+      } else {
+        await expect(cleanup).resolves.toBeUndefined();
+      }
       expect(request.mock.calls.map(([method, params]) => [method, params])).toEqual([
         ["thread/backgroundTerminals/list", { threadId: "thread-1" }],
         ["thread/backgroundTerminals/terminate", { threadId: "thread-1", processId: "10" }],
         ["thread/backgroundTerminals/terminate", { threadId: "thread-1", processId: "20" }],
         ["thread/backgroundTerminals/list", { threadId: "thread-1", limit: 1 }],
       ]);
+    },
+  );
+
+  it.each([false, true])(
+    "accepts an empty native terminal inventory (oneShot=%s)",
+    async (oneShot) => {
+      const request = vi.fn().mockResolvedValue({ data: [], nextCursor: null });
+      await expect(
+        terminateCodexBackgroundTerminals({ request } as never, "thread-1", oneShot),
+      ).resolves.toBeUndefined();
+      expect(request).toHaveBeenCalledOnce();
     },
   );
 

--- a/extensions/codex/src/app-server/attempt-client-cleanup.ts
+++ b/extensions/codex/src/app-server/attempt-client-cleanup.ts
@@ -166,6 +166,7 @@ export async function interruptCodexTurnAndWaitBestEffort(
 export async function terminateCodexBackgroundTerminals(
   client: CodexAppServerClient,
   threadId: string,
+  oneShotCliRun = false,
 ): Promise<void> {
   const options = {
     timeoutMs: CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS,
@@ -192,6 +193,11 @@ export async function terminateCodexBackgroundTerminals(
       );
       if (remaining.data.length > 0) {
         throw new Error("native background terminals remain running");
+      }
+      // Codex drops terminal entries before OS exit and supplies no process
+      // identity. A later ancestry snapshot can miss a reparented survivor.
+      if (oneShotCliRun) {
+        throw new Error("native terminal termination did not confirm process cleanup");
       }
     }
   } catch (cause) {

--- a/extensions/codex/src/app-server/client-exit.test.ts
+++ b/extensions/codex/src/app-server/client-exit.test.ts
@@ -28,8 +28,11 @@ describe("Codex app-server child exit", () => {
     const closing = harness.client.closeAndWait().then(settled);
     try {
       await vi.advanceTimersByTimeAsync(0);
-      expect(settled).toHaveBeenCalledExactlyOnceWith(true);
-      await expect(harness.client.closeAndWait()).resolves.toBe(true);
+      expect(settled).toHaveBeenCalledExactlyOnceWith({ exited: true, cleanup: "uncertain" });
+      await expect(harness.client.closeAndWait()).resolves.toEqual({
+        exited: true,
+        cleanup: "uncertain",
+      });
       expect(exited).toHaveBeenCalledExactlyOnceWith(code, signal);
       expect(harness.process).toMatchObject({ exitCode: code, signalCode: signal });
       expect(harness.stdinDestroyed).toBe(true);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -19,6 +19,7 @@ import {
   type CodexAppServerRequestResult,
   type CodexInitializeParams,
   type CodexInitializeResponse,
+  isJsonObject,
   isRpcResponse,
   type CodexServerNotification,
   type JsonValue,
@@ -33,6 +34,7 @@ import {
   closeCodexAppServerTransport,
   closeCodexAppServerTransportAndWait,
   hasCodexAppServerNaturalExit,
+  type CodexAppServerCloseResult,
   type CodexAppServerTransport,
 } from "./transport.js";
 import { CODEX_APP_SERVER_VERSION, MIN_SUPPORTED_CODEX_APP_SERVER_VERSION } from "./version.js";
@@ -221,6 +223,7 @@ export class CodexAppServerClient {
   private modelCatalogRevision = 0;
   private closed = false;
   private transportExited = false;
+  private nativeExecutionObserved = false;
   private closeError: Error | undefined;
   private serverVersion: string | undefined;
   private runtimeIdentity: CodexAppServerRuntimeIdentity | undefined;
@@ -749,9 +752,12 @@ export class CodexAppServerClient {
   async closeAndWait(options?: {
     exitTimeoutMs?: number;
     forceKillDelayMs?: number;
-  }): Promise<boolean> {
+  }): Promise<CodexAppServerCloseResult> {
     this.markClosed(new Error("codex app-server client is closed"));
-    return await closeCodexAppServerTransportAndWait(this.child, options);
+    const result = await closeCodexAppServerTransportAndWait(this.child, options);
+    // Codex can discard terminal handles before OS cleanup. Later ancestry
+    // containment cannot discharge a command whose descendants already reparented.
+    return this.nativeExecutionObserved ? { ...result, cleanup: "uncertain" } : result;
   }
 
   /** Closes this transport and runs cleanup only after physical process exit. */
@@ -770,10 +776,7 @@ export class CodexAppServerClient {
     }
     this.child.once("exit", runOnExit);
     try {
-      if (await this.closeAndWait()) {
-        this.child.off?.("exit", runOnExit);
-        runOnExit();
-      }
+      await this.closeAndWait();
     } catch (closeError) {
       embeddedAgentLog.warn("codex app-server shutdown after indeterminate request failed", {
         closeError,
@@ -788,6 +791,9 @@ export class CodexAppServerClient {
     }
     const id = "id" in message ? message.id : undefined;
     const method = "method" in message ? message.method : undefined;
+    if (method === "command/exec") {
+      this.nativeExecutionObserved = true;
+    }
     this.child.stdin.write(
       `${stringifyCodexAppServerMessage(message)}\n`,
       (error?: Error | null) => {
@@ -886,6 +892,14 @@ export class CodexAppServerClient {
       pending.reject(new CodexAppServerRpcError(response.error, pending.method));
       return;
     }
+    if (
+      pending.method === "thread/backgroundTerminals/list" &&
+      isJsonObject(response.result) &&
+      Array.isArray(response.result.data) &&
+      response.result.data.length > 0
+    ) {
+      this.nativeExecutionObserved = true;
+    }
     pending.resolve(response.result);
   }
 
@@ -969,6 +983,20 @@ export class CodexAppServerClient {
   }
 
   private handleNotification(notification: CodexServerNotification): void {
+    const params = notification.params;
+    if (
+      notification.method === "item/commandExecution/outputDelta" ||
+      notification.method === "item/commandExecution/terminalInteraction" ||
+      (isJsonObject(params) &&
+        ((isJsonObject(params.item) && params.item.type === "commandExecution") ||
+          (isJsonObject(params.turn) &&
+            Array.isArray(params.turn.items) &&
+            params.turn.items.some(
+              (item) => isJsonObject(item) && item.type === "commandExecution",
+            ))))
+    ) {
+      this.nativeExecutionObserved = true;
+    }
     if (notification.method === "account/updated") {
       this.modelCatalogRevision += 1;
     }

--- a/extensions/codex/src/app-server/compact.test.ts
+++ b/extensions/codex/src/app-server/compact.test.ts
@@ -1802,10 +1802,11 @@ describe("maybeCompactCodexAppServerSession", () => {
         fake.request.mockRejectedValueOnce(new Error("thread/compact/start timed out"));
       }
       const closeEntered = createDeferred<void>();
-      const closeGate = createDeferred<boolean>();
+      const closeGate = createDeferred<void>();
       fake.closeAndWait.mockImplementationOnce(async () => {
         closeEntered.resolve();
-        return await closeGate.promise;
+        await closeGate.promise;
+        return { exited: false, cleanup: "uncertain" };
       });
       const retirementOutcome = createDeferred<"retained" | "settled">();
       const errorSpy = vi.spyOn(embeddedAgentLog, "error").mockImplementation((message) => {
@@ -1848,14 +1849,14 @@ describe("maybeCompactCodexAppServerSession", () => {
         });
         queued = withCodexAppServerThreadMutation(binding.threadId, nextMutation);
         await patchSessionEntry({ ...scope, update: () => ({ sessionId: next.sessionId }) });
-        closeGate.resolve(false);
+        closeGate.resolve();
 
         const outcome = await retirementOutcome.promise;
         expect(bindingStore.read(current)).toEqual(binding);
         expect(outcome).toBe("retained");
         expect(nextMutation).not.toHaveBeenCalled();
       } finally {
-        closeGate.resolve(false);
+        closeGate.resolve();
         fake.emit({
           method: "turn/completed",
           params: {
@@ -1915,7 +1916,9 @@ describe("maybeCompactCodexAppServerSession", () => {
       });
       ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
       await retainCodexAppServerLiveThread(harness.client, binding.threadId);
-      const closeAndWait = vi.spyOn(harness.client, "closeAndWait").mockResolvedValue(false);
+      const closeAndWait = vi
+        .spyOn(harness.client, "closeAndWait")
+        .mockResolvedValue({ exited: false, cleanup: "uncertain" });
       const retirementOutcome = createDeferred<"retained" | "settled">();
       const errorSpy = vi.spyOn(embeddedAgentLog, "error").mockImplementation((message) => {
         if (message === "failed to retire unconfirmed codex app-server compaction") {
@@ -2016,7 +2019,7 @@ describe("maybeCompactCodexAppServerSession", () => {
       autoCompleteCompaction: false,
       rejectInterrupt: true,
     });
-    fake.closeAndWait.mockResolvedValueOnce(false);
+    fake.closeAndWait.mockResolvedValueOnce({ exited: false, cleanup: "uncertain" });
     const pluginConfig = {
       supervision: { enabled: true },
       appServer: { transport: "websocket" as const, url: "ws://127.0.0.1:45001" },
@@ -2376,7 +2379,7 @@ describe("maybeCompactCodexAppServerSession", () => {
   it("keeps the lifecycle fence when an unconfirmed stdio process does not stop", async () => {
     const fake = createFakeCodexClient({ retainedThreadId: "thread-stuck-stdio" });
     fake.request.mockRejectedValueOnce(new Error("thread/compact/start timed out"));
-    fake.closeAndWait.mockResolvedValueOnce(false);
+    fake.closeAndWait.mockResolvedValueOnce({ exited: false, cleanup: "uncertain" });
     setCodexAppServerClientFactoryForTest(async () => fake.client);
     const sessionFile = await writeTestBinding({ threadId: "thread-stuck-stdio" });
 
@@ -2395,7 +2398,7 @@ describe("maybeCompactCodexAppServerSession", () => {
   it("detaches a guarded remote start after releasing the binding lock", async () => {
     const fake = createFakeCodexClient();
     fake.request.mockRejectedValueOnce(new Error("thread/compact/start timed out"));
-    fake.closeAndWait.mockResolvedValueOnce(false);
+    fake.closeAndWait.mockResolvedValueOnce({ exited: false, cleanup: "uncertain" });
     const sessionFile = await writeTestBinding();
 
     const result = requireCompactResult(
@@ -2836,7 +2839,7 @@ function createFakeCodexClient(
   });
   const closeAndWait = vi.fn<CodexAppServerClient["closeAndWait"]>(async () => {
     close();
-    return true;
+    return { exited: true, cleanup: "closed" };
   });
   const addNotificationHandler = vi.fn(
     (handler: (notification: CodexServerNotification) => void) => {

--- a/extensions/codex/src/app-server/compact.ts
+++ b/extensions/codex/src/app-server/compact.ts
@@ -615,7 +615,7 @@ async function compactCodexNativeThread(
               forceKillDelayMs: 250,
             });
             if (appServer.start.transport === "stdio") {
-              if (transportStopped) {
+              if (transportStopped.exited) {
                 return;
               }
               // A local thread remains runnable with its stdio process. Keep

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -398,6 +398,7 @@ export async function buildDynamicTools(
     hasRepliedRef: params.hasRepliedRef,
     modelHasVision,
     computerContextEpoch: input.computerContextEpoch,
+    oneShotCliRun: params.oneShotCliRun,
     registerRunCleanup: input.registerRunCleanup,
     requireExplicitMessageTarget:
       params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),

--- a/extensions/codex/src/app-server/native-mcp-app.ts
+++ b/extensions/codex/src/app-server/native-mcp-app.ts
@@ -171,6 +171,9 @@ function createNativeMcpRuntime(params: {
       const status = (await loadStatuses()).find((entry) => entry.name === serverName);
       return { resourceTemplates: status?.resourceTemplates ?? [] } as never;
     },
+    // This facade owns no MCP transport. The retained app-server client owns
+    // process cleanup, including refusal to retire while another view holds it.
+    joinCleanup: async () => {},
     dispose: async () => {},
   };
   return runtime;

--- a/extensions/codex/src/app-server/run-attempt-cleanup.ts
+++ b/extensions/codex/src/app-server/run-attempt-cleanup.ts
@@ -4,6 +4,7 @@ import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
   unsubscribeCodexThreadBestEffort,
+  terminateCodexBackgroundTerminals,
 } from "./attempt-client-cleanup.js";
 import { resolveCodexAppServerClientInstanceId } from "./client.js";
 import { scheduleCodexNativeHookRelayUnregister } from "./native-hook-relay.js";
@@ -58,7 +59,16 @@ export async function cleanupCodexAttempt(
     : undefined;
   // Join late cancellation before releasing the subscription, but do not let a
   // failed terminal RPC skip resource cleanup. Surface that failure below.
-  await state.abortCleanup.catch(() => undefined);
+  if (params.oneShotCliRun) {
+    await runCleanupStep("codex-abort-cleanup", () => state.abortCleanup);
+  } else {
+    await state.abortCleanup?.catch(() => {});
+  }
+  if (params.oneShotCliRun) {
+    await runCleanupStep("codex-one-shot-terminals", () =>
+      terminateCodexBackgroundTerminals(resourceState.client, resourceState.thread.threadId, true),
+    );
+  }
   try {
     steeringQueueRef.current?.cancel();
     if (params.isFinalFallbackAttempt !== false) {
@@ -149,6 +159,11 @@ export async function cleanupCodexAttempt(
         if (!released) {
           // Never reuse a client whose previous thread may still publish notifications.
           await closeCodexStartupClientBestEffort(resourceState.client);
+          if (params.oneShotCliRun) {
+            await runCleanupStep("codex-one-shot-unsubscribe", async () => {
+              throw new Error("Codex one-shot thread unsubscribe was not confirmed");
+            });
+          }
         }
       }
     }
@@ -167,7 +182,18 @@ export async function cleanupCodexAttempt(
               ? "cancel"
               : "error";
       const cleanups = prompt.context.attemptTools.runCleanups.splice(0);
-      await Promise.allSettled(cleanups.map(async (cleanup) => await cleanup(cleanupReason)));
+      const settled = await Promise.allSettled(
+        cleanups.map(async (cleanup) => await cleanup(cleanupReason)),
+      );
+      const errors = settled.filter(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      if (params.oneShotCliRun && errors.length) {
+        throw new AggregateError(
+          errors.map((result) => result.reason),
+          "Codex tool cleanup failed",
+        );
+      }
     });
     await runCleanupStep("codex-route-release", releaseCurrentRoute);
     await checkpointCleanup;
@@ -181,7 +207,7 @@ export async function cleanupCodexAttempt(
       if (!nativeHookRelay) {
         return;
       }
-      if (state.shouldDelayNativeHookRelayUnregister) {
+      if (state.shouldDelayNativeHookRelayUnregister && !params.oneShotCliRun) {
         // Native hook subprocesses can finish shortly after turn completion.
         scheduleCodexNativeHookRelayUnregister({
           relay: nativeHookRelay,

--- a/extensions/codex/src/app-server/run-attempt-connection.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.test.ts
@@ -14,6 +14,7 @@ import { prepareCodexAttemptConnection } from "./run-attempt-connection.js";
 import {
   createCodexRuntimePlanFixture,
   createParams,
+  runCodexAppServerAttempt,
   setupRunAttemptTestHooks,
   tempDir,
 } from "./run-attempt-test-harness.js";
@@ -205,7 +206,9 @@ describe("prepareCodexAttemptConnection", () => {
     "loopback-server",
     "ordinary-loopback-server",
     "forwarded-server",
+    "forwarded-stdio-server",
     "unix-server",
+    "ordinary-unix-server",
     "remote-server",
     "sandbox",
     "remote",
@@ -213,6 +216,7 @@ describe("prepareCodexAttemptConnection", () => {
   ])("handles an installation target for %s execution before native startup", async (placement) => {
     const sessionFile = path.join(tempDir, "installation-target.jsonl");
     const params = createParams(sessionFile, path.join(tempDir, "workspace-installation-target"));
+    const createToolSurface = vi.fn(params.hostCapabilities.createToolSurface);
     const localProcessEnv = Object.freeze({
       OPENCLAW_STATE_DIR: "/fixture/diagnosed",
       OPENCLAW_CONFIG_PATH: "/fixture/custom.json",
@@ -220,11 +224,12 @@ describe("prepareCodexAttemptConnection", () => {
     });
     params.hostCapabilities = Object.freeze({
       ...params.hostCapabilities,
+      createToolSurface,
       preparedEnvironment: () => ({
         credentialScrubEnv: {},
         localIdentityEnv: {},
         managedLocalIdentity: false,
-        localProcessEnv: placement === "ordinary-loopback-server" ? undefined : localProcessEnv,
+        localProcessEnv: placement.startsWith("ordinary-") ? undefined : localProcessEnv,
       }),
     });
     if (["sandbox", "remote", "remote-only"].includes(placement)) {
@@ -235,15 +240,15 @@ describe("prepareCodexAttemptConnection", () => {
       } as NonNullable<typeof params.sandbox>;
     }
     registerCodexTestSessionIdentity(sessionFile, params.sessionId, params.sessionKey);
-    const pending = prepareCodexAttemptConnection({
-      params,
-      options: {
-        bindingStore: testCodexAppServerBindingStore,
-        ...(placement.endsWith("-server")
-          ? {
-              pluginConfig: {
-                appServer:
-                  placement === "unix-server"
+    const options = {
+      bindingStore: testCodexAppServerBindingStore,
+      ...(placement.endsWith("-server")
+        ? {
+            pluginConfig: {
+              appServer:
+                placement === "forwarded-stdio-server"
+                  ? { transport: "stdio", remoteWorkspaceRoot: "/remote/workspace" }
+                  : placement.endsWith("unix-server")
                     ? { transport: "unix", homeScope: "user", url: "unix:///fixture/native.sock" }
                     : {
                         transport: "websocket",
@@ -256,22 +261,34 @@ describe("prepareCodexAttemptConnection", () => {
                           ? { remoteWorkspaceRoot: "/remote/workspace" }
                           : {}),
                       },
-              },
-            }
-          : {}),
-      },
-    });
-    if (!["local", "ordinary-loopback-server", "unix-server"].includes(placement)) {
+            },
+          }
+        : {}),
+    };
+    const pending = prepareCodexAttemptConnection({ params, options });
+    if (placement !== "local" && !placement.startsWith("ordinary-")) {
       await expect(pending).rejects.toThrow("saved prompt");
+      const clientFactory = vi.fn(async () => {
+        throw new Error("unexpected app-server admission");
+      });
+      await expect(runCodexAppServerAttempt(params, { ...options, clientFactory })).rejects.toThrow(
+        /owned local Codex stdio.*saved prompt/,
+      );
+      expect(clientFactory).not.toHaveBeenCalled();
+      expect(createToolSurface).not.toHaveBeenCalled();
       return;
     }
     const connection = await pending;
-    if (placement === "ordinary-loopback-server") {
+    if (placement.startsWith("ordinary-")) {
+      expect(connection.appServer.start.transport).toBe(
+        placement === "ordinary-unix-server" ? "unix" : "websocket",
+      );
       expect(connection.shellEnvironment).toBeUndefined();
       expect(connection.appServer.start.env ?? {}).not.toHaveProperty("OPENCLAW_STATE_DIR");
       expect(connection.disableLoginShell).toBe(false);
       return;
     }
+    expect(connection.appServer.start.transport).toBe("stdio");
     expect(connection.shellEnvironment).toEqual(localProcessEnv);
     expect(connection.appServer.start.env).toMatchObject(localProcessEnv);
     expect(connection.disableLoginShell).toBe(true);

--- a/extensions/codex/src/app-server/run-attempt-connection.ts
+++ b/extensions/codex/src/app-server/run-attempt-connection.ts
@@ -130,7 +130,7 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
   const assertLocalTargetSupported = (unsupported: boolean) => {
     if (preparedEnvironment?.localProcessEnv && unsupported) {
       throw new Error(
-        "This runtime cannot target the diagnosed local installation. Use the saved prompt with a suggested external or manual handoff on this machine.",
+        "This runtime cannot target the diagnosed local installation. Use an owned local Codex stdio process, or use the saved prompt with a suggested external or manual handoff on this machine.",
       );
     }
   };
@@ -155,9 +155,9 @@ export async function prepareCodexAttemptConnection({ params, options }: CodexRu
     (preparedEnvironment !== undefined &&
       Object.keys(preparedEnvironment.credentialScrubEnv).length > 0);
   const withPreparedProcessEnv = <T extends CodexAppServerRuntimeOptions>(appServer: T) => {
-    // Loopback WebSockets can forward to another host; their URL does not attest peer locality.
+    // Peer locality is not process ownership: disconnected socket turns can outlive recovery.
     assertLocalTargetSupported(
-      appServer.start.transport === "websocket" || Boolean(appServer.remoteWorkspaceRoot),
+      appServer.start.transport !== "stdio" || Boolean(appServer.remoteWorkspaceRoot),
     );
     return shellEnvironment
       ? {

--- a/extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts
@@ -17,10 +17,10 @@ import {
   turnStartResult,
 } from "./run-attempt-test-harness.js";
 import { testCodexAppServerBindingStore } from "./session-binding.test-helpers.js";
-import * as sharedClientModule from "./shared-client.js";
 import {
   resetSharedCodexAppServerClientForTests,
   retainSharedCodexAppServerClientIfCurrent,
+  retireSharedCodexAppServerClientIfCurrent,
 } from "./shared-client.js";
 import { createClientHarness, waitForHarnessRequest } from "./test-support.js";
 import * as processSnapshot from "./transport-process-snapshot.js";
@@ -45,6 +45,17 @@ async function stopTaskOwnedProcess(pid: number): Promise<void> {
       { timeout: 2_000 },
     )
     .toBe(false);
+}
+
+function runOneShot(client: CodexAppServerClient, abortSignal?: AbortSignal) {
+  vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(client);
+  const params = createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace"));
+  params.oneShotCliRun = true;
+  params.cleanupBundleMcpOnRunEnd = true;
+  if (abortSignal) {
+    params.abortSignal = abortSignal;
+  }
+  return runCodexAppServerAttempt(params, { bindingStore: testCodexAppServerBindingStore });
 }
 
 setupRunAttemptTestHooks();
@@ -89,19 +100,9 @@ describe("Codex one-shot cleanup receipts", () => {
           }
         },
       });
-      vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(harness.client);
       const warning = vi.spyOn(embeddedAgentLog, "warn");
       const abort = new AbortController();
-      const params = createParams(
-        path.join(tempDir, "native-terminal-cleanup-session.jsonl"),
-        path.join(tempDir, "native-terminal-cleanup-workspace"),
-      );
-      params.oneShotCliRun = true;
-      params.cleanupBundleMcpOnRunEnd = true;
-      params.abortSignal = abort.signal;
-      const run = runCodexAppServerAttempt(params, {
-        bindingStore: testCodexAppServerBindingStore,
-      });
+      const run = runOneShot(harness.client, abort.signal);
       try {
         await waitForHarnessRequest(harness, "turn/start");
         await new Promise<void>((resolve) => {
@@ -128,24 +129,13 @@ describe("Codex one-shot cleanup receipts", () => {
     },
   );
 
-  it.each(["active lease", "pending acquire", "missing entry"] as const)(
+  it.each(["active lease", "missing entry"] as const)(
     "records uncertain one-shot cleanup when shared retirement is refused: %s",
     async (reason) => {
       const harness = createClientHarness();
-      vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(harness.client);
-      const close = vi.spyOn(harness.client, "close");
-      const closeAndWait = vi.spyOn(harness.client, "closeAndWait");
       const warning = vi.spyOn(embeddedAgentLog, "warn");
-      const params = createParams(
-        path.join(tempDir, "retained-cleanup-session.jsonl"),
-        path.join(tempDir, "retained-cleanup-workspace"),
-      );
-      params.oneShotCliRun = true;
-      params.cleanupBundleMcpOnRunEnd = true;
       let releasePeer: (() => void) | undefined;
-      const run = runCodexAppServerAttempt(params, {
-        bindingStore: testCodexAppServerBindingStore,
-      });
+      const run = runOneShot(harness.client);
       try {
         const initialize = await waitForHarnessRequest(harness, "initialize");
         harness.send({
@@ -156,26 +146,9 @@ describe("Codex one-shot cleanup receipts", () => {
         harness.send({ id: thread.id, result: threadStartResult() });
         const turn = await waitForHarnessRequest(harness, "turn/start");
         harness.send({ id: turn.id, result: turnStartResult() });
-        if (reason === "pending acquire") {
-          // Shared-client tests own the pending-startup race. This refusal is
-          // its contract with attempt cleanup, which must preserve that owner.
-          vi.spyOn(
-            sharedClientModule,
-            "clearSharedCodexAppServerClientIfCurrentAndUnclaimed",
-          ).mockReturnValue({
-            found: true,
-            closed: false,
-            activeLeases: 0,
-            pendingAcquires: 1,
-          });
-        } else {
-          releasePeer = retainSharedCodexAppServerClientIfCurrent(harness.client);
-          expect(releasePeer).toBeTypeOf("function");
-          if (reason === "missing entry") {
-            expect(
-              sharedClientModule.retireSharedCodexAppServerClientIfCurrent(harness.client),
-            ).toMatchObject({ closed: false });
-          }
+        releasePeer = retainSharedCodexAppServerClientIfCurrent(harness.client);
+        if (reason === "missing entry") {
+          retireSharedCodexAppServerClientIfCurrent(harness.client);
         }
         harness.send({
           method: "turn/completed",
@@ -189,9 +162,6 @@ describe("Codex one-shot cleanup receipts", () => {
         expect(warning).toHaveBeenCalledWith(
           expect.stringMatching(/agent cleanup failed:.*step=codex-shared-client-release/),
         );
-        expect(close).not.toHaveBeenCalled();
-        expect(closeAndWait).not.toHaveBeenCalled();
-        expect(harness.stdinDestroyed).toBe(false);
         const requestStart = harness.writes.length;
         const peerRead = harness.client.request("thread/read", {
           threadId: "thread-peer",
@@ -275,7 +245,6 @@ process.stdin.on("end", () => ${
       });
       const exited = once(child, "exit");
       const client = CodexAppServerClient.fromTransportForTests(child);
-      vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(client);
       if (shutdown === "unknown") {
         vi.spyOn(processSnapshot, "readCodexAppServerProcessSnapshot").mockRejectedValue(
           new processSnapshot.ProcessInspectionError("unavailable"),
@@ -295,15 +264,7 @@ process.stdin.on("end", () => ${
         }
       });
       const warning = vi.spyOn(embeddedAgentLog, "warn");
-      const params = createParams(
-        path.join(tempDir, "cleanup-session.jsonl"),
-        path.join(tempDir, "cleanup-workspace"),
-      );
-      params.oneShotCliRun = true;
-      params.cleanupBundleMcpOnRunEnd = true;
-      const run = runCodexAppServerAttempt(params, {
-        bindingStore: testCodexAppServerBindingStore,
-      });
+      const run = runOneShot(client);
       try {
         await Promise.race([
           turnStarted.promise,

--- a/extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { isPidAlive } from "openclaw/plugin-sdk/process-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
 import { CodexAppServerClient } from "./client.js";
@@ -26,8 +27,6 @@ import { createClientHarness, waitForHarnessRequest } from "./test-support.js";
 import * as processSnapshot from "./transport-process-snapshot.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
-const readTaskProcessSnapshot = processSnapshot.readCodexAppServerProcessSnapshot;
-
 async function stopTaskOwnedProcess(pid: number): Promise<void> {
   try {
     process.kill(pid, "SIGKILL");
@@ -36,15 +35,7 @@ async function stopTaskOwnedProcess(pid: number): Promise<void> {
       throw error;
     }
   }
-  await expect
-    .poll(
-      async () => {
-        const rows = await readTaskProcessSnapshot(Date.now() + 2_000, [pid]);
-        return rows.some((row) => row.pid === pid && !row.state.startsWith("Z"));
-      },
-      { timeout: 2_000 },
-    )
-    .toBe(false);
+  await expect.poll(() => isPidAlive(pid), { timeout: 2_000 }).toBe(false);
 }
 
 function runOneShot(client: CodexAppServerClient, abortSignal?: AbortSignal) {
@@ -279,17 +270,9 @@ process.stdin.on("end", () => ${
         const signalled = shutdown === "forced" || shutdown === "signalled";
         expect(child.exitCode).toBe(signalled ? null : 0);
         expect(child.signalCode).toBe(signalled ? "SIGKILL" : null);
-        if (shutdown === "unknown" || shutdown === "retired-command") {
-          expect(process.kill(descendantPid, 0)).toBe(true);
-        } else {
-          const snapshot = await processSnapshot.readCodexAppServerProcessSnapshot(
-            Date.now() + 2_000,
-            [descendantPid],
-          );
-          expect(
-            snapshot.some((row) => row.pid === descendantPid && !row.state.startsWith("Z")),
-          ).toBe(false);
-        }
+        await expect
+          .poll(() => isPidAlive(descendantPid), { timeout: 2_000 })
+          .toBe(shutdown === "unknown" || shutdown === "retired-command");
         // This is the cleanup guard that also records the one-shot recovery
         // receipt; a clean root exit must not bypass its failure path.
         if (shutdown === "confirmed") {

--- a/extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts
+++ b/extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts
@@ -1,0 +1,354 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readAttemptTerminal } from "./attempt-terminal.test-helper.js";
+import { CodexAppServerClient } from "./client.js";
+import { isJsonObject } from "./protocol.js";
+import {
+  createNativeRunParams as createParams,
+  runCodexAppServerAttempt,
+  setupRunAttemptTestHooks,
+  tempDir,
+  threadStartResult,
+  turnStartResult,
+} from "./run-attempt-test-harness.js";
+import { testCodexAppServerBindingStore } from "./session-binding.test-helpers.js";
+import * as sharedClientModule from "./shared-client.js";
+import {
+  resetSharedCodexAppServerClientForTests,
+  retainSharedCodexAppServerClientIfCurrent,
+} from "./shared-client.js";
+import { createClientHarness, waitForHarnessRequest } from "./test-support.js";
+import * as processSnapshot from "./transport-process-snapshot.js";
+import { CODEX_APP_SERVER_VERSION } from "./version.js";
+
+const readTaskProcessSnapshot = processSnapshot.readCodexAppServerProcessSnapshot;
+
+async function stopTaskOwnedProcess(pid: number): Promise<void> {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      throw error;
+    }
+  }
+  await expect
+    .poll(
+      async () => {
+        const rows = await readTaskProcessSnapshot(Date.now() + 2_000, [pid]);
+        return rows.some((row) => row.pid === pid && !row.state.startsWith("Z"));
+      },
+      { timeout: 2_000 },
+    )
+    .toBe(false);
+}
+
+setupRunAttemptTestHooks();
+
+describe("Codex one-shot cleanup receipts", () => {
+  beforeEach(() => {
+    resetSharedCodexAppServerClientForTests();
+  });
+
+  afterEach(() => {
+    resetSharedCodexAppServerClientForTests();
+  });
+
+  it.each(["completed", "cancelled"] as const)(
+    "preserves a %s one-shot outcome while native terminal cleanup remains uncertain",
+    async (completion) => {
+      let terminalTerminated = false;
+      const results: Record<string, unknown> = {
+        initialize: { userAgent: `openclaw/${CODEX_APP_SERVER_VERSION} (macOS; test)` },
+        "thread/start": threadStartResult(),
+        "turn/start": turnStartResult(),
+      };
+      const harness = createClientHarness({
+        onWrite: (line, send) => {
+          const request = JSON.parse(line) as { id?: number; method: string };
+          if (request.id === undefined) {
+            return;
+          }
+          let result = results[request.method] ?? {};
+          if (request.method === "thread/backgroundTerminals/list") {
+            result = { data: terminalTerminated ? [] : [{ processId: "10" }], nextCursor: null };
+          } else if (request.method === "thread/backgroundTerminals/terminate") {
+            terminalTerminated = true;
+            result = { terminated: true };
+          }
+          send({ id: request.id, result });
+          if (request.method === "turn/interrupt") {
+            send({
+              method: "turn/completed",
+              params: { threadId: "thread-1", turn: { id: "turn-1", status: "interrupted" } },
+            });
+          }
+        },
+      });
+      vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(harness.client);
+      const warning = vi.spyOn(embeddedAgentLog, "warn");
+      const abort = new AbortController();
+      const params = createParams(
+        path.join(tempDir, "native-terminal-cleanup-session.jsonl"),
+        path.join(tempDir, "native-terminal-cleanup-workspace"),
+      );
+      params.oneShotCliRun = true;
+      params.cleanupBundleMcpOnRunEnd = true;
+      params.abortSignal = abort.signal;
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+      });
+      try {
+        await waitForHarnessRequest(harness, "turn/start");
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        if (completion === "cancelled") {
+          abort.abort("cancelled");
+          expect(readAttemptTerminal(await run)).toMatchObject({ aborted: true, timedOut: false });
+        } else {
+          harness.send({
+            method: "turn/completed",
+            params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+          });
+          expect(readAttemptTerminal(await run)).toMatchObject({ aborted: false, timedOut: false });
+        }
+        expect(terminalTerminated).toBe(true);
+        const step =
+          completion === "cancelled" ? "codex-shared-client-release" : "codex-one-shot-terminals";
+        expect(warning).toHaveBeenCalledWith(expect.stringContaining(`step=${step} error=Codex`));
+      } finally {
+        harness.client.close();
+        await run.catch(() => undefined);
+      }
+    },
+  );
+
+  it.each(["active lease", "pending acquire", "missing entry"] as const)(
+    "records uncertain one-shot cleanup when shared retirement is refused: %s",
+    async (reason) => {
+      const harness = createClientHarness();
+      vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(harness.client);
+      const close = vi.spyOn(harness.client, "close");
+      const closeAndWait = vi.spyOn(harness.client, "closeAndWait");
+      const warning = vi.spyOn(embeddedAgentLog, "warn");
+      const params = createParams(
+        path.join(tempDir, "retained-cleanup-session.jsonl"),
+        path.join(tempDir, "retained-cleanup-workspace"),
+      );
+      params.oneShotCliRun = true;
+      params.cleanupBundleMcpOnRunEnd = true;
+      let releasePeer: (() => void) | undefined;
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+      });
+      try {
+        const initialize = await waitForHarnessRequest(harness, "initialize");
+        harness.send({
+          id: initialize.id,
+          result: { userAgent: `openclaw/${CODEX_APP_SERVER_VERSION} (macOS; test)` },
+        });
+        const thread = await waitForHarnessRequest(harness, "thread/start");
+        harness.send({ id: thread.id, result: threadStartResult() });
+        const turn = await waitForHarnessRequest(harness, "turn/start");
+        harness.send({ id: turn.id, result: turnStartResult() });
+        if (reason === "pending acquire") {
+          // Shared-client tests own the pending-startup race. This refusal is
+          // its contract with attempt cleanup, which must preserve that owner.
+          vi.spyOn(
+            sharedClientModule,
+            "clearSharedCodexAppServerClientIfCurrentAndUnclaimed",
+          ).mockReturnValue({
+            found: true,
+            closed: false,
+            activeLeases: 0,
+            pendingAcquires: 1,
+          });
+        } else {
+          releasePeer = retainSharedCodexAppServerClientIfCurrent(harness.client);
+          expect(releasePeer).toBeTypeOf("function");
+          if (reason === "missing entry") {
+            expect(
+              sharedClientModule.retireSharedCodexAppServerClientIfCurrent(harness.client),
+            ).toMatchObject({ closed: false });
+          }
+        }
+        harness.send({
+          method: "turn/completed",
+          params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+        });
+        const terminals = await waitForHarnessRequest(harness, "thread/backgroundTerminals/list");
+        harness.send({ id: terminals.id, result: { data: [], nextCursor: null } });
+        const unsubscribe = await waitForHarnessRequest(harness, "thread/unsubscribe");
+        harness.send({ id: unsubscribe.id, result: {} });
+        expect(readAttemptTerminal(await run)).toMatchObject({ aborted: false, timedOut: false });
+        expect(warning).toHaveBeenCalledWith(
+          expect.stringMatching(/agent cleanup failed:.*step=codex-shared-client-release/),
+        );
+        expect(close).not.toHaveBeenCalled();
+        expect(closeAndWait).not.toHaveBeenCalled();
+        expect(harness.stdinDestroyed).toBe(false);
+        const requestStart = harness.writes.length;
+        const peerRead = harness.client.request("thread/read", {
+          threadId: "thread-peer",
+          includeTurns: false,
+        });
+        const read = await waitForHarnessRequest(harness, "thread/read", requestStart);
+        const result = threadStartResult("thread-peer");
+        harness.send({ id: read.id, result });
+        await expect(peerRead).resolves.toEqual(result);
+      } finally {
+        releasePeer?.();
+        harness.client.close();
+        await run.catch(() => undefined);
+      }
+    },
+  );
+
+  it
+    .skipIf(process.platform === "win32")
+    .each(["confirmed", "unknown", "forced", "signalled", "retired-command"])(
+    "records one-shot cleanup accurately after %s app-server shutdown",
+    async (shutdown) => {
+      const rootPath = path.join(tempDir, "cleanup-root.mjs");
+      const descendantPath = path.join(tempDir, "cleanup-descendant.mjs");
+      const descendantPidPath = path.join(tempDir, "cleanup-descendant.pid");
+      await fs.writeFile(descendantPath, "setInterval(() => {}, 1_000);\n");
+      const launcherPath = path.join(tempDir, "cleanup-launcher.mjs");
+      await fs.writeFile(
+        launcherPath,
+        `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+const child = spawn(process.execPath, [process.argv[2]], { detached: true, stdio: "ignore" });
+child.unref();
+writeFileSync(process.argv[3], String(child.pid));
+`,
+      );
+      await fs.writeFile(
+        rootPath,
+        `
+import { spawn } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { createInterface } from "node:readline";
+const [descendantPath, descendantPidPath] = process.argv.slice(2);
+const descendant = spawn(process.execPath, ${shutdown === "retired-command" ? `[${JSON.stringify(launcherPath)}, descendantPath, descendantPidPath]` : "[descendantPath]"}, { detached: true, stdio: "ignore" });
+${shutdown === "retired-command" ? 'await new Promise(resolve => descendant.once("exit", resolve));' : "writeFileSync(descendantPidPath, String(descendant.pid));"}
+descendant.unref();
+const results = ${JSON.stringify({
+          initialize: { userAgent: `openclaw/${CODEX_APP_SERVER_VERSION} (macOS; test)` },
+          "config/read": { config: {}, origins: {}, layers: [] },
+          "configRequirements/read": { requirements: null },
+          "thread/start": threadStartResult(),
+          "turn/start": turnStartResult(),
+          "thread/backgroundTerminals/list": { data: [], nextCursor: null },
+        })};
+const send = (message) => process.stdout.write(JSON.stringify(message) + "\\n");
+createInterface({ input: process.stdin }).on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.method === "test/complete") {
+    ${shutdown === "retired-command" ? 'send({ method: "item/completed", params: { threadId: "thread-1", turnId: "turn-1", item: { type: "commandExecution", id: "retired-command", command: "fixture", cwd: process.cwd(), status: "completed", exitCode: 0, aggregatedOutput: "" } } });' : ""}
+    send({ method: "turn/completed", params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } } });
+  } else if (request.id !== undefined) {
+    send({ id: request.id, result: results[request.method] ?? {} });
+    if (request.method === "turn/start") {
+      send({ method: "turn/started", params: { threadId: "thread-1", turn: results["turn/start"].turn } });
+    }
+  }
+});
+process.stdin.on("end", () => ${
+          shutdown === "forced"
+            ? "setInterval(() => {}, 1_000)"
+            : shutdown === "signalled"
+              ? 'process.kill(process.pid, "SIGKILL")'
+              : "process.exit(0)"
+        });
+`,
+      );
+      const child = spawn(process.execPath, [rootPath, descendantPath, descendantPidPath], {
+        detached: true,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const exited = once(child, "exit");
+      const client = CodexAppServerClient.fromTransportForTests(child);
+      vi.spyOn(CodexAppServerClient, "start").mockResolvedValueOnce(client);
+      if (shutdown === "unknown") {
+        vi.spyOn(processSnapshot, "readCodexAppServerProcessSnapshot").mockRejectedValue(
+          new processSnapshot.ProcessInspectionError("unavailable"),
+        );
+      }
+      const turnStarted = createDeferred<void>();
+      const removeTurnStartedHandler = client.addNotificationHandler((notification) => {
+        if (
+          notification.method === "turn/started" &&
+          isJsonObject(notification.params) &&
+          notification.params.threadId === "thread-1" &&
+          isJsonObject(notification.params.turn) &&
+          notification.params.turn.id === "turn-1" &&
+          notification.params.turn.status === "inProgress"
+        ) {
+          turnStarted.resolve();
+        }
+      });
+      const warning = vi.spyOn(embeddedAgentLog, "warn");
+      const params = createParams(
+        path.join(tempDir, "cleanup-session.jsonl"),
+        path.join(tempDir, "cleanup-workspace"),
+      );
+      params.oneShotCliRun = true;
+      params.cleanupBundleMcpOnRunEnd = true;
+      const run = runCodexAppServerAttempt(params, {
+        bindingStore: testCodexAppServerBindingStore,
+      });
+      try {
+        await Promise.race([
+          turnStarted.promise,
+          run.then(() => {
+            throw new Error("Codex attempt settled before the fixture emitted turn/started");
+          }),
+        ]);
+        client.notify("test/complete");
+        expect(readAttemptTerminal(await run)).toMatchObject({ aborted: false, timedOut: false });
+        await exited;
+        const descendantPid = Number(await fs.readFile(descendantPidPath, "utf8"));
+        const signalled = shutdown === "forced" || shutdown === "signalled";
+        expect(child.exitCode).toBe(signalled ? null : 0);
+        expect(child.signalCode).toBe(signalled ? "SIGKILL" : null);
+        if (shutdown === "unknown" || shutdown === "retired-command") {
+          expect(process.kill(descendantPid, 0)).toBe(true);
+        } else {
+          const snapshot = await processSnapshot.readCodexAppServerProcessSnapshot(
+            Date.now() + 2_000,
+            [descendantPid],
+          );
+          expect(
+            snapshot.some((row) => row.pid === descendantPid && !row.state.startsWith("Z")),
+          ).toBe(false);
+        }
+        // This is the cleanup guard that also records the one-shot recovery
+        // receipt; a clean root exit must not bypass its failure path.
+        if (shutdown === "confirmed") {
+          expect(warning).not.toHaveBeenCalled();
+        } else {
+          expect(warning).toHaveBeenCalledWith(
+            expect.stringMatching(/agent cleanup failed:.*step=codex-shared-client-release/),
+          );
+        }
+      } finally {
+        removeTurnStartedHandler();
+        client.close();
+        child.kill("SIGKILL");
+        await exited;
+        await run.catch(() => undefined);
+        const descendantPid = Number(await fs.readFile(descendantPidPath, "utf8").catch(() => ""));
+        if (descendantPid) {
+          await stopTaskOwnedProcess(descendantPid);
+        }
+      }
+    },
+  );
+});

--- a/extensions/codex/src/app-server/run-attempt-resources.ts
+++ b/extensions/codex/src/app-server/run-attempt-resources.ts
@@ -156,8 +156,13 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       closed: retired.closed,
       matchedSharedClient: retired.found,
     });
-    if (retired.closed) {
-      await state.client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
+    // Retained peers prevent retirement; preserve their client without treating
+    // missing close evidence as a completed one-shot cleanup.
+    const result = retired.closed
+      ? await state.client.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 })
+      : undefined;
+    if (params.oneShotCliRun && result?.cleanup !== "closed") {
+      throw new Error("Codex one-shot client cleanup could not be confirmed");
     }
   };
   const releaseSandboxExecEnvironment = async () => {
@@ -173,7 +178,15 @@ export function prepareCodexAttemptResources(prompt: CodexAttemptPrompt) {
       await releaseSandboxExecEnvironment();
       const ownedClient = state.releaseSharedClientLease ? state.client : undefined;
       releaseSharedClientLeaseOnce();
-      await ownedClient?.closeAndWait({ exitTimeoutMs: 2_000, forceKillDelayMs: 250 });
+      if (ownedClient) {
+        const result = await ownedClient.closeAndWait({
+          exitTimeoutMs: 2_000,
+          forceKillDelayMs: 250,
+        });
+        if (params.oneShotCliRun && result.cleanup !== "closed") {
+          throw new Error("Codex isolated client cleanup could not be confirmed");
+        }
+      }
       return;
     }
     releaseSharedClientLeaseOnce();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1018,7 +1018,7 @@ function installCleanupTrackingClient(turnStartError?: Error) {
   const events: string[] = [];
   const closeAndWait = vi.fn(async () => {
     events.push("closeAndWait");
-    return true;
+    return { exited: true, cleanup: "closed" };
   });
   const state: {
     client?: unknown;
@@ -3190,7 +3190,7 @@ describe("runCodexAppServerAttempt", () => {
       sharedClientModule,
       "clearSharedCodexAppServerClientIfCurrentAndUnclaimed",
     );
-    const closeAndWait = vi.fn(async () => true);
+    const closeAndWait = vi.fn(async () => ({ exited: true, cleanup: "closed" }));
     let notify: ((notification: CodexServerNotification) => Promise<void>) | undefined;
     const request = vi.fn(async (method: string) => {
       if (method === "configRequirements/read") {

--- a/extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.native.test.ts
@@ -54,7 +54,7 @@ type Cleanup = () => Promise<void>;
 type NativePhase = "probe" | "action" | "side" | "hold" | "summary" | "health";
 
 async function closeNativeClient(client: CodexAppServerClient): Promise<void> {
-  expect(await client.closeAndWait()).toBe(true);
+  expect(await client.closeAndWait()).toMatchObject({ exited: true });
 }
 
 async function createNativeFixture(cleanups: Cleanup[], failures: unknown[]) {

--- a/extensions/codex/src/app-server/thread-lifecycle.native.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.native.test.ts
@@ -138,7 +138,9 @@ describe("native Codex cold thread recovery", () => {
         config: {},
         timeoutMs: 20_000,
       });
-      context.onTestFinished(async () => expect(await client.closeAndWait()).toBe(true));
+      context.onTestFinished(async () =>
+        expect(await client.closeAndWait()).toMatchObject({ exited: true }),
+      );
       expect(client.getRuntimeIdentity()?.serverVersion).toBe(CODEX_APP_SERVER_VERSION);
       const params = {
         ...createParams(path.join(root, "session.jsonl"), native.cwd),

--- a/extensions/codex/src/app-server/transport-process-containment.ts
+++ b/extensions/codex/src/app-server/transport-process-containment.ts
@@ -1,4 +1,5 @@
 import {
+  isDeadProcessState,
   readCodexAppServerProcess,
   readCodexAppServerProcessSnapshot,
   type PosixProcess,
@@ -17,19 +18,12 @@ const MAX_CONTAINED_PROCESSES = 512;
 const MAX_PROCESS_CONTAINMENT_MS = 2_000;
 const MAX_PROCESS_QUIESCE_PASSES = 16;
 
-export async function terminateCodexAppServerDescendants(
-  child: ContainableTransport,
-): Promise<(() => void) | "exited" | undefined> {
-  const contained = await containDescendants(child);
-  return contained === "exited" ? contained : contained?.resume;
-}
-
-/** A durable spawn fact, never a command-line match, selects the orphan root. */
+/** Discharges the registered root obligation, including an already-obsolete PID. */
 export async function terminateCodexAppServerOrphan(
   expected: CodexAppServerProcessIdentity,
 ): Promise<boolean> {
   const deadline = Date.now() + MAX_PROCESS_CONTAINMENT_MS;
-  const result = await containDescendants(
+  const result = await terminateCodexAppServerDescendants(
     { pid: expected.pid, kill: (signal) => signalProcess(expected.pid, signal ?? "SIGTERM") },
     expected,
     deadline,
@@ -53,7 +47,7 @@ export async function terminateCodexAppServerOrphan(
         return false;
       }
       const current = snapshot.find((row) => row.pid === expected.pid);
-      if (!current || !hasSameIdentity(current, expected) || current.state.startsWith("Z")) {
+      if (!current || !hasSameIdentity(current, expected) || isDeadProcessState(current.state)) {
         gone = true;
         return true;
       }
@@ -72,7 +66,7 @@ export async function terminateCodexAppServerOrphan(
   }
 }
 
-async function containDescendants(
+export async function terminateCodexAppServerDescendants(
   child: ContainableTransport,
   expected?: CodexAppServerProcessIdentity,
   deadline = Date.now() + MAX_PROCESS_CONTAINMENT_MS,
@@ -92,13 +86,13 @@ async function containDescendants(
   const root = snapshot.find((row) => row.pid === rootPid);
   // A retained direct child cannot have its PID reused before Node reaps it.
   // Preserve an OS-observed exit even when Node's exit callback is still queued.
-  if (!expected && (!root || root.state.startsWith("Z"))) {
+  if (!expected && (!root || isDeadProcessState(root.state))) {
     return "exited";
   }
   if (
     !root ||
     !(expected ? isSameLiveProcess(root, expected) : root.ppid === process.pid) ||
-    root.state.startsWith("Z")
+    isDeadProcessState(root.state)
   ) {
     return undefined;
   }
@@ -129,10 +123,38 @@ async function containDescendants(
       if (Date.now() >= deadline) {
         return undefined;
       }
-      if (!descendant.state.startsWith("Z")) {
+      if (!isDeadProcessState(descendant.state)) {
         if (!(await signalSameProcess(descendant, "SIGKILL", deadline)) || Date.now() >= deadline) {
           return undefined;
         }
+      }
+    }
+    // SIGKILL can remain pending for an uninterruptible process. Keep the root
+    // stopped until every retained identity is observed gone, replaced or dead.
+    const remaining = new Map(descendants.map((row) => [row.pid, row]));
+    while (remaining.size > 0) {
+      const terminationSnapshot = await readCodexAppServerProcessSnapshot(deadline, [
+        root.pid,
+        ...remaining.keys(),
+      ]).catch(() => undefined);
+      if (!terminationSnapshot || Date.now() >= deadline) {
+        return undefined;
+      }
+      const currentRoot = terminationSnapshot.find((row) => row.pid === root.pid);
+      if (!currentRoot || !isSameLiveRoot(currentRoot, root, true)) {
+        return undefined;
+      }
+      const currentByPid = new Map(terminationSnapshot.map((row) => [row.pid, row]));
+      for (const [pid, retained] of remaining) {
+        const current = currentByPid.get(pid);
+        if (!current || !hasSameIdentity(current, retained) || isDeadProcessState(current.state)) {
+          remaining.delete(pid);
+        }
+      }
+      if (remaining.size > 0) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, 20);
+        });
       }
     }
     resumeRootOnUnwind = false;
@@ -289,7 +311,7 @@ function collectDescendants(snapshot: PosixProcess[], rootPids: number[]): Posix
 }
 
 function isStoppedState(state: string): boolean {
-  return state.startsWith("T") || state.startsWith("t") || state.startsWith("Z");
+  return state.startsWith("T") || state.startsWith("t") || isDeadProcessState(state);
 }
 
 function isQuiescedState(state: string): boolean {
@@ -306,7 +328,7 @@ function isSameLiveProcess(
 ): boolean {
   return (
     current.pgid === expected.pgid &&
-    !current.state.startsWith("Z") &&
+    !isDeadProcessState(current.state) &&
     hasSameIdentity(current, expected)
   );
 }

--- a/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
@@ -4,7 +4,10 @@ import { PassThrough } from "node:stream";
 import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-store-runtime";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
-import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
+import {
+  terminateCodexAppServerDescendants,
+  terminateCodexAppServerOrphan,
+} from "./transport-process-containment.js";
 import { prepareCodexAppServerProcessRegistration } from "./transport-process-registration.js";
 import { readCodexAppServerProcessSnapshot } from "./transport-process-snapshot.js";
 
@@ -43,10 +46,10 @@ const neighbor = 500003;
 const command = "/opt/codex app-server --listen stdio://";
 const commandFingerprint = createHash("sha256").update(command).digest("hex");
 
-function addProcess(pid: number, ppid: number) {
+function addProcess(pid: number, ppid: number, state = "S", threads = 1) {
   procfs.files.set(
     `/proc/${pid}/stat`,
-    `${pid} (worker) S ${ppid} ${pid}${" 0".repeat(16)} 12345\n`,
+    `${pid} (worker) ${state} ${ppid} ${pid}${" 0".repeat(14)} ${threads} 0 12345\n`,
   );
   procfs.files.set(`/proc/${pid}/cmdline`, command.replaceAll(" ", "\0"));
 }
@@ -90,11 +93,14 @@ describe("Codex registration procfs boundary", () => {
     await state.cleanup();
   });
 
-  it.for(["immediate", "delayed"])(
+  it.for(["immediate", "delayed", "threaded zombie"])(
     "preserves a live owner's registration during %s inspection despite an unreadable unrelated process",
     async (mode) => {
       const registration = { parent, child: { ...child, commandFingerprint } };
       store.register("owned", registration);
+      if (mode === "threaded zombie") {
+        addProcess(parent.pid, 1, "Z", 2);
+      }
       if (mode === "delayed") {
         let now = Date.now();
         vi.spyOn(Date, "now").mockImplementation(() => now);
@@ -236,7 +242,7 @@ describe("Codex registration procfs boundary", () => {
           fault === "empty"
             ? ""
             : fault === "group-zero"
-              ? `${parent.pid} (worker) S 1 0${" 0".repeat(16)} 12345\n`
+              ? `${parent.pid} (worker) S 1 0${" 0".repeat(14)} 1 0 12345\n`
               : Object.assign(new Error("required inspection failed"), { code: fault }),
         );
       }
@@ -254,6 +260,43 @@ describe("Codex registration procfs boundary", () => {
     await expect(terminateCodexAppServerOrphan(child)).resolves.toBe(false);
     expect(kill).not.toHaveBeenCalled();
   });
+
+  it.for(["dead descendant", "threaded descendant", "threaded root", "unrelated threaded zombie"])(
+    "requires whole-process quiescence only from the owned tree: %s",
+    async (mode) => {
+      const threadedRoot = mode === "threaded root";
+      const related = mode !== "unrelated threaded zombie";
+      addProcess(child.pid, process.pid, threadedRoot ? "Z" : "S", threadedRoot ? 2 : 1);
+      addProcess(neighbor, related ? child.pid : 1, "Z", mode === "dead descendant" ? 1 : 2);
+      kill.mockImplementation((pid, signal) => {
+        if (pid === child.pid && !threadedRoot) {
+          addProcess(child.pid, process.pid, signal === "SIGSTOP" ? "T" : "S");
+        }
+        return true;
+      });
+
+      const contained = await terminateCodexAppServerDescendants({
+        pid: child.pid,
+        kill: (signal) => process.kill(child.pid, signal),
+      });
+
+      if (mode === "threaded descendant" || threadedRoot) {
+        expect(contained).toBeUndefined();
+        expect(kill).toHaveBeenCalledWith(child.pid, "SIGCONT");
+        if (!threadedRoot) {
+          expect(kill).toHaveBeenCalledWith(neighbor, "SIGSTOP");
+          expect(kill).toHaveBeenCalledWith(neighbor, "SIGCONT");
+        }
+      } else {
+        expect(contained).toMatchObject({ root: child });
+        if (contained && contained !== "exited") {
+          contained.resume();
+        }
+        expect(kill.mock.calls.every(([pid]) => pid === child.pid)).toBe(true);
+      }
+      expect(kill.mock.calls.some(([, signal]) => signal === "SIGKILL")).toBe(false);
+    },
+  );
 
   it.for(["ENOENT", "ESRCH"])(
     "retires verified disappeared identities only after full containment inspection: %s",

--- a/extensions/codex/src/app-server/transport-process-registration.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test.ts
@@ -126,7 +126,7 @@ describe("Codex process registration", () => {
     },
   );
 
-  it.for(["live", "unknown"])(
+  it.for(["live", "unknown", "threaded zombie"])(
     "retains an unreadable-command registration when the child is %s",
     async (mode) => {
       const registration = { parent, child: { ...child, commandFingerprint } };
@@ -138,10 +138,15 @@ describe("Codex process registration", () => {
         vi.mocked(readCodexAppServerProcessSnapshot)
           .mockResolvedValueOnce([observer, liveChild])
           .mockRejectedValue(new ProcessInspectionError("unavailable"));
+      } else if (mode === "threaded zombie") {
+        vi.mocked(readCodexAppServerProcessSnapshot).mockResolvedValue([
+          observer,
+          { ...liveChild, state: "Zl" },
+        ]);
       }
 
       await expect(prepareCodexAppServerProcessRegistration()).rejects.toMatchObject({
-        reason: mode === "live" ? "permission" : "unavailable",
+        reason: mode === "unknown" ? "unavailable" : "permission",
       });
 
       expect(store.lookup("orphan")).toEqual(registration);

--- a/extensions/codex/src/app-server/transport-process-registration.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.ts
@@ -5,6 +5,7 @@ import type { OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
 import { z } from "zod";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
 import {
+  isDeadProcessState,
   ProcessInspectionError,
   readCodexAppServerProcessCommand,
   readCodexAppServerProcessSnapshot,
@@ -59,14 +60,14 @@ async function reapRegisteredCodexAppServerOrphans(): Promise<void> {
       registration.child.pid,
     ]);
     const parent = snapshot.find((row) => row.pid === registration.parent.pid);
-    if (parent?.startedAt === registration.parent.startedAt && !parent.state.startsWith("Z")) {
+    if (parent?.startedAt === registration.parent.startedAt && !isDeadProcessState(parent.state)) {
       continue;
     }
     const child = snapshot.find((row) => row.pid === registration.child.pid);
     if (
       registration.child.commandFingerprint !== undefined &&
       child?.startedAt === registration.child.startedAt &&
-      !child.state.startsWith("Z")
+      !isDeadProcessState(child.state)
     ) {
       let command: string | undefined;
       try {

--- a/extensions/codex/src/app-server/transport-process-snapshot.test.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.test.ts
@@ -122,7 +122,7 @@ describe("Codex procfs command inspector", () => {
       const pgid = process.pid + Number(changed && mode === "regrouped");
       const replaced =
         (changed && mode === "replaced") || (commandReads > 1 && mode === "replaced after read");
-      return `${process.pid} (codex) ${state} ${ppid} ${pgid}${" 0".repeat(16)} ${replaced ? 54321 : 12345}\n`;
+      return `${process.pid} (codex) ${state} ${ppid} ${pgid}${" 0".repeat(14)} 1 0 ${replaced ? 54321 : 12345}\n`;
     });
     const observed = (await readCodexAppServerProcessSnapshot(undefined, [process.pid]))[0]!;
     const inspected = readCodexAppServerProcessCommand(observed, deadline);
@@ -188,8 +188,34 @@ describe("Codex procfs command inspector", () => {
 });
 
 describe("Codex procfs process inspector", () => {
-  it.for(["ENOENT", "ESRCH", "EACCES"] as const)(
-    "distinguishes a vanished neighbor from unreadable state: %s",
+  it.for(["1", "2", "0", "-1", "1.5", "missing", "9007199254740992"])(
+    "requires explicit thread evidence before classifying a zombie leader: %s",
+    async (threads, ctx) => {
+      ctx.onTestFinished(() => {
+        procfs.readFile.mockReset();
+        vi.restoreAllMocks();
+      });
+      vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+      procfs.readFile.mockImplementation(async (file) => {
+        if (file === "/proc/sys/kernel/random/boot_id") {
+          return "00000000-0000-0000-0000-000000000001";
+        }
+        expect(file).toBe(`/proc/${process.pid}/stat`);
+        return `${process.pid} (worker) Z ${process.ppid} ${process.pid}${" 0".repeat(14)} ${threads} 0 12345\n`;
+      });
+      const snapshot = readCodexAppServerProcessSnapshot(undefined, [process.pid]);
+      if (threads === "1" || threads === "2") {
+        await expect(snapshot).resolves.toEqual([
+          { ...observedProcess, state: threads === "1" ? "Z" : "Zl" },
+        ]);
+      } else {
+        await expect(snapshot).rejects.toMatchObject({ reason: "unavailable" });
+      }
+    },
+  );
+
+  it.for(["ENOENT", "ESRCH", "EACCES", "exiting"] as const)(
+    "distinguishes vanished or exiting neighbors from unreadable state: %s",
     async (code, ctx) => {
       ctx.onTestFinished(() => {
         procfs.readFile.mockReset();
@@ -206,9 +232,12 @@ describe("Codex procfs process inspector", () => {
         }
         if (file === `/proc/${process.pid}/stat`) {
           // Fields 3..22 follow the final ')', even when comm contains ')' and spaces.
-          return `${process.pid} (codex ) worker) S ${process.ppid} ${process.pid}${" 0".repeat(16)} 12345${" 0".repeat(30)}\n`;
+          return `${process.pid} (codex ) worker) S ${process.ppid} ${process.pid}${" 0".repeat(14)} 1 0 12345${" 0".repeat(30)}\n`;
         }
         if (file === `/proc/${neighborPid}/stat`) {
+          if (code === "exiting") {
+            return `${neighborPid} (worker) Z 0 -1${" 0".repeat(16)} 12345\n`;
+          }
           throw Object.assign(new Error("neighbor process read failed"), { code });
         }
         throw new Error(`Unexpected procfs read: ${file}`);
@@ -226,6 +255,11 @@ describe("Codex procfs process inspector", () => {
             startedAt: `${bootId}:12345`,
           },
         ]);
+      }
+      if (code === "exiting") {
+        await expect(
+          readCodexAppServerProcessSnapshot(undefined, [neighborPid]),
+        ).rejects.toMatchObject({ reason: "unavailable" });
       }
     },
   );

--- a/extensions/codex/src/app-server/transport-process-snapshot.ts
+++ b/extensions/codex/src/app-server/transport-process-snapshot.ts
@@ -10,6 +10,11 @@ export type PosixProcess = {
   startedAt: string;
 };
 
+/** A zombie leader can still own running threads, reported by the ps-style l flag. */
+export function isDeadProcessState(state: string): boolean {
+  return state.startsWith("Z") && !state.includes("l");
+}
+
 const PROCESS_COLUMNS = "pid=,ppid=,pgid=,stat=,lstart=";
 const MAX_PROCESS_CONTAINMENT_MS = 2_000;
 const PROCESS_INSPECTION_MAX_BYTES = 8 * 1024 * 1024;
@@ -287,12 +292,18 @@ async function readLinuxProcesses(
       ) {
         throw new ProcessInspectionError("unavailable");
       }
+      // An exiting task can lose its signal lock and report pgid=-1, threads=0.
+      // Full scans omit that row; selected owners still require usable group evidence.
       if (pgid > 0) {
+        const threads = Number(fields[17]);
+        if (!/^[1-9]\d*$/.test(fields[17] ?? "") || !Number.isSafeInteger(threads)) {
+          throw new ProcessInspectionError("unavailable");
+        }
         rows.push({
           pid: Number(entry),
           ppid,
           pgid,
-          state: fields[0]!,
+          state: `${fields[0]}${threads > 1 ? "l" : ""}`,
           startedAt: `${bootId}:${startTicks}`,
         });
       }

--- a/extensions/codex/src/app-server/transport-startup.test.ts
+++ b/extensions/codex/src/app-server/transport-startup.test.ts
@@ -44,7 +44,7 @@ describe.skipIf(process.platform === "win32")("Codex failed launcher startup", (
       } else {
         await vi.advanceTimersByTimeAsync(1);
       }
-      await expect(closing).resolves.toBe(mode === "drained");
+      await expect(closing).resolves.toEqual({ exited: mode === "drained", cleanup: "uncertain" });
       expect(diagnostic).toEqual(["last startup diagnostic"]);
       expect(hasCodexAppServerNaturalExit(child)).toBe(mode === "drained");
       expect(child.stdout.destroyed).toBe(true);

--- a/extensions/codex/src/app-server/transport-stdio.config.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.config.test.ts
@@ -189,7 +189,7 @@ async function readNativeConfig(startOptions: CodexAppServerStartOptions, env: N
     });
   } finally {
     lines.close();
-    expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+    expect(await closeCodexAppServerTransportAndWait(child)).toMatchObject({ exited: true });
     await closed;
   }
 }

--- a/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
+++ b/extensions/codex/src/app-server/transport-stdio.sandbox.test.ts
@@ -171,7 +171,7 @@ describe.skipIf(process.platform !== "darwin")("native Codex turn sandbox", () =
       const lines = createInterface({ input: child.stdout });
       context.onTestFinished(async () => {
         lines.close();
-        expect(await closeCodexAppServerTransportAndWait(child)).toBe(true);
+        expect(await closeCodexAppServerTransportAndWait(child)).toMatchObject({ exited: true });
       });
       const pending = new Map<
         number,

--- a/extensions/codex/src/app-server/transport-websocket.test.ts
+++ b/extensions/codex/src/app-server/transport-websocket.test.ts
@@ -106,7 +106,7 @@ describe("Codex app-server websocket transport", () => {
     });
     server.once("connection", (socket) => {
       socket.once("ping", () => resolvePing?.());
-      resolveConnected?.();
+      socket.once("message", () => resolveConnected?.());
     });
     await new Promise<void>((resolve) => {
       server.once("listening", resolve);
@@ -124,10 +124,8 @@ describe("Codex app-server websocket transport", () => {
       headers: {},
     });
     transports.push(transport);
+    transport.stdin.write("{}\n");
     await connected;
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
 
     await vi.advanceTimersByTimeAsync(20_000);
     await expect(receivedPing).resolves.toBeUndefined();
@@ -150,7 +148,7 @@ describe("Codex app-server websocket transport", () => {
     });
     server.once("connection", (socket) => {
       socket.once("ping", () => resolvePing?.());
-      resolveConnected?.();
+      socket.once("message", () => resolveConnected?.());
     });
     await new Promise<void>((resolve) => {
       server.once("listening", resolve);
@@ -171,10 +169,8 @@ describe("Codex app-server websocket transport", () => {
     const exited = new Promise<unknown>((resolve) => {
       transport.once("exit", (code) => resolve(code));
     });
+    transport.stdin.write("{}\n");
     await connected;
-    await new Promise<void>((resolve) => {
-      setImmediate(resolve);
-    });
 
     await vi.advanceTimersByTimeAsync(20_000);
     await expect(receivedPing).resolves.toBeUndefined();

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -1,8 +1,9 @@
-import { execFileSync, spawn } from "node:child_process";
+import { spawn } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { describe, expect, it, vi } from "vitest";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
 import * as processSnapshot from "./transport-process-snapshot.js";
@@ -25,23 +26,26 @@ const delay = (ms: number) =>
     setTimeout(resolve, ms);
   });
 
-function listProcesses(): ProcessRow[] {
-  return execFileSync("ps", ["-axo", "pid=,command="], {
-    encoding: "utf8",
-  })
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const match = /^(\d+)\s+(.*)$/.exec(line);
-      if (!match) {
-        throw new Error(`unexpected ps row: ${line}`);
-      }
-      return {
+async function listProcesses(tempDir: string): Promise<ProcessRow[]> {
+  // Stream and retain only owned fixtures: unrelated host command lines can
+  // exceed execFileSync's buffer and must not leak into a failed assertion.
+  const child = spawn("ps", ["-axo", "pid=,command="], { stdio: ["ignore", "pipe", "ignore"] });
+  const closed = once(child, "close");
+  const rows: ProcessRow[] = [];
+  for await (const line of createInterface({ input: child.stdout })) {
+    if (!line.includes(tempDir)) {
+      continue;
+    }
+    const match = /^\s*(\d+)\s+(.*)$/.exec(line);
+    if (match) {
+      rows.push({
         pid: Number(match[1]),
         command: match[2] ?? "",
-      };
-    });
+      });
+    }
+  }
+  expect((await closed)[0]).toBe(0);
+  return rows;
 }
 
 async function waitForFixtureEvents(logPath: string, count: number): Promise<FixtureEvent[]> {
@@ -67,8 +71,7 @@ async function readFixtureEvents(logPath: string): Promise<FixtureEvent[]> {
 async function removeTaskOwnedFixtureProcesses(tempDir: string): Promise<void> {
   const deadline = Date.now() + 2_000;
   while (Date.now() < deadline) {
-    const allRows = listProcesses();
-    const ownedRows = allRows.filter((row) => row.command.includes(tempDir));
+    const ownedRows = await listProcesses(tempDir);
     if (ownedRows.length === 0) {
       return;
     }
@@ -83,7 +86,7 @@ async function removeTaskOwnedFixtureProcesses(tempDir: string): Promise<void> {
     }
     await delay(20);
   }
-  const survivors = listProcesses().filter((row) => row.command.includes(tempDir));
+  const survivors = await listProcesses(tempDir);
   if (survivors.length > 0) {
     throw new Error(`task-owned process fixture survived cleanup: ${JSON.stringify(survivors)}`);
   }
@@ -195,11 +198,11 @@ process.stdin.on("end", () => process.exit(0));
           forceKillDelayMs: 500,
           exitTimeoutMs: 2_000,
         }),
-      ).resolves.toBe(true);
+      ).resolves.toEqual({ exited: true, cleanup: "closed" });
       expect(root.exitCode).toBe(0);
       expect(root.signalCode).toBeNull();
 
-      const survivors = listProcesses().filter((row) => row.command.includes(tempDir));
+      const survivors = await listProcesses(tempDir);
       expect(survivors).toEqual([]);
     } finally {
       await removeTaskOwnedFixtureProcesses(tempDir);
@@ -214,6 +217,7 @@ process.stdin.on("end", () => process.exit(0));
     ["root-resumed", false],
     ["traced", false],
     ["uninterruptible", false],
+    ["unconfirmed-termination", false],
     ["snapshot-failure", true],
     ["inspection-timeout", true],
     ["extended", false],
@@ -315,6 +319,12 @@ process.stdin.on("end", () => process.exit(0));
           [stoppedRoot, { ...sentinelIdentity, state: "U" }],
           [stoppedRoot, { ...sentinelIdentity, state: "U" }],
         ],
+        "unconfirmed-termination": [
+          runningTree,
+          runningTree,
+          [stoppedRoot, { ...sentinelIdentity, state: "U" }],
+          [stoppedRoot, { ...sentinelIdentity, state: "U" }],
+        ],
         "snapshot-failure": [runningTree, runningTree, rootStoppedTree, rootStoppedTree, undefined],
         "inspection-timeout": [runningTree, runningTree, "deadline"],
         extended: [
@@ -326,7 +336,22 @@ process.stdin.on("end", () => process.exit(0));
       };
       const snapshots = scenarios[mode];
       let inspection = 0;
+      let descendantSignalled = false;
+      const actualSnapshot = processSnapshot.readCodexAppServerProcessSnapshot;
+      const actualKill = process.kill.bind(process);
+      const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+        const signalled = actualKill(pid, signal);
+        if (pid === sentinelPid && signal === "SIGKILL") {
+          descendantSignalled = true;
+        }
+        return signalled;
+      });
       const readSnapshot = async (inspectionDeadline: number): Promise<PosixProcess[]> => {
+        // Identity faults exercise signalling; cleanup needs a separate OS
+        // observation. A queued kill alone must not certify an uninterruptible child.
+        if (descendantSignalled && mode !== "unconfirmed-termination") {
+          return await actualSnapshot(inspectionDeadline);
+        }
         const rows = snapshots[Math.min(inspection++, snapshots.length - 1)];
         if (rows === "deadline") {
           await delay(Math.max(1, inspectionDeadline - Date.now()));
@@ -350,15 +375,19 @@ process.stdin.on("end", () => process.exit(0));
       restoreInspection = () => {
         snapshotSpy.mockRestore();
         processSpy.mockRestore();
+        killSpy.mockRestore();
       };
       const closed = await closeCodexAppServerTransportAndWait(root, {
         forceKillDelayMs: 500,
         exitTimeoutMs: 2_000,
       });
       restoreInspection();
-      expect(closed).toBe(true);
+      expect(closed).toEqual({
+        exited: true,
+        cleanup: sentinelSurvived || mode === "unconfirmed-termination" ? "uncertain" : "closed",
+      });
       expect(root.exitCode).toBe(0);
-      const survived = listProcesses().some(
+      const survived = (await listProcesses(tempDir)).some(
         (row) => row.pid === sentinelPid && row.command.includes(tempDir),
       );
       expect(survived).toBe(sentinelSurvived);

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -5,7 +5,15 @@
 import { finished } from "node:stream/promises";
 import { terminateCodexAppServerDescendants } from "./transport-process-containment.js";
 
-type TransportClose = { closing: Promise<boolean>; naturalExit: boolean };
+export type CodexAppServerCloseResult =
+  | { exited: true; cleanup: "closed" | "uncertain" }
+  | { exited: false; cleanup: "uncertain" };
+
+type TransportClose = {
+  closing: Promise<"natural" | "contained" | "uncertain">;
+  naturalExit: boolean;
+  wasForced: () => boolean;
+};
 const CODEX_APP_SERVER_TRANSPORT_CLOSES = new WeakMap<object, TransportClose>();
 
 type TransportCloseOptions = { forceKillDelayMs?: number; drainStdio?: boolean };
@@ -58,34 +66,38 @@ function beginCodexAppServerTransportClose(
   if (current) {
     return current;
   }
-  const closing = (async () => {
+  let forced = false;
+  const forceKill = () => {
+    forced = true;
+    signalCodexAppServerTransport(child, "SIGKILL");
+  };
+  const closing: TransportClose["closing"] = (async () => {
     if (hasCodexAppServerTransportExited(child)) {
-      return true;
+      return "natural";
     }
     if (process.platform === "win32" || !child.pid || !child.kill) {
-      finishCodexAppServerTransportClose(child, options);
-      return false;
+      finishCodexAppServerTransportClose(child, options, forceKill);
+      return "uncertain";
     }
-    let resumeRoot: (() => void) | undefined;
+    let contained;
     try {
-      const contained = await terminateCodexAppServerDescendants(child);
-      if (contained === "exited") {
-        return true;
-      }
-      resumeRoot = contained;
+      contained = await terminateCodexAppServerDescendants(child);
     } catch {
-      resumeRoot = undefined;
+      contained = undefined;
+    }
+    if (contained === "exited") {
+      return "natural";
     }
     try {
-      finishCodexAppServerTransportClose(child, options, resumeRoot);
+      finishCodexAppServerTransportClose(child, options, forceKill, contained?.resume);
     } catch {
-      signalCodexAppServerTransport(child, "SIGKILL");
+      forceKill();
     }
-    // Descendant termination or stdin EOF can make a launcher exit cleanly.
-    // Record cleanup ownership here instead of inferring it from its exit code.
-    return false;
+    // Only observed descendant termination followed by graceful root exit
+    // certifies cleanup. EOF or a forced root exit alone cannot prove it.
+    return contained ? "contained" : "uncertain";
   })();
-  const closure = { closing, naturalExit: false };
+  const closure = { closing, naturalExit: false, wasForced: () => forced };
   CODEX_APP_SERVER_TRANSPORT_CLOSES.set(child, closure);
   return closure;
 }
@@ -93,6 +105,7 @@ function beginCodexAppServerTransportClose(
 function finishCodexAppServerTransportClose(
   child: CodexAppServerTransport,
   options: TransportCloseOptions,
+  killTransport: () => void,
   resumeRoot?: () => void,
 ): void {
   const forceKillDelayMs = options.forceKillDelayMs ?? 1_000;
@@ -101,7 +114,7 @@ function finishCodexAppServerTransportClose(
       if (hasCodexAppServerTransportExited(child)) {
         return;
       }
-      signalCodexAppServerTransport(child, "SIGKILL");
+      killTransport();
     },
     Math.max(1, forceKillDelayMs),
   );
@@ -125,11 +138,11 @@ function finishCodexAppServerTransportClose(
   child.stdin.unref?.();
 }
 
-/** Closes a transport and waits briefly for an exit event. */
+/** Reports physical settlement separately from confirmed process cleanup. */
 export async function closeCodexAppServerTransportAndWait(
   child: CodexAppServerTransport,
   options: TransportCloseOptions & { exitTimeoutMs?: number } = {},
-): Promise<boolean> {
+): Promise<CodexAppServerCloseResult> {
   const drained = options.drainStdio
     ? Promise.all(
         [child.stdout, child.stderr].map((stream) => finished(stream, { cleanup: true })),
@@ -139,20 +152,28 @@ export async function closeCodexAppServerTransportAndWait(
       )
     : undefined;
   const closure = beginCodexAppServerTransportClose(child, options);
-  const naturalExit = await closure.closing;
+  const containment = await closure.closing;
   const settled = await waitForCodexAppServerTransportExit(
     child,
     options.exitTimeoutMs ?? 2_000,
     drained,
   );
-  closure.naturalExit = naturalExit && settled;
+  closure.naturalExit = containment === "natural" && settled;
   if (options.drainStdio) {
     // Share the existing exit budget with pipe draining. A timed-out drain is
     // not a complete natural-exit diagnostic and must not authorize a retry.
     child.stdout.destroy?.();
     child.stderr.destroy?.();
   }
-  return settled;
+  return settled
+    ? {
+        exited: true,
+        cleanup:
+          containment === "contained" && !closure.wasForced() && child.signalCode == null
+            ? "closed"
+            : "uncertain",
+      }
+    : { exited: false, cleanup: "uncertain" };
 }
 
 function hasCodexAppServerTransportExited(child: CodexAppServerTransport): boolean {

--- a/extensions/codex/src/node-exec-server.runtime.ts
+++ b/extensions/codex/src/node-exec-server.runtime.ts
@@ -138,7 +138,7 @@ function createNodeExecServerProcessOwner(
         if (process.platform === "win32" && child.pid) {
           killProcessTree(child.pid, { graceMs: CODEX_EXEC_SERVER_TERMINATION_GRACE_MS });
         }
-        const exited = await closeCodexAppServerTransportAndWait(child, {
+        const { exited } = await closeCodexAppServerTransportAndWait(child, {
           forceKillDelayMs: CODEX_EXEC_SERVER_TERMINATION_GRACE_MS,
           exitTimeoutMs: CODEX_EXEC_SERVER_REAP_TIMEOUT_MS,
         });

--- a/extensions/codex/src/node-exec-server.test.ts
+++ b/extensions/codex/src/node-exec-server.test.ts
@@ -144,6 +144,38 @@ afterEach(() => {
 });
 
 describe("Codex node exec-server", () => {
+  it("reports an unconfirmed transport stop instead of treating its result object as success", async () => {
+    const transport = await import("./app-server/transport.js");
+    const close = transport.closeCodexAppServerTransportAndWait;
+    const failedClose = vi
+      .spyOn(transport, "closeCodexAppServerTransportAndWait")
+      .mockImplementation(async (...args) => {
+        await close(...args);
+        return { exited: false, cleanup: "uncertain" };
+      });
+    const command = createCodexNodeExecServerCommand();
+    const frames = createNodeFrames();
+    const workspace = createManagedWorkspaceInvocation(process.cwd());
+    const invocation = command.handle(
+      JSON.stringify({ placement: workspace.placement, authorization: "human-approved" }),
+      frames.io,
+      workspace.context,
+    );
+    const outcome = invocation.catch((error: unknown) => error);
+    try {
+      await Promise.race([frames.ready, invocation]);
+      frames.controller.abort(new Error("node cleanup fixture disconnected"));
+      await expect(outcome).resolves.toMatchObject({
+        message: "Codex node exec-server process tree did not terminate.",
+      });
+      await expect(command.onDisconnect?.()).rejects.toThrow("did not terminate");
+    } finally {
+      frames.controller.abort();
+      await outcome;
+      failedClose.mockRestore();
+    }
+  });
+
   it("uses admitted Full launch authority without asking for a human decision", async () => {
     const { placement } = createManagedWorkspaceInvocation(process.cwd());
     const request = vi.fn(async () => ({ decision: "deny" as const }));

--- a/src/agents/admitted-run-context.test.ts
+++ b/src/agents/admitted-run-context.test.ts
@@ -317,6 +317,54 @@ describe("prepared run admission", () => {
     recovery?.release();
   });
 
+  it.each([false, true])(
+    "keeps retained native policy fenced after foreground close (refusedRebind=%s)",
+    async (refusedRebind) => {
+      let current = true;
+      const { runtime, ...admissionFacts } = facts;
+      const prepared = prepareAgentRunAdmission({
+        cfg: {},
+        facts: { ...admissionFacts, runId: "native-source-lease" },
+        operationalRunInstance: createOperationalRunInstanceRef("native-source-lease"),
+        assertSourceCurrent: () => {
+          if (!current) {
+            throw new Error("source claim lost");
+          }
+        },
+      });
+      const admitted = await prepared.admit(runtime.kind);
+      const recovery = retainAdmittedRunBeforeToolCallRecovery(admitted);
+      expect(recovery).toBeDefined();
+      try {
+        if (refusedRebind) {
+          const refused = prepareAgentRunAdmission({
+            cfg: {},
+            facts: { ...admissionFacts, runId: "native-source-lease" },
+            operationalRunInstance: admitted.operationalRunInstance,
+            assertSourceCurrent: () => {},
+          });
+          try {
+            await expect(refused.admit(runtime.kind)).rejects.toThrow("already bound");
+          } finally {
+            refused.close();
+          }
+          expect(() => recovery!.assertActive()).not.toThrow();
+        }
+        prepared.close();
+        expect(() => recovery!.assertActive()).not.toThrow();
+        current = false;
+        expect(() => recovery!.assertActive()).toThrow("source claim lost");
+        current = true;
+        expect(() => recovery!.assertActive()).toThrow(
+          "source execution authority is no longer active",
+        );
+      } finally {
+        recovery?.release();
+        prepared.close();
+      }
+    },
+  );
+
   it("closes admitted authority when the owner binding hook fails", async () => {
     const { runtime, ...admissionFacts } = facts;
     let authority: ReturnType<typeof getAdmittedRunDelegatedAuthority>;

--- a/src/agents/admitted-run-context.ts
+++ b/src/agents/admitted-run-context.ts
@@ -43,15 +43,22 @@ export type PreparedAgentRunAdmission = Readonly<{
 type DelegatedAuthorityLease = {
   authority: AgentRunDelegatedAuthority;
   foregroundClosed: boolean;
+  assertSourceCurrent?: () => void;
 };
 
 const delegatedAuthorityLeases = new WeakMap<AdmittedRunContext, DelegatedAuthorityLease>();
 const activeNativeHookRecoveryLeases = new Map<string, DelegatedAuthorityLease>();
 
-function bindAdmittedRunDelegatedAuthority(context: AdmittedRunContext): void {
+function bindAdmittedRunDelegatedAuthority(
+  context: AdmittedRunContext,
+  assertSourceCurrent?: () => void,
+): void {
+  const authority = claimAgentRunDelegatedAuthority(
+    context.operationalRunInstance,
+    assertSourceCurrent,
+  );
   activeNativeHookRecoveryLeases.delete(context.operationalRunInstance.runId);
-  const authority = claimAgentRunDelegatedAuthority(context.operationalRunInstance);
-  const lease = { authority, foregroundClosed: false };
+  const lease = { authority, foregroundClosed: false, assertSourceCurrent };
   delegatedAuthorityLeases.set(context, lease);
 }
 
@@ -118,6 +125,8 @@ export function retainAdmittedRunBeforeToolCallRecovery(
   }
   activeNativeHookRecoveryLeases.set(runId, lease);
   const assertActive = () => {
+    // Retaining native policy outlives the foreground claim, never its source owner.
+    lease.assertSourceCurrent?.();
     if (
       getAgentRunLifecycleGeneration() !== lease.authority.lifecycleGeneration ||
       activeNativeHookRecoveryLeases.get(runId) !== lease
@@ -207,8 +216,24 @@ export function prepareAgentRunAdmission(params: {
   operationalRunInstance: OperationalRunInstanceRef;
   recovery?: ExecutionIdentityRecoveryAdmission;
   onAdmitted?: (context: AdmittedRunContext) => void | Promise<void>;
+  assertSourceCurrent?: () => void;
 }): PreparedAgentRunAdmission {
   const operationalRunInstance = params.operationalRunInstance;
+  const sourceAssertion = params.assertSourceCurrent;
+  let sourceClosed = false;
+  const assertSourceCurrent =
+    sourceAssertion &&
+    (() => {
+      if (sourceClosed) {
+        throw new Error("source execution authority is no longer active");
+      }
+      try {
+        sourceAssertion();
+      } catch (error) {
+        sourceClosed = true;
+        throw error;
+      }
+    });
   if (operationalRunInstance.runId !== params.facts.runId) {
     throw new Error("operational run instance disagrees with prepared admission");
   }
@@ -236,6 +261,7 @@ export function prepareAgentRunAdmission(params: {
       const fixedRuntimeKind = (admittedRuntimeKind ??= runtimeKind);
       admittedRuntimeInstanceId ??= runtimeInstanceId?.trim() || undefined;
       admitted ??= (async () => {
+        assertSourceCurrent?.();
         const facts = executionIdentitySpawnAdmission({
           operation: "attach",
           value: { ...params.facts, runtime: { kind: fixedRuntimeKind } },
@@ -248,6 +274,7 @@ export function prepareAgentRunAdmission(params: {
           runtimeInstanceId: admittedRuntimeInstanceId,
           ...(params.recovery ? { recovery: params.recovery } : {}),
         });
+        bindAdmittedRunDelegatedAuthority(context, assertSourceCurrent);
         admittedContext = context;
         try {
           await params.onAdmitted?.(context);
@@ -332,9 +359,7 @@ function admitPreparedAgentRun(params: {
     runId: params.facts.runId,
   });
   if (!isExecutionIdentityCollectionEnabled(params.cfg)) {
-    const context = Object.freeze({ operationalRunInstance });
-    bindAdmittedRunDelegatedAuthority(context);
-    return context;
+    return Object.freeze({ operationalRunInstance });
   }
   const executionIdentityToken =
     recovery.token ??
@@ -342,9 +367,7 @@ function admitPreparedAgentRun(params: {
       ? createExecutionIdentityAdmissionToken(params.facts.runId)
       : undefined);
   if (!executionIdentityToken) {
-    const context = Object.freeze({ operationalRunInstance });
-    bindAdmittedRunDelegatedAuthority(context);
-    return context;
+    return Object.freeze({ operationalRunInstance });
   }
 
   enqueueExecutionIdentityContextAtAdmission(params.facts, {
@@ -353,7 +376,5 @@ function admitPreparedAgentRun(params: {
     runtimeInstanceId: params.runtimeInstanceId,
     retryOnly: params.recovery?.retryOnly === true,
   });
-  const context = Object.freeze({ operationalRunInstance, executionIdentityToken });
-  bindAdmittedRunDelegatedAuthority(context);
-  return context;
+  return Object.freeze({ operationalRunInstance, executionIdentityToken });
 }

--- a/src/agents/agent-bundle-lsp-dependencies.ts
+++ b/src/agents/agent-bundle-lsp-dependencies.ts
@@ -1,18 +1,13 @@
 /** Owns the process/config dependencies used by the bundled LSP runtime. */
-import type { ChildProcess } from "node:child_process";
-import { killProcessTree } from "../process/kill-tree.js";
 import { spawnLspServerProcess } from "./agent-bundle-lsp-process.js";
 import { loadEmbeddedAgentLspConfig } from "./embedded-agent-lsp.js";
-import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
 
 export type BundleLspRuntimeDependencies = {
   loadLspConfig: typeof loadEmbeddedAgentLspConfig;
-  spawnServerProcess: (config: StdioMcpServerLaunchConfig) => ChildProcess;
-  killProcessTree: typeof killProcessTree;
+  spawnServerProcess: typeof spawnLspServerProcess;
 };
 
 export const defaultBundleLspRuntimeDependencies: BundleLspRuntimeDependencies = {
   loadLspConfig: loadEmbeddedAgentLspConfig,
   spawnServerProcess: spawnLspServerProcess,
-  killProcessTree,
 };

--- a/src/agents/agent-bundle-lsp-process.ts
+++ b/src/agents/agent-bundle-lsp-process.ts
@@ -1,30 +1,30 @@
 /** Spawns bundled LSP server processes with sanitized environment and platform handling. */
-import { spawn, type ChildProcess } from "node:child_process";
 import { sanitizeHostExecEnv } from "../infra/host-env-security.js";
 import {
   materializeWindowsSpawnProgram,
   resolveWindowsSpawnProgram,
 } from "../plugin-sdk/windows-spawn.js";
+import { createOwnedStdioProcess, type OwnedStdioProcess } from "../process/owned-stdio.js";
 import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
 
 type LspSpawnDependencies = {
-  spawn: typeof spawn;
+  spawn: typeof createOwnedStdioProcess;
   sanitizeHostExecEnv: typeof sanitizeHostExecEnv;
   resolveWindowsSpawnProgram: typeof resolveWindowsSpawnProgram;
   materializeWindowsSpawnProgram: typeof materializeWindowsSpawnProgram;
 };
 
 const defaultLspSpawnDependencies: LspSpawnDependencies = {
-  spawn,
+  spawn: createOwnedStdioProcess,
   sanitizeHostExecEnv,
   resolveWindowsSpawnProgram,
   materializeWindowsSpawnProgram,
 };
 
-export function spawnLspServerProcess(
+export async function spawnLspServerProcess(
   config: StdioMcpServerLaunchConfig,
   dependencies: LspSpawnDependencies = defaultLspSpawnDependencies,
-): ChildProcess {
+): Promise<OwnedStdioProcess> {
   const mergedEnv = dependencies.sanitizeHostExecEnv({
     baseEnv: process.env,
     overrides: config.env ?? null,
@@ -35,12 +35,12 @@ export function spawnLspServerProcess(
     allowShellFallback: true,
   });
   const invocation = dependencies.materializeWindowsSpawnProgram(program, config.args ?? []);
-  return dependencies.spawn(invocation.command, invocation.argv, {
-    stdio: ["pipe", "pipe", "pipe"],
+  return await dependencies.spawn({
+    argv: [invocation.command, ...invocation.argv],
     env: mergedEnv,
+    exactEnv: true,
     cwd: config.cwd,
-    detached: process.platform !== "win32",
-    windowsHide: invocation.windowsHide ?? process.platform === "win32",
-    shell: invocation.shell,
+    // Stable LSP config permits unresolved Windows wrappers to use Node's shell parsing.
+    ...(invocation.shell === true ? { windowsShell: true } : {}),
   });
 }

--- a/src/agents/agent-bundle-lsp-runtime.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.test.ts
@@ -2,13 +2,15 @@
 import { EventEmitter } from "node:events";
 import { PassThrough, Writable } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { OwnedStdioCleanupError, type OwnedStdioProcess } from "../process/owned-stdio.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   createBundleLspToolRuntime as createProductionBundleLspToolRuntime,
   disposeAllBundleLspRuntimes,
 } from "./agent-bundle-lsp-runtime.js";
+import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
 const spawnMock = vi.fn();
-const killProcessTreeMock = vi.fn();
 const loadEmbeddedAgentLspConfigMock = vi.fn();
 
 function createBundleLspToolRuntime(
@@ -19,7 +21,6 @@ function createBundleLspToolRuntime(
     dependencies: {
       loadLspConfig: loadEmbeddedAgentLspConfigMock,
       spawnServerProcess: spawnMock,
-      killProcessTree: killProcessTreeMock,
     },
   });
 }
@@ -37,7 +38,7 @@ function parseWrittenLspBody(text: string): Record<string, unknown> | null {
   return JSON.parse(text.slice(bodyStart + 4)) as Record<string, unknown>;
 }
 
-class MockChildProcess extends EventEmitter {
+class MockChildProcess extends EventEmitter implements OwnedStdioProcess {
   exitCode: number | null = null;
   signalCode: NodeJS.Signals | null = null;
   killed = false;
@@ -46,6 +47,12 @@ class MockChildProcess extends EventEmitter {
   readonly stderr = new PassThrough();
   readonly stdin: Writable;
   readonly receivedMessages: Record<string, unknown>[] = [];
+  readonly supportsRawOutput = true;
+  readonly closed = createDeferredCore<{ code: number | null; signal: NodeJS.Signals | null }>();
+  readonly extinction = createDeferredCore();
+  holdExtinction = false;
+  private firstError?: { error: Error; source: "process" | "stdin" | "stdout" | "stderr" };
+  private readonly errorListeners = new Set<Parameters<OwnedStdioProcess["onError"]>[0]>();
 
   constructor(
     private readonly initializeResponsePrefix = "",
@@ -62,7 +69,49 @@ class MockChildProcess extends EventEmitter {
         callback();
       },
     });
+    const observeError = (source: "process" | "stdin" | "stdout" | "stderr") => (error: Error) => {
+      this.firstError ??= { error, source };
+      for (const listener of this.errorListeners) {
+        listener(error, source);
+      }
+    };
+    this.on("error", observeError("process"));
+    this.stdin.on("error", observeError("stdin"));
+    this.stdout.on("error", observeError("stdout"));
+    this.stderr.on("error", observeError("stderr"));
+    this.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+      this.closed.resolve({ code, signal });
+      if (!this.holdExtinction) {
+        this.extinction.resolve();
+      }
+    });
+    void this.extinction.promise.catch(() => {});
   }
+
+  onExit: OwnedStdioProcess["onExit"] = (listener) => {
+    this.on("exit", listener);
+    if (this.exitCode !== null || this.signalCode !== null) {
+      listener(this.exitCode, this.signalCode);
+    }
+  };
+  onError: OwnedStdioProcess["onError"] = (listener) => {
+    this.errorListeners.add(listener);
+    if (this.firstError) {
+      listener(this.firstError.error, this.firstError.source);
+    }
+  };
+  onStdout: OwnedStdioProcess["onStdout"] = (listener, onRaw) => {
+    this.stdout.on("data", (chunk: Buffer) => {
+      onRaw?.(chunk);
+      listener(chunk.toString("utf8"));
+    });
+  };
+  onStderr: OwnedStdioProcess["onStderr"] = (listener) => {
+    this.stderr.on("data", (chunk: Buffer) => listener(chunk.toString("utf8")));
+  };
+  wait = () => this.closed.promise;
+  waitForExtinction = () => this.extinction.promise;
+  dispose = vi.fn();
 
   kill = vi.fn((signal: NodeJS.Signals = "SIGTERM") => {
     this.killed = true;
@@ -78,6 +127,13 @@ class MockChildProcess extends EventEmitter {
       return;
     }
     this.receivedMessages.push(body);
+    if (body.method === "exit") {
+      queueMicrotask(() => {
+        this.exitCode = 0;
+        this.emit("exit", 0, null);
+        this.emit("close", 0, null);
+      });
+    }
     if (typeof body.id !== "number" || typeof body.method !== "string") {
       return;
     }
@@ -122,7 +178,6 @@ describe("bundle LSP runtime", () => {
   afterEach(async () => {
     await disposeAllBundleLspRuntimes();
     spawnMock.mockReset();
-    killProcessTreeMock.mockReset();
     loadEmbeddedAgentLspConfigMock.mockReset();
   });
 
@@ -160,7 +215,8 @@ describe("bundle LSP runtime", () => {
 
     await runtime.dispose();
 
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000, detached: true });
+    expect(child.dispose).toHaveBeenCalledOnce();
+    expect(child.kill).not.toHaveBeenCalled();
   });
 
   it("fails LSP startup immediately when the child process cannot spawn", async () => {
@@ -175,7 +231,7 @@ describe("bundle LSP runtime", () => {
 
     expect(runtime.sessions).toEqual([]);
     expect(runtime.tools).toEqual([]);
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000, detached: true });
+    expect(child.dispose).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -397,7 +453,7 @@ describe("bundle LSP runtime", () => {
     child.stdout.write(Buffer.concat([header, body]));
 
     await expect(request).rejects.toThrow(/LSP framing error: body is not valid UTF-8/i);
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000, detached: true });
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
 
     await runtime.dispose();
   });
@@ -465,7 +521,7 @@ describe("bundle LSP runtime", () => {
     ]);
 
     expect(outcome).toMatch(/LSP framing error/i);
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000, detached: true });
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
 
     await runtime.dispose();
   });
@@ -479,11 +535,78 @@ describe("bundle LSP runtime", () => {
 
     await disposeAllBundleLspRuntimes();
 
-    expect(killProcessTreeMock).toHaveBeenCalledWith(4321, { graceMs: 1000, detached: true });
+    expect(child.dispose).toHaveBeenCalledOnce();
 
-    killProcessTreeMock.mockClear();
     await runtime.dispose();
-    expect(killProcessTreeMock).not.toHaveBeenCalled();
+    expect(child.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("joins repeated disposal until the exited LSP server's descendants settle", async () => {
+    configureSingleLspServer();
+    const child = new MockChildProcess();
+    child.holdExtinction = true;
+    spawnMock.mockReturnValue(child);
+    const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+    const cleanupScope = createAgentCleanupScope();
+    let settled = false;
+    const cleanup = cleanupScope
+      .run(async () => {
+        await Promise.all([runtime.dispose(), runtime.dispose()]);
+      })
+      .then(() => {
+        settled = true;
+      });
+    try {
+      await vi.waitFor(() => expect(child.exitCode).toBe(0));
+      expect(settled).toBe(false);
+      expect(child.dispose).not.toHaveBeenCalled();
+    } finally {
+      child.extinction.resolve();
+      await cleanup;
+    }
+    expect(cleanupScope.outcome).toBe("closed");
+    expect(child.dispose).toHaveBeenCalledOnce();
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(child.receivedMessages.filter((message) => message.method === "shutdown")).toHaveLength(
+      1,
+    );
+  });
+
+  it.each(["rejected", "unsupported"] as const)(
+    "records uncertain cleanup when LSP descendant settlement is %s",
+    async (extinction) => {
+      configureSingleLspServer();
+      const child = new MockChildProcess();
+      if (extinction === "rejected") {
+        child.extinction.reject(new Error("descendant settlement failed"));
+      } else {
+        Object.defineProperty(child, "waitForExtinction", { value: undefined });
+      }
+      spawnMock.mockReturnValue(child);
+      const runtime = await createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" });
+      expect(runtime.tools.map((tool) => tool.name)).toContain("lsp_hover_typescript");
+      const cleanupScope = createAgentCleanupScope();
+
+      // Global/manual cleanup can precede an automatic owner joining the same resources.
+      await runtime.dispose();
+      await cleanupScope.run(() => runtime.dispose());
+
+      expect(cleanupScope.outcome).toBe("uncertain");
+      expect(child.dispose).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("records uncertain cleanup when process construction cannot confirm reclamation", async () => {
+    configureSingleLspServer();
+    spawnMock.mockRejectedValue(new OwnedStdioCleanupError("startup cleanup was not confirmed"));
+    const cleanupScope = createAgentCleanupScope();
+
+    const runtime = await cleanupScope.run(() =>
+      createBundleLspToolRuntime({ workspaceDir: "/tmp/workspace" }),
+    );
+
+    expect(runtime.tools).toEqual([]);
+    expect(cleanupScope.outcome).toBe("uncertain");
   });
 
   it.each([
@@ -522,7 +645,7 @@ describe("bundle LSP runtime", () => {
       1,
     );
     expect(child.receivedMessages.filter((message) => message.method === "exit")).toHaveLength(1);
-    expect(killProcessTreeMock).toHaveBeenCalledTimes(1);
+    expect(child.dispose).toHaveBeenCalledOnce();
   });
 
   it("rejects outstanding requests before shutdown and detaches their abort listeners", async () => {
@@ -565,6 +688,6 @@ describe("bundle LSP runtime", () => {
       "shutdown",
       "exit",
     ]);
-    expect(killProcessTreeMock).toHaveBeenCalledTimes(1);
+    expect(child.dispose).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -1,11 +1,16 @@
 /** Session-scoped embedded LSP runtime and tool materialization for agent bundles. */
-import type { ChildProcess } from "node:child_process";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createAbortError } from "../infra/abort-signal.js";
+import { toErrorObject } from "../infra/errors.js";
 import { logDebug, logWarn } from "../logger.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { setPluginToolMeta } from "../plugins/tool-metadata.js";
+import {
+  closeOwnedStdioProcess,
+  OwnedStdioCleanupError,
+  type OwnedStdioProcess,
+} from "../process/owned-stdio.js";
 import { createPendingRequestRegistry } from "../shared/pending-request-registry.js";
 import {
   defaultBundleLspRuntimeDependencies,
@@ -15,6 +20,7 @@ import {
   resolveStdioMcpServerLaunchConfig,
   describeStdioMcpServerLaunchConfig,
 } from "./mcp-stdio.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
@@ -22,15 +28,15 @@ import type { AnyAgentTool } from "./tools/common.js";
 
 type LspSession = {
   serverName: string;
-  process: ChildProcess;
+  process: OwnedStdioProcess;
   requestId: number;
   pendingRequests: ReturnType<typeof createPendingRequestRegistry<number, unknown, undefined>>;
   buffer: Buffer;
   initialized: boolean;
   capabilities: LspServerCapabilities;
   disposed: boolean;
-  // Cleanup must use the same process owner that spawned this session.
-  killProcessTree: BundleLspRuntimeDependencies["killProcessTree"];
+  forceClose: boolean;
+  disposal?: Promise<void>;
   // Preserve a terminal process/transport failure so later requests reject immediately
   // instead of waiting for the per-request timeout.
   failure?: Error;
@@ -69,11 +75,7 @@ function delay(ms: number): Promise<void> {
   });
 }
 
-function createLspSession(
-  serverName: string,
-  child: ChildProcess,
-  killProcessTree: BundleLspRuntimeDependencies["killProcessTree"],
-): LspSession {
+function createLspSession(serverName: string, child: OwnedStdioProcess): LspSession {
   return {
     serverName,
     process: child,
@@ -83,7 +85,7 @@ function createLspSession(
     initialized: false,
     capabilities: {},
     disposed: false,
-    killProcessTree,
+    forceClose: false,
   };
 }
 
@@ -109,33 +111,30 @@ function lspProcessExitError(
 }
 
 function attachLspProcessHandlers(session: LspSession): void {
-  session.process.on("error", (error) => {
-    failLspSession(session, error);
+  session.process.onError((error, source) => {
+    if (source === "stderr") {
+      logWarn(`bundle-lsp:${session.serverName}: stderr failed: ${String(error)}`);
+    } else {
+      session.forceClose = true;
+      failLspSession(session, error);
+    }
   });
-  session.process.on("exit", (code, signal) => {
+  session.process.onExit((code, signal) => {
     // Block new requests immediately, but let stdout drain any final response before close.
     rememberLspFailure(session, lspProcessExitError(session, code, signal));
   });
-  session.process.on("close", (code, signal) => {
-    failLspSession(session, lspProcessExitError(session, code, signal));
-  });
-  session.process.stdout?.on("data", (chunk: Buffer | string) =>
-    handleIncomingData(session, chunk),
+  void session.process.wait().then(
+    ({ code, signal }) => failLspSession(session, lspProcessExitError(session, code, signal)),
+    (error: unknown) => failLspSession(session, toErrorObject(error, "LSP process failed")),
   );
-  session.process.stdout?.on("error", (error) => {
-    failLspSession(session, error);
-  });
-  session.process.stdin?.on("error", (error) => {
-    failLspSession(session, error);
-  });
-  session.process.stderr?.setEncoding("utf-8");
-  session.process.stderr?.on("data", (chunk: string) => {
+  session.process.onStdout(
+    () => {},
+    (chunk) => handleIncomingData(session, chunk),
+  );
+  session.process.onStderr((chunk) => {
     for (const line of chunk.split(/\r?\n/).filter(Boolean)) {
       logDebug(`bundle-lsp:${session.serverName}: ${line.trim()}`);
     }
-  });
-  session.process.stderr?.on("error", (error) => {
-    logWarn(`bundle-lsp:${session.serverName}: stderr failed: ${String(error)}`);
   });
 }
 
@@ -277,7 +276,6 @@ function sendRequest(
     try {
       session.process.stdin?.write(
         encodeLspMessage({ jsonrpc: "2.0", method: "$/cancelRequest", params: { id } }),
-        "utf-8",
       );
     } catch {
       // Best-effort notification; the local tool promise must still settle.
@@ -297,7 +295,7 @@ function sendRequest(
   const message = { jsonrpc: "2.0", id, method, params };
   try {
     const encoded = encodeLspMessage(message);
-    session.process.stdin?.write(encoded, "utf-8");
+    session.process.stdin?.write(encoded);
   } catch (error) {
     // Preserve Promise-executor behavior for synchronous stream failures; timeout owns cleanup.
     pending.reject(error);
@@ -339,8 +337,9 @@ function handleIncomingData(session: LspSession, chunk: Buffer | string) {
     }
   }
   if (!parsed.ok) {
+    session.forceClose = true;
     failLspSession(session, parsed.error);
-    terminateLspProcessTree(session);
+    void disposeSession(session).catch(() => {});
   }
 }
 
@@ -361,55 +360,57 @@ async function initializeSession(session: LspSession): Promise<LspServerCapabili
   // Send initialized notification
   session.process.stdin?.write(
     encodeLspMessage({ jsonrpc: "2.0", method: "initialized", params: {} }),
-    "utf-8",
   );
 
   session.initialized = true;
   return result?.capabilities ?? {};
 }
 
-function hasLspProcessExited(child: ChildProcess): boolean {
-  return child.exitCode !== null || child.signalCode !== null;
-}
-
-function terminateLspProcessTree(session: LspSession): void {
-  const pid = session.process.pid;
-  if (pid && !hasLspProcessExited(session.process)) {
-    session.killProcessTree(pid, { graceMs: LSP_PROCESS_TREE_KILL_GRACE_MS, detached: true });
-    return;
-  }
-  if (!hasLspProcessExited(session.process)) {
-    session.process.kill("SIGTERM");
-  }
-}
-
-async function disposeSession(session: LspSession) {
-  if (session.disposed) {
-    return;
+function disposeSession(session: LspSession): Promise<void> {
+  if (session.disposal) {
+    return session.disposal;
   }
   session.disposed = true;
   // Release abort listeners before shutdown forbids cancellation notifications.
   session.pendingRequests.rejectAll(lspSessionDisposedError());
-  activeBundleLspSessions.delete(session);
-
-  if (session.initialized) {
-    try {
-      const shutdown = sendRequest(session, "shutdown").catch(() => undefined);
-      await Promise.race([shutdown, delay(LSP_SHUTDOWN_GRACE_MS)]);
-      session.process.stdin?.write(
-        encodeLspMessage({ jsonrpc: "2.0", method: "exit", params: null }),
-        "utf-8",
-      );
-    } catch {
-      // best-effort
+  session.disposal = (async () => {
+    if (session.initialized && !session.failure) {
+      try {
+        const shutdown = sendRequest(session, "shutdown").catch(() => undefined);
+        await Promise.race([shutdown, delay(LSP_SHUTDOWN_GRACE_MS)]);
+        session.process.stdin?.write(
+          encodeLspMessage({ jsonrpc: "2.0", method: "exit", params: null }),
+        );
+      } catch {
+        // Protocol shutdown is advisory; the process owner still joins physical cleanup.
+      }
     }
-  }
-  session.pendingRequests.rejectAll(lspSessionDisposedError());
-  terminateLspProcessTree(session);
+    session.pendingRequests.rejectAll(lspSessionDisposedError());
+    try {
+      await closeOwnedStdioProcess(session.process, {
+        graceMs: LSP_PROCESS_TREE_KILL_GRACE_MS,
+        force: session.forceClose,
+      });
+    } catch (error) {
+      recordAgentCleanupFailure();
+      logWarn(
+        `bundle-lsp:${session.serverName}: process cleanup could not confirm descendant shutdown; inspect this server before retrying automatic recovery.`,
+      );
+      throw error;
+    } finally {
+      activeBundleLspSessions.delete(session);
+    }
+  })();
+  return session.disposal;
 }
 
 async function disposeSessions(sessions: Iterable<LspSession>): Promise<void> {
-  await Promise.allSettled(Array.from(sessions, (session) => disposeSession(session)));
+  const results = await Promise.allSettled(
+    Array.from(sessions, (session) => disposeSession(session)),
+  );
+  if (results.some((result) => result.status === "rejected")) {
+    recordAgentCleanupFailure();
+  }
 }
 
 function createLspPositionTool(params: {
@@ -578,11 +579,7 @@ export async function createBundleLspToolRuntime(params: {
       let session: LspSession | undefined;
 
       try {
-        session = createLspSession(
-          serverName,
-          dependencies.spawnServerProcess(launchConfig),
-          dependencies.killProcessTree,
-        );
+        session = createLspSession(serverName, await dependencies.spawnServerProcess(launchConfig));
         registerActiveLspSession(session);
         attachLspProcessHandlers(session);
 
@@ -615,7 +612,9 @@ export async function createBundleLspToolRuntime(params: {
         );
       } catch (error) {
         if (session) {
-          await disposeSession(session);
+          await disposeSessions([session]);
+        } else if (error instanceof OwnedStdioCleanupError) {
+          recordAgentCleanupFailure();
         }
         logWarn(
           `bundle-lsp: failed to start server "${serverName}" (${describeStdioMcpServerLaunchConfig(launchConfig)}): ${String(error)}`,
@@ -629,9 +628,7 @@ export async function createBundleLspToolRuntime(params: {
         serverName: s.serverName,
         capabilities: s.capabilities,
       })),
-      dispose: async () => {
-        await disposeSessions(sessions);
-      },
+      dispose: () => disposeSessions(sessions),
     };
   } catch (error) {
     await disposeSessions(sessions);

--- a/src/agents/agent-bundle-lsp-runtime.windows-spawn.test.ts
+++ b/src/agents/agent-bundle-lsp-runtime.windows-spawn.test.ts
@@ -1,5 +1,11 @@
 /** Tests LSP server spawning with Windows shim and sanitized env handling. */
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import {
+  materializeWindowsSpawnProgram,
+  resolveWindowsSpawnProgram,
+} from "../plugin-sdk/windows-spawn.js";
+import { createOwnedStdioProcess } from "../process/owned-stdio.js";
+import { withMockedWindowsPlatform } from "../test-utils/vitest-spies.js";
 import { spawnLspServerProcess } from "./agent-bundle-lsp-process.js";
 import type { StdioMcpServerLaunchConfig } from "./mcp-stdio.js";
 
@@ -7,6 +13,9 @@ const resolveWindowsSpawnProgramMock = vi.fn();
 const materializeWindowsSpawnProgramMock = vi.fn();
 const sanitizeHostExecEnvMock = vi.fn();
 const spawnMock = vi.fn();
+const { spawnWithFallbackMock } = vi.hoisted(() => ({ spawnWithFallbackMock: vi.fn() }));
+
+vi.mock("../process/spawn-utils.js", () => ({ spawnWithFallback: spawnWithFallbackMock }));
 
 function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): unknown[] {
   const call = mock.mock.calls[0];
@@ -16,9 +25,9 @@ function firstMockCall(mock: { mock: { calls: unknown[][] } }, label: string): u
   return call;
 }
 
-function spawnServer(config: StdioMcpServerLaunchConfig): void {
+async function spawnServer(config: StdioMcpServerLaunchConfig): Promise<void> {
   try {
-    spawnLspServerProcess(config, {
+    await spawnLspServerProcess(config, {
       resolveWindowsSpawnProgram: resolveWindowsSpawnProgramMock,
       materializeWindowsSpawnProgram: materializeWindowsSpawnProgramMock,
       sanitizeHostExecEnv: sanitizeHostExecEnvMock,
@@ -35,6 +44,7 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
     spawnMock.mockImplementation(() => {
       throw new Error("stop after spawn");
     });
+    spawnWithFallbackMock.mockRejectedValue(new Error("captured Windows spawn"));
   });
 
   it("calls sanitizeHostExecEnv with baseEnv/overrides, not a flat merged object", async () => {
@@ -50,7 +60,7 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
       windowsHide: true,
     });
 
-    spawnServer({
+    await spawnServer({
       command: "typescript-language-server",
       args: ["--stdio"],
       env: configEnv,
@@ -76,7 +86,7 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
       windowsHide: true,
     });
 
-    spawnServer({ command: "typescript-language-server", args: ["--stdio"] });
+    await spawnServer({ command: "typescript-language-server", args: ["--stdio"] });
 
     const resolveParams = firstMockCall(
       resolveWindowsSpawnProgramMock,
@@ -98,24 +108,53 @@ describe("spawnLspServerProcess Windows .cmd shim handling", () => {
       windowsHide: true,
     });
 
-    spawnServer({ command: "typescript-language-server", args: ["--stdio"] });
+    await spawnServer({ command: "typescript-language-server", args: ["--stdio"] });
 
-    const spawnCall = firstMockCall(spawnMock, "child process spawn");
-    expect(spawnCall?.[0]).toBe("cmd.exe");
-    expect(spawnCall?.[1]).toEqual(["/c", "typescript-language-server.cmd", "--stdio"]);
-    const spawnOptions = spawnCall?.[2] as
-      | {
-          env?: Record<string, string>;
-          stdio?: string[];
-          detached?: boolean;
-          shell?: boolean;
-          windowsHide?: boolean;
-        }
-      | undefined;
-    expect(spawnOptions?.env).toBe(sanitizedEnv);
-    expect(spawnOptions?.stdio).toEqual(["pipe", "pipe", "pipe"]);
-    expect(spawnOptions?.detached).toBe(process.platform !== "win32");
-    expect(spawnOptions?.shell).toBe(true);
-    expect(spawnOptions?.windowsHide).toBe(true);
+    expect(spawnMock).toHaveBeenCalledExactlyOnceWith({
+      argv: ["cmd.exe", "/c", "typescript-language-server.cmd", "--stdio"],
+      env: sanitizedEnv,
+      exactEnv: true,
+      cwd: undefined,
+      windowsShell: true,
+    });
+  });
+
+  it("preserves the shipped Windows shell fallback through the owned adapter", async () => {
+    const sanitizedEnv = { PATH: "", PATHEXT: ".EXE;.CMD;.BAT" };
+    sanitizeHostExecEnvMock.mockReturnValue(sanitizedEnv);
+
+    await expect(
+      withMockedWindowsPlatform(() =>
+        spawnLspServerProcess(
+          {
+            command: "C:\\Program Files\\language-server.cmd",
+            args: ["--stdio", "two words", "%LSP_ARGUMENT%", "echo ready & exit /b"],
+          },
+          {
+            sanitizeHostExecEnv: sanitizeHostExecEnvMock,
+            resolveWindowsSpawnProgram,
+            materializeWindowsSpawnProgram,
+            spawn: createOwnedStdioProcess,
+          },
+        ),
+      ),
+    ).rejects.toThrow("captured Windows spawn");
+
+    expect(spawnWithFallbackMock).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        argv: [
+          "C:\\Program Files\\language-server.cmd",
+          "--stdio",
+          "two words",
+          "%LSP_ARGUMENT%",
+          "echo ready & exit /b",
+        ],
+        options: expect.objectContaining({
+          env: sanitizedEnv,
+          shell: true,
+          windowsHide: true,
+        }),
+      }),
+    );
   });
 });

--- a/src/agents/agent-bundle-mcp-combined.ts
+++ b/src/agents/agent-bundle-mcp-combined.ts
@@ -9,6 +9,7 @@ import type {
   McpToolCatalogDiagnostic,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 
 function compareCatalogTools(left: McpCatalogTool, right: McpCatalogTool): number {
   return (
@@ -91,6 +92,8 @@ export function createCombinedSessionMcpRuntime(params: {
   const parts = params.parts;
   // Empty partitions still own run/view leases; populated ones carry reused server leases.
   let activeLeases = 0;
+  let disposal: Promise<void> | undefined;
+  let cleanupFailure: PromiseRejectedResult | undefined;
   let lastUsedAt = Math.max(Date.now(), ...parts.map((part) => part.lastUsedAt));
   let cachedCatalog: McpToolCatalog | null = null;
   let mergedSourceCatalogs: ReadonlyArray<McpToolCatalog> | null = null;
@@ -291,8 +294,34 @@ export function createCombinedSessionMcpRuntime(params: {
       }
       return await owner.getPrompt(serverName, name, args);
     },
+    async joinCleanup() {
+      await disposal;
+      const outcomes = await Promise.allSettled(
+        parts.map(async (part) => {
+          if (!part.joinCleanup) {
+            throw new Error("MCP runtime does not expose cleanup ownership");
+          }
+          await part.joinCleanup();
+        }),
+      );
+      cleanupFailure ??= outcomes.find((outcome) => outcome.status === "rejected");
+      if (cleanupFailure) {
+        recordAgentCleanupFailure();
+        throw cleanupFailure.reason;
+      }
+    },
     async dispose() {
-      await Promise.allSettled(parts.map((part) => part.dispose()));
+      // SDK parts may throw without retaining their own failure. The facade owns
+      // that result across callers while Gateway disposal stays best effort.
+      disposal ??= Promise.allSettled(parts.map(async (part) => await part.dispose())).then(
+        (outcomes) => {
+          cleanupFailure ??= outcomes.find((outcome) => outcome.status === "rejected");
+        },
+      );
+      await disposal;
+      if (cleanupFailure) {
+        recordAgentCleanupFailure();
+      }
     },
   };
 }

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -16,6 +16,7 @@ import type {
   SessionMcpConfigReload,
   SessionMcpRuntime,
 } from "./agent-bundle-mcp-types.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 
 // Gateway shutdown preparation and CLI command imports load this before turns.
 // The process-owned sweep must not retain its first requesting turn.
@@ -41,6 +42,7 @@ type SessionMcpRuntimeManagerStore = {
   advertisedScopedCatalogBySessionId: Map<string, AdvertisedScopedCatalogEntry>;
   runtimeWorkChains: Map<string, Promise<unknown>>;
   disposalInFlight?: Promise<void>;
+  pendingDisposals: Map<string, Set<Promise<void>>>;
   createRuntime: CreateSessionMcpRuntime;
   now: () => number;
   idleSweepIntervalMs: number;
@@ -94,6 +96,7 @@ export function createSessionMcpRuntimeManagerStore(
      * Entries are removed when their chain drains.
      */
     runtimeWorkChains: new Map(),
+    pendingDisposals: new Map(),
     createRuntime: opts.createRuntime ?? createSessionMcpRuntime,
     now: opts.now ?? Date.now,
     idleSweepIntervalMs: opts.idleSweepIntervalMs ?? SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS,
@@ -126,6 +129,41 @@ function scopedCatalogToolsSignature(tools: readonly McpCatalogTool[]): string {
 }
 
 export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntimeManagerStore) {
+  const disposeRuntime = async (runtime: SessionMcpRuntime) => {
+    try {
+      await runtime.dispose();
+      if (!runtime.joinCleanup) {
+        throw new Error("MCP runtime does not expose cleanup ownership");
+      }
+      await runtime.joinCleanup();
+    } catch (error) {
+      recordAgentCleanupFailure();
+      throw error;
+    }
+  };
+  const trackDisposal = (runtimeKeys: string[], close: () => Promise<void>): Promise<void> => {
+    const disposal = Promise.resolve()
+      .then(close)
+      .catch((error: unknown) => {
+        recordAgentCleanupFailure();
+        throw error;
+      })
+      .finally(() => {
+        for (const runtimeKey of runtimeKeys) {
+          const pending = store.pendingDisposals.get(runtimeKey);
+          pending?.delete(disposal);
+          if (pending?.size === 0) {
+            store.pendingDisposals.delete(runtimeKey);
+          }
+        }
+      });
+    for (const runtimeKey of runtimeKeys) {
+      const pending = store.pendingDisposals.get(runtimeKey) ?? new Set<Promise<void>>();
+      store.pendingDisposals.set(runtimeKey, pending);
+      pending.add(disposal);
+    }
+    return disposal;
+  };
   const forgetSessionKeysForSessionId = (sessionId: string) => {
     for (const [sessionKey, mappedSessionId] of store.sessionIdBySessionKey.entries()) {
       if (mappedSessionId === sessionId) {
@@ -184,7 +222,7 @@ export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntime
 
   const sweepIdleRuntimes = async (): Promise<number> => {
     const nowMs = store.now();
-    const expired: SessionMcpRuntime[] = [];
+    const expired: Array<{ runtimeKey: string; runtime: SessionMcpRuntime }> = [];
     for (const [runtimeKey, runtime] of store.runtimesBySessionId.entries()) {
       if ((runtime.activeLeases ?? 0) > 0) {
         continue;
@@ -199,16 +237,20 @@ export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntime
       }
       store.runtimesBySessionId.delete(runtimeKey);
       store.connectionMetaByRuntimeKey.delete(runtimeKey);
-      expired.push(runtime);
+      expired.push({ runtimeKey, runtime });
     }
-    const touchedSessionIds = new Set(expired.map((runtime) => runtime.sessionId));
+    const touchedSessionIds = new Set(expired.map(({ runtime }) => runtime.sessionId));
     for (const sessionId of touchedSessionIds) {
       if (runtimeKeysForSessionId(sessionId).length === 0) {
         store.deferredRetirementSessionIds.delete(sessionId);
         forgetSessionKeysForSessionId(sessionId);
       }
     }
-    await Promise.allSettled(expired.map((runtime) => runtime.dispose()));
+    await Promise.allSettled(
+      expired.map(({ runtimeKey, runtime }) =>
+        trackDisposal([runtimeKey], () => disposeRuntime(runtime)),
+      ),
+    );
     return expired.length;
   };
 
@@ -254,7 +296,7 @@ export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntime
         }
         store.runtimesBySessionId.delete(runtimeKey);
         store.connectionMetaByRuntimeKey.delete(runtimeKey);
-        await current.dispose();
+        await Promise.allSettled([trackDisposal([runtimeKey], () => disposeRuntime(current))]);
       });
     }
   };
@@ -295,7 +337,9 @@ export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntime
     const runtime = store.runtimesBySessionId.get(runtimeKey);
     store.runtimesBySessionId.delete(runtimeKey);
     store.connectionMetaByRuntimeKey.delete(runtimeKey);
-    await runtime?.dispose();
+    if (runtime) {
+      await disposeRuntime(runtime);
+    }
   };
 
   const disposeManagedRuntimes = (
@@ -305,12 +349,27 @@ export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntime
     const runtimeKeys = [
       ...new Set(
         sessionId === undefined
-          ? [...store.runtimesBySessionId.keys(), ...store.runtimeWorkChains.keys()]
-          : [sessionId, ...runtimeKeysForSessionId(sessionId)],
+          ? [
+              ...store.runtimesBySessionId.keys(),
+              ...store.runtimeWorkChains.keys(),
+              ...store.pendingDisposals.keys(),
+            ]
+          : [
+              sessionId,
+              ...runtimeKeysForSessionId(sessionId),
+              ...[...store.pendingDisposals.keys()].filter(
+                (key) => parseRuntimeCacheSessionId(key) === sessionId,
+              ),
+            ],
       ),
     ];
+    // Capture before queuing: the previous owner may unpublish and settle before
+    // this caller enters the runtime-key chain, but its receipt still belongs here.
+    const previousDisposals = new Set(
+      runtimeKeys.flatMap((key) => [...(store.pendingDisposals.get(key) ?? [])]),
+    );
     const priorDisposal = store.disposalInFlight;
-    const disposal = runExclusiveOnRuntimeKeys(runtimeKeys, async () => {
+    const queued = runExclusiveOnRuntimeKeys(runtimeKeys, async () => {
       await priorDisposal;
       // Clear bookkeeping after admitted acquisitions finish, before successors run.
       if (sessionId === undefined) {
@@ -328,8 +387,16 @@ export function createSessionMcpRuntimeManagerLifecycle(store: SessionMcpRuntime
         store.advertisedScopedCatalogBySessionId.delete(sessionId);
         forgetSessionKeysForSessionId(sessionId);
       }
-      await Promise.allSettled(runtimeKeys.map(disposeRuntimeKeyNow));
+      const outcomes = await Promise.allSettled([
+        ...previousDisposals,
+        ...runtimeKeys.map(disposeRuntimeKeyNow),
+      ]);
+      const failed = outcomes.find((outcome) => outcome.status === "rejected");
+      if (failed) {
+        throw failed.reason;
+      }
     });
+    const disposal = trackDisposal(runtimeKeys, () => queued).catch(() => undefined);
     if (sessionId === undefined) {
       // New session keys also wait for a global teardown already in progress.
       store.disposalInFlight = disposal;

--- a/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
+++ b/src/agents/agent-bundle-mcp-manager.lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./agent-bundle-mcp-runtime-shared.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { testing as resolverTesting } from "./mcp-connection-resolver.js";
+import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
 vi.mock("./agent-bundle-mcp-runtime.js", () => {
   throw new Error("Lifecycle-only MCP work must not import the transport runtime");
@@ -59,6 +60,7 @@ function createRuntimeFixture(input: Parameters<CreateSessionMcpRuntime>[0]): Se
     getCatalog: async () => ({ version: 1, generatedAt: 0, servers: {}, tools: [] }),
     peekCatalog: () => null,
     callTool: async () => ({ content: [] }),
+    joinCleanup: async () => {},
     dispose: vi.fn(async () => {}),
   };
 }
@@ -111,6 +113,33 @@ afterEach(async () => {
 });
 
 describe("MCP manager creation ownership", () => {
+  it("joins an unpublished disposal and reports its failure in the joining caller", async () => {
+    const manager = createManager(createRuntimeFixture);
+    const runtime = await manager.getOrCreate(params);
+    const closing = holdDisposal(runtime);
+    runtime.joinCleanup = async () => {
+      throw new Error("cleanup owner lost");
+    };
+    const first = manager.disposeSession(params.sessionId);
+    await closing.started;
+    const cleanupScope = createAgentCleanupScope();
+    let joined = false;
+    const second = cleanupScope.run(() =>
+      manager.disposeSession(params.sessionId).then(() => {
+        joined = true;
+      }),
+    );
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(joined).toBe(false);
+    closing.release();
+    await Promise.all([first, second]);
+    expect(runtime.dispose).toHaveBeenCalledOnce();
+    expect(cleanupScope.outcome).toBe("uncertain");
+    expect(manager.listRuntimeKeys()).toEqual([]);
+  });
+
   it("constructs and retires an empty manager without binding or importing transports", async () => {
     const manager = createManager();
 

--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -1,6 +1,5 @@
 /** Materializes configured MCP catalog entries into agent tools and runtime helpers. */
 import crypto from "node:crypto";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { normalizeToolParameterSchema } from "@openclaw/ai/internal/openai";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -31,20 +30,12 @@ import {
 } from "./mcp-content.js";
 import { isMcpToolAllowed } from "./mcp-tool-filter.js";
 import { buildMcpAppCanvasPayload, fetchMcpAppView } from "./mcp-ui-resource.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { toToolSearchJsonSafe } from "./tool-search-json.js";
 import type { AnyAgentTool } from "./tools/common.js";
 function isAppOnlyTool(tool: McpCatalogTool): boolean {
   return tool.uiVisibility !== undefined && !tool.uiVisibility.includes("model");
-}
-
-async function releaseRuntimeLease(params: {
-  runtime: SessionMcpRuntime;
-  releaseLease?: () => void;
-}): Promise<void> {
-  // Keep lifecycle imports out of read-only tool metadata loading.
-  const { releaseSessionMcpRuntime } = await import("./agent-bundle-mcp-manager-api.js");
-  await releaseSessionMcpRuntime(params);
 }
 
 function buildAppToolPolicyProjections(params: {
@@ -97,17 +88,6 @@ function buildAppToolPolicyProjections(params: {
     tools.push(projection);
   }
   return tools.toSorted((a, b) => a.name.localeCompare(b.name));
-}
-
-function toAgentToolResult(params: {
-  serverName: string;
-  toolName: string;
-  result: CallToolResult;
-}): AgentToolResult<unknown> {
-  return projectMcpCallToolResult(params.result, {
-    mcpServer: params.serverName,
-    mcpTool: params.toolName,
-  });
 }
 
 function toJsonAgentToolResult(params: {
@@ -448,156 +428,173 @@ export async function materializeBundleMcpToolsForRun(params: {
   disposeRuntime?: () => Promise<void>;
 }): Promise<BundleMcpToolRuntime> {
   const runtime = params.runtime;
-  let disposed = false;
+  let disposal: Promise<void> | undefined;
   let allowedAppToolsByServer: Map<string, Set<string>> | undefined;
-  const releaseLease = params.releaseLease ?? runtime.acquireLease?.();
-  runtime.markUsed();
-  let catalog;
+  let releaseLease: (() => void) | undefined;
+  const dispose = async () => {
+    disposal ??= (async () => {
+      // Failure to release the lease cannot strand this view's private runtime.
+      try {
+        // Keep lifecycle imports out of read-only tool metadata loading.
+        const { releaseSessionMcpRuntime } = await import("./agent-bundle-mcp-manager-api.js");
+        await releaseSessionMcpRuntime({ runtime, releaseLease });
+      } finally {
+        await params.disposeRuntime?.();
+      }
+    })();
+    try {
+      try {
+        await disposal;
+      } finally {
+        // The captured owner survives eviction; every caller observes its outcome.
+        if (runtime.joinCleanup) {
+          await runtime.joinCleanup();
+        } else {
+          recordAgentCleanupFailure();
+        }
+      }
+    } catch (error) {
+      recordAgentCleanupFailure();
+      throw error;
+    }
+  };
   try {
-    catalog = await runtime.getCatalog();
+    releaseLease = params.releaseLease ?? runtime.acquireLease?.();
+    runtime.markUsed();
+    const catalog = await runtime.getCatalog();
+    const reservedToolNames = params.reservedToolNames
+      ? Array.from(params.reservedToolNames)
+      : undefined;
+    const materializedCatalog = mergeMcpConnectCatalog(catalog, runtime.requesterConnect);
+    const tools = buildBundleMcpToolsFromCatalog({
+      catalog: materializedCatalog,
+      reservedToolNames,
+      createExecute: (tool) => (toolCallId: string, input: unknown, signal?: AbortSignal) =>
+        runWithSessionMcpRequestSignal(signal, async () => {
+          if (!Object.hasOwn(catalog.servers, tool.serverName)) {
+            const connect = runtime.requesterConnect?.createExecute(tool.serverName);
+            if (connect) {
+              return setMcpCodeModeGuestResultFromAgentResult(await connect(toolCallId, input));
+            }
+          }
+          runtime.markUsed();
+          const { serverName, toolName } = tool;
+          const result = await runtime.callTool(serverName, toolName, input);
+          const agentResult = projectMcpCallToolResult(result, {
+            mcpServer: serverName,
+            mcpTool: toolName,
+          });
+          // Requester-scoped servers never mint app views (outlive run; no requester id on view boundary).
+          const scopedServer = runtime.isRequesterScopedServer?.(serverName) === true;
+          if (runtime.mcpAppsEnabled && tool.uiResourceUri && !scopedServer) {
+            const allowedAppToolNames = allowedAppToolsByServer
+              ? (allowedAppToolsByServer.get(serverName) ?? new Set<string>())
+              : undefined;
+            const view = await fetchMcpAppView({
+              runtime,
+              agentId: params.agentId,
+              serverName,
+              toolName,
+              uiResourceUri: tool.uiResourceUri,
+              toolCallId,
+              toolInput: input,
+              toolResult: result,
+              ...(allowedAppToolNames ? { allowedAppToolNames } : {}),
+            });
+            if (view) {
+              (agentResult.details as Record<string, unknown>).mcpAppPreview =
+                buildMcpAppCanvasPayload({
+                  ...view,
+                  ...(runtime.sessionKey ? { originSessionKey: runtime.sessionKey } : {}),
+                  ...(result["_meta"] !== undefined
+                    ? { resultMetaState: "unavailable" as const }
+                    : {}),
+                });
+            }
+          }
+          return agentResult;
+        }),
+      createResourceListExecute: runtime.listResources
+        ? (serverName) => (_toolCallId, _input, signal) =>
+            runWithSessionMcpRequestSignal(signal, async () => {
+              runtime.markUsed();
+              return toJsonAgentToolResult({
+                serverName,
+                operation: "resources_list",
+                value: await runtime.listResources?.(serverName),
+              });
+            })
+        : undefined,
+      createResourceReadExecute: runtime.readResource
+        ? (serverName) => (_toolCallId: string, input: unknown, signal?: AbortSignal) =>
+            runWithSessionMcpRequestSignal(signal, async () => {
+              const uri = requireStringArg(input, "uri");
+              runtime.markUsed();
+              return toJsonAgentToolResult({
+                serverName,
+                operation: "resources_read",
+                value: await runtime.readResource?.(serverName, uri),
+              });
+            })
+        : undefined,
+      createPromptListExecute: runtime.listPrompts
+        ? (serverName) => (_toolCallId, _input, signal) =>
+            runWithSessionMcpRequestSignal(signal, async () => {
+              runtime.markUsed();
+              return toJsonAgentToolResult({
+                serverName,
+                operation: "prompts_list",
+                value: await runtime.listPrompts?.(serverName),
+              });
+            })
+        : undefined,
+      createPromptGetExecute: runtime.getPrompt
+        ? (serverName) => (_toolCallId: string, input: unknown, signal?: AbortSignal) =>
+            runWithSessionMcpRequestSignal(signal, async () => {
+              runtime.markUsed();
+              return toJsonAgentToolResult({
+                serverName,
+                operation: "prompts_get",
+                value: await runtime.getPrompt?.(
+                  serverName,
+                  requireStringArg(input, "name"),
+                  optionalStringRecordArg(input, "arguments"),
+                ),
+              });
+            })
+        : undefined,
+    });
+    const appTools = buildAppToolPolicyProjections({
+      catalog: materializedCatalog,
+      modelTools: tools,
+      reservedToolNames,
+    });
+
+    return {
+      tools,
+      appTools,
+      ...(catalog.diagnostics && catalog.diagnostics.length > 0
+        ? { diagnostics: catalog.diagnostics }
+        : {}),
+      restrictAppTools: (allowedTools) => {
+        const next = new Map<string, Set<string>>();
+        for (const allowedTool of allowedTools) {
+          const mcp = getPluginToolMeta(allowedTool)?.mcp;
+          if (!mcp || mcp.operation !== "tool") {
+            continue;
+          }
+          const names = next.get(mcp.serverName) ?? new Set<string>();
+          names.add(mcp.toolName);
+          next.set(mcp.serverName, names);
+        }
+        allowedAppToolsByServer = next;
+      },
+      dispose,
+    };
   } catch (error) {
-    await releaseRuntimeLease({ runtime, releaseLease });
+    await dispose().catch(() => undefined);
     throw error;
   }
-  const reservedToolNames = params.reservedToolNames
-    ? Array.from(params.reservedToolNames)
-    : undefined;
-  const materializedCatalog = mergeMcpConnectCatalog(catalog, runtime.requesterConnect);
-  const tools = buildBundleMcpToolsFromCatalog({
-    catalog: materializedCatalog,
-    reservedToolNames,
-    createExecute: (tool) => (toolCallId: string, input: unknown, signal?: AbortSignal) =>
-      runWithSessionMcpRequestSignal(signal, async () => {
-        if (!Object.hasOwn(catalog.servers, tool.serverName)) {
-          const connect = runtime.requesterConnect?.createExecute(tool.serverName);
-          if (connect) {
-            return setMcpCodeModeGuestResultFromAgentResult(await connect(toolCallId, input));
-          }
-        }
-        runtime.markUsed();
-        const { serverName, toolName } = tool;
-        const result = await runtime.callTool(serverName, toolName, input);
-        const agentResult = toAgentToolResult({
-          serverName,
-          toolName,
-          result,
-        });
-        // Requester-scoped servers never mint app views (outlive run; no requester id on view boundary).
-        const scopedServer = runtime.isRequesterScopedServer?.(serverName) === true;
-        if (runtime.mcpAppsEnabled && tool.uiResourceUri && !scopedServer) {
-          const allowedAppToolNames = allowedAppToolsByServer
-            ? (allowedAppToolsByServer.get(serverName) ?? new Set<string>())
-            : undefined;
-          const view = await fetchMcpAppView({
-            runtime,
-            agentId: params.agentId,
-            serverName,
-            toolName,
-            uiResourceUri: tool.uiResourceUri,
-            toolCallId,
-            toolInput: input,
-            toolResult: result,
-            ...(allowedAppToolNames ? { allowedAppToolNames } : {}),
-          });
-          if (view) {
-            (agentResult.details as Record<string, unknown>).mcpAppPreview =
-              buildMcpAppCanvasPayload({
-                ...view,
-                ...(runtime.sessionKey ? { originSessionKey: runtime.sessionKey } : {}),
-                ...(result["_meta"] !== undefined
-                  ? { resultMetaState: "unavailable" as const }
-                  : {}),
-              });
-          }
-        }
-        return agentResult;
-      }),
-    createResourceListExecute: runtime.listResources
-      ? (serverName) => (_toolCallId, _input, signal) =>
-          runWithSessionMcpRequestSignal(signal, async () => {
-            runtime.markUsed();
-            return toJsonAgentToolResult({
-              serverName,
-              operation: "resources_list",
-              value: await runtime.listResources?.(serverName),
-            });
-          })
-      : undefined,
-    createResourceReadExecute: runtime.readResource
-      ? (serverName) => (_toolCallId: string, input: unknown, signal?: AbortSignal) =>
-          runWithSessionMcpRequestSignal(signal, async () => {
-            const uri = requireStringArg(input, "uri");
-            runtime.markUsed();
-            return toJsonAgentToolResult({
-              serverName,
-              operation: "resources_read",
-              value: await runtime.readResource?.(serverName, uri),
-            });
-          })
-      : undefined,
-    createPromptListExecute: runtime.listPrompts
-      ? (serverName) => (_toolCallId, _input, signal) =>
-          runWithSessionMcpRequestSignal(signal, async () => {
-            runtime.markUsed();
-            return toJsonAgentToolResult({
-              serverName,
-              operation: "prompts_list",
-              value: await runtime.listPrompts?.(serverName),
-            });
-          })
-      : undefined,
-    createPromptGetExecute: runtime.getPrompt
-      ? (serverName) => (_toolCallId: string, input: unknown, signal?: AbortSignal) =>
-          runWithSessionMcpRequestSignal(signal, async () => {
-            runtime.markUsed();
-            return toJsonAgentToolResult({
-              serverName,
-              operation: "prompts_get",
-              value: await runtime.getPrompt?.(
-                serverName,
-                requireStringArg(input, "name"),
-                optionalStringRecordArg(input, "arguments"),
-              ),
-            });
-          })
-      : undefined,
-  });
-  const appTools = buildAppToolPolicyProjections({
-    catalog: materializedCatalog,
-    modelTools: tools,
-    reservedToolNames,
-  });
-
-  return {
-    tools,
-    appTools,
-    ...(catalog.diagnostics && catalog.diagnostics.length > 0
-      ? { diagnostics: catalog.diagnostics }
-      : {}),
-    restrictAppTools: (allowedTools) => {
-      const next = new Map<string, Set<string>>();
-      for (const allowedTool of allowedTools) {
-        const mcp = getPluginToolMeta(allowedTool)?.mcp;
-        if (!mcp || mcp.operation !== "tool") {
-          continue;
-        }
-        const names = next.get(mcp.serverName) ?? new Set<string>();
-        names.add(mcp.toolName);
-        next.set(mcp.serverName, names);
-      }
-      allowedAppToolsByServer = next;
-    },
-    dispose: async () => {
-      if (disposed) {
-        return;
-      }
-      disposed = true;
-      // Reset/delete can request retirement while this run owns the lease.
-      // Dispose as soon as the final run, view, or request lease has released.
-      await releaseRuntimeLease({ runtime, releaseLease });
-      await params.disposeRuntime?.();
-    },
-  };
 }
 
 export async function createBundleMcpToolRuntime(params: {
@@ -628,12 +625,11 @@ export async function createBundleMcpToolRuntime(params: {
       ? { safeServerNamesByServer: params.safeServerNamesByServer }
       : {}),
   });
-  const materialized = await materializeBundleMcpToolsForRun({
+  return await materializeBundleMcpToolsForRun({
     runtime,
     reservedToolNames: params.reservedToolNames,
     disposeRuntime: async () => {
       await runtime.dispose();
     },
   });
-  return materialized;
 }

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -41,6 +41,7 @@ import { writeExecutable } from "./bundle-mcp-shared.test-harness.js";
 import { updateMcpAppModelContext } from "./mcp-app-model-context.js";
 import { fetchMcpAppView, getMcpAppViewLease } from "./mcp-ui-resource.js";
 import { testing as mcpUiResourceTesting } from "./mcp-ui-resource.test-support.js";
+import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
 vi.mock("./embedded-agent-mcp.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./embedded-agent-mcp.js")>();
@@ -647,6 +648,7 @@ function makeRuntime(
       content: [{ type: "text", text: toolName }],
       isError: false,
     }),
+    joinCleanup: async () => {},
     dispose: async () => {},
   };
 }
@@ -6036,7 +6038,7 @@ process.stdin.on("end", () => {
   );
 
   it(
-    "force-closes streamable-http transport when DELETE hangs past the timeout",
+    "retains failed HTTP retirement for a later materialized cleanup after eviction",
     { timeout: 15_000 },
     async () => {
       testing.setBundleMcpDisposeTimeoutMsForTest(50);
@@ -6117,11 +6119,22 @@ process.stdin.on("end", () => {
         const catalog = await runtime.getCatalog();
         expect(catalog.tools).toHaveLength(1);
 
+        const materialized = await materializeBundleMcpToolsForRun({ runtime });
         const start = Date.now();
         await runtime.dispose();
         const elapsed = Date.now() - start;
 
         expect(elapsed).toBeLessThan(1_000);
+        await retireSessionMcpRuntime({
+          sessionId: runtime.sessionId,
+          reason: "external retirement before final run cleanup",
+        });
+        const cleanupScope = createAgentCleanupScope();
+        await cleanupScope.run(async () => {
+          await expect(materialized.dispose()).rejects.toThrow("could not confirm closure");
+          await expect(materialized.dispose()).rejects.toThrow("could not confirm closure");
+        });
+        expect(cleanupScope.outcome).toBe("uncertain");
       } finally {
         server.close();
       }

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -57,6 +57,7 @@ import { collectMcpPaginatedItems } from "./mcp-pagination.js";
 import { isMcpToolAllowed, normalizeMcpToolFilter } from "./mcp-tool-filter.js";
 import { normalizeMcpToolCatalog, type McpToolCatalogMetadata } from "./mcp-tool-metadata.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 
 type BundleMcpSession = {
   serverName: string;
@@ -68,6 +69,7 @@ type BundleMcpSession = {
   disconnectReason?: string;
   retiring: boolean;
   connectPromise?: Promise<void>;
+  disposePromise?: Promise<void>;
   detachStderr?: () => void;
   toolMetadata?: McpToolCatalogMetadata;
 };
@@ -190,7 +192,7 @@ function setBundleMcpDisposeTimeoutMsForTest(timeoutMs?: number): void {
       : undefined;
 }
 
-function disposeBundleMcpSession(session: BundleMcpSession): Promise<void> {
+function disposeBundleMcpSession(session: BundleMcpSession): Promise<"closed" | "uncertain"> {
   return disposeMcpClient(
     session,
     getBundleMcpTestState().disposeTimeoutMs ?? BUNDLE_MCP_DISPOSE_TIMEOUT_MS,
@@ -311,12 +313,21 @@ export function createSessionMcpRuntime(
   );
   let invalidated = false;
   let pendingDisposal = Promise.resolve();
+  let cleanupFailure: PromiseRejectedResult | undefined;
   const disposeParts = (parts: SessionMcpRuntime[]) => {
     // Replacement must join cleanup already started by config publication.
     pendingDisposal = Promise.allSettled([
       pendingDisposal,
-      ...parts.map((part) => part.dispose()),
-    ]).then(() => undefined);
+      ...parts.map(async (part) => {
+        await part.dispose();
+        if (!part.joinCleanup) {
+          throw new Error("MCP runtime does not expose cleanup ownership");
+        }
+        await part.joinCleanup();
+      }),
+    ]).then((results) => {
+      cleanupFailure ??= results.find((result) => result.status === "rejected");
+    });
     return pendingDisposal;
   };
   const runtime = createCombinedSessionMcpRuntime({
@@ -353,6 +364,19 @@ export function createSessionMcpRuntime(
     },
   };
   runtime.mcpAppsEnabled = params.cfg?.mcp?.apps?.enabled === true;
+  const joinParts = runtime.joinCleanup;
+  runtime.joinCleanup = async () => {
+    await pendingDisposal;
+    try {
+      await joinParts?.();
+    } catch (error) {
+      cleanupFailure ??= { status: "rejected", reason: error };
+    }
+    if (cleanupFailure) {
+      recordAgentCleanupFailure();
+      throw cleanupFailure.reason;
+    }
+  };
   runtime.dispose = async () => {
     connectFingerprints.clear();
     invalidated = true;
@@ -360,6 +384,9 @@ export function createSessionMcpRuntime(
     owned.clear();
     sessionMcpRuntimeOwners.delete(runtime);
     await disposeParts(retired);
+    if (cleanupFailure) {
+      recordAgentCleanupFailure();
+    }
   };
   sessionMcpRuntimeOwners.set(runtime, {
     isCurrent: () => !invalidated,
@@ -465,6 +492,31 @@ function createServerMcpRuntime(
   const catalogRetryIsDue = (): boolean =>
     catalogRetryAfterMs !== undefined && Date.now() >= catalogRetryAfterMs;
   let currentSession: BundleMcpSession | undefined;
+  let disposal: Promise<void> | undefined;
+  let cleanupFailed = false;
+  const pendingDisposals = new Set<Promise<void>>();
+  const disposeSession = (session: BundleMcpSession): Promise<void> => {
+    if (session.disposePromise) {
+      return session.disposePromise;
+    }
+    const closing = disposeBundleMcpSession(session)
+      .then((outcome) => {
+        if (outcome === "uncertain") {
+          cleanupFailed = true;
+          recordAgentCleanupFailure();
+        }
+      })
+      .catch((error: unknown) => {
+        cleanupFailed = true;
+        recordAgentCleanupFailure();
+        throw error;
+      })
+      .finally(() => pendingDisposals.delete(closing));
+    session.disposePromise = closing;
+    pendingDisposals.add(closing);
+    return closing;
+  };
+
   let serverBackoff: McpServerBackoffState | undefined;
   const recordServerToolFailure = (session: BundleMcpSession, nowMs: number) => {
     if (currentSession !== session || session.retiring) {
@@ -533,7 +585,7 @@ function createServerMcpRuntime(
     }
     session.retiring = true;
     currentSession = undefined;
-    await disposeBundleMcpSession(session);
+    await disposeSession(session);
     return true;
   };
   const localRequestTimeouts = new WeakSet<object>();
@@ -1074,33 +1126,52 @@ function createServerMcpRuntime(
         ),
       );
     },
-    async dispose() {
-      if (retiredCatalog) {
-        return;
+    async joinCleanup() {
+      await disposal;
+      await Promise.allSettled(pendingDisposals);
+      if (cleanupFailed) {
+        recordAgentCleanupFailure();
+        throw new Error("MCP runtime cleanup could not confirm closure");
       }
-      retiredCatalog = {
-        version: 1,
-        generatedAt: Date.now(),
-        servers: {},
-        tools: [],
-        diagnostics: [
-          {
-            serverName,
-            safeServerName: params.safeServerNamesByServer?.get(serverName) ?? serverName,
-            launchSummary: serverName,
-            message: "MCP server runtime retired; retry discovery on the next turn.",
-          },
-        ],
-      };
-      lifecycleAbortController.abort(createDisposedError(params.sessionId));
-      catalog = null;
-      catalogRetryAfterMs = undefined;
-      catalogInFlight = undefined;
-      const session = currentSession;
-      currentSession = undefined;
-      if (session) {
-        await disposeBundleMcpSession(session);
+    },
+    dispose() {
+      if (!disposal) {
+        retiredCatalog = {
+          version: 1,
+          generatedAt: Date.now(),
+          servers: {},
+          tools: [],
+          diagnostics: [
+            {
+              serverName,
+              safeServerName: params.safeServerNamesByServer?.get(serverName) ?? serverName,
+              launchSummary: serverName,
+              message: "MCP server runtime retired; retry discovery on the next turn.",
+            },
+          ],
+        };
+        lifecycleAbortController.abort(createDisposedError(params.sessionId));
+        catalog = null;
+        catalogRetryAfterMs = undefined;
+        const pendingCatalog = catalogInFlight;
+        catalogInFlight = undefined;
+        const session = currentSession;
+        currentSession = undefined;
+        disposal = (async () => {
+          if (session) {
+            await disposeSession(session).catch(() => undefined);
+          }
+          await pendingCatalog?.catch(() => undefined);
+          await Promise.allSettled(pendingDisposals);
+        })();
       }
+      // Physical cleanup is single-flight; uncertainty belongs to every caller.
+      void disposal.then(() => {
+        if (cleanupFailed) {
+          recordAgentCleanupFailure();
+        }
+      });
+      return disposal;
     },
   };
   return runtime;

--- a/src/agents/agent-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/agent-bundle-mcp-tools.materialize.test.ts
@@ -3,21 +3,21 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { expectDefined } from "@openclaw/normalization-core";
 import { validateToolArguments } from "openclaw/plugin-sdk/llm";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import { createCombinedSessionMcpRuntime } from "./agent-bundle-mcp-combined.js";
 import {
   buildBundleMcpToolsFromCatalog,
   createBundleMcpToolRuntime,
   materializeBundleMcpToolsForRun,
 } from "./agent-bundle-mcp-materialize.js";
-import type {
-  McpCatalogTool,
-  McpToolCatalogDiagnostic,
-  SessionMcpRuntime,
-} from "./agent-bundle-mcp-types.js";
+import { makeToolRuntime } from "./agent-bundle-mcp-tools.test-support.js";
+import type { McpCatalogTool } from "./agent-bundle-mcp-types.js";
 import { applyEmbeddedAttemptToolsAllow } from "./embedded-agent-runner/run/attempt-tool-construction-plan.js";
 import { getMcpAppViewLease } from "./mcp-ui-resource.js";
 import { testing as mcpUiResourceTesting } from "./mcp-ui-resource.test-support.js";
+import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 import { isToolResultError } from "./tool-result-error.js";
 
 const MCP_APP_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
@@ -26,71 +26,6 @@ function expectTextContentBlock(block: unknown, text: string) {
   const content = block as { type?: string; text?: string } | undefined;
   expect(content?.type).toBe("text");
   expect(content?.text).toBe(text);
-}
-
-function makeToolRuntime(
-  params: {
-    tools?: McpCatalogTool[];
-    serverName?: string;
-    result?: CallToolResult;
-    resultText?: string;
-    diagnostics?: readonly McpToolCatalogDiagnostic[];
-    supportsParallelToolCalls?: boolean;
-  } = {},
-): SessionMcpRuntime {
-  const serverName = params.serverName ?? "bundleProbe";
-  const tools = params.tools ?? [
-    {
-      serverName,
-      safeServerName: serverName,
-      toolName: "bundle_probe",
-      description: "Bundle probe",
-      inputSchema: { type: "object", properties: {} },
-      fallbackDescription: "Bundle probe",
-    },
-  ];
-  return {
-    sessionId: "session-collision",
-    workspaceDir: "/tmp",
-    configFingerprint: "fingerprint",
-    createdAt: 0,
-    lastUsedAt: 0,
-    markUsed: () => {},
-    getCatalog: async () => ({
-      version: 1,
-      generatedAt: 0,
-      servers: {
-        [serverName]: {
-          serverName,
-          launchSummary: serverName,
-          toolCount: tools.length,
-          supportsParallelToolCalls: params.supportsParallelToolCalls ?? false,
-        },
-      },
-      tools,
-      ...(params.diagnostics ? { diagnostics: params.diagnostics } : {}),
-    }),
-    peekCatalog: () => ({
-      version: 1,
-      generatedAt: 0,
-      servers: {
-        [serverName]: {
-          serverName,
-          launchSummary: serverName,
-          toolCount: tools.length,
-          supportsParallelToolCalls: params.supportsParallelToolCalls ?? false,
-        },
-      },
-      tools,
-      ...(params.diagnostics ? { diagnostics: params.diagnostics } : {}),
-    }),
-    callTool: async () =>
-      params.result ?? {
-        content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
-        isError: false,
-      },
-    dispose: async () => {},
-  };
 }
 
 async function executeMcpToolResult(result: CallToolResult) {
@@ -109,6 +44,150 @@ describe("createBundleMcpToolRuntime", () => {
   afterEach(() => {
     mcpUiResourceTesting.clearViewStore();
   });
+
+  it("joins concurrent disposal without releasing the captured lease twice", async () => {
+    const closing = createDeferred();
+    const started = createDeferred();
+    const releaseLease = vi.fn();
+    const runtime = makeToolRuntime();
+    runtime.acquireLease = () => releaseLease;
+    const disposeRuntime = vi.fn(async () => {
+      started.resolve();
+      await closing.promise;
+    });
+    const materialized = await materializeBundleMcpToolsForRun({ runtime, disposeRuntime });
+    const first = materialized.dispose();
+    await started.promise;
+    let joined = false;
+    const second = materialized.dispose().then(() => {
+      joined = true;
+    });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(joined).toBe(false);
+      expect(releaseLease).toHaveBeenCalledOnce();
+    } finally {
+      closing.resolve();
+      await Promise.all([first, second]);
+    }
+    expect(disposeRuntime).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { kind: "single", failureAt: "join" },
+    { kind: "combined", failureAt: "join" },
+    { kind: "combined", failureAt: "synchronous-join" },
+    { kind: "combined", failureAt: "dispose" },
+    { kind: "combined", failureAt: "synchronous-dispose" },
+  ] as const)(
+    "replays a $kind owner's $failureAt failure in each final caller",
+    async ({ kind, failureAt }) => {
+      const failed = makeToolRuntime();
+      const sibling = makeToolRuntime();
+      sibling.dispose = vi.fn(async () => {});
+      sibling.joinCleanup = vi.fn(async () => {});
+      const failure = new Error("cleanup owner lost");
+      const failingCleanup = failureAt.startsWith("synchronous")
+        ? vi.fn(() => {
+            throw failure;
+          })
+        : vi.fn(async () => {
+            throw failure;
+          });
+      const disposing = failureAt.endsWith("dispose");
+      if (disposing) {
+        failed.dispose = failingCleanup;
+      } else {
+        failed.joinCleanup = failingCleanup;
+      }
+      const runtime =
+        kind === "single"
+          ? failed
+          : createCombinedSessionMcpRuntime({
+              sessionId: failed.sessionId,
+              workspaceDir: failed.workspaceDir,
+              parts: [failed, sibling],
+            });
+      const materialized = await materializeBundleMcpToolsForRun({ runtime });
+      if (disposing) {
+        // The physical failure predates both final callers' cleanup contexts.
+        await runtime.dispose();
+        await runtime.dispose();
+        expect(failingCleanup).toHaveBeenCalledOnce();
+        expect(sibling.dispose).toHaveBeenCalledOnce();
+      }
+      for (let index = 0; index < 2; index += 1) {
+        const cleanupScope = createAgentCleanupScope();
+        await cleanupScope.run(async () => {
+          await expect(materialized.dispose()).rejects.toBe(failure);
+        });
+        expect(cleanupScope.outcome).toBe("uncertain");
+      }
+      if (kind === "combined") {
+        expect(sibling.joinCleanup).toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("keeps an unreported shared cleanup owner uncertain without closing its peers", async () => {
+    const runtime = makeToolRuntime();
+    delete runtime.joinCleanup;
+    const dispose = vi.spyOn(runtime, "dispose");
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const cleanupScope = createAgentCleanupScope();
+    await cleanupScope.run(() => materialized.dispose());
+    expect(cleanupScope.outcome).toBe("uncertain");
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { failureAt: "catalog", cleanupFault: "dispose", outcome: "uncertain" },
+    { failureAt: "catalog", cleanupFault: "release", outcome: "uncertain" },
+    { failureAt: "acquire", cleanupFault: "none", outcome: "closed" },
+    { failureAt: "dispose", cleanupFault: "release", outcome: "uncertain" },
+  ] as const)(
+    "settles every private cleanup step after $failureAt fails ($cleanupFault)",
+    async ({ failureAt, cleanupFault, outcome }) => {
+      const runtime = makeToolRuntime();
+      const cause = new Error("preparation failed");
+      const releaseFailure = new Error("lease release failed");
+      if (failureAt === "catalog") {
+        runtime.getCatalog = vi.fn().mockRejectedValue(cause);
+      }
+      runtime.acquireLease = () => {
+        if (failureAt === "acquire") {
+          throw cause;
+        }
+        return () => {
+          if (cleanupFault === "release") {
+            throw releaseFailure;
+          }
+        };
+      };
+      runtime.dispose =
+        cleanupFault === "dispose"
+          ? vi.fn().mockRejectedValue(new Error("cleanup failed"))
+          : vi.fn(async () => {});
+      runtime.joinCleanup = vi.fn(async () => {});
+      const cleanupScope = createAgentCleanupScope();
+      await cleanupScope.run(async () => {
+        await expect(
+          (async () => {
+            const materialized = await createBundleMcpToolRuntime({
+              workspaceDir: "/tmp",
+              createRuntime: () => runtime,
+            });
+            await materialized.dispose();
+          })(),
+        ).rejects.toBe(failureAt === "dispose" ? releaseFailure : cause);
+      });
+      expect(runtime.dispose).toHaveBeenCalledOnce();
+      expect(runtime.joinCleanup).toHaveBeenCalledOnce();
+      expect(cleanupScope.outcome).toBe(outcome);
+    },
+  );
 
   it("keeps app-only MCP tools out of the model tool catalog", async () => {
     const runtime = await materializeBundleMcpToolsForRun({

--- a/src/agents/agent-bundle-mcp-tools.test-support.ts
+++ b/src/agents/agent-bundle-mcp-tools.test-support.ts
@@ -1,0 +1,62 @@
+/** Synthetic session MCP runtime shared by catalog materialization cases. */
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  McpCatalogTool,
+  McpToolCatalog,
+  McpToolCatalogDiagnostic,
+  SessionMcpRuntime,
+} from "./agent-bundle-mcp-types.js";
+
+export function makeToolRuntime(
+  params: {
+    tools?: McpCatalogTool[];
+    serverName?: string;
+    result?: CallToolResult;
+    resultText?: string;
+    diagnostics?: readonly McpToolCatalogDiagnostic[];
+    supportsParallelToolCalls?: boolean;
+  } = {},
+): SessionMcpRuntime {
+  const serverName = params.serverName ?? "bundleProbe";
+  const tools = params.tools ?? [
+    {
+      serverName,
+      safeServerName: serverName,
+      toolName: "bundle_probe",
+      description: "Bundle probe",
+      inputSchema: { type: "object", properties: {} },
+      fallbackDescription: "Bundle probe",
+    },
+  ];
+  const peekCatalog = (): McpToolCatalog => ({
+    version: 1,
+    generatedAt: 0,
+    servers: {
+      [serverName]: {
+        serverName,
+        launchSummary: serverName,
+        toolCount: tools.length,
+        supportsParallelToolCalls: params.supportsParallelToolCalls ?? false,
+      },
+    },
+    tools,
+    ...(params.diagnostics ? { diagnostics: params.diagnostics } : {}),
+  });
+  return {
+    sessionId: "session-collision",
+    workspaceDir: "/tmp",
+    configFingerprint: "fingerprint",
+    createdAt: 0,
+    lastUsedAt: 0,
+    markUsed: () => {},
+    getCatalog: async () => peekCatalog(),
+    peekCatalog,
+    callTool: async () =>
+      params.result ?? {
+        content: [{ type: "text", text: params.resultText ?? "FROM-BUNDLE" }],
+        isError: false,
+      },
+    joinCleanup: async () => {},
+    dispose: async () => {},
+  };
+}

--- a/src/agents/agent-bundle-mcp-types.ts
+++ b/src/agents/agent-bundle-mcp-types.ts
@@ -163,6 +163,9 @@ export type SessionMcpRuntime = {
   ) => Promise<ListResourceTemplatesResult>;
   listPrompts?: (serverName: string) => Promise<unknown>;
   getPrompt?: (serverName: string, name: string, args?: Record<string, string>) => Promise<unknown>;
+  /** Joins cleanup already owned by this runtime, without closing live shared peers.
+   * Rejects when an earlier retirement or disposal could not confirm closure. */
+  joinCleanup?: () => Promise<void>;
   dispose: () => Promise<void>;
 };
 

--- a/src/agents/agent-command-execution-identity.test.ts
+++ b/src/agents/agent-command-execution-identity.test.ts
@@ -43,12 +43,14 @@ describe("sanitizePublicAgentCommandIngressOpts", () => {
       prompt: "create an automation",
       cronCreatorAuthorityCapability: forgedCapability,
       pinnedWidgetAuthoring: true,
+      assertSourceCurrent: () => {},
     } as unknown as AgentCommandIngressOpts;
 
     expect(sanitizePublicAgentCommandIngressOpts(opts)).toMatchObject({
       prompt: "create an automation",
       cronCreatorAuthorityCapability: undefined,
       pinnedWidgetAuthoring: undefined,
+      assertSourceCurrent: undefined,
     });
   });
 });

--- a/src/agents/agent-command-execution-identity.ts
+++ b/src/agents/agent-command-execution-identity.ts
@@ -43,20 +43,17 @@ function systemIngress(boundary: string): AgentCommandAdmissionIngress {
   return { kind: "system", boundary, state: "present" };
 }
 
-function prepareAgentCommandRunAdmission(params: {
-  admission?: AgentCommandOpts["executionIdentityAdmission"];
-  agentId: string;
-  cfg: OpenClawConfig;
-  ingress: AgentCommandAdmissionIngress;
-  operationalRunInstance: OperationalRunInstanceRef;
-  runId: string;
-  onAdmitted?: Parameters<typeof prepareAgentRunAdmission>[0]["onAdmitted"];
-}) {
-  return prepareAgentCommandRunAdmissionWithSpawnFacts(params);
-}
-
-function prepareAgentCommandRunAdmissionWithSpawnFacts(
-  params: Parameters<typeof prepareAgentCommandRunAdmission>[0],
+function prepareAgentCommandRunAdmission(
+  params: {
+    admission?: AgentCommandOpts["executionIdentityAdmission"];
+    agentId: string;
+    cfg: OpenClawConfig;
+    ingress: AgentCommandAdmissionIngress;
+    operationalRunInstance: OperationalRunInstanceRef;
+    runId: string;
+    onAdmitted?: Parameters<typeof prepareAgentRunAdmission>[0]["onAdmitted"];
+    assertSourceCurrent?: () => void;
+  },
   spawnFacts?: AgentCommandExecutionIdentitySpawnFacts,
 ) {
   const admissionFacts = getAgentCommandAdmissionFacts(params.operationalRunInstance) ?? {
@@ -83,6 +80,7 @@ function prepareAgentCommandRunAdmissionWithSpawnFacts(
     }),
     ...(params.admission ? { recovery: params.admission } : {}),
     ...(params.onAdmitted ? { onAdmitted: params.onAdmitted } : {}),
+    assertSourceCurrent: params.assertSourceCurrent,
   });
 }
 
@@ -166,6 +164,7 @@ export function prepareAgentCommandExecutionIdentity(params: {
     ingress: params.ingress,
     operationalRunInstance,
     runId: prepared.runId,
+    assertSourceCurrent: opts.assertSourceCurrent,
     onAdmitted: async (admittedRunContext) => {
       await opts.onAdmittedRunContext?.(admittedRunContext);
       admittedContext = admittedRunContext;
@@ -185,7 +184,7 @@ export function prepareAgentCommandExecutionIdentity(params: {
   };
   const spawnFacts = readAgentCommandExecutionIdentitySpawnFacts(opts);
   const preparedAdmission = spawnFacts
-    ? prepareAgentCommandRunAdmissionWithSpawnFacts(admissionParams, spawnFacts)
+    ? prepareAgentCommandRunAdmission(admissionParams, spawnFacts)
     : executionIdentity.prepare(admissionParams);
   const admission = opts.onPostAdmittedRunContext
     ? withPostAdmissionExecutionOwnerBinding(preparedAdmission, opts.onPostAdmittedRunContext)
@@ -222,6 +221,7 @@ export function sanitizePublicAgentCommandIngressOpts(
     pinnedWidgetAuthoring: undefined,
     executionIdentityAdmission: undefined,
     operationalRunInstance: undefined,
+    assertSourceCurrent: undefined,
     cronCreatorAuthorityCapability: undefined,
     onAdmittedRunContext: undefined,
     onPostAdmittedRunContext: undefined,

--- a/src/agents/agent-tools.memory-flush-append-write.test.ts
+++ b/src/agents/agent-tools.memory-flush-append-write.test.ts
@@ -6,6 +6,7 @@ import { validateJsonSchemaValue } from "../plugins/schema-validator.js";
 import { wrapToolMemoryFlushAppendOnlyWrite } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { createWriteTool } from "./sessions/tools/index.js";
+import { withGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 
 const RELATIVE_PATH = "memory/2026-08-08.md";
 
@@ -63,6 +64,53 @@ describe("wrapToolMemoryFlushAppendOnlyWrite output contract", () => {
     );
     return (result as { details?: unknown }).details;
   }
+
+  it.each(["revoked", "replaced", "active"] as const)(
+    "checks %s source authority after provenance work before appending",
+    async (authority) => {
+      const absolute = path.join(root, RELATIVE_PATH);
+      await fs.mkdir(path.dirname(absolute), { recursive: true });
+      await fs.writeFile(absolute, "seed\n");
+      const originalClaim = {};
+      let claim: object | undefined = originalClaim;
+      let reachedCommit = false;
+      const wrapped = wrapToolMemoryFlushAppendOnlyWrite(baseWriteTool(), {
+        root,
+        relativePath: RELATIVE_PATH,
+        memoryWriteProvenance: {
+          classifies: async () => true,
+          write: async ({ commit }) => {
+            reachedCommit = true;
+            if (authority === "revoked") {
+              claim = undefined;
+            }
+            if (authority === "replaced") {
+              claim = {};
+            }
+            await commit();
+          },
+          clearAfterDelete: async () => {},
+        },
+      });
+      const pending = withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:memory-flush-authority",
+          receiptAuthority: () => claim === originalClaim,
+        },
+        () => wrapped.execute("source-append", { path: RELATIVE_PATH, content: "hello" }),
+      );
+      if (authority === "active") {
+        await expect(pending).resolves.toMatchObject({ details: { changed: true } });
+      } else {
+        await expect(pending).rejects.toThrow("authority is no longer active");
+      }
+      expect(reachedCommit).toBe(true);
+      expect(await fs.readFile(absolute, "utf8")).toBe(
+        authority === "active" ? "seed\nhello" : "seed\n",
+      );
+    },
+  );
 
   it("returns write-schema-conforming details when creating the memory file", async () => {
     const details = await runAppend();

--- a/src/agents/agent-tools.read.host-write-integrity.test.ts
+++ b/src/agents/agent-tools.read.host-write-integrity.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHostWorkspaceEditTool, createHostWorkspaceWriteTool } from "./agent-tools.read.js";
 import { createApplyPatchTool } from "./apply-patch.js";
+import { withGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 
 describe("unrestricted host tool writes", () => {
   let tempDir = "";
@@ -24,11 +25,21 @@ describe("unrestricted host tool writes", () => {
     return filePath;
   }
 
-  it.each(["write", "edit", "apply_patch"] as const)(
-    "fences %s after asynchronous file preparation when permissions change",
-    async (kind) => {
+  it.each(
+    (["write", "edit", "apply_patch"] as const).flatMap((kind) =>
+      (["aborted", "revoked", "replaced", "active"] as const).map((authority) => ({
+        kind,
+        authority,
+      })),
+    ),
+  )(
+    "checks $authority authority for $kind after asynchronous file preparation",
+    async ({ kind, authority }) => {
       const filePath = await createFile("original content\n");
       const generation = new AbortController();
+      const originalClaim = {};
+      let currentClaim: object | undefined = originalClaim;
+      let prepared = false;
       const realOpen = fs.open.bind(fs);
       vi.spyOn(fs, "open").mockImplementation(async (target, flags, mode) => {
         const handle = await realOpen(target, flags as never, mode as never);
@@ -36,7 +47,14 @@ describe("unrestricted host tool writes", () => {
           const read = handle.read.bind(handle);
           handle.read = (async (...args: Parameters<typeof read>) => {
             const result = await read(...args);
-            generation.abort(new Error("Permission change"));
+            prepared = true;
+            if (authority === "aborted") {
+              generation.abort(new Error("Permission change"));
+            } else if (authority === "revoked") {
+              currentClaim = undefined;
+            } else if (authority === "replaced") {
+              currentClaim = {};
+            }
             return result;
           }) as typeof handle.read;
         }
@@ -60,8 +78,26 @@ describe("unrestricted host tool writes", () => {
         return tool.execute("permission-write", input);
       };
 
-      await expect(execute()).rejects.toThrow("Permission change");
-      expect(await fs.readFile(filePath, "utf8")).toBe("original content\n");
+      const pending = withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:source-file-authority",
+          receiptAuthority: () => currentClaim === originalClaim,
+        },
+        execute,
+      );
+      if (authority === "active") {
+        await expect(pending).resolves.toBeDefined();
+      } else {
+        await expect(pending).rejects.toThrow(
+          authority === "aborted" ? "Permission change" : "authority is no longer active",
+        );
+      }
+      expect(prepared).toBe(true);
+      expect(generation.signal.aborted).toBe(authority === "aborted");
+      expect(await fs.readFile(filePath, "utf8")).toBe(
+        authority === "active" ? "replacement content\n" : "original content\n",
+      );
     },
   );
 

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -25,6 +25,7 @@ import {
 } from "../media/media-reference.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import { clampNumber } from "../utils.js";
+import { captureAgentToolSourceExecutionGuard } from "./agent-tool-source-execution-guard.js";
 import {
   REQUIRED_PARAM_GROUPS,
   assertRequiredParams,
@@ -695,9 +696,11 @@ async function appendMemoryFlushContent(params: {
   content: string;
   sandbox?: MemoryFlushAppendOnlyWriteOptions["sandbox"];
   signal?: AbortSignal;
+  assertCurrent: () => void;
 }) {
   if (!params.sandbox) {
     const root = await fsRoot(params.root);
+    params.assertCurrent();
     await root.append(params.relativePath, params.content, {
       mkdir: true,
       prependNewlineIfNeeded: true,
@@ -714,26 +717,23 @@ async function appendMemoryFlushContent(params: {
   const separator =
     existing.length > 0 && !existing.endsWith("\n") && !params.content.startsWith("\n") ? "\n" : "";
   const next = `${existing}${separator}${params.content}`;
-  if (params.sandbox) {
-    const parent = path.posix.dirname(params.relativePath);
-    if (parent && parent !== ".") {
-      await params.sandbox.bridge.mkdirp({
-        filePath: parent,
-        cwd: params.sandbox.root,
-        signal: params.signal,
-      });
-    }
-    await params.sandbox.bridge.writeFile({
-      filePath: params.relativePath,
+  const parent = path.posix.dirname(params.relativePath);
+  params.assertCurrent();
+  if (parent && parent !== ".") {
+    await params.sandbox.bridge.mkdirp({
+      filePath: parent,
       cwd: params.sandbox.root,
-      data: next,
-      mkdir: true,
       signal: params.signal,
     });
-    return;
   }
-  await fs.mkdir(path.dirname(params.absolutePath), { recursive: true });
-  await fs.writeFile(params.absolutePath, next, "utf-8");
+  params.assertCurrent();
+  await params.sandbox.bridge.writeFile({
+    filePath: params.relativePath,
+    cwd: params.sandbox.root,
+    data: next,
+    mkdir: true,
+    signal: params.signal,
+  });
 }
 
 /** Restrict a write tool to appending memory-flush content to one path. */
@@ -746,6 +746,7 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
     ...tool,
     description: `${tool.description} During memory flush, this tool may only append to ${options.relativePath}.`,
     execute: async (toolCallId, args, signal, onUpdate) => {
+      const assertCurrent = captureAgentToolSourceExecutionGuard(signal);
       const record = getToolParamsRecord(args);
       const normalizedRecord = record
         ? await normalizeFileToolPathParamsFromKeys(
@@ -794,6 +795,7 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
           content,
           sandbox: options.sandbox,
           signal,
+          assertCurrent,
         });
       const memoryWriteProvenance = options.memoryWriteProvenance;
       if (memoryWriteProvenance && (await memoryWriteProvenance.classifies(allowedAbsolutePath))) {
@@ -806,6 +808,7 @@ export function wrapToolMemoryFlushAppendOnlyWrite(
       } else {
         await commit();
       }
+      assertCurrent();
       // This wrapper inherits the write tool's output schema, so report only
       // the authoritative `changed`; deriving `created` before append is racy.
       return {
@@ -1372,6 +1375,7 @@ async function writeWorkspaceFile(
   content: string,
   abortSignal?: AbortSignal,
 ) {
+  const assertCurrent = captureAgentToolSourceExecutionGuard(abortSignal);
   // Validate the path before starting the fs-safe root: call getRoot() (which opens the
   // root dir, rejecting if the workspace is missing) only after toCanonicalRelativeWorkspacePath
   // succeeds. Eagerly starting it would orphan a rejecting root promise as an unhandled
@@ -1385,7 +1389,7 @@ async function writeWorkspaceFile(
     throw new FsSafeError("symlink", `refusing to write to symlink: ${absolutePath}`);
   }
   const rootHandle = await getRoot();
-  abortSignal?.throwIfAborted();
+  assertCurrent();
   await rootHandle.write(relative, content, { mkdir: true });
 }
 
@@ -1405,7 +1409,7 @@ function createHostWriteOperations(
       {
         mkdir: async (dir: string) => {
           const resolved = resolveHostPath(dir);
-          options?.abortSignal?.throwIfAborted();
+          captureAgentToolSourceExecutionGuard(options?.abortSignal)();
           await fs.mkdir(resolved, { recursive: true });
         },
         writeFile: (filePath: string, content: string) =>
@@ -1428,10 +1432,11 @@ function createHostWriteOperations(
   return withMemoryWriteProvenance(
     {
       mkdir: async (dir: string) => {
+        const assertCurrent = captureAgentToolSourceExecutionGuard(options?.abortSignal);
         const relative = toRelativeWorkspacePath(root, dir, { allowRoot: true });
         const resolved = relative ? path.resolve(root, relative) : path.resolve(root);
         await assertSandboxPath({ filePath: resolved, cwd: root, root });
-        options?.abortSignal?.throwIfAborted();
+        assertCurrent();
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: (absolutePath: string, content: string) =>

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -26,6 +26,7 @@ import type {
 } from "../plugins/hook-types.js";
 import { appendRuntimePluginToolGrant } from "../plugins/tool-grant-allowlist.js";
 import { getPluginToolMeta } from "../plugins/tool-metadata.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
 import { getActiveSecretsRuntimeConfigSnapshot } from "../secrets/runtime-state.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../security/dangerous-tools.js";
 import type { InputProvenance } from "../sessions/input-provenance.js";
@@ -539,6 +540,14 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     sessionId: options?.sessionId,
     agentId,
   });
+  if (options?.oneShotCliRun && scopeKey && options.registerRunCleanup) {
+    const supervisor = getProcessSupervisor();
+    // Register before launch: root completion can precede final cleanup,
+    // which must retain the tree and any earlier extinction failure.
+    options.registerRunCleanup(
+      supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true }),
+    );
+  }
   options?.recordToolPrepStage?.("tool-policy");
   const execConfig = resolveExecToolConfig({ cfg: options?.config, agentId });
   const execRuntimeConfig = options?.exec?.config ?? options?.config;

--- a/src/agents/apply-patch-file-ops.ts
+++ b/src/agents/apply-patch-file-ops.ts
@@ -10,6 +10,7 @@ import {
   FsSafeError,
   root as fsRoot,
 } from "../infra/fs-safe.js";
+import { captureAgentToolSourceExecutionGuard } from "./agent-tool-source-execution-guard.js";
 import { writeHostFile } from "./host-file-write.js";
 import {
   type MemoryWriteProvenanceObserver,
@@ -60,6 +61,7 @@ export async function createPatchTarget(params: {
 }
 
 export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promise<PatchFileOps> {
+  const assertCurrent = captureAgentToolSourceExecutionGuard(options.signal);
   if (options.sandbox) {
     const { root, bridge } = options.sandbox;
     return withPatchMemoryWriteProvenance({
@@ -70,7 +72,7 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
           return decodeUtf8File(buf, filePath);
         },
         writeFile: (filePath, content) => {
-          options.signal?.throwIfAborted();
+          assertCurrent();
           return bridge.writeFile({ filePath, cwd: root, data: content, signal: options.signal });
         },
         createFileExclusive: (filePath, content) => {
@@ -79,7 +81,7 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
               "Sandbox filesystem bridge does not support atomic file creation; refusing to overwrite an existing path.",
             );
           }
-          options.signal?.throwIfAborted();
+          assertCurrent();
           return bridge.createFileExclusive({
             filePath,
             cwd: root,
@@ -88,11 +90,11 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
           });
         },
         remove: (filePath) => {
-          options.signal?.throwIfAborted();
+          assertCurrent();
           return bridge.remove({ filePath, cwd: root, force: false, signal: options.signal });
         },
         mkdirp: (dir) => {
-          options.signal?.throwIfAborted();
+          assertCurrent();
           return bridge.mkdirp({ filePath: dir, cwd: root, signal: options.signal });
         },
       },
@@ -109,7 +111,7 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
         },
         createFileExclusive: async (filePath, content) => {
           try {
-            options.signal?.throwIfAborted();
+            assertCurrent();
             await fs.writeFile(filePath, content, { encoding: "utf8", flag: "wx" });
             return "created";
           } catch (error) {
@@ -120,11 +122,11 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
           }
         },
         remove: (filePath) => {
-          options.signal?.throwIfAborted();
+          assertCurrent();
           return fs.rm(filePath);
         },
         mkdirp: async (dir) => {
-          options.signal?.throwIfAborted();
+          assertCurrent();
           await fs.mkdir(dir, { recursive: true });
         },
       },
@@ -169,13 +171,13 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
       },
       writeFile: async (filePath, content) => {
         const relative = await toCanonicalMutationRelative(filePath);
-        options.signal?.throwIfAborted();
+        assertCurrent();
         await root.write(relative, content, { encoding: "utf8" });
       },
       createFileExclusive: async (filePath, content) => {
         const relative = await toCanonicalMutationRelative(filePath);
         try {
-          options.signal?.throwIfAborted();
+          assertCurrent();
           await root.create(relative, content, { encoding: "utf8" });
           return "created";
         } catch (error) {
@@ -193,12 +195,12 @@ export async function resolvePatchFileOps(options: ApplyPatchFileOptions): Promi
       },
       remove: async (filePath) => {
         const relative = await toCanonicalMutationRelative(filePath);
-        options.signal?.throwIfAborted();
+        assertCurrent();
         await root.remove(relative);
       },
       mkdirp: async (dir) => {
         const relative = await toCanonicalMutationRelative(dir, { allowRoot: true });
-        options.signal?.throwIfAborted();
+        assertCurrent();
         if (relative === "" || relative === ".") {
           await root.ensureRoot();
           return;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -242,6 +242,77 @@ describe("sandbox exec preparation failures", () => {
     },
   );
 
+  it.each([
+    { mode: "child", usePty: false, loseAt: 1, authority: "revoked", spawns: 0 },
+    { mode: "PTY", usePty: true, loseAt: 1, authority: "replaced", spawns: 0 },
+    { mode: "PTY fallback", usePty: true, loseAt: 2, authority: "revoked", spawns: 1 },
+    { mode: "child construction", usePty: false, loseAt: -1, authority: "revoked", spawns: 1 },
+    { mode: "PTY construction", usePty: true, loseAt: -1, authority: "revoked", spawns: 1 },
+    { mode: "child control", usePty: false, loseAt: 0, authority: "active", spawns: 1 },
+    { mode: "PTY fallback control", usePty: true, loseAt: 0, authority: "active", spawns: 2 },
+  ])(
+    "checks $authority source authority before $mode admission without polling",
+    async ({ usePty, loseAt, authority, spawns }) => {
+      const originalClaim = {};
+      let currentClaim: object | undefined = originalClaim;
+      let checks = 0;
+      const generation = new AbortController();
+      const warnings: string[] = [];
+      supervisorMock.spawn.mockImplementation(async (input: SpawnInput) => {
+        // The real supervisor preserves this callback across queued construction.
+        await Promise.resolve();
+        if (loseAt === -1) {
+          currentClaim = undefined;
+        }
+        input.assertCurrent?.();
+        if (input.mode === "pty") {
+          throw new Error("PTY unavailable");
+        }
+        return runtimeManagedRun(input);
+      });
+      const pending = withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:source-exec-authority",
+          receiptAuthority: () => currentClaim === originalClaim,
+        },
+        () =>
+          runExecProcess({
+            command: "source-authority-command",
+            workdir: process.cwd(),
+            env: {},
+            usePty,
+            warnings,
+            maxOutput: 1000,
+            pendingMaxOutput: 1000,
+            notifyOnExit: false,
+            timeoutSec: null,
+            startupSignal: generation.signal,
+            beforeSpawn: async () => {
+              if (++checks === loseAt) {
+                currentClaim = authority === "replaced" ? {} : undefined;
+              }
+              return undefined;
+            },
+          }),
+      );
+      if (authority === "active") {
+        const handle = await pending;
+        await expect(handle.promise).resolves.toMatchObject({ status: "completed" });
+      } else {
+        await expect(pending).rejects.toThrow("authority is no longer active");
+      }
+      expect(generation.signal.aborted).toBe(false);
+      expect(supervisorMock.spawn).toHaveBeenCalledTimes(spawns);
+      expect(warnings).toEqual(
+        usePty && loseAt !== -1 && spawns > 0
+          ? [expect.stringContaining("retrying without PTY")]
+          : [],
+      );
+      expect(listRunningSessions()).toHaveLength(0);
+    },
+  );
+
   it("keeps turn authority out of process lifetime while preserving foreground updates", async () => {
     const exit = createDeferred<RunExit>();
     const identity = {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -37,6 +37,7 @@ import {
   type DeliveryContext,
 } from "../utils/delivery-context.shared.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
+import { captureAgentToolSourceExecutionGuard } from "./agent-tool-source-execution-guard.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import {
   addSession,
@@ -694,6 +695,8 @@ export async function runExecProcess({
   /** Revalidates authorization after async preparation, immediately before each spawn attempt. */
   beforeSpawn?: () => Promise<AgentToolResult<ExecToolDetails> | undefined>;
 }): Promise<ExecProcessHandle> {
+  let assertSourceActive: (() => void) | undefined =
+    captureAgentToolSourceExecutionGuard(initialStartupSignal);
   const startedAt = Date.now();
   const sessionId = createSessionSlug(isProcessSessionIdTaken);
   const execCommand = opts.execCommand ?? opts.command;
@@ -740,7 +743,6 @@ export async function runExecProcess({
   // Foreground delivery keeps its caller context only until yield, abort, or exit.
   // Clearing the callback also releases the completed turn's captured authority.
   let onUpdate = initialOnUpdate && AsyncLocalStorage.bind(initialOnUpdate);
-  let startupSignal = initialStartupSignal;
   let beforeSpawn = initialBeforeSpawn;
   let onSettledBeforeNotify = initialOnSettledBeforeNotify;
 
@@ -945,27 +947,30 @@ export async function runExecProcess({
   };
 
   const assertPreSpawnAuthorized = async () => {
-    startupSignal?.throwIfAborted();
+    assertSourceActive?.();
     const denied = await beforeSpawn?.();
-    startupSignal?.throwIfAborted();
+    assertSourceActive?.();
     if (denied) {
       throw new ExecProcessPreflightError(denied);
     }
   };
   const spawn = (input: SpawnInput) => {
-    // No await between the final cancellation check and supervisor admission.
-    startupSignal?.throwIfAborted();
-    return withoutGatewayToolCallerIdentity(() => supervisor.spawn(input));
+    // No await between source authority validation and supervisor admission.
+    assertSourceActive?.();
+    return withoutGatewayToolCallerIdentity(() =>
+      supervisor.spawn({ ...input, assertCurrent: assertSourceActive }),
+    );
   };
 
   try {
-    startupSignal?.throwIfAborted();
+    assertSourceActive?.();
     const spawnSpec = await prepareSpawnSpec();
     usingPty = spawnSpec.mode === "pty";
     const spawnBase = {
       runId: sessionId,
       sessionId: opts.sessionKey?.trim() || sessionId,
       backendId: opts.sandbox ? "exec-sandbox" : "exec-host",
+      ...(opts.sandbox ? { cleanupOwnership: "external" as const } : {}),
       scopeKey: opts.scopeKey,
       cwd: opts.workdir,
       env: spawnSpec.env,
@@ -983,7 +988,7 @@ export async function runExecProcess({
           argv: spawnSpec.argv,
         });
       } catch (err) {
-        startupSignal?.throwIfAborted();
+        assertSourceActive?.();
         const warning = `Warning: PTY spawn failed (${String(err)}); retrying without PTY for \`${opts.command}\`.`;
         logWarn(
           `exec: PTY spawn failed (${String(err)}); retrying without PTY for "${opts.command}".`,
@@ -1021,8 +1026,8 @@ export async function runExecProcess({
     });
     throw error;
   } finally {
-    startupSignal = undefined;
     beforeSpawn = undefined;
+    assertSourceActive = undefined;
   }
   session.stdin = managedRun.stdin;
   session.pid = managedRun.pid;

--- a/src/agents/cli-runner.reliability.test.ts
+++ b/src/agents/cli-runner.reliability.test.ts
@@ -244,6 +244,20 @@ function makeClaudePreparedContext(
   return buildPreparedContext({ provider: "claude-cli", model: "opus", ...overrides });
 }
 
+async function admitPreparedContext(
+  context: PreparedCliRunContext,
+  runtime: "embedded" | "plugin-harness" = "embedded",
+) {
+  const admission = prepareSystemAgentRunAdmission(
+    {},
+    context.params.runId,
+    "main",
+    "cli-recovery-test",
+  );
+  context.params.admittedRunContext = await admission.admit(runtime);
+  return admission;
+}
+
 async function usePluginLiveBackend(context: PreparedCliRunContext, execute: CliBackendExecute) {
   const backend: CliBackendConfig = {
     command: "/bin/sh",
@@ -259,13 +273,7 @@ async function usePluginLiveBackend(context: PreparedCliRunContext, execute: Cli
   context.preparedBackend.backend = backend;
   context.backendResolved.config = backend;
   context.executionTarget = { kind: "plugin", execute };
-  const admission = prepareSystemAgentRunAdmission(
-    {},
-    context.params.runId,
-    "main",
-    "plugin-recovery-test",
-  );
-  context.params.admittedRunContext = await admission.admit("plugin-harness");
+  const admission = await admitPreparedContext(context, "plugin-harness");
   return { admission, context };
 }
 
@@ -720,7 +728,9 @@ describe("runCliAgent reliability", () => {
     expect(freshArgv).not.toContain("--resume-session-at");
   });
 
-  it("falls back to cold reseed when Claude lacks the checkpoint flag", async () => {
+  it("falls back to cold reseed when Claude lacks the checkpoint flag", async ({
+    onTestFinished,
+  }) => {
     supervisorSpawnMock
       .mockResolvedValueOnce(
         makeManagedRun({
@@ -750,6 +760,7 @@ describe("runCliAgent reliability", () => {
       cliSessionId: "old-claude-session",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
+    onTestFinished((await admitPreparedContext(context)).close);
     context.preparedBackend.backend = {
       ...context.preparedBackend.backend,
       resumeArgs: ["--resume", "{sessionId}"],
@@ -785,7 +796,9 @@ describe("runCliAgent reliability", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(3);
   });
 
-  it("cold reseeds an initially armed checkpoint after a Claude downgrade", async () => {
+  it("cold reseeds an initially armed checkpoint after a Claude downgrade", async ({
+    onTestFinished,
+  }) => {
     supervisorSpawnMock
       .mockResolvedValueOnce(
         makeManagedRun({
@@ -804,6 +817,7 @@ describe("runCliAgent reliability", () => {
       cliSessionId: "downgraded-session",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
+    onTestFinished((await admitPreparedContext(context)).close);
     context.preparedBackend.backend = {
       ...context.preparedBackend.backend,
       resumeArgs: ["--resume", "{sessionId}"],
@@ -839,7 +853,9 @@ describe("runCliAgent reliability", () => {
     expect(supervisorSpawnMock).toHaveBeenCalledTimes(2);
   });
 
-  it("does not treat unsupported-flag wording fragments as a Claude downgrade", async () => {
+  it("does not treat unsupported-flag wording fragments as a Claude downgrade", async ({
+    onTestFinished,
+  }) => {
     supervisorSpawnMock.mockResolvedValueOnce(
       makeManagedRun({
         exitCode: 1,
@@ -854,6 +870,7 @@ describe("runCliAgent reliability", () => {
       cliSessionId: "existing-session",
       openClawHistoryPrompt: CLI_RESEED_PROMPT,
     });
+    onTestFinished((await admitPreparedContext(context)).close);
     context.preparedBackend.backend = {
       ...context.preparedBackend.backend,
       resumeArgs: ["--resume", "{sessionId}"],

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -23,6 +23,7 @@ import {
   startDiagnosticRunActivityTracking,
 } from "../logging/diagnostic-run-activity.js";
 import type { getProcessSupervisor } from "../process/supervisor/index.js";
+import { prepareSystemAgentRunAdmission } from "./admitted-run-context.js";
 import {
   buildPreparedCliRunContext,
   captureModelCallDiagnostics,
@@ -212,7 +213,9 @@ describe("runCliAgent spawn path", () => {
     expect(logLine).not.toContain("claude-session-secret");
   });
 
-  it("streams a node-placed Claude resume through the normal JSONL parser", async () => {
+  it("streams a node-placed Claude resume through the normal JSONL parser", async ({
+    onTestFinished,
+  }) => {
     const writeSystemPrompt = vi.fn(writeCliSystemPromptFile);
     let toolAvailability: unknown = "unset";
     const invokeNode = vi.fn(async (params: Parameters<typeof invokeNodeClaudeCliRun>[0]) => {
@@ -299,6 +302,14 @@ describe("runCliAgent spawn path", () => {
     context.params.claimCliSessionFork = vi.fn(async () => true);
     context.params.persistCliSessionForkSuccessor = vi.fn(async () => {});
 
+    const admission = prepareSystemAgentRunAdmission(
+      {},
+      context.params.runId,
+      "main",
+      "cli-node-resume-test",
+    );
+    onTestFinished(admission.close);
+    context.params.admittedRunContext = await admission.admit("embedded");
     const output = await executePreparedCliRun(context, "source-node-session");
 
     expect(output).toMatchObject({ text: "node answer", sessionId: "forked-node-session" });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -28,6 +28,7 @@ import {
   markAuthProfileSuccess,
 } from "./auth-profiles.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
+import { runCliCleanup } from "./cli-runner/cleanup.js";
 import { acceptsCliLiveSession } from "./cli-runner/cli-live-session-registry.js";
 import {
   resolveCliSessionId,
@@ -713,7 +714,9 @@ export async function runPreparedCliAgent(
   }
   let cleanupError: Error | undefined;
   try {
-    await context.preparedBackend.cleanup?.();
+    await runCliCleanup(params, "cli-backend-release", async () => {
+      await context.preparedBackend.cleanup?.();
+    });
   } catch (error) {
     cleanupError = error as Error;
   }

--- a/src/agents/cli-runner/cleanup.ts
+++ b/src/agents/cli-runner/cleanup.ts
@@ -1,0 +1,25 @@
+import { toErrorObject } from "../../infra/errors.js";
+import { recordModelFallbackStop } from "../failover-error.js";
+import { runOwnedAgentCleanup } from "../run-cleanup-timeout.js";
+import { cliBackendLog } from "./log.js";
+import type { RunCliAgentParams } from "./types.js";
+
+/** Join CLI cleanup; replacement requires closure before any provider can proceed. */
+export async function runCliCleanup(
+  params: Pick<RunCliAgentParams, "runId" | "sessionId" | "oneShotCliRun">,
+  step: string,
+  cleanup: () => Promise<void>,
+  settlement?: "required",
+): Promise<void> {
+  try {
+    await runOwnedAgentCleanup({ ...params, step, cleanup, settlement, log: cliBackendLog });
+  } catch (error) {
+    if (settlement !== "required") {
+      throw error;
+    }
+    const failure = toErrorObject(error, "CLI resource cleanup failed");
+    // A different provider must not replace resources whose previous owner is still unclosed.
+    recordModelFallbackStop(failure);
+    throw failure;
+  }
+}

--- a/src/agents/cli-runner/cli-live-session-registry.test.ts
+++ b/src/agents/cli-runner/cli-live-session-registry.test.ts
@@ -356,11 +356,14 @@ describe("generic plugin-owned live session registry", () => {
         expect(cleanupScope.outcome).toBe("uncertain");
         const next = await createOwner({ sessionId: owner.sessionId });
         next.context.params.oneShotCliRun = true;
-        const nextRestart = expect(restartCliLiveSession(next.context)).rejects.toThrow(
-          "resource replacement refused",
+        const nextRestart = restartCliLiveSession(next.context).then(
+          () => undefined,
+          (error: unknown) => error,
         );
         await vi.advanceTimersByTimeAsync(10_000);
-        await nextRestart;
+        expect(await nextRestart).toMatchObject({
+          message: expect.stringContaining("resource replacement refused"),
+        });
         expect(() => next.register()).toThrow("cleanup has not settled");
         owner.exited.resolve();
         await restartCliLiveSession(next.context);

--- a/src/agents/cli-runner/cli-live-session-registry.test.ts
+++ b/src/agents/cli-runner/cli-live-session-registry.test.ts
@@ -4,8 +4,13 @@ import type {
   CliBackendLiveSessionCapability,
   CliBackendLiveSessionHandle,
 } from "../../plugins/cli-backend.types.js";
-import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
+import {
+  prepareSystemAgentRunAdmission,
+  resolveAdmittedRunActiveAssertion,
+} from "../admitted-run-context.js";
 import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { hasModelFallbackStop } from "../failover-error.js";
+import { createAgentCleanupScope } from "../run-cleanup-timeout.js";
 import {
   acceptsCliLiveSession,
   buildCliLiveOwnerKey,
@@ -13,7 +18,9 @@ import {
   createCliLiveSessionCapability,
   getCliLiveSessionGeneration,
   hasCliLiveSession,
+  restartCliLiveSession,
 } from "./cli-live-session-registry.js";
+import { settlePreparedCliRun } from "./cli-run-settlement.js";
 import { buildCliLiveSessionFingerprint } from "./live-session-fingerprint.js";
 
 const admissions: Array<ReturnType<typeof prepareSystemAgentRunAdmission>> = [];
@@ -52,6 +59,14 @@ async function createOwner(
   );
   admissions.push(admission);
   context.params.admittedRunContext = await admission.admit("plugin-harness");
+  const controller = new AbortController();
+  context.params.abortSignal = controller.signal;
+  let callerCurrent = true;
+  context.params.assertCurrent = () => {
+    if (!callerCurrent) {
+      throw new Error("caller is no longer active");
+    }
+  };
   const grant = options.capture
     ? {
         transportToken: options.capture.token,
@@ -71,7 +86,7 @@ async function createOwner(
     argv0: options.argv0,
     env: { PATH: "/usr/bin:/bin" },
     beginCapture,
-    abortSignal: new AbortController().signal,
+    abortSignal: controller.signal,
     ...(options.cleanup ? { claimResources: () => options.cleanup } : {}),
     ...(options.capture ? { captureKey: options.capture.key } : {}),
     ...(options.requiredGeneration ? { requiredGeneration: options.requiredGeneration } : {}),
@@ -102,6 +117,8 @@ async function createOwner(
     capability,
     close,
     context,
+    controller,
+    revokeCaller: () => (callerCurrent = false),
     exited,
     grant,
     register,
@@ -216,19 +233,168 @@ describe("generic plugin-owned live session registry", () => {
     expect(hasCliLiveSession(identity)).toBe(false);
   });
 
-  it("rejects registration once its exact admitted run has closed", async () => {
-    const owner = await createOwner();
-    owner.admission.close();
+  it.each(["admission", "caller", "signal"] as const)(
+    "rejects registration after %s revocation",
+    async (revocation) => {
+      const owner = await createOwner();
+      if (revocation === "admission") {
+        owner.admission.close();
+      } else if (revocation === "caller") {
+        owner.revokeCaller();
+      } else {
+        owner.controller.abort();
+      }
 
-    expect(() => owner.register()).toThrow("no longer active");
-    expect(
-      hasCliLiveSession({
-        backendId: "claude-cli",
-        agentId: "main",
-        sessionId: owner.sessionId,
-        sessionKey: owner.sessionKey,
-      }),
-    ).toBe(false);
+      expect(() => owner.register()).toThrow(
+        revocation === "signal" ? /no longer active|aborted/ : "no longer active",
+      );
+      expect(
+        hasCliLiveSession({
+          backendId: "claude-cli",
+          agentId: "main",
+          sessionId: owner.sessionId,
+          sessionKey: owner.sessionKey,
+        }),
+      ).toBe(false);
+    },
+  );
+
+  it("fences caller-revoked live access while allowing its owned cleanup", async () => {
+    const owner = await createOwner();
+    owner.register();
+    owner.capability.activate(owner.session);
+    expect(owner.capability.current()).toBe(owner.session);
+    owner.revokeCaller();
+    expect(owner.controller.signal.aborted).toBe(false);
+    expect(resolveAdmittedRunActiveAssertion(owner.context.params.admittedRunContext)).toBeTypeOf(
+      "function",
+    );
+    expect(() => owner.capability.current()).toThrow("caller is no longer active");
+    expect(() => owner.capability.activate(owner.session)).toThrow("caller is no longer active");
+    await closeCliLiveSession(owner.context, "restart");
+    expect(owner.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a caller-revoked restart before closing the registered process", async () => {
+    const owner = await createOwner();
+    owner.register();
+    owner.revokeCaller();
+    await expect(restartCliLiveSession(owner.context)).rejects.toThrow(
+      "caller is no longer active",
+    );
+    expect(owner.close).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    "rechecks caller authority after registered process cleanup (revoked=%s)",
+    async (revoked) => {
+      const entered = createDeferred();
+      const held = createDeferred();
+      const owner = await createOwner({
+        cleanup: async () => {
+          entered.resolve();
+          await held.promise;
+        },
+      });
+      owner.register();
+      const restarting = await createOwner({ sessionId: owner.sessionId });
+      const run = restartCliLiveSession(restarting.context);
+      const observed = run.then(
+        () => "restarted",
+        (error: unknown) => error,
+      );
+      try {
+        await entered.promise;
+        if (revoked) {
+          restarting.revokeCaller();
+        }
+        expect(restarting.controller.signal.aborted).toBe(false);
+        expect(
+          resolveAdmittedRunActiveAssertion(restarting.context.params.admittedRunContext),
+        ).toBeTypeOf("function");
+      } finally {
+        held.resolve();
+      }
+      expect(await observed).toEqual(
+        revoked ? new Error("caller is no longer active") : "restarted",
+      );
+      expect(owner.close).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["retained", "registered"] as const)(
+    "refuses replacement when the %s process has not exited by the cleanup deadline",
+    async (ownerKind) => {
+      const owner = await createOwner({ deferExit: true });
+      owner.register();
+      const restarting =
+        ownerKind === "retained" ? owner : await createOwner({ sessionId: owner.sessionId });
+      restarting.context.params.oneShotCliRun = true;
+      const replacement = vi.fn();
+      const cleanupScope = createAgentCleanupScope();
+      vi.useFakeTimers();
+      const observed = cleanupScope
+        .run(async () => {
+          await restartCliLiveSession(restarting.context);
+          replacement();
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      try {
+        await vi.advanceTimersByTimeAsync(10_000);
+        const failure = await observed;
+        expect(failure).toBeInstanceOf(Error);
+        expect(failure).toMatchObject({
+          message: expect.stringContaining("resource replacement refused"),
+        });
+        expect(hasModelFallbackStop(failure)).toBe(true);
+        expect(replacement).not.toHaveBeenCalled();
+        expect(owner.close).toHaveBeenCalledOnce();
+        expect(owner.capability.current()).toBeUndefined();
+        expect(cleanupScope.outcome).toBe("uncertain");
+        const next = await createOwner({ sessionId: owner.sessionId });
+        next.context.params.oneShotCliRun = true;
+        const nextRestart = expect(restartCliLiveSession(next.context)).rejects.toThrow(
+          "resource replacement refused",
+        );
+        await vi.advanceTimersByTimeAsync(10_000);
+        await nextRestart;
+        expect(() => next.register()).toThrow("cleanup has not settled");
+        owner.exited.resolve();
+        await restartCliLiveSession(next.context);
+        expect(() => next.register()).not.toThrow();
+      } finally {
+        owner.exited.resolve();
+        await observed;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("joins natural retirement that starts while restart is awaiting the previous owner", async () => {
+    const held = createDeferred();
+    const cleanup = vi.fn(() => held.promise);
+    const original = await createOwner({ cleanup });
+    original.register();
+    const next = await createOwner({ sessionId: original.sessionId });
+    let settled = false;
+    const restarting = restartCliLiveSession(next.context).then(() => {
+      settled = true;
+    });
+    original.capability.remove(original.session);
+    original.exited.resolve();
+    try {
+      await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+      expect(settled).toBe(false);
+    } finally {
+      held.resolve();
+      await restarting;
+    }
+    next.register();
+    expect(next.capability.current()).toBe(next.session);
+    expect(original.close).not.toHaveBeenCalled();
   });
 
   it("rejects the same process handle under a different owner despite a matching fingerprint", async () => {
@@ -306,26 +472,35 @@ describe("generic plugin-owned live session registry", () => {
     expect(original.capability.current()).toBeUndefined();
   });
 
-  it("fences MCP capture when its admitted authority closes during process transfer", async () => {
-    const original = await createOwner({
-      sessionId: "transfer-closed-owner",
-      capture: { token: "original-process-token", key: "original-capture" },
-    });
-    original.register();
-    const resumed = await createOwner({
-      sessionId: "transfer-closed-owner",
-      capture: { token: "replacement-turn-token", key: "replacement-capture" },
-    });
-    resumed.grant?.adoptProcessToken.mockImplementation(() => resumed.admission.close());
+  it.each(["admission", "caller"] as const)(
+    "fences MCP capture when %s authority closes during process transfer",
+    async (authority) => {
+      const original = await createOwner({
+        sessionId: "transfer-closed-owner",
+        capture: { token: "original-process-token", key: "original-capture" },
+      });
+      original.register();
+      const resumed = await createOwner({
+        sessionId: "transfer-closed-owner",
+        capture: { token: "replacement-turn-token", key: "replacement-capture" },
+      });
+      resumed.grant?.adoptProcessToken.mockImplementation(() => {
+        if (authority === "caller") {
+          resumed.revokeCaller();
+        } else {
+          resumed.admission.close();
+        }
+      });
 
-    expect(() => resumed.capability.activate(original.session)).toThrow("no longer active");
+      expect(() => resumed.capability.activate(original.session)).toThrow("no longer active");
 
-    expect(resumed.grant?.adoptProcessToken).toHaveBeenCalledExactlyOnceWith(
-      "original-process-token",
-    );
-    expect(resumed.beginCapture).not.toHaveBeenCalled();
-    expect(original.capability.current()).toBe(original.session);
-  });
+      expect(resumed.grant?.adoptProcessToken).toHaveBeenCalledExactlyOnceWith(
+        "original-process-token",
+      );
+      expect(resumed.beginCapture).not.toHaveBeenCalled();
+      expect(original.capability.current()).toBe(original.session);
+    },
+  );
 
   it.each([
     {
@@ -374,6 +549,132 @@ describe("generic plugin-owned live session registry", () => {
     expect(owner.close).toHaveBeenCalledWith("restart");
     expect(owner.waitForExit).toHaveBeenCalledOnce();
     expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it.each([false, true])(
+    "retains natural cleanup until replacement is safe (fails=%s)",
+    async (fails) => {
+      const held = createDeferred();
+      const failure = new Error("artifact cleanup failed");
+      const cleanup = vi.fn(async () => {
+        await held.promise;
+        if (fails) {
+          throw failure;
+        }
+      });
+      const original = await createOwner({ cleanup });
+      original.register();
+      original.capability.remove(original.session);
+      original.exited.resolve();
+      const successor = await createOwner({ sessionId: original.sessionId });
+      expect(() => successor.register()).toThrow("cleanup has not settled");
+      original.revokeCaller();
+      const completed = vi.fn();
+      const rejected = vi.fn();
+      const closing = closeCliLiveSession(original.context, "restart").then(completed, rejected);
+      try {
+        await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+        expect(successor.close).not.toHaveBeenCalled();
+        expect(completed).not.toHaveBeenCalled();
+        expect(rejected).not.toHaveBeenCalled();
+      } finally {
+        held.resolve();
+        await closing;
+      }
+      expect(fails ? rejected : completed).toHaveBeenCalledOnce();
+      if (fails) {
+        expect(rejected).toHaveBeenCalledWith(failure);
+        await expect(restartCliLiveSession(successor.context)).rejects.toBe(failure);
+        expect(() => successor.register()).toThrow("cleanup has not settled");
+      } else {
+        successor.register();
+        await closeCliLiveSession(original.context, "restart");
+        expect(successor.capability.current()).toBe(successor.session);
+      }
+    },
+  );
+
+  it.each([
+    "agent-error",
+    "agent-and-cleanup-error",
+    "cleanup-error",
+    "delivered-cleanup-error",
+    "stalled",
+  ] as const)("retains the natural cleanup result through settlement: %s", async (outcome) => {
+    vi.useFakeTimers();
+    const held = createDeferred();
+    const originalError = new Error("original agent failure");
+    const cleanupError = new Error("registered cleanup failure");
+    const owner = await createOwner({
+      cleanup: async () => {
+        if (outcome === "stalled") {
+          await held.promise;
+        } else if (outcome !== "agent-error") {
+          throw cleanupError;
+        }
+      },
+    });
+    owner.context.params.oneShotCliRun = true;
+    owner.context.params.cleanupCliLiveSessionOnRunEnd = true;
+    owner.register();
+    owner.capability.remove(owner.session);
+    owner.exited.resolve();
+    const cleanupScope = createAgentCleanupScope();
+    const result = {
+      payloads: [{ text: "original delivery" }],
+      meta: { durationMs: 1 },
+      didSendViaMessagingTool: outcome === "delivered-cleanup-error",
+    };
+    const run = cleanupScope.run(() =>
+      settlePreparedCliRun({
+        context: owner.context,
+        run: async () => {
+          if (outcome === "agent-error" || outcome === "agent-and-cleanup-error") {
+            throw originalError;
+          }
+          return result;
+        },
+      }),
+    );
+    let settled = false;
+    const observed = run
+      .then(
+        (value) => ({ value }),
+        (error: unknown) => ({ error }),
+      )
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    try {
+      if (outcome === "stalled") {
+        await vi.advanceTimersByTimeAsync(9999);
+        expect(settled).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+      }
+      expect(await observed).toEqual(
+        outcome === "agent-error" || outcome === "agent-and-cleanup-error"
+          ? { error: originalError }
+          : outcome === "cleanup-error"
+            ? { error: cleanupError }
+            : { value: result },
+      );
+      expect(cleanupScope.outcome).toBe(outcome === "agent-error" ? "closed" : "uncertain");
+    } finally {
+      held.resolve();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let a previous turn close a process activated by its successor", async () => {
+    const original = await createOwner({ sessionId: "transferred-close" });
+    original.register();
+    const successor = await createOwner({ sessionId: "transferred-close" });
+    successor.capability.activate(original.session);
+    await closeCliLiveSession(original.context, "restart");
+    expect(original.close).not.toHaveBeenCalled();
+    await closeCliLiveSession(successor.context, "restart");
+    expect(original.close).toHaveBeenCalledOnce();
   });
 
   it("evicts an idle owner at capacity and fails closed when every owner is active", async () => {

--- a/src/agents/cli-runner/cli-live-session-registry.test.ts
+++ b/src/agents/cli-runner/cli-live-session-registry.test.ts
@@ -400,16 +400,25 @@ describe("generic plugin-owned live session registry", () => {
     expect(original.close).not.toHaveBeenCalled();
   });
 
-  it("rejects the same process handle under a different owner despite a matching fingerprint", async () => {
-    const original = await createOwner({ sessionId: "original-owner" });
-    const other = await createOwner({ sessionId: "different-owner" });
-    original.register();
-
-    expect(other.capability.fingerprint).toBe(original.capability.fingerprint);
-    expect(() => other.capability.register(original.session)).toThrow();
-    expect(other.capability.current()).toBeUndefined();
-    expect(original.capability.current()).toBe(original.session);
-  });
+  it.each([false, true])(
+    "rejects the same process handle under a different owner (retired=%s)",
+    async (retired) => {
+      const original = await createOwner({ sessionId: "original-owner" });
+      const other = await createOwner({ sessionId: "different-owner" });
+      original.register();
+      if (retired) {
+        original.capability.remove(original.session);
+      }
+      try {
+        expect(other.capability.fingerprint).toBe(original.capability.fingerprint);
+        expect(() => other.capability.register(original.session)).toThrow();
+        expect(other.capability.current()).toBeUndefined();
+        expect(original.capability.current()).toBe(retired ? undefined : original.session);
+      } finally {
+        other.capability.remove(original.session);
+      }
+    },
+  );
 
   it.each([
     {
@@ -645,9 +654,9 @@ describe("generic plugin-owned live session registry", () => {
         (value) => ({ value }),
         (error: unknown) => ({ error }),
       )
-      .then((result) => {
+      .then((settledOutcome) => {
         settled = true;
-        return result;
+        return settledOutcome;
       });
     try {
       if (outcome === "stalled") {

--- a/src/agents/cli-runner/cli-live-session-registry.ts
+++ b/src/agents/cli-runner/cli-live-session-registry.ts
@@ -37,6 +37,7 @@ type CliLiveSessionRecord = {
 
 const liveSessions = new Map<string, CliLiveSessionRecord>();
 const retiredSessionCleanup = new Map<string, Promise<void>>();
+const retiringSessionHandles = new WeakSet<CliBackendLiveSessionHandle>();
 
 function buildCliLiveRegistryKey(owner: CliLiveSessionOwner): string {
   return `${owner.backendId}:${buildCliLiveOwnerKey(owner)}`;
@@ -255,6 +256,7 @@ export function createCliLiveSessionCapability(params: {
         !handle.generation.trim() ||
         liveSessions.has(ownerKey) ||
         // Owner keys stay private; one process handle must never cross owners.
+        retiringSessionHandles.has(handle) ||
         Array.from(liveSessions.values()).some((record) => record.handle === handle)
       ) {
         throw new Error("CLI live session registration does not match its admitted owner.");
@@ -304,11 +306,13 @@ export function createCliLiveSessionCapability(params: {
       record.capture?.revoke();
       liveSessions.delete(ownerKey);
       record.approvalGrants.clear();
+      retiringSessionHandles.add(handle);
       // Native runtime artifacts remain process-owned until its child exits.
-      record.cleanupPromise = handle
-        .waitForExit()
+      record.cleanupPromise = Promise.resolve()
+        .then(() => handle.waitForExit())
         .then(() => record.cleanup?.())
         .then(() => {
+          retiringSessionHandles.delete(handle);
           if (retiredSessionCleanup.get(ownerKey) === record.cleanupPromise) {
             retiredSessionCleanup.delete(ownerKey);
           }

--- a/src/agents/cli-runner/cli-live-session-registry.ts
+++ b/src/agents/cli-runner/cli-live-session-registry.ts
@@ -4,6 +4,7 @@ import type {
   CliBackendLiveSessionCloseReason,
   CliBackendLiveSessionHandle,
 } from "../../plugins/cli-backend.types.js";
+import { runCliCleanup } from "./cleanup.js";
 import { createCliRunCurrentAssertion } from "./execution-target.js";
 import { createCliFailoverError } from "./exit-error.js";
 import { buildCliLiveSessionFingerprint } from "./live-session-fingerprint.js";
@@ -23,6 +24,7 @@ type CliLiveSessionOwner = {
 
 type CliLiveSessionRecord = {
   handle: CliBackendLiveSessionHandle;
+  owner: PreparedCliRunContext["preparedBackend"];
   approvalGrants: Set<string>;
   cleanup?: () => Promise<void>;
   cleanupPromise?: Promise<void>;
@@ -34,6 +36,7 @@ type CliLiveSessionRecord = {
 };
 
 const liveSessions = new Map<string, CliLiveSessionRecord>();
+const retiredSessionCleanup = new Map<string, Promise<void>>();
 
 function buildCliLiveRegistryKey(owner: CliLiveSessionOwner): string {
   return `${owner.backendId}:${buildCliLiveOwnerKey(owner)}`;
@@ -85,14 +88,66 @@ export async function closeCliLiveSession(
   context: PreparedCliRunContext,
   reason: CliBackendLiveSessionCloseReason,
 ): Promise<void> {
-  const record = liveSessions.get(buildCliLiveSessionKey(context));
-  if (!record) {
-    return;
+  await runCliCleanup(context.params, "cli-live-session-close", async () => {
+    await context.preparedBackend.closeLiveSession?.(reason);
+  });
+}
+
+/** Explicit fresh/fork execution owns replacement of the current idle process. */
+export async function restartCliLiveSession(
+  context: PreparedCliRunContext,
+  signal = context.params.abortSignal,
+): Promise<void> {
+  const assertActive = createCliRunCurrentAssertion(context.params, signal);
+  assertActive();
+  const key = buildCliLiveSessionKey(context);
+  const record = liveSessions.get(key);
+  const pendingCleanup = retiredSessionCleanup.get(key);
+  await runCliCleanup(
+    context.params,
+    "cli-live-session-close",
+    async () => {
+      assertActive();
+      await context.preparedBackend.closeLiveSession?.("restart");
+      await pendingCleanup;
+    },
+    "required",
+  );
+  if (record) {
+    await runCliCleanup(
+      context.params,
+      "cli-live-session-restart",
+      () => {
+        // One-shot cleanup schedules this callback; fence the actual close.
+        assertActive();
+        return closeRecord(record, "restart");
+      },
+      "required",
+    );
   }
-  // close removes its registry record synchronously; retain the private record
-  // until its original child exits and process-owned artifacts finish cleanup.
-  record.handle.close(reason);
+  assertActive();
+}
+
+async function closeRecord(
+  record: CliLiveSessionRecord,
+  reason: CliBackendLiveSessionCloseReason,
+): Promise<void> {
+  if (!record.cleanupPromise) {
+    record.handle.close(reason);
+  }
   await (record.cleanupPromise ?? record.handle.waitForExit());
+}
+
+function retainCleanup(context: PreparedCliRunContext, record: CliLiveSessionRecord): void {
+  const owner = context.preparedBackend;
+  record.owner = owner;
+  owner.closeLiveSession = async (reason) => {
+    // Natural removal retains this exact cleanup promise. A later turn may
+    // borrow the live process, but the old turn cannot close that successor.
+    if (record.owner === owner || record.cleanupPromise) {
+      await closeRecord(record, reason);
+    }
+  };
 }
 
 function ensureCliLiveSessionCapacity(context: PreparedCliRunContext): void {
@@ -189,6 +244,9 @@ export function createCliLiveSessionCapability(params: {
     },
     register: (handle) => {
       assertActive();
+      if (retiredSessionCleanup.has(ownerKey)) {
+        throw new Error("Previous CLI live session cleanup has not settled.");
+      }
       if (params.requiredGeneration) {
         throw requiredSessionError("cli_live_session_changed");
       }
@@ -205,6 +263,7 @@ export function createCliLiveSessionCapability(params: {
       const cleanup = params.claimResources?.();
       const record: CliLiveSessionRecord = {
         handle,
+        owner: params.context.preparedBackend,
         approvalGrants: new Set(),
         ...(cleanup ? { cleanup } : {}),
         ...(grant && params.captureKey
@@ -218,6 +277,7 @@ export function createCliLiveSessionCapability(params: {
           : {}),
       };
       liveSessions.set(ownerKey, record);
+      retainCleanup(params.context, record);
       cliBackendLog.info(
         `cli live session start: provider=${params.context.backendResolved.id} model=${params.context.normalizedModel} activeSessions=${liveSessions.size}`,
       );
@@ -234,6 +294,7 @@ export function createCliLiveSessionCapability(params: {
         requireRegisteredRecord(handle);
         params.beginCapture(record.capture.key);
       }
+      retainCleanup(params.context, record);
     },
     remove: (handle) => {
       const record = liveSessions.get(ownerKey);
@@ -243,13 +304,20 @@ export function createCliLiveSessionCapability(params: {
       record.capture?.revoke();
       liveSessions.delete(ownerKey);
       record.approvalGrants.clear();
-      if (record.cleanup) {
-        // Native runtime artifacts remain process-owned until its child exits.
-        record.cleanupPromise = handle.waitForExit().then(record.cleanup);
-        void record.cleanupPromise.catch((error: unknown) => {
-          cliBackendLog.warn(`cli live session cleanup failed: ${String(error)}`);
+      // Native runtime artifacts remain process-owned until its child exits.
+      record.cleanupPromise = handle
+        .waitForExit()
+        .then(() => record.cleanup?.())
+        .then(() => {
+          if (retiredSessionCleanup.get(ownerKey) === record.cleanupPromise) {
+            retiredSessionCleanup.delete(ownerKey);
+          }
         });
-      }
+      // A fresh prepared context must still join the retired owner after a timeout.
+      retiredSessionCleanup.set(ownerKey, record.cleanupPromise);
+      void record.cleanupPromise.catch((error: unknown) => {
+        cliBackendLog.warn(`cli live session cleanup failed: ${String(error)}`);
+      });
     },
   });
 }

--- a/src/agents/cli-runner/cli-run-settlement.ts
+++ b/src/agents/cli-runner/cli-run-settlement.ts
@@ -21,7 +21,9 @@ import { resolveAuthProfileFailureReason } from "../embedded-agent-runner/run/au
 import { buildEmbeddedRunPayloads } from "../embedded-agent-runner/run/payloads.js";
 import { mergeAttemptToolMediaPayloads } from "../embedded-agent-runner/run/tool-media-payloads.js";
 import { coerceToFailoverError, isFailoverError } from "../failover-error.js";
+import { recordAgentCleanupFailure } from "../run-cleanup-timeout.js";
 import { CliAuthProfilePreparationError } from "./auth-profile-preparation-error.js";
+import { runCliCleanup } from "./cleanup.js";
 import { hashCliReseedPrompt } from "./reseed-envelope.js";
 import type { ClaudeCliRunDiagnosticLifecycle } from "./run-diagnostics.js";
 import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
@@ -177,6 +179,7 @@ export async function settlePreparedCliRun(params: {
   const terminalRunError = runError;
   let cleanupError: unknown;
   const recordCleanupError = (error: unknown) => {
+    recordAgentCleanupFailure();
     cleanupError ??= error;
   };
   if (runParams.cleanupCliLiveSessionOnRunEnd === true) {
@@ -192,10 +195,12 @@ export async function settlePreparedCliRun(params: {
     // a newer run. Never retire the newer runtime or close the shared listener.
     try {
       const { retireSessionMcpRuntime } = await import("../agent-bundle-mcp-tools.js");
-      await retireSessionMcpRuntime({
-        sessionId: runParams.sessionId,
-        reason: "cli-run-end",
-        onError: recordCleanupError,
+      await runCliCleanup(runParams, "cli-bundle-mcp-retire", async () => {
+        await retireSessionMcpRuntime({
+          sessionId: runParams.sessionId,
+          reason: "cli-run-end",
+          onError: recordCleanupError,
+        });
       });
     } catch (error) {
       recordCleanupError(error);
@@ -692,6 +697,7 @@ export function settleCliBackendOutcome(params: {
     runResult,
   } = params;
   if (cleanupError) {
+    recordAgentCleanupFailure();
     if (!deliveredMessagingSideEffect) {
       if (runFailed) {
         log.warn(`CLI run also failed before backend cleanup: ${formatErrorMessage(runError)}`);

--- a/src/agents/cli-runner/execute-plugin.policy.test.ts
+++ b/src/agents/cli-runner/execute-plugin.policy.test.ts
@@ -1,37 +1,26 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type {
-  CliBackendExecute,
-  CliBackendExecuteContext,
-  CliBackendToolPermissionResult,
-} from "../../plugins/cli-backend.types.js";
+import type { CliBackendToolPermissionResult } from "../../plugins/cli-backend.types.js";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../../plugins/hook-runner-global.js";
 import type { PluginHookHandlerMap } from "../../plugins/hook-types.js";
 import { createMockPluginRegistry } from "../../plugins/hooks.test-fixtures.js";
-import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
 import * as beforeToolCall from "../agent-tools.before-tool-call.js";
-import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { callGatewayTool } from "../tools/gateway.js";
-import { executePluginOwnedProcess } from "./execute-plugin.js";
-import type { PreparedCliRunContext } from "./types.js";
+import {
+  closePluginTestAdmissions,
+  createExecution,
+  requestNativeTool,
+  runPlugin,
+  SUCCESS_RESULT,
+} from "./execute-plugin.test-support.js";
 
 vi.mock("../tools/gateway.js", () => ({
   callGatewayTool: vi.fn(),
 }));
 
 const mockCallGatewayTool = vi.mocked(callGatewayTool);
-const activeAdmissions: Array<ReturnType<typeof prepareSystemAgentRunAdmission>> = [];
-let nextRunId = 0;
-
-const SUCCESS_RESULT = {
-  type: "result",
-  subtype: "success",
-  is_error: false,
-  result: "completed",
-  session_id: "sdk-session",
-};
 
 function installBeforeToolCallHook(
   handler: PluginHookHandlerMap["before_tool_call"],
@@ -48,75 +37,40 @@ function installBeforeToolCallHook(
   );
 }
 
-async function createExecution(
-  options: { nativeTools?: string[]; abortSignal?: AbortSignal } = {},
-) {
-  const runId = "plugin-policy-" + ++nextRunId;
-  const config = { tools: { exec: { security: "full" as const, ask: "off" as const } } };
-  const admission = prepareSystemAgentRunAdmission(config, runId, "main", "plugin-test");
-  activeAdmissions.push(admission);
-  const context = buildPreparedCliRunContext({
-    provider: "claude-cli",
-    model: "claude-sonnet-4-6",
-    agentId: "main",
-    runId,
-    sessionId: "sdk-session",
-    sessionKey: "agent:main:main",
-    prompt: "hello",
-    config,
-    executionMode: "agent",
-    timeoutMs: 5_000,
-    ...(options.nativeTools
-      ? { cliToolAvailability: { native: options.nativeTools, openClaw: [] } }
-      : {}),
-    systemPrompt: "Follow host policy.",
-    backend: { command: "/bin/sh", args: [] },
-  });
-  context.params.admittedRunContext = await admission.admit("plugin-harness");
-  if (options.abortSignal) {
-    context.params.abortSignal = options.abortSignal;
-  }
-  return { admission, context };
-}
-
-function runPlugin(context: PreparedCliRunContext, execute: CliBackendExecute) {
-  return executePluginOwnedProcess({
-    context,
-    execute,
-    executionCommand: "/bin/sh",
-    executionArgs: ["-p", "--permission-mode", "bypassPermissions"],
-    env: { PATH: "/bin:/usr/bin" },
-    prompt: context.params.prompt,
-    useResume: false,
-    sessionId: "sdk-session",
-    noOutputTimeoutMs: 2_000,
-    consumeStdout: () => {},
-  });
-}
-
-function requestNativeTool(
-  execution: CliBackendExecuteContext,
-  toolName = "Bash",
-  toolInput: Record<string, unknown> = { command: "echo approved" },
-) {
-  return execution.requestToolPermission({
-    toolName,
-    toolInput,
-    toolCallId: "native-" + toolName,
-    ...(execution.abortSignal ? { abortSignal: execution.abortSignal } : {}),
-  });
-}
-
 afterEach(() => {
   resetGlobalHookRunner();
-  for (const admission of activeAdmissions.splice(0)) {
-    admission.close();
-  }
+  closePluginTestAdmissions();
   mockCallGatewayTool.mockReset();
   vi.restoreAllMocks();
 });
 
 describe("plugin-owned CLI native tool policy", () => {
+  it("denies native tools when caller authority expires during policy or before a retained call", async () => {
+    const { context } = await createExecution({ nativeTools: ["WebFetch"] });
+    let callerCurrent = true;
+    context.params.assertCurrent = () => {
+      if (!callerCurrent) {
+        throw new Error("caller revoked");
+      }
+    };
+    const hook = vi.fn(async () => {
+      callerCurrent = false;
+    });
+    installBeforeToolCallHook(hook);
+    await runPlugin(context, async function* (execution) {
+      await expect(
+        requestNativeTool(execution, "WebFetch", { url: "https://example.com" }),
+      ).resolves.toMatchObject({ behavior: "deny" });
+      await expect(
+        requestNativeTool(execution, "WebFetch", { url: "https://example.com/retained" }),
+      ).resolves.toMatchObject({ behavior: "deny" });
+      expect(execution.abortSignal?.aborted).toBe(false);
+      yield SUCCESS_RESULT;
+    });
+    expect(hook).toHaveBeenCalledOnce();
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("runs canonical policy before native approval and carries rewritten params plus run context", async () => {
     const policy = vi.spyOn(beforeToolCall, "runBeforeToolCallHook");
     const hook = vi.fn(async (_event: unknown, _context: unknown) => ({

--- a/src/agents/cli-runner/execute-plugin.test-support.ts
+++ b/src/agents/cli-runner/execute-plugin.test-support.ts
@@ -1,0 +1,131 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type {
+  CliBackendExecute,
+  CliBackendExecuteContext,
+} from "../../plugins/cli-backend.types.js";
+import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
+import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { executePluginOwnedProcess } from "./execute-plugin.js";
+import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
+
+const activeAdmissions: Array<ReturnType<typeof prepareSystemAgentRunAdmission>> = [];
+let nextRunId = 0;
+
+export const SUCCESS_RESULT = {
+  type: "result",
+  subtype: "success",
+  is_error: false,
+  result: "completed",
+  session_id: "sdk-session",
+};
+
+export async function createExecution(
+  options: {
+    config?: OpenClawConfig;
+    sessionEntry?: RunCliAgentParams["sessionEntry"];
+    nativeTools?: string[];
+    abortSignal?: AbortSignal;
+    timeoutMs?: number;
+    runId?: string;
+    resumeArgs?: string[];
+  } = {},
+) {
+  const runId = options.runId ?? `plugin-owner-${++nextRunId}`;
+  const config = options.config ?? { tools: { exec: { security: "full", ask: "off" } } };
+  const admission = prepareSystemAgentRunAdmission(config, runId, "main", "plugin-test");
+  activeAdmissions.push(admission);
+  const context = buildPreparedCliRunContext({
+    provider: "claude-cli",
+    model: "claude-sonnet-4-6",
+    agentId: "main",
+    runId,
+    sessionId: "sdk-session",
+    sessionKey: "agent:main:main",
+    prompt: "hello",
+    config,
+    executionMode: "agent",
+    timeoutMs: options.timeoutMs ?? 5_000,
+    sessionEntry: options.sessionEntry,
+    ...(options.nativeTools
+      ? { cliToolAvailability: { native: options.nativeTools, openClaw: [] } }
+      : {}),
+    systemPrompt: "  Follow host policy.  ",
+    backend: {
+      command: "/bin/sh",
+      args: [],
+      ...(options.resumeArgs ? { resumeArgs: options.resumeArgs } : {}),
+    },
+  });
+  context.params.admittedRunContext = await admission.admit("plugin-harness");
+  if (options.abortSignal) {
+    context.params.abortSignal = options.abortSignal;
+  }
+
+  return { admission, context };
+}
+
+export function runPlugin(
+  context: PreparedCliRunContext,
+  execute: CliBackendExecute,
+  options: {
+    noOutputTimeoutMs?: number;
+    consumeStdout?: (chunk: string) => void;
+    sessionId?: string;
+    useResume?: boolean;
+    forceNewSession?: boolean;
+    liveSession?: boolean;
+    requiredGeneration?: string;
+    onNoOutputTimeout?: NonNullable<
+      Parameters<typeof executePluginOwnedProcess>[0]["onNoOutputTimeout"]
+    >;
+    onOutstandingWorkChange?: (active: boolean) => void;
+    onInterrupted?: (reason: "aborted" | "timeout") => boolean;
+  } = {},
+) {
+  return executePluginOwnedProcess({
+    context,
+    execute,
+    executionCommand: "/bin/sh",
+    executionArgs: ["-p", "--permission-mode", "bypassPermissions"],
+    env: { PATH: "/bin:/usr/bin", OPENCLAW_TEST_MARKER: "host-owned" },
+    prompt: context.params.prompt,
+    promptContext: context.promptContext,
+    useResume: options.useResume ?? Boolean(options.requiredGeneration),
+    sessionId: options.sessionId ?? "sdk-session",
+    ...(options.forceNewSession ? { forceNewSession: true } : {}),
+    ...(options.liveSession || options.requiredGeneration
+      ? {
+          liveSession: {
+            beginCapture: () => {},
+            ...(options.requiredGeneration
+              ? { requiredGeneration: options.requiredGeneration }
+              : {}),
+          },
+        }
+      : {}),
+    ...(options.onNoOutputTimeout ? { onNoOutputTimeout: options.onNoOutputTimeout } : {}),
+    onOutstandingWorkChange: options.onOutstandingWorkChange,
+    ...(options.onInterrupted ? { onInterrupted: options.onInterrupted } : {}),
+    noOutputTimeoutMs: options.noOutputTimeoutMs ?? 2_000,
+    consumeStdout: options.consumeStdout ?? (() => {}),
+  });
+}
+
+export function requestNativeTool(
+  execution: CliBackendExecuteContext,
+  toolName = "Bash",
+  toolInput: Record<string, unknown> = { command: "echo approved" },
+) {
+  return execution.requestToolPermission({
+    toolName,
+    toolInput,
+    toolCallId: `native-${toolName}`,
+    ...(execution.abortSignal ? { abortSignal: execution.abortSignal } : {}),
+  });
+}
+
+export function closePluginTestAdmissions(): void {
+  for (const admission of activeAdmissions.splice(0)) {
+    admission.close();
+  }
+}

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -8,124 +8,27 @@ import type {
   CliBackendLiveSessionHandle,
   CliBackendToolPermissionResult,
 } from "../../plugins/cli-backend.types.js";
-import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
-import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
+import { resolveAdmittedRunActiveAssertion } from "../admitted-run-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import {
   closeCliLiveSession,
   createCliLiveSessionCapability,
 } from "./cli-live-session-registry.js";
-import { executePluginOwnedProcess } from "./execute-plugin.js";
-import type { PreparedCliRunContext, RunCliAgentParams } from "./types.js";
+import {
+  closePluginTestAdmissions,
+  createExecution,
+  requestNativeTool,
+  runPlugin,
+  SUCCESS_RESULT,
+} from "./execute-plugin.test-support.js";
+import type { PreparedCliRunContext } from "./types.js";
 
 vi.mock("../tools/gateway.js", () => ({
   callGatewayTool: vi.fn(),
 }));
 
 const mockCallGatewayTool = vi.mocked(callGatewayTool);
-const activeAdmissions: Array<ReturnType<typeof prepareSystemAgentRunAdmission>> = [];
 const activeSessions = new Set<CliBackendLiveSessionHandle>();
-let nextRunId = 0;
-
-const SUCCESS_RESULT = {
-  type: "result",
-  subtype: "success",
-  is_error: false,
-  result: "completed",
-  session_id: "sdk-session",
-};
-
-async function createExecution(
-  options: {
-    config?: OpenClawConfig;
-    sessionEntry?: RunCliAgentParams["sessionEntry"];
-    nativeTools?: string[];
-    abortSignal?: AbortSignal;
-    timeoutMs?: number;
-    runId?: string;
-    resumeArgs?: string[];
-  } = {},
-) {
-  const runId = options.runId ?? `plugin-owner-${++nextRunId}`;
-  const config = options.config ?? { tools: { exec: { security: "full", ask: "off" } } };
-  const admission = prepareSystemAgentRunAdmission(config, runId, "main", "plugin-test");
-  activeAdmissions.push(admission);
-  const context = buildPreparedCliRunContext({
-    provider: "claude-cli",
-    model: "claude-sonnet-4-6",
-    agentId: "main",
-    runId,
-    sessionId: "sdk-session",
-    sessionKey: "agent:main:main",
-    prompt: "hello",
-    config,
-    executionMode: "agent",
-    timeoutMs: options.timeoutMs ?? 5_000,
-    sessionEntry: options.sessionEntry,
-    ...(options.nativeTools
-      ? { cliToolAvailability: { native: options.nativeTools, openClaw: [] } }
-      : {}),
-    systemPrompt: "  Follow host policy.  ",
-    backend: {
-      command: "/bin/sh",
-      args: [],
-      ...(options.resumeArgs ? { resumeArgs: options.resumeArgs } : {}),
-    },
-  });
-  context.params.admittedRunContext = await admission.admit("plugin-harness");
-  if (options.abortSignal) {
-    context.params.abortSignal = options.abortSignal;
-  }
-
-  return { admission, context };
-}
-
-function runPlugin(
-  context: PreparedCliRunContext,
-  execute: CliBackendExecute,
-  options: {
-    noOutputTimeoutMs?: number;
-    consumeStdout?: (chunk: string) => void;
-    sessionId?: string;
-    useResume?: boolean;
-    forceNewSession?: boolean;
-    liveSession?: boolean;
-    requiredGeneration?: string;
-    onNoOutputTimeout?: NonNullable<
-      Parameters<typeof executePluginOwnedProcess>[0]["onNoOutputTimeout"]
-    >;
-    onOutstandingWorkChange?: (active: boolean) => void;
-    onInterrupted?: (reason: "aborted" | "timeout") => boolean;
-  } = {},
-) {
-  return executePluginOwnedProcess({
-    context,
-    execute,
-    executionCommand: "/bin/sh",
-    executionArgs: ["-p", "--permission-mode", "bypassPermissions"],
-    env: { PATH: "/bin:/usr/bin", OPENCLAW_TEST_MARKER: "host-owned" },
-    prompt: context.params.prompt,
-    promptContext: context.promptContext,
-    useResume: options.useResume ?? Boolean(options.requiredGeneration),
-    sessionId: options.sessionId ?? "sdk-session",
-    ...(options.forceNewSession ? { forceNewSession: true } : {}),
-    ...(options.liveSession || options.requiredGeneration
-      ? {
-          liveSession: {
-            beginCapture: () => {},
-            ...(options.requiredGeneration
-              ? { requiredGeneration: options.requiredGeneration }
-              : {}),
-          },
-        }
-      : {}),
-    ...(options.onNoOutputTimeout ? { onNoOutputTimeout: options.onNoOutputTimeout } : {}),
-    onOutstandingWorkChange: options.onOutstandingWorkChange,
-    ...(options.onInterrupted ? { onInterrupted: options.onInterrupted } : {}),
-    noOutputTimeoutMs: options.noOutputTimeoutMs ?? 2_000,
-    consumeStdout: options.consumeStdout ?? (() => {}),
-  });
-}
 
 function registerOwnerSession(context: PreparedCliRunContext, generation: string) {
   const capability = createCliLiveSessionCapability({
@@ -165,27 +68,12 @@ function waitUntilAborted(execution: CliBackendExecuteContext): Promise<void> {
   });
 }
 
-function requestNativeTool(
-  execution: CliBackendExecuteContext,
-  toolName = "Bash",
-  toolInput: Record<string, unknown> = { command: "echo approved" },
-) {
-  return execution.requestToolPermission({
-    toolName,
-    toolInput,
-    toolCallId: `native-${toolName}`,
-    ...(execution.abortSignal ? { abortSignal: execution.abortSignal } : {}),
-  });
-}
-
 afterEach(() => {
   for (const session of activeSessions) {
     session.close("restart");
   }
   activeSessions.clear();
-  for (const admission of activeAdmissions.splice(0)) {
-    admission.close();
-  }
+  closePluginTestAdmissions();
   mockCallGatewayTool.mockReset();
   vi.restoreAllMocks();
   vi.useRealTimers();
@@ -235,78 +123,161 @@ describe("plugin-owned CLI execution host boundary", () => {
     );
   });
 
-  it("runs plugin user questions through the shared Gateway question flow", async () => {
-    const { context } = await createExecution({
-      runId: "plugin-user-input",
-      nativeTools: ["AskUserQuestion"],
-    });
-    context.params.sessionKey = "main";
-    context.params.runtimePolicySessionKey = "agent:main:telegram:default:direct:canonical-sender";
-    let promptDelivered = createDeferred();
-    const onBlockReply = vi.fn(async () => {
-      promptDelivered.resolve();
-    });
-    context.params.onBlockReply = onBlockReply;
-    const requests = new Map<string, { questions: Array<{ questionId: string }> }>();
-    mockCallGatewayTool.mockImplementation(async (method, _opts, rawParams) => {
-      const params = rawParams as {
-        id: string;
-        questions?: Array<{ questionId: string }>;
-        sessionKey?: string;
-      };
-      if (method === "question.request") {
-        expect(params.sessionKey).toBe(context.params.sessionKey);
-        requests.set(params.id, { questions: params.questions ?? [] });
-        return { id: params.id };
-      }
-      if (method === "question.waitAnswer") {
-        const request = requests.get(params.id);
-        await promptDelivered.promise;
-        promptDelivered = createDeferred();
-        return {
-          status: "answered",
-          answers: {
-            answers: Object.fromEntries(
-              (request?.questions ?? []).map((question) => [
-                question.questionId,
-                [question.questionId],
-              ]),
-            ),
-          },
-        };
-      }
-      if (method === "question.resolve") {
-        return { status: "cancelled" };
-      }
-      throw new Error(`Unexpected Gateway method: ${method}`);
-    });
-    let result: unknown;
-
-    await runPlugin(context, async function* (execution) {
-      result = await execution.requestUserInput({
-        toolName: "AskUserQuestion",
-        toolCallId: "claude-question",
-        questions: [
-          {
-            id: "one",
-            header: "One",
-            question: "First question?",
-            isOther: true,
-            options: [{ label: "A" }, { label: "B" }],
-          },
-        ],
+  it.each([false, true])(
+    "runs plugin user questions with current caller authority (revoked=%s)",
+    async (revoked) => {
+      const { context } = await createExecution({
+        runId: "plugin-user-input",
+        nativeTools: ["AskUserQuestion"],
       });
+      context.params.sessionKey = "main";
+      let callerCurrent = true;
+      context.params.assertCurrent = () => {
+        if (!callerCurrent) {
+          throw new Error("caller revoked");
+        }
+      };
+      context.params.runtimePolicySessionKey =
+        "agent:main:telegram:default:direct:canonical-sender";
+      let promptDelivered = createDeferred();
+      const onBlockReply = vi.fn(async () => {
+        promptDelivered.resolve();
+      });
+      context.params.onBlockReply = onBlockReply;
+      const requests = new Map<string, { questions: Array<{ questionId: string }> }>();
+      mockCallGatewayTool.mockImplementation(async (method, _opts, rawParams) => {
+        const params = rawParams as {
+          id: string;
+          questions?: Array<{ questionId: string }>;
+          sessionKey?: string;
+        };
+        if (method === "question.request") {
+          expect(params.sessionKey).toBe(context.params.sessionKey);
+          requests.set(params.id, { questions: params.questions ?? [] });
+          return { id: params.id };
+        }
+        if (method === "question.waitAnswer") {
+          const request = requests.get(params.id);
+          await promptDelivered.promise;
+          promptDelivered = createDeferred();
+          callerCurrent = !revoked;
+          return {
+            status: "answered",
+            answers: {
+              answers: Object.fromEntries(
+                (request?.questions ?? []).map((question) => [
+                  question.questionId,
+                  [question.questionId],
+                ]),
+              ),
+            },
+          };
+        }
+        if (method === "question.resolve") {
+          return { status: "cancelled" };
+        }
+        throw new Error(`Unexpected Gateway method: ${method}`);
+      });
+      let result: unknown;
+
+      await runPlugin(context, async function* (execution) {
+        result = await execution.requestUserInput({
+          toolName: "AskUserQuestion",
+          toolCallId: "claude-question",
+          questions: [
+            {
+              id: "one",
+              header: "One",
+              question: "First question?",
+              isOther: true,
+              options: [{ label: "A" }, { label: "B" }],
+            },
+          ],
+        });
+        yield SUCCESS_RESULT;
+      });
+
+      expect(result).toEqual(
+        revoked
+          ? expect.objectContaining({ status: "cancelled" })
+          : {
+              status: "answered",
+              answers: {
+                one: ["one"],
+              },
+            },
+      );
+      expect([...requests.keys()]).toEqual(["claude-question:0"]);
+      expect(onBlockReply).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["caller", "admission"] as const)(
+    "rejects %s revocation before restart or plugin execution",
+    async (authority) => {
+      const { context, admission } = await createExecution();
+      const session = registerOwnerSession(context, "dispatch-owner");
+      if (authority === "caller") {
+        context.params.assertCurrent = () => {
+          throw new Error("caller revoked");
+        };
+      } else {
+        admission.close();
+      }
+      const execute = vi.fn(async function* () {
+        yield SUCCESS_RESULT;
+      });
+      await expect(
+        runPlugin(context, execute, { liveSession: true, forceNewSession: true }),
+      ).rejects.toThrow();
+      expect(session.close).not.toHaveBeenCalled();
+      expect(execute).not.toHaveBeenCalled();
+      await expect(runPlugin(context, execute)).rejects.toThrow();
+      expect(execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not close a successor or execute after caller revocation during restart cleanup", async () => {
+    const { context } = await createExecution();
+    const successor = await createExecution();
+    const session = registerOwnerSession(successor.context, "successor-during-restart");
+    const entered = createDeferred();
+    const held = createDeferred();
+    let callerCurrent = true;
+    context.params.assertCurrent = () => {
+      if (!callerCurrent) {
+        throw new Error("caller revoked");
+      }
+    };
+    context.preparedBackend.closeLiveSession = async () => {
+      entered.resolve();
+      await held.promise;
+    };
+    const execute = vi.fn(async function* () {
       yield SUCCESS_RESULT;
     });
-
-    expect(result).toEqual({
-      status: "answered",
-      answers: {
-        one: ["one"],
+    const run = runPlugin(context, execute, { liveSession: true, forceNewSession: true });
+    const observed = run.catch((error: unknown) => error);
+    try {
+      await entered.promise;
+      callerCurrent = false;
+      expect(resolveAdmittedRunActiveAssertion(context.params.admittedRunContext)).toBeTypeOf(
+        "function",
+      );
+    } finally {
+      held.resolve();
+    }
+    expect(await observed).toEqual(new Error("caller revoked"));
+    expect(session.close).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+    await runPlugin(
+      successor.context,
+      async function* (execution) {
+        expect(execution.liveSession?.current()).toBe(session.handle);
+        yield SUCCESS_RESULT;
       },
-    });
-    expect([...requests.keys()]).toEqual(["claude-question:0"]);
-    expect(onBlockReply).toHaveBeenCalledOnce();
+      { liveSession: true },
+    );
   });
 
   it("restarts true fresh sessions while preserving legitimate no-resume warm reuse", async () => {
@@ -653,26 +624,39 @@ describe("plugin-owned CLI execution host boundary", () => {
     expect(mockCallGatewayTool).toHaveBeenCalledTimes(2);
   });
 
-  it("denies approval when its exact admitted authority closes during the awaited decision", async () => {
-    const { admission, context } = await createExecution({
-      config: { tools: { exec: { security: "allowlist", ask: "on-miss" } } },
-      nativeTools: ["WebFetch"],
-    });
-    mockCallGatewayTool.mockImplementationOnce(async () => {
-      admission.close();
-      return { id: "approval-closed", decision: "allow-once" };
-    });
-    let decision: CliBackendToolPermissionResult | undefined;
+  it.each(["admission", "caller"] as const)(
+    "denies approval when %s authority closes during the awaited decision",
+    async (authority) => {
+      const { admission, context } = await createExecution({
+        config: { tools: { exec: { security: "allowlist", ask: "on-miss" } } },
+        nativeTools: ["WebFetch"],
+      });
+      let callerCurrent = true;
+      context.params.assertCurrent = () => {
+        if (!callerCurrent) {
+          throw new Error("caller revoked");
+        }
+      };
+      mockCallGatewayTool.mockImplementationOnce(async () => {
+        if (authority === "caller") {
+          callerCurrent = false;
+        } else {
+          admission.close();
+        }
+        return { id: "approval-closed", decision: "allow-once" };
+      });
+      let decision: CliBackendToolPermissionResult | undefined;
 
-    await runPlugin(context, async function* (execution) {
-      decision = await requestNativeTool(execution, "WebFetch", { url: "https://example.com" });
-      yield SUCCESS_RESULT;
-    });
+      await runPlugin(context, async function* (execution) {
+        decision = await requestNativeTool(execution, "WebFetch", { url: "https://example.com" });
+        yield SUCCESS_RESULT;
+      });
 
-    expect(decision).toEqual(
-      expect.objectContaining({ behavior: "deny", message: expect.stringContaining("closed") }),
-    );
-  });
+      expect(decision).toEqual(
+        expect.objectContaining({ behavior: "deny", message: expect.stringContaining("closed") }),
+      );
+    },
+  );
 
   it("cancels an in-flight native approval and never releases its late decision", async () => {
     const controller = new AbortController();

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -573,7 +573,7 @@ describe("plugin-owned CLI execution host boundary", () => {
       nativeTools: ["WebFetch"],
       runId: "plugin-approval-first",
     });
-    const originalHandle = registerOwnerSession(first.context, "original-live-process");
+    registerOwnerSession(first.context, "original-live-process");
 
     const runApprovedTurn = async (context: PreparedCliRunContext, repeat: boolean) => {
       await runPlugin(context, async function* (execution) {
@@ -612,7 +612,7 @@ describe("plugin-owned CLI execution host boundary", () => {
     });
     expect(mockCallGatewayTool).toHaveBeenCalledOnce();
 
-    originalHandle.handle.close("restart");
+    await closeCliLiveSession(first.context, "restart");
     registerOwnerSession(first.context, "replacement-live-process");
     const replacement = await createExecution({
       config,

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -19,10 +19,11 @@ import { FailoverError, isSignalTimeoutReason } from "../failover-error.js";
 import { withAgentQuestionAnswerAuthority } from "../harness/host-private-capabilities.js";
 import { runStructuredInput } from "../harness/structured-input-execution.js";
 import { compileStructuredInputQuestions } from "../harness/structured-input.js";
+import { recordAgentCleanupFailure } from "../run-cleanup-timeout.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
 import { normalizeToolPolicyName } from "../tool-policy.js";
 import {
-  closeCliLiveSession,
+  restartCliLiveSession,
   createCliLiveSessionCapability,
   getCliLiveSessionApprovalGrants,
 } from "./cli-live-session-registry.js";
@@ -383,6 +384,9 @@ async function closePluginIterator(
         timeout.unref();
       }),
     ]);
+  } catch (error) {
+    recordAgentCleanupFailure();
+    throw error;
   } finally {
     clearTimeout(timeout);
   }
@@ -518,7 +522,7 @@ export async function executePluginOwnedProcess(params: {
       if (params.liveSession.requiredGeneration) {
         throw new Error("The required CLI live session cannot be replaced by a fresh process.");
       }
-      await closeCliLiveSession(params.context, "restart");
+      await restartCliLiveSession(params.context, signal);
     }
     assertCurrent();
     if (params.liveSession) {
@@ -532,8 +536,7 @@ export async function executePluginOwnedProcess(params: {
         claimResources: params.context.preparedBackend.claimLiveSessionResources,
       });
     }
-    run.assertCurrent?.();
-    signal.throwIfAborted();
+    assertCurrent();
     const execution = params.execute({
       command,
       argv0: params.executionArgv0,

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -34,6 +34,7 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
+import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
 import { hashCliImageTurnEntryId } from "../cli-image-turn-correlation.js";
 import { findCliTerminalStopError } from "../failover-error.js";
@@ -1098,9 +1099,9 @@ describe("executePreparedCliRun supervisor output capture", () => {
     },
   );
 
-  it.each([false, true])(
+  it.for([false, true])(
     "preserves primary run failure through fork persistence errors (watchdog=%s)",
-    async (watchdog) => {
+    async (watchdog, { onTestFinished }) => {
       const stdout = `${JSON.stringify(
         watchdog
           ? {
@@ -1144,6 +1145,14 @@ describe("executePreparedCliRun supervisor output capture", () => {
       context.preparedBackend.backend.resumeArgs = ["--resume", "{sessionId}"];
       context.preparedBackend.backend.forkArg = "--fork-session";
       context.params.forkCliSessionOnResume = true;
+      const admission = prepareSystemAgentRunAdmission(
+        {},
+        context.params.runId,
+        "main",
+        "fork-test",
+      );
+      onTestFinished(admission.close);
+      context.params.admittedRunContext = await admission.admit("embedded");
       context.params.claimCliSessionFork = vi.fn().mockResolvedValue(true);
       context.params.persistCliSessionForkSuccessor = persistCliSessionForkSuccessor;
       context.params.restoreCliSessionFork = restoreCliSessionFork;
@@ -1282,7 +1291,9 @@ describe("executePreparedCliRun supervisor output capture", () => {
     }
   });
 
-  it("persists plugin-owned successor session ids for forked resumes", async () => {
+  it("persists plugin-owned successor session ids for forked resumes", async ({
+    onTestFinished,
+  }) => {
     const parseJsonlEvent: CliBackendParseJsonlEvent = (line) => {
       const event = JSON.parse(line) as { type: string; session?: string; text?: string };
       return event.type === "session"
@@ -1318,6 +1329,9 @@ describe("executePreparedCliRun supervisor output capture", () => {
     context.preparedBackend.backend.resumeArgs = ["--resume", "{sessionId}"];
     context.preparedBackend.backend.forkArg = "--fork-session";
     context.params.forkCliSessionOnResume = true;
+    const admission = prepareSystemAgentRunAdmission({}, context.params.runId, "main", "fork-test");
+    onTestFinished(admission.close);
+    context.params.admittedRunContext = await admission.admit("embedded");
     context.params.claimCliSessionFork = vi.fn().mockResolvedValue(true);
     context.params.persistCliSessionForkSuccessor = persistCliSessionForkSuccessor;
 

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -28,10 +28,11 @@ import {
 import type { MediaImageLayout } from "../embedded-agent-runner/run/prompt-image-metadata.js";
 import { applyPluginTextReplacements } from "../plugin-text-transforms.js";
 import { prepareCliBundleMcpCaptureAttempt } from "./bundle-mcp.js";
+import { runCliCleanup } from "./cleanup.js";
 import {
   acceptsCliLiveSession,
   buildCliLiveOwnerKey,
-  closeCliLiveSession,
+  restartCliLiveSession,
 } from "./cli-live-session-registry.js";
 import { executeDeps } from "./execute-deps.js";
 import { createCliEventHandlers } from "./execute-events.js";
@@ -341,7 +342,9 @@ export async function executePreparedCliRun(
   };
   const cleanupOuterResource = async (cleanup: (() => Promise<void>) | undefined) => {
     try {
-      await cleanup?.();
+      await runCliCleanup(params, "cli-outer-resource", async () => {
+        await cleanup?.();
+      });
     } catch (error) {
       if (completedOutput?.didSendViaMessagingTool) {
         cliBackendLog.warn(
@@ -601,12 +604,16 @@ export async function executePreparedCliRun(
       });
       toolTracking.finalizeCapture(events.finalizeParsedTools);
       try {
-        await cleanupMcpCaptureAttempt?.();
+        await runCliCleanup(params, "cli-mcp-capture", async () => {
+          await cleanupMcpCaptureAttempt?.();
+        });
       } catch (error) {
         recordRunError(error);
       }
       try {
-        restoreSkillEnv?.();
+        await runCliCleanup(params, "cli-skill-env", async () => {
+          restoreSkillEnv?.();
+        });
       } catch (error) {
         recordRunError(error);
       }
@@ -639,7 +646,7 @@ export async function executePreparedCliRun(
         }
         // The fork argument only applies at process startup; a cached warm child
         // would run inside the source session. Force a fresh spawn.
-        await closeCliLiveSession(context, "restart");
+        await restartCliLiveSession(context);
       }
       return await executeAttempt();
     });

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -93,6 +93,7 @@ import {
   buildActiveMusicGenerationTaskPromptContextForSession,
   buildActiveVideoGenerationTaskPromptContextForSession,
 } from "../media-generation-task-status.js";
+import { createAgentCleanupScope } from "../run-cleanup-timeout.js";
 import type { SandboxWorkspaceInfo } from "../sandbox/types.js";
 import { SessionManager } from "../sessions/session-manager.js";
 import {
@@ -4245,38 +4246,50 @@ describe("prepareCliRunContext", () => {
     expect(context.params.cliToolAvailability).toEqual({ native: [], openClaw: [] });
   });
 
-  it("requires prepared-execution backends to enforce the derived disabled-tools cap", async () => {
-    const cleanup = vi.fn(async () => {});
-    const prepareExecution = vi.fn(async () => ({ cleanup }));
-    setRawCliBackendForPrepareTest({
-      id: "settings-cli",
-      pluginId: "settings-plugin",
-      bundleMcp: false,
-      nativeToolMode: "selectable",
-      toolAvailabilityEnforcement: "prepare-execution",
-      prepareExecution,
-      config: {
-        command: "settings-cli",
-        args: ["--print"],
-        output: "jsonl",
-        input: "stdin",
-        sessionMode: "existing",
-      },
-    });
+  it.each([false, true])(
+    "preserves preparation refusal after cleanup (fails=%s)",
+    async (fails) => {
+      const cleanup = vi.fn(async () => {
+        if (fails) {
+          throw new Error("preparation cleanup failed");
+        }
+      });
+      const prepareExecution = vi.fn(async () => ({ cleanup }));
+      setRawCliBackendForPrepareTest({
+        id: "settings-cli",
+        pluginId: "settings-plugin",
+        bundleMcp: false,
+        nativeToolMode: "selectable",
+        toolAvailabilityEnforcement: "prepare-execution",
+        prepareExecution,
+        config: {
+          command: "settings-cli",
+          args: ["--print"],
+          output: "jsonl",
+          input: "stdin",
+          sessionMode: "existing",
+        },
+      });
 
-    await expect(
-      fixture.prepare({
-        provider: "settings-cli",
-        disableTools: true,
-      }),
-    ).rejects.toThrow(
-      "did not enforce exact per-run tool availability during execution preparation",
-    );
-    expect(prepareExecution).toHaveBeenCalledWith(
-      expect.objectContaining({ toolAvailability: { native: [], openClaw: [] } }),
-    );
-    expect(cleanup).toHaveBeenCalledOnce();
-  });
+      const cleanupScope = createAgentCleanupScope();
+      await expect(
+        cleanupScope.run(() =>
+          fixture.prepare({
+            provider: "settings-cli",
+            disableTools: true,
+            oneShotCliRun: true,
+          }),
+        ),
+      ).rejects.toThrow(
+        "did not enforce exact per-run tool availability during execution preparation",
+      );
+      expect(prepareExecution).toHaveBeenCalledWith(
+        expect.objectContaining({ toolAvailability: { native: [], openClaw: [] } }),
+      );
+      expect(cleanup).toHaveBeenCalledOnce();
+      expect(cleanupScope.outcome).toBe(fails ? "uncertain" : "closed");
+    },
+  );
 
   it("still rejects disableTools when a selectable backend cannot enforce an exact cap", async () => {
     setRawCliBackendForPrepareTest({

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -138,6 +138,7 @@ import {
 import { CliAuthProfilePreparationError } from "./auth-profile-preparation-error.js";
 import { prepareCliBundleMcpConfig } from "./bundle-mcp.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
+import { runCliCleanup } from "./cleanup.js";
 import {
   resolveBundledCliBackendAuthPolicy,
   type BundledCliBackendAuthPolicy,
@@ -2217,7 +2218,9 @@ export async function prepareCliRunContext(
     };
   } catch (err) {
     try {
-      await cleanupPreparedResources?.();
+      await runCliCleanup(params, "cli-prepare-failure", async () => {
+        await cleanupPreparedResources?.();
+      });
     } catch (cleanupErr) {
       cliBackendLog.warn(`cli backend cleanup after prepare failure failed: ${String(cleanupErr)}`);
     }

--- a/src/agents/cli-runner/types.ts
+++ b/src/agents/cli-runner/types.ts
@@ -324,6 +324,10 @@ type CliPreparedBackend = {
   backend: CliBackendConfig;
   beforeExecution?: () => Promise<void>;
   cleanup?: () => Promise<void>;
+  /** Exact process cleanup retained across attempt copies and natural registry removal. */
+  closeLiveSession?: (
+    reason: import("../../plugins/cli-backend.types.js").CliBackendLiveSessionCloseReason,
+  ) => Promise<void>;
   /** Transfer process-owned native skill artifacts without claiming turn-scoped MCP/auth state. */
   claimLiveSessionResources?: () => (() => Promise<void>) | undefined;
   /** Private child-only credential transport; never serialized into env or public plugin state. */

--- a/src/agents/command/types.ts
+++ b/src/agents/command/types.ts
@@ -140,6 +140,8 @@ export type AgentCommandOpts = {
   deliveryTargetMode?: ChannelOutboundTargetMode;
   bestEffortDeliver?: boolean;
   abortSignal?: AbortSignal;
+  /** Private source-owner fence; cancellation alone does not establish current authority. */
+  assertSourceCurrent?: () => void;
   lane?: string;
   runId?: string;
   /** Immutable gateway lifecycle ownership captured when this run was admitted. */
@@ -249,6 +251,7 @@ export type AgentCommandIngressOpts = Omit<
   | "pinnedWidgetAuthoring"
   | "executionIdentityAdmission"
   | "operationalRunInstance"
+  | "assertSourceCurrent"
   | "skillLibraryAuthoring"
   | "cronCreatorAuthorityCapability"
   | "onAdmittedRunContext"

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -4,6 +4,7 @@ import {
   makeRegistry,
 } from "../../../config/plugin-auto-enable.test-helpers.js";
 import { setPluginToolMeta } from "../../../plugins/tool-metadata.js";
+import { createAgentCleanupScope } from "../../run-cleanup-timeout.js";
 import { createStubTool } from "../../test-helpers/agent-tool-stubs.js";
 import { attachToolAllowlistIntersection } from "../../tool-policy.js";
 
@@ -419,50 +420,44 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     ]);
   });
 
-  it("disposes prepared bundle runtimes when later policy setup fails", async () => {
-    const disposeMcp = vi.fn(async () => {});
-    const disposeLsp = vi.fn(async () => {});
-    mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
-    mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
-      tools: [],
-      dispose: disposeMcp,
-    });
-    mocks.createBundleLspToolRuntime.mockResolvedValue({
-      tools: [],
-      dispose: disposeLsp,
-    });
-    mocks.applyFinalEffectiveToolPolicy.mockImplementation(() => {
-      throw new Error("bundle policy failed");
-    });
+  it.each([undefined, "MCP", "LSP"])(
+    "disposes prepared runtimes after policy failure and retains %s cleanup failure",
+    async (failedCleanup) => {
+      const disposeMcp = vi.fn(async () => {
+        if (failedCleanup === "MCP") {
+          throw new Error("MCP disposal failed");
+        }
+      });
+      const disposeLsp = vi.fn(async () => {
+        if (failedCleanup === "LSP") {
+          throw new Error("LSP disposal failed");
+        }
+      });
+      mocks.acquireSessionMcpRuntime.mockResolvedValue({ runtime: {}, releaseLease: () => {} });
+      mocks.materializeBundleMcpToolsForRun.mockResolvedValue({
+        tools: [],
+        dispose: disposeMcp,
+      });
+      mocks.createBundleLspToolRuntime.mockResolvedValue({
+        tools: [],
+        dispose: disposeLsp,
+      });
+      mocks.applyFinalEffectiveToolPolicy.mockImplementation(() => {
+        throw new Error("bundle policy failed");
+      });
 
-    const input = {
-      agentDir: "/tmp/agent",
-      attempt: {
-        config: {},
-        model: {},
-        modelId: "model",
-        provider: "provider",
-        runId: "run",
-        runtimePlan: {},
-        sessionId: "session",
-      },
-      setup: createAttemptSetupFixture(),
-      isRawModelRun: false,
-      preparedToolBase: {
-        cronCreatorToolAllowlist: [],
-        effectiveToolsAllow: undefined,
-        localModelLeanPreserveToolNames: [],
-        runtimeCapabilityProfile: undefined,
-        toolsEnabled: true,
-        toolsRaw: [],
-      },
-    } as unknown as Parameters<typeof prepareEmbeddedAttemptBundleTools>[0];
+      const input = createInput([], []);
 
-    await expect(prepareEmbeddedAttemptBundleTools(input)).rejects.toThrow("bundle policy failed");
-    expect(mocks.applyFinalEffectiveToolPolicy).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceDir: "/tmp/workspace" }),
-    );
-    expect(disposeMcp).toHaveBeenCalledOnce();
-    expect(disposeLsp).toHaveBeenCalledOnce();
-  });
+      const cleanupScope = createAgentCleanupScope();
+      await expect(
+        cleanupScope.run(() => prepareEmbeddedAttemptBundleTools(input)),
+      ).rejects.toThrow("bundle policy failed");
+      expect(cleanupScope.outcome).toBe(failedCleanup ? "uncertain" : "closed");
+      expect(mocks.applyFinalEffectiveToolPolicy).toHaveBeenCalledWith(
+        expect.objectContaining({ workspaceDir: "/tmp/workspace" }),
+      );
+      expect(disposeMcp).toHaveBeenCalledOnce();
+      expect(disposeLsp).toHaveBeenCalledOnce();
+    },
+  );
 });

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -8,6 +8,7 @@ import {
 } from "../../agent-bundle-mcp-tools.js";
 import { wrapToolWithAbortSignal } from "../../agent-tools.abort.js";
 import { filterLocalModelLeanTools } from "../../local-model-lean.js";
+import { recordAgentCleanupFailure } from "../../run-cleanup-timeout.js";
 import { normalizeAgentRuntimeTools } from "../../runtime-plan/tools.js";
 import { createRuntimeToolMatcher } from "../../tool-policy-match.js";
 import { replaceWithEffectiveToolAllowlist } from "../../tool-policy.js";
@@ -256,15 +257,11 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
       },
     };
   } catch (error) {
-    try {
-      await bundleMcpRuntime?.dispose();
-    } catch {
-      // Preserve the preparation error; cleanup is best-effort.
-    }
-    try {
-      await bundleLspRuntime?.dispose();
-    } catch {
-      // Preserve the preparation error; cleanup is best-effort.
+    const cleanup = await Promise.allSettled(
+      [bundleMcpRuntime, bundleLspRuntime].map(async (runtime) => await runtime?.dispose()),
+    );
+    if (cleanup.some((result) => result.status === "rejected")) {
+      recordAgentCleanupFailure();
     }
     throw error;
   }

--- a/src/agents/embedded-agent-runner/run/attempt-session-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-settle.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createAgentCleanupScope } from "../../run-cleanup-timeout.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { createEmbeddedAttemptSessionSettleTracker } from "./attempt-session-settle.js";
 
@@ -11,6 +12,19 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 describe("createEmbeddedAttemptSessionSettleTracker", () => {
+  it("preserves a teardown failure raised outside the caller async context", async () => {
+    const tracker = createEmbeddedAttemptSessionSettleTracker({
+      abort: async () => {
+        throw new Error("native abort failed");
+      },
+    });
+    await expect(tracker.abortActiveSession()).rejects.toThrow("native abort failed");
+    const cleanupScope = createAgentCleanupScope();
+    await cleanupScope.run(async () => {
+      await tracker.buildAbortSettlePromise();
+    });
+    expect(cleanupScope.outcome).toBe("uncertain");
+  });
   it("waits for both prompt and abort settlement during cleanup", async () => {
     const prompt = deferred();
     const abort = deferred();

--- a/src/agents/embedded-agent-runner/run/attempt-session-settle.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-settle.ts
@@ -5,6 +5,7 @@
 import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
 import type { createTrajectoryRuntimeRecorder } from "../../../trajectory/runtime.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
+import { recordAgentCleanupFailure } from "../../run-cleanup-timeout.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { clearToolSearchCatalog, type ToolSearchCatalogRef } from "../../tool-search.js";
@@ -23,6 +24,7 @@ export function createEmbeddedAttemptSessionSettleTracker(
   activeSession: Pick<AgentSession, "abort">,
 ) {
   const inFlight = new Set<Promise<void>>();
+  let abortCleanupFailed = false;
   const trackSettlePromise = (promise: Promise<void>): Promise<void> => {
     inFlight.add(promise);
     const settled = () => {
@@ -34,9 +36,26 @@ export function createEmbeddedAttemptSessionSettleTracker(
 
   return {
     abortActiveSession: (reason?: unknown) =>
-      trackSettlePromise(Promise.resolve(activeSession.abort(reason))),
-    buildAbortSettlePromise: () =>
-      inFlight.size === 0 ? null : Promise.allSettled(inFlight).then<void>(() => undefined),
+      trackSettlePromise(
+        Promise.resolve(activeSession.abort(reason)).catch((error: unknown) => {
+          abortCleanupFailed = true;
+          throw error;
+        }),
+      ),
+    buildAbortSettlePromise: () => {
+      // Abort callbacks can run outside the caller's async context. Record their
+      // retained failure from the cleanup owner that joins settlement.
+      if (abortCleanupFailed) {
+        recordAgentCleanupFailure();
+      }
+      return inFlight.size === 0
+        ? null
+        : Promise.allSettled(inFlight).then(() => {
+            if (abortCleanupFailed) {
+              recordAgentCleanupFailure();
+            }
+          });
+    },
     trackPromptSettlePromise: trackSettlePromise,
   };
 }
@@ -144,11 +163,13 @@ export async function cleanupEmbeddedAttemptSessionPhase(
       sessionId: attempt.sessionId,
     });
   } catch (err) {
+    recordAgentCleanupFailure();
     cleanupError = err;
   } finally {
     try {
       await input.transcriptLifecycle.dispose();
     } catch (err) {
+      recordAgentCleanupFailure();
       cleanupError ??= err;
     }
   }

--- a/src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-subscription-cleanup.ts
@@ -1,6 +1,7 @@
 /** Cleans up embedded attempt subscription resources. */
 import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
 import { isFastTestRuntimeEnv } from "../../../infra/test-runtime-env.js";
+import { recordAgentCleanupFailure, runAgentCleanupStep } from "../../run-cleanup-timeout.js";
 import { log } from "../logger.js";
 
 // Invalid overrides retain the normal/test defaults; partial numeric parsing
@@ -28,31 +29,16 @@ export async function waitForEmbeddedAbortSettle(params: {
     return;
   }
 
-  const reason = params.reason ?? "embedded";
-  let timeout: NodeJS.Timeout | undefined;
-  // Abort settlement is advisory cleanup; timeout or errors are logged but do
-  // not block disposing attempt-owned resources.
-  const outcome = await Promise.race([
-    params.promise
-      .then(() => "settled" as const)
-      .catch((err: unknown) => {
-        log.warn(
-          `${reason} abort settle failed: runId=${params.runId} sessionId=${params.sessionId} err=${String(err)}`,
-        );
-        return "errored" as const;
-      }),
-    new Promise<"timed_out">((resolve) => {
-      timeout = setTimeout(() => resolve("timed_out"), EMBEDDED_ABORT_SETTLE_TIMEOUT_MS);
-    }),
-  ]);
-  if (timeout) {
-    clearTimeout(timeout);
-  }
-  if (outcome === "timed_out") {
-    log.warn(
-      `${reason} abort settle timed out: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${EMBEDDED_ABORT_SETTLE_TIMEOUT_MS}`,
-    );
-  }
+  await runAgentCleanupStep({
+    runId: params.runId,
+    sessionId: params.sessionId,
+    step: `${params.reason ?? "embedded"}-abort-settle`,
+    log,
+    timeoutMs: EMBEDDED_ABORT_SETTLE_TIMEOUT_MS,
+    cleanup: async () => {
+      await params.promise;
+    },
+  });
 }
 
 /**
@@ -78,7 +64,7 @@ export async function cleanupEmbeddedAttemptResources(params: {
   try {
     params.removeToolResultContextGuard?.();
   } catch {
-    /* best-effort */
+    recordAgentCleanupFailure();
   }
   if (params.aborted && params.abortSettlePromise) {
     await waitForEmbeddedAbortSettle({
@@ -94,22 +80,22 @@ export async function cleanupEmbeddedAttemptResources(params: {
       ...(params.aborted ? { timeoutMs: 0 } : {}),
     });
   } catch {
-    /* best-effort */
+    recordAgentCleanupFailure();
   }
 
   try {
     params.session?.dispose();
   } catch {
-    /* best-effort */
+    recordAgentCleanupFailure();
   }
   try {
     await params.bundleMcpRuntime?.dispose();
   } catch {
-    /* best-effort */
+    recordAgentCleanupFailure();
   }
   try {
     await params.bundleLspRuntime?.dispose();
   } catch {
-    /* best-effort */
+    recordAgentCleanupFailure();
   }
 }

--- a/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-prepare.ts
@@ -26,6 +26,7 @@ import {
 } from "../../local-model-lean.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { supportsModelTools } from "../../model-tool-support.js";
+import { recordAgentCleanupFailure } from "../../run-cleanup-timeout.js";
 import {
   resolveSessionPermissionExecMode,
   type PreparedSessionPermissionPolicy,
@@ -148,10 +149,15 @@ export function prepareEmbeddedAttemptToolBase(params: {
   const runCleanups: Array<(reason: string) => Promise<void>> = [];
   const generationCleanups: Array<(reason: string) => Promise<void>> = [];
   const retiringGenerations = new Set<Promise<void>>();
+  let retiredCleanupFailed = false;
   const retireToolGeneration = (reason: string) => {
     const cleanups = generationCleanups.splice(0);
     const settled = Promise.allSettled(cleanups.map(async (cleanup) => await cleanup(reason))).then(
-      () => {},
+      (results) => {
+        if (results.some((result) => result.status === "rejected")) {
+          retiredCleanupFailed = true;
+        }
+      },
     );
     retiringGenerations.add(settled);
     void settled.then(() => retiringGenerations.delete(settled));
@@ -369,6 +375,9 @@ export function prepareEmbeddedAttemptToolBase(params: {
     toolAbortController.abort();
     retireToolGeneration(reason);
     await Promise.all(retiringGenerations);
+    if (retiredCleanupFailed) {
+      recordAgentCleanupFailure();
+    }
   });
 
   return {

--- a/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { buildAgentRunTerminalOutcomeFromAttempt } from "../../agent-run-terminal-outcome.js";
+import { createAgentCleanupScope } from "../../run-cleanup-timeout.js";
 import {
   cleanupTempPaths,
   createContextEngineAttemptRunner,
@@ -25,6 +27,51 @@ describe("runEmbeddedAttempt abort races", () => {
     await cleanupTempPaths(tempPaths);
     tempPaths.length = 0;
   });
+
+  it.each([false, true])(
+    "bounds registered one-shot cleanup after a completed turn (fails=%s)",
+    async (fails) => {
+      const held = createDeferred();
+      const started = createDeferred();
+      const cleanupScope = createAgentCleanupScope();
+      hoisted.createOpenClawCodingToolsMock.mockImplementation((options: unknown) => {
+        (
+          options as { registerRunCleanup: (cleanup: () => Promise<void>) => void }
+        ).registerRunCleanup(async () => {
+          started.resolve();
+          await held.promise;
+          if (fails) {
+            throw new Error("registered resource teardown failed");
+          }
+        });
+        return [];
+      });
+      const attempt = cleanupScope.run(() =>
+        createContextEngineAttemptRunner({
+          contextEngine: createContextEngineBootstrapAndAssemble(),
+          sessionKey: "agent:main:triage:cleanup",
+          tempPaths,
+          sessionPrompt: async () => {
+            vi.useFakeTimers();
+          },
+          attemptOverrides: { oneShotCliRun: true, disableTools: false },
+        }),
+      );
+      try {
+        await started.promise;
+        if (fails) {
+          held.resolve();
+        }
+        await vi.advanceTimersByTimeAsync(10_000);
+        expect(cleanupScope.outcome).toBe("uncertain");
+        expect((await attempt).terminal).toEqual({ kind: "ok" });
+      } finally {
+        held.resolve();
+        await attempt;
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("preserves a run-budget timeout when abort blocks prompt submission", async () => {
     let releasePendingEvents!: () => void;

--- a/src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.subscription-cleanup.test.ts
@@ -50,7 +50,7 @@ describe("waitForEmbeddedAbortSettle timeout policy", () => {
 
       expect(settled).toBe(true);
       expect(mocks.warn).toHaveBeenCalledExactlyOnceWith(
-        `embedded abort settle timed out: runId=run-1 sessionId=session-1 timeoutMs=${timeoutMs}`,
+        `agent cleanup timed out: runId=run-1 sessionId=session-1 step=embedded-abort-settle timeoutMs=${timeoutMs}`,
       );
       expect(vi.getTimerCount()).toBe(0);
     },
@@ -70,7 +70,7 @@ describe("waitForSessionsYieldAbortSettle", () => {
     await wait;
 
     expect(mocks.warn).toHaveBeenCalledExactlyOnceWith(
-      "sessions_yield abort settle timed out: runId=run-1 sessionId=session-1 timeoutMs=1250",
+      "agent cleanup timed out: runId=run-1 sessionId=session-1 step=sessions_yield-abort-settle timeoutMs=1250",
     );
     expect(vi.getTimerCount()).toBe(0);
   });
@@ -84,7 +84,7 @@ describe("waitForSessionsYieldAbortSettle", () => {
     });
 
     expect(mocks.warn).toHaveBeenCalledExactlyOnceWith(
-      "sessions_yield abort settle failed: runId=run-1 sessionId=session-1 err=Error: settle failed",
+      "agent cleanup failed: runId=run-1 sessionId=session-1 step=sessions_yield-abort-settle error=settle failed",
     );
     expect(vi.getTimerCount()).toBe(0);
   });
@@ -169,7 +169,7 @@ describe("cleanupEmbeddedAttemptResources", () => {
 
     expect(order).toEqual(["flush", "dispose"]);
     expect(mocks.warn).toHaveBeenCalledWith(
-      `embedded abort settle timed out: runId=run-1 sessionId=session-1 timeoutMs=${abortSettleTimeoutMs}`,
+      `agent cleanup timed out: runId=run-1 sessionId=session-1 step=embedded-abort-settle timeoutMs=${abortSettleTimeoutMs}`,
     );
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -1,4 +1,3 @@
-/** Orchestrates one embedded-agent attempt from prompt setup through stream result. */
 import {
   assertContextEngineHostSupport,
   OPENCLAW_EMBEDDED_CONTEXT_ENGINE_HOST,
@@ -12,6 +11,7 @@ import {
   projectAgentRunAttemptTerminal,
 } from "../../agent-run-terminal-outcome.js";
 import { resolveAgentDir } from "../../agent-scope.js";
+import { recordAgentCleanupFailure, runOwnedAgentCleanup } from "../../run-cleanup-timeout.js";
 import {
   clearToolSearchCatalog,
   type ToolSearchCatalogRef,
@@ -88,6 +88,8 @@ export async function runEmbeddedAttempt(
   let toolSearchCatalogRef: ToolSearchCatalogRef | undefined;
   let toolSearchCatalogApplied = false;
   let runCleanups: Array<(reason: string) => Promise<void>> = [];
+  const cleanupStep = (step: string, cleanup: () => Promise<void>) =>
+    runOwnedAgentCleanup({ ...params, step, cleanup, log });
   const cleanupEmbeddedPrepResourcesAfterEarlyExit = async () => {
     if (toolSearchCatalogApplied) {
       clearToolSearchCatalog({
@@ -102,14 +104,14 @@ export async function runEmbeddedAttempt(
     try {
       await bundleMcpRuntime?.dispose();
     } catch {
-      /* best-effort */
+      recordAgentCleanupFailure();
     } finally {
       bundleMcpRuntime = undefined;
     }
     try {
       await bundleLspRuntime?.dispose();
     } catch {
-      /* best-effort */
+      recordAgentCleanupFailure();
     } finally {
       bundleLspRuntime = undefined;
     }
@@ -396,20 +398,29 @@ export async function runEmbeddedAttempt(
           : {}),
       };
     } finally {
-      await cleanupEmbeddedAttemptSessionPhase({
-        attempt: params,
-        ...resources,
-        transcriptLifecycle: sessionLock.transcriptLifecycle,
-        bundleMcpRuntime,
-        bundleLspRuntime,
-        toolSearchCatalogRef,
-        sandboxSessionKey,
-        sessionAgentId,
-        trajectoryEndRecorded: executionState.trajectoryEndRecorded,
-        deferredLifecycleOwner: executionState.deferredLifecycleOwner,
-        emitDiagnosticRunCompleted,
-        state: executionState,
-      });
+      // Transfer resources to the session cleanup owner before awaiting it. A
+      // bounded timeout must not let outer early-exit cleanup dispose them twice.
+      const sessionMcpRuntime = bundleMcpRuntime;
+      const sessionLspRuntime = bundleLspRuntime;
+      bundleMcpRuntime = undefined;
+      bundleLspRuntime = undefined;
+      toolSearchCatalogApplied = false;
+      await cleanupStep("embedded-session", () =>
+        cleanupEmbeddedAttemptSessionPhase({
+          attempt: params,
+          ...resources,
+          transcriptLifecycle: sessionLock.transcriptLifecycle,
+          bundleMcpRuntime: sessionMcpRuntime,
+          bundleLspRuntime: sessionLspRuntime,
+          toolSearchCatalogRef,
+          sandboxSessionKey,
+          sessionAgentId,
+          trajectoryEndRecorded: executionState.trajectoryEndRecorded,
+          deferredLifecycleOwner: executionState.deferredLifecycleOwner,
+          emitDiagnosticRunCompleted,
+          state: executionState,
+        }),
+      );
     }
   } catch (error) {
     const terminalOutcome = buildAgentRunTerminalOutcomeFromAttempt({
@@ -433,12 +444,20 @@ export async function runEmbeddedAttempt(
             ? "error"
             : "completion";
     const cleanups = runCleanups.splice(0);
-    await Promise.allSettled(cleanups.map(async (cleanup) => await cleanup(cleanupReason)));
+    await cleanupStep("embedded-registered-resources", async () => {
+      const settled = await Promise.allSettled(
+        cleanups.map(async (cleanup) => await cleanup(cleanupReason)),
+      );
+      if (settled.some((result) => result.status === "rejected")) {
+        recordAgentCleanupFailure();
+      }
+    });
     externalAbortController.dispose();
     clearToolActivityRun(params.runId);
     try {
-      await cleanupEmbeddedPrepResourcesAfterEarlyExit();
+      await cleanupStep("embedded-preparation", cleanupEmbeddedPrepResourcesAfterEarlyExit);
     } catch (cleanupErr) {
+      recordAgentCleanupFailure();
       log.warn(
         `failed to clean up embedded prep resources after early attempt exit: runId=${params.runId} ${String(cleanupErr)}`,
       );

--- a/src/agents/embedded-agent-runner/run/run-settlement.ts
+++ b/src/agents/embedded-agent-runner/run/run-settlement.ts
@@ -7,7 +7,7 @@ import {
   retireSessionMcpRuntimeForSessionKey,
 } from "../../agent-bundle-mcp-tools.js";
 import type { ContextEngineLogicalTurnLease } from "../../harness/context-engine-logical-turn.js";
-import { runAgentCleanupStep } from "../../run-cleanup-timeout.js";
+import { recordAgentCleanupFailure, runAgentCleanupStep } from "../../run-cleanup-timeout.js";
 import { log } from "../logger.js";
 import { clearProviderPromptState } from "../provider-prompt-state.js";
 import { forgetPromptBuildDrainCacheForRun } from "./attempt-prompt-helpers.js";
@@ -121,6 +121,7 @@ export async function settleEmbeddedRun(input: {
       log,
       cleanup: async () => {
         const onError = (errorLocal: unknown, sessionId: string) => {
+          recordAgentCleanupFailure();
           log.warn(
             `bundle-mcp cleanup failed after run for ${sessionId}: ${formatErrorMessage(errorLocal)}`,
           );

--- a/src/agents/host-file-write.ts
+++ b/src/agents/host-file-write.ts
@@ -1,6 +1,7 @@
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { hasErrnoCode } from "../infra/errors.js";
+import { captureAgentToolSourceExecutionGuard } from "./agent-tool-source-execution-guard.js";
 import { expandOsHomePrefix } from "./sessions/tools/path-utils.js";
 
 function resolveHostPath(filePath: string): string {
@@ -46,13 +47,13 @@ async function overwriteHostFileInPlace(
   handle: FileHandle,
   payload: Buffer,
   currentSize: number,
-  abortSignal?: AbortSignal,
+  assertCurrent: () => void,
 ) {
   const prefixLength = Math.min(payload.length, currentSize);
   const originalPrefix = await readHostFilePrefix(handle, prefixLength);
   // Prefix preparation may outlive the tool generation. Once mutation starts,
   // preserve the existing whole-write rollback boundary.
-  abortSignal?.throwIfAborted();
+  assertCurrent();
   let prefixStarted = false;
   try {
     if (payload.length > currentSize) {
@@ -96,18 +97,19 @@ export async function writeHostFile(
   content: string,
   abortSignal?: AbortSignal,
 ) {
+  const assertCurrent = captureAgentToolSourceExecutionGuard(abortSignal);
   const resolved = resolveHostPath(absolutePath);
-  abortSignal?.throwIfAborted();
+  assertCurrent();
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   const handle = await openHostFileForUpdate(resolved);
   if (!handle) {
-    abortSignal?.throwIfAborted();
+    assertCurrent();
     await fs.writeFile(resolved, content, "utf-8");
     return;
   }
   try {
     const stat = await handle.stat();
-    await overwriteHostFileInPlace(handle, Buffer.from(content, "utf-8"), stat.size, abortSignal);
+    await overwriteHostFileInPlace(handle, Buffer.from(content, "utf-8"), stat.size, assertCurrent);
   } finally {
     await handle.close().catch(() => undefined);
   }

--- a/src/agents/mcp-client-lifecycle.ts
+++ b/src/agents/mcp-client-lifecycle.ts
@@ -5,6 +5,7 @@ import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { OpenClawStreamableHTTPClientTransport } from "./mcp-http-transport.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 
 type LifecycleSession = {
   client: Pick<Client, "close">;
@@ -87,10 +88,7 @@ export async function connectMcpClient(params: {
 async function settleWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   return await Promise.race([
-    promise.then(
-      () => true,
-      () => true,
-    ),
+    promise.then(() => true),
     new Promise<false>((resolve) => {
       timer = setTimeout(() => resolve(false), timeoutMs);
       timer.unref?.();
@@ -98,33 +96,34 @@ async function settleWithin(promise: Promise<unknown>, timeoutMs: number): Promi
   ]).finally(() => clearTimeout(timer));
 }
 
-async function ignoreCloseFailure(close: () => void | PromiseLike<unknown>): Promise<void> {
-  try {
-    await close();
-  } catch {
-    // Disposal is best-effort, but each later close step must still run.
-  }
-}
-
 export async function disposeMcpClient(
   session: LifecycleSession,
   timeoutMs = 5_000,
-): Promise<void> {
-  try {
-    const closed = await settleWithin(
-      (async () => {
-        if (session.transportType === "streamable-http") {
-          await ignoreCloseFailure(() => session.transport.terminateSession?.());
-        }
-        await ignoreCloseFailure(() => session.transport.close());
-        await ignoreCloseFailure(() => session.client.close());
-      })(),
-      timeoutMs,
-    );
-    if (closed) {
-      return;
+): Promise<"closed" | "uncertain"> {
+  let failed = false;
+  const markFailed = () => {
+    failed = true;
+    recordAgentCleanupFailure();
+  };
+  const ignoreCloseFailure = async (close: () => void | PromiseLike<unknown>) => {
+    try {
+      await close();
+    } catch {
+      markFailed();
     }
-
+  };
+  try {
+    const graceful = (async () => {
+      if (session.transportType === "streamable-http") {
+        await ignoreCloseFailure(() => session.transport.terminateSession?.());
+      }
+      await ignoreCloseFailure(() => session.transport.close());
+      await ignoreCloseFailure(() => session.client.close());
+    })();
+    const closed = await settleWithin(graceful, timeoutMs);
+    if (closed) {
+      return failed ? "uncertain" : "closed";
+    }
     // Closing an HTTP transport aborts a hung DELETE. Stdio owns a process
     // group, so force it dead before disposal can report completion.
     const { transport } = session;
@@ -132,13 +131,18 @@ export async function disposeMcpClient(
       session.transportType === "stdio" && transport instanceof OpenClawStdioClientTransport
         ? () => transport.forceClose()
         : () => transport.close();
-    await settleWithin(
+    const forced = await settleWithin(
       Promise.all([
+        graceful,
         ignoreCloseFailure(closeTransport),
         ignoreCloseFailure(() => session.client.close()),
       ]),
       timeoutMs,
     );
+    if (!forced) {
+      markFailed();
+    }
+    return failed ? "uncertain" : "closed";
   } finally {
     // Shutdown itself may emit the last diagnostic; detach only after it settles.
     session.detachStderr?.();

--- a/src/agents/mcp-stderr.test.ts
+++ b/src/agents/mcp-stderr.test.ts
@@ -2,6 +2,7 @@ import { once } from "node:events";
 import process from "node:process";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { disposeMcpClient } from "./mcp-client-lifecycle.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
@@ -126,16 +127,16 @@ describe("MCP stderr diagnostics", () => {
   it("keeps diagnostics attached through forced disposal", async () => {
     vi.useFakeTimers();
     const probe = createStderrProbe();
-    const close = vi
-      .spyOn(probe.transport, "close")
-      .mockImplementation(() => new Promise(() => {}));
+    const closed = createDeferred();
+    const close = vi.spyOn(probe.transport, "close").mockReturnValue(closed.promise);
     const forceClose = vi.spyOn(probe.transport, "forceClose").mockImplementation(async () => {
       probe.stderr.write("forced shutdown tail");
+      closed.resolve();
     });
     try {
       const disposing = disposeMcpClient({ ...probe, client: { close: async () => {} } }, 50);
       await vi.advanceTimersByTimeAsync(50);
-      await disposing;
+      await expect(disposing).resolves.toBe("closed");
       expect(forceClose).toHaveBeenCalledOnce();
       expect(logDebug.mock.calls).toEqual([["bundle-mcp:probe: forced shutdown tail"]]);
       expect(vi.getTimerCount()).toBe(0);

--- a/src/agents/mcp-stdio-transport.test.ts
+++ b/src/agents/mcp-stdio-transport.test.ts
@@ -1,102 +1,140 @@
-// Exercises MCP stdio process lifecycle, JSON-RPC IO, and close escalation.
-import type { SpawnOptions } from "node:child_process";
-import { EventEmitter } from "node:events";
+import { once } from "node:events";
+// MCP framing and disposal preserve the spawn owner's independent cleanup receipt.
 import fs from "node:fs/promises";
-import { PassThrough } from "node:stream";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { PassThrough, type Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { OwnedStdioCleanupError, type OwnedStdioProcess } from "../process/owned-stdio.js";
+import { disposeMcpClient } from "./mcp-client-lifecycle.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
+import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
-const signalProcessTreeMock = vi.hoisted(() => vi.fn());
+const closeMock = vi.hoisted(() => vi.fn());
+vi.mock("../process/owned-stdio.js", async (importOriginal) => {
+  const { OwnedStdioCleanupError: CleanupError } =
+    await importOriginal<typeof import("../process/owned-stdio.js")>();
+  return {
+    createOwnedStdioProcess: spawnMock,
+    closeOwnedStdioProcess: closeMock,
+    OwnedStdioCleanupError: CleanupError,
+  };
+});
 
-vi.mock("node:child_process", async () => ({
-  ...(await vi.importActual<typeof import("node:child_process")>("node:child_process")),
-  spawn: spawnMock,
-}));
-
-vi.mock("../process/kill-tree.js", () => ({
-  signalProcessTree: signalProcessTreeMock,
-}));
-
-class MockChildProcess extends EventEmitter {
-  // Minimal child-process surface needed by the transport: stdio streams,
-  // pid, and lifecycle events.
-  exitCode: number | null = null;
-  pid = 4321;
-  stdin = new PassThrough();
-  stdout = new PassThrough();
-  stderr = new PassThrough();
+const transports: OpenClawStdioClientTransport[] = [];
+function createTransport(params: ConstructorParameters<typeof OpenClawStdioClientTransport>[0]) {
+  const transport = new OpenClawStdioClientTransport(params);
+  transports.push(transport);
+  return transport;
+}
+const childCleanups: Array<() => void> = [];
+function createChild() {
+  const root = createDeferred<{ code: number | null; signal: NodeJS.Signals | null }>();
+  const extinction = createDeferred();
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  let onError:
+    | ((error: Error, source: "process" | "stdin" | "stdout" | "stderr") => void)
+    | undefined;
+  const child = {
+    pid: 4321,
+    stdin,
+    supportsRawOutput: true,
+    onStdout: (_decoded: (text: string) => void, raw?: (chunk: Buffer) => void) => {
+      if (raw) {
+        stdout.on("data", raw);
+      }
+    },
+    onStderr: (_decoded: (text: string) => void, raw?: (chunk: Buffer) => void) => {
+      if (raw) {
+        stderr.on("data", raw);
+      }
+    },
+    onExit: () => {},
+    onError: (listener: NonNullable<typeof onError>) => {
+      onError = listener;
+    },
+    wait: () => root.promise,
+    waitForExtinction: () => extinction.promise,
+    kill: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const fixture = {
+    child,
+    root,
+    extinction,
+    stdin,
+    stdout,
+    stderr,
+    emitError: (error: Error) => onError?.(error, "stderr"),
+  };
+  childCleanups.push(() => {
+    root.resolve({ code: 0, signal: null });
+    extinction.resolve();
+    stdin.destroy();
+    stdout.destroy();
+    stderr.destroy();
+  });
+  spawnMock.mockImplementation(async ({ stderrDestination }: { stderrDestination?: Writable }) => {
+    if (stderrDestination) {
+      stderr.pipe(stderrDestination, { end: false });
+    }
+    return child;
+  });
+  return fixture;
 }
 
-describe("OpenClawStdioClientTransport", () => {
-  afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
-    spawnMock.mockReset();
-    signalProcessTreeMock.mockReset();
+beforeEach(() => {
+  closeMock.mockImplementation(async (child: OwnedStdioProcess) => {
+    await child.wait();
+    await child.waitForExtinction?.();
   });
+});
+afterEach(async () => {
+  for (const cleanup of childCleanups.splice(0)) {
+    cleanup();
+  }
+  await Promise.allSettled(transports.splice(0).map((transport) => transport.close()));
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  spawnMock.mockReset();
+  closeMock.mockReset();
+});
 
-  it("starts stdio MCP servers in a disposable process group on POSIX", async () => {
-    // Detached POSIX process groups let OpenClaw clean up child tool servers
-    // without relying on shell-specific process trees.
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({
+describe("OpenClawStdioClientTransport", () => {
+  it("preserves the configured command, target environment and stderr stream", async () => {
+    createChild();
+    const transport = createTransport({
       command: "npx",
       args: ["-y", "example-mcp"],
       env: { EXAMPLE: "1" },
       cwd: "/tmp/example",
       stderr: "pipe",
     });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const [command, args, options] = spawnMock.mock.calls.at(0) as [string, string[], SpawnOptions];
-    if (process.platform === "linux") {
-      expect(command).toBe("/bin/sh");
-      expect(args).toEqual([
-        "-c",
-        'echo 1000 > /proc/self/oom_score_adj 2>/dev/null; exec "$0" "$@"',
-        "npx",
-        "-y",
-        "example-mcp",
-      ]);
-    } else {
-      expect(command).toBe("npx");
-      expect(args).toEqual(["-y", "example-mcp"]);
-    }
-    expect(options.cwd).toBe("/tmp/example");
-    expect(options.detached).toBe(process.platform !== "win32");
-    expect(options.shell).toBe(false);
-    expect(options.stdio).toEqual(["pipe", "pipe", "pipe"]);
-    expect(options.env?.EXAMPLE).toBe("1");
+    await transport.start();
+    expect(spawnMock).toHaveBeenCalledWith({
+      argv: ["npx", "-y", "example-mcp"],
+      cwd: "/tmp/example",
+      env: expect.objectContaining({ EXAMPLE: "1" }),
+      abortSignal: expect.any(AbortSignal),
+      stderrDestination: transport.stderr,
+    });
     expect(transport.pid).toBe(4321);
     expect(transport.stderr).toBeInstanceOf(PassThrough);
   });
 
-  it("does not infer Agent Plugins data-dir ownership from subprocess env", async () => {
-    const mkdirSpy = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-    const transport = new OpenClawStdioClientTransport({
+  it("does not infer plugin data directory ownership from server environment", async () => {
+    const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+    createChild();
+    await createTransport({
       command: "node",
-      env: { PLUGIN_ROOT: "/plugin", PLUGIN_DATA: "/user-owned-file" },
-    });
-
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    expect(mkdirSpy).not.toHaveBeenCalled();
-    const options = spawnMock.mock.calls.at(0)?.[2] as SpawnOptions;
-    expect(options.env).toMatchObject({
-      PLUGIN_ROOT: "/plugin",
-      PLUGIN_DATA: "/user-owned-file",
-    });
-    mkdirSpy.mockRestore();
+      env: {
+        PLUGIN_ROOT: "/plugin",
+        PLUGIN_DATA: "/user-owned-file",
+      },
+    }).start();
+    expect(mkdir).not.toHaveBeenCalled();
   });
 
   it.each(["close", "forceClose"] as const)(
@@ -104,238 +142,225 @@ describe("OpenClawStdioClientTransport", () => {
     async (closeMethod) => {
       const preparation = createDeferred<undefined>();
       vi.spyOn(fs, "mkdir").mockReturnValue(preparation.promise);
-      const child = new MockChildProcess();
-      spawnMock.mockImplementation(() => {
-        queueMicrotask(() => child.emit("spawn"));
-        return child;
-      });
-      const transport = new OpenClawStdioClientTransport({
+      createChild();
+      const transport = createTransport({
         command: "node",
         prepareDataDir: "/owned-plugin-data",
       });
       const onclose = vi.fn();
       Object.assign(transport, { onclose });
       const started = transport.start();
-      await transport[closeMethod]();
+      const closing = transport[closeMethod]();
+      expect(onclose).not.toHaveBeenCalled();
       preparation.resolve(undefined);
 
       await expect(started).rejects.toThrow("closed");
+      await closing;
       expect(spawnMock).not.toHaveBeenCalled();
-      expect(onclose).toHaveBeenCalledTimes(1);
+      expect(onclose).toHaveBeenCalledOnce();
       await transport.close();
       await transport.forceClose();
-      expect(onclose).toHaveBeenCalledTimes(1);
-      await expect(transport.start()).rejects.toThrow();
+      expect(onclose).toHaveBeenCalledOnce();
+      await expect(transport.start()).rejects.toThrow("closed");
       expect(spawnMock).not.toHaveBeenCalled();
     },
   );
 
-  it("kills the process tree when graceful stdio close does not exit", async () => {
-    vi.useFakeTimers();
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const closing = transport.close();
-    await vi.advanceTimersByTimeAsync(2000);
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGTERM", { detached: true });
-
-    child.exitCode = 0;
-    child.emit("close", 0);
-    await closing;
-  });
-
-  it("force-SIGKILLs synchronously when the owned process group outlives TERM", async () => {
-    vi.useFakeTimers();
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const closing = transport.close();
-    await vi.advanceTimersByTimeAsync(2000);
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGTERM", { detached: true });
-    expect(signalProcessTreeMock).not.toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
-
-    await vi.advanceTimersByTimeAsync(2000);
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
-
-    child.exitCode = 0;
-    child.emit("close", 0);
-    await closing;
-  });
-
-  it("force-closes an in-flight repeated graceful shutdown before returning", async () => {
-    vi.useFakeTimers();
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const closing = transport.close();
-    const repeatedClose = transport.close();
-    const forced = transport.forceClose();
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
-
-    child.exitCode = 0;
-    child.emit("close", 0);
-    await expect(forced).resolves.toBeUndefined();
-    await expect(closing).resolves.toBeUndefined();
-    await expect(repeatedClose).resolves.toBeUndefined();
-    expect(transport.pid).toBeNull();
-  });
-
-  it("immediately kills the retained process group after the stdio leader exits", async () => {
-    vi.useFakeTimers();
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    child.exitCode = 1;
-    child.emit("close", 1);
-    const closing = transport.close();
-
-    expect(signalProcessTreeMock).toHaveBeenCalledWith(4321, "SIGKILL", { detached: true });
-    await vi.advanceTimersByTimeAsync(500);
-    await closing;
-  });
-
-  it("does not signal a retired group when the child close event arrives late", async () => {
-    vi.useFakeTimers();
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+  it("joins one disposal across root exit, repeated close and forced escalation", async () => {
+    const fixture = createChild();
+    const transport = createTransport({ command: "node" });
     const onclose = vi.fn();
     Object.assign(transport, { onclose });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    child.exitCode = 0;
+    await transport.start();
     const closing = transport.close();
-    await vi.advanceTimersByTimeAsync(2000);
+    const settled = vi.fn();
+    void closing.then(settled);
+    expect(transport.close()).toBe(closing);
+    expect(transport.forceClose()).toBe(closing);
+    expect(fixture.child.kill).toHaveBeenCalledWith("SIGKILL");
+    fixture.root.resolve({ code: 0, signal: null });
+    await vi.waitFor(() => expect(onclose).toHaveBeenCalledOnce());
+    expect(settled).not.toHaveBeenCalled();
+    expect(transport.pid).toBe(4321);
+    fixture.extinction.resolve();
     await closing;
+    expect(closeMock).toHaveBeenCalledOnce();
+    expect(transport.pid).toBeNull();
+    await transport.forceClose();
+    await transport.close();
+    expect(fixture.child.kill).toHaveBeenCalledOnce();
+    expect(onclose).toHaveBeenCalledOnce();
+  });
+
+  it("keeps failed owner cleanup uncertain through repeated disposal", async () => {
+    const fixture = createChild();
+    const failure = new Error("cleanup owner lost");
+    const cleanupScope = createAgentCleanupScope();
+    const transport = createTransport({ command: "node" });
+    await transport.start();
+    const closing = transport.close();
+    fixture.root.resolve({ code: 0, signal: null });
+    fixture.extinction.reject(failure);
+    await expect(closing).rejects.toBe(failure);
+    await cleanupScope.run(async () => {
+      await expect(
+        disposeMcpClient({
+          transport,
+          transportType: "stdio",
+          client: { close: () => transport.close() },
+        }),
+      ).resolves.toBe("uncertain");
+      await expect(transport.close()).rejects.toBe(failure);
+    });
+    expect(cleanupScope.outcome).toBe("uncertain");
+  });
+
+  it.each([
+    { confirmed: true, outcome: "closed" },
+    { confirmed: false, outcome: "uncertain" },
+  ] as const)(
+    "reports $outcome when forced shutdown confirmation is $confirmed",
+    async ({ confirmed, outcome }) => {
+      vi.useFakeTimers();
+      const fixture = createChild();
+      fixture.child.kill.mockImplementation(() => {
+        if (confirmed) {
+          fixture.root.resolve({ code: null, signal: "SIGKILL" });
+          fixture.extinction.resolve();
+        }
+      });
+      const transport = createTransport({ command: "node" });
+      await transport.start();
+      const cleanupScope = createAgentCleanupScope();
+      const disposal = cleanupScope.run(() =>
+        disposeMcpClient(
+          {
+            transport,
+            transportType: "stdio",
+            client: { close: () => transport.close() },
+          },
+          50,
+        ),
+      );
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(disposal).resolves.toBe(outcome);
+      expect(cleanupScope.outcome).toBe(outcome);
+    },
+  );
+
+  it("cancels pending startup and replays its failed cleanup to later disposal", async () => {
+    const failure = new OwnedStdioCleanupError("startup owner lost", {
+      cause: new Error("MCP startup aborted"),
+    });
+    spawnMock.mockImplementation(
+      ({ abortSignal }: { abortSignal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          abortSignal.addEventListener("abort", () => reject(failure), { once: true });
+        }),
+    );
+    const transport = createTransport({ command: "node" });
+    const startup = transport.start().catch((error: unknown) => error);
+    await expect(transport.forceClose()).rejects.toBe(failure);
+    expect(await startup).toBe(failure);
     expect(transport.pid).toBeNull();
 
-    child.emit("close", 0);
-    expect(signalProcessTreeMock).not.toHaveBeenCalled();
-    expect(onclose).toHaveBeenCalledTimes(1);
+    const cleanupScope = createAgentCleanupScope();
+    await cleanupScope.run(async () => {
+      await expect(transport.close()).rejects.toBe(failure);
+    });
+    expect(cleanupScope.outcome).toBe("uncertain");
   });
 
-  it("sends and receives JSON-RPC messages over stdio", async () => {
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+  it("sends and receives JSON-RPC while preserving fragmented UTF-8 bytes", async () => {
+    const fixture = createChild();
+    const transport = createTransport({ command: "node" });
     const onmessage = vi.fn();
     Object.assign(transport, { onmessage });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
+    await transport.start();
     await transport.send({ jsonrpc: "2.0", id: 1, method: "ping" });
-    expect(child.stdin.read()?.toString()).toBe('{"jsonrpc":"2.0","id":1,"method":"ping"}\n');
-
-    child.stdout.write('{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n');
-    expect(onmessage).toHaveBeenCalledWith({
-      jsonrpc: "2.0",
-      id: 1,
-      result: { ok: true },
-    });
+    expect(fixture.stdin.read()?.toString()).toBe('{"jsonrpc":"2.0","id":1,"method":"ping"}\n');
+    const message = { jsonrpc: "2.0", id: 1, result: { text: "🦞" } };
+    const bytes = Buffer.from(`${JSON.stringify(message)}\n`);
+    const split = bytes.indexOf(Buffer.from("🦞")) + 1;
+    fixture.stdout.write(bytes.subarray(0, split));
+    fixture.stdout.write(bytes.subarray(split));
+    expect(onmessage).toHaveBeenCalledWith(message);
   });
 
-  it("rejects send() with EPIPE when child stdin is closed (#75438)", async () => {
-    const child = new MockChildProcess();
-    const brokenStdin = new PassThrough();
-    brokenStdin.write = (_chunk: unknown, cbOrEncoding?: unknown, cb?: unknown) => {
-      const callback =
-        typeof cbOrEncoding === "function" ? cbOrEncoding : typeof cb === "function" ? cb : null;
-      const err = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
-      if (callback) {
-        (callback as (err: Error) => void)(err);
-      }
-      return false;
-    };
-    child.stdin = brokenStdin;
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    await expect(transport.send({ jsonrpc: "2.0", id: 2, method: "ping" })).rejects.toThrow(
-      "EPIPE",
+  it.each(["callback", "throw"])("rejects failed stdin writes through %s", async (mode) => {
+    const fixture = createChild();
+    const failure = new Error("write EPIPE");
+    vi.spyOn(fixture.stdin, "write").mockImplementation(
+      (
+        _data,
+        encodingOrCallback: BufferEncoding | ((error?: Error | null) => void),
+        callback?: (error?: Error | null) => void,
+      ) => {
+        if (mode === "throw") {
+          throw failure;
+        }
+        const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+        done?.(failure);
+        return false;
+      },
     );
+    const transport = createTransport({ command: "node" });
+    await transport.start();
+    await expect(transport.send({ jsonrpc: "2.0", id: 1, method: "ping" })).rejects.toBe(failure);
   });
 
-  it("rejects send() when stdin.write throws synchronously (#75438)", async () => {
-    const child = new MockChildProcess();
-    const brokenStdin = new PassThrough();
-    brokenStdin.write = () => {
-      throw Object.assign(new Error("write after end"), { code: "ERR_STREAM_DESTROYED" });
-    };
-    child.stdin = brokenStdin;
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    await expect(transport.send({ jsonrpc: "2.0", id: 3, method: "ping" })).rejects.toThrow(
-      "write after end",
-    );
-  });
-
-  it("reports stderr pipe errors without an unhandled error crash", async () => {
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
-
-    const transport = new OpenClawStdioClientTransport({ command: "npx", stderr: "pipe" });
+  it("forwards owner stream errors and retains stderr diagnostics", async () => {
+    const fixture = createChild();
+    const transport = createTransport({ command: "node", stderr: "pipe" });
     const onerror = vi.fn();
     Object.assign(transport, { onerror });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const error = new Error("simulated pipe error");
-    expect(() => child.stderr?.emit("error", error)).not.toThrow();
-    expect(onerror).toHaveBeenCalledWith(error);
-
-    child.stderr.write("server diagnostic");
+    await transport.start();
+    const failure = new Error("simulated pipe failure");
+    fixture.emitError(failure);
+    fixture.stderr.write("server diagnostic");
+    expect(onerror).toHaveBeenCalledWith(failure);
     expect(transport.stderr?.read()?.toString()).toBe("server diagnostic");
   });
 
-  it("reports an oversized stdout frame without an unhandled error crash", async () => {
-    const child = new MockChildProcess();
-    spawnMock.mockReturnValue(child);
+  it("backpressures unread stderr and delivers every byte when the reader resumes", async () => {
+    const fixture = createChild();
+    const transport = createTransport({ command: "node", stderr: "pipe" });
+    await transport.start();
+    const destination = transport.stderr!;
+    const chunk = Buffer.alloc(16 * 1024, 0xad);
+    let completed = false;
+    const writing = (async () => {
+      for (let index = 0; index < 64; index += 1) {
+        if (!fixture.stderr.write(chunk)) {
+          await once(fixture.stderr, "drain");
+        }
+      }
+      completed = true;
+    })();
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+    expect(completed).toBe(false);
+    expect(destination.readableLength + destination.writableLength).toBeLessThanOrEqual(
+      4 * destination.writableHighWaterMark,
+    );
+    const received: Buffer[] = [];
+    destination.on("data", (data: Buffer) => received.push(data));
+    await writing;
+    fixture.root.resolve({ code: 0, signal: null });
+    fixture.extinction.resolve();
+    await transport.close();
+    expect(Buffer.concat(received)).toEqual(Buffer.alloc(chunk.length * 64, 0xad));
+  });
 
-    const transport = new OpenClawStdioClientTransport({ command: "npx" });
+  it("reports an oversized stdout frame without an unhandled error crash", async () => {
+    const fixture = createChild();
+    const transport = createTransport({ command: "node" });
     const onerror = vi.fn();
     Object.assign(transport, { onerror });
-    const started = transport.start();
-    child.emit("spawn");
-    await started;
-
-    const oversized = Buffer.alloc(10 * 1024 * 1024 + 1, 0x20);
-    expect(() => child.stdout.emit("data", oversized)).not.toThrow();
-    expect(onerror).toHaveBeenCalledTimes(1);
-    const reported = onerror.mock.calls.at(0)?.at(0) as Error;
-    expect(reported).toBeInstanceOf(Error);
-    expect(reported.message).toMatch(/exceeded maximum size/);
+    await transport.start();
+    expect(() => fixture.stdout.write(Buffer.alloc(10 * 1024 * 1024 + 1, 0x20))).not.toThrow();
+    expect(onerror).toHaveBeenCalledOnce();
+    expect(onerror.mock.calls[0]?.[0].message).toMatch(/exceeded maximum size/);
   });
 });

--- a/src/agents/mcp-stdio-transport.ts
+++ b/src/agents/mcp-stdio-transport.ts
@@ -1,7 +1,6 @@
 /**
  * OpenClaw stdio transport wrapper for MCP server subprocesses.
  */
-import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs/promises";
 import process from "node:process";
 import { PassThrough } from "node:stream";
@@ -11,8 +10,13 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { mergeProcessEnv } from "../infra/process-env.js";
-import { signalProcessTree } from "../process/kill-tree.js";
-import { prepareOomScoreAdjustedSpawn } from "../process/linux-oom-score.js";
+import {
+  closeOwnedStdioProcess,
+  createOwnedStdioProcess,
+  OwnedStdioCleanupError,
+  type OwnedStdioProcess,
+} from "../process/owned-stdio.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 
 type OpenClawStdioServerParameters = {
   command: string;
@@ -23,15 +27,6 @@ type OpenClawStdioServerParameters = {
   stderr?: "pipe" | "overlapped" | "inherit" | "ignore";
 };
 
-const CLOSE_TIMEOUT_MS = 2000;
-const SIGKILL_REAP_TIMEOUT_MS = 500;
-
-function delay(ms: number) {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, ms).unref();
-  });
-}
-
 export class OpenClawStdioClientTransport implements Transport {
   onclose?: () => void;
   onerror?: (error: Error) => void;
@@ -39,8 +34,13 @@ export class OpenClawStdioClientTransport implements Transport {
 
   private readonly readBuffer = new ReadBuffer();
   private readonly stderrStream: PassThrough | null = null;
-  private state: "ready" | "started" | "closing" | "closed" = "ready";
-  private process?: ChildProcess;
+  private process?: OwnedStdioProcess;
+  private starting?: Promise<void>;
+  private closing?: Promise<void>;
+  private forceRequested = false;
+  private closeNotified = false;
+  private readonly startupAbort = new AbortController();
+  private startupCleanupError?: OwnedStdioCleanupError;
 
   constructor(private readonly serverParams: OpenClawStdioServerParameters) {
     if (serverParams.stderr === "pipe" || serverParams.stderr === "overlapped") {
@@ -49,13 +49,16 @@ export class OpenClawStdioClientTransport implements Transport {
   }
 
   async start(): Promise<void> {
-    if (this.state !== "ready") {
+    if (this.starting || this.closing) {
       throw new Error(
         "OpenClawStdioClientTransport already started or closed; Client.connect() starts transports automatically.",
       );
     }
-    this.state = "started";
+    this.starting = this.startProcess();
+    return this.starting;
+  }
 
+  private async startProcess(): Promise<void> {
     const prepareDataDir = this.serverParams.prepareDataDir?.trim();
     if (prepareDataDir) {
       try {
@@ -67,67 +70,77 @@ export class OpenClawStdioClientTransport implements Transport {
         );
       }
     }
-    // Directory preparation yields before a child exists. Retirement must
-    // close that launch as well as any process it already created.
-    if (this.state !== "started") {
+
+    // Directory preparation may finish after shutdown has retired this launch.
+    if (this.startupAbort.signal.aborted) {
       throw new Error("MCP stdio transport is closed");
     }
 
-    await new Promise<void>((resolve, reject) => {
-      const baseEnv = mergeProcessEnv([getDefaultEnvironment(), this.serverParams.env]);
-      const preparedSpawn = prepareOomScoreAdjustedSpawn(
-        this.serverParams.command,
-        this.serverParams.args ?? [],
-        { env: baseEnv },
-      );
-      const child = spawn(preparedSpawn.command, preparedSpawn.args, {
+    try {
+      const child = await createOwnedStdioProcess({
+        argv: [this.serverParams.command, ...(this.serverParams.args ?? [])],
         cwd: this.serverParams.cwd,
-        detached: process.platform !== "win32",
-        env: preparedSpawn.env,
-        shell: false,
-        stdio: ["pipe", "pipe", this.serverParams.stderr ?? "inherit"],
-        windowsHide: process.platform === "win32",
+        env: mergeProcessEnv([getDefaultEnvironment(), this.serverParams.env]),
+        abortSignal: this.startupAbort.signal,
+        stderrDestination:
+          this.stderrStream ?? (this.serverParams.stderr === "ignore" ? undefined : process.stderr),
       });
       this.process = child;
-
-      child.on("error", (error: Error) => {
-        reject(error);
-        this.onerror?.(error);
-      });
-      child.on("spawn", () => resolve());
-      child.on("close", () => {
-        // Shutdown can finish before a delayed close event. Only the live
-        // child handle still owns the detached group; its PID can be reused later.
-        if (this.process === child && process.platform !== "win32" && child.pid) {
-          signalProcessTree(child.pid, "SIGKILL", { detached: true });
-        }
-        this.process = undefined;
-        this.finishClose();
-      });
-      child.stdin?.on("error", (error: Error) => this.onerror?.(error));
-      child.stdout?.on("data", (chunk: Buffer) => {
+      child.onError((error) => this.onerror?.(error));
+      const receive = (chunk: Buffer) => {
         try {
           this.readBuffer.append(chunk);
           this.processReadBuffer();
         } catch (error) {
           this.onerror?.(error instanceof Error ? error : new Error(String(error)));
-          void this.close();
+          void this.close().catch(() => {});
         }
-      });
-      child.stdout?.on("error", (error: Error) => this.onerror?.(error));
-      if (this.stderrStream && child.stderr) {
-        child.stderr.on("error", (error: Error) => this.onerror?.(error));
-        child.stderr.pipe(this.stderrStream);
+      };
+      child.onStdout((text) => {
+        if (!child.supportsRawOutput) {
+          receive(Buffer.from(text));
+        }
+      }, receive);
+      if (this.serverParams.stderr === "ignore") {
+        child.onStderr(() => {});
       }
-    });
+      // Root closure retires the connection immediately; the retained owner still
+      // joins descendants before disposal can certify completed cleanup.
+      void child.wait().then(
+        () => {
+          void this.close().catch(() => {});
+          this.notifyClosed();
+        },
+        (error: unknown) => {
+          this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+          void this.close().catch(() => {});
+          this.notifyClosed();
+        },
+      );
+    } catch (error) {
+      if (error instanceof OwnedStdioCleanupError) {
+        this.startupCleanupError = error;
+        recordAgentCleanupFailure();
+      }
+      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
   }
 
   get stderr() {
-    return this.stderrStream ?? this.process?.stderr ?? null;
+    return this.stderrStream;
   }
 
   get pid() {
     return this.process?.pid ?? null;
+  }
+
+  private notifyClosed(): void {
+    if (this.closeNotified) {
+      return;
+    }
+    this.closeNotified = true;
+    this.onclose?.();
   }
 
   private processReadBuffer() {
@@ -144,60 +157,44 @@ export class OpenClawStdioClientTransport implements Transport {
     }
   }
 
-  async close(): Promise<void> {
-    await this.stopProcess(false);
-  }
-
-  async forceClose(): Promise<void> {
-    await this.stopProcess(true);
-  }
-
-  private finishClose(): void {
-    if (this.state === "closed") {
-      return;
+  close(): Promise<void> {
+    if (this.starting && !this.process) {
+      this.startupAbort.abort();
     }
-    this.state = "closed";
-    this.readBuffer.clear();
-    this.onclose?.();
-  }
-
-  private async stopProcess(force: boolean): Promise<void> {
-    if (this.state === "closed") {
-      return;
-    }
-    this.state = "closing";
-    const processToClose = this.process;
-    if (processToClose) {
-      const isRunning = () => this.process === processToClose && processToClose.exitCode === null;
-      const closePromise = new Promise<void>((resolve) => {
-        processToClose.once("close", () => resolve());
-      });
-      if (!force) {
-        try {
-          processToClose.stdin?.end();
-        } catch {
-          // best-effort
+    this.closing ??= (async () => {
+      // A connect timeout can request disposal while the spawn owner is admitting.
+      await this.starting?.catch(() => undefined);
+      try {
+        if (this.startupCleanupError) {
+          throw this.startupCleanupError;
         }
-        await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
-        if (isRunning() && processToClose.pid) {
-          signalProcessTree(processToClose.pid, "SIGTERM", { detached: true });
-          await Promise.race([closePromise, delay(CLOSE_TIMEOUT_MS)]);
+        if (this.process) {
+          await closeOwnedStdioProcess(this.process, { force: this.forceRequested });
         }
+      } catch (error) {
+        recordAgentCleanupFailure();
+        throw error;
+      } finally {
+        this.process = undefined;
+        this.readBuffer.clear();
+        this.stderrStream?.end();
+        this.notifyClosed();
       }
-      if (processToClose.pid && (isRunning() || (force && process.platform !== "win32"))) {
-        signalProcessTree(processToClose.pid, "SIGKILL", { detached: true });
-        if (processToClose.exitCode === null) {
-          await Promise.race([closePromise, delay(SIGKILL_REAP_TIMEOUT_MS)]);
-        }
-      }
-    }
-    this.process = undefined;
-    this.finishClose();
+    })();
+    // Attach observation in this caller's scope, including already failed startup.
+    void this.closing.catch(() => recordAgentCleanupFailure());
+    return this.closing;
+  }
+
+  forceClose(): Promise<void> {
+    this.forceRequested = true;
+    this.process?.kill("SIGKILL");
+    return this.close();
   }
 
   send(message: JSONRPCMessage): Promise<void> {
     return new Promise((resolve, reject) => {
-      const stdin = this.state === "started" ? this.process?.stdin : undefined;
+      const stdin = this.closing ? undefined : this.process?.stdin;
       if (!stdin) {
         throw new Error("Not connected");
       }
@@ -205,18 +202,13 @@ export class OpenClawStdioClientTransport implements Transport {
       // Settle from the write callback so async EPIPE rejects instead of
       // escaping to uncaughtException. (#75438)
       try {
-        const flushed = stdin.write(json, (err) => {
+        stdin.write(json, (err) => {
           if (err) {
             reject(err);
           } else {
             resolve();
           }
         });
-        if (!flushed) {
-          // Back-pressure: drain fires when the buffer empties, but the
-          // write callback above still owns promise settlement.
-          stdin.once("drain", () => {});
-        }
       } catch (err) {
         reject(err instanceof Error ? err : new Error(String(err)));
       }

--- a/src/agents/memory-write-provenance.test.ts
+++ b/src/agents/memory-write-provenance.test.ts
@@ -1,14 +1,75 @@
+import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readMemoryArtifactProvenance } from "../memory/memory-artifact-provenance.js";
 import { resetPluginStateStoreForTests } from "../plugin-state/plugin-state-store.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { createMemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
+import {
+  createMemoryWriteProvenanceObserver,
+  withMemoryWriteProvenance,
+} from "./memory-write-provenance.js";
+import { withGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 
 afterEach(() => {
   resetPluginStateStoreForTests();
 });
 
 describe("memory write provenance", () => {
+  it.each(
+    (["write-classification", "write-observer", "remove-classification"] as const).flatMap(
+      (phase) => [false, true].map((revoke) => ({ phase, revoke })),
+    ),
+  )("preserves caller authority across $phase (revoke=$revoke)", async ({ phase, revoke }) => {
+    await withStateDirEnv("openclaw-memory-source-authority-", async ({ tempRoot }) => {
+      const target = `${tempRoot}/MEMORY.md`;
+      await fs.writeFile(target, "before");
+      let active = true;
+      const operations = withMemoryWriteProvenance(
+        {
+          readFile: (file: string) => fs.readFile(file),
+          writeFile: (file: string, content: string) => fs.writeFile(file, content),
+          remove: (file: string) => fs.rm(file),
+        },
+        {
+          classifies: async () => {
+            if (phase !== "write-observer" && revoke) {
+              active = false;
+            }
+            return true;
+          },
+          write: async ({ commit }) => {
+            if (phase === "write-observer" && revoke) {
+              active = false;
+            }
+            await commit();
+          },
+          clearAfterDelete: async () => {},
+        },
+      );
+      const pending = withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:memory-authority",
+          receiptAuthority: () => active,
+        },
+        () =>
+          phase === "remove-classification"
+            ? operations.remove(target)
+            : operations.writeFile(target, "after"),
+      );
+      if (revoke) {
+        await expect(pending).rejects.toThrow("authority is no longer active");
+        expect(await fs.readFile(target, "utf8")).toBe("before");
+      } else {
+        await pending;
+        if (phase === "remove-classification") {
+          await expect(fs.stat(target)).rejects.toMatchObject({ code: "ENOENT" });
+        } else {
+          expect(await fs.readFile(target, "utf8")).toBe("after");
+        }
+      }
+    });
+  });
+
   it("rolls provenance back when the filesystem write fails", async () => {
     await withStateDirEnv("openclaw-memory-provenance-", async ({ tempRoot }) => {
       const observer = createMemoryWriteProvenanceObserver({

--- a/src/agents/memory-write-provenance.ts
+++ b/src/agents/memory-write-provenance.ts
@@ -7,6 +7,7 @@ import {
   normalizeMemoryArtifactRelativePath,
   recordMemoryArtifactWriteProvenance,
 } from "../memory/memory-artifact-provenance.js";
+import { captureAgentToolSourceExecutionGuard } from "./agent-tool-source-execution-guard.js";
 
 export type MemoryWriteProvenanceObserver = {
   classifies: (absolutePath: string) => Promise<boolean>;
@@ -36,8 +37,14 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
   return {
     ...operations,
     writeFile: async (absolutePath: string, content: string) => {
+      // Retained provenance callbacks keep the invocation's original owner.
+      const assertCurrent = captureAgentToolSourceExecutionGuard();
+      const commit = () => {
+        assertCurrent();
+        return operations.writeFile(absolutePath, content);
+      };
       if (!(await observer.classifies(absolutePath))) {
-        await operations.writeFile(absolutePath, content);
+        await commit();
         return;
       }
       const contentBefore = await operations
@@ -53,12 +60,13 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
         absolutePath,
         contentBefore,
         contentAfter: content,
-        commit: () => operations.writeFile(absolutePath, content),
+        commit,
       });
     },
     ...(remove
       ? {
           remove: async (absolutePath: string) => {
+            const assertCurrent = captureAgentToolSourceExecutionGuard();
             const contentBefore = (await observer.classifies(absolutePath))
               ? await operations
                   .readFile(absolutePath)
@@ -70,6 +78,7 @@ export function withMemoryWriteProvenance<T extends ProvenanceWriteOperations>(
                     return "";
                   })
               : "";
+            assertCurrent();
             await remove(absolutePath);
             await observer.clearAfterDelete(absolutePath, contentBefore);
           },

--- a/src/agents/run-cleanup-timeout.test.ts
+++ b/src/agents/run-cleanup-timeout.test.ts
@@ -1,6 +1,6 @@
 // Verifies agent cleanup steps time out with bounded diagnostic logging.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { runAgentCleanupStep } from "./run-cleanup-timeout.js";
+import { runAgentCleanupStep, createAgentCleanupScope } from "./run-cleanup-timeout.js";
 
 const AGENT_CLEANUP_STEP_TIMEOUT_MS = 10_000;
 const CLEANUP_TIMEOUT_DETAILS_MAX_CHARS = 512;
@@ -268,6 +268,39 @@ describe("agent cleanup timeout", () => {
     );
   });
 
+  it.each([false, true])(
+    "preserves nested cleanup uncertainty and the original run outcome (fails=%s)",
+    async (fails) => {
+      const failure = new Error("run failed");
+      const outer = createAgentCleanupScope();
+      const inner = createAgentCleanupScope();
+      const result = outer.run(() =>
+        inner.run(async () => {
+          await runAgentCleanupStep({
+            runId: "nested",
+            sessionId: "isolated",
+            step: "registered-owner",
+            cleanup: async () => {
+              throw new Error("cleanup failed");
+            },
+            log,
+          });
+          if (fails) {
+            throw failure;
+          }
+          return "result";
+        }),
+      );
+      if (fails) {
+        await expect(result).rejects.toBe(failure);
+      } else {
+        await expect(result).resolves.toBe("result");
+      }
+      expect(inner.outcome).toBe("uncertain");
+      expect(outer.outcome).toBe("uncertain");
+    },
+  );
+
   it.each([
     {
       runId: "run-invalid-env-number",
@@ -325,4 +358,45 @@ describe("agent cleanup timeout", () => {
       "agent cleanup failed: runId=run-2 sessionId=session-2 step=context-engine-dispose error=dispose failed",
     );
   });
+  it.each([
+    { label: "completed", settles: true, fails: false, outcome: "closed" },
+    { label: "failed", settles: true, fails: true, outcome: "uncertain" },
+    { label: "stalled", settles: false, fails: false, outcome: "uncertain" },
+    { label: "late rejection", settles: false, fails: true, outcome: "uncertain" },
+  ])(
+    "bounds automatic cleanup and records $label ownership",
+    async ({ settles, fails, outcome }) => {
+      let settle!: () => void;
+      const held = new Promise<void>((resolve) => {
+        settle = resolve;
+      });
+      const scope = createAgentCleanupScope();
+      const result = scope.run(() =>
+        runAgentCleanupStep({
+          runId: "automatic",
+          sessionId: "isolated",
+          step: "registered-owner",
+          log,
+          timeoutMs: 5,
+          cleanup: async () => {
+            await held;
+            if (fails) {
+              throw new Error("teardown failed");
+            }
+          },
+        }),
+      );
+      try {
+        if (settles) {
+          settle();
+        }
+        await vi.advanceTimersByTimeAsync(5);
+        expect(scope.outcome).toBe(outcome);
+        await expect(result).resolves.toBeUndefined();
+      } finally {
+        settle();
+        await result;
+      }
+    },
+  );
 });

--- a/src/agents/run-cleanup-timeout.test.ts
+++ b/src/agents/run-cleanup-timeout.test.ts
@@ -11,6 +11,17 @@ describe("agent cleanup timeout", () => {
     warn: vi.fn(),
   };
 
+  const timeoutWithDetails = (getTimeoutDetails: () => string) =>
+    runAgentCleanupStep({
+      runId: "run-trajectory",
+      sessionId: "session-trajectory",
+      step: "agent-trajectory-flush",
+      cleanup: () => new Promise<never>(() => {}),
+      log,
+      timeoutMs: 5,
+      getTimeoutDetails,
+    });
+
   beforeEach(() => {
     vi.useFakeTimers();
     log.warn.mockClear();
@@ -89,18 +100,9 @@ describe("agent cleanup timeout", () => {
   });
 
   it("bounds cleanup timeout details before logging", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
     const oversizedDetails = `queuedBytes=${"9".repeat(CLEANUP_TIMEOUT_DETAILS_MAX_CHARS * 2)}`;
 
-    const result = runAgentCleanupStep({
-      runId: "run-trajectory",
-      sessionId: "session-trajectory",
-      step: "agent-trajectory-flush",
-      cleanup,
-      log,
-      timeoutMs: 5,
-      getTimeoutDetails: () => oversizedDetails,
-    });
+    const result = timeoutWithDetails(() => oversizedDetails);
 
     await vi.advanceTimersByTimeAsync(5);
     await expect(result).resolves.toBeUndefined();
@@ -117,21 +119,12 @@ describe("agent cleanup timeout", () => {
   });
 
   it("keeps truncated cleanup timeout details UTF-16 safe", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
     const prefixLength =
       CLEANUP_TIMEOUT_DETAILS_MAX_CHARS - CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX.length;
     const detailsPrefix = "a".repeat(prefixLength - 1);
     const oversizedDetails = `${detailsPrefix}😀${"b".repeat(CLEANUP_TIMEOUT_DETAILS_MAX_CHARS)}`;
 
-    const result = runAgentCleanupStep({
-      runId: "run-trajectory",
-      sessionId: "session-trajectory",
-      step: "agent-trajectory-flush",
-      cleanup,
-      log,
-      timeoutMs: 5,
-      getTimeoutDetails: () => oversizedDetails,
-    });
+    const result = timeoutWithDetails(() => oversizedDetails);
 
     await vi.advanceTimersByTimeAsync(5);
     await expect(result).resolves.toBeUndefined();
@@ -168,18 +161,9 @@ describe("agent cleanup timeout", () => {
 
   it("bounds cleanup timeout detail errors before logging", async () => {
     // Diagnostic failures must not produce unbounded logs or fail cleanup.
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
 
-    const result = runAgentCleanupStep({
-      runId: "run-trajectory",
-      sessionId: "session-trajectory",
-      step: "agent-trajectory-flush",
-      cleanup,
-      log,
-      timeoutMs: 5,
-      getTimeoutDetails: () => {
-        throw new Error("details unavailable ".repeat(CLEANUP_TIMEOUT_DETAILS_MAX_CHARS));
-      },
+    const result = timeoutWithDetails(() => {
+      throw new Error("details unavailable ".repeat(CLEANUP_TIMEOUT_DETAILS_MAX_CHARS));
     });
 
     await vi.advanceTimersByTimeAsync(5);

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -1,17 +1,51 @@
 /**
  * Agent cleanup timeout guard.
  *
- * Bounds cleanup steps so run completion cannot hang forever while preserving late-failure diagnostics.
+ * Bounds cleanup without certifying automatic ownership after timeout or failure.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import {
   parseStrictPositiveInteger,
   resolveOptionalIntegerOption,
 } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatErrorMessage } from "../infra/errors.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
-// Cleanup steps must not block run completion forever. This module bounds each
-// cleanup step and logs enough context to debug late failures.
+// Cleanup failures follow the originating run across nested async cleanup.
+const oneShotCleanup = resolveGlobalSingleton(
+  Symbol.for("openclaw.oneShotCleanupOutcome"),
+  () => new AsyncLocalStorage<{ uncertain: boolean }>(),
+);
+
+export function recordAgentCleanupFailure(): void {
+  const receipt = oneShotCleanup.getStore();
+  if (receipt) {
+    receipt.uncertain = true;
+  }
+}
+
+export function createAgentCleanupScope() {
+  const receipt = { uncertain: false };
+  return {
+    get outcome(): "closed" | "uncertain" {
+      return receipt.uncertain ? "uncertain" : "closed";
+    },
+    async run<T>(operation: () => Promise<T>): Promise<T> {
+      const parent = oneShotCleanup.getStore();
+      try {
+        return await oneShotCleanup.run(receipt, operation);
+      } finally {
+        // Nested executors cannot certify an outer owner after child cleanup failed.
+        if (receipt.uncertain && parent) {
+          parent.uncertain = true;
+        }
+      }
+    },
+  };
+}
+
+// The budget bounds reporting, not resource closure; automatic timeout stays uncertain.
 const AGENT_CLEANUP_STEP_TIMEOUT_MS = 10_000;
 const AGENT_CLEANUP_STEP_TIMEOUT_ENV = "OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS";
 const TRAJECTORY_FLUSH_TIMEOUT_ENV = "OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS";
@@ -22,14 +56,6 @@ const CLEANUP_TIMEOUT_DETAILS_TRUNCATED_SUFFIX = "...[truncated]";
 type AgentCleanupLogger = {
   warn: (message: string) => void;
 };
-
-function parseTimeoutEnvValue(value: string | undefined): number | undefined {
-  const trimmed = value?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  return parseStrictPositiveInteger(trimmed);
-}
 
 function resolveCleanupTimeoutDetails(
   getTimeoutDetails: (() => string | undefined) | undefined,
@@ -65,17 +91,54 @@ function resolveAgentCleanupStepTimeoutMs(params: {
 
   const env = params.env ?? process.env;
   if (params.step === "openclaw-trajectory-flush") {
-    const trajectoryTimeoutMs = parseTimeoutEnvValue(env[TRAJECTORY_FLUSH_TIMEOUT_ENV]);
+    const trajectoryTimeoutMs = parseStrictPositiveInteger(env[TRAJECTORY_FLUSH_TIMEOUT_ENV]);
     if (trajectoryTimeoutMs !== undefined) {
       return trajectoryTimeoutMs;
     }
   }
 
-  return parseTimeoutEnvValue(env[AGENT_CLEANUP_STEP_TIMEOUT_ENV]) ?? AGENT_CLEANUP_STEP_TIMEOUT_MS;
+  return (
+    parseStrictPositiveInteger(env[AGENT_CLEANUP_STEP_TIMEOUT_ENV]) ?? AGENT_CLEANUP_STEP_TIMEOUT_MS
+  );
 }
 
-/** Run one cleanup step with timeout logging and late-rejection handling. */
-export async function runAgentCleanupStep(params: {
+/** Preserve the owner's errors while bounding automatic one-shot resource settlement. */
+export async function runOwnedAgentCleanup(params: {
+  runId: string;
+  sessionId: string;
+  oneShotCliRun?: boolean;
+  settlement?: "required";
+  step: string;
+  cleanup: () => Promise<void>;
+  log: AgentCleanupLogger;
+}): Promise<void> {
+  if (!params.oneShotCliRun) {
+    try {
+      await params.cleanup();
+    } catch (error) {
+      recordAgentCleanupFailure();
+      throw error;
+    }
+    return;
+  }
+  const outcome = await settleAgentCleanupStep({
+    runId: params.runId,
+    sessionId: params.sessionId,
+    step: params.step,
+    log: params.log,
+    cleanup: params.cleanup,
+  });
+  if (typeof outcome === "object") {
+    throw outcome.error;
+  }
+  if (outcome === "timeout" && params.settlement === "required") {
+    throw new Error(
+      `Agent cleanup timed out before ${params.step} settled; resource replacement refused.`,
+    );
+  }
+}
+
+type AgentCleanupStepParams = {
   runId: string;
   sessionId: string;
   step: string;
@@ -84,7 +147,18 @@ export async function runAgentCleanupStep(params: {
   log: AgentCleanupLogger;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
-}): Promise<void> {
+};
+
+/** Run one cleanup step with timeout logging and late-rejection handling. */
+export async function runAgentCleanupStep(params: AgentCleanupStepParams): Promise<void> {
+  await settleAgentCleanupStep(params);
+}
+
+type AgentCleanupStepOutcome = "done" | "timeout" | { error: unknown };
+
+async function settleAgentCleanupStep(
+  params: AgentCleanupStepParams,
+): Promise<AgentCleanupStepOutcome> {
   const timeoutMs = resolveAgentCleanupStepTimeoutMs({
     step: params.step,
     timeoutMs: params.timeoutMs,
@@ -93,13 +167,16 @@ export async function runAgentCleanupStep(params: {
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   let timedOut = false;
   const cleanupPromise = Promise.resolve().then(params.cleanup);
-  const observedCleanupPromise = cleanupPromise.catch((error: unknown) => {
-    if (!timedOut) {
+  const observedCleanupPromise = cleanupPromise
+    .then(() => "done" as const)
+    .catch((error: unknown) => {
+      recordAgentCleanupFailure();
+      const phase = timedOut ? "rejected after timeout" : "failed";
       params.log.warn(
-        `agent cleanup failed: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} error=${formatErrorMessage(error)}`,
+        `agent cleanup ${phase}: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} error=${formatErrorMessage(error)}`,
       );
-    }
-  });
+      return { error };
+    });
   const timeoutPromise = new Promise<"timeout">((resolve) => {
     timeoutHandle = setTimeout(() => {
       timedOut = true;
@@ -107,24 +184,16 @@ export async function runAgentCleanupStep(params: {
     }, timeoutMs);
     timeoutHandle.unref?.();
   });
-  const result = await Promise.race([
-    observedCleanupPromise.then(() => "done" as const),
-    timeoutPromise,
-  ]);
+  const result = await Promise.race([observedCleanupPromise, timeoutPromise]);
   if (timeoutHandle) {
     clearTimeout(timeoutHandle);
   }
   if (result === "timeout") {
+    recordAgentCleanupFailure();
     const details = resolveCleanupTimeoutDetails(params.getTimeoutDetails);
     params.log.warn(
       `agent cleanup timed out: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} timeoutMs=${timeoutMs}${details}`,
     );
-    // Keep observing the original cleanup promise so late failures do not turn
-    // into unhandled rejections after the timeout path returned.
-    void cleanupPromise.catch((error: unknown) => {
-      params.log.warn(
-        `agent cleanup rejected after timeout: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} error=${formatErrorMessage(error)}`,
-      );
-    });
   }
+  return result;
 }

--- a/src/agents/sessions/tools/edit.ts
+++ b/src/agents/sessions/tools/edit.ts
@@ -13,6 +13,7 @@ import {
 import { Box, Container, Spacer, Text } from "@earendil-works/pi-tui";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { Type } from "typebox";
+import { captureAgentToolSourceExecutionGuard } from "../../agent-tool-source-execution-guard.js";
 import { normalizeToLF } from "../../line-endings.js";
 import { renderDiff } from "../../modes/interactive/components/diff.js";
 import type { AgentTool } from "../../runtime/index.js";
@@ -411,6 +412,7 @@ export function createEditToolDefinition(
       void toolCallId;
       void onUpdate;
       void ctx;
+      const assertCurrent = captureAgentToolSourceExecutionGuard();
       const { path, edits: originalEdits } = validateEditInput(input);
       const absolutePath = resolvePath(path, cwd);
       const queueKey = resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey, signal);
@@ -419,6 +421,7 @@ export function createEditToolDefinition(
         if (signal?.aborted) {
           throw new Error("Operation aborted");
         }
+        assertCurrent();
 
         let realEdits: Edit[] = [];
         let expectedContent: string | undefined;
@@ -441,6 +444,7 @@ export function createEditToolDefinition(
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
+          assertCurrent();
 
           const { bom, text: content } = stripBom(rawContent);
           const normalizedContent = normalizeToLF(content);
@@ -466,12 +470,14 @@ export function createEditToolDefinition(
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
+          assertCurrent();
           if (!(await verifyPersistedUtf8File(absolutePath, expectedContent, ops))) {
             throw new Error(
               `Edit verification failed for ${path}: the persisted regular file does not match the requested content. Inspect the target and retry.`,
             );
           }
 
+          assertCurrent();
           const diffResult = generateDiffString(baseContent, newContent);
           const patch = generateUnifiedPatch(path, baseContent, newContent);
           return {
@@ -491,6 +497,7 @@ export function createEditToolDefinition(
             },
           };
         } catch (error: unknown) {
+          assertCurrent();
           const normalizedError = error instanceof Error ? error : new Error(String(error));
           const currentContent = await ops
             .readFile(absolutePath)
@@ -500,6 +507,7 @@ export function createEditToolDefinition(
             expectedContent !== undefined &&
             (await verifyPersistedUtf8File(absolutePath, expectedContent, ops))
           ) {
+            assertCurrent();
             return {
               content: [
                 {

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -14,6 +14,7 @@ import { Container, Text } from "@earendil-works/pi-tui";
 import { structuredPatch } from "diff";
 import { Type } from "typebox";
 import { isMissingPathError } from "../../../infra/errors.js";
+import { captureAgentToolSourceExecutionGuard } from "../../agent-tool-source-execution-guard.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import { getLanguageFromPath, highlightCode } from "../../modes/interactive/theme/theme.js";
 import type { AgentTool } from "../../runtime/index.js";
@@ -536,6 +537,7 @@ export function createWriteToolDefinition(
       void toolCallId;
       void onUpdate;
       void ctx;
+      const assertCurrent = captureAgentToolSourceExecutionGuard();
       const absolutePath = resolvePath(path, cwd);
       const dir = dirname(absolutePath);
       const queueKey = resolveFileMutationQueueKey(absolutePath, ops.resolveQueueKey, signal);
@@ -544,6 +546,7 @@ export function createWriteToolDefinition(
         if (signal?.aborted) {
           throw new Error("Operation aborted");
         }
+        assertCurrent();
         // No-op: file already has identical content. Not terminal — the model
         // may still be mid-task and needs a continuation, not an ended turn.
         if (precheck.state === "same") {
@@ -553,21 +556,26 @@ export function createWriteToolDefinition(
         }
         const details = await resolveWriteDetails({ absolutePath, content, ops, path, precheck });
         try {
+          assertCurrent();
           await ops.mkdir(dir);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
+          assertCurrent();
           await ops.writeFile(absolutePath, content);
           if (signal?.aborted) {
             throw new Error("Operation aborted");
           }
+          assertCurrent();
           if (!(await verifyPersistedUtf8File(absolutePath, content, ops))) {
             throw new Error(
               `Write verification failed for ${path}: the persisted regular file does not match the requested content. Inspect the target and retry.`,
             );
           }
+          assertCurrent();
           return successfulWriteResult(path, content, details);
         } catch (error: unknown) {
+          assertCurrent();
           const recovered = await recoverSuccessfulWrite({
             absolutePath,
             content,
@@ -579,6 +587,7 @@ export function createWriteToolDefinition(
             signal,
           });
           if (recovered) {
+            assertCurrent();
             return recovered;
           }
           throw error;

--- a/src/commands/agent-exec.budget.test.ts
+++ b/src/commands/agent-exec.budget.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { bindAgentToolSourceExecutionGuard } from "../agents/agent-tool-source-execution-guard.js";
 import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.js";
 import { createStubTool } from "../agents/test-helpers/agent-tool-stubs.js";
@@ -136,28 +137,55 @@ describe("bounded agent exec", () => {
         baseConfig,
         maxToolCalls: 1,
         runAgent: async (opts) => {
+          const ready = createDeferred();
+          let output = "";
           child = await getProcessSupervisor().spawn({
             mode: "child",
-            argv: [process.execPath, "-e", "setInterval(() => {}, 1000)"],
+            argv: [
+              process.execPath,
+              "-e",
+              `process.once("SIGTERM", () => setTimeout(() => process.exit(0), 250));
+               process.stdout.write("ready");
+               setInterval(() => {}, 1000);`,
+            ],
             sessionId: String(opts.sessionId),
             scopeKey: String(opts.sessionKey),
             backendId: "budget-test",
             timeoutMs: 30_000,
+            onStdout: (chunk) => {
+              output += chunk;
+              if (output.includes("ready")) {
+                ready.resolve();
+              }
+            },
           });
+          await Promise.race([
+            ready.promise,
+            child.wait().then(() => {
+              throw new Error("The background process exited before readiness");
+            }),
+          ]);
           return success();
         },
       });
 
-      expect(result.exitCode).toBe(0);
-      expect(await child?.wait()).toMatchObject({ reason: "manual-cancel" });
+      expect(result.exitCode).toBe(process.platform === "win32" ? 1 : 0);
+      if (process.platform === "win32") {
+        expect(result.envelope.error?.message).toContain(
+          "cannot confirm owned execution-tree settlement",
+        );
+      }
       const pid = child?.pid;
       expect(pid).toBeTypeOf("number");
       if (pid === undefined) {
         throw new Error("The background process did not start");
       }
+      // No post-return wait may supply the cleanup that the command must own.
       expect(() => process.kill(pid, 0)).toThrow();
+      expect(await child?.wait()).toMatchObject({ reason: "manual-cancel" });
     } finally {
       child?.cancel();
+      await child?.wait();
       await child?.waitForExtinction?.();
     }
   });

--- a/src/commands/agent-exec.state-lock.test.ts
+++ b/src/commands/agent-exec.state-lock.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  recordAgentCleanupFailure,
+  createAgentCleanupScope,
+} from "../agents/run-cleanup-timeout.js";
 import { acquireGatewayLock, type GatewayLockOptions } from "../infra/gateway-lock.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { agentExecCommand } from "./agent-exec.js";
@@ -67,6 +71,50 @@ function createSignalProcess() {
 }
 
 describe("agent exec retained-state ownership", () => {
+  it.each([false, true])(
+    "retains state after uncertain runtime cleanup (retained=%s)",
+    async (retained) => {
+      const root = tempDirs.make("openclaw-agent-exec-uncertain-cleanup-");
+      const lockOptions = createGatewayLockOptions(root);
+      const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+      const cleanupScope = createAgentCleanupScope();
+      let runStateDir: string | undefined;
+      try {
+        const result = await cleanupScope.run(() =>
+          agentExecCommand("inspect", retained ? { stateDir: root } : {}, createRuntime().runtime, {
+            gatewayLockOptions: lockOptions,
+            runAgent: async () => {
+              runStateDir = process.env.OPENCLAW_STATE_DIR;
+              if (!runStateDir) {
+                throw new Error("Expected the command's state directory");
+              }
+              await fs.writeFile(path.join(runStateDir, "owned-work"), "still owned");
+              recordAgentCleanupFailure();
+              return successResult();
+            },
+          }),
+        );
+        expect.soft(result.exitCode).toBe(1);
+        expect.soft(cleanupScope.outcome).toBe("uncertain");
+        expect.soft(process.env.OPENCLAW_STATE_DIR).toBe(previousStateDir);
+        expect(runStateDir).toBeDefined();
+        await expect(fs.readFile(path.join(runStateDir!, "owned-work"), "utf8")).resolves.toBe(
+          "still owned",
+        );
+        if (retained) {
+          const owner = JSON.parse(
+            await fs.readFile(path.join(lockOptions.lockDir!, "gateway.state.lock"), "utf8"),
+          );
+          expect(owner).toMatchObject({ pid: process.pid, role: "agent-embedded" });
+        }
+      } finally {
+        if (!retained && runStateDir) {
+          await fs.rm(runStateDir, { recursive: true, force: true });
+        }
+      }
+    },
+  );
+
   it("refuses a state directory owned by a live Gateway", async () => {
     const stateDir = tempDirs.make("openclaw-agent-exec-gateway-owner-");
     const lockOptions = createGatewayLockOptions(stateDir, {

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { findAgentRunTerminalOutcome } from "../agents/agent-run-terminal-error.js";
 import { createAgentToolExecutionBudget } from "../agents/agent-tool-source-execution-guard.js";
+import {
+  recordAgentCleanupFailure,
+  createAgentCleanupScope,
+} from "../agents/run-cleanup-timeout.js";
 import { isExecutionIdentityCollectionEnabled } from "../audit/audit-config.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -222,7 +226,9 @@ export async function agentExecCommand(
   });
   let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
   let processScopeKey: string | undefined;
+  let cleanupProcessScope: (() => Promise<void>) | undefined;
   let commandResult: AgentExecCommandResult;
+  const runtimeCleanup = createAgentCleanupScope();
   let temporaryStateDir: string | undefined;
   let restoreEnvironment: (() => void) | undefined;
   let restoreConfigEnvironment: (() => void) | undefined;
@@ -347,11 +353,17 @@ export async function agentExecCommand(
     const storedAuthAgentDir = resolveAgentDir(baseConfig, execAgentId);
     runtimePaths = await import("../config/paths.js");
     const storedAuthStateDir = runtimePaths.resolveStateDir();
-    // Bounded runs own their process scope, including commands that yielded to background.
+    // Capture cleanup before a child can finish or lose its native owner.
     processScopeKey =
       deps.timeoutMs !== undefined || deps.maxToolCalls !== undefined
         ? `agent:${execAgentId}:agent-exec:${sessionId}`
         : undefined;
+    if (processScopeKey) {
+      const { getProcessSupervisor } = await import("../process/supervisor/index.js");
+      cleanupProcessScope = getProcessSupervisor().acquireScopeCleanup(processScopeKey, {
+        requireProcessTree: true,
+      });
+    }
     restoreEnvironment = setAgentExecEnvironment({ stateDir, cwd });
     runtimePaths.pinRuntimePaths();
     if (opts.stateDir) {
@@ -450,10 +462,12 @@ export async function agentExecCommand(
             storedAuthStateDir,
             runWithPluginInstallRoots,
           );
-    const result = await toolBudget.run(() =>
-      withHostExecInheritedEnvOmitted(
-        listKnownProviderAuthEnvVarNames({ env: process.env }),
-        runWithAuthScope,
+    const result = await runtimeCleanup.run(() =>
+      toolBudget.run(() =>
+        withHostExecInheritedEnvOmitted(
+          listKnownProviderAuthEnvVarNames({ env: process.env }),
+          runWithAuthScope,
+        ),
       ),
     );
     signal.throwIfAborted();
@@ -478,23 +492,27 @@ export async function agentExecCommand(
     };
   }
 
-  let cleanupError: unknown;
+  let cleanupError: unknown =
+    runtimeCleanup.outcome === "uncertain"
+      ? new Error(
+          "Agent runtime cleanup did not settle; state ownership retained until this process exits",
+        )
+      : undefined;
   clearTimeout(timeoutTimer);
-  if (processScopeKey) {
+  if (cleanupProcessScope) {
     abortController.abort(new Error("Agent execution completed"));
     try {
-      const { getProcessSupervisor } = await import("../process/supervisor/index.js");
-      const supervisor = getProcessSupervisor();
-      supervisor.cancelScope(processScopeKey);
-      await supervisor.waitForScope?.(processScopeKey);
+      await cleanupProcessScope();
     } catch (error) {
       cleanupError = error;
     }
   }
   await stopLocalAuditWriter?.().catch(() => undefined);
-  await stateLock?.release().catch((error: unknown) => {
-    cleanupError ??= error;
-  });
+  if (!cleanupError) {
+    await stateLock?.release().catch((error: unknown) => {
+      cleanupError = error;
+    });
+  }
   const runCleanupStep = (step: () => void) => {
     try {
       step();
@@ -511,7 +529,7 @@ export async function agentExecCommand(
       : configIo?.clearRuntimeConfigSnapshot(),
   );
   runCleanupStep(() => runtimePaths?.pinRuntimePaths());
-  if (temporaryStateDir) {
+  if (temporaryStateDir && !cleanupError) {
     try {
       await fs.rm(temporaryStateDir, { recursive: true, force: true });
     } catch (error) {
@@ -519,6 +537,7 @@ export async function agentExecCommand(
     }
   }
   if (cleanupError) {
+    recordAgentCleanupFailure();
     const cleanupFailure = new Error(
       `Agent exec cleanup failed: ${formatErrorMessage(cleanupError)}`,
     );

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -3,6 +3,7 @@
  */
 import { spawn } from "node:child_process";
 import { once } from "node:events";
+import { createServer } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isProcessAlive } from "../../test/helpers/process-wait.js";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
@@ -11,6 +12,10 @@ import {
   type ReplyOperation,
 } from "../auto-reply/reply/reply-run-registry.js";
 import type { InternalHookEvent } from "../hooks/internal-hooks.js";
+import {
+  emitTrustedDiagnosticEvent,
+  waitForDiagnosticEventsDrained,
+} from "../infra/diagnostic-events.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getActivePluginRegistry,
@@ -22,9 +27,11 @@ import {
   PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS,
   startPluginServices,
 } from "../plugins/services.js";
+import type { OpenClawPluginService } from "../plugins/types.js";
 import { getProcessSupervisor, type ManagedRun } from "../process/supervisor/index.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalMap, resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { loadBundledPluginFacade } from "../test-utils/bundled-plugin-public-surface.js";
 import type {
   GatewayCloseParams as GatewayTeardownParams,
   GatewayClosePrepareParams,
@@ -286,6 +293,101 @@ describe("createGatewayCloseHandler", () => {
     expect(httpClose).toHaveBeenCalled();
     expect(result.warnings.length).toBeGreaterThan(0);
     expect(getActivePluginRegistry()).toBeNull();
+  });
+
+  it("does not retire Gateway dependencies after real diagnostic shutdown rejects with exports pending", async () => {
+    const { createDiagnosticsOtelService } = await loadBundledPluginFacade<{
+      createDiagnosticsOtelService: () => OpenClawPluginService;
+    }>({ pluginId: "diagnostics-otel", artifactBasename: "runtime-api.js" });
+    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "2");
+    vi.stubEnv("OTEL_BSP_MAX_QUEUE_SIZE", "100");
+    vi.stubEnv("OTEL_NODE_RESOURCE_DETECTORS", "none");
+    const pending = new Set<import("node:http").ServerResponse>();
+    const requestsReady = createDeferredCore();
+    let requests = 0;
+    const collector = createServer((req, res) => {
+      req.resume();
+      requests++;
+      if (requests === 2) {
+        res.statusCode = 400;
+        res.end("synthetic rejected batch");
+      } else {
+        pending.add(res);
+        res.on("close", () => pending.delete(res));
+      }
+      if (requests === 4) {
+        requestsReady.resolve();
+      }
+    });
+    collector.listen(0, "127.0.0.1");
+    await once(collector, "listening");
+    const address = collector.address();
+    if (!address || typeof address === "string") {
+      throw new Error("missing collector address");
+    }
+    const service = createDiagnosticsOtelService();
+    const registry = createEmptyPluginRegistry();
+    registry.services.push({
+      pluginId: "diagnostics-otel",
+      service,
+      source: "test",
+      origin: "bundled",
+    });
+    setActivePluginRegistry(registry);
+    const pluginServices = await startPluginServices({
+      registry,
+      config: {
+        diagnostics: {
+          enabled: true,
+          otel: {
+            enabled: true,
+            endpoint: `http://127.0.0.1:${address.port}`,
+            traces: true,
+            metrics: false,
+            logs: false,
+            sampleRate: 1,
+            flushIntervalMs: 60_000,
+          },
+        },
+      },
+    });
+    try {
+      for (let index = 0; index < 7; index++) {
+        emitTrustedDiagnosticEvent({
+          type: "message.processed",
+          channel: "synthetic",
+          outcome: "completed",
+          durationMs: 1,
+        });
+      }
+      await waitForDiagnosticEventsDrained();
+      const clearSecretsRuntimeSnapshot = vi.fn();
+      const deps = createGatewayCloseTestDeps({ pluginServices, clearSecretsRuntimeSnapshot });
+      const outcome = await createGatewayCloseHandler(deps)({
+        reason: "gateway startup failed",
+      }).then(
+        (result) => ({ status: "fulfilled", result }),
+        (error: unknown) => ({ status: "rejected", error }),
+      );
+      await requestsReady.promise;
+      expect(pending.size).toBe(3);
+      expect(deps.heartbeatRunner.stop).toHaveBeenCalledOnce();
+      expect(outcome.status).toBe("rejected");
+      expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
+      expect(getActivePluginRegistry()).toBe(registry);
+      expect(clearSecretsRuntimeSnapshot).not.toHaveBeenCalled();
+    } finally {
+      for (const response of pending) {
+        response.end();
+      }
+      collector.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        collector.close(() => resolve());
+      });
+      await pluginServices.stop().catch(() => {});
+      await waitForDiagnosticEventsDrained();
+      vi.unstubAllEnvs();
+    }
   });
 
   it("completes a clean shutdown with a ShutdownResult", async () => {

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -3,7 +3,6 @@
  */
 import { spawn } from "node:child_process";
 import { once } from "node:events";
-import { createServer } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isProcessAlive } from "../../test/helpers/process-wait.js";
 import { isAgentRunRestartAbortReason } from "../agents/run-termination.js";
@@ -12,10 +11,6 @@ import {
   type ReplyOperation,
 } from "../auto-reply/reply/reply-run-registry.js";
 import type { InternalHookEvent } from "../hooks/internal-hooks.js";
-import {
-  emitTrustedDiagnosticEvent,
-  waitForDiagnosticEventsDrained,
-} from "../infra/diagnostic-events.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getActivePluginRegistry,
@@ -31,7 +26,6 @@ import type { OpenClawPluginService } from "../plugins/types.js";
 import { getProcessSupervisor, type ManagedRun } from "../process/supervisor/index.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalMap, resolveGlobalSingleton } from "../shared/global-singleton.js";
-import { loadBundledPluginFacade } from "../test-utils/bundled-plugin-public-surface.js";
 import type {
   GatewayCloseParams as GatewayTeardownParams,
   GatewayClosePrepareParams,
@@ -295,98 +289,30 @@ describe("createGatewayCloseHandler", () => {
     expect(getActivePluginRegistry()).toBeNull();
   });
 
-  it("does not retire Gateway dependencies after real diagnostic shutdown rejects with exports pending", async () => {
-    const { createDiagnosticsOtelService } = await loadBundledPluginFacade<{
-      createDiagnosticsOtelService: () => OpenClawPluginService;
-    }>({ pluginId: "diagnostics-otel", artifactBasename: "runtime-api.js" });
-    vi.stubEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", "2");
-    vi.stubEnv("OTEL_BSP_MAX_QUEUE_SIZE", "100");
-    vi.stubEnv("OTEL_NODE_RESOURCE_DETECTORS", "none");
-    const pending = new Set<import("node:http").ServerResponse>();
-    const requestsReady = createDeferredCore();
-    let requests = 0;
-    const collector = createServer((req, res) => {
-      req.resume();
-      requests++;
-      if (requests === 2) {
-        res.statusCode = 400;
-        res.end("synthetic rejected batch");
-      } else {
-        pending.add(res);
-        res.on("close", () => pending.delete(res));
-      }
-      if (requests === 4) {
-        requestsReady.resolve();
-      }
-    });
-    collector.listen(0, "127.0.0.1");
-    await once(collector, "listening");
-    const address = collector.address();
-    if (!address || typeof address === "string") {
-      throw new Error("missing collector address");
-    }
-    const service = createDiagnosticsOtelService();
-    const registry = createEmptyPluginRegistry();
-    registry.services.push({
-      pluginId: "diagnostics-otel",
-      service,
-      source: "test",
-      origin: "bundled",
-    });
-    setActivePluginRegistry(registry);
-    const pluginServices = await startPluginServices({
-      registry,
-      config: {
-        diagnostics: {
-          enabled: true,
-          otel: {
-            enabled: true,
-            endpoint: `http://127.0.0.1:${address.port}`,
-            traces: true,
-            metrics: false,
-            logs: false,
-            sampleRate: 1,
-            flushIntervalMs: 60_000,
-          },
-        },
+  it("retains Gateway dependencies when a trusted diagnostic service rejects shutdown", async () => {
+    const service: OpenClawPluginService = {
+      id: "diagnostics-otel",
+      start: async () => {},
+      stop: async () => {
+        throw new Error("synthetic plugin cleanup failed");
       },
-    });
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.services.push({ pluginId: service.id, service, source: "test", origin: "bundled" });
+    setActivePluginRegistry(registry);
+    const pluginServices = await startPluginServices({ registry, config: {} });
+    const clearSecretsRuntimeSnapshot = vi.fn();
+    const deps = createGatewayCloseTestDeps({ pluginServices, clearSecretsRuntimeSnapshot });
     try {
-      for (let index = 0; index < 7; index++) {
-        emitTrustedDiagnosticEvent({
-          type: "message.processed",
-          channel: "synthetic",
-          outcome: "completed",
-          durationMs: 1,
-        });
-      }
-      await waitForDiagnosticEventsDrained();
-      const clearSecretsRuntimeSnapshot = vi.fn();
-      const deps = createGatewayCloseTestDeps({ pluginServices, clearSecretsRuntimeSnapshot });
-      const outcome = await createGatewayCloseHandler(deps)({
-        reason: "gateway startup failed",
-      }).then(
-        (result) => ({ status: "fulfilled", result }),
-        (error: unknown) => ({ status: "rejected", error }),
-      );
-      await requestsReady.promise;
-      expect(pending.size).toBe(3);
+      await expect(
+        createGatewayCloseHandler(deps)({ reason: "gateway startup failed" }),
+      ).rejects.toThrow("synthetic plugin cleanup failed");
       expect(deps.heartbeatRunner.stop).toHaveBeenCalledOnce();
-      expect(outcome.status).toBe("rejected");
       expect(mocks.closePluginStateDatabase).not.toHaveBeenCalled();
       expect(getActivePluginRegistry()).toBe(registry);
       expect(clearSecretsRuntimeSnapshot).not.toHaveBeenCalled();
     } finally {
-      for (const response of pending) {
-        response.end();
-      }
-      collector.closeAllConnections();
-      await new Promise<void>((resolve) => {
-        collector.close(() => resolve());
-      });
       await pluginServices.stop().catch(() => {});
-      await waitForDiagnosticEventsDrained();
-      vi.unstubAllEnvs();
     }
   });
 

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -607,9 +607,9 @@ export async function completeGatewayClose(
       warnings,
     });
   } finally {
-    // Grace lets independent teardown advance; pending plugin cleanup still owns
-    // shared state. Its rejection was reported by the disposal policy above.
-    await pluginServicesCleanup?.catch(() => {});
+    // Grace lets independent teardown advance; failed plugin cleanup still owns
+    // shared state and must prevent a new Gateway lifecycle from starting.
+    await pluginServicesCleanup;
     await params.finishRequestEntries?.();
     if (mediaCleanupStopResult === "drained") {
       await shutdownStep("plugin-state-store", () => closePluginStateDatabase(), warnings);

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -547,7 +547,18 @@ describe("createGatewayKernel", () => {
       kernel.kernel.setGatewayLifetimeSidecars([persistentSidecar, successfulPeer]);
 
       await expect(kernel.closeOnStartupFailure()).rejects.toMatchObject({
-        errors: [{ cause: persistentError }],
+        errors: [
+          {
+            message:
+              "shutdown step failed (gateway lifetime sidecars): persistent sidecar cleanup failed",
+            cause: persistentError,
+          },
+          {
+            message:
+              "shutdown step failed (late sidecar cleanup): persistent sidecar cleanup failed",
+            cause: persistentError,
+          },
+        ],
       });
       expect(persistentStop).toHaveBeenCalledTimes(2);
       expect(successfulPeer.stop).toHaveBeenCalledOnce();

--- a/src/gateway/server-lifecycle.ts
+++ b/src/gateway/server-lifecycle.ts
@@ -619,7 +619,7 @@ export async function prepareGatewayLifecycle(params: {
         { name: "gateway lifetime sidecars", run: stopRegisteredGatewayLifetimeSidecars },
         { name: "post-ready sidecars", run: stopRegisteredPostReadySidecars },
         { name: "gateway close prelude", run: runClosePrelude },
-        { name: "late sidecar cleanup", run: sealAndJoinRegisteredSidecarStops },
+        { name: "late sidecar cleanup", run: sealAndJoinRegisteredSidecarStops, required: true },
         {
           name: "gateway close",
           run: close,

--- a/src/gateway/server-sidecar-owners.ts
+++ b/src/gateway/server-sidecar-owners.ts
@@ -5,14 +5,13 @@ export function createGatewaySidecarStopOwner(params: {
   setRegistered: (sidecars: GatewayPostReadySidecarHandle[]) => void;
 }) {
   let activeStop: Promise<void> | null = null;
+  let failure: Error | undefined;
   let phase: "open" | "closing" | "sealed" = "open";
   const publish = (sidecars: readonly GatewayPostReadySidecarHandle[]) => {
     if (phase === "sealed") {
       throw new Error("cannot publish a Gateway sidecar after shutdown sealed its owner");
     }
-    params.setRegistered(
-      mergeGatewaySidecarOwners({ registered: params.getRegistered(), published: sidecars }),
-    );
+    params.setRegistered([...new Set([...params.getRegistered(), ...sidecars])]);
     if (phase === "closing") {
       void stop().catch(() => {});
     }
@@ -30,7 +29,7 @@ export function createGatewaySidecarStopOwner(params: {
     // Install single-flight before any stop can synchronously publish another owner.
     const stopping = Promise.resolve().then(async () => {
       const failedSidecars = new Set<GatewayPostReadySidecarHandle>();
-      let failure: unknown;
+      failure = undefined;
       try {
         while (params.getRegistered().some((sidecar) => !failedSidecars.has(sidecar))) {
           const sidecars = [
@@ -58,13 +57,16 @@ export function createGatewaySidecarStopOwner(params: {
           );
           if (pending.length > 0) {
             const rejected = results.find((result) => result.status === "rejected");
-            failure ??= rejected?.reason;
+            failure ??=
+              rejected?.reason instanceof Error
+                ? rejected.reason
+                : new Error(String(rejected?.reason));
             for (const sidecar of pending) {
               failedSidecars.add(sidecar);
             }
           }
         }
-        if (failedSidecars.size > 0) {
+        if (failure) {
           // Preserve ownership after the bounded shutdown retry. A later close can try again.
           params.setRegistered([...failedSidecars, ...params.getRegistered()]);
           throw failure;
@@ -79,30 +81,19 @@ export function createGatewaySidecarStopOwner(params: {
   };
 
   const sealAndJoin = async () => {
-    let failure: Error | undefined;
-    while (true) {
-      const stopping = activeStop;
-      if (!stopping) {
-        phase = "sealed";
-        break;
-      }
+    for (let pending = activeStop; pending; pending = activeStop) {
       try {
-        await stopping;
+        await pending;
       } catch (error) {
         failure ??= error instanceof Error ? error : new Error(String(error));
       }
     }
-    if (failure) {
-      throw failure;
+    phase = "sealed";
+    // A settled failed stop still owns its handles and original failure until a retry succeeds.
+    if (failure || params.getRegistered().length > 0) {
+      throw failure ?? new Error("Gateway sidecar cleanup did not complete");
     }
   };
 
   return { publish, beginClose, stop, sealAndJoin };
-}
-
-function mergeGatewaySidecarOwners(params: {
-  registered: readonly GatewayPostReadySidecarHandle[];
-  published: readonly GatewayPostReadySidecarHandle[];
-}): GatewayPostReadySidecarHandle[] {
-  return [...new Set([...params.registered, ...params.published])];
 }

--- a/src/gateway/server-start.ts
+++ b/src/gateway/server-start.ts
@@ -137,7 +137,11 @@ export async function startGatewayServerCore(
                 },
               },
               { name: "gateway close prelude", run: runClosePrelude },
-              { name: "late sidecar cleanup", run: sealAndJoinRegisteredSidecarStops },
+              {
+                name: "late sidecar cleanup",
+                run: sealAndJoinRegisteredSidecarStops,
+                required: true,
+              },
               { name: "gateway close", run: close },
             ],
             onError: (message) => log.error(message),

--- a/src/gateway/server-startup-lifetime.test.ts
+++ b/src/gateway/server-startup-lifetime.test.ts
@@ -121,7 +121,15 @@ describe("Gateway startup lifetime", () => {
         expect(await startupOutcome).toBe(startupError);
         const outcome = await closeOutcome;
         if (cleanup === "failed") {
-          expect(outcome).toMatchObject({ errors: [{ cause: cleanupError }] });
+          expect(outcome).toMatchObject({
+            errors: [
+              {
+                message: expect.stringContaining("gateway lifetime sidecars"),
+                cause: cleanupError,
+              },
+              { message: expect.stringContaining("late sidecar cleanup"), cause: cleanupError },
+            ],
+          });
         } else {
           expect(outcome).toBeUndefined();
         }

--- a/src/infra/agent-run-delegated-authority.test.ts
+++ b/src/infra/agent-run-delegated-authority.test.ts
@@ -155,6 +155,92 @@ test("terminal clear preserves exact authority until its outer owner closes", ()
   }
 });
 
+test.each(["parent", "approval"])("exact %s cleanup does not consult a revoked source", (kind) => {
+  let current = true;
+  const assertSourceCurrent = vi.fn(() => {
+    if (!current) {
+      throw new Error("source retired");
+    }
+  });
+  const parent = claimAgentRunDelegatedAuthority(
+    { instanceId: "source-cleanup-instance", runId: "source-cleanup-run" },
+    assertSourceCurrent,
+  );
+  const authority =
+    kind === "parent"
+      ? parent
+      : claimAgentRunApprovalAuthority(parent, [new AbortController().signal]);
+  current = false;
+  assertSourceCurrent.mockClear();
+  expect(releaseAgentRunDelegatedAuthority(authority)).toBe(true);
+  expect(assertSourceCurrent).not.toHaveBeenCalled();
+  if (kind === "approval") {
+    expect(releaseAgentRunDelegatedAuthority(parent)).toBe(true);
+  }
+  expect(getAgentRunContext("source-cleanup-run")).toBeUndefined();
+});
+
+test.each(["replacement", "restart"])(
+  "rechecks the exact owner after a source callback causes %s",
+  (outcome) => {
+    let duringCheck: (() => void) | undefined;
+    const sourceAssertion = () => {
+      const run = duringCheck;
+      duringCheck = undefined;
+      run?.();
+    };
+    const first = claimAgentRunDelegatedAuthority(
+      { instanceId: "source-first", runId: "source-run" },
+      sourceAssertion,
+    );
+    let successor: typeof first | undefined;
+    duringCheck = () => {
+      if (outcome === "restart") {
+        rotateAgentEventLifecycleGeneration();
+      }
+      successor = claimAgentRunDelegatedAuthority({
+        instanceId: "source-next",
+        runId: "source-run",
+      });
+    };
+    expect(validateAgentRunDelegatedAuthority(first)).toBe(false);
+    expect(validateAgentRunDelegatedAuthority(successor!)).toBe(true);
+    expect(releaseAgentRunDelegatedAuthority(first)).toBe(false);
+    expect(releaseAgentRunDelegatedAuthority(successor!)).toBe(true);
+  },
+);
+
+test.each(
+  [false, true].flatMap((revoked) =>
+    ["omitted", "replaced"].map((binding) => ({ revoked, binding })),
+  ),
+)(
+  "refuses a $binding source binding for the same instance (revoked=$revoked)",
+  ({ revoked, binding }) => {
+    const instance = { instanceId: "bound-instance", runId: "bound-run" };
+    let current = true;
+    const assertSourceCurrent = () => {
+      if (!current) {
+        throw new Error("source retired");
+      }
+    };
+    const authority = claimAgentRunDelegatedAuthority(instance, assertSourceCurrent);
+    const replacement = vi.fn();
+    try {
+      expect(claimAgentRunDelegatedAuthority(instance, assertSourceCurrent)).toBe(authority);
+      current = !revoked;
+      expect(() =>
+        claimAgentRunDelegatedAuthority(instance, binding === "replaced" ? replacement : undefined),
+      ).toThrow("already bound");
+      expect(replacement).not.toHaveBeenCalled();
+      // Refusing admission must leave the original owner available for exact cleanup.
+      expect(releaseAgentRunDelegatedAuthority(authority)).toBe(true);
+    } finally {
+      releaseAgentRunDelegatedAuthority(authority);
+    }
+  },
+);
+
 test("same-generation stale terminal clear cannot revoke a reused-run successor", () => {
   const runId = "same-generation-successor";
   claimAgentRunDelegatedAuthority({ instanceId: "old-instance", runId });

--- a/src/infra/agent-run-registry.ts
+++ b/src/infra/agent-run-registry.ts
@@ -1,6 +1,5 @@
 // Owns process-local agent run context, ownership, and projection state.
 import { randomUUID } from "node:crypto";
-import type { VerboseLevel } from "../auto-reply/thinking.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { registerListener } from "../shared/listeners.js";
@@ -9,68 +8,17 @@ import {
   type AgentRunApprovalClosureReason,
 } from "./agent-run-approval-leases.js";
 import type { AgentRunDelegatedAuthority } from "./agent-run-authority.types.js";
+import type {
+  AgentRunContext,
+  AgentRunContextOwnership,
+  AgentRunRegistryState,
+  ProjectedAgentRunIndex,
+  ProjectedAgentRunState,
+} from "./agent-run-registry.types.js";
 import { clearAgentRunUsage, resetAgentRunUsageForTest } from "./agent-run-usage.js";
 
 export type { AgentRunDelegatedAuthority } from "./agent-run-authority.types.js";
-
-/** Per-run metadata used to stamp events and gate Control UI visibility. */
-type AgentRunContext = {
-  sessionKey?: string;
-  /** Resolved agent owner, including for unscoped session keys. */
-  agentId?: string;
-  /** Owning run's sessionId; stamped onto lifecycle events. */
-  sessionId?: string;
-  /** Gateway lifecycle generation captured when the run was registered. */
-  lifecycleGeneration?: string;
-  /** Producer-owned start captured from this run's accepted lifecycle event. */
-  lifecycleStartedAt?: number;
-  verboseLevel?: VerboseLevel;
-  isHeartbeat?: boolean;
-  /** Whether control UI clients should receive chat/agent updates for this run. */
-  isControlUiVisible?: boolean;
-  projectSessionActive?: boolean;
-  /** Exact scheduler wait leases; absent during ordinary runtime preparation. */
-  capacityWaits?: Set<symbol>;
-  /** Whether hidden events may reach exact sessions.messages subscribers.
-   * Internal maintenance sharing a foreground key disables this to prevent selected-chat leaks. */
-  projectSessionMessages?: boolean;
-  /** Whether lifecycle events may update the shared session row. */
-  projectSessionLifecycle?: boolean;
-  /** Sticky diagnostic provenance only; never authorization for recovery work. */
-  mainSessionRestartRecovery?: true;
-  /** Active cadence state by job; admission permits one invocation per job. */
-  cronRunsByJobId?: Map<string, { pacingEnabled: boolean; nextCheckMs?: number }>;
-  /** Timestamp when this context was first registered (for TTL-based cleanup). */
-  registeredAt?: number;
-  /** Timestamp of last activity (updated on every emitAgentEvent). */
-  lastActiveAt?: number;
-  /** Exact approval authority owned by this operational execution. */
-  delegatedAuthority?: AgentRunDelegatedAuthority;
-  approvalLeases?: AgentRunApprovalLeases;
-};
-
-type AgentRunContextOwnership = {
-  lifecycleGeneration: string;
-  claimIds: Set<string>;
-  /** Live execution claims are lifecycle-owned and must not be expired by the projection sweeper. */
-  sweepProtectedClaimIds: Set<string>;
-  preserveAfterRelease: boolean;
-  clearRequested: boolean;
-  exclusiveClaimId?: string;
-  clearListeners?: Map<string, (claimId: string) => void>;
-};
-
-type AgentRunRegistryState = {
-  contexts: Map<string, AgentRunContext>;
-  owners: Map<string, AgentRunContextOwnership>;
-  queuedRunContextLeases?: WeakMap<AgentRunContext, number>;
-  lifecycleGeneration: string;
-  sequenceResetHandler?: (runId: string) => void;
-  delegatedAuthorityClosedHandlers?: Set<
-    (authority: AgentRunDelegatedAuthority, approvalReason?: AgentRunApprovalClosureReason) => void
-  >;
-  version: number;
-};
+export type { ProjectedAgentRunIndex } from "./agent-run-registry.types.js";
 
 const AGENT_RUN_REGISTRY_STATE_KEY = Symbol.for("openclaw.agentRunRegistry.state");
 
@@ -102,6 +50,7 @@ export function rotateAgentRunRegistryLifecycleGeneration(): string {
     const authority = context.delegatedAuthority;
     if (authority) {
       delete context.delegatedAuthority;
+      delete context.assertSourceCurrent;
       notifyDelegatedAuthorityClosed(state, authority);
     }
   }
@@ -427,6 +376,7 @@ export function getAgentRunContextOwnerStatus(
 /** Claims approval authority for the exact admitted operational execution. */
 export function claimAgentRunDelegatedAuthority(
   operationalRunInstance: Readonly<{ instanceId: string; runId: string }>,
+  assertSourceCurrent?: () => void,
 ): AgentRunDelegatedAuthority {
   const instanceId = operationalRunInstance.instanceId.trim();
   const runId = operationalRunInstance.runId.trim();
@@ -434,11 +384,20 @@ export function claimAgentRunDelegatedAuthority(
     throw new Error("agent run delegated authority requires an operational run instance");
   }
   const state = getAgentRunRegistryState();
-  const lifecycleGeneration = state.lifecycleGeneration;
   const currentInstance =
     operationalRunInstance.instanceId === instanceId && operationalRunInstance.runId === runId
       ? operationalRunInstance
       : Object.freeze({ instanceId, runId });
+  const bound = state.contexts.get(runId);
+  // Check the binding before callbacks or liveness validation can retire it.
+  if (
+    bound?.delegatedAuthority?.operationalRunInstance.instanceId === instanceId &&
+    bound.assertSourceCurrent !== assertSourceCurrent
+  ) {
+    throw new Error("agent run source authority is already bound");
+  }
+  assertSourceCurrent?.();
+  const lifecycleGeneration = state.lifecycleGeneration;
   const active = getActiveAgentRunDelegatedAuthority(currentInstance);
   if (active) {
     return active;
@@ -474,6 +433,7 @@ export function claimAgentRunDelegatedAuthority(
     throw new Error("agent run delegated authority lost its lifecycle during admission");
   }
   context.delegatedAuthority = authority;
+  context.assertSourceCurrent = assertSourceCurrent;
   return authority;
 }
 
@@ -483,17 +443,36 @@ export function getActiveAgentRunDelegatedAuthority(
 ): AgentRunDelegatedAuthority | undefined {
   const context = getAgentRunRegistryState().contexts.get(operationalRunInstance.runId);
   const authority = context?.delegatedAuthority;
-  return authority &&
-    authority.operationalRunInstance.instanceId === operationalRunInstance.instanceId &&
-    authority.operationalRunInstance.runId === operationalRunInstance.runId &&
+  if (
+    !context ||
+    !authority ||
+    authority.operationalRunInstance.instanceId !== operationalRunInstance.instanceId ||
+    authority.operationalRunInstance.runId !== operationalRunInstance.runId ||
     // A clear request is projection state; the exact live claim still owns authority.
     getAgentRunContextOwnerStatus(
       operationalRunInstance.runId,
       authority.claimId,
       authority.lifecycleGeneration,
-    ) !== undefined
-    ? authority
-    : undefined;
+    ) === undefined
+  ) {
+    return undefined;
+  }
+  try {
+    context.assertSourceCurrent?.();
+    return getAgentRunContext(operationalRunInstance.runId) === context &&
+      context.delegatedAuthority === authority &&
+      getAgentRunContextOwnerStatus(
+        operationalRunInstance.runId,
+        authority.claimId,
+        authority.lifecycleGeneration,
+      ) !== undefined
+      ? authority
+      : undefined;
+  } catch {
+    // A copied approval cannot outlive its source; retire the exact owner at detection.
+    releaseAgentRunContext(operationalRunInstance.runId, authority.claimId);
+    return undefined;
+  }
 }
 
 export function validateAgentRunDelegatedAuthority(authority: AgentRunDelegatedAuthority): boolean {
@@ -525,13 +504,23 @@ export function claimAgentRunApprovalAuthority(
 
 /** Compare-releases only the exact authority owned by one admitted execution. */
 export function releaseAgentRunDelegatedAuthority(authority: AgentRunDelegatedAuthority): boolean {
-  if (!validateAgentRunDelegatedAuthority(authority)) {
+  const { runId, instanceId } = authority.operationalRunInstance;
+  const context = getAgentRunContext(runId);
+  const active = context?.delegatedAuthority;
+  // Cleanup compares ownership without asking a revoked source for permission to retire.
+  if (
+    !context ||
+    !active ||
+    active.operationalRunInstance.instanceId !== instanceId ||
+    active.lifecycleGeneration !== authority.lifecycleGeneration ||
+    getAgentRunContextOwnerStatus(runId, active.claimId, active.lifecycleGeneration) === undefined
+  ) {
     return false;
   }
-  const leases = getAgentRunContext(authority.operationalRunInstance.runId)?.approvalLeases;
-  if (!leases?.release(authority.claimId)) {
-    releaseAgentRunContext(authority.operationalRunInstance.runId, authority.claimId);
+  if (active.claimId !== authority.claimId) {
+    return context.approvalLeases?.release(authority.claimId) === true;
   }
+  releaseAgentRunContext(runId, authority.claimId);
   return true;
 }
 
@@ -552,15 +541,6 @@ export function listAgentRunsForSession(params: {
   }
   return runs.toSorted((a, b) => a.runId.localeCompare(b.runId));
 }
-
-type ProjectedAgentRunState = "queued" | "running" | "capacity-wait";
-
-export type ProjectedAgentRunIndex = {
-  sessionKeys: ReadonlyMap<string, ProjectedAgentRunState>;
-  sessionIds: ReadonlyMap<string, ProjectedAgentRunState>;
-  ownerlessSessionKeys: ReadonlyMap<string, ProjectedAgentRunState>;
-  ownerlessSessionIds: ReadonlyMap<string, ProjectedAgentRunState>;
-};
 
 function projectedRunIdentity(agentId: string, value: string): string {
   return `${normalizeAgentId(agentId)}\0${value}`;
@@ -714,6 +694,7 @@ export function releaseAgentRunContext(runId: string, claimId: string | undefine
   const authority = context?.delegatedAuthority;
   if (context && authority?.claimId === claimId) {
     delete context.delegatedAuthority;
+    delete context.assertSourceCurrent;
     notifyDelegatedAuthorityClosed(state, authority);
   }
   owners.sweepProtectedClaimIds.delete(claimId);

--- a/src/infra/agent-run-registry.types.ts
+++ b/src/infra/agent-run-registry.types.ts
@@ -1,0 +1,76 @@
+import type { VerboseLevel } from "../auto-reply/thinking.js";
+import type {
+  AgentRunApprovalLeases,
+  AgentRunApprovalClosureReason,
+} from "./agent-run-approval-leases.js";
+import type { AgentRunDelegatedAuthority } from "./agent-run-authority.types.js";
+
+/** Per-run metadata used to stamp events and gate Control UI visibility. */
+export type AgentRunContext = {
+  sessionKey?: string;
+  /** Resolved agent owner, including for unscoped session keys. */
+  agentId?: string;
+  /** Owning run's sessionId; stamped onto lifecycle events. */
+  sessionId?: string;
+  /** Gateway lifecycle generation captured when the run was registered. */
+  lifecycleGeneration?: string;
+  /** Producer-owned start captured from this run's accepted lifecycle event. */
+  lifecycleStartedAt?: number;
+  verboseLevel?: VerboseLevel;
+  isHeartbeat?: boolean;
+  /** Whether control UI clients should receive chat/agent updates for this run. */
+  isControlUiVisible?: boolean;
+  projectSessionActive?: boolean;
+  /** Exact scheduler wait leases; absent during ordinary runtime preparation. */
+  capacityWaits?: Set<symbol>;
+  /** Whether hidden events may reach exact sessions.messages subscribers.
+   * Internal maintenance sharing a foreground key disables this to prevent selected-chat leaks. */
+  projectSessionMessages?: boolean;
+  /** Whether lifecycle events may update the shared session row. */
+  projectSessionLifecycle?: boolean;
+  /** Sticky diagnostic provenance only; never authorization for recovery work. */
+  mainSessionRestartRecovery?: true;
+  /** Active cadence state by job; admission permits one invocation per job. */
+  cronRunsByJobId?: Map<string, { pacingEnabled: boolean; nextCheckMs?: number }>;
+  /** Timestamp when this context was first registered (for TTL-based cleanup). */
+  registeredAt?: number;
+  /** Timestamp of last activity (updated on every emitAgentEvent). */
+  lastActiveAt?: number;
+  /** Exact approval authority owned by this operational execution. */
+  delegatedAuthority?: AgentRunDelegatedAuthority;
+  /** Exact in-process source owner, intentionally absent from serialized authority. */
+  assertSourceCurrent?: () => void;
+  approvalLeases?: AgentRunApprovalLeases;
+};
+
+export type AgentRunContextOwnership = {
+  lifecycleGeneration: string;
+  claimIds: Set<string>;
+  /** Live execution claims are lifecycle-owned and must not be expired by the projection sweeper. */
+  sweepProtectedClaimIds: Set<string>;
+  preserveAfterRelease: boolean;
+  clearRequested: boolean;
+  exclusiveClaimId?: string;
+  clearListeners?: Map<string, (claimId: string) => void>;
+};
+
+export type AgentRunRegistryState = {
+  contexts: Map<string, AgentRunContext>;
+  owners: Map<string, AgentRunContextOwnership>;
+  queuedRunContextLeases?: WeakMap<AgentRunContext, number>;
+  lifecycleGeneration: string;
+  sequenceResetHandler?: (runId: string) => void;
+  delegatedAuthorityClosedHandlers?: Set<
+    (authority: AgentRunDelegatedAuthority, approvalReason?: AgentRunApprovalClosureReason) => void
+  >;
+  version: number;
+};
+
+export type ProjectedAgentRunState = "queued" | "running" | "capacity-wait";
+
+export type ProjectedAgentRunIndex = {
+  sessionKeys: ReadonlyMap<string, ProjectedAgentRunState>;
+  sessionIds: ReadonlyMap<string, ProjectedAgentRunState>;
+  ownerlessSessionKeys: ReadonlyMap<string, ProjectedAgentRunState>;
+  ownerlessSessionIds: ReadonlyMap<string, ProjectedAgentRunState>;
+};

--- a/src/node-host/mcp.ts
+++ b/src/node-host/mcp.ts
@@ -259,9 +259,9 @@ async function listAllTools(
   return { tools: normalized.tools, metadata: normalized.metadata };
 }
 
-function disposeNodeHostMcpSession(session: NodeHostMcpSession): Promise<void> {
+async function disposeNodeHostMcpSession(session: NodeHostMcpSession): Promise<void> {
   session.abortController.abort(new Error("node host MCP session retired"));
-  return disposeMcpClient(session);
+  await disposeMcpClient(session);
 }
 
 /** Starts process-lifetime MCP server state for the node host. */

--- a/src/process/owned-stdio.real.test.ts
+++ b/src/process/owned-stdio.real.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from "vitest";
+import { closeOwnedStdioProcess, createOwnedStdioProcess } from "./owned-stdio.js";
+
+it.skipIf(process.platform === "win32")(
+  "drains protocol output and shutdown diagnostics before confirming real stdio cleanup",
+  async () => {
+    const diagnostic = "shutdown: 🌊\n".repeat(8192);
+    const child = await createOwnedStdioProcess({
+      argv: [
+        process.execPath,
+        "-e",
+        `process.stdin.resume();
+process.stdin.on("end", () => {
+  process.stdout.write("done\\n", () => {
+    process.stderr.write("shutdown: 🌊\\n".repeat(8192), () => process.exit(0));
+  });
+});`,
+      ],
+      env: {},
+      exactEnv: true,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.onStdout((chunk) => {
+      stdout += chunk;
+    });
+    child.onStderr((chunk) => {
+      stderr += chunk;
+    });
+    const result = child.wait();
+    try {
+      await closeOwnedStdioProcess(child);
+      await expect(result).resolves.toEqual({ code: 0, signal: null });
+      expect(stdout).toBe("done\n");
+      expect(stderr).toBe(diagnostic);
+    } finally {
+      await closeOwnedStdioProcess(child, { force: true }).catch(() => undefined);
+    }
+  },
+);

--- a/src/process/owned-stdio.test.ts
+++ b/src/process/owned-stdio.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createOwnedStdioProcess, OwnedStdioCleanupError } from "./owned-stdio.js";
+
+const createChild = vi.hoisted(() => vi.fn());
+vi.mock("./supervisor/adapters/child.js", () => ({ createChildAdapter: createChild }));
+
+afterEach(() => createChild.mockReset());
+
+describe("owned stdio startup cleanup", () => {
+  it("joins an admitted child's cleanup before reporting the original startup failure", async () => {
+    const cleanup = createDeferred();
+    const original = new Error("startup failed after admission");
+    createChild.mockImplementation(({ onSpawnCleanup }) => {
+      onSpawnCleanup(cleanup.promise);
+      throw original;
+    });
+    const rejected = vi.fn();
+    const starting = createOwnedStdioProcess({ argv: ["server"] }).catch((error: unknown) => {
+      rejected(error);
+      return error;
+    });
+    await Promise.resolve();
+    expect(rejected).not.toHaveBeenCalled();
+    cleanup.resolve();
+    expect(await starting).toBe(original);
+  });
+
+  it.each(["rejected", "unsettled"])(
+    "reports %s constructor cleanup as uncertainty rather than an ordinary spawn error",
+    async (outcome) => {
+      const cleanup = createDeferred();
+      const original = new Error("startup failed after admission");
+      createChild.mockImplementation(({ onSpawnCleanup }) => {
+        onSpawnCleanup(cleanup.promise);
+        if (outcome === "rejected") {
+          cleanup.reject(new Error("owner lost"));
+        }
+        throw original;
+      });
+      try {
+        await expect(createOwnedStdioProcess({ argv: ["server"] })).rejects.toMatchObject({
+          constructor: OwnedStdioCleanupError,
+          cause: original,
+        });
+      } finally {
+        cleanup.resolve();
+      }
+    },
+  );
+});

--- a/src/process/owned-stdio.ts
+++ b/src/process/owned-stdio.ts
@@ -1,0 +1,103 @@
+import type { Writable } from "node:stream";
+import { createChildAdapter } from "./supervisor/adapters/child.js";
+import type { SpawnProcessAdapter } from "./supervisor/types.js";
+
+export type OwnedStdioProcess = SpawnProcessAdapter<NodeJS.Signals | null> &
+  Required<Pick<SpawnProcessAdapter<NodeJS.Signals | null>, "onExit" | "onError">>;
+
+export class OwnedStdioCleanupError extends Error {}
+
+export async function createOwnedStdioProcess(params: {
+  argv: string[];
+  argv0?: string;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  exactEnv?: true;
+  /** Preserve the configured Windows wrapper's shipped Node shell launch contract. */
+  windowsShell?: true;
+  abortSignal?: AbortSignal;
+  /** Consume stderr through a native pipe instead of callback observation. */
+  stderrDestination?: Writable;
+}): Promise<OwnedStdioProcess> {
+  let startupCleanup: Promise<boolean> | undefined;
+  try {
+    return await createChildAdapter({
+      ...params,
+      ownProcessTree: true,
+      stdinMode: "pipe-open",
+      onSpawnCleanup: (cleanup) => {
+        startupCleanup = cleanup.then(
+          () => true,
+          () => false,
+        );
+      },
+    });
+  } catch (error) {
+    if (
+      startupCleanup &&
+      (!(await settlesWithin(startupCleanup, 500)) || !(await startupCleanup))
+    ) {
+      throw new OwnedStdioCleanupError("stdio startup cleanup did not confirm closure", {
+        cause: error,
+      });
+    }
+    throw error;
+  }
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Protocol EOF requests shutdown; only the spawn owner can certify descendant extinction. */
+export async function closeOwnedStdioProcess(
+  process: OwnedStdioProcess,
+  options: { graceMs?: number; force?: boolean } = {},
+): Promise<void> {
+  const settled = Promise.allSettled([
+    process.wait(),
+    process.waitForExtinction?.() ??
+      Promise.reject(new Error("stdio process cleanup cannot confirm descendant extinction")),
+  ]);
+  try {
+    if (!options.force) {
+      try {
+        process.stdin?.end();
+      } catch {
+        // Broken input cannot prevent the spawn owner from reclaiming the process tree.
+        process.kill("SIGTERM");
+      }
+      const graceMs = options.graceMs ?? 2_000;
+      if (!(await settlesWithin(settled, graceMs))) {
+        process.kill("SIGTERM");
+        if (!(await settlesWithin(settled, graceMs))) {
+          process.kill("SIGKILL");
+        }
+      }
+    } else {
+      process.kill("SIGKILL");
+    }
+    if (!(await settlesWithin(settled, 500))) {
+      throw new Error("stdio process cleanup did not confirm descendant extinction");
+    }
+    const failure = (await settled).find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failure) {
+      throw failure.reason;
+    }
+  } finally {
+    process.dispose();
+  }
+}

--- a/src/process/supervisor/supervisor.scope-extinction.test.ts
+++ b/src/process/supervisor/supervisor.scope-extinction.test.ts
@@ -64,53 +64,42 @@ describe("process supervisor scope extinction", () => {
     expect(adapter.disposeMock).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    { failed: false, acquired: true },
-    { failed: true, acquired: true },
-    { failed: true, acquired: false },
-  ])(
-    "retains extinction until its scope joins (failed=$failed, acquired=$acquired)",
-    async ({ failed, acquired }) => {
-      const extinction = createDeferred();
-      const adapter = Object.assign(createStubChildAdapter(), {
-        waitForExtinction: () => extinction.promise,
-      });
-      createChildAdapterMock.mockResolvedValue(adapter);
-      const supervisor = createProcessSupervisor();
-      const scopeKey = "scope:one-shot-late-join";
-      const cleanup = acquired
-        ? supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true })
-        : () => supervisor.waitForScope!(scopeKey);
-      const run = await spawnChild(supervisor, {
-        sessionId: scopeKey,
-        scopeKey,
-        argv: createSilentIdleArgv(),
-      });
-      adapter.settle(0);
-      await expect(run.wait()).resolves.toMatchObject({ exitCode: 0 });
-      if (failed) {
-        extinction.reject(new Error("cleanup identity lost"));
-        await expect(run.waitForExtinction!()).rejects.toThrow("cleanup identity lost");
-        await expect(cleanup()).rejects.toThrow("cleanup identity lost");
-        await expect(cleanup()).rejects.toThrow("cleanup identity lost");
-      } else {
-        extinction.resolve();
-        await run.waitForExtinction!();
-        await expect(cleanup()).resolves.toBeUndefined();
-      }
-      // The released owner must neither poison a new run nor retain the old admission.
-      if (acquired) {
-        await expect(
-          supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true })(),
-        ).resolves.toBeUndefined();
-      }
-      if (failed) {
-        await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
-      } else {
-        await supervisor.shutdown();
-      }
-    },
-  );
+  it.each([false, true])("retains extinction until its scope joins (failed=%s)", async (failed) => {
+    const extinction = createDeferred();
+    const adapter = Object.assign(createStubChildAdapter(), {
+      waitForExtinction: () => extinction.promise,
+    });
+    createChildAdapterMock.mockResolvedValue(adapter);
+    const supervisor = createProcessSupervisor();
+    const scopeKey = "scope:one-shot-late-join";
+    const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+    const run = await spawnChild(supervisor, {
+      sessionId: scopeKey,
+      scopeKey,
+      argv: createSilentIdleArgv(),
+    });
+    adapter.settle(0);
+    await expect(run.wait()).resolves.toMatchObject({ exitCode: 0 });
+    if (failed) {
+      extinction.reject(new Error("cleanup identity lost"));
+      await expect(run.waitForExtinction!()).rejects.toThrow("cleanup identity lost");
+      await expect(cleanup()).rejects.toThrow("cleanup identity lost");
+      await expect(cleanup()).rejects.toThrow("cleanup identity lost");
+    } else {
+      extinction.resolve();
+      await run.waitForExtinction!();
+      await expect(cleanup()).resolves.toBeUndefined();
+    }
+    // The released owner must neither poison a new run nor retain the old admission.
+    await expect(
+      supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true })(),
+    ).resolves.toBeUndefined();
+    if (failed) {
+      await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
+    } else {
+      await supervisor.shutdown();
+    }
+  });
 
   it.each(["child", "pty", "external"] as const)(
     "keeps %s execution available but reports unsupported one-shot cleanup",

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -454,11 +454,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         (error: unknown) => {
           recordScopeCleanupFailure(owner, error);
           cleanupFailure ??= { error };
-          // Legacy late scope joins still read this owner; acquired scopes retain
-          // the failure separately and can release the adapter's runtime graph.
-          if (owner.cleanupOwners.length > 0) {
-            ownedRuns.delete(owner);
-          }
+          ownedRuns.delete(owner);
           cleanup.reject(error);
         },
       );
@@ -716,7 +712,6 @@ export function createProcessSupervisor(): ProcessSupervisor & {
     spawn,
     cancel,
     cancelScope,
-    waitForScope: (scopeKey: string) => waitForRuns(scopeKey),
     shutdown,
     getRecord: (runId: string) => registry.get(runId),
   };

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -154,6 +154,5 @@ export interface ProcessSupervisor {
   spawn(input: SpawnInput): Promise<ManagedRun>;
   cancel(runId: string, reason?: TerminationReason): void;
   cancelScope(scopeKey: string, reason?: TerminationReason): void;
-  waitForScope?: (scopeKey: string) => Promise<void>;
   getRecord(runId: string): RunRecord | undefined;
 }

--- a/src/worker/worker.runtime.test.ts
+++ b/src/worker/worker.runtime.test.ts
@@ -55,6 +55,7 @@ import {
   deleteSession,
   listRunningSessions,
   markBackgrounded,
+  waitForExecScope,
 } from "../agents/bash-process-registry.js";
 import { runExecProcess } from "../agents/bash-tools.exec-runtime.js";
 import { saveExecApprovals, type ExecApprovalsFile } from "../infra/exec-approvals.js";
@@ -1710,7 +1711,7 @@ describe("worker runtime", () => {
         expect(settled).not.toHaveBeenCalled();
         if (processState === "completed") {
           await writeFile(path.join(workspaceDir, "finish-marker"), "finish");
-          await supervisor.waitForScope?.(scopeKey);
+          await waitForExecScope(scopeKey);
           await waitForFast(() =>
             expect(
               listRunningSessions().filter((session) => session.scopeKey === scopeKey),
@@ -1775,7 +1776,7 @@ describe("worker runtime", () => {
           await command;
         } finally {
           supervisor.cancelScope(scopeKey, "manual-cancel");
-          await supervisor.waitForScope?.(scopeKey);
+          await waitForExecScope(scopeKey);
         }
       }
       expect(listRunningSessions().filter((session) => session.scopeKey === scopeKey)).toHaveLength(
@@ -1819,7 +1820,7 @@ describe("worker runtime", () => {
         await command;
       } finally {
         supervisor.cancelScope(scopeKey, "manual-cancel");
-        await supervisor.waitForScope?.(scopeKey);
+        await waitForExecScope(scopeKey);
       }
     }
   });
@@ -1869,7 +1870,6 @@ describe("worker runtime", () => {
           deleteSession(run.session.id);
         }
         await finalizing.promise;
-        await getProcessSupervisor().waitForScope?.(scopeKey);
         const closing = environment.close();
         await Promise.resolve();
 
@@ -2182,7 +2182,7 @@ describe("worker runtime", () => {
           await command;
         } finally {
           supervisor.cancelScope(scopeKey, "manual-cancel");
-          await supervisor.waitForScope?.(scopeKey);
+          await waitForExecScope(scopeKey);
         }
       }
     },

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -69,6 +69,12 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
   await chmod(stateDir, 0o700);
   const previousStateDir = process.env.OPENCLAW_STATE_DIR;
   const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const scopeKey = `worker:${sessionId}`;
+  // Worker state owns command completion and exec finalizers; its parent owns
+  // process placement. This lease does not infer remote or PTY tree extinction.
+  const cleanupScope = getProcessSupervisor().acquireScopeCleanup(scopeKey, {
+    requireProcessTree: false,
+  });
   process.env.OPENCLAW_STATE_DIR = stateDir;
   process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");
   let closing: Promise<void> | undefined;
@@ -76,11 +82,13 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
     stateDir,
     close: () =>
       (closing ??= (async () => {
-        const supervisor = getProcessSupervisor();
-        const scopeKey = `worker:${sessionId}`;
-        supervisor.cancelScope(scopeKey, "manual-cancel");
-        await supervisor.waitForScope?.(scopeKey);
-        await waitForExecScope(scopeKey);
+        // Even uncertain process cleanup must join the known finalizers before
+        // reporting failure; those callbacks still own this environment's state.
+        const settled = await Promise.allSettled([cleanupScope(), waitForExecScope(scopeKey)]);
+        const failed = settled.find((result) => result.status === "rejected");
+        if (failed?.status === "rejected") {
+          throw failed.reason;
+        }
         // Exec finalizers can open state; release its handle before Windows removes the file.
         closeOpenClawStateDatabaseByPath(
           resolveOpenClawStateSqlitePath({ OPENCLAW_STATE_DIR: stateDir }),

--- a/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
+++ b/test/vitest/vitest.extension-codex-app-server-attempt-extra.config.ts
@@ -9,6 +9,7 @@ export function createExtensionCodexAppServerAttemptExtraVitestConfig(
       "extensions/codex/src/app-server/run-attempt.agent-end-context.test.ts",
       "extensions/codex/src/app-server/run-attempt.auth-context.test.ts",
       "extensions/codex/src/app-server/run-attempt-lifecycle-controller.test.ts",
+      "extensions/codex/src/app-server/run-attempt-one-shot-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt-thread-cleanup.test.ts",
       "extensions/codex/src/app-server/run-attempt.channel-tool-progress.test.ts",
       "extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts",


### PR DESCRIPTION
Related: #135868
Foundation: #139517 (merged)

## What Problem This Solves

Cleanup could be reported as finished after a command returned, a transport exited, or a session left its registry, even though the previous owner had not confirmed resource closure. A later CLI invocation could replace that work, and a bounded agent invocation could release its state too early. Native Codex terminal entries could also disappear before descendant cleanup finished.

This is Stage 3, part 2 of the #135868 split: cleanup evidence and its agent consumers (concern C), including the coupled Gateway close and sidecar lifetime propagation from concern F.

## Why This Change Was Made

MCP and LSP use the shared stdio process owner. CLI sessions retain cleanup by execution identity, including after natural retirement or a previous timeout. Codex reports physical transport exit separately from descendant cleanup, and native execution observations remain uncertain when the pinned upstream contract supplies no OS cleanup proof.

One cleanup scope carries failures through nested agent cleanup without replacing the original result or cancellation. Retained host writes recheck their source authority. Gateway lifetime cleanup preserves failures instead of authorizing the next lifecycle. Existing best-effort plugin disposal remains compatible; explicit cleanup joins provide the stronger evidence needed by owned work.

The change removes the old late supervisor join, duplicate cleanup timers and error observers, one-use adapters, and an unnecessary asynchronous finalizer callback. Tests share typed fixtures and exercise real process/output boundaries alongside the relevant refusal and failure cases.

## User Impact

Completed output and cancellation outcomes remain available. Cleanup uncertainty retains bounded agent state and locks, prevents replacement of an unclosed CLI session, and prevents unsafe lifecycle completion. This does not enable automatic recovery; activation remains in the later #135868 stage.

## Evidence

The selected suites cover CLI, MCP/LSP, embedded runs, Codex, process ownership, agent authority, worker/node-host, Gateway teardown, and memory promotion. Three fixture failures found in the broad run were repaired and their complete relevant suites passed: Gateway shutdown now expects both retained failure phases; CLI replacement awaits its owner; WebSocket fake time starts after a client frame. Final focused correction proof passed 189 tests, with a separate 34-test node-host supplement.

Real macOS tests exercise anchored process groups and scope extinction. A real stdio child receives protocol EOF and drains complete output plus 8,192 Unicode diagnostic lines before successful cleanup. Seven consumer regressions failed on pre-fix production for the intended reasons and passed after repair. The import-cycle check reports zero runtime cycles. Final committed-branch independent review is clean through P2.

[Full Linux changed check/build after the embedded-runner reconciliation](https://github.com/openclaw/openclaw/actions/runs/34008423348) passed in the configured Blacksmith Testbox (exit 0); its lease completed and stopped. The complete embedded-runner rerun passed 4,442 tests. The subsequent MCP-only reconciliation passed 28 focused tests, including real-child output, with its complete selected core/coreTests gate passing. Final branch review is clean through P2. Exact-head hosted CI is required before landing. Local extension declaration preparation hits parent-checkout dependency resolution; the isolated gate supplies the full check/build proof.

Judged consumer delta: production +1,581/−821 (net +760), tests +2,937/−978 (net +1,959), docs +10/−1, tooling zero. Including #139517, Stage 3 is +1,155 production and +2,593 test lines, compared with the audited source path set's +1,187 production and +2,689 tests. Remaining production growth carries native cleanup evidence, retained failed-owner state, and final-effect authority checks; the campaign still needs offsets elsewhere to reach its cumulative production limit.

Codex's pinned rust-v0.153.4 contract was checked in thread_processor.rs:2362–2423, unified_exec/process_manager.rs:1697–1728, unified_exec/process.rs:240–252, and utils/pty/src/process.rs:219–269. Their termination/list acknowledgments do not certify kernel process extinction. The paired-node exec-server caller also reads the explicit physical-exit field from the new close result.

Windows process utility paths use fixtures; native Windows utility execution was not separately demonstrated. Codex protocol tests use a synthetic app-server and source inspection of rust-v0.153.4. POSIX group ownership does not certify deliberately escaped descendants.

## Review follow-through

The conflicts with #139597 and #139616 are reconciled: retain shared attempt setup/resources and a single settlement set, plus MCP shutdown fencing during data-directory preparation and protection against signaling retired owners. The directly affected cleanup suites pass all 53 cases; the final reconciled-head checks and CI are recorded before landing.

ClawSweeper's configuration/data-model flags do not identify a schema or serialized-format change. The file and memory paths add checks of the original invocation's current authority before committing effects. Existing configuration fields, stored provenance fields, and migration versions are unchanged. Retaining state after uncertain cleanup is the intended safety contract; completed command output alone does not authorize releasing it.

The optional MCP `joinCleanup` hook preserves existing best-effort `dispose`. A runtime without the hook remains usable but cannot certify shared cleanup. `agent-bundle-mcp-tools.materialize.test.ts` covers that case without closing shared peers. `agent-exec.state-lock.test.ts` covers both fresh temporary state and retained state after uncertainty, plus normal lock release. These are boundary tests, not installed-upgrade proof.

The optional rank-up move for a full fresh/existing installation matrix is deferred to the installed recovery matrix in Stage 5. Native Windows execution is also explicitly outside this lane's fixture-only proof. On that platform, as elsewhere, uncertain cleanup may block later owned work even after a command completes; this conservative outcome is intentional and remains documented.

CI caught two test-integration omissions: a Gateway fixture imported a concrete plugin test facade into core, and the new Codex suite lacked full-suite shard registration. The repair exercises the existing trusted-diagnostic service contract through the real service manager with a synthetic service, keeps the same dependency-retention assertions, and registers the Codex suite in its existing attempt shard. All 108 affected tests passed, including unchanged boundary/coverage checks; the selected changed gate and independent review passed. No guard or baseline was relaxed.

The next CI run caught unrelated suppression-inventory line drift from main in `fetch-guard.socks.test.ts`. Main repaired it in #139747; this branch rebased onto that merge with an unchanged patch, and both inventory tests passed. No inventory edit was added to this PR.
