### PR TITLE
fix(sessions): prevent cleanup failures during other database writes

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -333,10 +333,13 @@ ordering while awaiting its driver.
 Session reclamation keeps its deletion transaction on a worker connection.
 Archive publication and cascading deletion remain atomic. Before COMMIT, the
 worker publishes its authorization request in shared memory and waits for the
-parent's current owner check. Synchronous transcript writers service that request
-between short SQLite lock-admission attempts, in the reclamation owner's captured
-async context. Only admission is retried; append callbacks and mutations are never
-replayed. The original lock-admission deadline is retained. After granting approval,
+parent's current owner check. Synchronous writers service that request at the shared
+SQLite transaction boundary between short lock-admission attempts, in the reclamation
+owner's captured async context. This includes session entries, delivery records, and
+first-use board and Goal schema transactions. Registration uses the open connection's
+native database location, so other connections and reopened handles share admission.
+Only admission is retried; transaction callbacks and mutations are never replayed.
+The original lock-admission deadline is retained. After granting approval,
 the parent synchronously joins transaction settlement before allowing owner retirement;
 that mandatory join cannot be abandoned at the append deadline.
 
@@ -563,7 +566,7 @@ The shared cache targets 64 handles, but live borrows, synchronous transactions,
 
 Concurrent runs normally share the cached writer for an agent database on the main thread. Workers and diagnostics can open additional connections to the same file; the connection count is operation-dependent. Canonical agent connections set SQLite's busy timeout before use. A timeout cannot resolve a worker holding a write transaction while waiting for a blocked main thread: synchronous transcript appends do not join the asynchronous session write queue. Transaction callbacks must finish synchronously, and a competing writer must not depend on the main event loop to release its lock.
 
