### PR TITLE
test(agents): share deletion fixtures

### DIFF
--- a/src/commands/agents.delete.test-helpers.ts
+++ b/src/commands/agents.delete.test-helpers.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  listAgentEntries,
+  toAgentEntriesRecord,
+  tryResolveSoleAgentId,
+} from "../agents/agent-scope-config.js";
+import { tryGetLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
+import { resolveSessionStorePathCore, type SessionEntry } from "../config/sessions.js";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { GatewayTransportError } from "../gateway/transport-error.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+
+export function gatewayTransportError(
+  kind: "closed" | "timeout",
+  code?: number,
+): GatewayTransportError {
+  return new GatewayTransportError({
+    kind,
+    code,
+    message: `gateway ${kind}`,
+    connectionDetails: { url: "ws://127.0.0.1:1", urlSource: "test", message: "test gateway" },
+  });
+}
+
+function resolveFixtureStoreAgentId(cfg: OpenClawConfig, deletedAgentId: string): string {
+  const storeConfig = cfg.session?.store;
+  if (typeof storeConfig === "string" && !storeConfig.includes("{agentId}")) {
+    return (
+      tryGetLegacyDefaultAgentId(cfg) ??
+      listAgentEntries(cfg).find((entry) => entry.default === true)?.id ??
+      tryResolveSoleAgentId(cfg) ??
+      deletedAgentId
+    );
+  }
+  return deletedAgentId;
+}
+
+export function createAgentsDeleteFixture(setConfig: (cfg: OpenClawConfig) => void) {
+  return async (params: {
+    stateDir: string;
+    cfg: OpenClawConfig;
+    deletedAgentId?: string;
+    sessions: Record<string, { sessionId: string; updatedAt: number }>;
+  }) => {
+    const deletedAgentId = params.deletedAgentId ?? "ops";
+    const authored = structuredClone(params.cfg);
+    const roster = listAgentEntries(authored);
+    if (!roster.some((entry) => entry.default === true)) {
+      const existingDefault = roster.find((entry) => entry.id !== deletedAgentId);
+      if (existingDefault) {
+        existingDefault.default = true;
+      } else {
+        roster.unshift({ id: "main", default: true });
+      }
+    }
+    const { list: _legacyList, ...agents } = authored.agents ?? {};
+    const cfg: OpenClawConfig = {
+      ...authored,
+      agents: { ...agents, entries: toAgentEntriesRecord(roster) },
+    };
+    const storeAgentId = resolveFixtureStoreAgentId(cfg, deletedAgentId);
+    for (const [sessionKey, entry] of Object.entries(params.sessions)) {
+      const entryAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? storeAgentId;
+      const entryStorePath = resolveSessionStorePathCore(cfg.session?.store, {
+        agentId: entryAgentId,
+      });
+      await replaceSessionEntry({ agentId: entryAgentId, sessionKey, storePath: entryStorePath }, {
+        ...entry,
+        delivery: { kind: "none" },
+      } satisfies SessionEntry);
+    }
+    await fs.mkdir(path.join(params.stateDir, `workspace-${deletedAgentId}`), { recursive: true });
+    await fs.mkdir(path.join(params.stateDir, "agents", deletedAgentId, "agent"), {
+      recursive: true,
+    });
+
+    setConfig(cfg);
+  };
+}
+
+export function readAgentDeleteJsonLogs(
+  calls: ReadonlyArray<readonly unknown[]>,
+): Array<Record<string, unknown>> {
+  return calls
+    .filter((call): call is [string, ...unknown[]] => {
+      const arg = call[0];
+      return typeof arg === "string" && arg.startsWith("{");
+    })
+    .map((call) => JSON.parse(call[0]) as Record<string, unknown>);
+}

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -1,30 +1,16 @@
-// Agents delete tests cover config removal, workspace-state cleanup, and binding updates.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  listAgentEntries,
-  toAgentEntriesRecord,
-  tryResolveSoleAgentId,
-} from "../agents/agent-scope-config.js";
-import {
   readPersistedAuthProfileStoreRaw,
   writePersistedAuthProfileStoreRaw,
 } from "../agents/auth-profiles/sqlite.js";
