### PR TITLE
fix(acp): preserve queued output and cancel failed deliveries

### DIFF
--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -181,8 +181,10 @@ Then verify backend health:
 
 The `acpx` plugin embeds the ACP runtime directly (no separate `acpx` binary or
 version to configure). By default it registers the embedded backend during
-Gateway startup and waits for a startup probe before the gateway `ready`
-signal. Set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` or
+Gateway startup and waits for one health probe before the gateway `ready`
+signal. That probe also supplies failure diagnostics and is bounded by
+`plugins.entries.acpx.config.timeoutSeconds`; an unhealthy result does not
+launch a second probe. Set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` or
 `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1` only for scripts or environments that
 intentionally keep the startup probe disabled. Run `/acp doctor` for an explicit
 on-demand probe.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -156,6 +156,7 @@ Quick `/acp` flow from chat:
     - Bound follow-up messages go directly to the ACP session until the binding is closed, detached, reset, or expired.
     - Gateway commands stay local. `/acp ...`, `/status`, and `/session` are never sent as normal prompt text to a bound ACP harness.
     - `cancel` aborts the active turn when the backend supports cancellation; it does not delete the binding or session metadata.
+    - Turn completion waits for queued output delivery. If delivery fails, OpenClaw cancels the active turn and waits for backend cleanup before starting the next queued turn, within the configured turn timeout.
     - `close` ends the ACP session from OpenClaw's point of view and removes the binding. A harness may still keep its own upstream history if it supports resume.
     - The acpx plugin cleans up OpenClaw-owned wrapper and adapter process trees after `close`, and reaps stale OpenClaw-owned ACPX orphans during Gateway startup.
     - Idle runtime workers are eligible for cleanup after the built-in idle period; stored session metadata remains available for `/acp sessions`.
@@ -592,7 +593,8 @@ config-the-default error).
 <ParamField path="thinking" type="string">
   Explicit thinking/reasoning effort. For Codex ACP, `minimal` maps to low
   effort, `low`/`medium`/`high`/`xhigh` map directly, and `off` omits the
-  reasoning-effort startup override. When omitted, ACP spawns use existing
+  reasoning-effort startup override. An explicit value takes precedence over
+  a reasoning suffix in `model`, including `off`. When omitted, ACP spawns use existing
   subagent thinking defaults, the configured target agent's `thinkingDefault`, and per-model
   `agents.defaults.models["provider/model"].params.thinking` for the selected
   model.

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1407,6 +1407,53 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     ).not.toContain("gpt-5.6-sol/medium");
   });
 
