### PR TITLE
fix(update): finish npm upgrades from 2026.9.1

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -170,7 +170,9 @@ chat, the Control UI, the CLI, and automatic update campaigns. Dry-run previews
 and updates refused after admission keep a skipped or failed record with their
 reason. CLI invocations rejected before admission leave state untouched. The same ID follows
 the detached updater and the restarted Gateway, so reconnecting does not lose
-the outcome.
+the outcome. Post-core finalization children report back to their parent without
+creating a separate update run, including when an older updater cannot forward
+a run ID.
 
 `openclaw update --json` includes `runId` and the `run` record. `openclaw update status --json`
 includes `activeRun` when a run is active and `lastRun` when history exists.

--- a/scripts/e2e/lib/update-first-hop-package-fixtures.mjs
+++ b/scripts/e2e/lib/update-first-hop-package-fixtures.mjs
@@ -4,7 +4,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export const LEGACY_UPDATE_COMPAT_CHUNKS = ["shared-DTaQo6Hi.js", "shared-Y6bNiw2w.js"];
+export const LEGACY_UPDATE_COMPAT_CHUNKS = [
+  "shared-DTaQo6Hi.js",
+  "shared-Y6bNiw2w.js",
+  "shared-DFJEouXv.js",
+];
 export const FUTURE_FIXTURE_VERSION = "2026.9.99-first-hop.0";
 
 function readJson(filePath) {

--- a/scripts/runtime-postbuild.mts
+++ b/scripts/runtime-postbuild.mts
@@ -188,26 +188,18 @@ const LEGACY_PLUGIN_INSTALL_RUNTIME_COMPAT_ALIASES = [
   aliasFileName: PLUGIN_INSTALL_RUNTIME_ALIAS.aliasFileName,
   sourceIncludes: LEGACY_PLUGIN_INSTALL_RUNTIME_MARKERS,
 }));
-/** Compatibility chunks kept for live gateways loading old CLI exit modules. */
+/** Compatibility chunks for old updater and CLI exit modules after package replacement. */
 const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
