### PR TITLE
fix(discord): keep recording independent of voice conversations

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1350,10 +1350,8 @@ speech without conversational input or commands. Normal conversation requires a
 fresh receive stream after the current stream ends; brief pauses within
 `voice.captureSilenceGraceMs` keep the current stream and its recording-only behavior.
 
-Recording requires batch audio understanding. If `tools.media.audio.enabled` is
-`false`, starting capture fails with an enablement message; ordinary realtime
-conversation remains available.
-Recording uses one per-speaker audio stream and batch transcription, with the
+Full recording coverage requires batch audio understanding. Recording uses one
+per-speaker audio stream and batch transcription, with the
 receiver's user ID, independently resolved display label, and audio-ingress time.
 Authorized speakers can also feed realtime conversation from the same decoded
 audio. Recording continues when all realtime speaker connections are busy.
@@ -1362,6 +1360,20 @@ recording independent of realtime provider delivery and conversation authorizati
 these are segments within the same capture session, not separate meetings.
 In `stt-tts` mode, authorized conversation shares that batch transcription and
 waits for the normal end of speech before responding.
+
+Existing realtime-only setups can record final text from their active per-speaker
+connections when batch transcription is disabled or no batch backend is available.
+This limited route requires every submitted audio packet to belong to the same
+active capture; it waits for all batch work to settle and never duplicates a
+successful or silent batch result. Mixed capture input, failed or oversized audio,
+and provider continuity resets cannot produce recording fallback text. It covers
+only speakers admitted to realtime conversation, so it does not provide independent
+room recording. `/vc status` shows a coverage warning and directs operators to
+configure audio transcription. Starting capture with `tools.media.audio.enabled`
+set to `false` requires an existing active realtime conversation; otherwise it returns an
+enablement error. Pending realtime finals are limited to 1 MiB and 1,000 entries
+per speaker connection.
+
 Conversation authorization and replies run separately from recording. Each voice
 connection permits eight unfinished voice requests, with at most 1 MiB of decoded
 audio waiting for admission per request. Batch requests retain at most 1 MiB of

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1281,7 +1281,7 @@ Notes:
 - `agent-proxy` routes speech through `discord-voice`, which preserves normal owner/tool authorization for the speaker and target session but hides the agent `tts` tool because Discord voice owns playback. By default, `agent-proxy` gives the consult full owner-equivalent tool access for owner speakers (`voice.realtime.toolPolicy: "owner"`) and strongly prefers consulting the OpenClaw agent before substantive answers (`voice.realtime.consultPolicy: "always"`). In that default `always` mode, the realtime layer does not auto-speak filler before the consult answer; it captures and transcribes speech, then speaks the routed OpenClaw answer. If multiple forced consult answers finish while Discord is still playing the first answer, later exact-speech answers are queued until playback idles instead of replacing speech mid-sentence.
 - Realtime voice buffers generated audio when Discord playback temporarily falls behind and tolerates brief provider or network gaps. Each provider response keeps its own buffered audio, including native tool continuations. Normal backpressure does not cancel the response, and queued answers wait until Discord finishes playing the previous answer, even if its provider response or audio encoder has already finished.
 - OpenAI and xAI interruptions truncate each retained native audio item at the amount Discord consumed. Queued items are discarded at zero, and completed replies that have finished playing are left intact. Playback progress survives temporary gaps in the same response; OpenAI's echo guard uses the combined consumed duration of retained items.
-- If a speaker's realtime connection fails, other speakers stay connected. Check the `realtime speaker failed` log and try speaking again to open a new connection. If the initial provider connection fails during `/vc join`, joining fails; check the `realtime session failed terminally` log and retry `/vc join`. Temporary provider reconnects do not end the Discord voice session.
+- If a speaker's realtime connection fails, other speakers stay connected. Check the `realtime speaker failed` log and try speaking again to open a new connection. If the initial provider connection fails during `/vc join`, joining fails while an already-connected recorder keeps recording; check the `realtime session failed terminally` log and retry `/vc join`. Temporary provider reconnects do not end the Discord voice session.
 - In `stt-tts` mode, STT uses `tools.media.audio`; `voice.model` does not affect transcription.
 - `stt-tts` replies remain active until Discord finishes playing them; long responses are not cut off by a fixed one-minute playback deadline.
 - In realtime modes, `voice.realtime.provider`, `voice.realtime.model`, and `voice.realtime.speakerVoice` configure the realtime audio session. For OpenAI Realtime 2.1 plus the Codex brain, use `voice.realtime.model: "gpt-realtime-2.1"` and `voice.model: "openai/gpt-5.6-sol"`.
@@ -1296,13 +1296,13 @@ Notes:
 - Voice transcript turns and `/vc` commands use Discord entries in `commands.ownerAllowFrom` for owner status. When no Discord command owner is configured, the selected Discord account's `allowFrom` (or legacy `dm.allowFrom`) can still authorize voice access without granting owner status. Agent tool visibility follows the configured tool policy for the routed session.
 - If `voice.autoJoin` has multiple entries for the same guild, OpenClaw joins the last configured channel for that guild.
 - `voice.autoJoin[].whenOccupied` defaults to `false`. Set it to `true` for an auto-managed room that should contain the bot only while at least one human is present. OpenClaw joins on the first human arrival and leaves after the last human departs; the OpenClaw bot and other bots do not count. Startup, fresh gateway sessions, and resumed gateway sessions reconcile from Discord's voice-state roster.
-- Occupancy management owns only sessions that it joined. A manual `/vc join`, transcript capture, follow-user session, active session in another channel, or other ad-hoc join is not moved or disconnected when the configured room empties.
+- Occupancy management owns only sessions that it joined. A manual `/vc join`, standalone transcript-only session, follow-user session, active session in another channel, or other ad-hoc join is not moved or disconnected when the configured room empties. Attaching transcript capture to an occupancy-managed session preserves that ownership.
 - `voice.allowedChannels` is an optional residency allowlist. Leave it unset to allow `/vc join` into any authorized Discord voice channel. When set, `/vc join`, startup auto-join, and bot voice-state moves are restricted to the listed `{ guildId, channelId }` entries. Set it to an empty array to deny all Discord voice joins. If Discord moves the bot outside the allowlist, OpenClaw leaves that channel and rejoins the configured auto-join target when one is available.
 - `voice.daveEncryption` and `voice.decryptionFailureTolerance` pass through to `@discordjs/voice` join options; the upstream defaults are `daveEncryption=true` and `decryptionFailureTolerance=24`.
 - OpenClaw uses the bundled `libopus-wasm` codec for Discord voice receive and realtime raw PCM playback. It ships a pinned libopus WebAssembly build and does not require native opus addons.
 - `voice.connectTimeoutMs` controls the initial `@discordjs/voice` Ready wait for `/vc join` and auto-join attempts. Default: `30000`.
 - `voice.reconnectGraceMs` controls how long OpenClaw waits for a disconnected voice session to begin reconnecting before destroying it. Default: `15000`.
-- In `stt-tts` mode, voice playback does not stop just because another user starts speaking. To avoid feedback loops, OpenClaw ignores new voice capture while TTS is playing; speak after playback finishes for the next turn. Realtime modes forward speaker starts as barge-in signals to the realtime provider.
+- In `stt-tts` mode, voice playback does not stop just because another user starts speaking. To avoid feedback loops, OpenClaw does not admit new conversational turns while TTS is playing; an explicitly started capture still records that speech. Speak after playback finishes for the next conversational turn. Realtime modes forward authorized speaker starts as barge-in signals when interruption is enabled.
 - In realtime modes, echo from speakers into an open mic can look like barge-in and interrupt playback. For echo-heavy Discord rooms, set `voice.realtime.providers.openai.interruptResponseOnInputAudio: false` to keep OpenAI from auto-interrupting on input audio. Add `voice.realtime.bargeIn: true` if you still want Discord speaker-start events to interrupt active playback. The OpenAI realtime bridge ignores playback truncations shorter than `voice.realtime.minBargeInAudioEndMs` as likely echo/noise and logs them as skipped instead of clearing Discord playback.
 - `voice.captureSilenceGraceMs` controls how long OpenClaw waits after Discord reports a speaker has stopped before finalizing that audio segment for STT. Default: `2000`; raise it if Discord splits normal pauses into choppy partial transcripts.
 - When ElevenLabs is the selected TTS provider, Discord voice playback uses streaming TTS and starts from the provider response stream. Providers without streaming support fall back to the synthesized temp-file path.
@@ -1312,11 +1312,94 @@ Notes:
 - Verbose Discord voice logs include a bounded one-line STT transcript preview for each accepted speaker segment, so debugging shows both the user side and the agent reply side without dumping unbounded transcript text.
 - In `agent-proxy` mode, forced consult fallback skips likely incomplete transcript fragments such as text ending in `...` or a trailing connector like "and", plus obvious non-actionable closings like "be right back" or "bye". Logs show `forced agent consult skipped reason=...` when this prevents a stale queued answer.
 
+### Capture voice transcripts
+
+`voice.autoJoin` controls presence and conversation; it does not start durable
+recording. Start capture explicitly with the `transcripts` agent tool, or configure
+an existing `transcripts.autoStart` source. See [Transcripts CLI](/cli/transcripts#configuration)
+for configuration and inspection commands.
+
+An authorized agent can start capture with:
+
+```json
+{
+  "action": "start",
+  "providerId": "discord-voice",
+  "accountId": "work",
+  "guildId": "123456789012345678",
+  "channelId": "234567890123456789"
+}
+```
+
+Capture subscribes to that exact account, guild, and channel until stopped. It
+attaches to an existing matching voice connection without changing conversation
+or occupancy ownership. When it matches the account's configured `voice.autoJoin`
+target, normal voice conversation remains enabled regardless of which starts
+first. With `voice.autoJoin[].whenOccupied: true`, continuous capture waits through empty rooms and resumes
+on the next normal join. It also follows same-channel connection recovery and
+replacement of the same account's voice manager. Capture never moves an existing
+connection to another channel.
+
+An authorized capture records participants in the selected room independently of
+command access. Guild/channel users and roles, `commands.ownerAllowFrom`, and
+wake-name gates still control conversation, agent tools, and active-run controls;
+recording does not grant any of those permissions. Speech during protected
+playback is recorded without interrupting playback or triggering a reply.
+If OpenClaw first subscribes to someone already speaking, it records the available
+speech without conversational input or commands. Normal conversation requires a
+fresh receive stream after the current stream ends; brief pauses within
+`voice.captureSilenceGraceMs` keep the current stream and its recording-only behavior.
+
+Recording requires batch audio understanding. If `tools.media.audio.enabled` is
+`false`, starting capture fails with an enablement message; ordinary realtime
+conversation remains available.
+Recording uses one per-speaker audio stream and batch transcription, with the
+receiver's user ID, independently resolved display label, and audio-ingress time.
+Authorized speakers can also feed realtime conversation from the same decoded
+audio. Recording continues when all realtime speaker connections are busy.
+This costs an additional batch transcription for realtime speech, but keeps durable
+recording independent of realtime provider delivery and conversation authorization. Continuous speech is split into contiguous, bounded audio uploads;
+these are segments within the same capture session, not separate meetings.
+In `stt-tts` mode, authorized conversation shares that batch transcription and
+waits for the normal end of speech before responding.
+Conversation authorization and replies run separately from recording. Each voice
+connection permits eight unfinished voice requests, with at most 1 MiB of decoded
+audio waiting for admission per request. Batch requests retain at most 1 MiB of
+transcript text and 1,000 segments. Reaching a limit discards that entire voice
+request and continues recording; speak again after pending requests finish, or
+use a shorter utterance.
+Pending Discord recording work is capped across the Gateway process at 128 chunks
+and 64 MiB of WAV data. If transcription or saving notes cannot keep up, the
+affected receive stream stops and the capture stays registered. This budget
+survives voice reconnections; wait for pending audio processing to finish, then
+speak again.
+If transcription fails or omits input (such as an oversized upload), a chunk loses command access, or starting or stopping
+capture discards an uncaptured fragment below the minimum duration, successful notes remain
+saved, but the incomplete utterance does not trigger an agent reply or active-run
+control. Restored access applies to subsequent utterances, not missing chunks.
+A completed transcription with no text is allowed and does not invalidate the utterance.
+
+With no configured auto-join target or active conversation in that guild, a
+manual capture joins silently in transcript-only mode. A subsequent `/vc join`
+enables normal conversation on that connection. A capture for another channel
+stays registered without taking over the configured or active conversation,
+including when a recorder reconnect waits behind a newer conversation join.
+
+Stop with the `transcripts` tool's `stop` action and the returned `sessionId`.
+Stopping capture works while disconnected and does not disconnect a connection
+owned by conversation. Already-received audio can finish recording across a
+connection transition while the same capture remains active. Stop or replacement
+revokes pending publication; old audio cannot enter a new capture.
+Starting a new capture for the same registered source transfers the subscription
+without reconnecting or repeating target validation, even while it is dormant.
+Continuous capture can span multiple room occupations until explicitly stopped. For automatic
+meeting boundaries, use `transcripts.autoStart[].whenOccupied` as described below.
+Summaries are not automatically posted to Discord.
+
 ### Meeting notes
 
 Use the `discord-voice` transcripts provider to keep a note-taking bot in a voice
-channel only while humans are present. Capture is listen-only: the bot never
-speaks in that channel and does not start a realtime conversation provider.
+channel only while humans are present. Without a conversational auto-join target or active conversation, capture is listen-only and does not start a realtime provider. Attaching capture to an existing conversation preserves its ownership.
 Enable Discord voice, configure an authenticated [speech-to-text provider](/nodes/audio),
 and add an occupancy-driven transcript source:
 
@@ -1528,7 +1611,7 @@ Voice as an extension of an existing Discord channel session:
 
 In `agent-proxy` mode the bot joins the configured voice channel, but OpenClaw agent turns use the target channel's normal routed session and agent. The realtime voice session speaks the returned result back into the voice channel. The supervisor agent can still use normal message tools according to its tool policy, including sending a separate Discord message if that is the right action.
 
-While a delegated OpenClaw run is active, new Discord voice transcripts are treated as live run control before starting another agent turn. Phrases such as "status", "cancel that", "use the smaller fix", or "when you're done also check tests" are classified as status, cancel, steering, or follow-up input for the active session. Status, cancel, accepted steering, and follow-up outcomes are spoken back into the voice channel so the caller knows whether OpenClaw handled the request.
+While a delegated OpenClaw run is active, command-authorized Discord conversation transcripts are treated as live run control before starting another agent turn. Phrases such as "status", "cancel that", "use the smaller fix", or "when you're done also check tests" are classified as status, cancel, steering, or follow-up input for the active session. Status, cancel, accepted steering, and follow-up outcomes are spoken back into the voice channel so the caller knows whether OpenClaw handled the request.
 
 When OpenClaw cancels a delegated consult, Discord records cancellation rather than a failure and does not play the generic error fallback. Matching late provider tool calls receive the same terminal cancellation instead of restarting the work. The voice session remains available for the next request; timeouts and genuine failures keep their normal error handling.
 
@@ -1585,7 +1668,7 @@ Expected voice logs:
 - On barge-in detection: `discord voice: realtime barge-in detected source=speaker-start ...` or `discord voice: realtime barge-in detected source=active-speaker-audio ...`, followed by `discord voice: realtime barge-in requested reason=... outputAudioMs=... outputActive=...`
 - On realtime interruption: `discord voice: realtime model interrupt requested client:response.cancel reason=barge-in`, followed by either `discord voice: realtime model audio truncated client:conversation.item.truncate reason=barge-in audioEndMs=...` or `discord voice: realtime model interrupt confirmed server:response.done status=cancelled ...`
 - On ignored echo/noise: `discord voice: realtime model interrupt ignored client:conversation.item.truncate.skipped reason=barge-in audioEndMs=0 minAudioEndMs=250`
-- On disabled barge-in: `discord voice: realtime capture ignored during playback (barge-in disabled) ...`
+- On disabled barge-in: `discord voice: capture ignored: ... reason=protected playback`
 - On idle playback: `discord voice: realtime barge-in ignored reason=... outputActive=false ... playbackChunks=0`
 
 To debug cut-off audio, read the realtime voice logs as a timeline:
@@ -1613,8 +1696,11 @@ Common patterns:
 - Immediate cut-off with `source=active-speaker-audio`, small `outputAudioMs`, and the same user nearby usually points to speaker echo entering the mic. Raise `voice.realtime.minBargeInAudioEndMs`, lower speaker volume, use headphones, or set `voice.realtime.providers.openai.interruptResponseOnInputAudio: false`.
 - `source=speaker-start` followed by `speaker turn closed ... hasAudio=false` means Discord reported a speaker start but no audio reached OpenClaw. That can be a transient Discord voice event, noise gate behavior, or a client briefly keying the mic.
 - `audio playback stopped reason=output-audio-overflow` means sustained delivery problems exceeded the bounded pending-audio queue. Check the associated `Discord realtime audio playback overflow` error and preceding provider or Discord connection diagnostics; ordinary playback backpressure should not produce this error.
+- `Discord voice receive backlog exceeded` means identity lookup, decoding, or local disk could not keep up with incoming audio. OpenClaw bounds each receive stream at 1,000 pending packets and 1 MiB of encoded audio; speak again after the bottleneck clears. Other speakers and any registered capture remain active, and incomplete speech cannot become a new conversation command.
+- `conversation audio backlog exceeded`, `conversation is busy`, or `conversation transcript limit exceeded` means a conversation limit was reached. Recording continues; wait for pending requests to finish or repeat a shorter, complete request.
+- `Discord voice recording backlog exceeded` means pending WAV files reached the recording queue's chunk or byte limit. The affected utterance stops, and the registered capture remains available after pending audio processing catches up.
 - `audio playback stopped reason=stream-close` without a nearby barge-in or `provider-clear-audio` means the local Discord playback stream ended unexpectedly. Check the preceding provider and Discord player logs.
-- `capture ignored during playback (barge-in disabled)` means OpenClaw intentionally dropped input while assistant audio was active. Enable `voice.realtime.bargeIn` if you want speech to interrupt playback.
+- `capture ignored: ... reason=protected playback` means OpenClaw intentionally withheld conversational input while assistant audio was active. An explicitly started capture still records that speech. Enable `voice.realtime.bargeIn` if you want speech to interrupt playback.
 - `barge-in ignored ... outputActive=false` means Discord or provider VAD reported speech, but OpenClaw had no active playback to interrupt. This should not cut off audio.
 
 Credentials are resolved per component: LLM route auth for `voice.model`, STT auth for `tools.media.audio`, TTS auth for `tts`/`voice.tts`, and realtime provider auth for `voice.realtime.providers` or the provider's normal auth config.

--- a/docs/nodes/audio.md
+++ b/docs/nodes/audio.md
@@ -20,6 +20,14 @@ When audio understanding is enabled (or auto-detected), OpenClaw:
 
 When transcription succeeds, `CommandBody`/`RawBody` are also set to the transcript so slash commands still work. With `--verbose`, logs show when transcription runs and when it replaces the body.
 
+For plugin callers, file transcription returns `decision.attachmentProcessing`,
+keyed by attachment index. `"completed"` means a CLI or provider completed input
+processing, including successful empty output; `"omitted"` means none completed.
+This fact is separate from usable transcript text and attachment display markers.
+An absent field in an older SDK result means processing is unknown. For Discord
+batch voice, known omitted input prevents a partial utterance from becoming a
+conversation command or active-run control; valid captured notes remain saved.
+
 ## Auto-detection (default)
 
 If you have not configured models and `tools.media.audio.enabled` is not `false`, OpenClaw auto-detects in this order and stops at the first working option:

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -8,6 +8,7 @@ import { attachDiscordGatewayLogging } from "../gateway-logging.js";
 import { isFatalGatewayCloseCode } from "../internal/gateway-close-codes.js";
 import { GatewayCloseCodes } from "../internal/gateway.js";
 import { getDiscordGatewayEmitter, waitForDiscordGatewayStop } from "../monitor.gateway.js";
+import { setDiscordTranscriptsVoiceManager } from "../voice/transcripts-source.js";
 import type { DiscordVoiceManager } from "../voice/voice-runtime.js";
 import {
   DISCORD_GATEWAY_TRANSPORT_ACTIVITY_EVENT,
@@ -563,10 +564,10 @@ export async function runDiscordGatewayLifecycle(params: {
     );
     if (params.voiceManager) {
       await params.voiceManager.destroy();
-      const { setDiscordTranscriptsVoiceManager } = await import("../voice/transcripts-source.js");
       setDiscordTranscriptsVoiceManager({
         accountId: params.accountId,
         manager: null,
+        expectedManager: params.voiceManager,
       });
       params.voiceManagerRef.current = null;
     }

--- a/extensions/discord/src/monitor/provider.ts
+++ b/extensions/discord/src/monitor/provider.ts
@@ -24,6 +24,7 @@ import { GatewayCloseCodes } from "../internal/gateway.js";
 import { parseApplicationIdFromToken } from "../probe.js";
 import { normalizeDiscordToken } from "../token.js";
 import { resolveDiscordVoiceEnabled } from "../voice/config.js";
+import { setDiscordTranscriptsVoiceManager } from "../voice/transcripts-source.js";
 import { createDiscordAutoPresenceController } from "./auto-presence.js";
 import { resolveDiscordSlashCommandConfig } from "./commands.js";
 import type { MutableDiscordGateway } from "./gateway-handle.js";
@@ -427,7 +428,6 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
         runtime,
         botUserId,
       });
-      const { setDiscordTranscriptsVoiceManager } = await import("../voice/transcripts-source.js");
       setDiscordTranscriptsVoiceManager({
         accountId: account.accountId,
         manager: voiceManager,

--- a/extensions/discord/src/voice/audio.test.ts
+++ b/extensions/discord/src/voice/audio.test.ts
@@ -48,7 +48,6 @@ vi.mock("openclaw/plugin-sdk/temp-path", async (importOriginal) => {
 import {
   createDiscordOpusEncodeStream,
   createDiscordOpusPlaybackStream,
-  decodeOpusStream,
   decodeOpusStreamChunks,
   writeVoiceWavFile,
 } from "./audio.js";
@@ -80,43 +79,27 @@ async function collectBuffers(stream: Readable): Promise<Buffer[]> {
   return chunks;
 }
 
-const decodeModes = [
-  { mode: "buffered", decode: decodeOpusStream },
-  {
-    mode: "streaming",
-    decode: async (stream: Readable, params: Parameters<typeof decodeOpusStream>[1]) => {
-      const chunks: Buffer[] = [];
-      await decodeOpusStreamChunks(stream, { ...params, onChunk: (chunk) => chunks.push(chunk) });
-      return Buffer.concat(chunks);
-    },
-  },
-];
-
 describe("discord voice opus codec", () => {
-  it.each(decodeModes)(
-    "round-trips Discord PCM through $mode Opus decoding",
-    async ({ decode }) => {
-      const encoder = createDiscordOpusEncodeStream();
-      const packetsPromise = collectBuffers(encoder);
+  it("round-trips Discord PCM while preserving the source packet identity", async () => {
+    const encoder = createDiscordOpusEncodeStream();
+    const packetsPromise = collectBuffers(encoder);
 
-      encoder.end(Buffer.alloc(960 * 2 * 2));
-      const packets = await packetsPromise;
+    encoder.end(Buffer.alloc(960 * 2 * 2));
+    const packets = await packetsPromise;
 
-      expect(packets).toHaveLength(1);
-      expect(packets[0]?.length).toBeGreaterThan(0);
+    expect(packets).toHaveLength(1);
+    expect(packets[0]?.length).toBeGreaterThan(0);
 
-      const onVerbose = vi.fn();
-      const onWarn = vi.fn();
-      const decoded = await decode(Readable.from(packets), {
-        maxBytes: 20 * 1024 * 1024,
-        onVerbose,
-        onWarn,
-      });
-      expect(decoded.length).toBe(960 * 2 * 2);
-      expect(onVerbose).toHaveBeenCalledWith("opus decoder: libopus-wasm");
-      expect(onWarn).not.toHaveBeenCalled();
-    },
-  );
+    const onVerbose = vi.fn();
+    const onWarn = vi.fn();
+    const onChunk = vi.fn();
+    await decodeOpusStreamChunks(Readable.from(packets), { onVerbose, onWarn, onChunk });
+    expect(onChunk).toHaveBeenCalledOnce();
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(960 * 2 * 2);
+    expect(onChunk.mock.calls[0]?.[1]).toBe(packets[0]);
+    expect(onVerbose).toHaveBeenCalledWith("opus decoder: libopus-wasm");
+    expect(onWarn).not.toHaveBeenCalled();
+  });
 
   it("pads final partial PCM frames before encoding", async () => {
     const encoder = createDiscordOpusEncodeStream();
@@ -126,50 +109,37 @@ describe("discord voice opus codec", () => {
     const packets = await packetsPromise;
 
     expect(packets).toHaveLength(1);
-    const decoded = await decodeOpusStream(Readable.from(packets), {
-      maxBytes: 20 * 1024 * 1024,
+    const onChunk = vi.fn();
+    await decodeOpusStreamChunks(Readable.from(packets), {
+      onChunk,
       onVerbose: vi.fn(),
       onWarn: vi.fn(),
     });
-    expect(decoded).toHaveLength(960 * 2 * 2);
+    expect(onChunk).toHaveBeenCalledOnce();
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(960 * 2 * 2);
   });
 
-  it.each(decodeModes)(
-    "preserves decoded audio and reports $mode stream failures",
-    async ({ decode }) => {
-      const err = new Error("memory access out of bounds");
-      const onError = vi.fn();
-      const stream = Readable.from(
-        (async function* () {
-          yield Buffer.from([0xf8, 0xff, 0xfe]);
-          throw err;
-        })(),
-      );
+  it("preserves decoded audio and reports stream failures", async () => {
+    const err = new Error("memory access out of bounds");
+    const onError = vi.fn();
+    const stream = Readable.from(
+      (async function* () {
+        yield Buffer.from([0xf8, 0xff, 0xfe]);
+        throw err;
+      })(),
+    );
 
-      const decoded = await decode(stream, {
-        maxBytes: 20 * 1024 * 1024,
-        onError,
-        onVerbose: vi.fn(),
-        onWarn: vi.fn(),
-      });
+    const onChunk = vi.fn();
+    await decodeOpusStreamChunks(stream, {
+      onChunk,
+      onError,
+      onVerbose: vi.fn(),
+      onWarn: vi.fn(),
+    });
 
-      expect(onError).toHaveBeenCalledWith(err);
-      expect(decoded).toHaveLength(960 * 2 * 2);
-    },
-  );
-  it("rejects oversized decoded input without returning a truncated successful capture", async () => {
-    const stream = Readable.from([
-      Buffer.from([0xf8, 0xff, 0xfe]),
-      Buffer.from([0xf8, 0xff, 0xfe]),
-    ]);
-    await expect(
-      decodeOpusStream(stream, {
-        maxBytes: 3840,
-        onVerbose: vi.fn(),
-        onWarn: vi.fn(),
-      }),
-    ).rejects.toThrow("speak a shorter segment");
-    expect(stream.destroyed).toBe(true);
+    expect(onError).toHaveBeenCalledWith(err);
+    expect(onChunk).toHaveBeenCalledOnce();
+    expect(onChunk.mock.calls[0]?.[0]).toHaveLength(960 * 2 * 2);
   });
 
   it("streams audio beyond a batch-sized budget without accumulating or truncating it", async () => {

--- a/extensions/discord/src/voice/audio.ts
+++ b/extensions/discord/src/voice/audio.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements audio behavior.
 import { spawn } from "node:child_process";
 import { Transform, type Readable, type TransformCallback } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
@@ -11,7 +10,6 @@ import {
 } from "libopus-wasm";
 import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 import { resamplePcm } from "openclaw/plugin-sdk/realtime-voice";
-import { readByteStreamWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { tempWorkspace, resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
@@ -226,28 +224,15 @@ function pcmInt16ToBuffer(pcm: Int16Array): Buffer {
   return Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength);
 }
 
-export async function decodeOpusStream(
-  stream: Readable,
-  params: OpusDecodeCallbacks & { maxBytes: number },
-): Promise<Buffer> {
-  return await readByteStreamWithLimit(decodeOpusFrames(stream, params), {
-    maxBytes: params.maxBytes,
-    onOverflow: () =>
-      new Error(
-        `Discord voice capture exceeds the transcription PCM limit (${params.maxBytes} bytes); speak a shorter segment.`,
-      ),
-  });
-}
-
 export async function decodeOpusStreamChunks(
   stream: Readable,
   params: OpusDecodeCallbacks & {
-    onChunk: (pcm48kStereo: Buffer) => void;
+    onChunk: (pcm48kStereo: Buffer, packet: Buffer) => void | Promise<void>;
   },
 ): Promise<void> {
   try {
-    for await (const pcm of decodeOpusFrames(stream, params)) {
-      params.onChunk(pcm);
+    for await (const { pcm, packet } of decodeOpusFrames(stream, params)) {
+      await params.onChunk(pcm, packet);
     }
   } catch (err) {
     params.onError?.(err);
@@ -257,7 +242,7 @@ export async function decodeOpusStreamChunks(
 async function* decodeOpusFrames(
   stream: Readable,
   params: OpusDecodeCallbacks,
-): AsyncGenerator<Buffer> {
+): AsyncGenerator<{ pcm: Buffer; packet: Buffer }> {
   let decoder: LibopusDecoder;
   try {
     decoder = await createLibopusDecoder({ channels: CHANNELS, sampleRate: SAMPLE_RATE });
@@ -278,7 +263,7 @@ async function* decodeOpusFrames(
       }
       const decoded = decoder.decode(chunk, { maxFrameSize: DISCORD_OPUS_FRAME_SIZE });
       if (decoded.length > 0) {
-        yield pcmInt16ToBuffer(decoded);
+        yield { pcm: pcmInt16ToBuffer(decoded), packet: chunk };
       }
     }
   } catch (err) {

--- a/extensions/discord/src/voice/capture-state.ts
+++ b/extensions/discord/src/voice/capture-state.ts
@@ -1,8 +1,8 @@
-// Discord plugin module implements capture state behavior.
 import type { Readable } from "node:stream";
 
 type VoiceCaptureEntry = {
   stream?: Readable;
+  startRecording?: () => void;
   finalizeTimer?: ReturnType<typeof setTimeout>;
 };
 
@@ -29,6 +29,27 @@ export function clearVoiceCaptureFinalizeTimer(capture: VoiceCaptureEntry): bool
   clearTimeout(capture.finalizeTimer);
   delete capture.finalizeTimer;
   return true;
+}
+
+export async function waitForVoiceCaptureAdmission(params: {
+  capture: VoiceCaptureEntry;
+  conversationAuthorized: Promise<boolean>;
+  isRecordingCurrent: () => boolean;
+}): Promise<boolean> {
+  const recordingStarted = new Promise<void>((resolve) => {
+    params.capture.startRecording = resolve;
+  });
+  try {
+    await Promise.race([params.conversationAuthorized, recordingStarted]);
+  } catch (error) {
+    // Receive owns conversation failures once recording has its own authority.
+    if (!params.isRecordingCurrent()) {
+      throw error;
+    }
+  } finally {
+    delete params.capture.startRecording;
+  }
+  return params.isRecordingCurrent() || (await params.conversationAuthorized);
 }
 
 export function beginVoiceCapture(

--- a/extensions/discord/src/voice/command.ts
+++ b/extensions/discord/src/voice/command.ts
@@ -271,7 +271,8 @@ export function createDiscordVoiceCommand(params: VoiceCommandContext): CommandW
         return;
       }
       const lines = sessions.map(
-        (entry) => `• ${formatMention({ channelId: entry.channelId })} (guild ${entry.guildId})`,
+        (entry) =>
+          `• ${formatMention({ channelId: entry.channelId })} (guild ${entry.guildId})${entry.warning ? `\n${entry.warning}` : ""}`,
       );
       await interaction.reply({ content: lines.join("\n"), ephemeral: true });
     }

--- a/extensions/discord/src/voice/owner-access.ts
+++ b/extensions/discord/src/voice/owner-access.ts
@@ -1,7 +1,36 @@
-// Discord plugin module implements voice owner resolution.
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveDiscordAccountAllowFrom } from "../accounts.js";
 import { resolveDiscordCommandOwnerAllowFrom } from "../command-owners.js";
+import type { Client } from "../internal/discord.js";
+import { resolveFetchedDiscordThreadLikeChannelContext } from "../monitor/thread-channel-context.js";
+
+export async function resolveDiscordVoiceAccessTarget(params: {
+  client: Client;
+  guildId: string;
+  channelId: string;
+}) {
+  const [guild, channel] = await Promise.all([
+    params.client.fetchGuild(params.guildId).catch(() => null),
+    params.client.fetchChannel(params.channelId).catch(() => null),
+  ]);
+  if (!guild || !channel) {
+    return undefined;
+  }
+  const context = await resolveFetchedDiscordThreadLikeChannelContext({
+    client: params.client,
+    channel,
+    channelIdFallback: params.channelId,
+  });
+  return {
+    guild,
+    ...(context.channelName ? { channelName: context.channelName } : {}),
+    channelSlug: context.channelSlug,
+    ...(context.parentId ? { parentId: context.parentId } : {}),
+    ...(context.threadParentName ? { parentName: context.threadParentName } : {}),
+    ...(context.threadParentSlug ? { parentSlug: context.threadParentSlug } : {}),
+    scope: context.isThreadChannel ? ("thread" as const) : ("channel" as const),
+  };
+}
 
 export function resolveDiscordVoiceAccess(params: {
   cfg: OpenClawConfig;

--- a/extensions/discord/src/voice/participant-context.ts
+++ b/extensions/discord/src/voice/participant-context.ts
@@ -47,6 +47,34 @@ export function listDiscordVoiceParticipantStates(params: {
   return gateway.listVoiceChannelStates(params.guildId, params.channelId);
 }
 
+export function createDiscordVoiceOccupancyWatcher(
+  params: { client: Client; botUserId?: string; guildId: string; channelId: string },
+  listener: (state: { occupied: boolean }) => void,
+) {
+  const guildId = params.guildId.trim();
+  const channelId = params.channelId.trim();
+  let wasOccupied: boolean | undefined;
+  return {
+    guildId,
+    refresh: () => {
+      const states = listDiscordVoiceParticipantStates({
+        client: params.client,
+        guildId,
+        channelId,
+      });
+      if (states === null) {
+        return;
+      }
+      const occupied =
+        countDiscordVoiceHumanParticipants({ states, botUserId: params.botUserId }) > 0;
+      if (occupied !== wasOccupied) {
+        wasOccupied = occupied;
+        listener({ occupied });
+      }
+    },
+  };
+}
+
 function retainParticipantId(selected: string[], userId: string): void {
   if (selected.includes(userId)) {
     return;

--- a/extensions/discord/src/voice/realtime-playback.integration.test-support.ts
+++ b/extensions/discord/src/voice/realtime-playback.integration.test-support.ts
@@ -11,6 +11,7 @@ import { DiscordRealtimePlayer } from "./realtime-player.js";
 import { createVoiceReceiveRecoveryState } from "./receive-recovery.js";
 import { loadDiscordVoiceSdk } from "./sdk-runtime.js";
 import type { VoiceSessionEntry } from "./session.js";
+import { DiscordVoiceConversationQueue } from "./voice-conversation-input.js";
 
 export function createRealtimePlaybackFixture(onTalkEvent?: (event: TalkEvent) => void) {
   const voiceSdk = loadDiscordVoiceSdk();
@@ -30,6 +31,7 @@ export function createRealtimePlaybackFixture(onTalkEvent?: (event: TalkEvent) =
   );
   const entry: VoiceSessionEntry = {
     generation: 1,
+    captureOnly: false,
     autoJoinWhenOccupied: false,
     sessionLifecycle: { status: "active" },
     guildId: "guild",
@@ -49,6 +51,7 @@ export function createRealtimePlaybackFixture(onTalkEvent?: (event: TalkEvent) =
     player,
     playbackQueue: Promise.resolve(),
     processingQueue: Promise.resolve(),
+    conversations: new DiscordVoiceConversationQueue(),
     audioInputBudget: { enabled: false },
     ttsStreamFallbackWarned: false,
     capture: createVoiceCaptureState(),

--- a/extensions/discord/src/voice/realtime-recording.ts
+++ b/extensions/discord/src/voice/realtime-recording.ts
@@ -1,8 +1,10 @@
-import type { DiscordVoiceSegmentOutcome } from "./segment.js";
-import type { VoiceSessionEntry } from "./session.js";
-import type { DiscordVoiceAudioReceipt } from "./voice-recording.js";
+import type {
+  DiscordVoiceSegmentOutcome,
+  DiscordVoiceAudioReceipt,
+  DiscordVoiceTranscriptCapture,
+} from "./recording-types.js";
 
-type Capture = VoiceSessionEntry["transcripts"];
+type Capture = DiscordVoiceTranscriptCapture | undefined;
 const MAX_REALTIME_RECORDING_BYTES = 1024 * 1024;
 const MAX_REALTIME_RECORDING_FINALS = 1_000;
 
@@ -107,7 +109,7 @@ export class DiscordRealtimeRecording {
 
   constructor(
     private readonly params: {
-      entry: VoiceSessionEntry;
+      entry: { guildId: string; channelId: string; voiceSessionKey: string };
       isCurrent: () => boolean;
       warn: (message: string) => void;
     },

--- a/extensions/discord/src/voice/realtime-recording.ts
+++ b/extensions/discord/src/voice/realtime-recording.ts
@@ -1,0 +1,231 @@
+import type { DiscordVoiceSegmentOutcome } from "./segment.js";
+import type { VoiceSessionEntry } from "./session.js";
+import type { DiscordVoiceAudioReceipt } from "./voice-recording.js";
+
+type Capture = VoiceSessionEntry["transcripts"];
+const MAX_REALTIME_RECORDING_BYTES = 1024 * 1024;
+const MAX_REALTIME_RECORDING_FINALS = 1_000;
+
+/** One native input owns its submitted receipts and every batch job before it seals. */
+export class DiscordRealtimeRecordingInput {
+  initialReceipt: DiscordVoiceAudioReceipt | undefined;
+  capture: Capture;
+  startedAt: number | undefined;
+  hasAudio = false;
+  eligible = true;
+  unavailable: boolean;
+  private audioSealed = false;
+  private batchSealed = false;
+  private pending = 0;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(batchDisabled: boolean) {
+    this.unavailable = batchDisabled;
+  }
+
+  noteReceipt(receipt: DiscordVoiceAudioReceipt): void {
+    this.initialReceipt ??= receipt;
+  }
+
+  submit(receipt: DiscordVoiceAudioReceipt | undefined): void {
+    if (!this.hasAudio) {
+      this.hasAudio = true;
+      this.capture = receipt?.capture;
+      this.startedAt = receipt?.startedAt;
+    }
+    if (!receipt?.capture || receipt.capture !== this.capture) {
+      this.eligible = false;
+    }
+    this.notify();
+  }
+
+  observeBatch(result: Promise<DiscordVoiceSegmentOutcome>): void {
+    this.pending += 1;
+    void result
+      .then(
+        (outcome) => {
+          if (outcome.status === "unavailable") {
+            this.unavailable = true;
+          } else {
+            this.eligible = false;
+          }
+        },
+        () => {
+          this.eligible = false;
+        },
+      )
+      .finally(() => {
+        this.pending -= 1;
+        this.notify();
+      });
+  }
+
+  exclude(): void {
+    this.eligible = false;
+    this.notify();
+  }
+
+  sealAudio(): void {
+    this.audioSealed = true;
+    this.notify();
+  }
+
+  sealBatch(): void {
+    this.batchSealed = true;
+    this.notify();
+  }
+
+  get complete(): boolean {
+    return this.audioSealed && this.batchSealed && this.pending === 0;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+/** Realtime text is usable only when the whole provider generation has one recording owner. */
+export class DiscordRealtimeRecording {
+  private readonly inputs = new Map<DiscordRealtimeRecordingInput, () => void>();
+  private capture: Capture;
+  private speaker: { id: string; label: string } | undefined;
+  private firstStartedAt: number | undefined;
+  private sawInput = false;
+  private multipleInputs = false;
+  private unavailable = false;
+  private stopped = false;
+  private publishing = false;
+  private bytes = 0;
+  private finals: Array<{ text: string; bytes: number; startedAt?: number }> = [];
+
+  constructor(
+    private readonly params: {
+      entry: VoiceSessionEntry;
+      isCurrent: () => boolean;
+      warn: (message: string) => void;
+    },
+  ) {}
+
+  attach(input: DiscordRealtimeRecordingInput, speaker: { id: string; label: string }): void {
+    if (this.stopped) {
+      return;
+    }
+    let observed = false;
+    const changed = () => {
+      if (input.hasAudio && (!input.eligible || !input.capture?.isCurrent())) {
+        this.close();
+        return;
+      }
+      if (input.hasAudio && !observed) {
+        observed = true;
+        if (this.capture && this.capture !== input.capture) {
+          this.close();
+          return;
+        }
+        this.capture = input.capture;
+        this.speaker ??= speaker;
+        this.multipleInputs ||= this.sawInput;
+        this.sawInput = true;
+        this.firstStartedAt ??= input.startedAt;
+      }
+      if (input.complete) {
+        if (input.hasAudio && !input.unavailable) {
+          this.close();
+          return;
+        }
+        this.unavailable ||= input.hasAudio && input.unavailable;
+        this.inputs.get(input)?.();
+        this.inputs.delete(input);
+      }
+      void this.publish();
+    };
+    this.inputs.set(input, input.subscribe(changed));
+    changed();
+  }
+
+  transcript(text: string): void {
+    if (this.stopped || !this.capture?.isCurrent() || !this.params.isCurrent()) {
+      return;
+    }
+    const bytes = Buffer.byteLength(text);
+    if (
+      this.finals.length + Number(this.publishing) >= MAX_REALTIME_RECORDING_FINALS ||
+      bytes > MAX_REALTIME_RECORDING_BYTES - this.bytes
+    ) {
+      this.params.warn(
+        "discord voice: realtime recording backlog exceeded; configure batch audio transcription for independent recording.",
+      );
+      this.close();
+      return;
+    }
+    this.bytes += bytes;
+    this.finals.push({
+      text,
+      bytes,
+      ...(!this.multipleInputs ? { startedAt: this.firstStartedAt } : {}),
+    });
+    void this.publish();
+  }
+
+  close(): void {
+    this.stopped = true;
+    for (const unsubscribe of this.inputs.values()) {
+      unsubscribe();
+    }
+    this.inputs.clear();
+    for (const final of this.finals) {
+      this.bytes -= final.bytes;
+    }
+    this.finals = [];
+  }
+
+  private async publish(): Promise<void> {
+    if (this.publishing || this.stopped || this.inputs.size > 0 || !this.unavailable) {
+      return;
+    }
+    this.publishing = true;
+    try {
+      while (this.finals.length > 0 && !this.stopped && this.inputs.size === 0) {
+        const capture = this.capture;
+        const speaker = this.speaker;
+        if (!capture?.isCurrent() || !speaker || !this.params.isCurrent()) {
+          this.close();
+          break;
+        }
+        const final = this.finals.shift()!;
+        try {
+          await capture.onUtterance({
+            sessionId: capture.sessionId,
+            ...(final.startedAt !== undefined
+              ? { startedAt: new Date(final.startedAt).toISOString() }
+              : {}),
+            final: true,
+            speaker,
+            text: final.text,
+            metadata: {
+              channel: "discord",
+              guildId: this.params.entry.guildId,
+              channelId: this.params.entry.channelId,
+              voiceSessionKey: this.params.entry.voiceSessionKey,
+            },
+          });
+        } catch {
+          this.params.warn(
+            "discord voice: realtime recording publication failed; check transcript storage.",
+          );
+        } finally {
+          this.bytes -= final.bytes;
+        }
+      }
+    } finally {
+      this.publishing = false;
+    }
+  }
+}

--- a/extensions/discord/src/voice/realtime-session.runtime.ts
+++ b/extensions/discord/src/voice/realtime-session.runtime.ts
@@ -1,6 +1,7 @@
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { DiscordRealtimePlayer } from "./realtime-player.js";
+import type { DiscordRealtimeRecordingInput } from "./realtime-recording.js";
 import {
   DiscordRealtimeSpeakerSession,
   type DiscordRealtimeSessionParams,
@@ -70,7 +71,11 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
     this.sessions.clear();
   }
 
-  beginSpeakerTurn(context: VoiceRealtimeSpeakerContext, userId: string): VoiceRealtimeSpeakerTurn {
+  beginSpeakerTurn(
+    context: VoiceRealtimeSpeakerContext,
+    userId: string,
+    recordingInput?: DiscordRealtimeRecordingInput,
+  ): VoiceRealtimeSpeakerTurn {
     if (this.closed) {
       throw new Error("Discord realtime voice session is closed");
     }
@@ -80,7 +85,10 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       }
     }
     let speaker = this.speakers.get(userId);
-    if (speaker && speaker.transcripts !== this.params.entry.transcripts) {
+    const transcripts = recordingInput?.initialReceipt
+      ? recordingInput.initialReceipt.capture
+      : this.params.entry.transcripts;
+    if (speaker && speaker.transcripts !== transcripts) {
       // Subscription replacement fences transcript delivery, but must not cut a valid spoken
       // answer short. The old connection drains with its original source and receives no new input.
       this.speakers.delete(userId);
@@ -100,7 +108,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
       speaker = {
         userId,
         senderIsOwner: context.senderIsOwner,
-        transcripts: this.params.entry.transcripts,
+        transcripts,
         session,
       };
       this.speakers.set(userId, speaker);
@@ -111,7 +119,7 @@ export class DiscordRealtimeVoiceSession implements VoiceRealtimeSession {
         void session.connect().catch((error: unknown) => this.handleSpeakerFailure(session, error));
       }
     }
-    return speaker.session.beginSpeakerTurn(context, userId);
+    return speaker.session.beginSpeakerTurn(context, userId, recordingInput);
   }
 
   handleBargeIn(reason = "barge-in"): void {

--- a/extensions/discord/src/voice/realtime-speaker-session.ts
+++ b/extensions/discord/src/voice/realtime-speaker-session.ts
@@ -32,6 +32,10 @@ import { formatVoiceLogPreview } from "./log-preview.js";
 import { DiscordRealtimeConsults, type AgentProxyConsultState } from "./realtime-consults.js";
 import { DiscordRealtimePlayback } from "./realtime-playback.js";
 import type { DiscordRealtimePlayer } from "./realtime-player.js";
+import {
+  DiscordRealtimeRecording,
+  type DiscordRealtimeRecordingInput,
+} from "./realtime-recording.js";
 import { DiscordRealtimeTurns } from "./realtime-turns.js";
 import {
   logVoiceVerbose,
@@ -124,6 +128,7 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
   private readonly playback: DiscordRealtimePlayback<AgentProxyConsultState>;
   private readonly turns: DiscordRealtimeTurns;
   private readonly consults: DiscordRealtimeConsults;
+  private readonly recording: DiscordRealtimeRecording;
   private lifecycle: {
     status: "inactive" | "starting" | "active" | "stopped";
     generation: number;
@@ -150,6 +155,7 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
       sessionId: string;
     },
   ) {
+    this.recording = this.createRecording();
     this.harness = createRealtimeVoiceSessionHarness<AgentProxyConsultState>({
       talk: {
         sessionId: this.params.sessionId,
@@ -395,6 +401,9 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
           this.turns.handlePartialUserTranscript(text);
           return;
         }
+        if (text.trim()) {
+          this.recording.transcript(text.trim());
+        }
         void this.trackOperation(() => this.turns.handleFinalUserTranscript(text)).catch(
           (error: unknown) => this.logRealtimeError(formatErrorMessage(error)),
         );
@@ -468,6 +477,7 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
 
   close(): void {
     this.lifecycle.status = "stopped";
+    this.recording.close();
     this.drain();
     this.providerContinuityEpoch += 1;
     this.flushSuppressedRealtimeErrors();
@@ -480,15 +490,23 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
     this.realtimeProviderId = undefined;
   }
 
-  beginSpeakerTurn(context: VoiceRealtimeSpeakerContext, userId: string): VoiceRealtimeSpeakerTurn {
+  beginSpeakerTurn(
+    context: VoiceRealtimeSpeakerContext,
+    userId: string,
+    recordingInput?: DiscordRealtimeRecordingInput,
+  ): VoiceRealtimeSpeakerTurn {
     if (!this.inputOpen || this.isStopped()) {
       throw new Error("Discord realtime speaker input is closed");
     }
     const turn = this.turns.beginSpeakerTurn(context, userId);
+    if (recordingInput) {
+      this.recording.attach(recordingInput, { id: userId, label: context.speakerLabel });
+    }
     let closed = false;
     const capture: VoiceRealtimeSpeakerTurn = {
-      sendInputAudio: (audio) => {
+      sendInputAudio: (audio, receipt) => {
         if (!closed) {
+          recordingInput?.submit(receipt);
           this.lastActivityAt = Date.now();
           turn.sendInputAudio(audio);
         }
@@ -500,11 +518,19 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
         closed = true;
         this.captures.delete(capture);
         this.lastActivityAt = Date.now();
-        if (reason === "incomplete-input") {
-          // Retire this provider connection before a late transcript can dispatch partial speech.
-          this.params.onTerminalError(new Error("Discord realtime received incomplete speech."));
-        } else {
-          turn.close();
+        try {
+          if (reason === "incomplete-input") {
+            recordingInput?.exclude();
+            // Retire this provider connection before a late transcript can dispatch partial speech.
+            this.params.onTerminalError(new Error("Discord realtime received incomplete speech."));
+          } else {
+            turn.close();
+          }
+        } catch (error) {
+          recordingInput?.exclude();
+          throw error;
+        } finally {
+          recordingInput?.sealAudio();
         }
       },
     };
@@ -632,9 +658,21 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
       this.lifecycle.status = "starting";
     }
     this.providerContinuityEpoch += 1;
+    // Provider queues may replay earlier input without new Discord send callbacks.
+    // Only a fresh speaker connection can establish recording receipts again.
+    this.recording.close();
     this.consults.resetProviderContinuity();
     this.turns.resetProviderContinuity();
     this.playback.resetProviderContinuity(reason);
+  }
+
+  private createRecording(): DiscordRealtimeRecording {
+    const epoch = this.providerContinuityEpoch;
+    return new DiscordRealtimeRecording({
+      entry: this.params.entry,
+      isCurrent: () => !this.isStopped() && this.providerContinuityEpoch === epoch,
+      warn: (message) => logger.warn(message),
+    });
   }
 
   private logRealtimeError(message: string): void {

--- a/extensions/discord/src/voice/realtime-speaker-session.ts
+++ b/extensions/discord/src/voice/realtime-speaker-session.ts
@@ -493,14 +493,19 @@ export class DiscordRealtimeSpeakerSession implements VoiceRealtimeSession {
           turn.sendInputAudio(audio);
         }
       },
-      close: () => {
+      close: (reason) => {
         if (closed) {
           return;
         }
         closed = true;
         this.captures.delete(capture);
         this.lastActivityAt = Date.now();
-        turn.close();
+        if (reason === "incomplete-input") {
+          // Retire this provider connection before a late transcript can dispatch partial speech.
+          this.params.onTerminalError(new Error("Discord realtime received incomplete speech."));
+        } else {
+          turn.close();
+        }
       },
     };
     this.captures.add(capture);

--- a/extensions/discord/src/voice/realtime-speaker-sessions.test.ts
+++ b/extensions/discord/src/voice/realtime-speaker-sessions.test.ts
@@ -16,6 +16,9 @@ defineDiscordVoiceTests(
     lastAgentCommandArgs,
     lastRealtimeBridge,
     sentUserMessages,
+    createClient,
+    startTranscripts,
+    receiveRecordedSpeech,
   }) => {
     it("preserves immediate acknowledgments for installed providers with unscoped marks", async () => {
       const { entry, manager } = await createJoinedAgentProxyFixture();
@@ -32,15 +35,19 @@ defineDiscordVoiceTests(
     it.each(["guest-first", "owner-first"] as const)(
       "keeps speaker authority and transcript labels with their input connections: %s",
       async (order) => {
+        const client = createClient();
+        client.fetchMember.mockImplementation(async (_guildId, userId) => ({
+          nickname: userId === "guest" ? "Ada" : "Grace",
+          roles: [],
+          user: { id: userId },
+        }));
         const { entry, manager } = await createJoinedAgentProxyFixture({
+          client,
           config: { voice: { realtime: { requireWakeName: false } } },
         });
         const onUtterance = vi.fn();
         try {
-          await manager.join(
-            { guildId: "g1", channelId: "1001" },
-            { transcripts: { sessionId: "shared-room", onUtterance } },
-          );
+          await startTranscripts(manager, onUtterance, "shared-room");
           beginSpeakerTurn(entry, {
             userId: "guest",
             speakerLabel: "Ada",
@@ -84,6 +91,8 @@ defineDiscordVoiceTests(
               agentId: "agent-1",
               sessionKey: "discord:g1:c1",
             });
+            expect(onUtterance).toHaveBeenCalledTimes(index);
+            await receiveRecordedSpeech(manager, turn.text, entry, turn.id);
             expect(onUtterance).toHaveBeenCalledWith(
               expect.objectContaining({
                 sessionId: "shared-room",
@@ -228,12 +237,7 @@ defineDiscordVoiceTests(
       const newTranscript = vi.fn();
       let pending: Promise<void> | void = undefined;
       try {
-        await manager.join(
-          { guildId: "g1", channelId: "1001" },
-          {
-            transcripts: { sessionId: "old-subscription", onUtterance: oldTranscript },
-          },
-        );
+        await startTranscripts(manager, oldTranscript, "old-subscription");
         const originalCapture = beginSpeakerTurn(entry);
         const original = lastRealtimeBridge();
         pending = original.bridgeParams.onToolCall?.(
@@ -246,12 +250,7 @@ defineDiscordVoiceTests(
           original.session,
         );
         await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledOnce());
-        await manager.join(
-          { guildId: "g1", channelId: "1001" },
-          {
-            transcripts: { sessionId: "new-subscription", onUtterance: newTranscript },
-          },
-        );
+        await startTranscripts(manager, newTranscript, "new-subscription");
         beginSpeakerTurn(entry).close();
         const replacement = lastRealtimeBridge();
         const sentBeforeLateAudio = original.session.sendAudio.mock.calls.length;
@@ -265,6 +264,8 @@ defineDiscordVoiceTests(
         });
         expect(replacement.session.submitToolResult).not.toHaveBeenCalled();
         await emitFinalRealtimeUserTranscript(replacement.bridgeParams, "Fresh question.");
+        expect(newTranscript).not.toHaveBeenCalled();
+        await receiveRecordedSpeech(manager, "Fresh question.", entry);
         expect(newTranscript).toHaveBeenCalledWith(
           expect.objectContaining({ sessionId: "new-subscription", text: "Fresh question." }),
         );

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -20,6 +20,9 @@ defineDiscordVoiceTests(
     createManager,
     makeVoiceConfig,
     createAgentProxyManager,
+    startTranscripts,
+    stopTranscripts,
+    receiveRecordedSpeech,
     getSessionEntry,
     beginSpeakerTurn,
     createWakeNameFixture,
@@ -43,21 +46,15 @@ defineDiscordVoiceTests(
         await manager.join({ guildId: "g1", channelId: "1001" });
         const first = vi.fn();
         const second = vi.fn();
-        await manager.join(
-          { guildId: "g1", channelId: "1001" },
-          { transcripts: { sessionId: "old", onUtterance: first } },
-        );
+        await startTranscripts(manager, first, "old");
         const entry = getSessionEntry(manager);
         const bridge = lastRealtimeBridgeParams();
         beginSpeakerTurn(entry);
         if (ordering === "before-delivery") {
           bridge?.onTranscript?.("user", "old room speech", true);
         }
-        const replacing = manager.join(
-          { guildId: "g1", channelId: "1001" },
-          { transcripts: { sessionId: "new", onUtterance: second } },
-        );
-        await replacing;
+        await stopTranscripts("old");
+        await startTranscripts(manager, second, "new");
         if (ordering === "before-final") {
           bridge?.onTranscript?.("user", "old room speech", true);
         }
@@ -66,9 +63,13 @@ defineDiscordVoiceTests(
         expect(second).not.toHaveBeenCalled();
         beginSpeakerTurn(entry);
         await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "fresh room speech");
+        expect(second).not.toHaveBeenCalled();
+        await receiveRecordedSpeech(manager, "fresh room speech");
         expect(second).toHaveBeenCalledWith(
           expect.objectContaining({ sessionId: "new", text: "fresh room speech" }),
         );
+        expect(first).not.toHaveBeenCalled();
+        expect(second).toHaveBeenCalledOnce();
         await manager.destroy();
       },
     );
@@ -708,7 +709,6 @@ defineDiscordVoiceTests(
 
     it("treats a bare wake name as an activation for the next realtime transcript", async () => {
       agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "follow-up answer" }] });
-      const onUtterance = vi.fn();
       const manager = createAgentProxyManager(
         undefined,
         { voice: { realtime: { consultPolicy: "auto", requireWakeName: true } } },
@@ -720,15 +720,6 @@ defineDiscordVoiceTests(
       );
 
       await manager.join({ guildId: "g1", channelId: "1001" });
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance,
-          },
-        },
-      );
       const entry = getSessionEntry(manager);
       const bridgeParams = lastRealtimeBridgeParams();
 
@@ -748,15 +739,6 @@ defineDiscordVoiceTests(
       expect(lastAgentCommandArgs().message).not.toContain("Multy");
       expect(lastAgentCommandArgs().extraSystemPrompt).toBe("owner prompt");
       expectUserMessageIncludes("follow-up answer");
-      await vi.waitFor(() =>
-        expect(onUtterance).toHaveBeenCalledWith(
-          expect.objectContaining({
-            sessionId: "notes-1",
-            text: "What's your take on rebuilding everything?",
-            speaker: { id: "u-owner", label: "Owner" },
-          }),
-        ),
-      );
     });
 
     it("reuses recently ignored speaker context when wake-name consult has no pending turn", async () => {

--- a/extensions/discord/src/voice/realtime-turns.ts
+++ b/extensions/discord/src/voice/realtime-turns.ts
@@ -11,7 +11,6 @@ import {
   type RealtimeVoiceWakeNamePolicy,
 } from "openclaw/plugin-sdk/realtime-voice";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { convertDiscordPcm48kStereoToRealtimePcm24kMono } from "./audio.js";
 import type { DiscordRealtimePlaybackPort } from "./realtime-playback.js";
 import { mergeRealtimePartialTranscript } from "./realtime-transcript.js";
@@ -31,8 +30,6 @@ const DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS = 3_000;
 export type DiscordRealtimeSpeakerContext = VoiceRealtimeSpeakerContext & { userId: string };
 
 type PendingSpeakerTurn = {
-  // Final text keeps the audio turn's subscription across capture replacement.
-  transcripts: VoiceSessionEntry["transcripts"];
   inputDiscordBytes: number;
   inputRealtimeBytes: number;
   inputChunks: number;
@@ -42,12 +39,6 @@ type PendingSpeakerTurn = {
   lastAudioAt?: number;
   hasAudio: boolean;
   closed: boolean;
-};
-
-type TranscriptUtteranceAttribution = {
-  transcripts: VoiceSessionEntry["transcripts"];
-  context: DiscordRealtimeSpeakerContext;
-  startedAt: number;
 };
 
 type DiscordRealtimeVoiceConfig = NonNullable<DiscordAccountConfig["voice"]>["realtime"];
@@ -63,9 +54,7 @@ export class DiscordRealtimeTurns {
   private pendingWakeNameFollowup:
     | {
         context: DiscordRealtimeSpeakerContext;
-        startedAt: number;
         expiresAt: number;
-        transcripts: VoiceSessionEntry["transcripts"];
       }
     | undefined;
 
@@ -105,7 +94,6 @@ export class DiscordRealtimeTurns {
       startedAt: Date.now(),
       hasAudio: false,
       closed: false,
-      transcripts: this.params.entry.transcripts,
       inputDiscordBytes: 0,
       inputRealtimeBytes: 0,
       inputChunks: 0,
@@ -151,29 +139,24 @@ export class DiscordRealtimeTurns {
       return;
     }
     this.partialUserTranscript = "";
-    const transcriptsTurn = this.lastSpeakerTurn;
-    let transcriptAttribution = this.transcriptAttributionFromTurn(transcriptsTurn);
     const humanParticipantCount = this.params.getHumanParticipantCount();
     const requireWakeName = this.isWakeNameRequired(humanParticipantCount);
     const wakeNameResult = this.resolveWakeNameTranscript(trimmed, requireWakeName);
     let forcedSpeakerContext: DiscordRealtimeSpeakerContext | undefined;
     if (!wakeNameResult.allowed) {
       const pendingWakeNameFollowup = this.consumePendingWakeNameFollowup();
-      transcriptAttribution ??= pendingWakeNameFollowup;
       if (!pendingWakeNameFollowup) {
-        this.recordTranscriptUtterance(trimmed, transcriptAttribution, providerEpoch);
         this.consumePendingSpeakerContext();
         logger.info(
           `discord voice: realtime wake-name gate ignored transcript chars=${trimmed.length} humanParticipants=${humanParticipantCount} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId} wakeNames=${this.params.wakeNames().join(",") || "none"}`,
         );
         return;
       }
-      forcedSpeakerContext = pendingWakeNameFollowup.context;
+      forcedSpeakerContext = pendingWakeNameFollowup;
       logger.info(
         `discord voice: realtime wake-name follow-up accepted chars=${trimmed.length} speaker=${forcedSpeakerContext.speakerLabel} voiceSession=${this.params.entry.voiceSessionKey} agent=${this.params.entry.route.agentId}`,
       );
     }
-    this.recordTranscriptUtterance(trimmed, transcriptAttribution, providerEpoch);
     const acceptedText = wakeNameResult.allowed ? wakeNameResult.text || trimmed : trimmed;
     if (wakeNameResult.allowed && !wakeNameResult.text.trim()) {
       this.armWakeNameFollowup();
@@ -331,56 +314,7 @@ export class DiscordRealtimeTurns {
     return isRealtimeVoiceWakeNameRequired(this.params.wakeNamePolicy(), humanParticipantCount);
   }
 
-  private transcriptAttributionFromTurn(
-    turn: PendingSpeakerTurn | undefined,
-  ): TranscriptUtteranceAttribution | undefined {
-    return turn
-      ? { context: turn.context, startedAt: turn.startedAt, transcripts: turn.transcripts }
-      : undefined;
-  }
-
-  private recordTranscriptUtterance(
-    text: string,
-    attribution: TranscriptUtteranceAttribution | undefined,
-    providerEpoch: number,
-  ): void {
-    const transcripts = attribution?.transcripts;
-    if (!transcripts || !attribution || this.params.entry.transcripts !== transcripts) {
-      return;
-    }
-    const context = attribution.context;
-    const utterance = {
-      sessionId: transcripts.sessionId,
-      startedAt: new Date(attribution.startedAt).toISOString(),
-      final: true,
-      speaker: { id: context.userId, label: context.speakerLabel },
-      text,
-      metadata: {
-        channel: "discord",
-        guildId: this.params.entry.guildId,
-        channelId: this.params.entry.channelId,
-        voiceSessionKey: this.params.entry.voiceSessionKey,
-      },
-    };
-    void Promise.resolve()
-      .then(() => {
-        if (
-          providerEpoch !== this.params.providerEpoch() ||
-          this.params.entry.transcripts !== transcripts
-        ) {
-          return;
-        }
-        return transcripts.onUtterance(utterance);
-      })
-      .catch((error: unknown) => {
-        logger.warn(
-          `discord voice: realtime transcripts utterance failed: ${formatErrorMessage(error)}`,
-        );
-      });
-  }
-
   private armWakeNameFollowup(): void {
-    const turn = this.lastSpeakerTurn;
     const context = this.consumePendingSpeakerContext();
     if (!context) {
       logger.warn(
@@ -394,8 +328,6 @@ export class DiscordRealtimeTurns {
     }
     this.pendingWakeNameFollowup = {
       context,
-      transcripts: turn?.transcripts,
-      startedAt: turn?.startedAt ?? Date.now(),
       expiresAt,
     };
     logger.info(
@@ -403,7 +335,7 @@ export class DiscordRealtimeTurns {
     );
   }
 
-  private consumePendingWakeNameFollowup(): TranscriptUtteranceAttribution | undefined {
+  private consumePendingWakeNameFollowup(): DiscordRealtimeSpeakerContext | undefined {
     const pending = this.pendingWakeNameFollowup;
     this.pendingWakeNameFollowup = undefined;
     const now = asDateTimestampMs(Date.now());
@@ -412,11 +344,7 @@ export class DiscordRealtimeTurns {
       return undefined;
     }
     this.consumePendingSpeakerContext();
-    return {
-      context: pending.context,
-      startedAt: pending.startedAt,
-      transcripts: pending.transcripts,
-    };
+    return pending.context;
   }
 }
 

--- a/extensions/discord/src/voice/recording-types.ts
+++ b/extensions/discord/src/voice/recording-types.ts
@@ -1,0 +1,20 @@
+import type { TranscriptUtterance } from "openclaw/plugin-sdk/transcripts";
+
+export type DiscordVoiceTranscriptCapture = {
+  sessionId: string;
+  warning?: string;
+  isCurrent: () => boolean;
+  onBatchUnavailable?: () => void;
+  onUtterance: (utterance: TranscriptUtterance) => void | Promise<void>;
+};
+
+export type DiscordVoiceAudioReceipt = {
+  capture: DiscordVoiceTranscriptCapture | undefined;
+  startedAt: number;
+};
+
+export type DiscordVoiceSegmentOutcome =
+  | { status: "transcribed"; text: string; conversationAuthorized: Promise<boolean> }
+  | { status: "excluded" }
+  | { status: "unavailable" }
+  | { status: "empty"; conversationAuthorized: Promise<boolean> };

--- a/extensions/discord/src/voice/segment.test.ts
+++ b/extensions/discord/src/voice/segment.test.ts
@@ -12,80 +12,14 @@ defineDiscordVoiceTests(
     entersStateMock,
     getSessionEntry,
     getLastAudioPlayer,
-    getVoiceReceive,
+    receiveRecordedSpeech,
     lastTtsStreamArgs,
     loggerWarnMock,
     makeVoiceConfig,
-    processVoiceSegment,
-    transcribeAudioFileMock,
-    decodeOpusStreamMock,
+    receiveVoiceUtterance,
     textToSpeechMock,
     textToSpeechStreamMock,
   }) => {
-    it.each(["transcribing", "queued"] as const)(
-      "drops retired transcript audio while %s",
-      async (phase) => {
-        const client = createClientWithMember("u-guest", "Guest", "4321");
-        const manager = createManager(
-          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
-          client,
-        );
-        const first = vi.fn();
-        const second = vi.fn();
-        const onStop = vi.fn();
-        await manager.join(
-          { guildId: "g1", channelId: "1001" },
-          { transcripts: { sessionId: "old", onUtterance: first, onStop } },
-        );
-        const entry = getSessionEntry(manager);
-        let release!: () => void;
-        const gate = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        let entered!: () => void;
-        const started = new Promise<void>((resolve) => {
-          entered = resolve;
-        });
-        let processing: Promise<void>;
-        if (phase === "transcribing") {
-          transcribeAudioFileMock.mockImplementationOnce(async () => {
-            entered();
-            await gate;
-            return { text: "retired" };
-          });
-          processing = getVoiceReceive(manager).processSegment({
-            entry,
-            wavPath: "/tmp/test.wav",
-            userId: "u-guest",
-            durationSeconds: 1,
-          });
-          await started;
-        } else {
-          entry.processingQueue = gate;
-          decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(192_000));
-          await getVoiceReceive(manager).handleSpeakingStart(entry, "u-guest");
-          processing = entry.processingQueue;
-        }
-        await manager.join(
-          { guildId: "g1", channelId: "1001" },
-          { transcripts: { sessionId: "new", onUtterance: second } },
-        );
-        release();
-        await processing;
-        expect(first).not.toHaveBeenCalled();
-        expect(second).not.toHaveBeenCalled();
-        expect(onStop).toHaveBeenCalledOnce();
-        await getVoiceReceive(manager).processSegment({
-          entry,
-          wavPath: "/tmp/test.wav",
-          userId: "u-guest",
-          durationSeconds: 1,
-        });
-        expect(second).toHaveBeenCalledOnce();
-        await manager.destroy();
-      },
-    );
-
     it("keeps streaming TTS audio alive until Discord finishes playback without a duration deadline", async () => {
       const release = vi.fn(async () => undefined);
       let finishPlayback!: () => void;
@@ -117,11 +51,11 @@ defineDiscordVoiceTests(
 
       const client = createClientWithMember("u-guest", "Guest", "4321");
       const manager = createManager(
-        { groupPolicy: "open", allowFrom: ["discord:u-guest"] },
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
         client,
         {},
       );
-      await processVoiceSegment(manager, "u-guest");
+      await receiveVoiceUtterance(manager, "u-guest");
 
       expect(lastTtsStreamArgs().channel).toBe("discord");
       expect(lastTtsStreamArgs().disableFallback).toBe(true);
@@ -167,11 +101,11 @@ defineDiscordVoiceTests(
       });
       const client = createClientWithMember("u-guest", "Guest", "4321");
       const manager = createManager(
-        { groupPolicy: "open", allowFrom: ["discord:u-guest"] },
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
         client,
       );
 
-      await processVoiceSegment(manager, "u-guest");
+      await receiveVoiceUtterance(manager, "u-guest");
 
       await vi.waitFor(() =>
         expect(loggerWarnMock).toHaveBeenCalledWith(
@@ -230,12 +164,7 @@ defineDiscordVoiceTests(
           return true;
         });
 
-        await getVoiceReceive(manager).processSegment({
-          entry,
-          wavPath: "/tmp/test.wav",
-          userId: "u-guest",
-          durationSeconds: 1.2,
-        });
+        await receiveRecordedSpeech(manager, undefined, entry, "u-guest");
         await vi.waitFor(() =>
           expect(entersStateMock).toHaveBeenCalledWith(
             entry.player,

--- a/extensions/discord/src/voice/segment.ts
+++ b/extensions/discord/src/voice/segment.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements segment behavior.
 import { Readable } from "node:stream";
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { unlinkIfExists } from "openclaw/plugin-sdk/media-runtime";
@@ -7,11 +6,7 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { maybeControlDiscordVoiceAgentRun } from "./agent-control.js";
 import { createDiscordOpusPlaybackStream } from "./audio.js";
-import {
-  type DiscordVoiceIngressContext,
-  resolveDiscordVoiceIngressContext,
-  runDiscordVoiceAgentTurn,
-} from "./ingress.js";
+import { type DiscordVoiceIngressContext, runDiscordVoiceAgentTurn } from "./ingress.js";
 import { formatVoiceLogPreview } from "./log-preview.js";
 import { formatVoiceIngressPrompt } from "./prompt.js";
 import { loadDiscordVoiceSdk } from "./sdk-runtime.js";
@@ -21,75 +16,108 @@ import { synthesizeVoiceReplyAudio, transcribeVoiceAudio } from "./tts.js";
 
 const logger = createSubsystemLogger("discord/voice");
 
-export async function processDiscordVoiceSegment(params: {
+type DiscordVoiceResponseParams = {
   entry: VoiceSessionEntry;
   accountId: string;
-  wavPath: string;
   userId: string;
-  durationSeconds: number;
   cfg: OpenClawConfig;
   discordConfig: DiscordAccountConfig;
   runtime: RuntimeEnv;
   admissionAllowFrom?: string[];
   fetchGuildName: (guildId: string) => Promise<string | undefined>;
   speakerContext: DiscordVoiceSpeakerContextResolver;
-  ingressContext?: DiscordVoiceIngressContext;
-  resolveIngressContext?: () => Promise<DiscordVoiceIngressContext | null>;
-  transcripts?: VoiceSessionEntry["transcripts"];
   enqueuePlayback: (entry: VoiceSessionEntry, task: () => Promise<void>) => void;
-}) {
+};
+
+type DiscordVoiceSegmentParams = Pick<DiscordVoiceResponseParams, "entry" | "userId" | "cfg"> & {
+  wavPath: string;
+  durationSeconds: number;
+  resolveIngressContext: () => Promise<DiscordVoiceIngressContext | null>;
+  isConversationCurrent: () => boolean;
+  onConversationOnly: () => void;
+  recording?: {
+    capture: NonNullable<VoiceSessionEntry["transcripts"]>;
+    startedAt: number;
+    speaker: Promise<{ label: string }>;
+  };
+};
+
+export type DiscordVoiceSegmentOutcome =
+  | { status: "transcribed"; text: string; conversationAuthorized: Promise<boolean> }
+  | { status: "excluded" }
+  | { status: "empty"; conversationAuthorized: Promise<boolean> };
+
+export async function processDiscordVoiceSegment(
+  params: DiscordVoiceSegmentParams,
+): Promise<DiscordVoiceSegmentOutcome> {
   const { entry, wavPath, userId, durationSeconds } = params;
+  const conversationCurrent = () =>
+    !entry.captureOnly &&
+    entry.sessionLifecycle.status === "active" &&
+    params.isConversationCurrent();
   logVoiceVerbose(
     `segment processing (${durationSeconds.toFixed(2)}s): guild ${entry.guildId} channel ${entry.channelId}`,
   );
-  const ingress =
-    params.ingressContext ??
-    (params.resolveIngressContext
-      ? await params.resolveIngressContext()
-      : await resolveDiscordVoiceIngressContext({
-          entry,
-          userId,
-          cfg: params.cfg,
-          discordConfig: params.discordConfig,
-          admissionAllowFrom: params.admissionAllowFrom,
-          fetchGuildName: params.fetchGuildName,
-          speakerContext: params.speakerContext,
-        }));
-  if (!ingress) {
+  // Recording owns STT; conversation authorization cannot hold the recording queue.
+  const ingress = params.resolveIngressContext().catch((error: unknown) => {
+    logger.warn(`discord voice: conversation authorization failed: ${formatErrorMessage(error)}`);
+    return null;
+  });
+  const conversationAuthorized = ingress.then(
+    (context) => Boolean(context) && conversationCurrent(),
+  );
+  const recording = params.recording;
+  let admitted: DiscordVoiceIngressContext | null = null;
+  if (!recording?.capture.isCurrent()) {
+    params.onConversationOnly();
+    admitted = await ingress;
+  }
+  if (!recording?.capture.isCurrent() && (!admitted || !conversationCurrent())) {
     logVoiceVerbose(
       `segment unauthorized: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
     );
-    return;
+    return { status: "excluded" };
   }
-  const transcript = await transcribeVoiceAudio({
+  const speakerLabel = recording?.capture.isCurrent()
+    ? (await recording.speaker).label
+    : (admitted?.speakerLabel ?? userId);
+  if (!recording?.capture.isCurrent()) {
+    params.onConversationOnly();
+    admitted = await ingress;
+  }
+  if (!recording?.capture.isCurrent() && (!admitted || !conversationCurrent())) {
+    return { status: "excluded" };
+  }
+  const { text: transcript, processing } = await transcribeVoiceAudio({
     cfg: params.cfg,
     agentId: entry.route.agentId,
     filePath: wavPath,
   });
+  // Known omitted input cannot become a partial command. Completed silent input
+  // remains empty, including CLI success without text and successful fallback.
+  if (processing === "omitted") {
+    return { status: "excluded" };
+  }
   if (!transcript) {
     logVoiceVerbose(
       `transcription empty: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
     );
-    return;
+    return { status: "empty", conversationAuthorized };
   }
   logVoiceVerbose(
     `transcription ok (${transcript.length} chars): guild ${entry.guildId} channel ${entry.channelId}`,
   );
   logVoiceVerbose(
-    `transcript from ${ingress.speakerLabel} (${userId}) in guild ${entry.guildId} channel ${entry.channelId}: ${formatVoiceLogPreview(transcript)}`,
+    `transcript from ${speakerLabel} (${userId}) in guild ${entry.guildId} channel ${entry.channelId}: ${formatVoiceLogPreview(transcript)}`,
   );
-  if (params.transcripts) {
-    // Ingress and STT awaits can outlive this binding while the voice entry is reused.
-    if (entry.sessionLifecycle.status === "stopped" || entry.transcripts !== params.transcripts) {
-      return;
-    }
-    await params.transcripts.onUtterance({
-      sessionId: params.transcripts.sessionId,
-      startedAt: new Date().toISOString(),
+  if (recording?.capture.isCurrent()) {
+    await recording.capture.onUtterance({
+      sessionId: recording.capture.sessionId,
+      startedAt: new Date(recording.startedAt).toISOString(),
       final: true,
       speaker: {
         id: userId,
-        label: ingress.speakerLabel,
+        label: speakerLabel,
       },
       text: transcript,
       metadata: {
@@ -99,9 +127,22 @@ export async function processDiscordVoiceSegment(params: {
         voiceSessionKey: entry.voiceSessionKey,
       },
     });
+  }
+  return { status: "transcribed", text: transcript, conversationAuthorized };
+}
+
+export async function respondToDiscordVoiceTranscript(
+  params: DiscordVoiceResponseParams & {
+    ingress: DiscordVoiceIngressContext;
+    transcript: string;
+  },
+): Promise<void> {
+  const { entry, ingress, transcript, userId } = params;
+  const conversationCurrent = () =>
+    !entry.captureOnly && entry.sessionLifecycle.status === "active";
+  if (!conversationCurrent()) {
     return;
   }
-
   let replyText: string;
   const control = await maybeControlDiscordVoiceAgentRun({
     entry,

--- a/extensions/discord/src/voice/segment.ts
+++ b/extensions/discord/src/voice/segment.ts
@@ -45,6 +45,7 @@ type DiscordVoiceSegmentParams = Pick<DiscordVoiceResponseParams, "entry" | "use
 export type DiscordVoiceSegmentOutcome =
   | { status: "transcribed"; text: string; conversationAuthorized: Promise<boolean> }
   | { status: "excluded" }
+  | { status: "unavailable" }
   | { status: "empty"; conversationAuthorized: Promise<boolean> };
 
 export async function processDiscordVoiceSegment(
@@ -88,11 +89,19 @@ export async function processDiscordVoiceSegment(
   if (!recording?.capture.isCurrent() && (!admitted || !conversationCurrent())) {
     return { status: "excluded" };
   }
-  const { text: transcript, processing } = await transcribeVoiceAudio({
+  const {
+    text: transcript,
+    processing,
+    unavailable,
+  } = await transcribeVoiceAudio({
     cfg: params.cfg,
     agentId: entry.route.agentId,
     filePath: wavPath,
   });
+  if (unavailable) {
+    recording?.capture.onBatchUnavailable?.();
+    return { status: "unavailable" };
+  }
   // Known omitted input cannot become a partial command. Completed silent input
   // remains empty, including CLI success without text and successful fallback.
   if (processing === "omitted") {

--- a/extensions/discord/src/voice/segment.ts
+++ b/extensions/discord/src/voice/segment.ts
@@ -9,6 +9,7 @@ import { createDiscordOpusPlaybackStream } from "./audio.js";
 import { type DiscordVoiceIngressContext, runDiscordVoiceAgentTurn } from "./ingress.js";
 import { formatVoiceLogPreview } from "./log-preview.js";
 import { formatVoiceIngressPrompt } from "./prompt.js";
+import type { DiscordVoiceSegmentOutcome } from "./recording-types.js";
 import { loadDiscordVoiceSdk } from "./sdk-runtime.js";
 import { logVoiceVerbose, PLAYBACK_READY_TIMEOUT_MS, type VoiceSessionEntry } from "./session.js";
 import type { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
@@ -41,12 +42,6 @@ type DiscordVoiceSegmentParams = Pick<DiscordVoiceResponseParams, "entry" | "use
     speaker: Promise<{ label: string }>;
   };
 };
-
-export type DiscordVoiceSegmentOutcome =
-  | { status: "transcribed"; text: string; conversationAuthorized: Promise<boolean> }
-  | { status: "excluded" }
-  | { status: "unavailable" }
-  | { status: "empty"; conversationAuthorized: Promise<boolean> };
 
 export async function processDiscordVoiceSegment(
   params: DiscordVoiceSegmentParams,

--- a/extensions/discord/src/voice/session.ts
+++ b/extensions/discord/src/voice/session.ts
@@ -6,7 +6,9 @@ import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { TranscriptUtterance } from "openclaw/plugin-sdk/transcripts";
 import { ChannelType } from "../internal/discord.js";
 import type { VoiceCaptureState } from "./capture-state.js";
+import type { DiscordRealtimeRecordingInput } from "./realtime-recording.js";
 import type { VoiceReceiveRecoveryState } from "./receive-recovery.js";
+import type { DiscordVoiceAudioReceipt } from "./voice-recording.js";
 
 export const MIN_SEGMENT_SECONDS = 0.35;
 export const CAPTURE_FINALIZE_GRACE_MS = 2_000;
@@ -27,6 +29,7 @@ export type VoiceOperationResult = {
   channelId?: string;
   channelName?: string;
   guildId?: string;
+  warning?: string;
 };
 
 export type VoiceJoinOptions = {
@@ -71,13 +74,14 @@ export type VoiceRealtimeAgentTurnParams = {
 
 export type VoiceRealtimeSpeakerTurn = {
   close: (reason?: "incomplete-input") => void;
-  sendInputAudio: (discordPcm48kStereo: Buffer) => void;
+  sendInputAudio: (discordPcm48kStereo: Buffer, receipt?: DiscordVoiceAudioReceipt) => void;
 };
 
 export type VoiceRealtimeSession = {
   beginSpeakerTurn: (
     context: VoiceRealtimeSpeakerContext,
     userId: string,
+    recordingInput?: DiscordRealtimeRecordingInput,
   ) => VoiceRealtimeSpeakerTurn;
   close: () => void;
   connect: () => Promise<void>;
@@ -117,7 +121,9 @@ export type VoiceSessionEntry = {
   realtimeLifecycle: VoiceRealtimeLifecycle;
   transcripts?: {
     sessionId: string;
+    warning?: string;
     isCurrent: () => boolean;
+    onBatchUnavailable?: () => void;
     onUtterance: (utterance: TranscriptUtterance) => void | Promise<void>;
   };
   receiveRecovery: VoiceReceiveRecoveryState;

--- a/extensions/discord/src/voice/session.ts
+++ b/extensions/discord/src/voice/session.ts
@@ -3,12 +3,11 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import type { DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { TranscriptUtterance } from "openclaw/plugin-sdk/transcripts";
 import { ChannelType } from "../internal/discord.js";
 import type { VoiceCaptureState } from "./capture-state.js";
 import type { DiscordRealtimeRecordingInput } from "./realtime-recording.js";
 import type { VoiceReceiveRecoveryState } from "./receive-recovery.js";
-import type { DiscordVoiceAudioReceipt } from "./voice-recording.js";
+import type { DiscordVoiceAudioReceipt, DiscordVoiceTranscriptCapture } from "./recording-types.js";
 
 export const MIN_SEGMENT_SECONDS = 0.35;
 export const CAPTURE_FINALIZE_GRACE_MS = 2_000;
@@ -119,13 +118,7 @@ export type VoiceSessionEntry = {
   ttsStreamFallbackWarned: boolean;
   capture: VoiceCaptureState;
   realtimeLifecycle: VoiceRealtimeLifecycle;
-  transcripts?: {
-    sessionId: string;
-    warning?: string;
-    isCurrent: () => boolean;
-    onBatchUnavailable?: () => void;
-    onUtterance: (utterance: TranscriptUtterance) => void | Promise<void>;
-  };
+  transcripts?: DiscordVoiceTranscriptCapture;
   receiveRecovery: VoiceReceiveRecoveryState;
   stop: (reason?: string) => void;
 };

--- a/extensions/discord/src/voice/session.ts
+++ b/extensions/discord/src/voice/session.ts
@@ -32,7 +32,7 @@ export type VoiceOperationResult = {
 export type VoiceJoinOptions = {
   preserveFollowState?: boolean;
   autoJoinWhenOccupied?: boolean;
-  transcripts?: VoiceSessionEntry["transcripts"];
+  captureOnly?: boolean;
 };
 
 export type VoiceSessionGeneration = {
@@ -70,7 +70,7 @@ export type VoiceRealtimeAgentTurnParams = {
 };
 
 export type VoiceRealtimeSpeakerTurn = {
-  close: () => void;
+  close: (reason?: "incomplete-input") => void;
   sendInputAudio: (discordPcm48kStereo: Buffer) => void;
 };
 
@@ -93,6 +93,7 @@ type VoiceRealtimeLifecycle =
 
 export type VoiceSessionEntry = {
   generation: number;
+  captureOnly: boolean;
   autoJoinWhenOccupied: boolean;
   sessionLifecycle: { status: "active" } | { status: "stopped"; reason: string };
   guildId: string;
@@ -105,7 +106,9 @@ export type VoiceSessionEntry = {
   connection: import("@discordjs/voice").VoiceConnection;
   player: import("@discordjs/voice").AudioPlayer;
   playbackQueue: Promise<void>;
+  // Conversation-only segments may retain their WAV after this recording frontier settles.
   processingQueue: Promise<void>;
+  conversations: import("./voice-conversation-input.js").DiscordVoiceConversationQueue;
   audioInputBudget: Awaited<
     ReturnType<PluginRuntime["mediaUnderstanding"]["resolveAudioInputBudget"]>
   >;
@@ -114,8 +117,8 @@ export type VoiceSessionEntry = {
   realtimeLifecycle: VoiceRealtimeLifecycle;
   transcripts?: {
     sessionId: string;
+    isCurrent: () => boolean;
     onUtterance: (utterance: TranscriptUtterance) => void | Promise<void>;
-    onStop?: () => void | Promise<void>;
   };
   receiveRecovery: VoiceReceiveRecoveryState;
   stop: (reason?: string) => void;

--- a/extensions/discord/src/voice/transcripts-capture.test.ts
+++ b/extensions/discord/src/voice/transcripts-capture.test.ts
@@ -1,0 +1,761 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { setDiscordTranscriptsVoiceManager } from "./transcripts-source.js";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    createConnectionMock,
+    joinVoiceChannelMock,
+    entersStateMock,
+    createAudioPlayerMock,
+    resolveRealtimeBootstrapContextInstructionsMock,
+    createRealtimeVoiceBridgeSessionMock,
+    realtimeSessionMock,
+    createManager,
+    createAgentProxyManager,
+    expectConnectedStatus,
+    getSessionEntry,
+    getVoiceReceive,
+    createJoinedAgentProxyFixture,
+    startTranscripts,
+    stopTranscripts,
+    beginSpeakerTurn,
+    lastRealtimeBridgeParams,
+    emitFinalRealtimeUserTranscript,
+    receiveRecordedSpeech,
+    transcribeAudioFileMock,
+    agentCommandMock,
+    makeVoiceConfig,
+    emitDecryptFailure,
+    createClient,
+    configureVoiceStateGateway,
+    enqueueSystemEventMock,
+    updateVoiceState,
+  }) => {
+    it.each(
+      (["manager replacement", "receive recovery"] as const).flatMap((phase) =>
+        (["ready", "stopped", "reopened"] as const).map((outcome) => ({ phase, outcome })),
+      ),
+    )(
+      "transfers the source subscription while $phase is still connecting ($outcome)",
+      async ({ phase, outcome }) => {
+        const original = createAgentProxyManager(undefined, { allowFrom: ["discord:u-owner"] });
+        const firstNotes = vi.fn();
+        const secondNotes = vi.fn();
+        const reopenedNotes = vi.fn();
+        expect(await startTranscripts(original, firstNotes)).toMatchObject({ ok: true });
+        const manager =
+          phase === "manager replacement"
+            ? createAgentProxyManager(undefined, { allowFrom: ["discord:u-owner"] })
+            : original;
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const connecting = createDeferred<void>();
+        const ready = createDeferred<undefined>();
+        entersStateMock.mockImplementationOnce(() => {
+          connecting.resolve();
+          return ready.promise;
+        });
+        const joins = vi.spyOn(manager, "join");
+        try {
+          if (phase === "manager replacement") {
+            setDiscordTranscriptsVoiceManager({ accountId: "default", manager });
+          } else {
+            emitDecryptFailure(manager);
+            emitDecryptFailure(manager);
+            emitDecryptFailure(manager);
+          }
+          await connecting.promise;
+          expect(await startTranscripts(manager, secondNotes, "replacement")).toMatchObject({
+            ok: true,
+          });
+          if (outcome !== "ready") {
+            expect(await stopTranscripts("replacement")).toMatchObject({ ok: true });
+          }
+          const reopened =
+            outcome === "reopened"
+              ? startTranscripts(manager, reopenedNotes, "reopened")
+              : undefined;
+          ready.resolve(undefined);
+          expect(await joins.mock.results[0]!.value).toMatchObject({ ok: outcome === "ready" });
+          if (reopened) {
+            expect(await reopened).toMatchObject({ ok: true });
+          }
+          expect(joins).toHaveBeenCalledTimes(reopened ? 2 : 1);
+          expect(joinVoiceChannelMock).toHaveBeenCalledTimes(reopened ? 3 : 2);
+          expect(connection.destroy).toHaveBeenCalledTimes(outcome === "ready" ? 0 : 1);
+          if (outcome === "stopped") {
+            expect(manager.status()).toEqual([]);
+            return;
+          }
+          expectConnectedStatus(manager, "1001");
+          await receiveRecordedSpeech(manager, "the transferred source owns this note");
+          expect(firstNotes).not.toHaveBeenCalled();
+          expect(secondNotes).toHaveBeenCalledTimes(reopened ? 0 : 1);
+          expect(reopenedNotes).toHaveBeenCalledTimes(reopened ? 1 : 0);
+          expect(await stopTranscripts(reopened ? "reopened" : "replacement")).toMatchObject({
+            ok: true,
+          });
+          expect(manager.status()).toEqual([]);
+        } finally {
+          ready.resolve(undefined);
+          await Promise.allSettled(joins.mock.results.map((result) => result.value));
+          joins.mockRestore();
+          await manager.destroy();
+          await original.destroy();
+          setDiscordTranscriptsVoiceManager({
+            accountId: "default",
+            manager: null,
+            expectedManager: manager,
+          });
+        }
+      },
+    );
+
+    it.each(["during queued capture", "before fresh capture"])(
+      "respects explicit leave %s behind an unresolved manual join",
+      async (order) => {
+        const client = createClient();
+        const resolved = createDeferred<Awaited<ReturnType<typeof client.fetchChannel>>>();
+        client.fetchChannel.mockImplementationOnce(() => resolved.promise);
+        const manager = createManager(
+          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-owner"] }),
+          client,
+        );
+        const manual = manager.join({ guildId: "g1", channelId: "1001" });
+        expect(client.fetchChannel).toHaveBeenCalledOnce();
+        const captureStart = vi.spyOn(manager, "startTranscriptsCapture");
+        const sink = vi.fn();
+        const capture =
+          order === "during queued capture" ? startTranscripts(manager, sink) : undefined;
+        try {
+          if (capture) {
+            await vi.waitFor(() => expect(captureStart).toHaveBeenCalledOnce());
+          }
+          expect(await manager.leave({ guildId: "g1" })).toMatchObject({ ok: true });
+          resolved.resolve({
+            id: "1001",
+            guildId: "g1",
+            type: 2,
+            guild: { id: "g1", name: "Guild" },
+          });
+          expect(await manual).toMatchObject({ ok: false });
+          if (capture) {
+            expect(await capture).toMatchObject({ ok: false });
+            expect(joinVoiceChannelMock).not.toHaveBeenCalled();
+            expect(manager.status()).toEqual([]);
+          }
+          // A completed leave only cancels earlier intent, not a new request.
+          expect(await startTranscripts(manager, sink, "fresh-notes")).toMatchObject({ ok: true });
+          expectConnectedStatus(manager, "1001");
+          await receiveRecordedSpeech(manager, "fresh capture note");
+          expect(sink).toHaveBeenCalledOnce();
+          expect(agentCommandMock).not.toHaveBeenCalled();
+        } finally {
+          resolved.resolve({
+            id: "1001",
+            guildId: "g1",
+            type: 2,
+            guild: { id: "g1", name: "Guild" },
+          });
+          await Promise.allSettled([manual, capture]);
+          captureStart.mockRestore();
+          await manager.destroy();
+        }
+      },
+    );
+
+    it.each(["capture-start", "recovery"])(
+      "keeps the subscription when the room empties during %s",
+      async (phase) => {
+        const client = createClient();
+        const human = {
+          guild_id: "g1",
+          channel_id: "1001",
+          user_id: "u-owner",
+          member: { user: { id: "u-owner", bot: false } },
+        };
+        let states: Array<Record<string, unknown>> = [human];
+        configureVoiceStateGateway(client, () => states);
+        const manager = createManager(
+          makeVoiceConfig(
+            {
+              mode: "agent-proxy",
+              autoJoin: [{ guildId: "g1", channelId: "1001", whenOccupied: true }],
+              realtime: { provider: "openai", requireWakeName: true },
+            },
+            { groupPolicy: "open" },
+          ),
+          client,
+        );
+        const onUtterance = vi.fn();
+        if (phase === "recovery") {
+          await manager.autoJoin();
+          await startTranscripts(manager, onUtterance);
+        }
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const ready = createDeferred<undefined>();
+        entersStateMock.mockImplementationOnce(() => ready.promise);
+        const start =
+          phase === "capture-start" ? startTranscripts(manager, onUtterance) : undefined;
+        if (phase === "recovery") {
+          emitDecryptFailure(manager);
+          emitDecryptFailure(manager);
+          emitDecryptFailure(manager);
+        }
+        await vi.waitFor(() =>
+          expect(joinVoiceChannelMock).toHaveBeenCalledTimes(phase === "recovery" ? 2 : 1),
+        );
+        states = [];
+        const departure = updateVoiceState(manager, "u-owner", null, human.member);
+        ready.resolve(undefined);
+        if (start) {
+          expect(await start).toMatchObject({ ok: true });
+        }
+        await departure;
+        await vi.waitFor(() => expect(connection.destroy).toHaveBeenCalledOnce());
+        await vi.waitFor(() => expect(manager.status()).toEqual([]));
+        states = [human];
+        await updateVoiceState(manager, "u-owner", "1001", human.member);
+        await receiveRecordedSpeech(manager, "after returning to the room");
+        expect(onUtterance).toHaveBeenCalledOnce();
+      },
+    );
+    it.each(["capture-first", "restart"])(
+      "keeps unrelated capture dormant beside configured conversation (%s)",
+      async (order) => {
+        const client = createClient();
+        configureVoiceStateGateway(client, () => [
+          {
+            guild_id: "g1",
+            channel_id: "1001",
+            user_id: "u-owner",
+            member: { user: { id: "u-owner", bot: false } },
+          },
+        ]);
+        const config = makeVoiceConfig(
+          {
+            mode: "agent-proxy",
+            autoJoin: [{ guildId: "g1", channelId: "1001", whenOccupied: true }],
+            realtime: { provider: "openai", requireWakeName: true },
+          },
+          { groupPolicy: "open", allowFrom: ["discord:u-owner"] },
+        );
+        let manager = createManager(config, client);
+        if (order === "restart") {
+          await manager.autoJoin();
+        }
+        const onUtterance = vi.fn();
+        expect(await startTranscripts(manager, onUtterance, "other-room", "1002")).toMatchObject({
+          ok: true,
+        });
+        if (order === "restart") {
+          const oldManager = manager;
+          manager = createManager(config, client);
+          setDiscordTranscriptsVoiceManager({ accountId: "default", manager });
+          await oldManager.destroy();
+        }
+        try {
+          await manager.autoJoin();
+          expectConnectedStatus(manager, "1001");
+          await receiveRecordedSpeech(manager, "not the capture channel");
+          expect(onUtterance).not.toHaveBeenCalled();
+          await manager.join({ guildId: "g1", channelId: "1002" });
+          await receiveRecordedSpeech(manager, "the selected channel");
+          expect(onUtterance).toHaveBeenCalledOnce();
+          expect(await stopTranscripts("other-room", "1002")).toMatchObject({ ok: true });
+          expectConnectedStatus(manager, "1002");
+        } finally {
+          await manager.destroy();
+          setDiscordTranscriptsVoiceManager({
+            accountId: "default",
+            manager: null,
+            expectedManager: manager,
+          });
+        }
+      },
+    );
+
+    it("retires an uncommitted capture-only entry when its registration is replaced", async () => {
+      const connection = createConnectionMock();
+      connection.receiver.speaking.users.set("guest", Date.now());
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const client = createClient();
+      configureVoiceStateGateway(client, () => []);
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-owner"] }),
+        client,
+      );
+      const firstUtterance = vi.fn();
+      const nextUtterance = vi.fn();
+      let replacement: ReturnType<typeof startTranscripts> | undefined;
+      enqueueSystemEventMock.mockImplementationOnce(() => {
+        replacement = startTranscripts(manager, nextUtterance, "notes-2");
+        return true;
+      });
+      expect(await startTranscripts(manager, firstUtterance)).toMatchObject({ ok: false });
+      expect(await replacement).toMatchObject({ ok: true });
+      expect(connection.receiver.subscribe).not.toHaveBeenCalled();
+      expectConnectedStatus(manager, "1001");
+      await receiveRecordedSpeech(manager);
+      expect(firstUtterance).not.toHaveBeenCalled();
+      expect(nextUtterance).toHaveBeenCalledOnce();
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { channelId: "1002", outcome: "ready" },
+      { channelId: "1001", outcome: "ready" },
+      { channelId: "1002", outcome: "failed" },
+      { channelId: "1002", outcome: "cancelled" },
+      { channelId: "1002", outcome: "revoked capture" },
+    ])(
+      "reconciles registered capture recovery after newer $channelId join is $outcome",
+      async ({ channelId, outcome }) => {
+        const manager = createAgentProxyManager(undefined, { allowFrom: ["discord:u-owner"] });
+        const onUtterance = vi.fn();
+        await startTranscripts(manager, onUtterance);
+        const captureEntry = getSessionEntry(manager);
+        const capture = captureEntry.transcripts;
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const ready = createDeferred<undefined>();
+        entersStateMock.mockImplementationOnce(() => ready.promise);
+        const joins = vi.spyOn(manager, "join");
+        const leave = manager.leave.bind(manager);
+        let manual: ReturnType<typeof manager.join> | undefined;
+        const leaving = vi.spyOn(manager, "leave").mockImplementationOnce(async (...args) => {
+          const result = await leave(...args);
+          manual = manager.join({ guildId: "g1", channelId });
+          return result;
+        });
+        try {
+          emitDecryptFailure(manager);
+          emitDecryptFailure(manager);
+          emitDecryptFailure(manager);
+          // Recovery has left its old transport and is now queued behind the newer join.
+          await vi.waitFor(() => expect(joins).toHaveBeenCalledTimes(2));
+          expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2);
+          if (outcome === "revoked capture") {
+            expect(await stopTranscripts()).toMatchObject({ ok: true });
+          } else if (outcome === "cancelled") {
+            expect(await manager.leave({ guildId: "g1" })).toMatchObject({ ok: true });
+          }
+          if (outcome === "failed") {
+            ready.reject(new Error("synthetic ready failure"));
+          } else {
+            ready.resolve(undefined);
+          }
+          const manualSucceeded = outcome === "ready" || outcome === "revoked capture";
+          expect(await manual).toMatchObject({ ok: manualSucceeded });
+          expect(await joins.mock.results[1]!.value).toMatchObject({
+            ok: outcome !== "revoked capture",
+          });
+          await vi.waitFor(() =>
+            expect(captureEntry.receiveRecovery.decryptRecoveryInFlight).toBe(false),
+          );
+          captureEntry.stop();
+          if (manualSucceeded) {
+            expect(connection.destroy).not.toHaveBeenCalled();
+            expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2);
+            expectConnectedStatus(manager, channelId);
+            expect(getSessionEntry(manager).connection).toBe(connection);
+            expect(getSessionEntry(manager).realtimeLifecycle.status).toBe("active");
+            await receiveRecordedSpeech(manager, "newer conversation");
+            expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+            expect(onUtterance).toHaveBeenCalledTimes(channelId === "1001" ? 1 : 0);
+            if (outcome === "ready") {
+              if (channelId !== "1001") {
+                // Only an ordinary manual join may move residency to the dormant capture.
+                expect(await manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({
+                  ok: true,
+                });
+                await receiveRecordedSpeech(manager, "original capture still registered");
+              }
+              expect(getSessionEntry(manager).transcripts).toBe(capture);
+              expect(onUtterance).toHaveBeenCalledOnce();
+              expect(await stopTranscripts()).toMatchObject({ ok: true });
+              expectConnectedStatus(manager, "1001");
+            }
+          } else {
+            expect(connection.destroy).toHaveBeenCalledOnce();
+            expect(joinVoiceChannelMock).toHaveBeenCalledTimes(3);
+            expectConnectedStatus(manager, "1001");
+            expect(getSessionEntry(manager).transcripts).toBe(capture);
+            expect(getSessionEntry(manager).realtimeLifecycle.status).toBe("inactive");
+            await receiveRecordedSpeech(manager, "silent capture after failed newer join");
+            expect(onUtterance).toHaveBeenCalledOnce();
+            expect(agentCommandMock).not.toHaveBeenCalled();
+            expect(await stopTranscripts()).toMatchObject({ ok: true });
+            expect(manager.status()).toEqual([]);
+          }
+        } finally {
+          ready.resolve(undefined);
+          await Promise.allSettled(joins.mock.results.map((result) => result.value));
+          leaving.mockRestore();
+          joins.mockRestore();
+        }
+      },
+    );
+
+    it("does not let cancelled capture recovery fence a newer manual audio session", async () => {
+      const manager = createAgentProxyManager();
+      await startTranscripts(manager);
+      const captureEntry = getSessionEntry(manager);
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const ready = createDeferred<undefined>();
+      entersStateMock.mockImplementationOnce(() => ready.promise);
+      const leave = manager.leave.bind(manager);
+      let manual: ReturnType<typeof manager.join> | undefined;
+      vi.spyOn(manager, "leave").mockImplementationOnce(async (...args) => {
+        const result = await leave(...args);
+        manual = manager.join({ guildId: "g1", channelId: "1001" });
+        return result;
+      });
+      emitDecryptFailure(manager);
+      emitDecryptFailure(manager);
+      emitDecryptFailure(manager);
+      await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2));
+      expect(await stopTranscripts()).toMatchObject({ ok: true });
+      ready.resolve(undefined);
+      expect(await manual).toMatchObject({ ok: true });
+      await vi.waitFor(() =>
+        expect(captureEntry.receiveRecovery.decryptRecoveryInFlight).toBe(false),
+      );
+      await vi.waitFor(() => expectConnectedStatus(manager, "1001"));
+      const entry = getSessionEntry(manager);
+      beginSpeakerTurn(entry);
+      await emitFinalRealtimeUserTranscript(
+        lastRealtimeBridgeParams(),
+        "OpenClaw, are you still listening?",
+      );
+      expect(agentCommandMock).toHaveBeenCalledOnce();
+      expect(connection.destroy).not.toHaveBeenCalled();
+    });
+    it("cancels a pending capture-only join without leaving an orphan connection", async () => {
+      const manager = createAgentProxyManager();
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const ready = createDeferred<undefined>();
+      entersStateMock.mockImplementationOnce(() => ready.promise);
+      const starting = startTranscripts(manager);
+      await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledOnce());
+      expect(await stopTranscripts()).toMatchObject({ ok: true });
+      ready.resolve(undefined);
+      expect(await starting).toMatchObject({ ok: false });
+      expect(connection.destroy).toHaveBeenCalledOnce();
+      expect(manager.status()).toEqual([]);
+    });
+
+    it("keeps standalone capture silent across recovery and discards STT completing after stop", async () => {
+      const manager = createManager(
+        makeVoiceConfig(
+          { mode: "agent-proxy" },
+          { groupPolicy: "open", allowFrom: ["discord:u-owner"] },
+        ),
+      );
+      const onUtterance = vi.fn();
+      await startTranscripts(manager, onUtterance);
+      const receiveSegment = () => receiveRecordedSpeech(manager);
+      await receiveSegment();
+      expect(onUtterance).toHaveBeenCalledOnce();
+      emitDecryptFailure(manager);
+      emitDecryptFailure(manager);
+      emitDecryptFailure(manager);
+      await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2));
+      await receiveSegment();
+      expect(onUtterance).toHaveBeenCalledTimes(2);
+      expect(createRealtimeVoiceBridgeSessionMock).not.toHaveBeenCalled();
+      const stt = createDeferred<{ text: string }>();
+      transcribeAudioFileMock.mockImplementationOnce(() => stt.promise);
+      const pending = receiveSegment();
+      await vi.waitFor(() => expect(transcribeAudioFileMock).toHaveBeenCalledTimes(3));
+      expect(await stopTranscripts()).toMatchObject({ ok: true });
+      stt.resolve({ text: "late STT" });
+      await pending;
+      expect(onUtterance).toHaveBeenCalledTimes(2);
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      expect(manager.status()).toEqual([]);
+    });
+    it("rebinds capture to a replacement account manager and fences old cleanup", async () => {
+      const config = {
+        voice: {
+          enabled: true,
+          mode: "agent-proxy" as const,
+          autoJoin: [{ guildId: "g1", channelId: "1001" }],
+          realtime: { provider: "openai", requireWakeName: true },
+        },
+        groupPolicy: "open" as const,
+      };
+      const oldManager = createManager(config);
+      await oldManager.autoJoin();
+      const onUtterance = vi.fn();
+      await startTranscripts(oldManager, onUtterance);
+      const oldEntry = getSessionEntry(oldManager);
+      const replacement = createManager(config);
+      setDiscordTranscriptsVoiceManager({ accountId: "default", manager: replacement });
+      await oldManager.destroy();
+      setDiscordTranscriptsVoiceManager({
+        accountId: "default",
+        manager: null,
+        expectedManager: oldManager,
+      });
+      try {
+        await replacement.autoJoin();
+        await receiveRecordedSpeech(replacement, "replacement manager note");
+        expect(onUtterance).toHaveBeenCalledOnce();
+        await receiveRecordedSpeech(oldManager, "stale manager", oldEntry);
+        expect(onUtterance).toHaveBeenCalledOnce();
+        expect(await stopTranscripts()).toMatchObject({ ok: true });
+        expectConnectedStatus(replacement, "1001");
+      } finally {
+        await replacement.destroy();
+        setDiscordTranscriptsVoiceManager({
+          accountId: "default",
+          manager: null,
+          expectedManager: replacement,
+        });
+      }
+    });
+
+    it("stops an exact offline subscription and never reattaches it", async () => {
+      const manager = createAgentProxyManager();
+      const onUtterance = vi.fn();
+      await startTranscripts(manager, onUtterance);
+      const capture = getSessionEntry(manager).transcripts;
+      await manager.destroy();
+      setDiscordTranscriptsVoiceManager({
+        accountId: "default",
+        manager: null,
+        expectedManager: manager,
+      });
+      expect(await stopTranscripts("notes-1", "1002")).toMatchObject({ ok: false });
+      expect(await stopTranscripts()).toMatchObject({ ok: true });
+      await capture?.onUtterance?.({ sessionId: "notes-1", text: "late note", final: true });
+      expect(onUtterance).not.toHaveBeenCalled();
+      const replacement = createAgentProxyManager();
+      setDiscordTranscriptsVoiceManager({ accountId: "default", manager: replacement });
+      try {
+        await replacement.join({ guildId: "g1", channelId: "1001" });
+        await receiveRecordedSpeech(replacement, "uncaptured note");
+        expect(onUtterance).not.toHaveBeenCalled();
+      } finally {
+        await replacement.destroy();
+        setDiscordTranscriptsVoiceManager({
+          accountId: "default",
+          manager: null,
+          expectedManager: replacement,
+        });
+      }
+    });
+    it("attaches transcripts capture to an existing voice session", async () => {
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-owner"] }),
+      );
+
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const onUtterance = vi.fn();
+      const result = await startTranscripts(manager, onUtterance, "notes-1");
+
+      const entry = getSessionEntry(manager);
+      expect(result.ok).toBe(true);
+      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      expect(entry.transcripts?.sessionId).toBe("notes-1");
+      await receiveRecordedSpeech(manager);
+      expect(onUtterance).toHaveBeenCalledOnce();
+      expect(agentCommandMock).toHaveBeenCalledOnce();
+      expect(await stopTranscripts()).toMatchObject({ ok: true });
+      expectConnectedStatus(manager, "1001");
+    });
+
+    it("does not leave a newer transcripts-only session for a stale stop", async () => {
+      const manager = createAgentProxyManager();
+      const firstUtterance = vi.fn();
+      const secondUtterance = vi.fn();
+
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      await startTranscripts(manager, firstUtterance, "notes-1");
+      const oldCapture = getSessionEntry(manager).transcripts;
+      await startTranscripts(manager, secondUtterance, "notes-2");
+      await oldCapture?.onUtterance?.({ text: "stale capture", final: true });
+      expect(firstUtterance).not.toHaveBeenCalled();
+
+      const result = await stopTranscripts("notes-1");
+      const entry = getSessionEntry(manager);
+
+      expect(result.ok).toBe(false);
+      expect(entry.transcripts?.sessionId).toBe("notes-2");
+      expectConnectedStatus(manager, "1001");
+      await receiveRecordedSpeech(manager, "replacement capture");
+      expect(secondUtterance).toHaveBeenCalledOnce();
+    });
+
+    it("upgrades a transcripts-only session to realtime on a normal join", async () => {
+      const manager = createAgentProxyManager();
+      const onUtterance = vi.fn();
+
+      await startTranscripts(manager, onUtterance, "notes-1");
+      expect(createRealtimeVoiceBridgeSessionMock).not.toHaveBeenCalled();
+      expect(createAudioPlayerMock).toHaveBeenCalledWith({
+        behaviors: { maxMissedFrames: 100 },
+      });
+
+      const entry = getSessionEntry(manager);
+      expect(entry.realtimeLifecycle.status).toBe("inactive");
+      const realtimeReady = createDeferred<undefined>();
+      realtimeSessionMock.connect.mockImplementationOnce(() => realtimeReady.promise);
+
+      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
+
+      await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
+      expect(entry.realtimeLifecycle.status).toBe("starting");
+
+      realtimeReady.resolve(undefined);
+      const result = await upgrade;
+
+      expect(result.ok).toBe(true);
+      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1);
+      expect(realtimeSessionMock.connect).toHaveBeenCalledTimes(1);
+      expect(entry.transcripts?.sessionId).toBe("notes-1");
+      expect(entry.realtimeLifecycle.status).toBe("active");
+      const attempts = getVoiceReceive(manager).daveRecoveryAttempts;
+      attempts.set("g1", Date.now());
+
+      const stopNotesResult = await stopTranscripts("notes-1");
+
+      expect(stopNotesResult.ok).toBe(true);
+      expect(entry.transcripts).toBeUndefined();
+      expect(entry.realtimeLifecycle.status).toBe("active");
+      expect(realtimeSessionMock.close).not.toHaveBeenCalled();
+      expect(attempts.has("g1")).toBe(true);
+      expectConnectedStatus(manager, "1001");
+    });
+
+    it("closes a pending realtime upgrade if the voice entry stops before connect resolves", async () => {
+      const manager = createAgentProxyManager();
+      const onUtterance = vi.fn();
+
+      await startTranscripts(manager, onUtterance, "notes-1");
+      const entry = getSessionEntry(manager);
+      const realtimeReady = createDeferred<undefined>();
+      realtimeSessionMock.connect.mockImplementationOnce(() => realtimeReady.promise);
+
+      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
+
+      await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
+      expect(entry.realtimeLifecycle.status).toBe("starting");
+
+      entry.stop();
+      expect(realtimeSessionMock.close).toHaveBeenCalled();
+      expect(entry.realtimeLifecycle.status).toBe("stopped");
+
+      realtimeReady.resolve(undefined);
+      const result = await upgrade;
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("stopped before startup completed");
+      expect(entry.realtimeLifecycle.status).toBe("stopped");
+    });
+
+    it.each(["bootstrap", "connect"])(
+      "detaches transcripts without leaving voice during pending realtime upgrade (%s)",
+      async (phase) => {
+        const manager = createAgentProxyManager();
+        const onUtterance = vi.fn();
+
+        await startTranscripts(manager, onUtterance, "notes-1");
+        const entry = getSessionEntry(manager);
+        const realtimeReady = createDeferred<undefined>();
+        const pending =
+          phase === "bootstrap"
+            ? resolveRealtimeBootstrapContextInstructionsMock
+            : realtimeSessionMock.connect;
+        pending.mockImplementationOnce(() => realtimeReady.promise);
+
+        const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
+
+        await vi.waitFor(() => expect(pending).toHaveBeenCalledOnce());
+        const stopNotesResult = await stopTranscripts("notes-1");
+
+        expect(stopNotesResult.ok).toBe(true);
+        expect(entry.transcripts).toBeUndefined();
+        expect(entry.realtimeLifecycle.status).toBe(
+          phase === "bootstrap" ? "inactive" : "starting",
+        );
+
+        realtimeReady.resolve(undefined);
+        const result = await upgrade;
+
+        expect(result.ok).toBe(true);
+        expect(entry.realtimeLifecycle.status).toBe("active");
+        expectConnectedStatus(manager, "1001");
+      },
+    );
+
+    it("does not start realtime upgrade if the voice entry leaves during bootstrap", async () => {
+      const manager = createAgentProxyManager();
+      const onUtterance = vi.fn();
+
+      await startTranscripts(manager, onUtterance, "notes-1");
+      const bootstrapReady = createDeferred<undefined>();
+      resolveRealtimeBootstrapContextInstructionsMock.mockImplementationOnce(
+        () => bootstrapReady.promise,
+      );
+
+      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
+      await Promise.resolve();
+
+      const leaveResult = await manager.leave({ guildId: "g1" });
+      bootstrapReady.resolve(undefined);
+      const result = await upgrade;
+
+      expect(leaveResult.ok).toBe(true);
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("stopped before startup completed");
+      expect(createRealtimeVoiceBridgeSessionMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps realtime playback alive when transcripts attaches to an existing voice session", async () => {
+      const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture({
+        config: { voice: { realtime: { consultPolicy: "auto" } } },
+      });
+
+      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(24_000));
+      const stopCallsBeforeTranscripts = player.stop.mock.calls.length;
+      const onUtterance = vi.fn(async () => undefined);
+
+      const result = await startTranscripts(manager, onUtterance, "notes-1");
+
+      expect(result.ok).toBe(true);
+      expect(entry.transcripts?.sessionId).toBe("notes-1");
+      expect(realtimeSessionMock.close).not.toHaveBeenCalled();
+      expect(player.stop).toHaveBeenCalledTimes(stopCallsBeforeTranscripts);
+
+      await receiveRecordedSpeech(manager, "meeting note transcript");
+
+      await vi.waitFor(() =>
+        expect(onUtterance).toHaveBeenCalledWith(
+          expect.objectContaining({
+            final: true,
+            sessionId: "notes-1",
+            speaker: { id: "u-owner", label: "u-owner" },
+            text: "meeting note transcript",
+            metadata: expect.objectContaining({
+              channel: "discord",
+              channelId: "1001",
+              guildId: "g1",
+              voiceSessionKey: "discord:g1:c1",
+            }),
+          }),
+        ),
+      );
+      expect(player.stop).toHaveBeenCalledTimes(stopCallsBeforeTranscripts);
+    });
+  },
+);

--- a/extensions/discord/src/voice/transcripts-conversation.test.ts
+++ b/extensions/discord/src/voice/transcripts-conversation.test.ts
@@ -1,0 +1,496 @@
+import fs from "node:fs/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createDiscordRecordingFixture } from "./transcripts-recording.test-support.js";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+const voiceIngress = await import("./ingress.js");
+const voiceAudio = await import("./audio.js");
+
+defineDiscordVoiceTests((harness) => {
+  const {
+    expect,
+    it,
+    vi,
+    beginSpeakerTurn,
+    getSessionConnection,
+    startTranscripts,
+    stopTranscripts,
+    transcribeAudioFileMock,
+    realtimeSessionMock,
+    agentCommandMock,
+    loggerWarnMock,
+    controlRealtimeVoiceAgentRunMock,
+    lastRealtimeBridgeParams,
+    emitFinalRealtimeUserTranscript,
+  } = harness;
+  const fixture = createDiscordRecordingFixture(harness);
+
+  it("keeps recording when realtime conversation has reached its speaker limit", async () => {
+    const f = await fixture();
+    await startTranscripts(f.manager, f.sink);
+    for (let index = 0; index < 8; index++) {
+      beginSpeakerTurn(f.entry, { userId: `guest-${index}`, senderIsOwner: false }).close();
+    }
+    await f.audio("100000000000000001", 7);
+    expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: "audio-7-96000" }),
+    );
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("Voice is busy"));
+    expect(agentCommandMock).not.toHaveBeenCalled();
+    expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+    expect(f.entry.transcripts?.isCurrent()).toBe(true);
+  });
+
+  it.each(["agent-proxy", "stt-tts"] as const)(
+    "records through stalled %s admission and retires only overflowing conversation audio",
+    async (mode) => {
+      const f = await fixture(mode, false, {
+        tools: { media: { audio: { maxBytes: 192_044 } } },
+      });
+      await startTranscripts(f.manager, f.sink);
+      const release = createDeferred<void>();
+      const resolveIngress = voiceIngress.resolveDiscordVoiceIngressContext;
+      const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+      authorize.mockImplementationOnce(async (params) => {
+        await release.promise;
+        return resolveIngress(params);
+      });
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      try {
+        for (let segment = 1; segment <= 6; segment++) {
+          for (let frame = 0; frame < 50; frame++) {
+            stream.write(Buffer.alloc(3_840, 8));
+          }
+          await vi.waitFor(() => expect(f.sink).toHaveBeenCalledTimes(segment));
+        }
+        expect(stream.destroyed).toBe(false);
+        expect(loggerWarnMock).toHaveBeenCalledWith(
+          expect.stringContaining("conversation audio backlog"),
+        );
+        expect(f.entry.transcripts?.isCurrent()).toBe(true);
+        stream.end();
+        release.resolve();
+        await receiving;
+        await f.entry.processingQueue;
+        expect(f.sink).toHaveBeenCalledTimes(6);
+        expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+        await f.audio("100000000000000001", 9);
+        expect(f.sink).toHaveBeenCalledTimes(7);
+        if (mode === "stt-tts") {
+          expect(agentCommandMock).toHaveBeenCalledOnce();
+        } else {
+          expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+        }
+      } finally {
+        release.resolve();
+        stream.end();
+        await receiving;
+        await f.entry.processingQueue;
+        authorize.mockRestore();
+      }
+    },
+  );
+
+  it.each(["chunk", "final"] as const)(
+    "records subsequent speech while %s conversation authorization is stalled",
+    async (phase) => {
+      const f = await fixture("stt-tts");
+      await startTranscripts(f.manager, f.sink);
+      const queued = createDeferred<void>();
+      f.entry.processingQueue = queued.promise;
+      const resolveIngress = voiceIngress.resolveDiscordVoiceIngressContext;
+      const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+      const authorized = createDeferred<null>();
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      try {
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledOnce());
+        await authorize.mock.results[0]!.value;
+        stream.end(Buffer.alloc(96_000, 1));
+        await vi.waitFor(() => expect(f.entry.processingQueue).not.toBe(queued.promise));
+        if (phase === "final") {
+          authorize.mockImplementationOnce(resolveIngress);
+        }
+        authorize.mockImplementationOnce(() => authorized.promise);
+        queued.resolve();
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledTimes(phase === "final" ? 3 : 2));
+        await vi.waitFor(() => expect(f.sink).toHaveBeenCalledOnce());
+        const next = f.begin("guest");
+        f.streams.get("guest")!.end(Buffer.alloc(96_000, 2));
+        await next;
+        await vi.waitFor(() => expect(f.sink).toHaveBeenCalledTimes(2));
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        authorized.resolve(null);
+        await receiving;
+        await f.entry.processingQueue;
+        await Promise.all(f.conversations.mock.results.map((result) => result.value));
+        expect(agentCommandMock).not.toHaveBeenCalled();
+      } finally {
+        queued.resolve();
+        authorized.resolve(null);
+        stream.end();
+        await receiving;
+        await f.entry.processingQueue;
+        authorize.mockRestore();
+      }
+    },
+  );
+
+  it("keeps recording when queued conversation reauthorization fails", async () => {
+    const f = await fixture("stt-tts");
+    await startTranscripts(f.manager, f.sink);
+    const queued = createDeferred<void>();
+    f.entry.processingQueue = queued.promise;
+    const receiving = f.begin("100000000000000001");
+    f.streams.get("100000000000000001")!.end(Buffer.alloc(96_000, 1));
+    await receiving;
+    const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+    try {
+      authorize.mockRejectedValue(new Error("Conversation authorization unavailable"));
+      queued.resolve();
+      await f.entry.processingQueue;
+      expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ text: "audio-1-96000" }),
+      );
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining("Conversation authorization unavailable"),
+      );
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+    } finally {
+      authorize.mockRestore();
+      queued.resolve();
+      await f.entry.processingQueue;
+    }
+    await f.audio("100000000000000001", 2);
+    expect(f.sink).toHaveBeenCalledTimes(2);
+    expect(agentCommandMock).toHaveBeenCalledOnce();
+  });
+
+  it("bounds pending conversation admission while every speaker keeps recording", async () => {
+    const f = await fixture("stt-tts");
+    await startTranscripts(f.manager, f.sink);
+    const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+    const authorized = createDeferred<null>();
+    authorize.mockImplementation(() => authorized.promise);
+    const receivers: Promise<void>[] = [];
+    try {
+      for (let index = 0; index < 9; index++) {
+        const userId = `guest-${index}`;
+        receivers.push(f.begin(userId));
+        f.streams.get(userId)!.end(Buffer.alloc(96_000, index));
+      }
+      await Promise.all(receivers);
+      await f.entry.processingQueue;
+      expect(f.sink).toHaveBeenCalledTimes(9);
+      expect(authorize).toHaveBeenCalledTimes(8);
+      expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("conversation is busy"));
+      authorized.resolve(null);
+      await Promise.all(f.conversations.mock.results.map((result) => result.value));
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      authorize.mockRestore();
+      await f.audio("100000000000000001", 9);
+      expect(f.sink).toHaveBeenCalledTimes(10);
+      expect(agentCommandMock).toHaveBeenCalledOnce();
+    } finally {
+      authorized.resolve(null);
+      for (const stream of f.streams.values()) {
+        stream.end();
+      }
+      await Promise.all(receivers);
+      await f.entry.processingQueue;
+      authorize.mockRestore();
+    }
+  });
+
+  it("keeps recording later speech while a conversation response is pending", async () => {
+    const f = await fixture("stt-tts");
+    await startTranscripts(f.manager, f.sink);
+    const response = createDeferred<{ payloads: [] }>();
+    agentCommandMock.mockImplementationOnce(() => response.promise);
+    const first = f.begin("100000000000000001");
+    f.streams.get("100000000000000001")!.end(Buffer.alloc(96_000, 1));
+    try {
+      await first;
+      await vi.waitFor(() => expect(agentCommandMock).toHaveBeenCalledOnce());
+      const next = f.begin("guest");
+      f.streams.get("guest")!.end(Buffer.alloc(96_000, 2));
+      await next;
+      await f.entry.processingQueue;
+      expect(f.sink).toHaveBeenCalledTimes(2);
+      response.resolve({ payloads: [] });
+      await Promise.all(f.conversations.mock.results.map((result) => result.value));
+      expect(agentCommandMock).toHaveBeenCalledOnce();
+    } finally {
+      response.resolve({ payloads: [] });
+      await first;
+      await f.entry.processingQueue;
+    }
+  });
+
+  it.each([false, true])(
+    "keeps recording when realtime audio delivery fails (close failure=%s)",
+    async (closeFailure) => {
+      const f = await fixture();
+      await startTranscripts(f.manager, f.sink);
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      try {
+        stream.write(Buffer.alloc(96_000, 1));
+        await vi.waitFor(() => expect(realtimeSessionMock.sendAudio).toHaveBeenCalledOnce());
+        realtimeSessionMock.sendAudio.mockImplementationOnce(() => {
+          throw new Error("Realtime audio delivery unavailable");
+        });
+        if (closeFailure) {
+          realtimeSessionMock.close.mockImplementationOnce(() => {
+            throw new Error("Realtime provider close failed");
+          });
+        }
+        stream.end(Buffer.alloc(96_000, 2));
+        await receiving;
+        await f.entry.processingQueue;
+        expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ text: "audio-1-192000" }),
+        );
+        await emitFinalRealtimeUserTranscript(
+          lastRealtimeBridgeParams(),
+          "Send incomplete request",
+        );
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+        expect(f.entry.transcripts?.isCurrent()).toBe(true);
+      } finally {
+        stream.end();
+        await receiving;
+        await f.entry.processingQueue;
+      }
+    },
+  );
+
+  it.each(["allowed", "denied", "failed"] as const)(
+    "starts recording while conversation admission is pending and later %s",
+    async (outcome) => {
+      const f = await fixture();
+      const userId = outcome === "allowed" ? "100000000000000001" : "guest";
+      const release = createDeferred<void>();
+      const resolveIngress = voiceIngress.resolveDiscordVoiceIngressContext;
+      const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+      authorize.mockImplementationOnce(async (params) => {
+        await release.promise;
+        if (outcome === "failed") {
+          throw new Error("Conversation authorization unavailable");
+        }
+        return resolveIngress(params);
+      });
+      const receiving = f.begin(userId);
+      const settled = receiving.catch(() => undefined);
+      try {
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledOnce());
+        expect(f.streams.size).toBe(0);
+        f.entry.connection.receiver.speaking.users.set(userId, Date.now());
+        await startTranscripts(f.manager, f.sink);
+        await vi.waitFor(() => expect(f.streams.has(userId)).toBe(true));
+        f.streams.get(userId)!.end(Buffer.alloc(96_000, 8));
+        expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+        release.resolve();
+        await receiving;
+        await f.entry.processingQueue;
+        expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({ text: "audio-8-96000" }),
+        );
+        expect(getSessionConnection(f.entry).receiver.subscribe).toHaveBeenCalledOnce();
+        expect(authorize).toHaveBeenCalledOnce();
+        if (outcome === "allowed") {
+          expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+        } else {
+          expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+        }
+        expect(agentCommandMock).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        await f.manager.destroy();
+        f.streams.get(userId)?.end();
+        await settled;
+        authorize.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    { wait: "queued", result: "allowed" },
+    { wait: "queued", result: "denied" },
+    { wait: "queued", result: "retired" },
+    { wait: "identity", result: "allowed" },
+    { wait: "identity", result: "denied" },
+    { wait: "identity", result: "retired" },
+  ] as const)(
+    "records a replacement while retired $wait audio waits for $result conversation authority",
+    async ({ wait, result }) => {
+      const f = await fixture("stt-tts");
+      await startTranscripts(f.manager, f.sink);
+      const queued = createDeferred<void>();
+      const identity = createDeferred<void>();
+      const identityStarted = createDeferred<void>();
+      const authorized = createDeferred<{ speakerLabel: string; senderIsOwner: boolean } | null>();
+      if (wait === "queued") {
+        f.entry.processingQueue = queued.promise;
+      }
+      const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+      const writeWav = voiceAudio.writeVoiceWavFile;
+      const files: Array<{ path: string; released: ReturnType<typeof createDeferred<void>> }> = [];
+      const writes = vi.spyOn(voiceAudio, "writeVoiceWavFile").mockImplementation(async (pcm) => {
+        const wav = await writeWav(pcm);
+        const released = createDeferred<void>();
+        files.push({ path: wav.path, released });
+        return {
+          ...wav,
+          cleanup: async () => {
+            await wav.cleanup();
+            released.resolve();
+          },
+        };
+      });
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      const replacement = vi.fn();
+      let next: Promise<void> | undefined;
+      try {
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledOnce());
+        await authorize.mock.results[0]!.value;
+        if (wait === "identity") {
+          const member = f.client.fetchMember.getMockImplementation()!;
+          f.client.fetchMember.mockImplementationOnce(async (...args) => {
+            identityStarted.resolve();
+            await identity.promise;
+            return member(...args);
+          });
+        }
+        authorize.mockImplementationOnce(() => authorized.promise);
+        stream.end(Buffer.alloc(96_000, 1));
+        await receiving;
+        if (wait === "identity") {
+          await identityStarted.promise;
+          await vi.waitFor(() => expect(authorize).toHaveBeenCalledTimes(2));
+        }
+        expect(files).toHaveLength(1);
+        await stopTranscripts();
+        await startTranscripts(f.manager, replacement, "notes-2");
+        queued.resolve();
+        identity.resolve();
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledTimes(2));
+        next = f.begin("100000000000000001");
+        f.streams.get("100000000000000001")!.end(Buffer.alloc(96_000, 2));
+        await next;
+        await vi.waitFor(() =>
+          expect(replacement).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({ sessionId: "notes-2", text: "audio-2-96000" }),
+          ),
+        );
+        expect(f.sink).not.toHaveBeenCalled();
+        expect(transcribeAudioFileMock).toHaveBeenCalledOnce();
+        await fs.access(files[0]!.path);
+        if (result === "retired") {
+          await f.manager.leave({ guildId: "g1" });
+          await files[0]!.released.promise;
+        }
+        authorized.resolve(
+          result === "denied" ? null : { speakerLabel: "Owner", senderIsOwner: true },
+        );
+        await Promise.all(f.conversations.mock.results.map((call) => call.value));
+        await Promise.all(files.map((file) => file.released.promise));
+        expect(f.sink).not.toHaveBeenCalled();
+        expect(replacement).toHaveBeenCalledOnce();
+        if (result === "allowed") {
+          expect(transcribeAudioFileMock).toHaveBeenCalledTimes(2);
+          expect(agentCommandMock.mock.calls.map(([call]) => call)).toEqual([
+            expect.objectContaining({ message: expect.stringContaining("audio-1-96000") }),
+            expect.objectContaining({ message: expect.stringContaining("audio-2-96000") }),
+          ]);
+        } else {
+          expect(transcribeAudioFileMock).toHaveBeenCalledOnce();
+          expect(agentCommandMock).toHaveBeenCalledTimes(result === "retired" ? 0 : 1);
+        }
+      } finally {
+        queued.resolve();
+        identity.resolve();
+        authorized.resolve(null);
+        stream.end();
+        await receiving;
+        await next;
+        await f.entry.processingQueue;
+        await f.manager.destroy();
+        await Promise.all(f.conversations.mock.results.map((call) => call.value));
+        await Promise.all(files.map((file) => file.released.promise));
+        writes.mockRestore();
+        authorize.mockRestore();
+      }
+    },
+  );
+
+  it.each(["session", "input"] as const)(
+    "does not transcribe after granted conversation %s retires during recording identity",
+    async (retirement) => {
+      const f = await fixture("stt-tts", false, {
+        tools: { media: { audio: { maxBytes: 192_044 } } },
+      });
+      await startTranscripts(f.manager, f.sink);
+      const identity = createDeferred<void>();
+      const identityStarted = createDeferred<void>();
+      const released = createDeferred<void>();
+      const authorize = vi.spyOn(voiceIngress, "resolveDiscordVoiceIngressContext");
+      const writeWav = voiceAudio.writeVoiceWavFile;
+      const writes = vi
+        .spyOn(voiceAudio, "writeVoiceWavFile")
+        .mockImplementationOnce(async (pcm) => {
+          const wav = await writeWav(pcm);
+          return {
+            ...wav,
+            cleanup: async () => {
+              await wav.cleanup();
+              released.resolve();
+            },
+          };
+        });
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      try {
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledOnce());
+        await authorize.mock.results[0]!.value;
+        const member = f.client.fetchMember.getMockImplementation()!;
+        f.client.fetchMember.mockImplementationOnce(async (...args) => {
+          identityStarted.resolve();
+          await identity.promise;
+          return member(...args);
+        });
+        stream.write(Buffer.alloc(192_000, 1));
+        await identityStarted.promise;
+        await vi.waitFor(() => expect(authorize).toHaveBeenCalledTimes(2));
+        await authorize.mock.results[1]!.value;
+        await stopTranscripts();
+        if (retirement === "session") {
+          await f.manager.leave({ guildId: "g1" });
+        } else {
+          stream.destroy(new Error("Receive socket failed"));
+        }
+        await receiving;
+        identity.resolve();
+        await released.promise;
+        expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+        expect(f.sink).not.toHaveBeenCalled();
+        expect(agentCommandMock).not.toHaveBeenCalled();
+      } finally {
+        identity.resolve();
+        stream.end();
+        await receiving;
+        await released.promise;
+        await f.entry.processingQueue;
+        await f.manager.destroy();
+        writes.mockRestore();
+        authorize.mockRestore();
+      }
+    },
+  );
+});

--- a/extensions/discord/src/voice/transcripts-readiness.test.ts
+++ b/extensions/discord/src/voice/transcripts-readiness.test.ts
@@ -1,0 +1,438 @@
+import fs from "node:fs/promises";
+import { PassThrough } from "node:stream";
+import { SpeakingMap } from "@discordjs/voice";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    expectDefined,
+    it,
+    vi,
+    createClient,
+    createManager,
+    createConnectionMock,
+    joinVoiceChannelMock,
+    entersStateMock,
+    resolveRealtimeBootstrapContextInstructionsMock,
+    realtimeSessionMock,
+    createRealtimeSessionMock,
+    createRealtimeVoiceBridgeSessionMock,
+    realtimeBridgeAt,
+    configureVoiceStateGateway,
+    getSessionEntry,
+    getLastAudioPlayer,
+    startTranscripts,
+    stopTranscripts,
+    emitDecryptFailure,
+    decodeOpusStreamChunksMock,
+    transcribeAudioFileMock,
+    agentCommandMock,
+    controlRealtimeVoiceAgentRunMock,
+    enqueueSystemEventMock,
+  }) => {
+    const sentAudioCount = () =>
+      createRealtimeVoiceBridgeSessionMock.mock.calls.reduce(
+        (count, _call, index) =>
+          count + realtimeBridgeAt(index).session.sendAudio.mock.calls.length,
+        0,
+      );
+
+    function fixture(
+      occupied: boolean,
+      mode: "agent-proxy" | "bidi" | "stt-tts" = "agent-proxy",
+      participant = "guest",
+    ) {
+      const client = createClient();
+      client.fetchMember.mockResolvedValue({
+        nickname: "Guest",
+        roles: [],
+        user: { id: participant },
+      });
+      const states = [
+        {
+          user_id: participant,
+          channel_id: "1001",
+          member: { user: { id: participant, bot: false } },
+        },
+      ];
+      configureVoiceStateGateway(client, () => states);
+      const manager = createManager(
+        {
+          groupPolicy: "open",
+          allowFrom: ["discord:owner"],
+          voice: {
+            enabled: true,
+            mode,
+            realtime: { provider: "openai", requireWakeName: true, bargeIn: false },
+            ...(occupied
+              ? { autoJoin: [{ guildId: "g1", channelId: "1001", whenOccupied: true }] }
+              : {}),
+          },
+        },
+        client,
+      );
+      const connection = createConnectionMock();
+      const speaking = new SpeakingMap();
+      connection.receiver.speaking = {
+        users: speaking.users,
+        on: vi.fn(speaking.on.bind(speaking)),
+        off: vi.fn(speaking.off.bind(speaking)),
+      };
+      const stream = new PassThrough({ objectMode: true });
+      connection.receiver.subscribe.mockReturnValue(stream);
+      decodeOpusStreamChunksMock.mockImplementation(async (input, params) => {
+        for await (const packet of input) {
+          await params.onChunk(packet, packet);
+        }
+      });
+      transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+        const wav = await fs.readFile(filePath);
+        return { text: `${wav.toString("ascii", 0, 4)}-${wav[44]}-${wav.length - 44}` };
+      });
+      const received = createDeferred<void>();
+      const sink = vi.fn(() => received.resolve());
+      return { manager, connection, speaking, stream, states, received, sink };
+    }
+
+    it.each([
+      { name: "capture-only", occupied: false, recovery: false, stage: "ready", overlap: "none" },
+      {
+        name: "occupied autoJoin bootstrap",
+        occupied: true,
+        recovery: false,
+        stage: "bootstrap",
+        overlap: "none",
+      },
+      {
+        name: "occupied autoJoin connect",
+        occupied: true,
+        recovery: false,
+        stage: "connect",
+        overlap: "none",
+      },
+      {
+        name: "capture-only recovery",
+        occupied: false,
+        recovery: true,
+        stage: "ready",
+        overlap: "none",
+      },
+      {
+        name: "occupied recovery",
+        occupied: true,
+        recovery: true,
+        stage: "connect",
+        overlap: "none",
+      },
+      {
+        name: "overlapping start event",
+        occupied: true,
+        recovery: false,
+        stage: "connect",
+        overlap: "after",
+      },
+      {
+        name: "start event before scan",
+        occupied: true,
+        recovery: false,
+        stage: "connect",
+        overlap: "before",
+      },
+    ])(
+      "records speech already in progress at $name readiness",
+      async ({ occupied, recovery, stage, overlap }) => {
+        const f = fixture(occupied);
+        if (recovery) {
+          expect(await startTranscripts(f.manager, f.sink)).toMatchObject({ ok: true });
+        }
+        joinVoiceChannelMock.mockReturnValueOnce(f.connection);
+        const waiting = createDeferred<void>();
+        const ready = createDeferred<undefined>();
+        const provider = recovery ? createRealtimeSessionMock() : realtimeSessionMock;
+        if (recovery) {
+          createRealtimeVoiceBridgeSessionMock.mockReturnValueOnce(provider);
+        }
+        const pending =
+          stage === "ready"
+            ? entersStateMock
+            : stage === "bootstrap"
+              ? resolveRealtimeBootstrapContextInstructionsMock
+              : provider.connect;
+        pending.mockImplementationOnce(() => {
+          waiting.resolve();
+          return ready.promise;
+        });
+        const joins = vi.spyOn(f.manager, "join");
+        const starting = recovery ? undefined : startTranscripts(f.manager, f.sink);
+        if (recovery) {
+          emitDecryptFailure(f.manager);
+          emitDecryptFailure(f.manager);
+          emitDecryptFailure(f.manager);
+        }
+        const starts = vi.fn();
+        f.speaking.on("start", starts);
+        try {
+          await vi.waitFor(() => expect(joins).toHaveBeenCalledOnce());
+          await Promise.race([
+            waiting.promise,
+            Promise.resolve(joins.mock.results[0]!.value).then((result) => {
+              throw new Error(`Voice join completed before its readiness gate: ${result.message}`);
+            }),
+          ]);
+          vi.useFakeTimers();
+          // Native speaking state exists before OpenClaw installs its receive listeners.
+          f.speaking.onPacket("guest");
+          expect(f.connection.receiver.subscribe).not.toHaveBeenCalled();
+          if (overlap === "before") {
+            // Roster publication follows listener installation and session-map publication.
+            enqueueSystemEventMock.mockImplementationOnce(() => {
+              f.speaking.emit("start", "guest");
+              return true;
+            });
+          }
+          ready.resolve(undefined);
+          expect(await joins.mock.results[0]!.value).toMatchObject({ ok: true });
+          if (starting) {
+            expect(await starting).toMatchObject({ ok: true });
+          }
+          expect(f.connection.receiver.subscribe).toHaveBeenCalledExactlyOnceWith(
+            "guest",
+            expect.anything(),
+          );
+          // Continuous packets refresh the native timeout without another start event.
+          f.speaking.onPacket("guest");
+          expect(starts).toHaveBeenCalledTimes(overlap === "before" ? 2 : 1);
+          if (overlap === "after") {
+            f.speaking.emit("start", "guest");
+          }
+          f.stream.end(Buffer.alloc(96_000, 7));
+          await f.received.promise;
+          await getSessionEntry(f.manager).processingQueue;
+          expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+              sessionId: "notes-1",
+              speaker: { id: "guest", label: "Guest" },
+              text: "RIFF-7-96000",
+            }),
+          );
+          expect(f.connection.receiver.subscribe).toHaveBeenCalledOnce();
+          expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce();
+          expect(transcribeAudioFileMock).toHaveBeenCalledOnce();
+          expect(sentAudioCount()).toBe(0);
+          expect(agentCommandMock).not.toHaveBeenCalled();
+          expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+          expect(getLastAudioPlayer().play).not.toHaveBeenCalled();
+        } finally {
+          ready.resolve(undefined);
+          await f.manager.destroy();
+          f.stream.destroy();
+          vi.clearAllTimers();
+          vi.useRealTimers();
+          joins.mockRestore();
+        }
+      },
+    );
+
+    it.each([
+      { mode: "stt-tts", origin: "readiness" },
+      { mode: "agent-proxy", origin: "readiness" },
+      { mode: "stt-tts", origin: "playback" },
+      { mode: "bidi", origin: "playback" },
+      { mode: "stt-tts", origin: "recovery" },
+      { mode: "bidi", origin: "recovery" },
+      { mode: "stt-tts", origin: "native" },
+      { mode: "agent-proxy", origin: "native" },
+    ] as const)(
+      "keeps $origin speech authority through scanning and grace in $mode",
+      async ({ mode, origin }) => {
+        const f = fixture(true, mode, "owner");
+        const subscribed = createDeferred<void>();
+        f.connection.receiver.subscribe.mockImplementationOnce(() => {
+          subscribed.resolve();
+          return f.stream;
+        });
+        const writeSpeech = (stream: PassThrough, marker: number) => {
+          for (let frame = 0; frame < 25; frame++) {
+            stream.write(Buffer.alloc(3_840, marker));
+          }
+        };
+        transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+          const wav = await fs.readFile(filePath);
+          return {
+            text:
+              wav.readUInt8(44) === 1
+                ? "Do not"
+                : origin === "playback"
+                  ? "stop that"
+                  : "send the update",
+          };
+        });
+        vi.useFakeTimers();
+        try {
+          if (origin === "recovery") {
+            expect(await startTranscripts(f.manager, f.sink)).toMatchObject({ ok: true });
+          }
+          joinVoiceChannelMock.mockReturnValueOnce(f.connection);
+          if (origin === "playback" || origin === "native") {
+            expect(await f.manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({
+              ok: true,
+            });
+            if (origin === "playback") {
+              getLastAudioPlayer().state.status = "playing";
+            }
+          }
+          // Native speaking state knows about packets that had no subscriber yet.
+          f.speaking.onPacket("owner");
+          if (origin === "native") {
+            await subscribed.promise;
+            writeSpeech(f.stream, 1);
+          } else {
+            expect(f.connection.receiver.subscribe).not.toHaveBeenCalled();
+          }
+          if (origin === "playback") {
+            getLastAudioPlayer().state.status = "idle";
+          }
+          if (origin === "recovery") {
+            emitDecryptFailure(f.manager);
+            emitDecryptFailure(f.manager);
+            emitDecryptFailure(f.manager);
+          } else {
+            expect(await startTranscripts(f.manager, f.sink)).toMatchObject({ ok: true });
+          }
+          await subscribed.promise;
+          const entry = getSessionEntry(f.manager);
+          const conversations = vi.spyOn(entry.conversations, "enqueue");
+          writeSpeech(f.stream, 2);
+          // A native restart inside OpenClaw's grace retains this same owned receive stream.
+          await vi.advanceTimersByTimeAsync(SpeakingMap.DELAY + 400);
+          f.speaking.onPacket("owner");
+          writeSpeech(f.stream, 3);
+          expect(f.connection.receiver.subscribe).toHaveBeenCalledOnce();
+          await vi.advanceTimersByTimeAsync(SpeakingMap.DELAY + 2_000);
+          await f.received.promise;
+          await entry.processingQueue;
+          await Promise.all(conversations.mock.results.map((result) => result.value));
+          expect(f.stream.destroyed).toBe(true);
+          expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+            expect.objectContaining({
+              sessionId: "notes-1",
+              text: origin === "playback" ? "stop that" : "send the update",
+            }),
+          );
+          if (origin === "native" && mode === "stt-tts") {
+            expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledExactlyOnceWith({
+              sessionKey: expectDefined(entry.route?.sessionKey, "voice session route"),
+              text: "Do not\nsend the update",
+            });
+            expect(agentCommandMock).toHaveBeenCalledOnce();
+            expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+              message: expect.stringContaining("Do not\nsend the update"),
+            });
+          } else {
+            expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+            expect(agentCommandMock).not.toHaveBeenCalled();
+          }
+          if (origin === "native" && mode !== "stt-tts") {
+            expect(sentAudioCount()).toBeGreaterThan(0);
+          } else {
+            expect(sentAudioCount()).toBe(0);
+          }
+          const audioCalls = sentAudioCount();
+          const nextNote = createDeferred<void>();
+          const nextSubscribed = createDeferred<void>();
+          const nextStream = new PassThrough({ objectMode: true });
+          f.connection.receiver.subscribe.mockImplementationOnce(() => {
+            nextSubscribed.resolve();
+            return nextStream;
+          });
+          f.sink.mockImplementationOnce(() => nextNote.resolve());
+          transcribeAudioFileMock.mockResolvedValue({ text: "A complete new request" });
+          f.speaking.onPacket("owner");
+          await nextSubscribed.promise;
+          writeSpeech(nextStream, 4);
+          nextStream.end();
+          await nextNote.promise;
+          await entry.processingQueue;
+          await Promise.all(conversations.mock.results.map((result) => result.value));
+          expect(f.connection.receiver.subscribe).toHaveBeenCalledTimes(2);
+          expect(decodeOpusStreamChunksMock).toHaveBeenCalledTimes(2);
+          expect(transcribeAudioFileMock).toHaveBeenCalledTimes(
+            origin === "native" && mode === "stt-tts" ? 3 : 2,
+          );
+          expect(f.sink).toHaveBeenCalledTimes(2);
+          if (mode === "stt-tts") {
+            expect(agentCommandMock).toHaveBeenCalledTimes(origin === "native" ? 2 : 1);
+          } else {
+            expect(sentAudioCount()).toBeGreaterThan(audioCalls);
+          }
+        } finally {
+          await f.manager.destroy();
+          f.stream.destroy();
+          vi.clearAllTimers();
+          vi.useRealTimers();
+        }
+      },
+    );
+
+    it.each(["agent-proxy", "bidi", "stt-tts"] as const)(
+      "does not start receiving existing speech on %s join without capture",
+      async (mode) => {
+        const f = fixture(false, mode);
+        f.speaking.users.set("owner", Date.now());
+        joinVoiceChannelMock.mockReturnValueOnce(f.connection);
+        try {
+          expect(await f.manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({
+            ok: true,
+          });
+          expect(f.connection.receiver.subscribe).not.toHaveBeenCalled();
+          expect(decodeOpusStreamChunksMock).not.toHaveBeenCalled();
+          expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+          expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+          expect(agentCommandMock).not.toHaveBeenCalled();
+        } finally {
+          await f.manager.destroy();
+          f.stream.destroy();
+        }
+      },
+    );
+
+    it.each(["cancelled", "failed", "emptied"])(
+      "does not subscribe existing speech after capture join is %s",
+      async (outcome) => {
+        const f = fixture(outcome !== "cancelled");
+        f.speaking.users.set("guest", Date.now());
+        joinVoiceChannelMock.mockReturnValueOnce(f.connection);
+        const waiting = createDeferred<void>();
+        const ready = createDeferred<undefined>();
+        entersStateMock.mockImplementationOnce(() => {
+          waiting.resolve();
+          return ready.promise;
+        });
+        const starting = startTranscripts(f.manager, f.sink);
+        await waiting.promise;
+        try {
+          if (outcome === "cancelled") {
+            expect(await stopTranscripts()).toMatchObject({ ok: true });
+          } else if (outcome === "failed") {
+            realtimeSessionMock.connect.mockRejectedValueOnce(new Error("provider unavailable"));
+          } else {
+            f.states.length = 0;
+          }
+          ready.resolve(undefined);
+          expect(await starting).toMatchObject({ ok: outcome === "emptied" });
+          expect(f.manager.status()).toEqual([]);
+          expect(f.connection.destroy).toHaveBeenCalledOnce();
+          expect(f.connection.receiver.subscribe).not.toHaveBeenCalled();
+          expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+          expect(f.sink).not.toHaveBeenCalled();
+        } finally {
+          ready.resolve(undefined);
+          await f.manager.destroy();
+          f.stream.destroy();
+        }
+      },
+    );
+  },
+);

--- a/extensions/discord/src/voice/transcripts-realtime-recording.test.ts
+++ b/extensions/discord/src/voice/transcripts-realtime-recording.test.ts
@@ -1,0 +1,305 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { CommandInteraction } from "../internal/discord.js";
+import { createDiscordVoiceCommand } from "./command.js";
+import { createDiscordRecordingFixture } from "./transcripts-recording.test-support.js";
+import { discordVoiceTranscriptsSourceProvider } from "./transcripts-source.js";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+const OWNER = "100000000000000001";
+const unavailable = {
+  text: undefined,
+  decision: {
+    capability: "audio",
+    outcome: "skipped",
+    attachments: [{ attachmentIndex: 0, attempts: [] }],
+    attachmentDispositions: { 0: { kind: "no-model" } },
+    attachmentProcessing: { 0: "omitted" },
+  },
+} satisfies Awaited<ReturnType<PluginRuntime["mediaUnderstanding"]["transcribeAudioFile"]>>;
+
+defineDiscordVoiceTests((harness) => {
+  const {
+    expect,
+    it,
+    vi,
+    startTranscripts,
+    stopTranscripts,
+    transcribeAudioFileMock,
+    lastRealtimeBridgeParams,
+    emitFinalRealtimeUserTranscript,
+    agentCommandMock,
+    realtimeSessionMock,
+    resolveVoiceIngressWithParticipantsMock,
+  } = harness;
+  const fixture = createDiscordRecordingFixture(harness);
+
+  it.each(["agent-proxy", "bidi"] as const)(
+    "retains fully bound %s recording and exposes limited coverage through vc status",
+    async (mode) => {
+      const f = await fixture(mode);
+      transcribeAudioFileMock.mockResolvedValue(unavailable);
+      expect(await startTranscripts(f.manager, f.sink)).toMatchObject({ ok: true });
+      await f.audio(OWNER, 1);
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "Keep the meeting note.");
+      expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          text: "Keep the meeting note.",
+          speaker: { id: OWNER, label: "Owner" },
+        }),
+      );
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      const reply = vi.fn();
+      const command = createDiscordVoiceCommand({
+        cfg: {},
+        discordConfig: {},
+        accountId: "default",
+        groupPolicy: "open",
+        useAccessGroups: false,
+        getManager: () => f.manager,
+        ephemeralDefault: true,
+      });
+      await command.run({
+        guild: { id: "g1", name: "Guild" },
+        user: { id: OWNER, username: "owner" },
+        rawData: { data: { options: [{ name: "status", type: 1 }] }, member: { roles: [] } },
+        defer: vi.fn(),
+        reply,
+      } as unknown as CommandInteraction);
+      expect(reply).toHaveBeenCalledWith({
+        content: expect.stringContaining("only safely bound realtime finals can be recorded"),
+        ephemeral: true,
+      });
+    },
+  );
+
+  it("preserves realtime-only capture when batch audio is explicitly disabled", async () => {
+    const cfg = {
+      channels: { discord: { token: "test-token", voice: { enabled: true } } },
+      tools: { media: { audio: { enabled: false } } },
+    };
+    const f = await fixture("agent-proxy", false, cfg);
+    await startTranscripts(f.manager, f.sink);
+    expect(
+      await discordVoiceTranscriptsSourceProvider.start!({
+        cfg,
+        onUtterance: f.sink,
+        session: {
+          sessionId: "notes-1",
+          startedAt: new Date().toISOString(),
+          source: {
+            providerId: "discord-voice",
+            accountId: "default",
+            guildId: "g1",
+            channelId: "1001",
+          },
+        },
+      }),
+    ).toMatchObject({ ok: true });
+    await f.audio(OWNER, 1);
+    await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "Realtime-only note.");
+    expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ text: "Realtime-only note." }),
+    );
+    expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["unavailable", "silent", "transcribed"] as const)(
+    "holds an early realtime final until the batch result settles as %s",
+    async (outcome) => {
+      const f = await fixture();
+      const pending = createDeferred<void>();
+      transcribeAudioFileMock.mockImplementation(async () => {
+        await pending.promise;
+        return outcome === "unavailable"
+          ? unavailable
+          : outcome === "silent"
+            ? {
+                ...unavailable,
+                decision: {
+                  ...unavailable.decision,
+                  attachmentDispositions: { 0: { kind: "failed" } },
+                  attachmentProcessing: { 0: "completed" },
+                },
+              }
+            : { text: "Batch note." };
+      });
+      await startTranscripts(f.manager, f.sink);
+      const receiving = f.begin(OWNER);
+      f.streams.get(OWNER)!.end(Buffer.alloc(96_000, 1));
+      await receiving;
+      try {
+        await vi.waitFor(() => expect(transcribeAudioFileMock).toHaveBeenCalledOnce());
+        await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "Realtime note.");
+        expect(f.sink).not.toHaveBeenCalled();
+      } finally {
+        pending.resolve();
+        await f.entry.processingQueue;
+        await Promise.all(f.conversations.mock.results.map((result) => result.value));
+      }
+      await vi.waitFor(() =>
+        expect(f.sink.mock.calls.map(([utterance]) => utterance.text)).toEqual(
+          outcome === "unavailable"
+            ? ["Realtime note."]
+            : outcome === "transcribed"
+              ? ["Batch note."]
+              : [],
+        ),
+      );
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "Late duplicate.");
+      expect(f.sink).toHaveBeenCalledTimes(
+        outcome === "unavailable" ? 2 : outcome === "transcribed" ? 1 : 0,
+      );
+    },
+  );
+
+  it.each(["failure", "oversized", "unknown-omitted"] as const)(
+    "does not reinterpret %s batch input as unavailable",
+    async (outcome) => {
+      const f = await fixture();
+      if (outcome === "failure") {
+        transcribeAudioFileMock.mockRejectedValue(new Error("Transcription failed"));
+      } else {
+        transcribeAudioFileMock.mockResolvedValue({
+          text: undefined,
+          decision: {
+            ...unavailable.decision,
+            attachments:
+              outcome === "oversized"
+                ? [
+                    {
+                      attachmentIndex: 0,
+                      attempts: [
+                        { type: "provider", outcome: "skipped", reason: "maxBytes exceeded" },
+                      ],
+                    },
+                  ]
+                : unavailable.decision.attachments,
+            attachmentDispositions:
+              outcome === "oversized"
+                ? { 0: { kind: "failed", reason: "maxBytes exceeded" } }
+                : undefined,
+          },
+        });
+      }
+      await startTranscripts(f.manager, f.sink);
+      await f.audio(OWNER, 1);
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "Unproven note.");
+      expect(f.sink).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["same", "replaced"] as const)(
+    "keeps %s capture receipts across delayed conversation authorization",
+    async (captureState) => {
+      const f = await fixture();
+      const pending = createDeferred<void>();
+      const finishedInputs = vi.spyOn(f.entry.conversations, "finishAudio");
+      const { resolveDiscordVoiceIngressContextWithParticipants: original } = await vi.importActual<
+        typeof import("./participant-context.js")
+      >("./participant-context.js");
+      resolveVoiceIngressWithParticipantsMock.mockImplementation(
+        async (...args: Parameters<typeof original>) => {
+          await pending.promise;
+          return await original(...args);
+        },
+      );
+      transcribeAudioFileMock.mockResolvedValue(unavailable);
+      await startTranscripts(f.manager, f.sink);
+      const receiving = f.begin(OWNER);
+      f.streams.get(OWNER)!.end(Buffer.alloc(96_000, 1));
+      await receiving;
+      const replacement = vi.fn();
+      try {
+        await f.entry.processingQueue;
+        expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+        if (captureState === "replaced") {
+          await startTranscripts(f.manager, replacement, "notes-2");
+        }
+      } finally {
+        pending.resolve();
+        await Promise.all(finishedInputs.mock.results.map((result) => result.value));
+      }
+      expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "Old capture note.");
+      expect(f.sink).toHaveBeenCalledTimes(captureState === "same" ? 1 : 0);
+      expect(replacement).not.toHaveBeenCalled();
+      await f.audio(OWNER, 2);
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "New capture note.");
+      const currentSink = captureState === "same" ? f.sink : replacement;
+      expect(currentSink).toHaveBeenLastCalledWith(
+        expect.objectContaining({ text: "New capture note." }),
+      );
+    },
+  );
+
+  it.each(["start", "replace", "continuity reset"] as const)(
+    "rejects ambiguous input spanning capture %s and recovers on a fresh connection",
+    async (transition) => {
+      const f = await fixture();
+      transcribeAudioFileMock.mockResolvedValue(unavailable);
+      if (transition !== "start") {
+        await startTranscripts(f.manager, f.sink);
+      }
+      const receiving = f.begin(OWNER);
+      await vi.waitFor(() => expect(f.streams.has(OWNER)).toBe(true));
+      const stream = f.streams.get(OWNER)!;
+      stream.write(Buffer.alloc(96_000, 1));
+      await vi.waitFor(() => expect(realtimeSessionMock.sendAudio).toHaveBeenCalled());
+      const oldBridge = lastRealtimeBridgeParams();
+      const replacement = vi.fn();
+      if (transition === "continuity reset") {
+        oldBridge.onEvent?.({ direction: "client", type: "session.continuity.reset" });
+      } else {
+        await startTranscripts(f.manager, replacement, "notes-2");
+      }
+      stream.end(Buffer.alloc(96_000, 2));
+      await receiving;
+      await f.entry.processingQueue;
+      await Promise.all(f.conversations.mock.results.map((result) => result.value));
+      await emitFinalRealtimeUserTranscript(oldBridge, "Mixed note.");
+      expect(f.sink).not.toHaveBeenCalled();
+      expect(replacement).not.toHaveBeenCalled();
+      if (transition === "continuity reset") {
+        await stopTranscripts();
+        await startTranscripts(f.manager, replacement, "notes-2");
+      }
+      await f.audio(OWNER, 3);
+      const nextBridge = lastRealtimeBridgeParams();
+      expect(nextBridge).not.toBe(oldBridge);
+      await emitFinalRealtimeUserTranscript(oldBridge, "Late old note.");
+      await emitFinalRealtimeUserTranscript(nextBridge, "Fresh note.");
+      expect(replacement).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ text: "Fresh note." }),
+      );
+    },
+  );
+
+  it.each(["count", "bytes"] as const)(
+    "bounds pending realtime final %s including a blocked publication",
+    async (bound) => {
+      const f = await fixture();
+      transcribeAudioFileMock.mockResolvedValue(unavailable);
+      await startTranscripts(f.manager, f.sink);
+      await f.audio(OWNER, 1);
+      const pending = createDeferred<void>();
+      f.sink.mockImplementationOnce(() => pending.promise);
+      const bridge = lastRealtimeBridgeParams();
+      try {
+        bridge.onTranscript?.("user", "first", true);
+        expect(f.sink).toHaveBeenCalledOnce();
+        if (bound === "count") {
+          for (let i = 0; i < 1_000; i++) {
+            bridge.onTranscript?.("user", "queued", true);
+          }
+        } else {
+          bridge.onTranscript?.("user", "x".repeat(1024 * 1024 - 4), true);
+        }
+      } finally {
+        pending.resolve();
+      }
+      await emitFinalRealtimeUserTranscript(bridge, "After overflow.");
+      expect(f.sink).toHaveBeenCalledOnce();
+    },
+  );
+});

--- a/extensions/discord/src/voice/transcripts-recording.test-support.ts
+++ b/extensions/discord/src/voice/transcripts-recording.test-support.ts
@@ -1,0 +1,102 @@
+import fs from "node:fs/promises";
+import { PassThrough } from "node:stream";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { DiscordVoiceTestHarness } from "./voice-test-harness.test-support.js";
+
+export function createDiscordRecordingFixture({
+  expect,
+  vi,
+  createClient,
+  createManager,
+  getSessionEntry,
+  getSessionConnection,
+  handleSpeakingStart,
+  decodeOpusStreamChunksMock,
+  transcribeAudioFileMock,
+  configureVoiceStateGateway,
+}: DiscordVoiceTestHarness) {
+  return async function fixture(
+    mode: "agent-proxy" | "bidi" | "stt-tts" = "agent-proxy",
+    occupied = false,
+    cfg: OpenClawConfig = {},
+    roleGated = false,
+  ) {
+    const client = createClient();
+    client.fetchMember.mockImplementation(async (_guildId, userId) => ({
+      nickname: userId === "100000000000000001" ? "Owner" : "Guest",
+      roles: [],
+      user: { id: userId },
+    }));
+    const states = [
+      {
+        user_id: "100000000000000001",
+        channel_id: "1001",
+        member: { user: { id: "100000000000000001", bot: false } },
+      },
+    ];
+    if (occupied) {
+      configureVoiceStateGateway(client, () => states);
+    }
+    const manager = createManager(
+      {
+        groupPolicy: "open",
+        guilds: {
+          g1: {
+            channels: {
+              "1001": roleGated
+                ? { roles: ["role:200000000000000001"] }
+                : { users: ["100000000000000001"] },
+            },
+          },
+        },
+        voice: {
+          enabled: true,
+          mode,
+          realtime: { provider: "openai", requireWakeName: true },
+          ...(occupied
+            ? { autoJoin: [{ guildId: "g1", channelId: "1001", whenOccupied: true }] }
+            : {}),
+        },
+      },
+      client,
+      { ...cfg, commands: { ownerAllowFrom: ["discord:100000000000000001"] } },
+    );
+    if (occupied) {
+      await manager.autoJoin();
+    } else {
+      await manager.join({ guildId: "g1", channelId: "1001" });
+    }
+    const entry = getSessionEntry(manager);
+    const conversations = vi.spyOn(entry.conversations, "enqueue");
+    const streams = new Map<string, PassThrough>();
+    getSessionConnection(entry).receiver.subscribe.mockImplementation((userId: string) => {
+      const stream = new PassThrough({ objectMode: true });
+      streams.set(userId, stream);
+      return stream;
+    });
+    decodeOpusStreamChunksMock.mockImplementation(async (stream, params) => {
+      try {
+        for await (const chunk of stream) {
+          await params.onChunk(chunk, chunk);
+        }
+      } catch (error) {
+        params.onError?.(error);
+      }
+    });
+    transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+      const wav = await fs.readFile(filePath);
+      return { text: `audio-${wav[44]}-${wav.length - 44}` };
+    });
+    const sink = vi.fn();
+    const begin = (userId: string) => handleSpeakingStart(manager, entry, userId);
+    const audio = async (userId: string, marker: number) => {
+      const receiving = begin(userId);
+      await vi.waitFor(() => expect(streams.has(userId)).toBe(true));
+      streams.get(userId)!.end(Buffer.alloc(96_000, marker));
+      await receiving;
+      await entry.processingQueue;
+      await Promise.all(conversations.mock.results.map((result) => result.value));
+    };
+    return { client, manager, entry, streams, sink, begin, audio, states, conversations };
+  };
+}

--- a/extensions/discord/src/voice/transcripts-recording.test.ts
+++ b/extensions/discord/src/voice/transcripts-recording.test.ts
@@ -34,12 +34,12 @@ defineDiscordVoiceTests((harness) => {
   } = harness;
   const fixture = createDiscordRecordingFixture(harness);
 
-  it.each(["fresh", "realtime", "replacement"] as const)(
+  it.each(["fresh", "replacement"] as const)(
     "rejects disabled batch recording before changing %s ownership",
     async (phase) => {
       const config = { channels: { discord: { token: "test-token", voice: { enabled: true } } } };
       const disabledAudio = { ...config, tools: { media: { audio: { enabled: false } } } };
-      const f = await fixture("agent-proxy", false, phase === "replacement" ? {} : disabledAudio);
+      const f = await fixture("stt-tts", false, phase === "replacement" ? {} : disabledAudio);
       const source = {
         providerId: "discord-voice",
         accountId: "default",
@@ -79,7 +79,7 @@ defineDiscordVoiceTests((harness) => {
         } else {
           expectConnectedStatus(f.manager, "1001");
           await f.audio("100000000000000001", 1);
-          expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+          expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
           if (phase === "replacement") {
             expect(f.sink).toHaveBeenCalledOnce();
           } else {

--- a/extensions/discord/src/voice/transcripts-recording.test.ts
+++ b/extensions/discord/src/voice/transcripts-recording.test.ts
@@ -1,0 +1,871 @@
+import fs from "node:fs/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createDiscordRecordingFixture } from "./transcripts-recording.test-support.js";
+import {
+  discordVoiceTranscriptsSourceProvider,
+  setDiscordTranscriptsVoiceManager,
+} from "./transcripts-source.js";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+const voiceAudio = await import("./audio.js");
+
+defineDiscordVoiceTests((harness) => {
+  const {
+    expect,
+    expectDefined,
+    it,
+    vi,
+    getSessionConnection,
+    getLastAudioPlayer,
+    startTranscripts,
+    stopTranscripts,
+    decodeOpusStreamChunksMock,
+    transcribeAudioFileMock,
+    resolveAudioInputBudgetMock,
+    realtimeSessionMock,
+    agentCommandMock,
+    loggerWarnMock,
+    controlRealtimeVoiceAgentRunMock,
+    lastRealtimeBridgeParams,
+    emitFinalRealtimeUserTranscript,
+    updateVoiceState,
+    joinVoiceChannelMock,
+    expectConnectedStatus,
+  } = harness;
+  const fixture = createDiscordRecordingFixture(harness);
+
+  it.each(["fresh", "realtime", "replacement"] as const)(
+    "rejects disabled batch recording before changing %s ownership",
+    async (phase) => {
+      const config = { channels: { discord: { token: "test-token", voice: { enabled: true } } } };
+      const disabledAudio = { ...config, tools: { media: { audio: { enabled: false } } } };
+      const f = await fixture("agent-proxy", false, phase === "replacement" ? {} : disabledAudio);
+      const source = {
+        providerId: "discord-voice",
+        accountId: "default",
+        guildId: "g1",
+        channelId: "1001",
+      };
+      const onStatus = vi.fn();
+      setDiscordTranscriptsVoiceManager({ accountId: "default", manager: f.manager });
+      try {
+        if (phase === "fresh") {
+          await f.manager.leave({ guildId: "g1" });
+        } else if (phase === "replacement") {
+          expect(
+            await discordVoiceTranscriptsSourceProvider.start!({
+              cfg: config,
+              session: { sessionId: "first", source, startedAt: new Date().toISOString() },
+              onUtterance: f.sink,
+              onStatus,
+            }),
+          ).toMatchObject({ ok: true });
+        }
+        const joins = joinVoiceChannelMock.mock.calls.length;
+        expect(
+          await discordVoiceTranscriptsSourceProvider.start!({
+            cfg: disabledAudio,
+            session: { sessionId: "unsupported", source, startedAt: new Date().toISOString() },
+            onUtterance: vi.fn(),
+          }),
+        ).toMatchObject({ ok: false, error: expect.stringContaining("tools.media.audio.enabled") });
+        expect(joinVoiceChannelMock).toHaveBeenCalledTimes(joins);
+        expect(onStatus).not.toHaveBeenCalled();
+        expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject(
+          phase === "replacement" ? [{ active: true, sessionId: "first" }] : [],
+        );
+        if (phase === "fresh") {
+          expect(f.manager.status()).toEqual([]);
+        } else {
+          expectConnectedStatus(f.manager, "1001");
+          await f.audio("100000000000000001", 1);
+          expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+          if (phase === "replacement") {
+            expect(f.sink).toHaveBeenCalledOnce();
+          } else {
+            expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+          }
+        }
+      } finally {
+        await discordVoiceTranscriptsSourceProvider.stop!({ sessionId: "first", source });
+        await discordVoiceTranscriptsSourceProvider.stop!({ sessionId: "unsupported", source });
+        setDiscordTranscriptsVoiceManager({
+          accountId: "default",
+          manager: null,
+          expectedManager: f.manager,
+        });
+        await f.manager.destroy();
+      }
+    },
+  );
+
+  it.each(["agent-proxy", "bidi"] as const)(
+    "records overlapping participants once with receiver IDs in %s",
+    async (mode) => {
+      const f = await fixture(mode);
+      await startTranscripts(f.manager, f.sink);
+      const starts = ["100000000000000001", "guest-a", "guest-b"].map(f.begin);
+      // The packet that triggered speaking.start is delivered immediately after the listener.
+      expect([...f.streams.keys()]).toEqual(["100000000000000001", "guest-a", "guest-b"]);
+      for (const [index, stream] of [...f.streams.values()].entries()) {
+        stream.end(Buffer.alloc(96_000, index + 1));
+      }
+      await Promise.all(starts);
+      await f.entry.processingQueue;
+      expect(
+        f.sink.mock.calls
+          .map(([u]) => [u.speaker.id, u.speaker.label, u.text])
+          .toSorted(([leftSpeakerId], [rightSpeakerId]) =>
+            leftSpeakerId.localeCompare(rightSpeakerId),
+          ),
+      ).toEqual([
+        ["100000000000000001", "Owner", "audio-1-96000"],
+        ["guest-a", "Guest", "audio-2-96000"],
+        ["guest-b", "Guest", "audio-3-96000"],
+      ]);
+      expect(decodeOpusStreamChunksMock).toHaveBeenCalledTimes(3);
+      expect(transcribeAudioFileMock).toHaveBeenCalledTimes(3);
+      expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "ambient mixed final");
+      await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "second mixed final");
+      expect(f.sink).toHaveBeenCalledTimes(3);
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("records protected-playback speech without interruption or conversational fallthrough", async () => {
+    const f = await fixture();
+    await startTranscripts(f.manager, f.sink);
+    const player = getLastAudioPlayer();
+    player.state.status = "playing";
+    const stopCalls = player.stop.mock.calls.length;
+    await Promise.all([f.audio("100000000000000001", 1), f.audio("guest", 2)]);
+    expect(f.sink).toHaveBeenCalledTimes(2);
+    expect(player.stop).toHaveBeenCalledTimes(stopCalls);
+    expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+    expect(agentCommandMock).not.toHaveBeenCalled();
+    expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+    expect(player.play).not.toHaveBeenCalled();
+  });
+
+  it("shares one batch transcription between recording and authorized conversation", async () => {
+    const f = await fixture("stt-tts");
+    await startTranscripts(f.manager, f.sink);
+    await f.audio("100000000000000001", 1);
+    await f.audio("guest", 2);
+    expect(transcribeAudioFileMock).toHaveBeenCalledTimes(2);
+    expect(f.sink).toHaveBeenCalledTimes(2);
+    expect(agentCommandMock).toHaveBeenCalledOnce();
+    expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+    expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { excluded: 1, dispatch: "conversation" },
+    { excluded: 2, dispatch: "conversation" },
+    { excluded: 1, dispatch: "control" },
+    { excluded: 2, dispatch: "control" },
+  ])(
+    "withholds $dispatch after chunk $excluded loses authorization",
+    async ({ excluded, dispatch }) => {
+      const f = await fixture(
+        "stt-tts",
+        false,
+        {
+          tools: { media: { audio: { maxBytes: 192_044 } } },
+        },
+        true,
+      );
+      let allowed = true;
+      f.client.fetchMember.mockImplementation(async (_guild, userId) => ({
+        nickname: "Guest",
+        roles: allowed ? ["200000000000000001"] : [],
+        user: { id: userId },
+      }));
+      const texts =
+        dispatch === "control"
+          ? ["please", "do not", "stop that"]
+          : ["Opening", "do not", "send the update"];
+      if (dispatch === "control") {
+        controlRealtimeVoiceAgentRunMock.mockResolvedValue({
+          ok: true,
+          mode: "cancel",
+          active: true,
+          aborted: true,
+          sessionKey: expectDefined(f.entry.route?.sessionKey, "voice session route"),
+          message: "Cancelled",
+          speak: false,
+          show: true,
+          suppress: true,
+        });
+      }
+      const writeWav = voiceAudio.writeVoiceWavFile;
+      const wavSpy = vi.spyOn(voiceAudio, "writeVoiceWavFile").mockImplementation(async (pcm) => {
+        // Admission has completed; change the observed member roles before the chunk's queue check.
+        allowed = pcm[0] !== excluded;
+        return writeWav(pcm);
+      });
+      transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+        const wav = await fs.readFile(filePath);
+        return { text: texts[wav.readUInt8(44) - 1] };
+      });
+      await startTranscripts(f.manager, f.sink);
+      const receiving = f.begin("guest");
+      const stream = f.streams.get("guest")!;
+      try {
+        for (let marker = 1; marker <= 3; marker++) {
+          const recorded = createDeferred<void>();
+          f.sink.mockImplementationOnce(() => recorded.resolve());
+          stream.write(Buffer.alloc(192_000, marker));
+          await recorded.promise;
+          expect(f.sink).toHaveBeenCalledTimes(marker);
+          await f.entry.processingQueue;
+          expect(wavSpy).toHaveBeenCalledTimes(marker);
+          expect(allowed).toBe(marker !== excluded);
+        }
+        allowed = true;
+        stream.end();
+        await receiving;
+        await f.entry.processingQueue;
+        expect(f.sink.mock.calls.map(([u]) => u.text)).toEqual(texts);
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+        transcribeAudioFileMock.mockResolvedValue({ text: "A complete new request" });
+        await f.audio("guest", 4);
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(f.sink).toHaveBeenCalledTimes(4);
+      } finally {
+        stream.end();
+        await receiving;
+        await f.entry.processingQueue;
+        wavSpy.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    { mode: "agent-proxy", ownFailure: false },
+    { mode: "agent-proxy", ownFailure: true },
+    { mode: "stt-tts", ownFailure: false },
+    { mode: "stt-tts", ownFailure: true },
+  ] as const)(
+    "retains failures after decode while $mode admission waits (own=$ownFailure)",
+    async ({ mode, ownFailure }) => {
+      const f = await fixture(mode);
+      await startTranscripts(f.manager, f.sink);
+      await f.audio("100000000000000001", 7);
+      const release = createDeferred<void>();
+      const decoded = createDeferred<void>();
+      const member = f.client.fetchMember.getMockImplementation()!;
+      f.client.fetchMember.mockImplementationOnce(async (...args) => {
+        await release.promise;
+        return member(...args);
+      });
+      decodeOpusStreamChunksMock.mockImplementation(async (input, params) => {
+        for await (const packet of input) {
+          decoded.resolve();
+          await params.onChunk(packet, packet);
+        }
+      });
+      const audioCalls = realtimeSessionMock.sendAudio.mock.calls.length;
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      stream.write(Buffer.alloc(96_000, 8));
+      await decoded.promise;
+      const others: Promise<void>[] = [];
+      const fail = (userId: string) => {
+        others.push(f.begin(userId));
+        f.streams.get(userId)!.destroy(new Error("DecryptionFailed(InvalidCiphertext)"));
+      };
+      try {
+        if (ownFailure) {
+          stream.destroy(new Error("DecryptionFailed(InvalidCiphertext)"));
+        } else {
+          fail("failed-1");
+        }
+        fail("failed-2");
+        await vi.waitFor(() => expect(f.entry.receiveRecovery.decryptFailureCount).toBe(2));
+        release.resolve();
+        if (!ownFailure) {
+          stream.end();
+        }
+        await receiving;
+        await Promise.all(others);
+        await f.entry.processingQueue;
+        expect(f.entry.receiveRecovery.decryptFailureCount).toBe(2);
+        if (ownFailure) {
+          expect(realtimeSessionMock.sendAudio.mock.calls.length).toBe(audioCalls);
+          expect(f.sink).toHaveBeenCalledOnce();
+        } else {
+          expect(f.sink).toHaveBeenCalledTimes(2);
+        }
+        fail("failed-3");
+        await Promise.all(others);
+        await vi.waitFor(() => {
+          expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2);
+          expectConnectedStatus(f.manager, "1001");
+        });
+      } finally {
+        release.resolve();
+        stream.end();
+        await receiving;
+        await Promise.all(others);
+      }
+    },
+  );
+
+  it.each(["normal", "decoder failure"])(
+    "finalizes batch conversation after %s utterance end",
+    async (ending) => {
+      const f = await fixture("stt-tts", false, {
+        tools: { media: { audio: { maxBytes: 192_044 } } },
+      });
+      if (ending === "decoder failure") {
+        decodeOpusStreamChunksMock.mockImplementation(async (input, params) => {
+          for await (const packet of input) {
+            if (packet[0] === 2) {
+              params.onError?.(new Error("memory access out of bounds"));
+              return;
+            }
+            await params.onChunk(packet, packet);
+          }
+        });
+      }
+      await startTranscripts(f.manager, f.sink);
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      stream.write(Buffer.alloc(192_000, 1));
+      await vi.waitFor(() => expect(f.sink).toHaveBeenCalledOnce());
+      await f.entry.processingQueue;
+      try {
+        expect(agentCommandMock).not.toHaveBeenCalled();
+      } finally {
+        stream.end(Buffer.alloc(192_000, 2));
+        await receiving;
+        await f.entry.processingQueue;
+        await Promise.all(f.conversations.mock.results.map((result) => result.value));
+      }
+      if (ending === "decoder failure") {
+        expect(transcribeAudioFileMock).toHaveBeenCalledOnce();
+        expect(f.sink).toHaveBeenCalledOnce();
+        expect(agentCommandMock).not.toHaveBeenCalled();
+      } else {
+        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(2);
+        expect(f.sink).toHaveBeenCalledTimes(2);
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+          message: expect.stringContaining("audio-1-192000\naudio-2-192000"),
+        });
+      }
+    },
+  );
+
+  it.each([
+    { dispatch: "conversation", middle: "failure" },
+    { dispatch: "control", middle: "failure" },
+    { dispatch: "conversation", middle: "success" },
+    { dispatch: "control", middle: "success" },
+    { dispatch: "conversation", middle: "empty" },
+    { dispatch: "conversation", middle: "cleanup failure" },
+  ])(
+    "settles every chunk before $dispatch dispatch with middle $middle",
+    async ({ dispatch, middle }) => {
+      const f = await fixture("stt-tts", false, {
+        tools: { media: { audio: { maxBytes: 192_044 } } },
+      });
+      await startTranscripts(f.manager, f.sink);
+      const texts =
+        dispatch === "control"
+          ? ["please", "now", "stop that"]
+          : ["Opening context", "middle context", "closing context"];
+      const sessionKey = expectDefined(f.entry.route?.sessionKey, "voice session route");
+      const release = createDeferred<void>();
+      const wavPaths: string[] = [];
+      transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+        wavPaths.push(filePath);
+        const wav = await fs.readFile(filePath);
+        const marker = wav.readUInt8(44);
+        if (marker === 2) {
+          await release.promise;
+          if (middle === "failure") {
+            throw new Error("synthetic transcription failure");
+          }
+          if (middle === "empty") {
+            return { text: undefined };
+          }
+        }
+        return { text: texts[marker - 1] };
+      });
+      controlRealtimeVoiceAgentRunMock.mockResolvedValue({
+        ok: true,
+        mode: "cancel",
+        sessionKey,
+        active: true,
+        aborted: true,
+        message: "Cancelled",
+        speak: false,
+        show: true,
+        suppress: true,
+      });
+      const writeWav = voiceAudio.writeVoiceWavFile;
+      const cleanupSpy =
+        middle === "cleanup failure"
+          ? vi.spyOn(voiceAudio, "writeVoiceWavFile").mockImplementation(async (pcm) => {
+              const wav = await writeWav(pcm);
+              return {
+                ...wav,
+                cleanup: async () => {
+                  await wav.cleanup();
+                  if (pcm[0] === 2) {
+                    throw new Error("synthetic cleanup failure after disposal");
+                  }
+                },
+              };
+            })
+          : undefined;
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      stream.write(Buffer.alloc(192_000, 1));
+      stream.write(Buffer.alloc(192_000, 2));
+      stream.end(Buffer.alloc(192_000, 3));
+      try {
+        // Speech ends while the middle STT request is still pending, so the finalizer
+        // is already queued before its outcome is known.
+        await receiving;
+        await vi.waitFor(() => expect(transcribeAudioFileMock).toHaveBeenCalledTimes(2));
+        expect(f.sink.mock.calls.map(([utterance]) => utterance.text)).toEqual([texts[0]]);
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        await f.entry.processingQueue;
+        cleanupSpy?.mockRestore();
+      }
+      if (middle === "cleanup failure") {
+        expect(loggerWarnMock).toHaveBeenCalledWith(
+          expect.stringContaining("synthetic cleanup failure after disposal"),
+        );
+      }
+      const savedTexts = middle === "failure" || middle === "empty" ? [texts[0], texts[2]] : texts;
+      expect(f.sink.mock.calls.map(([utterance]) => utterance.text)).toEqual(savedTexts);
+      expect(wavPaths).toHaveLength(3);
+      for (const wavPath of wavPaths) {
+        await expect(fs.access(wavPath)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+      if (middle === "failure") {
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+        // A failed utterance must not poison the next one on the same receiver.
+        transcribeAudioFileMock.mockResolvedValue({ text: "A complete new request" });
+        await f.audio("100000000000000001", 4);
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(f.sink).toHaveBeenLastCalledWith(
+          expect.objectContaining({ text: "A complete new request" }),
+        );
+      } else if (dispatch === "control") {
+        expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledExactlyOnceWith({
+          sessionKey,
+          text: texts.join("\n"),
+        });
+        expect(agentCommandMock).not.toHaveBeenCalled();
+      } else {
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+          message: expect.stringContaining(savedTexts.join("\n")),
+        });
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each([
+    { transition: "enable", speech: "short conversation" },
+    { transition: "disable", speech: "short conversation" },
+    { transition: "enable", speech: "short control" },
+    { transition: "disable", speech: "short control" },
+    { transition: "enable", speech: "complete" },
+    { transition: "disable", speech: "complete" },
+  ])(
+    "preserves capture and dispatches only complete speech across $transition with $speech",
+    async ({ transition, speech }) => {
+      const f = await fixture("stt-tts", false, {
+        tools: { media: { audio: { maxBytes: 192_044 } } },
+      });
+      const complete = speech === "complete";
+      const uncapturedFrames = complete ? 50 : 12;
+      const openingFrames = transition === "enable" ? uncapturedFrames : 50;
+      const closingFrames = transition === "enable" ? 50 : uncapturedFrames;
+      const capturedMarker = transition === "enable" ? 2 : 1;
+      const capturedText = speech === "short control" ? "stop that" : "Send the update";
+      const texts = complete
+        ? ["Opening context", "closing context"]
+        : transition === "enable"
+          ? ["Do not", capturedText]
+          : [capturedText, "actually don't"];
+      const transcribedMarkers: number[] = [];
+      transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
+        const wav = await fs.readFile(filePath);
+        const marker = wav.readUInt8(44);
+        transcribedMarkers.push(marker);
+        return { text: texts[marker - 1] };
+      });
+      const openingDecoded = createDeferred<void>();
+      decodeOpusStreamChunksMock.mockImplementationOnce(async (input, params) => {
+        let decoded = 0;
+        for await (const packet of input) {
+          await params.onChunk(packet, packet);
+          if (++decoded === openingFrames) {
+            openingDecoded.resolve();
+          }
+        }
+      });
+      if (transition === "disable") {
+        expect(await startTranscripts(f.manager, f.sink)).toMatchObject({ ok: true });
+      }
+      const receiving = f.begin("100000000000000001");
+      const stream = f.streams.get("100000000000000001")!;
+      try {
+        // Each decoded packet is 20 ms of 48 kHz stereo PCM. Change capture only
+        // after the receiver has consumed the opening speech, before utterance end.
+        for (let frame = 0; frame < openingFrames; frame++) {
+          stream.write(Buffer.alloc(3_840, 1));
+        }
+        await openingDecoded.promise;
+        await f.entry.processingQueue;
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+        expect(
+          transition === "enable"
+            ? await startTranscripts(f.manager, f.sink)
+            : await stopTranscripts(),
+        ).toMatchObject({ ok: true });
+        for (let frame = 0; frame < closingFrames; frame++) {
+          stream.write(Buffer.alloc(3_840, 2));
+        }
+      } finally {
+        stream.end();
+        await receiving;
+        await f.entry.processingQueue;
+      }
+      expect(getSessionConnection(f.entry).receiver.subscribe).toHaveBeenCalledOnce();
+      expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce();
+      await Promise.all(f.conversations.mock.results.map((result) => result.value));
+      expect(transcribedMarkers).toEqual(complete ? [1, 2] : [capturedMarker]);
+      expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ text: texts[capturedMarker - 1], sessionId: "notes-1" }),
+      );
+      expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+      if (complete) {
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+          message: expect.stringContaining(texts.join("\n")),
+        });
+      } else {
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        transcribeAudioFileMock.mockResolvedValue({ text: "A complete new request" });
+        await f.audio("100000000000000001", 3);
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+          message: expect.stringContaining("A complete new request"),
+        });
+        expect(f.sink).toHaveBeenCalledTimes(transition === "enable" ? 2 : 1);
+      }
+    },
+  );
+
+  it("preserves one complete batch utterance when recording is not active", async () => {
+    const f = await fixture("stt-tts", false, {
+      tools: { media: { audio: { maxBytes: 192_044 } } },
+    });
+    const receiving = f.begin("100000000000000001");
+    const stream = f.streams.get("100000000000000001")!;
+    stream.write(Buffer.alloc(64_000, 1));
+    stream.write(Buffer.alloc(64_000, 2));
+    stream.end(Buffer.alloc(64_000, 3));
+    await receiving;
+    await f.entry.processingQueue;
+    await Promise.all(f.conversations.mock.results.map((result) => result.value));
+    expect(transcribeAudioFileMock).toHaveBeenCalledOnce();
+    expect(agentCommandMock).toHaveBeenCalledOnce();
+    expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+      message: expect.stringContaining("audio-1-192000"),
+    });
+    expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+    expect(f.sink).not.toHaveBeenCalled();
+  });
+
+  it.each(["identity", "decoder"])("revokes opening packets while %s is pending", async (stage) => {
+    const f = await fixture();
+    await startTranscripts(f.manager, f.sink);
+    const { promise: blocked, resolve: release } = createDeferred<void>();
+    if (stage === "identity") {
+      f.client.fetchMember.mockImplementation(async () => {
+        await blocked;
+        return { nickname: "Guest", user: { id: "guest" } };
+      });
+    } else {
+      decodeOpusStreamChunksMock.mockImplementation(async (stream, params) => {
+        await blocked;
+        for await (const pcm of stream) {
+          await params.onChunk(pcm, pcm);
+        }
+      });
+    }
+    const receiving = f.begin("guest");
+    expect(f.streams.has("guest")).toBe(true);
+    f.streams.get("guest")!.end(Buffer.alloc(96_000, 3));
+    await stopTranscripts();
+    const replacement = vi.fn();
+    await startTranscripts(f.manager, replacement, "notes-2");
+    release();
+    await receiving;
+    await f.entry.processingQueue;
+    expect(f.sink).not.toHaveBeenCalled();
+    expect(replacement).not.toHaveBeenCalled();
+    expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+    expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+    expect(agentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["start", "replace"])(
+    "binds new audio during continuous speech at capture %s",
+    async (phase) => {
+      const f = await fixture();
+      if (phase === "replace") {
+        await startTranscripts(f.manager, f.sink);
+      }
+      const receiving = f.begin("100000000000000001");
+      await vi.waitFor(() => expect(f.streams.has("100000000000000001")).toBe(true));
+      const stream = f.streams.get("100000000000000001")!;
+      stream.write(Buffer.alloc(96_000, 1));
+      await vi.waitFor(() => expect(realtimeSessionMock.sendAudio).toHaveBeenCalled());
+      const nextSink = vi.fn();
+      await startTranscripts(f.manager, nextSink, "notes-2");
+      stream.end(Buffer.alloc(96_000, 2));
+      await receiving;
+      await f.entry.processingQueue;
+      expect(nextSink).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ text: "audio-2-96000" }),
+      );
+      expect(f.sink).not.toHaveBeenCalled();
+      expect(getSessionConnection(f.entry).receiver.subscribe).toHaveBeenCalledOnce();
+      expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("starts recording a continuously speaking denied participant", async () => {
+    const f = await fixture();
+    await f.begin("guest");
+    expect(f.streams.size).toBe(0);
+    f.entry.connection.receiver.speaking.users.set("guest", Date.now());
+    await startTranscripts(f.manager, f.sink);
+    expect(f.streams.has("guest")).toBe(true);
+    f.streams.get("guest")!.end(Buffer.alloc(96_000, 2));
+    await vi.waitFor(() => expect(f.sink).toHaveBeenCalledOnce());
+    expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+    expect(agentCommandMock).not.toHaveBeenCalled();
+  });
+
+  it.each([3_884, 192_044])(
+    "retains recording chunks under the prepared %i-byte upload cap with ingress timestamps",
+    async (maxBytes) => {
+      const pcmBytes = maxBytes - 44;
+      resolveAudioInputBudgetMock.mockResolvedValueOnce({ enabled: true, maxBytes });
+      const f = await fixture("agent-proxy", false, {
+        tools: {
+          media: {
+            models: [
+              { provider: "example", capabilities: ["image"], maxBytes: 96_044 },
+              { provider: "example", capabilities: ["audio"], maxBytes },
+            ],
+          },
+        },
+      });
+      await startTranscripts(f.manager, f.sink);
+      const receiving = f.begin("guest");
+      const clock = vi.spyOn(Date, "now");
+      try {
+        clock.mockReturnValue(1_000_000);
+        f.streams.get("guest")!.write(Buffer.alloc(pcmBytes, 1));
+        clock.mockReturnValue(1_010_000);
+        f.streams.get("guest")!.end(Buffer.alloc(pcmBytes, 2));
+        await receiving;
+        await f.entry.processingQueue;
+        expect(f.sink.mock.calls.map(([u]) => [Date.parse(u.startedAt), u.text])).toEqual([
+          [1_000_000, `audio-1-${pcmBytes}`],
+          [1_010_000, `audio-2-${pcmBytes}`],
+        ]);
+      } finally {
+        clock.mockRestore();
+      }
+    },
+  );
+
+  it("retains queued WAV input until processing owns its release", async () => {
+    const f = await fixture();
+    await startTranscripts(f.manager, f.sink);
+    const { promise: blocked, resolve: release } = createDeferred<void>();
+    f.entry.processingQueue = blocked;
+    const removals = vi.spyOn(fs, "rm");
+    vi.useFakeTimers();
+    try {
+      const receiving = f.begin("guest");
+      f.streams.get("guest")!.end(Buffer.alloc(96_000, 3));
+      await receiving;
+      await vi.advanceTimersByTimeAsync(30 * 60 * 1_000 + 1);
+      await Promise.all(removals.mock.results.map((result) => result.value));
+      release();
+      await f.entry.processingQueue;
+      expect(f.sink).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ text: "audio-3-96000" }),
+      );
+    } finally {
+      release();
+      vi.useRealTimers();
+      removals.mockRestore();
+    }
+  });
+
+  it.each(["missing", "disabled"])(
+    "grants no passive receive access with %s capture",
+    async (kind) => {
+      const f = await fixture(
+        "agent-proxy",
+        false,
+        kind === "disabled" ? { transcripts: { enabled: false } } : {},
+      );
+      await f.begin("guest");
+      expect(f.streams.size).toBe(0);
+      expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+      expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("flushes bounded contiguous long speech with ingress timestamps", async () => {
+    const f = await fixture();
+    const packetCount = 130;
+    const consumed = Array.from({ length: packetCount }, () => createDeferred<void>());
+    const processed = createDeferred<void>();
+    decodeOpusStreamChunksMock.mockImplementationOnce(async (input, params) => {
+      let decodedPackets = 0;
+      try {
+        for await (const packet of input) {
+          await params.onChunk(packet, packet);
+          consumed[decodedPackets]!.resolve();
+          decodedPackets += 1;
+          if (decodedPackets === packetCount) {
+            processed.resolve();
+          }
+        }
+        if (decodedPackets < packetCount) {
+          processed.reject(new Error("Voice input ended before all test packets were processed"));
+        }
+      } catch (error) {
+        processed.reject(error);
+        params.onError?.(error);
+      }
+    });
+    await startTranscripts(f.manager, f.sink);
+    const startedBefore = Date.now();
+    const receiving = f.begin("guest");
+    await vi.waitFor(() => expect(f.streams.has("guest")).toBe(true));
+    const stream = f.streams.get("guest")!;
+    const frame = Buffer.alloc(192_000, 7);
+    try {
+      const clock = vi.spyOn(Date, "now");
+      try {
+        for (let second = 0; second < packetCount; second++) {
+          clock.mockReturnValue(startedBefore + second * 1_000);
+          stream.write(frame);
+          await consumed[second]!.promise;
+        }
+      } finally {
+        clock.mockRestore();
+      }
+      // Observe the real WAV write/queue work, not a one-second disk deadline.
+      await processed.promise;
+      await f.entry.processingQueue;
+      expect(transcribeAudioFileMock).toHaveBeenCalled();
+    } finally {
+      stream.end();
+      await receiving;
+      await f.entry.processingQueue;
+    }
+    const utterances = f.sink.mock.calls.map(([u]) => u);
+    expect(utterances.length).toBeGreaterThan(1);
+    expect(utterances.every((u) => u.speaker.id === "guest")).toBe(true);
+    expect(utterances.reduce((bytes, u) => bytes + Number(u.text.split("-")[2]), 0)).toBe(
+      packetCount * frame.length,
+    );
+    expect(Date.parse(utterances[0].startedAt)).toBeGreaterThanOrEqual(startedBefore);
+    expect(
+      Date.parse(utterances.at(-1).startedAt) - Date.parse(utterances[0].startedAt),
+    ).toBeGreaterThan(60_000);
+  });
+
+  it.each(["queue", "stt"])(
+    "revokes captured audio during %s without redirecting it to a replacement",
+    async (stage) => {
+      const f = await fixture();
+      await startTranscripts(f.manager, f.sink);
+      const { promise: blocked, resolve: release } = createDeferred<void>();
+      if (stage === "queue") {
+        f.entry.processingQueue = blocked;
+      } else {
+        transcribeAudioFileMock.mockImplementationOnce(async () => {
+          await blocked;
+          return { text: "stale recording" };
+        });
+      }
+      const receiving = f.begin("guest");
+      await vi.waitFor(() => expect(f.streams.has("guest")).toBe(true));
+      f.streams.get("guest")!.end(Buffer.alloc(96_000));
+      await receiving;
+      if (stage === "stt") {
+        await vi.waitFor(() => expect(transcribeAudioFileMock).toHaveBeenCalledOnce());
+      }
+      await stopTranscripts();
+      const replacement = vi.fn();
+      await startTranscripts(f.manager, replacement, "notes-2");
+      release();
+      await f.entry.processingQueue;
+      expect(f.sink).not.toHaveBeenCalled();
+      expect(replacement).not.toHaveBeenCalled();
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps already-received final audio across occupancy departure and rejects stale bytes", async () => {
+    const f = await fixture("agent-proxy", true);
+    await startTranscripts(f.manager, f.sink);
+    const { promise: decoderReady, resolve: releaseDecoder } = createDeferred<void>();
+    decodeOpusStreamChunksMock.mockImplementation(async (stream, params) => {
+      await decoderReady;
+      for await (const pcm of stream) {
+        await params.onChunk(pcm, pcm);
+      }
+    });
+    const receiving = f.begin("guest");
+    expect(f.streams.has("guest")).toBe(true);
+    f.streams.get("guest")!.write(Buffer.alloc(96_000, 4));
+    await vi.waitFor(() => expect(f.streams.get("guest")!.readableLength).toBe(0));
+    f.states.length = 0;
+    await updateVoiceState(f.manager, "100000000000000001", null);
+    f.streams.get("guest")!.emit("data", Buffer.alloc(96_000, 9));
+    releaseDecoder();
+    await receiving;
+    await f.entry.processingQueue;
+    expect(f.sink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        speaker: { id: "guest", label: "Guest" },
+        text: "audio-4-96000",
+      }),
+    );
+    await f.begin("stale-speaker");
+    expect(f.streams.has("stale-speaker")).toBe(false);
+    expect(agentCommandMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/voice/transcripts-source.test.ts
+++ b/extensions/discord/src/voice/transcripts-source.test.ts
@@ -1,17 +1,44 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Discord tests cover transcripts source plugin behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { Guild, RequestClient } from "../internal/discord.js";
 import {
   discordVoiceTranscriptsSourceProvider,
   setDiscordTranscriptsVoiceManager,
 } from "./transcripts-source.js";
-import type { DiscordVoiceManager } from "./voice-runtime.js";
+
+type TranscriptsManager = NonNullable<
+  Parameters<typeof setDiscordTranscriptsVoiceManager>[0]["manager"]
+>;
 
 describe("discordVoiceTranscriptsSourceProvider", () => {
-  afterEach(() => {
-    setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: null });
-    setDiscordTranscriptsVoiceManager({ accountId: "delayed", manager: null });
-    setDiscordTranscriptsVoiceManager({ accountId: "work", manager: null });
+  const managers = new Map<string, TranscriptsManager>();
+  function registerManager(params: { accountId: string; manager: Partial<TranscriptsManager> }) {
+    const manager: TranscriptsManager = {
+      resolveAccessTarget: vi.fn(async () => undefined),
+      startTranscriptsCapture: vi.fn(async () => ({ ok: true, message: "joined" })),
+      stopTranscriptsCapture: vi.fn(async () => {}),
+      watchChannelOccupancy: vi.fn(() => vi.fn()),
+      ...params.manager,
+    };
+    managers.set(params.accountId, manager);
+    setDiscordTranscriptsVoiceManager({ accountId: params.accountId, manager });
+  }
+  afterEach(async () => {
+    for (const [accountId, manager] of managers) {
+      const active = await discordVoiceTranscriptsSourceProvider.status!({
+        providerId: "discord-voice",
+        accountId,
+      });
+      for (const capture of active) {
+        await discordVoiceTranscriptsSourceProvider.stop!({
+          sessionId: capture.sessionId!,
+          source: capture.source!,
+        });
+      }
+      setDiscordTranscriptsVoiceManager({ accountId, manager: null, expectedManager: manager });
+    }
+    managers.clear();
     vi.useRealTimers();
   });
 
@@ -20,16 +47,21 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
   });
 
   it("authorizes the resolved target with the native voice policy", async () => {
-    setDiscordTranscriptsVoiceManager({
+    const guild = new Guild<true>(
+      { rest: new RequestClient("token-primary"), fetchUser: vi.fn() },
+      "g1",
+    );
+    vi.spyOn(guild, "name", "get").mockReturnValue("Guild One");
+    registerManager({
       accountId: "primary",
       manager: {
         resolveAccessTarget: vi.fn(async () => ({
-          guild: { id: "g1", name: "Guild One" },
+          guild,
           channelName: "General Voice",
           channelSlug: "general-voice",
-          scope: "channel",
+          scope: "channel" as const,
         })),
-      } as unknown as DiscordVoiceManager,
+      },
     });
     const cfg = {
       channels: {
@@ -112,64 +144,90 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
   it.each([undefined, "Operator meeting"])(
     "starts capture, retains title %s, and reports retirement",
     async (title) => {
-      const join = vi.fn<DiscordVoiceManager["join"]>(async () => ({
+      const join = vi.fn<TranscriptsManager["startTranscriptsCapture"]>(async () => ({
         ok: true,
         message: "joined",
         channelName: "Planning room",
       }));
-      setDiscordTranscriptsVoiceManager({
+      registerManager({ accountId: "primary", manager: { startTranscriptsCapture: join } });
+      const source = {
+        providerId: "discord-voice",
         accountId: "primary",
-        manager: { join } as unknown as DiscordVoiceManager,
-      });
-
+        guildId: "g1",
+        channelId: "c1",
+      };
       const onUtterance = vi.fn();
       const onStatus = vi.fn();
       const result = await discordVoiceTranscriptsSourceProvider.start?.({
-        session: {
-          sessionId: "notes-1",
-          title,
-          startedAt: new Date().toISOString(),
-          source: {
-            providerId: "discord-voice",
-            accountId: "primary",
-            guildId: "g1",
-            channelId: "c1",
-          },
-        },
+        session: { sessionId: "notes-1", title, startedAt: new Date().toISOString(), source },
         onUtterance,
         onStatus,
       });
-
       expect(result).toMatchObject({ ok: true, session: { title: title ?? "Planning room" } });
-      expect(join).toHaveBeenCalledWith(
-        { guildId: "g1", channelId: "c1" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance,
-            onStop: expect.any(Function),
+      expect(join).toHaveBeenCalledExactlyOnceWith({
+        accountId: "primary",
+        guildId: "g1",
+        channelId: "c1",
+      });
+      const replacementTitle = title ? undefined : "Replacement meeting";
+      expect(
+        await discordVoiceTranscriptsSourceProvider.start!({
+          session: {
+            sessionId: "notes-2",
+            title: replacementTitle,
+            startedAt: new Date().toISOString(),
+            source,
           },
-        },
-      );
-      await join.mock.calls[0]?.[1]?.transcripts?.onStop?.();
+          onUtterance,
+        }),
+      ).toMatchObject({ ok: true, session: { title: replacementTitle ?? "Planning room" } });
+      expect(join).toHaveBeenCalledOnce();
       expect(onStatus).toHaveBeenCalledExactlyOnceWith({
         active: false,
         sessionId: "notes-1",
-        source: {
-          providerId: "discord-voice",
-          accountId: "primary",
-          guildId: "g1",
-          channelId: "c1",
-        },
+        source,
       });
+      await discordVoiceTranscriptsSourceProvider.stop!({ sessionId: "notes-2", source });
     },
   );
 
+  it("keeps the active capture when its manager changes before replacement admission", async () => {
+    registerManager({ accountId: "primary", manager: {} });
+    const source = {
+      providerId: "discord-voice",
+      accountId: "primary",
+      guildId: "g1",
+      channelId: "c1",
+    };
+    const onStatus = vi.fn();
+    expect(
+      await discordVoiceTranscriptsSourceProvider.start!({
+        session: { sessionId: "first", source, startedAt: new Date().toISOString() },
+        onUtterance: vi.fn(),
+        onStatus,
+      }),
+    ).toMatchObject({ ok: true });
+    const replacement = discordVoiceTranscriptsSourceProvider.start!({
+      session: { sessionId: "second", source, startedAt: new Date().toISOString() },
+      onUtterance: vi.fn(),
+    });
+    registerManager({ accountId: "primary", manager: {} });
+    expect(await replacement).toMatchObject({ ok: false });
+    expect(onStatus).not.toHaveBeenCalled();
+    expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject([
+      { active: true, sessionId: "first" },
+    ]);
+    expect(
+      await discordVoiceTranscriptsSourceProvider.stop!({ sessionId: "first", source }),
+    ).toMatchObject({ ok: true });
+    expect(onStatus).toHaveBeenCalledOnce();
+  });
+
   it("uses the sole voice-capable account instead of a text-only default", async () => {
     const workJoin = vi.fn(async () => ({ ok: true, message: "joined work" }));
-    setDiscordTranscriptsVoiceManager({
+    registerManager({
       accountId: "work",
-      manager: { join: workJoin } as unknown as DiscordVoiceManager,
+      manager: { startTranscriptsCapture: workJoin },
     });
     const source = {
       providerId: "discord-voice",
@@ -289,9 +347,9 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
 
   it("excludes voice accounts whose configured credentials are unavailable", async () => {
     const primaryJoin = vi.fn(async () => ({ ok: true, message: "joined primary" }));
-    setDiscordTranscriptsVoiceManager({
+    registerManager({
       accountId: "primary",
-      manager: { join: primaryJoin } as unknown as DiscordVoiceManager,
+      manager: { startTranscriptsCapture: primaryJoin },
     });
     const unavailableAccount = {
       token: { source: "env", provider: "default", id: "DISCORD_WORK_TOKEN" },
@@ -417,9 +475,9 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     expect(join).not.toHaveBeenCalled();
 
-    setDiscordTranscriptsVoiceManager({
+    registerManager({
       accountId: "delayed",
-      manager: { join } as unknown as DiscordVoiceManager,
+      manager: { startTranscriptsCapture: join },
     });
 
     await expect(resultPromise).resolves.toMatchObject({ ok: true });
@@ -455,16 +513,16 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
       const unsubscribe = vi.fn(() => {
         listener = undefined;
       });
-      const watchChannelOccupancy = vi.fn<DiscordVoiceManager["watchChannelOccupancy"]>(
+      const watchChannelOccupancy = vi.fn<TranscriptsManager["watchChannelOccupancy"]>(
         (_room, callback) => {
           listener = callback;
           callback({ occupied: true });
           return unsubscribe;
         },
       );
-      const manager = { watchChannelOccupancy } as unknown as DiscordVoiceManager;
+      const manager = { watchChannelOccupancy };
       if (readiness === "registered") {
-        setDiscordTranscriptsVoiceManager({ accountId: "work", manager });
+        registerManager({ accountId: "work", manager });
       }
       const transitions: string[] = [];
       const request = discordVoiceTranscriptsSourceProvider.watchOccupancy?.({
@@ -491,7 +549,7 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
       if (readiness === "delayed") {
         await vi.advanceTimersByTimeAsync(1_000);
         expect(transitions).toEqual([]);
-        setDiscordTranscriptsVoiceManager({ accountId: "work", manager });
+        registerManager({ accountId: "work", manager });
       }
       const result = await request;
       expect(result?.ok).toBe(true);
@@ -509,6 +567,104 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
       expect(transitions).toEqual(["occupied", "empty"]);
       expect(unsubscribe).toHaveBeenCalledOnce();
       expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it("keeps occupancy transitions across replacement manager snapshots", async () => {
+    const listeners: Array<(state: { occupied: boolean }) => void> = [];
+    const replace = (occupied: boolean) => {
+      registerManager({
+        accountId: "work",
+        manager: {
+          watchChannelOccupancy: (_target, listener) => {
+            listeners.push(listener);
+            listener({ occupied });
+            return vi.fn();
+          },
+        },
+      });
+    };
+    replace(false);
+    const transitions: boolean[] = [];
+    const result = await discordVoiceTranscriptsSourceProvider.watchOccupancy!({
+      source: { providerId: "discord-voice", accountId: "work", guildId: "g1", channelId: "c1" },
+      onOccupied: () => transitions.push(true),
+      onEmpty: () => transitions.push(false),
+    });
+    if (!result.ok) {
+      throw new Error(result.error);
+    }
+    try {
+      expect.soft(transitions).toEqual([]);
+      listeners[0]!({ occupied: true });
+      expect.soft(transitions).toEqual([true]);
+      replace(true);
+      expect.soft(transitions).toEqual([true]);
+      replace(false);
+      expect.soft(transitions).toEqual([true, false]);
+      replace(false);
+      expect(transitions).toEqual([true, false]);
+    } finally {
+      result.value.stop();
+    }
+  });
+
+  it.each(["stop", "abort"])(
+    "reattaches occupancy to replacement managers and fences retired callbacks after %s",
+    async (ending) => {
+      const listeners: Array<(state: { occupied: boolean }) => void> = [];
+      const releases = [vi.fn(), vi.fn(), vi.fn()];
+      const replace = (occupied: boolean) => {
+        const release = releases[listeners.length]!;
+        registerManager({
+          accountId: "work",
+          manager: {
+            watchChannelOccupancy: (_target, listener) => {
+              listeners.push(listener);
+              listener({ occupied });
+              return release;
+            },
+          },
+        });
+      };
+      replace(true);
+      const transitions: boolean[] = [];
+      const abortController = new AbortController();
+      const result = await discordVoiceTranscriptsSourceProvider.watchOccupancy!({
+        source: { providerId: "discord-voice", accountId: "work", guildId: "g1", channelId: "c1" },
+        abortSignal: abortController.signal,
+        onOccupied: () => transitions.push(true),
+        onEmpty: () => transitions.push(false),
+      });
+      if (!result.ok) {
+        throw new Error(result.error);
+      }
+      try {
+        const retired = managers.get("work")!;
+        setDiscordTranscriptsVoiceManager({
+          accountId: "work",
+          manager: null,
+          expectedManager: retired,
+        });
+        listeners[0]!({ occupied: false });
+        expect(transitions).toEqual([true]);
+        expect(releases[0]).toHaveBeenCalledOnce();
+        replace(false);
+        listeners[0]!({ occupied: true });
+        expect(transitions).toEqual([true, false]);
+        if (ending === "abort") {
+          abortController.abort();
+        } else {
+          result.value.stop();
+        }
+        listeners[1]!({ occupied: true });
+        replace(true);
+        expect(listeners).toHaveLength(2);
+        expect(transitions).toEqual([true, false]);
+        expect(releases[1]).toHaveBeenCalledOnce();
+      } finally {
+        result.value.stop();
+      }
     },
   );
 
@@ -536,9 +692,9 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
         await vi.advanceTimersByTimeAsync(1_000);
       }
       await expect(result).resolves.toMatchObject({ ok: false });
-      setDiscordTranscriptsVoiceManager({
+      registerManager({
         accountId: "delayed",
-        manager: { watchChannelOccupancy } as unknown as DiscordVoiceManager,
+        manager: { watchChannelOccupancy },
       });
       expect(watchChannelOccupancy).not.toHaveBeenCalled();
       expect(vi.getTimerCount()).toBe(0);
@@ -546,10 +702,24 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
   );
 
   it("stops Discord transcripts without owning promoted voice sessions", async () => {
-    const leave = vi.fn(async () => ({ ok: true, message: "stopped notes" }));
-    setDiscordTranscriptsVoiceManager({
+    const stop = vi.fn(async () => {});
+    registerManager({
       accountId: "primary",
-      manager: { leave } as unknown as DiscordVoiceManager,
+      manager: { stopTranscriptsCapture: stop },
+    });
+
+    await discordVoiceTranscriptsSourceProvider.start!({
+      session: {
+        sessionId: "notes-1",
+        startedAt: new Date().toISOString(),
+        source: {
+          providerId: "discord-voice",
+          accountId: "primary",
+          guildId: "g1",
+          channelId: "c1",
+        },
+      },
+      onUtterance: vi.fn(),
     });
 
     const result = await discordVoiceTranscriptsSourceProvider.stop?.({
@@ -563,23 +733,18 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
     });
 
     expect(result).toMatchObject({ ok: true, sessionId: "notes-1" });
-    expect(leave).toHaveBeenCalledWith(
-      {
-        guildId: "g1",
-        channelId: "c1",
-      },
-      {
-        transcriptsSessionId: "notes-1",
-      },
-    );
+    expect(stop).toHaveBeenCalledExactlyOnceWith({
+      accountId: "primary",
+      guildId: "g1",
+      channelId: "c1",
+    });
   });
 
   it("does not route accountless lifecycle calls to an arbitrary voice manager", async () => {
-    const leave = vi.fn(async () => ({ ok: true, message: "stopped notes" }));
-    const status = vi.fn(() => [{ ok: true, message: "active", guildId: "g1" }]);
-    setDiscordTranscriptsVoiceManager({
+    const stop = vi.fn(async () => {});
+    registerManager({
       accountId: "primary",
-      manager: { leave, status } as unknown as DiscordVoiceManager,
+      manager: { stopTranscriptsCapture: stop },
     });
     const source = { providerId: "discord-voice", guildId: "g1", channelId: "c1" };
 
@@ -590,7 +755,6 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
       error: "Discord transcripts require accountId to stop a voice session.",
     });
     await expect(discordVoiceTranscriptsSourceProvider.status?.(source)).resolves.toEqual([]);
-    expect(leave).not.toHaveBeenCalled();
-    expect(status).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/voice/transcripts-source.test.ts
+++ b/extensions/discord/src/voice/transcripts-source.test.ts
@@ -18,6 +18,7 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
       resolveAccessTarget: vi.fn(async () => undefined),
       startTranscriptsCapture: vi.fn(async () => ({ ok: true, message: "joined" })),
       stopTranscriptsCapture: vi.fn(async () => {}),
+      hasRealtimeCapture: vi.fn(() => false),
       watchChannelOccupancy: vi.fn(() => vi.fn()),
       ...params.manager,
     };

--- a/extensions/discord/src/voice/transcripts-source.ts
+++ b/extensions/discord/src/voice/transcripts-source.ts
@@ -28,6 +28,7 @@ type DiscordTranscriptsManager = {
   >;
   startTranscriptsCapture: (target: CaptureTarget) => Promise<VoiceOperationResult>;
   stopTranscriptsCapture: (target: CaptureTarget) => Promise<void>;
+  hasRealtimeCapture: (target: CaptureTarget) => boolean;
   watchChannelOccupancy: (
     target: CaptureTarget,
     listener: (state: { occupied: boolean }) => void,
@@ -389,13 +390,6 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     return { ok: true, value: { stop } };
   },
   async start(request) {
-    if (request.cfg?.tools?.media?.audio?.enabled === false) {
-      return {
-        ok: false,
-        error:
-          "Discord transcripts require batch audio understanding; enable tools.media.audio.enabled.",
-      };
-    }
     const managerResolution = await waitForManager({ ...request, source: request.session.source });
     if (!managerResolution.ok) {
       return managerResolution;
@@ -417,6 +411,16 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
       return { ok: false, error: "Discord voice manager changed before capture could start." };
     }
     const source = { accountId, guildId, channelId };
+    if (
+      request.cfg?.tools?.media?.audio?.enabled === false &&
+      !manager.hasRealtimeCapture(source)
+    ) {
+      return {
+        ok: false,
+        error:
+          "Discord transcripts require batch audio understanding when no realtime conversation is active; enable tools.media.audio.enabled.",
+      };
+    }
     const key = captureKey(source);
     const previous = captures.get(key);
     const capture: CaptureRegistration = {
@@ -428,6 +432,14 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
       onStatus: request.onStatus,
       sessionId: request.session.sessionId,
       isCurrent: () => captures.get(key) === capture,
+      onBatchUnavailable: () => {
+        if (!capture.isCurrent() || capture.warning) {
+          return;
+        }
+        capture.warning =
+          "Independent batch transcription is unavailable; only safely bound realtime finals can be recorded. Configure audio transcription for full recording coverage.";
+        logger.warn(`discord voice: ${capture.warning}`);
+      },
       onUtterance: (utterance) => {
         // Received audio may finish after transport replacement, but never after source revocation.
         if (capture.isCurrent()) {
@@ -455,6 +467,9 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
       }
       capture.started = true;
       capture.channelName = channelName;
+      if (request.cfg?.tools?.media?.audio?.enabled === false) {
+        capture.onBatchUnavailable?.();
+      }
       return {
         ok: true,
         session: {
@@ -511,7 +526,9 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
       .map((capture) => ({
         active: capture.started,
         sessionId: capture.sessionId,
-        message: "Capture registered; recording while connected to the selected channel.",
+        message:
+          capture.warning ??
+          "Capture registered; recording while connected to the selected channel.",
         source: { providerId: "discord-voice", ...capture.source },
       }));
   },

--- a/extensions/discord/src/voice/transcripts-source.ts
+++ b/extensions/discord/src/voice/transcripts-source.ts
@@ -1,18 +1,86 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { summarizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-// Discord plugin module implements transcripts source behavior.
 import type {
   TranscriptSourceProvider,
+  TranscriptStartRequest,
   TranscriptOccupancyWatchRequest,
 } from "openclaw/plugin-sdk/transcripts";
 import { listEnabledDiscordAccounts, resolveDiscordAccount } from "../accounts.js";
 import { authorizeDiscordVoiceIngress } from "./access.js";
 import { resolveDiscordVoiceEnabled } from "./config.js";
 import { resolveDiscordVoiceAccess } from "./owner-access.js";
-import type { DiscordVoiceManager } from "./voice-runtime.js";
+import type { VoiceOperationResult, VoiceSessionEntry } from "./session.js";
 
-const managersByAccountId = new Map<string, DiscordVoiceManager>();
+type CaptureSource = { accountId: string; guildId: string; channelId: string };
+type CaptureTarget = Pick<CaptureSource, "guildId" | "channelId">;
+type DiscordTranscriptsManager = {
+  resolveAccessTarget: (
+    target: CaptureTarget,
+  ) => Promise<
+    | Pick<
+        Parameters<typeof authorizeDiscordVoiceIngress>[0],
+        "guild" | "channelName" | "channelSlug" | "parentId" | "parentName" | "parentSlug" | "scope"
+      >
+    | undefined
+  >;
+  startTranscriptsCapture: (target: CaptureTarget) => Promise<VoiceOperationResult>;
+  stopTranscriptsCapture: (target: CaptureTarget) => Promise<void>;
+  watchChannelOccupancy: (
+    target: CaptureTarget,
+    listener: (state: { occupied: boolean }) => void,
+  ) => () => void;
+};
+const managersByAccountId = new Map<string, DiscordTranscriptsManager>();
+type CaptureRegistration = NonNullable<VoiceSessionEntry["transcripts"]> & {
+  source: CaptureSource;
+  readonly subscriptionToken: symbol;
+  started: boolean;
+  channelName?: string;
+  onStatus: TranscriptStartRequest["onStatus"];
+};
+const captures = new Map<string, CaptureRegistration>();
+const logger = createSubsystemLogger("discord/voice");
+
+function captureKey(source: CaptureSource): string {
+  return JSON.stringify([source.accountId, source.guildId, source.channelId]);
+}
+
+function notifyCaptureRetired(capture: CaptureRegistration | undefined): void {
+  if (!capture?.onStatus) {
+    return;
+  }
+  // Registration revocation owns terminal state; replaceable voice transports do not.
+  // Persistence failures remain retryable in core without blocking the next capture.
+  try {
+    void Promise.resolve(
+      capture.onStatus({
+        active: false,
+        sessionId: capture.sessionId,
+        source: { providerId: "discord-voice", ...capture.source },
+      }),
+    ).catch((error: unknown) =>
+      logger.warn(
+        `discord voice: transcripts terminal notification failed: ${formatErrorMessage(error)}`,
+      ),
+    );
+  } catch (error) {
+    logger.warn(
+      `discord voice: transcripts terminal notification failed: ${formatErrorMessage(error)}`,
+    );
+  }
+}
+
+export function resolveDiscordTranscriptsCapture(
+  source: CaptureSource,
+  manager: DiscordTranscriptsManager,
+): CaptureRegistration | undefined {
+  return managersByAccountId.get(source.accountId) === manager
+    ? captures.get(captureKey(source))
+    : undefined;
+}
 const managerWaiters = new Set<{
   accountId?: string;
   resolve: () => void;
@@ -32,19 +100,46 @@ function summarizeAccountIdsForError(accountIds: readonly string[]): string {
   });
 }
 
-export function setDiscordTranscriptsVoiceManager(params: {
-  accountId: string;
-  manager: DiscordVoiceManager | null;
-}): void {
+export function setDiscordTranscriptsVoiceManager(
+  params: { accountId: string } & (
+    | { manager: DiscordTranscriptsManager }
+    | { manager: null; expectedManager: DiscordTranscriptsManager }
+  ),
+): void {
+  if (managersByAccountId.get(params.accountId) === params.manager) {
+    return;
+  }
   if (params.manager) {
-    managersByAccountId.set(params.accountId, params.manager);
-    for (const waiter of managerWaiters) {
-      if (!waiter.accountId || waiter.accountId === params.accountId) {
-        waiter.resolve();
+    const manager = params.manager;
+    managersByAccountId.set(params.accountId, manager);
+    // Account restart replaces transport authority, not an explicitly started subscription.
+    for (const capture of captures.values()) {
+      if (capture.started && capture.source.accountId === params.accountId) {
+        void manager
+          .startTranscriptsCapture(capture.source)
+          .then((result) => {
+            if (
+              !result.ok &&
+              resolveDiscordTranscriptsCapture(capture.source, manager)?.subscriptionToken ===
+                capture.subscriptionToken
+            ) {
+              logger.warn(`discord voice: transcripts reattach failed: ${result.message}`);
+            }
+          })
+          .catch((error: unknown) =>
+            logger.warn(`discord voice: transcripts reattach failed: ${formatErrorMessage(error)}`),
+          );
       }
     }
-  } else {
+  } else if (managersByAccountId.get(params.accountId) === params.expectedManager) {
     managersByAccountId.delete(params.accountId);
+  } else {
+    return;
+  }
+  for (const waiter of managerWaiters) {
+    if (!waiter.accountId || waiter.accountId === params.accountId) {
+      waiter.resolve();
+    }
   }
 }
 
@@ -118,7 +213,10 @@ async function waitForManager(
     TranscriptOccupancyWatchRequest,
     "cfg" | "source" | "abortSignal" | "startupWaitMs"
   >,
-): Promise<{ ok: true; value: DiscordVoiceManager | undefined } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; value: { accountId: string; manager: DiscordTranscriptsManager } | undefined }
+  | { ok: false; error: string }
+> {
   const accountResolution = resolveDiscordTranscriptsAccountId({
     cfg: request.cfg,
     source: request.source,
@@ -128,8 +226,8 @@ async function waitForManager(
   }
   const accountId = accountResolution.value;
   const existing = accountId ? managersByAccountId.get(accountId) : undefined;
-  if (existing) {
-    return { ok: true, value: existing };
+  if (existing && accountId) {
+    return { ok: true, value: { accountId, manager: existing } };
   }
   if (request.abortSignal?.aborted) {
     return { ok: true, value: undefined };
@@ -156,7 +254,8 @@ async function waitForManager(
   if (request.abortSignal?.aborted) {
     return { ok: true, value: undefined };
   }
-  return { ok: true, value: accountId ? managersByAccountId.get(accountId) : undefined };
+  const manager = accountId ? managersByAccountId.get(accountId) : undefined;
+  return { ok: true, value: accountId && manager ? { accountId, manager } : undefined };
 }
 
 export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
@@ -221,8 +320,8 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     if (!managerResolution.ok) {
       return managerResolution;
     }
-    const manager = managerResolution.value;
-    if (!manager) {
+    const binding = managerResolution.value;
+    if (!binding) {
       return { ok: false, error: "Discord voice manager is not available." };
     }
     if (request.abortSignal?.aborted) {
@@ -233,30 +332,76 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     if (!guildId || !channelId) {
       return { ok: false, error: "Discord transcripts require guildId and channelId." };
     }
-    const unsubscribe = manager.watchChannelOccupancy({ guildId, channelId }, ({ occupied }) => {
-      if (occupied) {
-        request.onOccupied();
-      } else {
-        request.onEmpty();
-      }
-    });
+    const { accountId } = binding;
+    let stopped = false;
+    let wasOccupied = false;
+    let currentManager: DiscordTranscriptsManager | undefined;
+    let unsubscribe: (() => void) | undefined;
+    const watcher = {
+      accountId,
+      resolve: () => {
+        const manager = managersByAccountId.get(accountId);
+        if (stopped || currentManager === manager) {
+          return;
+        }
+        currentManager = manager;
+        unsubscribe?.();
+        unsubscribe = undefined;
+        const release = manager?.watchChannelOccupancy({ guildId, channelId }, ({ occupied }) => {
+          if (
+            stopped ||
+            request.abortSignal?.aborted ||
+            managersByAccountId.get(accountId) !== manager
+          ) {
+            return;
+          }
+          if (occupied === wasOccupied) {
+            return;
+          }
+          wasOccupied = occupied;
+          if (occupied) {
+            request.onOccupied();
+          } else {
+            request.onEmpty();
+          }
+        });
+        if (stopped || currentManager !== manager) {
+          release?.();
+        } else {
+          unsubscribe = release;
+        }
+      },
+    };
     const stop = () => {
-      unsubscribe();
+      stopped = true;
+      managerWaiters.delete(watcher);
+      unsubscribe?.();
+      unsubscribe = undefined;
       request.abortSignal?.removeEventListener("abort", stop);
     };
+    managerWaiters.add(watcher);
     request.abortSignal?.addEventListener("abort", stop, { once: true });
     if (request.abortSignal?.aborted) {
       stop();
+    } else {
+      watcher.resolve();
     }
     return { ok: true, value: { stop } };
   },
   async start(request) {
+    if (request.cfg?.tools?.media?.audio?.enabled === false) {
+      return {
+        ok: false,
+        error:
+          "Discord transcripts require batch audio understanding; enable tools.media.audio.enabled.",
+      };
+    }
     const managerResolution = await waitForManager({ ...request, source: request.session.source });
     if (!managerResolution.ok) {
       return managerResolution;
     }
-    const manager = managerResolution.value;
-    if (!manager) {
+    const binding = managerResolution.value;
+    if (!binding) {
       return { ok: false, error: "Discord voice manager is not available." };
     }
     if (request.abortSignal?.aborted) {
@@ -267,28 +412,64 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     if (!guildId || !channelId) {
       return { ok: false, error: "Discord transcripts require guildId and channelId." };
     }
-    const joined = await manager.join(
-      { guildId, channelId },
-      {
-        transcripts: {
-          sessionId: request.session.sessionId,
-          onUtterance: request.onUtterance,
-          onStop: () =>
-            request.onStatus?.({
-              sessionId: request.session.sessionId,
-              active: false,
-              source: request.session.source,
-            }),
-        },
-      },
-    );
-    if (!joined.ok) {
-      return { ok: false, error: joined.message };
+    const { accountId, manager } = binding;
+    if (managersByAccountId.get(accountId) !== manager) {
+      return { ok: false, error: "Discord voice manager changed before capture could start." };
     }
-    const title = joined.channelName?.trim();
-    const session =
-      !request.session.title && title ? { ...request.session, title } : request.session;
-    return { ok: true, session };
+    const source = { accountId, guildId, channelId };
+    const key = captureKey(source);
+    const previous = captures.get(key);
+    const capture: CaptureRegistration = {
+      source,
+      subscriptionToken: previous?.started
+        ? previous.subscriptionToken
+        : Symbol("discord-transcripts-subscription"),
+      started: false,
+      onStatus: request.onStatus,
+      sessionId: request.session.sessionId,
+      isCurrent: () => captures.get(key) === capture,
+      onUtterance: (utterance) => {
+        // Received audio may finish after transport replacement, but never after source revocation.
+        if (capture.isCurrent()) {
+          return request.onUtterance(utterance);
+        }
+      },
+    };
+    captures.set(key, capture);
+    notifyCaptureRetired(previous);
+    try {
+      let channelName = previous?.channelName;
+      // An admitted source transfers atomically; replacing its sink does not reacquire transport.
+      if (!previous?.started) {
+        const joined = await manager.startTranscriptsCapture(source);
+        if (!joined.ok) {
+          return { ok: false, error: joined.message };
+        }
+        channelName = joined.channelName;
+      }
+      if (
+        request.abortSignal?.aborted ||
+        resolveDiscordTranscriptsCapture(source, manager) !== capture
+      ) {
+        return { ok: false, error: "Discord transcripts start was cancelled." };
+      }
+      capture.started = true;
+      capture.channelName = channelName;
+      return {
+        ok: true,
+        session: {
+          ...request.session,
+          ...(!request.session.title && channelName?.trim() ? { title: channelName.trim() } : {}),
+          source: { ...request.session.source, accountId, guildId, channelId },
+        },
+      };
+    } finally {
+      if (!capture.started && captures.get(key) === capture) {
+        captures.delete(key);
+        notifyCaptureRetired(capture);
+        await manager.stopTranscriptsCapture(source);
+      }
+    }
   },
   async stop(request) {
     const accountId = request.source.accountId?.trim();
@@ -298,26 +479,21 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
         error: "Discord transcripts require accountId to stop a voice session.",
       };
     }
-    const manager = managersByAccountId.get(accountId);
-    if (!manager) {
-      return { ok: false, error: "Discord voice manager is not available." };
-    }
     const guildId = request.source.guildId?.trim();
-    if (!guildId) {
-      return { ok: false, error: "Discord transcripts require guildId." };
+    const channelId = request.source.channelId?.trim();
+    if (!guildId || !channelId) {
+      return { ok: false, error: "Discord transcripts require guildId and channelId." };
     }
-    const result = await manager.leave(
-      {
-        guildId,
-        channelId: request.source.channelId,
-      },
-      {
-        transcriptsSessionId: request.sessionId,
-      },
-    );
-    if (!result.ok) {
-      return { ok: false, error: result.message };
+    const source = { accountId, guildId, channelId };
+    const key = captureKey(source);
+    const capture = captures.get(key);
+    if (capture?.sessionId !== request.sessionId) {
+      return { ok: false, error: "Transcripts session is not active in this voice channel." };
     }
+    // Revoke before any await: retained callbacks and pending joins lose this exact capture.
+    captures.delete(key);
+    notifyCaptureRetired(capture);
+    await managersByAccountId.get(accountId)?.stopTranscriptsCapture(source);
     return { ok: true, sessionId: request.sessionId, stoppedAt: new Date().toISOString() };
   },
   async status(source) {
@@ -325,18 +501,18 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
     if (!accountId) {
       return [];
     }
-    const manager = managersByAccountId.get(accountId);
-    return (
-      manager?.status().map((entry) => ({
-        active: entry.ok,
-        message: entry.message,
-        source: {
-          providerId: "discord-voice",
-          accountId,
-          guildId: entry.guildId,
-          channelId: entry.channelId,
-        },
-      })) ?? []
-    );
+    return [...captures.values()]
+      .filter(
+        (capture) =>
+          capture.source.accountId === accountId &&
+          (!source.guildId || capture.source.guildId === source.guildId.trim()) &&
+          (!source.channelId || capture.source.channelId === source.channelId.trim()),
+      )
+      .map((capture) => ({
+        active: capture.started,
+        sessionId: capture.sessionId,
+        message: "Capture registered; recording while connected to the selected channel.",
+        source: { providerId: "discord-voice", ...capture.source },
+      }));
   },
 };

--- a/extensions/discord/src/voice/transcripts-target.test.ts
+++ b/extensions/discord/src/voice/transcripts-target.test.ts
@@ -1,0 +1,598 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { DiscordError } from "../internal/discord.js";
+import {
+  discordVoiceTranscriptsSourceProvider,
+  setDiscordTranscriptsVoiceManager,
+} from "./transcripts-source.js";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    ChannelType,
+    createClient,
+    createManager,
+    createConnectionMock,
+    entersStateMock,
+    makeVoiceConfig,
+    configureVoiceStateGateway,
+    joinVoiceChannelMock,
+    createRealtimeVoiceBridgeSessionMock,
+    realtimeSessionMock,
+    getSessionEntry,
+    startTranscripts,
+    stopTranscripts,
+    receiveRecordedSpeech,
+  }) => {
+    type Residency = "live" | "other autoJoin" | "empty autoJoin" | "unknown autoJoin";
+    const source = {
+      providerId: "discord-voice",
+      accountId: "default",
+      guildId: "g1",
+      channelId: "1002",
+    };
+    async function fixture(residency: Residency) {
+      const client = createClient();
+      const states: Array<Record<string, unknown>> = [];
+      if (residency !== "unknown autoJoin") {
+        configureVoiceStateGateway(client, () => states);
+      }
+      const manager = createManager(
+        makeVoiceConfig(
+          {
+            mode: "agent-proxy",
+            ...(residency !== "live"
+              ? {
+                  autoJoin: [
+                    {
+                      guildId: "g1",
+                      channelId: residency === "other autoJoin" ? "1001" : "1002",
+                      whenOccupied: true,
+                    },
+                  ],
+                }
+              : {}),
+          },
+          { groupPolicy: "open", allowFrom: ["discord:u-owner"] },
+        ),
+        client,
+      );
+      const preservedNotes = vi.fn();
+      if (residency === "live") {
+        expect(await manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({
+          ok: true,
+        });
+        expect(await startTranscripts(manager, preservedNotes, "preserved")).toMatchObject({
+          ok: true,
+        });
+      }
+      const entry = residency === "live" ? getSessionEntry(manager) : undefined;
+      const snapshot = entry ? { ...entry } : undefined;
+      if (snapshot) {
+        delete snapshot.transcripts;
+      }
+      const connection = joinVoiceChannelMock.mock.results.at(-1)?.value;
+      const joins = joinVoiceChannelMock.mock.calls.length;
+      const bridges = createRealtimeVoiceBridgeSessionMock.mock.calls.length;
+      const assertResidencyPreserved = () => {
+        expect(joinVoiceChannelMock).toHaveBeenCalledTimes(joins);
+        expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(bridges);
+        if (entry) {
+          expect(getSessionEntry(manager)).toBe(entry);
+          expect(entry).toMatchObject(snapshot!);
+          expect(connection?.destroy).not.toHaveBeenCalled();
+          expect(manager.status()).toMatchObject([{ channelId: "1001" }]);
+        } else {
+          expect(manager.status()).toEqual([]);
+        }
+      };
+      return {
+        client,
+        manager,
+        preservedNotes,
+        assertResidencyPreserved,
+        states,
+        entry,
+        connection,
+      };
+    }
+
+    it.each(["live", "other autoJoin", "empty autoJoin"] as const)(
+      "transfers a registered dormant capture during a Discord lookup outage (%s)",
+      async (residency) => {
+        const { client, manager, assertResidencyPreserved } = await fixture(residency);
+        const originalFetch = client.fetchChannel.getMockImplementation()!;
+        const firstNotes = vi.fn();
+        const secondNotes = vi.fn();
+        const firstStatus = vi.fn();
+        const secondStatus = vi.fn();
+        setDiscordTranscriptsVoiceManager({ accountId: "default", manager });
+        const start = (
+          sessionId: string,
+          onUtterance: typeof firstNotes,
+          onStatus: typeof firstStatus,
+        ) =>
+          discordVoiceTranscriptsSourceProvider.start!({
+            session: { sessionId, source, startedAt: new Date().toISOString() },
+            onUtterance,
+            onStatus,
+          });
+        try {
+          expect(await start("first-dormant", firstNotes, firstStatus)).toMatchObject({ ok: true });
+          assertResidencyPreserved();
+          client.fetchChannel.mockRejectedValue(new Error("synthetic Discord lookup outage"));
+          expect(await start("second-dormant", secondNotes, secondStatus)).toMatchObject({
+            ok: true,
+          });
+          expect(firstStatus).toHaveBeenCalledExactlyOnceWith({
+            active: false,
+            sessionId: "first-dormant",
+            source,
+          });
+          expect(await stopTranscripts("first-dormant", "1002")).toMatchObject({ ok: false });
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject([
+            { active: true, sessionId: "second-dormant" },
+          ]);
+          assertResidencyPreserved();
+
+          client.fetchChannel.mockImplementation(originalFetch);
+          expect(await manager.join({ guildId: "g1", channelId: "1002" })).toMatchObject({
+            ok: true,
+          });
+          await receiveRecordedSpeech(manager, "the replacement owns this note");
+          expect(firstNotes).not.toHaveBeenCalled();
+          expect(secondNotes).toHaveBeenCalledOnce();
+          expect(await stopTranscripts("second-dormant", "1002")).toMatchObject({ ok: true });
+          expect(secondStatus).toHaveBeenCalledOnce();
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toEqual([]);
+        } finally {
+          client.fetchChannel.mockImplementation(originalFetch);
+          await stopTranscripts("first-dormant", "1002");
+          await stopTranscripts("second-dormant", "1002");
+          setDiscordTranscriptsVoiceManager({
+            accountId: "default",
+            manager: null,
+            expectedManager: manager,
+          });
+        }
+      },
+    );
+
+    it("does not retain a stopped capture's late fatal autoJoin failure", async () => {
+      const manager = createManager(
+        makeVoiceConfig({
+          mode: "agent-proxy",
+          autoJoin: [{ guildId: "g1", channelId: "1002" }],
+        }),
+      );
+      const entered = createDeferred<void>();
+      const connect = createDeferred<void>();
+      realtimeSessionMock.connect.mockImplementationOnce(async () => {
+        entered.resolve();
+        await connect.promise;
+      });
+      const starting = startTranscripts(manager, vi.fn(), "stopped-autoJoin", "1002");
+      await entered.promise;
+      expect(await stopTranscripts("stopped-autoJoin", "1002")).toMatchObject({ ok: true });
+      connect.reject(new Error("forbidden synthetic startup"));
+      expect(await starting).toMatchObject({ ok: false });
+      expect(manager.status()).toEqual([]);
+      expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toEqual([]);
+
+      await manager.autoJoin();
+      expect(manager.status()).toMatchObject([{ channelId: "1002" }]);
+      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      { whenOccupied: undefined, transition: "none" },
+      { whenOccupied: false, transition: "none" },
+      { whenOccupied: true, transition: "none" },
+      { whenOccupied: false, transition: "stop" },
+      { whenOccupied: false, transition: "replacement" },
+      { whenOccupied: false, transition: "leave" },
+    ])(
+      "preserves capture autoJoin ownership (whenOccupied=$whenOccupied, $transition)",
+      async ({ whenOccupied, transition }) => {
+        const client = createClient();
+        configureVoiceStateGateway(client, () => [
+          {
+            guild_id: "g1",
+            channel_id: "1002",
+            user_id: "u-owner",
+            member: { user: { id: "u-owner", bot: false } },
+          },
+        ]);
+        const manager = createManager(
+          makeVoiceConfig(
+            {
+              mode: "agent-proxy",
+              autoJoin: [
+                {
+                  guildId: "g1",
+                  channelId: "1002",
+                  ...(whenOccupied === undefined ? {} : { whenOccupied }),
+                },
+              ],
+            },
+            { groupPolicy: "open", allowFrom: ["discord:u-owner"] },
+          ),
+          client,
+        );
+        const entered = createDeferred<void>();
+        const target = createDeferred<Awaited<ReturnType<typeof client.fetchChannel>>>();
+        client.fetchChannel.mockImplementationOnce(() => {
+          entered.resolve();
+          return target.promise;
+        });
+        const readyEntered = createDeferred<void>();
+        const ready = createDeferred<undefined>();
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        entersStateMock.mockImplementationOnce(() => {
+          readyEntered.resolve();
+          return ready.promise;
+        });
+        const captureNotes = vi.fn();
+        const capturing = startTranscripts(manager, captureNotes, "queued-capture", "1002");
+        await entered.promise;
+        // The external join follows target resolution, after its owner continuation
+        // enqueues autoJoin but before that queue's deferred reconciliation runs.
+        const manual = target.promise.then(async () => {
+          await Promise.resolve();
+          return await manager.join({ guildId: "g1", channelId: "1003" });
+        });
+        target.resolve({
+          id: "1002",
+          type: ChannelType.GuildVoice,
+          guildId: "g1",
+          guild: { id: "g1", name: "Synthetic guild" },
+        });
+        let replacement: ReturnType<typeof startTranscripts> | undefined;
+        try {
+          await readyEntered.promise;
+          if (transition === "stop") {
+            expect(await stopTranscripts("queued-capture", "1002")).toMatchObject({ ok: true });
+          } else if (transition === "replacement") {
+            replacement = startTranscripts(manager, vi.fn(), "replacement", "1002");
+          } else if (transition === "leave") {
+            await manager.leave({ guildId: "g1", channelId: "1003" });
+          }
+          ready.resolve(undefined);
+          if (transition === "leave") {
+            expect(await manual).toMatchObject({ ok: false });
+            expect(await capturing).toMatchObject({ ok: true });
+            expect(manager.status()).toEqual([]);
+            expect(connection.destroy).toHaveBeenCalledOnce();
+            expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+            return;
+          }
+          expect(await manual).toMatchObject({ ok: true });
+          expect(connection.destroy).not.toHaveBeenCalled();
+          const entry = getSessionEntry(manager);
+          const snapshot = { ...entry };
+          expect(await capturing).toMatchObject({ ok: transition === "none" });
+          if (replacement) {
+            expect(await replacement).toMatchObject({ ok: true });
+          }
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject(
+            transition === "stop"
+              ? []
+              : [
+                  {
+                    active: true,
+                    sessionId: transition === "replacement" ? "replacement" : "queued-capture",
+                  },
+                ],
+          );
+          expect(getSessionEntry(manager)).toBe(entry);
+          expect(entry).toMatchObject(snapshot);
+          expect(connection.destroy).not.toHaveBeenCalled();
+          expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+          expect(manager.status()).toMatchObject([{ channelId: "1003" }]);
+          const notes = vi.fn();
+          expect(await startTranscripts(manager, notes, "manual-recorder", "1003")).toMatchObject({
+            ok: true,
+          });
+          await receiveRecordedSpeech(manager, "newer manual conversation remains recordable");
+          expect(notes).toHaveBeenCalledOnce();
+          if (transition === "none" && whenOccupied !== true) {
+            // Ordinary configured autoJoin retains its independent conversation policy.
+            await manager.autoJoin();
+            expect(manager.status()).toMatchObject([{ channelId: "1002" }]);
+            expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2);
+            await receiveRecordedSpeech(manager, "configured conversation records its own source");
+            expect(captureNotes).toHaveBeenCalledOnce();
+            expect(notes).toHaveBeenCalledOnce();
+          }
+        } finally {
+          ready.resolve(undefined);
+          await Promise.all([capturing, manual, replacement]);
+        }
+      },
+    );
+
+    it.each([
+      { residency: "live", invalid: "text" },
+      { residency: "live", invalid: "denied" },
+      { residency: "other autoJoin", invalid: "thread" },
+      { residency: "other autoJoin", invalid: "lookup failure" },
+      { residency: "empty autoJoin", invalid: "category" },
+      { residency: "empty autoJoin", invalid: "wrong guild" },
+      { residency: "unknown autoJoin", invalid: "text" },
+      { residency: "unknown autoJoin", invalid: "wrong guild" },
+    ] as const)(
+      "rejects $invalid capture beside $residency without changing residency",
+      async ({ residency, invalid }) => {
+        const f = await fixture(residency);
+        f.client.fetchChannel.mockImplementation(async (id) => {
+          if (invalid === "denied") {
+            throw new DiscordError(new Response(null, { status: 403 }), {
+              message: "Missing Access",
+              code: 50001,
+            });
+          }
+          if (invalid === "lookup failure") {
+            throw new TypeError("synthetic lookup failure");
+          }
+          const guildId = invalid === "wrong guild" ? "other-guild" : "g1";
+          return {
+            id,
+            guildId,
+            guild: { id: guildId, name: "Synthetic guild" },
+            type:
+              invalid === "text"
+                ? ChannelType.GuildText
+                : invalid === "thread"
+                  ? ChannelType.PublicThread
+                  : invalid === "category"
+                    ? ChannelType.GuildCategory
+                    : ChannelType.GuildVoice,
+          };
+        });
+        // Operator authorization does not validate a Discord channel's recording capability.
+        expect(
+          await discordVoiceTranscriptsSourceProvider.accessControl!.authorize({
+            action: "start",
+            caller: { kind: "operator", source: "local" },
+            source,
+          }),
+        ).toEqual({ ok: true, value: undefined });
+        const result = await startTranscripts(f.manager, vi.fn(), "invalid-target", "1002");
+        expect(result).toMatchObject({ ok: false });
+        expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toEqual([]);
+        expect(await stopTranscripts("invalid-target", "1002")).toMatchObject({ ok: false });
+        f.assertResidencyPreserved();
+        if (residency === "live") {
+          await receiveRecordedSpeech(f.manager, "the original recorder remains active");
+          expect(f.preservedNotes).toHaveBeenCalledOnce();
+        }
+      },
+    );
+
+    it.each(
+      (["live", "other autoJoin", "empty autoJoin", "unknown autoJoin"] as const).flatMap(
+        (residency) =>
+          [ChannelType.GuildVoice, ChannelType.GuildStageVoice].map((type) => ({
+            residency,
+            type,
+          })),
+      ),
+    )(
+      "registers valid channel type $type beside $residency without joining",
+      async ({ residency, type }) => {
+        const f = await fixture(residency);
+        f.client.fetchChannel.mockImplementation(async (id) => ({
+          id,
+          type,
+          guildId: "g1",
+          guild: { id: "g1", name: "Synthetic guild" },
+        }));
+        expect(await startTranscripts(f.manager, vi.fn(), "valid-target", "1002")).toMatchObject({
+          ok: true,
+        });
+        expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject([
+          { active: true, sessionId: "valid-target", source },
+        ]);
+        f.assertResidencyPreserved();
+      },
+    );
+    it("reuses an exact live target without another channel lookup or generation", async () => {
+      const f = await fixture("live");
+      f.client.fetchChannel.mockClear();
+      f.client.fetchChannel.mockRejectedValue(new Error("REST unavailable after readiness"));
+      const notes = vi.fn();
+      expect(await startTranscripts(f.manager, notes, "same-target")).toMatchObject({ ok: true });
+      expect(f.client.fetchChannel).not.toHaveBeenCalled();
+      f.assertResidencyPreserved();
+      await receiveRecordedSpeech(f.manager, "existing validated transport");
+      expect(notes).toHaveBeenCalledOnce();
+      expect(f.preservedNotes).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { transition: "source stop", reject: false },
+      { transition: "source stop", reject: true },
+      { transition: "source replacement", reject: true },
+      { transition: "manager replacement", reject: true },
+      { transition: "destroy", reject: true },
+      { transition: "leave", reject: false },
+    ])(
+      "fences pending validation across $transition (reject=$reject)",
+      async ({ transition, reject }) => {
+        const f = await fixture("live");
+        const entered = createDeferred<void>();
+        const release = createDeferred<void>();
+        const fetchChannel = f.client.fetchChannel.getMockImplementation()!;
+        f.client.fetchChannel.mockImplementationOnce(async (id) => {
+          entered.resolve();
+          await release.promise;
+          return fetchChannel(id);
+        });
+        const starting = startTranscripts(f.manager, vi.fn(), "pending-target", "1002");
+        let replacement: ReturnType<typeof createManager> | undefined;
+        try {
+          await entered.promise;
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject([
+            { active: false, sessionId: "pending-target" },
+          ]);
+          f.assertResidencyPreserved();
+          if (transition === "source stop") {
+            expect(await stopTranscripts("pending-target", "1002")).toMatchObject({ ok: true });
+          } else if (transition === "source replacement") {
+            expect(await startTranscripts(f.manager, vi.fn(), "replacement", "1002")).toMatchObject(
+              {
+                ok: true,
+              },
+            );
+          } else if (transition === "manager replacement") {
+            replacement = createManager(
+              makeVoiceConfig({
+                autoJoin: [{ guildId: "g1", channelId: "1003", whenOccupied: true }],
+              }),
+            );
+            setDiscordTranscriptsVoiceManager({ accountId: "default", manager: replacement });
+          } else if (transition === "destroy") {
+            await f.manager.destroy();
+          } else {
+            expect(await f.manager.leave({ guildId: "g1" })).toMatchObject({ ok: true });
+          }
+          if (reject) {
+            release.reject(new Error("stale lookup failure"));
+          } else {
+            release.resolve();
+          }
+          const result = await starting;
+          expect(result).toMatchObject(
+            transition === "leave"
+              ? { ok: true }
+              : { ok: false, error: expect.stringContaining("cancelled") },
+          );
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject(
+            transition === "source replacement"
+              ? [{ active: true, sessionId: "replacement" }]
+              : transition === "leave"
+                ? [{ active: true, sessionId: "pending-target" }]
+                : [],
+          );
+          expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+          if (transition === "destroy" || transition === "leave") {
+            expect(f.manager.status()).toEqual([]);
+            expect(f.connection?.destroy).toHaveBeenCalledOnce();
+          } else {
+            f.assertResidencyPreserved();
+            if (transition !== "manager replacement") {
+              await receiveRecordedSpeech(f.manager, "unrelated capture survived");
+              expect(f.preservedNotes).toHaveBeenCalledOnce();
+            }
+          }
+        } finally {
+          release.resolve();
+          await starting;
+          if (replacement) {
+            await replacement.destroy();
+            setDiscordTranscriptsVoiceManager({
+              accountId: "default",
+              manager: null,
+              expectedManager: replacement,
+            });
+          }
+        }
+      },
+    );
+
+    it.each([
+      { residency: "live", channelId: "1003" },
+      { residency: "empty autoJoin", channelId: "1003" },
+      { residency: "other autoJoin", channelId: "1002" },
+    ] as const)(
+      "keeps a newer $channelId join authoritative during $residency lookup",
+      async ({ residency, channelId }) => {
+        const f = await fixture(residency);
+        const entered = createDeferred<void>();
+        const release = createDeferred<void>();
+        const readyEntered = createDeferred<void>();
+        const ready = createDeferred<undefined>();
+        const fetchChannel = f.client.fetchChannel.getMockImplementation()!;
+        f.client.fetchChannel.mockImplementationOnce(async (id) => {
+          entered.resolve();
+          await release.promise;
+          return fetchChannel(id);
+        });
+        const starting = startTranscripts(f.manager, vi.fn(), "pending-target", "1002");
+        await entered.promise;
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        entersStateMock.mockImplementationOnce(() => {
+          readyEntered.resolve();
+          return ready.promise;
+        });
+        const manual = f.manager.join({ guildId: "g1", channelId });
+        try {
+          await readyEntered.promise;
+          release.resolve();
+          // The capture cannot commit while the newer transport is still being admitted.
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject([
+            { active: false, sessionId: "pending-target" },
+          ]);
+          ready.resolve(undefined);
+          expect(await manual).toMatchObject({ ok: true });
+          const entry = getSessionEntry(f.manager);
+          const snapshot = { ...entry };
+          expect(await starting).toMatchObject({ ok: true });
+          expect(getSessionEntry(f.manager)).toBe(entry);
+          expect(entry).toMatchObject(snapshot);
+          expect(connection.destroy).not.toHaveBeenCalled();
+          expect(joinVoiceChannelMock).toHaveBeenCalledTimes(residency === "live" ? 2 : 1);
+          expect(f.manager.status()).toMatchObject([{ channelId }]);
+          expect(await discordVoiceTranscriptsSourceProvider.status!(source)).toMatchObject([
+            { active: true, sessionId: "pending-target" },
+          ]);
+        } finally {
+          release.resolve();
+          ready.resolve(undefined);
+          await Promise.all([starting, manual]);
+        }
+      },
+    );
+
+    it.each(["empty autoJoin", "unknown autoJoin"] as const)(
+      "reconsiders $residency occupancy after target validation",
+      async (residency) => {
+        const f = await fixture(residency);
+        const entered = createDeferred<void>();
+        const release = createDeferred<void>();
+        const fetchChannel = f.client.fetchChannel.getMockImplementation()!;
+        f.client.fetchChannel.mockImplementationOnce(async (id) => {
+          entered.resolve();
+          await release.promise;
+          return fetchChannel(id);
+        });
+        const notes = vi.fn();
+        const starting = startTranscripts(f.manager, notes, "occupied-target", "1002");
+        try {
+          await entered.promise;
+          f.states.push({
+            guild_id: "g1",
+            channel_id: "1002",
+            user_id: "u-owner",
+            member: { user: { id: "u-owner", bot: false } },
+          });
+          configureVoiceStateGateway(f.client, () => f.states);
+          release.resolve();
+          expect(await starting).toMatchObject({ ok: true });
+          expect(f.manager.status()).toMatchObject([{ channelId: "1002" }]);
+          expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+          expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledOnce();
+          await receiveRecordedSpeech(f.manager, "newly occupied target");
+          expect(notes).toHaveBeenCalledOnce();
+        } finally {
+          release.resolve();
+          await starting;
+        }
+      },
+    );
+  },
+);

--- a/extensions/discord/src/voice/transcripts.test-support.ts
+++ b/extensions/discord/src/voice/transcripts.test-support.ts
@@ -1,0 +1,55 @@
+import { afterEach, vi } from "vitest";
+import {
+  discordVoiceTranscriptsSourceProvider,
+  setDiscordTranscriptsVoiceManager,
+} from "./transcripts-source.js";
+import type { DiscordVoiceManager } from "./voice-runtime.js";
+
+export function createDiscordVoiceTranscriptFixture() {
+  const captures: Array<{
+    sessionId: string;
+    source: { providerId: string; accountId: string; guildId: string; channelId: string };
+  }> = [];
+  const captureManagers = new Set<DiscordVoiceManager>();
+  const registeredManagers = new Map<string, DiscordVoiceManager>();
+  const startTranscripts = async (
+    manager: DiscordVoiceManager,
+    onUtterance = vi.fn(),
+    sessionId = "notes-1",
+    channelId = "1001",
+    accountId = "default",
+  ) => {
+    setDiscordTranscriptsVoiceManager({ accountId, manager });
+    registeredManagers.set(accountId, manager);
+    captureManagers.add(manager);
+    const source = { providerId: "discord-voice", accountId, guildId: "g1", channelId };
+    captures.push({ sessionId, source });
+    return await discordVoiceTranscriptsSourceProvider.start!({
+      session: { sessionId, source, startedAt: new Date().toISOString() },
+      onUtterance,
+    });
+  };
+  const stopTranscripts = async (
+    sessionId = "notes-1",
+    channelId = "1001",
+    accountId = "default",
+  ) =>
+    await discordVoiceTranscriptsSourceProvider.stop!({
+      sessionId,
+      source: { providerId: "discord-voice", accountId, guildId: "g1", channelId },
+    });
+  afterEach(async () => {
+    for (const capture of captures.splice(0)) {
+      await discordVoiceTranscriptsSourceProvider.stop!(capture);
+    }
+    for (const [accountId, manager] of registeredManagers) {
+      setDiscordTranscriptsVoiceManager({ accountId, manager: null, expectedManager: manager });
+    }
+    registeredManagers.clear();
+    for (const manager of captureManagers) {
+      await manager.destroy();
+    }
+    captureManagers.clear();
+  });
+  return { startTranscripts, stopTranscripts };
+}

--- a/extensions/discord/src/voice/transcripts.test-support.ts
+++ b/extensions/discord/src/voice/transcripts.test-support.ts
@@ -1,3 +1,4 @@
+import type { TranscriptStartRequest } from "openclaw/plugin-sdk/transcripts";
 import { afterEach, vi } from "vitest";
 import {
   discordVoiceTranscriptsSourceProvider,
@@ -14,7 +15,7 @@ export function createDiscordVoiceTranscriptFixture() {
   const registeredManagers = new Map<string, DiscordVoiceManager>();
   const startTranscripts = async (
     manager: DiscordVoiceManager,
-    onUtterance = vi.fn(),
+    onUtterance: TranscriptStartRequest["onUtterance"] = vi.fn(),
     sessionId = "notes-1",
     channelId = "1001",
     accountId = "default",

--- a/extensions/discord/src/voice/tts.ts
+++ b/extensions/discord/src/voice/tts.ts
@@ -1,4 +1,3 @@
-// Discord plugin module implements tts behavior.
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig, TtsConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -38,14 +37,17 @@ export async function transcribeVoiceAudio(params: {
   cfg: OpenClawConfig;
   agentId: string;
   filePath: string;
-}): Promise<string | undefined> {
+}) {
   const result = await getDiscordRuntime().mediaUnderstanding.transcribeAudioFile({
     filePath: params.filePath,
     cfg: params.cfg,
     agentDir: resolveAgentDir(params.cfg, params.agentId),
     mime: "audio/wav",
   });
-  return normalizeOptionalString(result.text);
+  return {
+    text: normalizeOptionalString(result.text),
+    processing: result.decision?.attachmentProcessing?.[0],
+  };
 }
 
 export async function synthesizeVoiceReplyAudio(params: {

--- a/extensions/discord/src/voice/tts.ts
+++ b/extensions/discord/src/voice/tts.ts
@@ -47,6 +47,12 @@ export async function transcribeVoiceAudio(params: {
   return {
     text: normalizeOptionalString(result.text),
     processing: result.decision?.attachmentProcessing?.[0],
+    unavailable:
+      result.decision?.outcome === "skipped" &&
+      result.decision.attachmentDispositions?.[0]?.kind === "no-model" &&
+      result.decision.attachmentProcessing?.[0] === "omitted" &&
+      result.decision.attachments.length > 0 &&
+      result.decision.attachments.every((attachment) => attachment.attempts.length === 0),
   };
 }
 

--- a/extensions/discord/src/voice/voice-auto-join.test.ts
+++ b/extensions/discord/src/voice/voice-auto-join.test.ts
@@ -23,7 +23,83 @@ defineDiscordVoiceTests(
     makeVoiceConfig,
     expectConnectedStatus,
     updateVoiceState,
+    startTranscripts,
+    stopTranscripts,
+    getSessionEntry,
+    beginSpeakerTurn,
+    lastRealtimeBridgeParams,
+    emitFinalRealtimeUserTranscript,
+    receiveRecordedSpeech,
+    agentCommandMock,
   }) => {
+    it.each(["capture-first", "voice-first"])(
+      "keeps explicit capture and wake-name conversation through occupancy (%s)",
+      async (order) => {
+        const client = createClient();
+        const human = {
+          guild_id: "g1",
+          user_id: "u-owner",
+          channel_id: "1001",
+          member: { user: { id: "u-owner", bot: false } },
+        };
+        let states: Array<Record<string, unknown>> = order === "voice-first" ? [human] : [];
+        configureVoiceStateGateway(client, () => states);
+        const manager = createManager(
+          makeVoiceConfig(
+            {
+              mode: "agent-proxy",
+              autoJoin: [{ guildId: "g1", channelId: "1001", whenOccupied: true }],
+              realtime: { provider: "openai", requireWakeName: true },
+            },
+            { groupPolicy: "open", allowFrom: ["discord:u-owner"] },
+          ),
+          client,
+        );
+        const onUtterance = vi.fn();
+        if (order === "voice-first") {
+          await manager.autoJoin();
+        }
+        expect(await startTranscripts(manager, onUtterance)).toMatchObject({ ok: true });
+        if (order === "capture-first") {
+          await manager.autoJoin();
+          expect(manager.status()).toEqual([]);
+          expect(joinVoiceChannelMock).not.toHaveBeenCalled();
+          states = [human];
+          await updateVoiceState(manager, "u-owner", "1001", human.member);
+        }
+        for (const text of ["first occupation", "second occupation"]) {
+          expectConnectedStatus(manager, "1001");
+          const entry = getSessionEntry(manager);
+          expect(entry.realtimeLifecycle.status).toBe("active");
+          await receiveRecordedSpeech(manager, text);
+          await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), text);
+          expect(onUtterance).toHaveBeenCalledWith(
+            expect.objectContaining({ sessionId: "notes-1", text }),
+          );
+          expect(agentCommandMock).not.toHaveBeenCalled();
+          states = [];
+          await updateVoiceState(manager, "u-owner", null, human.member);
+          expect(manager.status()).toEqual([]);
+          states = [human];
+          await updateVoiceState(manager, "u-owner", "1001", human.member);
+        }
+        beginSpeakerTurn(getSessionEntry(manager));
+        await emitFinalRealtimeUserTranscript(
+          lastRealtimeBridgeParams(),
+          "OpenClaw, what is the next step?",
+        );
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        states = [];
+        await updateVoiceState(manager, "u-owner", null, human.member);
+        expect(await stopTranscripts()).toMatchObject({ ok: true });
+        states = [human];
+        await updateVoiceState(manager, "u-owner", "1001", human.member);
+        const count = onUtterance.mock.calls.length;
+        await receiveRecordedSpeech(manager, "after capture stop");
+        await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "after capture stop");
+        expect(onUtterance).toHaveBeenCalledTimes(count);
+      },
+    );
     it("autoJoin uses the last configured channel for duplicate guild entries", async () => {
       const manager = createManager({
         voice: {

--- a/extensions/discord/src/voice/voice-conversation-input.ts
+++ b/extensions/discord/src/voice/voice-conversation-input.ts
@@ -3,6 +3,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { DiscordVoiceIngressContext } from "./ingress.js";
 import type { DiscordVoiceSegmentOutcome } from "./segment.js";
 import type { VoiceRealtimeSpeakerTurn } from "./session.js";
+import type { DiscordVoiceAudioReceipt } from "./voice-recording.js";
 
 const MAX_PENDING_CONVERSATIONS = 8;
 // Encoded packet limits do not bound the decoded audio waiting for authorization.
@@ -23,7 +24,7 @@ class DiscordVoiceConversationInput {
   private state: "pending" | "admitted" | "retired" = "pending";
   private context: DiscordVoiceIngressContext | null = null;
   private turn: VoiceRealtimeSpeakerTurn | undefined;
-  private audio: Buffer[] = [];
+  private audio: Array<{ pcm: Buffer; receipt?: DiscordVoiceAudioReceipt }> = [];
   private pendingAudioBytes = 0;
   private text: string[] = [];
   private textBytes = 0;
@@ -47,8 +48,8 @@ class DiscordVoiceConversationInput {
       const audio = this.audio;
       this.audio = [];
       this.pendingAudioBytes = 0;
-      for (const pcm of audio) {
-        this.sendAudio(pcm);
+      for (const { pcm, receipt } of audio) {
+        this.sendAudio(pcm, receipt);
       }
     })().catch((error: unknown) => {
       this.retire();
@@ -65,7 +66,7 @@ class DiscordVoiceConversationInput {
     return this.state === "retired";
   }
 
-  sendAudio(pcm: Buffer): void {
+  sendAudio(pcm: Buffer, receipt?: DiscordVoiceAudioReceipt): void {
     if (this.state === "retired") {
       return;
     }
@@ -83,12 +84,12 @@ class DiscordVoiceConversationInput {
       }
       this.pendingAudioBytes += pcm.length;
       if (this.params.createTurn) {
-        this.audio.push(Buffer.from(pcm));
+        this.audio.push({ pcm: Buffer.from(pcm), receipt });
       }
       return;
     }
     try {
-      this.turn?.sendInputAudio(pcm);
+      this.turn?.sendInputAudio(pcm, receipt);
     } catch (error) {
       this.retire();
       this.params.warn(`discord voice: conversation audio failed: ${formatErrorMessage(error)}`);
@@ -139,7 +140,7 @@ class DiscordVoiceConversationInput {
       if (this.state === "retired") {
         return false;
       }
-      if (outcome.status === "excluded") {
+      if (outcome.status === "excluded" || outcome.status === "unavailable") {
         this.retire();
         return false;
       }

--- a/extensions/discord/src/voice/voice-conversation-input.ts
+++ b/extensions/discord/src/voice/voice-conversation-input.ts
@@ -1,9 +1,8 @@
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { DiscordVoiceIngressContext } from "./ingress.js";
-import type { DiscordVoiceSegmentOutcome } from "./segment.js";
+import type { DiscordVoiceAudioReceipt, DiscordVoiceSegmentOutcome } from "./recording-types.js";
 import type { VoiceRealtimeSpeakerTurn } from "./session.js";
-import type { DiscordVoiceAudioReceipt } from "./voice-recording.js";
 
 const MAX_PENDING_CONVERSATIONS = 8;
 // Encoded packet limits do not bound the decoded audio waiting for authorization.

--- a/extensions/discord/src/voice/voice-conversation-input.ts
+++ b/extensions/discord/src/voice/voice-conversation-input.ts
@@ -1,0 +1,242 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import type { DiscordVoiceIngressContext } from "./ingress.js";
+import type { DiscordVoiceSegmentOutcome } from "./segment.js";
+import type { VoiceRealtimeSpeakerTurn } from "./session.js";
+
+const MAX_PENDING_CONVERSATIONS = 8;
+// Encoded packet limits do not bound the decoded audio waiting for authorization.
+const MAX_PENDING_CONVERSATION_AUDIO_BYTES = 1024 * 1024;
+const MAX_CONVERSATION_TEXT_BYTES = 1024 * 1024;
+const MAX_CONVERSATION_SEGMENTS = 1_000;
+
+type ConversationParams = {
+  authorize: () => Promise<DiscordVoiceIngressContext | null>;
+  isCurrent: () => boolean;
+  canAdmit: () => boolean;
+  createTurn?: (context: DiscordVoiceIngressContext) => VoiceRealtimeSpeakerTurn;
+  warn: (message: string) => void;
+};
+
+class DiscordVoiceConversationInput {
+  private readonly cancelled = createDeferred<void>();
+  private state: "pending" | "admitted" | "retired" = "pending";
+  private context: DiscordVoiceIngressContext | null = null;
+  private turn: VoiceRealtimeSpeakerTurn | undefined;
+  private audio: Buffer[] = [];
+  private pendingAudioBytes = 0;
+  private text: string[] = [];
+  private textBytes = 0;
+  private segments: Promise<boolean>[] = [];
+  private authorizationQueue: Promise<void> = Promise.resolve();
+  readonly ready: Promise<void>;
+
+  constructor(private readonly params: ConversationParams) {
+    const admission = (async () => {
+      const context = await params.authorize();
+      if (this.state === "retired") {
+        return;
+      }
+      if (!context || !params.isCurrent() || !params.canAdmit()) {
+        this.retire();
+        return;
+      }
+      this.turn = params.createTurn?.(context);
+      this.context = context;
+      this.state = "admitted";
+      const audio = this.audio;
+      this.audio = [];
+      this.pendingAudioBytes = 0;
+      for (const pcm of audio) {
+        this.sendAudio(pcm);
+      }
+    })().catch((error: unknown) => {
+      this.retire();
+      params.warn(`discord voice: conversation admission failed: ${formatErrorMessage(error)}`);
+    });
+    this.ready = Promise.race([admission, this.cancelled.promise]);
+  }
+
+  get ingress(): DiscordVoiceIngressContext | null {
+    return this.state === "admitted" && this.params.isCurrent() ? this.context : null;
+  }
+
+  get retired(): boolean {
+    return this.state === "retired";
+  }
+
+  sendAudio(pcm: Buffer): void {
+    if (this.state === "retired") {
+      return;
+    }
+    if (!this.params.isCurrent()) {
+      this.retire();
+      return;
+    }
+    if (this.state === "pending") {
+      if (pcm.length > MAX_PENDING_CONVERSATION_AUDIO_BYTES - this.pendingAudioBytes) {
+        this.params.warn(
+          "discord voice: conversation audio backlog exceeded; recording continues, but speak again for a conversation response.",
+        );
+        this.retire();
+        return;
+      }
+      this.pendingAudioBytes += pcm.length;
+      if (this.params.createTurn) {
+        this.audio.push(Buffer.from(pcm));
+      }
+      return;
+    }
+    try {
+      this.turn?.sendInputAudio(pcm);
+    } catch (error) {
+      this.retire();
+      this.params.warn(`discord voice: conversation audio failed: ${formatErrorMessage(error)}`);
+    }
+  }
+
+  authorizeSegment(
+    resolve: () => Promise<DiscordVoiceIngressContext | null>,
+  ): Promise<DiscordVoiceIngressContext | null> {
+    const permission = this.authorizationQueue
+      .then(async () => {
+        await this.ready;
+        if (!this.ingress) {
+          return null;
+        }
+        const context = await Promise.race([resolve(), this.cancelled.promise.then(() => null)]);
+        if (!context || !this.params.isCurrent()) {
+          this.retire();
+          return null;
+        }
+        return context;
+      })
+      .catch((error: unknown) => {
+        this.retire();
+        throw error;
+      });
+    this.authorizationQueue = permission.then(
+      () => undefined,
+      () => undefined,
+    );
+    return permission;
+  }
+
+  addSegment(result: Promise<DiscordVoiceSegmentOutcome>): void {
+    if (this.state === "retired") {
+      return;
+    }
+    if (this.segments.length >= MAX_CONVERSATION_SEGMENTS) {
+      this.params.warn(
+        "discord voice: conversation transcript limit exceeded; recording continues, but speak a shorter request for a conversation response.",
+      );
+      this.retire();
+      return;
+    }
+    const index = this.text.length;
+    this.text.push("");
+    const completed = result.then(async (outcome) => {
+      if (this.state === "retired") {
+        return false;
+      }
+      if (outcome.status === "excluded") {
+        this.retire();
+        return false;
+      }
+      const text = outcome.status === "transcribed" ? outcome.text : "";
+      const bytes = Buffer.byteLength(text);
+      if (bytes > MAX_CONVERSATION_TEXT_BYTES - this.textBytes) {
+        this.params.warn(
+          "discord voice: conversation transcript limit exceeded; recording continues, but speak a shorter request for a conversation response.",
+        );
+        this.retire();
+        return false;
+      }
+      this.textBytes += bytes;
+      this.text[index] = text;
+      const allowed = await outcome.conversationAuthorized;
+      if (!allowed) {
+        this.retire();
+      }
+      return allowed;
+    });
+    this.segments.push(Promise.race([completed, this.cancelled.promise.then(() => false)]));
+  }
+
+  async transcript(): Promise<string | undefined> {
+    await this.ready;
+    await Promise.all(this.segments);
+    return this.ingress ? this.text.filter(Boolean).join("\n") || undefined : undefined;
+  }
+
+  async finishAudio(): Promise<void> {
+    await this.ready;
+    this.turn?.close();
+    this.turn = undefined;
+  }
+
+  retire(): void {
+    if (this.state === "retired") {
+      return;
+    }
+    this.state = "retired";
+    this.context = null;
+    this.audio = [];
+    this.text = [];
+    this.segments = [];
+    const turn = this.turn;
+    this.turn = undefined;
+    // Revoke authority and release waiters before provider teardown can call back or throw.
+    this.cancelled.resolve();
+    try {
+      turn?.close("incomplete-input");
+    } catch (error) {
+      this.params.warn(`discord voice: conversation close failed: ${formatErrorMessage(error)}`);
+    }
+  }
+}
+
+export class DiscordVoiceConversationQueue {
+  private readonly inputs = new Set<DiscordVoiceConversationInput>();
+  private queue: Promise<void> = Promise.resolve();
+  private stopped = false;
+
+  start(params: ConversationParams): DiscordVoiceConversationInput | undefined {
+    if (this.stopped || this.inputs.size >= MAX_PENDING_CONVERSATIONS) {
+      params.warn("discord voice: conversation is busy; recording continues.");
+      return undefined;
+    }
+    const input = new DiscordVoiceConversationInput(params);
+    this.inputs.add(input);
+    return input;
+  }
+
+  enqueue(input: DiscordVoiceConversationInput, task: () => Promise<void>): Promise<void> {
+    const completion = this.queue
+      .then(async () => {
+        if (this.inputs.has(input) && !input.retired) {
+          await task();
+        }
+      })
+      .finally(() => this.release(input));
+    this.queue = completion.catch(() => undefined);
+    return completion;
+  }
+
+  finishAudio(input: DiscordVoiceConversationInput): Promise<void> {
+    return input.finishAudio().finally(() => this.release(input));
+  }
+
+  release(input: DiscordVoiceConversationInput): void {
+    input.retire();
+    this.inputs.delete(input);
+  }
+
+  close(): void {
+    this.stopped = true;
+    for (const input of this.inputs) {
+      input.retire();
+    }
+    this.inputs.clear();
+  }
+}

--- a/extensions/discord/src/voice/voice-occupancy.test.ts
+++ b/extensions/discord/src/voice/voice-occupancy.test.ts
@@ -14,6 +14,8 @@ defineDiscordVoiceTests(
     createRealtimeVoiceBridgeSessionMock,
     makeAgentProxyConfig,
     ChannelType,
+    startTranscripts,
+    stopTranscripts,
   }) => {
     const room = { guildId: "g1", channelId: "1001" };
     const voiceState = (userId: string, channelId: string | null, bot = false): APIVoiceState =>
@@ -47,16 +49,21 @@ defineDiscordVoiceTests(
       try {
         await update(voiceState("helper-bot", "1001", true));
         await update(voiceState("own-bot", "1001"));
-        expect(listener).not.toHaveBeenCalled();
+        expect(listener).toHaveBeenCalledExactlyOnceWith({ occupied: false });
         await update(voiceState("human-one", "1001"));
         await update(voiceState("human-two", "1001"));
         await update(voiceState("human-one", null));
         await update(voiceState("human-two", "1002"));
-        expect(listener.mock.calls).toEqual([[{ occupied: true }], [{ occupied: false }]]);
+        expect(listener.mock.calls).toEqual([
+          [{ occupied: false }],
+          [{ occupied: true }],
+          [{ occupied: false }],
+        ]);
         stop();
         await update(voiceState("human-one", "1001"));
-        expect(listener).toHaveBeenCalledTimes(2);
+        expect(listener).toHaveBeenCalledTimes(3);
         expect(otherListener.mock.calls).toEqual([
+          [{ occupied: false }],
           [{ occupied: true }],
           [{ occupied: false }],
           [{ occupied: true }],
@@ -108,8 +115,8 @@ defineDiscordVoiceTests(
       expect(listener).toHaveBeenCalledExactlyOnceWith({ occupied: true });
       try {
         for (const sessionId of ["first", "second"]) {
-          await manager.join(room, { transcripts: { sessionId, onUtterance: vi.fn() } });
-          await manager.leave(room, { transcriptsSessionId: sessionId });
+          await startTranscripts(manager, vi.fn(), sessionId, "1001", "primary");
+          await stopTranscripts(sessionId, "1001", "primary");
         }
         await update(voiceState("human-one", null));
         await update(voiceState("human-one", "1001"));
@@ -154,8 +161,16 @@ defineDiscordVoiceTests(
         expect(client.fetchChannel).toHaveBeenCalledExactlyOnceWith("1001");
         expect(createRealtimeVoiceBridgeSessionMock).not.toHaveBeenCalled();
       } finally {
-        setDiscordTranscriptsVoiceManager({ accountId: "primary", manager: null });
+        await discordVoiceTranscriptsSourceProvider.stop?.({
+          sessionId: "notes",
+          source: { providerId: "discord-voice", accountId: "primary", ...room },
+        });
         await manager.destroy();
+        setDiscordTranscriptsVoiceManager({
+          accountId: "primary",
+          manager: null,
+          expectedManager: manager,
+        });
       }
     });
   },

--- a/extensions/discord/src/voice/voice-receive-backlog.test.ts
+++ b/extensions/discord/src/voice/voice-receive-backlog.test.ts
@@ -1,0 +1,241 @@
+import { AudioReceiveStream, EndBehaviorType } from "@discordjs/voice";
+import { createEncoder } from "libopus-wasm";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    createClientWithMember,
+    createConnectionMock,
+    joinVoiceChannelMock,
+    createManager,
+    createAgentProxyManager,
+    beginSpeakerTurn,
+    lastRealtimeBridge,
+    emitFinalRealtimeUserTranscript,
+    makeVoiceConfig,
+    getSessionEntry,
+    handleSpeakingStart,
+    startTranscripts,
+    stopTranscripts,
+    transcribeAudioFileMock,
+    agentCommandMock,
+    controlRealtimeVoiceAgentRunMock,
+    loggerWarnMock,
+    decodeOpusStreamChunksMock,
+  }) => {
+    it.each(["admission", "decoder"])(
+      "bounds packets while %s is pending without retiring the room capture",
+      async (stage) => {
+        const actual = await vi.importActual<typeof import("./audio.js")>("./audio.js");
+        const blocked = createDeferred<void>();
+        decodeOpusStreamChunksMock.mockImplementation(async (input, params) => {
+          if (stage === "decoder") {
+            await blocked.promise;
+          }
+          await actual.decodeOpusStreamChunks(input, params);
+        });
+        const client = createClientWithMember("u-speaker", "Speaker", "0");
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const manager = createManager(
+          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+          client,
+          { tools: { media: { audio: { maxBytes: 192_044 } } } },
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const sink = vi.fn();
+        await startTranscripts(manager, sink);
+        const entry = getSessionEntry(manager);
+        const capture = entry.transcripts;
+        const conversations = vi.spyOn(entry.conversations, "enqueue");
+        if (stage === "admission") {
+          client.fetchMember.mockImplementationOnce(async () => {
+            await blocked.promise;
+            return { user: { id: "u-speaker" } };
+          });
+        }
+        const stream = new AudioReceiveStream({ end: { behavior: EndBehaviorType.Manual } });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const receiving = handleSpeakingStart(manager, entry, "u-speaker");
+        // The SDK's UDP producer ignores push() backpressure. These valid 20 ms
+        // Opus silence frames must stay bounded before identity or decode settles.
+        try {
+          for (let frame = 0; frame < 2_000; frame++) {
+            stream.push(Buffer.from([0xf8, 0xff, 0xfe]));
+          }
+          await vi.waitFor(() => expect(stream.destroyed).toBe(true));
+          expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("receive backlog"));
+          expect(entry.capture.size).toBe(0);
+          blocked.resolve();
+          await receiving;
+          await entry.processingQueue;
+          expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+          expect(agentCommandMock).not.toHaveBeenCalled();
+          expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+          expect(sink).not.toHaveBeenCalled();
+          expect(entry.capture.size).toBe(0);
+          expect(entry.transcripts).toBe(capture);
+          expect(entry.sessionLifecycle.status).toBe("active");
+
+          const next = new AudioReceiveStream({ end: { behavior: EndBehaviorType.Manual } });
+          connection.receiver.subscribe.mockReturnValueOnce(next);
+          const resumed = handleSpeakingStart(manager, entry, "u-speaker");
+          for (let frame = 0; frame < 20; frame++) {
+            next.push(Buffer.from([0xf8, 0xff, 0xfe]));
+          }
+          next.push(null);
+          await resumed;
+          await entry.processingQueue;
+          await Promise.all(conversations.mock.results.map((result) => result.value));
+          expect(sink).toHaveBeenCalledOnce();
+          expect(agentCommandMock).toHaveBeenCalledOnce();
+        } finally {
+          await stopTranscripts();
+          await manager.destroy();
+          stream.destroy();
+          blocked.resolve();
+          await receiving;
+          await entry.processingQueue;
+        }
+      },
+    );
+    it.each([true, false])(
+      "bounds encoded bytes with batch transcription enabled=%s",
+      async (enabled) => {
+        const actual = await vi.importActual<typeof import("./audio.js")>("./audio.js");
+        const blocked = createDeferred<void>();
+        decodeOpusStreamChunksMock.mockImplementation(async (input, params) => {
+          await blocked.promise;
+          await actual.decodeOpusStreamChunks(input, params);
+        });
+        const client = createClientWithMember("u-speaker", "Speaker", "0");
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const manager = createAgentProxyManager(
+          client,
+          { allowFrom: ["discord:u-speaker"] },
+          { tools: { media: { audio: { enabled } } } },
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const entry = getSessionEntry(manager);
+        const stream = new AudioReceiveStream({ end: { behavior: EndBehaviorType.Manual } });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const receiving = handleSpeakingStart(manager, entry, "u-speaker");
+        try {
+          await vi.waitFor(() => expect(connection.receiver.subscribe).toHaveBeenCalled());
+          const encoder = await createEncoder({
+            channels: 2,
+            sampleRate: 48_000,
+            bitrate: 512_000,
+            vbr: false,
+          });
+          let packet: Buffer;
+          try {
+            packet = Buffer.from(encoder.encode(new Int16Array(1_920), { frameSize: 960 }));
+          } finally {
+            encoder.free();
+          }
+          // High-bitrate Opus crosses the byte bound before the packet-count bound.
+          for (let frame = 0; frame < 950; frame++) {
+            stream.push(packet);
+          }
+          await vi.waitFor(() => expect(stream.destroyed).toBe(true));
+          expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("receive backlog"));
+          blocked.resolve();
+          await receiving;
+          expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+          expect(agentCommandMock).not.toHaveBeenCalled();
+          expect(entry.sessionLifecycle.status).toBe("active");
+          expect(entry.capture.size).toBe(0);
+        } finally {
+          stream.destroy();
+          blocked.resolve();
+          await receiving;
+          await manager.destroy();
+        }
+      },
+    );
+
+    it.each(["backlog", "decoder", "decryption", "stream"] as const)(
+      "retires only the incomplete realtime speaker after a %s failure",
+      async (failure) => {
+        const audio = await import("./audio.js");
+        const actual = await vi.importActual<typeof import("./audio.js")>("./audio.js");
+        decodeOpusStreamChunksMock.mockImplementation(actual.decodeOpusStreamChunks);
+        const diskStarted = createDeferred<void>();
+        const diskReady = createDeferred<void>();
+        const write = vi.spyOn(audio, "writeVoiceWavFile").mockImplementationOnce(async (pcm) => {
+          diskStarted.resolve();
+          await diskReady.promise;
+          return await actual.writeVoiceWavFile(pcm);
+        });
+        const client = createClientWithMember("u-speaker", "Speaker", "0");
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const manager = createAgentProxyManager(
+          client,
+          { allowFrom: ["discord:u-speaker"], voice: { realtime: { requireWakeName: false } } },
+          { tools: { media: { audio: { maxBytes: 3_884 } } } },
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const sink = vi.fn();
+        await startTranscripts(manager, sink);
+        const entry = getSessionEntry(manager);
+        const capture = entry.transcripts;
+        beginSpeakerTurn(entry, { userId: "u-other", senderIsOwner: false }).close();
+        const other = lastRealtimeBridge();
+        const stream = new AudioReceiveStream({ end: { behavior: EndBehaviorType.Manual } });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const receiving = handleSpeakingStart(manager, entry, "u-speaker");
+        try {
+          stream.push(Buffer.from([0xf8, 0xff, 0xfe]));
+          await diskStarted.promise;
+          const interrupted = lastRealtimeBridge();
+          expect(interrupted.session).not.toBe(other.session);
+          if (failure === "backlog") {
+            for (let frame = 0; frame < 2_000; frame++) {
+              stream.push(Buffer.from([0xf8, 0xff, 0xfe]));
+            }
+          } else if (failure === "decoder") {
+            stream.push(Buffer.from([0xff]));
+            diskReady.resolve();
+            await receiving;
+          } else {
+            stream.destroy(
+              new Error(failure === "decryption" ? "Failed to decrypt" : "Receive socket failed"),
+            );
+          }
+          await vi.waitFor(() => expect(stream.destroyed).toBe(true));
+          await emitFinalRealtimeUserTranscript(
+            interrupted.bridgeParams,
+            "Send the incomplete request",
+          );
+          expect(agentCommandMock).not.toHaveBeenCalled();
+          expect(interrupted.session.close).toHaveBeenCalledOnce();
+          expect(other.session.close).not.toHaveBeenCalled();
+          expect(entry.transcripts).toBe(capture);
+          expect(entry.sessionLifecycle.status).toBe("active");
+          await emitFinalRealtimeUserTranscript(other.bridgeParams, "Read the complete request");
+          expect(agentCommandMock).toHaveBeenCalledOnce();
+          diskReady.resolve();
+          await receiving;
+          await entry.processingQueue;
+          expect(agentCommandMock).toHaveBeenCalledOnce();
+          expect(entry.capture.size).toBe(0);
+        } finally {
+          diskReady.resolve();
+          stream.destroy();
+          await receiving;
+          await entry.processingQueue;
+          write.mockRestore();
+          await stopTranscripts();
+          await manager.destroy();
+        }
+      },
+    );
+  },
+);

--- a/extensions/discord/src/voice/voice-receive-limits.test.ts
+++ b/extensions/discord/src/voice/voice-receive-limits.test.ts
@@ -1,0 +1,118 @@
+import { PassThrough } from "node:stream";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    createConnectionMock,
+    joinVoiceChannelMock,
+    createManager,
+    makeVoiceConfig,
+    getSessionEntry,
+    handleSpeakingStart,
+    transcribeAudioFileMock,
+    loggerWarnMock,
+    decodeOpusStreamChunksMock,
+  }) => {
+    it.each([0, -1])(
+      "accounts for the WAV header at the transcription limit (offset %i)",
+      async (offset) => {
+        decodeOpusStreamChunksMock.mockImplementation(
+          (await vi.importActual<typeof import("./audio.js")>("./audio.js")).decodeOpusStreamChunks,
+        );
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        const manager = createManager(
+          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+          undefined,
+          { tools: { media: { audio: { maxBytes: 20 * 3840 + 44 + offset } } } },
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const entry = getSessionEntry(manager);
+        const conversations = vi.spyOn(entry.conversations, "enqueue");
+        const stream = new PassThrough({ objectMode: true });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const completion = handleSpeakingStart(manager, entry, "u-speaker");
+        const outcome =
+          offset === 0
+            ? expect(completion).resolves.toBeUndefined()
+            : expect(completion).rejects.toThrow("speak a shorter segment");
+        for (let frame = 0; frame < 20; frame += 1) {
+          stream.write(Buffer.from([0xf8, 0xff, 0xfe]));
+        }
+        stream.end();
+        await outcome;
+        await entry.processingQueue;
+        await Promise.all(conversations.mock.results.map((result) => result.value));
+        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(offset === 0 ? 1 : 0);
+        expect(stream.destroyed).toBe(true);
+        expect(entry.capture.size).toBe(0);
+        if (offset < 0) {
+          expect(loggerWarnMock).toHaveBeenCalledWith(
+            expect.stringContaining("speak a shorter segment"),
+          );
+        }
+        await manager.destroy();
+      },
+    );
+
+    it("allows the same speaker to restart after an oversized capture without transcribing a prefix", async () => {
+      decodeOpusStreamChunksMock.mockImplementation(
+        (await vi.importActual<typeof import("./audio.js")>("./audio.js")).decodeOpusStreamChunks,
+      );
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const manager = createManager(
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
+        undefined,
+        { tools: { media: { audio: { maxBytes: 20 * 3840 + 44 } } } },
+      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+      const conversations = vi.spyOn(entry.conversations, "enqueue");
+      for (const frames of [21, 20]) {
+        const stream = new PassThrough({ objectMode: true });
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+        const completion = handleSpeakingStart(manager, entry, "u-speaker");
+        const outcome =
+          frames === 21
+            ? expect(completion).rejects.toThrow("speak a shorter segment")
+            : expect(completion).resolves.toBeUndefined();
+        for (let frame = 0; frame < frames; frame += 1) {
+          stream.write(Buffer.from([0xf8, 0xff, 0xfe]));
+        }
+        stream.end();
+        await outcome;
+        await entry.processingQueue;
+        await Promise.all(conversations.mock.results.map((result) => result.value));
+        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(frames === 21 ? 0 : 1);
+        expect(stream.destroyed).toBe(true);
+        expect(entry.capture.size).toBe(0);
+      }
+      await manager.destroy();
+    });
+
+    it("records disabled batch transcription without decoding or retaining a capture", async () => {
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      const manager = createManager(undefined, undefined, {
+        tools: { media: { audio: { enabled: false } } },
+      });
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      const entry = getSessionEntry(manager);
+      const stream = new PassThrough({ objectMode: true });
+      connection.receiver.subscribe.mockReturnValueOnce(stream);
+      await handleSpeakingStart(manager, entry, "u-speaker");
+      expect(decodeOpusStreamChunksMock).not.toHaveBeenCalled();
+      expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.stringContaining("audio understanding is disabled"),
+      );
+      expect(stream.destroyed).toBe(true);
+      expect(entry.capture.size).toBe(0);
+      await manager.destroy();
+    });
+  },
+);

--- a/extensions/discord/src/voice/voice-receive.test.ts
+++ b/extensions/discord/src/voice/voice-receive.test.ts
@@ -1,4 +1,4 @@
-import type { Readable } from "node:stream";
+import { PassThrough, type Readable } from "node:stream";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { DiscordVoiceIngressContext } from "./ingress.js";
 import type { MockCallSource } from "./manager.e2e.test-support.js";
@@ -6,7 +6,6 @@ import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
 defineDiscordVoiceTests(
   ({
-    PassThrough,
     VoiceOpcodes,
     expect,
     it,
@@ -22,13 +21,12 @@ defineDiscordVoiceTests(
     resolveVoiceIngressWithParticipantsMock,
     loggerWarnMock,
     realtimeSessionMock,
-    decodeOpusStreamMock,
     decodeOpusStreamChunksMock,
     createClient,
     createManager,
+    createAgentProxyManager,
     makeVoiceConfig,
     configureVoiceStateGateway,
-    createAgentProxyManager,
     createFollowManager,
     expectConnectedStatus,
     getSessionEntry,
@@ -40,7 +38,63 @@ defineDiscordVoiceTests(
     makePoisonedDaveConnections,
     updateVoiceState,
     handleSpeakingStart,
+    startTranscripts,
+    stopTranscripts,
+    beginSpeakerTurn,
+    lastRealtimeBridgeParams,
+    emitFinalRealtimeUserTranscript,
+    receiveRecordedSpeech,
+    agentCommandMock,
   }) => {
+    it.each(["agent-proxy", "bidi"] as const)(
+      "keeps exact capture and %s conversation after destructive recovery",
+      async (mode) => {
+        const manager = createManager(
+          makeVoiceConfig(
+            { mode, realtime: { provider: "openai", requireWakeName: true } },
+            { groupPolicy: "open", allowFrom: ["discord:u-owner"] },
+          ),
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const onUtterance = vi.fn();
+        expect(await startTranscripts(manager, onUtterance)).toMatchObject({ ok: true });
+        await receiveRecordedSpeech(manager, "before recovery");
+        await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "before recovery");
+        expect(onUtterance).toHaveBeenCalledOnce();
+        const oldEntry = getSessionEntry(manager);
+        emitDecryptFailure(manager);
+        emitDecryptFailure(manager);
+        emitDecryptFailure(manager);
+        await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2));
+        await receiveRecordedSpeech(manager, "after recovery");
+        await emitFinalRealtimeUserTranscript(lastRealtimeBridgeParams(), "after recovery");
+        expect(onUtterance).toHaveBeenCalledTimes(2);
+        expect(agentCommandMock).not.toHaveBeenCalled();
+        await receiveRecordedSpeech(manager, "stale connection", oldEntry);
+        expect(onUtterance).toHaveBeenCalledTimes(2);
+        expect(await stopTranscripts()).toMatchObject({ ok: true });
+        expectConnectedStatus(manager, "1001");
+        beginSpeakerTurn(getSessionEntry(manager));
+        if (mode === "agent-proxy") {
+          await emitFinalRealtimeUserTranscript(
+            lastRealtimeBridgeParams(),
+            "OpenClaw, what changed?",
+          );
+        } else {
+          await lastRealtimeBridgeParams().onToolCall?.(
+            {
+              itemId: "consult-after-recovery",
+              callId: "consult-after-recovery",
+              name: "openclaw_agent_consult",
+              args: { question: "what changed?" },
+            },
+            realtimeSessionMock,
+          );
+        }
+        expect(agentCommandMock).toHaveBeenCalledOnce();
+        expect(onUtterance).toHaveBeenCalledTimes(2);
+      },
+    );
     it("authorizes realtime speakers before subscribing receiver streams", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
@@ -744,24 +798,11 @@ defineDiscordVoiceTests(
     });
 
     it("streams realtime with batch transcription disabled and resets receive recovery", async () => {
-      const connection = createConnectionMock();
-      joinVoiceChannelMock.mockReturnValueOnce(connection);
-      decodeOpusStreamChunksMock.mockImplementationOnce(
-        async (
-          _stream: Readable,
-          params: {
-            onChunk: (pcm48kStereo: Buffer) => void;
-          },
-        ) => {
-          params.onChunk(Buffer.alloc(8));
-        },
-      );
       const manager = createAgentProxyManager(
         undefined,
         { allowFrom: ["discord:u-speaker"] },
         { tools: { media: { audio: { enabled: false } } } },
       );
-
       await manager.join({ guildId: "g1", channelId: "1001" });
       emitDecryptFailure(manager);
       emitDecryptFailure(manager);
@@ -769,16 +810,9 @@ defineDiscordVoiceTests(
       const attempts = getVoiceReceive(manager).daveRecoveryAttempts;
       attempts.set("g1", Date.now());
       expect(entry.receiveRecovery.decryptFailureCount).toBe(2);
-      const stream = {
-        on: vi.fn(),
-        destroy: vi.fn(),
-        async *[Symbol.asyncIterator]() {},
-      };
-      connection.receiver.subscribe.mockReturnValueOnce(stream);
-
-      await handleSpeakingStart(manager, entry, "u-speaker");
-
-      expect(decodeOpusStreamChunksMock).toHaveBeenCalledTimes(1);
+      await receiveRecordedSpeech(manager, undefined, entry, "u-speaker");
+      expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce();
+      expect(realtimeSessionMock.sendAudio).toHaveBeenCalled();
       expect(transcribeAudioFileMock).not.toHaveBeenCalled();
       expect(loggerWarnMock).not.toHaveBeenCalledWith(
         expect.stringContaining("audio understanding is disabled"),
@@ -786,219 +820,185 @@ defineDiscordVoiceTests(
       expect(entry.receiveRecovery.decryptFailureCount).toBe(0);
       expect(entry.receiveRecovery.lastDecryptFailureAt).toBe(0);
       expect(attempts.has("g1")).toBe(false);
-      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
     });
 
-    it("cleans up realtime receive streams after WASM bounds failures", async () => {
-      const connection = createConnectionMock();
-      joinVoiceChannelMock.mockReturnValueOnce(connection);
-      decodeOpusStreamChunksMock.mockImplementationOnce(
-        async (
-          stream: Readable,
-          params: {
-            onError: (err: unknown) => void;
-          },
-        ) => {
-          const err = new Error("memory access out of bounds");
-          params.onError(err);
-          const errorListener = (
-            stream as unknown as {
-              on: ReturnType<typeof vi.fn>;
-            }
-          ).on.mock.calls.find(([event]) => event === "error")?.[1] as
-            | ((err: unknown) => void)
-            | undefined;
-          errorListener?.(err);
-        },
-      );
-      const manager = createAgentProxyManager(undefined, {
-        allowFrom: ["discord:u-speaker"],
-      });
-
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      const entry = getSessionEntry(manager);
-      const stream = {
-        on: vi.fn(),
-        off: vi.fn(),
-        destroy: vi.fn(),
-        destroyed: false,
-        async *[Symbol.asyncIterator]() {},
-      };
-      connection.receiver.subscribe.mockReturnValueOnce(stream);
-
-      await handleSpeakingStart(manager, entry, "u-speaker");
-
-      const errorListener = stream.on.mock.calls.find(([event]) => event === "error")?.[1];
-      expect(errorListener).toBeTypeOf("function");
-      expect(stream.off).toHaveBeenCalledWith("error", errorListener);
-      expect(stream.destroy).toHaveBeenCalledTimes(1);
-      expect(entry.capture.has("u-speaker")).toBe(false);
-      expect(entry.receiveRecovery.decryptFailureCount).toBe(1);
-    });
-
-    it("keeps receive recovery state after non-realtime decoder failures", async () => {
-      const connection = createConnectionMock();
-      joinVoiceChannelMock.mockReturnValueOnce(connection);
-      decodeOpusStreamMock.mockImplementationOnce(
-        async (
-          _stream: Readable,
-          params: {
-            onError: (err: unknown) => void;
-          },
-        ) => {
-          params.onError(new Error("memory access out of bounds"));
-          return Buffer.alloc(8);
-        },
-      );
-      const manager = createManager(
-        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
-      );
-
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      const entry = getSessionEntry(manager);
-      const stream = {
-        on: vi.fn(),
-        off: vi.fn(),
-        destroy: vi.fn(),
-        destroyed: false,
-        async *[Symbol.asyncIterator]() {},
-      };
-      connection.receiver.subscribe.mockReturnValueOnce(stream);
-
-      await handleSpeakingStart(manager, entry, "u-speaker");
-
-      expect(transcribeAudioFileMock).not.toHaveBeenCalled();
-      expect(entry.receiveRecovery.decryptFailureCount).toBe(1);
-      expect(entry.receiveRecovery.lastDecryptFailureAt).toBeGreaterThan(0);
-      expect(stream.destroy).toHaveBeenCalledTimes(1);
-    });
-
-    it.each([0, -1])(
-      "accounts for the WAV header at the transcription limit (offset %i)",
-      async (offset) => {
+    it.each([
+      { mode: "agent-proxy", captureOnly: false },
+      { mode: "bidi", captureOnly: false },
+      { mode: "stt-tts", captureOnly: false },
+      { mode: "stt-tts", captureOnly: true },
+    ] as const)(
+      "resets recovery once per stream while other speakers fail in $mode (captureOnly=$captureOnly)",
+      async ({ mode, captureOnly }) => {
         const connection = createConnectionMock();
         joinVoiceChannelMock.mockReturnValueOnce(connection);
         const manager = createManager(
-          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
-          undefined,
-          { tools: { media: { audio: { maxBytes: 20 * 3840 + 44 + offset } } } },
+          makeVoiceConfig(
+            { mode, realtime: { provider: "openai" } },
+            { groupPolicy: "open", allowFrom: ["discord:u-speaker", "discord:u-failing"] },
+          ),
         );
-        await manager.join({ guildId: "g1", channelId: "1001" });
+        if (captureOnly) {
+          expect(await startTranscripts(manager)).toMatchObject({ ok: true });
+        } else {
+          expect(await manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({
+            ok: true,
+          });
+        }
         const entry = getSessionEntry(manager);
-        const stream = new PassThrough({ objectMode: true });
-        connection.receiver.subscribe.mockReturnValueOnce(stream);
-        const completion = handleSpeakingStart(manager, entry, "u-speaker");
-        const outcome =
-          offset === 0
-            ? expect(completion).resolves.toBeUndefined()
-            : expect(completion).rejects.toThrow("speak a shorter segment");
-        for (let frame = 0; frame < 20; frame += 1) {
-          stream.write(Buffer.from([0xf8, 0xff, 0xfe]));
-        }
-        stream.end();
-        await outcome;
+        let decoded = createDeferred<void>();
+        decodeOpusStreamChunksMock.mockImplementation(
+          async (
+            input: Readable,
+            callbacks: { onChunk: (pcm: Buffer, packet: Buffer) => void | Promise<void> },
+          ) => {
+            for await (const packet of input) {
+              await callbacks.onChunk(Buffer.alloc(packet[0] === 0 ? 0 : 3_840), packet);
+              decoded.resolve();
+            }
+          },
+        );
+        const openStream = async (userId: string) => {
+          const stream = new PassThrough({ objectMode: true });
+          const subscribed = createDeferred<void>();
+          connection.receiver.subscribe.mockImplementationOnce(() => {
+            subscribed.resolve();
+            return stream;
+          });
+          const receiving = handleSpeakingStart(manager, entry, userId);
+          await subscribed.promise;
+          return { stream, receiving };
+        };
+        const failOtherSpeaker = async () => {
+          const other = await openStream("u-failing");
+          // The native receiver destroys the speaker's subscription when decryption fails.
+          other.stream.destroy(new Error("DecryptionFailed(InvalidCiphertext)"));
+          await other.receiving;
+        };
+        const writePacket = async (stream: PassThrough, marker: number) => {
+          decoded = createDeferred<void>();
+          stream.write(Buffer.from([marker]));
+          await decoded.promise;
+        };
+        const openHealthyStream = async () => {
+          await failOtherSpeaker();
+          await failOtherSpeaker();
+          const attempts = getVoiceReceive(manager).daveRecoveryAttempts;
+          attempts.set("g1", Date.now());
+          const healthy = await openStream("u-speaker");
+          await writePacket(healthy.stream, 0);
+          expect(entry.receiveRecovery.decryptFailureCount).toBe(2);
+          expect(attempts.has("g1")).toBe(true);
+          await writePacket(healthy.stream, 1);
+          expect(entry.receiveRecovery.decryptFailureCount).toBe(0);
+          expect(entry.receiveRecovery.lastDecryptFailureAt).toBe(0);
+          expect(attempts.has("g1")).toBe(false);
+          return healthy;
+        };
+
+        const first = await openHealthyStream();
+        first.stream.end();
+        await first.receiving;
         await entry.processingQueue;
-        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(offset === 0 ? 1 : 0);
-        expect(stream.destroyed).toBe(true);
-        expect(entry.capture.size).toBe(0);
-        if (offset < 0) {
-          expect(loggerWarnMock).toHaveBeenCalledWith(
-            expect.stringContaining("speak a shorter segment"),
-          );
+        // A fresh stream on the same entry still gets its own successful-audio reset.
+        const healthy = await openHealthyStream();
+        try {
+          for (let failure = 1; failure <= 3; failure++) {
+            await failOtherSpeaker();
+            if (failure < 3) {
+              await writePacket(healthy.stream, 1);
+              expect(connection.destroy).not.toHaveBeenCalled();
+            }
+          }
+          await vi.waitFor(() => {
+            expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2);
+            expect(getSessionEntry(manager)).not.toBe(entry);
+            expectConnectedStatus(manager, "1001");
+          });
+          expect(connection.destroy).toHaveBeenCalledOnce();
+          expect(healthy.stream.destroyed).toBe(true);
+          if (captureOnly) {
+            expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
+            expect(agentCommandMock).not.toHaveBeenCalled();
+          }
+        } finally {
+          healthy.stream.destroy();
+          await healthy.receiving;
+          await manager.destroy();
         }
-        await manager.destroy();
       },
     );
 
-    it("allows the same speaker to restart after an oversized capture without transcribing a prefix", async () => {
-      const connection = createConnectionMock();
-      joinVoiceChannelMock.mockReturnValueOnce(connection);
-      const manager = createManager(
-        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
-        undefined,
-        { tools: { media: { audio: { maxBytes: 20 * 3840 + 44 } } } },
-      );
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      const entry = getSessionEntry(manager);
-      for (const frames of [21, 20]) {
+    it.each(["agent-proxy", "stt-tts"] as const)(
+      "cleans up %s receive streams without clearing decoder failure state",
+      async (mode) => {
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
         const stream = new PassThrough({ objectMode: true });
-        connection.receiver.subscribe.mockReturnValueOnce(stream);
-        const completion = handleSpeakingStart(manager, entry, "u-speaker");
-        const outcome =
-          frames === 21
-            ? expect(completion).rejects.toThrow("speak a shorter segment")
-            : expect(completion).resolves.toBeUndefined();
-        for (let frame = 0; frame < frames; frame += 1) {
-          stream.write(Buffer.from([0xf8, 0xff, 0xfe]));
-        }
-        stream.end();
-        await outcome;
-        await entry.processingQueue;
-        expect(transcribeAudioFileMock).toHaveBeenCalledTimes(frames === 21 ? 0 : 1);
-        expect(stream.destroyed).toBe(true);
-        expect(entry.capture.size).toBe(0);
-      }
-      await manager.destroy();
-    });
+        decodeOpusStreamChunksMock.mockImplementationOnce(async (input, params) => {
+          for await (const packet of input) {
+            const err = new Error("memory access out of bounds");
+            params.onError?.(err);
+            stream.emit("error", err);
+            await params.onChunk(Buffer.alloc(8), packet);
+          }
+        });
+        const manager = createManager(
+          makeVoiceConfig(
+            { mode, realtime: { provider: "openai" } },
+            { groupPolicy: "open", allowFrom: ["discord:u-speaker"] },
+          ),
+        );
 
-    it("records disabled batch transcription without decoding or retaining a capture", async () => {
-      const connection = createConnectionMock();
-      joinVoiceChannelMock.mockReturnValueOnce(connection);
-      const manager = createManager(undefined, undefined, {
-        tools: { media: { audio: { enabled: false } } },
-      });
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      const entry = getSessionEntry(manager);
-      const stream = new PassThrough({ objectMode: true });
-      connection.receiver.subscribe.mockReturnValueOnce(stream);
-      await handleSpeakingStart(manager, entry, "u-speaker");
-      expect(decodeOpusStreamMock).not.toHaveBeenCalled();
-      expect(transcribeAudioFileMock).not.toHaveBeenCalled();
-      expect(loggerWarnMock).toHaveBeenCalledWith(
-        expect.stringContaining("audio understanding is disabled"),
-      );
-      expect(stream.destroyed).toBe(true);
-      expect(entry.capture.size).toBe(0);
-      await manager.destroy();
-    });
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const entry = getSessionEntry(manager);
+        connection.receiver.subscribe.mockReturnValueOnce(stream);
+
+        const receiving = handleSpeakingStart(manager, entry, "u-speaker");
+        stream.end(Buffer.from("opus-packet"));
+        await receiving;
+        await entry.processingQueue;
+
+        expect(stream.destroyed).toBe(true);
+        expect(stream.listenerCount("error")).toBe(0);
+        expect(entry.capture.has("u-speaker")).toBe(false);
+        expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+        expect(entry.receiveRecovery.decryptFailureCount).toBe(1);
+        expect(entry.receiveRecovery.lastDecryptFailureAt).toBeGreaterThan(0);
+      },
+    );
 
     it("processes partial non-realtime audio after abort-like stream endings", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
-      decodeOpusStreamMock.mockImplementationOnce(
-        async (
-          _stream: Readable,
-          params: {
-            onError: (err: unknown) => void;
-          },
-        ) => {
+      decodeOpusStreamChunksMock.mockImplementationOnce(async (input, params) => {
+        for await (const packet of input) {
+          await params.onChunk(Buffer.alloc(48_000), packet);
           const err = new Error("The operation was aborted");
           err.name = "AbortError";
-          params.onError(err);
-          return Buffer.alloc(48_000);
-        },
-      );
+          params.onError?.(err);
+        }
+      });
       const manager = createManager(
         makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
       );
 
       await manager.join({ guildId: "g1", channelId: "1001" });
       const entry = getSessionEntry(manager);
-      const stream = {
-        on: vi.fn(),
-        off: vi.fn(),
-        destroy: vi.fn(),
-        destroyed: false,
-        async *[Symbol.asyncIterator]() {},
-      };
+      const conversations = vi.spyOn(entry.conversations, "enqueue");
+      const stream = new PassThrough({ objectMode: true });
       connection.receiver.subscribe.mockReturnValueOnce(stream);
 
-      await handleSpeakingStart(manager, entry, "u-speaker");
+      const receiving = handleSpeakingStart(manager, entry, "u-speaker");
+      stream.end(Buffer.from("opus-packet"));
+      await receiving;
       await entry.processingQueue;
+      await Promise.all(conversations.mock.results.map((result) => result.value));
 
       expect(transcribeAudioFileMock).toHaveBeenCalledTimes(1);
       expect(entry.receiveRecovery.decryptFailureCount).toBe(0);
-      expect(stream.destroy).toHaveBeenCalledTimes(1);
+      expect(stream.destroyed).toBe(true);
     });
 
     it("allows the same speaker to restart after finalize fires", async () => {
@@ -1023,11 +1023,7 @@ defineDiscordVoiceTests(
         expect(destroyFirstStream).toHaveBeenCalledTimes(1);
         expect(entry.capture.has("u1")).toBe(false);
 
-        const secondStream = {
-          on: vi.fn(),
-          destroy: vi.fn(),
-          async *[Symbol.asyncIterator]() {},
-        };
+        const secondStream = new PassThrough({ objectMode: true });
         connection.receiver.subscribe.mockReturnValueOnce(secondStream);
 
         await handleSpeakingStart(manager, entry, "u1");

--- a/extensions/discord/src/voice/voice-receive.ts
+++ b/extensions/discord/src/voice/voice-receive.ts
@@ -31,6 +31,7 @@ import {
   recoverDaveZeroTransition as tryRecoverDaveZeroTransition,
   resetVoiceReceiveRecoveryState,
 } from "./receive-recovery.js";
+import type { DiscordVoiceAudioReceipt } from "./recording-types.js";
 import { loadDiscordVoiceSdk } from "./sdk-runtime.js";
 import { respondToDiscordVoiceTranscript } from "./segment.js";
 import {
@@ -43,7 +44,7 @@ import {
   type VoiceSessionEntry,
 } from "./session.js";
 import type { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
-import { DiscordVoiceRecording, type DiscordVoiceAudioReceipt } from "./voice-recording.js";
+import { DiscordVoiceRecording } from "./voice-recording.js";
 
 const logger = createSubsystemLogger("discord/voice");
 // UDP cannot apply backpressure; bound pending packets as well as their encoded bytes.

--- a/extensions/discord/src/voice/voice-receive.ts
+++ b/extensions/discord/src/voice/voice-receive.ts
@@ -1,21 +1,22 @@
+import { PassThrough } from "node:stream";
 import type { OpenClawConfig, DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { Client } from "../internal/discord.js";
-import {
-  decodeOpusStream,
-  decodeOpusStreamChunks,
-  VOICE_WAV_HEADER_BYTES,
-  writeVoiceWavFile,
-} from "./audio.js";
+import { decodeOpusStreamChunks } from "./audio.js";
 import {
   beginVoiceCapture,
   clearVoiceCaptureFinalizeTimer,
   finishVoiceCapture,
   scheduleVoiceCaptureFinalize,
+  waitForVoiceCaptureAdmission,
 } from "./capture-state.js";
-import { type DiscordVoiceIngressContext, runDiscordVoiceAgentTurn } from "./ingress.js";
+import {
+  type DiscordVoiceIngressContext,
+  runDiscordVoiceAgentTurn,
+  resolveDiscordVoiceIngressContext,
+} from "./ingress.js";
 import { formatVoiceLogPreview } from "./log-preview.js";
 import type { DiscordVoiceMembershipTracker } from "./membership.js";
 import { resolveDiscordVoiceIngressContextWithParticipants } from "./participant-context.js";
@@ -30,21 +31,23 @@ import {
   resetVoiceReceiveRecoveryState,
 } from "./receive-recovery.js";
 import { loadDiscordVoiceSdk } from "./sdk-runtime.js";
-import { processDiscordVoiceSegment } from "./segment.js";
+import { respondToDiscordVoiceTranscript } from "./segment.js";
 import {
   CAPTURE_FINALIZE_GRACE_MS,
-  isDiscordRealtimeVoiceMode,
   logVoiceVerbose,
   MIN_SEGMENT_SECONDS,
-  resolveDiscordVoiceMode,
   resolveVoiceTimeoutMs,
   type VoiceOperationResult,
-  type VoiceRealtimeSpeakerTurn,
+  type VoiceJoinOptions,
   type VoiceSessionEntry,
 } from "./session.js";
 import type { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
+import { DiscordVoiceRecording, type DiscordVoiceAudioReceipt } from "./voice-recording.js";
 
 const logger = createSubsystemLogger("discord/voice");
+// UDP cannot apply backpressure; bound pending packets as well as their encoded bytes.
+const MAX_PENDING_OPUS_PACKETS = 1_000;
+const MAX_PENDING_OPUS_BYTES = 1024 * 1024;
 
 export class DiscordVoiceReceive {
   readonly daveRecoveryAttempts = new Map<string, number>();
@@ -62,7 +65,7 @@ export class DiscordVoiceReceive {
       isFollowOwnedGuild: (guildId: string) => boolean;
       join: (
         params: { guildId: string; channelId: string },
-        options?: { preserveFollowState?: boolean; autoJoinWhenOccupied?: boolean },
+        options?: VoiceJoinOptions,
       ) => Promise<VoiceOperationResult>;
       leave: (
         params: { guildId: string },
@@ -73,18 +76,6 @@ export class DiscordVoiceReceive {
       speakerContext: DiscordVoiceSpeakerContextResolver;
     },
   ) {}
-
-  getRecoveryAttempt(guildId: string): number | undefined {
-    return this.daveRecoveryAttempts.get(guildId);
-  }
-
-  deleteRecoveryAttempt(guildId: string): void {
-    this.daveRecoveryAttempts.delete(guildId);
-  }
-
-  clearRecoveryAttempts(): void {
-    this.daveRecoveryAttempts.clear();
-  }
 
   scheduleCaptureFinalize(entry: VoiceSessionEntry, userId: string, reason: string): void {
     const graceMs = resolveVoiceTimeoutMs(
@@ -103,223 +94,331 @@ export class DiscordVoiceReceive {
     });
   }
 
-  async handleSpeakingStart(entry: VoiceSessionEntry, userId: string): Promise<void> {
-    if (!userId) {
+  async handleSpeakingStart(
+    entry: VoiceSessionEntry,
+    userId: string,
+    origin: "native" | "scan" = "native",
+  ): Promise<void> {
+    if (!userId || !this.params.isEntryCurrent(entry)) {
       return;
     }
-    const botUserId = this.params.botUserId();
-    if (botUserId && userId === botUserId) {
+
+    if (userId === this.params.botUserId()) {
       return;
     }
     this.params.membership.notePresent(entry, userId);
     const activeCapture = entry.capture.get(userId);
     if (activeCapture) {
       const extended = clearVoiceCaptureFinalizeTimer(activeCapture);
+      if (entry.transcripts?.isCurrent()) {
+        activeCapture.startRecording?.();
+      }
       logVoiceVerbose(
         `capture start ignored (already active): guild ${entry.guildId} channel ${entry.channelId} user ${userId}${extended ? " (finalize canceled)" : ""}`,
       );
       return;
     }
 
-    logVoiceVerbose(
-      `capture start: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-    );
-    const voiceSdk = loadDiscordVoiceSdk();
-    // Queued STT belongs to the subscription that received the audio.
-    const transcripts = entry.transcripts;
-    const voiceMode = resolveDiscordVoiceMode(this.params.discordConfig.voice);
+    const capture = entry.transcripts;
     const realtime =
-      entry.realtimeLifecycle.status === "active" && isDiscordRealtimeVoiceMode(voiceMode)
-        ? entry.realtimeLifecycle.instance
-        : undefined;
-    if (entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing && !realtime) {
+      entry.realtimeLifecycle.status === "active" ? entry.realtimeLifecycle.instance : undefined;
+    const playing = entry.player.state.status === loadDiscordVoiceSdk().AudioPlayerStatus.Playing;
+    // Scans cannot recover unsubscribed packets. Only a native start may admit
+    // conversation for a new receive stream; already-owned streams keep their admission.
+    const conversationAllowed =
+      origin === "native" && !entry.captureOnly && !(playing && !realtime?.isBargeInEnabled());
+    if (!capture && !conversationAllowed) {
       logVoiceVerbose(
-        `capture ignored during playback: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
+        `capture ignored: guild ${entry.guildId} channel ${entry.channelId} user ${userId} reason=${playing ? "protected playback" : "inactive capture"}`,
       );
       return;
     }
-    // Own start/end events while admission awaits; subscribing still requires authorization.
-    const capture = beginVoiceCapture(entry.capture, userId);
-    let streamAborted = false;
-    let receiveFailureHandled = false;
-    let receiveStreamEndHandled = false;
-    let pendingWavCleanup: (() => Promise<void>) | undefined;
-    const handleStreamError = (err: unknown) => {
-      const analysis = analyzeVoiceReceiveError(err);
-      if (analysis.isAbortLike && !analysis.countsAsDecryptFailure) {
-        if (receiveStreamEndHandled) {
-          return;
-        }
-        receiveStreamEndHandled = true;
-        streamAborted = true;
-        this.handleReceiveError(entry, err);
-        return;
-      }
-      if (receiveFailureHandled) {
-        return;
-      }
-      receiveFailureHandled = true;
-      this.handleReceiveError(entry, err);
-    };
+    // A recorder can promote this reservation while native conversation admission
+    // waits, without repeating admission or subscribing before either authority exists.
+    const reservation = beginVoiceCapture(entry.capture, userId);
     try {
-      const realtimeIngress = realtime
-        ? await this.resolveDiscordVoiceIngressContext(entry, userId)
-        : undefined;
-      if (realtime && !realtimeIngress) {
-        logVoiceVerbose(
-          `realtime capture unauthorized: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-        );
-        return;
-      }
-      if (!this.params.isEntryCurrent(entry) || entry.capture.get(userId) !== capture) {
-        return;
-      }
-      if (entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing && realtime) {
-        if (!realtime.isBargeInEnabled()) {
-          logger.info(
-            `discord voice: realtime capture ignored during playback (barge-in disabled): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
+      let realtimeIngress: Promise<DiscordVoiceIngressContext | null> | undefined;
+      if (realtime && !capture) {
+        realtimeIngress = this.resolveDiscordVoiceIngressContext(entry, userId);
+        const admitted = await waitForVoiceCaptureAdmission({
+          capture: reservation,
+          conversationAuthorized: realtimeIngress.then((context) => context !== null),
+          isRecordingCurrent: () => entry.transcripts?.isCurrent() === true,
+        });
+        if (!admitted) {
+          logVoiceVerbose(
+            `realtime capture unauthorized: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
           );
           return;
         }
-        logVoiceVerbose(
-          `realtime barge-in: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-        );
-        logger.info(
-          `discord voice: realtime barge-in detected source=speaker-start guild=${entry.guildId} channel=${entry.channelId} user=${userId} playerStatus=${entry.player.state.status}`,
-        );
-        realtime.handleBargeIn("speaker-start");
       }
-      this.enableDaveReceivePassthrough(
-        entry,
-        `speaker ${userId} start`,
-        DAVE_RECEIVE_PASSTHROUGH_REARM_EXPIRY_SECONDS,
-      );
-      const stream = (capture.stream = entry.connection.receiver.subscribe(userId, {
-        end: {
-          behavior: voiceSdk.EndBehaviorType.Manual,
-        },
-      }));
-      stream.on("error", handleStreamError);
-      if (realtime && realtimeIngress) {
-        const turn = realtime.beginSpeakerTurn(realtimeIngress, userId);
-        try {
-          await this.processRealtimeAudioCapture({
-            entry,
-            onReceiveError: handleStreamError,
-            stream,
-            turn,
-          });
-        } finally {
-          turn.close();
-        }
+      if (!this.params.isEntryCurrent(entry) || entry.capture.get(userId) !== reservation) {
         return;
       }
-      if (!entry.audioInputBudget.enabled) {
-        logger.warn(
-          "discord voice: capture skipped: audio understanding is disabled; enable tools.media.audio.enabled to transcribe voice.",
-        );
-        return;
-      }
-      const pcm = await decodeOpusStream(stream, {
-        maxBytes: Math.max(0, entry.audioInputBudget.maxBytes - VOICE_WAV_HEADER_BYTES),
-        onError: handleStreamError,
-        onVerbose: logVoiceVerbose,
-        onWarn: (message) => logger.warn(message),
-      });
-      if (receiveFailureHandled) {
-        return;
-      }
-      if (!this.params.isEntryCurrent(entry)) {
-        return;
-      }
-      if (pcm.length === 0) {
-        logVoiceVerbose(
-          `capture empty: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-        );
-        return;
-      }
-      this.resetDecryptFailureState(entry);
-      const { path: wavPath, durationSeconds, cleanup } = await writeVoiceWavFile(pcm);
-      pendingWavCleanup = cleanup;
-      if (!this.params.isEntryCurrent(entry)) {
-        return;
-      }
-      const minimumDurationSeconds = streamAborted ? 0.2 : MIN_SEGMENT_SECONDS;
-      if (durationSeconds < minimumDurationSeconds) {
-        logVoiceVerbose(
-          `capture too short (${durationSeconds.toFixed(2)}s): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-        );
-        return;
-      }
-      logVoiceVerbose(
-        `capture ready (${durationSeconds.toFixed(2)}s): guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
-      );
-      const previousProcessing = entry.processingQueue;
-      entry.processingQueue = (async () => {
-        try {
-          await previousProcessing;
-          if (!this.params.isEntryCurrent(entry)) {
-            return;
-          }
-          if (entry.transcripts !== transcripts) {
-            return;
-          }
-          await this.processSegment({ entry, wavPath, userId, durationSeconds });
-        } finally {
-          await cleanup();
-        }
-      })().catch((err: unknown) =>
-        logger.warn(`discord voice: processing failed: ${formatErrorMessage(err)}`),
-      );
-      // Processing owns the WAV until its queue work settles, even after this receive stream ends.
-      pendingWavCleanup = undefined;
-    } catch (err) {
-      if (!receiveFailureHandled) {
-        this.handleReceiveError(entry, err);
-      }
-      throw err;
+      await this.receiveSpeaker(entry, userId, reservation, conversationAllowed, realtimeIngress);
     } finally {
-      const stream = capture.stream;
-      stream?.off?.("error", handleStreamError);
-      const finishedActiveCapture = finishVoiceCapture(entry.capture, userId, capture);
+      const stream = reservation.stream;
+      const finishedActiveCapture = finishVoiceCapture(entry.capture, userId, reservation);
       if (finishedActiveCapture && stream && !stream.destroyed) {
         stream.destroy();
       }
-      await pendingWavCleanup?.();
     }
   }
 
-  async processSegment(params: {
-    entry: VoiceSessionEntry;
-    wavPath: string;
-    userId: string;
-    durationSeconds: number;
-  }): Promise<void> {
-    await processDiscordVoiceSegment({
-      ...params,
+  captureCurrentSpeakers(entry: VoiceSessionEntry): void {
+    for (const userId of entry.connection.receiver.speaking.users.keys()) {
+      void this.handleSpeakingStart(entry, userId, "scan").catch((error: unknown) =>
+        logger.warn(`discord voice: capture failed: ${formatErrorMessage(error)}`),
+      );
+    }
+  }
+
+  private responseContext(entry: VoiceSessionEntry, userId: string) {
+    return {
+      entry,
+      userId,
       accountId: this.params.accountId,
       cfg: this.params.cfg,
       discordConfig: this.params.discordConfig,
       admissionAllowFrom: this.params.admissionAllowFrom,
       runtime: this.params.runtime,
       speakerContext: this.params.speakerContext,
-      resolveIngressContext: () =>
-        this.resolveDiscordVoiceIngressContext(params.entry, params.userId),
-      transcripts: params.entry.transcripts,
-      fetchGuildName: async (guildId) => {
+      fetchGuildName: async (guildId: string) => {
         const guild = await this.params.client.fetchGuild(guildId).catch(() => null);
         return guild && typeof guild.name === "string" && guild.name.trim()
           ? guild.name
           : undefined;
       },
-      enqueuePlayback: (entry, task) => {
-        entry.playbackQueue = entry.playbackQueue
+      enqueuePlayback: (playbackEntry: VoiceSessionEntry, task: () => Promise<void>) => {
+        playbackEntry.playbackQueue = playbackEntry.playbackQueue
           .then(task)
           .catch((err: unknown) =>
             logger.warn(`discord voice: playback failed: ${formatErrorMessage(err)}`),
           );
       },
+    };
+  }
+
+  private async receiveSpeaker(
+    entry: VoiceSessionEntry,
+    userId: string,
+    reservation: ReturnType<typeof beginVoiceCapture>,
+    conversationAllowed: boolean,
+    admittedIngress?: Promise<DiscordVoiceIngressContext | null>,
+  ): Promise<void> {
+    const voiceSdk = loadDiscordVoiceSdk();
+    const realtime =
+      entry.realtimeLifecycle.status === "active" ? entry.realtimeLifecycle.instance : undefined;
+    const protectedPlayback = () =>
+      entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing &&
+      !realtime?.isBargeInEnabled();
+    this.enableDaveReceivePassthrough(
+      entry,
+      `speaker ${userId} start`,
+      DAVE_RECEIVE_PASSTHROUGH_REARM_EXPIRY_SECONDS,
+    );
+    const stream = (reservation.stream = entry.connection.receiver.subscribe(userId, {
+      end: { behavior: voiceSdk.EndBehaviorType.Manual },
+    }));
+    if (!entry.audioInputBudget.enabled && !realtime) {
+      logger.warn(
+        "discord voice: capture skipped: audio understanding is disabled; enable tools.media.audio.enabled to transcribe voice.",
+      );
+      return;
+    }
+    // Reserve packets before identity/decoder awaits. Normal socket close ends this owned input
+    // without destroying packets already received under the source subscription.
+    const input = new PassThrough({ objectMode: true });
+    const receipts = new WeakMap<Buffer, DiscordVoiceAudioReceipt>();
+    let failed = false;
+    let pendingPackets = 0;
+    let pendingBytes = 0;
+    const acceptPacket = (packet: Buffer) => {
+      if (
+        failed ||
+        !packet.length ||
+        !this.params.isEntryCurrent(entry) ||
+        entry.capture.get(userId) !== reservation
+      ) {
+        return;
+      }
+      const capture = entry.transcripts;
+      if (!capture && !conversationAllowed) {
+        return;
+      }
+      if (
+        pendingPackets >= MAX_PENDING_OPUS_PACKETS ||
+        packet.length > MAX_PENDING_OPUS_BYTES - pendingBytes
+      ) {
+        onError(new Error("Discord voice receive backlog exceeded; try speaking again."));
+        finishVoiceCapture(entry.capture, userId, reservation);
+        input.destroy();
+        stream.destroy();
+        return;
+      }
+      pendingPackets += 1;
+      pendingBytes += packet.length;
+      const receivedPacket = Buffer.from(packet);
+      receipts.set(receivedPacket, { capture, startedAt: Date.now() });
+      input.write(receivedPacket);
+    };
+    const endInput = () => input.end();
+    let aborted = false;
+    let resetReceiveRecovery = false;
+    const onError = (error: unknown) => {
+      const analysis = analyzeVoiceReceiveError(error);
+      if (analysis.isAbortLike && !analysis.countsAsDecryptFailure) {
+        if (!aborted) {
+          aborted = true;
+          this.handleReceiveError(entry, error);
+        }
+        return;
+      }
+      if (failed) {
+        return;
+      }
+      failed = true;
+      conversation?.retire();
+      this.handleReceiveError(entry, error);
+    };
+    stream.on("data", acceptPacket);
+    stream.on("end", endInput);
+    stream.on("close", endInput);
+    stream.on("error", onError);
+    const conversation = conversationAllowed
+      ? entry.conversations.start({
+          authorize: () =>
+            admittedIngress ??
+            (realtime
+              ? this.resolveDiscordVoiceIngressContext(entry, userId)
+              : resolveDiscordVoiceIngressContext(this.responseContext(entry, userId))),
+          isCurrent: () => this.params.isEntryCurrent(entry),
+          canAdmit: () => !protectedPlayback(),
+          createTurn: realtime
+            ? (context) => {
+                if (entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing) {
+                  realtime.handleBargeIn("speaker-start");
+                }
+                return realtime.beginSpeakerTurn(context, userId);
+              }
+            : undefined,
+          warn: (message) => logger.warn(message),
+        })
+      : undefined;
+    const recording = new DiscordVoiceRecording({
+      entry,
+      cfg: this.params.cfg,
+      userId,
+      isInputComplete: () => !failed,
+      minimumSeconds: () => (aborted ? 0.2 : MIN_SEGMENT_SECONDS),
+      canConverse: () => !realtime && conversation?.ingress != null,
+      resolveIngressContext: async () => {
+        if (realtime || !conversation) {
+          return null;
+        }
+        return await conversation.authorizeSegment(() =>
+          resolveDiscordVoiceIngressContext(this.responseContext(entry, userId)),
+        );
+      },
+      resolveSpeaker: () => this.params.speakerContext.resolveIdentity(entry.guildId, userId),
+      onSegment: (outcome) => {
+        if (!realtime) {
+          conversation?.addSegment(outcome);
+        }
+      },
+      onExcluded: () => {
+        if (!realtime) {
+          conversation?.retire();
+        }
+      },
     });
+    let conversationCompletion: Promise<void> | undefined;
+    try {
+      if (!conversation && !entry.transcripts?.isCurrent()) {
+        return;
+      }
+      await decodeOpusStreamChunks(input, {
+        onChunk: async (pcm, packet) => {
+          const receipt = receipts.get(packet);
+          if (!receipt || failed) {
+            return;
+          }
+          pendingPackets -= 1;
+          pendingBytes -= packet.length;
+          receipts.delete(packet);
+          // Recovery counters are shared by speakers. Later healthy packets must not
+          // erase another speaker's failures after this stream's first successful decode.
+          if (!resetReceiveRecovery && pcm.length > 0) {
+            resetReceiveRecovery = true;
+            this.resetDecryptFailureState(entry);
+          }
+          if (!receipt.capture && conversation && !conversation.ingress) {
+            const admitted = await waitForVoiceCaptureAdmission({
+              capture: reservation,
+              conversationAuthorized: conversation.ready.then(() => conversation.ingress !== null),
+              isRecordingCurrent: () => entry.transcripts?.isCurrent() === true,
+            });
+            if (!admitted) {
+              finishVoiceCapture(entry.capture, userId, reservation);
+              stream.destroy();
+              return;
+            }
+          }
+          if (failed) {
+            return;
+          }
+          conversation?.sendAudio(pcm);
+          await recording.append(pcm, receipt);
+        },
+        onError,
+        onVerbose: logVoiceVerbose,
+        onWarn: (message) => logger.warn(message),
+      });
+      await recording.finish();
+      // Conversation completion no longer owns this speaker's receive reservation.
+      finishVoiceCapture(entry.capture, userId, reservation);
+      stream.destroy();
+      if (conversation) {
+        if (realtime) {
+          conversationCompletion = entry.conversations.finishAudio(conversation);
+        } else if (!failed) {
+          const recordingComplete = recording.completion;
+          conversationCompletion = entry.conversations
+            .enqueue(conversation, async () => {
+              await recordingComplete;
+              const transcript = await conversation.transcript();
+              if (!transcript || !this.params.isEntryCurrent(entry)) {
+                return;
+              }
+              const currentIngress = await this.resolveDiscordVoiceIngressContext(entry, userId);
+              if (!currentIngress || !this.params.isEntryCurrent(entry)) {
+                return;
+              }
+              await respondToDiscordVoiceTranscript({
+                ...this.responseContext(entry, userId),
+                ingress: currentIngress,
+                transcript,
+              });
+            })
+            .catch((error: unknown) =>
+              logger.warn(`discord voice: processing failed: ${formatErrorMessage(error)}`),
+            );
+        }
+      }
+    } finally {
+      if (conversationCompletion) {
+        void conversationCompletion.catch((error: unknown) =>
+          logger.warn(`discord voice: conversation failed: ${formatErrorMessage(error)}`),
+        );
+      } else if (conversation) {
+        entry.conversations.release(conversation);
+      }
+      stream.off("data", acceptPacket);
+      stream.off("end", endInput);
+      stream.off("close", endInput);
+      stream.off("error", onError);
+      input.destroy();
+    }
   }
 
   handleReceiveError(entry: VoiceSessionEntry, err: unknown): void {
@@ -403,28 +502,6 @@ export class DiscordVoiceReceive {
       },
       reason,
       expirySeconds,
-      onVerbose: logVoiceVerbose,
-      onWarn: (message) => logger.warn(message),
-    });
-  }
-
-  private async processRealtimeAudioCapture(params: {
-    entry: VoiceSessionEntry;
-    onReceiveError: (err: unknown) => void;
-    stream: import("node:stream").Readable;
-    turn: VoiceRealtimeSpeakerTurn;
-  }): Promise<void> {
-    const { entry, onReceiveError, stream, turn } = params;
-    let resetReceiveRecovery = false;
-    await decodeOpusStreamChunks(stream, {
-      onChunk: (pcm) => {
-        if (!resetReceiveRecovery && pcm.length > 0) {
-          resetReceiveRecovery = true;
-          this.resetDecryptFailureState(entry);
-        }
-        turn.sendInputAudio(pcm);
-      },
-      onError: onReceiveError,
       onVerbose: logVoiceVerbose,
       onWarn: (message) => logger.warn(message),
     });
@@ -562,7 +639,11 @@ export class DiscordVoiceReceive {
     }
     const result = await this.params.join(
       { guildId: entry.guildId, channelId: entry.channelId },
-      { preserveFollowState, autoJoinWhenOccupied: entry.autoJoinWhenOccupied },
+      {
+        preserveFollowState,
+        autoJoinWhenOccupied: entry.autoJoinWhenOccupied,
+        captureOnly: entry.captureOnly,
+      },
     );
     if (!result.ok) {
       logger.warn(`discord voice: rejoin after decrypt failures failed: ${result.message}`);

--- a/extensions/discord/src/voice/voice-receive.ts
+++ b/extensions/discord/src/voice/voice-receive.ts
@@ -20,6 +20,7 @@ import {
 import { formatVoiceLogPreview } from "./log-preview.js";
 import type { DiscordVoiceMembershipTracker } from "./membership.js";
 import { resolveDiscordVoiceIngressContextWithParticipants } from "./participant-context.js";
+import { DiscordRealtimeRecordingInput } from "./realtime-recording.js";
 import {
   analyzeVoiceReceiveError,
   DAVE_RECEIVE_PASSTHROUGH_REARM_EXPIRY_SECONDS,
@@ -285,6 +286,9 @@ export class DiscordVoiceReceive {
     stream.on("end", endInput);
     stream.on("close", endInput);
     stream.on("error", onError);
+    const realtimeRecording = realtime
+      ? new DiscordRealtimeRecordingInput(!entry.audioInputBudget.enabled)
+      : undefined;
     const conversation = conversationAllowed
       ? entry.conversations.start({
           authorize: () =>
@@ -299,7 +303,7 @@ export class DiscordVoiceReceive {
                 if (entry.player.state.status === voiceSdk.AudioPlayerStatus.Playing) {
                   realtime.handleBargeIn("speaker-start");
                 }
-                return realtime.beginSpeakerTurn(context, userId);
+                return realtime.beginSpeakerTurn(context, userId, realtimeRecording);
               }
             : undefined,
           warn: (message) => logger.warn(message),
@@ -322,11 +326,15 @@ export class DiscordVoiceReceive {
       },
       resolveSpeaker: () => this.params.speakerContext.resolveIdentity(entry.guildId, userId),
       onSegment: (outcome) => {
+        realtimeRecording?.observeBatch(outcome);
         if (!realtime) {
           conversation?.addSegment(outcome);
         }
       },
       onExcluded: () => {
+        if (entry.audioInputBudget.enabled) {
+          realtimeRecording?.exclude();
+        }
         if (!realtime) {
           conversation?.retire();
         }
@@ -367,7 +375,8 @@ export class DiscordVoiceReceive {
           if (failed) {
             return;
           }
-          conversation?.sendAudio(pcm);
+          realtimeRecording?.noteReceipt(receipt);
+          conversation?.sendAudio(pcm, receipt);
           await recording.append(pcm, receipt);
         },
         onError,
@@ -406,6 +415,7 @@ export class DiscordVoiceReceive {
         }
       }
     } finally {
+      realtimeRecording?.sealBatch();
       if (conversationCompletion) {
         void conversationCompletion.catch((error: unknown) =>
           logger.warn(`discord voice: conversation failed: ${formatErrorMessage(error)}`),

--- a/extensions/discord/src/voice/voice-recording-backlog.test.ts
+++ b/extensions/discord/src/voice/voice-recording-backlog.test.ts
@@ -1,0 +1,143 @@
+import fs from "node:fs/promises";
+import { PassThrough } from "node:stream";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+const voiceAudio = await import("./audio.js");
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    createManager,
+    makeVoiceConfig,
+    getSessionEntry,
+    getSessionConnection,
+    handleSpeakingStart,
+    startTranscripts,
+    decodeOpusStreamChunksMock,
+    transcribeAudioFileMock,
+    loggerWarnMock,
+  }) => {
+    it.each([
+      { limit: "jobs", blocked: "transcription", frames: 1, attempts: 256, expectedFiles: 128 },
+      { limit: "bytes", blocked: "publication", frames: 500, attempts: 40, expectedFiles: 34 },
+    ] as const)(
+      "bounds queued WAV $limit during stalled $blocked across reconnect",
+      async (scenario) => {
+        const manager = createManager(makeVoiceConfig(), undefined, {
+          tools: { media: { audio: { maxBytes: scenario.frames * 3_840 + 44 } } },
+        });
+        const release = createDeferred<void>();
+        const sink = vi.fn(async () => {
+          if (scenario.blocked === "publication") {
+            await release.promise;
+          }
+        });
+        await startTranscripts(manager, sink);
+        const entry = getSessionEntry(manager);
+        decodeOpusStreamChunksMock.mockImplementation(async (input, callbacks) => {
+          try {
+            for await (const packet of input) {
+              await callbacks.onChunk(Buffer.alloc(3_840, packet[0]), packet);
+            }
+          } catch (error) {
+            callbacks.onError?.(error);
+          }
+        });
+        transcribeAudioFileMock.mockImplementation(async () => {
+          if (scenario.blocked === "transcription") {
+            await release.promise;
+          }
+          return { text: "Recorded speech" };
+        });
+        let created = createDeferred<void>();
+        const files: Array<{ path: string; bytes: number }> = [];
+        const writeWav = voiceAudio.writeVoiceWavFile;
+        const writes = vi.spyOn(voiceAudio, "writeVoiceWavFile").mockImplementation(async (pcm) => {
+          const wav = await writeWav(pcm);
+          files.push({ path: wav.path, bytes: (await fs.stat(wav.path)).size });
+          created.resolve();
+          return wav;
+        });
+        const streams: PassThrough[] = [];
+        const receive = (target = entry) => {
+          const stream = new PassThrough({ objectMode: true });
+          streams.push(stream);
+          getSessionConnection(target).receiver.subscribe.mockReturnValueOnce(stream);
+          const receiving = handleSpeakingStart(manager, target, "guest").catch(
+            (error: unknown) => {
+              if (!(error instanceof Error) || !error.message.includes("recording backlog")) {
+                throw error;
+              }
+            },
+          );
+          return { stream, receiving };
+        };
+        const first = receive();
+        try {
+          for (let chunk = 0; chunk < scenario.attempts; chunk++) {
+            created = createDeferred<void>();
+            for (let frame = 0; frame < scenario.frames; frame++) {
+              first.stream.write(Buffer.from([7]));
+            }
+            const continuing = await Promise.race([
+              created.promise.then(() => true),
+              first.receiving.then(() => false),
+            ]);
+            if (!continuing) {
+              break;
+            }
+          }
+          first.stream.end();
+          await first.receiving;
+          expect(files).toHaveLength(scenario.expectedFiles);
+          expect(files.reduce((total, file) => total + file.bytes, 0)).toBeLessThanOrEqual(
+            64 * 1024 * 1024,
+          );
+          expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("recording backlog"));
+          expect(entry.transcripts?.isCurrent()).toBe(true);
+
+          await manager.leave({ guildId: "g1" });
+          expect(
+            await manager.startTranscriptsCapture({ guildId: "g1", channelId: "1001" }),
+          ).toMatchObject({ ok: true });
+          const replacement = getSessionEntry(manager);
+          const blocked = receive(replacement);
+          for (let frame = 0; frame < scenario.frames; frame++) {
+            blocked.stream.write(Buffer.from([8]));
+          }
+          blocked.stream.end();
+          await blocked.receiving;
+          expect(files).toHaveLength(scenario.expectedFiles);
+
+          release.resolve();
+          await entry.processingQueue;
+          await Promise.all(
+            files.map(async (file) => {
+              await expect(fs.access(file.path)).rejects.toMatchObject({ code: "ENOENT" });
+            }),
+          );
+          const calls = sink.mock.calls.length;
+          const resumed = receive(replacement);
+          resumed.stream.end(Buffer.from([9]));
+          await resumed.receiving;
+          await replacement.processingQueue;
+          expect(files).toHaveLength(scenario.expectedFiles + 1);
+          expect(sink).toHaveBeenCalledTimes(calls + 1);
+          expect(replacement.transcripts?.isCurrent()).toBe(true);
+        } finally {
+          release.resolve();
+          for (const stream of streams) {
+            stream.end();
+          }
+          await first.receiving;
+          await entry.processingQueue;
+          await manager.destroy();
+          writes.mockRestore();
+        }
+      },
+    );
+  },
+);

--- a/extensions/discord/src/voice/voice-recording.ts
+++ b/extensions/discord/src/voice/voice-recording.ts
@@ -1,0 +1,202 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { VOICE_WAV_HEADER_BYTES, writeVoiceWavFile } from "./audio.js";
+import type { DiscordVoiceIngressContext } from "./ingress.js";
+import { processDiscordVoiceSegment, type DiscordVoiceSegmentOutcome } from "./segment.js";
+import type { VoiceSessionEntry } from "./session.js";
+
+const logger = createSubsystemLogger("discord/voice");
+const PCM_BYTES_PER_MILLISECOND = (48_000 * 2 * 2) / 1_000;
+const MAX_PENDING_RECORDING_JOBS = 128;
+const MAX_PENDING_RECORDING_BYTES = 64 * 1024 * 1024;
+let pendingRecordingJobs = 0;
+let pendingRecordingBytes = 0;
+
+function reserveRecordingWav(bytes: number): () => void {
+  // The file budget outlives individual transports and managers.
+  if (
+    pendingRecordingJobs >= MAX_PENDING_RECORDING_JOBS ||
+    bytes > MAX_PENDING_RECORDING_BYTES - pendingRecordingBytes
+  ) {
+    throw new Error(
+      "Discord voice recording backlog exceeded; wait for pending audio processing to finish, then speak again.",
+    );
+  }
+  pendingRecordingJobs += 1;
+  pendingRecordingBytes += bytes;
+  return () => {
+    pendingRecordingJobs -= 1;
+    pendingRecordingBytes -= bytes;
+  };
+}
+
+export type DiscordVoiceAudioReceipt = {
+  capture: VoiceSessionEntry["transcripts"];
+  startedAt: number;
+};
+
+export class DiscordVoiceRecording {
+  private readonly segmentBytes: number;
+  private chunks: Buffer[] = [];
+  private bytes = 0;
+  private chunked = false;
+  private capture: VoiceSessionEntry["transcripts"];
+  private startedAt = 0;
+  private speaker: Promise<{ label: string }> | undefined;
+  private overflow: Error | undefined;
+  completion: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly params: {
+      entry: VoiceSessionEntry;
+      cfg: OpenClawConfig;
+      userId: string;
+      isInputComplete: () => boolean;
+      minimumSeconds: () => number;
+      canConverse: () => boolean;
+      resolveIngressContext: () => Promise<DiscordVoiceIngressContext | null>;
+      resolveSpeaker: () => Promise<{ label: string }>;
+      onSegment: (outcome: Promise<DiscordVoiceSegmentOutcome>) => void;
+      onExcluded: () => void;
+    },
+  ) {
+    const budget = params.entry.audioInputBudget;
+    // Include the WAV header and keep complete stereo PCM frames within the upload cap.
+    this.segmentBytes = budget.enabled
+      ? Math.max(
+          0,
+          Math.floor(
+            (Math.min(budget.maxBytes, MAX_PENDING_RECORDING_BYTES) - VOICE_WAV_HEADER_BYTES) / 4,
+          ) * 4,
+        )
+      : 0;
+  }
+
+  async append(pcm: Buffer, receipt: DiscordVoiceAudioReceipt): Promise<void> {
+    if (!this.segmentBytes) {
+      this.params.onExcluded();
+      return;
+    }
+    this.chunked ||= receipt.capture !== undefined;
+    if (receipt.capture !== this.capture) {
+      await this.flush();
+    }
+    this.capture = receipt.capture;
+    if (!this.capture?.isCurrent() && !this.params.canConverse()) {
+      this.params.onExcluded();
+      return;
+    }
+    if (!this.chunked && this.bytes + pcm.length > this.segmentBytes) {
+      this.chunks = [];
+      this.bytes = 0;
+      this.overflow = new Error(
+        "Discord voice audio exceeds the transcription limit; speak a shorter segment.",
+      );
+      logger.warn(`discord voice: ${this.overflow.message}`);
+      throw this.overflow;
+    }
+    for (let offset = 0; offset < pcm.length;) {
+      if (!this.bytes) {
+        this.startedAt = receipt.startedAt + offset / PCM_BYTES_PER_MILLISECOND;
+      }
+      const length = Math.min(this.segmentBytes - this.bytes, pcm.length - offset);
+      this.chunks.push(pcm.subarray(offset, offset + length));
+      this.bytes += length;
+      offset += length;
+      if (this.chunked && this.bytes === this.segmentBytes) {
+        await this.flush();
+      }
+    }
+  }
+
+  async finish(): Promise<void> {
+    await this.flush();
+    if (this.overflow) {
+      throw this.overflow;
+    }
+  }
+
+  private async flush(): Promise<void> {
+    if (!this.bytes) {
+      return;
+    }
+    const chunks = this.chunks;
+    const bytes = this.bytes;
+    const startedAt = this.startedAt;
+    const capture = this.capture;
+    this.chunks = [];
+    this.bytes = 0;
+    if (!this.params.isInputComplete() || (!capture?.isCurrent() && !this.params.canConverse())) {
+      return;
+    }
+    if (!capture && bytes / (PCM_BYTES_PER_MILLISECOND * 1_000) < this.params.minimumSeconds()) {
+      // Discarding a short uncaptured fragment makes the remaining utterance incomplete.
+      this.params.onExcluded();
+      return;
+    }
+    const recording = capture
+      ? {
+          capture,
+          startedAt,
+          speaker: (this.speaker ??= this.params.resolveSpeaker()),
+        }
+      : undefined;
+    const releaseBudget = reserveRecordingWav(bytes + VOICE_WAV_HEADER_BYTES);
+    let wav: Awaited<ReturnType<typeof writeVoiceWavFile>>;
+    try {
+      wav = await writeVoiceWavFile(Buffer.concat(chunks, bytes));
+    } catch (error) {
+      releaseBudget();
+      throw error;
+    }
+    const cleanup = async () => {
+      try {
+        await wav.cleanup();
+      } catch (error) {
+        logger.warn(`discord voice: recording cleanup failed: ${formatErrorMessage(error)}`);
+      } finally {
+        releaseBudget();
+      }
+    };
+    // Disk writes can outlive every owner; do not retain their WAV behind unrelated work.
+    if (!this.params.isInputComplete() || (!capture?.isCurrent() && !this.params.canConverse())) {
+      await cleanup();
+      return;
+    }
+    const { entry } = this.params;
+    const conversationOnly = createDeferred<void>();
+    const previousProcessing = entry.processingQueue;
+    const processing = (async (): Promise<DiscordVoiceSegmentOutcome> => {
+      let outcome: DiscordVoiceSegmentOutcome = { status: "excluded" };
+      try {
+        await previousProcessing;
+        outcome = await processDiscordVoiceSegment({
+          entry,
+          cfg: this.params.cfg,
+          wavPath: wav.path,
+          durationSeconds: wav.durationSeconds,
+          userId: this.params.userId,
+          resolveIngressContext: this.params.resolveIngressContext,
+          isConversationCurrent: this.params.canConverse,
+          onConversationOnly: () => conversationOnly.resolve(),
+          recording,
+        });
+      } catch (error) {
+        this.params.onExcluded();
+        logger.warn(`discord voice: recording failed: ${formatErrorMessage(error)}`);
+      } finally {
+        await cleanup();
+      }
+      return outcome;
+    })();
+    // Register in audio order before work starts. A retired recorder releases its
+    // queue slot, while the same operation retains the WAV for authorized conversation.
+    this.params.onSegment(processing);
+    this.completion = entry.processingQueue = Promise.race([
+      processing.then(() => undefined),
+      conversationOnly.promise,
+    ]);
+  }
+}

--- a/extensions/discord/src/voice/voice-recording.ts
+++ b/extensions/discord/src/voice/voice-recording.ts
@@ -4,7 +4,8 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { VOICE_WAV_HEADER_BYTES, writeVoiceWavFile } from "./audio.js";
 import type { DiscordVoiceIngressContext } from "./ingress.js";
-import { processDiscordVoiceSegment, type DiscordVoiceSegmentOutcome } from "./segment.js";
+import type { DiscordVoiceAudioReceipt, DiscordVoiceSegmentOutcome } from "./recording-types.js";
+import { processDiscordVoiceSegment } from "./segment.js";
 import type { VoiceSessionEntry } from "./session.js";
 
 const logger = createSubsystemLogger("discord/voice");
@@ -31,11 +32,6 @@ function reserveRecordingWav(bytes: number): () => void {
     pendingRecordingBytes -= bytes;
   };
 }
-
-export type DiscordVoiceAudioReceipt = {
-  capture: VoiceSessionEntry["transcripts"];
-  startedAt: number;
-};
 
 export class DiscordVoiceRecording {
   private readonly segmentBytes: number;

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough, type Readable } from "node:stream";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
 
 defineDiscordVoiceTests(
@@ -8,8 +9,6 @@ defineDiscordVoiceTests(
     expect,
     it,
     vi,
-    createVoiceCaptureState,
-    createVoiceReceiveRecoveryState,
     createDefaultVoiceStates,
     createConnectionMock,
     joinVoiceChannelMock,
@@ -25,20 +24,17 @@ defineDiscordVoiceTests(
     loggerWarnMock,
     controlRealtimeVoiceAgentRunMock,
     realtimeSessionMock,
-    decodeOpusStreamMock,
+    decodeOpusStreamChunksMock,
     managerModule,
     realtimeModule,
-    segmentModule,
     configureVoiceStateGateway,
     createClient,
     createClientWithMember,
-    createRuntime,
     createManager,
     makeVoiceConfig,
     createFollowManager,
     getSessionEntry,
     getLastAudioPlayer,
-    getVoiceReceive,
     beginSpeakerTurn,
     lastAgentCommandArgs,
     lastAgentCommandToolNames,
@@ -46,23 +42,15 @@ defineDiscordVoiceTests(
     createJoinedAgentProxyFixture,
     lastTtsArgs,
     expectUserMessageNotIncludes,
-    processVoiceSegment,
+    receiveVoiceUtterance,
     updateVoiceState,
     handleSpeakingStart,
+    receiveRecordedSpeech,
   }) => {
     it("composes join, audio ingress, agent dispatch, playback, and leave", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
-      decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(96_000));
       agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "composed voice reply" }] });
-      const stream = {
-        on: vi.fn(),
-        off: vi.fn(),
-        destroy: vi.fn(),
-        destroyed: false,
-        async *[Symbol.asyncIterator]() {},
-      };
-      connection.receiver.subscribe.mockReturnValueOnce(stream);
       const manager = createManager({
         groupPolicy: "open",
         allowFrom: ["discord:u-speaker"],
@@ -71,8 +59,7 @@ defineDiscordVoiceTests(
 
       expect((await manager.join({ guildId: "g1", channelId: "1001" })).ok).toBe(true);
       const entry = getSessionEntry(manager);
-      await handleSpeakingStart(manager, entry, "u-speaker");
-      await entry.processingQueue;
+      await receiveRecordedSpeech(manager, undefined, entry, "u-speaker");
       await entry.playbackQueue;
 
       expect(connection.receiver.subscribe).toHaveBeenCalledWith(
@@ -91,7 +78,10 @@ defineDiscordVoiceTests(
         userId: "u-owner",
         client: () => createClientWithMember("u-owner", "Owner", "1234"),
         manager: (client: ReturnType<typeof createClient>) =>
-          createManager({ groupPolicy: "open", allowFrom: ["discord:u-owner"] }, client),
+          createManager(
+            makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-owner"] }),
+            client,
+          ),
         expectedOwner: false,
         toolNames: { include: ["exec"], exclude: ["gateway", "nodes", "openclaw"] },
       },
@@ -104,7 +94,10 @@ defineDiscordVoiceTests(
         client: () => createClientWithMember("u-guest", "Guest", "4321"),
         manager: (client: ReturnType<typeof createClient>) =>
           createManager(
-            { groupPolicy: "allowlist", allowFrom: [allowFrom], guilds: { g1: {} } },
+            makeVoiceConfig(
+              {},
+              { groupPolicy: "allowlist", allowFrom: [allowFrom], guilds: { g1: {} } },
+            ),
             client,
           ),
         expectedOwner: false,
@@ -114,9 +107,13 @@ defineDiscordVoiceTests(
         userId: "100000000000000001",
         client: () => createClientWithMember("100000000000000001", "Owner", "1234"),
         manager: (client: ReturnType<typeof createClient>) =>
-          createManager({ groupPolicy: "open", dmPolicy: "disabled" }, client, {
-            commands: { ownerAllowFrom: ["discord:100000000000000001"] },
-          }),
+          createManager(
+            makeVoiceConfig({}, { groupPolicy: "open", dmPolicy: "disabled" }),
+            client,
+            {
+              commands: { ownerAllowFrom: ["discord:100000000000000001"] },
+            },
+          ),
         expectedOwner: true,
         toolNames: { include: ["gateway", "nodes", "openclaw"], exclude: [] },
       },
@@ -125,9 +122,13 @@ defineDiscordVoiceTests(
         userId: "u-owner",
         client: () => createClientWithMember("u-owner", "Owner", "1234"),
         manager: (client: ReturnType<typeof createClient>) =>
-          createManager({ groupPolicy: "open", dmPolicy: "disabled" }, client, {
-            commands: { ownerAllowFrom: ["discord:*"] },
-          }),
+          createManager(
+            makeVoiceConfig({}, { groupPolicy: "open", dmPolicy: "disabled" }),
+            client,
+            {
+              commands: { ownerAllowFrom: ["discord:*"] },
+            },
+          ),
         expectedOwner: false,
         toolNames: { include: ["exec"], exclude: ["gateway", "nodes", "openclaw"] },
       },
@@ -136,9 +137,13 @@ defineDiscordVoiceTests(
         userId: "u-guest",
         client: () => createClientWithMember("u-guest", "Guest", "4321"),
         manager: (client: ReturnType<typeof createClient>) =>
-          createManager({ groupPolicy: "open", dmPolicy: "disabled" }, client, {
-            commands: { ownerAllowFrom: ["telegram:u-guest"] },
-          }),
+          createManager(
+            makeVoiceConfig({}, { groupPolicy: "open", dmPolicy: "disabled" }),
+            client,
+            {
+              commands: { ownerAllowFrom: ["telegram:u-guest"] },
+            },
+          ),
         expectedOwner: null,
       },
       {
@@ -157,17 +162,21 @@ defineDiscordVoiceTests(
         expectedOwner: null,
       },
       {
-        name: "accepts open-policy voice speakers",
+        name: "does not grant voice commands from open group policy alone",
         userId: "u-guest",
         client: () => createClientWithMember("u-guest", "Guest", "4321"),
         manager: (client: ReturnType<typeof createClient>) =>
-          createManager({ groupPolicy: "open", allowFrom: ["discord:u-owner"] }, client),
+          createManager(
+            makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-owner"] }),
+            client,
+          ),
+        expectedOwner: null,
       },
     ])(
       "$name",
       async ({ client: createScenarioClient, manager: createScenarioManager, ...scenario }) => {
         const client = createScenarioClient();
-        await processVoiceSegment(createScenarioManager(client), scenario.userId);
+        await receiveVoiceUtterance(createScenarioManager(client), scenario.userId);
 
         if (scenario.expectedOwner === null) {
           expect(agentCommandMock).not.toHaveBeenCalled();
@@ -204,54 +213,18 @@ defineDiscordVoiceTests(
       const discordConfig: ConstructorParameters<
         typeof managerModule.DiscordVoiceManager
       >[0]["discordConfig"] = { groupPolicy: "open", allowFrom: ["discord:u-owner"] };
-      const manager = createManager(discordConfig, client);
-      const enqueuePlayback = vi.fn();
-      const speakerContext = (
-        manager as unknown as {
-          speakerContext: Parameters<
-            typeof segmentModule.processDiscordVoiceSegment
-          >[0]["speakerContext"];
-        }
-      ).speakerContext;
-
-      await segmentModule.processDiscordVoiceSegment({
-        accountId: "default",
-        entry: {
-          guildId: "g1",
-          channelId: "1001",
-          sessionChannelId: "1001",
-          voiceSessionKey: "discord:g1:1001",
-          route: { sessionKey: "discord:g1:1001", agentId: "agent-1" },
-          connection: createConnectionMock(),
-          player: createAudioPlayerMock(),
-          sessionLifecycle: { status: "active" },
-          playbackQueue: Promise.resolve(),
-          processingQueue: Promise.resolve(),
-          ttsStreamFallbackWarned: false,
-          capture: createVoiceCaptureState(),
-          receiveRecovery: createVoiceReceiveRecoveryState(),
-          isStopped: () => false,
-          stop: vi.fn(),
-        } as unknown as Parameters<typeof segmentModule.processDiscordVoiceSegment>[0]["entry"],
-        wavPath: "/tmp/test.wav",
-        userId: "u-owner",
-        durationSeconds: 1.2,
-        cfg: {},
-        discordConfig,
-        admissionAllowFrom: ["discord:u-owner"],
-        runtime: createRuntime(),
-        fetchGuildName: async () => "Guild One",
-        speakerContext,
-        enqueuePlayback,
-      });
+      const manager = createManager(makeVoiceConfig({}, discordConfig), client);
+      await receiveVoiceUtterance(manager, "u-owner");
+      const entry = getSessionEntry(manager);
+      await entry.playbackQueue;
 
       expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
-        sessionKey: "discord:g1:1001",
+        sessionKey: entry.route?.sessionKey,
         text: "use the smaller implementation",
       });
       expect(agentCommandMock).not.toHaveBeenCalled();
       expect(lastTtsArgs().text).toBe("Got it. I steered the active run.");
-      expect(enqueuePlayback).toHaveBeenCalledTimes(1);
+      expect(getLastAudioPlayer().play).toHaveBeenCalledTimes(1);
     });
 
     it("passes configured model override to agent command in voice flow", async () => {
@@ -276,7 +249,7 @@ defineDiscordVoiceTests(
         client,
         {},
       );
-      await processVoiceSegment(manager, "u-guest");
+      await receiveVoiceUtterance(manager, "u-guest");
 
       expect(agentCommandMock, JSON.stringify(logVerboseMock.mock.calls)).toHaveBeenCalled();
       const commandArgs = lastAgentCommandArgs() as
@@ -298,12 +271,12 @@ defineDiscordVoiceTests(
 
       const client = createClientWithMember("u-guest", "Guest", "4321");
       const manager = createManager(
-        { groupPolicy: "open", allowFrom: ["discord:u-guest"] },
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
         client,
         {},
       );
       try {
-        await processVoiceSegment(manager, "u-guest");
+        await receiveVoiceUtterance(manager, "u-guest");
         await vi.waitFor(async () => {
           const exists = await fs.access(audioPath).then(
             () => true,
@@ -336,12 +309,12 @@ defineDiscordVoiceTests(
       });
       const client = createClientWithMember("u-debug", "Debug", "0001", "Debug Speaker");
       const manager = createManager(
-        { groupPolicy: "open", allowFrom: ["discord:u-debug"] },
+        makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-debug"] }),
         client,
         {},
       );
 
-      await processVoiceSegment(manager, "u-debug");
+      await receiveVoiceUtterance(manager, "u-debug");
 
       const transcriptLog = logVerboseMock.mock.calls
         .map((call) => String(call[0]))
@@ -361,15 +334,9 @@ defineDiscordVoiceTests(
       );
       await manager.join({ guildId: "g1", channelId: "1001" });
       const entry = getSessionEntry(manager);
-      const receive = getVoiceReceive(manager);
 
       for (let index = 0; index < 2; index += 1) {
-        await receive.processSegment({
-          entry,
-          wavPath: "/tmp/test.wav",
-          userId: "u-guest",
-          durationSeconds: 1.2,
-        });
+        await receiveRecordedSpeech(manager, undefined, entry, "u-guest");
       }
       await entry.playbackQueue;
 
@@ -407,12 +374,7 @@ defineDiscordVoiceTests(
       await manager.join({ guildId: "g1", channelId: "1001" });
       const entry = getSessionEntry(manager);
 
-      await getVoiceReceive(manager).processSegment({
-        entry,
-        wavPath: "/tmp/test.wav",
-        userId: "u-guest",
-        durationSeconds: 1.2,
-      });
+      await receiveRecordedSpeech(manager, undefined, entry, "u-guest");
       await entry.playbackQueue;
 
       expect(textToSpeechMock).toHaveBeenCalledOnce();
@@ -427,7 +389,6 @@ defineDiscordVoiceTests(
     it("releases late TTS without playback after the voice session leaves", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
-      decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(96_000));
       agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "late voice reply" }] });
       const release = vi.fn(async () => undefined);
       let resolveStream!: (value: unknown) => void;
@@ -436,20 +397,13 @@ defineDiscordVoiceTests(
           resolveStream = resolve;
         }),
       );
-      connection.receiver.subscribe.mockReturnValueOnce({
-        on: vi.fn(),
-        off: vi.fn(),
-        destroy: vi.fn(),
-        destroyed: false,
-        async *[Symbol.asyncIterator]() {},
-      });
       const manager = createManager(
         makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
       );
       await manager.join({ guildId: "g1", channelId: "1001" });
       const entry = getSessionEntry(manager);
 
-      const speaking = handleSpeakingStart(manager, entry, "u-speaker");
+      const speaking = receiveRecordedSpeech(manager, undefined, entry, "u-speaker");
       await vi.waitFor(() => expect(textToSpeechStreamMock).toHaveBeenCalledOnce());
       await manager.leave({ guildId: "g1" });
       resolveStream({
@@ -473,6 +427,7 @@ defineDiscordVoiceTests(
       const client = createClientWithMember("u-guest", "Guest", "4321");
       const manager = createManager(
         {
+          voice: { enabled: true, mode: "stt-tts" },
           groupPolicy: "open",
           allowFrom: ["discord:u-guest"],
           guilds: {
@@ -488,7 +443,7 @@ defineDiscordVoiceTests(
         client,
         {},
       );
-      await processVoiceSegment(manager, "u-guest");
+      await receiveVoiceUtterance(manager, "u-guest");
 
       const commandArgs = lastAgentCommandArgs() as { extraSystemPrompt?: string } | undefined;
 
@@ -510,6 +465,7 @@ defineDiscordVoiceTests(
       configureVoiceStateGateway(client, createDefaultVoiceStates);
       const manager = createManager(
         {
+          voice: { enabled: true, mode: "stt-tts" },
           groupPolicy: "open",
           allowFrom: ["discord:u-owner"],
           guilds: {
@@ -526,7 +482,7 @@ defineDiscordVoiceTests(
         "bot-user",
       );
 
-      await processVoiceSegment(manager, "u-owner");
+      await receiveVoiceUtterance(manager, "u-owner");
 
       const commandArgs = lastAgentCommandArgs() as { extraSystemPrompt?: string } | undefined;
       expect(commandArgs?.extraSystemPrompt).toContain("Use short voice replies.");
@@ -536,17 +492,6 @@ defineDiscordVoiceTests(
       expect(commandArgs?.extraSystemPrompt).toContain(
         "Use this roster when asked who is currently present",
       );
-    });
-
-    it("reuses speaker context cache for repeated segments from the same speaker", async () => {
-      const client = createClientWithMember("u-cache", "Cache", "1111", "Cached Speaker");
-      const manager = createManager({ allowFrom: ["discord:u-cache"] }, client);
-      const runSegment = async () => await processVoiceSegment(manager, "u-cache");
-
-      await runSegment();
-      await runSegment();
-
-      expect(client.fetchMember).toHaveBeenCalledTimes(3);
     });
 
     it("persists full speaker context in cache writes", async () => {
@@ -563,6 +508,7 @@ defineDiscordVoiceTests(
       });
       const manager = createManager(
         {
+          voice: { enabled: true, mode: "stt-tts" },
           groupPolicy: "allowlist",
           guilds: {
             g1: {
@@ -577,7 +523,7 @@ defineDiscordVoiceTests(
         client,
       );
 
-      await processVoiceSegment(manager, "u-role");
+      await receiveVoiceUtterance(manager, "u-role");
 
       const cache = (
         manager as unknown as {
@@ -608,49 +554,15 @@ defineDiscordVoiceTests(
 
     it("re-fetches member roles for repeated voice auth checks", async () => {
       const client = createClient();
-      client.fetchMember
-        .mockResolvedValueOnce({
-          nickname: "Role Speaker",
-          roles: ["role-voice"],
-          user: {
-            id: "u-role",
-            username: "role",
-            globalName: "Role",
-            discriminator: "2222",
-          },
-        })
-        .mockResolvedValueOnce({
-          nickname: "Role Speaker",
-          roles: ["role-voice"],
-          user: {
-            id: "u-role",
-            username: "role",
-            globalName: "Role",
-            discriminator: "2222",
-          },
-        })
-        .mockResolvedValueOnce({
-          nickname: "Role Speaker",
-          roles: [],
-          user: {
-            id: "u-role",
-            username: "role",
-            globalName: "Role",
-            discriminator: "2222",
-          },
-        })
-        .mockResolvedValue({
-          nickname: "Role Speaker",
-          roles: [],
-          user: {
-            id: "u-role",
-            username: "role",
-            globalName: "Role",
-            discriminator: "2222",
-          },
-        });
+      const member = {
+        nickname: "Role Speaker",
+        roles: ["role-voice"],
+        user: { id: "u-role", username: "role", globalName: "Role", discriminator: "2222" },
+      };
+      client.fetchMember.mockResolvedValue(member);
       const manager = createManager(
         {
+          voice: { enabled: true, mode: "stt-tts" },
           groupPolicy: "allowlist",
           guilds: {
             g1: {
@@ -665,11 +577,13 @@ defineDiscordVoiceTests(
         client,
       );
 
-      await processVoiceSegment(manager, "u-role");
-      await processVoiceSegment(manager, "u-role");
+      await receiveVoiceUtterance(manager, "u-role");
+      expect(agentCommandMock).toHaveBeenCalledTimes(1);
+      client.fetchMember.mockResolvedValue({ ...member, roles: [] });
+      await receiveVoiceUtterance(manager, "u-role");
 
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
-      expect(client.fetchMember).toHaveBeenCalledTimes(3);
+      expect(client.fetchMember).toHaveBeenLastCalledWith("g1", "u-role");
     });
 
     it("fetches guild metadata before allowlist checks when the session lacks a guild name", async () => {
@@ -686,6 +600,7 @@ defineDiscordVoiceTests(
       });
       const manager = createManager(
         {
+          voice: { enabled: true, mode: "stt-tts" },
           groupPolicy: "allowlist",
           guilds: {
             "guild-one": {
@@ -700,7 +615,7 @@ defineDiscordVoiceTests(
         client,
       );
 
-      await processVoiceSegment(manager, "u-owner");
+      await receiveVoiceUtterance(manager, "u-owner");
 
       expect(client.fetchGuild).toHaveBeenCalledWith("g1");
       expect(agentCommandMock).toHaveBeenCalledTimes(1);
@@ -763,30 +678,34 @@ defineDiscordVoiceTests(
     it("does not run STT or playback after leave wins decoding", async () => {
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
-      let resolveDecode!: (audio: Buffer) => void;
-      decodeOpusStreamMock.mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveDecode = resolve;
-        }),
+      let resolveDecode!: () => void;
+      const decodeReady = new Promise<void>((resolve) => {
+        resolveDecode = resolve;
+      });
+      decodeOpusStreamChunksMock.mockImplementationOnce(
+        async (
+          input: Readable,
+          callbacks: { onChunk: (pcm: Buffer, packet: Buffer) => void | Promise<void> },
+        ) => {
+          for await (const packet of input) {
+            await decodeReady;
+            await callbacks.onChunk(Buffer.alloc(96_000), packet);
+          }
+        },
       );
       const manager = createManager(
         makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-speaker"] }),
       );
       await manager.join({ guildId: "g1", channelId: "1001" });
       const entry = getSessionEntry(manager);
-      const stream = {
-        on: vi.fn(),
-        off: vi.fn(),
-        destroy: vi.fn(),
-        destroyed: false,
-        async *[Symbol.asyncIterator]() {},
-      };
+      const stream = new PassThrough({ objectMode: true });
       connection.receiver.subscribe.mockReturnValueOnce(stream);
 
       const speaking = handleSpeakingStart(manager, entry, "u-speaker");
-      await vi.waitFor(() => expect(decodeOpusStreamMock).toHaveBeenCalledOnce());
+      stream.end(Buffer.from("opus-packet"));
+      await vi.waitFor(() => expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce());
       await manager.leave({ guildId: "g1" });
-      resolveDecode(Buffer.alloc(96_000));
+      resolveDecode();
       await speaking;
       await entry.processingQueue;
 
@@ -854,19 +773,14 @@ defineDiscordVoiceTests(
       expect(realtimeSessionMock.close).toHaveBeenCalledOnce();
     });
 
-    it("provider reset fences transcript, tool, playback, and consult completions", async () => {
-      const onUtterance = vi.fn();
+    it("provider reset fences tool, playback, and consult completions", async () => {
       let resolveConsult!: (result: { payloads: Array<{ text: string }> }) => void;
       agentCommandMock.mockReturnValueOnce(
         new Promise((resolve) => {
           resolveConsult = resolve;
         }),
       );
-      const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture();
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        { transcripts: { sessionId: "transcript-1", onUtterance } },
-      );
+      const { bridgeParams, entry, player } = await createJoinedAgentProxyFixture();
       beginSpeakerTurn(entry);
       const consult = bridgeParams.onToolCall?.(
         {
@@ -889,7 +803,6 @@ defineDiscordVoiceTests(
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(onUtterance).not.toHaveBeenCalled();
       expect(realtimeSessionMock.submitToolResult).not.toHaveBeenCalled();
       expect(player.play).toHaveBeenCalledTimes(playCallsBeforeReset);
       expectUserMessageNotIncludes("stale consult completion");

--- a/extensions/discord/src/voice/voice-runtime.ts
+++ b/extensions/discord/src/voice/voice-runtime.ts
@@ -3,12 +3,12 @@ import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import { formatMention } from "../mentions.js";
-import { resolveFetchedDiscordThreadLikeChannelContext } from "../monitor/thread-channel-context.js";
 import { resolveDiscordVoiceEnabled } from "./config.js";
 import { DiscordVoiceMembershipTracker } from "./membership.js";
-import { resolveDiscordVoiceAccess } from "./owner-access.js";
+import { resolveDiscordVoiceAccess, resolveDiscordVoiceAccessTarget } from "./owner-access.js";
 import {
   countDiscordVoiceHumanParticipants,
+  createDiscordVoiceOccupancyWatcher,
   listDiscordVoiceParticipantStates,
 } from "./participant-context.js";
 import {
@@ -18,6 +18,7 @@ import {
   type VoiceSessionEntry,
 } from "./session.js";
 import { DiscordVoiceSpeakerContextResolver } from "./speaker-context.js";
+import { resolveDiscordTranscriptsCapture } from "./transcripts-source.js";
 import {
   DiscordVoiceFollowing,
   normalizeVoiceChannelResidencies,
@@ -37,19 +38,6 @@ const DISCORD_VOICE_FATAL_AUTOJOIN_ERROR_PATTERNS = [
   "forbidden",
 ];
 
-function isVoiceChannelAllowed(params: {
-  allowedChannels: VoiceChannelResidency[] | null;
-  guildId: string;
-  channelId: string;
-}): boolean {
-  return (
-    params.allowedChannels === null ||
-    params.allowedChannels.some(
-      (entry) => entry.guildId === params.guildId && entry.channelId === params.channelId,
-    )
-  );
-}
-
 function formatAutoJoinFailureKey(entry: { guildId: string; channelId: string }): string {
   return `${entry.guildId}:${entry.channelId}`;
 }
@@ -63,9 +51,19 @@ function isFatalAutoJoinFailure(message: string): boolean {
 
 type VoiceGuildLifecycle =
   | { status: "inactive"; generation: number }
-  | { status: "starting"; generation: number; instance: { guildId: string; channelId: string } }
+  | {
+      status: "starting";
+      generation: number;
+      cancelled: boolean;
+      instance: { guildId: string; channelId: string; captureOnly: boolean };
+    }
   | { status: "active"; generation: number; instance: VoiceSessionEntry }
   | { status: "stopped"; generation: number; reason: string };
+
+type CaptureJoinOrigin = {
+  isCurrent: () => boolean;
+  isResidencyUnchanged: () => boolean;
+};
 
 export class DiscordVoiceManager {
   private sessions = new Map<string, VoiceSessionEntry>();
@@ -75,7 +73,7 @@ export class DiscordVoiceManager {
   private readonly botUserId?: string;
   private readonly client: Client;
   private readonly voiceEnabled: boolean;
-  private readonly autoJoinTasks = new Map<string, Promise<void>>();
+  private readonly autoJoinTasks = new Map<string, Promise<VoiceOperationResult | undefined>>();
   private readonly fatalAutoJoinFailures = new Map<
     string,
     { message: string; skipLogged: boolean }
@@ -89,6 +87,10 @@ export class DiscordVoiceManager {
   private readonly following: DiscordVoiceFollowing;
   private readonly receive: DiscordVoiceReceive;
   private readonly voiceSessions: DiscordVoiceSessions;
+  private readonly getTranscripts: (target: {
+    guildId: string;
+    channelId: string;
+  }) => ReturnType<typeof resolveDiscordTranscriptsCapture>;
   // Room watchers outlive individual bot sessions; only unsubscribe/destroy retires them.
   private readonly occupancyWatchers = new Set<{ guildId: string; refresh: () => void }>();
   private destroyed = false;
@@ -104,6 +106,13 @@ export class DiscordVoiceManager {
     this.client = params.client;
     this.botUserId = params.botUserId;
     this.voiceEnabled = resolveDiscordVoiceEnabled(params.discordConfig.voice);
+    this.getTranscripts = ({ guildId, channelId }) =>
+      this.destroyed
+        ? undefined
+        : resolveDiscordTranscriptsCapture(
+            { guildId, channelId, accountId: params.accountId },
+            this,
+          );
     const voiceAccess = resolveDiscordVoiceAccess(params);
     this.admissionAllowFrom = voiceAccess.admissionAllowFrom;
     this.ownerAllowFrom = voiceAccess.ownerAllowFrom;
@@ -143,11 +152,11 @@ export class DiscordVoiceManager {
       autoJoinChannels: this.autoJoinChannels,
       botUserId: () => this.botUserId,
       client: params.client,
-      deleteRecoveryAttempt: (guildId) => this.receive.deleteRecoveryAttempt(guildId),
+      deleteRecoveryAttempt: (guildId) => this.receive.daveRecoveryAttempts.delete(guildId),
       destroyed: () => this.destroyed,
       destroyVoiceConnection: destroyVoiceConnectionSafely,
       discordConfig: params.discordConfig,
-      getRecoveryAttempt: (guildId) => this.receive.getRecoveryAttempt(guildId),
+      getRecoveryAttempt: (guildId) => this.receive.daveRecoveryAttempts.get(guildId),
       getSession: (guildId) => this.sessions.get(guildId),
       hasVoiceLifecycle: (guildId) => {
         const lifecycle = this.guildLifecycles.get(guildId);
@@ -166,6 +175,7 @@ export class DiscordVoiceManager {
       client: params.client,
       destroyed: () => this.destroyed,
       discordConfig: params.discordConfig,
+      getTranscripts: this.getTranscripts,
       membership: this.membership,
       onLeaveFollowState: (guildId) => {
         this.following.followedVoiceGuilds.delete(guildId);
@@ -197,28 +207,10 @@ export class DiscordVoiceManager {
     if (this.destroyed) {
       return () => undefined;
     }
-    const guildId = params.guildId.trim();
-    const channelId = params.channelId.trim();
-    let wasOccupied = false;
-    const watcher = {
-      guildId,
-      refresh: () => {
-        const states = listDiscordVoiceParticipantStates({
-          client: this.client,
-          guildId,
-          channelId,
-        });
-        if (states === null) {
-          return;
-        }
-        const occupied =
-          countDiscordVoiceHumanParticipants({ states, botUserId: this.botUserId }) > 0;
-        if (occupied !== wasOccupied) {
-          wasOccupied = occupied;
-          listener({ occupied });
-        }
-      },
-    };
+    const watcher = createDiscordVoiceOccupancyWatcher(
+      { ...params, client: this.client, botUserId: this.botUserId },
+      listener,
+    );
     this.occupancyWatchers.add(watcher);
     watcher.refresh();
     return () => {
@@ -290,40 +282,66 @@ export class DiscordVoiceManager {
   }
 
   isAllowedVoiceChannel(params: { guildId: string; channelId: string }): boolean {
-    return isVoiceChannelAllowed({
-      allowedChannels: this.allowedChannels,
-      guildId: params.guildId.trim(),
-      channelId: params.channelId.trim(),
-    });
+    const guildId = params.guildId.trim();
+    const channelId = params.channelId.trim();
+    return (
+      this.allowedChannels === null ||
+      this.allowedChannels.some(
+        (entry) => entry.guildId === guildId && entry.channelId === channelId,
+      )
+    );
   }
 
   async resolveAccessTarget(params: { guildId: string; channelId: string }) {
-    const [guild, channel] = await Promise.all([
-      this.client.fetchGuild(params.guildId).catch(() => null),
-      this.client.fetchChannel(params.channelId).catch(() => null),
-    ]);
-    if (!guild || !channel) {
-      return undefined;
-    }
-    const context = await resolveFetchedDiscordThreadLikeChannelContext({
-      client: this.client,
-      channel,
-      channelIdFallback: params.channelId,
-    });
-    return {
-      guild,
-      ...(context.channelName ? { channelName: context.channelName } : {}),
-      channelSlug: context.channelSlug,
-      ...(context.parentId ? { parentId: context.parentId } : {}),
-      ...(context.threadParentName ? { parentName: context.threadParentName } : {}),
-      ...(context.threadParentSlug ? { parentSlug: context.threadParentSlug } : {}),
-      scope: context.isThreadChannel ? ("thread" as const) : ("channel" as const),
-    };
+    return await resolveDiscordVoiceAccessTarget({ ...params, client: this.client });
   }
 
-  async join(
+  startTranscriptsCapture(target: {
+    guildId: string;
+    channelId: string;
+  }): Promise<VoiceOperationResult> {
+    return this.join(target, { captureOnly: true });
+  }
+
+  async stopTranscriptsCapture(target: { guildId: string; channelId: string }): Promise<void> {
+    const lifecycle = this.guildLifecycles.get(target.guildId);
+    if (lifecycle?.status !== "starting" && lifecycle?.status !== "active") {
+      return;
+    }
+    if (lifecycle.instance.channelId === target.channelId && lifecycle.instance.captureOnly) {
+      await this.leave(target, { captureRetirement: true });
+    }
+  }
+
+  join(
     params: { guildId: string; channelId: string },
     options?: VoiceJoinOptions,
+  ): Promise<VoiceOperationResult> {
+    const target = { guildId: params.guildId.trim(), channelId: params.channelId.trim() };
+    const capture = options?.captureOnly ? this.getTranscripts(target) : undefined;
+    const residency = this.guildLifecycles.get(target.guildId);
+    // Configured conversation handoffs retain this source subscription and residency,
+    // rather than borrowing a fresh subscription or a newer join's transport ownership.
+    return this.joinOwned(
+      params,
+      options,
+      options?.captureOnly
+        ? {
+            isCurrent: () =>
+              capture !== undefined &&
+              // A recording handoff retains pending transport work for this admitted source.
+              this.getTranscripts(target)?.subscriptionToken === capture.subscriptionToken &&
+              (capture.started || residency?.status !== "starting" || !residency.cancelled),
+            isResidencyUnchanged: () => this.guildLifecycles.get(target.guildId) === residency,
+          }
+        : undefined,
+    );
+  }
+
+  private async joinOwned(
+    params: { guildId: string; channelId: string },
+    options?: VoiceJoinOptions,
+    captureOrigin?: CaptureJoinOrigin,
   ): Promise<VoiceOperationResult> {
     if (this.destroyed) {
       return { ok: false, message: "Discord voice manager is stopped." };
@@ -351,29 +369,109 @@ export class DiscordVoiceManager {
       };
     }
     logVoiceVerbose(`join requested: guild ${guildId} channel ${channelId}`);
-
+    const captureIsCurrent = () => captureOrigin?.isCurrent() ?? true;
+    let deferredTargetValidated = false;
     while (true) {
       const activeJoinTask = this.joinTasks.get(guildId);
-      if (!activeJoinTask) {
-        break;
+      if (activeJoinTask) {
+        logVoiceVerbose(
+          `join: waiting for active guild join guild ${guildId} channel ${channelId}`,
+        );
+        await activeJoinTask.catch(() => undefined);
+        continue;
       }
-      logVoiceVerbose(`join: waiting for active guild join guild ${guildId} channel ${channelId}`);
-      await activeJoinTask.catch(() => undefined);
       if (this.destroyed) {
         return { ok: false, message: "Discord voice manager is stopped.", guildId, channelId };
       }
+      // A queued recovery must not invalidate the manual join it just waited behind.
+      if (!captureIsCurrent()) {
+        return { ok: false, message: "Discord voice join was cancelled.", guildId, channelId };
+      }
+      if (options?.captureOnly && !deferredTargetValidated) {
+        const entry = this.sessions.get(guildId);
+        const liveTarget = entry?.channelId === channelId && this.isEntryCurrent(entry);
+        if (!liveTarget && (entry || this.resolveAutoJoinTarget(guildId))) {
+          const resolved = await this.voiceSessions.resolveChannel({ guildId, channelId });
+          if (this.destroyed || !captureIsCurrent()) {
+            return { ok: false, message: "Discord voice join was cancelled.", guildId, channelId };
+          }
+          if (!resolved.ok) {
+            return resolved.error;
+          }
+          // Validation claims no residency. Reread joins and entries after the lookup;
+          // never scan an old entry or displace a newer transport with this capture.
+          deferredTargetValidated = true;
+          continue;
+        }
+      }
+      break;
     }
-
+    if (captureOrigin) {
+      const entry = this.sessions.get(guildId);
+      const autoJoin = this.resolveAutoJoinTarget(guildId);
+      // Recheck after queued joins, before claiming a generation: a valid capture
+      // never displaces existing or configured residency, including during recovery.
+      // A transport left during validation does not turn a dormant start into a join.
+      if (
+        entry ||
+        (autoJoin && (autoJoin.channelId !== channelId || !captureOrigin.isResidencyUnchanged())) ||
+        (deferredTargetValidated && !autoJoin)
+      ) {
+        if (entry?.channelId === channelId) {
+          this.receive.captureCurrentSpeakers(entry);
+        }
+        return {
+          ok: true,
+          message: "Capture registered for the selected voice channel.",
+          guildId,
+          channelId,
+          ...(entry?.channelId === channelId && entry.channelName
+            ? { channelName: entry.channelName }
+            : {}),
+        };
+      }
+      if (options?.captureOnly && autoJoin?.channelId === channelId) {
+        return (
+          (await this.enqueueAutoJoin(autoJoin, captureOrigin)) ?? {
+            ok: true,
+            message: "Capture waiting for the configured voice channel.",
+            guildId,
+            channelId,
+          }
+        );
+      }
+    }
+    const waitingForOccupancy = () => {
+      if (!options?.autoJoinWhenOccupied) {
+        return false;
+      }
+      const count = this.countHumanParticipants({ guildId, channelId });
+      return count === null || count === 0;
+    };
+    const waitingResult = {
+      ok: true,
+      message: "Waiting for an occupied voice channel.",
+      guildId,
+      channelId,
+    };
+    if (waitingForOccupancy()) {
+      return waitingResult;
+    }
     const generation = ++this.nextGuildGeneration;
     const starting: VoiceGuildLifecycle = {
       status: "starting",
       generation,
-      instance: { guildId, channelId },
+      cancelled: false,
+      instance: { guildId, channelId, captureOnly: options?.captureOnly === true },
     };
     this.guildLifecycles.set(guildId, starting);
     const isCurrent = () => {
       const lifecycle = this.guildLifecycles.get(guildId);
-      return lifecycle?.status === "starting" && lifecycle.generation === generation;
+      return (
+        lifecycle?.status === "starting" &&
+        lifecycle.generation === generation &&
+        captureIsCurrent()
+      );
     };
     const joinTask = this.voiceSessions.joinUnlocked({ guildId, channelId }, options, {
       generation,
@@ -382,21 +480,43 @@ export class DiscordVoiceManager {
     this.joinTasks.set(guildId, joinTask);
     try {
       const result = await joinTask;
-      if (result.ok && isCurrent()) {
-        const entry = this.sessions.get(guildId);
-        if (!entry) {
-          this.guildLifecycles.set(guildId, {
-            status: "stopped",
-            generation,
-            reason: "join completed without a session",
-          });
-          return { ...result, ok: false, message: "Discord voice join was cancelled." };
+      const entry = this.sessions.get(guildId);
+      if (
+        !entry ||
+        entry.generation !== generation ||
+        !isCurrent() ||
+        (!result.ok && entry.captureOnly && !entry.transcripts)
+      ) {
+        // Stop only this attempt's transport; cancellation or failed promotion can leave no owner.
+        if (entry?.generation === generation) {
+          entry.stop("voice join ended without an owner");
         }
-        this.guildLifecycles.set(guildId, { status: "active", generation, instance: entry });
+        if (this.guildLifecycles.get(guildId) === starting) {
+          this.guildLifecycles.set(guildId, { status: "inactive", generation });
+        }
+        return result.ok
+          ? { ...result, ok: false, message: "Discord voice join was cancelled." }
+          : result;
+      }
+      // Starting owns a pending normal join. Commit residency only on success; a failed
+      // promotion keeps the previous owner active so capture, stop, and occupancy still work.
+      if (result.ok && !options?.captureOnly) {
+        entry.captureOnly = false;
+        entry.autoJoinWhenOccupied = options?.autoJoinWhenOccupied === true;
+      }
+      this.guildLifecycles.set(guildId, { status: "active", generation, instance: entry });
+      if (result.ok) {
         this.fatalAutoJoinFailures.delete(formatAutoJoinFailureKey({ guildId, channelId }));
+        // Recovery can finish after the last human leaves. Keep capture registered, not presence.
+        if (waitingForOccupancy()) {
+          await this.leave({ guildId, channelId });
+          return waitingResult;
+        }
+        // Speech can begin before readiness installs listeners; continuous packets emit no new start.
+        if (entry.transcripts) {
+          this.receive.captureCurrentSpeakers(entry);
+        }
         return { ...result, ...(entry.channelName ? { channelName: entry.channelName } : {}) };
-      } else if (!result.ok && isCurrent()) {
-        this.guildLifecycles.set(guildId, { status: "inactive", generation });
       }
       return result;
     } finally {
@@ -408,14 +528,14 @@ export class DiscordVoiceManager {
 
   async leave(
     params: { guildId: string; channelId?: string },
-    options?: { preserveFollowState?: boolean; transcriptsSessionId?: string },
+    options?: { preserveFollowState?: boolean; captureRetirement?: true },
   ): Promise<VoiceOperationResult> {
     const guildId = params.guildId.trim();
     const lifecycle = this.guildLifecycles.get(guildId);
     if (lifecycle?.status === "starting") {
-      if (options?.transcriptsSessionId && this.sessions.has(guildId)) {
-        return await this.voiceSessions.leave(params, options);
-      }
+      // Queued initial captures retain this join owner after cleanup. Explicit
+      // leave cancels that intent; retiring another capture does not cancel it.
+      lifecycle.cancelled = !options?.captureRetirement;
       this.guildLifecycles.set(guildId, {
         status: "stopped",
         generation: lifecycle.generation,
@@ -437,15 +557,6 @@ export class DiscordVoiceManager {
     }
     const result = await this.voiceSessions.leave(params, options);
     if (result.ok) {
-      const activeEntry = this.sessions.get(guildId);
-      if (options?.transcriptsSessionId && activeEntry) {
-        this.guildLifecycles.set(guildId, {
-          status: "active",
-          generation: activeEntry.generation,
-          instance: activeEntry,
-        });
-        return result;
-      }
       const currentLifecycle = this.guildLifecycles.get(guildId);
       if (lifecycle && currentLifecycle && currentLifecycle.generation !== lifecycle.generation) {
         return result;
@@ -501,28 +612,46 @@ export class DiscordVoiceManager {
       });
     }
     this.sessions.clear();
-    this.receive.clearRecoveryAttempts();
+    this.receive.daveRecoveryAttempts.clear();
   }
 
   private isEntryCurrent(entry: VoiceSessionEntry): boolean {
     const lifecycle = this.guildLifecycles.get(entry.guildId);
-    return (
-      lifecycle?.status === "active" &&
-      lifecycle.generation === entry.generation &&
-      lifecycle.instance === entry &&
-      entry.sessionLifecycle.status === "active"
-    );
+    if (
+      !lifecycle ||
+      lifecycle.generation !== entry.generation ||
+      entry.sessionLifecycle.status !== "active"
+    ) {
+      return false;
+    }
+    // Conversation promotion must not pause an already-ready recorder. A starting
+    // generation may receive only through its exact existing same-channel transport.
+    return lifecycle.status === "active"
+      ? lifecycle.instance === entry
+      : lifecycle.status === "starting" &&
+          lifecycle.instance.channelId === entry.channelId &&
+          this.sessions.get(entry.guildId) === entry;
   }
 
   private resolveAutoJoinTarget(guildId: string): VoiceChannelResidency | undefined {
     return this.autoJoinChannels.toReversed().find((entry) => entry.guildId === guildId.trim());
   }
 
-  private enqueueAutoJoin(entry: VoiceChannelResidency): Promise<void> {
+  private countHumanParticipants(target: { guildId: string; channelId: string }): number | null {
+    const states = listDiscordVoiceParticipantStates({ client: this.client, ...target });
+    return states === null
+      ? null
+      : countDiscordVoiceHumanParticipants({ states, botUserId: this.botUserId });
+  }
+
+  private enqueueAutoJoin(
+    entry: VoiceChannelResidency,
+    captureOrigin?: CaptureJoinOrigin,
+  ): Promise<VoiceOperationResult | undefined> {
     const previous = this.autoJoinTasks.get(entry.guildId) ?? Promise.resolve();
     const task = previous
       .catch(() => undefined)
-      .then(async () => await this.reconcileAutoJoinEntry(entry))
+      .then(async () => await this.reconcileAutoJoinEntry(entry, captureOrigin))
       .finally(() => {
         if (this.autoJoinTasks.get(entry.guildId) === task) {
           this.autoJoinTasks.delete(entry.guildId);
@@ -532,9 +661,15 @@ export class DiscordVoiceManager {
     return task;
   }
 
-  private async reconcileAutoJoinEntry(entry: VoiceChannelResidency): Promise<void> {
+  private async reconcileAutoJoinEntry(
+    entry: VoiceChannelResidency,
+    captureOrigin?: CaptureJoinOrigin,
+  ): Promise<VoiceOperationResult | undefined> {
     if (this.destroyed) {
-      return;
+      return { ok: false, message: "Discord voice manager is stopped." };
+    }
+    if (captureOrigin && !captureOrigin.isCurrent()) {
+      return { ok: false, message: "Discord voice join was cancelled." };
     }
     const failureKey = formatAutoJoinFailureKey(entry);
     const fatalFailure = this.fatalAutoJoinFailures.get(failureKey);
@@ -545,29 +680,23 @@ export class DiscordVoiceManager {
         );
         fatalFailure.skipLogged = true;
       }
-      return;
+      return { ok: false, message: fatalFailure.message };
     }
 
-    if (entry.whenOccupied) {
-      const states = listDiscordVoiceParticipantStates({
-        client: this.client,
-        guildId: entry.guildId,
-        channelId: entry.channelId,
-      });
-      if (states === null) {
+    // Capture-triggered work keeps its original source/residency guards through
+    // joinOwned. Ordinary reconciliation alone owns leaving an empty channel.
+    if (entry.whenOccupied && !captureOrigin) {
+      const humanCount = this.countHumanParticipants(entry);
+      if (humanCount === null) {
         logVoiceVerbose(
           `autoJoin waiting for guild voice snapshot guild=${entry.guildId} channel=${entry.channelId}`,
         );
-        return;
+        return undefined;
       }
-      const humanCount = countDiscordVoiceHumanParticipants({
-        states,
-        botUserId: this.botUserId,
-      });
       const existing = this.sessions.get(entry.guildId);
       if (humanCount === 0) {
         if (!existing?.autoJoinWhenOccupied || existing.channelId !== entry.channelId) {
-          return;
+          return undefined;
         }
         logger.info(
           `discord voice: occupied autoJoin leaving empty channel guild=${entry.guildId} channel=${entry.channelId}`,
@@ -578,11 +707,11 @@ export class DiscordVoiceManager {
             `discord voice: occupied autoJoin failed to leave guild=${entry.guildId} channel=${entry.channelId}: ${result.message}`,
           );
         }
-        return;
+        return undefined;
       }
       const lifecycle = this.guildLifecycles.get(entry.guildId);
       if (existing || lifecycle?.status === "starting" || lifecycle?.status === "active") {
-        return;
+        return undefined;
       }
       logger.info(
         `discord voice: occupied autoJoin joining guild=${entry.guildId} channel=${entry.channelId} humans=${humanCount}`,
@@ -591,7 +720,15 @@ export class DiscordVoiceManager {
       logVoiceVerbose(`autoJoin: joining guild ${entry.guildId} channel ${entry.channelId}`);
     }
 
-    const result = await this.join(entry, { autoJoinWhenOccupied: entry.whenOccupied === true });
+    const result = await this.joinOwned(
+      entry,
+      { autoJoinWhenOccupied: entry.whenOccupied === true },
+      captureOrigin,
+    );
+    // A retired capture's late provider failure must not suppress ordinary autoJoin.
+    if (captureOrigin && !captureOrigin.isCurrent()) {
+      return { ok: false, message: "Discord voice join was cancelled." };
+    }
     if (!result.ok) {
       logger.warn(
         `discord voice: autoJoin skipped guild=${entry.guildId} channel=${entry.channelId}: ${result.message}`,
@@ -603,6 +740,7 @@ export class DiscordVoiceManager {
         });
       }
     }
+    return result;
   }
 }
 

--- a/extensions/discord/src/voice/voice-runtime.ts
+++ b/extensions/discord/src/voice/voice-runtime.ts
@@ -1,6 +1,5 @@
 import type { DiscordAccountConfig, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { createSubsystemLogger, type RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import type { APIVoiceState, Client } from "../internal/discord.js";
 import { formatMention } from "../mentions.js";
 import { resolveDiscordVoiceEnabled } from "./config.js";
@@ -269,13 +268,11 @@ export class DiscordVoiceManager {
 
   status(): VoiceOperationResult[] {
     return Array.from(this.guildLifecycles.values())
-      .filter(
-        (lifecycle): lifecycle is Extract<VoiceGuildLifecycle, { status: "active" }> =>
-          lifecycle.status === "active",
-      )
+      .filter((lifecycle) => lifecycle.status === "active")
       .map(({ instance: session }) => ({
         ok: true,
         message: `connected: guild ${session.guildId} channel ${session.channelId}`,
+        warning: session.transcripts?.warning,
         guildId: session.guildId,
         channelId: session.channelId,
       }));
@@ -296,10 +293,16 @@ export class DiscordVoiceManager {
     return await resolveDiscordVoiceAccessTarget({ ...params, client: this.client });
   }
 
-  startTranscriptsCapture(target: {
-    guildId: string;
-    channelId: string;
-  }): Promise<VoiceOperationResult> {
+  hasRealtimeCapture(target: { guildId: string; channelId: string }): boolean {
+    const entry = this.sessions.get(target.guildId);
+    return (
+      entry?.channelId === target.channelId &&
+      this.isEntryCurrent(entry) &&
+      entry.realtimeLifecycle.status === "active"
+    );
+  }
+
+  startTranscriptsCapture(target: { guildId: string; channelId: string }) {
     return this.join(target, { captureOnly: true });
   }
 

--- a/extensions/discord/src/voice/voice-session.lifecycle.test.ts
+++ b/extensions/discord/src/voice/voice-session.lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { DiscordError } from "../internal/discord.js";
 import type { MockCallSource } from "./manager.e2e.test-support.js";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
@@ -17,17 +18,13 @@ defineDiscordVoiceTests(
     joinVoiceChannelMock,
     entersStateMock,
     createAudioPlayerMock,
-    resolveRealtimeBootstrapContextInstructionsMock,
-    createRealtimeVoiceBridgeSessionMock,
     realtimeSessionMock,
     managerModule,
     createClient,
     createManager,
-    createAgentProxyManager,
     expectConnectedStatus,
     getSessionEntry,
     beginSpeakerTurn,
-    getVoiceReceive,
     getLastAudioPlayer,
     expectOffEventWithFunction,
     createJoinedAgentProxyFixture,
@@ -79,27 +76,16 @@ defineDiscordVoiceTests(
       });
 
       const manager = createManager();
-      const oldStopped = vi.fn();
-      const newStopped = vi.fn();
 
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        { transcripts: { sessionId: "old", onUtterance: vi.fn(), onStop: oldStopped } },
-      );
-      await manager.join(
-        { guildId: "g1", channelId: "1002" },
-        { transcripts: { sessionId: "new", onUtterance: vi.fn(), onStop: newStopped } },
-      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      await manager.join({ guildId: "g1", channelId: "1002" });
 
       const oldDisconnected = oldConnection.handlers.get("disconnected");
       expect(oldDisconnected).toBeTypeOf("function");
       await oldDisconnected?.();
 
       expectConnectedStatus(manager, "1002");
-      expect(oldStopped).toHaveBeenCalledOnce();
-      expect(newStopped).not.toHaveBeenCalled();
       await manager.destroy();
-      expect(newStopped).toHaveBeenCalledOnce();
     });
 
     it("keeps the new session when an old destroyed handler fires", async () => {
@@ -108,313 +94,16 @@ defineDiscordVoiceTests(
       joinVoiceChannelMock.mockReturnValueOnce(oldConnection).mockReturnValueOnce(newConnection);
 
       const manager = createManager();
-      const oldStopped = vi.fn();
-      const newStopped = vi.fn();
 
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        { transcripts: { sessionId: "old", onUtterance: vi.fn(), onStop: oldStopped } },
-      );
-      await manager.join(
-        { guildId: "g1", channelId: "1002" },
-        { transcripts: { sessionId: "new", onUtterance: vi.fn(), onStop: newStopped } },
-      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
+      await manager.join({ guildId: "g1", channelId: "1002" });
 
       const oldDestroyed = oldConnection.handlers.get("destroyed");
       expect(oldDestroyed).toBeTypeOf("function");
       oldDestroyed?.();
 
       expectConnectedStatus(manager, "1002");
-      expect(oldStopped).toHaveBeenCalledOnce();
-      expect(newStopped).not.toHaveBeenCalled();
       await manager.destroy();
-      expect(newStopped).toHaveBeenCalledOnce();
-    });
-
-    it("attaches transcripts capture to an existing voice session", async () => {
-      const manager = createManager();
-
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      const onUtterance = vi.fn();
-      const result = await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance,
-          },
-        },
-      );
-
-      const entry = getSessionEntry(manager);
-      expect(result.ok).toBe(true);
-      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
-      expect(entry.transcripts).toEqual({
-        sessionId: "notes-1",
-        onUtterance,
-      });
-    });
-
-    it("does not leave a newer transcripts-only session for a stale stop", async () => {
-      const manager = createAgentProxyManager();
-      const firstUtterance = vi.fn();
-      const secondUtterance = vi.fn();
-
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance: firstUtterance,
-          },
-        },
-      );
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-2",
-            onUtterance: secondUtterance,
-          },
-        },
-      );
-
-      const result = await manager.leave(
-        { guildId: "g1", channelId: "1001" },
-        { transcriptsSessionId: "notes-1" },
-      );
-      const entry = getSessionEntry(manager);
-
-      expect(result.ok).toBe(false);
-      expect(entry.transcripts).toEqual({
-        sessionId: "notes-2",
-        onUtterance: secondUtterance,
-      });
-      expectConnectedStatus(manager, "1001");
-    });
-
-    it("upgrades a transcripts-only session to realtime on a normal join", async () => {
-      const manager = createAgentProxyManager();
-      const onUtterance = vi.fn();
-      const onStop = vi.fn();
-
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onStop,
-            onUtterance,
-          },
-        },
-      );
-      expect(createRealtimeVoiceBridgeSessionMock).not.toHaveBeenCalled();
-      expect(createAudioPlayerMock).toHaveBeenCalledWith({
-        behaviors: { maxMissedFrames: 100 },
-      });
-
-      const entry = getSessionEntry(manager);
-      expect(entry.realtimeLifecycle.status).toBe("inactive");
-      let resolveRealtimeReady!: () => void;
-      const realtimeReady = new Promise<undefined>((resolve) => {
-        resolveRealtimeReady = () => resolve(undefined);
-      });
-      realtimeSessionMock.connect.mockImplementationOnce(async () => realtimeReady);
-
-      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
-
-      await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
-      expect(entry.realtimeLifecycle.status).toBe("starting");
-
-      resolveRealtimeReady();
-      const result = await upgrade;
-
-      expect(result.ok).toBe(true);
-      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
-      expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1);
-      expect(realtimeSessionMock.connect).toHaveBeenCalledTimes(1);
-      expect(entry.transcripts).toEqual({
-        sessionId: "notes-1",
-        onStop,
-        onUtterance,
-      });
-      expect(entry.realtimeLifecycle.status).toBe("active");
-      const attempts = getVoiceReceive(manager).daveRecoveryAttempts;
-      attempts.set("g1", Date.now());
-
-      const stopNotesResult = await manager.leave(
-        { guildId: "g1", channelId: "1001" },
-        { transcriptsSessionId: "notes-1" },
-      );
-
-      expect(stopNotesResult.ok).toBe(true);
-      expect(entry.transcripts).toBeUndefined();
-      expect(onStop).toHaveBeenCalledOnce();
-      expect(entry.realtimeLifecycle.status).toBe("active");
-      expect(realtimeSessionMock.close).not.toHaveBeenCalled();
-      expect(attempts.has("g1")).toBe(true);
-      expectConnectedStatus(manager, "1001");
-    });
-
-    it("closes a pending realtime upgrade if the voice entry stops before connect resolves", async () => {
-      const manager = createAgentProxyManager();
-      const onUtterance = vi.fn();
-
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance,
-          },
-        },
-      );
-      const entry = getSessionEntry(manager);
-      let resolveRealtimeReady!: () => void;
-      const realtimeReady = new Promise<undefined>((resolve) => {
-        resolveRealtimeReady = () => resolve(undefined);
-      });
-      realtimeSessionMock.connect.mockImplementationOnce(async () => realtimeReady);
-
-      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
-
-      await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
-      expect(entry.realtimeLifecycle.status).toBe("starting");
-
-      entry.stop();
-      expect(realtimeSessionMock.close).toHaveBeenCalled();
-      expect(entry.realtimeLifecycle.status).toBe("stopped");
-
-      resolveRealtimeReady();
-      const result = await upgrade;
-
-      expect(result.ok).toBe(false);
-      expect(result.message).toContain("stopped before startup completed");
-      expect(entry.realtimeLifecycle.status).toBe("stopped");
-    });
-
-    it("detaches transcripts without leaving voice during pending realtime upgrade", async () => {
-      const manager = createAgentProxyManager();
-      const onUtterance = vi.fn();
-      const onStop = vi.fn();
-
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onStop,
-            onUtterance,
-          },
-        },
-      );
-      const entry = getSessionEntry(manager);
-      let resolveRealtimeReady!: () => void;
-      const realtimeReady = new Promise<undefined>((resolve) => {
-        resolveRealtimeReady = () => resolve(undefined);
-      });
-      realtimeSessionMock.connect.mockImplementationOnce(async () => realtimeReady);
-
-      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
-
-      await vi.waitFor(() => expect(createRealtimeVoiceBridgeSessionMock).toHaveBeenCalledTimes(1));
-      const stopNotesResult = await manager.leave(
-        { guildId: "g1", channelId: "1001" },
-        { transcriptsSessionId: "notes-1" },
-      );
-
-      expect(stopNotesResult.ok).toBe(true);
-      expect(entry.transcripts).toBeUndefined();
-      expect(onStop).toHaveBeenCalledOnce();
-      expect(entry.realtimeLifecycle.status).toBe("starting");
-
-      resolveRealtimeReady();
-      const result = await upgrade;
-
-      expect(result.ok).toBe(true);
-      expect(entry.realtimeLifecycle.status).toBe("active");
-      expectConnectedStatus(manager, "1001");
-    });
-
-    it("does not start realtime upgrade if the voice entry leaves during bootstrap", async () => {
-      const manager = createAgentProxyManager();
-      const onUtterance = vi.fn();
-
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance,
-          },
-        },
-      );
-      let resolveBootstrap!: () => void;
-      const bootstrapReady = new Promise<undefined>((resolve) => {
-        resolveBootstrap = () => resolve(undefined);
-      });
-      resolveRealtimeBootstrapContextInstructionsMock.mockImplementationOnce(
-        async () => bootstrapReady,
-      );
-
-      const upgrade = manager.join({ guildId: "g1", channelId: "1001" });
-      await Promise.resolve();
-
-      const leaveResult = await manager.leave({ guildId: "g1" });
-      resolveBootstrap();
-      const result = await upgrade;
-
-      expect(leaveResult.ok).toBe(true);
-      expect(result.ok).toBe(false);
-      expect(result.message).toContain("stopped before startup completed");
-      expect(createRealtimeVoiceBridgeSessionMock).not.toHaveBeenCalled();
-    });
-
-    it("keeps realtime playback alive when transcripts attaches to an existing voice session", async () => {
-      const { bridgeParams, entry, manager, player } = await createJoinedAgentProxyFixture({
-        config: { voice: { realtime: { consultPolicy: "auto" } } },
-      });
-
-      bridgeParams?.audioSink?.sendAudio(Buffer.alloc(24_000));
-      const stopCallsBeforeTranscripts = player.stop.mock.calls.length;
-      const onUtterance = vi.fn(async () => undefined);
-
-      const result = await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        {
-          transcripts: {
-            sessionId: "notes-1",
-            onUtterance,
-          },
-        },
-      );
-
-      expect(result.ok).toBe(true);
-      expect(entry.transcripts?.sessionId).toBe("notes-1");
-      expect(realtimeSessionMock.close).not.toHaveBeenCalled();
-      expect(player.stop).toHaveBeenCalledTimes(stopCallsBeforeTranscripts);
-
-      const turn = beginSpeakerTurn(entry, { initialAudio: Buffer.alloc(3840) });
-      bridgeParams?.onTranscript?.("user", "meeting note transcript", true);
-
-      await vi.waitFor(() =>
-        expect(onUtterance).toHaveBeenCalledWith(
-          expect.objectContaining({
-            final: true,
-            sessionId: "notes-1",
-            speaker: { id: "u-owner", label: "Owner" },
-            text: "meeting note transcript",
-            metadata: expect.objectContaining({
-              channel: "discord",
-              channelId: "1001",
-              guildId: "g1",
-              voiceSessionKey: "discord:g1:c1",
-            }),
-          }),
-        ),
-      );
-      turn.close();
     });
 
     it("destroys stale tracked voice connections before joining", async () => {
@@ -784,22 +473,25 @@ defineDiscordVoiceTests(
 
     it("deduplicates concurrent joins for the same guild and channel", async () => {
       const connection = createConnectionMock();
-      let resolveReady!: () => void;
-      const readyPromise = new Promise<undefined>((resolve) => {
-        resolveReady = () => resolve(undefined);
-      });
+      const waiting = createDeferred<void>();
+      const ready = createDeferred<undefined>();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
-      entersStateMock.mockImplementationOnce(async () => readyPromise);
+      entersStateMock.mockImplementationOnce(() => {
+        waiting.resolve();
+        return ready.promise;
+      });
       const manager = createManager();
 
       const firstJoin = manager.join({ guildId: "g1", channelId: "1001" });
-      await Promise.resolve();
       const secondJoin = manager.join({ guildId: "g1", channelId: "1001" });
-      await Promise.resolve();
+      await waiting.promise;
 
-      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      try {
+        expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      } finally {
+        ready.resolve(undefined);
+      }
 
-      resolveReady();
       const [firstResult, secondResult] = await Promise.all([firstJoin, secondJoin]);
 
       expect(firstResult.ok).toBe(true);
@@ -812,68 +504,72 @@ defineDiscordVoiceTests(
       const firstConnection = createConnectionMock();
       const secondConnection = createConnectionMock();
       const thirdConnection = createConnectionMock();
-      let resolveFirstReady!: () => void;
-      let resolveSecondReady!: () => void;
-      let resolveThirdReady!: () => void;
-      const firstReady = new Promise<undefined>((resolve) => {
-        resolveFirstReady = () => resolve(undefined);
-      });
-      const secondReady = new Promise<undefined>((resolve) => {
-        resolveSecondReady = () => resolve(undefined);
-      });
-      const thirdReady = new Promise<undefined>((resolve) => {
-        resolveThirdReady = () => resolve(undefined);
-      });
+      const waiting = createDeferred<void>();
+      const firstReady = createDeferred<undefined>();
+      const secondReady = createDeferred<undefined>();
+      const thirdReady = createDeferred<undefined>();
       joinVoiceChannelMock
         .mockReturnValueOnce(firstConnection)
         .mockReturnValueOnce(secondConnection)
         .mockReturnValueOnce(thirdConnection);
       entersStateMock
-        .mockImplementationOnce(async () => firstReady)
-        .mockImplementationOnce(async () => secondReady)
-        .mockImplementationOnce(async () => thirdReady);
+        .mockImplementationOnce(() => {
+          waiting.resolve();
+          return firstReady.promise;
+        })
+        .mockImplementationOnce(() => secondReady.promise)
+        .mockImplementationOnce(() => thirdReady.promise);
       const manager = createManager();
 
       const firstJoin = manager.join({ guildId: "g1", channelId: "1001" });
-      await Promise.resolve();
       const secondJoin = manager.join({ guildId: "g1", channelId: "1002" });
       const thirdJoin = manager.join({ guildId: "g1", channelId: "1003" });
-      await Promise.resolve();
+      await waiting.promise;
 
-      expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
+      try {
+        expect(joinVoiceChannelMock).toHaveBeenCalledTimes(1);
 
-      resolveFirstReady();
-      await firstJoin;
-      await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2));
-      expect(entersStateMock).toHaveBeenCalledTimes(2);
+        firstReady.resolve(undefined);
+        await firstJoin;
+        await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(2));
+        expect(entersStateMock).toHaveBeenCalledTimes(2);
 
-      resolveSecondReady();
-      await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(3));
-      resolveThirdReady();
-      const [secondResult, thirdResult] = await Promise.all([secondJoin, thirdJoin]);
+        secondReady.resolve(undefined);
+        await vi.waitFor(() => expect(joinVoiceChannelMock).toHaveBeenCalledTimes(3));
+        thirdReady.resolve(undefined);
+        const [secondResult, thirdResult] = await Promise.all([secondJoin, thirdJoin]);
 
-      expect(secondResult.ok).toBe(true);
-      expect(thirdResult.ok).toBe(true);
-      expect(entersStateMock).toHaveBeenCalledTimes(3);
+        expect(secondResult.ok).toBe(true);
+        expect(thirdResult.ok).toBe(true);
+        expect(entersStateMock).toHaveBeenCalledTimes(3);
+      } finally {
+        firstReady.resolve(undefined);
+        secondReady.resolve(undefined);
+        thirdReady.resolve(undefined);
+        await Promise.all([firstJoin, secondJoin, thirdJoin]);
+      }
     });
 
     it("does not start queued joins after the voice manager is destroyed", async () => {
       const connection = createConnectionMock();
-      let resolveReady!: () => void;
-      const readyPromise = new Promise<undefined>((resolve) => {
-        resolveReady = () => resolve(undefined);
-      });
+      const waiting = createDeferred<void>();
+      const ready = createDeferred<undefined>();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
-      entersStateMock.mockImplementationOnce(async () => readyPromise);
+      entersStateMock.mockImplementationOnce(() => {
+        waiting.resolve();
+        return ready.promise;
+      });
       const manager = createManager();
 
       const firstJoin = manager.join({ guildId: "g1", channelId: "1001" });
-      await Promise.resolve();
       const queuedJoin = manager.join({ guildId: "g1", channelId: "1002" });
-      await Promise.resolve();
+      await waiting.promise;
 
-      await manager.destroy();
-      resolveReady();
+      try {
+        await manager.destroy();
+      } finally {
+        ready.resolve(undefined);
+      }
       const [firstResult, queuedResult] = await Promise.all([firstJoin, queuedJoin]);
 
       expect(firstResult.ok).toBe(false);
@@ -982,17 +678,12 @@ defineDiscordVoiceTests(
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
       const manager = createManager();
-      const onStop = vi.fn();
 
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        { transcripts: { sessionId: "notes", onUtterance: vi.fn(), onStop } },
-      );
+      await manager.join({ guildId: "g1", channelId: "1001" });
       connection.handlers.get("disconnected")?.();
       await vi.waitFor(() =>
         expect(entersStateMock).toHaveBeenCalledWith(connection, "connecting", 15_000),
       );
-      expect(onStop).not.toHaveBeenCalled();
 
       entersStateMock.mockClear();
       entersStateMock.mockRejectedValueOnce(new Error("still disconnected"));
@@ -1006,7 +697,6 @@ defineDiscordVoiceTests(
       expect(entersStateMock).toHaveBeenCalledWith(connection, "connecting", 15_000);
       await vi.waitFor(() => expect(connection.destroy).toHaveBeenCalledTimes(1));
       await vi.waitFor(() => expect(manager.status()).toStrictEqual([]));
-      expect(onStop).toHaveBeenCalledOnce();
     });
 
     it("closes realtime sessions when disconnected recovery destroys the connection", async () => {

--- a/extensions/discord/src/voice/voice-session.promotion.test.ts
+++ b/extensions/discord/src/voice/voice-session.promotion.test.ts
@@ -1,0 +1,243 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    vi,
+    createConnectionMock,
+    joinVoiceChannelMock,
+    realtimeSessionMock,
+    resolveRealtimeBootstrapContextInstructionsMock,
+    loggerWarnMock,
+    createAgentProxyManager,
+    createManager,
+    createClient,
+    configureVoiceStateGateway,
+    makeVoiceConfig,
+    expectConnectedStatus,
+    getSessionEntry,
+    startTranscripts,
+    stopTranscripts,
+    receiveRecordedSpeech,
+    agentCommandMock,
+    updateVoiceState,
+  }) => {
+    it.each([
+      { mode: "agent-proxy", stop: "after" },
+      { mode: "agent-proxy", stop: "during" },
+      { mode: "bidi", stop: "after" },
+      { mode: "bidi", stop: "during" },
+    ] as const)(
+      "disconnects capture stopped $stop a failed $mode promotion",
+      async ({ mode, stop }) => {
+        const manager = createAgentProxyManager(undefined, { voice: { mode } });
+        const connection = createConnectionMock();
+        joinVoiceChannelMock.mockReturnValueOnce(connection);
+        expect(await startTranscripts(manager)).toMatchObject({ ok: true });
+        const { promise: connect, reject: rejectConnect } = createDeferred<undefined>();
+        realtimeSessionMock.connect.mockImplementationOnce(() => connect);
+
+        const joining = manager.join({ guildId: "g1", channelId: "1001" });
+        await vi.waitFor(() => expect(realtimeSessionMock.connect).toHaveBeenCalledOnce());
+        if (stop === "during") {
+          expect(await stopTranscripts()).toMatchObject({ ok: true });
+          expect(connection.destroy).not.toHaveBeenCalled();
+        }
+        rejectConnect(new Error("provider unavailable"));
+        expect(await joining).toMatchObject({
+          ok: false,
+          message: "Failed to start Discord realtime voice: provider unavailable",
+        });
+        if (stop === "after") {
+          expect(connection.destroy).not.toHaveBeenCalled();
+          expect(await stopTranscripts()).toMatchObject({ ok: true });
+        }
+        expect(connection.destroy).toHaveBeenCalledOnce();
+        expect(manager.status()).toEqual([]);
+        expect(realtimeSessionMock.close).toHaveBeenCalled();
+        expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+      },
+    );
+
+    it.each(["bootstrap", "unavailable bootstrap", "connect"])(
+      "keeps recording while conversation promotion waits for %s",
+      async (phase) => {
+        const manager = createAgentProxyManager();
+        const onUtterance = vi.fn();
+        await startTranscripts(manager, onUtterance);
+        const entry = getSessionEntry(manager);
+        const { promise: ready, resolve: finish } = createDeferred<void>();
+        const pending =
+          phase !== "connect"
+            ? resolveRealtimeBootstrapContextInstructionsMock
+            : realtimeSessionMock.connect;
+        pending.mockImplementationOnce(async () => {
+          await ready;
+          if (phase === "unavailable bootstrap") {
+            throw new Error("synthetic optional context unavailable");
+          }
+          return undefined;
+        });
+        const joining = manager.join({ guildId: "g1", channelId: "1001" });
+        try {
+          await vi.waitFor(() => expect(pending).toHaveBeenCalledOnce());
+          await receiveRecordedSpeech(manager, "recorded during promotion");
+          expect(onUtterance).toHaveBeenCalledWith(
+            expect.objectContaining({ text: "recorded during promotion" }),
+          );
+          expect(agentCommandMock).not.toHaveBeenCalled();
+        } finally {
+          finish();
+          await joining;
+        }
+        expect(await joining).toMatchObject({ ok: true });
+        expect(getSessionEntry(manager)).toBe(entry);
+        expectConnectedStatus(manager, "1001");
+        expect(realtimeSessionMock.connect).toHaveBeenCalledOnce();
+        if (phase === "unavailable bootstrap") {
+          expect(loggerWarnMock).toHaveBeenCalledWith(
+            "discord voice: realtime bootstrap context unavailable: synthetic optional context unavailable",
+          );
+        }
+        expect(await stopTranscripts()).toMatchObject({ ok: true });
+        expectConnectedStatus(manager, "1001");
+        expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+      },
+    );
+
+    it("resumes silent recording after failed promotion and can retry conversation", async () => {
+      const manager = createAgentProxyManager();
+      const onUtterance = vi.fn();
+      await startTranscripts(manager, onUtterance);
+      realtimeSessionMock.connect.mockRejectedValueOnce(new Error("provider unavailable"));
+
+      expect(await manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({ ok: false });
+      await receiveRecordedSpeech(manager, "still recording");
+      expect(onUtterance).toHaveBeenCalledWith(
+        expect.objectContaining({ text: "still recording" }),
+      );
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      expectConnectedStatus(manager, "1001");
+
+      expect(await manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({ ok: true });
+      expect(await stopTranscripts()).toMatchObject({ ok: true });
+      expectConnectedStatus(manager, "1001");
+      expect(getSessionEntry(manager).realtimeLifecycle.status).toBe("active");
+      expect(joinVoiceChannelMock).toHaveBeenCalledOnce();
+    });
+
+    it("preserves replacement capture when a pending promotion fails", async () => {
+      const manager = createAgentProxyManager();
+      const connection = createConnectionMock();
+      joinVoiceChannelMock.mockReturnValueOnce(connection);
+      await startTranscripts(manager);
+      const { promise: connect, reject: rejectConnect } = createDeferred<undefined>();
+      realtimeSessionMock.connect.mockImplementationOnce(() => connect);
+      const joining = manager.join({ guildId: "g1", channelId: "1001" });
+      await vi.waitFor(() => expect(realtimeSessionMock.connect).toHaveBeenCalledOnce());
+      const onUtterance = vi.fn();
+      const replacement = startTranscripts(manager, onUtterance, "notes-2");
+      await vi.waitFor(() =>
+        expect(getSessionEntry(manager).transcripts?.sessionId).toBe("notes-2"),
+      );
+      rejectConnect(new Error("provider unavailable"));
+      expect(await joining).toMatchObject({ ok: false });
+      expect(await replacement).toMatchObject({ ok: true });
+      expect(await stopTranscripts()).toMatchObject({ ok: false });
+      await receiveRecordedSpeech(manager, "replacement recording");
+      expect(onUtterance).toHaveBeenCalledOnce();
+      expect(agentCommandMock).not.toHaveBeenCalled();
+      expect(connection.destroy).not.toHaveBeenCalled();
+      expect(await stopTranscripts("notes-2")).toMatchObject({ ok: true });
+      expect(connection.destroy).toHaveBeenCalledOnce();
+      expect(manager.status()).toEqual([]);
+    });
+
+    it.each([false, true])(
+      "retains existing occupancy ownership (%s) after failed promotion",
+      async (whenOccupied) => {
+        const client = createClient();
+        const human = {
+          guild_id: "g1",
+          channel_id: "1001",
+          user_id: "u-owner",
+          member: { user: { id: "u-owner", bot: false } },
+        };
+        let states: Array<Record<string, unknown>> = [human];
+        configureVoiceStateGateway(client, () => states);
+        const config = makeVoiceConfig(
+          {
+            mode: "stt-tts",
+            autoJoin: [{ guildId: "g1", channelId: "1001", whenOccupied: true }],
+          },
+          { groupPolicy: "open" },
+        );
+        const manager = createManager(config, client);
+        await manager.join(
+          { guildId: "g1", channelId: "1001" },
+          { autoJoinWhenOccupied: whenOccupied },
+        );
+        const connection = joinVoiceChannelMock.mock.results[0]!.value;
+        await startTranscripts(manager);
+        // Exercise realtime attachment on a transport with an established conversation owner.
+        config.voice!.mode = "agent-proxy";
+        realtimeSessionMock.connect.mockRejectedValueOnce(new Error("provider unavailable"));
+
+        expect(
+          await manager.join(
+            { guildId: "g1", channelId: "1001" },
+            {
+              autoJoinWhenOccupied: !whenOccupied,
+            },
+          ),
+        ).toMatchObject({ ok: false });
+        expect(await stopTranscripts()).toMatchObject({ ok: true });
+        expect(connection.destroy).not.toHaveBeenCalled();
+        expectConnectedStatus(manager, "1001");
+        states = [];
+        await updateVoiceState(manager, "u-owner", null, human.member);
+        if (whenOccupied) {
+          expect(connection.destroy).toHaveBeenCalledOnce();
+          expect(manager.status()).toEqual([]);
+        } else {
+          expect(connection.destroy).not.toHaveBeenCalled();
+          expectConnectedStatus(manager, "1001");
+        }
+      },
+    );
+
+    it.each(["resolve", "reject"])(
+      "does not revive a cancelled promotion when connect later %ss",
+      async (settlement) => {
+        const manager = createAgentProxyManager();
+        const oldConnection = createConnectionMock();
+        const replacementConnection = createConnectionMock();
+        joinVoiceChannelMock
+          .mockReturnValueOnce(oldConnection)
+          .mockReturnValueOnce(replacementConnection);
+        await startTranscripts(manager);
+        const oldEntry = getSessionEntry(manager);
+        const connect = createDeferred<undefined>();
+        realtimeSessionMock.connect.mockImplementationOnce(() => connect.promise);
+        const joining = manager.join({ guildId: "g1", channelId: "1001" });
+        await vi.waitFor(() => expect(realtimeSessionMock.connect).toHaveBeenCalledOnce());
+        expect(await manager.leave({ guildId: "g1" })).toMatchObject({ ok: true });
+        expect(await stopTranscripts()).toMatchObject({ ok: true });
+        const replacement = manager.join({ guildId: "g1", channelId: "1002" });
+        if (settlement === "resolve") {
+          connect.resolve(undefined);
+        } else {
+          connect.reject(new Error("provider unavailable"));
+        }
+        expect(await joining).toMatchObject({ ok: false });
+        expect(await replacement).toMatchObject({ ok: true });
+        oldEntry.stop();
+        expect(oldConnection.destroy).toHaveBeenCalledOnce();
+        expect(replacementConnection.destroy).not.toHaveBeenCalled();
+        expectConnectedStatus(manager, "1002");
+      },
+    );
+  },
+);

--- a/extensions/discord/src/voice/voice-session.terminal.test.ts
+++ b/extensions/discord/src/voice/voice-session.terminal.test.ts
@@ -15,6 +15,7 @@ defineDiscordVoiceTests(
     createAgentProxyManager,
     expectConnectedStatus,
     getSessionEntry,
+    startTranscripts,
     getVoiceReceive,
     getLastAudioPlayer,
     loggerErrorMock,
@@ -45,16 +46,9 @@ defineDiscordVoiceTests(
         try {
           await manager.join({ guildId: "g1", channelId: "1001" });
           const entry = getSessionEntry(manager);
-          const onStop = vi.fn();
-          const transcripts = {
-            sessionId: "notes-1",
-            onUtterance: vi.fn(),
-            onStop: () => {
-              onStop(entry.transcripts);
-              entry.stop();
-            },
-          };
-          await manager.join({ guildId: "g1", channelId: "1001" }, { transcripts });
+          const onUtterance = vi.fn();
+          await startTranscripts(manager, onUtterance);
+          const registration = entry.transcripts;
           decodeOpusStreamChunksMock.mockReturnValueOnce(decoding.promise);
           receive = handleSpeakingStart(manager, entry, "u-owner");
           await vi.waitFor(() => expect(decodeOpusStreamChunksMock).toHaveBeenCalledOnce());
@@ -79,8 +73,8 @@ defineDiscordVoiceTests(
 
           expect(manager.status()).toEqual([]);
           expect(entry.realtimeLifecycle.status).toBe("stopped");
-          expect(entry.transcripts).toBeUndefined();
-          expect(onStop).toHaveBeenCalledExactlyOnceWith(undefined);
+          expect(entry.transcripts).toBe(registration);
+          expect(registration?.isCurrent()).toBe(true);
           expect(captureStream.destroy).toHaveBeenCalledOnce();
           expect(entry.capture.size).toBe(0);
           expect(oldConnection.destroy).toHaveBeenCalledTimes(boundary === "leave" ? 1 : 0);
@@ -97,16 +91,8 @@ defineDiscordVoiceTests(
 
           await manager.join({ guildId: "g1", channelId: "1001" });
           const replacement = getSessionEntry(manager);
+          expect(replacement.transcripts).toBe(registration);
           const replacementProvider = lastRealtimeBridge();
-          const replacementTranscripts = {
-            sessionId: "notes-2",
-            onUtterance: vi.fn(),
-            onStop: vi.fn(),
-          };
-          await manager.join(
-            { guildId: "g1", channelId: "1001" },
-            { transcripts: replacementTranscripts },
-          );
           const inputCalls = oldProvider.sendAudio.mock.calls.length;
           turn.sendInputAudio(Buffer.alloc(3840));
           turn.close();
@@ -125,10 +111,8 @@ defineDiscordVoiceTests(
           expect(loggerErrorMock).not.toHaveBeenCalled();
           expect(oldProvider.sendAudio).toHaveBeenCalledTimes(inputCalls);
           expect(player.play).toHaveBeenCalledOnce();
-          expect(onStop).toHaveBeenCalledOnce();
-          expect(replacementTranscripts.onStop).not.toHaveBeenCalled();
-          expect(transcripts.onUtterance).not.toHaveBeenCalled();
-          expect(replacementTranscripts.onUtterance).not.toHaveBeenCalled();
+          expect(registration?.isCurrent()).toBe(true);
+          expect(onUtterance).not.toHaveBeenCalled();
           beginSpeakerTurn(replacement);
           expect(replacementProvider.session.sendAudio).toHaveBeenCalledOnce();
           expect(oldProvider.sendAudio).toHaveBeenCalledTimes(inputCalls);

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -1,4 +1,3 @@
-import type { Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig, DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -164,7 +163,10 @@ export class DiscordVoiceSessions {
   }: {
     guildId: string;
     channelId: string;
-  }): Promise<Result<Awaited<ReturnType<Client["fetchChannel"]>>, VoiceOperationResult>> {
+  }): Promise<
+    | { ok: true; value: Awaited<ReturnType<Client["fetchChannel"]>> }
+    | { ok: false; error: VoiceOperationResult }
+  > {
     let channelInfo: Awaited<ReturnType<Client["fetchChannel"]>>;
     try {
       channelInfo = await this.params.client.fetchChannel(channelId);

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -1,3 +1,4 @@
+import type { Result } from "@openclaw/normalization-core/result";
 import type { OpenClawConfig, DiscordAccountConfig } from "openclaw/plugin-sdk/config-contracts";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -29,6 +30,7 @@ import {
   type VoiceSessionGeneration,
   type VoiceSessionEntry,
 } from "./session.js";
+import { DiscordVoiceConversationQueue } from "./voice-conversation-input.js";
 import type { DiscordVoiceReceive } from "./voice-receive.js";
 
 const logger = createSubsystemLogger("discord/voice");
@@ -36,20 +38,6 @@ const REALTIME_PLAYBACK_MAX_MISSED_FRAMES = 100;
 
 function isVoiceSessionStopped(entry: VoiceSessionEntry): boolean {
   return entry.sessionLifecycle.status === "stopped";
-}
-
-function retireTranscripts(entry: VoiceSessionEntry): void {
-  const transcripts = entry.transcripts;
-  entry.transcripts = undefined;
-  // Detach before notifying: retained delivery and reentrant stop cannot target
-  // this binding or a replacement installed while notification settles.
-  try {
-    void Promise.resolve(transcripts?.onStop?.()).catch((error: unknown) => {
-      logger.warn(`discord voice: transcripts retirement failed: ${formatErrorMessage(error)}`);
-    });
-  } catch (error) {
-    logger.warn(`discord voice: transcripts retirement failed: ${formatErrorMessage(error)}`);
-  }
 }
 
 type DiscordVoiceSdk = ReturnType<typeof loadDiscordVoiceSdk>;
@@ -149,6 +137,10 @@ export class DiscordVoiceSessions {
       cfg: OpenClawConfig;
       client: Client;
       destroyed: () => boolean;
+      getTranscripts: (entry: {
+        guildId: string;
+        channelId: string;
+      }) => VoiceSessionEntry["transcripts"];
       discordConfig: DiscordAccountConfig;
       membership: DiscordVoiceMembershipTracker;
       onLeaveFollowState: (guildId: string) => void;
@@ -164,6 +156,40 @@ export class DiscordVoiceSessions {
       return;
     }
     this.params.membership.activate(entry, this.params.botUserId());
+  }
+
+  async resolveChannel({
+    guildId,
+    channelId,
+  }: {
+    guildId: string;
+    channelId: string;
+  }): Promise<Result<Awaited<ReturnType<Client["fetchChannel"]>>, VoiceOperationResult>> {
+    let channelInfo: Awaited<ReturnType<Client["fetchChannel"]>>;
+    try {
+      channelInfo = await this.params.client.fetchChannel(channelId);
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          ok: false,
+          message: `Failed to resolve Discord channel ${channelId}: ${formatErrorMessage(err)}`,
+          guildId,
+          channelId,
+        },
+      };
+    }
+    if (!isVoiceChannel(channelInfo.type)) {
+      return {
+        ok: false,
+        error: { ok: false, message: `Channel ${channelId} is not a voice channel.` },
+      };
+    }
+    const channelGuildId = "guildId" in channelInfo ? channelInfo.guildId : undefined;
+    if (channelGuildId && channelGuildId !== guildId) {
+      return { ok: false, error: { ok: false, message: "Voice channel is not in this guild." } };
+    }
+    return { ok: true, value: channelInfo };
   }
 
   async joinUnlocked(
@@ -183,16 +209,11 @@ export class DiscordVoiceSessions {
 
     const existing = this.params.sessions.get(guildId);
     if (existing && existing.channelId === channelId) {
-      existing.autoJoinWhenOccupied = options?.autoJoinWhenOccupied === true;
       if (authority) {
         existing.generation = authority.generation;
       }
-      if (options?.transcripts) {
-        retireTranscripts(existing);
-        existing.transcripts = options.transcripts;
-      }
       if (
-        !options?.transcripts &&
+        (!options?.captureOnly || !existing.captureOnly) &&
         isDiscordRealtimeVoiceMode(voiceMode) &&
         existing.realtimeLifecycle.status !== "active" &&
         existing.realtimeLifecycle.status !== "starting"
@@ -223,32 +244,15 @@ export class DiscordVoiceSessions {
       await this.leave({ guildId }, { preserveFollowState: options?.preserveFollowState });
     }
 
-    let channelInfo: Awaited<ReturnType<Client["fetchChannel"]>>;
-    try {
-      channelInfo = await this.params.client.fetchChannel(channelId);
-    } catch (err) {
-      // A leave or replacement can invalidate the join while the REST lookup is pending;
-      // cancellation remains authoritative over a stale lookup failure.
-      if (authority && !authority.isCurrent()) {
-        return cancelledJoinResult();
-      }
-      return {
-        ok: false,
-        message: `Failed to resolve Discord channel ${channelId}: ${formatErrorMessage(err)}`,
-        guildId,
-        channelId,
-      };
-    }
+    const resolved = await this.resolveChannel(params);
+    // Leave or replacement wins over a lookup that failed after this join lost ownership.
     if (authority && !authority.isCurrent()) {
       return cancelledJoinResult();
     }
-    if (!isVoiceChannel(channelInfo.type)) {
-      return { ok: false, message: `Channel ${channelId} is not a voice channel.` };
+    if (!resolved.ok) {
+      return resolved.error;
     }
-    const channelGuildId = "guildId" in channelInfo ? channelInfo.guildId : undefined;
-    if (channelGuildId && channelGuildId !== guildId) {
-      return { ok: false, message: "Voice channel is not in this guild." };
-    }
+    const channelInfo = resolved.value;
 
     const voicePlugin = this.params.client.getPlugin<VoicePlugin>("voice");
     if (!voicePlugin) {
@@ -410,7 +414,6 @@ export class DiscordVoiceSessions {
         return;
       }
       entry.sessionLifecycle = { status: "stopped", reason: optionsLocal.reason };
-      retireTranscripts(entry);
       // A late callback from an old connection must not remove its replacement.
       if (this.params.sessions.get(guildId) === entry) {
         this.params.sessions.delete(guildId);
@@ -419,6 +422,7 @@ export class DiscordVoiceSessions {
       connection.receiver.speaking.off("start", speakingHandler);
       connection.receiver.speaking.off("end", speakingEndHandler);
       stopVoiceCaptureState(entry.capture);
+      entry.conversations.close();
       connection.off(voiceSdk.VoiceConnectionStatus.Disconnected, disconnectedHandler);
       connection.off(voiceSdk.VoiceConnectionStatus.Destroyed, destroyedHandler);
       player.off("error", playerErrorHandler);
@@ -443,8 +447,10 @@ export class DiscordVoiceSessions {
       this.params.onSessionStopped(entry, optionsLocal.reason);
     };
 
+    const getTranscripts = this.params.getTranscripts;
     const entry: VoiceSessionEntry = {
       generation: authority?.generation ?? 0,
+      captureOnly: options?.captureOnly === true,
       autoJoinWhenOccupied: options?.autoJoinWhenOccupied === true,
       sessionLifecycle: { status: "active" },
       guildId,
@@ -467,10 +473,13 @@ export class DiscordVoiceSessions {
       player,
       playbackQueue: Promise.resolve(),
       processingQueue: Promise.resolve(),
+      conversations: new DiscordVoiceConversationQueue(),
       audioInputBudget,
       ttsStreamFallbackWarned: false,
       capture: createVoiceCaptureState(),
-      transcripts: options?.transcripts,
+      get transcripts(): VoiceSessionEntry["transcripts"] {
+        return getTranscripts(entry);
+      },
       receiveRecovery: createVoiceReceiveRecoveryState(),
       realtimeLifecycle: { status: "inactive", generation: 0 },
       stop(reason) {
@@ -535,7 +544,7 @@ export class DiscordVoiceSessions {
     connection.on(voiceSdk.VoiceConnectionStatus.Disconnected, disconnectedHandler);
     connection.on(voiceSdk.VoiceConnectionStatus.Destroyed, destroyedHandler);
     player.on("error", playerErrorHandler);
-    if (!options?.transcripts && isDiscordRealtimeVoiceMode(voiceMode)) {
+    if (!entry.captureOnly && isDiscordRealtimeVoiceMode(voiceMode)) {
       const realtimeResult = await this.attachRealtimeSession(entry, voiceMode, {
         isCurrent: authority?.isCurrent,
       });
@@ -590,7 +599,7 @@ export class DiscordVoiceSessions {
 
   async leave(
     params: { guildId: string; channelId?: string },
-    options?: { preserveFollowState?: boolean; transcriptsSessionId?: string },
+    options?: { preserveFollowState?: boolean },
   ): Promise<VoiceOperationResult> {
     const guildId = params.guildId.trim();
     logVoiceVerbose(`leave requested: guild ${guildId} channel ${params.channelId ?? "current"}`);
@@ -601,31 +610,9 @@ export class DiscordVoiceSessions {
     if (params.channelId && params.channelId !== entry.channelId) {
       return { ok: false, message: "Not connected to that voice channel." };
     }
-    if (options?.transcriptsSessionId) {
-      if (!entry.transcripts || entry.transcripts.sessionId !== options.transcriptsSessionId) {
-        return {
-          ok: false,
-          message: "Transcripts session is not active in this voice channel.",
-          guildId,
-          channelId: entry.channelId,
-        };
-      }
-      if (
-        entry.realtimeLifecycle.status === "active" ||
-        entry.realtimeLifecycle.status === "starting"
-      ) {
-        retireTranscripts(entry);
-        return {
-          ok: true,
-          message: `Stopped transcripts for ${formatMention({ channelId: entry.channelId })}.`,
-          guildId,
-          channelId: entry.channelId,
-        };
-      }
-    }
     entry.stop();
     if (!entry.receiveRecovery.decryptRecoveryInFlight) {
-      this.params.receive.deleteRecoveryAttempt(guildId);
+      this.params.receive.daveRecoveryAttempts.delete(guildId);
     }
     if (!options?.preserveFollowState) {
       this.params.onLeaveFollowState(guildId);
@@ -673,7 +660,23 @@ export class DiscordVoiceSessions {
         logger.error(
           `discord voice: realtime session failed terminally guild=${entry.guildId} channel=${entry.channelId}: ${formatErrorMessage(error)}`,
         );
-        entry.stop("realtime terminal error");
+        const lifecycle = entry.realtimeLifecycle;
+        if (
+          options?.requireLiveEntry &&
+          lifecycle.status === "starting" &&
+          lifecycle.instance === realtime
+        ) {
+          // Failed promotion retires only its realtime attempt. The already-ready
+          // receiver still belongs to the previous capture or conversation owner.
+          entry.realtimeLifecycle = {
+            status: "stopped",
+            generation: lifecycle.generation,
+            reason: "realtime terminal error",
+          };
+          realtime.close();
+        } else {
+          entry.stop("realtime terminal error");
+        }
       },
       runAgentTurn: ({ context, message, toolsAllow, userId }) =>
         this.params.receive.runDiscordRealtimeAgentTurn({

--- a/extensions/discord/src/voice/voice-test-harness.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-harness.test-support.ts
@@ -18,6 +18,7 @@ import {
 } from "./manager.e2e.test-support.js";
 import { createVoiceReceiveRecoveryState, DECRYPT_FAILURE_WINDOW_MS } from "./receive-recovery.js";
 import type { VoiceRealtimeSpeakerContext, VoiceSessionEntry } from "./session.js";
+import { createDiscordVoiceTranscriptFixture } from "./transcripts.test-support.js";
 import { voiceTestMocks } from "./voice-test-mocks.test-support.js";
 
 const {
@@ -32,6 +33,7 @@ const {
   resolveRealtimeBootstrapContextInstructionsMock,
   resolveVoiceIngressWithParticipantsMock,
   transcribeAudioFileMock,
+  resolveAudioInputBudgetMock,
   prepareTtsRequestMock,
   textToSpeechStreamMock,
   textToSpeechMock,
@@ -43,7 +45,6 @@ const {
   controlRealtimeVoiceAgentRunMock,
   createRealtimeSessionMock,
   realtimeSessionMock,
-  decodeOpusStreamMock,
   decodeOpusStreamChunksMock,
   updateVoiceStateMock,
   enqueueSystemEventMock,
@@ -51,10 +52,9 @@ const {
   isSecretOwnerAvailableMock,
   canonicalizeRealtimeVoiceProviderIdMock,
 } = voiceTestMocks;
-const [managerModule, realtimeModule, segmentModule] = await Promise.all([
+const [managerModule, realtimeModule] = await Promise.all([
   import("./voice-runtime.js"),
   import("./realtime-session.runtime.js"),
-  import("./segment.js"),
 ]);
 
 const { configureVoiceStateGateway, createClient, createClientWithMember } =
@@ -62,6 +62,7 @@ const { configureVoiceStateGateway, createClient, createClientWithMember } =
 const createRuntime = createVoiceTestRuntime;
 
 function buildVoiceTestHarness() {
+  const { startTranscripts, stopTranscripts } = createDiscordVoiceTranscriptFixture();
   const managers = new Set<InstanceType<typeof managerModule.DiscordVoiceManager>>();
   afterEach(async () => {
     await Promise.all([...managers].map((manager) => manager.destroy()));
@@ -128,7 +129,8 @@ function buildVoiceTestHarness() {
     );
     createAudioResourceMock.mockClear();
     realtimeSessionMock.close.mockClear();
-    realtimeSessionMock.connect.mockClear();
+    realtimeSessionMock.connect.mockReset();
+    realtimeSessionMock.connect.mockResolvedValue(undefined);
     realtimeSessionMock.sendAudio.mockClear();
     realtimeSessionMock.sendUserMessage.mockClear();
     realtimeSessionMock.handleBargeIn.mockClear();
@@ -159,9 +161,14 @@ function buildVoiceTestHarness() {
       provider: { id: "openai", capabilities: { supportsActivationNameGating: true } },
       providerConfig: { model: "gpt-realtime-2", voice: "cedar" },
     });
-    decodeOpusStreamMock.mockReset();
     decodeOpusStreamChunksMock.mockReset();
     decodeOpusStreamChunksMock.mockResolvedValue(undefined);
+    resolveAudioInputBudgetMock.mockReset();
+    resolveAudioInputBudgetMock.mockImplementation(async ({ cfg }) =>
+      cfg.tools?.media?.audio?.enabled === false
+        ? { enabled: false }
+        : { enabled: true, maxBytes: cfg.tools?.media?.audio?.maxBytes ?? 20 * 1024 * 1024 },
+    );
   });
 
   const createManager = (
@@ -287,12 +294,6 @@ function buildVoiceTestHarness() {
           daveRecoveryAttempts: Map<string, number>;
           handleReceiveError: (entry: unknown, error: unknown) => void;
           handleSpeakingStart: (entry: unknown, userId: string) => Promise<void>;
-          processSegment: (params: {
-            entry: unknown;
-            wavPath: string;
-            userId: string;
-            durationSeconds: number;
-          }) => Promise<void>;
           scheduleCaptureFinalize: (entry: unknown, userId: string, reason: string) => void;
         };
       }
@@ -547,31 +548,13 @@ function buildVoiceTestHarness() {
     return { firstConnection, secondConnection };
   };
 
-  const processVoiceSegment = async (
+  const receiveVoiceUtterance = async (
     manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
     userId: string,
-  ) =>
-    await getVoiceReceive(manager).processSegment({
-      entry: {
-        guildId: "g1",
-        channelId: "1001",
-        sessionChannelId: "1001",
-        voiceSessionKey: "discord:g1:1001",
-        route: { sessionKey: "discord:g1:1001", agentId: "agent-1" },
-        connection: createConnectionMock(),
-        player: createAudioPlayerMock(),
-        sessionLifecycle: { status: "active" },
-        playbackQueue: Promise.resolve(),
-        processingQueue: Promise.resolve(),
-        audioInputBudget: { enabled: true, maxBytes: 20 * 1024 * 1024 },
-        ttsStreamFallbackWarned: false,
-        capture: createVoiceCaptureState(),
-        receiveRecovery: createVoiceReceiveRecoveryState(),
-      },
-      wavPath: "/tmp/test.wav",
-      userId,
-      durationSeconds: 1.2,
-    });
+  ) => {
+    expect(await manager.join({ guildId: "g1", channelId: "1001" })).toMatchObject({ ok: true });
+    await receiveRecordedSpeech(manager, undefined, getSessionEntry(manager), userId);
+  };
 
   const updateVoiceState = async (
     manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
@@ -593,7 +576,51 @@ function buildVoiceTestHarness() {
     userId: string,
   ) => await getVoiceReceive(manager).handleSpeakingStart(entry, userId);
 
+  const getSessionConnection = (entry: VoiceSessionEntry) =>
+    expectDefined(
+      joinVoiceChannelMock.mock.results.find(({ value }) => Object.is(value, entry.connection))
+        ?.value,
+      "voice session connection",
+    );
+
+  const receiveRecordedSpeech = async (
+    manager: InstanceType<typeof managerModule.DiscordVoiceManager>,
+    text?: string,
+    entry = getSessionEntry(manager),
+    userId = "u-owner",
+  ) => {
+    const conversations = vi.spyOn(entry.conversations, "enqueue");
+    const stream = new PassThrough({ objectMode: true });
+    getSessionConnection(entry).receiver.subscribe.mockReturnValueOnce(stream);
+    // Mock the codec and provider response, retaining receive ownership and WAV/STT dispatch.
+    decodeOpusStreamChunksMock.mockImplementation(
+      async (
+        input: import("node:stream").Readable,
+        callbacks: { onChunk: (pcm: Buffer, packet: Buffer) => void | Promise<void> },
+      ) => {
+        for await (const pcm of input) {
+          await callbacks.onChunk(pcm, pcm);
+        }
+      },
+    );
+    if (text !== undefined) {
+      transcribeAudioFileMock.mockResolvedValue({ text });
+    }
+    try {
+      const receiving = handleSpeakingStart(manager, entry, userId);
+      stream.end(Buffer.alloc(96_000));
+      await receiving;
+      await entry.processingQueue;
+      await Promise.all(conversations.mock.results.map((result) => result.value));
+    } finally {
+      stream.destroy();
+      conversations.mockRestore();
+    }
+  };
+
   return {
+    startTranscripts,
+    stopTranscripts,
     PassThrough,
     DAVESession,
     expectDefined,
@@ -621,6 +648,7 @@ function buildVoiceTestHarness() {
     resolveRealtimeBootstrapContextInstructionsMock,
     resolveVoiceIngressWithParticipantsMock,
     transcribeAudioFileMock,
+    resolveAudioInputBudgetMock,
     prepareTtsRequestMock,
     textToSpeechStreamMock,
     textToSpeechMock,
@@ -632,7 +660,6 @@ function buildVoiceTestHarness() {
     controlRealtimeVoiceAgentRunMock,
     createRealtimeSessionMock,
     realtimeSessionMock,
-    decodeOpusStreamMock,
     decodeOpusStreamChunksMock,
     updateVoiceStateMock,
     enqueueSystemEventMock,
@@ -641,7 +668,6 @@ function buildVoiceTestHarness() {
     canonicalizeRealtimeVoiceProviderIdMock,
     managerModule,
     realtimeModule,
-    segmentModule,
     configureVoiceStateGateway,
     createClient,
     createClientWithMember,
@@ -654,6 +680,7 @@ function buildVoiceTestHarness() {
     createFollowManager,
     expectConnectedStatus,
     getSessionEntry,
+    getSessionConnection,
     getVoiceReceive,
     getVoiceFollowing,
     beginSpeakerTurn,
@@ -680,13 +707,14 @@ function buildVoiceTestHarness() {
     emitDecryptFailure,
     installFailingDaveSession,
     makePoisonedDaveConnections,
-    processVoiceSegment,
+    receiveVoiceUtterance,
     updateVoiceState,
     handleSpeakingStart,
+    receiveRecordedSpeech,
   };
 }
 
-type DiscordVoiceTestHarness = ReturnType<typeof buildVoiceTestHarness>;
+export type DiscordVoiceTestHarness = ReturnType<typeof buildVoiceTestHarness>;
 
 export function defineDiscordVoiceTests(
   register: (harness: DiscordVoiceTestHarness) => void,

--- a/extensions/discord/src/voice/voice-test-mocks.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-mocks.test-support.ts
@@ -13,6 +13,7 @@ const {
   resolveRealtimeBootstrapContextInstructionsMock,
   resolveVoiceIngressWithParticipantsMock,
   transcribeAudioFileMock,
+  resolveAudioInputBudgetMock,
   prepareTtsRequestMock,
   textToSpeechStreamMock,
   textToSpeechMock,
@@ -24,7 +25,6 @@ const {
   controlRealtimeVoiceAgentRunMock,
   createRealtimeSessionMock,
   realtimeSessionMock,
-  decodeOpusStreamMock,
   decodeOpusStreamChunksMock,
   updateVoiceStateMock,
   enqueueSystemEventMock,
@@ -40,6 +40,7 @@ const {
     off: ReturnType<typeof vi.fn>;
     receiver: {
       speaking: {
+        users: Map<string, number>;
         on: ReturnType<typeof vi.fn>;
         off: ReturnType<typeof vi.fn>;
       };
@@ -77,6 +78,7 @@ const {
       off: vi.fn() as Mock,
       receiver: {
         speaking: {
+          users: new Map(),
           on: vi.fn() as Mock,
           off: vi.fn() as Mock,
         },
@@ -210,8 +212,9 @@ const {
     ),
     createRealtimeSessionMock: createRealtimeSessionMockLocal,
     realtimeSessionMock: realtimeSessionMockLocal,
-    decodeOpusStreamMock: vi.fn() as Mock,
-    decodeOpusStreamChunksMock: vi.fn() as Mock,
+    resolveAudioInputBudgetMock:
+      vi.fn<PluginRuntime["mediaUnderstanding"]["resolveAudioInputBudget"]>(),
+    decodeOpusStreamChunksMock: vi.fn<(typeof import("./audio.js"))["decodeOpusStreamChunks"]>(),
     updateVoiceStateMock: vi.fn() as Mock,
     enqueueSystemEventMock: vi.fn() as Mock,
     assertSecretOwnerAvailableMock: vi.fn() as Mock,
@@ -234,6 +237,7 @@ export const voiceTestMocks = {
   resolveRealtimeBootstrapContextInstructionsMock,
   resolveVoiceIngressWithParticipantsMock,
   transcribeAudioFileMock,
+  resolveAudioInputBudgetMock,
   prepareTtsRequestMock,
   textToSpeechStreamMock,
   textToSpeechMock,
@@ -245,7 +249,6 @@ export const voiceTestMocks = {
   controlRealtimeVoiceAgentRunMock,
   createRealtimeSessionMock,
   realtimeSessionMock,
-  decodeOpusStreamMock,
   decodeOpusStreamChunksMock,
   updateVoiceStateMock,
   enqueueSystemEventMock,
@@ -427,10 +430,6 @@ vi.mock("./audio.js", async () => {
       }),
     ),
     createDiscordOpusPlaybackStream: vi.fn(() => new PassThrough()),
-    decodeOpusStream: (...args: Parameters<typeof actual.decodeOpusStream>) =>
-      decodeOpusStreamMock.getMockImplementation()
-        ? decodeOpusStreamMock(...args)
-        : actual.decodeOpusStream(...args),
     decodeOpusStreamChunks: decodeOpusStreamChunksMock,
   };
 });
@@ -454,14 +453,7 @@ vi.mock("../runtime.js", () => ({
   getDiscordRuntime: () => ({
     agent: { runCommandFromIngress: agentCommandMock },
     mediaUnderstanding: {
-      resolveAudioInputBudget: async ({
-        cfg,
-      }: {
-        cfg: import("openclaw/plugin-sdk/config-contracts").OpenClawConfig;
-      }) =>
-        cfg.tools?.media?.audio?.enabled === false
-          ? { enabled: false }
-          : { enabled: true, maxBytes: cfg.tools?.media?.audio?.maxBytes ?? 20 * 1024 * 1024 },
+      resolveAudioInputBudget: resolveAudioInputBudgetMock,
       transcribeAudioFile: transcribeAudioFileMock,
     },
     tts: {

--- a/extensions/discord/src/voice/voice-wav-lifetime.test.ts
+++ b/extensions/discord/src/voice/voice-wav-lifetime.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, vi } from "vitest";
 import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
@@ -37,8 +38,10 @@ defineDiscordVoiceTests(
     createManager,
     makeVoiceConfig,
     getSessionEntry,
+    getSessionConnection,
     handleSpeakingStart,
-    decodeOpusStreamMock,
+    startTranscripts,
+    decodeOpusStreamChunksMock,
     transcribeAudioFileMock,
     loggerWarnMock,
   }) => {
@@ -54,23 +57,51 @@ defineDiscordVoiceTests(
       await fs.rm(workspace.rootDir, { recursive: true, force: true });
     });
 
-    async function fixture() {
+    async function fixture(recording = true) {
       const manager = createManager(
         makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:guest"] }),
         createClientWithMember("guest", "Guest", "1234"),
       );
       const sink = vi.fn();
-      await manager.join(
-        { guildId: "g1", channelId: "1001" },
-        { transcripts: { sessionId: "notes", onUtterance: sink } },
-      );
-      decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(192_000));
+      if (recording) {
+        await startTranscripts(manager, sink, "notes");
+      } else {
+        await manager.join({ guildId: "g1", channelId: "1001" });
+      }
+      decodeOpusStreamChunksMock.mockImplementation(async (input, callbacks) => {
+        for await (const pcm of input) {
+          await callbacks.onChunk(pcm, pcm);
+        }
+      });
       transcribeAudioFileMock.mockImplementation(async ({ filePath }) => {
         const wav = await fs.readFile(filePath);
         expect(wav.toString("ascii", 0, 4)).toBe("RIFF");
         return { text: "Meeting notes" };
       });
-      return { manager, entry: getSessionEntry(manager), sink };
+      const entry = getSessionEntry(manager);
+      const audio = await import("./audio.js");
+      const writeWav = audio.writeVoiceWavFile;
+      const cleanups: Promise<void>[] = [];
+      vi.spyOn(audio, "writeVoiceWavFile").mockImplementation(async (pcm) => {
+        const wav = await writeWav(pcm);
+        const released = createDeferred<void>();
+        cleanups.push(released.promise);
+        return {
+          ...wav,
+          cleanup: async () => {
+            await wav.cleanup();
+            released.resolve();
+          },
+        };
+      });
+      const receive = async (pcm = Buffer.alloc(192_000)) => {
+        const stream = new PassThrough({ objectMode: true });
+        getSessionConnection(entry).receiver.subscribe.mockReturnValueOnce(stream);
+        const receiving = handleSpeakingStart(manager, entry, "guest");
+        stream.end(pcm);
+        await receiving;
+      };
+      return { manager, entry, sink, receive, released: () => Promise.all(cleanups) };
     }
 
     it.each(["queued", "transcribing"] as const)(
@@ -93,7 +124,7 @@ defineDiscordVoiceTests(
         const removals = vi.spyOn(fs, "rm");
         vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
         try {
-          await handleSpeakingStart(f.manager, f.entry, "guest");
+          await f.receive();
           if (phase === "transcribing") {
             await transcribing.promise;
           }
@@ -102,6 +133,7 @@ defineDiscordVoiceTests(
           expect(await fs.readdir(workspace.rootDir)).toHaveLength(1);
           blocked.resolve();
           await f.entry.processingQueue;
+          await f.released();
           expect(f.sink).toHaveBeenCalledExactlyOnceWith(
             expect.objectContaining({ text: "Meeting notes" }),
           );
@@ -109,6 +141,7 @@ defineDiscordVoiceTests(
         } finally {
           blocked.resolve();
           await f.entry.processingQueue;
+          await f.released();
           await f.manager.destroy();
         }
       },
@@ -116,39 +149,44 @@ defineDiscordVoiceTests(
 
     it.each([
       "transcription failure",
+      "rejected queue",
       "left channel",
       "replaced capture",
       "short audio",
       "left during write",
     ] as const)("releases WAV input after %s without waiting for a timer", async (reason) => {
-      const f = await fixture();
+      const f = await fixture(
+        reason === "transcription failure" ||
+          reason === "rejected queue" ||
+          reason === "replaced capture",
+      );
       const blocked = createDeferred<void>();
       f.entry.processingQueue = blocked.promise;
       if (reason === "transcription failure") {
         transcribeAudioFileMock.mockRejectedValueOnce(new Error("STT unavailable"));
-      } else if (reason === "short audio") {
-        decodeOpusStreamMock.mockReset().mockResolvedValueOnce(Buffer.alloc(960));
       } else if (reason === "left during write") {
         workspace.afterWrite = async () => {
           await f.manager.leave({ guildId: "g1" });
         };
       }
       try {
-        await handleSpeakingStart(f.manager, f.entry, "guest");
+        await f.receive(reason === "short audio" ? Buffer.alloc(960) : undefined);
         if (reason === "left channel") {
           await f.manager.leave({ guildId: "g1" });
         } else if (reason === "replaced capture") {
-          await f.manager.join(
-            { guildId: "g1", channelId: "1001" },
-            { transcripts: { sessionId: "replacement", onUtterance: vi.fn() } },
-          );
+          await startTranscripts(f.manager, vi.fn(), "replacement");
         }
         if (reason === "left during write") {
           expect(f.manager.status()).toEqual([]);
           expect(await fs.readdir(workspace.rootDir)).toEqual([]);
         }
-        blocked.resolve();
+        if (reason === "rejected queue") {
+          blocked.reject(new Error("Previous processing failed"));
+        } else {
+          blocked.resolve();
+        }
         await f.entry.processingQueue;
+        await f.released();
         expect(f.sink).not.toHaveBeenCalled();
         if (reason === "transcription failure") {
           expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining("STT unavailable"));
@@ -159,6 +197,7 @@ defineDiscordVoiceTests(
       } finally {
         blocked.resolve();
         await f.entry.processingQueue;
+        await f.released();
         await f.manager.destroy();
       }
     });

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1593,6 +1593,7 @@ describe("applyMediaUnderstanding", () => {
       outcome: "no-attachment",
       attachments: [],
       attachmentDispositions: {},
+      attachmentProcessing: {},
     });
   });
 

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -71,6 +71,7 @@ import {
 import type {
   MediaAttachment,
   MediaAttachmentDisposition,
+  MediaAttachmentProcessing,
   MediaUnderstandingCapability,
   MediaUnderstandingDecision,
   MediaUnderstandingModelDecision,
@@ -665,10 +666,12 @@ async function runAttachmentEntries(params: {
 }): Promise<{
   output: MediaUnderstandingOutput | null;
   attempts: MediaUnderstandingModelDecision[];
+  processing: MediaAttachmentProcessing;
 }> {
   const { entries, capability } = params;
   const attachmentIndex = params.attachment.index;
   const attempts: MediaUnderstandingModelDecision[] = [];
+  let processing: MediaAttachmentProcessing = "omitted";
   for await (const candidate of entries) {
     const { entry } = candidate;
     const entryType = entry.type ?? (entry.command ? "cli" : "provider");
@@ -716,6 +719,8 @@ async function runAttachmentEntries(params: {
         continue;
       }
       const result = attempt.value;
+      // Successful empty CLI/API output was processed; unavailable auth was not.
+      processing = "completed";
       if (result?.text) {
         const decision = buildModelDecision({ entry, entryType, outcome: "success" });
         if (result.provider) {
@@ -729,7 +734,7 @@ async function runAttachmentEntries(params: {
           decision.observedBackend = result.observedBackend;
         }
         attempts.push(decision);
-        return { output: result, attempts };
+        return { output: result, attempts, processing };
       }
       attempts.push(
         buildModelDecision({ entry, entryType, outcome: "skipped", reason: "empty output" }),
@@ -766,7 +771,7 @@ async function runAttachmentEntries(params: {
     }
   }
 
-  return { output: null, attempts };
+  return { output: null, attempts, processing };
 }
 
 function hasFailedMediaAttempt(attachments: MediaUnderstandingDecision["attachments"]): boolean {
@@ -803,6 +808,12 @@ export async function runCapability(params: {
     policy: config.attachments,
   });
   const selectedAttachmentIndexes = selection.selected.map((attachment) => attachment.index);
+  const attachmentProcessing: Record<number, MediaAttachmentProcessing> = Object.fromEntries(
+    [...selectedAttachmentIndexes, ...selection.droppedAttachmentIndexes].map((index) => [
+      index,
+      "omitted",
+    ]),
+  );
   const activeProvider = params.activeModel?.provider?.trim();
   // One memoized owner for the native-vision fact. Probed lazily — only when
   // the skip branch must decide, or an image decision carries a renderable
@@ -854,6 +865,7 @@ export async function runCapability(params: {
       outcome,
       attachments,
       attachmentDispositions,
+      attachmentProcessing,
       ...(nativeVisionActive !== undefined ? { nativeVisionActive } : {}),
     };
   };
@@ -982,7 +994,7 @@ export async function runCapability(params: {
   const attachmentDecisions: MediaUnderstandingDecision["attachments"] = [];
   const attachmentDispositions = buildDispositions({ kind: "failed" }, { kind: "not-selected" });
   for (const attachment of selection.selected) {
-    const { output, attempts } = await runAttachmentEntries({
+    const { output, attempts, processing } = await runAttachmentEntries({
       capability,
       cfg,
       ctx,
@@ -1010,6 +1022,7 @@ export async function runCapability(params: {
     if (output) {
       outputs.push(output);
     }
+    attachmentProcessing[attachment.index] = processing;
     attachmentDispositions[attachment.index] = output
       ? { kind: "handled" }
       : attempts.length > 0

--- a/src/media-understanding/runtime.audio-disposition.test.ts
+++ b/src/media-understanding/runtime.audio-disposition.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MediaUnderstandingModelConfig } from "../config/types.tools.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { withAudioFixture } from "./runner.test-utils.js";
+import { transcribeAudioFile } from "./runtime.js";
+
+const cli = vi.hoisted(() => vi.fn());
+vi.mock("../process/exec.js", () => ({ runExec: cli }));
+
+describe("audio processing disposition", () => {
+  it.each([
+    { name: "empty CLI", entries: ["cli"], text: "", handled: true },
+    { name: "empty API", entries: ["api"], text: "", handled: true },
+    { name: "omitted API then empty CLI", entries: ["omitted", "cli"], text: "", handled: true },
+    { name: "empty CLI then omitted API", entries: ["cli", "omitted"], text: "", handled: true },
+    {
+      name: "omitted API then successful fallback",
+      entries: ["omitted", "api"],
+      text: "whole input",
+      handled: true,
+    },
+    { name: "all input omitted", entries: ["omitted"], text: "", handled: false },
+  ])("records completed processing for $name", async ({ name, entries, text, handled }) => {
+    cli.mockReset().mockResolvedValue({ stdout: text, stderr: "" });
+    const api = vi.fn(async () => ({ text }));
+    const registry = createEmptyPluginRegistry();
+    registry.mediaUnderstandingProviders.push({
+      pluginId: "synthetic-audio",
+      source: "test",
+      provider: { id: "synthetic-audio", capabilities: ["audio"], transcribeAudio: api },
+    });
+    const models: MediaUnderstandingModelConfig[] = entries.map((entry) =>
+      entry === "cli"
+        ? { type: "cli", command: "synthetic-stt", capabilities: ["audio"] }
+        : {
+            provider: "synthetic-audio",
+            model: "synthetic-stt",
+            capabilities: ["audio"],
+            ...(entry === "omitted" ? { maxBytes: 1_024 } : {}),
+          },
+    );
+    await withAudioFixture(`disposition-${name.replaceAll(" ", "-")}`, async ({ mediaPath }) => {
+      const result = await withPluginRuntimeRegistryScope(registry, () =>
+        transcribeAudioFile({
+          filePath: mediaPath,
+          mime: "audio/wav",
+          cfg: {
+            models: {
+              providers: {
+                "synthetic-audio": {
+                  baseUrl: "https://unused.invalid",
+                  apiKey: "synthetic-fixture-key",
+                  models: [],
+                },
+              },
+            },
+            tools: { media: { models } },
+          },
+        }),
+      );
+      expect(cli).toHaveBeenCalledTimes(entries.includes("cli") ? 1 : 0);
+      expect(api).toHaveBeenCalledTimes(entries.includes("api") ? 1 : 0);
+      expect(result.text).toBe(text || undefined);
+      expect(result.decision?.outcome).toBe(text ? "success" : "skipped");
+      expect(result.decision?.attachmentDispositions).toEqual({
+        0: { kind: text ? "handled" : "failed" },
+      });
+      expect(result.decision?.attachmentProcessing).toEqual({
+        0: handled ? "completed" : "omitted",
+      });
+    });
+  });
+});

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -212,6 +212,7 @@ describe("media-understanding runtime", () => {
         outcome: "disabled",
         attachments: [],
         attachmentDispositions: { 0: { kind: "capability-disabled" } },
+        attachmentProcessing: { 0: "omitted" },
         nativeVisionActive: false,
       },
     });

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -179,6 +179,9 @@ export async function runMediaUnderstandingFile(
   const decisionBase = {
     capability: params.capability,
     attachments: [],
+    attachmentProcessing: Object.fromEntries(
+      attachments.map(({ index }) => [index, "omitted" as const]),
+    ),
     ...(params.capability === "image" ? { nativeVisionActive: false } : {}),
   };
   if (attachments.length === 0) {

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -54,6 +54,8 @@ export type MediaAttachmentDisposition =
   | { kind: "scope-denied" }
   | { kind: "failed"; reason?: string };
 
+export type MediaAttachmentProcessing = "completed" | "omitted";
+
 export type MediaUnderstandingDecision = {
   capability: MediaUnderstandingCapability;
   outcome: MediaUnderstandingDecisionOutcome;
@@ -63,6 +65,9 @@ export type MediaUnderstandingDecision = {
   // (runner, apply-capability, runtime) always populate it; absence renders no
   // markers rather than breaking plugin compilation.
   attachmentDispositions?: Record<number, MediaAttachmentDisposition>;
+  // CLI/provider completion is independent of usable output or a rendered marker.
+  // Optional for shipped SDK decision literals; absence means unknown processing.
+  attachmentProcessing?: Record<number, MediaAttachmentProcessing>;
   nativeVisionActive?: boolean;
 };
 

--- a/test/transcripts-discord-audio.integration.test.ts
+++ b/test/transcripts-discord-audio.integration.test.ts
@@ -1,0 +1,214 @@
+import fs from "node:fs/promises";
+import { PassThrough } from "node:stream";
+import { setImmediate } from "node:timers/promises";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { transcribeAudioFile } from "openclaw/plugin-sdk/media-understanding-runtime";
+import { vi } from "vitest";
+import { loadDiscordVoiceTestHarness } from "../extensions/discord/test-api.js";
+import type { MediaUnderstandingModelConfig } from "../src/config/types.tools.js";
+import { createEmptyPluginRegistry } from "../src/plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../src/plugins/runtime/gateway-request-scope.js";
+
+const { defineDiscordVoiceTests } = await loadDiscordVoiceTestHarness();
+const cli = vi.hoisted(() => vi.fn());
+vi.mock("../src/process/exec.js", () => ({ runExec: cli }));
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    it,
+    createManager,
+    makeVoiceConfig,
+    getSessionEntry,
+    getSessionConnection,
+    handleSpeakingStart,
+    startTranscripts,
+    decodeOpusStreamChunksMock,
+    transcribeAudioFileMock,
+    agentCommandMock,
+    controlRealtimeVoiceAgentRunMock,
+  }) => {
+    it.each(
+      ["conversation", "control"].flatMap((dispatch) =>
+        ["oversized", "empty CLI", "fallback"].map((opening) => ({ dispatch, opening })),
+      ),
+    )(
+      "preserves whole-utterance $dispatch across capture with $opening opening audio",
+      async ({ dispatch, opening }) => {
+        const suffix = dispatch === "control" ? "stop that" : "send the update";
+        const oversized = opening === "oversized";
+        const prefix = oversized ? "Do not" : dispatch === "control" ? "please" : "Opening context";
+        const openingFrames = oversized ? 300 : 50;
+        cli
+          .mockReset()
+          .mockResolvedValueOnce({ stdout: "", stderr: "" })
+          .mockResolvedValue({ stdout: suffix, stderr: "" });
+        const provider = vi.fn(async ({ buffer, model }: { buffer: Buffer; model?: string }) => {
+          if (model === "unavailable-stt") {
+            throw new Error("synthetic model unavailable");
+          }
+          return { text: buffer[44] === 1 ? prefix : suffix };
+        });
+        const registry = createEmptyPluginRegistry();
+        registry.mediaUnderstandingProviders.push({
+          pluginId: "synthetic-audio",
+          source: "test/transcripts-discord-audio.integration.test.ts",
+          provider: { id: "synthetic-audio", capabilities: ["audio"], transcribeAudio: provider },
+        });
+        const apiModel: MediaUnderstandingModelConfig = {
+          provider: "synthetic-audio",
+          model: "synthetic-stt",
+          capabilities: ["audio"],
+        };
+        const models: MediaUnderstandingModelConfig[] =
+          opening === "empty CLI"
+            ? [{ type: "cli", command: "synthetic-stt", capabilities: ["audio"] }]
+            : [
+                ...(opening === "fallback" ? [{ ...apiModel, model: "unavailable-stt" }] : []),
+                apiModel,
+              ];
+        const cfg = {
+          tools: {
+            media: {
+              audio: { maxBytes: 1_048_576 },
+              models,
+            },
+          },
+          models: {
+            providers: {
+              "synthetic-audio": {
+                baseUrl: "https://unused.invalid",
+                apiKey: "synthetic-fixture-key",
+                models: [],
+              },
+            },
+          },
+        };
+        const manager = createManager(
+          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-owner"] }),
+          undefined,
+          cfg,
+        );
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const entry = getSessionEntry(manager);
+        if (dispatch === "control") {
+          controlRealtimeVoiceAgentRunMock.mockResolvedValue({
+            ok: true,
+            mode: "cancel",
+            sessionKey: entry.route.sessionKey,
+            active: true,
+            aborted: true,
+            message: "Cancelled",
+            speak: false,
+            show: true,
+            suppress: true,
+          });
+        }
+        const stream = new PassThrough({ objectMode: true });
+        getSessionConnection(entry).receiver.subscribe.mockReturnValueOnce(stream);
+        const openingDecoded = createDeferred<void>();
+        decodeOpusStreamChunksMock.mockImplementation(async (input, options) => {
+          let frames = 0;
+          for await (const packet of input) {
+            await options.onChunk(packet, packet);
+            if (++frames === openingFrames) {
+              openingDecoded.resolve();
+            }
+          }
+        });
+        const wavSizes: number[] = [];
+        const wavPaths: string[] = [];
+        const results: Awaited<ReturnType<typeof transcribeAudioFile>>[] = [];
+        transcribeAudioFileMock.mockImplementation(async (params) => {
+          wavPaths.push(params.filePath);
+          wavSizes.push((await fs.stat(params.filePath)).size);
+          const result = await withPluginRuntimeRegistryScope(registry, () =>
+            transcribeAudioFile(params),
+          );
+          results.push(result);
+          return result;
+        });
+        const recorded = createDeferred<void>();
+        const sink = vi.fn(() => recorded.resolve());
+        const receiving = handleSpeakingStart(manager, entry, "u-owner");
+        const receivingOutcome = oversized
+          ? expect(receiving).rejects.toThrow("speak a shorter segment")
+          : receiving;
+        const recordingStream = oversized ? new PassThrough({ objectMode: true }) : stream;
+        try {
+          // Main rejects oversized uncaptured input before writing a WAV. A later
+          // capture scan may record its suffix, but cannot admit it as a new command.
+          // Successful-empty and fallback siblings use a one-second opening chunk.
+          for (let frame = 0; frame < openingFrames; frame++) {
+            if (stream.destroyed) {
+              break;
+            }
+            stream.write(Buffer.alloc(3_840, 1));
+            await setImmediate();
+          }
+          if (oversized) {
+            await receivingOutcome;
+            expect(stream.destroyed).toBe(true);
+            expect(transcribeAudioFileMock).not.toHaveBeenCalled();
+            getSessionConnection(entry).receiver.subscribe.mockReturnValueOnce(recordingStream);
+            entry.connection.receiver.speaking.users.set("u-owner", Date.now());
+          } else {
+            await openingDecoded.promise;
+          }
+          expect(await startTranscripts(manager, sink)).toMatchObject({ ok: true });
+          for (let frame = 0; frame < 50; frame++) {
+            recordingStream.write(Buffer.alloc(3_840, 2));
+          }
+          recordingStream.end();
+          await receivingOutcome;
+          await recorded.promise;
+          await entry.processingQueue;
+          expect(wavSizes).toEqual(oversized ? [192_044] : [192_044, 192_044]);
+          expect(results[0]).toMatchObject({
+            text: oversized ? suffix : opening === "fallback" ? prefix : undefined,
+            decision: {
+              outcome: opening === "empty CLI" ? "skipped" : "success",
+              attachmentDispositions: {
+                0: { kind: opening === "empty CLI" ? "failed" : "handled" },
+              },
+              attachmentProcessing: { 0: "completed" },
+            },
+          });
+          expect(provider).toHaveBeenCalledTimes(opening === "empty CLI" ? 0 : oversized ? 1 : 4);
+          expect(cli).toHaveBeenCalledTimes(opening === "empty CLI" ? 2 : 0);
+          if (oversized) {
+            expect(provider.mock.calls[0]![0].buffer).toHaveLength(192_044);
+            expect(provider.mock.calls[0]![0].buffer[44]).toBe(2);
+          }
+          expect(sink).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ text: suffix }));
+          for (const wavPath of wavPaths) {
+            await expect(fs.stat(wavPath)).rejects.toMatchObject({ code: "ENOENT" });
+          }
+          const completeText = opening === "fallback" ? `${prefix}\n${suffix}` : suffix;
+          if (oversized) {
+            expect(agentCommandMock).not.toHaveBeenCalled();
+            expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+          } else if (dispatch === "control") {
+            expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledExactlyOnceWith({
+              sessionKey: entry.route.sessionKey,
+              text: completeText,
+            });
+            expect(agentCommandMock).not.toHaveBeenCalled();
+          } else {
+            expect(agentCommandMock).toHaveBeenCalledOnce();
+            expect(agentCommandMock.mock.calls[0]?.[0]).toMatchObject({
+              message: expect.stringContaining(completeText),
+            });
+            expect(controlRealtimeVoiceAgentRunMock).not.toHaveBeenCalled();
+          }
+        } finally {
+          stream.end();
+          recordingStream.end();
+          await receivingOutcome;
+          await entry.processingQueue;
+          await manager.destroy();
+        }
+      },
+    );
+  },
+);

--- a/test/transcripts-tool.discord-lifecycle.integration.test.ts
+++ b/test/transcripts-tool.discord-lifecycle.integration.test.ts
@@ -23,10 +23,9 @@ defineDiscordVoiceTests(
     createManager,
     makeVoiceConfig,
     getSessionEntry,
-    getVoiceReceive,
+    receiveRecordedSpeech,
     expectConnectedStatus,
     requireRecord,
-    transcribeAudioFileMock,
     lastRealtimeBridgeParams,
     beginSpeakerTurn,
   }) => {
@@ -77,30 +76,16 @@ defineDiscordVoiceTests(
           ).resolves.toMatchObject({
             details: { sessionId: "first", providerId: "discord-voice", accountId },
           });
-          const entry = getSessionEntry(manager);
-          const segment = {
-            entry,
-            wavPath: path.join(stateDir, "speech.wav"),
-            userId: "u-speaker",
-            durationSeconds: 1,
-          };
-          transcribeAudioFileMock.mockResolvedValueOnce({
-            text: "Keep the original historical note.",
-          });
-          await getVoiceReceive(manager).processSegment(segment);
+          const record = (text: string) =>
+            receiveRecordedSpeech(manager, text, getSessionEntry(manager), "u-speaker");
+          await record("Keep the original historical note.");
 
           await expect(
             execute({ action: "start", sessionId: "second", ...source }),
           ).resolves.toMatchObject({
             details: { sessionId: "second", providerId: "discord-voice", accountId },
           });
-          transcribeAudioFileMock.mockResolvedValueOnce({
-            text: "This belongs only to the replacement.",
-          });
-          await getVoiceReceive(manager).processSegment({
-            ...segment,
-            entry: getSessionEntry(manager),
-          });
+          await record("This belongs only to the replacement.");
 
           const first = expectDefined(await store.readSession("first"), "first capture");
           const second = expectDefined(await store.readSession("second"), "second capture");
@@ -172,6 +157,7 @@ defineDiscordVoiceTests(
             const recoveredText = "The same capture continues after reconnect.";
             secondTexts.push(recoveredText);
             recovered.onTranscript?.("user", recoveredText, true);
+            await record(recoveredText);
             await vi.waitFor(async () => {
               expect(
                 (await store.readUtterancesForSession(second)).map((utterance) => utterance.text),
@@ -182,16 +168,20 @@ defineDiscordVoiceTests(
           } else {
             await manager.destroy();
           }
-          await vi.waitFor(async () => {
-            await expect(execute({ action: "status" })).resolves.toMatchObject({
-              details: { active: [], pendingFinalization: [] },
-            });
-            expect(await store.readSession("second")).toMatchObject({
-              stoppedAt: expect.any(String),
-            });
-          });
           expect(manager.status()).toEqual([]);
+          await expect(execute({ action: "status" })).resolves.toMatchObject({
+            details: { active: [expect.objectContaining({ sessionId: "second" })] },
+          });
+          expect((await store.readSession("second"))?.stoppedAt).toBeUndefined();
           expect(providerStop).not.toHaveBeenCalled();
+          await execute({ action: "stop", sessionId: "second" });
+          await expect(execute({ action: "status" })).resolves.toMatchObject({
+            details: { active: [], pendingFinalization: [] },
+          });
+          expect(await store.readSession("second")).toMatchObject({
+            stoppedAt: expect.any(String),
+          });
+          expect(providerStop).toHaveBeenCalledOnce();
 
           if (provider) {
             const stoppedSecond = expectDefined(await store.readSession("second"), "ended capture");
@@ -208,7 +198,7 @@ defineDiscordVoiceTests(
             provider.onReady?.();
             provider.onTranscript?.("user", "Late text from the retired provider.", true);
             await execute({ action: "stop", sessionId: "second" });
-            expect(providerStop).not.toHaveBeenCalled();
+            expect(providerStop).toHaveBeenCalledOnce();
             expectConnectedStatus(manager, "1001");
             await expect(execute({ action: "status" })).resolves.toMatchObject({
               details: {
@@ -229,6 +219,11 @@ defineDiscordVoiceTests(
           }
         } finally {
           try {
+            for (const capture of await discordVoiceTranscriptsSourceProvider.status!(source)) {
+              if (capture.sessionId) {
+                await execute({ action: "stop", sessionId: capture.sessionId });
+              }
+            }
             await manager.destroy();
             await vi.waitFor(async () => {
               await expect(execute({ action: "status" })).resolves.toMatchObject({
@@ -236,7 +231,11 @@ defineDiscordVoiceTests(
               });
             });
           } finally {
-            setDiscordTranscriptsVoiceManager({ accountId, manager: null });
+            setDiscordTranscriptsVoiceManager({
+              accountId,
+              manager: null,
+              expectedManager: manager,
+            });
             providerStop.mockRestore();
             closeOpenClawStateDatabaseForTest();
             tempDirs.cleanup();

--- a/test/transcripts-tool.discord-provider.integration.test.ts
+++ b/test/transcripts-tool.discord-provider.integration.test.ts
@@ -98,6 +98,7 @@ describe("transcripts tool with the registered Discord provider", () => {
     registerManager({
       accountId: "account-a",
       manager: {
+        hasRealtimeCapture: () => false,
         startTranscriptsCapture: accountAJoin,
         stopTranscriptsCapture: accountALeave,
         watchChannelOccupancy: () => () => {},
@@ -107,6 +108,7 @@ describe("transcripts tool with the registered Discord provider", () => {
     registerManager({
       accountId: "account-b",
       manager: {
+        hasRealtimeCapture: () => false,
         startTranscriptsCapture: accountBJoin,
         stopTranscriptsCapture: accountBLeave,
         watchChannelOccupancy: () => () => {},
@@ -231,6 +233,7 @@ describe("transcripts tool with the registered Discord provider", () => {
     registerManager({
       accountId: "account-a",
       manager: {
+        hasRealtimeCapture: () => false,
         startTranscriptsCapture: join,
         stopTranscriptsCapture: async () => {},
         watchChannelOccupancy: () => () => {},

--- a/test/transcripts-tool.discord-provider.integration.test.ts
+++ b/test/transcripts-tool.discord-provider.integration.test.ts
@@ -19,8 +19,7 @@ type DiscordTranscriptsVoiceManager = NonNullable<
 
 const tempDirs = createTempDirTracker();
 
-const resolveAccessTarget = async (guildId: string, channelId: string) => ({
-  guild: { id: guildId, name: guildId },
+const resolveAccessTarget = async (channelId: string) => ({
   channelName: channelId,
   channelSlug: channelId,
   scope: "channel" as const,
@@ -68,10 +67,23 @@ describe("transcripts tool with the registered Discord provider", () => {
     setActivePluginRegistry(registry, "discord-transcripts-tool-test");
   });
 
-  afterEach(() => {
+  const managers = new Map<string, DiscordTranscriptsVoiceManager>();
+  function registerManager(params: { accountId: string; manager: DiscordTranscriptsVoiceManager }) {
+    managers.set(params.accountId, params.manager);
+    setDiscordTranscriptsVoiceManager(params);
+  }
+  afterEach(async () => {
+    for (const entry of activeSessions.values()) {
+      await discordVoiceTranscriptsSourceProvider.stop!({
+        sessionId: entry.session.sessionId,
+        source: entry.session.source,
+      });
+    }
     activeSessions.clear();
-    setDiscordTranscriptsVoiceManager({ accountId: "account-a", manager: null });
-    setDiscordTranscriptsVoiceManager({ accountId: "account-b", manager: null });
+    for (const [accountId, manager] of managers) {
+      setDiscordTranscriptsVoiceManager({ accountId, manager: null, expectedManager: manager });
+    }
+    managers.clear();
     setActivePluginRegistry(createEmptyPluginRegistry(), "discord-transcripts-tool-test-cleanup");
     closeOpenClawStateDatabaseForTest();
     tempDirs.cleanup();
@@ -80,26 +92,26 @@ describe("transcripts tool with the registered Discord provider", () => {
   it("keeps a model-requested account switch on the trusted Discord account", async () => {
     const stateDir = tempDirs.make("openclaw-transcripts-discord-provider-");
     const accountAJoin = vi.fn(async () => ({ ok: true, message: "joined account-a" }));
-    const accountALeave = vi.fn(async () => ({ ok: true, message: "left account-a" }));
+    const accountALeave = vi.fn(async () => {});
     const accountBJoin = vi.fn(async () => ({ ok: true, message: "joined account-b" }));
-    const accountBLeave = vi.fn(async () => ({ ok: true, message: "left account-b" }));
-    setDiscordTranscriptsVoiceManager({
+    const accountBLeave = vi.fn(async () => {});
+    registerManager({
       accountId: "account-a",
       manager: {
-        join: accountAJoin,
-        leave: accountALeave,
-        resolveAccessTarget: ({ guildId, channelId }: { guildId: string; channelId: string }) =>
-          resolveAccessTarget(guildId, channelId),
-      } as unknown as DiscordTranscriptsVoiceManager,
+        startTranscriptsCapture: accountAJoin,
+        stopTranscriptsCapture: accountALeave,
+        watchChannelOccupancy: () => () => {},
+        resolveAccessTarget: ({ channelId }) => resolveAccessTarget(channelId),
+      },
     });
-    setDiscordTranscriptsVoiceManager({
+    registerManager({
       accountId: "account-b",
       manager: {
-        join: accountBJoin,
-        leave: accountBLeave,
-        resolveAccessTarget: ({ guildId, channelId }: { guildId: string; channelId: string }) =>
-          resolveAccessTarget(guildId, channelId),
-      } as unknown as DiscordTranscriptsVoiceManager,
+        startTranscriptsCapture: accountBJoin,
+        stopTranscriptsCapture: accountBLeave,
+        watchChannelOccupancy: () => () => {},
+        resolveAccessTarget: ({ channelId }) => resolveAccessTarget(channelId),
+      },
     });
     const config = {
       channels: {
@@ -216,13 +228,14 @@ describe("transcripts tool with the registered Discord provider", () => {
   it("rejects a Discord sender that the voice command policy denies", async () => {
     const stateDir = tempDirs.make("openclaw-transcripts-discord-provider-denied-");
     const join = vi.fn(async () => ({ ok: true, message: "joined" }));
-    setDiscordTranscriptsVoiceManager({
+    registerManager({
       accountId: "account-a",
       manager: {
-        join,
-        resolveAccessTarget: ({ guildId, channelId }: { guildId: string; channelId: string }) =>
-          resolveAccessTarget(guildId, channelId),
-      } as unknown as DiscordTranscriptsVoiceManager,
+        startTranscriptsCapture: join,
+        stopTranscriptsCapture: async () => {},
+        watchChannelOccupancy: () => () => {},
+        resolveAccessTarget: ({ channelId }) => resolveAccessTarget(channelId),
+      },
     });
     const config = {
       channels: {


### PR DESCRIPTION
Related: #130860, #127426. Follows #139484 and #139572.

## What Problem This Solves

Fixes an issue where Discord meeting recordings could lose speech or stop when a voice connection changed, conversation authorization or a reply stalled, or realtime speaker connections were busy. Starting a recording during an in-flight conversation authorization could also miss a participant who was already speaking. Incomplete audio could reach a conversation or active-run control after a receive failure.

## Why This Change Was Made

The Discord source now owns recording across connection and manager replacement. Each speaker has one bounded receive stream, and each audio packet retains the recording authority and timestamp under which it arrived. Recording can promote an existing pending receive reservation while conversation keeps its original admission request and authorization checks. Recording, pending conversation input, and serialized responses have separate lifecycle owners; conversation work cannot occupy the recording queue. Replacing an already-registered source transfers its subscription atomically without repeating Discord target validation, preserving dormant captures through lookup outages and carrying pending connection recovery to the new recording. Transport work follows the admitted source subscription; audio publication still requires the exact current recording. Stop and replacement revoke the exact recording; incomplete receive input retires its realtime speaker before recovery. Pending conversation input has explicit decoded-audio, utterance, and text limits, while recording continues. Realtime send and close failures are contained within the conversation owner.

Contiguous recording chunks share batch transcription with authorized `stt-tts` conversation, but command dispatch waits for the complete utterance. Shared media results distinguish completed empty transcription from omitted input. WAV files remain owned until processing releases them, preserving the cleanup fix from #139484. A retired recording releases its queue slot while an independently authorized conversation retains the same input operation. Pending WAV work is capped process-wide at 128 jobs and 64 MiB before files are created, including across reconnects. Input that loses every owner during the file write is cleaned immediately, before any pending processing queue.

## User Impact

Explicitly authorized meeting recordings continue across transport changes and conversation failures, retain short answers and bounded upload chunks, and keep speaker identity and audio-ingress timestamps. Failed or incomplete speech cannot become a partial conversation command. Existing realtime-only setups retain safely bound per-speaker final transcripts when batch transcription is disabled or no backend is available. This limited route waits for every covered batch operation, never duplicates successful or silent batch output, and rejects mixed capture input, failed/oversized/unknown input, and provider continuity resets. It does not promote realtime credentials or start another provider session. `/vc status` exposes the limited-coverage warning and directs operators to configure batch transcription for full room coverage. The documentation explains the lifecycle, authorization boundary, upload limits, and diagnostics.

## Evidence

- Independent P0–P2 review passed for the refactor. The final compatibility review has no accepted/actionable findings. Its sole status-length report was disproven: `/vc status` filters to the invocation guild, and the manager owns at most one active connection per guild.

- A complete 626-case voice run and all 11 cross-plugin integrations passed before rebase. On current main, 106 affected recording/conversation/capture/WAV cases and all 11 cross-plugin integrations passed, including the landed immediate-cleanup regression. The full changed-file gate passed, followed by focused verification of the final owner repairs. Final extension production/test and root integration types, lint, formatting, and diff checks passed. A full-run test polling race was repaired by awaiting the actual publication callback, preserving the assertion and timeout settings.

- Final compatibility proof: all 16 real-manager cases passed, including `/vc status`, disabled batch audio, delayed admission, batch settlement/silence/duplicates, capture replacement, provider resets, and bounded pending finals. A broad run passed 640 voice cases and all 11 integrations; its one test failure emitted a provider final before admission completed and passed after waiting for the actual turn-completion promise. All selected changed-file checks passed after fixture typing and status lint repairs, including production/test types, lint, dead-export scans, and boundary guards.
- CI exposed three missing capture-only fixture methods and a type import cycle. The fixture repair passed canonical root test types and both provider integrations. Shared capture, receipt, and segment-result contracts now live in a true type-only leaf; both runtime and Madge cycle guards pass, all six edited modules emit identical JavaScript, and the leaf emits none. The final full build, all three affected type lanes, lint, 18 focused cases, and independent review passed.
- An isolated real media-runtime probe confirmed that a setup with only realtime-scoped provider credentials and no local STT returns the canonical no-model/omitted result with no attempted batch backend. The probe used actual provider selection/auth hooks and a network fence; no credentials were promoted.
- Focused regressions reproduced lost recordings during queued authorization failure, pending initial admission, and realtime speaker-capacity exhaustion; occupancy replacement also reproduced spurious source transitions. Each is covered at its owning boundary.
- Real libopus invalid-packet, decryption-error, and stream-error cases verify that incomplete speech cannot dispatch. Receive tests cover queue bounds, no-capture authorization, silence finalization, teardown, replacement, long speech, small upload budgets, and WAV cleanup.
- Live OpenAI speech generation and file transcription passed with synthetic audio using `gpt-4o-mini-tts` and `gpt-4o-transcribe`: all three expected markers were recognized, input processing completed, and temporary audio was removed. All eight production source files in that proof match this slice.
- Discord transport proof uses synthetic connections with real SDK and libopus behavior. No live Discord room was used.