+  it.each([
+    { thinking: "off", expectedEffort: undefined },
+    { thinking: "low", expectedEffort: "low" },
+    { thinking: undefined, expectedEffort: "high" },
+  ])(
+    "honors explicit thinking=$thinking over Codex ACP model suffixes",
+    async ({ thinking, expectedEffort }) => {
+      const baseStore: TestSessionStore = {
+        load: vi.fn(async () => undefined),
+        save: vi.fn(async () => {}),
+      };
+      const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+        openclawGatewayInstanceId: "gateway-test",
+        openclawProcessLeaseStore: makeLeaseStore().store,
+        openclawWrapperRoot: "/tmp/openclaw/acpx",
+        agentRegistry: {
+          resolve: () => CODEX_ACP_WRAPPER_COMMAND,
+          list: () => ["codex"],
+        },
+      });
+      vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+        await wrappedStore.save({ name: input.sessionKey, cwd: "/tmp", pid: 777 });
+        return {
+          sessionKey: input.sessionKey,
+          backend: "acpx",
+          runtimeSessionName: input.sessionKey,
+        };
+      });
+
+      await runtime.ensureSession({
+        sessionKey: "agent:codex:acp:test",
+        agent: "codex",
+        mode: "persistent",
+        model: "openai/gpt-5.6-luna/high",
+        thinking,
+      });
+
+      const [record] = vi.mocked(baseStore.save).mock.calls[0]!;
+      expect(record.agentCommand).toContain('"model":"gpt-5.6-luna"');
+      if (expectedEffort) {
+        expect(record.agentCommand).toContain(`"model_reasoning_effort":"${expectedEffort}"`);
+      } else {
+        expect(record.agentCommand).not.toContain("model_reasoning_effort");
+      }
+    },
+  );
+
   it("starts Codex ACP without injecting a leaked non-openai default model", async () => {
     const baseStore: TestSessionStore = {
       load: vi.fn(async () => undefined),

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1414,9 +1414,10 @@ describe("AcpxRuntime fresh reset wrapper", () => {
   ])(
     "honors explicit thinking=$thinking over Codex ACP model suffixes",
     async ({ thinking, expectedEffort }) => {
+      const save = vi.fn<TestSessionStore["save"]>(async () => {});
       const baseStore: TestSessionStore = {
         load: vi.fn(async () => undefined),
-        save: vi.fn(async () => {}),
+        save,
       };
       const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
         openclawGatewayInstanceId: "gateway-test",
@@ -1444,7 +1445,7 @@ describe("AcpxRuntime fresh reset wrapper", () => {
         thinking,
       });
 
-      const [record] = vi.mocked(baseStore.save).mock.calls[0]!;
+      const [record] = save.mock.calls[0]!;
       expect(record.agentCommand).toContain('"model":"gpt-5.6-luna"');
       if (expectedEffort) {
         expect(record.agentCommand).toContain(`"model_reasoning_effort":"${expectedEffort}"`);

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -629,7 +629,8 @@ function classifyCodexAcpModelRequest(
       : { kind: "unsupported" };
   }
 
-  const reasoningEffort = thinkingReasoningEffort ?? modelReasoningEffort;
+  // Explicit `off` omits the override even when the model carries an effort suffix.
+  const reasoningEffort = rawThinking?.trim() ? thinkingReasoningEffort : modelReasoningEffort;
   return {
     kind: "override",
     override: {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -875,7 +875,7 @@ describe("createAcpxRuntimeService", () => {
     });
     vi.useFakeTimers();
     let settled = false;
-    const started = service.start(ctx).then(() => {
+    const started = Promise.resolve(service.start(ctx)).then(() => {
       settled = true;
     });
     try {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -76,7 +76,6 @@ const { acpxRuntimeConstructorMock, createAgentRegistryMock, createFileSessionSt
         getStatus: vi.fn(async () => ({ summary: "ready" })),
         isHealthy: vi.fn(() => true),
         prepareFreshSession: vi.fn(async () => {}),
-        probeAvailability: vi.fn(async () => {}),
         runTurn: vi.fn(async function* () {}),
         setConfigOption: vi.fn(async () => {}),
         setMode: vi.fn(async () => {}),
@@ -318,10 +317,11 @@ describe("createAcpxRuntimeService", () => {
     const releaseProbe = createDeferred<void>();
     const events: string[] = [];
     const runtime = createMockRuntime({
-      probeAvailability: vi.fn(async () => {
+      doctor: vi.fn(async () => {
         events.push("probe");
         probeStarted.resolve();
         await releaseProbe.promise;
+        return { ok: true, message: "ok" };
       }),
     });
     const publish = vi.fn((backend: { runtime: unknown; healthy?: () => boolean }) => {
@@ -359,13 +359,13 @@ describe("createAcpxRuntimeService", () => {
     const workspaceDir = testWorkspace.dir;
     const stateDir = path.join(workspaceDir, "custom-state");
     const ctx = createServiceContext(workspaceDir);
-    const probeAvailability = vi.fn(async () => {
+    const doctor = vi.fn(async () => {
       await fs.access(stateDir);
+      return { ok: true, message: "ok" };
     });
     const runtime = createMockRuntime({
-      doctor: async () => ({ ok: true, message: "ok" }),
+      doctor,
       isHealthy: () => false,
-      probeAvailability,
     });
     const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { stateDir },
@@ -375,7 +375,7 @@ describe("createAcpxRuntimeService", () => {
     await service.start(ctx);
 
     await fs.access(stateDir);
-    expect(probeAvailability).not.toHaveBeenCalled();
+    expect(doctor).not.toHaveBeenCalled();
     expect(getAcpRuntimeBackend("acpx")?.healthy).toBeUndefined();
 
     await service.stop?.(ctx);
@@ -387,15 +387,15 @@ describe("createAcpxRuntimeService", () => {
     const ctx = createServiceContext(workspaceDir);
     let releaseProbe!: () => void;
     const probeStarted = vi.fn();
-    const probeAvailability = vi.fn(
+    const doctor = vi.fn(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<{ ok: boolean; message: string }>((resolve) => {
           probeStarted();
-          releaseProbe = resolve;
+          releaseProbe = () => resolve({ ok: true, message: "ok" });
         }),
     );
     const runtime = createMockRuntime({
-      probeAvailability,
+      doctor,
       isHealthy: () => true,
     });
     const service = createAcpxRuntimeService(ctx, {
@@ -839,9 +839,9 @@ describe("createAcpxRuntimeService", () => {
     process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     const workspaceDir = testWorkspace.dir;
     const ctx = createServiceContext(workspaceDir);
-    const probeAvailability = vi.fn(async () => {});
+    const doctor = vi.fn(async () => ({ ok: true, message: "ok" }));
     const runtime = createMockRuntime({
-      probeAvailability,
+      doctor,
       isHealthy: () => true,
     });
     const service = createAcpxRuntimeService(ctx, {
@@ -850,35 +850,50 @@ describe("createAcpxRuntimeService", () => {
 
     await service.start(ctx);
 
-    expect(probeAvailability).toHaveBeenCalledOnce();
+    expect(doctor).toHaveBeenCalledOnce();
+    expect(runtime.probeAvailability).not.toHaveBeenCalled();
     expect(getAcpRuntimeBackend("acpx")?.healthy?.()).toBe(true);
 
     await service.stop?.(ctx);
   });
 
-  it("bounds the opt-in embedded runtime startup probe wait with the configured timeout", async () => {
+  it("bounds startup diagnostics after an unhealthy probe", async () => {
     process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
-    const workspaceDir = testWorkspace.dir;
-    const ctx = createServiceContext(workspaceDir);
-    const probeAvailability = vi.fn(() => new Promise<void>(() => {}));
+    const ctx = createServiceContext(testWorkspace.dir);
+    const doctorStarted = createDeferred<void>();
+    const releaseDoctor = createDeferred<{ ok: boolean; message: string }>();
     const runtime = createMockRuntime({
-      probeAvailability,
       isHealthy: () => false,
+      doctor: vi.fn(() => {
+        doctorStarted.resolve();
+        return releaseDoctor.promise;
+      }),
     });
     const service = createAcpxRuntimeService(ctx, {
       pluginConfig: { timeoutSeconds: 0.001 },
       runtimeFactory: () => runtime as never,
     });
-
-    await service.start(ctx);
-
-    expect(probeAvailability).toHaveBeenCalledOnce();
-    expect(getAcpRuntimeBackend("acpx")?.healthy?.()).toBe(false);
-    expect(ctx.logger.warn).toHaveBeenCalledWith(
-      "embedded acpx runtime setup failed: embedded acpx runtime backend startup probe timed out after 0.001s",
-    );
-
-    await service.stop?.(ctx);
+    vi.useFakeTimers();
+    let settled = false;
+    const started = service.start(ctx).then(() => {
+      settled = true;
+    });
+    try {
+      await doctorStarted.promise;
+      await vi.advanceTimersByTimeAsync(1);
+      expect(settled).toBe(true);
+      expect(runtime.doctor).toHaveBeenCalledOnce();
+      expect(runtime.probeAvailability).not.toHaveBeenCalled();
+      expect(getAcpRuntimeBackend("acpx")?.healthy?.()).toBe(false);
+      expect(ctx.logger.warn).toHaveBeenCalledWith(
+        "embedded acpx runtime setup failed: embedded acpx runtime backend startup probe timed out after 0.001s",
+      );
+    } finally {
+      releaseDoctor.resolve({ ok: false, message: "unavailable" });
+      await started;
+      await service.stop?.(ctx);
+      vi.useRealTimers();
+    }
   });
 
   it("passes the default runtime timeout to the embedded runtime factory", async () => {
@@ -945,11 +960,10 @@ describe("createAcpxRuntimeService", () => {
     process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE = "1";
     const workspaceDir = testWorkspace.dir;
     const ctx = createServiceContext(workspaceDir);
-    const probeAvailability = vi.fn(async () => {});
+    const doctor = vi.fn(async () => ({ ok: false, message: "nope" }));
     const runtime = createMockRuntime({
-      doctor: async () => ({ ok: false, message: "nope" }),
+      doctor,
       isHealthy: () => false,
-      probeAvailability,
     });
     const service = createAcpxRuntimeService(ctx, {
       runtimeFactory: () => runtime as never,
@@ -957,7 +971,7 @@ describe("createAcpxRuntimeService", () => {
 
     await service.start(ctx);
 
-    expect(probeAvailability).not.toHaveBeenCalled();
+    expect(doctor).not.toHaveBeenCalled();
     expect(getAcpRuntimeBackend("acpx")?.runtime).toBe(runtime);
     expect(getAcpRuntimeBackend("acpx")?.healthy).toBeUndefined();
 

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -48,7 +48,6 @@ import {
 } from "./state.js";
 
 type AcpxRuntimeLike = CompleteAcpRuntime & {
-  probeAvailability(): Promise<void>;
   isHealthy(): boolean;
 };
 const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
@@ -145,9 +144,6 @@ function createLazyDefaultRuntime(params: AcpxRuntimeFactoryParams): AcpxRuntime
 
   return {
     ...createLazyAcpRuntimeProxy(resolveRuntime),
-    async probeAvailability() {
-      await (await resolveRuntime()).probeAvailability();
-    },
     isHealthy() {
       return runtime?.isHealthy() ?? false;
     },
@@ -445,29 +441,23 @@ export function createAcpxRuntimeService(
       lifecycleRevision += 1;
       const currentRevision = lifecycleRevision;
       try {
-        await measureAcpxStartup(ctx, "probe.availability", () =>
+        const doctorReport = await measureAcpxStartup(ctx, "probe.availability", () =>
           withStartupProbeTimeout({
-            promise: startedRuntime.probeAvailability(),
+            promise: startedRuntime.doctor(),
             timeoutSeconds: pluginConfig.timeoutSeconds ?? DEFAULT_ACPX_TIMEOUT_SECONDS,
           }),
         );
         if (currentRevision !== lifecycleRevision) {
           return;
         }
-        if (startedRuntime.isHealthy()) {
+        if (doctorReport.ok) {
           detailAcpxStartup(ctx, "probe.result", [["healthyCount", 1]]);
           ctx.logger.info("embedded acpx runtime backend ready");
           return;
         }
-        const doctorReport = await measureAcpxStartup(ctx, "probe.doctor", () =>
-          startedRuntime.doctor(),
-        );
-        if (currentRevision !== lifecycleRevision) {
-          return;
-        }
         detailAcpxStartup(ctx, "probe.result", [["healthyCount", 0]]);
         ctx.logger.warn(
-          `embedded acpx runtime backend probe failed: ${doctorReport ? formatDoctorFailureMessage(doctorReport) : "backend remained unhealthy after probe"}`,
+          `embedded acpx runtime backend probe failed: ${formatDoctorFailureMessage(doctorReport)}`,
         );
       } catch (err) {
         if (currentRevision !== lifecycleRevision) {

--- a/src/acp/control-plane/manager.turn-delivery.test.ts
+++ b/src/acp/control-plane/manager.turn-delivery.test.ts
@@ -1,0 +1,182 @@
+import type { AcpRuntimeEvent, AcpRuntimeTurnResult } from "@openclaw/acp-core/runtime/types";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  AcpSessionManager,
+  baseCfg,
+  createRuntime,
+  hoisted,
+  installAcpSessionManagerTestLifecycle,
+  readySessionMeta,
+} from "./manager.test-helpers.js";
+
+describe("AcpSessionManager turn delivery", () => {
+  installAcpSessionManagerTestLifecycle();
+
+  function setupRuntime() {
+    const runtimeState = createRuntime();
+    const sessionKey = "agent:codex:acp:delivery";
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey,
+      storeSessionKey: sessionKey,
+      acp: readySessionMeta(),
+    });
+    return { runtimeState, sessionKey, manager: new AcpSessionManager() };
+  }
+
+  it.each(["completed", "cancelled", "failed"] as const)(
+    "preserves queued output behind slow delivery when the backend has %s",
+    async (terminalStatus) => {
+      vi.useFakeTimers();
+      const { runtimeState, sessionKey, manager } = setupRuntime();
+      const deliveryStarted = createDeferred<void>();
+      const releaseDelivery = createDeferred<void>();
+      const result = createDeferred<AcpRuntimeTurnResult>();
+      const events: AcpRuntimeEvent[] = [];
+      let streamClosed = false;
+      runtimeState.runtime.startTurn = vi.fn((input) => ({
+        requestId: input.requestId,
+        promptStarted: Promise.resolve(),
+        events: (async function* () {
+          yield { type: "tool_call" as const, text: "Reading the result" };
+          // ACPX closes its queue on completion; closeStream discards queued events.
+          if (!streamClosed) {
+            yield { type: "text_delta" as const, text: "Final deliverable" };
+          }
+        })(),
+        result: result.promise,
+        cancel: vi.fn(async () => {}),
+        closeStream: vi.fn(async () => {
+          streamClosed = true;
+        }),
+      }));
+      const turn = manager
+        .runTurn({
+          provenance: "system",
+          cfg: baseCfg,
+          sessionKey,
+          text: "Produce a deliverable",
+          mode: "prompt",
+          requestId: `slow-delivery-${terminalStatus}`,
+          onEvent: async (event) => {
+            events.push(event);
+            if (event.type === "tool_call") {
+              deliveryStarted.resolve();
+              await releaseDelivery.promise;
+            }
+          },
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+
+      try {
+        await deliveryStarted.promise;
+        result.resolve(
+          terminalStatus === "failed"
+            ? { status: "failed", error: { message: "Backend failed after output" } }
+            : { status: terminalStatus },
+        );
+        await vi.advanceTimersByTimeAsync(1);
+        releaseDelivery.resolve();
+        const error = await turn;
+
+        expect(events.map((event) => event.type)).toEqual([
+          "tool_call",
+          "text_delta",
+          terminalStatus === "failed" ? "error" : "done",
+        ]);
+        if (terminalStatus === "failed") {
+          expect(error).toMatchObject({ message: "Backend failed after output" });
+        } else {
+          expect(error).toBeUndefined();
+        }
+      } finally {
+        result.resolve({ status: "cancelled" });
+        releaseDelivery.resolve();
+        await turn;
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([true, false])(
+    "cancels failed event delivery and waits for cleanup before starting queued work (prompt submitted: %s)",
+    async (promptSubmitted) => {
+      vi.useFakeTimers();
+      const { runtimeState, sessionKey, manager } = setupRuntime();
+      const deliveryStarted = createDeferred<void>();
+      const promptStarted = createDeferred<void>();
+      const result = createDeferred<AcpRuntimeTurnResult>();
+      const cancel = vi.fn(async () => {});
+      const deliveryError = new Error("Channel delivery failed");
+      const starts: string[] = [];
+      runtimeState.runtime.startTurn = vi.fn((input) => {
+        starts.push(input.requestId);
+        return {
+          requestId: input.requestId,
+          promptStarted:
+            input.requestId === "first" && !promptSubmitted
+              ? promptStarted.promise
+              : Promise.resolve(),
+          events: (async function* () {
+            if (input.requestId === "first") {
+              yield { type: "status" as const, text: "Session resumed" };
+            }
+          })(),
+          result:
+            input.requestId === "first"
+              ? result.promise
+              : Promise.resolve({ status: "completed" as const }),
+          cancel,
+          closeStream: vi.fn(async () => {}),
+        };
+      });
+      const input = {
+        provenance: "system" as const,
+        cfg: baseCfg,
+        sessionKey,
+        text: "Do work",
+        mode: "prompt" as const,
+      };
+      const first = manager
+        .runTurn({
+          ...input,
+          requestId: "first",
+          onEvent: () => {
+            deliveryStarted.resolve();
+            throw deliveryError;
+          },
+        })
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      let second: Promise<void> | undefined;
+
+      try {
+        await deliveryStarted.promise;
+        second = manager.runTurn({ ...input, requestId: "second" });
+        await vi.advanceTimersByTimeAsync(1);
+
+        expect(cancel).toHaveBeenCalledOnce();
+        expect(starts).toEqual(["first"]);
+        result.resolve({ status: "cancelled" });
+        expect(await first).toMatchObject({ message: deliveryError.message });
+        await second;
+        expect(starts).toEqual(["first", "second"]);
+      } finally {
+        result.resolve({ status: "cancelled" });
+        promptStarted.resolve();
+        await first;
+        await second;
+        vi.useRealTimers();
+      }
+    },
+  );
+});

--- a/src/acp/control-plane/manager.turn-delivery.test.ts
+++ b/src/acp/control-plane/manager.turn-delivery.test.ts
@@ -33,8 +33,8 @@ describe("AcpSessionManager turn delivery", () => {
     async (terminalStatus) => {
       vi.useFakeTimers();
       const { runtimeState, sessionKey, manager } = setupRuntime();
-      const deliveryStarted = createDeferred<void>();
-      const releaseDelivery = createDeferred<void>();
+      const deliveryStarted = createDeferred();
+      const releaseDelivery = createDeferred();
       const result = createDeferred<AcpRuntimeTurnResult>();
       const events: AcpRuntimeEvent[] = [];
       let streamClosed = false;
@@ -110,8 +110,8 @@ describe("AcpSessionManager turn delivery", () => {
     async (promptSubmitted) => {
       vi.useFakeTimers();
       const { runtimeState, sessionKey, manager } = setupRuntime();
-      const deliveryStarted = createDeferred<void>();
-      const promptStarted = createDeferred<void>();
+      const deliveryStarted = createDeferred();
+      const promptStarted = createDeferred();
       const result = createDeferred<AcpRuntimeTurnResult>();
       const cancel = vi.fn(async () => {});
       const deliveryError = new Error("Channel delivery failed");

--- a/src/acp/control-plane/manager.turn-results.test.ts
+++ b/src/acp/control-plane/manager.turn-results.test.ts
@@ -1159,8 +1159,12 @@ describe("AcpSessionManager turn results", () => {
     });
   });
 
-  it("fails immediately when startTurn events fail before terminal result settles", async () => {
+  it("cancels a failed startTurn event stream before surfacing its error", async () => {
     const runtimeState = createRuntime();
+    const result = createDeferred<{ status: "cancelled" }>();
+    const cancel = vi.fn(async () => {
+      result.resolve({ status: "cancelled" });
+    });
     const closeStream = vi.fn(async () => {});
     runtimeState.runtime.startTurn = vi.fn((input) => ({
       requestId: input.requestId,
@@ -1168,8 +1172,8 @@ describe("AcpSessionManager turn results", () => {
         yield { type: "text_delta" as const, stream: "output" as const, text: "partial" };
         throw new AcpRuntimeError("ACP_TURN_FAILED", "event stream disconnected");
       })(),
-      result: new Promise<never>(() => {}),
-      cancel: vi.fn(async () => {}),
+      result: result.promise,
+      cancel,
       closeStream,
     }));
     hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
@@ -1196,6 +1200,7 @@ describe("AcpSessionManager turn results", () => {
       code: "ACP_TURN_FAILED",
       message: "event stream disconnected",
     });
+    expect(cancel).toHaveBeenCalledOnce();
     expect(closeStream).toHaveBeenCalledWith({ reason: "turn-events-error" });
   });
 

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -44,7 +44,10 @@ async function consumeAcpTurnEvents(params: {
   let sawOutput = false;
   let terminalStatus: AcpTurnStreamOutcome["terminalStatus"];
 
-  const deliverEvent = async (event: AcpRuntimeEvent) => {
+  for await (const event of params.events) {
+    if (!params.eventGate.open) {
+      continue;
+    }
     let forwardedEvent = event;
     if (event.type === "done") {
       // Legacy runTurn adapters may omit status but retain the cancellation reason.
@@ -56,18 +59,15 @@ async function consumeAcpTurnEvents(params: {
         normalizeText(event.message) || "ACP turn failed before completion.",
         event.detailCode ? { detailCode: event.detailCode } : undefined,
       );
-    } else if (event.type === "text_delta" || event.type === "tool_call") {
+    }
+    const outputEvent =
+      event.type === "text_delta" || event.type === "tool_call" ? event : undefined;
+    if (outputEvent) {
       sawOutput = true;
-      await params.onOutputEvent?.(event);
     }
-    await params.onEvent?.(forwardedEvent);
-  };
-
-  for await (const event of params.events) {
-    if (!params.eventGate.open) {
-      continue;
-    }
-    params.eventGate.pendingDelivery = deliverEvent(event);
+    params.eventGate.pendingDelivery = Promise.resolve(
+      outputEvent ? params.onOutputEvent?.(outputEvent) : undefined,
+    ).then(() => params.onEvent?.(forwardedEvent));
     try {
       await params.eventGate.pendingDelivery;
     } finally {

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -12,6 +12,7 @@ import { normalizeText } from "./runtime-options.js";
 /** Mutable gate used to suppress late events after timeout/cancel races. */
 type AcpTurnEventGate = {
   open: boolean;
+  pendingDelivery?: Promise<void>;
 };
 
 /** Summary of whether a turn stream emitted user-visible output or terminal events. */
@@ -43,10 +44,7 @@ async function consumeAcpTurnEvents(params: {
   let sawOutput = false;
   let terminalStatus: AcpTurnStreamOutcome["terminalStatus"];
 
-  for await (const event of params.events) {
-    if (!params.eventGate.open) {
-      continue;
-    }
+  const deliverEvent = async (event: AcpRuntimeEvent) => {
     let forwardedEvent = event;
     if (event.type === "done") {
       // Legacy runTurn adapters may omit status but retain the cancellation reason.
@@ -63,6 +61,18 @@ async function consumeAcpTurnEvents(params: {
       await params.onOutputEvent?.(event);
     }
     await params.onEvent?.(forwardedEvent);
+  };
+
+  for await (const event of params.events) {
+    if (!params.eventGate.open) {
+      continue;
+    }
+    params.eventGate.pendingDelivery = deliverEvent(event);
+    try {
+      await params.eventGate.pendingDelivery;
+    } finally {
+      params.eventGate.pendingDelivery = undefined;
+    }
   }
 
   if (params.eventGate.open && streamError) {
@@ -146,15 +156,6 @@ export async function consumeAcpTurnStream(params: {
       },
       (error: unknown) => ({ kind: "prompt-start-error" as const, error }),
     );
-    const eventsPromise = consumeAcpTurnEvents({
-      events: turn.events,
-      eventGate: params.eventGate,
-      onEvent: params.onEvent,
-      onOutputEvent: params.onOutputEvent,
-    }).then(
-      (outcome) => ({ kind: "events" as const, outcome }),
-      (error: unknown) => ({ kind: "event-error" as const, error }),
-    );
     const resultPromise = turn.result.then(
       (result) => {
         promptReadinessOpen = false;
@@ -163,6 +164,22 @@ export async function consumeAcpTurnStream(params: {
       (error: unknown) => {
         promptReadinessOpen = false;
         return { kind: "result-error" as const, error };
+      },
+    );
+    const eventsPromise = consumeAcpTurnEvents({
+      events: turn.events,
+      eventGate: params.eventGate,
+      onEvent: params.onEvent,
+      onOutputEvent: params.onOutputEvent,
+    }).then(
+      (outcome) => ({ kind: "events" as const, outcome }),
+      async (error: unknown) => {
+        // Event delivery can fail before prompt readiness. Cancel its producer
+        // immediately, then retain the actor until backend cleanup completes.
+        await turn.cancel({ reason: "turn-events-error" }).catch(() => {});
+        await turn.closeStream({ reason: "turn-events-error" }).catch(() => {});
+        await resultPromise;
+        return { kind: "event-error" as const, error };
       },
     );
 
@@ -185,7 +202,6 @@ export async function consumeAcpTurnStream(params: {
     let result: AcpRuntimeTurnResult | null = null;
     const firstOutcome = await Promise.race([eventsPromise, resultPromise]);
     if (firstOutcome.kind === "event-error") {
-      await turn.closeStream({ reason: "turn-events-error" }).catch(() => {});
       throw firstOutcome.error;
     }
     if (firstOutcome.kind === "events") {
@@ -207,9 +223,15 @@ export async function consumeAcpTurnStream(params: {
     }
 
     let closedTerminalStream = false;
-    if (!eventOutcome) {
+    while (!eventOutcome) {
+      // Channel delivery can outlive the backend result. Only an idle event
+      // iterator may be closed; closeStream discards queued ACPX output.
+      await params.eventGate.pendingDelivery?.catch(() => {});
       let eventsOutcome = await Promise.race([eventsPromise, waitForQueuedEvents()]);
       if (eventsOutcome === "pending") {
+        if (params.eventGate.pendingDelivery) {
+          continue;
+        }
         await turn.closeStream({ reason: `turn-result-${result.status}` }).catch(() => {});
         closedTerminalStream = true;
         eventsOutcome = await eventsPromise;


### PR DESCRIPTION
Closes #139680 — ACP output loss when completion overtakes slow delivery.

## What Problem This Solves

Fixes ACP sessions reporting completion after dropping buffered output while a channel delivery callback is still running. A real Codex ACP run requesting twenty lines completed with OpenClaw delivering only the first character, `1`. Delivery errors could also leave the backend running after the session actor was released, including errors emitted before prompt submission.

The same ACP/acpx review found that an unhealthy startup probe launched a second, unbounded diagnostic probe, and explicit `thinking: "off"` did not override a reasoning suffix in a Codex ACP model selection.

## Why This Change Was Made

The stream consumer now records pending delivery at the owning boundary. Terminal results wait for delivery before closing an idle event iterator; acpx's destructive `closeStream()` is no longer used to interrupt a callback that still has queued output behind it. Event failures cancel the exact turn immediately and retain actor ownership through the canonical backend result, preserving the original delivery error and authoritative prompt-readiness evidence.

Startup uses one bounded `doctor()` call for health and diagnostics, removing the duplicate probe. Explicit thinking selection takes precedence over the model suffix, including an explicit value that omits the startup override. No configuration keys, protocol versions, dependency versions, or SQLite schemas change.

## User Impact

ACP users receive queued output before completion; a failed delivery cancels its producer before queued work proceeds. Startup diagnostics respect the configured deadline. Codex ACP `thinking: "off"` behaves as documented even with a `/high` model suffix.

## Evidence

All regressions were captured failing before their corresponding production repair: completed/cancelled/failed output draining, cancellation and actor ordering, cancellation before prompt readiness, startup diagnostic deadline, and explicit thinking precedence.

- `node scripts/run-vitest.mjs src/acp/control-plane`: 28 files, 251 tests passed after the initial stream repair.
- Final `node scripts/run-vitest.mjs src/acp/control-plane/manager.turn-delivery.test.ts src/acp/control-plane/manager.turn-results.test.ts src/acp/control-plane/manager.failover.test.ts`: 42 tests passed, including the additional readiness repair.
- `node scripts/run-vitest.mjs extensions/acpx`: 24 files, 279 tests passed, including real subprocess ownership/restart coverage.
- Live authenticated Codex ACP through the OpenClaw plugin and core stream consumer, using isolated temporary state: before repair, one character; after repair, 87 chunks/212 characters including the requested final sentence. A persistent follow-up recalled that sentence. Injected delivery failures on pre-prompt status and post-prompt text both ended with the real backend result `cancelled`; the next prompt completed successfully.
- Live scope: real adapter/provider, with controlled backpressure/failure at the OpenClaw delivery callback. No live messaging-channel send or Control UI change; callback ordering is verified directly instead of inferred from a screenshot.

Independent Codex autoreview (`--mode local --max-priority P2` with caller/dependency evidence) was scoped-clean; the final staged candidate also passed with no actionable P0–P2 findings after static-gate cleanup. `pnpm build` passed, including plugin runtime and declaration/export checks. Final changed-file gates passed (`node scripts/check-changed.mjs -- <all nine changed paths>`), including core/plugin types, test types, lint, architecture, imports, and schema guards. The final test-only correction also passed a separate extension-test typecheck. Final exact-head CI is [run 34010182404](https://github.com/openclaw/openclaw/actions/runs/34010182404), completed successfully for `237be214a5a20d6a053f0a29b419c10b479f57c8`. Initial CI caught a test chaining `.then` on the `void | Promise<void>` lifecycle return and lint errors from callback-local error classification/redundant test type arguments; the follow-up commit normalizes the lifecycle return, keeps error classification in the iterator owner, and removes the redundant generics. Core lint and the 42 focused tests pass after those corrections. A final test-only follow-up retains a typed `save` mock directly to satisfy unbound-method lint; extension lint/typecheck and all 109 runtime tests pass afterward, with a clean independent review of that correction.

Production LOC: +42/-29 (net +13); tests: +284/-35; docs: +7/-3. Growth records the pending delivery and exact-turn cleanup ownership; the plugin removes duplicate probing. No new options or abstraction layers. The deslop pass preserves only comments that explain queue destruction or ownership ordering.

Dependency evidence: pinned acpx 0.13.1 `startTurn`, `cleanupRuntimeTurn`, and `probeRuntime` implementations; `closeStream` clears queued events, normal finalization preserves them, and `doctor` already owns health plus diagnostics. Codex source personally checked: `codex-rs/app-server/src/request_processors/turn_processor.rs:1555` (exact-turn interruption), `codex-rs/app-server/src/bespoke_event_handling.rs:1394` (terminal notification), and `codex-rs/core/src/config/mod.rs:943` (optional reasoning effort).

The same three defective code paths are present in stable tag `v2026.9.2`.

Provenance: stream closure/cancellation behavior dates to 635b947e32e0 (2026-05-17, Peter Steinberger); duplicate startup probing dates to c18cc769ce71 (2026-05-10, Peter Steinberger). Thinking precedence was carried by bb2b68b34e30 / #71643, authored by @91wan and merged by @steipete on 2026-04-25.

Follow-up identified during review: ACPX command normalization and generated wrappers flatten structured argv to strings, while pinned acpx requires argv on Windows. Preserve argv across wrapper generation, leases, persisted session identity, and reuse comparisons in a separate platform-focused repair. Legacy plugin `runTurn` also retains repeated session-store reads; consolidate it with `startTurn` when repairing that shared command/operation boundary.


### ClawSweeper compatibility request

Additional live compatibility proof passed: created a persistent Codex ACP session with the previous high-reasoning startup-command shape, saved a phrase, closed the runtime, constructed a new runtime instance, and resumed using the saved upstream session ID with explicit `thinking: "off"`. The new stored command omitted the reasoning override and the session recalled `The copper owl remembers.`. This tests persisted-session reuse across the changed startup setting without a migration.

Reviewed the requested data-model compatibility proof. No stored data model or migration changes are introduced: `service.ts` only replaces the duplicate probe sequence and removes its unused lazy proxy method; existing migration, keyed-store, and lease code is untouched. `pendingDelivery` is process-local turn state. The model change uses the existing startup-config shape. A schema migration is therefore not applicable. Existing real-process owner tests passed for global/shared-project histories across runtime restart and controls, and the live persistent session passed follow-up and post-cancellation reuse. This addresses the sole before-merge request; there were no correctness or security findings.
