### PR TITLE
refactor(doctor): simplify pristine startup planning

### DIFF
--- a/src/commands/doctor/shared/pristine-startup-state.test.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
-  canSkipPristineStartupStateMigrations,
   planPristineStartupConfigMigrations,
   planPristineStartupStateMigrations,
 } from "./pristine-startup-state.js";
@@ -133,18 +132,20 @@ describe("pristine startup state", () => {
       plugins: { enabled: true, entries: { browser: { enabled: false } } },
     });
 
-    expect(canSkipPristineStartupStateMigrations(env)).toBe(true);
+    expect(planPristineStartupStateMigrations(env).skipAllStateMigrations).toBe(true);
   });
 
   it("rejects existing state and migration-bearing agent config", () => {
-    expect(canSkipPristineStartupStateMigrations(createFixture({}, ["agents"]))).toBe(false);
     expect(
-      canSkipPristineStartupStateMigrations(
+      planPristineStartupStateMigrations(createFixture({}, ["agents"])).skipAllStateMigrations,
+    ).toBe(false);
+    expect(
+      planPristineStartupStateMigrations(
         createFixture({
           memory: { search: { provider: "local" } },
           agents: { defaults: {} },
         }),
-      ),
+      ).skipAllStateMigrations,
     ).toBe(false);
   });
 
