### PR TITLE
fix(update): preserve restart outcomes and update-history ownership

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -748,6 +748,7 @@ openclaw gateway restart
     - On macOS, `gateway stop` uses `launchctl bootout` by default, which removes the LaunchAgent from the current boot session without persisting a disable — KeepAlive auto-recovery stays active for future crashes and `gateway start` re-enables cleanly without a manual `launchctl enable`. Pass `--disable` to persistently suppress KeepAlive and RunAtLoad so the gateway does not respawn until the next explicit `gateway start`; use this when a manual stop should survive reboots.
     - Gateway lifecycle mutations append best-effort key-value audit records to `<state-dir>/logs/gateway-restart.log`, including CLI start, stop, and restart operations, safe restart requests, supervisor restarts, and detached handoffs.
     - Lifecycle commands accept `--json` for scripting.
+    - A restart that completes native activation or accepted recovery but fails its health check emits `action: "restart"`, `ok: false`, and `result: "restart-health-failed"`, retaining its error, hints, warnings, and exit code 1. This diagnostic does not authorize another activation. Refusals, unexpected exceptions, and definition repair without confirmed activation do not emit this result. A scheduled restart reports acceptance, without claiming successor health.
 
   </Accordion>
   <Accordion title="Managed Gateway heap sizing">

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -223,10 +223,9 @@ fields and adds optional `activeRun` and `lastRun` records. While a run is activ
 the Gateway broadcasts `update.run.changed` with `runId`, `phase`, `status`, and
 `updatedAtMs`. Reconnect and read the row to recover changes missed during restart.
 
-The pre-restart notice can arrive before staging begins while the managed Gateway
-parks for the updater. That notice does not advance the recorded phase. If the
-Control UI cannot read fresh progress, it shows the read error alongside the last
-recorded run; use **Check status** to retry without starting another update.
+Native service-stop observations do not advance the update's recorded phase.
+If the Control UI cannot read fresh progress, it shows the read error alongside
+the last recorded run; use **Check status** to retry without starting another update.
 
 Phases are `requested`, `staging`, `validating`, optional `repairing`, `activating`,
 `restarting`, `verifying`, and `finished`. Status is `running`, `succeeded`,

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -202,6 +202,9 @@ the outcome. Post-core finalization children report back to their parent without
 creating a separate update run, including when an older updater cannot forward
 a run ID.
 
+Triage preserves the original update report. Any update launched during repair
+gets a separate `runId`.
+
 `openclaw update --json` includes `runId` and the `run` record. `openclaw update status --json`
 includes `activeRun` when a run is active and `lastRun` when history exists.
 Human output, chat completion notices, the Control UI update view, and the
@@ -219,6 +222,11 @@ openclaw gateway call update.runs.get --params '{"runId":"<run-id>"}'
 fields and adds optional `activeRun` and `lastRun` records. While a run is active,
 the Gateway broadcasts `update.run.changed` with `runId`, `phase`, `status`, and
 `updatedAtMs`. Reconnect and read the row to recover changes missed during restart.
+
+The pre-restart notice can arrive before staging begins while the managed Gateway
+parks for the updater. That notice does not advance the recorded phase. If the
+Control UI cannot read fresh progress, it shows the read error alongside the last
+recorded run; use **Check status** to retry without starting another update.
 
 Phases are `requested`, `staging`, `validating`, optional `repairing`, `activating`,
 `restarting`, `verifying`, and `finished`. Status is `running`, `succeeded`,

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -887,6 +887,11 @@ alone, use `openclaw triage --non-interactive`; add `--update-result <path>` to
 include a saved update-failure artifact. See [Triage](/cli/triage) for command
 formatting and installation targeting.
 
+Triage keeps the failed update's report intact. An update started during repair
+creates its own history entry. After package replacement, restart commands run
+from the updated installation. A restart accepted by the service owner can still
+fail readiness checks; inspect `openclaw gateway status --deep` before retrying.
+
 Keep a stopped, unverified Gateway stopped and preserve migrated state during
 repair. A reachable candidate retained after a schema migration can continue
 serving while you diagnose it.

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -5,7 +5,10 @@ import {
   codeModeRetentionEntrypoint,
 } from "../../src/agents/code-mode-retention-entrypoint.test-support.ts";
 import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
-import { cliRecoveryEntrypoints } from "../../src/cli/cli-entrypoint.test-support.ts";
+import {
+  cliRecoveryEntrypoints,
+  gatewayDirectStopEntrypoints,
+} from "../../src/cli/cli-entrypoint.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
 import { sessionListCacheRetentionEntrypoint } from "../../src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts";
 import { sessionChildCacheRetentionEntrypoint } from "../../src/gateway/session-child-cache-retention-entrypoint.test-support.ts";
@@ -29,6 +32,7 @@ export const vitestWorkerBuildEntries = {
       codeModeDescriptionRetentionEntrypoint,
       ...cliCompactionBackendEntrypoints,
       ...Object.values(cliRecoveryEntrypoints),
+      ...Object.values(gatewayDirectStopEntrypoints),
       ...Object.values(cronOwnerHardeningEntrypoints),
       ...Object.values(tuiPtyRuntimeEntrypoints),
       ...Object.values(sessionTitleRetentionEntrypoints),

--- a/src/cli/cli-entrypoint.test-support.ts
+++ b/src/cli/cli-entrypoint.test-support.ts
@@ -16,3 +16,37 @@ export const cliRecoveryEntrypoints = {
     distWorkerPath: "agents/cli-session.js",
   },
 } as const;
+
+// Direct-stop children use the invocation's prepared graph before readiness starts.
+export const gatewayDirectStopEntrypoints = {
+  ingressDrain: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../channels/message/ingress-drain",
+    distWorkerPath: "channels/message/ingress-drain.js",
+  },
+  ingressQueue: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../channels/message/ingress-queue",
+    distWorkerPath: "channels/message/ingress-queue.js",
+  },
+  runs: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../agents/embedded-agent-runner/runs",
+    distWorkerPath: "agents/embedded-agent-runner/runs.js",
+  },
+  activeRunProjections: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../agents/embedded-agent-runner/active-run-projections",
+    distWorkerPath: "agents/embedded-agent-runner/active-run-projections.js",
+  },
+  runLoop: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "gateway-cli/run-loop",
+    distWorkerPath: "cli/gateway-cli/run-loop.js",
+  },
+  workAdmission: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../process/gateway-work-admission",
+    distWorkerPath: "process/gateway-work-admission.js",
+  },
+} as const;

--- a/src/cli/daemon-cli.ts
+++ b/src/cli/daemon-cli.ts
@@ -23,6 +23,6 @@ export {
 export {
   finishUpdateRun,
   getUpdateRun,
-  recordUpdateRunPhase,
+  recordUpdateRunStep,
   recordUpdateRunVerification,
 } from "../infra/update-run-ledger.js";

--- a/src/cli/daemon-cli/lifecycle-core.test.ts
+++ b/src/cli/daemon-cli/lifecycle-core.test.ts
@@ -665,7 +665,9 @@ describe("runServiceRestart token drift", () => {
       postRestartCheck,
     });
 
-    expect(postRestartCheck).toHaveBeenCalledTimes(1);
+    expect(postRestartCheck).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ activationAccepted: true }),
+    );
     expect(service.restart).not.toHaveBeenCalled();
     const payload = readJsonLog<{ result?: string; message?: string }>();
     expect(payload.result).toBe("restarted");

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -50,15 +50,15 @@ type DaemonLifecycleOptions = {
   disable?: boolean;
 };
 
