### PR TITLE
refactor(test): reuse Google conversion record guard

### DIFF
--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -1,5 +1,3 @@
-// Google shared conversion tests cover runtime-to-Google payload conversion.
-
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import type { Context, Tool } from "../types.js";
@@ -19,17 +17,6 @@ const convertMessagesForTest = convertMessages as unknown as (
   model: GoogleSharedTestModel,
   context: Context,
 ) => ReturnType<typeof convertMessages>;
-
-function requireRecordProperty(
-  record: Record<string, unknown>,
-  key: string,
-): Record<string, unknown> {
-  const value = record[key];
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`expected object property ${key}`);
-  }
-  return value as Record<string, unknown>;
-}
 
 describe("google-shared convertTools", () => {
   it("keeps Google tool declarations stable across discovery order", () => {
@@ -559,7 +546,7 @@ describe("google-shared convertMessages", () => {
       (part) => typeof part === "object" && part !== null && "functionResponse" in part,
     );
     const toolResponse = assertRecord(toolResponsePart);
-    expect(requireRecordProperty(toolResponse, "functionResponse").name).toBe("myTool");
+    expect(assertRecord(toolResponse.functionResponse).name).toBe("myTool");
     expect(expectDefined(contents[3], "contents[3] test invariant").role).toBe("user");
   });
 
@@ -589,7 +576,7 @@ describe("google-shared convertMessages", () => {
       (part) => typeof part === "object" && part !== null && "functionCall" in part,
     );
     const toolCall = assertRecord(toolCallPart);
-    expect(requireRecordProperty(toolCall, "functionCall").name).toBe("myTool");
+    expect(assertRecord(toolCall.functionCall).name).toBe("myTool");
   });
 
   it("strips tool call and response ids for google-gemini-cli", () => {
@@ -676,7 +663,7 @@ describe("google-shared convertMessages", () => {
     const toolResponsePart = contents[0]?.parts?.find(
       (part) => typeof part === "object" && part !== null && "functionResponse" in part,
     );
-    const toolResponse = requireRecordProperty(assertRecord(toolResponsePart), "functionResponse");
+    const toolResponse = assertRecord(assertRecord(toolResponsePart).functionResponse);
     expect(assertRecord(toolResponse.response).output).toBe(
       '{"type":"json","payload":{"sessionKey":"current","status":"ok"}}',
     );


### PR DESCRIPTION
## What Problem This Solves

The Google conversion tests maintain a second record guard even though the same suite already imports and uses an equivalent shared guard.

## Why This Change Was Made

Use the existing guard at the three nested-property reads and remove the duplicate helper. Missing, null, primitive and array values still fail; valid records retain their identity. The function-name and response assertions introduced by the earlier test hardening stay intact.

## User Impact

No runtime or API behavior changes. This removes 13 test lines while preserving the conversion, ordering, signature and tool-response coverage.

## Evidence

The full conversion suite passed all 36 expanded cases before and after, with identical native case names and results. All 59 assertion sites remain. Formatting and the independent review through P2 passed.

The normal 19-stage changed gate passed, including the compiler-selected packages test graph, dead-export scans and lint. Testbox [run 34009967764](https://github.com/openclaw/openclaw/actions/runs/34009967764) completed its command successfully; the one-shot lease and temporary source capsule were cleaned up. No live Google API call was needed for this test-only refactor.
