### PR TITLE
fix(auto-reply): preserve queued messages across watchdog retries

### DIFF
--- a/docs/concepts/queue.md
+++ b/docs/concepts/queue.md
@@ -154,6 +154,12 @@ queued input reaches the transcript, it appears as interrupted input after
 restart and requires an explicit resend. The in-memory queue is not replayed.
 Host sleep that preserves the process can continue the existing queue normally.
 
+Channel messages retained by durable ingress remain retryable when a queued
+attempt is abandoned before agent-turn adoption. Abandonment releases that
+attempt's inbound and queue dedupe entries before ingress retries it. Messages
+already adopted or consumed keep duplicate suppression, so transport redelivery
+does not repeat their effects.
+
 - Applies to auto-reply agent runs across all inbound channels that use the gateway reply pipeline (WhatsApp web, Telegram, Slack, Discord, Signal, iMessage, webchat, etc.).
 - Default lane (`main`) is process-wide for inbound turns; set `agents.defaults.maxConcurrent` to allow multiple sessions in parallel.
 - Heartbeat embedded runs use the bounded `cron-nested` lane for global admission so slow background work does not block inbound replies, while their configured heartbeat session lane still serializes work for that session.

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -3,18 +3,13 @@ import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GroupKeyResolution } from "../config/sessions.js";
-import { channelRouteDedupeKey } from "../plugin-sdk/channel-route.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { createInboundDebouncer, type InboundDebounceCreateParams } from "./inbound-debounce.js";
 import { resolveGroupRequireMention } from "./reply/groups.js";
 import { finalizeInboundContext } from "./reply/inbound-context.js";
