### PR TITLE
improve: parse repeated log context once

### DIFF
--- a/src/logging/parse-log-line.ts
+++ b/src/logging/parse-log-line.ts
@@ -49,6 +49,9 @@ function resolveContext(
   meta: Record<string, unknown> | undefined,
 ): LogContext {
   const metadataContext = parseMetaName(meta?.name);
+  if (meta?.name === value["0"]) {
+    return metadataContext;
+  }
   const positionalContext = parseMetaName(value["0"]);
   return {
     subsystem: metadataContext.subsystem ?? positionalContext.subsystem,


### PR DESCRIPTION
## What Problem This Solves

Structured log inspection repeats context parsing when a record carries the same subsystem metadata in both its logger name and positional message fields. That adds avoidable work when displaying or filtering batches of logs.

## Why This Change Was Made

Reuse the first parsed context when the two raw values are identical. Different values retain the existing per-field subsystem/module/plugin fallback. The public result still includes the same explicit fields, including undefined values; log text, filtering, redaction, and persistence are unchanged. Production change: +3 lines, with no cache, dependency, or public API addition.

## User Impact

Log records with repeated JSON context take less parsing work without changing their displayed content. Whole-parser median latency improved 12.65–22.22% for the four valid repeated-context workloads in both measurement orders. This is not a universal or whole-Gateway speedup: different plain strings were 12.99–14.54% slower (+42–47 ns), and some other control cases also regressed.

## Evidence

- Existing parser, log-tail/redaction, and UI log-data suites: 34/34 tests across four complete files; normal wrapper exit 0 in 4.231 seconds.
- Normal managed P2 review: exit 0, scoped-clean, with no accepted/actionable findings.
- Fixed B0/C0/C1/B1 fresh-process measurement on the same Node version and source base: 17 workloads, eight 2,000-call batches per workload, and 1,088,000 timed outputs checked against independent exact expected objects. All four processes exited 0.
- Representative repeated-subsystem medians: 695.47 → 573.23 ns and 666.48 → 582.17 ns. Repeated complete context improved 17.75% in both orders; the longer repeated context improved 22.22% / 19.97%.
- All adverse results are retained: 11/34 median comparisons, 12/34 maximum batch-mean comparisons, and 83/272 same-index batch comparisons. Different structured precedence medians regressed 3.09% / 2.67%; positional-only medians regressed 3.99% / 1.38%. Batch maxima are not population tail latency. No allocation, startup, provider, or whole-Gateway gain is claimed.
- After refreshing the unchanged parser patch to `5b099995413589f41904cef1413c62239542aa7c`, the normal changed-file gate passed all 28 selected checks in 650.058 seconds, including both core typecheck lanes, all three dead-export scans, and import-cycle validation. The prior services shard blocker (721 > 720) was repaired separately by #139645; no check was skipped or relaxed here. The earlier timing and focused-test results remain attributed to their original source base.