-import {
-  retainLegacyDefaultAgentId,
-  tryGetLegacyDefaultAgentId,
-} from "../config/legacy.default-agent-owner.js";
+import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveSessionStorePathCore } from "../config/sessions.js";
-import type { SessionEntry } from "../config/sessions.js";
-import {
-  listSessionEntriesReadOnly,
-  replaceSessionEntry,
-} from "../config/sessions/session-accessor.js";
+import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { makeCronJob } from "../cron/delivery.test-helpers.js";
 import { loadCronStore, resolveCronJobsStorePath, saveCronStore } from "../cron/store.js";
-import { GatewayTransportError } from "../gateway/transport-error.js";
 import { readExecApprovalsSnapshot, saveExecApprovals } from "../infra/exec-approvals.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
@@ -116,6 +102,11 @@ vi.mock("../wizard/clack-prompter.js", () => ({
 }));
 
 import { agentsDeleteCommand } from "./agents.commands.delete.js";
+import {
+  createAgentsDeleteFixture,
+  gatewayTransportError,
+  readAgentDeleteJsonLogs,
+} from "./agents.delete.test-helpers.js";
 
 const runtime = createTestRuntime();
 const sharedAuthStore = {
@@ -125,71 +116,10 @@ const sharedAuthStore = {
   },
 };
 
-function gatewayTransportError(kind: "closed" | "timeout", code?: number): GatewayTransportError {
-  return new GatewayTransportError({
-    kind,
-    code,
-    message: `gateway ${kind}`,
-    connectionDetails: { url: "ws://127.0.0.1:1", urlSource: "test", message: "test gateway" },
-  });
-}
-
-function resolveFixtureStoreAgentId(cfg: OpenClawConfig, deletedAgentId: string): string {
-  const storeConfig = cfg.session?.store;
-  if (typeof storeConfig === "string" && !storeConfig.includes("{agentId}")) {
-    return (
-      tryGetLegacyDefaultAgentId(cfg) ??
-      listAgentEntries(cfg).find((entry) => entry.default === true)?.id ??
-      tryResolveSoleAgentId(cfg) ??
-      deletedAgentId
-    );
-  }
-  return deletedAgentId;
-}
-
-async function arrangeAgentsDeleteTest(params: {
-  stateDir: string;
-  cfg: OpenClawConfig;
-  deletedAgentId?: string;
-  sessions: Record<string, { sessionId: string; updatedAt: number }>;
-}) {
-  const deletedAgentId = params.deletedAgentId ?? "ops";
-  const authored = structuredClone(params.cfg);
-  const roster = listAgentEntries(authored);
-  if (!roster.some((entry) => entry.default === true)) {
-    const existingDefault = roster.find((entry) => entry.id !== deletedAgentId);
-    if (existingDefault) {
-      existingDefault.default = true;
-    } else {
-      roster.unshift({ id: "main", default: true });
-    }
-  }
-  const { list: _legacyList, ...agents } = authored.agents ?? {};
-  const cfg: OpenClawConfig = {
-    ...authored,
-    agents: { ...agents, entries: toAgentEntriesRecord(roster) },
-  };
-  const storeAgentId = resolveFixtureStoreAgentId(cfg, deletedAgentId);
-  const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: deletedAgentId });
-  for (const [sessionKey, entry] of Object.entries(params.sessions)) {
-    const entryAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? storeAgentId;
-    const entryStorePath = resolveSessionStorePathCore(cfg.session?.store, {
-      agentId: entryAgentId,
-    });
-    await replaceSessionEntry({ agentId: entryAgentId, sessionKey, storePath: entryStorePath }, {
-      ...entry,
-      delivery: { kind: "none" },
-    } as SessionEntry);
-  }
-  await fs.mkdir(path.join(params.stateDir, `workspace-${deletedAgentId}`), { recursive: true });
-  await fs.mkdir(path.join(params.stateDir, "agents", deletedAgentId, "agent"), {
-    recursive: true,
-  });
-
+const arrangeAgentsDeleteTest = createAgentsDeleteFixture((cfg) => {
   configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
-
-  return storePath;
-}
+});
+const readJsonLogs = () => readAgentDeleteJsonLogs(runtime.log.mock.calls);
 
 function expectSessionStore(
   cfg: OpenClawConfig,
@@ -220,15 +150,6 @@ function expectSessionStore(
       ]),
     ),
   );
