### PR TITLE
test(daemon): consolidate service lifecycle coverage

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -990,24 +990,15 @@ describe("launchd runtime parsing", () => {
     });
   });
 
-  it("does not set pid when pid = 0", () => {
-    const output = ["state = running", "pid = 0"].join("\n");
-    const info = parseLaunchctlPrint(output);
-    expect(info.pid).toBeUndefined();
-    expect(info.state).toBe("running");
-  });
-
-  it("sets pid for positive values", () => {
-    const output = ["state = running", "pid = 1234"].join("\n");
-    const info = parseLaunchctlPrint(output);
-    expect(info.pid).toBe(1234);
-  });
-
-  it("does not set pid for negative values", () => {
-    const output = ["state = waiting", "pid = -1"].join("\n");
-    const info = parseLaunchctlPrint(output);
-    expect(info.pid).toBeUndefined();
-    expect(info.state).toBe("waiting");
+  it.each([
+    { pid: 0, state: "running", expected: undefined },
+    { pid: 1234, state: "running", expected: 1234 },
+    { pid: -1, state: "waiting", expected: undefined },
+  ])("accepts only positive launchctl PIDs ($pid)", ({ pid, state: serviceState, expected }) => {
+    expect(parseLaunchctlPrint(`state = ${serviceState}\npid = ${pid}`)).toEqual({
+      state: serviceState,
+      pid: expected,
+    });
   });
 
   it("rejects pid and exit status values with junk suffixes", () => {
@@ -2688,22 +2679,18 @@ describe("launchd install", () => {
     expect(output).toContain("Stopped LaunchAgent");
   });
 
-  it("refuses in-band LaunchAgent stop before launchctl bootout", async () => {
-    const env = createDefaultLaunchdEnv();
-
-    await withProcessEnv(
-      {
-        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
-      },
-      async () => {
-        await expect(stopLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
+  it.each([undefined, true])(
+    "refuses in-band LaunchAgent stop before any native mutation (disable=%s)",
+    async (disable) => {
+      const env = createDefaultLaunchdEnv();
+      await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () => {
+        await expect(stopLaunchAgent({ env, stdout: new PassThrough(), disable })).rejects.toThrow(
           "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
         );
-      },
-    );
-
-    expect(state.launchctlCalls).toEqual([]);
-  });
+      });
+      expect(state.launchctlCalls).toEqual([]);
+    },
+  );
 
   it("disables the current LaunchAgent before scheduling maintenance bootout", async () => {
     const env = createDefaultLaunchdEnv();
@@ -2830,17 +2817,18 @@ describe("launchd install", () => {
     expect(output).toContain("Stopped LaunchAgent");
   });
 
-  it("verifies the configured gateway port is released before reporting stop success", async () => {
-    const env = createLaunchdEnvWithGatewayPort("19003");
+  it.each([
+    { mode: "bootout", port: 19003, disable: undefined },
+    { mode: "disable-stop", port: 19005, disable: true },
+  ])("verifies port release before reporting $mode success", async ({ port, disable }) => {
+    const env = createLaunchdEnvWithGatewayPort(String(port));
     let output = "";
     const stdout = capturePassThroughOutput((text) => (output += text));
 
-    await stopLaunchAgent({ env, stdout });
+    await stopLaunchAgent({ env, stdout, disable });
 
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19003);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19003, {
-      probeHosts: ["127.0.0.1"],
-    });
+    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(port);
+    expect(inspectPortUsage).toHaveBeenCalledWith(port, { probeHosts: ["127.0.0.1"] });
     expect(output).toContain("Stopped LaunchAgent");
   });
 
@@ -2909,31 +2897,39 @@ describe("launchd install", () => {
     });
   });
 
-  it("fails stop when the verified gateway port remains busy after cleanup", async () => {
-    const env = createLaunchdEnvWithGatewayPort("19004");
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    const onMutation = vi.fn();
-    let output = "";
-    inspectPortUsage.mockResolvedValue({
-      port: 19004,
-      status: "busy",
-      listeners: [],
-      hints: [],
-    });
-    probePortUsage.mockResolvedValue("busy");
-    formatPortDiagnostics.mockReturnValue(["Port 19004 is held by pid 4242."]);
+  it.each([
+    { mode: "bootout", port: 19004, disable: undefined },
+    { mode: "disable-bootout", port: 19008, disable: true },
+  ] as const)(
+    "rejects $mode success while the gateway port stays busy",
+    async ({ mode, port, disable }) => {
+      const env = createLaunchdEnvWithGatewayPort(String(port));
+      let output = "";
+      const stdout = capturePassThroughOutput((text) => (output += text));
+      const onMutation = vi.fn();
+      if (disable) {
+        state.disableError = "Operation not permitted";
+      }
+      inspectPortUsage.mockResolvedValue({ port, status: "busy", listeners: [], hints: [] });
+      probePortUsage.mockResolvedValue("busy");
+      formatPortDiagnostics.mockReturnValue([`Port ${port} is held by pid 4242.`]);
 
-    await expect(runStopLaunchAgentWithFakeTimers({ env, stdout, onMutation })).rejects.toThrow(
-      "gateway port 19004 is still busy after LaunchAgent stop\nPort 19004 is held by pid 4242.",
-    );
+      await expect(
+        runStopLaunchAgentWithFakeTimers({ env, stdout, disable, onMutation }),
+      ).rejects.toThrow(
+        `gateway port ${port} is still busy after LaunchAgent stop\nPort ${port} is held by pid 4242.`,
+      );
 
-    expect(onMutation).toHaveBeenCalledWith({ mode: "bootout" });
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19004);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19004, {
-      probeHosts: ["127.0.0.1"],
-    });
-    expect(output).not.toContain("Stopped LaunchAgent");
-  });
+      expect(onMutation).toHaveBeenCalledWith({ mode });
+      expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(port);
+      expect(inspectPortUsage).toHaveBeenCalledWith(port, { probeHosts: ["127.0.0.1"] });
+      expect(launchctlCommandNames()).toContain("bootout");
+      if (disable) {
+        expect(output).toContain("used bootout fallback");
+      }
+      expect(output).not.toContain("Stopped LaunchAgent");
+    },
+  );
 
   it("does not treat a co-located Gateway's own port as busy when stopping a node-host LaunchAgent", async () => {
     const env = {
@@ -2998,39 +2994,6 @@ describe("launchd install", () => {
     expect(output).toContain("Stopped LaunchAgent");
   });
 
-  it("verifies the configured gateway port is released before reporting disable stop success", async () => {
-    const env = createLaunchdEnvWithGatewayPort("19005");
-    let output = "";
-    const stdout = capturePassThroughOutput((text) => (output += text));
-
-    await stopLaunchAgent({ env, stdout, disable: true });
-
-    expect(cleanStaleGatewayProcessesSync).toHaveBeenCalledWith(19005);
-    expect(inspectPortUsage).toHaveBeenCalledWith(19005, {
-      probeHosts: ["127.0.0.1"],
-    });
-    expect(output).toContain("Stopped LaunchAgent");
-  });
-
-  it("refuses in-band LaunchAgent disable-stop before any launchctl call", async () => {
-    const env = createDefaultLaunchdEnv();
-
-    await withProcessEnv(
-      {
-        LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
-      },
-      async () => {
-        await expect(
-          stopLaunchAgent({ env, stdout: new PassThrough(), disable: true }),
-        ).rejects.toThrow(
-          "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
-        );
-      },
-    );
-
-    expect(state.launchctlCalls).toEqual([]);
-  });
-
   it("treats already-unloaded services as successfully stopped without bootout fallback (--disable)", async () => {
     const env = createDefaultLaunchdEnv();
     const stdout = capturePassThroughOutput((text) => (output += text));
@@ -3069,101 +3032,58 @@ describe("launchd install", () => {
     expect(output).not.toContain("degraded");
   });
 
-  it("falls back to bootout when disable fails so stop remains authoritative (--disable)", async () => {
-    const env = createDefaultLaunchdEnv();
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    let output = "";
-    state.disableError = "Operation not permitted";
+  it.each([
+    {
+      reason: "disable fails",
+      overrides: { disableError: "Operation not permitted" },
+      run: stopLaunchAgent,
+      warning: "used bootout fallback",
+      stopCalled: false,
+    },
+    {
+      reason: "stop leaves a running process",
+      overrides: { stopLeavesRunning: true },
+      run: runStopLaunchAgentWithFakeTimers,
+      warning: "did not fully stop the service",
+      stopCalled: true,
+    },
+    {
+      reason: "print reports running without a PID",
+      overrides: { stopLeavesRunning: true, printOutput: "state = running\n" },
+      run: runStopLaunchAgentWithFakeTimers,
+      warning: "did not fully stop the service",
+      stopCalled: true,
+    },
+    {
+      reason: "stop errors",
+      overrides: { stopError: "stop failed due to transient launchd error" },
+      run: stopLaunchAgent,
+      warning: "launchctl stop failed; used bootout fallback",
+      stopCalled: true,
+    },
+    {
+      reason: "print cannot confirm stop",
+      overrides: { printError: "launchctl print permission denied", printFailuresRemaining: 11 },
+      run: runStopLaunchAgentWithFakeTimers,
+      warning: "could not confirm stop",
+      stopCalled: true,
+    },
+  ])(
+    "uses bootout fallback when $reason (--disable)",
+    async ({ overrides, run, warning, stopCalled }) => {
+      const env = createDefaultLaunchdEnv();
+      let output = "";
+      const stdout = capturePassThroughOutput((text) => (output += text));
+      Object.assign(state, overrides);
 
-    await stopLaunchAgent({ env, stdout, disable: true });
+      await run({ env, stdout, disable: true });
 
-    expect(launchctlCommandNames()).not.toContain("stop");
-    expect(launchctlCommandNames()).toContain("bootout");
-    expect(output).toContain("Stopped LaunchAgent (degraded)");
-    expect(output).toContain("used bootout fallback");
-  });
-
-  it("does not report degraded stop success when fallback cleanup leaves the port busy", async () => {
-    const env = createLaunchdEnvWithGatewayPort("19008");
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    const onMutation = vi.fn();
-    let output = "";
-    state.disableError = "Operation not permitted";
-    inspectPortUsage.mockResolvedValue({
-      port: 19008,
-      status: "busy",
-      listeners: [],
-      hints: [],
-    });
-    probePortUsage.mockResolvedValue("busy");
-    formatPortDiagnostics.mockReturnValue(["Port 19008 is held by pid 4242."]);
-
-    await expect(
-      runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true, onMutation }),
-    ).rejects.toThrow(
-      "gateway port 19008 is still busy after LaunchAgent stop\nPort 19008 is held by pid 4242.",
-    );
-
-    expect(onMutation).toHaveBeenCalledWith({ mode: "disable-bootout" });
-    expect(launchctlCommandNames()).toContain("bootout");
-    expect(output).toContain("used bootout fallback");
-    expect(output).not.toContain("Stopped LaunchAgent");
-  });
-
-  it("falls back to bootout when stop does not fully stop the service (--disable)", async () => {
-    const env = createDefaultLaunchdEnv();
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    let output = "";
-    state.stopLeavesRunning = true;
-
-    await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
-
-    expect(launchctlCommandNames()).toContain("stop");
-    expect(launchctlCommandNames()).toContain("bootout");
-    expect(output).toContain("Stopped LaunchAgent (degraded)");
-    expect(output).toContain("did not fully stop the service");
-  });
-
-  it("treats launchctl print state=running as running even when pid is missing (--disable)", async () => {
-    const env = createDefaultLaunchdEnv();
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    let output = "";
-    state.stopLeavesRunning = true;
-    state.printOutput = "state = running\n";
-
-    await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
-
-    expect(launchctlCommandNames()).toContain("bootout");
-    expect(output).toContain("Stopped LaunchAgent (degraded)");
-    expect(output).toContain("did not fully stop the service");
-  });
-
-  it("falls back to bootout when launchctl stop itself errors (--disable)", async () => {
-    const env = createDefaultLaunchdEnv();
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    let output = "";
-    state.stopError = "stop failed due to transient launchd error";
-
-    await stopLaunchAgent({ env, stdout, disable: true });
-
-    expect(launchctlCommandNames()).toContain("bootout");
-    expect(output).toContain("Stopped LaunchAgent (degraded)");
-    expect(output).toContain("launchctl stop failed; used bootout fallback");
-  });
-
-  it("falls back to bootout when launchctl print cannot confirm the stop state (--disable)", async () => {
-    const env = createDefaultLaunchdEnv();
-    const stdout = capturePassThroughOutput((text) => (output += text));
-    let output = "";
-    state.printError = "launchctl print permission denied";
-    state.printFailuresRemaining = 11;
-
-    await runStopLaunchAgentWithFakeTimers({ env, stdout, disable: true });
-
-    expect(launchctlCommandNames()).toContain("bootout");
-    expect(output).toContain("Stopped LaunchAgent (degraded)");
-    expect(output).toContain("could not confirm stop");
-  });
+      expect(launchctlCommandNames().includes("stop")).toBe(stopCalled);
+      expect(launchctlCommandNames()).toContain("bootout");
+      expect(output).toContain("Stopped LaunchAgent (degraded)");
+      expect(output).toContain(warning);
+    },
+  );
 
   it("throws when launchctl print cannot confirm stop and bootout also fails (--disable)", async () => {
     const env = createDefaultLaunchdEnv();

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -324,43 +324,51 @@ describe("installScheduledTask", () => {
     });
   });
 
-  it("creates hidden launcher Windows tasks when requested", async () => {
+  it.each([
+    { kind: "new", query: missingTaskResponse, marker: "1", xmlIndex: 1 },
+    { kind: "existing", query: okSchtasksResponse, marker: "true", xmlIndex: 2 },
+  ])("uses the requested hidden launcher for $kind tasks", async ({ query, marker, xmlIndex }) => {
     await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(missingTaskResponse);
-
+      schtasksResponses.push(query);
       const { scriptPath } = await installDefaultGatewayTask({
         ...env,
         USERDOMAIN: "WORKSTATION",
         USERNAME: "alice",
-        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "1",
+        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: marker,
       });
       const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
       const rawLauncher = await fs.readFile(launcherPath);
       const launcher = decodeWindowsLauncherScript({ buffer: rawLauncher });
 
       expectInitialTaskQuery();
-      // wscript only accepts UTF-16 LE with BOM or ANSI; UTF-16 keeps CJK paths intact.
+      if (xmlIndex === 2) {
+        expect(schtasksCalls[1]).toEqual([
+          "/Change",
+          "/TN",
+          "OpenClaw Gateway",
+          "/TR",
+          expect.stringContaining("gateway.vbs"),
+        ]);
+        expect(schtasksCalls[1]?.[4]).toContain(launcherPath);
+      }
+      // wscript requires a BOM for UTF-16; XML owns the interactive principal.
       expect(rawLauncher.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
-      // XML owns the domain user and InteractiveToken. `/NP` would turn it into
-      // non-interactive S4U, so the command must not override the principal.
-      expect(schtasksCalls[1]?.slice(0, 5)).toEqual([
+      expect(schtasksCalls[xmlIndex]?.slice(0, 5)).toEqual([
         "/Create",
         "/F",
         "/TN",
         "OpenClaw Gateway",
         "/XML",
       ]);
-      expect(schtasksCalls[1]).not.toContain("/RU");
-      expect(schtasksCalls[1]).not.toContain("/NP");
-      const captured = xmlPayloadCaptures.find((entry) => entry.index === 1);
-      expect(captured?.xml).toContain("<UserId>WORKSTATION\\alice</UserId>");
-      expect(captured?.xml).toContain("<LogonType>InteractiveToken</LogonType>");
-      expect(launcher).toContain("WScript.Shell");
-      expect(launcher).toContain(scriptPath);
+      expect(schtasksCalls[xmlIndex]).not.toContain("/RU");
+      expect(schtasksCalls[xmlIndex]).not.toContain("/NP");
+      const xml = xmlPayloadCaptures.find((entry) => entry.index === xmlIndex)?.xml;
+      expect(xml).toContain("<UserId>WORKSTATION\\alice</UserId>");
+      expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
       expect(launcher).toContain(
         `WScript.Quit CreateObject("WScript.Shell").Run("""${scriptPath}""", 0, True)`,
       );
-      expectTaskRunCall(2);
+      expectTaskRunCall(xmlIndex + 1);
     });
   });
 
@@ -499,134 +507,66 @@ describe("installScheduledTask", () => {
     });
   });
 
-  it("creates an interactive domain Scheduled Task via XML with battery start/continue enabled (#59299)", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(missingTaskResponse);
+  it.each([
+    {
+      kind: "new domain task",
+      domain: "WORKSTATION",
+      user: "WORKSTATION\\alice",
+      query: missingTaskResponse,
+      commands: ["/Query", "/Create", "/Run"],
+      xmlIndex: 1,
+    },
+    {
+      kind: "new workgroup task",
+      domain: "WORKGROUP",
+      user: "alice",
+      query: missingTaskResponse,
+      commands: ["/Query", "/Create", "/Run"],
+      xmlIndex: 1,
+    },
+    {
+      kind: "upgraded task",
+      domain: "WORKSTATION",
+      user: "WORKSTATION\\alice",
+      query: okSchtasksResponse,
+      commands: ["/Query", "/Change", "/Create", "/Run"],
+      xmlIndex: 2,
+    },
+  ])(
+    "preserves interactive identity and battery settings for a $kind (#59299)",
+    async ({ domain, user, query, commands, xmlIndex }) => {
+      await withUserProfileDir(async (_tmpDir, env) => {
+        schtasksResponses.push(query);
+        await installDefaultGatewayTask({ ...env, USERDOMAIN: domain, USERNAME: "alice" });
 
-      await installDefaultGatewayTask({
-        ...env,
-        USERDOMAIN: "WORKSTATION",
-        USERNAME: "alice",
+        expectInitialTaskQuery();
+        expect(schtasksCalls.map((call) => call[0])).toEqual(commands);
+        const createCall = schtasksCalls[xmlIndex];
+        expect(createCall?.slice(0, 5)).toEqual([
+          "/Create",
+          "/F",
+          "/TN",
+          "OpenClaw Gateway",
+          "/XML",
+        ]);
+        expect(createCall).not.toContain("/RU");
+        expect(createCall).not.toContain("/NP");
+        expectTaskRunCall(xmlIndex + 1);
+        const xml = xmlPayloadCaptures.find((entry) => entry.index === xmlIndex)?.xml;
+        expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
+        expect(xml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
+        expect(xml).toContain("<RestartOnFailure>");
+        expect(xml).toContain("<Interval>PT1M</Interval>");
+        expect(xml).toContain("<Count>3</Count>");
+        expect(xml).toContain("<LogonTrigger>");
+        expect(xml).toContain("<RunLevel>LeastPrivilege</RunLevel>");
+        expect(xml).toContain(`<UserId>${user}</UserId>`);
+        expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
+        expect(xml).not.toContain("<GroupId>S-1-5-32-545</GroupId>");
+        expect(xml).toContain("<Exec>");
       });
-
-      // `/Create` must use `/XML <path>` so battery flags can be set; the
-      // CLI flag form (`/SC ONLOGON /RL LIMITED /TR ...`) cannot express
-      // `DisallowStartIfOnBatteries`/`StopIfGoingOnBatteries`.
-      const createCall = schtasksCalls[1];
-      expect(createCall?.[0]).toBe("/Create");
-      expect(createCall).toContain("/XML");
-      expect(createCall).not.toContain("/RU");
-      expect(createCall).not.toContain("/NP");
-
-      const captured = xmlPayloadCaptures.find((entry) => entry.index === 1);
-      expect(captured).toBeDefined();
-      const xml = captured?.xml ?? "";
-      expect(xml).toContain("<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>");
-      expect(xml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
-      expect(xml).toContain("<RestartOnFailure>");
-      expect(xml).toContain("<Interval>PT1M</Interval>");
-      expect(xml).toContain("<Count>3</Count>");
-      // Preserve the prior CLI semantics: ONLOGON trigger, LeastPrivilege, exec action.
-      expect(xml).toContain("<LogonTrigger>");
-      expect(xml).toContain("<RunLevel>LeastPrivilege</RunLevel>");
-      expect(xml).toContain("<UserId>WORKSTATION\\alice</UserId>");
-      expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
-      expect(xml).toContain("<Exec>");
-    });
-  });
-
-  it("omits /RU for workgroup accounts so schtasks can use the current local user", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(missingTaskResponse);
-
-      await installDefaultGatewayTask({
-        ...env,
-        USERDOMAIN: "WORKGROUP",
-        USERNAME: "alice",
-      });
-
-      expectInitialTaskQuery();
-      const createCall = schtasksCalls[1];
-      expect(createCall?.slice(0, 5)).toEqual(["/Create", "/F", "/TN", "OpenClaw Gateway", "/XML"]);
-      expect(createCall).not.toContain("/RU");
-      const captured = xmlPayloadCaptures.find((entry) => entry.index === 1);
-      expect(captured?.xml).toContain("<UserId>alice</UserId>");
-      expect(captured?.xml).not.toContain("<GroupId>S-1-5-32-545</GroupId>");
-      expectTaskRunCall(2);
-    });
-  });
-
-  it("re-applies the XML on /Change so upgraded tasks adopt battery flags (#59299)", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      // /Query /TN yes, /Change ok, /Create /XML ok (upgrade), /Run ok.
-      schtasksResponses.push(
-        okSchtasksResponse,
-        okSchtasksResponse,
-        okSchtasksResponse,
-        okSchtasksResponse,
-      );
-
-      await installDefaultGatewayTask(env);
-
-      expectInitialTaskQuery();
-      expect(schtasksCalls[1]?.[0]).toBe("/Change");
-      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
-        "/Create",
-        "/F",
-        "/TN",
-        "OpenClaw Gateway",
-        "/XML",
-      ]);
-      const upgradeCapture = xmlPayloadCaptures.find((entry) => entry.index === 2);
-      expect(upgradeCapture).toBeDefined();
-      const upgradeXml = upgradeCapture?.xml ?? "";
-      expect(upgradeXml).toContain(
-        "<DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>",
-      );
-      expect(upgradeXml).toContain("<StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>");
-      expect(upgradeXml).toContain("<RestartOnFailure>");
-      expectTaskRunCall(3);
-    });
-  });
-
-  it("updates existing tasks to use the hidden launcher when requested", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      // /Query /TN, /Change (TR-only), /Create /XML (upgrade re-apply), /Run.
-      schtasksResponses.push(
-        okSchtasksResponse,
-        okSchtasksResponse,
-        okSchtasksResponse,
-        okSchtasksResponse,
-      );
-
-      const { scriptPath } = await installDefaultGatewayTask({
-        ...env,
-        USERDOMAIN: "WORKSTATION",
-        USERNAME: "alice",
-        OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER: "true",
-      });
-      const launcherPath = scriptPath.replace(/\.cmd$/i, ".vbs");
-
-      expectInitialTaskQuery();
-      expect(schtasksCalls[1]).toEqual([
-        "/Change",
-        "/TN",
-        "OpenClaw Gateway",
-        "/TR",
-        expect.stringContaining("gateway.vbs"),
-      ]);
-      expect(schtasksCalls[1]?.[4]).toContain(launcherPath);
-      // Upgrade XML re-apply runs after /Change so older tasks pick up battery flags.
-      expect(schtasksCalls[2]?.slice(0, 5)).toEqual([
-        "/Create",
-        "/F",
-        "/TN",
-        "OpenClaw Gateway",
-        "/XML",
-      ]);
-      expectTaskRunCall(3);
-    });
-  });
+    },
+  );
 
   it("falls back to /Create when /Change fails on an existing task", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {
@@ -641,40 +581,33 @@ describe("installScheduledTask", () => {
     });
   });
 
