### PR TITLE
fix(docker): restore browser-enabled Gateway startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -347,13 +347,10 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
     if [ -n "$OPENCLAW_INSTALL_BROWSER" ]; then \
       apt-get update && \
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
+      install -d -m 0755 -o node -g node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" && \
       mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      # chown the parent .cache dir, not just ms-playwright: mkdir -p creates
-      # /home/node/.cache as root:root, and the node-owned gateway needs to create
-      # /home/node/.cache/openclaw-<uid> at runtime. Mirrors the #85968 .config fix.
-      chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" && \
-      stat -c '%U:%G %a' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" | grep -qx 'node:node 755'; \
+      chown -R node:node "$PLAYWRIGHT_BROWSERS_PATH"; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.

--- a/Dockerfile
+++ b/Dockerfile
@@ -350,7 +350,7 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
       # chown the parent .cache dir, not just ms-playwright: mkdir -p creates
-      # /home/node/.cache as root:root, and the gateway (USER node) needs to create
+      # /home/node/.cache as root:root, and the node-owned gateway needs to create
       # /home/node/.cache/openclaw-<uid> at runtime. Mirrors the #85968 .config fix.
       chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" && \
       stat -c '%U:%G %a' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" | grep -qx 'node:node 755'; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -349,7 +349,11 @@ RUN --mount=type=cache,id=openclaw-bookworm-apt-cache,target=/var/cache/apt,shar
       DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends xvfb && \
       mkdir -p "$PLAYWRIGHT_BROWSERS_PATH" && \
       node /app/node_modules/playwright-core/cli.js install --with-deps chromium && \
-      chown -R node:node "$PLAYWRIGHT_BROWSERS_PATH"; \
+      # chown the parent .cache dir, not just ms-playwright: mkdir -p creates
+      # /home/node/.cache as root:root, and the gateway (USER node) needs to create
+      # /home/node/.cache/openclaw-<uid> at runtime. Mirrors the #85968 .config fix.
+      chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" && \
+      stat -c '%U:%G %a' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")" | grep -qx 'node:node 755'; \
     fi
 
 # Optionally install Docker CLI for sandbox container management.

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -184,12 +184,8 @@ describe("Dockerfile", () => {
     // /home/node/.cache/openclaw-<uid> at runtime. The chown must target the
     // parent dir, not just the ms-playwright subdir.
     const dockerfile = await readFile(dockerfilePath, "utf8");
-    expect(dockerfile).toContain(
-      'chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")"',
-    );
-    expect(dockerfile).toContain(
-      "stat -c '%U:%G %a' \"$(dirname \"$PLAYWRIGHT_BROWSERS_PATH\")\"",
-    );
+    expect(dockerfile).toContain('chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")"');
+    expect(dockerfile).toContain('stat -c \'%U:%G %a\' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")"');
   });
 
   it("uses the Docker target platform for both frozen installs", async () => {

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -178,16 +178,6 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
 
-  it("chowns the parent .cache dir so the gateway can create runtime cache subdirs", async () => {
-    // Regression: mkdir -p PLAYWRIGHT_BROWSERS_PATH creates /home/node/.cache as
-    // root:root, and the gateway (USER node) needs to create
-    // /home/node/.cache/openclaw-<uid> at runtime. The chown must target the
-    // parent dir, not just the ms-playwright subdir.
-    const dockerfile = await readFile(dockerfilePath, "utf8");
-    expect(dockerfile).toContain('chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")"');
-    expect(dockerfile).toContain('stat -c \'%U:%G %a\' "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")"');
-  });
-
   it("uses the Docker target platform for both frozen installs", async () => {
     const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
     const installs = dockerfile.match(/^RUN .*pnpm install[^\n]+/gm) ?? [];

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -178,6 +178,20 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain("apt-get install -y --no-install-recommends xvfb");
   });
 
+  it("chowns the parent .cache dir so the gateway can create runtime cache subdirs", async () => {
+    // Regression: mkdir -p PLAYWRIGHT_BROWSERS_PATH creates /home/node/.cache as
+    // root:root, and the gateway (USER node) needs to create
+    // /home/node/.cache/openclaw-<uid> at runtime. The chown must target the
+    // parent dir, not just the ms-playwright subdir.
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain(
+      'chown -R node:node "$(dirname "$PLAYWRIGHT_BROWSERS_PATH")"',
+    );
+    expect(dockerfile).toContain(
+      "stat -c '%U:%G %a' \"$(dirname \"$PLAYWRIGHT_BROWSERS_PATH\")\"",
+    );
+  });
+
   it("uses the Docker target platform for both frozen installs", async () => {
     const dockerfile = collapseDockerContinuations(await readFile(dockerfilePath, "utf8"));
     const installs = dockerfile.match(/^RUN .*pnpm install[^\n]+/gm) ?? [];


### PR DESCRIPTION
## What Problem This Solves

Fixes browser-enabled Docker images failing to create OpenClaw's private SQLite cache and start the Gateway as the non-root `node` user. Installing Chromium created a root-owned parent cache directory, although the browser directory itself was node-owned.

## Why This Change Was Made

Create the image-owned cache parent with `node:node` ownership and mode `0755` before installing Chromium. Keep the existing browser-directory ownership step. Only the parent is initialized; unrelated cache entries retain their owners.

## User Impact

Browser-enabled images can start the Gateway and create private runtime caches while retaining Chromium. Browser-disabled images and operator-supplied home/cache mounts keep their existing behavior and ownership.

## Evidence

Built and exercised the final Linux/amd64 images from baseline `391550bbd9afa8c8df2f324422ab46a4b01296ec` and candidate `2ace28dd70d6d75487d0c1c9701d9fe4100a4a3c`, both with and without `OPENCLAW_INSTALL_BROWSER=1`.

| Final-image check | Baseline with browser | Candidate with browser |
| --- | --- | --- |
| Default runtime user | `node`, uid/gid `1000` | `node`, uid/gid `1000` |
| `/home/node/.cache` | `0:0`, mode `0755` | `1000:1000`, mode `0755` |
| `openclaw database ownership status --json` with an existing synthetic SQLite file | Exit 1: unable to create private cache | Exit 0; private cache mode `0700` |
| Packaged SQLite snapshot | Cache creation fails | Directory `0700`, file `0600`, marker readback intact |
| Chromium through packaged Playwright | Executable resolves and runs | Executable resolves and runs |
| Gateway startup and shipped health check | Startup exits 1 with the cache error | Health check exits 0; `/healthz` and `/startupz` return 200 |

Additional controls:

- Browser-disabled baseline and candidate both start successfully and retain matching cache ownership and modes.
- A supplied writable home/cache mount keeps its owners, modes, and foreign-owned sentinel while the Gateway starts.
- A supplied unwritable cache keeps its foreign owner and reports the permission failure instead of taking ownership.
- A separate final-image fixture with an unrelated cache entry seeded before browser installation preserves that entry's `2001:2002` owner, `0755`/`0644` modes, and contents.
- Independent source-blind acceptance passed all nine prewritten clauses using fresh final-image runtimes and varied SQLite inputs.
- All 34 focused Dockerfile tests passed through `node scripts/run-vitest.mjs src/dockerfile.test.ts`. Formatting and whitespace checks passed; independent code review found no P0–P2 issues.

The new source-string test was removed because it required the broader recursive ownership command. The final-image checks above exercise the actual filesystem and Gateway behavior. Contributor commits and credit are retained.