-}
-
-function readJsonLogs(): Array<Record<string, unknown>> {
-  return runtime.log.mock.calls
-    .filter((call): call is [string, ...unknown[]] => {
-      const arg = call[0];
-      return typeof arg === "string" && arg.startsWith("{");
-    })
-    .map((call) => JSON.parse(call[0]) as Record<string, unknown>);
 }
 
 describe("agents delete command", () => {

--- a/src/commands/agents.delete.workspace.test.ts
+++ b/src/commands/agents.delete.workspace.test.ts
@@ -1,21 +1,9 @@
-// Agents delete tests cover workspace trashing, sharing, and workspace-state cleanup.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  listAgentEntries,
-  toAgentEntriesRecord,
-  tryResolveSoleAgentId,
-} from "../agents/agent-scope-config.js";
-import { tryGetLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveSessionStorePathCore } from "../config/sessions.js";
-import type { SessionEntry } from "../config/sessions.js";
-import {
-  listSessionEntriesCore,
-  replaceSessionEntry,
-} from "../config/sessions/session-accessor.js";
+import { listSessionEntriesCore } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { GatewayTransportError } from "../gateway/transport-error.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
@@ -92,74 +80,18 @@ vi.mock("../wizard/clack-prompter.js", () => ({
 }));
 
 import { agentsDeleteCommand } from "./agents.commands.delete.js";
+import {
+  createAgentsDeleteFixture,
+  gatewayTransportError,
+  readAgentDeleteJsonLogs,
+} from "./agents.delete.test-helpers.js";
 
 const runtime = createTestRuntime();
 
-function gatewayTransportError(kind: "closed" | "timeout", code?: number): GatewayTransportError {
-  return new GatewayTransportError({
-    kind,
-    code,
-    message: `gateway ${kind}`,
-    connectionDetails: { url: "ws://127.0.0.1:1", urlSource: "test", message: "test gateway" },
-  });
-}
-
-function resolveFixtureStoreAgentId(cfg: OpenClawConfig, deletedAgentId: string): string {
-  const storeConfig = cfg.session?.store;
-  if (typeof storeConfig === "string" && !storeConfig.includes("{agentId}")) {
-    return (
-      tryGetLegacyDefaultAgentId(cfg) ??
-      listAgentEntries(cfg).find((entry) => entry.default === true)?.id ??
-      tryResolveSoleAgentId(cfg) ??
-      deletedAgentId
-    );
-  }
-  return deletedAgentId;
-}
-
-async function arrangeAgentsDeleteTest(params: {
-  stateDir: string;
-  cfg: OpenClawConfig;
-  deletedAgentId?: string;
-  sessions: Record<string, { sessionId: string; updatedAt: number }>;
-}) {
-  const deletedAgentId = params.deletedAgentId ?? "ops";
-  const authored = structuredClone(params.cfg);
-  const roster = listAgentEntries(authored);
-  if (!roster.some((entry) => entry.default === true)) {
-    const existingDefault = roster.find((entry) => entry.id !== deletedAgentId);
-    if (existingDefault) {
-      existingDefault.default = true;
-    } else {
-      roster.unshift({ id: "main", default: true });
-    }
-  }
-  const { list: _legacyList, ...agents } = authored.agents ?? {};
-  const cfg: OpenClawConfig = {
-    ...authored,
-    agents: { ...agents, entries: toAgentEntriesRecord(roster) },
-  };
-  const storeAgentId = resolveFixtureStoreAgentId(cfg, deletedAgentId);
-  const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: deletedAgentId });
-  for (const [sessionKey, entry] of Object.entries(params.sessions)) {
-    const entryAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? storeAgentId;
-    const entryStorePath = resolveSessionStorePathCore(cfg.session?.store, {
-      agentId: entryAgentId,
-    });
-    await replaceSessionEntry({ agentId: entryAgentId, sessionKey, storePath: entryStorePath }, {
-      ...entry,
-      delivery: { kind: "none" },
-    } as SessionEntry);
-  }
-  await fs.mkdir(path.join(params.stateDir, `workspace-${deletedAgentId}`), { recursive: true });
-  await fs.mkdir(path.join(params.stateDir, "agents", deletedAgentId, "agent"), {
-    recursive: true,
-  });
-
+const arrangeAgentsDeleteTest = createAgentsDeleteFixture((cfg) => {
   configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
-
-  return storePath;
-}
+});
+const readJsonLogs = () => readAgentDeleteJsonLogs(runtime.log.mock.calls);
 
 function expectSessionStore(
   cfg: OpenClawConfig,
@@ -190,15 +122,6 @@ function expectSessionStore(
       ]),
     ),
   );
