### PR TITLE
refactor(cli): remove redundant Gmail option projection

### DIFF
--- a/src/cli/webhooks-cli.test.ts
+++ b/src/cli/webhooks-cli.test.ts
@@ -166,4 +166,140 @@ describe("webhooks cli", () => {
       expect.objectContaining({ tailscale: undefined }),
     );
   });
+
+  const omittedCommonOptions = {
+    topic: undefined,
+    subscription: undefined,
+    label: undefined,
+    hookUrl: undefined,
+    hookToken: undefined,
+    pushToken: undefined,
+    bind: undefined,
+    port: undefined,
+    path: undefined,
+    includeBody: undefined,
+    maxBytes: undefined,
+    renewEveryMinutes: undefined,
+    tailscale: undefined,
+    tailscalePath: undefined,
+    tailscaleTarget: undefined,
+  };
+  const explicitCommonArgs = [
+    "--topic",
+    " projects/fixture/topics/custom ",
+    "--subscription",
+    " custom-subscription ",
+    "--label",
+    " CUSTOM ",
+    "--hook-url",
+    " https://fixture.invalid/hooks/gmail ",
+    "--hook-token",
+    " fixture-hook ",
+    "--push-token",
+    " fixture-push ",
+    "--bind",
+    " 127.0.0.2 ",
+    "--port",
+    "9807",
+    "--path",
+    " /custom-push ",
+    "--include-body",
+    "--max-bytes",
+    "54321",
+    "--renew-minutes",
+    "29",
+    "--tailscale",
+    " serve ",
+    "--tailscale-path",
+    " /public-gmail ",
+    "--tailscale-target",
+    " http://127.0.0.3:8789 ",
+  ];
+  const explicitCommonOptions = {
+    topic: "projects/fixture/topics/custom",
+    subscription: "custom-subscription",
+    label: "CUSTOM",
+    hookUrl: "https://fixture.invalid/hooks/gmail",
+    hookToken: "fixture-hook",
+    pushToken: "fixture-push",
+    bind: "127.0.0.2",
+    port: 9807,
+    path: "/custom-push",
+    includeBody: true,
+    maxBytes: 54321,
+    renewEveryMinutes: 29,
+    tailscale: "serve",
+    tailscalePath: "/public-gmail",
+    tailscaleTarget: "http://127.0.0.3:8789",
+  };
+
+  it.each([
+    {
+      name: "setup defaults",
+      command: "setup",
+      args: ["--account", "fixture@example.invalid"],
+      expected: {
+        ...omittedCommonOptions,
+        account: "fixture@example.invalid",
+        project: undefined,
+        topic: "gog-gmail-watch",
+        subscription: "gog-gmail-watch-push",
+        label: "INBOX",
+        bind: "127.0.0.1",
+        port: 8788,
+        path: "/gmail-pubsub",
+        includeBody: true,
+        maxBytes: 20_000,
+        renewEveryMinutes: 720,
+        tailscale: "funnel",
+        pushEndpoint: undefined,
+        json: false,
+      },
+    },
+    {
+      name: "run omissions",
+      command: "run",
+      args: [],
+      expected: { account: undefined, ...omittedCommonOptions },
+    },
+    {
+      name: "setup explicit options",
+      command: "setup",
+      args: [
+        "--account",
+        " fixture@example.invalid ",
+        "--project",
+        " fixture-project ",
+        "--push-endpoint",
+        " https://fixture.invalid/push ",
+        "--json",
+        ...explicitCommonArgs,
+      ],
+      expected: {
+        account: "fixture@example.invalid",
+        project: "fixture-project",
+        ...explicitCommonOptions,
+        pushEndpoint: "https://fixture.invalid/push",
+        json: true,
+      },
+    },
+    {
+      name: "run explicit options",
+      command: "run",
+      args: ["--account", " fixture@example.invalid ", ...explicitCommonArgs],
+      expected: { account: "fixture@example.invalid", ...explicitCommonOptions },
+    },
+  ])("passes $name to the Gmail command owner", async ({ command, args, expected }) => {
+    const program = createProgram();
+
+    await program.parseAsync(["webhooks", "gmail", command, ...args], { from: "user" });
+
+    const runner = command === "setup" ? mocks.runGmailSetup : mocks.runGmailService;
+    expect(runner).toHaveBeenCalledOnce();
+    const actual = runner.mock.calls[0]?.[0];
+    for (const key of Object.keys(expected)) {
+      expect(Object.hasOwn(actual, key), key).toBe(true);
+    }
+    expect(actual).toStrictEqual(expected);
+  });
 });

