### PR TITLE
test(gateway): share worker session tool fixtures

### DIFF
--- a/src/gateway/worker-environments/worker-session-tool-executor.send.test.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.send.test.ts
@@ -1,115 +1,26 @@
+// Register the shared tool mocks before any runtime dependency is evaluated.
+import "./worker-session-tool-executor.test-support.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DecisionReceiptV1 } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { configureRuntimeActionDecisionSink } from "../../audit/runtime-action-decision.js";
-import type { SessionEntry } from "../../config/sessions.js";
 import { releaseAgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
 import {
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
-import {
+const {
+  workerSessionToolTestMocks,
   SOURCE,
   TARGET,
   PARENT,
   PARENT_EXECUTION_IDENTITY_TOKEN,
   installWorkerSessionToolTestFixture,
-} from "./worker-session-tool-executor.test-support.js";
+} = await import("./worker-session-tool-executor.test-support.js");
 
-const sessionEntries = vi.hoisted(() => new Map<string, SessionEntry>());
-const delivered = vi.hoisted(() => vi.fn());
-const gatewayRequest = vi.hoisted(() => vi.fn());
-const gatewayCreate = vi.hoisted(() => vi.fn());
-const gatewayRuntimeIdentity = vi.hoisted(() => vi.fn());
-const dispatchChild = vi.hoisted(() => vi.fn());
-const spawnCallerIdentity = vi.hoisted(() => vi.fn());
-const spawnArgs = vi.hoisted(() => vi.fn());
-const scopedSessionAccess = vi.hoisted(() =>
-  vi.fn(async (params: { run: () => Promise<unknown> }) => await params.run()),
-);
-
-vi.mock("../session-utils.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../session-utils.js")>();
-  return {
-    ...actual,
-    loadGatewaySessionEntryReadOnly: (sessionKey: string) => ({
-      agentId: parseAgentSessionKey(sessionKey)?.agentId,
-      canonicalKey: sessionKey,
-      entry: structuredClone(sessionEntries.get(sessionKey)),
-    }),
-  };
-});
-
-vi.mock("../../agents/tools/sessions-send-tool.js", () => ({
-  createSessionsSendTool: (options: unknown) => ({
-    execute: async (toolCallId: string, args: unknown) => {
-      await delivered({ args, options, toolCallId });
-      return {
-        content: [{ type: "text", text: "sent" }],
-        details: { status: "ok" },
-      };
-    },
-  }),
-}));
-
-vi.mock("../../agents/tools/sessions-spawn-tool.js", async () => {
-  const { getGatewayToolCallerIdentity } =
-    await import("../../agents/tools/gateway-caller-context.js");
-  return {
-    createSessionsSpawnTool: (options: {
-      agentSessionKey: string;
-      callGateway: (method: string, params: Record<string, unknown>) => Promise<unknown>;
-    }) => ({
-      execute: async (_toolCallId: string, args: { task: string; worktree?: boolean }) => {
-        spawnCallerIdentity(getGatewayToolCallerIdentity());
-        spawnArgs(args);
-        const details = await options.callGateway("sessions.create", {
-          parentSessionKey: options.agentSessionKey,
-          task: args.task,
-          ...(args.worktree ? { worktree: true } : {}),
-        });
-        return {
-          content: [{ type: "text", text: "spawned" }],
-          details,
-        };
-      },
-    }),
-  };
-});
-
-vi.mock("../../agents/tools/scoped-session-access.js", () => ({
-  runWithScopedSessionAccess: (params: unknown) => scopedSessionAccess(params as never),
-}));
-
-vi.mock("../../agents/tools/in-process-gateway.js", () => ({
-  callAgentToolGatewayRequest: (request: unknown) => gatewayRequest(request),
-  callInProcessGatewayTool: (method: string, params: Record<string, unknown>) =>
-    gatewayRequest({ method, params }),
-  callInProcessGatewayToolWithCreation: (
-    method: string,
-    params: Record<string, unknown>,
-    creation: unknown,
-    options: unknown,
-  ) => gatewayCreate({ creation, method, options, params }),
-  withAgentToolGatewayRuntimeIdentity: (request: unknown, identity: unknown) => {
-    gatewayRuntimeIdentity(request, identity);
-    return request;
-  },
-}));
-
-const fixtureMocks = {
-  sessionEntries,
-  delivered,
-  gatewayRequest,
-  gatewayCreate,
-  gatewayRuntimeIdentity,
-  dispatchChild,
-  spawnCallerIdentity,
-  spawnArgs,
-  scopedSessionAccess,
-};
+const fixtureMocks = workerSessionToolTestMocks();
+const { sessionEntries, delivered, gatewayRequest, scopedSessionAccess } = fixtureMocks;
 
 describe("worker session tool send delivery", () => {
   const getFixture = installWorkerSessionToolTestFixture(fixtureMocks);

--- a/src/gateway/worker-environments/worker-session-tool-executor.test-support.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.test-support.ts
@@ -11,6 +11,7 @@ import {
   type AgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
 import { tryBeginGatewayRootWorkAdmission } from "../../process/gateway-work-admission.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -19,6 +20,91 @@ import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import { createWorkerSessionPlacementStore } from "./placement-store.js";
 import { bindWorkerTurnOwner } from "./placement-turn-claim-events.js";
 import { createWorkerSessionToolExecutor } from "./worker-session-tool-executor.js";
+
+const sharedMocks = vi.hoisted(() => ({
+  sessionEntries: new Map<string, SessionEntry>(),
+  delivered: vi.fn(),
+  gatewayRequest: vi.fn(),
+  gatewayCreate: vi.fn(),
+  gatewayRuntimeIdentity: vi.fn(),
+  dispatchChild: vi.fn(),
+  spawnCallerIdentity: vi.fn(),
+  spawnArgs: vi.fn(),
+  scopedSessionAccess: vi.fn(async (params: { run: () => Promise<unknown> }) => await params.run()),
+}));
+
+export function workerSessionToolTestMocks() {
+  return sharedMocks;
+}
+
+vi.mock("../session-utils.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../session-utils.js")>();
+  return {
+    ...actual,
+    loadGatewaySessionEntryReadOnly: (sessionKey: string) => ({
+      agentId: parseAgentSessionKey(sessionKey)?.agentId,
+      canonicalKey: sessionKey,
+      entry: structuredClone(sharedMocks.sessionEntries.get(sessionKey)),
+    }),
+  };
+});
+
+vi.mock("../../agents/tools/sessions-send-tool.js", () => ({
+  createSessionsSendTool: (options: unknown) => ({
+    execute: async (toolCallId: string, args: unknown) => {
+      await sharedMocks.delivered({ args, options, toolCallId });
+      return {
+        content: [{ type: "text", text: "sent" }],
+        details: { status: "ok" },
+      };
+    },
+  }),
+}));
+
+vi.mock("../../agents/tools/sessions-spawn-tool.js", async () => {
+  const { getGatewayToolCallerIdentity } =
+    await import("../../agents/tools/gateway-caller-context.js");
+  return {
+    createSessionsSpawnTool: (options: {
+      agentSessionKey: string;
+      callGateway: (method: string, params: Record<string, unknown>) => Promise<unknown>;
+    }) => ({
+      execute: async (_toolCallId: string, args: { task: string; worktree?: boolean }) => {
+        sharedMocks.spawnCallerIdentity(getGatewayToolCallerIdentity());
+        sharedMocks.spawnArgs(args);
+        const details = await options.callGateway("sessions.create", {
+          parentSessionKey: options.agentSessionKey,
+          task: args.task,
+          ...(args.worktree ? { worktree: true } : {}),
+        });
+        return {
+          content: [{ type: "text", text: "spawned" }],
+          details,
+        };
+      },
+    }),
+  };
+});
+
+vi.mock("../../agents/tools/scoped-session-access.js", () => ({
+  runWithScopedSessionAccess: (params: unknown) => sharedMocks.scopedSessionAccess(params as never),
+}));
+
+vi.mock("../../agents/tools/in-process-gateway.js", () => ({
+  callAgentToolGatewayRequest: (request: unknown) => sharedMocks.gatewayRequest(request),
+  callInProcessGatewayTool: (method: string, params: Record<string, unknown>) =>
+    sharedMocks.gatewayRequest({ method, params }),
+  callInProcessGatewayToolWithCreation: (
+    method: string,
+    params: Record<string, unknown>,
+    creation: unknown,
+    options: unknown,
+  ) => sharedMocks.gatewayCreate({ creation, method, options, params }),
+  withAgentToolGatewayRuntimeIdentity: (request: unknown, identity: unknown) => {
+    sharedMocks.gatewayRuntimeIdentity(request, identity);
+    return request;
+  },
+}));
 
 export const SOURCE = {
   agentId: "main",
@@ -151,7 +237,9 @@ async function createWorkerSessionToolTestFixture(
   dispatchChild.mockReset();
   spawnCallerIdentity.mockReset();
   spawnArgs.mockReset();
-  scopedSessionAccess.mockClear();
+  // Shared mocks must discard unused once overrides before the next fixture starts.
+  scopedSessionAccess.mockReset();
+  scopedSessionAccess.mockImplementation(async (params) => await params.run());
   const spawnState: { childSessionKey: string | undefined; order: string[] } = {
     childSessionKey: undefined,
     order: [],

--- a/src/gateway/worker-environments/worker-session-tool-executor.test.ts
+++ b/src/gateway/worker-environments/worker-session-tool-executor.test.ts
@@ -1,10 +1,11 @@
+// Register the shared tool mocks before any runtime dependency is evaluated.
+import "./worker-session-tool-executor.test-support.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DecisionReceiptV1 } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { createOperationalRunInstanceRef } from "../../agents/admitted-run-context.js";
 import type { ExecutionIdentityAdmissionToken } from "../../audit/execution-identity-admission.js";
 import { configureRuntimeActionDecisionSink } from "../../audit/runtime-action-decision.js";
-import type { SessionEntry } from "../../config/sessions.js";
 import { claimAgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
 import {
   initializeGlobalHookRunner,
@@ -12,103 +13,23 @@ import {
 } from "../../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../../plugins/hooks.test-helpers.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
-import { parseAgentSessionKey } from "../../routing/session-key.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { readAgentRuntimeExecutionLineage } from "../agent-runtime-execution-lineage.js";
 import type { WorkerConnectionIdentity } from "./connection-identity.js";
 import { bindWorkerTurnOwner } from "./placement-turn-claim-events.js";
 import * as environmentServiceModule from "./service.js";
-import {
+const {
+  workerSessionToolTestMocks,
   SOURCE,
   CHILD,
   GRANDCHILD,
   PARENT_EXECUTION_IDENTITY_TOKEN,
   resolveGatewayContext,
   installWorkerSessionToolTestFixture,
-} from "./worker-session-tool-executor.test-support.js";
+} = await import("./worker-session-tool-executor.test-support.js");
 
-const sessionEntries = vi.hoisted(() => new Map<string, SessionEntry>());
-const delivered = vi.hoisted(() => vi.fn());
-const gatewayRequest = vi.hoisted(() => vi.fn());
-const gatewayCreate = vi.hoisted(() => vi.fn());
-const gatewayRuntimeIdentity = vi.hoisted(() => vi.fn());
-const dispatchChild = vi.hoisted(() => vi.fn());
-const spawnCallerIdentity = vi.hoisted(() => vi.fn());
-const spawnArgs = vi.hoisted(() => vi.fn());
-const scopedSessionAccess = vi.hoisted(() =>
-  vi.fn(async (params: { run: () => Promise<unknown> }) => await params.run()),
-);
-
-vi.mock("../session-utils.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../session-utils.js")>();
-  return {
-    ...actual,
-    loadGatewaySessionEntryReadOnly: (sessionKey: string) => ({
-      agentId: parseAgentSessionKey(sessionKey)?.agentId,
-      canonicalKey: sessionKey,
-      entry: structuredClone(sessionEntries.get(sessionKey)),
-    }),
-  };
-});
-
-vi.mock("../../agents/tools/sessions-send-tool.js", () => ({
-  createSessionsSendTool: (options: unknown) => ({
-    execute: async (toolCallId: string, args: unknown) => {
-      await delivered({ args, options, toolCallId });
-      return {
-        content: [{ type: "text", text: "sent" }],
-        details: { status: "ok" },
-      };
-    },
-  }),
-}));
-
-vi.mock("../../agents/tools/sessions-spawn-tool.js", async () => {
-  const { getGatewayToolCallerIdentity } =
-    await import("../../agents/tools/gateway-caller-context.js");
-  return {
-    createSessionsSpawnTool: (options: {
-      agentSessionKey: string;
-      callGateway: (method: string, params: Record<string, unknown>) => Promise<unknown>;
-    }) => ({
-      execute: async (_toolCallId: string, args: { task: string; worktree?: boolean }) => {
-        spawnCallerIdentity(getGatewayToolCallerIdentity());
-        spawnArgs(args);
-        const details = await options.callGateway("sessions.create", {
-          parentSessionKey: options.agentSessionKey,
-          task: args.task,
-          ...(args.worktree ? { worktree: true } : {}),
-        });
-        return {
-          content: [{ type: "text", text: "spawned" }],
-          details,
-        };
-      },
-    }),
-  };
-});
-
-vi.mock("../../agents/tools/scoped-session-access.js", () => ({
-  runWithScopedSessionAccess: (params: unknown) => scopedSessionAccess(params as never),
-}));
-
-vi.mock("../../agents/tools/in-process-gateway.js", () => ({
-  callAgentToolGatewayRequest: (request: unknown) => gatewayRequest(request),
-  callInProcessGatewayTool: (method: string, params: Record<string, unknown>) =>
-    gatewayRequest({ method, params }),
-  callInProcessGatewayToolWithCreation: (
-    method: string,
-    params: Record<string, unknown>,
-    creation: unknown,
-    options: unknown,
-  ) => gatewayCreate({ creation, method, options, params }),
-  withAgentToolGatewayRuntimeIdentity: (request: unknown, identity: unknown) => {
-    gatewayRuntimeIdentity(request, identity);
-    return request;
-  },
-}));
-
-const fixtureMocks = {
+const fixtureMocks = workerSessionToolTestMocks();
+const {
   sessionEntries,
   delivered,
   gatewayRequest,
@@ -117,8 +38,7 @@ const fixtureMocks = {
   dispatchChild,
   spawnCallerIdentity,
   spawnArgs,
-  scopedSessionAccess,
-};
+} = fixtureMocks;
 
 describe("worker session tool topology", () => {
   const getFixture = installWorkerSessionToolTestFixture(fixtureMocks);


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Worker-session tool suites duplicate their mock registration and state, making setup and cleanup ownership harder to maintain.

## Why This Change Was Made

Move the repeated mock factories into the existing fixture owner. Register that owner before runtime imports, then retrieve its cached exports. Each fixture resets shared mocks and clears unused one-shot overrides while preserving real SQLite placements, delegated authority and disposal.

## User Impact

No production behavior changes. All 40 cases and five installer callsites remain unchanged. Net 81 test/support lines removed; the shared fixture has only the two test consumers.

## Evidence

Both suites pass all 40 cases before and after, including grouped nonisolated execution with shuffled ordering. Test bodies are byte-identical. A temporary unused one-shot override passes with the reset and causes two intended failures when reset is changed back to clear-only; instrumentation was removed.

The first gate found duplicate static imports. The final import structure passes targeted lint, the complete changed gate and fresh P2 review without suppressions. Formatting/diff checks and deslop pass. No runtime improvement is claimed.