-}
-
-function readJsonLogs(): Array<Record<string, unknown>> {
-  return runtime.log.mock.calls
-    .filter((call): call is [string, ...unknown[]] => {
-      const arg = call[0];
-      return typeof arg === "string" && arg.startsWith("{");
-    })
-    .map((call) => JSON.parse(call[0]) as Record<string, unknown>);
 }
 
 describe("agents delete workspace lifecycle", () => {
@@ -370,20 +293,27 @@ describe("agents delete workspace lifecycle", () => {
     });
   });
 
-  it("skips workspace removal when another agent shares the same workspace (#70890)", async () => {
+  it.each([
+    ["another agent shares the same workspace", "", ""],
+    ["another agent workspace overlaps a child path", "", "ops-child"],
+    ["deleting a parent workspace that contains another agent workspace", "main-child", ""],
+  ])("skips workspace removal when %s (#70890)", async (_relationship, mainPath, opsPath) => {
     await withStateDirEnv("openclaw-agents-delete-shared-workspace-", async ({ stateDir }) => {
       const sharedWorkspace = path.join(stateDir, "workspace-shared");
-      await fs.mkdir(sharedWorkspace, { recursive: true });
+      const mainWorkspace = path.join(sharedWorkspace, mainPath);
+      const opsWorkspace = path.join(sharedWorkspace, opsPath);
+      await fs.mkdir(mainWorkspace, { recursive: true });
+      await fs.mkdir(opsWorkspace, { recursive: true });
 
       const now = Date.now();
       const cfg: OpenClawConfig = {
         agents: {
           list: [
-            { id: "main", workspace: sharedWorkspace },
-            { id: "ops", workspace: sharedWorkspace },
+            { id: "main", workspace: mainWorkspace },
+            { id: "ops", workspace: opsWorkspace },
           ],
         },
-      } satisfies OpenClawConfig;
+      };
       await arrangeAgentsDeleteTest({
         stateDir,
         cfg,
@@ -396,89 +326,16 @@ describe("agents delete workspace lifecycle", () => {
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      // Workspace should still exist — it was shared
-      const retainedWorkspaceStats = await fs.stat(sharedWorkspace);
+      const retainedWorkspaceStats = await fs.stat(opsWorkspace);
       expect(retainedWorkspaceStats.isDirectory()).toBe(true);
-
-      // The JSON output should report why the workspace was retained.
       const jsonOutput = readJsonLogs();
       expect(jsonOutput).toHaveLength(1);
       expect(jsonOutput[0]?.workspaceRetained).toBe(true);
       expect(jsonOutput[0]?.workspaceRetainedReason).toBe("shared");
       expect(jsonOutput[0]?.workspaceSharedWith).toEqual(["main"]);
       const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
-      expect(trashedPaths).not.toContain(sharedWorkspace);
+      expect(trashedPaths).not.toContain(opsWorkspace);
       expect(workspaceStateMocks.deleteWorkspaceState).not.toHaveBeenCalled();
-    });
-  });
-
-  it("skips workspace removal when another agent workspace overlaps a child path (#70890)", async () => {
-    await withStateDirEnv("openclaw-agents-delete-overlapping-workspace-", async ({ stateDir }) => {
-      const sharedWorkspace = path.join(stateDir, "workspace-shared");
-      const childWorkspace = path.join(sharedWorkspace, "ops-child");
-      await fs.mkdir(childWorkspace, { recursive: true });
-
-      const now = Date.now();
-      const cfg: OpenClawConfig = {
-        agents: {
-          list: [
-            { id: "main", workspace: sharedWorkspace },
-            { id: "ops", workspace: childWorkspace },
-          ],
-        },
-      } satisfies OpenClawConfig;
-      await arrangeAgentsDeleteTest({
-        stateDir,
-        cfg,
-        deletedAgentId: "ops",
-        sessions: {
-          "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
-          "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
-        },
-      });
-
-      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
-
-      const output = readJsonLogs()[0];
-      expect(output?.workspaceRetained).toBe(true);
-      expect(output?.workspaceSharedWith).toEqual(["main"]);
-      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
-      expect(trashedPaths).not.toContain(childWorkspace);
-    });
-  });
-
-  it("skips workspace removal when deleting a parent workspace that contains another agent workspace (#70890)", async () => {
-    await withStateDirEnv("openclaw-agents-delete-parent-workspace-", async ({ stateDir }) => {
-      const sharedWorkspace = path.join(stateDir, "workspace-shared");
-      const childWorkspace = path.join(sharedWorkspace, "main-child");
-      await fs.mkdir(childWorkspace, { recursive: true });
-
-      const now = Date.now();
-      const cfg: OpenClawConfig = {
-        agents: {
-          list: [
-            { id: "main", workspace: childWorkspace },
-            { id: "ops", workspace: sharedWorkspace },
-          ],
-        },
-      } satisfies OpenClawConfig;
-      await arrangeAgentsDeleteTest({
-        stateDir,
-        cfg,
-        deletedAgentId: "ops",
-        sessions: {
-          "agent:ops:main": { sessionId: "sess-ops-main", updatedAt: now + 1 },
-          "agent:main:main": { sessionId: "sess-main", updatedAt: now + 2 },
-        },
-      });
-
-      await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
-
-      const output = readJsonLogs()[0];
-      expect(output?.workspaceRetained).toBe(true);
-      expect(output?.workspaceSharedWith).toEqual(["main"]);
-      const trashedPaths = fsSafeMocks.movePathToTrash.mock.calls.map(([targetPath]) => targetPath);
-      expect(trashedPaths).not.toContain(sharedWorkspace);
     });
   });
 


### PR DESCRIPTION
Related: #139676

## What Problem This Solves

Agent-deletion command suites copied the same fixture preparation when they were split to stay below the file-size limit. Maintaining two copies risks fixture drift and hides the distinct workspace-retention scenarios.

## Why This Change Was Made

Share narrowly scoped fixture and log helpers, keeping per-suite mocks, resets, and session readers local. Table the same-directory, child, and parent workspace cases with their original names and strongest existing assertions. This is maintainer-requested test cleanup following the Vitest 5 migration.

## User Impact

No runtime behavior changes. Test/support code shrinks by 130 lines; real filesystem and session fixture behavior stays intact.

## Evidence

- Before and after: 33 tests pass across both command suites and the deletion-safety sibling, with identical ordered names and status inventory.
- Scoped formatting, lint, guards, and all unused-export scans pass.
- Independent Codex review found no actionable P0–P2 findings.
- Refreshed onto main to include the upstream TS2339 fix; all canonical core-test type shards now pass. The umbrella changed check stops at a separate unchanged services-shard inventory limit (721 roots versus 720); all remaining gates pass independently. The full umbrella check is not claimed green, and hosted required CI must pass before landing.
- Single local runs took 25.37s and 24.89s; no speedup is claimed.

Required hosted CI passed on 0f172efd393cd082b461ac8de9264251fd58c411: [run34009515816](https://github.com/openclaw/openclaw/actions/runs/34009515816), 28 successful jobs and19 skips. ClawSweeper completed review with no findings; native landing merged this PR.
