### PR TITLE
fix: iMessage catchup permanently drops the oldest missed messages when a chat backlog exceeds perRunLimit

### DIFF
--- a/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
@@ -447,4 +447,165 @@ describe("runIMessageCatchup", () => {
     expect(summary.replayed).toBe(1);
     expect(dispatched).toEqual(["g-600"]);
   });
+
+  it("recovers the oldest rows when one chat's backlog exceeds perRunLimit", async () => {
+    // Regression: `messages.history` is served `ORDER BY date DESC LIMIT ?`,
+    // so the per-chat fetch limit must reach past the newest perRunLimit rows
+    // to include the oldest ones. Clamping the fetch limit to perRunLimit made
+    // the server trim the OLDEST rows before OpenClaw saw them, then the
+    // cursor advanced past them — permanent silent loss for that downtime
+    // window.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-06-10T11:00:00Z"),
+      lastSeenRowid: 0,
+    });
+    const backlogStartMs = Date.parse("2026-06-10T11:01:00Z");
+    const rowMs = (rowid: number) => backlogStartMs + rowid * 1_000;
+    const backlog = Array.from({ length: 100 }, (_, index) =>
+      makeRow({
+        id: index + 1,
+        guid: `g-${index + 1}`,
+        chat_id: 1,
+        created_at: new Date(rowMs(index + 1)).toISOString(),
+      }),
+    );
+    const { client, calls } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 1, last_message_at: new Date(rowMs(100)).toISOString() }] };
+      }
+      if (method === "messages.history") {
+        const p = params as { limit: number; start?: string };
+        const startMs = p.start ? Date.parse(p.start) : Number.NEGATIVE_INFINITY;
+        // Faithful to the real bridge: newest-first page of the requested size.
+        return {
+          messages: backlog
+            .filter((row) => Date.parse(String(row.created_at)) >= startMs)
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const dispatched: number[] = [];
+    const runCatchup = async () =>
+      await runIMessageCatchup({
+        client: client as never,
+        accountId: "default",
+        config: resolveCatchupConfig({ enabled: true, perRunLimit: 50, maxAgeMinutes: 60 }),
+        includeAttachments: false,
+        dispatchPayload: async (msg) => {
+          if (typeof msg.id === "number") {
+            dispatched.push(msg.id);
+          }
+        },
+      });
+
+    const first = await runCatchup();
+    // The first pass must hand out the OLDEST 50 rows and leave the cursor at
+    // the last dispatched rowid so the next startup resumes from there.
+    expect(dispatched).toEqual(Array.from({ length: 50 }, (_, index) => index + 1));
+    expect(first.cursorAfter.lastSeenRowid).toBe(50);
+    expect(first.fullyCaughtUp).toBe(false);
+
+    const second = await runCatchup();
+    expect(second.fullyCaughtUp).toBe(true);
+    expect(second.cursorAfter.lastSeenRowid).toBe(100);
+    expect(dispatched).toEqual(Array.from({ length: 100 }, (_, index) => index + 1));
+
+    // The per-chat fetch must have requested the full history budget, not the
+    // global perRunLimit.
+    const historyCalls = calls.filter((call) => call.method === "messages.history");
+    expect(historyCalls.length).toBeGreaterThan(0);
+    for (const call of historyCalls) {
+      expect((call.params as { limit: number }).limit).toBe(500);
+    }
+  });
+
+  it("still caps each pass at perRunLimit when one chat's backlog dominates", async () => {
+    // Fairness regression guard: raising the per-chat fetch budget must not
+    // let one noisy chat monopolize a pass. The cross-chat sort plus the
+    // global perRunLimit slice still bound every pass to the oldest N rows
+    // across all chats.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00Z"));
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-06-10T11:00:00Z"),
+      lastSeenRowid: 0,
+    });
+    const backlogStartMs = Date.parse("2026-06-10T11:01:00Z");
+    const rowMs = (rowid: number) => backlogStartMs + rowid * 1_000;
+    const db = [
+      ...Array.from({ length: 100 }, (_, index) => index + 1).map((rowid) =>
+        makeRow({
+          id: rowid,
+          guid: `quiet-${rowid}`,
+          chat_id: 2,
+          created_at: new Date(rowMs(rowid)).toISOString(),
+        }),
+      ),
+      ...Array.from({ length: 500 }, (_, index) => index + 101).map((rowid) =>
+        makeRow({
+          id: rowid,
+          guid: `noisy-${rowid}`,
+          chat_id: 1,
+          created_at: new Date(rowMs(rowid)).toISOString(),
+        }),
+      ),
+    ];
+    const { client } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        return {
+          chats: [
+            { id: 1, last_message_at: new Date(rowMs(600)).toISOString() },
+            { id: 2, last_message_at: new Date(rowMs(100)).toISOString() },
+          ],
+        };
+      }
+      if (method === "messages.history") {
+        const p = params as { chat_id: number; limit: number; start?: string };
+        const startMs = p.start ? Date.parse(p.start) : Number.NEGATIVE_INFINITY;
+        return {
+          messages: db
+            .filter(
+              (row) => row.chat_id === p.chat_id && Date.parse(String(row.created_at)) >= startMs,
+            )
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const dispatched: number[] = [];
+    const config = resolveCatchupConfig({ enabled: true, perRunLimit: 50, maxAgeMinutes: 60 });
+    const runCatchup = async () =>
+      await runIMessageCatchup({
+        client: client as never,
+        accountId: "default",
+        config,
+        includeAttachments: false,
+        dispatchPayload: async (msg) => {
+          if (typeof msg.id === "number") {
+            dispatched.push(msg.id);
+          }
+        },
+      });
+
+    const first = await runCatchup();
+    // Oldest 50 rowids across BOTH chats, not 50 rows owned by the noisy chat.
+    expect(dispatched).toEqual(Array.from({ length: 50 }, (_, index) => index + 1));
+    expect(first.fullyCaughtUp).toBe(false);
+    expect(first.cursorAfter.lastSeenRowid).toBe(50);
+
+    let last = first;
+    for (let pass = 0; pass < 20 && !last.fullyCaughtUp; pass++) {
+      last = await runCatchup();
+    }
+    expect(last.fullyCaughtUp).toBe(true);
+    expect(last.cursorAfter.lastSeenRowid).toBe(600);
+    expect(dispatched).toEqual(Array.from({ length: 600 }, (_, index) => index + 1));
+  });
 });

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -13,11 +13,12 @@ import {
 import { parseIMessageNotification } from "./parse-notification.js";
 import type { IMessagePayload } from "./types.js";
 
-// Per-chat history fetch budget. messages.history is per-chat; we cap each
-// chat's fetch to the global perRunLimit so a single noisy group cannot
-// dominate the cursor advance — the cross-chat sort + final slice still
-// caps the global pass at perRunLimit.
-const PER_CHAT_HISTORY_LIMIT_CAP = 500;
+// Per-chat history fetch budget. Upstream `messages.history` serves rows
+// `ORDER BY date DESC LIMIT ?`, so a smaller limit trims the OLDEST rows
+// server-side before we ever see them. Always request the full budget: the
+// cross-chat sort plus the perRunLimit slice below can only pick the true
+// oldest rows if the per-chat page reached them.
+const PER_CHAT_HISTORY_LIMIT = 500;
 
 // chats.list page size used during catchup. 200 covers far more than any
 // realistic offline window worth of distinct chats while staying well under
@@ -113,7 +114,6 @@ export async function runIMessageCatchup(
     }
     const chats = chatsResult?.chats ?? [];
     const collected: IMessageCatchupRow[] = [];
-    const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
     let historyFetchFailed = false;
     // Track the highest rowid / date the imsg bridge actually returned across
     // all chats, regardless of whether each row passed the parser. The catchup
@@ -143,7 +143,7 @@ export async function runIMessageCatchup(
           "messages.history",
           {
             chat_id: chatId,
-            limit: perChatLimit,
+            limit: PER_CHAT_HISTORY_LIMIT,
             start: sinceISO,
             attachments: includeAttachments,
           },


### PR DESCRIPTION
Fixes #139669

## What Problem This Solves

Fixes an issue where operators running the iMessage channel with `catchup.enabled: true` would silently lose the oldest messages that arrived during gateway downtime. When a single chat's backlog exceeded `perRunLimit` (default 50), the first startup after downtime dispatched only the newest page of that backlog, advanced the catchup cursor past everything else, and reported the channel fully caught up. The missed messages never reached the agent and nothing logged a loss.

## Why This Change Was Made

The imsg bridge serves `messages.history` as `ORDER BY date DESC LIMIT ?`, so a smaller per-chat limit trims the OLDEST rows server-side before OpenClaw sees them. The catchup bridge was clamping that limit to the global `perRunLimit`, which made the fetch window exactly as wide as one dispatch pass — the oldest rows beyond the window were never fetched, yet the cursor advanced past them, so no later startup could recover them either.

The fix requests the full per-chat history budget (the existing 500-row cap) instead of `min(perRunLimit, cap)`. Fairness and resumability were never the fetch limit's job: the cross-chat rowid sort plus the global `perRunLimit` slice still cap every pass at the oldest N rows across all chats, and the existing watermark clamp still parks the cursor at the last dispatched rowid so the next startup resumes exactly where the previous pass stopped. Sibling `messages.history` callers are unaffected — they want the most recent rows, which is what a descending limited query returns.

## User Impact

iMessage operators with catchup enabled no longer lose inbound messages during downtime windows that leave more than `perRunLimit` messages in a single chat. A 100-message backlog with `perRunLimit: 50` now replays as 1–50 on the first startup and 51–100 on the next, instead of replaying 51–100 and permanently dropping 1–50. Per-pass dispatch volume is unchanged (still capped at `perRunLimit`); the per-chat fetch grows to the already-documented 500-row budget.

## Evidence

Regression test (red on `main`, green after the fix):

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts extensions/imessage/src/monitor/cache-lifecycle.test.ts -t "recovers the oldest rows"` — failed before the fix with the first pass dispatching rowids 51–100; passes after.
- Full affected file: 44/44 pass (`extensions/imessage/src/monitor/cache-lifecycle.test.ts`, includes the new oldest-rows recovery and noisy-chat fairness tests).
- Sibling monitor suite: 273/273 pass (`extensions/imessage/src/monitor.behavior.test.ts`, covers `catchup`, `dm-history`, `conversation-repair`).
- `pnpm tsgo:extensions`, `pnpm lint:extensions`, `oxfmt --check` on changed files: clean.

Near-real before/after using the production `runIMessageCatchup` through the real `IMessageRpcClient` transport (spawn + newline-delimited JSON-RPC over stdio) against a stub `imsg` binary reproducing the bridge's `ORDER BY date DESC LIMIT ?` semantics — one chat, 100 missed messages, `perRunLimit: 50`, two simulated gateway startups:

Before (unfixed `main`):

```text
pass 1 dispatched: 51..100 (50 rows)
pass 1 cursorAfter: lastSeenRowid=100 fullyCaughtUp=true
pass 2 dispatched: (none)
total dispatched: 50/100 in rowid order 1..100: false
verdict: MESSAGE LOSS — oldest rows never reached the agent
```

After (this fix):

```text
pass 1 dispatched: 1..50 (50 rows)
pass 1 cursorAfter: lastSeenRowid=50 fullyCaughtUp=false
pass 2 dispatched: 51..100 (50 rows)
pass 2 cursorAfter: lastSeenRowid=100 fullyCaughtUp=true
total dispatched: 100/100 in rowid order 1..100: true
verdict: RECOVERED — no message loss
```
