### PR TITLE
feat(directives): emit directive.rejected diagnostic on pre-run rejection

### DIFF
--- a/extensions/diagnostics-otel/src/service-events.ts
+++ b/extensions/diagnostics-otel/src/service-events.ts
@@ -242,6 +242,9 @@ export function createDiagnosticsEventHandler(params: {
           return;
         case "model.failover":
           recordModelFailover(evt, metadata);
+          break;
+        case "directive.rejected":
+          break;
       }
     } catch (err) {
       logger.error(`diagnostics-otel: event handler failed (${evt.type}): ${formatError(err)}`);

--- a/extensions/diagnostics-prometheus/src/service.ts
+++ b/extensions/diagnostics-prometheus/src/service.ts
@@ -1011,6 +1011,7 @@ function recordDiagnosticEvent(
         numericValue(evt.queueLength),
       );
       break;
+    case "directive.rejected":
     case "diagnostic.heartbeat":
       break;
     case "telemetry.exporter":

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -358,7 +358,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +7: card projection plus three rendering helpers on channel-outbound and its shipped barrel.
       // +2: shared diff-stat rendering on channel-outbound and its shipped barrel.
       // +1: shared static UI guidance, separate from per-turn harness delivery policy.
-      4446,
+      // +1: directive.rejected diagnostic event type for pre-run rejection.
+      4447,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -426,6 +426,7 @@ describe("directive.rejected diagnostic trace", () => {
         OriginatingChannel: "webchat",
         MessageSidFull: "msg-123",
       });
+      const sessionEntry = { sessionId: "session-1", updatedAt: 1 };
       const result = await resolveReplyDirectives({
         ctx,
         cfg: { agents: { ownership: "explicit", entries: { main: {} } } },
@@ -434,11 +435,11 @@ describe("directive.rejected diagnostic trace", () => {
         workspaceDir: "/tmp/workspace",
         agentCfg: {},
         sessionCtx: ctx,
-        sessionEntry: { sessionId: "session-1", updatedAt: 1 },
+        sessionEntry,
         sessionStore: {},
         sessionKey: "agent:main:main",
         sessionScope: undefined,
-        groupResolution: undefined,
+        conversation: prepareReplyConversation({ ctx, sessionEntry }),
         isGroup: false,
         triggerBodyNormalized: "/model openai/gpt-5.5 -a -g",
         resetTriggered: false,

--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -1,5 +1,9 @@
 // Tests applying parsed directives to get-reply execution options.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  onInternalDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+} from "../../infra/diagnostic-events.js";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../../sessions/model-overrides.js";
 import { applyMixedDirectives } from "./directive-handling.mixed-inline.test-helpers.js";
 import type { HandleDirectiveOnlyParams } from "./directive-handling.params.js";
@@ -397,5 +401,76 @@ describe("applyInlineDirectiveOverrides", () => {
     expect(typing.cleanup).toHaveBeenCalledOnce();
     expect(mocks.applyModelSelection).not.toHaveBeenCalled();
     expect(mocks.handleDirective).not.toHaveBeenCalled();
+  });
+});
+
+describe("directive.rejected diagnostic trace", () => {
+  beforeEach(() => {
+    resetDiagnosticEventsForTest();
+  });
+
+  it("emits a pre_run directive.rejected trace when a model directive is rejected pre-run", async () => {
+    const events: Array<Record<string, unknown>> = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => {
+      events.push(event as unknown as Record<string, unknown>);
+    });
+
+    try {
+      const ctx = buildTestCtx({
+        Body: "/model openai/gpt-5.5 -a -g",
+        CommandBody: "/model openai/gpt-5.5 -a -g",
+        CommandAuthorized: true,
+        SessionKey: "agent:main:main",
+        Provider: "webchat",
+        Surface: "webchat",
+        OriginatingChannel: "webchat",
+        MessageSidFull: "msg-123",
+      });
+      const result = await resolveReplyDirectives({
+        ctx,
+        cfg: { agents: { ownership: "explicit", entries: { main: {} } } },
+        agentId: "main",
+        agentDir: "/tmp/main-agent",
+        workspaceDir: "/tmp/workspace",
+        agentCfg: {},
+        sessionCtx: ctx,
+        sessionEntry: { sessionId: "session-1", updatedAt: 1 },
+        sessionStore: {},
+        sessionKey: "agent:main:main",
+        sessionScope: undefined,
+        groupResolution: undefined,
+        isGroup: false,
+        triggerBodyNormalized: "/model openai/gpt-5.5 -a -g",
+        resetTriggered: false,
+        commandAuthorized: true,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.5",
+        aliasIndex: { byAlias: new Map(), byKey: new Map() },
+        provider: "openai",
+        model: "gpt-5.5",
+        hasResolvedHeartbeatModelOverride: false,
+        typing: createTypingController({}),
+      });
+
+      expect(result).toMatchObject({
+        kind: "reply",
+        reply: { text: "Use only one model scope option.", isError: true },
+      });
+
+      const rejected = events.find((e) => e.type === "directive.rejected");
+      expect(rejected).toBeDefined();
+      expect(rejected).toMatchObject({
+        type: "directive.rejected",
+        stage: "pre_run",
+        sessionKey: "agent:main:main",
+        channel: "webchat",
+        messageId: "msg-123",
+        directiveType: "model",
+        errorText: "Use only one model scope option.",
+      });
+      expect(rejected?.rawToken).toEqual(expect.any(String));
+    } finally {
+      unsubscribe();
+    }
   });
 });

--- a/src/auto-reply/reply/get-reply-directives-diagnostic.ts
+++ b/src/auto-reply/reply/get-reply-directives-diagnostic.ts
@@ -1,0 +1,69 @@
+// Diagnostic trace helpers for pre-run directive rejections. Kept in a
+// dedicated module so the directive resolver stays under its line budget and
+// the trace logic is independently testable.
+import { emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
+import type { FinalizedRuntimeMsgContext } from "../templating.js";
+import type { ReplyPayload } from "../types.js";
+import type { InlineDirectives } from "./directive-handling.parse.js";
+
+/**
+ * Derives the rejected directive category and its raw token from the parsed
+ * inline directives. The model directive is the most common rejection target
+ * (e.g. `/model <ref>` resolving to a disallowed model); other directive
+ * categories fall back to their type with no raw token.
+ */
+function deriveRejectedDirectiveFacts(directives: InlineDirectives): {
+  directiveType?: string;
+  rawToken?: string;
+} {
+  if (directives.hasModelDirective) {
+    return { directiveType: "model", rawToken: directives.rawModelDirective };
+  }
+  if (directives.hasElevatedDirective) {
+    return { directiveType: "elevated" };
+  }
+  if (directives.clearThinkLevel || directives.thinkLevel !== undefined) {
+    return { directiveType: "think" };
+  }
+  if (directives.reasoningLevel !== undefined) {
+    return { directiveType: "reasoning" };
+  }
+  if (directives.verboseLevel !== undefined) {
+    return { directiveType: "verbose" };
+  }
+  if (directives.clearFastMode || directives.fastMode !== undefined) {
+    return { directiveType: "fast" };
+  }
+  return {};
+}
+
+/**
+ * Emits a `directive.rejected` diagnostic trace when an inline directive was
+ * rejected before any agent run started, so external diagnostic surfaces can
+ * correlate the rejected inbound message with the parser decision. Only error
+ * replies (not ack/status replies) are traced.
+ */
+export function emitPreRunDirectiveRejectionDiagnostic(params: {
+  ctx: FinalizedRuntimeMsgContext;
+  sessionKey: string;
+  directives: InlineDirectives;
+  reply: ReplyPayload | ReplyPayload[] | undefined;
+}): void {
+  const { ctx, sessionKey, directives, reply } = params;
+  if (Array.isArray(reply) || !reply || reply.isError !== true) {
+    return;
+  }
+  const { directiveType, rawToken } = deriveRejectedDirectiveFacts(directives);
+  emitTrustedDiagnosticEvent({
+    type: "directive.rejected",
+    stage: "pre_run",
+    sessionKey,
+    channel: ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface,
+    messageId: ctx.MessageSidFull ?? ctx.MessageSid,
+    chatId: ctx.ChatId,
+    agentId: ctx.AgentId,
+    directiveType,
+    rawToken,
+    errorText: reply.text,
+  });
+}

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -47,6 +47,7 @@ import {
   resolveConfiguredDirectiveAliases,
 } from "./get-reply-directive-aliases.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
+import { emitPreRunDirectiveRejectionDiagnostic } from "./get-reply-directives-diagnostic.js";
 import { resolveReplyDirectiveRouting } from "./get-reply-directives-routing.js";
 import { type ReplyExecOverrides, resolveReplyExecOverrides } from "./get-reply-exec-overrides.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
@@ -530,6 +531,12 @@ export async function resolveReplyDirectives(params: {
   });
   if (applyResult.kind === "reply") {
     recordReplyPreRunRejection(resolveReplyOperationRunState(opts), applyResult.preRunRejection);
+    emitPreRunDirectiveRejectionDiagnostic({
+      ctx,
+      sessionKey,
+      directives,
+      reply: applyResult.reply,
+    });
     return { kind: "reply", reply: markCommandReplyForDelivery(applyResult.reply) };
   }
   directives = applyResult.directives;

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -253,6 +253,31 @@ export type DiagnosticMessageProcessedEvent = DiagnosticBaseEvent & {
   error?: string;
 };
 
+/**
+ * Pre-run directive rejection trace. Emitted when an inline reply directive
+ * (e.g. `/model <ref>`) is rejected before any agent run starts, so external
+ * diagnostic surfaces can correlate the rejected inbound message with the
+ * parser decision. Coarse `stage: "pre_run"` covers rejections surfaced from
+ * inline directive application; `errorText` carries the reply returned to the
+ * sender (it already contains the rejection reason).
+ */
+export type DiagnosticDirectiveRejectedEvent = DiagnosticBaseEvent & {
+  type: "directive.rejected";
+  stage: "pre_run";
+  sessionKey?: string;
+  sessionId?: string;
+  channel?: string;
+  messageId?: number | string;
+  chatId?: number | string;
+  agentId?: string;
+  /** Directive category that was rejected (e.g. "model"). */
+  directiveType?: string;
+  /** Raw token parsed for the directive, when available (e.g. the requested model ref). */
+  rawToken?: string;
+  /** Human-readable rejection text returned to the sender. */
+  errorText?: string;
+};
+
 export type DiagnosticMessageDeliveryKind = "text" | "media" | "edit" | "reaction" | "other";
 
 type DiagnosticMessageDeliveryBaseEvent = DiagnosticBaseEvent & {
@@ -847,6 +872,7 @@ export type DiagnosticEventPayload =
   | DiagnosticMessageDispatchStartedEvent
   | DiagnosticMessageDispatchCompletedEvent
   | DiagnosticMessageProcessedEvent
+  | DiagnosticDirectiveRejectedEvent
   | DiagnosticMessageDeliveryStartedEvent
   | DiagnosticMessageDeliveryCompletedEvent
   | DiagnosticMessageDeliveryErrorEvent

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -604,6 +604,12 @@ function sanitizeDiagnosticEvent(event: DiagnosticEventPayload): DiagnosticStabi
       record.model = event.fromModel;
       assignReasonCode(record, event.reason);
       break;
+    case "directive.rejected":
+      record.channel = event.channel;
+      record.source = event.agentId;
+      record.outcome = event.directiveType;
+      assignReasonCode(record, event.errorText);
+      break;
   }
 
   return record;


### PR DESCRIPTION
## What Problem This Solves

When an inline reply directive (e.g. `/model <ref>`) is rejected **before** any agent run starts — such as a conflicting model scope (`-a -g`), a locked model selection, or an unauthorized scope escalation — the rejection reply is sent back to the sender but no diagnostic trace is emitted. External diagnostic surfaces (OpenTelemetry, Prometheus, the internal diagnostic event log) have no visibility into these pre-run rejections, making it impossible to correlate rejected inbound messages with the parser decision or to observe rejection patterns over time.

This PR adds a `directive.rejected` diagnostic event type that fires whenever `resolveReplyDirectives` returns an error reply (`isError: true`) from inline directive application. The event carries the directive category (`model`, `elevated`, `think`, etc.), the raw token (e.g. the requested model ref), the channel, session key, and the error text returned to the sender.

## Evidence

### Local test verification

The new test `emits a pre_run directive.rejected trace when a model directive is rejected pre-run` sends a conflicting model scope directive (`/model openai/gpt-5.5 -a -g`) and asserts the diagnostic event is emitted with the correct fields:

```
expect(rejected).toMatchObject({
  type: "directive.rejected",
  stage: "pre_run",
  sessionKey: "agent:main:main",
  channel: "webchat",
  messageId: "msg-123",
  directiveType: "model",
  errorText: "Use only one model scope option.",
});
```

### Diagnostic handler coverage

The new event type is handled in all three diagnostic sinks:
1. **Internal diagnostic event log** (`src/infra/diagnostic-events.ts`) — new `DiagnosticDirectiveRejectedEvent` type added to the union
2. **OpenTelemetry** (`extensions/diagnostics-otel/src/service-events.ts`) — `case "directive.rejected": break;` added to the switch
3. **Prometheus** (`extensions/diagnostics-prometheus/src/service.ts`) — `case "directive.rejected":` fallthrough added before `diagnostic.heartbeat`
4. **Diagnostic stability sanitizer** (`src/logging/diagnostic-stability.ts`) — `case "directive.rejected":` added to `sanitizeDiagnosticEvent` with channel/source/outcome/reason-code fields

### Implementation details

- The trace is emitted in `get-reply-directives.ts` right before returning the error reply, so it fires only for pre-run rejections (not for post-run or ack/status replies).
- The diagnostic helper `emitPreRunDirectiveRejectionDiagnostic` is in a dedicated module (`get-reply-directives-diagnostic.ts`) to keep the directive resolver under its line budget.
- The helper derives the `directiveType` and `rawToken` from the parsed `InlineDirectives` (e.g. `hasModelDirective` → `directiveType: "model"` with `rawModelDirective` as the raw token).
- Only error replies (`isError: true`) trigger the trace; ack/status replies and array replies are skipped.
