### PR TITLE
chore(deps): register Koffi dependency ownership

### DIFF
--- a/scripts/lib/dependency-ownership.json
+++ b/scripts/lib/dependency-ownership.json
@@ -189,6 +189,11 @@
       "class": "core-runtime",
       "risk": ["archive-parser", "untrusted-files"]
     },
+    "koffi": {
+      "owner": "core:process-execution",
+      "class": "core-runtime",
+      "risk": ["native", "ffi", "process-execution", "secret-input"]
+    },
     "kysely": {
       "owner": "core:sqlite-storage",
       "class": "core-runtime",


### PR DESCRIPTION
## What Problem This Solves

The root runtime dependency ownership metadata was missing an entry for `koffi`, even though `koffi` is used by core process-execution code for native FFI paths.

## Why This Change Was Made

This adds the missing ownership metadata record only. It does not change package pins, lockfile data, runtime source, tests, generated artifacts, or build output.

## User Impact

No user-visible behavior changes. Maintainers get accurate dependency ownership and install-surface reporting for the core native process-execution paths that use `koffi`.

## Evidence

- Current public `main` still lacked the `koffi` ownership record before publication.
- Current public `main` already pins `koffi@3.1.6` in `package.json` and `pnpm-lock.yaml`.
- Patch scope: +5/-0 in `scripts/lib/dependency-ownership.json`.
- Patch SHA: `baabd7e5c9bc95d00d59a2cb03b59055b8cb0f096701f6857fca26712b2a4881`.
- Source inspection showed `koffi` imports under `src/process`, matching `owner=core:process-execution`, `class=core-runtime`, and risks `native`, `ffi`, `process-execution`, `secret-input`.
- `node --import ./scripts/tsx.mjs scripts/root-dependency-ownership-audit.mts --check`
- `node --import ./scripts/tsx.mjs scripts/dependency-ownership-surface-report.mts --check`
- `git diff --check`
- No build was run because this is a single metadata JSON record and does not touch package manifests, lockfiles, runtime code, tests, generated outputs, or published API.
