### PR TITLE
test(ui): consolidate theme contrast coverage

### DIFF
--- a/ui/src/styles/base-theme-contrast.node.test.ts
+++ b/ui/src/styles/base-theme-contrast.node.test.ts
@@ -13,9 +13,8 @@ const stylesDir = path.dirname(fileURLToPath(import.meta.url));
  * anyone noticing (issue #107299 measured `--muted` at 3.1–3.5:1 on dark
  * surfaces). Hex tokens are cheap to audit mechanically, so every
  * text-on-surface pairing a theme can produce is asserted here at >= 4.5:1
- * (AA, normal-size text). Non-hex values (rgba tints, color-mix) are skipped:
- * their contrast depends on a compositing surface and is audited in the
- * base.css comments instead.
+ * (AA, normal-size text). Text and surface tokens must resolve to opaque colors;
+ * translucent component paint is composited in the surface-specific cases below.
  */
 
 const TEXT_TOKENS = [
@@ -437,20 +436,14 @@ describe("Control UI theme contrast", () => {
     const failures: string[] = [];
     for (const [themeName, tokens] of themes) {
       for (const textToken of TEXT_TOKENS) {
-        const foreground = tokens.get(textToken);
-        if (!foreground?.startsWith("#")) {
-          continue;
-        }
+        const foreground = resolveOpaqueColor(`var(${textToken})`, tokens);
         for (const surfaceToken of SURFACE_TOKENS) {
-          const background = tokens.get(surfaceToken);
-          if (!background?.startsWith("#")) {
-            continue;
-          }
-          const ratio = contrastRatio(parseHex(foreground), parseHex(background));
+          const background = resolveOpaqueColor(`var(${surfaceToken})`, tokens);
+          const ratio = contrastRatio(foreground, background);
           const floor = AAA_THEMES.has(themeName) ? AAA_NORMAL_TEXT_MIN : AA_NORMAL_TEXT_MIN;
           if (ratio < floor) {
             failures.push(
-              `${themeName}: ${textToken} ${foreground} on ${surfaceToken} ${background} = ${ratio.toFixed(2)}:1 (< ${floor}:1)`,
+              `${themeName}: ${textToken} rgb(${foreground.join(", ")}) on ${surfaceToken} rgb(${background.join(", ")}) = ${ratio.toFixed(2)}:1 (< ${floor}:1)`,
             );
           }
         }

--- a/ui/src/styles/theme-contrast.test.ts
+++ b/ui/src/styles/theme-contrast.test.ts
@@ -1,82 +1,10 @@
 // @vitest-environment node
-import { readdirSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-
-function relativeLuminance(hex: string): number {
-  const channels = hex
-    .replace("#", "")
-    .match(/.{2}/g)
-    ?.map((part) => Number.parseInt(part, 16) / 255)
-    .map((channel) => (channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4));
-  if (!channels || channels.length !== 3) {
-    throw new Error(`invalid color: ${hex}`);
-  }
-  const r = channels[0];
-  const g = channels[1];
-  const b = channels[2];
-  if (r === undefined || g === undefined || b === undefined) {
-    throw new Error(`invalid color: ${hex}`);
-  }
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-}
-
-function contrastRatio(foreground: string, background: string): number {
-  const luminances = [relativeLuminance(foreground), relativeLuminance(background)].toSorted(
-    (a, b) => b - a,
-  );
-  const lighter = luminances[0];
-  const darker = luminances[1];
-  if (lighter === undefined || darker === undefined) {
-    throw new Error("expected two luminance values");
-  }
-  return (lighter + 0.05) / (darker + 0.05);
-}
-
-function mixOpaque(foreground: string, background: string, opacity: number): string {
-  const fh = foreground.replace("#", "");
-  const bh = background.replace("#", "");
-  const fr = Number.parseInt(fh.slice(0, 2), 16);
-  const fg = Number.parseInt(fh.slice(2, 4), 16);
-  const fb = Number.parseInt(fh.slice(4, 6), 16);
-  const br = Number.parseInt(bh.slice(0, 2), 16);
-  const bg = Number.parseInt(bh.slice(2, 4), 16);
-  const bb = Number.parseInt(bh.slice(4, 6), 16);
-  const r = Math.round(fr * opacity + br * (1 - opacity));
-  const g = Math.round(fg * opacity + bg * (1 - opacity));
-  const b = Math.round(fb * opacity + bb * (1 - opacity));
-  return `#${[r, g, b].map((n) => n.toString(16).padStart(2, "0")).join("")}`;
-}
-
-function readCssVarBlock(css: string, selector: string): Record<string, string> {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = css.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\}`, "u"));
-  const block = match?.[1];
-  if (!block) {
-    throw new Error(`missing CSS block for ${selector}`);
-  }
-  const vars: Record<string, string> = {};
-  for (const line of block.matchAll(/--([a-z0-9-]+):\s*(#[0-9a-fA-F]{6})\s*;/gu)) {
-    const name = line[1];
-    const value = line[2];
-    if (name === undefined || value === undefined) {
-      continue;
-    }
-    vars[name] = value.toLowerCase();
-  }
-  return vars;
-}
-
-function requireCssColor(vars: Record<string, string>, name: string): string {
-  const value = vars[name];
-  if (value === undefined) {
-    throw new Error(`missing CSS color --${name}`);
-  }
-  return value;
-}
 
 function readRuleBody(css: string, selector: string): string {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -95,45 +23,19 @@ function readOpacity(ruleBody: string): number {
 }
 
 describe("Control UI theme contrast", () => {
-  const themesDir = path.join(here, "..", "..", "public", "themes");
-  // Palettes moved out of the startup stylesheet; read them back for coverage.
-  const baseCss = [
-    readFileSync(path.join(here, "base.css"), "utf8"),
-    ...readdirSync(themesDir)
-      .filter((entry) => entry.endsWith(".css"))
-      .toSorted()
-      .map((entry) => readFileSync(path.join(themesDir, entry), "utf8")),
-  ].join("\n");
   const groupedCss = readFileSync(path.join(here, "chat", "grouped.css"), "utf8");
   const chatComposerCss = readFileSync(path.join(here, "chat", "composer.css"), "utf8");
   const layoutCss = readFileSync(path.join(here, "layout.css"), "utf8");
 
   it("keeps chat timestamps and slash-arg hints AA without opacity dimming", () => {
-    const dark = readCssVarBlock(baseCss, ":root");
-    const muted = requireCssColor(dark, "muted");
-    const backgrounds = [
-      requireCssColor(dark, "bg"),
-      requireCssColor(dark, "bg-elevated"),
-      requireCssColor(dark, "bg-muted"),
-      requireCssColor(dark, "card"),
-    ];
     const timestampRule = readRuleBody(groupedCss, ".chat-group-timestamp");
     const slashArgsRule = readRuleBody(chatComposerCss, ".slash-menu-args,\n.slash-menu-desc");
 
     expect(timestampRule).toMatch(/color:\s*var\(--muted\)/);
     expect(slashArgsRule).toMatch(/color:\s*var\(--muted\)/);
 
-    const timestampOpacity = readOpacity(timestampRule);
-    const slashArgsOpacity = readOpacity(slashArgsRule);
-    expect(timestampOpacity).toBe(1);
-    expect(slashArgsOpacity).toBe(1);
-
-    for (const background of backgrounds) {
-      const timestampFg = mixOpaque(muted, background, timestampOpacity);
-      const slashArgsFg = mixOpaque(muted, background, slashArgsOpacity);
-      expect(contrastRatio(timestampFg, background)).toBeGreaterThanOrEqual(4.5);
-      expect(contrastRatio(slashArgsFg, background)).toBeGreaterThanOrEqual(4.5);
-    }
+    expect(readOpacity(timestampRule)).toBe(1);
+    expect(readOpacity(slashArgsRule)).toBe(1);
   });
 
   it("keeps sidebar metadata on the AA-tested muted token without opacity dimming", () => {
@@ -148,26 +50,5 @@ describe("Control UI theme contrast", () => {
     expect(buildRule).toMatch(/color:\s*var\(--muted\)/);
     expect(sessionLabelRule).toMatch(/color:\s*var\(--muted\)/);
     expect(readOpacity(sessionLabelRule)).toBe(1);
-
-    const light = readCssVarBlock(baseCss, ':root:where([data-theme-mode="light"])');
-    for (const selector of [
-      null,
-      ':root[data-theme="openknot-light"]',
-      ':root[data-theme="dash-light"]',
-      ':root[data-theme="absolutely-light"]',
-      ':root[data-theme="tide-light"]',
-      ':root[data-theme="beacon-light"]',
-      ':root[data-theme="phosphor-light"]',
-      ':root[data-theme="crt-light"]',
-      ':root[data-theme="manuscript-light"]',
-      ':root[data-theme="rose-light"]',
-      ':root[data-theme="miami-light"]',
-    ]) {
-      const theme = selector ? { ...light, ...readCssVarBlock(baseCss, selector) } : light;
-      const muted = requireCssColor(theme, "muted");
-      for (const surface of ["bg", "bg-elevated", "bg-muted", "card"]) {
-        expect(contrastRatio(muted, requireCssColor(theme, surface))).toBeGreaterThanOrEqual(4.5);
-      }
-    }
   });
 });


### PR DESCRIPTION
Related: #139676

## What Problem This Solves

Theme contrast tests duplicated WCAG arithmetic, palette loading, and muted-color matrices. Maintaining both copies obscured that the broader suite silently skipped missing theme tokens.

## Why This Change Was Made

Keep contrast calculations in the existing broad suite and use its color resolver so missing tokens fail. Retain the smaller suite's distinct CSS token-selection and opacity regressions. This is maintainer-requested test cleanup following the Vitest 5 migration.

## User Impact

No styling or runtime changes. Test code shrinks by 126 lines, and missing text/surface tokens are detected consistently across all themes.

## Evidence

- Before and after: all 12 focused cases pass with matching inventory.
- Temporary missing-muted and timestamp-opacity mutations fail for their intended reasons; original CSS bytes were restored.
- Classified checks pass after fixing and rerunning one diagnostic-format lint failure.
- Independent Codex review found no actionable P0–P2 findings.
- Three warm pairs: median 2.012s before, 1.994s after, effectively unchanged.
- Required hosted CI must pass before landing.