-  it("throws when /Run fails after updating an existing task", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      // /Query /TN, /Change, /Create XML upgrade re-apply, /Run (fails).
-      schtasksResponses.push(
-        okSchtasksResponse,
-        okSchtasksResponse,
-        okSchtasksResponse,
-        accessDeniedResponse,
-      );
-
-      await expect(installDefaultGatewayTask(env)).rejects.toThrow(
-        "schtasks run failed: ERROR: Access is denied.",
-      );
-
-      expectInitialTaskQuery();
-      expect(schtasksCalls[1]?.[0]).toBe("/Change");
-      expect(schtasksCalls[2]?.[0]).toBe("/Create");
-      expectTaskRunCall(3);
-    });
-  });
-
-  it("throws when /Run fails after creating a new task", async () => {
-    await withUserProfileDir(async (_tmpDir, env) => {
-      schtasksResponses.push(missingTaskResponse, okSchtasksResponse, accessDeniedResponse);
-
-      await expect(installDefaultGatewayTask(env)).rejects.toThrow(
-        "schtasks run failed: ERROR: Access is denied.",
-      );
-
-      expectInitialTaskQuery();
-      expect(schtasksCalls[1]?.[0]).toBe("/Create");
-      expectTaskRunCall(2);
-    });
-  });
+  it.each([
+    {
+      kind: "existing",
+      responses: [okSchtasksResponse, okSchtasksResponse, okSchtasksResponse, accessDeniedResponse],
+      commands: ["/Query", "/Change", "/Create", "/Run"],
+      runIndex: 3,
+    },
+    {
+      kind: "new",
+      responses: [missingTaskResponse, okSchtasksResponse, accessDeniedResponse],
+      commands: ["/Query", "/Create", "/Run"],
+      runIndex: 2,
+    },
+  ])(
+    "propagates /Run failure after registering a $kind task",
+    async ({ responses, commands, runIndex }) => {
+      await withUserProfileDir(async (_tmpDir, env) => {
+        schtasksResponses.push(...responses);
+        await expect(installDefaultGatewayTask(env)).rejects.toThrow(
+          "schtasks run failed: ERROR: Access is denied.",
+        );
+        expectInitialTaskQuery();
+        expect(schtasksCalls.map((call) => call[0])).toEqual(commands);
+        expectTaskRunCall(runIndex);
+      });
+    },
+  );
 
   it("does not persist a frozen PATH snapshot into the generated task script", async () => {
     await withUserProfileDir(async (_tmpDir, env) => {


### PR DESCRIPTION
Related: #135868, #139333

## What Problem This Solves

The daemon tests repeat fixture construction and assertions across equivalent service-control and installation scenarios. This is test-deslop stage 2 (daemon) of the maintainer-requested #135868 split campaign, covering the native-manager owner neighborhood in concern D of the decision brief (§1 and §5).

## Why This Change Was Made

Keep the same scenarios as named table rows for LaunchAgent PID parsing, in-service stop refusal, port-release outcomes, and stop fallback diagnostics, plus Scheduled Task hidden launchers, XML policy, and activation failures. Preserve the original immediate versus fake-timer execution choices and complete boundary assertions. Shared XML assertions now apply to each registration row; the exact launcher invocation subsumes separate substring checks.

The active Windows stop/startup work in #139344 and update-control work in #139495 are outside this patch.

## User Impact

No runtime behavior changes. Tests lose 147 lines (+218/-365): `launchd.test.ts` 4,110→4,030 and `schtasks.install.test.ts` 734→667, total 4,844→4,697. Production, tooling, and docs are +0/-0. No test files, cases, production seams, suppressions, or baseline entries are removed.

Together with the landed -118 config cleanup (#139626), this would bring the original supplied +94 campaign tally to -171. Including the separately assigned +412 Crabbox-wrapper target (#139405), the expanded tracked tally would be +241, before other lanes' changes.

## Evidence

Paired full standard daemon-directory runs used baseline `ed9928bf306` with and without this test diff and identical repository routing:

| Run | Files | Cases | Passed / skipped | Vitest time | Wrapper time |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before | 40 | 1,353 | 1,344 / 9 | 28.83s | 34.05s |
| After | 40 | 1,353 | 1,344 / 9 | 21.82s | 25.48s |

Both runs exited 0. The standard suite excludes explicitly named optional native E2E files. No timeout, assertion, or expected-failure setting changed. Cache and host load differed, so durations are not a performance claim.

The full changed-check plan passed, including the compiler graph boundary, services type graph, format/lint, all selected guards, and all three dead-export scans. An initial lint pass caught a shadowed callback variable; it was renamed and both the full suite and changed-check plan passed afterward. Fresh local and branch Codex reviews are scoped-clean through P2 (no actionable findings, confidence 0.97). Branch review ran on ba05c7b0dff; the published landing candidate is b72707c7a6aa after the required main refreshes, with byte-identical changed files and unchanged inspected owners and lockfile. Exact-head CI [34009977959](https://github.com/openclaw/openclaw/actions/runs/34009977959) passed on b72707c7a6aa, including both Windows Node jobs. Native Testbox-backed prepare completed on that same unchanged head.

Every consolidated case retains named boundary proof:

| Removed scaffolding | Remaining coverage |
| --- | --- |
| Separate zero, positive, and negative PID fixtures | `src/daemon/launchd.test.ts:997` retains all three PID values and runtime states; full exit-status parsing and junk suffixes stay separate. |
| Repeated in-service stop refusal setup | `src/daemon/launchd.test.ts:2683` retains default and disable modes, the exact refusal, and zero native calls. XPC and marker-less ancestry cases remain. |
| Duplicate successful port-release checks | `src/daemon/launchd.test.ts:2823` retains both ports/modes and cleanup, host probing, and success output. |
| Duplicate busy-port failure setup | `src/daemon/launchd.test.ts:2904` retains both ports, observer modes, full diagnostics, fallback warning, and absence of success output. |
| Five repeated bootout-fallback bodies | `src/daemon/launchd.test.ts:3072` retains disable failure, lingering PID, running state without PID, stop error, and unclassifiable state, including their distinct diagnostics and timer choices. |
| Hidden launcher create/update bodies and weaker substring checks | `src/daemon/schtasks.install.test.ts:330` retains both marker spellings, UTF-16 BOM, exact VBS invocation, XML principal, update TR path, and run ordering. CJK and unrepresentable-encoding cases stay separate. |
| Domain/workgroup/create/upgrade XML scaffolding | `src/daemon/schtasks.install.test.ts:536` retains both user identities and registration paths, battery/restart policy, interactive least-privilege principal, and no /RU or /NP override. |
| Separate activation-failure bodies | `src/daemon/schtasks.install.test.ts:598` retains /Run failures after both creation and update, exact error, and complete command order. |

ClawSweeper [reviewed the current head b72707c7a6aa](https://github.com/openclaw/openclaw/pull/139694#issuecomment-5556750160) with no findings, no before-merge requirements, and no rank-up moves to apply.