-type RestartPostCheckContext = {
+type StartPostCheckContext = {
   json: boolean;
   stdout: Writable;
   warnings: string[];
   warn?: (message: string) => void;
-  fail: (message: string, hints?: string[]) => void;
+  fail: ReturnType<typeof createDaemonActionContext>["fail"];
 };
 
-type StartPostCheckContext = RestartPostCheckContext;
+type RestartPostCheckContext = StartPostCheckContext & { activationAccepted: boolean };
 
 type ServiceRecoveryResult<TResult extends "started" | "stopped" | "restarted"> = {
   result: TResult;
@@ -658,8 +658,9 @@ export async function runServiceRestart(params: {
     }
   }
 
+  let postCheckFailed = false;
   try {
-    let restartResult: GatewayServiceRestartResult = { outcome: "completed" };
+    let restartResult: GatewayServiceRestartResult | undefined;
     if (loaded && !handledRepair) {
       await prepareGatewayRestartIntent();
       try {
@@ -675,7 +676,10 @@ export async function runServiceRestart(params: {
         throw err;
       }
     }
-    let restartStatus = describeGatewayServiceRestart(params.serviceNoun, restartResult);
+    let restartStatus = describeGatewayServiceRestart(
+      params.serviceNoun,
+      restartResult ?? { outcome: "completed" },
+    );
     if (restartStatus.scheduled) {
       return emitScheduledRestart(restartStatus, loaded || recoveredLoadedState === true);
     }
@@ -685,7 +689,12 @@ export async function runServiceRestart(params: {
         stdout,
         warnings,
         warn,
-        fail,
+        // Definition repair alone does not record native activation.
+        activationAccepted: restartResult?.outcome === "completed" || Boolean(handledRecovery),
+        fail: (message, hints, result) => {
+          postCheckFailed = true;
+          fail(message, hints, result);
+        },
       });
       if (postRestartResult) {
         restartStatus = describeGatewayServiceRestart(params.serviceNoun, postRestartResult);
@@ -707,6 +716,10 @@ export async function runServiceRestart(params: {
     }
     return true;
   } catch (err) {
+    // A non-exiting runtime unwinds after emission; never replace that result.
+    if (postCheckFailed) {
+      throw err;
+    }
     const hints = params.renderStartHints();
     fail(`${params.serviceNoun} restart failed: ${String(err)}`, hints);
     return false;

--- a/src/cli/daemon-cli/lifecycle.test-helpers.ts
+++ b/src/cli/daemon-cli/lifecycle.test-helpers.ts
@@ -1,4 +1,5 @@
 type RestartPostCheckContext = {
+  activationAccepted: boolean;
   json: boolean;
   stdout: NodeJS.WritableStream;
   warnings: string[];

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -189,6 +189,12 @@ describe("runDaemonRestart health checks", () => {
   let runDaemonStop: typeof import("./lifecycle.js").runDaemonStop;
   let envSnapshot: ReturnType<typeof captureEnv>;
 
+  function failRestartCheck(message: string, hints?: string[]) {
+    const err = new Error(message) as Error & { hints?: string[] };
+    err.hints = hints;
+    throw err;
+  }
+
   function mockUnmanagedRestart({
     runPostRestartCheck = false,
   }: {
@@ -196,15 +202,14 @@ describe("runDaemonRestart health checks", () => {
   } = {}) {
     runServiceRestart.mockImplementation(
       async (params: RestartParams & { onNotLoaded?: () => Promise<unknown> }) => {
-        await params.onNotLoaded?.();
+        const activationAccepted = Boolean(await params.onNotLoaded?.());
         if (runPostRestartCheck) {
           await params.postRestartCheck?.({
+            activationAccepted,
             json: Boolean(params.opts?.json),
             stdout: process.stdout,
             warnings: [],
-            fail: (message: string) => {
-              throw new Error(message);
-            },
+            fail: failRestartCheck,
           });
         }
         return true;
@@ -288,16 +293,12 @@ describe("runDaemonRestart health checks", () => {
     stopSystemdService.mockReset().mockResolvedValue(undefined);
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
-      const fail = (message: string, hints?: string[]) => {
-        const err = new Error(message) as Error & { hints?: string[] };
-        err.hints = hints;
-        throw err;
-      };
       await params.postRestartCheck?.({
+        activationAccepted: true,
         json: Boolean(params.opts?.json),
         stdout: process.stdout,
         warnings: [],
-        fail,
+        fail: failRestartCheck,
       });
       return true;
     });
@@ -436,12 +437,11 @@ describe("runDaemonRestart health checks", () => {
         issues: [{ code: "port-mismatch", message: "service port is stale" }],
       });
       await params.postRestartCheck?.({
+        activationAccepted: false,
         json: true,
         stdout: process.stdout,
         warnings: [],
-        fail: (message: string) => {
-          throw new Error(message);
-        },
+        fail: failRestartCheck,
       });
       return true;
     });
@@ -982,14 +982,13 @@ describe("runDaemonRestart health checks", () => {
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([]);
     runServiceRestart.mockImplementation(
       async (params: RestartParams & { onNotLoaded?: () => Promise<unknown> }) => {
-        await params.onNotLoaded?.();
+        const activationAccepted = Boolean(await params.onNotLoaded?.());
         await params.postRestartCheck?.({
+          activationAccepted,
           json: Boolean(params.opts?.json),
           stdout: process.stdout,
           warnings: [],
-          fail: (message: string) => {
-            throw new Error(message);
-          },
+          fail: failRestartCheck,
         });
         return true;
       },

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -622,7 +622,8 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
       return null;
     },
-    postRestartCheck: async ({ warnings, fail, stdout, warn }) => {
+    postRestartCheck: async ({ warnings, fail, stdout, warn, activationAccepted: accepted }) => {
+      let activationAccepted = accepted;
       if (restartedWithoutServiceManager) {
         // Unmanaged restarts have no service-manager state to watch; use listener health and,
         // when targeted delivery required it, prove the previous lock owner was replaced.
@@ -656,6 +657,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         fail(
           `Gateway restart timed out after ${unmanagedRestartWaitSeconds}s waiting for health checks.`,
           [formatCliCommand("openclaw gateway status --deep"), formatCliCommand("openclaw doctor")],
+          activationAccepted ? "restart-health-failed" : undefined,
         );
         throw new Error("unreachable after gateway restart health failure");
       }
@@ -693,6 +695,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         if (retryRestart.outcome === "scheduled") {
           return retryRestart;
         }
+        activationAccepted = true;
         health = await waitForHealthy();
       }
 
@@ -726,10 +729,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         warnings.push(...diagnostics);
       }
 
-      fail(failure.failMessage, [
-        formatCliCommand("openclaw gateway status --deep"),
-        formatCliCommand("openclaw doctor"),
-      ]);
+      fail(
+        failure.failMessage,
+        [formatCliCommand("openclaw gateway status --deep"), formatCliCommand("openclaw doctor")],
+        activationAccepted ? "restart-health-failed" : undefined,
+      );
       throw new Error("unreachable after gateway restart failure");
     },
   });

--- a/src/cli/daemon-cli/response.ts
+++ b/src/cli/daemon-cli/response.ts
@@ -175,7 +175,7 @@ export function createDaemonActionContext(params: { action: DaemonAction; json: 
   stdout: Writable;
   warnings: string[];
   emit: (payload: Omit<DaemonActionResponse, "action">) => void;
-  fail: (message: string, hints?: string[]) => void;
+  fail: (message: string, hints?: string[], result?: "restart-health-failed") => void;
 } {
   const warnings: string[] = [];
   const stdout = params.json ? createNullWriter() : process.stdout;
@@ -190,12 +190,13 @@ export function createDaemonActionContext(params: { action: DaemonAction; json: 
       warnings: payload.warnings ?? (warnings.length ? warnings : undefined),
     });
   };
-  const fail = (message: string, hints?: string[]) => {
+  const fail = (message: string, hints?: string[], result?: "restart-health-failed") => {
     if (params.json) {
       emit({
         ok: false,
         error: message,
         hints,
+        ...(result ? { result } : {}),
       });
     } else {
       defaultRuntime.error(message);

--- a/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
+++ b/src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts
@@ -3,10 +3,11 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { withTestTimeout } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { gatewayDirectStopEntrypoints } from "../cli-entrypoint.test-support.js";
 
 const CHILD_READY_TIMEOUT_MS = 45_000;
 const TEST_TIMEOUT_MS = 60_000;
@@ -42,20 +43,21 @@ async function cleanupFixtures() {
 
 afterEach(cleanupFixtures);
 
-const moduleUrl = (relativePath: string) => pathToFileURL(path.resolve(relativePath)).href;
+const moduleUrl = (entry: Parameters<typeof resolveRuntimeWorkerUrl>[0]) =>
+  resolveRuntimeWorkerUrl(entry).href;
 
 const childScript = `
   import fs from "node:fs";
   import path from "node:path";
-  import { createChannelIngressDrain } from ${JSON.stringify(moduleUrl("src/channels/message/ingress-drain.ts"))};
-  import { createChannelIngressQueue } from ${JSON.stringify(moduleUrl("src/channels/message/ingress-queue.ts"))};
+  import { createChannelIngressDrain } from ${JSON.stringify(moduleUrl(gatewayDirectStopEntrypoints.ingressDrain))};
+  import { createChannelIngressQueue } from ${JSON.stringify(moduleUrl(gatewayDirectStopEntrypoints.ingressQueue))};
   import {
     clearActiveEmbeddedRun,
     setActiveEmbeddedRun,
-  } from ${JSON.stringify(moduleUrl("src/agents/embedded-agent-runner/runs.ts"))};
-  import { getActiveEmbeddedRunCount } from ${JSON.stringify(moduleUrl("src/agents/embedded-agent-runner/active-run-projections.ts"))};
-  import { runGatewayLoop } from ${JSON.stringify(moduleUrl("src/cli/gateway-cli/run-loop.ts"))};
-  import { getActiveGatewayRootWorkCount } from ${JSON.stringify(moduleUrl("src/process/gateway-work-admission.ts"))};
+  } from ${JSON.stringify(moduleUrl(gatewayDirectStopEntrypoints.runs))};
+  import { getActiveEmbeddedRunCount } from ${JSON.stringify(moduleUrl(gatewayDirectStopEntrypoints.activeRunProjections))};
+  import { runGatewayLoop } from ${JSON.stringify(moduleUrl(gatewayDirectStopEntrypoints.runLoop))};
+  import { getActiveGatewayRootWorkCount } from ${JSON.stringify(moduleUrl(gatewayDirectStopEntrypoints.workAdmission))};
 
   const tracePath = process.argv[1];
   const stateDir = process.argv[2];

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -8976,6 +8976,30 @@ describe("update-cli", () => {
     expectFailedManagedGitRestart("Gateway: restart failed: Error: restart unavailable");
   });
 
+  it("reports a refused installed restart for an already-stopped Git service", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    await setupManagedGitRootRefresh();
+    serviceReadRuntime.mockResolvedValue({ status: "stopped", state: "stopped" });
+    prepareRestartScript.mockResolvedValue(null);
+    const runFixtureCommand = requireValue(
+      vi.mocked(runCommandWithTimeout).getMockImplementation(),
+      "default command fixture",
+    );
+    vi.mocked(runCommandWithTimeout).mockImplementation(async (argv, options) =>
+      argv[2] === "gateway" && argv[3] === "restart"
+        ? commandResult({ code: 1, stderr: "native owner refused" })
+        : runFixtureCommand(argv, options),
+    );
+
+    await expect(updateCommand({ yes: true, json: true })).rejects.toEqual(new ExitError(1));
+
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(runRestartScript).not.toHaveBeenCalled();
+    expect(freshRestartCalls()).toHaveLength(1);
+    expect(lastWriteJsonCall()).toMatchObject({ status: "error", reason: "restart-unhealthy" });
+    expect(getErrorOutput()).toContain("native owner refused");
+  });
+
   it("stops a managed gateway rooted at the git checkout when switching package installs to dev", async () => {
     const prefix = createCaseDir("openclaw-update-package-root");
     const { nodeModules } = await setupInstalledPackageAtNodeModules(

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -6124,7 +6124,7 @@ describe("update-cli", () => {
       listener.listen(absentServicePort, "127.0.0.1");
       await once(listener, "listening");
       await expect(runWithGatewayServiceEnv({ yes: true })).rejects.toEqual(new ExitError(1));
-      expect(getErrorOutput()).toContain("Gateway service inspection is unavailable");
+      expect(getLogOutput()).toContain("Gateway service inspection is unavailable");
       expect(packageInstallCommandCall()).toBeUndefined();
       expectNoSideEffects(serviceStop, serviceStart, serviceRestart);
     } finally {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -168,6 +168,7 @@ vi.mock("../infra/update-managed-service-handoff.js", () => ({
   transferManagedServiceUpdateHandoff: managedUpdateHandoff.transfer,
   cancelManagedServiceUpdateHandoff: managedUpdateHandoff.cancel,
   activateManagedServiceUpdateHandoff: managedUpdateHandoff.activate,
+  isCurrentManagedServiceUpdateHandoffProcess: async () => false,
 }));
 vi.mock("../infra/update-repair-agent.js", () => ({
   prepareUnattendedUpdateRepair: unattendedRepair,

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1,8 +1,9 @@
 // Update CLI tests cover update command behavior, runtime calls, and output handling.
 import { createHash } from "node:crypto";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import { createServer } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
@@ -45,6 +46,7 @@ import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contra
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import { getFreePort } from "../test-utils/ports.js";
 import { VERSION } from "../version.js";
 import { createCliRuntimeCapture, getMockCallOutput } from "./test-runtime-capture.js";
 
@@ -91,6 +93,7 @@ const stateSchemaVersions = vi.hoisted(() => vi.fn());
 const mockedRunDaemonInstall = vi.fn();
 const serviceReadCommand = vi.fn();
 const serviceReadRuntime = vi.fn();
+let absentServicePort: number;
 const mockGetSelfAndAncestorPidsSync = vi.fn(() => new Set<number>([process.pid]));
 const terminateStaleGatewayPids = vi.fn();
 const inspectPortUsage = vi.fn();
@@ -468,13 +471,17 @@ vi.mock("../daemon/service.js", () => ({
     const command = await serviceReadCommand(
       args?.requireEffective ? { requireEffective: true } : undefined,
     );
-    const env = {
+    const env: NodeJS.ProcessEnv = {
       ...(args?.env ?? process.env),
       ...(process.platform === "win32" ? { PATH: path.dirname(process.execPath) } : undefined),
       ...(command && typeof command === "object" && "environment" in command
         ? (command.environment as NodeJS.ProcessEnv | undefined)
         : undefined),
     };
+    // An absent fixture service must probe its own port, not the operator's listener.
+    if (command === null) {
+      env.OPENCLAW_GATEWAY_PORT ??= String(absentServicePort);
+    }
     args?.validateEnvBeforeStatusRead?.(env);
     const [loadState, runtime] = await Promise.all([
       serviceLoaded({ env })
@@ -1083,23 +1090,19 @@ describe("update-cli", () => {
 
   const runRestartFallbackScenario = async (params: { daemonInstall: "ok" | "fail" }) => {
     mockOwnedGitService();
-    mockGitUpdateAfterMutation();
+    const entrypoint = path.join(process.cwd(), "dist", "index.js");
+    mockGitUpdateAfterMutation(makeOkUpdateResult({ root: process.cwd() }));
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(entrypoint);
     if (params.daemonInstall === "fail") {
-      vi.mocked(runDaemonInstall).mockRejectedValueOnce(new Error("refresh failed"));
-    } else {
-      vi.mocked(runDaemonInstall).mockResolvedValue(undefined);
+      mockGatewayInstallFailure(entrypoint);
     }
     prepareRestartScript.mockResolvedValue(null);
     serviceLoaded.mockResolvedValue(true);
-    vi.mocked(runDaemonRestart).mockResolvedValue(true);
 
     await updateCommand({});
 
-    expect(runDaemonInstall).toHaveBeenCalledWith({
-      force: true,
-      json: undefined,
-    });
-    expect(runDaemonRestart).toHaveBeenCalledTimes(1);
+    expect(gatewayCommandCall(entrypoint, "install")).toBeDefined();
+    expect(freshRestartCalls()).toHaveLength(1);
   };
 
   const setupNonInteractiveDowngrade = async () => {
@@ -1840,6 +1843,7 @@ describe("update-cli", () => {
   };
 
   beforeEach(async () => {
+    absentServicePort = await getFreePort();
     const gatewayEntrypoint = await import("../daemon/gateway-entrypoint.js");
     const actualGatewayEntrypoint = await vi.importActual<
       typeof import("../daemon/gateway-entrypoint.js")
@@ -2440,7 +2444,7 @@ describe("update-cli", () => {
         requireRunningServiceAfterRestart: true,
         timeoutMs: 1_000,
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBe("failed");
 
     expect(freshRestartCalls().length).toBe(1);
     expect(serviceStart).not.toHaveBeenCalled();
@@ -2813,7 +2817,10 @@ describe("update-cli", () => {
 
   it("finishes a human restart without rerunning stale doctor or leaking the service profile", async () => {
     mockOwnedGitService();
-    mockGitUpdateAfterMutation();
+    mockGitUpdateAfterMutation(makeOkUpdateResult({ root: process.cwd() }));
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(
+      path.join(process.cwd(), "dist", "index.js"),
+    );
     pathExists.mockImplementation(
       async (candidate: string) =>
         candidate === path.join(process.cwd(), "package.json") ||
@@ -2834,7 +2841,6 @@ describe("update-cli", () => {
       state: "running",
     });
     prepareRestartScript.mockResolvedValue(null);
-    vi.mocked(runDaemonRestart).mockResolvedValue(true);
 
     await withEnvAsync(
       {
@@ -2849,7 +2855,9 @@ describe("update-cli", () => {
     );
 
     expect(doctorCommand).not.toHaveBeenCalled();
-    expect(runDaemonRestart).toHaveBeenCalledOnce();
+    expect(freshRestartCalls()).toHaveLength(1);
+    expect(freshRestartCalls()[0]?.[1]).toMatchObject({ env: { OPENCLAW_PROFILE: "work" } });
+    expect(runDaemonRestart).not.toHaveBeenCalled();
     const completionCall = vi
       .mocked(spawnSync)
       .mock.calls.find(([, args]) => args?.[1] === "completion");
@@ -4915,7 +4923,9 @@ describe("update-cli", () => {
       );
       mockCurrentProcessFreshDoctor();
       serviceLoaded.mockResolvedValue(true);
-      vi.mocked(runDaemonRestart).mockResolvedValue(true);
+      vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(
+        path.join(process.cwd(), "dist", "index.js"),
+      );
       prepareRestartScript.mockResolvedValue(null);
       try {
         await updateCommand({ yes: true, json });
@@ -4925,6 +4935,8 @@ describe("update-cli", () => {
         });
       }
       expect(observedActivation).toBe(true);
+      expect(freshRestartCalls()).toHaveLength(1);
+      expect(runDaemonRestart).not.toHaveBeenCalled();
       const run = expectDefined(listUpdateRuns({ limit: 1 })[0], "admitted update run");
       expect(serviceStop, getErrorOutput()).toHaveBeenCalledOnce();
       expect(run, getErrorOutput()).toMatchObject({
@@ -5584,7 +5596,7 @@ describe("update-cli", () => {
     expect(schemaCalls.some((order) => order > stoppedAt)).toBe(true);
     expect(freshRestartCalls()).toEqual([
       [
-        [process.execPath, entrypoint, "gateway", "restart", "--preserve-definition"],
+        [process.execPath, entrypoint, "gateway", "restart", "--preserve-definition", "--json"],
         expect.objectContaining({ cwd: root, timeoutMs: 17_000, baseEnv: {} }),
       ],
     ]);
@@ -6100,6 +6112,28 @@ describe("update-cli", () => {
 
     expect(defaultRuntime.error).not.toHaveBeenCalledWith(packageUpdateInGatewayMessage);
     expectPackageInstallSpec("openclaw@9999.0.0");
+  });
+
+  it("refuses an absent service update while its selected port has a real listener", async () => {
+    await mockPackageInstallAtCaseDir();
+    const actualPortsProbe =
+      await vi.importActual<typeof import("../infra/ports-probe.js")>("../infra/ports-probe.js");
+    probePortUsage.mockImplementation(actualPortsProbe.probePortUsage);
+    const listener = createServer();
+    try {
+      listener.listen(absentServicePort, "127.0.0.1");
+      await once(listener, "listening");
+      await expect(runWithGatewayServiceEnv({ yes: true })).rejects.toEqual(new ExitError(1));
+      expect(getErrorOutput()).toContain("Gateway service inspection is unavailable");
+      expect(packageInstallCommandCall()).toBeUndefined();
+      expectNoSideEffects(serviceStop, serviceStart, serviceRestart);
+    } finally {
+      if (listener.listening) {
+        const closed = once(listener, "close");
+        listener.close();
+        await closed;
+      }
+    }
   });
 
   it("refuses package updates from inherited gateway service env when --no-restart leaves the gateway running", async () => {
@@ -10773,31 +10807,21 @@ describe("update-cli", () => {
       },
     },
     {
-      name: "falls back to daemon restart when service env refresh cannot complete",
+      name: "uses the installed Git CLI when service env refresh cannot complete",
       run: async () => {
-        vi.mocked(runDaemonRestart).mockResolvedValue(true);
         await runRestartFallbackScenario({ daemonInstall: "fail" });
       },
       assert: () => {
-        expect(runDaemonInstall).toHaveBeenCalledWith({
-          force: true,
-          json: undefined,
-        });
-        expect(runDaemonRestart).toHaveBeenCalledTimes(1);
+        expectNoSideEffects(runDaemonInstall, runDaemonRestart);
       },
     },
     {
-      name: "keeps going when daemon install succeeds but restart fallback still handles relaunch",
+      name: "uses the installed Git CLI after service env refresh succeeds",
       run: async () => {
-        vi.mocked(runDaemonRestart).mockResolvedValue(true);
         await runRestartFallbackScenario({ daemonInstall: "ok" });
       },
       assert: () => {
-        expect(runDaemonInstall).toHaveBeenCalledWith({
-          force: true,
-          json: undefined,
-        });
-        expect(runDaemonRestart).toHaveBeenCalledTimes(1);
+        expectNoSideEffects(runDaemonInstall, runDaemonRestart);
       },
     },
     {
@@ -10888,7 +10912,7 @@ describe("update-cli", () => {
         updatedEntrypoint,
         "gateway",
         "restart",
-        ...(json ? ["--json"] : []),
+        "--json",
       ]);
       expect(restartCall?.[1].cwd).toBe(updatedRoot);
       expect(runRestartScript).not.toHaveBeenCalled();
@@ -11038,7 +11062,13 @@ describe("update-cli", () => {
 
     const installCall = gatewayCommandCall(updatedEntrypoint, "install");
     expect(installCall?.[0][0]).toContain("node");
-    expect(installCall?.[0].slice(1)).toEqual([updatedEntrypoint, "gateway", "install", "--force"]);
+    expect(installCall?.[0].slice(1)).toEqual([
+      updatedEntrypoint,
+      "gateway",
+      "install",
+      "--force",
+      "--json",
+    ]);
     expect(installCall?.[1].cwd).toBe(updatedRoot);
     expect(installCall?.[1].timeoutMs).toBe(60_000);
     expect(gatewayCommandCall(updatedEntrypoint, "restart")).toBeUndefined();
@@ -11350,7 +11380,13 @@ describe("update-cli", () => {
 
     const installCall = gatewayCommandCall(entryPath, "install");
     expect(installCall?.[0][0]).toContain("node");
-    expect(installCall?.[0].slice(1)).toEqual([entryPath, "gateway", "install", "--force"]);
+    expect(installCall?.[0].slice(1)).toEqual([
+      entryPath,
+      "gateway",
+      "install",
+      "--force",
+      "--json",
+    ]);
     expect(installCall?.[1].cwd).toBe(String(root));
     expect(installCall?.[1].timeoutMs).toBe(60_000);
     const expectedEnv =
@@ -11369,29 +11405,30 @@ describe("update-cli", () => {
     "restores update flag $previous after restart (core mutation: $mutatesCore)",
     async ({ previous, mutatesCore }) => {
       await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: previous }, async () => {
-        mockRunningManagedGateway([
-          "node",
-          path.join(process.cwd(), "dist", "index.js"),
-          "gateway",
-        ]);
+        const entrypoint = path.join(process.cwd(), "dist", "index.js");
+        vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(entrypoint);
+        mockRunningManagedGateway(["node", entrypoint, "gateway"]);
         if (mutatesCore) {
-          mockGitUpdateAfterMutation();
+          mockGitUpdateAfterMutation(makeOkUpdateResult({ root: process.cwd() }));
         }
         prepareRestartScript.mockResolvedValue(null);
-        vi.mocked(runDaemonRestart).mockResolvedValue(true);
         vi.mocked(defaultRuntime.log).mockClear();
 
         await updateCommand({});
 
         expect(doctorCommand).not.toHaveBeenCalled();
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBe(previous);
+        const restartIndex = vi
+          .mocked(runCommandWithTimeout)
+          .mock.calls.findIndex(([argv]) => argv[2] === "gateway" && argv[3] === "restart");
+        const restartOrder = requireValue(
+          vi.mocked(runCommandWithTimeout).mock.invocationCallOrder[restartIndex],
+          "installed CLI restart call order",
+        );
         const snapshotOrders = createPreUpdateConfigSnapshotMock.mock.invocationCallOrder;
         expect(createPreUpdateConfigSnapshotMock).toHaveBeenCalledTimes(1);
         expect(requireValue(snapshotOrders[0], "restart snapshot call order")).toBeLessThan(
-          requireValue(
-            vi.mocked(runDaemonRestart).mock.invocationCallOrder[0],
-            "daemon restart call order",
-          ),
+          restartOrder,
         );
 
         const successIndex = vi
@@ -11400,12 +11437,7 @@ describe("update-cli", () => {
         expect(successIndex).toBeGreaterThanOrEqual(0);
         expect(
           vi.mocked(defaultRuntime.log).mock.invocationCallOrder[successIndex],
-        ).toBeGreaterThan(
-          requireValue(
-            vi.mocked(runDaemonRestart).mock.invocationCallOrder[0],
-            "restart call order",
-          ),
-        );
+        ).toBeGreaterThan(restartOrder);
       });
     },
   );

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -1,5 +1,5 @@
 // Restart helper tests cover update restart helper process selection and error handling.
-import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { execFile } from "node:child_process";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
@@ -7,6 +7,7 @@ import path from "node:path";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { getWindowsCmdExePath } from "../../infra/windows-install-roots.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS, spawnCommand } from "../../process/exec-spawn.js";
 import { prepareRestartScript, runRestartScript } from "./restart-helper.js";
 
 const windowsKillPolicyStartMarker = "# OPENCLAW_RESTART_KILL_POLICY_BEGIN";
@@ -31,15 +32,10 @@ function findPowerShell(): string | null {
 const powerShellPath = findPowerShell();
 const itWithPowerShell = powerShellPath ? it : it.skip;
 
-vi.mock("node:child_process", async () => {
-  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
-  return mockNodeBuiltinModule(
-    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
-    {
-      spawn: vi.fn(),
-    },
-  );
-});
+vi.mock("../../process/exec-spawn.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec-spawn.js")>()),
+  spawnCommand: vi.fn(),
+}));
 
 describe("restart-helper", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -1045,85 +1041,64 @@ Write-Output "OPENCLAW_RESTART_POLICY_OK"
   });
 
   describe("runRestartScript", () => {
-    it("spawns the script as a detached process on Linux", async () => {
-      Object.defineProperty(process, "platform", { value: "linux" });
-      const scriptPath = "/tmp/fake-script.sh";
-      const mockChild = { on: vi.fn(), unref: vi.fn() };
-      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
+    it.each([
+      { platform: "linux", script: "/tmp/fake-script.sh" },
+      { platform: "win32", script: "C:\\Temp\\fake-script.bat" },
+      { platform: "win32", script: "C:\\Temp\\me&(ow)\\fake-script.bat" },
+    ])("observes detached completion for $platform $script", async ({ platform, script }) => {
+      Object.defineProperty(process, "platform", { value: platform });
+      vi.mocked(spawnCommand).mockResolvedValue({ failed: false } as Awaited<
+        ReturnType<typeof spawnCommand>
+      >);
 
-      await runRestartScript(scriptPath);
+      await expect(runRestartScript(script, 1_000)).resolves.toBe(true);
 
-      expect(spawn).toHaveBeenCalledWith("/bin/sh", [scriptPath], {
+      const argv =
+        platform === "win32"
+          ? [
+              getWindowsCmdExePath(),
+              "/d",
+              "/s",
+              "/c",
+              script.includes("&") ? `"${script}"` : script,
+            ]
+          : ["/bin/sh", script];
+      expect(spawnCommand).toHaveBeenCalledWith(argv, {
         detached: true,
         stdio: "ignore",
-        windowsHide: true,
+        timeout: 1_000,
+        forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
       });
-      expect(mockChild.on).toHaveBeenCalledWith("error", expect.any(Function));
-      expect(mockChild.unref).toHaveBeenCalledTimes(1);
     });
 
-    it("uses cmd.exe on Windows", async () => {
-      Object.defineProperty(process, "platform", { value: "win32" });
-      const scriptPath = "C:\\Temp\\fake-script.bat";
-      const mockChild = { on: vi.fn(), unref: vi.fn() };
-      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
+    it.each([false, true])(
+      "does not grant activation on a spawn error (async=%s)",
+      async (asyncError) => {
+        const error = Object.assign(new Error("spawn /bin/sh ENOENT"), { code: "ENOENT" });
+        if (asyncError) {
+          vi.mocked(spawnCommand).mockRejectedValue(error);
+        } else {
+          vi.mocked(spawnCommand).mockImplementation(() => {
+            throw error;
+          });
+        }
+        await expect(runRestartScript("/tmp/fake-script.sh", 1_000)).resolves.toBe(false);
+      },
+    );
 
-      await runRestartScript(scriptPath);
-
-      expect(spawn).toHaveBeenCalledWith(getWindowsCmdExePath(), ["/d", "/s", "/c", scriptPath], {
-        detached: true,
-        stdio: "ignore",
-        windowsHide: true,
-      });
-      expect(mockChild.on).toHaveBeenCalledWith("error", expect.any(Function));
-      expect(mockChild.unref).toHaveBeenCalledTimes(1);
-    });
-
-    it("quotes cmd.exe /c paths with metacharacters on Windows", async () => {
-      Object.defineProperty(process, "platform", { value: "win32" });
-      const scriptPath = "C:\\Temp\\me&(ow)\\fake-script.bat";
-      const mockChild = { on: vi.fn(), unref: vi.fn() };
-      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
-
-      await runRestartScript(scriptPath);
-
-      expect(spawn).toHaveBeenCalledWith(
-        getWindowsCmdExePath(),
-        ["/d", "/s", "/c", `"${scriptPath}"`],
-        {
-          detached: true,
-          stdio: "ignore",
-          windowsHide: true,
-        },
+    it.skipIf(process.platform === "win32").each([
+      { name: "completed activation", body: "exit 0", accepted: true, timeout: 1_000 },
+      { name: "native refusal", body: "exit 78", accepted: false, timeout: 1_000 },
+      { name: "interrupted activation", body: "kill -TERM $$", accepted: false, timeout: 1_000 },
+      { name: "activation timeout", body: "exec sleep 10", accepted: false, timeout: 100 },
+    ])("uses the actual process result for $name", async ({ body, accepted, timeout }) => {
+      const actual = await vi.importActual<typeof import("../../process/exec-spawn.js")>(
+        "../../process/exec-spawn.js",
       );
-    });
-
-    it("does not throw when spawn fails synchronously", async () => {
-      Object.defineProperty(process, "platform", { value: "linux" });
-      vi.mocked(spawn).mockImplementation(() => {
-        throw Object.assign(new Error("spawn /bin/sh ENOENT"), { code: "ENOENT" });
-      });
-
-      await expect(runRestartScript("/tmp/fake-script.sh")).resolves.toBeUndefined();
-    });
-
-    it("handles child process spawn errors after the detached handoff", async () => {
-      Object.defineProperty(process, "platform", { value: "linux" });
-      let errorHandler: ((error: Error) => void) | undefined;
-      const mockChild = {
-        on: vi.fn((event: string, handler: (error: Error) => void) => {
-          if (event === "error") {
-            errorHandler = handler;
-          }
-          return mockChild;
-        }),
-        unref: vi.fn(),
-      };
-      vi.mocked(spawn).mockReturnValue(mockChild as unknown as ChildProcess);
-
-      await runRestartScript("/tmp/fake-script.sh");
-      expect(errorHandler).toBeDefined();
-      expect(() => errorHandler?.(new Error("spawn /bin/sh ENOENT"))).not.toThrow();
+      vi.mocked(spawnCommand).mockImplementation(actual.spawnCommand);
+      const script = path.join(tempDirs.make("openclaw-restart-result-"), "restart.sh");
+      await fs.writeFile(script, `#!/bin/sh\n${body}\n`);
+      await expect(runRestartScript(script, timeout)).resolves.toBe(accepted);
     });
   });
 });

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -1,5 +1,4 @@
 // Builds detached, platform-specific restart scripts for update handoff.
-import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -19,6 +18,7 @@ import {
   shellEscapeRestartLogValue,
 } from "../../daemon/restart-logs.js";
 import { getWindowsCmdExePath } from "../../infra/windows-install-roots.js";
+import { COMMAND_PROCESS_TREE_KILL_GRACE_MS, spawnCommand } from "../../process/exec-spawn.js";
 
 /**
  * Shell-escape a string for embedding in single-quoted shell arguments.
@@ -768,31 +768,23 @@ exit $status
   }
 }
 
-/**
- * Executes the prepared restart script as a **detached** process.
- *
- * The script must outlive the CLI process because the CLI itself is part
- * of the service being restarted — `systemctl restart` / `launchctl
- * kickstart -k` will terminate the current process tree.  Using
- * `spawn({ detached: true })` + `unref()` ensures the script survives
- * the parent's exit.
- *
- * Resolves immediately after spawning; the script runs independently.
- */
-export async function runRestartScript(scriptPath: string): Promise<void> {
+/** Observe native acceptance separately from the caller's subsequent health check. */
+export async function runRestartScript(scriptPath: string, timeoutMs: number): Promise<boolean> {
   const isWindows = process.platform === "win32";
   const file = isWindows ? getWindowsCmdExePath() : "/bin/sh";
   const args = isWindows ? ["/d", "/s", "/c", quoteCmdScriptArg(scriptPath)] : [scriptPath];
 
   try {
-    const child = spawn(file, args, {
+    await spawnCommand([file, ...args], {
+      // Keep the detached, stream-independent handoff on every platform, but
+      // observe its result before classifying failed health as an activation refusal.
       detached: true,
       stdio: "ignore",
-      windowsHide: true,
+      timeout: timeoutMs,
+      forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
     });
-    child.on("error", () => {});
-    child.unref();
+    return true;
   } catch {
-    // Restart handoff is best-effort; update completion must not crash here.
+    return false;
   }
 }

--- a/src/cli/update-cli/update-command-generation.test-support.ts
+++ b/src/cli/update-cli/update-command-generation.test-support.ts
@@ -70,7 +70,7 @@ export function registerGenerationRecoveryTests(
         requireRunningServiceAfterRestart: true,
         timeoutMs: 1000,
       }),
-    ).toBe(false);
+    ).toBe("failed");
     const record = getUpdateRun(run.runId, { env })!;
     expect(record.verification.serviceRunning).toBe(false);
     expect(renderUpdateRunReport({ ...record, status: "failed" }).headline).not.toContain(

--- a/src/cli/update-cli/update-command-generation.test-support.ts
+++ b/src/cli/update-cli/update-command-generation.test-support.ts
@@ -30,6 +30,7 @@ export function registerGenerationRecoveryTests(
       running: boolean;
       events: string[];
       stopAllowances: Array<string | undefined>;
+      writeJson: Mock;
     };
   },
 ) {
@@ -149,7 +150,7 @@ export function registerGenerationRecoveryTests(
         );
         return {
           code: healthy ? 0 : 1,
-          stdout: "",
+          stdout: JSON.stringify(mocks.writeJson.mock.lastCall?.[0]),
           stderr: "",
           signal: null,
           killed: false,

--- a/src/cli/update-cli/update-command-handoff.test.ts
+++ b/src/cli/update-cli/update-command-handoff.test.ts
@@ -115,9 +115,18 @@ process.stdin.once('end',()=>{if(child.exitCode===null&&child.signalCode===null)
       }
     };
     try {
-      await expect.poll(() => fs.readFile(resultPath, "utf8"), { timeout: 20_000 }).toBeDefined();
+      // Transfer releases the CLI before its detached helper finishes owning the lease.
+      await expect
+        .poll(
+          async () => {
+            await fs.readFile(resultPath, "utf8");
+            return fs.readFile(tracePath, "utf8");
+          },
+          { timeout: 20_000 },
+        )
+        .toContain('"event":"helper-exit"');
       const result = JSON.parse(await fs.readFile(resultPath, "utf8"));
-      await expect.poll(readLease).toBeUndefined();
+      expect(readLease()).toBeUndefined();
       expect(gateway.exitCode).toBeNull();
       expect(result.code, result.stderr).toBe(mode === "transfer" ? 0 : 23);
       const trace = (await fs.readFile(tracePath, "utf8"))
@@ -142,8 +151,8 @@ process.stdin.once('end',()=>{if(child.exitCode===null&&child.signalCode===null)
     } finally {
       gateway.stdin.end();
       await closed;
-      await expect.poll(readLease).toBeUndefined();
       await expect.poll(() => fs.readFile(tracePath, "utf8")).toContain('"event":"helper-exit"');
+      expect(readLease()).toBeUndefined();
     }
   },
 );

--- a/src/cli/update-cli/update-command-lease.test.ts
+++ b/src/cli/update-cli/update-command-lease.test.ts
@@ -23,7 +23,7 @@ const mocks = vi.hoisted(() => ({
   entrypoint: vi.fn(),
   root: vi.fn(),
   plugins: vi.fn<typeof import("./update-command-plugins.js").updatePluginsAfterCoreUpdate>(),
-  restart: vi.fn(async () => true),
+  restart: vi.fn(async () => "ok"),
   print: vi.fn(),
 }));
 

--- a/src/cli/update-cli/update-command-post-update-recovery.test.ts
+++ b/src/cli/update-cli/update-command-post-update-recovery.test.ts
@@ -31,7 +31,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("./progress.js", () => ({ printResult: mocks.printResult }));
 vi.mock("./update-command-service-command.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./update-command-service-command.js")>()),
-  runUpdatedInstallGatewayCommand: async () => true,
+  runUpdatedInstallGatewayCommand: async () => "accepted",
 }));
 vi.mock("../../config/config.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config/config.js")>()),

--- a/src/cli/update-cli/update-command-post-update-recovery.test.ts
+++ b/src/cli/update-cli/update-command-post-update-recovery.test.ts
@@ -14,7 +14,7 @@ import { defaultRuntime } from "../../runtime.js";
 const mocks = vi.hoisted(() => ({
   printResult: vi.fn(),
   restartCandidate: vi.fn<typeof import("./update-command-service.js").maybeRestartService>(
-    async () => true,
+    async () => "ok",
   ),
   stopCandidate: vi.fn(),
   restart:
@@ -455,7 +455,7 @@ describe("failed update recovery restart", () => {
   it.each([79, 80])(
     "does not restart again after post-activation convergence exits %s",
     async (childExitCode) => {
-      mocks.restartCandidate.mockResolvedValueOnce(true);
+      mocks.restartCandidate.mockResolvedValueOnce("ok");
       vi.stubEnv("OPENCLAW_UPDATE_RUN_HANDOFF", "1");
       const detail = "Fresh Doctor could not persist the migrated config.";
       mocks.freshProcess.mockResolvedValueOnce({
@@ -591,7 +591,7 @@ describe("failed package update recovery safety", () => {
         refreshDefinition: true,
       },
     });
-    mocks.restartCandidate.mockResolvedValueOnce(true);
+    mocks.restartCandidate.mockResolvedValueOnce("ok");
     const rollback = vi.fn(async () => ({
       name: "package rollback",
       activePackageRoot: originalRoot,

--- a/src/cli/update-cli/update-command-post-update-repair.test.ts
+++ b/src/cli/update-cli/update-command-post-update-repair.test.ts
@@ -221,9 +221,9 @@ describe("post-activation repair after rollback refusal or failure", () => {
           });
         }
         params.onVerificationFailure?.("readyz-unhealthy");
-        return false;
+        return "restart-health-failed";
       }
-      return mocks.healthy;
+      return mocks.healthy ? "ok" : "restart-health-failed";
     });
     vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
     vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
@@ -343,7 +343,7 @@ describe("post-activation repair after rollback refusal or failure", () => {
       });
       mocks.restartCommand.mockImplementationOnce(async () => {
         mocks.healthy = repaired;
-        return repaired;
+        return "accepted";
       });
       const validation = await repair.validate(signal);
       const attempt = {
@@ -503,12 +503,12 @@ describe("post-activation repair after rollback refusal or failure", () => {
           if (!mocks.healthy) {
             restart.onVerificationFailure?.("readyz-unhealthy");
           }
-          return mocks.healthy;
+          return mocks.healthy ? "ok" : "restart-health-failed";
         });
         mocks.restartCommand.mockImplementation(async () => {
           await startTask();
           mocks.healthy = true;
-          return true;
+          return "accepted";
         });
         mocks.repair.mockImplementation(async (repair) => {
           const signal = new AbortController().signal;

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -294,7 +294,7 @@ describe("successful update finalization ordering", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.readServiceState.mockReset();
-    mocks.restartService.mockReset().mockResolvedValue(true);
+    mocks.restartService.mockReset().mockResolvedValue("ok");
     mocks.stopService.mockReset();
     mocks.leaseActive = false;
     mocks.loadPluginRecords.mockResolvedValue({});
@@ -723,11 +723,11 @@ describe("successful update finalization ordering", () => {
           now += events.length === 1 ? 500 : 200;
           if (restartFailed && events.length > 1) {
             recordUpdateRunVerification(run.runId, { serviceRunning: false }, { env: serviceEnv });
-            return false;
+            return "restart-health-failed";
           }
           recordVerified();
           params.onVerified?.(now);
-          return true;
+          return "ok";
         });
         const plugins = { ...successfulPluginUpdate, changed };
         mocks.updatePlugins.mockImplementationOnce(async () => {

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -398,7 +398,6 @@ describe("successful update finalization ordering", () => {
 
     expect(defaultRuntime.error).not.toHaveBeenCalled();
     expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
-    expect(mocks.ensureCompletionCache).not.toHaveBeenCalled();
     expect(mocks.restartService).toHaveBeenCalledOnce();
   });
 
@@ -408,7 +407,6 @@ describe("successful update finalization ordering", () => {
     await finishSuccessfulPackageSwitch();
 
     expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
-    expect(mocks.ensureCompletionCache).not.toHaveBeenCalled();
     expect(mocks.restartService).toHaveBeenCalledOnce();
   });
 
@@ -987,7 +985,6 @@ describe("successful update finalization ordering", () => {
         await expectUpdateFailure(finishing, "readyz-unhealthy");
       }
 
-      expect(mocks.revalidateService).toHaveBeenCalledOnce();
       expect(mocks.restartService).toHaveBeenCalledOnce();
       expect(mocks.prepareRestartScript).not.toHaveBeenCalled();
       expect(mocks.restartService).toHaveBeenCalledWith(

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -29,7 +29,7 @@ const mocks = vi.hoisted(() => ({
   createServiceConfigIO: vi.fn(),
   readServiceState: vi.fn(),
   restartService: vi.fn<typeof import("./update-command-service.js").maybeRestartService>(
-    async () => true,
+    async () => "ok",
   ),
   stopService:
     vi.fn<
@@ -412,19 +412,22 @@ describe("successful update finalization ordering", () => {
     expect(mocks.restartService).toHaveBeenCalledOnce();
   });
 
-  it("keeps an unhealthy restart blocking before completion refresh", async () => {
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
-    mocks.restartService.mockResolvedValueOnce(false);
+  it.each(["failed", "restart-health-failed"] as const)(
+    "keeps %s blocking before completion refresh",
+    async (outcome) => {
+      Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+      mocks.restartService.mockResolvedValueOnce(outcome);
 
-    await expectUpdateFailure(finishSuccessfulPackageSwitch(), "restart-unhealthy");
+      await expectUpdateFailure(finishSuccessfulPackageSwitch(), "restart-unhealthy");
 
-    expect(mocks.printResult).toHaveBeenCalledOnce();
-    expectFailureReport("restart-unhealthy");
-    expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
-      expect.objectContaining({ reason: "restart-unhealthy" }),
-    );
-    expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
-  });
+      expect(mocks.printResult).toHaveBeenCalledOnce();
+      expectFailureReport("restart-unhealthy");
+      expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "restart-unhealthy" }),
+      );
+      expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
+    },
+  );
 
   it("reports elapsed time through restart and shell completion refresh", async () => {
     let now = 1_000;
@@ -432,7 +435,7 @@ describe("successful update finalization ordering", () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     mocks.restartService.mockImplementationOnce(async () => {
       now += 200;
-      return true;
+      return "ok";
     });
     mocks.checkCompletionStatus.mockImplementationOnce(async () => {
       now += 300;
@@ -969,7 +972,7 @@ describe("successful update finalization ordering", () => {
         if (!activated) {
           params.onVerificationFailure?.("readyz-unhealthy");
         }
-        return activated;
+        return activated ? "ok" : "failed";
       });
       const finishing = finishSuccessfulPackageSwitch({
         restartEnvironment: { ...process.env },

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -524,7 +524,7 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
           onVerified: recordVerifiedDowntime,
         }),
       );
-      if (restarted) {
+      if (restarted === "ok") {
         return;
       }
       const failure: UpdateRunResult = {

--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -249,7 +249,7 @@ describe("verified package rollback", () => {
         if (running.code !== 0) {
           throw new Error(running.stderr);
         }
-        return healthy;
+        return healthy ? "ok" : "restart-health-failed";
       });
       try {
         const outcome = await rollbackFailedUpdate({

--- a/src/cli/update-cli/update-command-rollback.test.ts
+++ b/src/cli/update-cli/update-command-rollback.test.ts
@@ -15,7 +15,7 @@ import { createWindowsTaskAutoStartRecovery } from "./update-command-windows-tas
 
 const mocks = vi.hoisted(() => ({
   stop: vi.fn(),
-  restart: vi.fn(),
+  restart: vi.fn<typeof import("./update-command-service.js").maybeRestartService>(),
   reachable: vi.fn(),
   execSchtasks: vi.fn<typeof import("../../daemon/schtasks-exec.js").execSchtasks>(),
 }));
@@ -26,7 +26,7 @@ vi.mock("./update-command-service-maintenance.js", async (importOriginal) => ({
 }));
 vi.mock("./update-command-service-command.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./update-command-service-command.js")>()),
-  runUpdatedInstallGatewayCommand: async () => true,
+  runUpdatedInstallGatewayCommand: async () => "accepted",
 }));
 vi.mock("./update-command-service.js", () => ({
   maybeStopManagedServiceBeforeMutableUpdate: mocks.stop,
@@ -96,7 +96,7 @@ describe("verified package rollback", () => {
     });
     mocks.restart.mockImplementation(async ({ onVerified }) => {
       onVerified?.(125);
-      return true;
+      return "ok";
     });
   });
   it.each([
@@ -466,10 +466,11 @@ describe("verified package rollback", () => {
     "restored-shims-failed",
     "partial-restore",
     "restart-unhealthy",
+    "restart-refused",
     "restart-threw",
   ] as const)("retains active installation identity after %s", async (failure) => {
     const restoredPackage = failure !== "source-failed" && failure !== "partial-restore";
-    const rollbackSucceeded = failure === "restart-unhealthy" || failure === "restart-threw";
+    const rollbackSucceeded = failure.startsWith("restart-");
     const activePackageRoot =
       failure === "partial-restore" ? null : restoredPackage ? previousRoot : candidateRoot;
     const stateDir = dirs.make("rollback-source-failed-");
@@ -489,7 +490,9 @@ describe("verified package rollback", () => {
     if (failure === "restart-threw") {
       mocks.restart.mockRejectedValueOnce(new Error("Service restart transport failed"));
     } else {
-      mocks.restart.mockResolvedValueOnce(false);
+      mocks.restart.mockResolvedValueOnce(
+        failure === "restart-unhealthy" ? "restart-health-failed" : "failed",
+      );
     }
     const outcome = await rollbackFailedUpdate({
       result,

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -294,7 +294,7 @@ export async function rollbackFailedUpdate(params: {
     }
     failureReason = "restart-unhealthy";
     let verifiedAtMs: number | undefined;
-    const healthy = await maybeRestartService({
+    const restartOutcome = await maybeRestartService({
       shouldRestart: true,
       result,
       channel: "stable",
@@ -314,6 +314,7 @@ export async function rollbackFailedUpdate(params: {
         verifiedAtMs = at;
       },
     });
+    const healthy = restartOutcome === "ok";
     return {
       result: {
         ...result,

--- a/src/cli/update-cli/update-command-service-command.process.test.ts
+++ b/src/cli/update-cli/update-command-service-command.process.test.ts
@@ -68,7 +68,7 @@ it.each(["restart", "install", "missing candidate"] as const)(
               '  compileCacheDisabled: process.env.NODE_DISABLE_COMPILE_CACHE,',
               '}));',
             ].join("\n"));
-            assert.equal(await runUpdatedInstallGatewayCommand(params, scenario, true), true);
+            assert.equal(await runUpdatedInstallGatewayCommand(params, scenario, true), "unverified");
             const observed = JSON.parse(await fs.readFile(receipt, "utf8"));
             assert.deepEqual(observed, {
               args: ["gateway", scenario, scenario === "install" ? "--force" : "--preserve-definition", "--json"],

--- a/src/cli/update-cli/update-command-service-command.ts
+++ b/src/cli/update-cli/update-command-service-command.ts
@@ -89,7 +89,12 @@ export async function runUpdatedInstallGatewayCommand(
     ...(params.signal ? { signal: params.signal, killProcessTree: true } : {}),
   });
   params.signal?.throwIfAborted();
-  const exited = res.termination === "exit" && res.signal === null && !res.killed;
+  const exited =
+    res.termination === "exit" &&
+    res.signal === null &&
+    !res.killed &&
+    res.cleanup !== "forced" &&
+    res.cleanup !== "uncertain";
   const complete = !res.stdoutTruncatedBytes && !res.outputLimitExceeded && !res.outputErrorStream;
   const response = complete ? safeParseJsonRecord(res.stdout) : undefined;
   if (exited && res.code === 0) {

--- a/src/cli/update-cli/update-command-service-command.ts
+++ b/src/cli/update-cli/update-command-service-command.ts
@@ -9,6 +9,11 @@ import { resolveUpdatedInstallCommandEnv } from "./update-command-service-env.js
 const SERVICE_REFRESH_TIMEOUT_MS = 60_000;
 export const DEFINITION_DENIAL = /\bSERVICE_DEFINITION_(?:SEALED|UNKNOWN):[^\n]*/;
 
+/** The installed CLI observed failed health after accepting activation, not a refusal. */
+export class GatewayRestartHealthError extends Error {
+  override name = "GatewayRestartHealthError";
+}
+
 export function isPackageManagerUpdateMode(
   mode: UpdateRunResult["mode"],
 ): mode is "npm" | "pnpm" | "bun" {
@@ -41,7 +46,7 @@ export async function runUpdatedInstallGatewayCommand(
   },
   action: "install" | "restart",
   preserveDefinition = false,
-): Promise<boolean> {
+): Promise<"accepted" | "unverified"> {
   params.signal?.throwIfAborted();
   const installing = action === "install";
   const entrypoint = await resolveGatewayInstallEntrypoint(params.result.root);
@@ -50,7 +55,7 @@ export async function runUpdatedInstallGatewayCommand(
       params.signal?.throwIfAborted();
       params.assertCurrent?.();
       await runDaemonInstall({ force: true, json: params.opts.json || undefined });
-      return true;
+      return "unverified";
     }
     throw new Error(
       `updated install entrypoint not found under ${params.result.root ?? "unknown"}`,
@@ -62,9 +67,8 @@ export async function runUpdatedInstallGatewayCommand(
   } else if (preserveDefinition) {
     args.push("--preserve-definition");
   }
-  if (params.opts.json) {
-    args.push("--json");
-  }
+  // Capture one structured child result in both outer output modes.
+  args.push("--json");
   const nodeRunner = params.nodeRunner ?? resolveNodeRunner();
   const commandEnv = resolveUpdatedInstallCommandEnv({
     processEnv: installing
@@ -85,11 +89,29 @@ export async function runUpdatedInstallGatewayCommand(
     ...(params.signal ? { signal: params.signal, killProcessTree: true } : {}),
   });
   params.signal?.throwIfAborted();
-  if (res.code === 0) {
-    return true;
+  const exited = res.termination === "exit" && res.signal === null && !res.killed;
+  const complete = !res.stdoutTruncatedBytes && !res.outputLimitExceeded && !res.outputErrorStream;
+  const response = complete ? safeParseJsonRecord(res.stdout) : undefined;
+  if (exited && res.code === 0) {
+    return action === "restart" &&
+      response?.action === "restart" &&
+      response.ok === true &&
+      (response.result === "restarted" || response.result === "scheduled")
+      ? "accepted"
+      : "unverified";
   }
   const operation = installing ? "refresh" : "restart";
-  throw new Error(
-    `updated install ${operation} failed (${entrypoint}): ${formatCommandFailure(res.stdout, res.stderr)}`,
-  );
+  const message = `updated install ${operation} failed (${entrypoint}): ${formatCommandFailure(res.stdout, res.stderr)}`;
+  if (
+    exited &&
+    res.code === 1 &&
+    action === "restart" &&
+    response?.action === "restart" &&
+    response.ok === false &&
+    response.result === "restart-health-failed" &&
+    typeof response.error === "string"
+  ) {
+    throw new GatewayRestartHealthError(message);
+  }
+  throw new Error(message);
 }

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -7,6 +7,10 @@ import {
   createMockGatewayService,
   mockSystemAccountHome,
 } from "../../daemon/service.test-helpers.js";
+import { openNodeSqliteDatabase } from "../../infra/node-sqlite.js";
+import * as openClawTmp from "../../infra/tmp-openclaw-dir.js";
+import { CONTROL_PLANE_UPDATE_SENTINEL_META_ENV } from "../../infra/update-control-plane-sentinel.js";
+import { getFileLockProcessStartTime } from "../../shared/pid-alive.js";
 import { makeTempWorkspace } from "../../test-helpers/workspace.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
@@ -36,6 +40,30 @@ vi.mock("node:child_process", async (importOriginal) => ({
 
 beforeEach(() => mockSystemAccountHome());
 afterEach(() => vi.restoreAllMocks());
+
+async function withServiceHome(run: (home: string) => Promise<void>): Promise<void> {
+  const home = await makeTempWorkspace("openclaw-update-service-");
+  try {
+    await withEnvAsync(
+      {
+        HOME: home,
+        USERPROFILE: home,
+        APPDATA: path.join(home, "AppData"),
+        OPENCLAW_GATEWAY_PORT: undefined,
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_STATE_DIR: undefined,
+        OPENCLAW_CONFIG_PATH: undefined,
+        OPENCLAW_PROFILE: undefined,
+        OPENCLAW_SUPERVISOR_MODE: undefined,
+        OPENCLAW_SERVICE_MARKER: undefined,
+        OPENCLAW_SERVICE_KIND: undefined,
+      },
+      () => run(home),
+    );
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+  }
+}
 
 type NativeOfflineCase = {
   platform: NodeJS.Platform;
@@ -107,68 +135,141 @@ const nativeOfflineCases: NativeOfflineCase[] = [
 
 it.each(nativeOfflineCases)(
   "requires affirmative native offline proof for owned $platform service ($label)",
-  async (scenario) => {
-    const home = await makeTempWorkspace("openclaw-update-offline-");
-    try {
-      await withEnvAsync(
-        {
-          HOME: home,
-          USERPROFILE: home,
-          APPDATA: path.join(home, "AppData"),
-          OPENCLAW_GATEWAY_PORT: undefined,
-          OPENCLAW_HOME: undefined,
-          OPENCLAW_STATE_DIR: undefined,
-          OPENCLAW_CONFIG_PATH: undefined,
-          OPENCLAW_PROFILE: undefined,
-          OPENCLAW_SUPERVISOR_MODE: undefined,
-          OPENCLAW_SERVICE_MARKER: undefined,
-          OPENCLAW_SERVICE_KIND: undefined,
+  (scenario) =>
+    withServiceHome(async (home) => {
+      mockProcessPlatform(scenario.platform);
+      mocks.taskState = scenario.state ?? 3;
+      const service = createMockGatewayService({
+        readCommand: async () => ({
+          programArguments: [process.execPath, path.join(process.cwd(), "openclaw.mjs"), "gateway"],
+          environment: { HOME: home },
+        }),
+        readRuntime:
+          scenario.platform === "win32"
+            ? readScheduledTaskRuntime
+            : async () => ({ status: scenario.runtime }),
+        isLoaded: async () => scenario.loaded,
+        isEnabled: async () => {
+          if (scenario.enabled === undefined) {
+            throw new Error("enabled state unavailable");
+          }
+          return scenario.enabled;
         },
-        async () => {
-          mockProcessPlatform(scenario.platform);
-          mocks.taskState = scenario.state ?? 3;
-          const service = createMockGatewayService({
-            readCommand: async () => ({
-              programArguments: [
-                process.execPath,
-                path.join(process.cwd(), "openclaw.mjs"),
-                "gateway",
-              ],
-              environment: { HOME: home },
-            }),
-            readRuntime:
-              scenario.platform === "win32"
-                ? readScheduledTaskRuntime
-                : async () => ({ status: scenario.runtime }),
-            isLoaded: async () => scenario.loaded,
-            isEnabled: async () => {
-              if (scenario.enabled === undefined) {
-                throw new Error("enabled state unavailable");
-              }
-              return scenario.enabled;
-            },
-          });
-          mocks.service.mockReturnValue(service);
-          const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
-            root: process.cwd(),
-            updateInstallKind: "package",
-            shouldRestart: true,
-            phase: "inspect",
-            jsonMode: true,
-          });
-          expect(inspected.serviceUpdateVerdict?.kind).toBe(
-            scenario.runtime === "unknown" ? "unavailable" : "owned",
-          );
-          expect(inspected.offline).toBe(scenario.offline);
-          expect(service.stop).not.toHaveBeenCalled();
-          expect(service.start).not.toHaveBeenCalled();
-          expect(service.restart).not.toHaveBeenCalled();
-          expect(service.stage).not.toHaveBeenCalled();
-          expect(service.install).not.toHaveBeenCalled();
-        },
+      });
+      mocks.service.mockReturnValue(service);
+      const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
+        root: process.cwd(),
+        updateInstallKind: "package",
+        shouldRestart: true,
+        phase: "inspect",
+        jsonMode: true,
+      });
+      expect(inspected.serviceUpdateVerdict?.kind).toBe(
+        scenario.runtime === "unknown" ? "unavailable" : "owned",
       );
+      expect(inspected.offline).toBe(scenario.offline);
+      expect(service.stop).not.toHaveBeenCalled();
+      expect(service.start).not.toHaveBeenCalled();
+      expect(service.restart).not.toHaveBeenCalled();
+      expect(service.stage).not.toHaveBeenCalled();
+      expect(service.install).not.toHaveBeenCalled();
+    }),
+);
+
+it
+  .runIf(process.platform === "linux" || process.platform === "darwin")
+  .each([
+    "current updater",
+    "missing marker",
+    "missing metadata",
+    "missing lease",
+    "replaced owner",
+    "different root",
+    "different run",
+    "stale start identity",
+    "parent lease",
+    "native preparation",
+  ])("keeps serving-ancestor inspection bound to the current updater: %s", (scenario) =>
+  withServiceHome(async (home) => {
+    const root = await fs.realpath(process.cwd());
+    const metaPath = path.join(home, "handoff-meta.json");
+    vi.spyOn(openClawTmp, "resolvePreferredOpenClawTmpDir").mockReturnValue(home);
+    await fs.writeFile(
+      metaPath,
+      JSON.stringify({
+        version: 1,
+        meta: {
+          root: scenario === "different root" ? home : root,
+          runId: scenario === "different run" ? "other-run" : "update-run",
+          handoffId: "owned-handoff",
+        },
+      }),
+    );
+    const leasePid = scenario === "parent lease" ? process.ppid : process.pid;
+    const startIdentity = getFileLockProcessStartTime(leasePid);
+    expect(startIdentity).not.toBeNull();
+    const db = openNodeSqliteDatabase(path.join(home, "managed-update-handoffs.sqlite"));
+    try {
+      db.exec(`CREATE TABLE managed_update_handoffs (
+        install_root TEXT PRIMARY KEY, owner TEXT NOT NULL, payload_json TEXT NOT NULL,
+        updated_at_ms INTEGER NOT NULL
+      ) STRICT;`);
+      if (scenario !== "missing lease") {
+        db.prepare("INSERT INTO managed_update_handoffs VALUES (?, ?, ?, ?)").run(
+          root,
+          scenario === "replaced owner" ? "replacement-handoff" : "owned-handoff",
+          JSON.stringify({
+            version: 1,
+            pid: leasePid,
+            startIdentity: scenario === "stale start identity" ? "stale" : String(startIdentity),
+          }),
+          Date.now(),
+        );
+      }
     } finally {
-      await fs.rm(home, { recursive: true, force: true });
+      db.close();
     }
-  },
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_RUN_HANDOFF: scenario === "missing marker" ? undefined : "1",
+        [CONTROL_PLANE_UPDATE_SENTINEL_META_ENV]:
+          scenario === "missing metadata" ? undefined : metaPath,
+      },
+      async () => {
+        const service = createMockGatewayService({
+          readCommand: async () => ({
+            programArguments: [process.execPath, path.join(root, "openclaw.mjs"), "gateway"],
+            environment: { HOME: home },
+          }),
+          readRuntime: async () => ({ status: "running", pid: process.ppid }),
+          isLoaded: async () => true,
+        });
+        mocks.service.mockReturnValue(service);
+        const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
+          root,
+          updateInstallKind: "package",
+          shouldRestart: true,
+          jsonMode: true,
+          phase: scenario === "native preparation" ? "prepare" : "inspect",
+          updateRun: { runId: "update-run", env: process.env },
+          handoffFromGateway: async () => false,
+        });
+        expect(inspected.serviceUpdateVerdict?.kind).toBe("owned");
+        if (scenario === "current updater") {
+          expect(inspected.blockMessage).toBeUndefined();
+        } else {
+          expect(inspected.blockMessage).toContain("inside the gateway process tree");
+        }
+        for (const mutate of [
+          service.stop,
+          service.start,
+          service.restart,
+          service.stage,
+          service.install,
+        ]) {
+          expect(mutate).not.toHaveBeenCalled();
+        }
+      },
+    );
+  }),
 );

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -19,6 +19,7 @@ import { resolveSystemdServiceName } from "../../daemon/systemd-service-files.js
 import { sha256Hex } from "../../infra/crypto-digest.js";
 import { readActiveGatewayLockIdentity } from "../../infra/gateway-lock.js";
 import { probePortUsage } from "../../infra/ports-probe.js";
+import { isCurrentManagedServiceUpdateHandoffProcess } from "../../infra/update-managed-service-handoff.js";
 import { getUpdateRun, recordUpdateRunPhase } from "../../infra/update-run-ledger.js";
 import { defaultRuntime } from "../../runtime.js";
 import { UpdatePreMutationError, type UpdateCommandOptions } from "./shared.js";
@@ -421,6 +422,15 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     const blockMessage = params.handoffFromGateway
       ? gatewayAncestryBlockMessage(serviceState.runtime?.pid)
       : undefined;
+    if (
+      blockMessage &&
+      (await isCurrentManagedServiceUpdateHandoffProcess({
+        root: params.root,
+        runId: params.updateRun?.runId,
+      }))
+    ) {
+      return inspected;
+    }
     return blockMessage ? { ...inspected, blockMessage } : inspected;
   }
   const updateRun = params.updateRun;

--- a/src/cli/update-cli/update-command-service-recovery.test-support.ts
+++ b/src/cli/update-cli/update-command-service-recovery.test-support.ts
@@ -150,7 +150,7 @@ export function registerRecoveryTests(params: {
         timeoutMs: 1_000,
       });
 
-      expect(activated).toBe(true);
+      expect(activated).toBe("ok");
       expect(mocks.events).toEqual([
         "native stop",
         "refresh activation",

--- a/src/cli/update-cli/update-command-service-recovery.ts
+++ b/src/cli/update-cli/update-command-service-recovery.ts
@@ -35,12 +35,6 @@ import {
 
 const CLI_NAME = resolveCliName();
 
-export function shouldUseLegacyProcessRestartAfterUpdate(params: {
-  updateMode: UpdateRunResult["mode"];
-}): boolean {
-  return !isPackageManagerUpdateMode(params.updateMode);
-}
-
 type PostUpdateGatewayHealthRecoveryDeps = {
   recoverLaunchAgent?: typeof recoverInstalledLaunchAgentAfterUpdate;
   waitForHealthy?: typeof waitForGatewayHealthyRestart;

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -127,6 +127,7 @@ export function registerInstallRootTransitionTests(getFixture: () => InstallRoot
           mocks.events.push("restart managed service");
           mocks.running = true;
           servingBuildId = "target-build";
+          return true;
         });
       }
       mocks.child.mockImplementation(async (argv) => {

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -346,14 +346,23 @@ export function registerRestartOutcomeTests(
     "truncated",
     "killed",
     "wrong exit",
+    "forced",
+    "uncertain",
+    "forced success",
+    "uncertain success",
     "install",
   ])("classifies only the complete owned restart health response (%s)", async (scenario) => {
     const { root, mocks } = getFixture();
+    const success = scenario.endsWith("success");
     const payload = {
       action: scenario === "wrong action" ? "install" : "restart",
-      ok: scenario === "wrong ok",
-      result: scenario === "wrong result" ? "unknown" : "restart-health-failed",
-      ...(scenario !== "missing error" && { error: "Gateway is unhealthy" }),
+      ok: success || scenario === "wrong ok",
+      result: success
+        ? "restarted"
+        : scenario === "wrong result"
+          ? "unknown"
+          : "restart-health-failed",
+      ...(!success && scenario !== "missing error" && { error: "Gateway is unhealthy" }),
     };
     const json = JSON.stringify(payload);
     const stdout =
@@ -367,12 +376,17 @@ export function registerRestartOutcomeTests(
               ? `${json}\n${json}`
               : json;
     mocks.child.mockResolvedValueOnce({
-      code: scenario === "wrong exit" ? 2 : 1,
+      code: success ? 0 : scenario === "wrong exit" ? 2 : 1,
       stdout,
       stderr: "",
       signal: scenario === "signal" ? "SIGTERM" : null,
       killed: scenario === "killed",
       termination: scenario === "signal" ? "signal" : scenario === "timeout" ? "timeout" : "exit",
+      cleanup: scenario.startsWith("forced")
+        ? "forced"
+        : scenario.startsWith("uncertain")
+          ? "uncertain"
+          : "normal",
       ...(scenario === "truncated" && { stdoutTruncatedBytes: 1 }),
     });
     await expect(

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -236,30 +236,28 @@ export function registerRestartOutcomeTests(
     ) => Promise<{ result: "restarted"; message: string; loaded: boolean }>;
   } = startRepair;
   it.each([
-    "health",
-    "native refusal",
-    "unexpected check",
-    "retry refusal",
-    "repair health",
-    "repair retry health",
+    ["health", "restart-health-failed"],
+    ["native refusal", "failed"],
+    ["unexpected check", "failed"],
+    ["retry refusal", "failed"],
+    ["repair health", "failed"],
+    ["repair retry health", "restart-health-failed"],
   ])(
     "carries the real lifecycle's serialized %s result through a child process",
-    async (scenario) => {
+    async (scenario, expected) => {
       const { root, mocks } = getFixture();
       const repairing = scenario.startsWith("repair ");
-      const repair = repairing
-        ? vi.spyOn(restartRepairOwner, "repairLoadedGatewayServiceForStart").mockResolvedValueOnce({
-            result: "restarted",
-            message: "Synthetic definition repair completed.",
-            loaded: true,
-          })
-        : undefined;
       if (repairing) {
+        vi.spyOn(restartRepairOwner, "repairLoadedGatewayServiceForStart").mockResolvedValueOnce({
+          result: "restarted",
+          message: "Synthetic definition repair completed.",
+          loaded: true,
+        });
         mocks.configSnapshot.mockResolvedValueOnce(undefined);
         mocks.capability.mockResolvedValue({ kind: "writable" });
       }
       const exit = new Error("test lifecycle exit");
-      const exitSpy = vi.mocked(defaultRuntime.exit).mockImplementationOnce(() => {
+      vi.mocked(defaultRuntime.exit).mockImplementationOnce(() => {
         throw exit;
       });
       if (scenario === "native refusal") {
@@ -288,7 +286,6 @@ export function registerRestartOutcomeTests(
             preserveDefinition: argv.includes("--preserve-definition"),
           }),
         ).rejects.toBe(exit);
-        expect(exitSpy).toHaveBeenCalledOnce();
         expect(mocks.writeJson).toHaveBeenCalledOnce();
         const serialized = JSON.stringify(mocks.writeJson.mock.lastCall?.[0]);
         await fs.writeFile(
@@ -316,93 +313,83 @@ export function registerRestartOutcomeTests(
           timeoutMs: 1000,
           nodeRunner: process.execPath,
         }),
-      ).toBe(
-        scenario === "health" || scenario === "repair retry health"
-          ? "restart-health-failed"
-          : "failed",
-      );
-      expect(mocks.restart).toHaveBeenCalledTimes(
-        scenario === "repair health" ? 0 : scenario === "retry refusal" ? 2 : 1,
-      );
-      if (repair) {
-        expect(repair).toHaveBeenCalledOnce();
-      }
+      ).toBe(expected);
       expect(mocks.child).toHaveBeenCalledOnce();
     },
   );
 
-  it.each([
-    "health",
-    "missing",
-    "malformed",
-    "mixed",
-    "multiple",
-    "wrong action",
-    "wrong result",
-    "wrong ok",
-    "missing error",
-    "signal",
-    "timeout",
-    "truncated",
-    "killed",
-    "wrong exit",
-    "forced",
-    "uncertain",
-    "forced success",
-    "uncertain success",
-    "install",
-  ])("classifies only the complete owned restart health response (%s)", async (scenario) => {
-    const { root, mocks } = getFixture();
-    const success = scenario.endsWith("success");
-    const payload = {
-      action: scenario === "wrong action" ? "install" : "restart",
-      ok: success || scenario === "wrong ok",
-      result: success
-        ? "restarted"
-        : scenario === "wrong result"
-          ? "unknown"
-          : "restart-health-failed",
-      ...(!success && scenario !== "missing error" && { error: "Gateway is unhealthy" }),
-    };
-    const json = JSON.stringify(payload);
-    const stdout =
-      scenario === "missing"
-        ? ""
-        : scenario === "malformed"
-          ? "{"
-          : scenario === "mixed"
-            ? `log before result\n${json}`
-            : scenario === "multiple"
-              ? `${json}\n${json}`
-              : json;
-    mocks.child.mockResolvedValueOnce({
-      code: success ? 0 : scenario === "wrong exit" ? 2 : 1,
-      stdout,
-      stderr: "",
-      signal: scenario === "signal" ? "SIGTERM" : null,
-      killed: scenario === "killed",
-      termination: scenario === "signal" ? "signal" : scenario === "timeout" ? "timeout" : "exit",
-      cleanup: scenario.startsWith("forced")
-        ? "forced"
-        : scenario.startsWith("uncertain")
-          ? "uncertain"
-          : "normal",
-      ...(scenario === "truncated" && { stdoutTruncatedBytes: 1 }),
-    });
-    await expect(
-      runUpdatedInstallGatewayCommand(
-        {
-          result: { root, mode: "npm" },
-          opts: { json: false },
-          invocationEnv: process.env,
-          nodeRunner: process.execPath,
-        },
-        scenario === "install" ? "install" : "restart",
-        true,
-      ),
-    ).rejects.toMatchObject({
-      name: scenario === "health" ? "GatewayRestartHealthError" : "Error",
-    });
-    expect(mocks.child.mock.lastCall?.[0]).toContain("--json");
-  });
+  const healthFailure = {
+    action: "restart",
+    ok: false,
+    result: "restart-health-failed",
+    error: "Gateway is unhealthy",
+  };
+  const json = JSON.stringify(healthFailure);
+  const success = JSON.stringify({ action: "restart", ok: true, result: "restarted" });
+  it.each<{
+    scenario: string;
+    response?: Partial<
+      Awaited<ReturnType<typeof import("../../process/exec.js").runCommandWithTimeout>>
+    >;
+    action?: "install" | "restart";
+  }>([
+    { scenario: "health" },
+    { scenario: "missing", response: { stdout: "" } },
+    { scenario: "malformed", response: { stdout: "{" } },
+    { scenario: "mixed", response: { stdout: `log before result\n${json}` } },
+    { scenario: "multiple", response: { stdout: `${json}\n${json}` } },
+    {
+      scenario: "wrong action",
+      response: { stdout: JSON.stringify({ ...healthFailure, action: "install" }) },
+    },
+    {
+      scenario: "wrong result",
+      response: { stdout: JSON.stringify({ ...healthFailure, result: "unknown" }) },
+    },
+    { scenario: "wrong ok", response: { stdout: JSON.stringify({ ...healthFailure, ok: true }) } },
+    {
+      scenario: "missing error",
+      response: { stdout: JSON.stringify({ ...healthFailure, error: undefined }) },
+    },
+    { scenario: "signal", response: { signal: "SIGTERM", termination: "signal" } },
+    { scenario: "timeout", response: { termination: "timeout" } },
+    { scenario: "truncated", response: { stdoutTruncatedBytes: 1 } },
+    { scenario: "killed", response: { killed: true } },
+    { scenario: "wrong exit", response: { code: 2 } },
+    { scenario: "forced", response: { cleanup: "forced" } },
+    { scenario: "uncertain", response: { cleanup: "uncertain" } },
+    { scenario: "forced success", response: { cleanup: "forced", code: 0, stdout: success } },
+    { scenario: "uncertain success", response: { cleanup: "uncertain", code: 0, stdout: success } },
+    { scenario: "install", action: "install" },
+  ])(
+    "classifies only the complete owned restart health response ($scenario)",
+    async ({ scenario, response, action = "restart" }) => {
+      const { root, mocks } = getFixture();
+      mocks.child.mockResolvedValueOnce({
+        code: 1,
+        stdout: json,
+        stderr: "",
+        signal: null,
+        killed: false,
+        termination: "exit",
+        cleanup: "normal",
+        ...response,
+      });
+      await expect(
+        runUpdatedInstallGatewayCommand(
+          {
+            result: { root, mode: "npm" },
+            opts: { json: false },
+            invocationEnv: process.env,
+            nodeRunner: process.execPath,
+          },
+          action,
+          true,
+        ),
+      ).rejects.toMatchObject({
+        name: scenario === "health" ? "GatewayRestartHealthError" : "Error",
+      });
+      expect(mocks.child.mock.lastCall?.[0]).toContain("--json");
+    },
+  );
 }

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -1,8 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, it, type Mock } from "vitest";
+import { expect, it, vi, type Mock } from "vitest";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
+import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
+import { runDaemonRestart } from "../daemon-cli/lifecycle.js";
+import * as startRepair from "../daemon-cli/start-repair.js";
+import { runUpdatedInstallGatewayCommand } from "./update-command-service-command.js";
 import {
   maybeRestartService,
   maybeStopManagedServiceBeforeMutableUpdate,
@@ -185,7 +189,9 @@ export function registerInstallRootTransitionTests(getFixture: () => InstallRoot
       });
       expect(activated).toBe(
         scenario !== "same-version stale launcher after refresh" &&
-          scenario !== "failed Git refresh retains original launcher",
+          scenario !== "failed Git refresh retains original launcher"
+          ? "ok"
+          : "failed",
       );
       expect(mocks.configSnapshot).toHaveBeenCalledTimes(
         scenario === "Git still serves previous build" ? 1 : 0,
@@ -206,4 +212,183 @@ export function registerInstallRootTransitionTests(getFixture: () => InstallRoot
       expect(mocks.child.mock.calls.filter(([argv]) => argv.includes("install"))).toHaveLength(1);
     },
   );
+}
+
+export function registerRestartOutcomeTests(
+  getFixture: () => {
+    root: string;
+    mocks: Pick<
+      InstallRootTransitionFixture["mocks"],
+      "child" | "health" | "configSnapshot" | "capability"
+    > & {
+      restart: Mock<() => Promise<{ outcome: "completed" }>>;
+      writeJson: Mock;
+    };
+  },
+) {
+  // Select the restart overload; Vitest otherwise infers the final start overload.
+  const restartRepairOwner: {
+    repairLoadedGatewayServiceForStart: (
+      params: Omit<
+        Parameters<typeof startRepair.repairLoadedGatewayServiceForStart>[0],
+        "action"
+      > & { action: "restart" },
+    ) => Promise<{ result: "restarted"; message: string; loaded: boolean }>;
+  } = startRepair;
+  it.each([
+    "health",
+    "native refusal",
+    "unexpected check",
+    "retry refusal",
+    "repair health",
+    "repair retry health",
+  ])(
+    "carries the real lifecycle's serialized %s result through a child process",
+    async (scenario) => {
+      const { root, mocks } = getFixture();
+      const repairing = scenario.startsWith("repair ");
+      const repair = repairing
+        ? vi.spyOn(restartRepairOwner, "repairLoadedGatewayServiceForStart").mockResolvedValueOnce({
+            result: "restarted",
+            message: "Synthetic definition repair completed.",
+            loaded: true,
+          })
+        : undefined;
+      if (repairing) {
+        mocks.configSnapshot.mockResolvedValueOnce(undefined);
+        mocks.capability.mockResolvedValue({ kind: "writable" });
+      }
+      const exit = new Error("test lifecycle exit");
+      const exitSpy = vi.mocked(defaultRuntime.exit).mockImplementationOnce(() => {
+        throw exit;
+      });
+      if (scenario === "native refusal") {
+        mocks.restart.mockRejectedValueOnce(new Error("native owner refused"));
+      } else if (scenario === "retry refusal") {
+        mocks.restart
+          .mockResolvedValueOnce({ outcome: "completed" })
+          .mockRejectedValueOnce(new Error("later native refusal"));
+      }
+      mocks.health.mockResolvedValue({
+        healthy: false,
+        staleGatewayPids:
+          scenario === "retry refusal" || scenario === "repair retry health" ? [4242] : [],
+        runtime: { status: "stopped" },
+        portUsage: { port: 19305, status: "free", listeners: [], hints: [] },
+      });
+      if (scenario === "unexpected check") {
+        mocks.health.mockRejectedValueOnce(new Error("health observer crashed"));
+      }
+      const actual =
+        await vi.importActual<typeof import("../../process/exec.js")>("../../process/exec.js");
+      mocks.child.mockImplementationOnce(async (argv, options) => {
+        await expect(
+          runDaemonRestart({
+            json: true,
+            preserveDefinition: argv.includes("--preserve-definition"),
+          }),
+        ).rejects.toBe(exit);
+        expect(exitSpy).toHaveBeenCalledOnce();
+        expect(mocks.writeJson).toHaveBeenCalledOnce();
+        const serialized = JSON.stringify(mocks.writeJson.mock.lastCall?.[0]);
+        await fs.writeFile(
+          path.join(root, "dist", "index.js"),
+          `process.stdout.write(${JSON.stringify(serialized)}); process.exitCode = 1;`,
+        );
+        return actual.runCommandWithTimeout(argv, options);
+      });
+      expect(
+        await maybeRestartService({
+          shouldRestart: true,
+          result: { status: "ok", mode: "npm", root, steps: [], durationMs: 0 },
+          channel: "stable",
+          opts: { json: false },
+          refreshServiceEnv: false,
+          serviceUpdateVerdict: {
+            kind: "owned",
+            root,
+            refreshDefinition: repairing,
+            fingerprint: "fixture",
+          },
+          serviceEnv: process.env,
+          requireRunningServiceAfterRestart: repairing,
+          gatewayPort: 19305,
+          timeoutMs: 1000,
+          nodeRunner: process.execPath,
+        }),
+      ).toBe(
+        scenario === "health" || scenario === "repair retry health"
+          ? "restart-health-failed"
+          : "failed",
+      );
+      expect(mocks.restart).toHaveBeenCalledTimes(
+        scenario === "repair health" ? 0 : scenario === "retry refusal" ? 2 : 1,
+      );
+      if (repair) {
+        expect(repair).toHaveBeenCalledOnce();
+      }
+      expect(mocks.child).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    "health",
+    "missing",
+    "malformed",
+    "mixed",
+    "multiple",
+    "wrong action",
+    "wrong result",
+    "wrong ok",
+    "missing error",
+    "signal",
+    "timeout",
+    "truncated",
+    "killed",
+    "wrong exit",
+    "install",
+  ])("classifies only the complete owned restart health response (%s)", async (scenario) => {
+    const { root, mocks } = getFixture();
+    const payload = {
+      action: scenario === "wrong action" ? "install" : "restart",
+      ok: scenario === "wrong ok",
+      result: scenario === "wrong result" ? "unknown" : "restart-health-failed",
+      ...(scenario !== "missing error" && { error: "Gateway is unhealthy" }),
+    };
+    const json = JSON.stringify(payload);
+    const stdout =
+      scenario === "missing"
+        ? ""
+        : scenario === "malformed"
+          ? "{"
+          : scenario === "mixed"
+            ? `log before result\n${json}`
+            : scenario === "multiple"
+              ? `${json}\n${json}`
+              : json;
+    mocks.child.mockResolvedValueOnce({
+      code: scenario === "wrong exit" ? 2 : 1,
+      stdout,
+      stderr: "",
+      signal: scenario === "signal" ? "SIGTERM" : null,
+      killed: scenario === "killed",
+      termination: scenario === "signal" ? "signal" : scenario === "timeout" ? "timeout" : "exit",
+      ...(scenario === "truncated" && { stdoutTruncatedBytes: 1 }),
+    });
+    await expect(
+      runUpdatedInstallGatewayCommand(
+        {
+          result: { root, mode: "npm" },
+          opts: { json: false },
+          invocationEnv: process.env,
+          nodeRunner: process.execPath,
+        },
+        scenario === "install" ? "install" : "restart",
+        true,
+      ),
+    ).rejects.toMatchObject({
+      name: scenario === "health" ? "GatewayRestartHealthError" : "Error",
+    });
+    expect(mocks.child.mock.lastCall?.[0]).toContain("--json");
+  });
 }

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -29,7 +29,10 @@ import {
   registerRecoveryTests,
   writeRecoveryConfig,
 } from "./update-command-service-recovery.test-support.js";
-import { registerInstallRootTransitionTests } from "./update-command-service-transition.test-support.js";
+import {
+  registerInstallRootTransitionTests,
+  registerRestartOutcomeTests,
+} from "./update-command-service-transition.test-support.js";
 import {
   maybeRestartService,
   maybeStopManagedServiceBeforeMutableUpdate,
@@ -66,7 +69,9 @@ const mocks = vi.hoisted(() => ({
   doctor: vi.fn(),
   configSnapshot: vi.fn<() => Promise<void>>(),
   error: vi.fn(),
+  exit: vi.fn(),
   log: vi.fn(),
+  writeJson: vi.fn(),
   capability:
     vi.fn<
       typeof import("../../daemon/systemd-definition-mutation.js").readSystemdDefinitionMutationCapability
@@ -152,7 +157,12 @@ vi.mock("./update-command-config-snapshot.js", () => ({
 }));
 vi.mock("./restart-helper.js", () => ({ runRestartScript: mocks.script }));
 vi.mock("../../runtime.js", () => ({
-  defaultRuntime: { log: mocks.log, error: mocks.error, exit: vi.fn(), writeJson: vi.fn() },
+  defaultRuntime: {
+    log: mocks.log,
+    error: mocks.error,
+    exit: mocks.exit,
+    writeJson: mocks.writeJson,
+  },
 }));
 vi.mock("../daemon-cli/restart-health.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../daemon-cli/restart-health.js")>()),
@@ -180,6 +190,7 @@ const writeConfig = (version: string) => writeRecoveryConfig(configPath, version
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  mocks.exit.mockReset();
   mockProcessPlatform("linux");
   root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-activation-")));
   vi.spyOn(os, "userInfo").mockReturnValue({ ...os.userInfo(), homedir: root });
@@ -258,7 +269,14 @@ beforeEach(async () => {
     }
     mocks.events.push("fresh CLI restart");
     mocks.running = true;
-    return { code: 0, stdout: "", stderr: "", signal: null, killed: false, termination: "exit" };
+    return {
+      code: 0,
+      stdout: JSON.stringify({ action: "restart", ok: true, result: "restarted" }),
+      stderr: "",
+      signal: null,
+      killed: false,
+      termination: "exit",
+    };
   });
   mocks.health.mockImplementation(async ({ port }) => readyRecoveryHealth(port, mocks.running));
   mocks.configSnapshot
@@ -274,6 +292,8 @@ afterEach(async () => {
 });
 
 describe("preserved update activation with real version guards", () => {
+  registerRestartOutcomeTests(() => ({ root, mocks }));
+
   it.each([
     ...(
       [
@@ -381,7 +401,7 @@ describe("preserved update activation with real version guards", () => {
         await program.parseAsync(args.slice(2), { from: "user" });
         return {
           code: 0,
-          stdout: "",
+          stdout: JSON.stringify(mocks.writeJson.mock.lastCall?.[0]),
           stderr: "",
           signal: null,
           killed: false,
@@ -446,7 +466,7 @@ describe("preserved update activation with real version guards", () => {
       });
       const allowed = !["uninspectable", "foreign"].includes(outcome);
       const buildMismatch = ["stale build", "missing build"].includes(outcome);
-      expect(activated).toBe(allowed && !buildMismatch);
+      expect(activated).toBe(!allowed ? "failed" : buildMismatch ? "restart-health-failed" : "ok");
       const restarts = mocks.child.mock.calls.filter(([args]) => args.includes("restart"));
       expect(restarts).toHaveLength(allowed ? (retried ? 2 : 1) : 0);
       for (const [args, options] of restarts) {
@@ -569,7 +589,7 @@ describe("preserved update activation with real version guards", () => {
       timeoutMs: 1000,
     });
     expect(repair).not.toHaveBeenCalled();
-    expect(activated).toBe(false);
+    expect(activated).toBe("failed");
     expect(mocks.error.mock.calls.flat().join("\n")).toContain("unknown option");
     expect(mocks.error.mock.calls.flat().join("\n")).toContain("stopped");
     expect(mocks.restart).not.toHaveBeenCalled();
@@ -697,7 +717,7 @@ describe("preserved update activation with real version guards", () => {
         timeoutMs: 1000,
       });
 
-      expect(activated, mocks.log.mock.calls.flat().join("\n")).toBe(true);
+      expect(activated, mocks.log.mock.calls.flat().join("\n")).toBe("ok");
       expect(mocks.events).toEqual([
         "native stop",
         "core updated",
@@ -710,6 +730,7 @@ describe("preserved update activation with real version guards", () => {
         "gateway",
         "restart",
         "--preserve-definition",
+        "--json",
       ]);
       expect(mocks.health.mock.calls[0]?.[0]).toMatchObject({
         port: 19305,
@@ -791,10 +812,11 @@ describe("preserved update activation with real version guards", () => {
     "handoff",
     "bootstrap denied",
     "parent unhealthy",
+    "parent recovery refusal",
     "parent late sealed",
     "parent late unknown",
     "stale retry",
-  ])("preserves actual LaunchAgent artifacts during %s activation", async (scenario) => {
+  ])("checks actual LaunchAgent artifacts during %s activation", async (scenario) => {
     mockProcessPlatform("darwin");
     const label = "ai.openclaw.gateway";
     const plistPath = resolveLaunchAgentPlistPath(process.env);
@@ -848,7 +870,7 @@ describe("preserved update activation with real version guards", () => {
     let nativeRunning = loaded;
     mocks.launchctl.mockImplementation(async (args) => {
       if (args[0] === "bootstrap") {
-        if (scenario === "bootstrap denied") {
+        if (scenario === "bootstrap denied" || scenario === "parent recovery refusal") {
           return { code: 13, stdout: "", stderr: "permission denied", termination: "exit" };
         }
         loaded = true;
@@ -884,11 +906,14 @@ describe("preserved update activation with real version guards", () => {
         portUsage: { port: 19305, status: "busy", listeners: [], hints: [] },
       });
     }
-    let result: boolean;
+    let result: boolean | Awaited<ReturnType<typeof maybeRestartService>>;
     if (scenario === "start demand") {
       await resolveGatewayService().start({ env: process.env, stdout: process.stdout });
       result = nativeRunning;
     } else if (scenario.startsWith("parent")) {
+      if (scenario === "parent recovery refusal") {
+        mocks.configSnapshot.mockResolvedValueOnce(undefined);
+      }
       const lateDenial = scenario.startsWith("parent late");
       const verdict = lateDenial
         ? await revalidateManagedGatewayServiceAfterUpdate({
@@ -897,7 +922,9 @@ describe("preserved update activation with real version guards", () => {
             }),
             root,
           })
-        : { kind: "unresolved" as const, root, fingerprint: "fixture" };
+        : scenario === "parent recovery refusal"
+          ? { kind: "owned" as const, root, fingerprint: "fixture", refreshDefinition: true }
+          : { kind: "unresolved" as const, root, fingerprint: "fixture" };
       if (lateDenial) {
         expect(verdict).toMatchObject({ kind: "owned", refreshDefinition: true });
         mocks.child.mockResolvedValueOnce({
@@ -931,7 +958,8 @@ describe("preserved update activation with real version guards", () => {
         serviceUpdateVerdict: verdict,
         serviceEnv: process.env,
         gatewayPort: lateDenial ? 19001 : 19305,
-        restartScriptPath: "/fixture/prepared-restart.sh",
+        restartScriptPath:
+          scenario === "parent recovery refusal" ? null : "/fixture/prepared-restart.sh",
         requireRunningServiceAfterRestart: true,
         timeoutMs: 1000,
       });
@@ -942,12 +970,26 @@ describe("preserved update activation with real version guards", () => {
     } else {
       result = await runDaemonRestart({ json: true, preserveDefinition: true });
     }
-    expect(result).toBe(scenario !== "bootstrap denied" && !scenario.startsWith("parent"));
-    expect(await snapshot()).toEqual(before);
-    expect(mocks.configSnapshot).not.toHaveBeenCalled();
-    expect(writeFile).not.toHaveBeenCalled();
-    expect(chmod).not.toHaveBeenCalled();
-    expect(rename).not.toHaveBeenCalled();
+    expect(result).toBe(
+      scenario === "parent recovery refusal"
+        ? "failed"
+        : scenario.startsWith("parent")
+          ? "restart-health-failed"
+          : scenario !== "bootstrap denied",
+    );
+    if (scenario === "parent recovery refusal") {
+      // Writable recovery migrates legacy service metadata before native bootstrap.
+      expect((await snapshot()).at(-1)).toEqual(before.at(-1));
+      expect(writeFile).toHaveBeenCalled();
+    } else {
+      expect(await snapshot()).toEqual(before);
+      expect(writeFile).not.toHaveBeenCalled();
+      expect(chmod).not.toHaveBeenCalled();
+      expect(rename).not.toHaveBeenCalled();
+    }
+    expect(mocks.configSnapshot).toHaveBeenCalledTimes(
+      scenario === "parent recovery refusal" ? 1 : 0,
+    );
     if (demandOnly || scenario === "unloaded") {
       const calls = mocks.launchctl.mock.calls.map(([args]) => args);
       const afterBootstrap = calls.slice(calls.findIndex((args) => args[0] === "bootstrap") + 1);
@@ -962,7 +1004,10 @@ describe("preserved update activation with real version guards", () => {
       );
       expect(mocks.health).toHaveBeenCalledTimes(2);
     }
-    if (scenario.startsWith("parent")) {
+    if (scenario === "parent recovery refusal") {
+      expect(mocks.launchctl.mock.calls.some(([args]) => args[0] === "bootstrap")).toBe(true);
+      expect(mocks.child).toHaveBeenCalledOnce();
+    } else if (scenario.startsWith("parent")) {
       expect(mocks.launchctl.mock.calls.every(([args]) => args[0] === "print")).toBe(true);
     } else if (scenario === "handoff") {
       expect(mocks.handoff).toHaveBeenCalledWith(expect.objectContaining({ mode: "kickstart" }));

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -480,7 +480,6 @@ describe("preserved update activation with real version guards", () => {
       expect(mocks.child.mock.calls.filter(([args]) => args.includes("install"))).toHaveLength(
         late ? 1 : 0,
       );
-      expect(mocks.restart).toHaveBeenCalledTimes(restarts.length);
       expect(mocks.health.mock.calls.every(([args]) => args.port === 19305)).toBe(true);
       if (retried) {
         expect(mocks.terminateStale).toHaveBeenCalledWith([4242]);

--- a/src/cli/update-cli/update-command-service.test-support.ts
+++ b/src/cli/update-cli/update-command-service.test-support.ts
@@ -3,7 +3,6 @@ import {
   formatPostUpdateGatewayRecoveryInstructions,
   hasLoadedLaunchdKeepAliveSupervisor,
   recoverLaunchAgentAndRecheckGatewayHealth,
-  shouldUseLegacyProcessRestartAfterUpdate,
 } from "./update-command-service-recovery.js";
 
 export const testing = {
@@ -11,5 +10,4 @@ export const testing = {
   recoverInstalledLaunchAgentAfterUpdate,
   recoverLaunchAgentAndRecheckGatewayHealth,
   hasLoadedLaunchdKeepAliveSupervisor,
-  shouldUseLegacyProcessRestartAfterUpdate,
 };

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -1,14 +1,13 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   createUpdateConfigSnapshot: vi.fn(async () => undefined),
-  doctorCommand: vi.fn<typeof import("../../commands/doctor.js").doctorCommand>(),
-  runDaemonInstall: vi.fn<typeof import("../daemon-cli.js").runDaemonInstall>(),
-  runDaemonRestart: vi.fn<typeof import("../daemon-cli.js").runDaemonRestart>(),
-  runRestartScript: vi.fn(async () => undefined),
-  runUpdatedInstallGatewayCommand: vi.fn(async () => "accepted"),
+  runRestartScript: vi.fn(async () => true),
+  runUpdatedInstallGatewayCommand: vi.fn<
+    typeof import("./update-command-service-command.js").runUpdatedInstallGatewayCommand
+  >(async (_params, action) => (action === "restart" ? "accepted" : "unverified")),
   waitForGatewayHealthyRestart: vi.fn(),
   waitForGatewayHttpReadiness: vi.fn(),
   runUpdateInferenceProbe: vi.fn(),
@@ -23,12 +22,6 @@ vi.mock("./update-command-inference.js", () => ({
 vi.mock("../daemon-cli/restart-health-probe.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../daemon-cli/restart-health-probe.js")>()),
   resolveGatewayRestartProbeContext: async () => ({ config: {}, auth: undefined }),
-}));
-
-vi.mock("../../commands/doctor.js", () => ({ doctorCommand: mocks.doctorCommand }));
-vi.mock("../daemon-cli.js", () => ({
-  runDaemonInstall: mocks.runDaemonInstall,
-  runDaemonRestart: mocks.runDaemonRestart,
 }));
 
 vi.mock("../../infra/gateway-supervision.js", async (importOriginal) => ({
@@ -54,12 +47,6 @@ vi.mock("./update-command-config-snapshot.js", () => ({
 import { maybeRestartService } from "./update-command-service.js";
 
 describe("maybeRestartService", () => {
-  afterEach(() => {
-    expect(mocks.doctorCommand).not.toHaveBeenCalled();
-    expect(mocks.runDaemonInstall).not.toHaveBeenCalled();
-    expect(mocks.runDaemonRestart).not.toHaveBeenCalled();
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.waitForGatewayHttpReadiness.mockResolvedValue({ healthz: 200, readyz: 200 });
@@ -78,41 +65,45 @@ describe("maybeRestartService", () => {
     });
   });
 
-  it("forwards the built Git identity into restart verification", async () => {
-    const result = {
-      status: "ok",
-      mode: "git",
-      root: "/tmp/openclaw-configured-ui-update",
-      after: { buildId: "new-build" },
-      steps: [],
-      durationMs: 0,
-    } satisfies UpdateRunResult;
+  it.each(["dev", "stable", "beta"] as const)(
+    "enforces the built Git identity for the %s channel",
+    async (channel) => {
+      const result = {
+        status: "ok",
+        mode: "git",
+        root: "/tmp/openclaw-configured-ui-update",
+        after: { buildId: "new-build" },
+        steps: [],
+        durationMs: 0,
+      } satisfies UpdateRunResult;
 
-    await expect(
-      maybeRestartService({
-        shouldRestart: true,
-        result,
-        channel: "dev",
-        opts: { json: true },
-        refreshServiceEnv: false,
-        serviceEnv: { HOME: "/home/operator" },
-        serviceInstallEnv: {},
-        gatewayPort: 18789,
-        restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
-        timeoutMs: 1_000,
-      }),
-    ).resolves.toBe("ok");
+      await expect(
+        maybeRestartService({
+          shouldRestart: true,
+          result,
+          channel,
+          opts: { json: true },
+          refreshServiceEnv: false,
+          serviceEnv: { HOME: "/home/operator" },
+          serviceInstallEnv: {},
+          gatewayPort: 18789,
+          restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
+          timeoutMs: 1_000,
+        }),
+      ).resolves.toBe("ok");
 
-    expect(mocks.runRestartScript).toHaveBeenCalledWith(
-      "/tmp/openclaw-configured-ui-restart.sh",
-      1_000,
-    );
-    expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
-      expect.objectContaining({ expectedBuildId: "new-build" }),
-    );
-  });
+      expect(mocks.runRestartScript).toHaveBeenCalledWith(
+        "/tmp/openclaw-configured-ui-restart.sh",
+        1_000,
+      );
+      expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
+        expect.objectContaining({ expectedBuildId: "new-build" }),
+      );
+    },
+  );
 
   it("does not infer activation from a detached script when the expected Git build is never observed", async () => {
+    mocks.runRestartScript.mockResolvedValueOnce(false);
     mocks.waitForGatewayHealthyRestart.mockResolvedValue({
       runtime: { status: "stopped" },
       portUsage: {
@@ -152,12 +143,12 @@ describe("maybeRestartService", () => {
 
   it.each(
     [false, true].flatMap((refreshServiceEnv) => [
-      { refreshServiceEnv, readyz: 503, inference: true, accepted: false },
-      { refreshServiceEnv, readyz: 200, inference: false, accepted: true },
+      { refreshServiceEnv, readyz: 503, inference: true, verified: false },
+      { refreshServiceEnv, readyz: 200, inference: false, verified: true },
     ]),
   )(
     "requires readyz=$readyz while inference=$inference remains advisory (refresh=$refreshServiceEnv)",
-    async ({ refreshServiceEnv, readyz, inference, accepted }) => {
+    async ({ refreshServiceEnv, readyz, inference, verified }) => {
       mocks.waitForGatewayHttpReadiness.mockResolvedValue({ healthz: 200, readyz });
       mocks.runUpdateInferenceProbe.mockResolvedValue(inference);
       const onVerified = vi.fn();
@@ -181,15 +172,15 @@ describe("maybeRestartService", () => {
         onVerified,
         onVerificationFailure,
       });
-      expect(actual).toBe(accepted);
+      expect(actual).toBe(verified ? "ok" : "restart-health-failed");
       expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
       expect(mocks.runRestartScript).toHaveBeenCalledTimes(refreshServiceEnv ? 0 : 1);
       expect(mocks.runUpdatedInstallGatewayCommand).toHaveBeenCalledTimes(
         refreshServiceEnv ? 1 : 0,
       );
-      expect(onVerified).toHaveBeenCalledTimes(accepted ? 1 : 0);
-      expect(mocks.runUpdateInferenceProbe).toHaveBeenCalledTimes(accepted ? 1 : 0);
-      if (accepted) {
+      expect(onVerified).toHaveBeenCalledTimes(verified ? 1 : 0);
+      expect(mocks.runUpdateInferenceProbe).toHaveBeenCalledTimes(verified ? 1 : 0);
+      if (verified) {
         expect(onVerificationFailure).not.toHaveBeenCalled();
       } else {
         expect(onVerificationFailure).toHaveBeenCalledWith("readyz-unhealthy");
@@ -220,43 +211,10 @@ describe("maybeRestartService", () => {
         timeoutMs: 1_000,
         onVerificationFailure,
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBe("restart-health-failed");
     expect(onVerificationFailure).toHaveBeenCalledWith("channel-errors");
     expect(mocks.runUpdateInferenceProbe).not.toHaveBeenCalled();
   });
-
-  it.each(["stable", "beta"] as const)(
-    "enforces the built Git identity for the %s channel",
-    async (channel) => {
-      const result = {
-        status: "ok",
-        mode: "git",
-        root: "/tmp/openclaw-channel-update",
-        after: { buildId: "new-build" },
-        steps: [],
-        durationMs: 0,
-      } satisfies UpdateRunResult;
-
-      await expect(
-        maybeRestartService({
-          shouldRestart: true,
-          result,
-          channel,
-          opts: { json: true },
-          refreshServiceEnv: false,
-          serviceEnv: { HOME: "/home/operator" },
-          serviceInstallEnv: {},
-          gatewayPort: 18789,
-          restartScriptPath: "/tmp/openclaw-channel-restart.sh",
-          timeoutMs: 1_000,
-        }),
-      ).resolves.toBe("ok");
-
-      expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
-        expect.objectContaining({ expectedBuildId: "new-build" }),
-      );
-    },
-  );
 
   it("reports service ownership skips to JSON callers", async () => {
     const errorSpy = vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   runDaemonInstall: vi.fn<typeof import("../daemon-cli.js").runDaemonInstall>(),
   runDaemonRestart: vi.fn<typeof import("../daemon-cli.js").runDaemonRestart>(),
   runRestartScript: vi.fn(async () => undefined),
-  runUpdatedInstallGatewayCommand: vi.fn(async () => true),
+  runUpdatedInstallGatewayCommand: vi.fn(async () => "accepted"),
   waitForGatewayHealthyRestart: vi.fn(),
   waitForGatewayHttpReadiness: vi.fn(),
   runUpdateInferenceProbe: vi.fn(),
@@ -101,15 +101,18 @@ describe("maybeRestartService", () => {
         restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
         timeoutMs: 1_000,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toBe("ok");
 
-    expect(mocks.runRestartScript).toHaveBeenCalledWith("/tmp/openclaw-configured-ui-restart.sh");
+    expect(mocks.runRestartScript).toHaveBeenCalledWith(
+      "/tmp/openclaw-configured-ui-restart.sh",
+      1_000,
+    );
     expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
       expect.objectContaining({ expectedBuildId: "new-build" }),
     );
   });
 
-  it("rejects a Git restart when the expected build is never observed", async () => {
+  it("does not infer activation from a detached script when the expected Git build is never observed", async () => {
     mocks.waitForGatewayHealthyRestart.mockResolvedValue({
       runtime: { status: "stopped" },
       portUsage: {
@@ -144,7 +147,7 @@ describe("maybeRestartService", () => {
         restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
         timeoutMs: 1_000,
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBe("failed");
   });
 
   it.each(
@@ -247,7 +250,7 @@ describe("maybeRestartService", () => {
           restartScriptPath: "/tmp/openclaw-channel-restart.sh",
           timeoutMs: 1_000,
         }),
-      ).resolves.toBe(true);
+      ).resolves.toBe("ok");
 
       expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
         expect.objectContaining({ expectedBuildId: "new-build" }),
@@ -274,7 +277,7 @@ describe("maybeRestartService", () => {
         serviceMutationSkipMessage: "service management skipped: ownership conflict",
         timeoutMs: 1_000,
       }),
-    ).resolves.toBe(true);
+    ).resolves.toBe("ok");
 
     expect(errorSpy).toHaveBeenCalledWith("service management skipped: ownership conflict");
   });

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -249,26 +249,6 @@ export async function maybeRestartService(params: {
       recordUpdateRunPhase(params.opts.run.runId, phase, undefined, { env: params.opts.run.env });
     }
   };
-  const waitForHealthy = async (
-    expectedGatewayVersion: string | undefined,
-    expectedGatewayBuildId: string | undefined,
-    requireRunningService?: boolean,
-  ) => {
-    const service = resolveGatewayService();
-    return waitForGatewayHealthyRestart({
-      service,
-      port: activation.gatewayPort,
-      expectedVersion: expectedGatewayVersion,
-      ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
-      env: activation.serviceEnv,
-      requireRunningService,
-      settle: { probes: 12 },
-      supervisorKeepsAlive: await hasLoadedLaunchdKeepAliveSupervisor({
-        service,
-        env: activation.serviceEnv,
-      }),
-    });
-  };
   const verifyRestartedGateway = async (
     expectedGatewayVersion: string | undefined,
     expectedGatewayBuildId: string | undefined,
@@ -357,11 +337,20 @@ export async function maybeRestartService(params: {
           await runUpdatedInstallGatewayCommand(activation, "install");
           if (expectedGatewayVersion && (isPackageUpdate || expectedGatewayBuildId)) {
             recordPhase("verifying");
-            const health = await waitForHealthy(
-              expectedGatewayVersion,
-              expectedGatewayBuildId,
-              true,
-            );
+            const service = resolveGatewayService();
+            const health = await waitForGatewayHealthyRestart({
+              service,
+              port: activation.gatewayPort,
+              expectedVersion: expectedGatewayVersion,
+              ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
+              env: activation.serviceEnv,
+              requireRunningService: true,
+              settle: { probes: 12 },
+              supervisorKeepsAlive: await hasLoadedLaunchdKeepAliveSupervisor({
+                service,
+                env: activation.serviceEnv,
+              }),
+            });
             refreshedGatewayHealth = health.healthy ? health : undefined;
             recordUpdateGatewayHealth(params.opts.run, health, activation.gatewayPort);
           }

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -19,7 +19,6 @@ import { defaultRuntime } from "../../runtime.js";
 import { replaceCliName, resolveCliName } from "../cli-name.js";
 import { formatCliCommand } from "../command-format.js";
 import { installCompletion } from "../completion-runtime.js";
-import { runDaemonRestart } from "../daemon-cli.js";
 import {
   terminateStaleGatewayPids,
   waitForGatewayHealthyRestart,
@@ -30,6 +29,7 @@ import type { UpdateCommandOptions } from "./shared.js";
 import { createUpdateConfigSnapshot } from "./update-command-config-snapshot.js";
 import {
   DEFINITION_DENIAL,
+  GatewayRestartHealthError,
   isPackageManagerUpdateMode,
   runUpdatedInstallGatewayCommand,
 } from "./update-command-service-command.js";
@@ -45,7 +45,6 @@ import {
 import {
   hasLoadedLaunchdKeepAliveSupervisor,
   recoverLaunchAgentAndRecheckGatewayHealth,
-  shouldUseLegacyProcessRestartAfterUpdate,
 } from "./update-command-service-recovery.js";
 import { recordUpdateGatewayHealth, verifyUpdatedGateway } from "./update-command-verification.js";
 
@@ -202,15 +201,15 @@ export async function maybeRestartService(params: {
   timeoutMs: number;
   onVerificationFailure?: (reason: string) => void;
   onVerified?: (verifiedAtMs: number) => void;
-}): Promise<boolean> {
+}): Promise<"ok" | "failed" | "restart-health-failed"> {
   const invocationEnv = resolveServiceRefreshEnv(process.env, params.invocationCwd);
   const serviceEnv = resolveServiceRefreshEnv(
     params.serviceEnv ?? invocationEnv,
     params.invocationCwd,
   );
-  const failed = async () => {
+  const failed = async (outcome: "failed" | "restart-health-failed" = "failed") => {
     await recordFailedUpdateGatewayState(params.opts.run, serviceEnv);
-    return false;
+    return outcome;
   };
   if (params.shouldRestart) {
     const message =
@@ -241,12 +240,34 @@ export async function maybeRestartService(params: {
   }
   if (activation.serviceMutationSkipMessage) {
     defaultRuntime.error(activation.serviceMutationSkipMessage);
-    return true;
+    return "ok";
   }
+  let activationAccepted = false;
+  let updatedInstallRestartNeedsServiceRootProof = false;
   const recordPhase = (phase: "restarting" | "verifying") => {
     if (params.opts.run) {
       recordUpdateRunPhase(params.opts.run.runId, phase, undefined, { env: params.opts.run.env });
     }
+  };
+  const waitForHealthy = async (
+    expectedGatewayVersion: string | undefined,
+    expectedGatewayBuildId: string | undefined,
+    requireRunningService?: boolean,
+  ) => {
+    const service = resolveGatewayService();
+    return waitForGatewayHealthyRestart({
+      service,
+      port: activation.gatewayPort,
+      expectedVersion: expectedGatewayVersion,
+      ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
+      env: activation.serviceEnv,
+      requireRunningService,
+      settle: { probes: 12 },
+      supervisorKeepsAlive: await hasLoadedLaunchdKeepAliveSupervisor({
+        service,
+        env: activation.serviceEnv,
+      }),
+    });
   };
   const verifyRestartedGateway = async (
     expectedGatewayVersion: string | undefined,
@@ -276,16 +297,14 @@ export async function maybeRestartService(params: {
             );
           }
           await terminateStaleGatewayPids(health.staleGatewayPids);
-          if (canRestartUpdatedInstall()) {
-            await runUpdatedInstallGatewayCommand(activation, "restart", preserveDefinition);
-          } else if (
-            shouldUseLegacyProcessRestartAfterUpdate({ updateMode: activation.result.mode })
-          ) {
-            await runDaemonRestart();
+          if (canRestartUpdatedInstall() || !isPackageUpdate) {
+            activationAccepted =
+              (await runUpdatedInstallGatewayCommand(activation, "restart", preserveDefinition)) ===
+              "accepted";
           }
           health = await reinspect();
         }
-        return await recoverLaunchAgentAndRecheckGatewayHealth({
+        const recovery = await recoverLaunchAgentAndRecheckGatewayHealth({
           updateRun: params.opts.run,
           preserveDefinition,
           health,
@@ -295,6 +314,10 @@ export async function maybeRestartService(params: {
           ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
           env: activation.serviceEnv,
         });
+        if (recovery.launchAgentRecovery?.attempted) {
+          activationAccepted = recovery.launchAgentRecovery.recovered;
+        }
+        return recovery;
       },
     });
     if (!verification.ok) {
@@ -327,7 +350,6 @@ export async function maybeRestartService(params: {
       let restarted = false;
       let restartInitiated = false;
       let refreshedGatewayHealth: GatewayRestartSnapshot | undefined;
-      let updatedInstallRestartNeedsServiceRootProof = false;
       let restartScriptPath = preserveDefinition ? null : activation.restartScriptPath;
       if (activation.refreshServiceEnv && activation.serviceInstallEnv !== null) {
         try {
@@ -335,20 +357,11 @@ export async function maybeRestartService(params: {
           await runUpdatedInstallGatewayCommand(activation, "install");
           if (expectedGatewayVersion && (isPackageUpdate || expectedGatewayBuildId)) {
             recordPhase("verifying");
-            const service = resolveGatewayService();
-            const health = await waitForGatewayHealthyRestart({
-              service,
-              port: activation.gatewayPort,
-              expectedVersion: expectedGatewayVersion,
-              ...(expectedGatewayBuildId ? { expectedBuildId: expectedGatewayBuildId } : {}),
-              env: activation.serviceEnv,
-              requireRunningService: true,
-              settle: { probes: 12 },
-              supervisorKeepsAlive: await hasLoadedLaunchdKeepAliveSupervisor({
-                service,
-                env: activation.serviceEnv,
-              }),
-            });
+            const health = await waitForHealthy(
+              expectedGatewayVersion,
+              expectedGatewayBuildId,
+              true,
+            );
             refreshedGatewayHealth = health.healthy ? health : undefined;
             recordUpdateGatewayHealth(params.opts.run, health, activation.gatewayPort);
           }
@@ -409,28 +422,38 @@ export async function maybeRestartService(params: {
       // Refresh already started and settled this process. Keep its health snapshot
       // while completing HTTP readiness and inference without another restart.
       if (refreshedGatewayHealth) {
-        return await verifyRestartedGateway(expectedGatewayVersion, expectedGatewayBuildId, {
-          requireRunningService: true,
-          health: refreshedGatewayHealth,
-        });
+        const healthy = await verifyRestartedGateway(
+          expectedGatewayVersion,
+          expectedGatewayBuildId,
+          {
+            requireRunningService: true,
+            health: refreshedGatewayHealth,
+          },
+        );
+        return healthy ? "ok" : await failed("restart-health-failed");
       }
       if (restartScriptPath) {
         if (!preserveDefinition) {
           await createUpdateConfigSnapshot();
         }
         recordPhase("restarting");
-        await runRestartScript(restartScriptPath);
+        activationAccepted = await runRestartScript(restartScriptPath, activation.timeoutMs);
         restartInitiated = true;
-      } else if (canRestartUpdatedInstall()) {
+      } else if (
+        canRestartUpdatedInstall() ||
+        (!isPackageUpdate && !activation.skipLegacyServiceRestart)
+      ) {
         if (!preserveDefinition) {
           await createUpdateConfigSnapshot();
         }
         recordPhase("restarting");
-        restarted = await runUpdatedInstallGatewayCommand(
+        const restart = await runUpdatedInstallGatewayCommand(
           activation,
           "restart",
           preserveDefinition,
         );
+        restarted = true;
+        activationAccepted = restart === "accepted";
         if (
           updatedInstallRestartNeedsServiceRootProof &&
           (await gatewayServiceCommandUsesRoot({
@@ -445,15 +468,6 @@ export async function maybeRestartService(params: {
           }
           return await failed();
         }
-      } else if (
-        shouldUseLegacyProcessRestartAfterUpdate({ updateMode: activation.result.mode }) &&
-        !activation.skipLegacyServiceRestart
-      ) {
-        if (!preserveDefinition) {
-          await createUpdateConfigSnapshot();
-        }
-        recordPhase("restarting");
-        restarted = await runDaemonRestart();
       } else if (!activation.opts.json) {
         defaultRuntime.log(theme.muted("Gateway: restart skipped (no installed service found)."));
       }
@@ -478,7 +492,7 @@ export async function maybeRestartService(params: {
           if (!activation.opts.json) {
             defaultRuntime.log("");
           }
-          return await failed();
+          return await failed(activationAccepted ? "restart-health-failed" : "failed");
         }
         if (!activation.opts.json && restartInitiated) {
           defaultRuntime.log(theme.success("Daemon restart completed."));
@@ -495,9 +509,12 @@ export async function maybeRestartService(params: {
         `Gateway: restart failed: ${String(err)}. Code update remains installed; a service stopped for update may still be stopped. ` +
           "Run `openclaw gateway status --deep` and ask its service owner to restart it manually.",
       );
+      if (err instanceof GatewayRestartHealthError && !updatedInstallRestartNeedsServiceRootProof) {
+        return await failed("restart-health-failed");
+      }
       return await failed();
     }
-    return true;
+    return "ok";
   }
 
   if (!activation.opts.json) {
@@ -517,5 +534,5 @@ export async function maybeRestartService(params: {
       );
     }
   }
-  return true;
+  return "ok";
 }

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -644,31 +644,6 @@ describe("collectMissingPluginInstallPayloads", () => {
   });
 });
 
-describe("shouldUseLegacyProcessRestartAfterUpdate", () => {
-  it("never restarts package updates through the pre-update process", () => {
-    expect(
-      updateCommandServiceTesting.shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "npm" }),
-    ).toBe(false);
-    expect(
-      updateCommandServiceTesting.shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "pnpm" }),
-    ).toBe(false);
-    expect(
-      updateCommandServiceTesting.shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "bun" }),
-    ).toBe(false);
-  });
-
-  it("keeps the in-process restart path for non-package updates", () => {
-    expect(
-      updateCommandServiceTesting.shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "git" }),
-    ).toBe(true);
-    expect(
-      updateCommandServiceTesting.shouldUseLegacyProcessRestartAfterUpdate({
-        updateMode: "unknown",
-      }),
-    ).toBe(true);
-  });
-});
-
 describe("formatPostUpdateGatewayRecoveryInstructions", () => {
   const result: UpdateRunResult = {
     status: "error",

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -313,7 +313,7 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
           requireRunningServiceAfterRestart: true,
           timeoutMs: UPDATE_RUNNER_TIMEOUT_MS,
         });
-        if (!activated) {
+        if (activated !== "ok") {
           throw new Error(
             "Gateway restart was not verified; run `openclaw gateway status --deep` before restarting manually.",
           );

--- a/src/flows/doctor-health.update.test.ts
+++ b/src/flows/doctor-health.update.test.ts
@@ -166,7 +166,7 @@ describe("runDoctorHealthFlow update outcomes", () => {
           const restart = vi.fn();
           restartUpdatedInstall.mockImplementation(async () => {
             running = true;
-            return true;
+            return "accepted";
           });
           mocks.service.mockReturnValue({
             readCommand: async () => ({

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -221,7 +221,7 @@ describe("update.run acknowledgement", () => {
     );
   });
 
-  it("records activation and awaits its notice before parking the managed gateway", async () => {
+  it("awaits one parking notice without advancing the updater phases", async () => {
     mockGlobalInstallSurface();
     detectRespawnSupervisorMock.mockReturnValue("launchd");
     getUpdateAvailableMock.mockReturnValue({
@@ -249,13 +249,21 @@ describe("update.run acknowledgement", () => {
     try {
       await Promise.race([started.promise, park]);
       expect(sendGatewayLifecycleNoticeMock).toHaveBeenCalledTimes(2);
-      expect(getUpdateRun(response.runId)?.phase).toBe("activating");
+      expect(getUpdateRun(response.runId)?.phase).toBe("requested");
       expect(parked).toBe(false);
     } finally {
       delivered.resolve(true);
     }
     await park;
     await beforePark();
+    expect(getUpdateRun(response.runId)?.phase).toBe("requested");
+    recordUpdateRunPhase(response.runId, "staging");
+    const validating = recordUpdateRunPhase(response.runId, "validating");
+    expect(
+      validating.steps
+        .filter(({ step }) => ["requested", "staging", "validating"].includes(step))
+        .map(({ step }) => step),
+    ).toEqual(["requested", "staging", "validating"]);
     expect(sendGatewayLifecycleNoticeMock).toHaveBeenCalledTimes(2);
     expect(sendGatewayLifecycleNoticeMock).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -165,8 +165,7 @@ export const updateHandlers: GatewayRequestHandlers = {
     let result: Awaited<ReturnType<typeof runGatewayUpdate>>;
     let handoff:
       | { status: "started"; pid?: number; command: string }
-      | { status: "already-running"; command: string; message: string }
-      | { status: "unavailable"; command: string; message: string }
+      | { status: "already-running" | "unavailable"; command: string; message: string }
       | null = null;
     let managedHandoffOwner: GatewayRestartIntent["successorOwner"];
     let ackDelivered = false;
@@ -689,12 +688,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             },
           })
         : null;
-    if (
-      (ackDelivered || ackQueued) &&
-      result.status !== "ok" &&
-      handoff?.status !== "started" &&
-      !restart
-    ) {
+    if ((ackDelivered || ackQueued) && result.status !== "ok" && handoff?.status !== "started") {
       await notify(outcomeRun, "finished");
     }
     context?.logGateway?.info(

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -400,6 +400,7 @@ export const updateHandlers: GatewayRequestHandlers = {
             const started = await startManagedServiceUpdateHandoff({
               runId,
               beforePark: async () => {
+                // Parking and stop completion preserve the phase so the updater can record staging/validation.
                 const current = getUpdateRun(runId);
                 if (!current) {
                   throw new Error("Update run disappeared before managed Gateway parking.");

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -53,6 +53,7 @@ import {
 import {
   createUpdateRun,
   finishUpdateRun,
+  getUpdateRun,
   recordUpdateRunPhase,
   recordUpdateRunStep,
   recordUpdateRunVerification,
@@ -399,8 +400,11 @@ export const updateHandlers: GatewayRequestHandlers = {
             const started = await startManagedServiceUpdateHandoff({
               runId,
               beforePark: async () => {
-                const activating = recordUpdateRunPhase(runId, "activating");
-                await notify(activating, "activating");
+                const current = getUpdateRun(runId);
+                if (!current) {
+                  throw new Error("Update run disappeared before managed Gateway parking.");
+                }
+                await notify(current, "parking");
               },
               requester: params.requester,
               root: installRoot,

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -404,7 +404,7 @@ export const updateHandlers: GatewayRequestHandlers = {
                 if (!current) {
                   throw new Error("Update run disappeared before managed Gateway parking.");
                 }
-                await notify(current, "parking");
+                await notify(current, current.phase === "requested" ? "parking" : "activating");
               },
               requester: params.requester,
               root: installRoot,

--- a/src/gateway/update-run-notice.runtime.ts
+++ b/src/gateway/update-run-notice.runtime.ts
@@ -29,16 +29,20 @@ export function createUpdateRunNotifier(
   const { sessionKey } = initial.origin;
   return async (run: UpdateRunRecord, kind: UpdateRunNoticeKind) => {
     const message = renderUpdateRunNotice(run, kind);
+    // Pre-park and later activation share one durable notice, never a fifth milestone.
+    const milestone = kind === "parking" ? "activating" : kind;
     const recorded =
       kind === "finished"
         ? run.verification.noticeDelivered === true
-        : run.steps.some((step) => step.step === `notice:${kind}` && step.status === "completed");
+        : run.steps.some(
+            (step) => step.step === `notice:${milestone}` && step.status === "completed",
+          );
     if (!message || recorded) {
       return { delivered: false, owned: recorded };
     }
     // Admission, the watcher, and successor startup share permanent delivery
     // ownership. A repeated phase or sentinel revision cannot send a fifth message.
-    const deliveryIntentId = `update-run-${kind}:${run.runId}`;
+    const deliveryIntentId = `update-run-${milestone}:${run.runId}`;
     let delivered = false;
     if (target.kind === "route") {
       delivered = await sendGatewayLifecycleNotice({
@@ -72,7 +76,7 @@ export function createUpdateRunNotifier(
     const owned = delivered || custody?.status === "pending" || custody?.status === "completed";
     if (owned && kind !== "finished") {
       recordUpdateRunStep(run.runId, {
-        step: `notice:${kind}`,
+        step: `notice:${milestone}`,
         status: "completed",
         endedAtMs: Date.now(),
       });

--- a/src/gateway/update-run-notice.runtime.ts
+++ b/src/gateway/update-run-notice.runtime.ts
@@ -1,6 +1,7 @@
 import { createDefaultDeps } from "../cli/deps.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { getRuntimeConfig } from "../config/config.js";
+import { runWithoutOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
 import { appendAssistantMessageToSessionTranscript } from "../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -27,62 +28,64 @@ export function createUpdateRunNotifier(
   }),
 ) {
   const { sessionKey } = initial.origin;
-  return async (run: UpdateRunRecord, kind: UpdateRunNoticeKind) => {
-    const message = renderUpdateRunNotice(run, kind);
-    // Pre-park and later activation share one durable notice, never a fifth milestone.
-    const milestone = kind === "parking" ? "activating" : kind;
-    const recorded =
-      kind === "finished"
-        ? run.verification.noticeDelivered === true
-        : run.steps.some(
-            (step) => step.step === `notice:${milestone}` && step.status === "completed",
-          );
-    if (!message || recorded) {
-      return { delivered: false, owned: recorded };
-    }
-    // Admission, the watcher, and successor startup share permanent delivery
-    // ownership. A repeated phase or sentinel revision cannot send a fifth message.
-    const deliveryIntentId = `update-run-${milestone}:${run.runId}`;
-    let delivered = false;
-    if (target.kind === "route") {
-      delivered = await sendGatewayLifecycleNotice({
-        ...target.route,
-        cfg,
-        deps,
-        sessionKey,
-        message,
-        deliveryIntentId,
-      });
-    } else if (target.kind === "internal") {
-      const internal = target.session;
-      const notice = await appendAssistantMessageToSessionTranscript({
-        agentId: internal.agentId,
-        sessionKey: internal.canonicalKey,
-        expectedSessionId: internal.entry.sessionId,
-        expectedLifecycleRevision: internal.entry.lifecycleRevision ?? null,
-        storePath: internal.storePath,
-        text: message,
-        idempotencyKey: deliveryIntentId,
-      }).catch((error: unknown) => ({ ok: false as const, reason: formatErrorMessage(error) }));
-      delivered = notice.ok;
-      if (!notice.ok) {
-        log.warn(`update run notice append failed: ${notice.reason}`);
+  // Update delivery belongs to the host and can outlive the requesting attempt.
+  return (run: UpdateRunRecord, kind: UpdateRunNoticeKind) =>
+    runWithoutOwnedSessionTranscriptWrites(async () => {
+      const message = renderUpdateRunNotice(run, kind);
+      // Pre-park and later activation share one durable notice, never a fifth milestone.
+      const milestone = kind === "parking" ? "activating" : kind;
+      const recorded =
+        kind === "finished"
+          ? run.verification.noticeDelivered === true
+          : run.steps.some(
+              (step) => step.step === `notice:${milestone}` && step.status === "completed",
+            );
+      if (!message || recorded) {
+        return { delivered: false, owned: recorded };
       }
-    }
-    if (delivered && kind === "finished") {
-      recordUpdateRunVerification(run.runId, { noticeDelivered: true });
-    }
-    const custody = target.kind === "route" ? findDeliveryIntentOwner(deliveryIntentId) : null;
-    const owned = delivered || custody?.status === "pending" || custody?.status === "completed";
-    if (owned && kind !== "finished") {
-      recordUpdateRunStep(run.runId, {
-        step: `notice:${milestone}`,
-        status: "completed",
-        endedAtMs: Date.now(),
-      });
-    }
-    return { delivered, owned };
-  };
+      // Admission, the watcher, and successor startup share permanent delivery
+      // ownership. A repeated phase or sentinel revision cannot send a fifth message.
+      const deliveryIntentId = `update-run-${milestone}:${run.runId}`;
+      let delivered = false;
+      if (target.kind === "route") {
+        delivered = await sendGatewayLifecycleNotice({
+          ...target.route,
+          cfg,
+          deps,
+          sessionKey,
+          message,
+          deliveryIntentId,
+        });
+      } else if (target.kind === "internal") {
+        const internal = target.session;
+        const notice = await appendAssistantMessageToSessionTranscript({
+          agentId: internal.agentId,
+          sessionKey: internal.canonicalKey,
+          expectedSessionId: internal.entry.sessionId,
+          expectedLifecycleRevision: internal.entry.lifecycleRevision ?? null,
+          storePath: internal.storePath,
+          text: message,
+          idempotencyKey: deliveryIntentId,
+        }).catch((error: unknown) => ({ ok: false as const, reason: formatErrorMessage(error) }));
+        delivered = notice.ok;
+        if (!notice.ok) {
+          log.warn(`update run notice append failed: ${notice.reason}`);
+        }
+      }
+      if (delivered && kind === "finished") {
+        recordUpdateRunVerification(run.runId, { noticeDelivered: true });
+      }
+      const custody = target.kind === "route" ? findDeliveryIntentOwner(deliveryIntentId) : null;
+      const owned = delivered || custody?.status === "pending" || custody?.status === "completed";
+      if (owned && kind !== "finished") {
+        recordUpdateRunStep(run.runId, {
+          step: `notice:${milestone}`,
+          status: "completed",
+          endedAtMs: Date.now(),
+        });
+      }
+      return { delivered, owned };
+    });
 }
 
 export async function notifyUpdateRunPhase(run: UpdateRunRecord): Promise<void> {

--- a/src/gateway/update-run-notice.test.ts
+++ b/src/gateway/update-run-notice.test.ts
@@ -1,3 +1,4 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   loadTranscriptEvents,
@@ -55,7 +56,7 @@ describe("host-owned update notices", () => {
       );
       expect(result).toEqual({ delivered: !replaced, owned: !replaced });
       const events = await loadTranscriptEvents(target);
-      const messages = events.filter((event) => event.type === "message");
+      const messages = events.filter((event) => asOptionalRecord(event)?.type === "message");
       expect(messages).toHaveLength(replaced ? 0 : 1);
       if (!replaced) {
         expect(messages[0]).toMatchObject({

--- a/src/gateway/update-run-notice.test.ts
+++ b/src/gateway/update-run-notice.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { withOwnedSessionTranscriptWrites } from "../config/sessions/transcript-write-context.js";
+import { createUpdateRun, getUpdateRun } from "../infra/update-run-ledger.js";
+import { renderUpdateRunNotice } from "../infra/update-run-report.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { createUpdateRunNotifier } from "./update-run-notice.runtime.js";
+
+describe("host-owned update notices", () => {
+  let state: OpenClawTestState;
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ prefix: "openclaw-update-notice-" });
+  });
+  afterEach(async () => {
+    await state.cleanup();
+  });
+
+  it.each([false, true])(
+    "outlives the requesting attempt while honoring session replacement (%s)",
+    async (replaced) => {
+      const target = {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "update-session",
+        storePath: state.statePath("agents", "main", "sessions", "sessions.json"),
+      };
+      await upsertSessionEntryCore(target, {
+        sessionId: target.sessionId,
+        lifecycleRevision: "admitted-session",
+        updatedAt: 1,
+      });
+      const run = createUpdateRun({ trigger: "chat", origin: { sessionKey: target.sessionKey } });
+      const notify = createUpdateRunNotifier(run, {}, {});
+      if (replaced) {
+        await upsertSessionEntryCore(target, {
+          sessionId: target.sessionId,
+          lifecycleRevision: "replacement-session",
+          updatedAt: 2,
+        });
+      }
+      const result = await withOwnedSessionTranscriptWrites(
+        {
+          sessionTarget: target,
+          withTranscriptWrite: async () => {
+            throw new Error("attempt disposed before transcript write");
+          },
+        },
+        () => notify(run, "parking"),
+      );
+      expect(result).toEqual({ delivered: !replaced, owned: !replaced });
+      const events = await loadTranscriptEvents(target);
+      const messages = events.filter((event) => event.type === "message");
+      expect(messages).toHaveLength(replaced ? 0 : 1);
+      if (!replaced) {
+        expect(messages[0]).toMatchObject({
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: renderUpdateRunNotice(run, "parking") }],
+          },
+        });
+        expect(getUpdateRun(run.runId)?.steps).toContainEqual(
+          expect.objectContaining({ step: "notice:activating", status: "completed" }),
+        );
+      }
+      expect(getUpdateRun(run.runId)?.phase).toBe("requested");
+    },
+  );
+});

--- a/src/infra/update-managed-service-handoff-boundary.test-support.ts
+++ b/src/infra/update-managed-service-handoff-boundary.test-support.ts
@@ -261,6 +261,14 @@ export function createManagedServiceManagerBoundary({
           ${updaterScript}
         })().catch((error) => { console.error(error); process.exit(18); });`;
       }
+      if (run) {
+        updaterScript = `void (async () => {
+          ${ledgerRuntimeImport}
+          ledger.recordUpdateRunPhase(${JSON.stringify(run.runId)}, "staging");
+          ledger.recordUpdateRunPhase(${JSON.stringify(run.runId)}, "validating");
+          ${updaterScript}
+        })().catch((error) => { console.error(error); process.exit(18); });`;
+      }
       if (options?.replaceLedgerWriter) {
         const installedLedgerModule = `${ledgerRuntimeImport}
         export const { finishUpdateRun } = ledger;

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -146,6 +146,23 @@ describe("managed service update handoff", () => {
     },
   );
 
+  itUnix.each(["systemd", "launchd"] as const)(
+    "preserves updater staging and validation history after %s parking",
+    async (kind) => {
+      const { run } = await runManagedServiceManagerBoundary(kind, {
+        ledger: true,
+        updaterExitCode: 0,
+        updaterResult: { status: "ok", mode: "npm" },
+      });
+      const steps = run?.steps.map((step) => step.step);
+      expect(steps).toEqual(expect.arrayContaining(["staging", "validating"]));
+      expect(steps).not.toContain("activating");
+      expect(run?.steps).toContainEqual(
+        expect.objectContaining({ step: "service-stop", status: "completed" }),
+      );
+    },
+  );
+
   itUnix.each(
     (["systemd", "launchd"] as const).flatMap((kind) =>
       [false, true].map((recover) => ({ kind, recover })),

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -363,104 +363,63 @@ describe("managed service update handoff", () => {
     },
   );
 
-  it("rejects failed helper spawns and removes the sensitive handoff directory", async () => {
+  it.each([
+    ["spawn error", { code: "ENOENT" }],
+    [
+      "launcher exit",
+      { message: "managed update handoff exited before signaling readiness (code=1, signal=null)" },
+    ],
+    [
+      "readiness timeout",
+      { message: "managed update handoff did not signal readiness within 30 seconds" },
+    ],
+  ] as const)("rejects %s and cleans up the sensitive handoff", async (failure, expected) => {
+    if (failure === "readiness timeout") {
+      vi.useFakeTimers();
+    }
     const child = createSpawnMock();
-    // Fire after spawn installs readiness listeners; preparation has no one-second deadline.
     spawnMock.mockImplementationOnce(() => {
+      // Readiness listeners and the deadline are installed after spawn returns.
       process.nextTick(() => {
-        child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+        if (failure === "spawn error") {
+          child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+        } else if (failure === "launcher exit") {
+          child.emit("exit", 1, null);
+        } else {
+          vi.advanceTimersByTime(30_000);
+        }
       });
       return child;
     });
+    let env: NodeJS.ProcessEnv | undefined;
+    if (failure === "launcher exit") {
+      const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
+      tempDirs.add(binDir);
+      await fs.writeFile(path.join(binDir, "systemd-run"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+      env = { PATH: binDir, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" };
+    }
     const { startManagedServiceUpdateHandoff } =
       await import("./update-managed-service-handoff.js");
-
     const resultPromise = startManagedServiceUpdateHandoff({
       root: MOCK_INSTALL_ROOT,
       restartDrainTimeoutMs: 300_000,
       parentPid: process.pid,
-      execPath: "/definitely/missing/openclaw-node",
+      execPath:
+        failure === "spawn error" ? "/definitely/missing/openclaw-node" : "/usr/local/bin/node",
       argv1: "/opt/openclaw/openclaw.mjs",
+      supervisor: failure === "launcher exit" ? "systemd" : undefined,
+      env,
       meta: { sessionKey: "agent:test:webchat:dm:user-123" },
     });
-    await expect(resultPromise).rejects.toMatchObject({ code: "ENOENT" });
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
-    const handoffDir = path.dirname(args[0] ?? "");
-    tempDirs.add(handoffDir);
-
-    expect(child.unref).not.toHaveBeenCalled();
-    await expect(pathExists(handoffDir)).resolves.toBe(false);
-    expect(child.listenerCount("exit")).toBe(0);
-    expect(child.listenerCount("error")).toBe(0);
-    expect(child.stdout.destroyed).toBe(true);
-  });
-
-  it("rejects a systemd-run launcher that exits before the helper is ready", async () => {
-    const child = createSpawnMock();
-    spawnMock.mockImplementationOnce(() => {
-      process.nextTick(() => child.emit("exit", 1, null));
-      return child;
-    });
-    const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
-    tempDirs.add(binDir);
-    await fs.writeFile(path.join(binDir, "systemd-run"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-    const { startManagedServiceUpdateHandoff } =
-      await import("./update-managed-service-handoff.js");
-
-    const resultPromise = startManagedServiceUpdateHandoff({
-      root: MOCK_INSTALL_ROOT,
-      restartDrainTimeoutMs: 300_000,
-      parentPid: process.pid,
-      execPath: "/usr/local/bin/node",
-      argv1: "/opt/openclaw/openclaw.mjs",
-      supervisor: "systemd",
-      env: { PATH: binDir, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
-      meta: {},
-    });
-    await expect(resultPromise).rejects.toThrow(
-      "managed update handoff exited before signaling readiness (code=1, signal=null)",
-    );
+    await expect(resultPromise).rejects.toMatchObject(expected);
     expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args.at(-2) ?? "");
     tempDirs.add(handoffDir);
 
-    expect(child.unref).not.toHaveBeenCalled();
-    await expect(pathExists(handoffDir)).resolves.toBe(false);
-    expect(child.listenerCount("exit")).toBe(0);
-    expect(child.listenerCount("error")).toBe(0);
-    expect(child.stdout.destroyed).toBe(true);
-  });
-
-  it("terminates a detached helper that misses the readiness deadline", async () => {
-    vi.useFakeTimers();
-    const child = createSpawnMock();
-    spawnMock.mockImplementationOnce(() => {
-      // The readiness timer is armed after spawn returns, not during filesystem preparation.
-      process.nextTick(() => vi.advanceTimersByTime(30_000));
-      return child;
-    });
-    const { startManagedServiceUpdateHandoff } =
-      await import("./update-managed-service-handoff.js");
-
-    const resultPromise = startManagedServiceUpdateHandoff({
-      root: MOCK_INSTALL_ROOT,
-      restartDrainTimeoutMs: 300_000,
-      parentPid: process.pid,
-      execPath: "/usr/local/bin/node",
-      argv1: "/opt/openclaw/openclaw.mjs",
-      meta: {},
-    });
-    await expect(resultPromise).rejects.toMatchObject({
-      message: "managed update handoff did not signal readiness within 30 seconds",
-    });
-    expect(spawnMock).toHaveBeenCalledTimes(1);
-    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
-    const handoffDir = path.dirname(args[0] ?? "");
-    tempDirs.add(handoffDir);
-
-    expect(forceKillChildProcessTreeMock).toHaveBeenCalledExactlyOnceWith(child);
+    if (failure === "readiness timeout") {
+      expect(forceKillChildProcessTreeMock).toHaveBeenCalledExactlyOnceWith(child);
+    }
     expect(child.unref).not.toHaveBeenCalled();
     await expect(pathExists(handoffDir)).resolves.toBe(false);
     expect(child.listenerCount("exit")).toBe(0);

--- a/src/infra/update-managed-service-handoff-runtime.test-support.ts
+++ b/src/infra/update-managed-service-handoff-runtime.test-support.ts
@@ -42,7 +42,7 @@ export async function prepareManagedServiceRuntimeFixture(params: {
       recoveryModulePath,
       `
       ${ledgerRuntimeImport}
-      export const { getUpdateRun, recordUpdateRunPhase, recordUpdateRunVerification } = ledger;
+      export const { getUpdateRun, recordUpdateRunStep, recordUpdateRunVerification } = ledger;
       ${options?.replaceLedgerWriter ? 'export function finishUpdateRun() { throw new Error("the previous runtime must not finalize the candidate"); }' : "export const { finishUpdateRun } = ledger;"}
     `,
     );

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -36,6 +36,7 @@ import type { UpdateChannel } from "./update-channels.js";
 import {
   CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
   MANAGED_SERVICE_UPDATE_UNSAFE_EXIT_CODE,
+  readControlPlaneUpdateSentinelMeta,
   UPDATE_RUN_ID_ENV,
   type ControlPlaneUpdateSentinelMetaFile,
 } from "./update-control-plane-sentinel.js";
@@ -2113,6 +2114,34 @@ export function claimManagedServiceUpdateHandoff(
   }
   active.claimed = true;
   return true;
+}
+
+/** A transferred updater may inspect its serving ancestor only under its current lease. */
+export async function isCurrentManagedServiceUpdateHandoffProcess(params: {
+  root: string;
+  runId: string | undefined;
+}): Promise<boolean> {
+  if (process.env.OPENCLAW_UPDATE_RUN_HANDOFF !== "1" || !params.runId) {
+    return false;
+  }
+  const meta = await readControlPlaneUpdateSentinelMeta();
+  const root = resolveUpdateInstallRoot(params.root);
+  if (
+    meta?.runId !== params.runId ||
+    !meta.handoffId ||
+    !meta.root ||
+    resolveUpdateInstallRoot(meta.root) !== root
+  ) {
+    return false;
+  }
+  const lease = readManagedServiceUpdateHandoffLease(root);
+  const startIdentity = getFileLockProcessStartTime(process.pid);
+  return (
+    lease?.owner === meta.handoffId &&
+    lease.pid === process.pid &&
+    startIdentity !== null &&
+    lease.startIdentity === String(startIdentity)
+  );
 }
 
 function readManagedServiceUpdateHandoffLease(

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -804,18 +804,18 @@ let finishBeforeParkNotice;
 
 function recordServiceStop() {
   serviceStoppedAtMs ??= Date.now();
-  // Native completion owns this step even when the handoff is cancelled before activation.
+  // Both native stop observations retain the updater phase; they do not own activation.
   pendingServiceStop?.then((stopped) => {
-    runLedger?.recordUpdateRunPhase(params.runId, "activating", {
-      step: { step: "service-stop", status: stopped.code === 0 || (params.serviceRecovery?.kind === "launchd" && isLaunchdNotLoaded(stopped)) ? "completed" : "failed", endedAtMs: Date.now() },
+    runLedger?.recordUpdateRunStep(params.runId, {
+      step: "service-stop", status: stopped.code === 0 || (params.serviceRecovery?.kind === "launchd" && isLaunchdNotLoaded(stopped)) ? "completed" : "failed", endedAtMs: Date.now(),
     });
   }).catch((error) => appendLog("could not record service stop completion: " + String(error)));
   try {
     const metaFile = JSON.parse(fs.readFileSync(params.metaPath, "utf-8"));
     metaFile.meta.serviceStoppedAtMs ??= serviceStoppedAtMs;
     fs.writeFileSync(params.metaPath, JSON.stringify(metaFile), { mode: 0o600 });
-    runLedger?.recordUpdateRunPhase(params.runId, "activating", {
-      step: { step: "service-stop", status: "in_progress", startedAtMs: metaFile.meta.serviceStoppedAtMs },
+    runLedger?.recordUpdateRunStep(params.runId, {
+      step: "service-stop", status: "in_progress", startedAtMs: metaFile.meta.serviceStoppedAtMs,
     });
   } catch (error) {
     appendLog("could not record service stop time: " + String(error));
@@ -1341,7 +1341,7 @@ async function collectUpdateFailureTriage() {
       // Admission and stop recording use the serving runtime. Terminal writes after
       // the updater starts must load the installed runtime in a fresh process.
       runLedger = await import(pathToFileURL(params.recoveryModulePath).href);
-      for (const name of ["finishUpdateRun", "getUpdateRun", "recordUpdateRunPhase", "recordUpdateRunVerification"]) {
+      for (const name of ["finishUpdateRun", "getUpdateRun", "recordUpdateRunStep", "recordUpdateRunVerification"]) {
         if (typeof runLedger[name] !== "function") throw new Error("managed update ledger writer is unavailable");
       }
     }

--- a/src/infra/update-repair-agent.test.ts
+++ b/src/infra/update-repair-agent.test.ts
@@ -186,16 +186,26 @@ describe("runUpdateRepairLoop", () => {
     expect(runtime.runUpdateRepairTurn).not.toHaveBeenCalled();
   });
 
-  it("stops at the tool budget after checking what changed", async () => {
-    runtime.runUpdateRepairTurn.mockResolvedValueOnce(turnResult("Stopped", 2));
-    const validate = vi
-      .fn()
-      .mockResolvedValueOnce(unhealthy(-2))
-      .mockResolvedValueOnce(unhealthy(-1));
-    const result = await runUpdateRepairLoop({ ...params(validate), budget: { maxToolCalls: 2 } });
-    expect(result).toMatchObject({ status: "aborted", reason: "tool-call-budget" });
-    expect(result.attempts[0]?.validation).toEqual(unhealthy(-1));
-  });
+  it.each([{ calls: [2] }, { calls: [1, 1] }])(
+    "shares the tool budget across improving turns: $calls",
+    async ({ calls }) => {
+      for (const toolCalls of calls) {
+        runtime.runUpdateRepairTurn.mockResolvedValueOnce(turnResult("Partial repair", toolCalls));
+      }
+      const validate = vi.fn(async () => unhealthy(-4 + validate.mock.calls.length));
+      const result = await runUpdateRepairLoop({
+        ...params(validate),
+        budget: { maxToolCalls: 2 },
+      });
+      expect(result).toMatchObject({ status: "aborted", reason: "tool-call-budget" });
+      expect(result.attempts.map((attempt) => attempt.toolCalls)).toEqual(calls);
+      expect(runtime.runUpdateRepairTurn.mock.calls.map(([input]) => input.maxToolCalls)).toEqual(
+        calls.length === 1 ? [2] : [2, 1],
+      );
+      expect(validate).toHaveBeenCalledTimes(calls.length + 1);
+      expect(result.attempts.at(-1)?.validation).toEqual(unhealthy(-3 + calls.length));
+    },
+  );
 
   it.each([
     ['REPAIR_RESULT: {"status":"partial","summary":"One error remains."}', "One error remains."],

--- a/src/infra/update-repair-agent.ts
+++ b/src/infra/update-repair-agent.ts
@@ -171,6 +171,7 @@ export async function runUpdateRepairLoop(params: UpdateRepairParams): Promise<U
     }
     const { route, modelFallbacks } = selected;
     params.onEvent?.({ type: "route-selected", model: route.model, provider: route.provider });
+    let remainingToolCalls = budget.maxToolCalls;
     for (let turn = 1; turn <= budget.maxTurns; turn += 1) {
       assertCurrent();
       const previousScore = finalValidation.score;
@@ -200,7 +201,7 @@ export async function runUpdateRepairLoop(params: UpdateRepairParams): Promise<U
             modelFallbacks,
             prompt: repairPrompt(params, finalValidation),
             timeoutMs,
-            maxToolCalls: budget.maxToolCalls,
+            maxToolCalls: remainingToolCalls,
             signal: turnSignal,
             isCurrent: () => {
               assertCurrent();
@@ -231,6 +232,7 @@ export async function runUpdateRepairLoop(params: UpdateRepairParams): Promise<U
         },
       };
       attempts.push(attempt);
+      remainingToolCalls -= outcome.toolCalls;
       finalValidation = attempt.validation;
       // Even failed/timed-out turns may have changed files. Validate after the
       // runner has drained; never infer repair from its self-reported result.
@@ -265,7 +267,7 @@ export async function runUpdateRepairLoop(params: UpdateRepairParams): Promise<U
       if (turnController.signal.aborted || outcome.envelope.status === "timeout") {
         return stop("aborted", "per-turn-budget");
       }
-      if (outcome.toolCalls >= budget.maxToolCalls) {
+      if (remainingToolCalls <= 0) {
         return stop("aborted", "tool-call-budget");
       }
       if (finalValidation.score === previousScore) {

--- a/src/infra/update-run-report.test.ts
+++ b/src/infra/update-run-report.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { UpdateRunRecord } from "./update-run-record.js";
 import {
+  renderUpdateRunNotice,
   renderUpdateRunReport,
   updateRunReportInputFromResult,
   updateRunReportInputFromSentinel,
@@ -43,6 +44,19 @@ describe("update run report", () => {
     );
     expect(report.markdown).toContain(reason);
     expect(report.markdown).toContain(guidance);
+  });
+
+  it("limits parking notices to the pre-updater milestone without loosening phase notices", () => {
+    const requested = run({ status: "running", phase: "requested" });
+    expect(renderUpdateRunNotice(requested, "parking")).toContain("Restarting the gateway now");
+    expect(renderUpdateRunNotice(requested, "activating")).toBeNull();
+    expect(renderUpdateRunNotice(requested, "verifying")).toBeNull();
+    for (const phase of ["staging", "activating", "verifying"] as const) {
+      const progressed = run({ status: "running", phase });
+      expect(renderUpdateRunNotice(progressed, "parking")).toBeNull();
+      expect(renderUpdateRunNotice(progressed, "ack")).toBeNull();
+    }
+    expect(renderUpdateRunNotice(run(), "parking")).toBeNull();
   });
 
   it("reports changed git commits when the package version stays the same", () => {

--- a/src/infra/update-run-report.ts
+++ b/src/infra/update-run-report.ts
@@ -6,7 +6,7 @@ import { summarizeUpdateStepFailure, type UpdateRunRecord } from "./update-run-r
 import type { UpdateRunResult } from "./update-runner-types.js";
 
 export type UpdateRunReport = { headline: string; lines: string[]; markdown: string };
-export type UpdateRunNoticeKind = "ack" | "activating" | "verifying" | "finished";
+export type UpdateRunNoticeKind = "ack" | "parking" | "activating" | "verifying" | "finished";
 type ReportInput = Pick<
   UpdateRunRecord,
   | "status"
@@ -30,7 +30,9 @@ export function renderUpdateRunNotice(
   if (kind === "finished") {
     return run.status === "running" ? null : renderUpdateRunReport(run).markdown;
   }
-  if (run.status !== "running" || run.phase !== (kind === "ack" ? "requested" : kind)) {
+  // Managed parking precedes updater staging; its notice must not advance the ledger phase.
+  const noticePhase = kind === "ack" || kind === "parking" ? "requested" : kind;
+  if (run.status !== "running" || run.phase !== noticePhase) {
     return null;
   }
   const from = run.before.version ? bounded(run.before.version, 120) : undefined;
@@ -39,7 +41,7 @@ export function renderUpdateRunNotice(
   if (kind === "ack") {
     return `⬆️ Updating OpenClaw ${from ?? "the current version"} → ${to ?? "the latest release"}. The gateway stays available while the update is validated; you'll get a message here when it finishes.`;
   }
-  if (kind === "activating") {
+  if (kind === "activating" || kind === "parking") {
     return `⏳ Restarting the gateway now${from && to ? ` (v${from} → v${to})` : ""}…`;
   }
   const running = run.verification.runningVersion

--- a/src/infra/update-triage.test.ts
+++ b/src/infra/update-triage.test.ts
@@ -6,6 +6,7 @@ import { quoteCliArg } from "../cli/quote-cli-arg.js";
 import * as exec from "../process/exec.js";
 import { isPidAlive } from "../shared/pid-alive.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { UPDATE_RUN_ID_ENV } from "./update-control-plane-sentinel.js";
 import { prepareUpdateFailureTriage, runUpdateFailureTriage } from "./update-triage.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -20,7 +21,7 @@ async function createInstalledTriage(params: { hang?: boolean; promptPath?: stri
     path.join(root, "dist", "index.js"),
     `
     const fs = require("node:fs");
-    fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ pid: process.pid }));
+    fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ pid: process.pid, updateRunId: process.env[${JSON.stringify(UPDATE_RUN_ID_ENV)}] ?? null }));
     ${params.hang ? "setInterval(() => {}, 1000);" : `process.stdout.write(JSON.stringify({ promptPath: ${JSON.stringify(promptPath)}, bundlePath: null, bundleError: "Snapshot unavailable" }));`}
   `,
   );
@@ -103,6 +104,18 @@ describe("update triage child lifecycle", () => {
       JSON.stringify({ promptPath, bundlePath: null, bundleError: "Snapshot unavailable" }),
     );
     expect(runtime.error).not.toHaveBeenCalled();
+  });
+
+  it("does not lend the completed update run identity to fresh triage", async () => {
+    const { target, receiptPath } = await createInstalledTriage();
+    const result = await runUpdateFailureTriage({
+      failure: { error: "Update failed" },
+      target: { ...target, env: { ...target.env, [UPDATE_RUN_ID_ENV]: "completed-update-run" } },
+      mode: "json",
+      runtime: { log: vi.fn(), error: vi.fn() },
+    });
+    expect(result.status).toBe("completed");
+    expect(JSON.parse(await fs.readFile(receiptPath, "utf8"))).toMatchObject({ updateRunId: null });
   });
 
   it("does not launch diagnostics after its owner closes during root discovery", async () => {

--- a/src/infra/update-triage.ts
+++ b/src/infra/update-triage.ts
@@ -19,6 +19,7 @@ import { formatErrorMessage } from "./errors.js";
 import { resolveOsHomeDir } from "./home-dir.js";
 import { installationTargetEnv, resolveInstallationTarget } from "./installation-target-context.js";
 import { tryProcessCwd } from "./safe-cwd.js";
+import { UPDATE_RUN_ID_ENV } from "./update-control-plane-sentinel.js";
 
 export type UpdateTriageTarget = {
   root?: string;
@@ -119,6 +120,7 @@ async function runPreparedUpdateFailureTriage(
     ...installationTargetEnv(installationTarget),
   };
   delete env.OPENCLAW_UPDATE_IN_PROGRESS;
+  delete env[UPDATE_RUN_ID_ENV];
   const redaction = { env, stateDir: installationTarget.stateDir };
   const { log, error: logError } = prepared.runtime;
   log("Update failed. Entering triage...");

--- a/ui/src/app/overlays-access.test-support.ts
+++ b/ui/src/app/overlays-access.test-support.ts
@@ -3,11 +3,7 @@ import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts"
 import type { ApplicationGateway, ApplicationGatewaySnapshot } from "./gateway.ts";
 import { createApplicationOverlays } from "./overlays.ts";
 
-export type RequestFn = (
-  method: string,
-  params?: unknown,
-  options?: { timeoutMs?: number | null },
-) => Promise<unknown>;
+export type RequestFn = (...args: Parameters<GatewayBrowserClient["request"]>) => Promise<unknown>;
 
 const SYSTEM_APPROVAL_TITLE = "OpenClaw change";
 const SYSTEM_APPROVAL_COMMAND = "Set gateway.port to 19001";

--- a/ui/src/app/overlays-update-campaign.test.ts
+++ b/ui/src/app/overlays-update-campaign.test.ts
@@ -382,6 +382,7 @@ describe("application update campaign overlays", () => {
 
     expect(overlays.snapshot.updateStatusRefreshing).toBe(false);
     expect(overlays.snapshot.updateStatusBanner).toEqual({
+      source: "read",
       tone: "danger",
       text: expect.stringContaining("Gateway unavailable"),
     });

--- a/ui/src/app/overlays-update-race.test.ts
+++ b/ui/src/app/overlays-update-race.test.ts
@@ -63,8 +63,9 @@ describe("update run response races", () => {
           : {},
       );
       let admitted = false;
-      const request = vi.fn<RequestFn>(async (method) => {
+      const request = vi.fn<RequestFn>(async (method, _params, options) => {
         if (method === "update.run") {
+          options?.onSent?.();
           admitted = true;
           return admission.promise;
         }
@@ -72,6 +73,7 @@ describe("update run response races", () => {
       });
       const harness = updateRunHarness(request);
       const overlays = createApplicationOverlays(harness.gateway);
+      await flushMicrotasks();
       const running = overlays.runUpdate();
       try {
         await flushMicrotasks();
@@ -200,6 +202,135 @@ describe("update run response races", () => {
     } finally {
       drained.resolve();
       await running;
+      overlays.dispose();
+    }
+  });
+  it.each([
+    { baseline: "unknown", discovered: "old", attach: false },
+    { baseline: "previous", discovered: "old", attach: false },
+    { baseline: "previous", discovered: "new", attach: true },
+    { baseline: "empty", discovered: "new", attach: true },
+    { baseline: "unknown", discovered: "active", attach: true },
+  ] as const)(
+    "reconciles lost admission using $baseline history and $discovered run identity",
+    async ({ baseline, discovered, attach }) => {
+      const previous = updateRunFixture({
+        status: "succeeded",
+        phase: "finished",
+        finishedAtMs: 3_000,
+      });
+      let found =
+        discovered === "old"
+          ? previous
+          : updateRunFixture({
+              runId: "00000000-0000-4000-8000-000000000002",
+              ...(discovered === "active"
+                ? {}
+                : { status: "succeeded", phase: "finished", finishedAtMs: 4_000 }),
+            });
+      let requested = false;
+      const request = vi.fn<RequestFn>(async (method, _params, options) => {
+        if (method === "update.run") {
+          options?.onSent?.();
+          requested = true;
+          throw new Error("Admission reply lost");
+        }
+        if (method === "update.runs.get") {
+          return { run: found };
+        }
+        if (method !== "update.status") {
+          return {};
+        }
+        if (!requested) {
+          if (baseline === "unknown") {
+            throw new Error("Initial history unavailable");
+          }
+          return baseline === "previous" ? { lastRun: previous } : {};
+        }
+        return found.status === "running" ? { activeRun: found } : { lastRun: found };
+      });
+      const harness = updateRunHarness(request);
+      const overlays = createApplicationOverlays(harness.gateway);
+      try {
+        await flushMicrotasks();
+        await overlays.runUpdate();
+        expect(requested).toBe(true);
+        if (attach) {
+          expect(overlays.snapshot.updateRun).toEqual(found);
+          if (discovered === "active") {
+            found = {
+              ...found,
+              status: "succeeded",
+              phase: "finished",
+              finishedAtMs: 4_000,
+              updatedAtMs: 4_000,
+            };
+            harness.emitEvent("update.run.changed", found);
+            await flushMicrotasks();
+            expect(overlays.snapshot.updateRun).toEqual(found);
+          }
+        } else {
+          expect(overlays.snapshot.updateRun).toBeNull();
+          expect(overlays.snapshot.updateStatusBanner?.text).toContain("Admission reply lost");
+          harness.update({ phase: "reconnecting" });
+          harness.update({ phase: "connected" });
+          await flushMicrotasks();
+          harness.emitEvent("update.run.changed", { ...previous, updatedAtMs: 4_000 });
+          await flushMicrotasks();
+          expect(overlays.snapshot.updateRun).toBeNull();
+          expect(overlays.snapshot.updateStatusBanner?.text).toContain("Admission reply lost");
+          await overlays.refreshUpdateStatus();
+          expect(overlays.snapshot.updateRun).toBeNull();
+          expect(overlays.snapshot.updateStatusBanner?.text).toContain("Admission reply lost");
+        }
+        expect(request.mock.calls.filter(([method]) => method === "update.run")).toHaveLength(1);
+      } finally {
+        overlays.dispose();
+      }
+    },
+  );
+
+  it("keeps a cold admission uncertain when disconnect precedes its lost reply", async () => {
+    const admission = deferred();
+    const previous = updateRunFixture({
+      status: "succeeded",
+      phase: "finished",
+      finishedAtMs: 3_000,
+    });
+    let historyReady = false;
+    const request = vi.fn<RequestFn>(async (method, _params, options) => {
+      if (method === "update.run") {
+        options?.onSent?.();
+        return admission.promise;
+      }
+      if (method !== "update.status") {
+        return {};
+      }
+      if (!historyReady) {
+        throw new Error("Initial history unavailable");
+      }
+      return { lastRun: previous };
+    });
+    const harness = updateRunHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    let operation: Promise<void> | undefined;
+    try {
+      await flushMicrotasks();
+      operation = overlays.runUpdate();
+      await flushMicrotasks();
+      expect(request.mock.calls.some(([method]) => method === "update.run")).toBe(true);
+      harness.update({ phase: "reconnecting" });
+      admission.reject(new Error("Socket lost"));
+      historyReady = true;
+      harness.update({ phase: "connected" });
+      await operation;
+      await flushMicrotasks();
+      expect(overlays.snapshot.updateRun).toBeNull();
+      expect(overlays.snapshot.updateStatusBanner?.tone).toBe("danger");
+      expect(overlays.snapshot.updateRunning).toBe(false);
+    } finally {
+      admission.resolve({});
+      await operation;
       overlays.dispose();
     }
   });

--- a/ui/src/app/overlays-update-race.test.ts
+++ b/ui/src/app/overlays-update-race.test.ts
@@ -207,6 +207,7 @@ describe("update run response races", () => {
   });
   it.each([
     { baseline: "unknown", discovered: "old", attach: false },
+    { baseline: "unknown", discovered: "old after disconnect", attach: false },
     { baseline: "previous", discovered: "old", attach: false },
     { baseline: "previous", discovered: "new", attach: true },
     { baseline: "empty", discovered: "new", attach: true },
@@ -214,26 +215,26 @@ describe("update run response races", () => {
   ] as const)(
     "reconciles lost admission using $baseline history and $discovered run identity",
     async ({ baseline, discovered, attach }) => {
+      const admission = deferred();
       const previous = updateRunFixture({
         status: "succeeded",
         phase: "finished",
         finishedAtMs: 3_000,
       });
-      let found =
-        discovered === "old"
-          ? previous
-          : updateRunFixture({
-              runId: "00000000-0000-4000-8000-000000000002",
-              ...(discovered === "active"
-                ? {}
-                : { status: "succeeded", phase: "finished", finishedAtMs: 4_000 }),
-            });
+      let found = discovered.startsWith("old")
+        ? previous
+        : updateRunFixture({
+            runId: "00000000-0000-4000-8000-000000000002",
+            ...(discovered === "active"
+              ? {}
+              : { status: "succeeded", phase: "finished", finishedAtMs: 4_000 }),
+          });
       let requested = false;
       const request = vi.fn<RequestFn>(async (method, _params, options) => {
         if (method === "update.run") {
           options?.onSent?.();
           requested = true;
-          throw new Error("Admission reply lost");
+          return admission.promise;
         }
         if (method === "update.runs.get") {
           return { run: found };
@@ -251,10 +252,22 @@ describe("update run response races", () => {
       });
       const harness = updateRunHarness(request);
       const overlays = createApplicationOverlays(harness.gateway);
+      let operation: Promise<void> | undefined;
+      const outcome =
+        discovered === "old after disconnect" ? "outcome is unknown" : "Admission reply lost";
       try {
         await flushMicrotasks();
-        await overlays.runUpdate();
-        expect(requested).toBe(true);
+        operation = overlays.runUpdate();
+        await flushMicrotasks();
+        if (discovered === "old after disconnect") {
+          harness.update({ phase: "reconnecting" });
+        }
+        admission.reject(new Error("Admission reply lost"));
+        if (discovered === "old after disconnect") {
+          harness.update({ phase: "connected" });
+        }
+        await operation;
+        await flushMicrotasks();
         if (attach) {
           expect(overlays.snapshot.updateRun).toEqual(found);
           if (discovered === "active") {
@@ -271,67 +284,26 @@ describe("update run response races", () => {
           }
         } else {
           expect(overlays.snapshot.updateRun).toBeNull();
-          expect(overlays.snapshot.updateStatusBanner?.text).toContain("Admission reply lost");
+          expect(overlays.snapshot.updateStatusBanner?.tone).toBe("danger");
+          expect(overlays.snapshot.updateStatusBanner?.text).toContain(outcome);
+          expect(overlays.snapshot.updateRunning).toBe(false);
           harness.update({ phase: "reconnecting" });
           harness.update({ phase: "connected" });
           await flushMicrotasks();
           harness.emitEvent("update.run.changed", { ...previous, updatedAtMs: 4_000 });
           await flushMicrotasks();
           expect(overlays.snapshot.updateRun).toBeNull();
-          expect(overlays.snapshot.updateStatusBanner?.text).toContain("Admission reply lost");
+          expect(overlays.snapshot.updateStatusBanner?.text).toContain(outcome);
           await overlays.refreshUpdateStatus();
           expect(overlays.snapshot.updateRun).toBeNull();
-          expect(overlays.snapshot.updateStatusBanner?.text).toContain("Admission reply lost");
+          expect(overlays.snapshot.updateStatusBanner?.text).toContain(outcome);
         }
         expect(request.mock.calls.filter(([method]) => method === "update.run")).toHaveLength(1);
       } finally {
+        admission.resolve({});
+        await operation;
         overlays.dispose();
       }
     },
   );
-
-  it("keeps a cold admission uncertain when disconnect precedes its lost reply", async () => {
-    const admission = deferred();
-    const previous = updateRunFixture({
-      status: "succeeded",
-      phase: "finished",
-      finishedAtMs: 3_000,
-    });
-    let historyReady = false;
-    const request = vi.fn<RequestFn>(async (method, _params, options) => {
-      if (method === "update.run") {
-        options?.onSent?.();
-        return admission.promise;
-      }
-      if (method !== "update.status") {
-        return {};
-      }
-      if (!historyReady) {
-        throw new Error("Initial history unavailable");
-      }
-      return { lastRun: previous };
-    });
-    const harness = updateRunHarness(request);
-    const overlays = createApplicationOverlays(harness.gateway);
-    let operation: Promise<void> | undefined;
-    try {
-      await flushMicrotasks();
-      operation = overlays.runUpdate();
-      await flushMicrotasks();
-      expect(request.mock.calls.some(([method]) => method === "update.run")).toBe(true);
-      harness.update({ phase: "reconnecting" });
-      admission.reject(new Error("Socket lost"));
-      historyReady = true;
-      harness.update({ phase: "connected" });
-      await operation;
-      await flushMicrotasks();
-      expect(overlays.snapshot.updateRun).toBeNull();
-      expect(overlays.snapshot.updateStatusBanner?.tone).toBe("danger");
-      expect(overlays.snapshot.updateRunning).toBe(false);
-    } finally {
-      admission.resolve({});
-      await operation;
-      overlays.dispose();
-    }
-  });
 });

--- a/ui/src/app/overlays-update-triage.test.ts
+++ b/ui/src/app/overlays-update-triage.test.ts
@@ -1,5 +1,7 @@
 // @vitest-environment node
+import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GatewayRequestError } from "../api/gateway.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { createUpdateRunFixture as updateRunFixture } from "../test-helpers/update-run.ts";
 import type { ApplicationGatewaySnapshot } from "./gateway.ts";
@@ -202,7 +204,14 @@ describe("update failure triage admission", () => {
   );
 
   it("reports a preparation failure without dispatching or diagnosing an update", async () => {
-    const request = vi.fn<RequestFn>(async () => ({}));
+    const previous = updateRunFixture({
+      status: "succeeded",
+      phase: "finished",
+      finishedAtMs: 3_000,
+    });
+    const request = vi.fn<RequestFn>(async (method) =>
+      method === "update.status" ? { lastRun: previous } : {},
+    );
     const harness = updateRunHarness(request);
     const onUpdateFailure = vi.fn();
     const overlays = createApplicationOverlays(harness.gateway, {
@@ -212,7 +221,10 @@ describe("update failure triage admission", () => {
       },
     });
     try {
+      await flushMicrotasks();
+      expect(overlays.snapshot.updateRun).toEqual(previous);
       await overlays.runUpdate();
+      expect(overlays.snapshot.updateRun).toBeNull();
       expect(request.mock.calls.some(([method]) => method === "update.run")).toBe(false);
       expect(overlays.snapshot.updateRunning).toBe(false);
       expect(overlays.snapshot.updateReconciliationPending).toBe(false);
@@ -285,4 +297,67 @@ describe("update failure triage admission", () => {
       overlays.dispose();
     }
   });
+  it.each([
+    { code: "INVALID_REQUEST", message: "Invalid update request parameters" },
+    { code: "INVALID_REQUEST", message: "Missing operator.admin scope" },
+    { code: "UNAVAILABLE", message: "Gateway restart admission is unavailable" },
+  ])("preserves the sent rejection $message over historical success", async (failure) => {
+    const previous = updateRunFixture({
+      status: "succeeded",
+      phase: "finished",
+      finishedAtMs: 3_000,
+    });
+    const request = vi.fn<RequestFn>(async (method, _params, options) => {
+      if (method === "update.run") {
+        options?.onSent?.();
+        throw new GatewayRequestError(failure);
+      }
+      return method === "update.status" ? { lastRun: previous } : {};
+    });
+    const harness = updateRunHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      await flushMicrotasks();
+      expect(overlays.snapshot.updateRun).toEqual(previous);
+      const statusReads = request.mock.calls.filter(
+        ([method]) => method === "update.status",
+      ).length;
+      await overlays.runUpdate();
+      expect(overlays.snapshot.updateStatusBanner?.text).toContain(failure.message);
+      expect(overlays.snapshot.updateRun).toBeNull();
+      expect(overlays.snapshot.updateRunning).toBe(false);
+      expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(
+        statusReads,
+      );
+    } finally {
+      overlays.dispose();
+    }
+  });
+
+  it.each(["recorded:1000", "stable-handoff"])(
+    "does not replay the stable v2026.9.1 consumed diagnostic %s after reload",
+    async (id) => {
+      const scope = gatewayCredentialScope("ws://gateway.test");
+      const stored = JSON.stringify({ triaged: [JSON.stringify([scope, null, id])] });
+      sessionStorage.setItem("openclaw:control-ui:update:v1", stored);
+      const harness = updateRunHarness(async () => ({
+        sentinel: {
+          kind: "update",
+          status: "error",
+          ts: 1_000,
+          stats: { reason: "build-failed", ...(id === "stable-handoff" ? { handoffId: id } : {}) },
+        },
+      }));
+      const onUpdateFailure = vi.fn();
+      const overlays = createApplicationOverlays(harness.gateway, { onUpdateFailure });
+      try {
+        await flushMicrotasks();
+        expect(overlays.snapshot.recordedUpdateAttempt?.reason).toBe("build-failed");
+        expect(onUpdateFailure).not.toHaveBeenCalled();
+        expect(sessionStorage.getItem("openclaw:control-ui:update:v1")).toBe(stored);
+      } finally {
+        overlays.dispose();
+      }
+    },
+  );
 });

--- a/ui/src/app/overlays-update-triage.test.ts
+++ b/ui/src/app/overlays-update-triage.test.ts
@@ -319,16 +319,10 @@ describe("update failure triage admission", () => {
     try {
       await flushMicrotasks();
       expect(overlays.snapshot.updateRun).toEqual(previous);
-      const statusReads = request.mock.calls.filter(
-        ([method]) => method === "update.status",
-      ).length;
       await overlays.runUpdate();
       expect(overlays.snapshot.updateStatusBanner?.text).toContain(failure.message);
       expect(overlays.snapshot.updateRun).toBeNull();
       expect(overlays.snapshot.updateRunning).toBe(false);
-      expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(
-        statusReads,
-      );
     } finally {
       overlays.dispose();
     }

--- a/ui/src/app/overlays-updates.ts
+++ b/ui/src/app/overlays-updates.ts
@@ -3,6 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { GatewayUpdateAvailableEventPayload } from "../../../src/gateway/events.js";
 import type { UpdateRunRecord } from "../../../src/infra/update-run-record.js";
 import { isReportableUpdateRun } from "../../../src/shared/update-outcome.js";
+import { GatewayRequestError } from "../api/gateway.ts";
 import type { UpdateHoldResult } from "../api/types.ts";
 import { controlUiBuildDiffersFrom } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
@@ -45,6 +46,9 @@ export type ApplicationUpdateOverlayHooks = {
   onUpdateFailure?: (failure: UpdateFailureTriage, admission: UpdateTriageAdmission) => void;
 };
 
+type UpdateHistory = { kind: "unknown" } | { kind: "known"; runId: string | null };
+type UpdateAdmissionAttempt = { history: UpdateHistory; requestSent: boolean };
+
 export function createApplicationUpdateOverlays(
   gateway: ApplicationGateway,
   onChange: () => void,
@@ -82,6 +86,8 @@ export function createApplicationUpdateOverlays(
   let updateReadGeneration = 0;
   let updateHoldInFlight = false;
   let runId: string | null = null;
+  let updateHistory: UpdateHistory = { kind: "unknown" };
+  let updateAttempt: UpdateAdmissionAttempt | null = null;
   let currentFailure: UpdateFailureTriage | null = null;
   let presentedFailure: UpdateFailureTriage | null = null;
 
@@ -192,10 +198,11 @@ export function createApplicationUpdateOverlays(
     presentFailureTriage();
   }
 
-  const publishError = (error: unknown) => {
+  const publishError = (error: unknown, source?: "read") => {
     snapshot = {
       ...snapshot,
       updateStatusBanner: {
+        ...(source ? { source } : {}),
         tone: "danger",
         text: t("updates.error", { error: formatUiError(error) }),
       },
@@ -214,6 +221,7 @@ export function createApplicationUpdateOverlays(
       invalidateFailureReport();
     }
     runId = run.runId;
+    updateAttempt = null;
     const failure = projectUpdateRunFailure(run);
     setCurrentFailure(failure);
     snapshot = {
@@ -251,7 +259,7 @@ export function createApplicationUpdateOverlays(
         if (response.run.status !== "running") {
           // Refresh the install owner's availability after completion so closing
           // the report cannot re-offer the just-installed target.
-          void refreshUpdateStatus();
+          void refreshUpdateStatus("completion");
         }
       } else {
         // A missing row is an explicit unknown outcome, never inferred success.
@@ -266,33 +274,40 @@ export function createApplicationUpdateOverlays(
       }
     } catch (error) {
       if (isCurrent()) {
-        publishError(error);
+        publishError(error, "read");
       }
     }
   };
 
   const applyUpdateStatusResponse = (response: UpdateRestartStatusResponse) => {
-    const { failure, ...status } = projectUpdateStatusResponse(response, snapshot);
-    snapshot = { ...snapshot, ...status, updateCampaignStatusHydrated: true };
+    const { failure, updateStatusBanner, recordedUpdateAttempt, ...status } =
+      projectUpdateStatusResponse(response, snapshot);
     const run = response.activeRun ?? response.lastRun;
+    const history = updateAttempt?.history;
+    // A failed history read is not an empty baseline. Until a current identity
+    // is observed, a status check cannot certify terminal history as this attempt.
+    const previousOutcome =
+      history !== undefined &&
+      (!run ||
+        (history.kind === "known" && run.runId === history.runId) ||
+        (history.kind === "unknown" && run.status !== "running" && run.runId !== runId));
+    updateHistory = { kind: "known", runId: run?.runId ?? null };
+    // Availability may refresh independently. Only the selected outcome owner
+    // can replace a run report or its current read error.
+    snapshot = { ...snapshot, ...status, updateCampaignStatusHydrated: true };
     if (
       run &&
+      !previousOutcome &&
       (!snapshot.updateRun ||
         run.runId === snapshot.updateRun.runId ||
         run.createdAtMs >= snapshot.updateRun.createdAtMs)
     ) {
       applyRun(run);
-    } else if (!snapshot.updateRun) {
-      setCurrentFailure(failure);
-      publish();
     } else {
-      // Schedule refreshes must not replace a run report with a retained sentinel.
-      const runFailure = projectUpdateRunFailure(snapshot.updateRun);
-      snapshot = {
-        ...snapshot,
-        updateStatusBanner: runFailure?.banner ?? null,
-        recordedUpdateAttempt: runFailure?.attempt ?? null,
-      };
+      if (!snapshot.updateRun && !previousOutcome) {
+        setCurrentFailure(failure);
+        snapshot = { ...snapshot, updateStatusBanner, recordedUpdateAttempt };
+      }
       publish();
     }
   };
@@ -307,7 +322,7 @@ export function createApplicationUpdateOverlays(
       publish();
     },
     onStatus: applyUpdateStatusResponse,
-    onError: publishError,
+    onError: (error) => publishError(error, "read"),
   });
   const updateCampaignPoller = createUpdateCampaignStatusPoller({
     canPoll: () =>
@@ -335,6 +350,8 @@ export function createApplicationUpdateOverlays(
       updateReadGeneration++;
       updateStatusRevision++;
       runId = null;
+      updateHistory = { kind: "unknown" };
+      updateAttempt = null;
       updateRequestRunning = false;
       setCurrentFailure(null);
       snapshot = {
@@ -361,6 +378,14 @@ export function createApplicationUpdateOverlays(
     if (connectedSourceChanged) {
       updateFailureReporter.invalidate();
       snapshot = { ...snapshot, updateFailureReportBusy: false };
+      if (
+        updateAttempt?.requestSent &&
+        !runId &&
+        !snapshot.updateRun &&
+        !snapshot.updateStatusBanner
+      ) {
+        snapshot = { ...snapshot, updateStatusBanner: resolveUnknownUpdateOutcomeBanner() };
+      }
       connectedEpoch++;
       updateReadGeneration++;
       updateStatusRevision++;
@@ -417,9 +442,12 @@ export function createApplicationUpdateOverlays(
     },
     synchronizeGateway,
     handleUpdateRunChanged(payload: unknown) {
+      const history = updateAttempt?.history;
       if (
         !isRecord(payload) ||
         typeof payload.runId !== "string" ||
+        (history?.kind === "known" && payload.runId === history.runId) ||
+        (!runId && history?.kind === "unknown" && payload.status !== "running") ||
         typeof payload.updatedAtMs !== "number" ||
         !activeClient ||
         !isCurrentClient(activeClient)
@@ -481,6 +509,13 @@ export function createApplicationUpdateOverlays(
       const sessionKey = options?.sessionKey ?? hooks.getActiveSessionKey?.();
       updateStatusRevision++;
       updateReadGeneration++;
+      const attempt: UpdateAdmissionAttempt = {
+        history: snapshot.updateRun
+          ? { kind: "known", runId: snapshot.updateRun.runId }
+          : updateHistory,
+        requestSent: false,
+      };
+      updateAttempt = attempt;
       runId = null;
       updateRequestRunning = true;
       setCurrentFailure(null);
@@ -502,6 +537,11 @@ export function createApplicationUpdateOverlays(
         const response = await client.request<UpdateRunResponse>(
           "update.run",
           sessionKey ? { sessionKey } : {},
+          {
+            onSent: () => {
+              attempt.requestSent = true;
+            },
+          },
         );
         if (!isCurrent()) {
           return;
@@ -526,9 +566,11 @@ export function createApplicationUpdateOverlays(
       } catch (error) {
         if (isCurrent()) {
           publishError(error);
-          // Admission may have succeeded before the response was lost. Discover
-          // its durable identity now, or in the next connection's bootstrap.
-          await refreshUpdateStatus("completion");
+          // A correlated rejection is the outcome of this request. Only transport
+          // loss after send needs discovery; retained history cannot replace a refusal.
+          if (attempt.requestSent && !(error instanceof GatewayRequestError)) {
+            await refreshUpdateStatus("completion");
+          }
         }
       } finally {
         if (isCurrent()) {

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -787,7 +787,7 @@ describe("application update overlays", () => {
 
     await overlays.runUpdate();
 
-    expect(request).not.toHaveBeenCalledWith("update.run", {});
+    expect(request.mock.calls.filter(([method]) => method === "update.run")).toEqual([]);
     expect(drainConfigWrites).not.toHaveBeenCalled();
     expect(overlays.snapshot.updateRunning).toBe(false);
     overlays.dispose();
@@ -820,9 +820,9 @@ describe("application update overlays", () => {
     ]);
     // Suspension publishes first so no NEW write can start while draining.
     expect(updateRunningWhenDrained).toBe(true);
-    expect(request).toHaveBeenCalledWith("update.run", {
-      sessionKey: "agent:main:originating-chat",
-    });
+    expect(
+      request.mock.calls.filter(([method]) => method === "update.run").map(([, params]) => params),
+    ).toEqual([{ sessionKey: "agent:main:originating-chat" }]);
     overlays.dispose();
   });
 
@@ -852,7 +852,11 @@ describe("application update overlays", () => {
     try {
       await overlays.runUpdate(options);
       const sessionKey = options?.sessionKey ?? activeSessionKey;
-      expect(request).toHaveBeenCalledWith("update.run", sessionKey ? { sessionKey } : {});
+      expect(
+        request.mock.calls
+          .filter(([method]) => method === "update.run")
+          .map(([, params]) => params),
+      ).toEqual([sessionKey ? { sessionKey } : {}]);
       expect(overlays.snapshot.updateRun).toEqual(run);
       expect(overlays.snapshot.updateRunning || overlays.snapshot.updateReconciliationPending).toBe(
         true,

--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -4,8 +4,11 @@ import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
 import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
 import { createUpdateRunFixture } from "../test-helpers/update-run.ts";
+import { flushMicrotasks, type RequestFn } from "./overlays-access.test-support.ts";
+import { createApplicationUpdateOverlays } from "./overlays-updates.ts";
 import { confirmAndStartUpdateRuntime } from "./update-confirmation.runtime.ts";
-import type { UpdateProgress } from "./update-confirmation.ts";
+import { createUpdateProgressWatcher, type UpdateProgress } from "./update-confirmation.ts";
+import { updateRunHarness } from "./update-run.test-support.ts";
 
 /** Drives the dialog the way the shell does: one live lifecycle stream. */
 function createProgressStream(
@@ -426,3 +429,110 @@ it("reports a request the Gateway never accepted instead of spinning forever", a
     vi.useRealTimers();
   }
 });
+
+it.each([
+  { status: "running", entry: "existing" },
+  { status: "failed", entry: "existing" },
+  { status: "succeeded", entry: "existing" },
+  { status: "running", entry: "started" },
+] as const)(
+  "keeps the $status report and exposes read recovery for a $entry run",
+  async ({ status, entry }) => {
+    const run = createUpdateRunFixture({
+      status,
+      phase: status === "running" ? "verifying" : "finished",
+      finishedAtMs: status === "running" ? null : 4_000,
+      reason: status === "failed" ? "build-failed" : null,
+    });
+    let admitted = entry === "existing";
+    let rejectRunReads = false;
+    const request = vi.fn<RequestFn>(async (method) => {
+      if (method === "update.run") {
+        admitted = true;
+        return { runId: run.runId };
+      }
+      if (method === "update.runs.get") {
+        if (rejectRunReads) {
+          throw new Error("Run status read failed");
+        }
+        return { run };
+      }
+      return method === "update.status" && admitted
+        ? { [status === "running" ? "activeRun" : "lastRun"]: run }
+        : {};
+    });
+    const harness = updateRunHarness(request);
+    const listeners = new Set<() => void>();
+    const updates = createApplicationUpdateOverlays(harness.gateway, () =>
+      listeners.forEach((emit) => emit()),
+    );
+    const overlays = {
+      get snapshot() {
+        return updates.snapshot;
+      },
+      subscribe(listener: () => void) {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    };
+    let operation: Promise<void> | undefined;
+    let settled: Promise<void> | undefined;
+    const startGatewayUpdate = vi.fn(() => {
+      operation = updates.runUpdate();
+    });
+    try {
+      await updates.refreshUpdateStatus();
+      settled = confirmAndStartUpdateRuntime({
+        ...(entry === "existing" ? { existingRun: run } : {}),
+        startGatewayUpdate,
+        onCheckStatus: () => updates.refreshUpdateStatus(),
+        watchUpdateProgress: createUpdateProgressWatcher({ gateway: harness.gateway, overlays }),
+        updateAvailable: UPDATE_AVAILABLE,
+        updateSchedule: null,
+        viaNativeApp: false,
+      });
+      const { modal } = await getRenderedModalDialog(document.body);
+      if (entry === "started") {
+        findButton("Update and restart").click();
+        await flushMicrotasks();
+        await operation;
+      }
+      rejectRunReads = true;
+      updates.handleUpdateRunChanged({ ...run, updatedAtMs: run.updatedAtMs + 1 });
+      await flushMicrotasks();
+      expect(updates.snapshot.updateStatusBanner?.text).toContain("Run status read failed");
+      const view = modal.querySelector<
+        HTMLElement & { run: unknown; updateComplete: Promise<boolean> }
+      >("openclaw-update-run-view")!;
+      await view.updateComplete;
+      expect(modal.textContent).toContain("Run status read failed");
+      expect(view.run).toEqual(run);
+      const check = findButton("Check status");
+      expect(check.disabled).toBe(false);
+      if (status === "running") {
+        expect(
+          [...modal.querySelectorAll("button")].some(
+            (button) => button.textContent?.trim() === "Retry update",
+          ),
+        ).toBe(false);
+      }
+      check.click();
+      await flushMicrotasks();
+      expect(modal.textContent).not.toContain("Run status read failed");
+      expect(view.run).toEqual(run);
+      expect(request.mock.calls.filter(([method]) => method === "update.run")).toHaveLength(
+        entry === "started" ? 1 : 0,
+      );
+      expect(startGatewayUpdate).toHaveBeenCalledTimes(entry === "started" ? 1 : 0);
+    } finally {
+      document.body
+        .querySelector("openclaw-modal-dialog")
+        ?.dispatchEvent(new Event("modal-cancel"));
+      await settled;
+      await operation;
+      updates.dispose();
+    }
+  },
+);

--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -5,7 +5,7 @@ import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
 import { getRenderedModalDialog, installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
 import { createUpdateRunFixture } from "../test-helpers/update-run.ts";
 import { flushMicrotasks, type RequestFn } from "./overlays-access.test-support.ts";
-import { createApplicationUpdateOverlays } from "./overlays-updates.ts";
+import { createApplicationOverlays } from "./overlays.ts";
 import { confirmAndStartUpdateRuntime } from "./update-confirmation.runtime.ts";
 import { createUpdateProgressWatcher, type UpdateProgress } from "./update-confirmation.ts";
 import { updateRunHarness } from "./update-run.test-support.ts";
@@ -462,32 +462,17 @@ it.each([
         : {};
     });
     const harness = updateRunHarness(request);
-    const listeners = new Set<() => void>();
-    const updates = createApplicationUpdateOverlays(harness.gateway, () =>
-      listeners.forEach((emit) => emit()),
-    );
-    const overlays = {
-      get snapshot() {
-        return updates.snapshot;
-      },
-      subscribe(listener: () => void) {
-        listeners.add(listener);
-        return () => {
-          listeners.delete(listener);
-        };
-      },
-    };
+    const overlays = createApplicationOverlays(harness.gateway);
     let operation: Promise<void> | undefined;
     let settled: Promise<void> | undefined;
-    const startGatewayUpdate = vi.fn(() => {
-      operation = updates.runUpdate();
-    });
     try {
-      await updates.refreshUpdateStatus();
+      await overlays.refreshUpdateStatus();
       settled = confirmAndStartUpdateRuntime({
         ...(entry === "existing" ? { existingRun: run } : {}),
-        startGatewayUpdate,
-        onCheckStatus: () => updates.refreshUpdateStatus(),
+        startGatewayUpdate: () => {
+          operation = overlays.runUpdate();
+        },
+        onCheckStatus: () => overlays.refreshUpdateStatus(),
         watchUpdateProgress: createUpdateProgressWatcher({ gateway: harness.gateway, overlays }),
         updateAvailable: UPDATE_AVAILABLE,
         updateSchedule: null,
@@ -500,9 +485,8 @@ it.each([
         await operation;
       }
       rejectRunReads = true;
-      updates.handleUpdateRunChanged({ ...run, updatedAtMs: run.updatedAtMs + 1 });
+      harness.emitEvent("update.run.changed", { ...run, updatedAtMs: run.updatedAtMs + 1 });
       await flushMicrotasks();
-      expect(updates.snapshot.updateStatusBanner?.text).toContain("Run status read failed");
       const view = modal.querySelector<
         HTMLElement & { run: unknown; updateComplete: Promise<boolean> }
       >("openclaw-update-run-view")!;
@@ -525,14 +509,13 @@ it.each([
       expect(request.mock.calls.filter(([method]) => method === "update.run")).toHaveLength(
         entry === "started" ? 1 : 0,
       );
-      expect(startGatewayUpdate).toHaveBeenCalledTimes(entry === "started" ? 1 : 0);
     } finally {
       document.body
         .querySelector("openclaw-modal-dialog")
         ?.dispatchEvent(new Event("modal-cancel"));
       await settled;
       await operation;
-      updates.dispose();
+      overlays.dispose();
     }
   },
 );

--- a/ui/src/app/update-confirmation.runtime.ts
+++ b/ui/src/app/update-confirmation.runtime.ts
@@ -27,7 +27,7 @@ const UPDATE_DIALOG_OPEN_CLASS = "update-dialog-open";
 type DialogPhase =
   | { kind: "confirm" }
   | { kind: "working"; connected: boolean }
-  | { kind: "run"; run: UpdateRunRecord; connected: boolean }
+  | { kind: "run"; run: UpdateRunRecord; connected: boolean; readError?: string | null }
   | { kind: "failed"; message: string };
 
 let updateDialogOpen = false;
@@ -145,6 +145,7 @@ export async function confirmAndStartUpdateRuntime(
       }
       const current = phase;
       const run = current.kind === "run" ? current.run : null;
+      const readError = current.kind === "run" ? current.readError : null;
       const working = current.kind === "working" || run?.status === "running";
       const failed =
         current.kind === "failed" ||
@@ -152,7 +153,7 @@ export async function confirmAndStartUpdateRuntime(
       const finished = run !== null && run.status !== "running";
       const body =
         current.kind === "run"
-          ? ""
+          ? (readError ?? "")
           : current.kind === "failed"
             ? current.message
             : current.kind === "working"
@@ -183,8 +184,8 @@ export async function confirmAndStartUpdateRuntime(
               }
               <div class="exec-approval-actions">
                 ${
-                  failed || finished
-                    ? html` ${failed && params.onCheckStatus ? html`<button type="button" class="btn" @click=${() => void params.onCheckStatus?.()}>${t("updates.dialog.checkStatus")}</button>` : nothing}
+                  failed || finished || readError
+                    ? html` ${(failed || readError) && params.onCheckStatus ? html`<button type="button" class="btn" @click=${() => void params.onCheckStatus?.()}>${t("updates.dialog.checkStatus")}</button>` : nothing}
                         ${
                           failed
                             ? html`<button
@@ -280,12 +281,18 @@ export async function confirmAndStartUpdateRuntime(
         }
         if (progress.run && (!staleFailure || progress.run.status === "running")) {
           sawBusy = true;
-          phase = { kind: "run", run: progress.run, connected: progress.connected };
+          phase = {
+            kind: "run",
+            run: progress.run,
+            connected: progress.connected,
+            readError: progress.readError,
+          };
           draw();
           return;
         }
-        if (progress.failure && !staleFailure) {
-          phase = { kind: "failed", message: progress.failure };
+        const failure = progress.failure ?? progress.readError;
+        if (failure && !staleFailure) {
+          phase = { kind: "failed", message: failure };
           draw();
           return;
         }
@@ -308,7 +315,12 @@ export async function confirmAndStartUpdateRuntime(
     if (params.existingRun && params.watchUpdateProgress) {
       watchProgress(params.watchUpdateProgress, (progress) => {
         if (progress.run) {
-          phase = { kind: "run", run: progress.run, connected: progress.connected };
+          phase = {
+            kind: "run",
+            run: progress.run,
+            connected: progress.connected,
+            readError: progress.readError,
+          };
           draw();
         }
       });

--- a/ui/src/app/update-confirmation.ts
+++ b/ui/src/app/update-confirmation.ts
@@ -14,6 +14,8 @@ export type UpdateProgress = {
   connected: boolean;
   /** Set once the update produced a definitive failure. */
   failure: string | null;
+  /** Reading fresh progress failed; the retained run remains authoritative. */
+  readError?: string | null;
 };
 
 // Keep the lazy confirmation entry independent of the application context.
@@ -27,7 +29,7 @@ type UpdateProgressSources = {
       updateRun: UpdateRunRecord | null;
       updateRunning: boolean;
       updateReconciliationPending: boolean;
-      updateStatusBanner: { tone: string; text: string } | null;
+      updateStatusBanner: { tone: string; text: string; source?: "read" } | null;
     };
     subscribe: (listener: () => void) => () => void;
   };
@@ -44,7 +46,8 @@ export function createUpdateProgressWatcher(
         run: update.updateRun,
         busy: update.updateRunning || update.updateReconciliationPending,
         connected: context.gateway.snapshot.phase === "connected",
-        failure: banner && banner.tone !== "info" ? banner.text : null,
+        failure: banner && banner.tone !== "info" && banner.source !== "read" ? banner.text : null,
+        readError: banner?.source === "read" ? banner.text : null,
       });
     };
     const stopOverlays = context.overlays.subscribe(emit);

--- a/ui/src/app/update-overlay-helpers.ts
+++ b/ui/src/app/update-overlay-helpers.ts
@@ -8,6 +8,7 @@ import { formatUiExternalText } from "../lib/format-error.ts";
 import { readUpdateAvailableValue, readUpdateScheduleValue } from "./update-schedule-dto.ts";
 
 export type ApplicationStatusBanner = {
+  source?: "read";
   tone: "danger" | "warn" | "info";
   text: string;
 };

--- a/ui/src/app/update-run-receipts.test.ts
+++ b/ui/src/app/update-run-receipts.test.ts
@@ -74,18 +74,47 @@ describe("update browser receipts", () => {
     expect(reloaded.triaged("ws://gateway.test", null, "1")).toBe(true);
     expect(reloaded.triaged("ws://gateway.test", null, "32")).toBe(true);
   });
-  it("extends the shipped tab receipt object without losing consumed failures on reload", () => {
-    const previous = JSON.stringify(["ws://gateway.test", null, "recorded:1000"]);
-    sessionStorage.setItem(TRIAGED_KEY, JSON.stringify({ triaged: [previous] }));
-    const receipts = createUpdateRunReceipts();
-    expect(receipts.recordTriage("ws://gateway.test", null, "new-run")).toBe(true);
-    expect(JSON.parse(sessionStorage.getItem(TRIAGED_KEY)!)).toEqual({
-      triaged: [previous, JSON.stringify(["ws://gateway.test", null, "new-run"])],
-    });
-    const reloaded = createUpdateRunReceipts();
-    expect(reloaded.triaged("ws://gateway.test", null, "recorded:1000")).toBe(true);
-    expect(reloaded.triaged("ws://gateway.test", null, "new-run")).toBe(true);
-    expect(reloaded.triaged("ws://gateway.test", "other", "new-run")).toBe(false);
-    expect(sessionStorage.getItem("openclaw:control-ui:update-triaged:v1")).toBeNull();
-  });
+  it.each(["2026.9.1", "2026.9.2", "both"])(
+    "preserves consumed failures from %s through reload and the next write",
+    (version) => {
+      const receipt = (run: string) => JSON.stringify(["ws://gateway.test", null, run]);
+      const previous = [];
+      if (version !== "2026.9.2") {
+        sessionStorage.setItem(TRIAGED_KEY, JSON.stringify({ triaged: [receipt("older")] }));
+        previous.push("older");
+      }
+      if (version !== "2026.9.1") {
+        sessionStorage.setItem(
+          "openclaw:control-ui:update-triaged:v1",
+          JSON.stringify([receipt("newer")]),
+        );
+        previous.push("newer");
+      }
+      const receipts = createUpdateRunReceipts();
+      for (const run of previous) {
+        expect(receipts.triaged("ws://gateway.test", null, run)).toBe(true);
+      }
+      expect(receipts.recordTriage("ws://gateway.test", null, "new-run")).toBe(true);
+      expect(JSON.parse(sessionStorage.getItem(TRIAGED_KEY)!)).toEqual({
+        triaged: [...previous, "new-run"].map(receipt),
+      });
+      const reloaded = createUpdateRunReceipts();
+      for (const run of [...previous, "new-run"]) {
+        expect(reloaded.triaged("ws://gateway.test", null, run)).toBe(true);
+      }
+      expect(reloaded.triaged("ws://gateway.test", "other", "new-run")).toBe(false);
+      expect(sessionStorage.getItem("openclaw:control-ui:update-triaged:v1")).toBeNull();
+    },
+  );
+
+  it.each(["not-json", JSON.stringify([42]), "x".repeat(32_768)])(
+    "does not admit triage over unreadable 2026.9.2 receipts (%#)",
+    (raw) => {
+      sessionStorage.setItem("openclaw:control-ui:update-triaged:v1", raw);
+      const receipts = createUpdateRunReceipts();
+      expect(receipts.recordTriage("ws://gateway.test", null, "new-run")).toBe(false);
+      expect(sessionStorage.getItem("openclaw:control-ui:update-triaged:v1")).toBe(raw);
+      expect(sessionStorage.getItem(TRIAGED_KEY)).toBeNull();
+    },
+  );
 });

--- a/ui/src/app/update-run-receipts.test.ts
+++ b/ui/src/app/update-run-receipts.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { createUpdateRunReceipts } from "./update-run-receipts.ts";
 
-const TRIAGED_KEY = "openclaw:control-ui:update-triaged:v1";
+const TRIAGED_KEY = "openclaw:control-ui:update:v1";
 beforeEach(() => {
   vi.stubGlobal("sessionStorage", createStorageMock());
   vi.stubGlobal("localStorage", createStorageMock());
@@ -37,10 +37,10 @@ describe("update browser receipts", () => {
     const storage = createStorageMock();
     storage.setItem(
       TRIAGED_KEY,
-      JSON.stringify([JSON.stringify(["ws://gateway.test", null, "previous"])]),
+      JSON.stringify({ triaged: [JSON.stringify(["ws://gateway.test", null, "previous"])] }),
     );
     if (failure === "invalid receipts") {
-      storage.setItem(TRIAGED_KEY, "false");
+      storage.setItem(TRIAGED_KEY, JSON.stringify({ triaged: false }));
     }
     if (failure === "oversized history") {
       storage.setItem(TRIAGED_KEY, "x".repeat(150_000));
@@ -73,5 +73,19 @@ describe("update browser receipts", () => {
     expect(reloaded.triaged("ws://gateway.test", null, "0")).toBe(false);
     expect(reloaded.triaged("ws://gateway.test", null, "1")).toBe(true);
     expect(reloaded.triaged("ws://gateway.test", null, "32")).toBe(true);
+  });
+  it("extends the shipped tab receipt object without losing consumed failures on reload", () => {
+    const previous = JSON.stringify(["ws://gateway.test", null, "recorded:1000"]);
+    sessionStorage.setItem(TRIAGED_KEY, JSON.stringify({ triaged: [previous] }));
+    const receipts = createUpdateRunReceipts();
+    expect(receipts.recordTriage("ws://gateway.test", null, "new-run")).toBe(true);
+    expect(JSON.parse(sessionStorage.getItem(TRIAGED_KEY)!)).toEqual({
+      triaged: [previous, JSON.stringify(["ws://gateway.test", null, "new-run"])],
+    });
+    const reloaded = createUpdateRunReceipts();
+    expect(reloaded.triaged("ws://gateway.test", null, "recorded:1000")).toBe(true);
+    expect(reloaded.triaged("ws://gateway.test", null, "new-run")).toBe(true);
+    expect(reloaded.triaged("ws://gateway.test", "other", "new-run")).toBe(false);
+    expect(sessionStorage.getItem("openclaw:control-ui:update-triaged:v1")).toBeNull();
   });
 });

--- a/ui/src/app/update-run-receipts.test.ts
+++ b/ui/src/app/update-run-receipts.test.ts
@@ -102,7 +102,6 @@ describe("update browser receipts", () => {
       for (const run of [...previous, "new-run"]) {
         expect(reloaded.triaged("ws://gateway.test", null, run)).toBe(true);
       }
-      expect(reloaded.triaged("ws://gateway.test", "other", "new-run")).toBe(false);
       expect(sessionStorage.getItem("openclaw:control-ui:update-triaged:v1")).toBeNull();
     },
   );

--- a/ui/src/app/update-run-receipts.ts
+++ b/ui/src/app/update-run-receipts.ts
@@ -5,35 +5,42 @@ import { getSafeLocalStorage, getSafeSessionStorage } from "../local-storage.ts"
 // always come from the Gateway ledger, including after a bundle reload.
 type ReceiptKind = "acknowledged" | "triaged";
 const TRIAGED_KEY = "openclaw:control-ui:update:v1";
+const ARRAY_TRIAGED_KEY = "openclaw:control-ui:update-triaged:v1";
 
 export function createUpdateRunReceipts() {
   const acknowledged = getSafeLocalStorage();
   const triaged = getSafeSessionStorage();
   const key = (kind: ReceiptKind) =>
     kind === "triaged" ? TRIAGED_KEY : "openclaw:control-ui:update-acknowledged:v1";
-  const read = (storage: Storage | null, kind: ReceiptKind): string[] | null => {
+  const read = (storage: Storage | null, storageKey: string): string[] | null => {
     try {
-      const raw = storage?.getItem(key(kind));
+      const raw = storage?.getItem(storageKey);
       if (raw === null || raw === undefined) {
         return [];
       }
       // v2026.9.1 shipped tab-scoped triage receipts in this object and size bound.
-      const limit = kind === "triaged" ? 4_096 * 33 : 32_768 - 1;
+      const objectFormat = storageKey === TRIAGED_KEY;
+      const limit = objectFormat ? 4_096 * 33 : 32_768 - 1;
       const saved: unknown = raw.length <= limit ? JSON.parse(raw) : null;
-      const value =
-        kind === "triaged"
-          ? isRecord(saved)
-            ? saved.triaged === undefined
-              ? []
-              : saved.triaged
-            : null
-          : saved;
+      const value = objectFormat
+        ? isRecord(saved)
+          ? saved.triaged === undefined
+            ? []
+            : saved.triaged
+          : null
+        : saved;
       return Array.isArray(value) && value.every((item): item is string => typeof item === "string")
         ? value.slice(-32)
         : null;
     } catch {
       return null;
     }
+  };
+  const readTriage = () => {
+    // Both 2026.9.1's object and 2026.9.2's array are shipped tab receipt formats.
+    const previous = read(triaged, TRIAGED_KEY);
+    const newer = read(triaged, ARRAY_TRIAGED_KEY);
+    return previous && newer ? [...new Set([...previous, ...newer])].slice(-32) : null;
   };
   const id = (gateway: string, profile: string | null, runId: string) =>
     JSON.stringify([gateway, profile, runId]);
@@ -42,7 +49,7 @@ export function createUpdateRunReceipts() {
       if (!storage) {
         return false;
       }
-      const previous = read(storage, kind);
+      const previous = kind === "triaged" ? readTriage() : read(storage, key(kind));
       // Unreadable history must not authorize another automatic diagnostic turn.
       if (!previous) {
         return false;
@@ -52,6 +59,9 @@ export function createUpdateRunReceipts() {
         key(kind),
         JSON.stringify(kind === "triaged" ? { triaged: receipts } : receipts),
       );
+      if (kind === "triaged") {
+        storage.removeItem(ARRAY_TRIAGED_KEY);
+      }
       return true;
     } catch {
       return false;
@@ -59,11 +69,11 @@ export function createUpdateRunReceipts() {
   };
   return {
     acknowledged: (gateway: string, profile: string | null, runId: string) =>
-      (read(acknowledged, "acknowledged") ?? []).includes(id(gateway, profile, runId)),
+      (read(acknowledged, key("acknowledged")) ?? []).includes(id(gateway, profile, runId)),
     acknowledge: (gateway: string, profile: string | null, runId: string) =>
       record(acknowledged, "acknowledged", id(gateway, profile, runId)),
     triaged: (gateway: string, profile: string | null, runId: string) =>
-      (read(triaged, "triaged") ?? []).includes(id(gateway, profile, runId)),
+      (readTriage() ?? []).includes(id(gateway, profile, runId)),
     recordTriage: (gateway: string, profile: string | null, runId: string) =>
       record(triaged, "triaged", id(gateway, profile, runId)),
   };

--- a/ui/src/app/update-run-receipts.ts
+++ b/ui/src/app/update-run-receipts.ts
@@ -1,17 +1,33 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { getSafeLocalStorage, getSafeSessionStorage } from "../local-storage.ts";
 
 // Only browser acknowledgments live here. Run identity, progress and outcomes
 // always come from the Gateway ledger, including after a bundle reload.
+type ReceiptKind = "acknowledged" | "triaged";
+const TRIAGED_KEY = "openclaw:control-ui:update:v1";
+
 export function createUpdateRunReceipts() {
   const acknowledged = getSafeLocalStorage();
   const triaged = getSafeSessionStorage();
-  const read = (storage: Storage | null, key: string): string[] | null => {
+  const key = (kind: ReceiptKind) =>
+    kind === "triaged" ? TRIAGED_KEY : "openclaw:control-ui:update-acknowledged:v1";
+  const read = (storage: Storage | null, kind: ReceiptKind): string[] | null => {
     try {
-      const raw = storage?.getItem(key);
+      const raw = storage?.getItem(key(kind));
       if (raw === null || raw === undefined) {
         return [];
       }
-      const value: unknown = raw.length < 32_768 ? JSON.parse(raw) : null;
+      // v2026.9.1 shipped tab-scoped triage receipts in this object and size bound.
+      const limit = kind === "triaged" ? 4_096 * 33 : 32_768 - 1;
+      const saved: unknown = raw.length <= limit ? JSON.parse(raw) : null;
+      const value =
+        kind === "triaged"
+          ? isRecord(saved)
+            ? saved.triaged === undefined
+              ? []
+              : saved.triaged
+            : null
+          : saved;
       return Array.isArray(value) && value.every((item): item is string => typeof item === "string")
         ? value.slice(-32)
         : null;
@@ -19,20 +35,23 @@ export function createUpdateRunReceipts() {
       return null;
     }
   };
-  const key = (kind: string) => `openclaw:control-ui:update-${kind}:v1`;
   const id = (gateway: string, profile: string | null, runId: string) =>
     JSON.stringify([gateway, profile, runId]);
-  const record = (storage: Storage | null, kind: string, receipt: string) => {
+  const record = (storage: Storage | null, kind: ReceiptKind, receipt: string) => {
     try {
       if (!storage) {
         return false;
       }
-      const previous = read(storage, key(kind));
+      const previous = read(storage, kind);
       // Unreadable history must not authorize another automatic diagnostic turn.
       if (!previous) {
         return false;
       }
-      storage.setItem(key(kind), JSON.stringify([...new Set([...previous, receipt])].slice(-32)));
+      const receipts = [...new Set([...previous, receipt])].slice(-32);
+      storage.setItem(
+        key(kind),
+        JSON.stringify(kind === "triaged" ? { triaged: receipts } : receipts),
+      );
       return true;
     } catch {
       return false;
@@ -40,11 +59,11 @@ export function createUpdateRunReceipts() {
   };
   return {
     acknowledged: (gateway: string, profile: string | null, runId: string) =>
-      (read(acknowledged, key("acknowledged")) ?? []).includes(id(gateway, profile, runId)),
+      (read(acknowledged, "acknowledged") ?? []).includes(id(gateway, profile, runId)),
     acknowledge: (gateway: string, profile: string | null, runId: string) =>
       record(acknowledged, "acknowledged", id(gateway, profile, runId)),
     triaged: (gateway: string, profile: string | null, runId: string) =>
-      (read(triaged, key("triaged")) ?? []).includes(id(gateway, profile, runId)),
+      (read(triaged, "triaged") ?? []).includes(id(gateway, profile, runId)),
     recordTriage: (gateway: string, profile: string | null, runId: string) =>
       record(triaged, "triaged", id(gateway, profile, runId)),
   };

--- a/ui/src/components/sidebar-issue-item.test.ts
+++ b/ui/src/components/sidebar-issue-item.test.ts
@@ -1,11 +1,20 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MentionInboxItem } from "../../../packages/gateway-protocol/src/index.js";
+import { createApplicationOverlays } from "../app/overlays.ts";
+import { updateRunHarness } from "../app/update-run.test-support.ts";
 import { SESSION_NAVIGATION_KEY_PARAM } from "../lib/sessions/route-navigation.ts";
+import { createStorageMock } from "../test-helpers/storage.ts";
+import { createUpdateRunFixture } from "../test-helpers/update-run.ts";
 import type { SidebarAttentionItem } from "./sidebar-attention-entries.ts";
-import { renderSidebarIssueItem, renderSidebarMentionItem } from "./sidebar-issue-item.ts";
+import { resolveSidebarUpdateAttention } from "./sidebar-attention-update.ts";
+import {
+  renderSidebarIssueItem,
+  renderSidebarMentionItem,
+  renderSidebarUpdateSurface,
+} from "./sidebar-issue-item.ts";
 
 const item: SidebarAttentionItem = {
   type: "attention",
@@ -128,4 +137,76 @@ describe("renderSidebarMentionItem", () => {
     expect(context.navigate).toHaveBeenCalledExactlyOnceWith("chat", navigation);
     expect(onClosePanel).toHaveBeenCalledOnce();
   });
+});
+
+describe("renderSidebarUpdateSurface", () => {
+  beforeEach(() => {
+    document.body.append(container);
+    vi.stubGlobal("sessionStorage", createStorageMock());
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+  afterEach(() => {
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+  it.each(["acknowledged", "expired", "visible"] as const)(
+    "dismisses the producer's current notice beside a %s terminal run",
+    async (state) => {
+      const run = createUpdateRunFixture({
+        status: "succeeded",
+        phase: "finished",
+        finishedAtMs: Date.now() - (state === "expired" ? 25 * 60 * 60 * 1_000 : 0),
+      });
+      const harness = updateRunHarness(async () => ({
+        lastRun: run,
+        updateAvailable: { currentVersion: "2.0.0", latestVersion: "3.0.0", channel: "stable" },
+      }));
+      harness.update({
+        hello: {
+          ...harness.gateway.snapshot.hello!,
+          server: { version: "2.0.0", bootId: "fixture-boot" },
+          features: { methods: ["update.run", "update.status"] },
+        },
+      });
+      const overlays = createApplicationOverlays(harness.gateway);
+      const context = { gateway: harness.gateway, overlays };
+      try {
+        await overlays.refreshUpdateStatus();
+        if (state === "acknowledged") {
+          overlays.acknowledgeUpdateRun();
+        }
+        const acknowledge = vi.spyOn(overlays, "acknowledgeUpdateRun");
+        const dismissal = resolveSidebarUpdateAttention(context).dismissal;
+        const expected = {
+          kind: "updateAvailable",
+          signature: JSON.stringify(
+            state === "visible" ? ["run", run.runId] : ["3.0.0", "fixture-boot"],
+          ),
+        };
+        expect(dismissal).toEqual(expected);
+        const dismiss = vi.fn();
+        render(
+          renderSidebarUpdateSurface({
+            context,
+            onDismiss: () => dismiss(dismissal),
+            onNavigate: vi.fn(),
+            visible: true,
+            watchUpdateProgress: undefined,
+          }),
+          container,
+        );
+        const card = container.querySelector<HTMLElement & { updateComplete: Promise<boolean> }>(
+          "openclaw-sidebar-update-card",
+        )!;
+        await card.updateComplete;
+        expect(container.textContent).toContain(state === "visible" ? "OpenClaw updated" : "3.0.0");
+        container.querySelector<HTMLButtonElement>(".sidebar-issues-panel__dismiss")!.click();
+        expect(dismiss).toHaveBeenCalledExactlyOnceWith(expected);
+        expect(acknowledge).not.toHaveBeenCalled();
+      } finally {
+        overlays.dispose();
+      }
+    },
+  );
 });

--- a/ui/src/components/sidebar-issue-item.test.ts
+++ b/ui/src/components/sidebar-issue-item.test.ts
@@ -176,7 +176,6 @@ describe("renderSidebarUpdateSurface", () => {
         if (state === "acknowledged") {
           overlays.acknowledgeUpdateRun();
         }
-        const acknowledge = vi.spyOn(overlays, "acknowledgeUpdateRun");
         const dismissal = resolveSidebarUpdateAttention(context).dismissal;
         const expected = {
           kind: "updateAvailable",
@@ -184,7 +183,6 @@ describe("renderSidebarUpdateSurface", () => {
             state === "visible" ? ["run", run.runId] : ["3.0.0", "fixture-boot"],
           ),
         };
-        expect(dismissal).toEqual(expected);
         const dismiss = vi.fn();
         render(
           renderSidebarUpdateSurface({
@@ -203,7 +201,7 @@ describe("renderSidebarUpdateSurface", () => {
         expect(container.textContent).toContain(state === "visible" ? "OpenClaw updated" : "3.0.0");
         container.querySelector<HTMLButtonElement>(".sidebar-issues-panel__dismiss")!.click();
         expect(dismiss).toHaveBeenCalledExactlyOnceWith(expected);
-        expect(acknowledge).not.toHaveBeenCalled();
+        expect(overlays.snapshot.updateRunAcknowledged).toBe(state === "acknowledged");
       } finally {
         overlays.dispose();
       }

--- a/ui/src/components/sidebar-issue-item.ts
+++ b/ui/src/components/sidebar-issue-item.ts
@@ -173,7 +173,7 @@ export function renderSidebarApprovalItem(params: {
 }
 
 export function renderSidebarUpdateSurface(params: {
-  context: ApplicationContext | undefined;
+  context: Pick<ApplicationContext, "gateway" | "overlays"> | undefined;
   onDismiss?: () => void;
   onNavigate: () => void;
   visible: boolean;
@@ -206,11 +206,7 @@ export function renderSidebarUpdateSurface(params: {
     .refreshRequired=${false}
     .onHoldUpdate=${() => context.overlays.holdUpdate()}
     .onReviewUpdate=${params.onNavigate}
-    .onDismiss=${
-      snapshot.updateRun && snapshot.updateRun.status !== "running"
-        ? () => context.overlays.acknowledgeUpdateRun()
-        : params.onDismiss
-    }
+    .onDismiss=${params.onDismiss}
   ></openclaw-sidebar-update-card>`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Updates could conflate a refused restart with accepted activation that failed health checks, erase staging/validation history during native parking, or let a status-read error obscure the recorded outcome. An already-transferred updater could also be refused during online inspection because its serving Gateway remains an ancestor.

Stage 4 of the #135868 split, concern E: the decision brief's “Restart outcome contract” and “History/notice semantics” (§§1–2; stack order §5). Original work by @steipete. #135868 remains open for the remaining recovery work.

## Why This Change Was Made

The updated installed CLI owns restart execution and its structured outcome. Observe script exit and process cleanup, retain native refusal versus accepted-but-unhealthy results, and preserve the updater's phase when recording service-stop observations. Host-owned notices retain the original session identity and lifecycle fencing after the requesting attempt ends. The before-park callback follows the phase already recorded by the updater and uses main's transferred-helper notice exchange.

Inspection recognizes an already-transferred updater only when canonical metadata and the live lease agree on root, run, handoff owner, current PID and process-start identity. This grants inspection only; native stop and activation retain their existing ownership checks. Main's bounded repair, independent health verification, abort checks and Windows suspension ownership are preserved; callers compare restart success explicitly with `ok`.

The UI preserves recorded outcomes across read failures, distinguishes unavailable history from an empty baseline, and retains both released receipt formats. The shared repair loop has one aggregate tool budget per invocation; automatic admission remains unchanged. Diagnostic triage drops a completed update-run identity.

## User Impact

Operators receive accurate restart results and durable progress/history, can retry status reads without losing the last outcome, and retain dismissed receipts after upgrading. A valid detached updater can validate while its serving Gateway remains online.

## Evidence

Final candidate: `bc696003ea21626b8ac398b0c2c323037632d668`. Local validation: 2,519 passing tests across 108 files, four existing platform skips. Full changed-file gate: passed in full on b7b926ba4d97; the final freshness rebase preserved all 67 changed-file blobs and the lockfile. Final branch review: clean P0–P2 branch review (no accepted/actionable findings). Exact-head CI: [run 34033238320](https://github.com/openclaw/openclaw/actions/runs/34033238320) is green, including Windows.

Counterproof covers restart/history outcomes, disposed-attempt notices, both shipped receipt formats, uncertain cleanup, Git refusal and rollback truthiness. The new helper-inspection regression fails with the observed ancestry refusal when only its two production changes are reverted from a committed checkpoint (one failure, 22 sibling passes); the fix passes all 23 cases. Main's existing internal transferred-notice test reproduced the callback phase mismatch before the one-line correction. New-main fixture migrations retain all repair, cancellation and restoration cases. A stale extracted-runtime export was corrected after 17 lifecycle cases failed, and all 164 lifecycle tests subsequently passed.

The copy-only prerequisite #140004 is merged and ancestry-verified at 6a7ed0668ecbe841a24cff5e291a92e0dee3b719. Both exact-source package builds and tarball inventory/import/integrity checks passed. The isolated launchd trials used the approved local mock provider; no external-provider credential was fetched.

| Trial on `bc696003ea21` | Observed outcome | Stable post-terminal proof | Notices | Updater/helper exit |
| --- | --- | --- | ---: | --- |
| A100 → B101, run `c06785d3-872e-4d60-b2d3-d1758911f067` | Succeeded; validated before native stop; staging and validation retained | 293 healthy B samples over 307.978 seconds | 4, same session | 0 / 0 |
| Cold C102, run `7e880af5-9c50-4625-a312-1be78274f699` | HTTP 500 with empty cache; `global-install-failed`; B's PID, process-start, boot and package/build identity unchanged | 186 healthy B samples over 194.993 seconds | 2, same session | 1 / 1 |

Cold C never entered candidate canary or repair, and caused no stop or restoration. Its `validating` ledger label comes from schema preflight before download. No manual service recovery occurred. Both owned launchd labels were unloaded, the Gateway plist removed, and all three ports independently verified closed after proof.

Fixture qualification: A→B's added controller failed to initialize its timer when an already-healthy B became terminal. After independently confirming over 300 seconds of terminal health, capture was released and the checkpoint completed. The original controller error is preserved; a separate adjudicator verified every product criterion and all four notices. The 2 ms staging receipt was bracketed by healthy samples 84 ms before and 920 ms after, not directly sampled; all 25 package-installation and 50 validating samples retained healthy A. The original rig used sampled health without a sample-in-every-phase requirement. Cold C ran to an automatic PASS with the timer corrected. These are scratch-fixture corrections, with no product changes.

Package SHA-256: A `9a9577faa105b64e52a823eb6b406b087f3add9407e9159c4b98e679b1a1d09a`; B `2a7ebd66f30fcbfa50b43fb9b49d60bdf23c7436ab02006e07e87c10f4262032`. Both embed the full published commit.

The three lead-approved concern-G files (`src/cli/cli-entrypoint.test-support.ts`, `src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts`, `scripts/lib/vitest-worker-build-entries.mts`) came into this stage to keep direct-stop suites inside their existing import deadline. No deadline was increased. Main superseded the earlier native-watch workaround, which is dropped.

ClawSweeper's earlier Git-refusal finding is fixed and regression-tested. Its current-head review has no code or security findings. The remaining packaged-proof/rank-up request is fulfilled above; migration and receipt compatibility are confirmed below. Historical attachment-access limitations do not require a product change: the retained captures and these new synthetic crops were inspected locally.

### Migration / upgrade compatibility proof

Maintainer verification on `bc696003ea21`: no SQLite schema, schema version, migration, stored update-run representation, retention rule, protocol version, dependency, or configuration option changes. The helper inspection reads existing lease ownership; it does not mutate the live lease store. CLI reply outcome discriminants are not persistent database fields. No migration or backfill is required for native history preservation. Both native observations use existing service-stop steps without advancing the phase. Browser upgrade proof retains [v2026.9.1 object receipts](https://github.com/openclaw/openclaw/blob/ad6fe23aecb9b833d68139b0ddc9f239b894d2f1/ui/src/app/update-success-notice.ts#L15) under `openclaw:control-ui:update:v1` and the [v2026.9.2 array receipts](https://github.com/openclaw/openclaw/blob/3928bad9badfcb6c7d140530435e806fb8092190/ui/src/app/update-run-receipts.ts). Tests cover reloads, profile isolation, corrupt-history refusal and migration only after a successful next write.

### Judged LOC

| Class | Added | Deleted | Net | Before → after |
| --- | ---: | ---: | ---: | ---: |
| Production | 371 | 199 | +172 | 11,267 → 11,439 |
| Tests/support | 1,353 | 513 | +840 | 29,934 → 30,774 |
| Tooling | 5 | 1 | +4 | 60 → 64 |
| Docs | 13 | 0 | +13 | 2,555 → 2,568 |

Tests/support fell from +860 to +746 during deslop; the reproduced current-helper ownership bug adds its bounded regression suite. The final test/support delta is +840 (the source branch adds +1,025 on these same paths). Final cleanup removes redundant mock assertions and uses main's extracted verification owner. No single-consumer support file was added. Production growth pays for explicit restart outcomes, host notice ownership, shipped receipt compatibility and exact current-updater inspection. Removed the direct in-process restart fallback, its selector, redundant health setup and detached-only completion assumption. Remaining source-branch automatic admission is excluded, not counted as a deletion.

<details>
<summary>Preserved synthetic UI and earlier packaged proof captures</summary>

The first two captures show the UI behavior. The remaining captures are historical packaged trials before later main changes; the final-candidate result above is authoritative. The copy-lease refusal was repaired separately in #140004.

![Before: status read error has no recovery action (synthetic fixture)](https://github.com/user-attachments/assets/21b9b547-a49f-440d-8d05-dd8a5d9bcc8b)

![After: recorded progress remains visible with Check status (synthetic fixture)](https://github.com/user-attachments/assets/d91c1302-6133-463f-b8e2-bb98a9f8ef64)

![Launchd A to B: durable notices and preserved staging and validation history](https://github.com/user-attachments/assets/892bd995-3f38-4eab-93d3-cb3604efb972)

![Cold-cache C failure: B restored and the original failed outcome retained](https://github.com/user-attachments/assets/82163e71-d124-4636-be8b-510bac630fa9)

![canary-lease-refusal](https://github.com/user-attachments/assets/7a08238f-c97f-4154-83ce-c0e0e9412223)

</details>

![A100 to B101 on bc696003ea21: four durable notices and preserved phases (synthetic)](https://github.com/user-attachments/assets/95da3c62-9d28-48fb-a2a9-cd82f8655667)

![Cold C on bc696003ea21: original failure and service-running outcome retained (synthetic)](https://github.com/user-attachments/assets/67890598-1053-44ec-8c41-ae14bd661f23)