-Periodic agent maintenance uses passive WAL checkpoints and bounded incremental vacuum. Session reclamation currently has a separate worker write connection and post-commit truncating checkpoints and vacuum; it can contend with active transcript writers. Full compaction belongs to offline Doctor maintenance. Run errors naming the Gateway state database retain a safe SQLite diagnosis; see [storage failure troubleshooting](/gateway/troubleshooting#agent-run-failed-with-a-storage-error).
+Periodic agent maintenance uses passive WAL checkpoints and bounded incremental vacuum. Session reclamation keeps deletion on a separate worker write connection and uses a passive checkpoint and bounded vacuum after commit; long deletion transactions can still contend with other writers. Full compaction belongs to offline Doctor maintenance. Run errors naming the Gateway state database retain a safe SQLite diagnosis; see [storage failure troubleshooting](/gateway/troubleshooting#agent-run-failed-with-a-storage-error).
 
 Quarantine decisions live only in a dedicated `openclaw-quarantine.sqlite` store, so they survive damage to the databases being quarantined. Verification results are logged.
 

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.test.ts
@@ -65,7 +65,7 @@ function createCommitFixture(
       assertCurrent: () => void,
       run: (authorize: () => unknown[]) => Promise<T>,
     ) {
-      return withSqliteReclamationAuthorization(gate, databasePath, assertCurrent, run);
+      return withSqliteReclamationAuthorization(gate, database, assertCurrent, run);
     },
     async close() {
       release();

--- a/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation-commit.ts
@@ -1,20 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
-import {
-  readSqliteBusyTimeout,
-  runWithSqliteBusyTimeout,
-  setSqliteBusyTimeout,
-} from "../../infra/sqlite-busy-timeout.js";
+import { setSqliteBusyTimeout } from "../../infra/sqlite-busy-timeout.js";
 import {
   isSqliteLockError,
   runSqliteImmediateTransactionSync,
+  withSqliteWriteAdmissionService,
 } from "../../infra/sqlite-transaction.js";
-import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
-import {
-  openOpenClawAgentDatabase,
-  runOpenClawAgentWriteTransaction,
-} from "../../state/openclaw-agent-db.js";
 
 const COMMIT_DECISION_TIMEOUT_MS = 5_000;
 const WAITING = 0;
@@ -24,20 +16,16 @@ const COMMITTING = 3;
 const SETTLED = 4;
 const REQUESTED = 5;
 
-const pendingAuthorizations = resolveGlobalSingleton(
-  Symbol.for("openclaw.sqliteReclamationAuthorizations"),
-  () => new Map<string, () => void>(),
-);
-
 /** Preserve the reclamation owner's context when an unrelated synchronous writer helps. */
 export async function withSqliteReclamationAuthorization<T>(
-  buffer: SharedArrayBuffer | undefined,
-  databasePath: string,
-  assertCurrent: (() => void) | undefined,
+  buffer: SharedArrayBuffer,
+  database: DatabaseSync,
+  assertCurrent: () => void,
   run: (authorize: () => unknown[]) => Promise<T>,
 ): Promise<T> {
-  if (!buffer || !assertCurrent) {
-    return await run(() => []);
+  const databasePath = database.location();
+  if (databasePath === null) {
+    throw new Error("SQLite reclamation authorization requires a file-backed database");
   }
   const shared = new Int32Array(buffer);
   const inOwnerContext = AsyncLocalStorage.snapshot();
@@ -74,55 +62,7 @@ export async function withSqliteReclamationAuthorization<T>(
       }
     }
   };
-  pendingAuthorizations.set(databasePath, service);
-  try {
-    return await run(authorize);
-  } finally {
-    pendingAuthorizations.delete(databasePath);
-  }
-}
-
-/** Retry only write admission; never replay an append or its synchronous callbacks. */
-export function runSqliteTranscriptWriteTransaction<T>(
-  operation: Parameters<typeof runOpenClawAgentWriteTransaction<T>>[0],
-  options: Parameters<typeof runOpenClawAgentWriteTransaction>[1],
-  transactionOptions?: Parameters<typeof runOpenClawAgentWriteTransaction>[2],
-): T {
-  const database = openOpenClawAgentDatabase(options);
-  const service = pendingAuthorizations.get(database.path);
-  if (!service || database.db.isTransaction) {
-    return runOpenClawAgentWriteTransaction(operation, options, transactionOptions);
-  }
-  const busyTimeoutMs = readSqliteBusyTimeout(database.db);
-  const deadline = performance.now() + busyTimeoutMs;
-  let entered = false;
-  while (true) {
-    try {
-      return runWithSqliteBusyTimeout(
-        database.db,
-        Math.min(25, Math.max(0, Math.ceil(deadline - performance.now()))),
-        (restore) =>
-          runOpenClawAgentWriteTransaction(
-            (current) => {
-              entered = true;
-              restore();
-              return operation(current);
-            },
-            options,
-            transactionOptions,
-          ),
-        { lockFailureReporting: "suppress" },
-      );
-    } catch (error) {
-      if (entered || !isSqliteLockError(error) || performance.now() >= deadline) {
-        throw error;
-      }
-      service();
-      if (performance.now() >= deadline) {
-        throw error;
-      }
-    }
-  }
+  return await withSqliteWriteAdmissionService(database, service, () => run(authorize));
 }
 
 function rejectCommit(shared: Int32Array): void {

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -2,12 +2,14 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import { afterEach, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { loadTranscriptEvents } from "./session-accessor.js";
+import { loadSessionEntry, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
 import { ensureSessionEntrySync } from "./session-accessor.sqlite-initial-entry.js";
 import {
   createHistoryEvictionReclamationPlan,
@@ -72,10 +74,18 @@ test.each([
   { operation: "append", rejected: true },
   { operation: "replace", rejected: false },
   { operation: "replace", rejected: true },
+  { operation: "entry", rejected: false },
+  { operation: "entry", rejected: true },
+  { operation: "board", rejected: false },
+  { operation: "board", rejected: true },
 ])(
-  "two synchronous transcript writers progress at reclamation ($operation, rejected: $rejected)",
+  "two synchronous writers progress at reclamation ($operation, rejected: $rejected)",
   async ({ operation, rejected }) => {
     const { databaseOptions, plan, scopes } = createFixture();
+    const board = new SqliteBoardStore({
+      env: databaseOptions.env,
+      resolveSession: ({ sessionKey }) => ({ ...databaseOptions, sessionKey }),
+    });
     const appends: unknown[] = [];
     const appendErrors: unknown[] = [];
     let commitChecks = 0;
@@ -86,6 +96,22 @@ test.each([
         // runtimes must service that request before its queued handler can return.
         for (const scope of scopes) {
           try {
+            if (operation === "entry") {
+              replaceSessionEntrySync(scope, { sessionId: scope.sessionId, updatedAt: 2 });
+              appends.push(loadSessionEntry(scope)?.updatedAt);
+              continue;
+            }
+            if (operation === "board") {
+              // First use enters the board's schema transaction before its canonical writer.
+              appends.push(
+                board.putWidget({
+                  sessionKey: scope.sessionKey,
+                  name: "writer-proof",
+                  content: { kind: "html", html: "<p>committed</p>" },
+                }).revision,
+              );
+              continue;
+            }
             const event = { type: "session", id: scope.sessionId };
             appends.push(
               operation === "replace"
@@ -123,14 +149,28 @@ test.each([
     expect(commitChecks).toBe(1);
     expect(appendErrors).toEqual([]);
     expect(appends).toEqual(
-      operation === "replace"
-        ? [true, true]
-        : [
-            { ok: true, value: true },
-            { ok: true, value: true },
-          ],
+      operation === "entry"
+        ? [2, 2]
+        : operation === "board"
+          ? [1, 1]
+          : operation === "replace"
+            ? [true, true]
+            : [
+                { ok: true, value: true },
+                { ok: true, value: true },
+              ],
     );
     for (const scope of scopes) {
+      if (operation === "entry") {
+        expect(loadSessionEntry(scope)).toMatchObject({ sessionId: scope.sessionId, updatedAt: 2 });
+        continue;
+      }
+      if (operation === "board") {
+        expect(board.getSnapshot({ sessionKey: scope.sessionKey }).widgets).toMatchObject([
+          { name: "writer-proof", revision: 1 },
+        ]);
+        continue;
+      }
       await expect(loadTranscriptEvents(scope)).resolves.toEqual([
         { type: "session", id: scope.sessionId },
       ]);

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -388,23 +388,27 @@ export async function runSqliteSessionReclamation(params: {
     ? new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT)
     : undefined;
   const recoveredCommitErrors: unknown[] = [];
-  const [workerResult] = await withSqliteReclamationAuthorization(
-    commitGate,
-    params.plan.databaseOptions.path,
-    assertCommitAllowed,
-    (authorize) =>
-      runSqliteTranscriptArchiveWorkerOperation<SqliteSessionReclamationWorkerResult>({
-        expectedMessageType: "reclaimed",
-        onCommitRequest: () => recoveredCommitErrors.push(...authorize()),
-        transferList: prepareReclamationWorkerTransferList(params.plan),
-        workerData: {
+  const runWorker = (authorize: () => unknown[]) =>
+    runSqliteTranscriptArchiveWorkerOperation<SqliteSessionReclamationWorkerResult>({
+      expectedMessageType: "reclaimed",
+      onCommitRequest: () => recoveredCommitErrors.push(...authorize()),
+      transferList: prepareReclamationWorkerTransferList(params.plan),
+      workerData: {
+        commitGate,
+        operation: "reclaim",
+        plan: params.plan,
+        type: "sqlite-transcript-archive-v2",
+      } satisfies SqliteSessionReclamationWorkerData,
+    });
+  const [workerResult] =
+    commitGate && assertCommitAllowed
+      ? await withSqliteReclamationAuthorization(
           commitGate,
-          operation: "reclaim",
-          plan: params.plan,
-          type: "sqlite-transcript-archive-v2",
-        } satisfies SqliteSessionReclamationWorkerData,
-      }),
-  );
+          openOpenClawAgentDatabase(params.plan.databaseOptions).db,
+          assertCommitAllowed,
+          runWorker,
+        )
+      : await runWorker(() => []);
   if (!workerResult) {
     throw new Error("SQLite session reclamation Worker returned no result");
   }

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -29,7 +29,6 @@ import {
   readTranscriptSnapshot,
   type SqliteTranscriptSnapshotRow,
 } from "./session-accessor.sqlite-read.js";
-import { runSqliteTranscriptWriteTransaction } from "./session-accessor.sqlite-reclamation-commit.js";
 import {
   cloneSessionEntry,
   resolveSqliteTranscriptScope,
@@ -211,7 +210,7 @@ export function replaceTranscriptEventsSync(
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let replaced = false;
-  runSqliteTranscriptWriteTransaction((database) => {
+  runOpenClawAgentWriteTransaction((database) => {
     assertOwnedTranscriptWriteCommit(fencedScope);
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
     if (
@@ -327,7 +326,7 @@ export function appendTranscriptEventSync(
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let result: Result<boolean, TranscriptAppendRefusal> = ok(false);
-  runSqliteTranscriptWriteTransaction((database) => {
+  runOpenClawAgentWriteTransaction((database) => {
     options.beforeCommitInTransaction?.();
     assertOwnedTranscriptWriteCommit(fencedScope);
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
@@ -366,7 +365,7 @@ export function persistCompactionBoundaryWithSessionEntrySync(
 ): string {
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
-  return runSqliteTranscriptWriteTransaction(
+  return runOpenClawAgentWriteTransaction(
     (database) => {
       assertOwnedTranscriptWriteCommit(fencedScope);
       const firstAppendedSeq = readNextTranscriptSeq(database, resolved.sessionId);
@@ -461,7 +460,7 @@ export function appendTranscriptMessageSync<TMessage>(
   const resolved = resolveSqliteTranscriptScope(fencedScope);
   let result: Result<TranscriptMessageAppendResult<TMessage> | undefined, TranscriptAppendRefusal> =
     ok(undefined);
-  runSqliteTranscriptWriteTransaction((database) => {
+  runOpenClawAgentWriteTransaction((database) => {
     assertOwnedTranscriptWriteCommit(fencedScope);
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
     const refusal = resolveTranscriptAppendRefusal(fresh?.entry, resolved, fencedScope);

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -2,10 +2,15 @@
 import type { DatabaseSync } from "node:sqlite";
 import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
 import { createSubsystemLogger, type SubsystemLogger } from "../logging/subsystem.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 // The cache-state module keeps this lifecycle edge off the kysely value graph
 // so cold control-plane paths using transactions do not load kysely.
 import { clearNodeSqliteKyselyCacheForDatabase } from "./kysely-sync-cache-state.js";
-import { shouldReportSqliteLockFailure } from "./sqlite-busy-timeout.js";
+import {
+  readSqliteBusyTimeout,
+  runWithSqliteBusyTimeout,
+  shouldReportSqliteLockFailure,
+} from "./sqlite-busy-timeout.js";
 
 const SQLITE_LOCK_ERROR_CODES = new Set(["SQLITE_BUSY", "SQLITE_LOCKED"]);
 // Node reports SQLite failures with a generic string code and the extended
@@ -19,6 +24,66 @@ const DEFAULT_SLOW_BUSY_WAIT_MS = 1_000;
 const DEFAULT_SLOW_TRANSACTION_HOLD_MS = 1_000;
 
 const transactionLog = createSubsystemLogger("sqlite/transaction");
+const writeAdmissionServices = resolveGlobalSingleton(
+  Symbol.for("openclaw.sqliteWriteAdmissionServices"),
+  () => new Map<string, Set<() => void>>(),
+);
+
+/** Keep worker-owned lock holders serviceable across connections and module graphs. */
+export async function withSqliteWriteAdmissionService<T>(
+  database: DatabaseSync,
+  service: () => void,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const location = database.location();
+  if (location === null) {
+    throw new Error("SQLite write admission service requires a file-backed database");
+  }
+  const services = writeAdmissionServices.get(location) ?? new Set<() => void>();
+  services.add(service);
+  writeAdmissionServices.set(location, services);
+  try {
+    return await operation();
+  } finally {
+    services.delete(service);
+    if (services.size === 0) {
+      writeAdmissionServices.delete(location);
+    }
+  }
+}
+
+function beginImmediateTransaction(db: DatabaseSync): void {
+  // Native location identifies reopened handles without probing the filesystem.
+  const location = writeAdmissionServices.size > 0 ? db.location() : null;
+  const services = location === null ? undefined : writeAdmissionServices.get(location);
+  if (!services) {
+    db.exec("BEGIN IMMEDIATE");
+    return;
+  }
+  const deadline = performance.now() + readSqliteBusyTimeout(db);
+  while (true) {
+    try {
+      runWithSqliteBusyTimeout(
+        db,
+        Math.min(25, Math.max(0, Math.ceil(deadline - performance.now()))),
+        () => db.exec("BEGIN IMMEDIATE"),
+      );
+      return;
+    } catch (error) {
+      if (!isSqliteLockError(error) || performance.now() >= deadline) {
+        throw error;
+      }
+      // Only admission repeats. Services retain their own authority and settlement
+      // rules; caller mutations and postcommit publication have not started yet.
+      for (const service of services) {
+        service();
+      }
+      if (performance.now() >= deadline) {
+        throw error;
+      }
+    }
+  }
+}
 
 export type SqliteTransactionOptions = {
   busyTimeoutMs?: number;
@@ -133,7 +198,11 @@ function execTimedTransactionStep(params: {
 }): number {
   const startedAt = Date.now();
   try {
-    params.db.exec(params.sql);
+    if (params.sql === "BEGIN IMMEDIATE") {
+      beginImmediateTransaction(params.db);
+    } else {
+      params.db.exec(params.sql);
+    }
     const elapsedMs = Date.now() - startedAt;
     logSlowTransactionStep({
       elapsedMs,


### PR DESCRIPTION
Related: #139469

## What Problem This Solves

Fixes an issue where session cleanup fails or other session and dashboard writes stall when reclamation is waiting for commit authorization. The earlier repair covered transcript appends and replacements, but synchronous session-entry updates and first-use board transactions still blocked the parent thread on the worker's SQLite write lock.

## Why This Change Was Made

Move the existing cooperative admission into the shared `BEGIN IMMEDIATE` boundary. Every transaction writer using that boundary can service the pending worker request before retrying admission; transaction callbacks, mutations, and commit are never replayed. Remove the transcript-only wrapper and return its four callers to the canonical agent database writer.

The reclamation owner still captures its own async context, validates current authority once, and synchronously joins COMMIT, rollback, or connection-close settlement after granting approval. Registration uses the already-open connection's native database location, covering separate and reopened connections without filesystem freshness checks. Deferred reads and nested savepoints retain their existing paths, and reclamation without an authorization callback does not acquire an extra parent connection.

### Accepted design

The maintainer explicitly approved this writer-coordination repair, live testing, and landing before implementation. It extends the cooperative design in #139469 to the shared transaction owner. Schemas, persisted representations, retention, deletion atomicity, rollback, and commit-time authorization remain unchanged. No configuration option or dependency is added. Long deletion or COMMIT operations and unrelated external-lock contention remain subject to their existing costs; this does not claim a universal latency bound.

## User Impact

Session-entry and dashboard writes can finish without making the cleanup worker lose its commit checkpoint. The common admission owner also covers delivery records and first-use Goal/pending-input schema transactions. The production change is net +12 lines after removing the feature-specific path; the additional scope registration provides the shared ownership boundary. Tests add 40 lines.

## Evidence

- Failing-first on unchanged production: synchronous entry and cold board writers caused `SQLite session reclamation commit checkpoint expired`; two cases failed and seven controls passed.
- The repaired focused suite passed 39 tests, including grant/rejection, owner-context preservation, abrupt worker exits, mandatory commit settlement, native busy timeouts, savepoints, and rollback.
- Final-source unmocked Node 24 SQLite/Worker probes passed four separate/reopened-connection cases on both macOS and Linux. The parent entered a real synchronous write while the worker held its lock and the ordinary authorization callback remained queued. They verified exactly one body and authority check, durable commit/rollback results, and timeout restoration; Linux competing writes took 27–28 ms.
- Independent P0–P2 review found no actionable findings.
- Broader session, state, board, and SQLite suites: **2,497 passed, 6 skipped** across 194 passing files and one skipped file. The existing 100,000-event cleanup kept its maximum heartbeat gap at **69.43 ms**, below the unchanged 500 ms limit.
- [Linux Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34009063255): the four unmocked cases and all **43 focused tests passed**; the same 100,000-event cleanup measured **12.57 ms** maximum heartbeat gap. The native wrapper exited 0 and the owned lease is independently confirmed completed with no IP. Critical production hashes match the local candidate.

The initial reused dependency link failed before tests because its Vitest version was stale. A fresh frozen install fixed setup without changing manifests. The first changed-check remote routing preflight did not run any checks; the wrapper continued locally. `node scripts/check-changed.mjs` then completed locally with exit 0, including core/test typechecks, lint, database guards, and zero runtime import cycles. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34009531718) passed for `b8b32763c98ebdb6405c44fcbe21c131042d9e91`, with no pending checks. ClawSweeper also completed its review of that head with no actionable findings or before-merge requests.