--- a/src/cli/webhooks-cli.ts
+++ b/src/cli/webhooks-cli.ts
@@ -125,7 +125,7 @@ function parseGmailSetupOptions(raw: Record<string, unknown>): GmailSetupOptions
   return {
     account,
     project: normalizeOptionalString(raw.project),
-    ...gmailOptionsFromCommon(common),
+    ...common,
     pushEndpoint: normalizeOptionalString(raw.pushEndpoint),
     json: Boolean(raw.json),
   };
@@ -135,11 +135,11 @@ function parseGmailRunOptions(raw: Record<string, unknown>): GmailRunOptions {
   const common = parseGmailCommonOptions(raw);
   return {
     account: normalizeOptionalString(raw.account),
-    ...gmailOptionsFromCommon(common),
+    ...common,
   };
 }
 
-function parseGmailCommonOptions(raw: Record<string, unknown>) {
+function parseGmailCommonOptions(raw: Record<string, unknown>): Omit<GmailRunOptions, "account"> {
   return {
     topic: normalizeOptionalString(raw.topic),
     subscription: normalizeOptionalString(raw.subscription),
@@ -156,28 +156,6 @@ function parseGmailCommonOptions(raw: Record<string, unknown>) {
     tailscale: tailscaleModeOption(raw.tailscale),
     tailscalePath: normalizeOptionalString(raw.tailscalePath),
     tailscaleTarget: normalizeOptionalString(raw.tailscaleTarget),
-  };
-}
-
-function gmailOptionsFromCommon(
-  common: ReturnType<typeof parseGmailCommonOptions>,
-): Omit<GmailRunOptions, "account"> {
-  return {
-    topic: common.topic,
-    subscription: common.subscription,
-    label: common.label,
-    hookUrl: common.hookUrl,
-    hookToken: common.hookToken,
-    pushToken: common.pushToken,
-    bind: common.bind,
-    port: common.port,
-    path: common.path,
-    includeBody: common.includeBody,
-    maxBytes: common.maxBytes,
-    renewEveryMinutes: common.renewEveryMinutes,
-    tailscale: common.tailscale,
-    tailscalePath: common.tailscalePath,
-    tailscaleTarget: common.tailscaleTarget,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Gmail webhook CLI parsed its common options, then copied the same fields through a second adapter before calling the setup or service owner. That duplicate list added maintenance work without changing the values.

## Why This Change Was Made

The common parser now returns the existing shared option type directly. Setup and run consume that result, removing the redundant projection: **22 fewer production lines**. The command-specific account, project, push-endpoint and JSON handling remain separate.

## User Impact

No intended behavior change. Setup defaults, omitted run options, whitespace normalization, validation, and saved-configuration reuse remain unchanged. No flags, configuration fields, dependencies or public API are added.

## Evidence

- The complete 26-case CLI suite passed. The four added table rows check setup defaults, run omissions, and explicit options through real Commander dispatch, including own properties whose values are undefined.
- The normal full application build passed all 16 phases on the candidate tree.
- A fresh built-CLI check ran explicit setup, then run with the common options omitted. The exact eight/four external-command traces and saved non-default settings matched expectations; run preserved the saved configuration bytes. One interrupt stopped the watcher and its child cleanly. The external Google, gog and Tailscale commands were synthetic: this is local CLI/configuration/lifecycle proof, not live cloud authentication or webhook delivery.
- All 29 required changed checks passed on the exact candidate tree through the configured Blacksmith Testbox on Linux Node 24.19. The lease and temporary checkout were cleaned up. A later reporting-portal sync timed out; that warning is retained separately from the successful checks.
- Precommit and separate signed-commit Codex reviews completed their native passes with no actionable P0–P2 findings. Their first passes were provisional pending the second; all pass reports are retained.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34008543142) passed for `4cece3b75dfa2a1c287b4ace4b7a2e353d4cd56c`. The completed ClawSweeper review has no findings or remaining before-merge actions. Landing still uses the native maintainer workflow; no failing check is being waived.

The tested tree `caed1ce5802e9a87c74037e87d6f208688121d42` was saved unchanged in signed commit `4cece3b75dfa2a1c287b4ace4b7a2e353d4cd56c`. Native build stamps were not rewritten after the save.
