### PR TITLE
refactor(protocol): share error-detail normalization

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1520,9 +1520,8 @@ packages/gateway-client/src/gateway-origin-scope.ts	1
 packages/gateway-client/src/pending-request.ts	2
 packages/gateway-client/src/protocol-client.ts	1
 packages/gateway-client/src/scope-upgrade.ts	4
-packages/gateway-protocol/src/clawhub-trust-error-details.ts	1
 packages/gateway-protocol/src/client-info.ts	4
-packages/gateway-protocol/src/connect-error-details.ts	12
+packages/gateway-protocol/src/connect-error-details.ts	9
 packages/gateway-protocol/src/gateway-error-details.ts	1
 packages/gateway-protocol/src/protocol-validator.ts	3
 packages/gateway-protocol/src/schema/audit-activity.ts	1

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -216,9 +216,9 @@
     "properties": {}
   },
   "controlUi": {
-    "entry": "dist/control-ui/00cf91d70469ae4e5a54b0e056272f32b40a303234c2b8255d538c25645da25b/index.js",
+    "entry": "dist/control-ui/3041fee4ed9fe2fdf67b9822431907f6776f8194057a2f4de981260449b34c98/index.js",
     "styles": [
-      "dist/control-ui/00cf91d70469ae4e5a54b0e056272f32b40a303234c2b8255d538c25645da25b/index.css"
+      "dist/control-ui/3041fee4ed9fe2fdf67b9822431907f6776f8194057a2f4de981260449b34c98/index.css"
     ]
   }
 }

--- a/packages/gateway-protocol/src/clawhub-trust-error-details.ts
+++ b/packages/gateway-protocol/src/clawhub-trust-error-details.ts
@@ -1,3 +1,4 @@
+import { readNonBlankString } from "@openclaw/normalization-core/string-coerce";
 import { isProtocolRecord } from "./protocol-value-normalization.js";
 
 /** Structured ClawHub trust details carried in gateway error payloads. */
@@ -13,10 +14,6 @@ export type ClawHubTrustErrorDetails = {
   version?: string;
   warning?: string;
 };