@@ -165,7 +166,7 @@ describe("pristine startup state", () => {
       "openai",
     );
 
-    expect(canSkipPristineStartupStateMigrations(env)).toBe(true);
+    expect(planPristineStartupStateMigrations(env).skipAllStateMigrations).toBe(true);
   });
 
   it("accepts canonical internal hook configuration", () => {
@@ -220,7 +221,7 @@ describe("pristine startup state", () => {
       { doctorContract: true },
     );
 
-    expect(canSkipPristineStartupStateMigrations(env)).toBe(false);
+    expect(planPristineStartupStateMigrations(env).skipAllStateMigrations).toBe(false);
   });
 
   it("skips migration discovery for manifest-owned stateless configured plugin paths", () => {
@@ -321,12 +322,13 @@ describe("pristine startup state", () => {
 
   it("rejects enabled plugin entries and includes", () => {
     expect(
-      canSkipPristineStartupStateMigrations(
+      planPristineStartupStateMigrations(
         createFixture({ plugins: { entries: { example: { enabled: true } } } }),
-      ),
+      ).skipAllStateMigrations,
     ).toBe(false);
-    expect(canSkipPristineStartupStateMigrations(createFixture({ $include: "base.json" }))).toBe(
-      false,
-    );
+    expect(
+      planPristineStartupStateMigrations(createFixture({ $include: "base.json" }))
+        .skipAllStateMigrations,
+    ).toBe(false);
   });
 });

--- a/src/commands/doctor/shared/pristine-startup-state.ts
+++ b/src/commands/doctor/shared/pristine-startup-state.ts
@@ -208,25 +208,12 @@ export function planPristineStartupConfigMigrations(
   }
   const skipCoreStateMigrations = configIsPristineCoreStateSafe(config);
   return {
-    skipAllStateMigrations: skipCoreStateMigrations && configIsPristineStateSafe(config, env),
+    skipAllStateMigrations:
+      skipCoreStateMigrations &&
+      hasOnlyMigrationSafePluginEntries(config, env) &&
+      !configMayRequireStartupPluginConvergence({ config: config as OpenClawConfig, env }),
     skipCoreStateMigrations,
   };
-}
-
-function configIsPristineStateSafe(
-  config: Record<string, unknown>,
-  env: NodeJS.ProcessEnv,
-): boolean {
-  if (!configIsPristineCoreStateSafe(config)) {
-    return false;
-  }
-  if (!hasOnlyMigrationSafePluginEntries(config, env)) {
-    return false;
-  }
-  return !configMayRequireStartupPluginConvergence({
-    config: config as OpenClawConfig,
-    env,
-  });
 }
 
 function stateDirHasOnlyConfig(stateDir: string, configPath: string): boolean {
@@ -241,16 +228,9 @@ function stateDirHasOnlyConfig(stateDir: string, configPath: string): boolean {
 }
 
 /**
- * A missing/empty state root plus migration-free bundled config has no legacy data to migrate.
+ * A missing/empty state root can skip core migrations; plugin config may still require work.
  * Keep ambiguity on the full migration path; this shortcut only accepts a proven new install.
  */
-export function canSkipPristineStartupStateMigrations(
-  env: NodeJS.ProcessEnv = process.env,
-): boolean {
-  return planPristineStartupStateMigrations(env).skipAllStateMigrations;
-}
-
-/** Separates provably absent core state from plugin-owned migration work. */
 export function planPristineStartupStateMigrations(
   env: NodeJS.ProcessEnv = process.env,
 ): PristineStartupMigrationPlan {
@@ -276,9 +256,5 @@ export function planPristineStartupStateMigrations(
     return { skipAllStateMigrations: false, skipCoreStateMigrations: false };
   }
   const config = fs.existsSync(configPath) ? tryReadJsonSync(configPath) : {};
-  const configPlan = planPristineStartupConfigMigrations(config, env);
-  return {
-    skipAllStateMigrations: configPlan.skipAllStateMigrations,
-    skipCoreStateMigrations: configPlan.skipCoreStateMigrations,
-  };
+  return planPristineStartupConfigMigrations(config, env);
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Startup migration planning retained a boolean wrapper after Gateway and Doctor moved to the richer two-field plan. Only tests still called the wrapper. The planner also evaluated the same pure core-safety predicate twice and copied its final result without changing it.

## Why This Change Was Made

Keep the existing plan as the single caller-facing result. Remove the unused wrapper, evaluate core safety once, and preserve the short-circuit order of core safety, plugin inspection and convergence detection. Return the fresh config plan directly. Existing tests assert the same decisions through the API used by production.

## User Impact

Migration decisions, physical-state checks and the separate core/plugin ownership remain unchanged. No public command, config option, storage schema, migration or policy changes. Production is **6 added / 30 removed (−24)**; tests **14 added / 12 removed (+2)** across two files.

## Evidence

- The same **20 tests across two files passed before and after**, including real CLI/Doctor child-process flows with synthetic RPC results and isolated state. These preserve first-start decisions, authored config bytes and existing-state behavior.
- Source and history review confirms Gateway and Doctor already consume both plan fields. The removed wrapper has only test callers and is absent from public package exports and Doctor SDK facades; stable `v2026.9.2` has the same arrangement.
- Independent review and three managed P2 passes found no actionable issue. The exact reviewed patch is `cea458ec19c86da131a0833a1ca84fdbdb764bdbbd60c0b50e3dd680094f4454` over `8ffe7768940e9f1d25035d62aa74dd341a7344c1`.
- All **29 canonical changed-check stages passed** after refreshing to `d33686b922398efe01acf18fffdce55599a54f19`, including core and core-test typechecks and all three dead-export scans. The exact reviewed patch, caller/process inputs and owned dependency graph are unchanged. No checks were bypassed or retried. Committed head `4b099423030ce5d8d5f5c0306a8736d1f2ab961d` matches that reviewed and validated patch. [Exact-head CI 34010249194](https://github.com/openclaw/openclaw/actions/runs/34010249194) passed: 107 jobs succeeded, 17 skipped, no failures. Its tested merge is `9a4b73d320d578f4ae6dbbc3e442a3def206a5bf`, parents `4e330557ae33e0f003c8b6e17524acd859b1d0de` and this exact head.

This is a behavior-preserving refactor, not a new migration or a measured startup-speed improvement.

## Compatibility evidence and review disposition

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/139702#issuecomment-5556780936) requests data-model compatibility proof based on the migration-related file classification. Its source findings are empty, and its own release comparison confirms unchanged migration eligibility, defaults and persistent format.

Compatibility is preserved at the actual boundary: both current code and stable `v2026.9.2` return the same fresh `{ skipAllStateMigrations, skipCoreStateMigrations }` plan. The patch retains physical-state checks and the short-circuit order of core safety, plugin inspection and convergence detection. Gateway and Doctor already consume those two booleans; the removed wrapper has only test callers and no public export. Returning the fresh plan directly introduces no shared or persisted object.

No schema, stored representation, data-writing operation, migration implementation or caller policy changes. The same 20 before/after tests include existing-state and stateful-config process cases and assert preservation of authored config bytes. All 29 changed checks and exact-head CI passed. This supplies the requested compatibility evidence for the unchanged contract; no data migration or upgrade procedure is required. The bot's original blocked rendering remains preserved rather than relabeled as a clean review.
