### PR TITLE
improve: avoid unnecessary plugin command matching

### DIFF
--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -633,6 +633,28 @@ describe("registerPluginCommand", () => {
     });
   });
 
+  it.each(["active_memory", "active-memory"])(
+    "prefers exact spelling %s even when its command rejects arguments",
+    (name) => {
+      const alternate = name.replace(/[_-]/g, name.includes("_") ? "-" : "_");
+      for (const [commandName, acceptsArgs] of [
+        [alternate, true],
+        [name, false],
+      ] as const) {
+        expect(
+          registerPluginCommand(commandName, {
+            name: commandName,
+            description: "Exact spelling selection",
+            acceptsArgs,
+            handler: async () => ({ text: "ok" }),
+          }),
+        ).toEqual({ ok: true });
+      }
+      expect(matchPluginCommand(`/${name}`)?.command.name).toBe(name);
+      expect(matchPluginCommand(`/${name} status`)).toBeNull();
+    },
+  );
+
   it("matches plugin slash commands when users insert whitespace after the slash", () => {
     registerPluginCommand("device-pair", {
       name: "pair",

--- a/src/plugins/plugin-command-matcher.ts
+++ b/src/plugins/plugin-command-matcher.ts
@@ -56,17 +56,16 @@ export function matchRegisteredPluginCommand(params: {
     return null;
   }
   const { keys, args } = invocation;
-  const command = keys
-    .map((candidateKey) =>
-      params.commands.find(
-        (candidate) =>
-          pluginCommandSupportsChannel(candidate, params.channel) &&
-          listInvocationKeys(candidate, params.aliasScope).includes(candidateKey),
-      ),
-    )
-    .find((candidate): candidate is RegisteredPluginCommand => candidate !== undefined);
-  if (!command || (args && !command.acceptsArgs)) {
-    return null;
+  for (const candidateKey of keys) {
+    const command = params.commands.find(
+      (candidate) =>
+        pluginCommandSupportsChannel(candidate, params.channel) &&
+        listInvocationKeys(candidate, params.aliasScope).includes(candidateKey),
+    );
+    if (command) {
+      // The preferred spelling owns argument rejection; do not try another command.
+      return args && !command.acceptsArgs ? null : { command, args };
+    }
   }
-  return { command, args };
+  return null;
 }


### PR DESCRIPTION
## What Problem This Solves

Plugin slash-command lookup keeps scanning alternate hyphen/underscore spellings after the preferred spelling already selected a command. Registries with more commands pay for unnecessary matching work on every such invocation.

## Why This Change Was Made

Stop after the first matching spelling while retaining registration order, channel filtering, and native alias scope. Argument rejection stays with the selected command; an alternate spelling cannot select a different command that accepts the arguments. No cache or registration/dispatch lifecycle change. Production code decreases by one line; two boundary cases add 22 test lines.

## User Impact

Commands resolve with less matching work while selecting the same plugin and arguments. This is a component improvement, not an end-to-end Gateway latency claim, and not every measured case improved.

## Evidence

The normal grouped command/runtime test run passed **74/74 tests** across both complete files. Independent peer review and managed P2 source review are clean. The earlier test attempt failed before collection because the shared installation had Vitest 4; the corrected private Vitest 5 installation passed without source workarounds. Its bundler emitted unresolved-import warnings while treating those imports as external; the full test result remained passing.

Fixed fresh-process B0/C0/C1/B1 measurement on Node 26.8.1 used the actual matcher, 72 rows covering 2/16/64 commands and both alias scopes, and retained all 3,456 batch means. All **479,520 calls** passed selected-object identity, arguments, or null checks. Representative median batch means (all-alias scope):

| Scenario | Forward baseline → candidate | Reverse baseline → candidate |
| --- | --- | --- |
| 64 commands, first exact separator match | 24.984 → 0.535 µs (−97.86%) | 24.765 → 0.547 µs (−97.79%) |
| 16 commands, last exact separator match | 11.469 → 5.792 µs (−49.50%) | 11.344 → 5.941 µs (−47.63%) |
| 2 commands, ordinary plain name | 0.882 → 0.891 µs (+1.03%) | 0.875 → 0.884 µs (+1.06%) |

There were **35/144 adverse median comparisons** and **47/144 adverse maximum-batch-mean comparisons**. The largest median increase was +6.79% (+72 ns, two-command channel-exclusion row); the largest relative maximum-batch increase was +165.30% (+893 ns, another provider's native alias). All results are retained. Maximum batch means are not population tail percentiles; no aggregate threshold or memory benefit is claimed.

The complete normal changed-file gate passed on refreshed base `5b099995413589f41904cef1413c62239542aa7c` with the same two-file patch, including core/test typechecking, lint, dead-export scans, and boundary guards (645.70 s). The earlier unrelated services test-root limit was resolved upstream before this refresh; no check was weakened or skipped. Focused tests and component timings above were captured on base `6c55a99226ed0611ca088004c81b00fb296f1f71`; the refreshed candidate preserves the measured source unchanged.
