### PR TITLE
test(plugins): share account policy inheritance fixtures

### DIFF
--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -136,6 +136,14 @@ test-only registry, manifest, public-artifact, and runtime fixture helpers.
 Core-only suites that depend on bundled OpenClaw inventory stay under
 `src/plugins/contracts` instead.
 
+For channel account-policy tests, `createAccountPolicyInheritanceCases()` from
+`openclaw/plugin-sdk/channel-test-helpers` returns four literal inheritance rows
+with fresh objects and arrays on each call, preserving omitted policy fields.
+Use it alongside `validateTestChannelConfig(channelId, channelConfig)`, which
+validates schema-parsed channel data through the host config boundary. Each
+plugin test still owns its schema parsing, account resolver, and assertions,
+including checks that omitted account policies remain absent.
+
 ### Types
 
 Focused testing subpaths also re-export types useful in test files:

--- a/extensions/discord/src/account-policy.test.ts
+++ b/extensions/discord/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { mergeDiscordAccountConfig, resolveDiscordAccountDmPolicy } from "./accounts.js";
 import { DiscordConfigSchema } from "./config-schema.js";
 
 describe("discord account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = DiscordConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("discord", channel);
     const resolved = {

--- a/extensions/googlechat/src/account-policy.test.ts
+++ b/extensions/googlechat/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { GoogleChatConfigSchema } from "../config-api.js";
 import { resolveGoogleChatConfigAccessorAccount } from "./accounts.js";
 
 describe("googlechat account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = GoogleChatConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("googlechat", channel);
     const resolved = resolveGoogleChatConfigAccessorAccount({

--- a/extensions/imessage/src/account-policy.test.ts
+++ b/extensions/imessage/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { resolveIMessageAccount } from "./accounts.js";
 import { IMessageConfigSchema } from "./config-schema.js";
 
 describe("imessage account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = IMessageConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("imessage", channel);
     const resolved = resolveIMessageAccount({

--- a/extensions/signal/src/account-policy.test.ts
+++ b/extensions/signal/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { resolveSignalAccountConfig } from "./accounts.js";
 import { SignalConfigSchema } from "./config-schema.js";
 
 describe("signal account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = SignalConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("signal", channel);
     const resolved = resolveSignalAccountConfig(cfg, "work");

--- a/extensions/slack/src/account-policy.test.ts
+++ b/extensions/slack/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { mergeSlackAccountConfig, resolveSlackAccountDmPolicy } from "./accounts.js";
 import { SlackConfigSchema } from "./config-schema.js";
 
 describe("slack account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = SlackConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("slack", channel);
     const resolved = {

--- a/extensions/telegram/src/account-policy.test.ts
+++ b/extensions/telegram/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { mergeTelegramAccountConfig } from "./account-config.js";
 import { TelegramConfigSchema } from "./config-schema.js";
 
 describe("telegram account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = TelegramConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("telegram", channel);
     const resolved = mergeTelegramAccountConfig(cfg, "work");

--- a/extensions/whatsapp/src/account-policy.test.ts
+++ b/extensions/whatsapp/src/account-policy.test.ts
@@ -1,35 +1,13 @@
-import { validateTestChannelConfig } from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "openclaw/plugin-sdk/channel-test-helpers";
 import { describe, expect, it } from "vitest";
 import { WhatsAppConfigSchema } from "../config-api.js";
 import { resolveMergedWhatsAppAccountConfig } from "./account-config.js";
 
 describe("whatsapp account policy inheritance after validation", () => {
-  it.each([
-    {
-      name: "inherits explicit open channel policies",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: {},
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-    {
-      name: "keeps unset group access closed and DMs paired",
-      root: {},
-      account: {},
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit account policies even when they equal the defaults",
-      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
-    },
-    {
-      name: "honors explicit open account policies over disabled channel policies",
-      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
-      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
-      expected: { groupPolicy: "open", dmPolicy: "open" },
-    },
-  ] as const)("$name", async ({ root, account, expected }) => {
+  it.each(createAccountPolicyInheritanceCases())("$name", async ({ root, account, expected }) => {
     const channel = WhatsAppConfigSchema.parse({ ...root, accounts: { work: account } });
     const cfg = await validateTestChannelConfig("whatsapp", channel);
     const resolved = resolveMergedWhatsAppAccountConfig({

--- a/src/plugin-sdk/channel-test-helpers.ts
+++ b/src/plugin-sdk/channel-test-helpers.ts
@@ -1,5 +1,8 @@
 // Channel test helper exports provide shared fixtures for plugin channel contract tests.
-export { validateTestChannelConfig } from "./test-helpers/channel-config.js";
+export {
+  createAccountPolicyInheritanceCases,
+  validateTestChannelConfig,
+} from "./test-helpers/channel-config.js";
 export { createDirectoryTestRuntime, expectDirectorySurface } from "./test-helpers/directory.js";
 export { expectDirectoryIds, type DirectoryListFn } from "./test-helpers/directory-ids.js";
 export {

--- a/src/plugin-sdk/test-helpers/channel-config.ts
+++ b/src/plugin-sdk/test-helpers/channel-config.ts
@@ -13,3 +13,32 @@ export async function validateTestChannelConfig(
   }
   return result.config;
 }
+
+export function createAccountPolicyInheritanceCases() {
+  return [
+    {
+      name: "inherits explicit open channel policies",
+      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
+      account: {},
+      expected: { groupPolicy: "open", dmPolicy: "open" },
+    },
+    {
+      name: "keeps unset group access closed and DMs paired",
+      root: {},
+      account: {},
+      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
+    },
+    {
+      name: "honors explicit account policies even when they equal the defaults",
+      root: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
+      account: { groupPolicy: "allowlist", dmPolicy: "pairing" },
+      expected: { groupPolicy: "allowlist", dmPolicy: "pairing" },
+    },
+    {
+      name: "honors explicit open account policies over disabled channel policies",
+      root: { groupPolicy: "disabled", dmPolicy: "disabled" },
+      account: { groupPolicy: "open", dmPolicy: "open", allowFrom: ["*"] },
+      expected: { groupPolicy: "open", dmPolicy: "open" },
+    },
+  ] as const;
+}


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Seven channel plugin suites repeat the same account-policy inheritance fixture rows, making the shared regression inputs harder to maintain consistently.

## Why This Change Was Made

Provide four fresh literal rows through the existing channel test-helper surface. Each plugin keeps its own schema parsing, host validation, account resolver and assertions. Omitted properties stay omitted; Telegram and Slack's additional cases remain intact. Document the helper's scope.

## User Impact

No plugin runtime or policy behavior changes. Net 122 test/support lines removed, with eight documentation lines added. All 41 existing tests remain selected.

## Evidence

All seven suites pass 41/41 before and after with identical full test identities. Runtime fixture comparisons preserve values, property absence and fresh nested allocations; expanded-source comparison confirms unchanged callbacks, assertions and extra cases.

The full changed gate passes, including SDK exports/surface, plugin boundaries, core and extension typechecks, dead exports and lint. Docs formatting/MDX checks, diff checks, deslop and final independent P2 review pass. Cache warmth differs between timing samples; no performance improvement is claimed.
