### PR TITLE
improve(plugins): speed up repeated model catalog lookups

### DIFF
--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -140,6 +140,80 @@ describe("manifest model suppression", () => {
     ).toBeUndefined();
   });
 
+  it("preserves ordered same-model rules and current route conditions", () => {
+    const config = {
+      models: {
+        providers: {
+          fixture: {
+            api: "openai-completions" as const,
+            baseUrl: "https://first.example/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    mocks.loadPluginMetadataSnapshot.mockReturnValue(
+      createMetadataSnapshot([
+        {
+          id: "z-fallback",
+          providers: ["fixture"],
+          modelCatalog: {
+            suppressions: [{ provider: "fixture", model: "model", reason: "Fallback." }],
+          },
+        },
+        {
+          id: "a-conditional",
+          providers: ["fixture"],
+          modelCatalog: {
+            suppressions: [
+              {
+                provider: "fixture",
+                model: "model",
+                reason: "First route.",
+                when: {
+                  baseUrlHosts: ["FIRST.EXAMPLE.", "shared.example"],
+                  providerConfigApiIn: ["OPENAI-COMPLETIONS"],
+                },
+              },
+              {
+                provider: "fixture",
+                model: "model",
+                reason: "Second route.",
+                retirement: { replacedBy: "successor" },
+                when: { baseUrlHosts: ["second.example", "shared.example"] },
+              },
+            ],
+          },
+        },
+      ]),
+    );
+    const resolver = buildManifestBuiltInModelSuppressionResolver({ config });
+    const input = { provider: "fixture", id: "model" };
+
+    expect(resolver({ ...input, baseUrl: "https://shared.example/v1" })).toEqual({
+      suppress: true,
+      errorMessage: "Unknown model: fixture/model. First route.",
+    });
+    expect(resolver({ ...input, baseUrl: "https://second.example/v1" })).toMatchObject({
+      retirement: { replacedBy: "successor" },
+    });
+    for (const baseUrl of ["https://other.example/v1", "invalid endpoint"]) {
+      expect(resolver({ ...input, baseUrl })?.errorMessage).toBe(
+        "Unknown model: fixture/model. Fallback.",
+      );
+    }
+    expect(
+      resolver({ ...input, baseUrl: "https://shared.example/v1", unconditionalOnly: true })
+        ?.errorMessage,
+    ).toBe("Unknown model: fixture/model. Fallback.");
+    expect(resolver(input)?.errorMessage).toBe("Unknown model: fixture/model. First route.");
+    config.models.providers.fixture.baseUrl = "https://second.example/v1";
+    expect(resolver(input)).toEqual({
+      suppress: true,
+      errorMessage: "Unknown model: fixture/model. Fallback.",
+    });
+  });
+
   it.each([undefined, "current-model"])(
     "preserves explicit retirement and successor %s only on the selected endpoint",
     (replacedBy) => {

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -14,6 +14,12 @@ import type { ManifestModelSuppressionResolver } from "./manifest-model-suppress
 import { getPluginMetadataSnapshotCache } from "./plugin-cache.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 
+type PreparedManifestSuppression = {
+  entry: ManifestModelCatalogSuppressionEntry;
+  allowedApis: ReadonlySet<string> | undefined;
+  allowedHosts: ReadonlySet<string> | undefined;
+};
+
 function listManifestModelCatalogSuppressions(params: {
   config?: OpenClawConfig;
   snapshot: PluginMetadataSnapshot;
@@ -79,26 +85,26 @@ function resolveConfiguredProviderValue(params: {
 }
 
 function manifestSuppressionMatchesConditions(params: {
-  suppression: ManifestModelCatalogSuppressionEntry;
+  suppression: PreparedManifestSuppression;
   provider: string;
   baseUrl?: string | null;
   config?: OpenClawConfig;
 }): boolean {
-  const when = params.suppression.when;
+  const { entry, allowedApis, allowedHosts } = params.suppression;
+  const when = entry.when;
   if (!when) {
     return true;
   }
   // Retirement repairs durable model choices. A missing route is unknown, even
   // when the provider's default endpoint is known; never retire a sibling auth route.
-  if (params.suppression.retirement && when.baseUrlHosts?.length && !params.baseUrl) {
+  if (entry.retirement && allowedHosts && !params.baseUrl) {
     return false;
   }
   const configuredProvider = resolveConfiguredProviderValue({
     provider: params.provider,
     config: params.config,
   });
-  if (when.providerConfigApiIn?.length) {
-    const allowedApis = new Set(when.providerConfigApiIn.map(normalizeLowercaseStringOrEmpty));
+  if (allowedApis) {
     const effectiveApi = configuredProvider
       ? normalizeLowercaseStringOrEmpty(configuredProvider.api)
       : params.provider;
@@ -106,7 +112,7 @@ function manifestSuppressionMatchesConditions(params: {
       return false;
     }
   }
-  if (when.baseUrlHosts?.length) {
+  if (allowedHosts) {
     const baseUrlHost = normalizeBaseUrlHost(params.baseUrl ?? configuredProvider?.baseUrl);
     if (!baseUrlHost && !params.baseUrl && !configuredProvider?.baseUrl) {
       return true;
@@ -114,7 +120,6 @@ function manifestSuppressionMatchesConditions(params: {
     if (!baseUrlHost) {
       return false;
     }
-    const allowedHosts = new Set(when.baseUrlHosts.map(normalizeSuppressionHost));
     if (!allowedHosts.has(baseUrlHost)) {
       return false;
     }
@@ -139,10 +144,28 @@ export function buildManifestBuiltInModelSuppressionResolver(params: {
   if (cached) {
     return cached;
   }
-  const suppressions = listManifestModelCatalogSuppressions({
+  const suppressions = new Map<string, PreparedManifestSuppression[]>();
+  for (const entry of listManifestModelCatalogSuppressions({
     snapshot,
     config: params.config,
-  });
+  })) {
+    const prepared: PreparedManifestSuppression = {
+      entry,
+      allowedApis: entry.when?.providerConfigApiIn?.length
+        ? new Set(entry.when.providerConfigApiIn.map(normalizeLowercaseStringOrEmpty))
+        : undefined,
+      allowedHosts: entry.when?.baseUrlHosts?.length
+        ? new Set(entry.when.baseUrlHosts.map(normalizeSuppressionHost))
+        : undefined,
+    };
+    // Preserve planner order when a route condition skips an earlier same-model rule.
+    const rules = suppressions.get(entry.mergeKey);
+    if (rules) {
+      rules.push(prepared);
+    } else {
+      suppressions.set(entry.mergeKey, [prepared]);
+    }
+  }
 
   const resolver: ManifestModelSuppressionResolver = (input) => {
     const provider = normalizeLowercaseStringOrEmpty(input.provider);
@@ -151,17 +174,16 @@ export function buildManifestBuiltInModelSuppressionResolver(params: {
       return undefined;
     }
     const mergeKey = buildModelCatalogMergeKey(provider, modelId);
-    const suppression = suppressions.find(
-      (entry) =>
-        entry.mergeKey === mergeKey &&
-        (!input.unconditionalOnly || !entry.when) &&
+    const suppression = suppressions.get(mergeKey)?.find(
+      (prepared) =>
+        (!input.unconditionalOnly || !prepared.entry.when) &&
         manifestSuppressionMatchesConditions({
-          suppression: entry,
+          suppression: prepared,
           provider,
           baseUrl: input.baseUrl,
           config: params.config,
         }),
-    );
+    )?.entry;
     if (!suppression) {
       return undefined;
     }


### PR DESCRIPTION
## What Problem This Solves

Catalog filtering and direct model lookup repeatedly scanned every planned suppression rule and rebuilt normalized API and host sets for conditional matches.

## Why This Change Was Made

Prepare ordered per-model buckets and immutable condition sets once in the existing snapshot/config-owned resolver. Current config and selected endpoints remain live inputs, preserving same-model precedence, unconditional lookups, and endpoint-scoped retirement behavior.

## User Impact

Repeated model catalog lookups do less work. The resolver retains additional prepared metadata in exchange for reduced scanning and allocation during lookups; no retained-heap reduction is claimed.

## Evidence

- All 56 suppression and manifest-planner tests pass, including a new ordering and route fixture verified against both the original and updated resolver.
- Production and plugin-test typechecks and targeted lint pass. Independent review and isolated autoreview found no actionable issues.
- A synthetic 130-rule probe reduced median misses from 516 to 142 ns/call and conditional hits from 692 to 443 ns/call. These are owner-level timings, not a Gateway heap or RSS measurement.

Full changed checks passed after incorporating the existing main branch shard rebalance. The rebased patch is byte-identical to the reviewed change.
