### PR TITLE
fix(agents): restore retry and fallback regression coverage

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -456,12 +456,12 @@ async function runAutoPinnedRotationCase(params: {
   runEmbeddedAttemptMock.mockReset();
   return withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
     await writeAuthStore(agentDir);
-    // Transient failures must exhaust three same-profile retries before rotating;
-    // credential/quota failures still rotate after the first failed attempt.
+    // This provider reports a three-retry cap; exhaust it before rotating.
+    // Credential/quota failures still rotate after the first failed attempt.
     const failureCount = params.exhaustTransientRetries ? 4 : 1;
     for (let attempt = 0; attempt < failureCount; attempt += 1) {
-      runEmbeddedAttemptMock.mockResolvedValueOnce(
-        params.failureStage === "prompt"
+      runEmbeddedAttemptMock.mockResolvedValueOnce({
+        ...(params.failureStage === "prompt"
           ? makeAttempt({
               terminal: {
                 kind: "failed",
@@ -469,8 +469,9 @@ async function runAutoPinnedRotationCase(params: {
                 error: new Error(params.errorMessage),
               },
             })
-          : makeErrorAttempt({ errorMessage: params.errorMessage }),
-      );
+          : makeErrorAttempt({ errorMessage: params.errorMessage })),
+        providerRetryMaxRetries: 3,
+      });
     }
     mockSingleSuccessfulAttempt();
     await runAutoPinnedOpenAiTurn({
@@ -821,7 +822,7 @@ describe("runEmbeddedAgent auth profile rotation", () => {
             terminal: {
               kind: "failed",
               source: "prompt",
-              error: new Error("supported values are: low, medium"),
+              error: new Error("Unsupported reasoning.effort; supported values are: low, medium"),
             },
           }),
         )
@@ -919,9 +920,9 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     }
   });
 
-  it("rotates for auto-pinned profiles across retryable stream failures", async () => {
+  it("rotates auto-pinned profiles on long-window rate limits without transient retries", async () => {
     await runAutoPinnedRotationCase({
-      errorMessage: "rate limit",
+      errorMessage: "429 Too Many Requests: subscription usage limit reached",
       sessionKey: "agent:test:auto",
       runId: "run:auto",
     });
@@ -1139,7 +1140,7 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeAuthStore(agentDir);
 
-      mockFailedThenSuccessfulAttempt("rate limit");
+      mockFailedThenSuccessfulAttempt("429 Too Many Requests: subscription usage limit reached");
 
       await runEmbeddedAgentInline({
         sessionId: "session:test",
@@ -1243,7 +1244,7 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     await withAgentWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeOpenAiCodexAuthStore(agentDir, true);
       mockFailedThenSuccessfulAttemptForModel({
-        errorMessage: "rate limit",
+        errorMessage: "429 Too Many Requests: subscription usage limit reached",
         provider: "codex-cli",
         model: "gpt-5.4",
       });
@@ -1726,7 +1727,7 @@ describe("runEmbeddedAgent auth profile rotation", () => {
         agentDir,
       );
 
-      mockFailedThenSuccessfulAttempt("rate limit");
+      mockFailedThenSuccessfulAttempt("429 Too Many Requests: subscription usage limit reached");
       await runAutoPinnedOpenAiTurn({
         agentDir,
         workspaceDir,

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -194,6 +194,8 @@ function makeAttemptForFault(
   }
   if (fault.status === 500) {
     return makeEmbeddedRunnerAttempt({
+      // Model fallback scenarios exercise exhaustion of a provider-reported cap.
+      providerRetryMaxRetries: 3,
       terminal: {
         kind: "failed",
         source: "prompt",
@@ -454,15 +456,17 @@ describe("runEmbeddedAgent provider fault sequences", () => {
     await expectPreparationInvalidationToDropRoutingWork("replace");
   });
 
-  it("429 -> 429 -> 200 consumes two same-model retries without rotating", async () => {
+  it("recovers four short rate limits with the default budget without rotating profiles", async () => {
     const faults = [
       { status: 429, window: "short" },
       { status: 429, window: "short" },
-      { status: 200, text: "third attempt ok" },
+      { status: 429, window: "short" },
+      { status: 429, window: "short" },
+      { status: 200, text: "fifth attempt ok" },
     ] satisfies ProviderFault[];
 
     await withScenarioWorkspace(async ({ agentDir, workspaceDir }) => {
-      writeProfiles(agentDir, { openai: 1 });
+      writeProfiles(agentDir, { openai: 2 });
       const observations: AttemptObservation[] = [];
       installFaultScript(faults, observations);
 
@@ -481,11 +485,13 @@ describe("runEmbeddedAgent provider fault sequences", () => {
       ).toEqual(
         faults.map(() => ({ provider: "openai", model: "mock-1", profileId: "openai:p1" })),
       );
-      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([1_000, 2_000]);
+      expect(sleepWithAbortMock.mock.calls.map(([delay]) => delay)).toEqual([
+        1_000, 2_000, 4_000, 8_000,
+      ]);
       expect(outcome.provider).toBe("openai");
       expect(outcome.model).toBe("mock-1");
       expect(outcome.attempts).toEqual([]);
-      expect(outcome.result.payloads?.[0]?.text).toContain("third attempt ok");
+      expect(outcome.result.payloads?.[0]?.text).toContain("fifth attempt ok");
       const usageStats = await readUsageStats(agentDir);
       expect(usageStats["openai:p1"]?.cooldownUntil).toBeUndefined();
       expect(usageStats["openai:p1"]?.disabledUntil).toBeUndefined();
@@ -500,7 +506,7 @@ describe("runEmbeddedAgent provider fault sequences", () => {
         [
           { status: 429, window: "long" },
           { status: 401 },
-          // Exhaust the default three transient retries before advancing the model.
+          // Exhaust the provider-reported three-retry cap before advancing the model.
           ...Array.from({ length: 4 }, () => ({ status: 500 as const })),
           { status: 200, text: "fallback chain ok" },
         ],

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -111,6 +111,7 @@ beforeEach(() => {
 const OVERLOADED_ERROR_PAYLOAD =
   '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}';
 const RATE_LIMIT_ERROR_MESSAGE = "rate limit exceeded";
+const LONG_RATE_LIMIT_ERROR_MESSAGE = "429 Too Many Requests: subscription usage limit reached";
 const NO_ENDPOINTS_FOUND_ERROR_MESSAGE = "404 No endpoints found for deepseek/deepseek-r1:free.";
 const NO_ERROR_DETAILS_MESSAGE = "Unknown error (no error details in response)";
 
@@ -270,7 +271,8 @@ function mockPrimaryFailureThenFallbackSuccess(
   runEmbeddedAttemptMock.mockImplementation(async (params: unknown) => {
     const attemptParams = params as EmbeddedAttemptParams;
     if (attemptParams.provider === primaryProvider) {
-      return await makePrimaryAttempt(attemptParams);
+      // Keep route/receipt scenarios bounded with a provider-reported retry cap.
+      return { ...(await makePrimaryAttempt(attemptParams)), providerRetryMaxRetries: 3 };
     }
     if (attemptParams.provider === "groq") {
       return makeFallbackSuccessAttempt();
@@ -363,6 +365,7 @@ function mockAllProvidersOverloaded() {
     const attemptParams = params as { provider: string; modelId: string; authProfileId?: string };
     if (attemptParams.provider === "openai" || attemptParams.provider === "groq") {
       return makeEmbeddedRunnerAttempt({
+        providerRetryMaxRetries: 3,
         assistantTexts: [],
         lastAssistant: buildEmbeddedRunnerAssistant({
           provider: attemptParams.provider,
@@ -506,9 +509,12 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       });
       expect(decisionWork).toHaveLength(5);
       expect(decisionWork.map((work) => work.receipt)).toMatchObject([
-        ...Array.from({ length: 4 }, () => ({
+        ...Array.from({ length: 4 }, (_, attempt) => ({
           action: { summary: "Requested openai/mock-1; selected openai/mock-1." },
-          decision: { reasonCode: "model_route_selected" },
+          decision: {
+            reasonCode:
+              attempt === 0 ? "model_route_selected" : "model_route_selected_after_fallback",
+          },
         })),
         {
           action: { summary: "Requested openai/mock-1; selected groq/mock-2." },
@@ -555,9 +561,9 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
           reason: work.receipt.decision.reasonCode,
         })),
       ).toEqual(
-        Array.from({ length: 4 }, () => ({
+        Array.from({ length: 4 }, (_, attempt) => ({
           target: JSON.stringify(["openai", "mock-1"]),
-          reason: "model_route_selected",
+          reason: attempt === 0 ? "model_route_selected" : "model_route_selected_after_fallback",
         })),
       );
     });
@@ -625,7 +631,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
       message:
         "402 You have reached your subscription quota limit. Please wait for automatic quota refresh in the rolling time window, upgrade to a higher plan, or use a Pay-As-You-Go API Key for unlimited access.",
       reason: "rate_limit",
-      primaryAttempts: 4,
+      primaryAttempts: 1,
       runName: "bare-402-cross-provider",
     },
   ])("$name", async ({ message, reason, primaryAttempts, runName }) => {
@@ -967,11 +973,11 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
     });
   });
 
-  it("caps rate-limit profile rotations and escalates to cross-provider fallback (#58572)", async () => {
+  it("caps long-window rate-limit profile rotations and escalates to fallback (#58572)", async () => {
     await withModelFallbackWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeFallbackMultiProfileAuthStore(agentDir);
 
-      mockPrimaryErrorThenFallbackSuccess(RATE_LIMIT_ERROR_MESSAGE);
+      mockPrimaryErrorThenFallbackSuccess(LONG_RATE_LIMIT_ERROR_MESSAGE);
 
       const result = await runEmbeddedFallback({
         agentDir,
@@ -1012,11 +1018,11 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
     });
   });
 
-  it("caps prompt-side rate-limit profile rotations before cross-provider fallback", async () => {
+  it("caps prompt-side long-window rate-limit rotations before cross-provider fallback", async () => {
     await withModelFallbackWorkspace(async ({ agentDir, workspaceDir }) => {
       await writeFallbackMultiProfileAuthStore(agentDir);
 
-      mockPrimaryPromptErrorThenFallbackSuccess(RATE_LIMIT_ERROR_MESSAGE);
+      mockPrimaryPromptErrorThenFallbackSuccess(LONG_RATE_LIMIT_ERROR_MESSAGE);
 
       const result = await runEmbeddedFallback({
         agentDir,


### PR DESCRIPTION
Related: #139397, #137322

## What Problem This Solves

Resolves stale agent retry and fallback E2E fixtures that fail after bounded same-model continuation became the default. The fixtures expected profile/model rotation after the former three-retry default, or immediately after short rate limits.

## Why This Change Was Made

Persistent overload and server-error composition fixtures now explicitly report the supported `retry.provider.maxRetries=3` setting. This exercises actual budget exhaustion while preserving their exact route, receipt and cooldown assertions. The production attempt writer carries that persisted setting through `providerRetryMaxRetries` into the retry controller; this is not a test-only override.

The default-policy scenario now survives four short rate limits with two available profiles, verifies exact 1/2/4/8-second waits, and succeeds on the original profile without cooldown or model fallback. Immediate-rotation scenarios use long quota windows, which intentionally skip transient recovery. Continuation receipts distinguish the initial selection from subsequent recovery selections, and the Copilot auth-refresh fixture identifies the reasoning parameter its error rejects.

This complements #137322's separate backoff-helper cleanup. It does not change production retry policy, default limits, or that contributor's draft.

## User Impact

No runtime behavior change. Restores meaningful release regression coverage for the eight-attempt/90-second policy and supported provider retry overrides.

## Evidence

- Original main fault-sequence fixture: two routing failures reproduced locally before the repair; fixed fixture: 8 tests passed.
- Auth-profile rotation and model-fallback E2E suites: 53 tests passed. After rebasing onto current main, all three scoped suites passed together: 61 tests.
- Unchanged retry-controller, retry-helper and persisted settings tests: 62 tests passed, retaining default eight-attempt/90-second and saved-setting coverage.
- E2E proof used the repository's documented `OPENCLAW_E2E_SKIP_BUILD=1` mode because these suites own mocked attempt/model fixtures; this is not live-provider proof.
- Independent review found no actionable P0–P2 findings; formatting, diff checks, focused lint, core test typechecking, coercion/deprecated-API checks, and both dead-code scans passed separately.
- Full canonical `check-changed` passed on the rebased head, including the affected core test type graph, lint and all three dead-code scans. The initial base was blocked by the unrelated services inventory of 721 roots exceeding the 720-root limit; rebasing picked up #139645, which repairs that inventory without changing the cap.