-  // v2026.8.2 and the exact d413210 build load these after replacing dist/.
-  // Remove only after both source artifacts fall outside the supported upgrade window.
-  {
-    dest: "dist/shared-Y6bNiw2w.js",
+  // v2026.8.2, the exact d413210 build, and v2026.9.1 load these after replacing dist/.
+  // Remove only after the source artifacts fall outside the supported upgrade window.
+  ...["shared-Y6bNiw2w.js", "shared-DTaQo6Hi.js", "shared-DFJEouXv.js"].map((fileName) => ({
+    dest: `dist/${fileName}`,
     contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
-  },
-  {
-    dest: "dist/shared-DTaQo6Hi.js",
-    contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
-  },
-  {
-    dest: "dist/memory-state-CcqRgDZU.js",
+  })),
+  ...["memory-state-CcqRgDZU.js", "memory-state-DwGdReW4.js"].map((fileName) => ({
+    dest: `dist/${fileName}`,
     contents: "export function hasMemoryRuntime() {\n  return false;\n}\n",
-  },
-  {
-    dest: "dist/memory-state-DwGdReW4.js",
-    contents: "export function hasMemoryRuntime() {\n  return false;\n}\n",
-  },
+  })),
 ];
 
 /**

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -560,7 +560,8 @@ vi.mock("../runtime.js", async (importOriginal) => ({
 vi.mock("../commands/triage.js", () => ({ triageCommand }));
 
 const { runGatewayUpdate } = await import("../infra/update-runner.js");
-const { getUpdateRun, listUpdateRuns } = await import("../infra/update-run-ledger.js");
+const { createUpdateRun, getUpdateRun, listUpdateRuns } =
+  await import("../infra/update-run-ledger.js");
 // Real recovery dependencies need the initialized runtime and child-process mocks.
 const { runUpdateFailureTriage } = await import("../infra/update-triage.js");
 const { resolveOpenClawPackageRoot } = await import("../infra/openclaw-root.js");
@@ -3759,23 +3760,38 @@ describe("update-cli", () => {
     );
   });
 
-  it("post-core resume children exit after writing a plugin update result", async () => {
-    const resultDir = createCaseDir("openclaw-post-core-result");
-    const resultPath = path.join(resultDir, "plugins.json");
-    await fs.mkdir(resultDir, { recursive: true });
+  it.each([false, true])(
+    "post-core resume children leave run ownership with the parent (forwarded run=%s)",
+    async (forwardedRun) => {
+      const resultDir = createCaseDir("openclaw-post-core-result");
+      const resultPath = path.join(resultDir, "plugins.json");
+      await fs.mkdir(resultDir, { recursive: true });
+      const parentRun = forwardedRun
+        ? createUpdateRun({
+            trigger: "cli",
+            before: { version: "2026.9.1" },
+            target: { version: "2026.9.2" },
+          })
+        : undefined;
+      const runsBefore = listUpdateRuns();
 
-    await runPostCoreCommand(
-      { restart: false },
-      { OPENCLAW_UPDATE_POST_CORE_RESULT_PATH: resultPath },
-    );
+      await runPostCoreCommand(
+        { restart: false },
+        {
+          OPENCLAW_UPDATE_POST_CORE_RESULT_PATH: resultPath,
+          OPENCLAW_UPDATE_RUN_ID: parentRun?.runId,
+        },
+      );
 
-    const result = JSON.parse(await fs.readFile(resultPath, "utf-8")) as {
-      status?: string;
-    };
-    expect(result.status).toBe("ok");
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
-    expectNoSideEffects(runGatewayUpdate, spawn);
-  });
+      const result = JSON.parse(await fs.readFile(resultPath, "utf-8")) as {
+        status?: string;
+      };
+      expect(result.status).toBe("ok");
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+      expectNoSideEffects(runGatewayUpdate, spawn);
+      expect(listUpdateRuns()).toEqual(runsBefore);
+    },
+  );
 
   it("post-core resume mode uses the parent install records snapshot for missing payload warnings", async () => {
     const resultDir = createCaseDir("openclaw-post-core-records");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -87,6 +87,18 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
   const prepared = await withUpdateInProgressEnv(invocationCwd, () =>
     prepareUpdateCommand(inputOpts),
   );
+  // Post-core children report phase results; the outer updater owns the run ledger.
+  if (prepared.postCoreUpdateResume) {
+    return await withUpdateInProgressEnv(invocationCwd, async () => {
+      const { resumePostCoreUpdate } = await import("./update-execution.runtime.js");
+      await resumePostCoreUpdate({
+        root: prepared.discoveredRoot,
+        channel: prepared.postCoreUpdateChannel,
+        opts: inputOpts,
+        timeoutMs: prepared.timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS,
+      });
+    });
+  }
   const run = await admitUpdateCommandRun({
     opts: inputOpts,
     root: prepared.servicePlan?.rootRedirect?.root ?? prepared.discoveredRoot,
@@ -98,7 +110,7 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
     runId: run.runId,
   };
   recoveryState.triageTarget.root = prepared.discoveredRoot;
-  const presentation = createUpdateProgress(!opts.json && !prepared.postCoreUpdateResume, run);
+  const presentation = createUpdateProgress(!opts.json, run);
   try {
     await withUpdateFailureTriage(
       { ...opts, invocationCwd },
@@ -140,12 +152,10 @@ export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<vo
             recoveryState.windowsTaskAutoStartRecovery?.complete();
           }
           if (failure) {
-            if (!prepared.postCoreUpdateResume) {
-              if (failure.error instanceof UpdateCommandFailure) {
-                completeUpdateCommandRun(failure.error.result, run);
-              } else {
-                failUpdateCommandRun(failure.error, run);
-              }
+            if (failure.error instanceof UpdateCommandFailure) {
+              completeUpdateCommandRun(failure.error.result, run);
+            } else {
+              failUpdateCommandRun(failure.error, run);
             }
             throw failure.error;
           }
@@ -166,8 +176,6 @@ async function updateCommandInternal(
 ): Promise<void> {
   const {
     startedAt,
-    postCoreUpdateResume,
-    postCoreUpdateChannel,
     timeoutMs,
     shouldRestart,
     requestedChannel,
@@ -179,17 +187,6 @@ async function updateCommandInternal(
   const updateStepTimeoutMs = timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
 
   let root = discoveredRoot;
-  if (postCoreUpdateResume) {
-    const { resumePostCoreUpdate } = await import("./update-execution.runtime.js");
-    await resumePostCoreUpdate({
-      root,
-      channel: postCoreUpdateChannel,
-      opts,
-      timeoutMs: updateStepTimeoutMs,
-    });
-    return;
-  }
-
   let updateInstallKind = installKind;
   const refuseUpdate = (reason: string, message?: string) =>
     reportPreMutationUpdateFailure({

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -54,6 +54,7 @@ const DIST_CHANNEL_CATALOG = "dist/channel-catalog.json";
 const DIST_BUILD_INFO = "dist/build-info.json";
 const DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT = "dist/shared-Y6bNiw2w.js";
 const DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT = "dist/shared-DTaQo6Hi.js";
+const DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1 = "dist/shared-DFJEouXv.js";
 const DIST_LEGACY_CLI_EXIT_COMPAT = "dist/memory-state-CcqRgDZU.js";
 const DIST_LEGACY_CLI_EXIT_COMPAT_ALT = "dist/memory-state-DwGdReW4.js";
 const DIST_STABLE_ROOT_RUNTIME_SOURCE = "dist/model-catalog.runtime-AbCd1234.js";
@@ -171,6 +172,7 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
     [DIST_BUILD_INFO]: '{"buildId":"test-build"}\n',
     [DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT]: "export function resolveNodeRunner() {}\n",
     [DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT]: "export function resolveNodeRunner() {}\n",
+    [DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1]: "export function resolveNodeRunner() {}\n",
     [DIST_LEGACY_CLI_EXIT_COMPAT]: "export function hasMemoryRuntime() { return false; }\n",
     [DIST_LEGACY_CLI_EXIT_COMPAT_ALT]: "export function hasMemoryRuntime() { return false; }\n",
     [DIST_OPENCLAW_ALIAS_PACKAGE]:
@@ -185,6 +187,7 @@ async function writeRuntimePostBuildScaffold(tmp: string): Promise<void> {
       DIST_PLUGIN_SDK_CORE,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT,
+      DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1,
       DIST_LEGACY_CLI_EXIT_COMPAT,
       DIST_LEGACY_CLI_EXIT_COMPAT_ALT,
       DIST_OPENCLAW_ALIAS_PACKAGE,
@@ -2029,6 +2032,7 @@ describe("run-node script", () => {
       DIST_BUILD_INFO,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT,
       DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_ALT,
+      DIST_LEGACY_UPDATE_NODE_RUNNER_COMPAT_2026_9_1,
       DIST_LEGACY_CLI_EXIT_COMPAT,
       DIST_STABLE_ROOT_RUNTIME_ALIAS,
       DIST_LEGACY_ROOT_RUNTIME_COMPAT,

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -1130,7 +1130,7 @@ describe("runtime postbuild static assets", () => {
     }
   });
 
-  it.each(["shared-Y6bNiw2w.js", "shared-DTaQo6Hi.js"])(
+  it.each(["shared-Y6bNiw2w.js", "shared-DTaQo6Hi.js", "shared-DFJEouXv.js"])(
     "preserves the old updater node-runner ABI through %s",
     async (chunk) => {
       const rootDir = createTempDir("openclaw-runtime-postbuild-");


### PR DESCRIPTION
Related: #139383
Supersedes #139615 after landing. Related: #138781. #139485 remains separately tracked.

## What Problem This Solves

Fixes an issue where users upgrading an npm-installed Gateway from 2026.9.1 would be left with a stopped service after package replacement. It also prevents the new post-core finalizer from creating an independent `requested`/`running` record that keeps the Updates page on “Updating…” after service recovery.

## Why This Change Was Made

The immutable 2026.9.1 updater lazily imports `shared-DFJEouXv.js` after npm replaces its package. The eager-import repair in #138781 already protects the current shared git/npm activation path, but cannot change that old running process. Generate the frozen filename through the existing zero-dependency Node-runner bridge, and consolidate duplicate registry entries by their shared content. This is a supported released-package upgrade contract; remove its facade only when 2026.9.1 leaves the supported upgrade window.

Post-core children now route to their phase-result owner before top-level update-run admission. The outer updater continues to own the ledger and terminal outcome, including when an older parent supplies no run ID. This removes the redundant child branch and child-only exceptions from the parent flow. The managed-service handoff, service authorization, schema, configuration, and public `update finalize` path retain their existing contracts.

Thanks to @TheCrazyLex (Alex Naidis) for the frozen-updater investigation and compatibility bridge in #139615, and @coygeek for the original report and second incident establishing the orphaned run. Contributor credit is retained in the commit.

## User Impact

An upgrade from the published 2026.9.1 package can refresh and restart the installed Gateway without loading a removed chunk. Finalization no longer opens an extra update run that cannot finish. Existing historical orphan records are not rewritten; this prevents new ones during the repaired upgrade.

The OCM hang in #139485 uses the separate target-installed `update finalize` path. Its pending operation is unproven, so this PR does not claim to fix it.

## Evidence

Exact reviewed and tested source: `52a9be8b0cfc2dce87a7ac059d0d5b31c63b6d4c`.

- The unmodified npm 2026.9.1 archive's `update-command-service-maintenance-CxFxUV1H.js:65` imports the missing facade and calls its named, zero-argument `resolveNodeRunner()` export. The bridge preserves the original executable selection.
- On Testbox, original source `5b099995413589f41904cef1413c62239542aa7c` failed both new regressions for the intended reasons: missing `shared-DFJEouXv.js`, and a legacy child creating a `requested`/`running` row. Older-facade and forwarded-ID siblings passed. The candidate passed all three facade cases and both ledger cases through `node scripts/run-vitest.mjs`.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34008216840) passed build, production/test types, lint, Node suites, docs, and `openclaw/ci-gate`. Independent local and branch P0–P2 reviews had no accepted/actionable findings. Formatting and `git diff --check` passed. Local test/typecheck attempts could not use this dependency-free worktree's older shared installation; the hosted checks and remote regression executions provide those results.

<!-- pr-behavior-proof:start -->
The real npm-global comparison ran on **Blacksmith Testbox**, lease `tbx_01m1taeg1t08p5ksgfsyfaxgfb`, [run](https://github.com/openclaw/openclaw/actions/runs/34007819439). Linux, Node 24.19.0, systemd 255 with actual user services. Each case used a fresh disposable OS account, private canonical `.openclaw` state in its temporary home, an isolated npm prefix, and a free loopback port (45627 and 35571). Normal token authentication used generated fixture credentials kept out of the transcript.

The repository Crabbox wrapper verified source tree `2310960f624961412590c35c399e38b2c567b83c`. The canonical package builder ran on the lease with `GIT_COMMIT` bound to the reviewed source and passed tarball integrity checks. Package SHA-256: `0ed6fa3d0f9ae5cfc536480f5c1a58f91bff76b916881e7526f6ed1f5a9b46f1`.

| Real upgrade | Exit | Native service | Update ledger |
| --- | ---: | --- | --- |
| Published 2026.9.1 → published 2026.9.2 | 1 | PID 16729 → 0; inactive/dead | One orphan `running/requested` row |
| Published 2026.9.1 → exact candidate | 0 | PID 17529 → 18133; active/running; healthy | No orphan row |
| Candidate → same candidate artifact | 0 | PID 18133 → 18851; active/running; healthy | Exactly one `succeeded/finished` row |

Sanitized live transcript:

```text
$ openclaw update --yes --tag 2026.9.2 --json
update_exit=1
OpenClaw 2026.9.2 (3928bad)
MainPID=0 ActiveState=inactive SubState=dead
Failed to refresh gateway service environment from updated install:
ENOENT: no such file or directory, open '<install>/dist/shared-DFJEouXv.js'
ledger: one running/requested row

$ openclaw update --yes --tag <candidate.tgz> --json
update_exit=0
OpenClaw 2026.9.2 (52a9be8)
MainPID=18133 ActiveState=active SubState=running
healthz: live
ledger: []

$ openclaw update --yes --tag <same-candidate.tgz> --json
exit=0
MainPID=18851 ActiveState=active SubState=running
healthz: live
ledger: one succeeded/finished row
```

The saved live Gateway RPC response reports `ok: true`, version `2026.9.2`, and build ID `2026.9.2-52a9be8b0cfc-2026-09-06T03-48-40.311Z`, matching the packaged build information exactly. At that probe systemd reported `result: success` and zero automatic restarts. Installed build-info bytes matched the candidate. The wrapper command exited 0; task services were stopped and lease cleanup confirmed **completed**. The second hop uses the same artifact and proves modern-parent completion, without claiming another chunk-hash transition.

The configured Testbox offers Linux, so native macOS launchd and the Mac app's update screen remain unproven. Linux with real systemd is the maintainer-authorized fallback for this lane.

An earlier supported loopback `auth.mode: none` replay restored the candidate service and left no orphan row, but the old 9.1 verifier exited 1 with `device identity required` in empty, unpaired state. This existing 9.1 readiness-client limitation is already fixed for newly launched 9.2 CLIs by #136995; package replacement cannot change the running old verifier. Fully successful unpaired no-auth upgrades remain outside this proof. The successful token-auth first hop also retained a nonfatal old-process schema-15/schema-16 health-state bookkeeping warning before exiting 0 with the healthy candidate. No schema or authentication policy was changed.

Setup-only retries corrected oversized command transport and the disposable user's Node visibility, canonical paths, working directory, and permissions. Those refusals happened before an upgrade and are separate from the behavioral controls above.
<!-- pr-behavior-proof:end -->

`git diff --numstat` against base `5b099995413589f41904cef1413c62239542aa7c`:

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production and build tooling | 26 | 37 | -11 |
| Tests and E2E fixture support | 43 | 19 | +24 |
| Documentation | 3 | 1 | +2 |

ClawSweeper disposition: the exact-head review found no introduced defect. Its package/ledger proof requests are satisfied above; the macOS coverage request uses the explicitly authorized Linux fallback and retains the native-platform gap. Historical orphan records and #139485's separate finalizer hang are not claimed as repaired.
