### PR TITLE
fix: keep session startup repairs responsive

### DIFF
--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as sessionDirs from "../../agents/session-dirs.js";
+import * as nodeSqlite from "../../infra/node-sqlite.js";
 import { invalidateRegisteredAgentDatabasesMemo } from "../../state/openclaw-agent-db-registry-listing.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
@@ -223,3 +224,65 @@ it("keeps copied state directories self-contained for combined gateway reads", a
     invalidateRegisteredAgentDatabasesMemo({ env });
   });
 });
+
+it.each(["registry", "main-key"] as const)(
+  "keeps the event loop responsive while repairing a cold %s startup contract",
+  async (repair) => {
+    const stateDir = fs.realpathSync.native(tempDirs.make("openclaw-startup-admission-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const options = { agentId: "main", env };
+    const cfg: OpenClawConfig = {
+      agents: { entries: { main: {} } },
+      session: {},
+    };
+    const initial = openOpenClawAgentDatabase(options);
+    setCanonicalSqliteSessionMainKey(initial, repair === "main-key" ? "previous" : "main");
+    closeOpenClawAgentDatabasesForTest();
+    if (repair === "registry") {
+      unregisterOpenClawAgentDatabase({ ...options, path: initial.path });
+    }
+    const originalOpen = nodeSqlite.openNodeSqliteDatabase;
+    let yielded = false;
+    let maintenanceSawProgress = false;
+    let maintenanceSawSelectedKey = false;
+    let tick: ReturnType<typeof setImmediate> | undefined;
+    const open = vi
+      .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+      .mockImplementation((location, behavior) => {
+        const database = originalOpen(location, behavior);
+        if (location === initial.path && behavior?.readOnly !== true) {
+          // Earlier async setup cannot satisfy this admission-phase progress check.
+          tick = setImmediate(() => {
+            yielded = true;
+            cfg.session!.mainKey = "later";
+          });
+        }
+        return database;
+      });
+    const log = { info: vi.fn(), warn: vi.fn() };
+    try {
+      await runSessionStartupMigration({
+        cfg,
+        env,
+        log,
+        deps: {
+          migrateManagedWorktreeCanonicalWorkspaces: async () => {
+            maintenanceSawProgress = yielded;
+            maintenanceSawSelectedKey = isCanonicalSqliteSessionMainKeyCurrent(options, undefined);
+            return 0;
+          },
+        },
+      });
+      expect(log.warn).not.toHaveBeenCalled();
+      expect(maintenanceSawProgress).toBe(true);
+      expect(maintenanceSawSelectedKey).toBe(true);
+      expect(listOpenClawRegisteredAgentDatabases({ env })).toContainEqual(
+        expect.objectContaining({ agentId: "main", path: initial.path }),
+      );
+      expect(isOpenClawAgentDatabaseOpen(initial.path)).toBe(false);
+    } finally {
+      if (tick) clearImmediate(tick);
+      open.mockRestore();
+    }
+  },
+);

--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -281,7 +281,9 @@ it.each(["registry", "main-key"] as const)(
       );
       expect(isOpenClawAgentDatabaseOpen(initial.path)).toBe(false);
     } finally {
-      if (tick) clearImmediate(tick);
+      if (tick) {
+        clearImmediate(tick);
+      }
       open.mockRestore();
     }
   },

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -5,7 +5,7 @@ import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent
 import {
   closeOpenClawAgentDatabaseByPath,
   isOpenClawAgentDatabaseOpen,
-  openOpenClawAgentDatabase,
+  withOpenClawAgentDatabaseAsync,
   resolveOpenClawAgentSqlitePath,
   type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
@@ -96,12 +96,14 @@ export async function runSessionStartupMigration(params: {
     let handedOff = false;
     try {
       try {
+        const mainKey = params.cfg.session?.mainKey;
         if (
           !registeredDatabases.has(`${options.agentId}\0${databasePath}`) ||
-          !isCanonicalSqliteSessionMainKeyCurrent(options, params.cfg.session?.mainKey)
+          !isCanonicalSqliteSessionMainKeyCurrent(options, mainKey)
         ) {
-          const database = openOpenClawAgentDatabase(options);
-          setCanonicalSqliteSessionMainKey(database, params.cfg.session?.mainKey);
+          await withOpenClawAgentDatabaseAsync(options, (database) =>
+            setCanonicalSqliteSessionMainKey(database, mainKey),
+          );
         }
         // Workspace metadata participates in claim matching. Preserve it during a
         // partial move so the next attempt can finish removing the source claim.


### PR DESCRIPTION
## What Problem This Solves

Gateway startup blocked the event loop while restoring a missing agent database registration or updating its canonical main-key record. These conditional repairs opened the database synchronously before transcript reconciliation could use asynchronous admission.

Related: #138888.

## Why This Change Was Made

Reuse the existing asynchronous database admission owner for that operation. Capture the chosen main key before awaiting the integrity Worker, then update it on the admitted connection. Maintenance ordering, warning behavior, runtime handoff, and cold/preexisting connection cleanup stay intact. No schema, configuration, integrity policy, or stored representation changes.

## User Impact

These startup repairs can process event-loop work while SQLite validates a large agent database. Validation still completes before the repaired connection is used. This does not remove the validation cost, claim a total startup-time improvement, or move all CLI maintenance off the main thread.

The separate legacy worktree metadata repair/query path remains a follow-up.

## Evidence

- **Native baseline:** unchanged production code on Linux/Node 26.7, with 500,000 synthetic cache rows (764 MB). Missing-registration and main-key repairs scanned on the main thread for 541–552 ms with zero parent timer ticks. The unchanged-state control used a Worker. Rows, registration, key, and lease cleanup were preserved.
- **Candidate native:** both repair cases now used Workers, allowing 53–54 parent timer ticks during 537–539 ms native scans. The unchanged-state control also passed. All three original-order scenarios preserved state and released their leases.
- **Built candidate, normal CLI:** `openclaw gateway run` reached readiness, authenticated `chat.history` returned the expected active branch, all four raw transcript rows and 500,000 cache rows remained unchanged, and SIGTERM exited 0 with zero leases. An independent read-only probe witnessed the old main key inside the runtime Worker scan: 525.8 ms, 52 parent ticks, maximum observed tick gap 10.1 ms. The identified pre-runtime CLI maintenance scan remained a measured negative control (577.7 ms, zero ticks); no unclassified scans were accepted.
- **Checks:** 171 tests passed across seven scoped files (six existing platform/volume cases skipped), including both new regression cases, lifecycle/lease siblings, worktree migration, and Gateway handoff/error paths. The new cases fail on the original code. Node 26.7 build passed. Independent Codex review found no actionable P0–P2 issues. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34009405254) is green.

The [Testbox proof command](https://github.com/openclaw/openclaw/actions/runs/34012481926) completed with exit 0 on the exact `b6b3370` source tree; its lease was stopped after evidence collection. The build and runtime proof ran in one invocation with complete source/build hashes and the original build commit retained. Earlier compiled-baseline attempts failed or remained unrun before qualifying the user path; they are not used for any paired compiled timing claim. The accepted comparison is the native baseline plus the compiled candidate behavior above.
