### PR TITLE
improve(cli): reduce memory used to shorten long labels

### DIFF
--- a/src/commands/text-format.test.ts
+++ b/src/commands/text-format.test.ts
@@ -3,21 +3,20 @@ import { describe, expect, it } from "vitest";
 import { formatTextCell, shortenText } from "./text-format.js";
 
 describe("shortenText", () => {
-  it("returns original text when it fits", () => {
-    expect(shortenText("openclaw", 16)).toBe("openclaw");
-  });
-
-  it("truncates and appends ellipsis when over limit", () => {
-    expect(shortenText("openclaw-status-output", 10)).toBe("openclaw-…");
-  });
-
-  it("returns an empty string for non-positive limits", () => {
-    expect(shortenText("openclaw", 0)).toBe("");
-    expect(shortenText("openclaw", -1)).toBe("");
-  });
-
-  it("counts multi-byte characters correctly", () => {
-    expect(shortenText("hello🙂world", 7)).toBe("hello🙂…");
+  it.each([
+    ["", 1, ""],
+    ["openclaw", 16, "openclaw"],
+    ["openclaw-status-output", 10, "openclaw-…"],
+    ["openclaw", 0, ""],
+    ["openclaw", -1, ""],
+    ["hello🙂world", 7, "hello🙂…"],
+    ["🙂🙂🙂", 3, "🙂🙂🙂"],
+    ["🙂🙂🙂🙂", 3, "🙂🙂…"],
+    ["a🙂🙂🙂🙂", 3, "a🙂…"],
+    ["🙂x", 1, "…"],
+    ["e\u0301x", 2, "e…"],
+  ])("shortens %j to %i code points", (input, maxLen, expected) => {
+    expect(shortenText(input, maxLen)).toBe(expected);
   });
 });
 

--- a/src/commands/text-format.ts
+++ b/src/commands/text-format.ts
@@ -8,7 +8,11 @@ export const shortenText = (value: string, maxLen: number) => {
   if (maxLen <= 0) {
     return "";
   }
-  const chars = Array.from(value);
+  if (value.length <= maxLen) {
+    return value;
+  }
+  // Include an overflow code point; each point occupies at most two UTF-16 units.
+  const chars = Array.from(value.slice(0, (maxLen + 1) * 2));
   return chars.length <= maxLen ? value : `${chars.slice(0, Math.max(0, maxLen - 1)).join("")}…`;
 };
 


### PR DESCRIPTION
## What Problem This Solves

Long message values and status labels created a character array for the entire input even when the CLI displayed only a short prefix.

## Why This Change Was Made

Skip conversion when the input already fits, and otherwise inspect only a prefix large enough to determine code-point overflow. Preserve the existing Unicode and ellipsis behavior.

## User Impact

CLI message and status formatting uses less temporary memory when shortening long values. Displayed text is unchanged.

## Evidence

The four focused formatting suites passed (75 tests); after adding one Unicode cutoff case, the final owner suite passed all 17 tests. Independent source review and isolated autoreview found no actionable issue.

A synthetic probe of the exported helper compared 91 output cases with the original implementation. Three allocation-profiler samples on Node 26.8.1 used a 250,000-character ASCII value, limit 96, and 100 calls per sample: median sampled allocations fell from 200.17 MB to 0.37 MB. This measures allocation during that synthetic workload, not Gateway retained heap or RSS.

Full changed checks passed after incorporating the existing main branch shard rebalance. The rebased patch is byte-identical to the reviewed change.