-
-function normalizeNonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
-}
 
 export function isClawHubTrustErrorCode(value: unknown): value is ClawHubTrustErrorCode {
   return (
@@ -46,14 +43,11 @@ export function readClawHubTrustErrorDetails(
   if (!isProtocolRecord(details)) {
     return undefined;
   }
-  const raw = details as {
-    clawhubTrustCode?: unknown;
-    version?: unknown;
-    warning?: unknown;
-  };
-  const code = isClawHubTrustErrorCode(raw.clawhubTrustCode) ? raw.clawhubTrustCode : undefined;
-  const version = normalizeNonEmptyString(raw.version);
-  const warning = normalizeNonEmptyString(raw.warning);
+  const code = isClawHubTrustErrorCode(details.clawhubTrustCode)
+    ? details.clawhubTrustCode
+    : undefined;
+  const version = readNonBlankString(details.version);
+  const warning = readNonBlankString(details.warning);
   if (!code && !version && !warning) {
     return undefined;
   }

--- a/packages/gateway-protocol/src/client-info.ts
+++ b/packages/gateway-protocol/src/client-info.ts
@@ -4,11 +4,7 @@
  * These values cross the WebSocket handshake boundary, so additions must stay
  * aligned with protocol schemas and server policy checks.
  */
-import { normalizeOptionalProtocolString } from "./protocol-value-normalization.js";
-
-function normalizeOptionalProtocolLowercaseString(raw?: string | null): string | undefined {
-  return normalizeOptionalProtocolString(raw)?.toLowerCase();
-}
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 
 /** Canonical client ids accepted in gateway hello/connect payloads. */
 export const GATEWAY_CLIENT_IDS = {
@@ -106,7 +102,7 @@ const GATEWAY_CLIENT_MODE_SET = new Set<GatewayClientMode>(Object.values(GATEWAY
 export function normalizeGatewayClientId(raw?: string | null): GatewayClientId | undefined {
   // Handshake input is intentionally case-insensitive, but policy decisions use
   // the canonical lowercase ids from the closed registry above.
-  const normalized = normalizeOptionalProtocolLowercaseString(raw);
+  const normalized = normalizeOptionalLowercaseString(raw);
   if (!normalized) {
     return undefined;
   }
@@ -122,7 +118,7 @@ export function normalizeGatewayClientName(raw?: string | null): GatewayClientNa
 
 /** Normalizes untrusted client modes and rejects unknown values. */
 export function normalizeGatewayClientMode(raw?: string | null): GatewayClientMode | undefined {
-  const normalized = normalizeOptionalProtocolLowercaseString(raw);
+  const normalized = normalizeOptionalLowercaseString(raw);
   if (!normalized) {
     return undefined;
   }

--- a/packages/gateway-protocol/src/connect-error-details.ts
+++ b/packages/gateway-protocol/src/connect-error-details.ts
@@ -4,22 +4,11 @@
  * These details cross client/server boundaries, so readers normalize untrusted
  * payloads before using them in reconnect decisions or user-facing messages.
  */
+import { normalizeOptionalTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import {
   isProtocolRecord,
   normalizeOptionalProtocolString,
 } from "./protocol-value-normalization.js";
-
-function normalizeOptionalConnectDetailStringList(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) {
-    return undefined;
-  }
-  const values = value
-    .map((entry) => normalizeOptionalProtocolString(entry))
-    .filter((entry): entry is string => Boolean(entry));
-  // Pairing details omit absent lists. Emitting empty arrays makes clients think
-  // the gateway intentionally supplied scope/role context when it did not.
-  return values.length > 0 ? values : undefined;
-}
 
 /** Structured connect-error codes carried in gateway error `details.code`. */
 export const ConnectErrorDetailCodes = {
@@ -235,7 +224,7 @@ export function readConnectErrorDetailCode(details: unknown): string | null {
   if (!isProtocolRecord(details)) {
     return null;
   }
-  const code = (details as { code?: unknown }).code;
+  const code = details.code;
   return typeof code === "string" && code.trim().length > 0 ? code.trim() : null;
 }
 
@@ -261,13 +250,11 @@ export function readConnectErrorRecoveryAdvice(details: unknown): ConnectErrorRe
   if (!isProtocolRecord(details)) {
     return {};
   }
-  const raw = details as {
-    canRetryWithDeviceToken?: unknown;
-    recommendedNextStep?: unknown;
-  };
   const canRetryWithDeviceToken =
-    typeof raw.canRetryWithDeviceToken === "boolean" ? raw.canRetryWithDeviceToken : undefined;
-  const normalizedNextStep = normalizeOptionalProtocolString(raw.recommendedNextStep) ?? "";
+    typeof details.canRetryWithDeviceToken === "boolean"
+      ? details.canRetryWithDeviceToken
+      : undefined;
+  const normalizedNextStep = normalizeOptionalProtocolString(details.recommendedNextStep) ?? "";
   const recommendedNextStep = CONNECT_RECOVERY_NEXT_STEP_VALUES.has(
     normalizedNextStep as ConnectRecoveryNextStep,
   )
@@ -292,23 +279,9 @@ export function normalizePairingConnectRequestId(value: unknown): string | undef
   return normalized && PAIRING_CONNECT_REQUEST_ID_PATTERN.test(normalized) ? normalized : undefined;
 }
 
-function normalizeStringArray(value: unknown): string[] | undefined {
-  return normalizeOptionalConnectDetailStringList(value);
-}
-
-function createPairingConnectErrorDetails(params: {
-  reason?: ConnectPairingRequiredReason;
-  requestId?: string;
-  remediationHint?: string;
-  recommendedNextStep?: ConnectRecoveryNextStep;
-  retryable?: boolean;
-  pauseReconnect?: boolean;
-  deviceId?: string;
-  requestedRole?: string;
-  requestedScopes?: string[];
-  approvedRoles?: string[];
-  approvedScopes?: string[];
-}): PairingConnectErrorDetails {
+function createPairingConnectErrorDetails(
+  params: Omit<PairingConnectErrorDetails, "code">,
+): PairingConnectErrorDetails {
   return {
     code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
     ...(params.reason ? { reason: params.reason } : {}),
@@ -361,28 +334,20 @@ export function buildPairingConnectRecoveryTitle(
 }
 
 /** Builds sanitized structured details for a pairing-required connect failure. */
-export function buildPairingConnectErrorDetails(params: {
-  reason: ConnectPairingRequiredReason | undefined;
-  requestId?: string;
-  remediationHint?: string;
-  recommendedNextStep?: ConnectRecoveryNextStep;
-  retryable?: boolean;
-  pauseReconnect?: boolean;
-  deviceId?: string;
-  requestedRole?: string;
-  requestedScopes?: string[];
-  approvedRoles?: string[];
-  approvedScopes?: string[];
-}): PairingConnectErrorDetails {
+export function buildPairingConnectErrorDetails(
+  params: Omit<PairingConnectErrorDetails, "code" | "reason"> & {
+    reason: ConnectPairingRequiredReason | undefined;
+  },
+): PairingConnectErrorDetails {
   const requestId = normalizePairingConnectRequestId(params.requestId);
   const remediationHint =
     normalizeOptionalProtocolString(params.remediationHint) ??
     buildPairingConnectRemediationHint(params.reason);
   const deviceId = normalizeOptionalProtocolString(params.deviceId);
   const requestedRole = normalizeOptionalProtocolString(params.requestedRole);
-  const requestedScopes = normalizeStringArray(params.requestedScopes);
-  const approvedRoles = normalizeStringArray(params.approvedRoles);
-  const approvedScopes = normalizeStringArray(params.approvedScopes);
+  const requestedScopes = normalizeOptionalTrimmedStringList(params.requestedScopes);
+  const approvedRoles = normalizeOptionalTrimmedStringList(params.approvedRoles);
+  const approvedScopes = normalizeOptionalTrimmedStringList(params.approvedScopes);
   return createPairingConnectErrorDetails({
     reason: params.reason,
     requestId,
@@ -418,42 +383,30 @@ export function readPairingConnectErrorDetails(
   if (!isProtocolRecord(details)) {
     return null;
   }
-  const raw = details as {
-    reason?: unknown;
-    requestId?: unknown;
-    remediationHint?: unknown;
-    recommendedNextStep?: unknown;
-    retryable?: unknown;
-    pauseReconnect?: unknown;
-    deviceId?: unknown;
-    requestedRole?: unknown;
-    requestedScopes?: unknown;
-    approvedRoles?: unknown;
-    approvedScopes?: unknown;
-  };
-  const reason = normalizePairingConnectReason(raw.reason);
-  const requestId = normalizePairingConnectRequestId(raw.requestId);
+  const reason = normalizePairingConnectReason(details.reason);
+  const requestId = normalizePairingConnectRequestId(details.requestId);
   const remediationHint =
-    normalizeOptionalProtocolString(raw.remediationHint) ??
+    normalizeOptionalProtocolString(details.remediationHint) ??
     buildPairingConnectRemediationHint(reason);
-  const normalizedNextStep = normalizeOptionalProtocolString(raw.recommendedNextStep) ?? "";
+  const normalizedNextStep = normalizeOptionalProtocolString(details.recommendedNextStep) ?? "";
   const recommendedNextStep = CONNECT_RECOVERY_NEXT_STEP_VALUES.has(
     normalizedNextStep as ConnectRecoveryNextStep,
   )
     ? (normalizedNextStep as ConnectRecoveryNextStep)
     : undefined;
-  const deviceId = normalizeOptionalProtocolString(raw.deviceId);
-  const requestedRole = normalizeOptionalProtocolString(raw.requestedRole);
-  const requestedScopes = normalizeStringArray(raw.requestedScopes);
-  const approvedRoles = normalizeStringArray(raw.approvedRoles);
-  const approvedScopes = normalizeStringArray(raw.approvedScopes);
+  const deviceId = normalizeOptionalProtocolString(details.deviceId);
+  const requestedRole = normalizeOptionalProtocolString(details.requestedRole);
+  const requestedScopes = normalizeOptionalTrimmedStringList(details.requestedScopes);
+  const approvedRoles = normalizeOptionalTrimmedStringList(details.approvedRoles);
+  const approvedScopes = normalizeOptionalTrimmedStringList(details.approvedScopes);
   return createPairingConnectErrorDetails({
     reason,
     requestId,
     remediationHint,
     recommendedNextStep,
-    retryable: typeof raw.retryable === "boolean" ? raw.retryable : undefined,
-    pauseReconnect: typeof raw.pauseReconnect === "boolean" ? raw.pauseReconnect : undefined,
+    retryable: typeof details.retryable === "boolean" ? details.retryable : undefined,
+    pauseReconnect:
+      typeof details.pauseReconnect === "boolean" ? details.pauseReconnect : undefined,
     deviceId,
     requestedRole,
     requestedScopes,

--- a/packages/gateway-protocol/src/protocol-value-normalization.ts
+++ b/packages/gateway-protocol/src/protocol-value-normalization.ts
@@ -2,17 +2,9 @@ export {
   asNullableRecord as asProtocolRecord,
   isRecord as isProtocolRecord,
 } from "@openclaw/normalization-core/record-coerce";
+export { normalizeOptionalString as normalizeOptionalProtocolString } from "@openclaw/normalization-core/string-coerce";
 
 /** Checks string presence without changing wire-significant whitespace. */
 export function isNonEmptyProtocolString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
-}
-
-/** Trims an optional untrusted string and rejects empty results. */
-export function normalizeOptionalProtocolString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed || undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Gateway clients and the server carried duplicate string/list normalization and repeated pairing-detail field declarations. Maintaining separate copies made it easier for reconnect guidance and error rendering to drift.

Cleanup companion to #135868; this PR does not extract a recovery feature stage.

## Why This Change Was Made

Reuse the existing normalization-core string/list helpers and the existing pairing-detail type. Remove redundant casts after the record guard. Keep the public function contracts, request-ID allowlist, reason/recovery enums, optional-field omission, and false boolean values unchanged. ClawHub version/warning strings still preserve their original whitespace.

The removed list implementation originated in #122458; its canonical replacement has the same non-array, empty-list, trimming, ordering, and duplicate-preservation behavior. The package already bundles normalization-core, so no dependency or protocol-version change is needed. Workboard consumes the protocol package in its browser bundle; its generated manifest now points to the matching immutable asset generation.

## User Impact

No intended user-visible behavior change. Production code is 65 lines smaller (+41/−106 across four protocol files and the generated Workboard manifest). Tests and docs are unchanged. The assertion baseline shrinks by one entry and lowers one count to match the removed casts.

## Evidence

- 194 unchanged focused tests passed across protocol validation, reconnect policy, normalization helpers, and Control UI connect-error formatting.
- 27,864 deterministic comparisons against the pre-change functions produced identical results, including malformed values, padded strings, empty/mixed lists, false booleans, and ClawHub whitespace.
- Full `pnpm build` passed, including published package declarations, plugin packaging, SDK checks, and the UI build.
- Complete changed checks passed in isolated Blacksmith Testbox, including core/extension production and test typing, all export scans, full core/extension/script lint, and architecture guards ([run 34011716299](https://github.com/openclaw/openclaw/actions/runs/34011716299), command exit 0). The local nested-worktree attempt encountered an ancestor `node_modules/punycode/package.json` declaration-input lookup; no dependency or guard was changed to bypass it.
- Independent local and branch Codex reviews found no actionable issues through P2.
- Fresh main rebase preserved all four tested source blobs and the lockfile; no protocol, normalization-core, gateway-client, or relevant build-owner changes intervened.

- Initial CI caught the omitted Workboard generated-asset pointer. The canonical generator reproduces the old hash on the parent and the new hash on this refactor; the regenerated metadata is now committed, and `pnpm plugins:assets:check` passes.

## Review disposition

ClawSweeper reviewed both the original and final heads without correctness/security findings or rank-up moves. Its noted build-artifacts failure was the omitted dependent Workboard manifest generation; this is corrected by the canonical generator and the generated-assets check now passes. Exact-head CI run 34012831867 is green at f3526b12cf5efcf484caa89364d056945df260d8. Its first attempt had a Matrix native-binary download ECONNRESET during setup; one failed-job retry passed. The complete isolated changed check also passed, and its one-shot lease was stopped. The delegated Testbox run may display cancelled after cleanup; its command result was succeeded/exit 0.