-import {
-  claimInboundDedupe,
-  commitInboundDedupe,
-  resetInboundDedupe,
-} from "./reply/inbound-dedupe.js";
+import { claimInboundDedupe, resetInboundDedupe } from "./reply/inbound-dedupe.js";
 import { normalizeInboundTextNewlines } from "./reply/inbound-text.js";
 import {
   buildMentionRegexes,
@@ -34,14 +29,13 @@ type TestChannelGroupContext = {
   accountId?: string | null;
 };
 
-function commitInboundForTest(ctx: MsgContext): string {
+function commitInboundForTest(ctx: MsgContext): void {
   const claim = claimInboundDedupe(ctx);
   expect(claim.status).toBe("claimed");
   if (claim.status !== "claimed") {
     throw new Error(`expected inbound dedupe claim, got ${claim.status}`);
   }
-  commitInboundDedupe(claim.key);
-  return claim.key;
+  claim.commit();
 }
 
 function normalizeTestSlug(raw?: string | null): string {
@@ -352,26 +346,6 @@ describe("finalizeInboundContext", () => {
 });
 
 describe("inbound dedupe", () => {
-  it("builds a stable key when MessageSid is present", () => {
-    const ctx: MsgContext = {
-      Provider: "telegram",
-      OriginatingChannel: "telegram",
-      OriginatingTo: "telegram:123",
-      MessageSid: "42",
-    };
-    expect(claimInboundDedupe(ctx, { inFlight: new Set() })).toEqual({
-      status: "claimed",
-      key: JSON.stringify([
-        "",
-        channelRouteDedupeKey({
-          channel: "telegram",
-          to: "telegram:123",
-        }),
-        "42",
-      ]),
-    });
-  });
-
   it("skips duplicates with the same key", () => {
     resetInboundDedupe();
     const ctx: MsgContext = {
@@ -380,8 +354,8 @@ describe("inbound dedupe", () => {
       OriginatingTo: "whatsapp:+1555",
       MessageSid: "msg-1",
     };
-    const key = commitInboundForTest(ctx);
-    expect(claimInboundDedupe(ctx)).toEqual({ status: "duplicate", key });
+    commitInboundForTest(ctx);
+    expect(claimInboundDedupe(ctx)).toEqual({ status: "duplicate" });
   });
 
   it("does not dedupe when the peer changes", () => {
@@ -403,13 +377,12 @@ describe("inbound dedupe", () => {
       OriginatingTo: "whatsapp:+1555",
       MessageSid: "msg-1",
     };
-    const alphaKey = commitInboundForTest({ ...base, SessionKey: "agent:alpha:main" });
+    commitInboundForTest({ ...base, SessionKey: "agent:alpha:main" });
     expect(
       claimInboundDedupe({ ...base, SessionKey: "agent:bravo:whatsapp:direct:+1555" }).status,
     ).toBe("claimed");
     expect(claimInboundDedupe({ ...base, SessionKey: "agent:alpha:main" })).toEqual({
       status: "duplicate",
-      key: alphaKey,
     });
   });
 
@@ -421,10 +394,10 @@ describe("inbound dedupe", () => {
       OriginatingTo: "telegram:7463849194",
       MessageSid: "msg-1",
     };
-    const key = commitInboundForTest({ ...base, SessionKey: "agent:main:main" });
+    commitInboundForTest({ ...base, SessionKey: "agent:main:main" });
     expect(
       claimInboundDedupe({ ...base, SessionKey: "agent:main:telegram:direct:7463849194" }),
-    ).toEqual({ status: "duplicate", key });
+    ).toEqual({ status: "duplicate" });
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-steer-adoption.question-recovery.test.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.question-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { QuestionWaitAnswerResult } from "../../../packages/gateway-protocol/src/index.js";
-import { createDeferred } from "../../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
@@ -111,6 +111,105 @@ async function withQuestionCreator(
 }
 
 describe("question response custody through reply adoption", () => {
+  it("cancels a waiting steer without waiting for its predecessor's acceptance", async () => {
+    const key = "agent:main:waiting-steer-abort";
+    const first = createQueueTestRun({ prompt: "first input", messageId: "first-input" });
+    await withQuestionCreator(key, first, async (operation, fingerprint) => {
+      const backendEntered = createDeferred();
+      const firstOutcome = createDeferred();
+      const firstAdopted = vi.fn(async () => {});
+      const firstAbandoned = vi.fn();
+      const secondDeferred = createDeferred();
+      const source = new AbortController();
+      const abandoned = vi.fn();
+      const settled = vi.fn();
+      const adopted = vi.fn(async () => {});
+      const followup = vi.fn(async (_run: FollowupRun) => {});
+      first.turnAdoptionLifecycle = { onAdopted: firstAdopted, onAbandoned: firstAbandoned };
+      const second: FollowupRun = {
+        ...first,
+        prompt: "waiting input",
+        messageId: "waiting-input",
+        abortSignal: source.signal,
+        turnAdoptionLifecycle: {
+          onDeferred: () => secondDeferred.resolve(),
+          onAdopted: adopted,
+          onAbandoned: abandoned,
+          onSettled: settled,
+        },
+      };
+      const queueMessage = vi.fn((_message: string) => {
+        backendEntered.resolve();
+        // No acceptance callback yet: the next parked input must wait for this outcome.
+        return firstOutcome.promise;
+      });
+      operation.attachBackend({
+        kind: "embedded",
+        runId: "accepted-backing-work",
+        toolAuthorityFingerprint: fingerprint,
+        cancel: vi.fn(),
+        messageInjectionV2: { version: 2, isAvailable: () => true, queueMessage },
+      });
+      operation.setPhase("running");
+      const startSteer = (run: FollowupRun) => {
+        const typing = createMockTypingController();
+        return runActiveReplySteer({
+          followupRun: run,
+          opts: undefined,
+          providedReplyOperation: operation,
+          queueKey: key,
+          releaseAdmissionTicket: () => {},
+          replyOperationRunState: undefined,
+          resolvedQueue: { mode: "steer", debounceMs: 0 },
+          restartRecoverySourceTurnId: run.messageId,
+          runFollowup: followup,
+          sessionCtx: {},
+          sessionKey: key,
+          touchActiveSessionEntry: async () => {},
+          typing,
+          typingSignals: createTypingSignaler({ typing, mode: "never", isHeartbeat: false }),
+          toolAuthorityFingerprint: fingerprint,
+        });
+      };
+      const firstSteer = startSteer(first);
+      let waitingSteer: ReturnType<typeof startSteer> | undefined;
+      try {
+        await Promise.race([
+          backendEntered.promise,
+          firstSteer.then(() => {
+            throw new Error("first steer did not reach backend injection");
+          }),
+        ]);
+        waitingSteer = startSteer(second);
+        await secondDeferred.promise;
+        source.abort(new Error("cancel source waiting for predecessor acceptance"));
+        await expect(
+          withTestTimeout(waitingSteer, 1_000, "cancelled steer still waits for predecessor"),
+        ).resolves.toBe("handled");
+        expect(abandoned).toHaveBeenCalledOnce();
+        expect(settled).toHaveBeenCalledOnce();
+        expect(adopted).not.toHaveBeenCalled();
+        expect(firstAdopted).not.toHaveBeenCalled();
+        expect(firstAbandoned).not.toHaveBeenCalled();
+        expect(queueMessage.mock.calls.map(([message]) => message)).toEqual(["first input"]);
+        expect(
+          enqueueFollowupRun(
+            key,
+            createQueueTestRun({ prompt: "waiting input", messageId: second.messageId }),
+            { mode: "followup", debounceMs: 0 },
+            "message-id",
+            followup,
+            false,
+          ),
+        ).toBe(true);
+      } finally {
+        firstOutcome.resolve();
+        await Promise.allSettled([firstSteer, waitingSteer]);
+        clearSessionQueues([key]);
+      }
+    });
+  });
+
   it.each(["confirmed", "unconfirmed"] as const)(
     "retains accepted input during source cancellation until its %s outcome settles",
     async (confirmation) => {

--- a/src/auto-reply/reply/agent-runner-steer-adoption.question-recovery.test.ts
+++ b/src/auto-reply/reply/agent-runner-steer-adoption.question-recovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { QuestionWaitAnswerResult } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
@@ -26,6 +27,7 @@ import {
   REPLY_OPERATION_RUN_STATE,
   type ReplyOperationRunState,
 } from "./reply-operation-run-state.js";
+import type { ReplyBackendQueueMessageResult } from "./reply-run-registry.contracts.js";
 import { createReplyOperation, replyRunRegistry } from "./reply-run-registry.js";
 import { prepareReplyToolAuthority } from "./reply-tool-authority.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -109,6 +111,131 @@ async function withQuestionCreator(
 }
 
 describe("question response custody through reply adoption", () => {
+  it.each(["confirmed", "unconfirmed"] as const)(
+    "retains accepted input during source cancellation until its %s outcome settles",
+    async (confirmation) => {
+      const key = `agent:main:accepted-steer-abort-${confirmation}`;
+      const run = createQueueTestRun({ prompt: text, messageId: `accepted-${confirmation}` });
+      await withQuestionCreator(key, run, async (operation, fingerprint) => {
+        const source = new AbortController();
+        const accepted = createDeferred();
+        const delivery = createDeferred<void | ReplyBackendQueueMessageResult>();
+        const adopted = vi.fn(async () => {});
+        const abandoned = vi.fn();
+        const settled = vi.fn();
+        const cancel = vi.fn();
+        const followup = vi.fn(async (_run: FollowupRun) => {});
+        run.abortSignal = source.signal;
+        run.turnAdoptionLifecycle = {
+          onAdopted: adopted,
+          onAbandoned: abandoned,
+          onSettled: settled,
+        };
+        operation.attachBackend({
+          kind: "embedded",
+          runId: "accepted-backing-work",
+          toolAuthorityFingerprint: fingerprint,
+          cancel,
+          messageInjectionV2: {
+            version: 2,
+            isAvailable: () => true,
+            queueMessage: (_message, options, assertCurrent) => {
+              assertCurrent();
+              options?.onQueueAccepted?.(true);
+              accepted.resolve();
+              return delivery.promise;
+            },
+          },
+        });
+        operation.setPhase("running");
+        const state: ReplyOperationRunState = {};
+        const typing = createMockTypingController();
+        const adoption = runActiveReplySteer({
+          followupRun: run,
+          opts: undefined,
+          providedReplyOperation: operation,
+          queueKey: key,
+          releaseAdmissionTicket: () => {},
+          replyOperationRunState: state,
+          resolvedQueue: { mode: "steer", debounceMs: 0 },
+          restartRecoverySourceTurnId: run.messageId,
+          runFollowup: followup,
+          sessionCtx: {},
+          sessionKey: key,
+          touchActiveSessionEntry: async () => {},
+          typing,
+          typingSignals: createTypingSignaler({ typing, mode: "never", isHeartbeat: false }),
+          toolAuthorityFingerprint: fingerprint,
+        });
+        void adoption.catch(() => undefined);
+        const tryDuplicate = () =>
+          enqueueFollowupRun(
+            key,
+            createQueueTestRun({ prompt: text, messageId: run.messageId }),
+            { mode: "followup", debounceMs: 0 },
+            "message-id",
+            followup,
+            false,
+          );
+        try {
+          await Promise.race([
+            accepted.promise,
+            adoption.then(() => {
+              throw new Error("steering finished before backend acceptance");
+            }),
+          ]);
+          source.abort(new Error("source released while accepted input awaits confirmation"));
+          // The injection owner still holds this input; cancellation must not make it replayable.
+          expect(abandoned).not.toHaveBeenCalled();
+          expect(settled).not.toHaveBeenCalled();
+          expect(adopted).not.toHaveBeenCalled();
+          expect(tryDuplicate()).toBe(false);
+          expect(followup).not.toHaveBeenCalled();
+          const siblingSource = new AbortController();
+          const siblingSettled = vi.fn();
+          const siblingCleanup = vi.fn(async (_run: FollowupRun) => {});
+          const sibling = createQueueTestRun({ prompt: "cancel sibling", messageId: "sibling" });
+          sibling.abortSignal = siblingSource.signal;
+          sibling.turnAdoptionLifecycle = { onAdopted: async () => {}, onSettled: siblingSettled };
+          expect(
+            enqueueFollowupRun(
+              key,
+              sibling,
+              { mode: "followup", debounceMs: 0 },
+              "message-id",
+              siblingCleanup,
+              false,
+            ),
+          ).toBe(true);
+          // An ordinary source's sweep must also respect the parked injection owner.
+          siblingSource.abort();
+          expect(siblingSettled).toHaveBeenCalledOnce();
+          expect(siblingCleanup).toHaveBeenCalledExactlyOnceWith(sibling);
+          expect(abandoned).not.toHaveBeenCalled();
+          expect(settled).not.toHaveBeenCalled();
+          expect(tryDuplicate()).toBe(false);
+          delivery.resolve(
+            confirmation === "confirmed"
+              ? undefined
+              : { transcriptCommit: "unconfirmed", errorMessage: "transcript confirmation lost" },
+          );
+          await expect(adoption).resolves.toBe("handled");
+          expect(state.admission).toEqual({ status: "accepted", mode: "steer" });
+          expect(adopted).toHaveBeenCalledOnce();
+          expect(settled).toHaveBeenCalledOnce();
+          expect(abandoned).not.toHaveBeenCalled();
+          expect(tryDuplicate()).toBe(false);
+          expect(followup).not.toHaveBeenCalled();
+          expect(cancel).toHaveBeenCalledTimes(confirmation === "unconfirmed" ? 1 : 0);
+        } finally {
+          delivery.resolve();
+          await adoption.catch(() => undefined);
+          clearSessionQueues([key]);
+        }
+      });
+    },
+  );
+
   it.each(["next-model", "tool-cap", "permission", "sender", "source-closure"] as const)(
     "uses creator policy and incoming source authority for %s",
     async (change) => {

--- a/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
@@ -23,7 +23,12 @@ import {
   type DispatchProcessedNote,
 } from "./dispatch-processed-outcome.js";
 import { resetInboundDedupe } from "./inbound-dedupe.js";
-import { clearSessionQueues, enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
+import {
+  clearSessionQueues,
+  enqueueFollowupRun,
+  scheduleFollowupDrain,
+  type FollowupRun,
+} from "./queue.js";
 import { createQueueTestRun } from "./queue.test-helpers.js";
 import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
 import { getExistingFollowupQueue } from "./queue/state.js";
@@ -72,7 +77,9 @@ describe("dispatch retry after queued ingress abandonment", () => {
         let dispatcher = createDispatcher();
         const outcomes: Array<DispatchProcessedNote | undefined> = [];
         const lifecycles: ChannelIngressDispatchLifecycle[] = [];
-        const unexpectedFollowup = vi.fn(async () => {});
+        const finishAbortedFollowup = vi.fn(async (run: FollowupRun) => {
+          expect(run.abortSignal?.aborted).toBe(true);
+        });
         const resolver = vi.fn(async (_ctx: MsgContext, options?: GetReplyOptions) => {
           if (resolver.mock.calls.length > 1) {
             return { text: "Queued message delivered" };
@@ -134,10 +141,10 @@ describe("dispatch retry after queued ingress abandonment", () => {
             await vi.advanceTimersByTimeAsync(1_000);
             await drain.waitForIdle();
             expect(lifecycles[0]?.abortSignal.aborted).toBe(true);
-            scheduleFollowupDrain(key, unexpectedFollowup);
+            scheduleFollowupDrain(key, finishAbortedFollowup);
             await vi.advanceTimersByTimeAsync(0);
             expect(getExistingFollowupQueue(key)?.items ?? []).toEqual([]);
-            expect(unexpectedFollowup).not.toHaveBeenCalled();
+            expect(finishAbortedFollowup).toHaveBeenCalledOnce();
           }
           expect(await queue.listPending()).toMatchObject([{ id: messageId, attempts: 1 }]);
           clock += 1_000;

--- a/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
@@ -23,12 +23,7 @@ import {
   type DispatchProcessedNote,
 } from "./dispatch-processed-outcome.js";
 import { resetInboundDedupe } from "./inbound-dedupe.js";
-import {
-  clearSessionQueues,
-  enqueueFollowupRun,
-  scheduleFollowupDrain,
-  type FollowupRun,
-} from "./queue.js";
+import { clearSessionQueues, enqueueFollowupRun, type FollowupRun } from "./queue.js";
 import { createQueueTestRun } from "./queue.test-helpers.js";
 import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
 import { getExistingFollowupQueue } from "./queue/state.js";
@@ -93,13 +88,35 @@ describe("dispatch retry after queued ingress abandonment", () => {
           run.turnAdoptionLifecycle = options?.turnAdoptionLifecycle;
           run.abortSignal = options?.turnAdoptionLifecycle?.abortSignal;
           expect(
-            enqueueFollowupRun(key, run, {
-              mode: "followup",
-              debounceMs: 0,
-              cap: 10,
-              dropPolicy: "summarize",
-            }),
+            enqueueFollowupRun(
+              key,
+              run,
+              {
+                mode: "followup",
+                debounceMs: 0,
+                cap: 10,
+                dropPolicy: "summarize",
+              },
+              "message-id",
+              finishAbortedFollowup,
+              false,
+            ),
           ).toBe(true);
+          if (abandonment === "watchdog-after-commit") {
+            expect(
+              enqueueFollowupRun(
+                key,
+                createQueueTestRun({
+                  prompt: "Healthy pending sibling",
+                  messageId: "healthy-sibling",
+                }),
+                { mode: "followup", debounceMs: 0 },
+                "message-id",
+                finishAbortedFollowup,
+                false,
+              ),
+            ).toBe(true);
+          }
           const runState = resolveReplyOperationRunState(options);
           if (!runState) {
             throw new Error("dispatch did not bind its run state");
@@ -141,10 +158,6 @@ describe("dispatch retry after queued ingress abandonment", () => {
             await vi.advanceTimersByTimeAsync(1_000);
             await drain.waitForIdle();
             expect(lifecycles[0]?.abortSignal.aborted).toBe(true);
-            scheduleFollowupDrain(key, finishAbortedFollowup);
-            await vi.advanceTimersByTimeAsync(0);
-            expect(getExistingFollowupQueue(key)?.items ?? []).toEqual([]);
-            expect(finishAbortedFollowup).toHaveBeenCalledOnce();
           }
           expect(await queue.listPending()).toMatchObject([{ id: messageId, attempts: 1 }]);
           clock += 1_000;
@@ -152,6 +165,12 @@ describe("dispatch retry after queued ingress abandonment", () => {
           await drain.waitForIdle();
           // The old bug tombstones this retry as a duplicate without invoking the resolver.
           expect(resolver).toHaveBeenCalledTimes(2);
+          if (abandonment === "watchdog-after-commit") {
+            expect(finishAbortedFollowup).toHaveBeenCalledOnce();
+            expect(getExistingFollowupQueue(key)?.items.map((run) => run.messageId)).toEqual([
+              "healthy-sibling",
+            ]);
+          }
           expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
             text: "Queued message delivered",
           });

--- a/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ingress-retry.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  bindIngressLifecycleToReplyOptions,
+  type ChannelIngressDispatchLifecycle,
+} from "../../channels/message/ingress-drain-lifecycle.js";
+import { createChannelIngressDrain } from "../../channels/message/ingress-drain.js";
+import {
+  createTestIngressQueue,
+  withTempState,
+} from "../../channels/message/ingress-drain.test-helpers.js";
+import type { MsgContext } from "../templating.js";
+import type { GetReplyOptions } from "../types.js";
+import { createDispatcher } from "./dispatch-from-config.shared.test-harness.js";
+import {
+  automaticDirectReplyConfig,
+  describe0BeforeEach0,
+  dispatchReplyFromConfig,
+  globalBeforeAll0,
+  setNoAbort,
+} from "./dispatch-from-config.test-harness.js";
+import {
+  withDispatchProcessedOutcomeSink,
+  type DispatchProcessedNote,
+} from "./dispatch-processed-outcome.js";
+import { resetInboundDedupe } from "./inbound-dedupe.js";
+import { clearSessionQueues, enqueueFollowupRun, scheduleFollowupDrain } from "./queue.js";
+import { createQueueTestRun } from "./queue.test-helpers.js";
+import { resetRecentQueuedMessageIdDedupe } from "./queue/enqueue.test-support.js";
+import { getExistingFollowupQueue } from "./queue/state.js";
+import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
+import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
+import { buildTestCtx } from "./test-ctx.js";
+
+beforeAll(globalBeforeAll0);
+beforeEach(() => {
+  describe0BeforeEach0();
+  setNoAbort();
+  resetRecentQueuedMessageIdDedupe();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  replyRunTesting.resetReplyRunRegistry();
+  resetInboundDedupe();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe("dispatch retry after queued ingress abandonment", () => {
+  it.each(["watchdog-after-commit", "abandon-before-commit"] as const)(
+    "delivers the same admitted message after %s and still suppresses a true duplicate",
+    async (abandonment) => {
+      await withTempState(async (stateDir) => {
+        let clock = Date.now();
+        const key = `agent:main:discord:direct:ingress-${abandonment}`;
+        const messageId = `retry-${abandonment}`;
+        const ctx = buildTestCtx({
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "direct",
+          From: "user:ingress-fixture",
+          To: "channel:ingress-fixture",
+          SessionKey: key,
+          MessageSid: messageId,
+          BodyForAgent: "Please deliver this queued message",
+        });
+        const queue = createTestIngressQueue(stateDir, { now: () => clock });
+        await queue.enqueue(
+          messageId,
+          { text: "Please deliver this queued message" },
+          { laneKey: key },
+        );
+        let dispatcher = createDispatcher();
+        const outcomes: Array<DispatchProcessedNote | undefined> = [];
+        const lifecycles: ChannelIngressDispatchLifecycle[] = [];
+        const unexpectedFollowup = vi.fn(async () => {});
+        const resolver = vi.fn(async (_ctx: MsgContext, options?: GetReplyOptions) => {
+          if (resolver.mock.calls.length > 1) {
+            return { text: "Queued message delivered" };
+          }
+          const run = createQueueTestRun({
+            prompt: "Please deliver this queued message",
+            messageId,
+            originatingChannel: "discord",
+            originatingTo: "channel:ingress-fixture",
+          });
+          run.turnAdoptionLifecycle = options?.turnAdoptionLifecycle;
+          run.abortSignal = options?.turnAdoptionLifecycle?.abortSignal;
+          expect(
+            enqueueFollowupRun(key, run, {
+              mode: "followup",
+              debounceMs: 0,
+              cap: 10,
+              dropPolicy: "summarize",
+            }),
+          ).toBe(true);
+          const runState = resolveReplyOperationRunState(options);
+          if (!runState) {
+            throw new Error("dispatch did not bind its run state");
+          }
+          runState.admission = { status: "accepted", mode: "followup" };
+          if (abandonment === "abandon-before-commit") {
+            clearSessionQueues([key]);
+          }
+          return undefined;
+        });
+        const drain = createChannelIngressDrain({
+          queue,
+          now: () => clock,
+          adoptionStallTimeoutMs: 1_000,
+          retryPolicy: { baseMs: 1, maxMs: 1 },
+          dispatchClaimedEvent: async (_event, lifecycle) => {
+            lifecycles.push(lifecycle);
+            dispatcher = createDispatcher();
+            const { processedOutcome } = await withDispatchProcessedOutcomeSink(() =>
+              dispatchReplyFromConfig({
+                ctx,
+                cfg: automaticDirectReplyConfig,
+                dispatcher,
+                replyOptions: bindIngressLifecycleToReplyOptions(lifecycle),
+                replyResolver: resolver,
+              }),
+            );
+            outcomes.push(processedOutcome);
+          },
+        });
+        try {
+          await drain.drainOnce();
+          await drain.waitForIdle();
+          expect(resolver).toHaveBeenCalledOnce();
+          expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+          if (abandonment === "watchdog-after-commit") {
+            expect(await queue.listClaims()).toHaveLength(1);
+            clock += 1_000;
+            await vi.advanceTimersByTimeAsync(1_000);
+            await drain.waitForIdle();
+            expect(lifecycles[0]?.abortSignal.aborted).toBe(true);
+            scheduleFollowupDrain(key, unexpectedFollowup);
+            await vi.advanceTimersByTimeAsync(0);
+            expect(getExistingFollowupQueue(key)?.items ?? []).toEqual([]);
+            expect(unexpectedFollowup).not.toHaveBeenCalled();
+          }
+          expect(await queue.listPending()).toMatchObject([{ id: messageId, attempts: 1 }]);
+          clock += 1_000;
+          expect(await drain.drainOnce()).toEqual({ started: 1 });
+          await drain.waitForIdle();
+          // The old bug tombstones this retry as a duplicate without invoking the resolver.
+          expect(resolver).toHaveBeenCalledTimes(2);
+          expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+            text: "Queued message delivered",
+          });
+          expect(outcomes.at(-1)).toMatchObject({ outcome: "completed" });
+          expect(await queue.listPending()).toEqual([]);
+          expect(await queue.listClaims()).toEqual([]);
+          expect((await queue.enqueue(messageId, { text: "duplicate" })).kind).toBe("completed");
+
+          const duplicateDispatcher = createDispatcher();
+          const duplicate = await withDispatchProcessedOutcomeSink(() =>
+            dispatchReplyFromConfig({
+              ctx,
+              cfg: automaticDirectReplyConfig,
+              dispatcher: duplicateDispatcher,
+              replyResolver: resolver,
+            }),
+          );
+          expect(duplicate.processedOutcome).toEqual({ outcome: "skipped", reason: "duplicate" });
+          expect(resolver).toHaveBeenCalledTimes(2);
+          expect(dispatcher.sendFinalReply).toHaveBeenCalledOnce();
+          expect(duplicateDispatcher.sendFinalReply).not.toHaveBeenCalled();
+        } finally {
+          drain.dispose();
+          clearSessionQueues([key]);
+        }
+      });
+    },
+  );
+});

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -40,7 +40,7 @@ import {
 import { extendPreparedDispatchState } from "./dispatch-from-config.phase-state.js";
 import type { PrepareDispatchDeliveryReadyState } from "./dispatch-from-config.prepare-delivery.js";
 import type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
-import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
+import { claimInboundDedupe } from "./inbound-dedupe.js";
 import { emitMessageReceivedHooks as emitSharedMessageReceivedHooks } from "./message-received-hooks.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
@@ -429,16 +429,19 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
       }),
     };
   }
-  const commitInboundDedupeIfClaimed = () => {
-    if (inboundDedupeClaim.status === "claimed") {
-      commitInboundDedupe(inboundDedupeClaim.key);
-    }
-  };
-  const releaseInboundDedupeIfClaimed = () => {
-    if (inboundDedupeClaim.status === "claimed") {
-      releaseInboundDedupe(inboundDedupeClaim.key);
-    }
-  };
+  const commitInboundDedupeIfClaimed = () => inboundDedupeClaim.commit?.();
+  const releaseInboundDedupeIfClaimed = () => inboundDedupeClaim.release?.();
+  const lifecycle = params.replyOptions?.turnAdoptionLifecycle;
+  if (lifecycle && inboundDedupeClaim.status === "claimed") {
+    const onAbandoned = lifecycle.onAbandoned;
+    lifecycle.onAbandoned = () => {
+      // Release before ingress retries, including abandonment before commit.
+      if (!state.inboundDedupeReplayUnsafe && !state.turnAdoptionState?.adopted) {
+        inboundDedupeClaim.release();
+      }
+      onAbandoned?.();
+    };
+  }
   const finishReplyOperationBusyDispatch = (opts?: {
     dedupeDisposition?: "commit" | "release";
     recordAgentDispatchCompleted?: boolean;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -15,7 +15,6 @@ import type {
   DispatchFromConfigParams,
   DispatchFromConfigResult,
 } from "./dispatch-from-config.types.js";
-import { commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { REPLY_ADMISSION_TICKET, reserveReplyAdmissionTicket } from "./reply-admission-ticket.js";
 import "./dispatch-from-config.events.js";
 
@@ -138,9 +137,9 @@ async function dispatchReplyFromConfigInner(
       }
       if (inboundDedupeClaim.status === "claimed") {
         if (errorState.turnAdoptionState?.adopted || errorState.inboundDedupeReplayUnsafe) {
-          commitInboundDedupe(inboundDedupeClaim.key);
+          inboundDedupeClaim.commit();
         } else {
-          releaseInboundDedupe(inboundDedupeClaim.key);
+          inboundDedupeClaim.release();
         }
       }
       if (err instanceof DispatchSessionRefreshRequiredError) {

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -1,8 +1,8 @@
 // Tests inbound dedupe state for repeated message ids.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../templating.js";
-import { claimInboundDedupe, commitInboundDedupe, resetInboundDedupe } from "./inbound-dedupe.js";
+import { claimInboundDedupe, resetInboundDedupe } from "./inbound-dedupe.js";
 
 const sharedInboundContext: MsgContext = {
   Provider: "discord",
@@ -15,23 +15,25 @@ const sharedInboundContext: MsgContext = {
   MessageSid: "msg-1",
 };
 
-function claimKey(ctx: MsgContext): string {
-  const result = claimInboundDedupe(ctx, { inFlight: new Set() });
+function claim(ctx: MsgContext) {
+  const result = claimInboundDedupe(ctx);
   expect(result.status).toBe("claimed");
   if (result.status !== "claimed") {
     throw new Error(`expected claimed inbound dedupe result, got ${result.status}`);
   }
-  return result.key;
+  return result;
 }
 
 describe("inbound dedupe", () => {
   afterEach(() => {
     resetInboundDedupe();
+    vi.useRealTimers();
   });
 
   it("deduplicates inbound messages with equivalent numeric and string thread ids", () => {
-    expect(claimKey({ ...sharedInboundContext, MessageThreadId: 77 })).toBe(
-      claimKey({ ...sharedInboundContext, MessageThreadId: "77" }),
+    claim({ ...sharedInboundContext, MessageThreadId: 77 }).commit();
+    expect(claimInboundDedupe({ ...sharedInboundContext, MessageThreadId: "77" }).status).toBe(
+      "duplicate",
     );
   });
 
@@ -50,7 +52,7 @@ describe("inbound dedupe", () => {
     if (firstClaim.status !== "claimed") {
       throw new Error("expected the first command target to be admitted");
     }
-    commitInboundDedupe(firstClaim.key);
+    firstClaim.commit();
 
     const secondClaim = claimInboundDedupe({
       ...firstTarget,
@@ -59,7 +61,6 @@ describe("inbound dedupe", () => {
     expect(secondClaim.status).toBe("claimed");
     expect(claimInboundDedupe(firstTarget)).toEqual({
       status: "duplicate",
-      key: firstClaim.key,
     });
   });
 
@@ -82,16 +83,11 @@ describe("inbound dedupe", () => {
       if (firstClaim.status !== "claimed") {
         throw new Error(`expected claimed inbound dedupe result, got ${firstClaim.status}`);
       }
-      const firstClaimKey = firstClaim.key;
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "inflight",
-        key: firstClaimKey,
       });
-      inboundB.releaseInboundDedupe(firstClaimKey);
-      expect(inboundA.claimInboundDedupe(sharedInboundContext)).toEqual({
-        status: "claimed",
-        key: firstClaimKey,
-      });
+      firstClaim.release();
+      expect(inboundB.claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
     } finally {
       inboundA.resetInboundDedupe();
       inboundB.resetInboundDedupe();
@@ -117,15 +113,40 @@ describe("inbound dedupe", () => {
       if (firstClaim.status !== "claimed") {
         throw new Error(`expected claimed inbound dedupe result, got ${firstClaim.status}`);
       }
-      const firstClaimKey = firstClaim.key;
-      inboundA.commitInboundDedupe(firstClaimKey);
+      firstClaim.commit();
       expect(inboundB.claimInboundDedupe(sharedInboundContext)).toEqual({
         status: "duplicate",
-        key: firstClaimKey,
       });
     } finally {
       inboundA.resetInboundDedupe();
       inboundB.resetInboundDedupe();
     }
+  });
+
+  it("cannot recommit a released claim or free its replacement", () => {
+    const abandoned = claim(sharedInboundContext);
+    abandoned.release();
+    const replacement = claim(sharedInboundContext);
+    abandoned.commit();
+    abandoned.release();
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("inflight");
+    replacement.commit();
+    abandoned.release();
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("duplicate");
+    replacement.release();
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
+  });
+
+  it("does not release a newer commit after the original entry expires", () => {
+    vi.useFakeTimers();
+    const expired = claim(sharedInboundContext);
+    expired.commit();
+    vi.advanceTimersByTime(20 * 60_000);
+    const replacement = claim(sharedInboundContext);
+    replacement.commit();
+    expired.release();
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("duplicate");
+    replacement.release();
+    expect(claimInboundDedupe(sharedInboundContext).status).toBe("claimed");
   });
 });

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -3,7 +3,7 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { resolveGlobalDedupeCache, type DedupeCache } from "../../infra/dedupe.js";
+import { resolveGlobalDedupeCache } from "../../infra/dedupe.js";
 import { channelRouteDedupeKey } from "../../plugin-sdk/channel-route.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
@@ -18,22 +18,20 @@ const DEFAULT_INBOUND_DEDUPE_MAX = 5000;
  * message cannot bypass dedupe by entering through a different chunk copy.
  */
 const INBOUND_DEDUPE_CACHE_KEY = Symbol.for("openclaw.inboundDedupeCache");
-const INBOUND_DEDUPE_INFLIGHT_KEY = Symbol.for("openclaw.inboundDedupeInflight");
+const INBOUND_DEDUPE_INFLIGHT_KEY = Symbol.for("openclaw.inboundDedupeClaims");
 
-const inboundDedupeCache: DedupeCache = resolveGlobalDedupeCache(INBOUND_DEDUPE_CACHE_KEY, {
+const inboundDedupeCache = resolveGlobalDedupeCache(INBOUND_DEDUPE_CACHE_KEY, {
   ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
   maxSize: DEFAULT_INBOUND_DEDUPE_MAX,
 });
 const inboundDedupeInFlight = resolveGlobalSingleton(
   INBOUND_DEDUPE_INFLIGHT_KEY,
-  () => new Set<string>(),
+  () => new Map<string, object>(),
 );
 
 type InboundDedupeClaimResult =
-  | { status: "invalid" }
-  | { status: "duplicate"; key: string }
-  | { status: "inflight"; key: string }
-  | { status: "claimed"; key: string };
+  | { status: "invalid" | "duplicate" | "inflight"; commit?: never; release?: never }
+  | { status: "claimed"; commit: () => void; release: () => void };
 
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
@@ -79,39 +77,36 @@ function buildInboundDedupeKey(ctx: MsgContext): string | null {
   return JSON.stringify([sessionScope, routeKey, messageId]);
 }
 
-export function claimInboundDedupe(
-  ctx: MsgContext,
-  opts?: { cache?: DedupeCache; now?: number; inFlight?: Set<string> },
-): InboundDedupeClaimResult {
+export function claimInboundDedupe(ctx: MsgContext): InboundDedupeClaimResult {
   const key = buildInboundDedupeKey(ctx);
   if (!key) {
     return { status: "invalid" };
   }
-  const cache = opts?.cache ?? inboundDedupeCache;
-  if (cache.peek(key, opts?.now)) {
-    return { status: "duplicate", key };
+  if (inboundDedupeCache.peek(key)) {
+    return { status: "duplicate" };
   }
-  const inFlight = opts?.inFlight ?? inboundDedupeInFlight;
-  if (inFlight.has(key)) {
-    return { status: "inflight", key };
+  if (inboundDedupeInFlight.has(key)) {
+    return { status: "inflight" };
   }
-  inFlight.add(key);
-  return { status: "claimed", key };
-}
-
-export function commitInboundDedupe(
-  key: string,
-  opts?: { cache?: DedupeCache; now?: number; inFlight?: Set<string> },
-): void {
-  const cache = opts?.cache ?? inboundDedupeCache;
-  cache.check(key, opts?.now);
-  const inFlight = opts?.inFlight ?? inboundDedupeInFlight;
-  inFlight.delete(key);
-}
-
-export function releaseInboundDedupe(key: string, opts?: { inFlight?: Set<string> }): void {
-  const inFlight = opts?.inFlight ?? inboundDedupeInFlight;
-  inFlight.delete(key);
+  const owner = {};
+  inboundDedupeInFlight.set(key, owner);
+  return {
+    status: "claimed",
+    commit: () => {
+      // Abandonment can precede dispatch finalization; retired claims cannot recommit.
+      if (inboundDedupeInFlight.get(key) === owner) {
+        inboundDedupeCache.check(key, undefined, owner);
+        inboundDedupeInFlight.delete(key);
+      }
+    },
+    release: () => {
+      if (inboundDedupeInFlight.get(key) === owner) {
+        inboundDedupeInFlight.delete(key);
+      }
+      // Expiry may have admitted a newer attempt; release only this claim's entry.
+      inboundDedupeCache.delete(key, owner);
+    },
+  };
 }
 
 export function resetInboundDedupe(): void {

--- a/src/auto-reply/reply/queue.dedupe.test.ts
+++ b/src/auto-reply/reply/queue.dedupe.test.ts
@@ -419,6 +419,86 @@ describe("followup queue deduplication", () => {
     clearSessionQueues([key]);
   });
 
+  it.each([
+    { storage: "pending", cap: 2, siblings: 1 },
+    { storage: "retained-summary", cap: 1, siblings: 1 },
+    { storage: "elided-summary", cap: 1, siblings: 2 },
+  ])(
+    "releases an aborted $storage source while the reply queue stays dormant",
+    async ({ storage, cap, siblings }) => {
+      const key = `test-dedup-dormant-abort-${storage}`;
+      const controller = new AbortController();
+      const onAbandoned = vi.fn();
+      const onSettled = vi.fn();
+      const runFollowup = vi.fn(async (_run: FollowupRun) => {});
+      const settings: QueueSettings = { ...collectSettings, cap };
+      const first = createRun({
+        prompt: "retry me",
+        messageId: "retry-id",
+        originatingChannel: "discord",
+        originatingTo: "channel:dormant",
+      });
+      first.abortSignal = controller.signal;
+      first.turnAdoptionLifecycle = { onAdopted: () => {}, onAbandoned, onSettled };
+      try {
+        expect(enqueueFollowupRun(key, first, settings, "message-id", runFollowup, false)).toBe(
+          true,
+        );
+        for (let index = 0; index < siblings; index += 1) {
+          expect(
+            enqueueFollowupRun(
+              key,
+              createRun({
+                prompt: `healthy sibling ${index}`,
+                messageId: `healthy-${index}`,
+                originatingChannel: "discord",
+                originatingTo: "channel:dormant",
+              }),
+              settings,
+              "message-id",
+              runFollowup,
+              false,
+            ),
+          ).toBe(true);
+        }
+        const queue = getExistingFollowupQueue(key);
+        const sources =
+          storage === "pending"
+            ? queue?.items
+            : storage === "retained-summary"
+              ? queue?.summarySources
+              : queue?.summaryElisions.flatMap((entry) => entry.sources);
+        expect(
+          sources?.some((run) => run.turnAdoptionLifecycle === first.turnAdoptionLifecycle),
+        ).toBe(true);
+        expect(onAbandoned).not.toHaveBeenCalled();
+        expect(runFollowup).not.toHaveBeenCalled();
+
+        controller.abort(new Error("ingress watchdog released claim"));
+        const retry = createRun({
+          prompt: "retry me",
+          messageId: "retry-id",
+          originatingChannel: "discord",
+          originatingTo: "channel:dormant",
+        });
+        retry.turnAdoptionLifecycle = { onAdopted: () => {} };
+        // No drain, promise join, or owner-clear event may be needed before ingress retries.
+        expect(
+          enqueueFollowupRun(key, retry, collectSettings, "message-id", runFollowup, false),
+        ).toBe(true);
+        expect(onAbandoned).toHaveBeenCalledOnce();
+        expect(onSettled).toHaveBeenCalledOnce();
+        await Promise.resolve();
+        expect(runFollowup.mock.calls.map(([run]) => run.messageId)).toEqual(
+          storage === "pending" ? ["retry-id"] : [],
+        );
+        expect(getExistingFollowupQueue(key)?.draining).toBe(false);
+      } finally {
+        clearSessionQueues([key]);
+      }
+    },
+  );
+
   it("allows re-enqueueing a message evicted by old-item queue overflow", () => {
     const key = `test-dedup-evicted-retry-${Date.now()}`;
     const evictSettings: QueueSettings = { mode: "collect", cap: 1, dropPolicy: "old" };

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1087,7 +1087,7 @@ async function runQueueSummaryDelivery(
 
 export async function dropAbortedFollowups(
   queue: FollowupQueueSummaryState & Pick<FollowupQueueState, "items">,
-  runFollowup?: (run: FollowupRun) => Promise<void>,
+  runFollowup: (run: FollowupRun) => Promise<void>,
 ): Promise<number> {
   const canDrop = (run: FollowupRun) =>
     isFollowupRunAborted(run) && !queue.inFlight.has(run) && !queue.activeSummarySources.has(run);
@@ -1109,7 +1109,7 @@ export async function dropAbortedFollowups(
   await Promise.all(
     pending.map(async (item) => {
       try {
-        await runFollowup?.(item);
+        await runFollowup(item);
       } catch (error) {
         // Aborted work cannot run again; report failed presentation cleanup without restoring it.
         defaultRuntime.error?.(`followup queue cancellation cleanup failed: ${String(error)}`);

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -986,22 +986,6 @@ function releaseQueueSummaryDeliveryForRetry(
   }
 }
 
-function dropAbortedQueueSummarySources(queue: FollowupQueueSummaryState): number {
-  let dropped = 0;
-  for (let index = queue.summarySources.length - 1; index >= 0; index -= 1) {
-    const source = expectDefined(queue.summarySources[index], "summary sources entry at index");
-    if (!isFollowupRunAborted(source)) {
-      continue;
-    }
-    queue.summarySources.splice(index, 1);
-    queue.summaryLines.splice(index, 1);
-    queue.droppedCount = Math.max(0, queue.droppedCount - 1);
-    completeFollowupRunLifecycle(source);
-    dropped += 1;
-  }
-  return dropped;
-}
-
 async function runQueueSummaryDelivery(
   queue: FollowupQueueSummaryState,
   delivery: QueueSummaryDelivery,
@@ -1101,26 +1085,38 @@ async function runQueueSummaryDelivery(
   }
 }
 
-async function dropAbortedFollowups(
-  queue: Pick<FollowupQueueState, "inFlight" | "items">,
-  runFollowup: (run: FollowupRun) => Promise<void>,
+export async function dropAbortedFollowups(
+  queue: FollowupQueueSummaryState & Pick<FollowupQueueState, "items">,
+  runFollowup?: (run: FollowupRun) => Promise<void>,
 ): Promise<number> {
-  let dropped = 0;
-  for (let index = queue.items.length - 1; index >= 0; index -= 1) {
-    const item = expectDefined(queue.items[index], "items entry at index");
-    if (isFollowupRunAborted(item)) {
-      queue.inFlight.add(item);
-      try {
-        await runFollowup(item);
-        completeFollowupRunLifecycle(item);
-        removeQueuedItemsByRef(queue.items, [item]);
-      } finally {
-        queue.inFlight.delete(item);
-      }
-      dropped += 1;
+  const canDrop = (run: FollowupRun) =>
+    isFollowupRunAborted(run) && !queue.inFlight.has(run) && !queue.activeSummarySources.has(run);
+  const pending = queue.items.filter(canDrop);
+  const summaries = [
+    ...queue.summarySources,
+    ...queue.summaryElisions.flatMap((entry) => entry.sources),
+  ].filter(canDrop);
+  // Detach identities and release both dedupe owners before ingress can retry.
+  removeQueuedItemsByRef(queue.items, pending);
+  consumeQueueSummaryDelivery(queue, { sources: summaries, droppedCount: summaries.length }, false);
+  for (const item of [...pending, ...summaries]) {
+    try {
+      completeFollowupRunLifecycle(item);
+    } catch (error) {
+      defaultRuntime.error?.(`followup queue cancellation settlement failed: ${String(error)}`);
     }
   }
-  return dropped;
+  await Promise.all(
+    pending.map(async (item) => {
+      try {
+        await runFollowup?.(item);
+      } catch (error) {
+        // Aborted work cannot run again; report failed presentation cleanup without restoring it.
+        defaultRuntime.error?.(`followup queue cancellation cleanup failed: ${String(error)}`);
+      }
+    }),
+  );
+  return pending.length + summaries.length;
 }
 
 function resolveCrossChannelKey(item: FollowupRun): { cross?: true; key?: string } {
@@ -1343,21 +1339,6 @@ async function drainElidedOverflowSummary(params: {
           (source) => resolveFollowupDeliveryContextKey(source) === entry.contextKey,
         )
       : [];
-  for (let index = entry.sources.length - 1; index >= 0; index -= 1) {
-    const source = expectDefined(entry.sources[index], "sources entry at index");
-    if (!isFollowupRunAborted(source)) {
-      continue;
-    }
-    entry.sources.splice(index, 1);
-    entry.summaryLines.splice(index, 1);
-    entry.count = Math.max(0, entry.count - 1);
-    params.queue.droppedCount = Math.max(0, params.queue.droppedCount - 1);
-    completeFollowupRunLifecycle(source);
-  }
-  if (entry.sources.length === 0) {
-    params.queue.summaryElisions.shift();
-    return true;
-  }
   const source = retainedSources.at(-1) ?? entry.sources.at(-1);
   if (!source) {
     return false;
@@ -1418,10 +1399,13 @@ async function drainElidedOverflowSummary(params: {
 }
 
 async function drainOverflowSummaryGroup(params: {
-  queue: FollowupQueueSummaryState;
+  queue: FollowupQueueState;
   runFollowup: (run: FollowupRun) => Promise<void>;
 }): Promise<boolean> {
-  if (dropAbortedQueueSummarySources(params.queue) > 0 && params.queue.droppedCount === 0) {
+  if (
+    (await dropAbortedFollowups(params.queue, params.runFollowup)) > 0 &&
+    params.queue.droppedCount === 0
+  ) {
     return true;
   }
   if (params.queue.evictedSummaryCount > 0) {

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1089,9 +1089,9 @@ export async function dropAbortedFollowups(
   queue: FollowupQueueSummaryState & Pick<FollowupQueueState, "items">,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): Promise<number> {
-  // Only the injection owner may retire a parked steer before its outcome settles.
+  // Waiting reservations are cancellable; started injections retain custody until their outcome.
   const canDrop = (run: FollowupRun) =>
-    !run.steerPending &&
+    run.steerPending?.phase !== "injecting" &&
     isFollowupRunAborted(run) &&
     !queue.inFlight.has(run) &&
     !queue.activeSummarySources.has(run);

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -1089,8 +1089,12 @@ export async function dropAbortedFollowups(
   queue: FollowupQueueSummaryState & Pick<FollowupQueueState, "items">,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): Promise<number> {
+  // Only the injection owner may retire a parked steer before its outcome settles.
   const canDrop = (run: FollowupRun) =>
-    isFollowupRunAborted(run) && !queue.inFlight.has(run) && !queue.activeSummarySources.has(run);
+    !run.steerPending &&
+    isFollowupRunAborted(run) &&
+    !queue.inFlight.has(run) &&
+    !queue.activeSummarySources.has(run);
   const pending = queue.items.filter(canDrop);
   const summaries = [
     ...queue.summarySources,

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -116,17 +116,18 @@ function appendQueueItem(params: {
   if (params.recentMessageIdKey) {
     recordRecentQueueMessageId(params.run, params.recentMessageIdKey);
   }
-  if (params.runFollowup) {
-    rememberFollowupDrainCallback(params.key, params.runFollowup);
+  const runFollowup = params.runFollowup;
+  if (runFollowup) {
+    rememberFollowupDrainCallback(params.key, runFollowup);
   }
   const signal = params.run.abortSignal;
   const lifecycle = params.run.turnAdoptionLifecycle;
-  if (signal && lifecycle) {
+  if (signal && lifecycle && runFollowup) {
     const onAbort = () => {
       const queue = getExistingFollowupQueue(params.key);
       if (queue) {
         // Cancellation must release pending ownership even while normal draining is dormant.
-        void dropAbortedFollowups(queue, params.runFollowup).catch((error: unknown) => {
+        void dropAbortedFollowups(queue, runFollowup).catch((error: unknown) => {
           defaultRuntime.error?.(`followup queue cancellation failed: ${String(error)}`);
         });
       }

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -1,6 +1,7 @@
 // Enqueues follow-up reply runs and schedules queue drains.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../../channels/chat-type.js";
+import { racePromiseWithAbortSignal } from "../../../infra/abort-signal.js";
 import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
 import { defaultRuntime } from "../../../runtime.js";
@@ -35,6 +36,7 @@ import {
   completeFollowupRunLifecycle,
   isFollowupRunAborted,
   markFollowupRunEnqueued,
+  resolveFollowupAbortSignal,
   type EnqueueFollowupRunOptions,
   type FollowupRun,
   type QueueDedupeMode,
@@ -189,7 +191,7 @@ export function enqueueFollowupRun(
       return false;
     }
     const { promise: acceptance, resolve: settle } = createDeferredCore<boolean>();
-    run.steerPending = { predecessor: queue.steerAcceptanceTail, settle };
+    run.steerPending = { phase: "waiting", predecessor: queue.steerAcceptanceTail, settle };
     queue.steerAcceptanceTail = acceptance;
     appendQueueItem({
       key,
@@ -434,11 +436,25 @@ export function parkSteerCandidate(
   );
   return {
     async admit() {
-      const predecessorAccepted = (await run.steerPending?.predecessor) ?? true;
+      const pending = run.steerPending;
+      const predecessorAccepted = await racePromiseWithAbortSignal(
+        pending?.predecessor ?? Promise.resolve(true),
+        resolveFollowupAbortSignal(run),
+      ).catch((error: unknown) => {
+        if (isFollowupRunAborted(run)) {
+          return false;
+        }
+        throw error;
+      });
       if (isFollowupRunAborted(run) || !isParkedFollowupRunOwned(key, run)) {
         return "cancelled";
       }
-      return predecessorAccepted ? "steer" : "fallback";
+      if (!predecessorAccepted || !pending || run.steerPending !== pending) {
+        return "fallback";
+      }
+      // The injection owner now decides whether this input can safely be replayed.
+      pending.phase = "injecting";
+      return "steer";
     },
     accepted: (accepted) => settleParkedSteerAcceptance(key, run, accepted),
     fallback: () => settleParkedSteerAcceptance(key, run, false),

--- a/src/auto-reply/reply/queue/enqueue.ts
+++ b/src/auto-reply/reply/queue/enqueue.ts
@@ -3,6 +3,7 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { normalizeChatType } from "../../../channels/chat-type.js";
 import { logMessageQueuedWithBacklogPolicy } from "../../../logging/diagnostic-runtime.js";
 import { channelRouteDedupeKey } from "../../../plugin-sdk/channel-route.js";
+import { defaultRuntime } from "../../../runtime.js";
 import { extractTextFromChatContent } from "../../../shared/chat-content.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
 import {
@@ -13,6 +14,7 @@ import {
 import {
   clearFollowupDrainCallback,
   createOverflowSummaryRetrySource,
+  dropAbortedFollowups,
   kickFollowupDrainIfIdle,
   rememberFollowupDrainCallback,
   resolveFollowupDeliveryContextKey,
@@ -116,6 +118,28 @@ function appendQueueItem(params: {
   }
   if (params.runFollowup) {
     rememberFollowupDrainCallback(params.key, params.runFollowup);
+  }
+  const signal = params.run.abortSignal;
+  const lifecycle = params.run.turnAdoptionLifecycle;
+  if (signal && lifecycle) {
+    const onAbort = () => {
+      const queue = getExistingFollowupQueue(params.key);
+      if (queue) {
+        // Cancellation must release pending ownership even while normal draining is dormant.
+        void dropAbortedFollowups(queue, params.runFollowup).catch((error: unknown) => {
+          defaultRuntime.error?.(`followup queue cancellation failed: ${String(error)}`);
+        });
+      }
+    };
+    const onSettled = lifecycle.onSettled;
+    lifecycle.onSettled = () => {
+      signal.removeEventListener("abort", onAbort);
+      onSettled?.();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
   }
   if (params.restartIfIdle && !params.queue.draining) {
     kickFollowupDrainIfIdle(params.key);

--- a/src/auto-reply/reply/queue/recent-message-ids.ts
+++ b/src/auto-reply/reply/queue/recent-message-ids.ts
@@ -1,14 +1,9 @@
 // Recent-queue message-id dedupe shared by enqueue admission and abandonment release.
 import { resolveGlobalDedupeCache } from "../../../infra/dedupe.js";
-import { resolveGlobalSingleton } from "../../../shared/global-singleton.js";
+import type { TurnAdoptionLifecycle } from "../../get-reply-options.types.js";
 
 const RECENT_QUEUE_MESSAGE_ID_TTL_MS = 5 * 60 * 1000;
 const RECENT_QUEUE_MESSAGE_ID_MAX_SIZE = 10_000;
-
-type RecentQueueMessageIdOwnership = {
-  key: string;
-  ownerToken: object;
-};
 
 /**
  * Keep queued message-id dedupe shared across bundled chunks so redeliveries
@@ -22,55 +17,27 @@ const RECENT_QUEUE_MESSAGE_IDS = resolveGlobalDedupeCache(
   },
 );
 
-/** Chunk-shared identity→key association so abandonment can free the entry. */
-const DEDUPE_IDENTITY_OWNERSHIPS = resolveGlobalSingleton(
-  Symbol.for("openclaw.recentQueueMessageIdOwnerships"),
-  () => new WeakMap<object, RecentQueueMessageIdOwnership>(),
-);
-
-type DedupeOwnedRun = { turnAdoptionLifecycle?: object };
-
-/**
- * The adoption lifecycle is the ownership identity that survives run cloning
- * (overflow-summary retry sources copy the lifecycle reference onto a new run
- * object), so it must key the association; completion release fires once per
- * lifecycle. Lifecycle-less runs never release, so keying them by the run
- * object keeps their entries for the full TTL.
- */
-function resolveDedupeIdentity(run: DedupeOwnedRun): object {
-  return run.turnAdoptionLifecycle ?? run;
-}
-
 export function peekRecentQueueMessageId(key: string, now = Date.now()): boolean {
   return RECENT_QUEUE_MESSAGE_IDS.peek(key, now);
 }
 
 export function recordRecentQueueMessageId(
-  run: DedupeOwnedRun,
+  run: { turnAdoptionLifecycle?: TurnAdoptionLifecycle },
   key: string,
   now = Date.now(),
 ): void {
   const ownerToken = {};
-  DEDUPE_IDENTITY_OWNERSHIPS.set(resolveDedupeIdentity(run), { key, ownerToken });
   RECENT_QUEUE_MESSAGE_IDS.delete(key);
   RECENT_QUEUE_MESSAGE_IDS.check(key, now, ownerToken);
-}
-
-/**
- * Frees a dropped run's dedupe identity. A run abandoned before admission makes
- * durable ingress release its claim for retry; that retry must be re-admittable
- * instead of being rejected as a recent duplicate.
- */
-export function releaseRecentQueueMessageId(run: DedupeOwnedRun): void {
-  const identity = resolveDedupeIdentity(run);
-  const ownership = DEDUPE_IDENTITY_OWNERSHIPS.get(identity);
-  if (!ownership) {
-    return;
+  const lifecycle = run.turnAdoptionLifecycle;
+  if (lifecycle) {
+    const onAbandoned = lifecycle.onAbandoned;
+    lifecycle.onAbandoned = () => {
+      // Lifecycle callbacks survive summary cloning. Free only this entry before retry.
+      RECENT_QUEUE_MESSAGE_IDS.delete(key, ownerToken);
+      onAbandoned?.();
+    };
   }
-  DEDUPE_IDENTITY_OWNERSHIPS.delete(identity);
-  // The key may have expired and been re-recorded by a newer same-ID run.
-  // Only the lifecycle that installed the current owner may release it.
-  RECENT_QUEUE_MESSAGE_IDS.delete(ownership.key, ownership.ownerToken);
 }
 
 export function resetRecentQueuedMessageIdDedupe(): void {

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -137,6 +137,7 @@ export type FollowupRun = {
   /** The current-turn hook already ran before this steer became a fallback. */
   /** Pending same-turn acceptance while this item remains parked in FIFO order. */
   steerPending?: {
+    phase: "waiting" | "injecting";
     predecessor: Promise<boolean>;
     settle: (accepted: boolean) => void;
   };

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -44,7 +44,6 @@ import type {
   VerboseLevel,
 } from "../directives.js";
 import type { ReplyOperationRunState } from "../reply-operation-run-state.js";
-import { releaseRecentQueueMessageId } from "./recent-message-ids.js";
 
 export type QueueDropPolicy = "old" | "new" | "summarize";
 
@@ -361,10 +360,6 @@ export function completeFollowupRunLifecycle(
     // non-rejecting promise. onSettled must still run after a synchronous throw.
     try {
       if (disposition !== "consumed" && !admittedTurnAdoptionLifecycles.has(lifecycle)) {
-        // The queue is relinquishing an un-admitted message: free its dedupe
-        // identity so the abandonment-triggered ingress retry can re-enqueue
-        // instead of being rejected as a recent duplicate and falsely completed.
-        releaseRecentQueueMessageId(run);
         lifecycle.onAbandoned?.();
       }
     } finally {


### PR DESCRIPTION
Closes #139341. Supersedes #139394 with contributor credit preserved.

## What Problem This Solves

Fixes an issue where users lose a queued channel message when the ingress watchdog abandons its attempt before agent-turn adoption. The retry could be rejected as a duplicate of the abandoned attempt, and durable ingress recorded completion and purged the payload without delivering the message.

Reported by @Jackten. This builds on @ruel225's diagnosis and lifecycle repair in #139394; thanks also to @obviyus for continued ownership investigation and channel recovery proof on that PR. Both contributors' human credit is preserved in the squash message.

## Why This Change Was Made

Both inbound and queue dedupe now register cleanup with the existing abandonment lifecycle. Inbound claims hold their own commit/release operations, so abandonment prevents late dispatch finalization from recreating the entry. Owner tokens prevent stale cleanup from removing a newer attempt's entry. Adopted, consumed, or otherwise replay-unsafe work remains deduplicated.

Source cancellation retires pending queued identities and their lifecycle synchronously, before asynchronous presentation cleanup. This also covers retained and elided overflow summaries. Normal draining deliberately waits for the active reply owner; cancellation must release abandoned messages while that queue remains dormant. Active/in-flight sources and healthy siblings keep their existing owners. Steering reservations distinguish waiting for a predecessor from injection custody: waiting admission races source cancellation, while a started injection remains with its finalizer until the accepted or uncertain outcome settles.

The repair removes the raw-key inbound mutation APIs, the queue's separate dedupe ownership lookup, and duplicate summary-cancellation paths. It is a maintainer-owned replacement because that refactor rewrites the original implementation; the contributor's human co-author credit is retained.

Production LOC from `git diff --numstat`: **+139 / -150 = -11**. Tests: **+556 / -54 = +502**. Documentation: **+6 / -0**. No configuration, schema, protocol, or dependency changes.

## User Impact

A safely abandoned queued message can be retried and delivered instead of disappearing or waiting behind its retired attempt. Genuine duplicates remain suppressed. Cancelling that message does not start healthy queued work while the active turn is still running.

## Evidence

Candidate: `843b389663e2c0bf0e92e1726d4dc117549f8231`.

- **380 tests across 16 files passed on Testbox**, covering dormant queue retry, late-bound runner cleanup, summary clones, active delivery, waiting steering reservations, accepted/unconfirmed steering outcomes, sibling cancellation, stale owners, and true duplicates.
- On original main `5b099995413589f41904cef1413c62239542aa7c`, all five ingress/readmission regressions failed for the intended reasons; the other 15 tests in those files passed.
- On the earlier candidate `5a9e1023a6e918453d6438da0e92b68cf50fff51`, all three steering regressions failed: waiting cancellation remained blocked, and confirmed/unconfirmed accepted input was abandoned before its outcome settled. The other 16 steering tests passed.
- Committed-branch autoreview: no accepted/actionable P0 or P1 findings. ClawSweeper's review of this head reported no remaining before-merge items.
- **Exact-head CI passed**: [run #34015487469](https://github.com/openclaw/openclaw/actions/runs/34015487469). Unrelated main fixture failures were repaired separately in #139747 and #139794 before this run.
- **Built-Gateway before/after proof passed** on Blacksmith Testbox lease `tbx_01m1tn3570aej9f8jtzhn41f80`: [run #34015564196](https://github.com/openclaw/openclaw/actions/runs/34015564196).

Both revisions used isolated synthetic state, a normal webchat `chat.send` blocker, a mock Slack Events/Web API server, and a mock OpenAI provider. A task-only preload invoked the original ingress-watchdog callback after the target's queued dispatch committed. Product source and timeout configuration were unchanged. Remote `node scripts/check-changed.mjs` passed, the full command exited 0 with `PROOF_COMPLETED`, and the final source binding matched the candidate. The lease was stopped successfully (`stopped (completed)`). The provider portal summary sync timed out after the successful proof; it did not affect command execution or lease cleanup.

Observed terminal trace (condensed):

```text
baseline: queued input -> watchdog release -> retry claimed while queue dormant
baseline: blocker released -> skipped:duplicate -> completed, payload_json="null"
baseline: target transcript entries=0, Slack deliveries=0
candidate: queued input -> watchdog release -> retry dispatched while blocker still held
candidate: blocker released -> target transcript entries=1 -> Slack deliveries=1
candidate: outbound receipt=sent, result_count=1; duplicate adds no model request or delivery
```

Verdict JSON:

```json
{
  "verdict": "PASS",
  "provider": "blacksmith-testbox",
  "leaseId": "tbx_01m1tn3570aej9f8jtzhn41f80",
  "baseline": {
    "sha": "5b099995413589f41904cef1413c62239542aa7c",
    "regressionsFailed": 5,
    "ingressStatus": "completed",
    "payload": "null",
    "inboundOutcome": "skipped:duplicate",
    "targetTranscriptEntries": 0,
    "deliveries": 0
  },
  "steeringBefore": {
    "sha": "5a9e1023a6e918453d6438da0e92b68cf50fff51",
    "regressionsFailed": 3
  },
  "candidate": {
    "sha": "843b389663e2c0bf0e92e1726d4dc117549f8231",
    "testsPassed": 380,
    "retryDispatchedWhileBlockerHeld": true,
    "ingressStatus": "completed",
    "attempts": 1,
    "targetTranscriptEntries": 1,
    "assistantTranscriptEntries": 1,
    "outboundOutcome": "sent",
    "outboundResultCount": 1,
    "deliveries": 1,
    "duplicateExtraModelRequests": 0,
    "duplicateExtraDeliveries": 0
  }
}
```

`completed` is the existing ingress adoption receipt; delivery is independently verified by the mock Slack API acceptance and outbound `sent` receipt. Live duplicate suppression includes the Slack transport boundary; focused regression also verifies core `skipped:duplicate`. External Slack/OpenAI services were not used.

ClawSweeper rank-up work is complete: the trace proves retry dispatch while the webchat blocker is still held, without manually draining the queue; the steering tests preserve injection custody across delayed outcomes and sibling sweeps.
