### PR TITLE
fix(update): stop stale beta plugins from looping gateway startup

### DIFF
--- a/config/env-var-count-budget.txt
+++ b/config/env-var-count-budget.txt
@@ -3,4 +3,4 @@
 # Worker bundle installation no longer injects OPENCLAW_STATE_DIR into a remote npm process.
 # The internal Node-version check no longer contributes a false OPENCLAW_* name.
 # The next-turn runtime-context preface constant no longer exists as an OPENCLAW_* name.
-498
+496

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -562,22 +562,25 @@ the sentinel.
 
 ### Plugin sync details
 
-After a beta core update, eligible official npm and trusted official ClawHub
-plugins with a default/latest catalog target try the exact installed core
-version. This also applies to a one-off `--tag <beta-version>` while the
-configured channel is stable, including when plugin synchronization resumes
-in a fresh process. Other default-line npm and ClawHub plugins on the beta
-channel try their plugin `@beta` tag.
+Managed npm plugins on the beta channel select the newest version by semantic
+version order from their `beta` and `latest` dist-tags, using the same policy as
+the core updater. This includes official plugins with a default/latest catalog
+target and managed `@beta` selectors. OpenClaw installs the exact inspected
+version and retains the recorded selector for future updates.
 
-If the selected beta plugin release is unavailable, OpenClaw falls back to the
-default/latest spec and reports a warning naming the requested and used targets.
+ClawHub plugins on the beta channel try their own `@beta` tag. If that release
+is unavailable, OpenClaw falls back to the default/latest spec and reports a
+warning naming the requested and used targets.
 Integrity, compatibility, trust, install-policy, and capability-consent failures
 do not trigger fallback. Availability fallback warnings do not fail the core
-update. Ordinary exact versions and explicit non-`latest` tags retain their selector.
+update. Ordinary exact versions, ranges, and explicit tags other than `beta`
+retain their selector.
 Doctor can refresh a stale official runtime plugin that is bound to the current
 OpenClaw release cohort. That repair stays on the recorded registry, verifies
 the replacement artifact, and records its exact version if the npm install was
 previously pinned.
+Already-current runtime plugins are kept in place; a no-op startup repair does
+not reinstall the package or invalidate the migration checkpoint.
 
 <Warning>
 If an exact pinned npm plugin update resolves to an artifact whose integrity differs from the stored install record, `openclaw update` aborts that plugin artifact update instead of installing it. Reinstall or update the plugin explicitly only after verifying you trust the new artifact.

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -16,8 +16,8 @@ OpenClaw ships four update channels:
   foreground-only. It receives read-only update hints when `update.checkOnStart`
   is enabled, including direct final extended-stable package installs, but never
   applies automatically.
-- **beta**: npm dist-tag `beta`. Falls back to `latest` when `beta` is missing
-  or older than the current stable release.
+- **beta**: the newest version by semantic version order from the npm `beta`
+  and `latest` dist-tags. An older beta tag never replaces a newer stable release.
 - **dev**: moving head of `main` (git), including when switching from a package install. `main`
   is for experimentation and active development; it may contain incomplete
   features or breaking changes. Do not run it for production gateways.
@@ -134,6 +134,10 @@ Switching channels with `openclaw update` also syncs plugin sources:
   the base release cohort for correction versions (for example, `YYYY.M.P-2`
   uses plugin `YYYY.M.P`).
 - npm-installed plugins are updated after the core update completes.
+- `beta` uses the same newest-of-`beta`/`latest` rule for managed npm plugins,
+  including official plugins such as `@openclaw/codex`. Exact version and range
+  pins retain their selector. Startup repair keeps an already-current plugin
+  instead of reinstalling it and requiring another restart.
 
 ## Checking current status
 

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -38,9 +38,8 @@ openclaw update --dry-run   # preview without applying
 `--dry-run` to preview planned actions, `--json` for structured results, or
 `openclaw update status --json` to inspect channel and availability state.
 
-`--channel beta` prefers the beta npm dist-tag, but falls back to stable/latest
-when the beta tag is missing or its version is older than the latest stable
-release. Use `--tag beta` for a one-off package update pinned to the raw npm
+`--channel beta` selects the newest version by semantic version order from the
+beta and latest npm dist-tags. Use `--tag beta` for a one-off package update pinned to the raw npm
 beta dist-tag instead.
 
 A saved `update.channel` remains the channel for future updates, automatic
@@ -79,11 +78,11 @@ not a self-contained package artifact. Use `openclaw update --channel dev` to
 switch to the supported checkout and build flow. Other explicit package specs
 keep their package-manager behavior.
 
-After a beta core update, eligible official npm plugins follow the exact installed
-beta version, including one-off `--tag` updates from a stable installation.
-For managed plugins, a missing beta release is a warning, not a failure: the
-core update can still succeed while a plugin falls back to its recorded
-default/latest release.
+Managed npm plugins on the beta channel use the same newest-of-beta/latest
+selection, including official plugins such as `@openclaw/codex`. An older beta
+tag cannot hold a plugin behind the current stable release. Startup repair
+leaves already-current packages in place so a no-op refresh does not require
+another restart.
 
 See [Release channels](/install/development-channels) for channel semantics.
 

--- a/src/auto-reply/reply/commands-plugins.install-clawhub-spec.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install-clawhub-spec.test.ts
@@ -17,6 +17,7 @@ const {
   installPluginFromClawHubMock,
   installPluginFromGitSpecMock,
   persistPluginInstallMock,
+  resolveNpmSpecMetadataMock,
 } = vi.hoisted(() => ({
   installPluginFromNpmPackArchiveMock: vi.fn(),
   installPluginFromNpmSpecMock: vi.fn(),
@@ -24,6 +25,12 @@ const {
   installPluginFromClawHubMock: vi.fn(),
   installPluginFromGitSpecMock: vi.fn(),
   persistPluginInstallMock: vi.fn(),
+  resolveNpmSpecMetadataMock: vi.fn(),
+}));
+
+vi.mock("../../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata: resolveNpmSpecMetadataMock,
 }));
 
 vi.mock("../../plugins/install.js", async (importOriginal) => ({
@@ -147,27 +154,49 @@ describe("chat plugin install release stream", () => {
   afterEach(async () => {
     installPluginFromNpmSpecMock.mockReset();
     persistPluginInstallMock.mockReset();
+    resolveNpmSpecMetadataMock.mockReset();
     await workspaceHarness.cleanupWorkspaces();
   });
 
-  it.each([false, true])(
-    "keeps beta artifact selection with capability acceptance %s",
-    async (acceptCapabilities) => {
+  it.each(
+    [
+      { beta: "2026.9.1-beta.1", selected: "2026.9.2" },
+      { beta: "2026.9.3-beta.1", selected: "2026.9.3-beta.1" },
+    ].flatMap((release) =>
+      [false, true].map((acceptCapabilities) => ({
+        beta: release.beta,
+        selected: release.selected,
+        acceptCapabilities,
+      })),
+    ),
+  )(
+    "selects $selected with capability acceptance $acceptCapabilities (beta=$beta)",
+    async ({ beta, selected, acceptCapabilities }) => {
       const cfg: OpenClawConfig = {
         commands: { text: true, plugins: true },
         plugins: { enabled: true },
         update: { channel: "beta" },
       };
+      for (const version of [beta, "2026.9.2"]) {
+        resolveNpmSpecMetadataMock.mockResolvedValueOnce({
+          ok: true,
+          metadata: {
+            name: "@openclaw/brave-plugin",
+            version,
+            resolvedSpec: `@openclaw/brave-plugin@${version}`,
+          },
+        });
+      }
       installPluginFromNpmSpecMock.mockResolvedValue({
         ok: true,
         pluginId: "brave",
         targetDir: "/tmp/brave",
-        version: "1.0.0",
+        version: selected,
         extensions: ["index.js"],
         npmResolution: {
           name: "@openclaw/brave-plugin",
-          version: "1.0.0",
-          resolvedSpec: "@openclaw/brave-plugin@1.0.0",
+          version: selected,
+          resolvedSpec: `@openclaw/brave-plugin@${selected}`,
         },
       });
       persistPluginInstallMock.mockResolvedValue({});
@@ -189,16 +218,22 @@ describe("chat plugin install release stream", () => {
         const result = await handlePluginsCommand(params, true);
 
         expect(mockFirstObjectArg(installPluginFromNpmSpecMock).spec).toBe(
-          "@openclaw/brave-plugin@beta",
+          `@openclaw/brave-plugin@${selected}`,
         );
+        expect(installPluginFromNpmSpecMock).toHaveBeenCalledOnce();
         if (acceptCapabilities) {
           expect(persistPluginInstallMock).toHaveBeenCalledWith(
             expect.objectContaining({
-              install: expect.objectContaining({ acceptedSurfaceHash: expect.any(String) }),
+              install: expect.objectContaining({
+                spec: "@openclaw/brave-plugin",
+                version: selected,
+                acceptedSurfaceHash: expect.any(String),
+              }),
             }),
           );
         } else {
           expect(result?.reply?.text).toContain("Plugin capabilities require approval");
+          expect(result?.reply?.text).toContain(`@openclaw/brave-plugin@${selected}`);
           expect(persistPluginInstallMock).not.toHaveBeenCalled();
         }
       });

--- a/src/auto-reply/reply/commands-plugins.install.test.ts
+++ b/src/auto-reply/reply/commands-plugins.install.test.ts
@@ -26,6 +26,7 @@ const {
   installPluginFromClawHubMock,
   installPluginFromGitSpecMock,
   persistPluginInstallMock,
+  resolveNpmSpecMetadataMock,
 } = vi.hoisted(() => ({
   installPluginFromNpmPackArchiveMock: vi.fn(),
   installPluginFromNpmSpecMock: vi.fn(),
@@ -33,6 +34,12 @@ const {
   installPluginFromClawHubMock: vi.fn(),
   installPluginFromGitSpecMock: vi.fn(),
   persistPluginInstallMock: vi.fn(),
+  resolveNpmSpecMetadataMock: vi.fn(),
+}));
+
+vi.mock("../../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata: resolveNpmSpecMetadataMock,
 }));
 
 vi.mock("../../plugins/install.js", async (importOriginal) => ({
@@ -71,6 +78,26 @@ vi.mock("../../plugins/install-persistence.js", async (importOriginal) => ({
 
 const workspaceHarness = createCommandWorkspaceHarness("openclaw-command-plugins-install-");
 
+function createInstallPolicyConfig(): OpenClawConfig {
+  return {
+    commands: { text: true, plugins: true },
+    plugins: { enabled: true },
+    security: {
+      installPolicy: {
+        enabled: true,
+        exec: { source: "exec", command: process.execPath, args: ["-e", "process.exit(1)"] },
+      },
+    },
+  };
+}
+
+async function writeConfigFixture(home: string, config: unknown): Promise<void> {
+  await fs.writeFile(
+    path.join(home, ".openclaw", "openclaw.json"),
+    `${JSON.stringify(config, null, 2)}\n`,
+  );
+}
+
 function mockNpmPluginInstall(pluginId: string, packageName: string, version = "1.0.0"): void {
   installPluginFromNpmSpecMock.mockResolvedValue({
     ok: true,
@@ -81,6 +108,23 @@ function mockNpmPluginInstall(pluginId: string, packageName: string, version = "
     npmResolution: { name: packageName, version, resolvedSpec: `${packageName}@${version}` },
   });
   persistPluginInstallMock.mockResolvedValue({});
+}
+
+function mockNpmChannelMetadata(packageName: string, beta: string, latest: string): void {
+  const versions = new Map([
+    [`${packageName}@beta`, beta],
+    [`${packageName}@latest`, latest],
+  ]);
+  resolveNpmSpecMetadataMock.mockImplementation(async ({ spec }: { spec: string }) => {
+    const version = versions.get(spec);
+    if (!version) {
+      throw new Error(`Unexpected registry spec: ${spec}`);
+    }
+    return {
+      ok: true,
+      metadata: { name: packageName, version, resolvedSpec: `${packageName}@${version}` },
+    };
+  });
 }
 
 function buildPluginsParams(
@@ -129,9 +173,12 @@ function expectPersistedInstall(pluginId: string, expectedInstall: Record<string
 }
 
 function expectNonClawHubChatInstallRejected(
-  result: NonNullable<Awaited<ReturnType<typeof handlePluginsCommand>>>,
+  result: Awaited<ReturnType<typeof handlePluginsCommand>>,
   expectedSource: string,
 ): void {
+  if (result === null) {
+    throw new Error("expected plugin install result");
+  }
   expect(result.shouldContinue).toBe(false);
   expect(result.reply?.text).toContain(expectedSource);
   expect(result.reply?.text).toContain("outside ClawHub review");
@@ -154,6 +201,7 @@ describe("handleCommands /plugins install", () => {
     installPluginFromClawHubMock.mockReset();
     installPluginFromGitSpecMock.mockReset();
     persistPluginInstallMock.mockReset();
+    resolveNpmSpecMetadataMock.mockReset();
     await workspaceHarness.cleanupWorkspaces();
   });
 
@@ -164,9 +212,6 @@ describe("handleCommands /plugins install", () => {
 
       const result = await handlePluginsCommand(params, true);
 
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(
         result,
         "Installing plugin from npm registry: @acme/policy-plugin@1.0.0",
@@ -175,27 +220,11 @@ describe("handleCommands /plugins install", () => {
   });
 
   it("installs an arbitrary npm package after a trailing --force acknowledgement", async () => {
-    const policyConfig: OpenClawConfig = {
-      commands: { text: true, plugins: true },
-      plugins: { enabled: true },
-      security: {
-        installPolicy: {
-          enabled: true,
-          exec: {
-            source: "exec",
-            command: process.execPath,
-            args: ["-e", "process.exit(1)"],
-          },
-        },
-      },
-    };
+    const policyConfig = createInstallPolicyConfig();
     mockNpmPluginInstall("policy-plugin", "@acme/policy-plugin");
 
     await withTempHome("openclaw-command-plugins-home-", async (home) => {
-      await fs.writeFile(
-        path.join(home, ".openclaw", "openclaw.json"),
-        `${JSON.stringify(policyConfig, null, 2)}\n`,
-      );
+      await writeConfigFixture(home, policyConfig);
       const workspaceDir = await workspaceHarness.createWorkspace();
       const params = buildPluginsParams(
         "/plugins install @acme/policy-plugin@1.0.0 --force --accept-capabilities",
@@ -233,89 +262,93 @@ describe("handleCommands /plugins install", () => {
   });
 
   it.each([
-    { version: "2026.8.1", installSpec: "@openclaw/brave-plugin" },
-    { version: "2026.8.1-beta.4", installSpec: "@openclaw/brave-plugin@2026.8.1-beta.4" },
-  ])("allows official catalog npm installs on core $version", async ({ version, installSpec }) => {
-    coreVersion.value = version;
-    const policyConfig: OpenClawConfig = {
-      commands: { text: true, plugins: true },
-      plugins: { enabled: true },
-      security: {
-        installPolicy: {
-          enabled: true,
-          exec: {
-            source: "exec",
-            command: process.execPath,
-            args: ["-e", "process.exit(1)"],
+    { version: "2026.8.1", installSpec: "@openclaw/brave-plugin", installVersion: "1.0.0" },
+    {
+      version: "2026.8.1-beta.4",
+      installSpec: "@openclaw/brave-plugin@2026.9.2",
+      installVersion: "2026.9.2",
+    },
+  ])(
+    "allows official catalog npm installs on core $version",
+    async ({ version, installSpec, installVersion }) => {
+      coreVersion.value = version;
+      if (version.includes("beta")) {
+        mockNpmChannelMetadata("@openclaw/brave-plugin", "2026.9.1-beta.1", "2026.9.2");
+      }
+      const policyConfig = createInstallPolicyConfig();
+      mockNpmPluginInstall("brave", "@openclaw/brave-plugin", installVersion);
+
+      await withTempHome("openclaw-command-plugins-home-", async (home) => {
+        await writeConfigFixture(home, policyConfig);
+        const workspaceDir = await workspaceHarness.createWorkspace();
+        const params = buildPluginsParams(
+          "/plugins install npm:@openclaw/brave-plugin --accept-capabilities",
+          workspaceDir,
+          { cfg: policyConfig },
+        );
+
+        const result = await handlePluginsCommand(params, true);
+
+        expect(result?.reply?.text).toContain('Installed plugin "brave"');
+        expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
+          spec: installSpec,
+          config: {
+            ...policyConfig,
+            agents: { entries: { main: {} } },
           },
-        },
-      },
-    };
-    mockNpmPluginInstall("brave", "@openclaw/brave-plugin");
-
-    await withTempHome("openclaw-command-plugins-home-", async (home) => {
-      await fs.writeFile(
-        path.join(home, ".openclaw", "openclaw.json"),
-        `${JSON.stringify(policyConfig, null, 2)}\n`,
-      );
-      const workspaceDir = await workspaceHarness.createWorkspace();
-      const params = buildPluginsParams(
-        "/plugins install npm:@openclaw/brave-plugin --accept-capabilities",
-        workspaceDir,
-        { cfg: policyConfig },
-      );
-
-      const result = await handlePluginsCommand(params, true);
-
-      expect(result?.reply?.text).toContain('Installed plugin "brave"');
-      expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
-        spec: installSpec,
-        config: {
-          ...policyConfig,
-          agents: { entries: { main: {} } },
-        },
-        expectedPluginId: "brave",
-        trustedSourceLinkedOfficialInstall: true,
+          expectedPluginId: "brave",
+          trustedSourceLinkedOfficialInstall: true,
+        });
+        expectPersistedInstall("brave", {
+          source: "npm",
+          spec: "@openclaw/brave-plugin",
+          installPath: "/tmp/brave",
+          version: installVersion,
+        });
       });
-      expectPersistedInstall("brave", {
-        source: "npm",
-        spec: "@openclaw/brave-plugin",
-        installPath: "/tmp/brave",
-        version: "1.0.0",
-      });
-    });
-  });
+    },
+  );
 
   it.each([
-    { version: "2026.8.1", installSpec: "@openclaw/discord" },
-    { version: "2026.8.1-beta.4", installSpec: "@openclaw/discord@2026.8.1-beta.4" },
-  ])("allows bundled-manifest npm installs on core $version", async ({ version, installSpec }) => {
-    coreVersion.value = version;
-    mockNpmPluginInstall("discord", "@openclaw/discord");
+    { version: "2026.8.1", installSpec: "@openclaw/discord", installVersion: "1.0.0" },
+    {
+      version: "2026.8.1-beta.4",
+      installSpec: "@openclaw/discord@2026.9.3-beta.1",
+      installVersion: "2026.9.3-beta.1",
+    },
+  ])(
+    "allows bundled-manifest npm installs on core $version",
+    async ({ version, installSpec, installVersion }) => {
+      coreVersion.value = version;
+      if (version.includes("beta")) {
+        mockNpmChannelMetadata("@openclaw/discord", "2026.9.3-beta.1", "2026.9.2");
+      }
+      mockNpmPluginInstall("discord", "@openclaw/discord", installVersion);
 
-    await withTempHome("openclaw-command-plugins-home-", async () => {
-      const workspaceDir = await workspaceHarness.createWorkspace();
-      const params = buildPluginsParams(
-        "/plugins install npm:@openclaw/discord --accept-capabilities",
-        workspaceDir,
-      );
+      await withTempHome("openclaw-command-plugins-home-", async () => {
+        const workspaceDir = await workspaceHarness.createWorkspace();
+        const params = buildPluginsParams(
+          "/plugins install npm:@openclaw/discord --accept-capabilities",
+          workspaceDir,
+        );
 
-      const result = await handlePluginsCommand(params, true);
+        const result = await handlePluginsCommand(params, true);
 
-      expect(result?.reply?.text).toContain('Installed plugin "discord"');
-      expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
-        spec: installSpec,
-        expectedPluginId: "discord",
-        trustedSourceLinkedOfficialInstall: true,
+        expect(result?.reply?.text).toContain('Installed plugin "discord"');
+        expectObjectFields(mockFirstObjectArg(installPluginFromNpmSpecMock), {
+          spec: installSpec,
+          expectedPluginId: "discord",
+          trustedSourceLinkedOfficialInstall: true,
+        });
+        expectPersistedInstall("discord", {
+          source: "npm",
+          spec: "@openclaw/discord",
+          installPath: "/tmp/discord",
+          version: installVersion,
+        });
       });
-      expectPersistedInstall("discord", {
-        source: "npm",
-        spec: "@openclaw/discord",
-        installPath: "/tmp/discord",
-        version: "1.0.0",
-      });
-    });
-  });
+    },
+  );
 
   it("installs bare bundled plugin ids from the bundled source without --force", async () => {
     persistPluginInstallMock.mockResolvedValue({});
@@ -373,9 +406,6 @@ describe("handleCommands /plugins install", () => {
 
       const result = await handlePluginsCommand(params, true);
 
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(result, "Installing plugin from npm registry: npm:brave");
     });
   });
@@ -386,9 +416,6 @@ describe("handleCommands /plugins install", () => {
       const params = buildPluginsParams("/plugins install npm-pack:/tmp/demo.tgz", workspaceDir);
 
       const result = await handlePluginsCommand(params, true);
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(
         result,
         "Installing plugin from local npm-pack archive: npm-pack:/tmp/demo.tgz",
@@ -454,9 +481,6 @@ describe("handleCommands /plugins install", () => {
 
       const params = buildPluginsParams(`/plugins install ${pluginDir}`, workspaceDir);
       const result = await handlePluginsCommand(params, true);
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(
         result,
         `Installing plugin from local path: ${pluginDir}`,
@@ -546,9 +570,6 @@ describe("handleCommands /plugins install", () => {
 
       const params = buildPluginsParams(`/plugins install ${pluginArchive}`, workspaceDir);
       const result = await handlePluginsCommand(params, true);
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(
         result,
         `Installing plugin from local archive: ${pluginArchive}`,
@@ -633,9 +654,6 @@ describe("handleCommands /plugins install", () => {
       const result = await handlePluginsCommand(params, true);
 
       expect(result?.shouldContinue).toBe(false);
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(
         result,
         `Installing plugin from local path: ${pluginDir}`,
@@ -885,10 +903,7 @@ describe("handleCommands /plugins install", () => {
     await withTempHome("openclaw-command-plugins-home-", async (home) => {
       const sharedConfigPath = path.join(home, ".openclaw", "shared.json5");
       await fs.writeFile(sharedConfigPath, `${JSON.stringify({ plugins: {} }, null, 2)}\n`);
-      await fs.writeFile(
-        path.join(home, ".openclaw", "openclaw.json"),
-        `${JSON.stringify({ $include: "./shared.json5" }, null, 2)}\n`,
-      );
+      await writeConfigFixture(home, { $include: "./shared.json5" });
       const workspaceDir = await workspaceHarness.createWorkspace();
       const params = buildPluginsParams("/plugins install @acme/demo", workspaceDir);
 
@@ -914,9 +929,6 @@ describe("handleCommands /plugins install", () => {
         workspaceDir,
       );
       const result = await handlePluginsCommand(params, true);
-      if (result === null) {
-        throw new Error("expected plugin install result");
-      }
       expectNonClawHubChatInstallRejected(result, "git:github.com/acme/git-demo@v1.2.3");
     });
   });
@@ -1026,13 +1038,24 @@ describe("handleCommands /plugins install", () => {
   });
 
   it.each([
-    { version: "2026.8.1", installSpec: "@wecom/wecom-openclaw-plugin@latest" },
-    { version: "2026.8.1-beta.4", installSpec: "@wecom/wecom-openclaw-plugin@2026.8.1-beta.4" },
+    {
+      version: "2026.8.1",
+      installSpec: "@wecom/wecom-openclaw-plugin@latest",
+      installVersion: "2026.7.2",
+    },
+    {
+      version: "2026.8.1-beta.4",
+      installSpec: "@wecom/wecom-openclaw-plugin@2026.9.2",
+      installVersion: "2026.9.2",
+    },
   ])(
     "allows catalog npm @latest chat installs on core $version",
-    async ({ version, installSpec }) => {
+    async ({ version, installSpec, installVersion }) => {
       coreVersion.value = version;
-      mockNpmPluginInstall("wecom-openclaw-plugin", "@wecom/wecom-openclaw-plugin", "2026.7.2");
+      if (version.includes("beta")) {
+        mockNpmChannelMetadata("@wecom/wecom-openclaw-plugin", "2026.9.1-beta.1", "2026.9.2");
+      }
+      mockNpmPluginInstall("wecom-openclaw-plugin", "@wecom/wecom-openclaw-plugin", installVersion);
 
       await withTempHome("openclaw-command-plugins-home-", async () => {
         const workspaceDir = await workspaceHarness.createWorkspace();
@@ -1055,9 +1078,9 @@ describe("handleCommands /plugins install", () => {
           source: "npm",
           spec: "@wecom/wecom-openclaw-plugin@latest",
           installPath: "/tmp/wecom-openclaw-plugin",
-          version: "2026.7.2",
+          version: installVersion,
           resolvedName: "@wecom/wecom-openclaw-plugin",
-          resolvedVersion: "2026.7.2",
+          resolvedVersion: installVersion,
         });
       });
     },

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -17,7 +17,6 @@ import {
 import * as slotSelection from "../plugins/slot-selection.js";
 import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
-import { VERSION } from "../version.js";
 import {
   applyExclusiveSlotSelectionMock,
   clearPluginRegistryLoadCacheMock,
@@ -52,6 +51,13 @@ import { runPluginInstallCommand } from "./plugins-install-command.js";
 
 // Default-selector assertions describe a stable build; beta cases set their own identity.
 const coreVersion = vi.hoisted(() => ({ value: "2026.8.1" }));
+const resolveNpmSpecMetadataMock = vi.hoisted(() =>
+  vi.fn<typeof import("../infra/install-source-utils.js").resolveNpmSpecMetadata>(),
+);
+vi.mock("../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata: resolveNpmSpecMetadataMock,
+}));
 vi.mock("../version.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../version.js")>()),
   get VERSION() {
@@ -66,8 +72,16 @@ const ORIGINAL_STDIN_TTY = Object.getOwnPropertyDescriptor(process.stdin, "isTTY
 const ORIGINAL_STDOUT_TTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 const PROFILE_STATE_ROOT = "/tmp/openclaw-ledger-profile";
 
-function expectedNpmInstallSpec(spec: string): string {
-  return VERSION.includes("-beta.") ? `${spec.replace(/@latest$/, "")}@${VERSION}` : spec;
+function mockNpmChannelMetadata(name: string, beta?: string, latest?: string): void {
+  resolveNpmSpecMetadataMock.mockImplementation(async ({ spec }) => {
+    if (spec !== `${name}@beta` && spec !== `${name}@latest`) {
+      throw new Error(`Unexpected npm metadata request: ${spec}`);
+    }
+    const version = spec === `${name}@beta` ? beta : latest;
+    return version
+      ? { ok: true, metadata: { name, version, resolvedSpec: `${name}@${version}` } }
+      : { ok: false, error: `Package not found on npm: ${spec}` };
+  });
 }
 
 const OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY = listOfficialExternalPluginCatalogEntries()
@@ -610,6 +624,9 @@ function primeBlockedHookConfigMutation(config = {} as OpenClawConfig): void {
 describe("plugins cli install", () => {
   beforeEach(() => {
     resetPluginsCliTestState();
+    resolveNpmSpecMetadataMock.mockReset().mockImplementation(async ({ spec }) => {
+      throw new Error(`Unexpected npm metadata request: ${spec}`);
+    });
   });
 
   afterEach(() => {
@@ -2053,21 +2070,73 @@ describe("plugins cli install", () => {
 
   it.each(
     [
-      { version: "2026.8.1", channel: "beta", installSelector: "beta" },
-      { version: "2026.8.1-beta.4", channel: undefined, installSelector: "2026.8.1-beta.4" },
-      { version: "2026.8.1-beta.4", channel: "stable", installSelector: "2026.8.1-beta.4" },
-      { version: "2026.7.33", channel: "extended-stable", installSelector: "2026.7.33" },
-    ].flatMap(({ version, channel, installSelector }) =>
+      {
+        version: "2026.8.1",
+        channel: "beta",
+        beta: "2026.8.2-beta.1",
+        latest: "2026.8.1",
+        installSelector: "2026.8.2-beta.1",
+      },
+      {
+        version: "2026.8.1",
+        channel: "beta",
+        beta: "2026.8.1-beta.4",
+        latest: "2026.8.1",
+        installSelector: "2026.8.1",
+      },
+      {
+        version: "2026.8.1",
+        channel: "beta",
+        beta: undefined,
+        latest: "2026.8.1",
+        installSelector: "2026.8.1",
+      },
+      {
+        version: "2026.8.1-beta.4",
+        channel: undefined,
+        beta: "2026.8.2-beta.1",
+        latest: "2026.8.1",
+        installSelector: "2026.8.2-beta.1",
+      },
+      {
+        version: "2026.8.1-beta.4",
+        channel: "stable",
+        beta: "2026.8.2-beta.1",
+        latest: "2026.8.1",
+        installSelector: "2026.8.2-beta.1",
+      },
+      {
+        version: "2026.7.33",
+        channel: "extended-stable",
+        beta: undefined,
+        latest: undefined,
+        installSelector: "2026.7.33",
+      },
+      {
+        version: "2026.8.1",
+        channel: "stable",
+        beta: undefined,
+        latest: undefined,
+        installSelector: undefined,
+      },
+      {
+        version: "2026.8.1-beta.4",
+        channel: "dev",
+        beta: undefined,
+        latest: undefined,
+        installSelector: undefined,
+      },
+    ].flatMap(({ version, channel, beta, latest, installSelector }) =>
       [
         "brave",
         "@openclaw/brave-plugin",
         "@openclaw/brave-plugin@latest",
         "npm:@openclaw/brave-plugin@latest",
-      ].map((arg) => ({ version, channel, installSelector, arg })),
+      ].map((arg) => ({ version, channel, beta, latest, installSelector, arg })),
     ),
   )(
-    "installs $installSelector for $arg on core $version with channel $channel",
-    async ({ version, channel, installSelector, arg }) => {
+    "installs $installSelector for $arg on core $version with channel $channel (beta=$beta, latest=$latest)",
+    async ({ version, channel, beta, latest, installSelector, arg }) => {
       coreVersion.value = version;
       primeSuccessfulPluginPersistence("brave");
       pluginCliConfigMock.mockReturnValue({
@@ -2075,41 +2144,46 @@ describe("plugins cli install", () => {
         ...(channel ? { update: { channel } } : {}),
       } as OpenClawConfig);
       findBundledPluginSourceMock.mockReturnValue(undefined);
+      mockNpmChannelMetadata("@openclaw/brave-plugin", beta, latest);
       installPluginFromNpmSpecMock.mockResolvedValue(createNpmPluginInstallResult("brave"));
 
       await runCapabilityAcceptedPluginsInstallCommand(["plugins", "install", arg]);
 
-      expect(npmInstallCall().spec).toBe(`@openclaw/brave-plugin@${installSelector}`);
-      expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
-      // The record keeps the operator's selector so a later channel change is
-      // not silently pinned to the beta dist-tag.
-      expect(persistedInstallRecord("brave").spec).toBe(
-        arg.endsWith("@latest") ? "@openclaw/brave-plugin@latest" : "@openclaw/brave-plugin",
+      const recordSpec = arg.endsWith("@latest")
+        ? "@openclaw/brave-plugin@latest"
+        : "@openclaw/brave-plugin";
+      expect(npmInstallCall().spec).toBe(
+        installSelector ? `@openclaw/brave-plugin@${installSelector}` : recordSpec,
       );
+      expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
+      expect(persistedInstallRecord("brave").spec).toBe(recordSpec);
+      expect(resolveNpmSpecMetadataMock).toHaveBeenCalledTimes(beta || latest ? 2 : 0);
     },
   );
 
-  it("does not install the stable release when no beta artifact is published", async () => {
+  it("does not retry a selected beta release when its artifact is unavailable", async () => {
     primeSuccessfulPluginPersistence("brave");
     pluginCliConfigMock.mockReturnValue({
       ...createEmptyPluginConfig(),
       update: { channel: "beta" },
     } as OpenClawConfig);
     findBundledPluginSourceMock.mockReturnValue(undefined);
+    mockNpmChannelMetadata("@openclaw/brave-plugin", "2026.8.2-beta.1", "2026.8.1");
     installPluginFromNpmSpecMock.mockResolvedValue({
       ok: false,
-      error: "npm error code ETARGET No matching version found for @openclaw/brave-plugin@beta",
+      error:
+        "npm error code ETARGET No matching version found for @openclaw/brave-plugin@2026.8.2-beta.1",
       code: "npm_package_not_found",
     });
 
     await expect(runPluginsCommand(["plugins", "install", "brave"])).rejects.toThrow("__exit__:1");
 
-    expect(npmInstallCall(0).spec).toBe("@openclaw/brave-plugin@beta");
+    expect(npmInstallCall(0).spec).toBe("@openclaw/brave-plugin@2026.8.2-beta.1");
     expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
     expect(installHooksFromNpmSpecMock).not.toHaveBeenCalled();
     expect(configWriteMock).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain(
-      "No @openclaw/brave-plugin@beta release is published for this gateway",
+      "No @openclaw/brave-plugin@2026.8.2-beta.1 release is published for this gateway",
     );
   });
 
@@ -2195,12 +2269,20 @@ describe("plugins cli install", () => {
     ...OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY.map((entry) => ({
       ...entry,
       version: "2026.8.1",
+      installVersion: undefined,
     })),
-    { ...OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY[0]!, version: "2026.8.1-beta.4" },
+    {
+      ...OFFICIAL_EXTERNAL_NPM_INSTALLS_WITHOUT_INTEGRITY[0]!,
+      version: "2026.8.1-beta.4",
+      installVersion: "2026.8.2-beta.1",
+    },
   ])(
     "keeps official external npm installs trusted without integrity for $pluginId on $version",
-    async ({ pluginId, npmSpec, version }) => {
+    async ({ pluginId, npmSpec, version, installVersion }) => {
       coreVersion.value = version;
+      if (installVersion) {
+        mockNpmChannelMetadata(npmSpec.replace(/@latest$/, ""), "2026.8.2-beta.1", "2026.8.1");
+      }
       await withTempDir("openclaw-official-plugin-install-", async (cwd) => {
         const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(cwd);
         try {
@@ -2214,7 +2296,9 @@ describe("plugins cli install", () => {
             lookup: { kind: "pluginId", value: pluginId },
           });
           expect(installPluginFromClawHubMock).not.toHaveBeenCalled();
-          expect(npmInstallCall().spec).toBe(expectedNpmInstallSpec(npmSpec));
+          expect(npmInstallCall().spec).toBe(
+            installVersion ? `${npmSpec.replace(/@latest$/, "")}@${installVersion}` : npmSpec,
+          );
           expect(npmInstallCall().expectedPluginId).toBe(pluginId);
           expect(npmInstallCall().trustedSourceLinkedOfficialInstall).toBe(true);
           expect(npmInstallCall().expectedIntegrity).toBeUndefined();
@@ -2426,13 +2510,14 @@ describe("plugins cli install", () => {
 
   it.each([
     { version: "2026.8.1", selector: "latest", installSelector: "latest" },
-    { version: "2026.8.1-beta.4", selector: "latest", installSelector: "2026.8.1-beta.4" },
+    { version: "2026.8.1-beta.4", selector: "latest", installSelector: "2026.8.2-beta.1" },
     { version: "2026.8.1-beta.4", selector: "next", installSelector: "next" },
     { version: "2026.8.1-beta.4", selector: "2026.6.1", installSelector: "2026.6.1" },
   ])(
     "trusts catalog npm @$selector on core $version",
     async ({ version, selector, installSelector }) => {
       coreVersion.value = version;
+      mockNpmChannelMetadata("@wecom/wecom-openclaw-plugin", "2026.8.2-beta.1", "2026.8.1");
       primeSuccessfulPluginPersistence("wecom-openclaw-plugin");
       findBundledPluginSourceMock.mockReturnValue(undefined);
       installPluginFromNpmSpecMock.mockResolvedValue(

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -9,6 +9,11 @@ import { createColdPluginFixture } from "../../plugins/test-helpers/cold-plugin-
 import { invokePluginArtifactInstallMock } from "../../plugins/test-helpers/install-fixtures.js";
 
 const installPluginFromNpmSpec = vi.fn();
+const resolveNpmSpecMetadata = vi.hoisted(() => vi.fn());
+vi.mock("../../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata,
+}));
 const applyPluginAutoEnable = vi.fn();
 vi.mock("../../plugins/install.js", () => ({
   installPluginFromNpmSpec: (params: Parameters<typeof invokePluginArtifactInstallMock>[1]) =>
@@ -205,6 +210,7 @@ function expectSetupSnapshotDoesNotScopeToPlugin(params: {
 }
 
 beforeEach(() => {
+  resolveNpmSpecMetadata.mockReset().mockRejectedValue(new Error("Unseeded npm metadata query"));
   clearPluginMetadataLifecycleCaches();
   vi.clearAllMocks();
   applyPluginAutoEnable.mockImplementation((params: { config: unknown }) => ({
@@ -429,50 +435,63 @@ describe("ensureChannelSetupPluginInstalled", () => {
     expect(await runInitialValueForChannel("beta")).toBe("npm");
   });
 
-  it("installs npm beta on the beta channel without persisting the beta tag", async () => {
-    const runtime = makeRuntime();
-    const { prompter, select } = makeSkipInstallPrompter(true);
-    const cfg: OpenClawConfig = { update: { channel: "beta" } };
-    installPluginFromNpmSpec.mockResolvedValue({
-      ok: true,
-      pluginId: "wecom-openclaw-plugin",
-      targetDir: "/tmp/wecom-openclaw-plugin",
-      version: "2026.5.4-beta.1",
-      npmResolution: {
-        name: "@openclaw/wecom",
-        version: "2026.5.4-beta.1",
-        resolvedSpec: "@openclaw/wecom@2026.5.4-beta.1",
-      },
-    });
-
-    const result = await ensureChannelSetupPluginInstalled({
-      cfg,
-      entry: {
-        id: "wecom",
+  it.each([
+    { beta: "2026.5.4-beta.1", latest: "2026.5.4", selected: "2026.5.4" },
+    { beta: "2026.5.5-beta.1", latest: "2026.5.4", selected: "2026.5.5-beta.1" },
+  ])(
+    "installs $selected on beta while preserving npm intent",
+    async ({ beta, latest, selected }) => {
+      const runtime = makeRuntime();
+      const { prompter, select } = makeSkipInstallPrompter(true);
+      const cfg: OpenClawConfig = { update: { channel: "beta" } };
+      resolveNpmSpecMetadata.mockImplementation(async ({ spec }: { spec: string }) => {
+        const version = spec === "@openclaw/wecom@beta" ? beta : latest;
+        expect(["@openclaw/wecom@beta", "@openclaw/wecom@latest"]).toContain(spec);
+        const name = "@openclaw/wecom";
+        const metadata = { name, version, resolvedSpec: `${name}@${version}` };
+        return { ok: true, metadata };
+      });
+      installPluginFromNpmSpec.mockResolvedValue({
+        ok: true,
         pluginId: "wecom-openclaw-plugin",
-        meta: {
-          id: "wecom",
-          label: "WeCom",
-          selectionLabel: "WeCom",
-          docsPath: "/channels/wecom",
-          blurb: "WeCom channel",
+        targetDir: "/tmp/wecom-openclaw-plugin",
+        version: selected,
+        npmResolution: {
+          name: "@openclaw/wecom",
+          version: selected,
+          resolvedSpec: `@openclaw/wecom@${selected}`,
         },
-        install: {
-          npmSpec: "@openclaw/wecom",
-        },
-      },
-      prompter,
-      runtime,
-      promptInstall: false,
-    });
+      });
 
-    expect(select).not.toHaveBeenCalled();
-    expectRecordFields(requireMockCallArg(installPluginFromNpmSpec, 0), "npm install args", {
-      spec: "@openclaw/wecom@beta",
-      expectedPluginId: "wecom-openclaw-plugin",
-    });
-    expect(result.cfg.plugins?.installs?.["wecom-openclaw-plugin"]?.spec).toBe("@openclaw/wecom");
-  });
+      const result = await ensureChannelSetupPluginInstalled({
+        cfg,
+        entry: {
+          id: "wecom",
+          pluginId: "wecom-openclaw-plugin",
+          meta: {
+            id: "wecom",
+            label: "WeCom",
+            selectionLabel: "WeCom",
+            docsPath: "/channels/wecom",
+            blurb: "WeCom channel",
+          },
+          install: {
+            npmSpec: "@openclaw/wecom",
+          },
+        },
+        prompter,
+        runtime,
+        promptInstall: false,
+      });
+
+      expect(select).not.toHaveBeenCalled();
+      expectRecordFields(requireMockCallArg(installPluginFromNpmSpec, 0), "npm install args", {
+        spec: `@openclaw/wecom@${selected}`,
+        expectedPluginId: "wecom-openclaw-plugin",
+      });
+      expect(result.cfg.plugins?.installs?.["wecom-openclaw-plugin"]?.spec).toBe("@openclaw/wecom");
+    },
+  );
 
   it("defaults to bundled local path on beta channel when available", async () => {
     const runtime = makeRuntime();

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -1,5 +1,8 @@
+import { isDeepStrictEqual } from "node:util";
 import { note } from "../../packages/terminal-core/src/note.js";
 import type { ConfigSnapshotReadMeasure } from "../config/io.js";
+import type { ConfigFileSnapshot } from "../config/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
@@ -14,6 +17,7 @@ import {
   migrationCheckpointIdentitiesMatch,
   resolveMigrationCheckpointIdentity,
 } from "./doctor-config-preflight-checkpoint.js";
+import { measureDoctorConfigPreflightStep } from "./doctor-config-preflight-measure.js";
 import type { DoctorConfigPreflightPluginSnapshotRead } from "./doctor-config-preflight-plugin-index.js";
 import {
   formatStartupPluginVerificationFailure,
@@ -21,6 +25,7 @@ import {
   runStartupUpgradeConvergence,
 } from "./doctor-config-preflight-plugin-verification.js";
 import {
+  throwStartupMigrationGuardRejected,
   throwStartupMigrationIdentityChanged,
   throwStartupMigrationRefusal,
 } from "./doctor-startup-migration-refusal.js";
@@ -38,13 +43,66 @@ type MigrationCheckpoint = {
   }) => void;
 };
 
+/** Settle package repairs before state migrations select their plugin owners. */
+export async function prepareStartupMigrationPlugins(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  measure?: ConfigSnapshotReadMeasure;
+  converge: boolean;
+  lease: StartupMigrationLease | undefined;
+  snapshotRead: DoctorConfigPreflightPluginSnapshotRead;
+  readRefreshedSnapshot: () => Promise<DoctorConfigPreflightPluginSnapshotRead>;
+  beforeStateMigrations?: (snapshot: ConfigFileSnapshot) => Promise<boolean>;
+}): Promise<DoctorConfigPreflightPluginSnapshotRead> {
+  if (params.converge) {
+    if (!params.lease) {
+      throw new Error("Startup plugin convergence requires the startup migration lease.");
+    }
+    params.lease.heartbeat();
+  }
+  setActiveDegradedPlugins([]);
+  const convergence = await (
+    params.converge ? runStartupUpgradeConvergence : refreshStartupPluginQuarantine
+  )(params);
+  setActiveDegradedPlugins(convergence.quarantinedPlugins);
+  if (convergence.blockingDiagnostic) {
+    throwStartupMigrationRefusal(
+      formatStartupPluginVerificationFailure(convergence.blockingDiagnostic),
+    );
+  }
+  if (!params.converge) {
+    return params.snapshotRead;
+  }
+  const refreshed = await params.readRefreshedSnapshot();
+  const snapshot = params.snapshotRead.snapshot;
+  if (
+    snapshot.path !== refreshed.snapshot.path ||
+    !isDeepStrictEqual(
+      snapshot.sourceConfig ?? snapshot.config,
+      refreshed.snapshot.sourceConfig ?? refreshed.snapshot.config,
+    )
+  ) {
+    throwStartupMigrationIdentityChanged();
+  }
+  if (
+    params.beforeStateMigrations &&
+    !(await measureDoctorConfigPreflightStep(
+      "converged-config-guard",
+      () => params.beforeStateMigrations?.(refreshed.snapshot),
+      params.measure,
+    ))
+  ) {
+    throwStartupMigrationGuardRejected();
+  }
+  return refreshed;
+}
+
 /** Completes startup verification and returns the accepted config and metadata generation. */
 export async function completeStartupMigrationPreflight(params: {
   freshConfigGuardAllowed: boolean | undefined;
   gatewayStartupCheckpointRequired: boolean;
   migrationCheckpoint: MigrationCheckpoint | undefined;
   migrationCheckpointIdentity: MigrationCheckpointIdentity | null;
-  measure?: ConfigSnapshotReadMeasure;
   readConfigSnapshotForPreflight: (
     allowCurrentPluginMetadata?: boolean,
   ) => Promise<DoctorConfigPreflightPluginSnapshotRead>;
@@ -59,7 +117,6 @@ export async function completeStartupMigrationPreflight(params: {
 }): Promise<DoctorConfigPreflightPluginSnapshotRead> {
   let snapshotRead = params.snapshotRead;
   const snapshot = snapshotRead.snapshot;
-  const baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
   if (
     (params.shouldRecordStateCheckpoint || params.shouldRecordStartupCheckpoint) &&
     params.startupMigrationHeartbeatError
@@ -92,43 +149,21 @@ export async function completeStartupMigrationPreflight(params: {
         ]),
       );
     }
-    setActiveDegradedPlugins([]);
-    if (snapshot.valid) {
-      const pluginConvergence = params.shouldRecordStartupCheckpoint
-        ? await runStartupUpgradeConvergence({
-            cfg: baseConfig,
-            env: process.env,
-            ...(params.measure ? { measure: params.measure } : {}),
-          })
-        : await refreshStartupPluginQuarantine({
-            cfg: baseConfig,
-            env: process.env,
-            ...(params.measure ? { measure: params.measure } : {}),
-          });
-      setActiveDegradedPlugins(pluginConvergence.quarantinedPlugins);
-      if (pluginConvergence.blockingDiagnostic) {
-        throwStartupMigrationRefusal(
-          formatStartupPluginVerificationFailure(pluginConvergence.blockingDiagnostic),
-        );
+    if (snapshot.valid && params.shouldRecordStartupCheckpoint) {
+      const convergedSnapshotRead = await params.readConfigSnapshotForPreflight(false);
+      const convergedBaseConfig =
+        convergedSnapshotRead.snapshot.sourceConfig ?? convergedSnapshotRead.snapshot.config ?? {};
+      const convergedIdentity = resolveMigrationCheckpointIdentity({
+        snapshot: convergedSnapshotRead.snapshot,
+        baseConfig: convergedBaseConfig,
+        pluginMigrationFingerprint: convergedSnapshotRead.pluginMigrationFingerprint,
+      });
+      if (
+        !migrationCheckpointIdentitiesMatch(params.migrationCheckpointIdentity, convergedIdentity)
+      ) {
+        throwStartupMigrationIdentityChanged();
       }
-      if (params.shouldRecordStartupCheckpoint) {
-        const convergedSnapshotRead = await params.readConfigSnapshotForPreflight(false);
-        const convergedBaseConfig =
-          convergedSnapshotRead.snapshot.sourceConfig ??
-          convergedSnapshotRead.snapshot.config ??
-          {};
-        const convergedIdentity = resolveMigrationCheckpointIdentity({
-          snapshot: convergedSnapshotRead.snapshot,
-          baseConfig: convergedBaseConfig,
-          pluginMigrationFingerprint: convergedSnapshotRead.pluginMigrationFingerprint,
-        });
-        if (
-          !migrationCheckpointIdentitiesMatch(params.migrationCheckpointIdentity, convergedIdentity)
-        ) {
-          throwStartupMigrationIdentityChanged();
-        }
-        snapshotRead = convergedSnapshotRead;
-      }
+      snapshotRead = convergedSnapshotRead;
     }
     recordStartupMigrationWarnings(params.startupMigrationWarnings);
   }

--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -476,7 +476,6 @@ describe("Doctor plugin persistence", () => {
             }
           }
           let acceptedRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
-          let beforeConvergenceRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
           let result: Awaited<ReturnType<typeof runDoctorConfigPreflight>> | undefined;
           let failure: string | undefined;
           try {
@@ -491,7 +490,6 @@ describe("Doctor plugin persistence", () => {
                 observe: false,
                 measure: async (name, operation) => {
                   if (name === "doctor.config-preflight.plugin-plan") {
-                    beforeConvergenceRead = acceptedRead;
                     // The real machine-state migration must finish before startup convergence begins.
                     expect(readBundledDiscoveryModeMemoized()).toBe("compat");
                   }
@@ -523,16 +521,12 @@ describe("Doctor plugin persistence", () => {
           const policyHash = resolveInstalledPluginIndexPolicyHash(config, process.env);
           expect(readBundledDiscoveryModeMemoized()).toBe("compat");
           expect(policyHash).not.toBe(initial.pluginMetadataSnapshot?.policyHash);
-          expect(beforeConvergenceRead).toBeDefined();
           expect(acceptedRead).toBeDefined();
           expect(acceptedRead?.snapshot.raw).toBe(initial.snapshot.raw);
           const durable = withPluginCache(createPluginCache(), () =>
             readPersistedInstalledPluginIndexSync({ env: process.env }),
           );
           expect.soft(durable?.policyHash).toBe(policyHash);
-          expect
-            .soft(beforeConvergenceRead?.pluginMigrationFingerprint)
-            .toBe(acceptedRead?.pluginMigrationFingerprint);
           expect.soft(acceptedRead?.pluginMetadataSnapshot?.registrySource).toBe("persisted");
           expect(result).toBeDefined();
           if (result) {

--- a/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test-helpers.ts
@@ -1,4 +1,39 @@
-import { vi } from "vitest";
+import { expect, vi } from "vitest";
+
+export function makePreflightConfigSnapshot(config: Record<string, unknown>) {
+  return {
+    exists: true,
+    valid: true,
+    config,
+    sourceConfig: config,
+    parsed: config,
+    legacyIssues: [] as Array<{ path: string; message: string }>,
+    warnings: [] as Array<{ path: string; message: string }>,
+    issues: [] as Array<{ path: string; message: string }>,
+  };
+}
+
+export function queueConfigSnapshot<T>(
+  reader: { mockResolvedValueOnce(snapshot: T): unknown },
+  snapshot: T,
+  count = 1,
+): void {
+  for (let index = 0; index < count; index += 1) {
+    reader.mockResolvedValueOnce(snapshot);
+  }
+}
+
+export function expectMigrationIdentity(): {
+  effectiveConfigFingerprint: unknown;
+  pluginDoctorConfigFingerprint: unknown;
+  pluginMigrationFingerprint: string;
+} {
+  return {
+    effectiveConfigFingerprint: expect.any(String),
+    pluginDoctorConfigFingerprint: expect.any(String),
+    pluginMigrationFingerprint: "plugin-migrations",
+  };
+}
 
 export type StateMigrationResult = {
   migrated: boolean;
@@ -7,6 +42,10 @@ export type StateMigrationResult = {
   warnings: string[];
   notices?: string[];
 };
+
+export function makeStateMigrationResult(changes: string[], migrated = true): StateMigrationResult {
+  return { migrated, skipped: false, changes, warnings: [] };
+}
 
 const maybeRepairPluginOpenClawHostLinks = vi.hoisted(() =>
   vi.fn(

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -11,8 +11,12 @@ import {
 } from "../plugins/runtime-degraded-state.js";
 import { ExitError } from "../runtime.js";
 import {
+  expectMigrationIdentity,
   getMaybeRepairPluginOpenClawHostLinksMock,
+  makePreflightConfigSnapshot,
   makeStartupConvergenceResult,
+  makeStateMigrationResult,
+  queueConfigSnapshot,
   stateCheckpointOptions,
   startupCheckpointOptions,
   type StartupConvergenceResult,
@@ -153,27 +157,6 @@ const runWithPluginMetadataSnapshot = vi.hoisted(() =>
 );
 const note = vi.hoisted(() => vi.fn());
 
-function queueConfigSnapshot(
-  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
-  count = 1,
-): void {
-  for (let index = 0; index < count; index += 1) {
-    readConfigFileSnapshot.mockResolvedValueOnce(snapshot);
-  }
-}
-
-function expectMigrationIdentity(): {
-  effectiveConfigFingerprint: unknown;
-  pluginDoctorConfigFingerprint: unknown;
-  pluginMigrationFingerprint: string;
-} {
-  return {
-    effectiveConfigFingerprint: expect.any(String),
-    pluginDoctorConfigFingerprint: expect.any(String),
-    pluginMigrationFingerprint: "plugin-migrations",
-  };
-}
-
 vi.mock("../infra/state-migrations.doctor.js", () => ({
   autoMigrateLegacyState,
 }));
@@ -236,8 +219,11 @@ vi.mock("./doctor/shared/legacy-config-issues.js", () => ({
 }));
 
 vi.mock("./doctor/shared/plugin-metadata-snapshot-scope.js", () => ({
-  createDoctorPluginMetadataSnapshotScope: () => ({
-    run: runWithPluginMetadataSnapshot,
+  createDoctorPluginMetadataSnapshotScope: (params: {
+    getBaseSnapshot: () => PluginMetadataSnapshot | undefined;
+  }) => ({
+    run: (_scope: unknown, operation: () => unknown) =>
+      runWithPluginMetadataSnapshot(params.getBaseSnapshot(), operation),
     invalidate: vi.fn(),
   }),
 }));
@@ -263,30 +249,14 @@ describe("runDoctorConfigPreflight state migration", () => {
       skipAllStateMigrations: false,
       skipCoreStateMigrations: false,
     });
-    autoMigrateLegacyStateDir.mockResolvedValue({
-      migrated: false,
-      skipped: false,
-      changes: [],
-      warnings: [],
-    });
-    autoMigrateLegacyState.mockResolvedValue({
-      migrated: true,
-      skipped: false,
-      changes: ["imported"],
-      warnings: [],
-    });
-    autoMigrateLegacyPluginDoctorState.mockResolvedValue({
-      migrated: true,
-      skipped: false,
-      changes: ["plugin-imported"],
-      warnings: [],
-    });
-    autoMigrateLegacyTaskStateSidecars.mockResolvedValue({
-      migrated: true,
-      skipped: false,
-      changes: ["task-imported"],
-      warnings: [],
-    });
+    autoMigrateLegacyStateDir.mockResolvedValue(makeStateMigrationResult([], false));
+    autoMigrateLegacyState.mockResolvedValue(makeStateMigrationResult(["imported"]));
+    autoMigrateLegacyPluginDoctorState.mockResolvedValue(
+      makeStateMigrationResult(["plugin-imported"]),
+    );
+    autoMigrateLegacyTaskStateSidecars.mockResolvedValue(
+      makeStateMigrationResult(["task-imported"]),
+    );
     repairLegacyCronStoreWithoutPrompt.mockResolvedValue({
       changes: ["cron-imported"],
       warnings: [],
@@ -606,7 +576,7 @@ describe("runDoctorConfigPreflight state migration", () => {
 
     expect(runPostCorePluginConvergence).toHaveBeenCalledWith({
       cfg: { gateway: { mode: "local", port: 19091 } },
-      env: expect.any(Object),
+      env: acquireStartupMigrationLeaseWithWait.mock.calls[0]?.[0]?.env,
       compatibilityHostVersion: "2026.7.2-beta.7",
     });
   });
@@ -630,10 +600,116 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(migrationOrder).toEqual(["host-links", "state"]);
   });
 
-  it("refuses startup when fresh plugin migration inputs change during convergence", async () => {
+  it.each(["stale", "state-current"] as const)(
+    "converges repaired plugins and migrations in one startup from a %s checkpoint",
+    async (checkpoint) => {
+      readMigrationCheckpointStatus.mockReturnValue(checkpoint);
+      pluginMigrationFingerprint.mockReturnValue("plugin-migrations-before");
+      runPostCorePluginConvergence.mockImplementationOnce(async () => {
+        expect(startupMigrationLeaseHeartbeat).toHaveBeenCalled();
+        expect(startupMigrationLeaseRelease).not.toHaveBeenCalled();
+        pluginMigrationFingerprint.mockReturnValue("plugin-migrations-after");
+        return makeStartupConvergenceResult({ changes: ["Refreshed managed plugin."] });
+      });
+      autoMigrateLegacyState.mockImplementationOnce(async () => {
+        expect(runWithPluginMetadataSnapshot.mock.calls.at(-1)?.[0]).toMatchObject({
+          configFingerprint: "plugin-migrations-after",
+        });
+        return { migrated: true, skipped: false, changes: [], warnings: [] };
+      });
+      recordSuccessfulStartupMigrations.mockImplementationOnce(() => {
+        readMigrationCheckpointStatus.mockReturnValue("startup-current");
+      });
+
+      const result = await runDoctorConfigPreflight(startupCheckpointOptions);
+
+      expect(result.pluginMetadataSnapshot?.configFingerprint).toBe("plugin-migrations-after");
+      expect(autoMigrateLegacyState).toHaveBeenCalledOnce();
+      const checkpointWrite = {
+        env: acquireStartupMigrationLeaseWithWait.mock.calls[0]?.[0]?.env,
+        identity: expect.objectContaining({
+          pluginMigrationFingerprint: "plugin-migrations-after",
+        }),
+        lease: startupMigrationLease,
+      };
+      expect(recordSuccessfulStateMigrations).toHaveBeenCalledWith(checkpointWrite);
+      expect(recordSuccessfulStartupMigrations).toHaveBeenCalledWith(checkpointWrite);
+
+      await runDoctorConfigPreflight(startupCheckpointOptions);
+
+      expect(runPostCorePluginConvergence).toHaveBeenCalledOnce();
+      expect(autoMigrateLegacyState).toHaveBeenCalledOnce();
+      expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["plugin repair", "converged config guard"] as const)(
+    "refuses state migrations when the startup lease is lost during %s",
+    async (lossBoundary) => {
+      readMigrationCheckpointStatus.mockReturnValue("stale");
+      const leaseError = new Error("Startup migration lease expired or was replaced.");
+      let convergenceComplete = false;
+      let leaseLost = false;
+      acquireStartupMigrationLeaseWithWait.mockResolvedValueOnce({
+        ...startupMigrationLease,
+        heartbeat: vi.fn(() => {
+          if (leaseLost) {
+            throw leaseError;
+          }
+        }),
+      });
+      runPostCorePluginConvergence.mockImplementationOnce(async () => {
+        convergenceComplete = true;
+        leaseLost = lossBoundary === "plugin repair";
+        return makeStartupConvergenceResult();
+      });
+
+      await expect(
+        runDoctorConfigPreflight({
+          ...startupCheckpointOptions,
+          beforeStateMigrations: async () => {
+            if (convergenceComplete && lossBoundary === "converged config guard") {
+              leaseLost = true;
+            }
+            return true;
+          },
+        }),
+      ).rejects.toBe(leaseError);
+
+      expect(maybeRepairPluginOpenClawHostLinks).not.toHaveBeenCalled();
+      expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+      expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+      expect(autoMigrateLegacyPluginDoctorState).not.toHaveBeenCalled();
+      expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
+      expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+      expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("rejects external config changes during plugin repair before state migrations", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
-    pluginMigrationFingerprint.mockImplementation((allowCurrentPluginMetadata) =>
-      runPostCorePluginConvergence.mock.calls.length > 0 && allowCurrentPluginMetadata === false
+    runPostCorePluginConvergence.mockImplementationOnce(async () => {
+      queueConfigSnapshot(
+        readConfigFileSnapshot,
+        makePreflightConfigSnapshot({ gateway: { mode: "local", port: 19092 } }),
+      );
+      return makeStartupConvergenceResult();
+    });
+
+    await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
+      "plugin migration inputs changed during startup convergence",
+    );
+
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
+    expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
+    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+  });
+
+  it("refuses startup when plugin migration inputs change after state migration", async () => {
+    readMigrationCheckpointStatus.mockReturnValue("stale");
+    pluginMigrationFingerprint.mockImplementation(() =>
+      autoMigrateLegacyState.mock.calls.length > 0
         ? "plugin-migrations-after"
         : "plugin-migrations-before",
     );
@@ -739,25 +815,11 @@ describe("runDoctorConfigPreflight state migration", () => {
   it("keeps ownerless install-record failures blocking", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
     queueConfigSnapshot(
-      {
-        exists: true,
-        valid: true,
-        config: {
-          gateway: { mode: "local", port: 19091 },
-          plugins: { entries: { discord: { enabled: true } } },
-        },
-        sourceConfig: {
-          gateway: { mode: "local", port: 19091 },
-          plugins: { entries: { discord: { enabled: true } } },
-        },
-        parsed: {
-          gateway: { mode: "local", port: 19091 },
-          plugins: { entries: { discord: { enabled: true } } },
-        },
-        legacyIssues: [],
-        warnings: [],
-        issues: [],
-      },
+      readConfigFileSnapshot,
+      makePreflightConfigSnapshot({
+        gateway: { mode: "local", port: 19091 },
+        plugins: { entries: { discord: { enabled: true } } },
+      }),
       3,
     );
     runPostCorePluginConvergence.mockResolvedValueOnce(
@@ -952,11 +1014,8 @@ describe("runDoctorConfigPreflight state migration", () => {
       }),
     ).rejects.toThrow("Configured plugin discord is not installed");
 
-    expect(recordSuccessfulStateMigrations).toHaveBeenCalledWith({
-      env: acquireStartupMigrationLeaseWithWait.mock.calls[0]?.[0]?.env,
-      identity: expectMigrationIdentity(),
-      lease: startupMigrationLease,
-    });
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
     expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(
       "- Configured plugin discord is not installed. Run `openclaw update repair` to retry plugin repair.",
@@ -968,26 +1027,12 @@ describe("runDoctorConfigPreflight state migration", () => {
   it("quarantines a plugin payload verification failure and checkpoints readiness", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
     queueConfigSnapshot(
-      {
-        exists: true,
-        valid: true,
-        config: {
-          gateway: { mode: "local", port: 19091 },
-          plugins: { entries: { discord: { enabled: true } } },
-        },
-        sourceConfig: {
-          gateway: { mode: "local", port: 19091 },
-          plugins: { entries: { discord: { enabled: true } } },
-        },
-        parsed: {
-          gateway: { mode: "local", port: 19091 },
-          plugins: { entries: { discord: { enabled: true } } },
-        },
-        legacyIssues: [],
-        warnings: [],
-        issues: [],
-      },
-      4,
+      readConfigFileSnapshot,
+      makePreflightConfigSnapshot({
+        gateway: { mode: "local", port: 19091 },
+        plugins: { entries: { discord: { enabled: true } } },
+      }),
+      5,
     );
     runPostCorePluginConvergence.mockResolvedValueOnce(
       makeStartupConvergenceResult({
@@ -1042,14 +1087,10 @@ describe("runDoctorConfigPreflight state migration", () => {
   it("does not checkpoint startup migrations when the config snapshot is invalid", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
     queueConfigSnapshot(
+      readConfigFileSnapshot,
       {
-        exists: true,
+        ...makePreflightConfigSnapshot({ gateway: { mode: "local", port: "bad" } }),
         valid: false,
-        config: { gateway: { mode: "local", port: "bad" } },
-        sourceConfig: { gateway: { mode: "local", port: "bad" } },
-        parsed: { gateway: { mode: "local", port: "bad" } },
-        legacyIssues: [],
-        warnings: [],
         issues: [{ path: "gateway.port", message: "invalid" }],
       },
       3,

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -39,6 +39,7 @@ import {
 import {
   completeStartupMigrationPreflight,
   noteStateMigrationResult,
+  prepareStartupMigrationPlugins,
 } from "./doctor-config-preflight-startup.js";
 import * as cronMigration from "./doctor-config-preflight.cron.js";
 import { maybeRepairPluginOpenClawHostLinks } from "./doctor-plugin-host-links.js";
@@ -142,7 +143,7 @@ export async function runDoctorConfigPreflight(
     skipPristineStartupStateMigrations || options.skipPristineCoreStateMigrations === true;
   let startupMigrationLease: StartupMigrationLease | undefined;
   let startupMigrationHeartbeat: ReturnType<typeof setInterval> | undefined;
-  let startupMigrationHeartbeatError: unknown;
+  let startupMigrationHeartbeatError: Error | undefined;
   const startupMigrationWarnings: string[] = [];
   const cronCodexRuntimePolicyTargets: CronCodexRuntimePolicyTarget[] = [];
   let doctorMediaPersistenceAttempted = false;
@@ -204,7 +205,10 @@ export async function runDoctorConfigPreflight(
       try {
         startupMigrationLease?.heartbeat();
       } catch (error) {
-        startupMigrationHeartbeatError = error;
+        startupMigrationHeartbeatError =
+          error instanceof Error
+            ? error
+            : new Error("OpenClaw startup migration lease heartbeat failed.");
       }
     }, 60_000);
     startupMigrationHeartbeat.unref?.();
@@ -220,6 +224,10 @@ export async function runDoctorConfigPreflight(
       warnings: gatewayStartupCheckpointRequired ? [] : result.warnings,
     });
   };
+  const planScopedConfigRepair = (snapshot: ConfigFileSnapshot) =>
+    runWithPluginMetadataSnapshot({ config: snapshot.sourceConfig ?? snapshot.config ?? {} }, () =>
+      planAutomaticConfigRepair(snapshot),
+    );
   const migrateLegacyConfigIfNeeded = async () => {
     if (legacyConfigMigrationComplete) {
       return;
@@ -293,7 +301,7 @@ export async function runDoctorConfigPreflight(
     }
     // A current state checkpoint proves this root already completed every automatic migration.
     // Keep repeated short-lived commands out of the legacy migration import graph.
-    const stateDirMigrations =
+    let stateDirMigrations =
       stateMigrationsRequested &&
       (!migrationCheckpoint || shouldRecordStateCheckpoint) &&
       !skipPristineStartupStateMigrations
@@ -323,10 +331,7 @@ export async function runDoctorConfigPreflight(
       // newer valid settings that the canonical Doctor migration would preserve.
       activeConfigRepair =
         typeof snapshot.raw === "string" && parseConfigJson5(snapshot.raw).ok
-          ? runWithPluginMetadataSnapshot(
-              { config: snapshot.sourceConfig ?? snapshot.config ?? {} },
-              () => planAutomaticConfigRepair(snapshot),
-            )
+          ? planScopedConfigRepair(snapshot)
           : null;
       let configRepaired = false;
       if (!activeConfigRepair && (await recoverConfigFromJsonRootSuffix(snapshot))) {
@@ -385,23 +390,13 @@ export async function runDoctorConfigPreflight(
     }
 
     let baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
-    const automaticConfigRepair =
+    let automaticConfigRepair =
       activeConfigRepair ??
       (gatewayStartupCheckpointRequired &&
       !snapshot.valid &&
       !shouldSkipPluginValidationForDoctorConfigPreflight()
-        ? runWithPluginMetadataSnapshot({ config: baseConfig }, () =>
-            planAutomaticConfigRepair(snapshot),
-          )
+        ? planScopedConfigRepair(snapshot)
         : null);
-    const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
-    if (migrationCheckpoint) {
-      migrationCheckpointIdentity = resolveMigrationCheckpointIdentity({
-        snapshot,
-        baseConfig,
-        pluginMigrationFingerprint: configSnapshotRead.pluginMigrationFingerprint,
-      });
-    }
     shouldPersistRefreshedPluginIndex =
       migrationCheckpoint !== undefined && needsRefreshedPluginIndexPersistence(configSnapshotRead);
     if (shouldPersistRefreshedPluginIndex) {
@@ -422,6 +417,51 @@ export async function runDoctorConfigPreflight(
     if (gatewayStartupCheckpointRequired && !freshConfigGuardAllowed) {
       throwStartupMigrationGuardRejected();
     }
+    if (gatewayStartupCheckpointRequired && (snapshot.valid || automaticConfigRepair)) {
+      const refreshed = await prepareStartupMigrationPlugins({
+        cfg: automaticConfigRepair?.config ?? baseConfig,
+        env: startupMigrationEnv,
+        measure: options.measure,
+        converge: shouldRecordStartupCheckpoint,
+        lease: startupMigrationLease,
+        snapshotRead: { ...configSnapshotRead, snapshot },
+        readRefreshedSnapshot: () => readConfigSnapshotForPreflight(false),
+        beforeStateMigrations: options.beforeStateMigrations,
+      });
+      if (shouldRecordStartupCheckpoint) {
+        if (
+          stateMigrationsRequested &&
+          configSnapshotRead.pluginMigrationFingerprint !== refreshed.pluginMigrationFingerprint
+        ) {
+          shouldRecordStateCheckpoint = true;
+          if (!stateDirMigrations && !skipPristineStartupStateMigrations) {
+            stateDirMigrations = await measurePreflightStep(
+              "state-migrations-import",
+              loadStateDirMigrations,
+            );
+          }
+        }
+        // The refreshed package inventory now owns both state migration and its checkpoint.
+        configSnapshotRead = refreshed;
+        shouldPersistRefreshedPluginIndex = needsRefreshedPluginIndexPersistence(refreshed);
+        snapshot = refreshed.snapshot;
+        baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
+        automaticConfigRepair = snapshot.valid ? null : planScopedConfigRepair(snapshot);
+      }
+    }
+    const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
+    if (migrationCheckpoint) {
+      migrationCheckpointIdentity = resolveMigrationCheckpointIdentity({
+        snapshot,
+        baseConfig,
+        pluginMigrationFingerprint: configSnapshotRead.pluginMigrationFingerprint,
+      });
+    }
+    // Package convergence and its guarded reread may outlive the admitted lease.
+    if (startupMigrationHeartbeatError) {
+      throw startupMigrationHeartbeatError;
+    }
+    startupMigrationLease?.heartbeat();
     if (stateDirMigrations && stateMigrationsAllowed && freshConfigGuardAllowed) {
       if (options.doctorOnlyStateMigrations === true) {
         const { detectLegacyExecApprovals, migrateLegacyExecApprovals } =
@@ -692,7 +732,6 @@ export async function runDoctorConfigPreflight(
       gatewayStartupCheckpointRequired,
       migrationCheckpoint,
       migrationCheckpointIdentity,
-      measure: options.measure,
       readConfigSnapshotForPreflight,
       shouldRecordStartupCheckpoint,
       shouldRecordStateCheckpoint,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.candidates.ts
@@ -7,7 +7,6 @@ import { compareOpenClawReleaseVersions } from "../../../infra/npm-registry-spec
 import {
   normalizeUpdateChannel,
   resolveRegistryUpdateChannel,
-  type UpdateChannel,
 } from "../../../infra/update-channels.js";
 import {
   resolveDefaultPluginExtensionsDir,
@@ -120,7 +119,6 @@ export async function resolveConfiguredPluginInstallContext(params: {
       installRecords: records,
       configuredPluginIds: params.configuredPluginIds,
       currentVersion,
-      updateChannel,
     });
   const installedPluginIdsWithRepairablePackages = new Set([
     ...installedPluginIdsWithRepairablePackageDiagnostics,
@@ -201,9 +199,6 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "extension entry unreadable",
   "requires compiled runtime output",
 ] as const;
-const OPENCLAW_BETA_COMPANION_VERSION_RE = /^(\d{4}\.[1-9]\d?\.[1-9]\d?)-beta\.[1-9]\d*$/;
-const OPENCLAW_STABLE_OR_BETA_COMPANION_VERSION_RE =
-  /^(\d{4}\.[1-9]\d?\.[1-9]\d?)(?:-beta\.[1-9]\d*)?$/;
 
 function setDownloadableInstallCandidate(params: {
   candidates: Map<string, DownloadableInstallCandidate>;
@@ -529,31 +524,12 @@ function resolveInstalledRuntimePackageVersion(params: {
 function installedRuntimePackageVersionIsStale(params: {
   installedVersion: string | undefined;
   currentVersion: string;
-  updateChannel: UpdateChannel;
 }): boolean {
   if (!params.installedVersion) {
     return false;
   }
-  if (
-    params.updateChannel === "beta" &&
-    betaCompanionMatchesCurrentStableVersion({
-      installedVersion: params.installedVersion,
-      currentVersion: params.currentVersion,
-    })
-  ) {
-    return false;
-  }
   const comparison = compareOpenClawReleaseVersions(params.installedVersion, params.currentVersion);
   return comparison === null ? params.installedVersion !== params.currentVersion : comparison < 0;
-}
-
-function betaCompanionMatchesCurrentStableVersion(params: {
-  installedVersion: string;
-  currentVersion: string;
-}): boolean {
-  const installedBase = OPENCLAW_BETA_COMPANION_VERSION_RE.exec(params.installedVersion)?.[1];
-  const currentBase = OPENCLAW_STABLE_OR_BETA_COMPANION_VERSION_RE.exec(params.currentVersion)?.[1];
-  return Boolean(installedBase && currentBase && installedBase === currentBase);
 }
 
 function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
@@ -561,7 +537,6 @@ function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
   installRecords: Record<string, PluginInstallRecord>;
   configuredPluginIds: ReadonlySet<string>;
   currentVersion: string;
-  updateChannel: UpdateChannel;
 }): Set<string> {
   const pluginIds = new Set<string>();
   const currentVersion = normalizeOptionalLowercaseString(params.currentVersion);
@@ -588,7 +563,6 @@ function collectInstalledPluginIdsWithStaleVersionBoundRuntimePackages(params: {
       installedRuntimePackageVersionIsStale({
         installedVersion,
         currentVersion,
-        updateChannel: params.updateChannel,
       })
     ) {
       pluginIds.add(candidate.pluginId);

--- a/src/commands/doctor/shared/missing-configured-plugin-install.health.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.health.ts
@@ -1,8 +1,8 @@
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import type { HealthFinding, HealthRepairEffect } from "../../../flows/health-checks.js";
+import { resolvePluginInstallSources } from "../../../plugins/install-channel-specs.js";
 import { isPayloadMissing } from "../../../plugins/payload-verification.js";
-import { resolveCompatibilityHostVersion } from "../../../version.js";
 import {
   collectDownloadableInstallCandidates,
   collectUpdateDeferredPluginIds,
@@ -13,10 +13,7 @@ import {
   collectConfiguredChannelIds,
   collectConfiguredPluginIds,
 } from "./missing-configured-plugin-install.ids.js";
-import {
-  resolveCandidateInstallSpec,
-  resolveRecordInstallPath,
-} from "./missing-configured-plugin-install.install.js";
+import { resolveRecordInstallPath } from "./missing-configured-plugin-install.install.js";
 import { isTrustedOfficialInstallRecordForCandidate } from "./missing-configured-plugin-install.records.js";
 import { shouldDeferConfiguredPluginInstallRepair } from "./update-phase.js";
 
@@ -95,7 +92,6 @@ export async function detectConfiguredPluginInstallHealthIssues(params: {
     bundledPluginsById,
     configuredPluginIdsWithStaleDescriptors: staleDescriptorPluginIds,
     records,
-    updateChannel,
     installedPluginIdsWithRepairablePackageDiagnostics: repairablePackageDiagnosticPluginIds,
     installedPluginIdsWithStaleVersionBoundRuntimePackages: staleVersionBoundRuntimePluginIds,
     installedPluginIdsWithRepairablePackages: repairableInstalledPluginIds,
@@ -228,11 +224,7 @@ export async function detectConfiguredPluginInstallHealthIssues(params: {
     ) {
       continue;
     }
-    const installSpec = resolveCandidateInstallSpec({
-      candidate,
-      updateChannel,
-      coreVersion: resolveCompatibilityHostVersion(env),
-    });
+    const installSpec = resolvePluginInstallSources(candidate)[0]?.spec;
     if (shouldReplaceBrokenOfficialInstall) {
       const installPath = resolveRecordInstallPath(record, env);
       if (staleVersionBoundRuntimePluginIds.has(candidate.pluginId)) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -6,7 +6,11 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
 import { parseRegistryNpmSpec } from "../../../infra/npm-registry-spec.js";
-import { expectedIntegrityForUpdate } from "../../../infra/package-update-utils.js";
+import {
+  comparePackageUpdateVersions,
+  expectedIntegrityForUpdate,
+  readInstalledPackageVersion,
+} from "../../../infra/package-update-utils.js";
 import type { UpdateChannel } from "../../../infra/update-channels.js";
 import {
   capturePluginCapabilityConsentHandlerErrors,
@@ -18,6 +22,7 @@ import { buildClawHubPluginInstallRecordFields } from "../../../plugins/clawhub-
 import { installPluginFromClawHub } from "../../../plugins/clawhub.js";
 import {
   installWithSourceFallback,
+  NpmChannelResolutionError,
   resolvePluginInstallSources,
   installWithChannelFallback,
   resolveClawHubInstallSpecsForUpdateChannel,
@@ -97,7 +102,10 @@ export async function installCandidate(params: {
     return result;
   } catch (error) {
     consent.rethrowCallbackError();
-    if (!(error instanceof ManagedPluginLifecycleError)) {
+    if (
+      !(error instanceof ManagedPluginLifecycleError) &&
+      !(error instanceof NpmChannelResolutionError)
+    ) {
       throw error;
     }
     return {
@@ -106,7 +114,11 @@ export async function installCandidate(params: {
       notices: [],
       warnings: [sanitizeTerminalText(error.message)],
       failedPluginId: params.candidate.pluginId,
-      ...(error.capabilityConsent ? { code: PLUGIN_CAPABILITY_CONSENT_REQUIRED } : {}),
+      ...(error instanceof NpmChannelResolutionError
+        ? { code: error.code }
+        : error.capabilityConsent
+          ? { code: PLUGIN_CAPABILITY_CONSENT_REQUIRED }
+          : {}),
     };
   }
 }
@@ -171,7 +183,7 @@ async function installCandidatePackage(
       })
     : null;
   const npmSpecs = candidate.npmSpec
-    ? resolveNpmInstallSpecsForUpdateChannel({
+    ? await resolveNpmInstallSpecsForUpdateChannel({
         spec: candidate.npmSpec,
         updateChannel: params.updateChannel,
         officialPackageName: candidate.trustedSourceLinkedOfficialInstall
@@ -204,6 +216,32 @@ async function installCandidatePackage(
   const existingNpmPackagePath = npmInstallSpec
     ? resolveExistingCandidateNpmPackagePath({ candidate, npmDir })
     : null;
+  if (staleRuntimeRepair && npmSpecs?.npmResolution?.version) {
+    const installPath = resolveRecordInstallPath(record, params.env) ?? existingNpmPackagePath;
+    const installedVersion = installPath
+      ? await readInstalledPackageVersion(installPath)
+      : undefined;
+    const selectedVersion = npmSpecs.npmResolution.version;
+    if (npmSpecs.channelReason) {
+      channelNotices.push(
+        `Plugin "${candidate.pluginId}" refresh: tag-behind-latest; beta follows latest ${selectedVersion}.`,
+      );
+    }
+    if (installedVersion && comparePackageUpdateVersions(selectedVersion, installedVersion) <= 0) {
+      return {
+        records: params.records,
+        changes: [],
+        notices: [
+          ...channelNotices,
+          `Plugin "${candidate.pluginId}" refresh: already-current (${installedVersion}).`,
+        ],
+        warnings: [],
+      };
+    }
+    channelNotices.push(
+      `Plugin "${candidate.pluginId}" refresh: newer-available (${installedVersion ?? "unknown"} -> ${selectedVersion}).`,
+    );
+  }
   const sources = resolvePluginInstallSources(candidate, recordedSource);
   if (sources.length === 0) {
     return {
@@ -298,6 +336,7 @@ async function installCandidatePackage(
   }
   const pluginId = installResult.pluginId;
   const recordSpec =
+    (record?.source === installedSource.source ? record.spec : undefined) ??
     (installedSource.source === "npm" ? npmSpecs : clawhubSpecs)?.recordSpec ??
     installedSource.spec;
   const installedRecord: PluginInstallRecord =
@@ -378,50 +417,6 @@ function resolveExistingCandidateClawHubPackagePath(params: {
   } catch {
     return null;
   }
-}
-
-export function resolveCandidateInstallSpec(params: {
-  candidate: DownloadableInstallCandidate;
-  updateChannel: UpdateChannel;
-  coreVersion: string;
-}): string | undefined {
-  if (
-    resolvePluginInstallSources(params.candidate)[0]?.source === "clawhub" &&
-    params.candidate.clawhubSpec
-  ) {
-    return resolveClawHubInstallSpecsForUpdateChannel({
-      spec: params.candidate.clawhubSpec,
-      updateChannel: params.updateChannel,
-      officialPackageName: params.candidate.trustedSourceLinkedOfficialInstall
-        ? parseClawHubPluginSpec(params.candidate.clawhubSpec)?.name
-        : undefined,
-      coreVersion: params.coreVersion,
-      versionBoundToCore: params.candidate.versionBoundToOpenClaw,
-    }).installSpec;
-  }
-  if (params.candidate.npmSpec) {
-    return resolveNpmInstallSpecsForUpdateChannel({
-      spec: params.candidate.npmSpec,
-      updateChannel: params.updateChannel,
-      officialPackageName: params.candidate.trustedSourceLinkedOfficialInstall
-        ? parseRegistryNpmSpec(params.candidate.npmSpec)?.name
-        : undefined,
-      coreVersion: params.coreVersion,
-      versionBoundToCore: params.candidate.versionBoundToOpenClaw,
-    }).installSpec;
-  }
-  if (params.candidate.clawhubSpec) {
-    return resolveClawHubInstallSpecsForUpdateChannel({
-      spec: params.candidate.clawhubSpec,
-      updateChannel: params.updateChannel,
-      officialPackageName: params.candidate.trustedSourceLinkedOfficialInstall
-        ? parseClawHubPluginSpec(params.candidate.clawhubSpec)?.name
-        : undefined,
-      coreVersion: params.coreVersion,
-      versionBoundToCore: params.candidate.versionBoundToOpenClaw,
-    }).installSpec;
-  }
-  return undefined;
 }
 
 export function resolveRecordInstallPath(

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -8,6 +8,7 @@ import {
   normalizePluginsConfig,
   resolveEffectiveEnableState,
 } from "../../../plugins/config-state.js";
+import { PLUGIN_INSTALL_ERROR_CODE } from "../../../plugins/install-types.js";
 import { writePersistedInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
 import { isPayloadMissing } from "../../../plugins/payload-verification.js";
 import { withPluginLifecycleLease } from "../../../plugins/plugin-lifecycle-lease.js";
@@ -183,7 +184,8 @@ async function repairMissingPluginInstallsWithLease(
     // A later failed attempt does not resolve an earlier consent refusal.
     let outcome = failedPlugins.get(pluginId);
     const retainedEnabledInstall =
-      code === PLUGIN_CAPABILITY_CONSENT_REQUIRED &&
+      (code === PLUGIN_CAPABILITY_CONSENT_REQUIRED ||
+        code === PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE) &&
       knownIds.has(pluginId) &&
       !isPayloadMissing(env, records[pluginId]?.installPath) &&
       !installedPluginIdsWithRepairablePackageDiagnostics.has(pluginId) &&
@@ -194,8 +196,7 @@ async function repairMissingPluginInstallsWithLease(
         config: normalizedPluginConfig,
         rootConfig: params.cfg,
       }).enabled;
-    // Consent refusal rolls back the replacement; a retained enabled artifact is
-    // still subject to the caller's payload smoke check, not a failed activation.
+    // Deferred replacements leave the installed artifact for the caller's payload smoke check.
     if (retainedEnabledInstall) {
       notices.push(
         `Kept installed plugin "${pluginId}"; replacement deferred. ${messages.join(" ")}`,
@@ -265,7 +266,14 @@ async function repairMissingPluginInstallsWithLease(
     // Dropping resolved fields forces an installer attempt, not a record mutation.
     const repairRecords = { ...nextRecords };
     for (const [pluginId, record] of missingRecordedPlugins) {
-      repairRecords[pluginId] = forceNpmInstallRecordRepair(record);
+      if (
+        !installedPluginIdsWithStaleVersionBoundRuntimePackages.has(pluginId) ||
+        installedPluginIdsWithRepairablePackageDiagnostics.has(pluginId) ||
+        configuredPluginIdsWithStaleDescriptors.has(pluginId) ||
+        isPayloadMissing(env, record.installPath)
+      ) {
+        repairRecords[pluginId] = forceNpmInstallRecordRepair(record);
+      }
     }
     const updateResult = await updateNpmInstalledPlugins({
       config: {
@@ -294,7 +302,13 @@ async function repairMissingPluginInstallsWithLease(
       beforePersistentEffect: params.beforePersistentEffect,
     });
     for (const outcome of updateResult.outcomes) {
-      if (outcome.status === "updated" || outcome.status === "unchanged") {
+      if (
+        outcome.status === "unchanged" &&
+        updateResult.config.plugins?.installs?.[outcome.pluginId] ===
+          repairRecords[outcome.pluginId]
+      ) {
+        notices.push(outcome.message);
+      } else if (outcome.status === "updated" || outcome.status === "unchanged") {
         repairedPluginIds.add(outcome.pluginId);
         failedPlugins.delete(outcome.pluginId);
         changes.push(
@@ -385,7 +399,10 @@ async function repairMissingPluginInstallsWithLease(
       updateChannel,
       mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
       preferNpm: preferNpmInstalls,
-      ...(installedPluginIdsWithStaleVersionBoundRuntimePackages.has(candidate.pluginId)
+      ...(installedPluginIdsWithStaleVersionBoundRuntimePackages.has(candidate.pluginId) &&
+      !installedPluginIdsWithRepairablePackageDiagnostics.has(candidate.pluginId) &&
+      !configuredPluginIdsWithStaleDescriptors.has(candidate.pluginId) &&
+      hasUsableRecord
         ? { repairReason: "stale-version-bound-runtime" as const }
         : {}),
       ...(params.onCapabilityConsent ? { onCapabilityConsent: params.onCapabilityConsent } : {}),
@@ -412,7 +429,11 @@ async function repairMissingPluginInstallsWithLease(
     nextRecords = installed.records;
     changes.push(...installed.changes);
     notices.push(...installed.notices);
-    if (!installed.failedPluginId && installed.records[candidate.pluginId]) {
+    if (
+      !installed.failedPluginId &&
+      installed.records !== previousRecords &&
+      installed.records[candidate.pluginId]
+    ) {
       repairedPluginIds.add(candidate.pluginId);
       failedPlugins.delete(candidate.pluginId);
     }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -12,10 +12,7 @@ import { resolveRegistryUpdateChannel } from "../../../infra/update-channels.js"
 import { resolvePluginArtifactDeclaredSurface } from "../../../plugins/capability-artifact.js";
 import type { PluginCapabilityConsentHandler } from "../../../plugins/capability-consent.js";
 import { computeDeclaredSurfaceHash } from "../../../plugins/capability-summary.js";
-import {
-  resolveClawHubInstallSpecsForUpdateChannel,
-  resolveNpmInstallSpecsForUpdateChannel,
-} from "../../../plugins/install-channel-specs.js";
+import { resolveClawHubInstallSpecsForUpdateChannel } from "../../../plugins/install-channel-specs.js";
 import type { PluginInstallArtifactConsentHandler } from "../../../plugins/install-types.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../../../plugins/installed-plugin-index-policy.js";
 import { isTrustedOfficialPluginInstallRecord } from "../../../plugins/official-external-install-records.js";
@@ -36,10 +33,9 @@ import {
 } from "./missing-configured-plugin-install.test-helpers.js";
 
 function expectedNpmInstallSpec(spec: string): string {
-  return resolveNpmInstallSpecsForUpdateChannel({
-    spec,
-    updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
-  }).installSpec;
+  return resolveRegistryUpdateChannel({ currentVersion: VERSION }) === "beta"
+    ? `${spec}@${VERSION}`
+    : spec;
 }
 
 function expectedClawHubInstallSpec(spec: string): string {
@@ -50,17 +46,19 @@ function expectedClawHubInstallSpec(spec: string): string {
 }
 
 function expectedCodexInstallSpec(): string {
-  return resolveNpmInstallSpecsForUpdateChannel({
-    spec: "@openclaw/codex",
-    updateChannel: resolveRegistryUpdateChannel({ currentVersion: VERSION }),
-    officialPackageName: "@openclaw/codex",
-    coreVersion: VERSION,
-    versionBoundToCore: true,
-  }).installSpec;
+  return `@openclaw/codex@${VERSION}`;
 }
 
-function currentOpenClawReleaseBase(): string {
-  return VERSION.replace(/-(?:alpha|beta)\.[1-9]\d*$/u, "");
+function mockNpmRegistryTags(tags: { beta?: string; latest: string }): void {
+  mocks.resolveNpmSpecMetadata.mockImplementation(async ({ spec }: { spec: string }) => {
+    const selectorIndex = spec.lastIndexOf("@");
+    const name = spec.slice(0, selectorIndex);
+    const tag = spec.slice(selectorIndex + 1);
+    const version = tag === "beta" ? tags.beta : tags.latest;
+    return version
+      ? { ok: true, metadata: { name, version, resolvedSpec: `${name}@${version}` } }
+      : { ok: false, error: `No ${tag} release for ${name}.` };
+  });
 }
 
 function expectRecordFields(record: unknown, expected: Record<string, unknown>) {
@@ -146,6 +144,7 @@ const mocks = vi.hoisted(() => ({
   ),
   validatePluginId: vi.fn(() => null),
   resolveProviderInstallCatalogEntries: vi.fn(),
+  resolveNpmSpecMetadata: vi.fn(),
   updateNpmInstalledPlugins: vi.fn(),
   writePersistedInstalledPluginIndexInstallRecords: vi.fn(),
 }));
@@ -269,6 +268,11 @@ vi.mock("../../../plugins/install-paths.js", () => ({
 
 vi.mock("../../../plugins/install.js", () => ({
   installPluginFromNpmSpec: mocks.installPluginFromNpmSpec,
+}));
+
+vi.mock("../../../infra/install-source-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../infra/install-source-utils.js")>()),
+  resolveNpmSpecMetadata: mocks.resolveNpmSpecMetadata,
 }));
 
 vi.mock("../../../plugins/clawhub.js", () => ({
@@ -874,6 +878,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockNpmRegistryTags({ beta: VERSION, latest: VERSION });
     // Explicit empty env fixtures fall back to the OS home, outside Vitest's env copy.
     vi.spyOn(os, "homedir").mockReturnValue(tempDirs.make("openclaw-doctor-home-"));
     prepareManagedPluginArtifactConsentHandler.mockResolvedValue({
@@ -1003,14 +1008,17 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  it("maps a missing configured plugin install to a structured finding and dry-run effect", async () => {
+  it("maps a missing beta-channel plugin to a structured finding and dry-run effect offline", async () => {
+    mocks.resolveNpmSpecMetadata.mockImplementation(() => {
+      throw new Error("Health detection must not query the npm registry.");
+    });
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
         id: "matrix",
         pluginId: "matrix",
         meta: { label: "Matrix" },
         install: {
-          npmSpec: "@openclaw/plugin-matrix@1.2.3",
+          npmSpec: "@openclaw/plugin-matrix",
           expectedIntegrity: "sha512-test",
         },
         trustedSourceLinkedOfficialInstall: true,
@@ -1024,6 +1032,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     } = await import("./missing-configured-plugin-install.js");
     const [issue] = await detectConfiguredPluginInstallHealthIssues({
       cfg: {
+        update: { channel: "beta" },
         channels: {
           matrix: { enabled: true, homeserver: "https://matrix.example.org" },
         },
@@ -1033,11 +1042,12 @@ describe("repairMissingConfiguredPluginInstalls", () => {
 
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.resolveNpmSpecMetadata).not.toHaveBeenCalled();
     expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
     expect(issue).toEqual({
       kind: "missing-install-record",
       pluginId: "matrix",
-      installSpec: "@openclaw/plugin-matrix@1.2.3",
+      installSpec: "@openclaw/plugin-matrix",
     });
     expect(
       configuredPluginInstallIssueToHealthFinding(expectDefined(issue, "issue test invariant")),
@@ -1045,7 +1055,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       checkId: "core/doctor/configured-plugin-installs",
       severity: "warning",
       target: "matrix",
-      fixHint: "Run `openclaw doctor --fix` to install @openclaw/plugin-matrix@1.2.3.",
+      fixHint: "Run `openclaw doctor --fix` to install @openclaw/plugin-matrix.",
     });
     expect(
       configuredPluginInstallIssueToRepairEffect(expectDefined(issue, "issue test invariant")),
@@ -1260,7 +1270,8 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.warnings).toStrictEqual([]);
   });
 
-  it("falls back to the operator selector when no beta release is published", async () => {
+  it("installs latest directly when no beta release is published", async () => {
+    mockNpmRegistryTags({ latest: "1.2.3" });
     const cfg = {
       security: { installPolicy: { enabled: true } },
       update: { channel: "beta" },
@@ -1277,27 +1288,20 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         trustedSourceLinkedOfficialInstall: true,
       },
     ]);
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
-      ok: false,
-      code: "npm_package_not_found",
-      error: "Package not found on npm: @openclaw/plugin-matrix@beta.",
-    });
 
     const { repairMissingConfiguredPluginInstalls } =
       await import("./missing-configured-plugin-install.js");
     const result = await repairMissingConfiguredPluginInstalls({ cfg, env: testEnv });
 
-    expect(mockCallArg(mocks.installPluginFromNpmSpec, 0)).toMatchObject({
-      spec: "@openclaw/plugin-matrix@beta",
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledOnce();
+    expect(mockCallArg(mocks.installPluginFromNpmSpec)).toMatchObject({
+      spec: "@openclaw/plugin-matrix@1.2.3",
     });
-    expect(mockCallArg(mocks.installPluginFromNpmSpec, 1)).toMatchObject({
+    expect(result.records.matrix).toMatchObject({
       spec: "@openclaw/plugin-matrix",
+      version: "1.2.3",
     });
-    expect(result.notices).toEqual(
-      expect.arrayContaining([
-        expect.stringContaining("No @openclaw/plugin-matrix@beta release is published"),
-      ]),
-    );
+    expect(result.warnings).toEqual([]);
   });
 
   it("retries the operator ClawHub selector when no beta release is published", async () => {
@@ -2340,6 +2344,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   ] as const)(
     "converges orphaned $layout npm payloads to the verified $channel target $version",
     async ({ layout, channel, coreVersion, npmSpec, version }) => {
+      mockNpmRegistryTags({ beta: version, latest: "2026.7.9" });
       const actual = await vi.importActual<typeof import("../../../plugins/capability-consent.js")>(
         "../../../plugins/capability-consent.js",
       );
@@ -3245,135 +3250,211 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     },
   );
 
-  it("does not refresh a converged beta Codex runtime plugin on the second doctor pass", async () => {
-    const codexBetaVersion = `${currentOpenClawReleaseBase()}-beta.4`;
-    const installDir = tempDirs.make("openclaw-plugin-stub-repair-");
-    fs.writeFileSync(
-      path.join(installDir, "package.json"),
-      JSON.stringify({ name: "@openclaw/codex", version: "2026.5.6" }),
-    );
-    const records = {
-      codex: {
-        source: "npm",
-        spec: "@openclaw/codex",
-        resolvedName: "@openclaw/codex",
-        resolvedSpec: "@openclaw/codex@2026.5.6",
-        resolvedVersion: "2026.5.6",
-        version: "2026.5.6",
-        integrity: "sha512-old-codex",
-        installPath: installDir,
-      },
-    };
-    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
-    mocks.loadPluginMetadataSnapshot.mockReturnValue({
-      plugins: [
-        {
-          id: "codex",
-          packageVersion: "2026.5.6",
-          providers: ["codex"],
+  it.each([
+    {
+      name: "stale beta follows newer latest",
+      installedVersion: "2026.9.1-beta.1",
+      betaVersion: "2026.9.1-beta.1",
+      latestVersion: "2026.9.2",
+      selectedVersion: "2026.9.2",
+      refresh: true,
+    },
+    {
+      name: "same-base beta follows newer latest",
+      installedVersion: "2026.9.2-beta.1",
+      betaVersion: "2026.9.2-beta.1",
+      latestVersion: "2026.9.2",
+      selectedVersion: "2026.9.2",
+      refresh: true,
+    },
+    {
+      name: "newer beta stays ahead of latest",
+      installedVersion: "2026.9.1-beta.1",
+      betaVersion: "2026.9.3-beta.1",
+      latestVersion: "2026.9.2",
+      selectedVersion: "2026.9.3-beta.1",
+      refresh: true,
+    },
+    {
+      name: "already-current beta older than the host is a no-op",
+      installedVersion: "2026.9.1-beta.1",
+      betaVersion: "2026.9.1-beta.1",
+      latestVersion: "2026.8.31",
+      selectedVersion: "2026.9.1-beta.1",
+      refresh: false,
+    },
+    {
+      name: "already-current same-base beta is a no-op",
+      installedVersion: "2026.9.2-beta.4",
+      betaVersion: "2026.9.2-beta.4",
+      latestVersion: "2026.9.1",
+      selectedVersion: "2026.9.2-beta.4",
+      refresh: false,
+    },
+    {
+      name: "registry tags behind the installed beta are a no-op",
+      installedVersion: "2026.9.1-beta.2",
+      betaVersion: "2026.9.1-beta.1",
+      latestVersion: "2026.8.31",
+      selectedVersion: "2026.9.1-beta.1",
+      refresh: false,
+    },
+    {
+      name: "registry outage retains a healthy installed beta",
+      installedVersion: "2026.9.1-beta.1",
+      betaVersion: "2026.9.1-beta.1",
+      latestVersion: "2026.9.2",
+      selectedVersion: "2026.9.2",
+      refresh: false,
+      registryUnavailable: true,
+    },
+    {
+      name: "registry outage cannot hide broken package diagnostics",
+      installedVersion: "2026.9.1-beta.1",
+      betaVersion: "2026.9.1-beta.1",
+      latestVersion: "2026.9.2",
+      selectedVersion: "2026.9.2",
+      refresh: false,
+      registryUnavailable: true,
+      brokenPayload: true,
+    },
+  ])(
+    "converges managed Codex startup: $name",
+    async ({
+      installedVersion,
+      betaVersion,
+      latestVersion,
+      selectedVersion,
+      refresh,
+      registryUnavailable = false,
+      brokenPayload = false,
+    }) => {
+      mockNpmRegistryTags({ beta: betaVersion, latest: latestVersion });
+      if (registryUnavailable) {
+        mocks.resolveNpmSpecMetadata.mockResolvedValue({
+          ok: false,
+          category: "metadata-env",
+          error: "registry unavailable",
+        });
+      }
+      const installDir = tempDirs.make("openclaw-beta-codex-convergence-");
+      const packageFile = path.join(installDir, "package.json");
+      const writePackageVersion = (version: string) =>
+        fs.writeFileSync(packageFile, JSON.stringify({ name: "@openclaw/codex", version }));
+      writePackageVersion(installedVersion);
+      const records = {
+        codex: {
+          source: "npm",
+          spec: "@openclaw/codex",
+          resolvedName: "@openclaw/codex",
+          resolvedSpec: `@openclaw/codex@${installedVersion}`,
+          resolvedVersion: installedVersion,
+          version: installedVersion,
+          integrity: "sha512-old-codex",
+          installPath: installDir,
         },
-      ],
-      diagnostics: [],
-      byPluginId: new Map([
-        [
-          "codex",
-          {
-            id: "codex",
-            packageVersion: "2026.5.6",
-            providers: ["codex"],
-          },
-        ],
-      ]),
-    });
-    mocks.installPluginFromNpmSpec.mockResolvedValueOnce(
-      successfulInstall({
-        pluginId: "codex",
-        npmSpec: "@openclaw/codex",
-        targetDir: installDir,
-        version: codexBetaVersion,
-        resolution: {
-          integrity: "sha512-new-codex-beta",
-        },
-      }),
-    );
-    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
-      {
-        id: "codex",
-        label: "Codex",
-        install: {
+      };
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.loadPluginMetadataSnapshot.mockImplementation(() => {
+        const { version } = JSON.parse(fs.readFileSync(packageFile, "utf8")) as { version: string };
+        const plugin = { id: "codex", packageVersion: version, providers: ["codex"] };
+        return {
+          plugins: [plugin],
+          diagnostics: brokenPayload ? brokenPluginSnapshot("codex", installDir).diagnostics : [],
+          byPluginId: new Map([["codex", plugin]]),
+        };
+      });
+      mocks.installPluginFromNpmSpec.mockImplementation(async () => {
+        writePackageVersion(selectedVersion);
+        return successfulInstall({
+          pluginId: "codex",
           npmSpec: "@openclaw/codex",
-          defaultChoice: "npm",
+          targetDir: installDir,
+          version: selectedVersion,
+        });
+      });
+      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+        officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
+      ]);
+      const params = {
+        cfg: {
+          update: { channel: "beta" as const },
+          agents: { defaults: { model: "openai/gpt-5.5" } },
         },
-      },
-    ]);
+        env: { ...testEnv, OPENCLAW_COMPATIBILITY_HOST_VERSION: "2026.9.2" },
+      };
+      const { repairMissingConfiguredPluginInstalls } =
+        await import("./missing-configured-plugin-install.js");
+      const firstPass = await repairMissingConfiguredPluginInstalls(params);
 
-    const cfg = {
-      update: { channel: "beta" as const },
-      agents: {
-        defaults: {
-          model: "openai/gpt-5.5",
-        },
-      },
-    };
-    const { repairMissingConfiguredPluginInstalls } =
-      await import("./missing-configured-plugin-install.js");
-    const firstPass = await repairMissingConfiguredPluginInstalls({
-      cfg,
-      env: testEnv,
-    });
+      if (refresh) {
+        expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledOnce();
+        expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+          spec: `@openclaw/codex@${selectedVersion}`,
+          expectedPluginId: "codex",
+          trustedSourceLinkedOfficialInstall: true,
+          mode: "update",
+        });
+        expect(firstPass.changes).toEqual([
+          `Refreshed stale configured plugin "codex" from @openclaw/codex@${selectedVersion}.`,
+        ]);
+        expect(firstPass.pluginInventoryChanged).toBe(true);
+        expect(firstPass.notices).toContain(
+          `Plugin "codex" refresh: newer-available (${installedVersion} -> ${selectedVersion}).`,
+        );
+        if (selectedVersion === latestVersion) {
+          expect(firstPass.notices).toContain(
+            `Plugin "codex" refresh: tag-behind-latest; beta follows latest ${selectedVersion}.`,
+          );
+        }
+        expectRecordFields(firstPass.records.codex, {
+          source: "npm",
+          spec: "@openclaw/codex",
+          installPath: installDir,
+          version: selectedVersion,
+          resolvedVersion: selectedVersion,
+          resolvedSpec: `@openclaw/codex@${selectedVersion}`,
+        });
+      } else {
+        expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+        expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+        expect(firstPass.records).toBe(records);
+        expect(firstPass.changes).toEqual([]);
+        expect(firstPass.pluginInventoryChanged).toBeUndefined();
+        expect(firstPass.repairedPluginIds).toBeUndefined();
+        if (registryUnavailable) {
+          expect(firstPass.notices ?? []).toEqual(
+            brokenPayload
+              ? []
+              : [expect.stringContaining('Kept installed plugin "codex"; replacement deferred.')],
+          );
+        } else {
+          expect(firstPass.notices).toContain(
+            `Plugin "codex" refresh: already-current (${installedVersion}).`,
+          );
+        }
+      }
+      expect(firstPass.warnings).toEqual(
+        brokenPayload ? [expect.stringContaining("registry unavailable")] : [],
+      );
+      mocks.installPluginFromNpmSpec.mockClear();
+      mocks.writePersistedInstalledPluginIndexInstallRecords.mockClear();
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(firstPass.records);
 
-    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: "@openclaw/codex@beta",
-      expectedPluginId: "codex",
-      trustedSourceLinkedOfficialInstall: true,
-      mode: "update",
-    });
-    expect(firstPass.changes).toEqual([
-      'Refreshed stale configured plugin "codex" from @openclaw/codex@beta.',
-    ]);
-    expectRecordFields(firstPass.records.codex, {
-      source: "npm",
-      spec: "@openclaw/codex",
-      installPath: installDir,
-      version: codexBetaVersion,
-      resolvedName: "@openclaw/codex",
-      resolvedVersion: codexBetaVersion,
-      resolvedSpec: `@openclaw/codex@${codexBetaVersion}`,
-    });
+      const secondPass = await repairMissingConfiguredPluginInstalls(params);
 
-    mocks.installPluginFromNpmSpec.mockClear();
-    mocks.writePersistedInstalledPluginIndexInstallRecords.mockClear();
-    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce(firstPass.records);
-    mocks.loadPluginMetadataSnapshot.mockReturnValue({
-      plugins: [
-        {
-          id: "codex",
-          packageVersion: codexBetaVersion,
-          providers: ["codex"],
-        },
-      ],
-      diagnostics: [],
-      byPluginId: new Map([
-        [
-          "codex",
-          {
-            id: "codex",
-            packageVersion: codexBetaVersion,
-            providers: ["codex"],
-          },
-        ],
-      ]),
-    });
-
-    const secondPass = await repairMissingConfiguredPluginInstalls({
-      cfg,
-      env: testEnv,
-    });
-
-    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
-    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
-    expect(secondPass).toEqual({ changes: [], warnings: [], records: firstPass.records });
-  });
+      expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+      expect(secondPass.changes).toEqual([]);
+      expect(secondPass.warnings).toEqual(firstPass.warnings);
+      if (registryUnavailable) {
+        expect(secondPass.notices).toEqual(firstPass.notices);
+      }
+      expect(secondPass.records).toBe(firstPass.records);
+      expect(secondPass.pluginInventoryChanged).toBeUndefined();
+      expect(secondPass.repairedPluginIds).toBeUndefined();
+    },
+  );
 
   it("does not downgrade a newer managed Codex runtime plugin", async () => {
     const installDir = tempDirs.make("openclaw-plugin-stub-repair-");
@@ -4037,12 +4118,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it.each([
-    { recordedConsentRequired: false, siblingConsentRequired: false },
-    { recordedConsentRequired: true, siblingConsentRequired: false },
-    { recordedConsentRequired: true, siblingConsentRequired: true },
+    { recordedSource: "npm", recordedConsentRequired: false, siblingConsentRequired: false },
+    { recordedSource: "npm", recordedConsentRequired: true, siblingConsentRequired: false },
+    { recordedSource: "npm", recordedConsentRequired: true, siblingConsentRequired: true },
+    { recordedSource: "git", recordedConsentRequired: false, siblingConsentRequired: false },
   ])(
-    "reinstalls a known configured plugin from the catalog when its recorded install path is missing (recorded consent=$recordedConsentRequired, sibling consent=$siblingConsentRequired)",
-    async ({ recordedConsentRequired, siblingConsentRequired }) => {
+    "reinstalls a known configured plugin from the catalog when its recorded install path is missing (source=$recordedSource, recorded consent=$recordedConsentRequired, sibling consent=$siblingConsentRequired)",
+    async ({ recordedSource, recordedConsentRequired, siblingConsentRequired }) => {
       const actual = await vi.importActual<typeof import("../../../plugins/capability-consent.js")>(
         "../../../plugins/capability-consent.js",
       );
@@ -4060,7 +4142,11 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         manifest: { contracts: { tools: ["fixture.write"] } },
       });
       const records = installedRecords("discord", {
-        spec: "@openclaw/discord",
+        source: recordedSource,
+        spec:
+          recordedSource === "git"
+            ? "git+https://example.test/plugins/discord.git#v1.0.0"
+            : "@openclaw/discord",
         installPath: path.join(root, "missing-discord"),
       });
       if (siblingConsentRequired) {
@@ -4114,11 +4200,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         outcomes: [
           {
             pluginId: "discord",
-            status: recordedConsentRequired ? "error" : "skipped",
+            status: recordedSource === "git" || recordedConsentRequired ? "error" : "skipped",
             ...(recordedConsentRequired ? { code: PLUGIN_CAPABILITY_CONSENT_REQUIRED } : {}),
             message: recordedConsentRequired
               ? "Review recorded capabilities."
-              : "No update applied.",
+              : recordedSource === "git"
+                ? "Git repository unavailable."
+                : "No update applied.",
           },
           ...(siblingConsentRequired
             ? [
@@ -4166,6 +4254,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       });
       const persistedRecords = mockCallArg(mocks.writePersistedInstalledPluginIndexInstallRecords);
       expectRecordFields((persistedRecords as Record<string, unknown>).discord, {
+        source: "npm",
         spec: "@openclaw/discord",
         installPath: artifactDir,
       });
@@ -4854,6 +4943,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
   });
 
   it("installs configured external web search plugins from beta on the beta channel", async () => {
+    mockNpmRegistryTags({ beta: "2026.5.4-beta.1", latest: "2026.5.3" });
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
       officialWebSearchPluginEntry({
         id: "brave",
@@ -4886,7 +4976,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
 
     expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
-      spec: "@openclaw/brave-plugin@beta",
+      spec: "@openclaw/brave-plugin@2026.5.4-beta.1",
       expectedPluginId: "brave",
       trustedSourceLinkedOfficialInstall: true,
     });
@@ -4901,7 +4991,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: testEnv,
     });
     expect(result.changes).toEqual([
-      'Installed missing configured plugin "brave" from @openclaw/brave-plugin@beta.',
+      'Installed missing configured plugin "brave" from @openclaw/brave-plugin@2026.5.4-beta.1.',
     ]);
   });
 

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -48,6 +48,11 @@ vi.mock("../plugins/bundled-sources.js", () => ({
 
 const installPluginFromNpmSpec = vi.hoisted(() => vi.fn());
 const installPluginFromNpmPackArchive = vi.hoisted(() => vi.fn());
+const runCommandWithTimeout = vi.hoisted(() => vi.fn());
+vi.mock("../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../process/exec.js")>()),
+  runCommandWithTimeout,
+}));
 vi.mock("../plugins/install.js", () => ({
   installPluginFromNpmSpec,
   installPluginFromNpmPackArchive,
@@ -199,9 +204,24 @@ type ClawHubInstallCall = {
 
 type PluginInstallRecord = Partial<PersistedPluginInstallRecord> & { pluginId?: string };
 
+function mockNpmChannelMetadata(
+  name: string,
+  beta: string | undefined,
+  latest: string | undefined,
+) {
+  for (const version of [beta, latest]) {
+    runCommandWithTimeout.mockResolvedValueOnce(
+      version
+        ? { code: 0, stdout: JSON.stringify({ name, version }), stderr: "" }
+        : { code: 1, stdout: "", stderr: "npm error code E404" },
+    );
+  }
+}
+
 describe("ensureOnboardingPluginInstalled", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    runCommandWithTimeout.mockReset();
     vi.stubEnv("OPENCLAW_ALLOW_PLUGIN_INSTALL_OVERRIDES", undefined);
     vi.stubEnv("OPENCLAW_PLUGIN_INSTALL_OVERRIDES", undefined);
     withTimeout.mockImplementation(async <T>(promise: Promise<T>) => await promise);
@@ -803,29 +823,36 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(npmCall.expectedPluginId).toBe("codex");
   });
 
-  it.each(["@openclaw/codex", "@openclaw/codex@latest"])(
-    "falls back to the operator selector %s when no beta release is published",
-    async (spec) => {
-      installPluginFromNpmSpec
-        .mockResolvedValueOnce({
-          ok: false,
-          code: "npm_package_not_found",
-          error: "Package not found on npm: @openclaw/codex@beta.",
-        })
-        .mockResolvedValue({
-          ok: true,
-          pluginId: "codex",
-          targetDir: "/tmp/openclaw/extensions/codex",
-          version: "2026.7.1",
-          npmResolution: {
-            name: "@openclaw/codex",
-            version: "2026.7.1",
-            resolvedSpec: "@openclaw/codex@2026.7.1",
-          },
-        });
-      const note = vi.fn();
+  it.each(
+    [
+      { beta: undefined, latest: "2026.9.2", selected: "2026.9.2" },
+      { beta: "2026.9.1-beta.1", latest: "2026.9.2", selected: "2026.9.2" },
+      { beta: "2026.9.3-beta.1", latest: "2026.9.2", selected: "2026.9.3-beta.1" },
+    ].flatMap(({ beta, latest, selected }) =>
+      ["@openclaw/codex", "@openclaw/codex@latest"].map((spec) => ({
+        beta,
+        latest,
+        selected,
+        spec,
+      })),
+    ),
+  )(
+    "selects $selected before npm install and preserves $spec (beta=$beta)",
+    async ({ beta, latest, selected, spec }) => {
+      mockNpmChannelMetadata("@openclaw/codex", beta, latest);
+      installPluginFromNpmSpec.mockResolvedValue({
+        ok: true,
+        pluginId: "codex",
+        targetDir: "/tmp/openclaw/extensions/codex",
+        version: selected,
+        npmResolution: {
+          name: "@openclaw/codex",
+          version: selected,
+          resolvedSpec: `@openclaw/codex@${selected}`,
+        },
+      });
 
-      await ensureOnboardingPluginInstalled({
+      const result = await ensureOnboardingPluginInstalled({
         cfg: { update: { channel: "beta" } },
         entry: {
           pluginId: "codex",
@@ -835,20 +862,18 @@ describe("ensureOnboardingPluginInstalled", () => {
         },
         prompter: {
           select: vi.fn(async () => "npm"),
-          note,
+          note: vi.fn(),
           progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
         } as never,
         runtime: { log: vi.fn() } as never,
       });
 
-      const calls = installPluginFromNpmSpec.mock.calls as [NpmSpecInstallCall][];
-      expect(calls[0]?.[0]?.spec).toBe("@openclaw/codex@beta");
-      expect(calls[1]?.[0]?.spec).toBe(spec);
-      expect(
-        note.mock.calls.some(([message]) =>
-          String(message).includes("No @openclaw/codex@beta release is published"),
-        ),
-      ).toBe(true);
+      expect(installPluginFromNpmSpec).toHaveBeenCalledOnce();
+      expect(installPluginFromNpmSpec).toHaveBeenCalledWith(
+        expect.objectContaining({ spec: `@openclaw/codex@${selected}` }),
+      );
+      expect(result.status).toBe("installed");
+      expect(result.cfg.plugins?.installs?.codex?.spec).toBe(spec);
     },
   );
 
@@ -1195,9 +1220,9 @@ describe("ensureOnboardingPluginInstalled", () => {
         { version: "2026.8.1", channel: "stable", installVersion: "2026.8.1" },
         { version: "2026.8.1-2", channel: "stable", installVersion: "2026.8.1" },
         { version: "2026.7.33-1", channel: "extended-stable", installVersion: "2026.7.33" },
-        { version: "2026.8.1", channel: "beta", installVersion: "beta" },
-        { version: "2026.8.1-beta.4", channel: undefined, installVersion: "2026.8.1-beta.4" },
-        { version: "2026.8.1-beta.4", channel: "stable", installVersion: "2026.8.1-beta.4" },
+        { version: "2026.8.1", channel: "beta", installVersion: "2026.8.2-beta.1" },
+        { version: "2026.8.1-beta.4", channel: undefined, installVersion: "2026.8.2-beta.1" },
+        { version: "2026.8.1-beta.4", channel: "stable", installVersion: "2026.8.2-beta.1" },
       ] as const
     ).flatMap(({ version, channel, installVersion }) =>
       ["@openclaw/codex", "@openclaw/codex@latest"].map((spec) => ({
@@ -1208,18 +1233,21 @@ describe("ensureOnboardingPluginInstalled", () => {
       })),
     ),
   )(
-    "aligns version-bound plugins from $spec on core $version with channel $channel",
+    "applies the release policy to version-bound plugins from $spec on core $version with channel $channel",
     async ({ version, channel, installVersion, spec }) => {
       coreVersion.value = version;
+      if (channel === "beta" || version.includes("beta")) {
+        mockNpmChannelMetadata("@openclaw/codex", "2026.8.2-beta.1", "2026.8.1");
+      }
       installPluginFromNpmSpec.mockResolvedValueOnce({
         ok: true,
         pluginId: "codex",
         targetDir: "/tmp/codex",
-        version: VERSION,
+        version: installVersion,
         npmResolution: {
           name: "@openclaw/codex",
-          version: VERSION,
-          resolvedSpec: `@openclaw/codex@${VERSION}`,
+          version: installVersion,
+          resolvedSpec: `@openclaw/codex@${installVersion}`,
         },
       });
 
@@ -1378,7 +1406,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     );
   });
 
-  it("offers registry npm specs without requiring an exact version or integrity pin", async () => {
+  it("offers floating npm specs on beta and skips without registry access", async () => {
     let captured:
       | {
           options: Array<{
@@ -1390,8 +1418,8 @@ describe("ensureOnboardingPluginInstalled", () => {
         }
       | undefined;
 
-    await ensureOnboardingPluginInstalled({
-      cfg: {},
+    const result = await ensureOnboardingPluginInstalled({
+      cfg: { update: { channel: "beta" } },
       entry: {
         pluginId: "demo-plugin",
         label: "Demo Plugin",
@@ -1414,6 +1442,8 @@ describe("ensureOnboardingPluginInstalled", () => {
     ]);
     expect(captured?.initialValue).toBe("npm");
     expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(result.status).toBe("skipped");
   });
 
   it("defaults dual-source remote installs to npm unless ClawHub is explicit", async () => {
@@ -1503,8 +1533,8 @@ describe("ensureOnboardingPluginInstalled", () => {
       version: "2026.8.1-beta.3",
       npmSpec: "@openclaw/demo-plugin",
       clawhubSpec: "clawhub:demo-plugin",
-      expectedNpmSpecs: ["@openclaw/demo-plugin@2026.8.1-beta.3", "@openclaw/demo-plugin"],
-      expectedClawHubSpec: "clawhub:demo-plugin@2026.8.1-beta.3",
+      expectedNpmSpecs: ["@openclaw/demo-plugin@latest"],
+      expectedClawHubSpec: "clawhub:demo-plugin@beta",
       installVersion: "2026.8.1-beta.3",
       trustedSourceLinkedOfficialInstall: true,
     },
@@ -1520,6 +1550,9 @@ describe("ensureOnboardingPluginInstalled", () => {
       trustedSourceLinkedOfficialInstall,
     }) => {
       coreVersion.value = version;
+      if (version.includes("beta")) {
+        mockNpmChannelMetadata("@openclaw/demo-plugin", undefined, undefined);
+      }
       for (const spec of expectedNpmSpecs) {
         installPluginFromNpmSpec.mockResolvedValueOnce({
           ok: false,
@@ -1931,7 +1964,7 @@ describe("ensureOnboardingPluginInstalled", () => {
     });
   });
 
-  it("records local install source metadata when a local path is selected", async () => {
+  it("records local install metadata on beta without registry access", async () => {
     await withTestDir({ prefix: "openclaw-onboarding-install-local-record-" }, async (temp) => {
       const workspaceDir = path.join(temp, "workspace");
       const pluginDir = path.join(workspaceDir, "plugins", "demo");
@@ -1939,12 +1972,12 @@ describe("ensureOnboardingPluginInstalled", () => {
       await fs.mkdir(pluginDir, { recursive: true });
 
       const result = await ensureOnboardingPluginInstalled({
-        cfg: {},
+        cfg: { update: { channel: "beta" } },
         entry: {
           pluginId: "demo-plugin",
           label: "Demo Plugin",
           install: {
-            npmSpec: "@demo/plugin@1.2.3",
+            npmSpec: "@demo/plugin",
             localPath: "plugins/demo",
           },
         },
@@ -1966,10 +1999,11 @@ describe("ensureOnboardingPluginInstalled", () => {
         source: "path",
         installPath: realPluginDir,
         sourcePath: "./plugins/demo",
-        spec: "@demo/plugin@1.2.3",
+        spec: "@demo/plugin",
       });
       expect(result.installed).toBe(true);
       expect(result.status).toBe("installed");
+      expect(runCommandWithTimeout).not.toHaveBeenCalled();
       expect(clearLoadInstalledPluginIndexInstallRecordsCache).toHaveBeenCalledOnce();
       expect(clearPluginMetadataLifecycleCaches).toHaveBeenCalledOnce();
       expect(invalidatePluginRuntimeDiscoveryAfterConfigMutation).toHaveBeenCalledWith(
@@ -1983,7 +2017,7 @@ describe("ensureOnboardingPluginInstalled", () => {
           source: "path",
           installPath: realPluginDir,
           sourcePath: "./plugins/demo",
-          spec: "@demo/plugin@1.2.3",
+          spec: "@demo/plugin",
         },
       });
     });

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -35,6 +35,7 @@ import {
 } from "../plugins/enable.js";
 import {
   installWithSourceFallback,
+  NpmChannelResolutionError,
   resolvePluginInstallSources,
   isUnavailablePluginSource,
   installWithChannelFallback,
@@ -1106,19 +1107,8 @@ export async function ensureOnboardingPluginInstalled(params: {
         versionBoundToCore: entry.versionBoundToOpenClaw,
       })
     : null;
-  const npmSpecs = npmSpec
-    ? resolveNpmInstallSpecsForUpdateChannel({
-        spec: npmSpec,
-        updateChannel,
-        officialPackageName: entry.trustedSourceLinkedOfficialInstall
-          ? parseRegistryNpmSpec(npmSpec)?.name
-          : undefined,
-        coreVersion: VERSION,
-        versionBoundToCore: entry.versionBoundToOpenClaw,
-      })
-    : null;
+  let npmSpecs: Awaited<ReturnType<typeof resolveNpmInstallSpecsForUpdateChannel>> | undefined;
   const clawhubInstallSpec = clawhubSpecs?.installSpec ?? clawhubSpec;
-  const npmInstallSpec = npmSpecs?.installSpec ?? npmSpec;
   const defaultChoice = resolveInstallDefaultChoice({
     cfg: next,
     entry,
@@ -1138,7 +1128,7 @@ export async function ensureOnboardingPluginInstalled(params: {
           prompter,
           autoConfirmSingleSource: params.autoConfirmSingleSource,
           effectiveClawHubSpec: clawhubInstallSpec,
-          effectiveNpmSpec: npmInstallSpec,
+          effectiveNpmSpec: npmSpec,
         });
 
   if (choice === "skip") {
@@ -1177,6 +1167,30 @@ export async function ensureOnboardingPluginInstalled(params: {
         "failed",
         "No declared remote install source.",
       );
+    }
+    if (npmSpec && sources.some((source) => source.source === "npm")) {
+      try {
+        npmSpecs = await resolveNpmInstallSpecsForUpdateChannel({
+          spec: npmSpec,
+          updateChannel,
+          officialPackageName: entry.trustedSourceLinkedOfficialInstall
+            ? parseRegistryNpmSpec(npmSpec)?.name
+            : undefined,
+          coreVersion: VERSION,
+          versionBoundToCore: entry.versionBoundToOpenClaw,
+        });
+      } catch (error) {
+        if (!(error instanceof NpmChannelResolutionError)) {
+          throw error;
+        }
+        await notePluginInstallFailure(prompter, npmSpec, error.message);
+        return incompletePluginInstall(
+          next,
+          entry.pluginId,
+          "failed",
+          formatInstallErrorDetail(error.message),
+        );
+      }
     }
     const { attempt: installOutcome, source: installedSource } = await installWithSourceFallback({
       sources,

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -1,7 +1,8 @@
 // Resolves OpenClaw update channels from config, tags, and versions.
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { parse as parseSemver } from "semver";
-import { normalizeLegacyDotBetaVersion } from "./semver.js";
+import { compareOpenClawReleaseVersions } from "./npm-registry-spec.js";
+import { compareValidSemver, normalizeLegacyDotBetaVersion } from "./semver.js";
 
 /** Release stream used to choose registry tags and update policy defaults. */
 export type UpdateChannel = "stable" | "extended-stable" | "beta" | "dev";
@@ -62,6 +63,26 @@ export function channelToNpmTag(channel: UpdateChannel): string {
     return "dev";
   }
   return "latest";
+}
+
+/** Beta follows the newest published beta or stable version, including plugin packages. */
+export function selectNpmChannelVersion<T extends { version: string | null }>(
+  beta: T,
+  latest: T,
+): T {
+  if (!latest.version) {
+    return beta;
+  }
+  if (!beta.version) {
+    return latest;
+  }
+  const comparison =
+    compareOpenClawReleaseVersions(beta.version, latest.version) ??
+    compareValidSemver(
+      normalizeLegacyDotBetaVersion(beta.version),
+      normalizeLegacyDotBetaVersion(latest.version),
+    );
+  return comparison !== null && comparison < 0 ? latest : beta;
 }
 
 /** Returns whether a version/tag explicitly targets the beta stream. */

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -14,6 +14,7 @@ import {
   channelToNpmTag,
   DEV_BRANCH,
   resolveDevUpstreamRefs,
+  selectNpmChannelVersion,
   type UpdateChannel,
 } from "./update-channels.js";
 import {
@@ -608,17 +609,7 @@ export async function resolveNpmChannelTag(params: {
     fetchTag(channelTag),
     fetchTag("latest"),
   ]);
-  if (!latestStatus.version) {
-    return channelStatus;
-  }
-  if (!channelStatus.version) {
-    return latestStatus;
-  }
-  const cmp = compareSemverStrings(channelStatus.version, latestStatus.version);
-  if (cmp != null && cmp < 0) {
-    return latestStatus;
-  }
-  return channelStatus;
+  return selectNpmChannelVersion(channelStatus, latestStatus);
 }
 
 export function compareSemverStrings(a: string | null, b: string | null): number | null {

--- a/src/plugins/install-channel-specs.test.ts
+++ b/src/plugins/install-channel-specs.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integrity.js";
 import {
   installWithSourceFallback,
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
 } from "./install-channel-specs.js";
+
+vi.mock("../infra/install-source-utils.js", () => ({ resolveNpmSpecMetadata: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(resolveNpmSpecMetadata).mockReset();
+});
 
 describe("installWithSourceFallback", () => {
   it.each(["notarget", "etarget"])(
@@ -41,43 +48,83 @@ describe("installWithSourceFallback", () => {
 });
 
 describe("resolveNpmInstallSpecsForUpdateChannel", () => {
-  it.each(["@openclaw/discord", "@openclaw/discord@latest"])(
-    "targets the exact core version for official extended-stable intent %s",
-    (spec) => {
-      expect(
-        resolveNpmInstallSpecsForUpdateChannel({
-          spec,
-          updateChannel: "extended-stable",
-          officialPackageName: "@openclaw/discord",
-          coreVersion: "2026.7.33",
-        }),
-      ).toEqual({
-        installSpec: "@openclaw/discord@2026.7.33",
-        recordSpec: spec,
-      });
+  it.each([
+    {
+      channel: "extended-stable" as const,
+      versionBoundToCore: false,
+      coreVersion: "2026.7.33",
+      expectedVersion: "2026.7.33",
+    },
+    {
+      channel: "stable" as const,
+      versionBoundToCore: true,
+      coreVersion: "2026.8.1",
+      expectedVersion: "2026.8.1",
+    },
+    {
+      channel: "stable" as const,
+      versionBoundToCore: true,
+      coreVersion: "2026.7.1-2",
+      expectedVersion: "2026.7.1",
+    },
+    {
+      channel: "extended-stable" as const,
+      versionBoundToCore: true,
+      coreVersion: "2026.7.1-2",
+      expectedVersion: "2026.7.1",
+    },
+  ])(
+    "preserves the $channel release-cohort contract for $coreVersion",
+    async ({ channel, versionBoundToCore, coreVersion, expectedVersion }) => {
+      for (const spec of ["@openclaw/codex", "@openclaw/codex@latest"]) {
+        expect(
+          await resolveNpmInstallSpecsForUpdateChannel({
+            spec,
+            updateChannel: channel,
+            officialPackageName: "@openclaw/codex",
+            coreVersion,
+            versionBoundToCore,
+          }),
+        ).toEqual({ installSpec: `@openclaw/codex@${expectedVersion}`, recordSpec: spec });
+      }
+      expect(resolveNpmSpecMetadata).not.toHaveBeenCalled();
     },
   );
 
-  it.each([
-    "@openclaw/discord@2026.6.33",
-    "@openclaw/discord@next",
-    "@openclaw/discord@beta",
-    "@openclaw/discord@^2026.6.0",
-    "https://registry.example.test/discord.tgz",
-  ])("preserves explicit extended-stable intent %s", (spec) => {
-    expect(
-      resolveNpmInstallSpecsForUpdateChannel({
-        spec,
-        updateChannel: "extended-stable",
-        officialPackageName: "@openclaw/discord",
-        coreVersion: "2026.7.33",
-      }),
-    ).toEqual({ installSpec: spec, recordSpec: spec });
-  });
+  it.each(["2026.6.33", "next", "^2026.6.0"])(
+    "preserves an explicit selector %s on beta",
+    async (selector) => {
+      const spec = `@openclaw/codex@${selector}`;
+      expect(
+        await resolveNpmInstallSpecsForUpdateChannel({
+          spec,
+          updateChannel: "beta",
+          officialPackageName: "@openclaw/codex",
+          coreVersion: "2026.8.1-beta.3",
+        }),
+      ).toEqual({ installSpec: spec, recordSpec: spec });
+      expect(resolveNpmSpecMetadata).not.toHaveBeenCalled();
+    },
+  );
 
-  it("does not rewrite a third-party package", () => {
+  it.each(["stable", "dev", "extended-stable"] as const)(
+    "preserves explicit beta on %s",
+    async (updateChannel) => {
+      const spec = "@openclaw/codex@beta";
+      expect(
+        await resolveNpmInstallSpecsForUpdateChannel({
+          spec,
+          updateChannel,
+          officialPackageName: "@openclaw/codex",
+          coreVersion: "2026.8.1-beta.3",
+        }),
+      ).toEqual({ installSpec: spec, recordSpec: spec });
+    },
+  );
+
+  it("does not rewrite a third-party extended-stable package", async () => {
     expect(
-      resolveNpmInstallSpecsForUpdateChannel({
+      await resolveNpmInstallSpecsForUpdateChannel({
         spec: "@acme/discord",
         updateChannel: "extended-stable",
         officialPackageName: "@openclaw/discord",
@@ -86,116 +133,95 @@ describe("resolveNpmInstallSpecsForUpdateChannel", () => {
     ).toEqual({ installSpec: "@acme/discord", recordSpec: "@acme/discord" });
   });
 
-  it("fails closed without an authoritative extended-stable core version", () => {
-    expect(() =>
-      resolveNpmInstallSpecsForUpdateChannel({
-        spec: "@openclaw/discord",
-        updateChannel: "extended-stable",
-        officialPackageName: "@openclaw/discord",
-      }),
-    ).toThrow("requires an exact core version");
-  });
-
-  it.each(["@openclaw/codex", "@openclaw/codex@latest"])(
-    "targets the exact core version for stable version-bound intent %s",
-    (spec) => {
-      expect(
-        resolveNpmInstallSpecsForUpdateChannel({
-          spec,
-          updateChannel: "stable",
-          officialPackageName: "@openclaw/codex",
-          coreVersion: "2026.8.1",
-          versionBoundToCore: true,
-        }),
-      ).toEqual({
-        installSpec: "@openclaw/codex@2026.8.1",
-        recordSpec: spec,
-      });
-    },
-  );
-
-  it.each([
-    { channel: "stable" as const, expectedVersion: "2026.7.1" },
-    { channel: "extended-stable" as const, expectedVersion: "2026.7.1" },
-  ])("preserves the $channel release-cohort contract", ({ channel, expectedVersion }) => {
-    expect(
+  it("fails closed without an authoritative extended-stable core version", async () => {
+    await expect(
       resolveNpmInstallSpecsForUpdateChannel({
         spec: "@openclaw/codex",
-        updateChannel: channel,
+        updateChannel: "extended-stable",
         officialPackageName: "@openclaw/codex",
-        coreVersion: "2026.7.1-2",
-        versionBoundToCore: true,
       }),
-    ).toEqual({
-      installSpec: `@openclaw/codex@${expectedVersion}`,
-      recordSpec: "@openclaw/codex",
-    });
+    ).rejects.toThrow("requires an exact core version");
   });
 
-  it.each(
-    [false, true].flatMap((versionBoundToCore) =>
-      ["@openclaw/codex", "@openclaw/codex@latest"].map((spec) => ({ versionBoundToCore, spec })),
-    ),
-  )(
-    "targets the installed beta core for $spec (version-bound=$versionBoundToCore)",
-    ({ versionBoundToCore, spec }) => {
-      expect(
-        resolveNpmInstallSpecsForUpdateChannel({
+  it.each([
+    {
+      beta: "2026.9.1-beta.1",
+      latest: "2026.9.2",
+      expected: "2026.9.2",
+      tag: "latest",
+      reason: "tag-behind-latest",
+    },
+    { beta: "2026.9.3-beta.1", latest: "2026.9.2", expected: "2026.9.3-beta.1", tag: "beta" },
+    { beta: "2026.9.2", latest: "2026.9.2", expected: "2026.9.2", tag: "beta" },
+    { beta: null, latest: "2026.9.2", expected: "2026.9.2", tag: "latest" },
+    { beta: "2026.9.3-beta.1", latest: null, expected: "2026.9.3-beta.1", tag: "beta" },
+  ])(
+    "selects $expected from beta=$beta latest=$latest before installation",
+    async ({ beta, latest, expected, tag, reason }) => {
+      vi.mocked(resolveNpmSpecMetadata).mockImplementation(async ({ spec }) => {
+        const version = spec.endsWith("@beta") ? beta : latest;
+        return version
+          ? {
+              ok: true,
+              metadata: {
+                name: "@openclaw/codex",
+                version,
+                resolvedSpec: `@openclaw/codex@${version}`,
+                integrity: `sha512-${version}`,
+              },
+            }
+          : { ok: false, error: "Package not found on npm" };
+      });
+      for (const spec of ["@openclaw/codex", "@openclaw/codex@latest", "@openclaw/codex@beta"]) {
+        const result = await resolveNpmInstallSpecsForUpdateChannel({
           spec,
           updateChannel: "beta",
           officialPackageName: "@openclaw/codex",
-          coreVersion: "2026.8.1-beta.3",
-          versionBoundToCore,
-        }),
-      ).toEqual({
-        installSpec: "@openclaw/codex@2026.8.1-beta.3",
-        recordSpec: spec,
-        fallbackSpec: spec,
-        fallbackLabel: "@openclaw/codex@2026.8.1-beta.3",
-      });
+          coreVersion: "2026.9.1-beta.1",
+          versionBoundToCore: true,
+        });
+        expect(result).toEqual({
+          installSpec: `@openclaw/codex@${expected}`,
+          recordSpec: spec,
+          npmResolution: {
+            name: "@openclaw/codex",
+            version: expected,
+            resolvedSpec: `@openclaw/codex@${expected}`,
+            integrity: `sha512-${expected}`,
+          },
+          channelTag: tag,
+          ...(reason ? { channelReason: reason } : {}),
+        });
+      }
     },
   );
 
-  it.each([
-    { spec: "@openclaw/discord", channel: "stable" as const, target: "@openclaw/discord" },
-    { spec: "@openclaw/discord", channel: "dev" as const, target: "@openclaw/discord" },
-    { spec: "@openclaw/discord@next", channel: "beta" as const, target: "@openclaw/discord@next" },
-    { spec: "@openclaw/discord@beta", channel: "beta" as const, target: "@openclaw/discord@beta" },
-    {
-      spec: "@openclaw/discord@2026.7.1",
-      channel: "beta" as const,
-      target: "@openclaw/discord@2026.7.1",
-    },
-  ])("preserves $channel selection for $spec on a beta core", ({ spec, channel, target }) => {
+  it("leaves missing packages to the install owner's declared-source fallback", async () => {
+    vi.mocked(resolveNpmSpecMetadata).mockResolvedValue({
+      ok: false,
+      error: "Package not found on npm",
+    });
     expect(
-      resolveNpmInstallSpecsForUpdateChannel({
-        spec,
-        updateChannel: channel,
-        officialPackageName: "@openclaw/discord",
-        coreVersion: "2026.8.1-beta.3",
+      await resolveNpmInstallSpecsForUpdateChannel({
+        spec: "@openclaw/codex@beta",
+        updateChannel: "beta",
       }),
-    ).toEqual({ installSpec: target, recordSpec: spec });
+    ).toEqual({ installSpec: "@openclaw/codex@latest", recordSpec: "@openclaw/codex@beta" });
   });
 
-  it.each([
-    { spec: "@acme/discord", coreVersion: "2026.8.1-beta.3" },
-    { spec: "@openclaw/discord", coreVersion: "2026.8.1" },
-    { spec: "@openclaw/discord", coreVersion: undefined },
-  ])("keeps moving beta selection for $spec with core $coreVersion", ({ spec, coreVersion }) => {
-    expect(
-      resolveNpmInstallSpecsForUpdateChannel({
-        spec,
-        updateChannel: "beta",
-        officialPackageName: "@openclaw/discord",
-        coreVersion,
-      }),
-    ).toEqual({
-      installSpec: `${spec}@beta`,
-      recordSpec: spec,
-      fallbackSpec: spec,
-      fallbackLabel: `${spec}@beta`,
-    });
-  });
+  it.each(["beta", "latest"] as const)(
+    "does not install the other tag when %s metadata fails",
+    async (failedTag) => {
+      vi.mocked(resolveNpmSpecMetadata).mockImplementation(async ({ spec }) =>
+        spec.endsWith(`@${failedTag}`)
+          ? { ok: false, category: "metadata-env", error: "Registry unavailable" }
+          : { ok: true, metadata: { name: "@openclaw/codex", version: "2026.9.1-beta.1" } },
+      );
+      await expect(
+        resolveNpmInstallSpecsForUpdateChannel({ spec: "@openclaw/codex", updateChannel: "beta" }),
+      ).rejects.toThrow("Registry unavailable");
+    },
+  );
 });
 
 describe("resolveClawHubInstallSpecsForUpdateChannel", () => {
@@ -203,8 +229,8 @@ describe("resolveClawHubInstallSpecsForUpdateChannel", () => {
     ["stable", false, "2026.7.33", undefined],
     ["stable", true, "2026.7.33", "2026.7.33"],
     ["beta", false, "2026.7.33", "beta"],
-    ["beta", false, "2026.8.1-beta.3", "2026.8.1-beta.3"],
-    ["beta", true, "2026.8.1-beta.3", "2026.8.1-beta.3"],
+    ["beta", false, "2026.8.1-beta.3", "beta"],
+    ["beta", true, "2026.8.1-beta.3", "beta"],
     ["extended-stable", false, "2026.7.33", "2026.7.33"],
   ] as const)(
     "resolves declared ClawHub defaults on %s (bound: %s, core: %s)",

--- a/src/plugins/install-channel-specs.ts
+++ b/src/plugins/install-channel-specs.ts
@@ -1,12 +1,13 @@
 // Parses channel-oriented plugin install specs from package inputs.
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
+import type { NpmSpecResolution } from "../infra/install-source-utils.js";
 import {
   isExactSemverVersion,
   parseRegistryNpmSpec,
   type ParsedRegistryNpmSpec,
   resolveOpenClawReleaseCohortVersion,
 } from "../infra/npm-registry-spec.js";
-import { isBetaTag, type UpdateChannel } from "../infra/update-channels.js";
+import { selectNpmChannelVersion, type UpdateChannel } from "../infra/update-channels.js";
 import { CLAWHUB_INSTALL_ERROR_CODE, isUnavailableClawHubTarget } from "./clawhub-error-codes.js";
 import { isUnavailableNpmTarget, PLUGIN_INSTALL_ERROR_CODE } from "./install-types.js";
 import type { PluginPackageInstall } from "./package-manifest.types.js";
@@ -80,7 +81,14 @@ type ChannelInstallSpecs = {
   recordSpec: string;
   fallbackSpec?: string;
   fallbackLabel?: string;
+  npmResolution?: NpmSpecResolution;
+  channelTag?: "beta" | "latest";
+  channelReason?: "tag-behind-latest";
 };
+
+export class NpmChannelResolutionError extends Error {
+  readonly code = PLUGIN_INSTALL_ERROR_CODE.NPM_METADATA_FAILURE;
+}
 
 /** Bare specs and latest retain default intent while following the active release channel. */
 export function resolveDefaultNpmSpec(spec: string): ParsedRegistryNpmSpec | null {
@@ -97,13 +105,16 @@ export function resolveDefaultNpmSpec(spec: string): ParsedRegistryNpmSpec | nul
   return null;
 }
 
-export function resolveNpmInstallSpecsForUpdateChannel(params: {
+type ChannelInstallParams = {
   spec: string;
   updateChannel?: UpdateChannel;
   officialPackageName?: string;
   coreVersion?: string;
   versionBoundToCore?: boolean;
-}): ChannelInstallSpecs {
+  timeoutMs?: number;
+};
+
+function resolveCoreBoundNpmSpec(params: ChannelInstallParams): string | undefined {
   if (
     params.updateChannel === "extended-stable" ||
     (params.updateChannel === "stable" && params.versionBoundToCore)
@@ -121,39 +132,66 @@ export function resolveNpmInstallSpecsForUpdateChannel(params: {
       const installVersion = params.versionBoundToCore
         ? resolveOpenClawReleaseCohortVersion(coreVersion)
         : coreVersion;
-      return {
-        installSpec: `${target.name}@${installVersion}`,
-        recordSpec: params.spec,
-      };
+      return `${target.name}@${installVersion}`;
     }
+  }
+  return undefined;
+}
+
+export async function resolveNpmInstallSpecsForUpdateChannel(
+  params: ChannelInstallParams,
+): Promise<ChannelInstallSpecs> {
+  const coreBoundSpec = resolveCoreBoundNpmSpec(params);
+  const target = parseRegistryNpmSpec(params.spec);
+  const selector = target?.selector?.toLowerCase();
+  if (
+    coreBoundSpec ||
+    params.updateChannel !== "beta" ||
+    !target ||
+    (target.selectorKind !== "none" &&
+      !(target.selectorKind === "tag" && (selector === "latest" || selector === "beta")))
+  ) {
     return {
-      installSpec: params.spec,
+      installSpec: coreBoundSpec ?? params.spec,
       recordSpec: params.spec,
     };
   }
-  const betaTarget = resolveDefaultNpmSpec(params.spec);
-  if (params.updateChannel !== "beta" || !betaTarget) {
-    return {
-      installSpec: params.spec,
-      recordSpec: params.spec,
-    };
+  const { resolveNpmSpecMetadata } = await import("../infra/install-source-utils.js");
+  const resolveTag = async (tag: "beta" | "latest") => {
+    const result = await resolveNpmSpecMetadata({
+      spec: `${target.name}@${tag}`,
+      timeoutMs: params.timeoutMs,
+    });
+    if (!result.ok) {
+      if (result.category === "metadata-env") {
+        throw new NpmChannelResolutionError(
+          `Could not resolve ${target.name}@${tag}: ${result.error}`,
+        );
+      }
+      return { version: null, metadata: undefined };
+    }
+    if (
+      result.metadata.name !== target.name ||
+      !isExactSemverVersion(result.metadata.version ?? "")
+    ) {
+      throw new NpmChannelResolutionError(
+        `Invalid npm channel metadata for ${target.name}@${tag}.`,
+      );
+    }
+    return { version: result.metadata.version ?? null, metadata: result.metadata, tag };
+  };
+  const [beta, latest] = await Promise.all([resolveTag("beta"), resolveTag("latest")]);
+  const selected = selectNpmChannelVersion(beta, latest);
+  if (!selected.version || !selected.metadata) {
+    // Preserve the install owner's normal unavailable-source result and declared source fallback.
+    return { installSpec: `${target.name}@latest`, recordSpec: params.spec };
   }
-  // The installed core survives post-update process handoffs; a moving beta tag
-  // can select a different release from an explicitly requested core version.
-  const coreVersion = params.coreVersion?.trim();
-  const betaVersion =
-    params.officialPackageName === betaTarget.name &&
-    coreVersion &&
-    isExactSemverVersion(coreVersion) &&
-    isBetaTag(coreVersion)
-      ? coreVersion
-      : "beta";
-  const betaSpec = `${betaTarget.name}@${betaVersion}`;
   return {
-    installSpec: betaSpec,
+    installSpec: `${target.name}@${selected.version}`,
     recordSpec: params.spec,
-    fallbackSpec: params.spec,
-    fallbackLabel: betaSpec,
+    npmResolution: selected.metadata,
+    channelTag: selected.tag,
+    ...(selected === latest && beta.version ? { channelReason: "tag-behind-latest" } : {}),
   };
 }
 
@@ -171,11 +209,11 @@ export function resolveClawHubInstallSpecsForUpdateChannel(params: {
     (params.updateChannel === "extended-stable" ||
       (params.updateChannel === "stable" && params.versionBoundToCore))
   ) {
-    const npm = resolveNpmInstallSpecsForUpdateChannel({
+    const npmSpec = resolveCoreBoundNpmSpec({
       ...params,
       spec: `${parsed.name}${parsed.version ? `@${parsed.version}` : ""}`,
     });
-    return { installSpec: `clawhub:${npm.installSpec}`, recordSpec: params.spec };
+    return { installSpec: npmSpec ? `clawhub:${npmSpec}` : params.spec, recordSpec: params.spec };
   }
   if (
     params.updateChannel !== "beta" ||
@@ -187,13 +225,7 @@ export function resolveClawHubInstallSpecsForUpdateChannel(params: {
       recordSpec: params.spec,
     };
   }
-  // Declared official sources share the installed core's beta cohort even when
-  // availability moves an install from npm to ClawHub.
-  const betaTarget =
-    params.officialPackageName === parsed.name
-      ? resolveNpmInstallSpecsForUpdateChannel({ ...params, spec: parsed.name }).installSpec
-      : `${parsed.name}@beta`;
-  const betaSpec = `clawhub:${betaTarget}`;
+  const betaSpec = `clawhub:${parsed.name}@beta`;
   return {
     installSpec: betaSpec,
     recordSpec: params.spec,

--- a/src/plugins/management-install.ts
+++ b/src/plugins/management-install.ts
@@ -24,6 +24,7 @@ import { installPluginFromClawHub } from "./clawhub.js";
 import { installPluginFromGitSpec } from "./git-install.js";
 import {
   installWithSourceFallback,
+  NpmChannelResolutionError,
   type PluginInstallSource,
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
@@ -230,10 +231,10 @@ async function persistManagedSourceInstall(params: {
  * does not carry, and answering for them from this boundary would pin plugins
  * the policy never opted in.
  */
-function resolveOfficialManagedInstallSpec(params: {
+async function resolveOfficialManagedInstallSpec(params: {
   request: Extract<ManagedPluginSourceInstallRequest, { source: "official" | "npm" | "clawhub" }>;
   config: OpenClawConfig;
-}): string | null {
+}): Promise<string | null> {
   const { request } = params;
   const trustedSourceLinkedOfficialInstall =
     request.source !== "official" && request.trustedSourceLinkedOfficialInstall === true;
@@ -271,7 +272,7 @@ function resolveOfficialManagedInstallSpec(params: {
           officialPackageName: packageName,
           coreVersion: VERSION,
         })
-      : resolveNpmInstallSpecsForUpdateChannel({
+      : await resolveNpmInstallSpecsForUpdateChannel({
           spec: request.spec,
           updateChannel,
           officialPackageName: packageName,
@@ -352,10 +353,18 @@ async function installManagedPluginSourceUnderLease(
   if (request.source !== "official" && request.source !== "npm" && request.source !== "clawhub") {
     return await installResolvedManagedPluginSource(params, assertOwned);
   }
-  const installSpec = resolveOfficialManagedInstallSpec({
-    request,
-    config: params.snapshot.config,
-  });
+  let installSpec: string | null;
+  try {
+    installSpec = await resolveOfficialManagedInstallSpec({
+      request,
+      config: params.snapshot.config,
+    });
+  } catch (error) {
+    if (!(error instanceof NpmChannelResolutionError)) {
+      throw error;
+    }
+    return { ok: false, error: error.message, code: error.code };
+  }
   if (!installSpec) {
     return await installResolvedManagedPluginSource(params, assertOwned);
   }

--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -8,15 +8,12 @@ import { installPluginFromGitSpec } from "./git-install.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import {
-  isUnavailableNpmTarget,
   PLUGIN_INSTALL_ERROR_CODE,
   type PluginInstallArtifactConsentHandler,
 } from "./install-types.js";
 import { installPluginFromNpmSpec } from "./install.js";
 import { installPluginFromMarketplace } from "./marketplace.js";
 import {
-  describeBetaNpmFallback,
-  describeNpmChannelFallback,
   formatBetaChannelFallbackOutcomeSuffix,
   resolveExactNpmSpecVersion,
   resolveNewerExactPinnedNpmDefaultLine,
@@ -218,9 +215,7 @@ type PluginUpdateSuccess = Extract<PluginUpdateInstallResult, { ok: true }>;
 type PluginUpdateAttemptState = {
   activeClawHubInstallSpec?: string;
   channelFallbackSuffix: string;
-  npmChannelFallback?: PluginUpdateChannelFallback;
   resultSource: UpdatablePluginInstallRecord["source"];
-  usedNpmFallback: boolean;
 };
 
 type PluginUpdateAttemptResult =
@@ -269,21 +264,17 @@ export async function buildDryRunPluginUpdateOutcome(params: {
   result: PluginUpdateSuccess;
   currentVersion?: string;
   effectiveSpec?: string;
-  fallbackSpec?: string;
-  usedNpmFallback: boolean;
   hasSpecOverride: boolean;
   updateChannel?: UpdateChannel;
   timeoutMs?: number;
   channelFallbackSuffix: string;
-  npmChannelFallback?: PluginUpdateChannelFallback;
 }): Promise<PluginUpdateOutcome> {
-  const probeSpec = params.usedNpmFallback ? params.fallbackSpec : params.effectiveSpec;
   const npmProbeVersion =
     params.record.source === "npm" ? resolveNpmResultVersion(params.result) : undefined;
   const resolvedProbeVersion =
     params.result.version ??
     npmProbeVersion ??
-    (params.record.source === "npm" ? resolveExactNpmSpecVersion(probeSpec) : undefined);
+    (params.record.source === "npm" ? resolveExactNpmSpecVersion(params.effectiveSpec) : undefined);
   const nextVersion = resolvedProbeVersion ?? "unknown";
   const currentLabel = params.currentVersion ?? "unknown";
   const unchanged = isPluginUpdateUnchanged({ ...params, nextVersion: resolvedProbeVersion });
@@ -314,7 +305,6 @@ export async function buildDryRunPluginUpdateOutcome(params: {
       currentVersion: params.currentVersion,
       nextVersion: newerExactPinnedDefaultLine?.version ?? resolvedProbeVersion,
       message,
-      ...(params.npmChannelFallback ? { channelFallback: params.npmChannelFallback } : {}),
     };
   }
 
@@ -327,7 +317,6 @@ export async function buildDryRunPluginUpdateOutcome(params: {
     currentVersion: params.currentVersion,
     nextVersion: resolvedProbeVersion,
     message: `${verb} ${params.pluginId}: ${currentLabel} -> ${nextVersion}.${params.channelFallbackSuffix}`,
-    ...(params.npmChannelFallback ? { channelFallback: params.npmChannelFallback } : {}),
   };
 }
 
@@ -343,11 +332,9 @@ export async function runPluginUpdateAttempt(params: {
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
   expectedIntegrity?: string;
-  npmSpecs?: PluginUpdateSpecPlan;
   clawhubSpecs?: PluginUpdateSpecPlan;
   trustedSourceLinkedOfficialInstall: boolean;
   expectedReplacementPluginId?: string;
-  getFallbackExpectedIntegrity: () => Promise<string | undefined>;
   installNpmSpecForUpdate: typeof installPluginFromNpmSpec;
   logger: PluginUpdateLogger;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
@@ -443,63 +430,8 @@ export async function runPluginUpdateAttempt(params: {
   }
 
   let activeClawHubInstallSpec = params.effectiveSpec;
-  let usedNpmFallback = false;
   let channelFallbackSuffix = "";
-  let npmChannelFallback: PluginUpdateChannelFallback | undefined;
   const resultSource = params.record.source;
-
-  if (
-    !result.ok &&
-    params.record.source === "npm" &&
-    params.npmSpecs?.fallbackSpec &&
-    isUnavailableNpmTarget(result)
-  ) {
-    params.logger.warn?.(
-      describeBetaNpmFallback({
-        pluginId: params.pluginId,
-        betaSpec: params.npmSpecs.fallbackLabel ?? params.effectiveSpec,
-        fallbackSpec: params.npmSpecs.fallbackSpec,
-        result,
-      }),
-    );
-    usedNpmFallback = true;
-    npmChannelFallback = describeNpmChannelFallback({
-      pluginId: params.pluginId,
-      requestedSpec: params.npmSpecs.fallbackLabel ?? params.effectiveSpec,
-      usedSpec: params.npmSpecs.fallbackSpec,
-      result,
-      verb: params.dryRun ? "would use" : "used",
-    });
-    channelFallbackSuffix = formatBetaChannelFallbackOutcomeSuffix({
-      fallbackLabel: params.npmSpecs.fallbackLabel ?? params.effectiveSpec,
-      fallbackSpec: params.npmSpecs.fallbackSpec,
-      verb: params.dryRun ? "would use" : "used",
-    });
-    result = await installNpmSpec(
-      installParams({
-        spec: params.npmSpecs.fallbackSpec,
-        config: params.config,
-        mode: "update",
-        extensionsDir: params.extensionsDir,
-        timeoutMs: params.timeoutMs,
-        ...dryRunOption,
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
-        onInstallPolicyWarning: params.onInstallPolicyWarning,
-        onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
-        trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
-        expectedPluginId: params.pluginId,
-        expectedReplacementPluginId: params.expectedReplacementPluginId,
-        expectedIntegrity: await params.getFallbackExpectedIntegrity(),
-        onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
-          pluginId: params.pluginId,
-          dryRun: params.dryRun,
-          logger: params.logger,
-          onIntegrityDrift: params.onIntegrityDrift,
-        }),
-        logger: params.logger,
-      }),
-    );
-  }
 
   if (
     !result.ok &&
@@ -539,8 +471,6 @@ export async function runPluginUpdateAttempt(params: {
     result,
     activeClawHubInstallSpec,
     channelFallbackSuffix,
-    npmChannelFallback,
     resultSource,
-    usedNpmFallback,
   };
 }

--- a/src/plugins/update-channel.ts
+++ b/src/plugins/update-channel.ts
@@ -22,6 +22,7 @@ import {
 import {
   installWithChannelFallback,
   installWithSourceFallback,
+  NpmChannelResolutionError,
   resolvePluginInstallSources,
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
@@ -161,15 +162,27 @@ export async function syncPluginsForUpdateChannel(params: {
         targetPluginId,
         npmSpec,
       });
-      const channelNpmSpecs =
-        npmSpec && trustedSourceLinkedOfficialInstall
-          ? resolveNpmInstallSpecsForUpdateChannel({
-              spec: npmSpec,
-              updateChannel: params.channel,
-              officialPackageName: resolveNpmSpecPackageName(npmSpec),
-              coreVersion: params.coreVersion,
-            })
-          : null;
+      let channelNpmSpecs: Awaited<
+        ReturnType<typeof resolveNpmInstallSpecsForUpdateChannel>
+      > | null;
+      try {
+        channelNpmSpecs =
+          npmSpec && trustedSourceLinkedOfficialInstall
+            ? await resolveNpmInstallSpecsForUpdateChannel({
+                spec: npmSpec,
+                updateChannel: params.channel,
+                officialPackageName: resolveNpmSpecPackageName(npmSpec),
+                coreVersion: params.coreVersion,
+              })
+            : null;
+      } catch (error) {
+        if (!(error instanceof NpmChannelResolutionError)) {
+          throw error;
+        }
+        summary.errors.push({ pluginId: targetPluginId, message: error.message, code: error.code });
+        logger.warn?.(error.message);
+        continue;
+      }
       const effectiveNpmSpec = channelNpmSpecs?.installSpec ?? npmSpec;
       const channelClawHubSpecs = clawhubSpec
         ? resolveClawHubInstallSpecsForUpdateChannel({

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -15,6 +15,7 @@ import {
 } from "./capability-consent.js";
 import { buildClawHubPluginInstallRecordFields } from "./clawhub-install-records.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
+import { NpmChannelResolutionError } from "./install-channel-specs.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.types.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import { PLUGIN_INSTALL_ERROR_CODE, resolvePluginInstallDir } from "./install.js";
@@ -59,13 +60,11 @@ import {
   stageDuplicateNpmPluginAlias,
 } from "./update-duplicate-aliases.js";
 import {
-  expectedIntegrityForNpmFallback,
   expectedIntegrityForNpmUpdate,
   isBundledVersionNewer,
   isNpmMetadataCompatibleWithCurrentHost,
   isPluginInstallRecordUpdateSource,
   isTrustedSourceLinkedOfficialNpmUpdate,
-  npmUpdateFailureSpec,
   resolveClawHubUpdateSpecs,
   resolveNpmSpecPackageName,
   resolveNpmUpdateSpecs,
@@ -219,17 +218,28 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    const npmSpecs =
-      record.source === "npm"
-        ? resolveNpmUpdateSpecs({
-            record,
-            specOverride: npmSpecOverride,
-            officialSpecOverride: officialNpmSpec,
-            updateChannel,
-            officialPackageName: resolveNpmSpecPackageName(trustedOfficialNpmSpec),
-            coreVersion: params.coreVersion,
-          })
-        : undefined;
+    let npmSpecs: Awaited<ReturnType<typeof resolveNpmUpdateSpecs>> | undefined;
+    try {
+      npmSpecs =
+        record.source === "npm"
+          ? await resolveNpmUpdateSpecs({
+              record,
+              specOverride: npmSpecOverride,
+              officialSpecOverride: officialNpmSpec,
+              updateChannel,
+              officialPackageName: resolveNpmSpecPackageName(trustedOfficialNpmSpec),
+              coreVersion: params.coreVersion,
+              timeoutMs: params.timeoutMs,
+            })
+          : undefined;
+    } catch (error) {
+      if (!(error instanceof NpmChannelResolutionError)) {
+        throw error;
+      }
+      outcomes.push({ pluginId, status: "error", code: error.code, message: error.message });
+      logger.warn?.(error.message);
+      continue;
+    }
     const clawhubSpecs =
       record.source === "clawhub"
         ? resolveClawHubUpdateSpecs({
@@ -269,21 +279,6 @@ export async function updateNpmInstalledPlugins(params: {
         record,
         trustedSourceLinkedOfficialInstall,
       });
-    let fallbackExpectedIntegrityLoaded = false;
-    let fallbackExpectedIntegrity: string | undefined;
-    const getFallbackExpectedIntegrity = async () => {
-      if (!fallbackExpectedIntegrityLoaded) {
-        fallbackExpectedIntegrity = await expectedIntegrityForNpmFallback({
-          fallbackSpec: npmSpecs?.fallbackSpec,
-          record,
-          timeoutMs: params.timeoutMs,
-          trustedSourceLinkedOfficialInstall,
-        });
-        fallbackExpectedIntegrityLoaded = true;
-      }
-      return fallbackExpectedIntegrity;
-    };
-
     if ((record.source === "npm" || record.source === "git") && !effectiveSpec) {
       recordSkippedOutcome(pluginId, `Skipping "${pluginId}" (missing ${record.source} spec).`);
       continue;
@@ -377,10 +372,12 @@ export async function updateNpmInstalledPlugins(params: {
       record.source === "npm" &&
       (currentVersion || (params.syncOfficialPluginInstalls && trustedSourceLinkedOfficialInstall))
     ) {
-      const metadataResult = await resolveNpmSpecMetadata({
-        spec: effectiveSpec!,
-        timeoutMs: params.timeoutMs,
-      });
+      const metadataResult = npmSpecs?.npmResolution
+        ? { ok: true as const, metadata: npmSpecs.npmResolution }
+        : await resolveNpmSpecMetadata({
+            spec: effectiveSpec!,
+            timeoutMs: params.timeoutMs,
+          });
       if (metadataResult.ok) {
         const bypassTrustedOfficialUnchangedNpmCheck = shouldBypassTrustedOfficialUnchangedNpmCheck(
           {
@@ -489,11 +486,9 @@ export async function updateNpmInstalledPlugins(params: {
           onInstallPolicyWarning: params.onInstallPolicyWarning,
           onBeforePluginArtifactCommit: capabilityConsent.onBeforePluginArtifactCommit,
           expectedIntegrity,
-          npmSpecs,
           clawhubSpecs,
           trustedSourceLinkedOfficialInstall,
           expectedReplacementPluginId: replacementPluginId,
-          getFallbackExpectedIntegrity,
           installNpmSpecForUpdate,
           logger,
           onIntegrityDrift: params.onIntegrityDrift,
@@ -521,14 +516,7 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
-    const {
-      result,
-      activeClawHubInstallSpec,
-      channelFallbackSuffix,
-      npmChannelFallback,
-      resultSource,
-      usedNpmFallback,
-    } = attempt;
+    const { result, activeClawHubInstallSpec, channelFallbackSuffix, resultSource } = attempt;
     if (!result.ok) {
       if (
         record.source === "clawhub" &&
@@ -556,11 +544,7 @@ export async function updateNpmInstalledPlugins(params: {
         resultSource === "npm"
           ? formatNpmInstallFailure({
               pluginId,
-              spec: npmUpdateFailureSpec({
-                effectiveSpec,
-                fallbackSpec: npmSpecs?.fallbackSpec,
-                usedFallback: usedNpmFallback,
-              }),
+              spec: effectiveSpec!,
               phase,
               result,
             })
@@ -586,7 +570,6 @@ export async function updateNpmInstalledPlugins(params: {
                   error: result.error,
                 });
       recordFailure(pluginId, message, {
-        channelFallback: npmChannelFallback,
         code,
         installedPayloadRunnable: await hasRunnableInstalledPayloadForFailure(code),
       });
@@ -600,13 +583,10 @@ export async function updateNpmInstalledPlugins(params: {
           result,
           currentVersion,
           effectiveSpec,
-          fallbackSpec: npmSpecs?.fallbackSpec,
-          usedNpmFallback,
           hasSpecOverride: Boolean(npmSpecOverride),
           updateChannel,
           timeoutMs: params.timeoutMs,
           channelFallbackSuffix,
-          npmChannelFallback,
         }),
       );
       completedCanonicalUpdates.add(pluginId);
@@ -687,7 +667,6 @@ export async function updateNpmInstalledPlugins(params: {
         currentVersion,
         nextVersion,
         channelFallbackSuffix,
-        channelFallback: npmChannelFallback,
       }),
     );
   }

--- a/src/plugins/update-source.ts
+++ b/src/plugins/update-source.ts
@@ -25,7 +25,6 @@ import {
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
 } from "./install-channel-specs.js";
-import { isUnavailableNpmTarget } from "./install-types.js";
 import { checkMinHostVersion } from "./min-host-version.js";
 import * as officialInstallRecords from "./official-external-install-records.js";
 import {
@@ -240,16 +239,20 @@ export async function resolveNewerExactPinnedNpmDefaultLine(params: {
     return undefined;
   }
 
-  const resolveMetadata = async (spec: string) =>
-    await resolveNpmSpecMetadata({ spec, timeoutMs: params.timeoutMs }).catch(() => undefined);
-  let registryLine: "beta" | "latest" = params.updateChannel === "beta" ? "beta" : "latest";
-  let metadataResult = await resolveMetadata(
-    registryLine === "beta" ? `${packageName}@beta` : packageName,
-  );
-  if (registryLine === "beta" && !metadataResult?.ok) {
-    registryLine = "latest";
-    metadataResult = await resolveMetadata(packageName);
+  const specs = await resolveNpmInstallSpecsForUpdateChannel({
+    spec: packageName,
+    updateChannel: params.updateChannel,
+    timeoutMs: params.timeoutMs,
+  }).catch(() => undefined);
+  if (!specs) {
+    return undefined;
   }
+  const registryLine = specs.channelTag ?? "latest";
+  const metadataResult = specs.npmResolution
+    ? { ok: true as const, metadata: specs.npmResolution }
+    : await resolveNpmSpecMetadata({ spec: specs.installSpec, timeoutMs: params.timeoutMs }).catch(
+        () => undefined,
+      );
   if (
     !metadataResult?.ok ||
     metadataResult.metadata.name !== packageName ||
@@ -346,48 +349,6 @@ export async function resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
     : undefined;
 }
 
-export async function expectedIntegrityForNpmFallback(params: {
-  fallbackSpec: string | undefined;
-  record: PluginInstallRecord;
-  timeoutMs?: number;
-  trustedSourceLinkedOfficialInstall: boolean;
-}): Promise<string | undefined> {
-  if (params.record.source !== "npm" || !params.fallbackSpec) {
-    return undefined;
-  }
-  if (params.fallbackSpec === params.record.spec) {
-    return expectedIntegrityForUpdate(params.record.spec, params.record.integrity);
-  }
-  if (!params.trustedSourceLinkedOfficialInstall) {
-    return undefined;
-  }
-  const fallbackMetadata = await resolveNpmSpecMetadata({
-    spec: params.fallbackSpec,
-    timeoutMs: params.timeoutMs,
-  });
-  if (!fallbackMetadata.ok) {
-    return undefined;
-  }
-  const trustedPrereleaseFallback = await resolveTrustedOfficialPrereleaseFallbackMetadataForUpdate(
-    {
-      metadata: fallbackMetadata.metadata,
-      spec: params.fallbackSpec,
-      timeoutMs: params.timeoutMs,
-    },
-  );
-  const expectedIntegrityMetadata =
-    trustedPrereleaseFallback?.metadata ?? fallbackMetadata.metadata;
-  if (!isNpmMetadataCompatibleWithCurrentHost(expectedIntegrityMetadata)) {
-    return undefined;
-  }
-  return expectedIntegrityForNpmUpdate({
-    effectiveSpec: params.fallbackSpec,
-    metadata: expectedIntegrityMetadata,
-    record: params.record,
-    trustedSourceLinkedOfficialInstall: true,
-  });
-}
-
 export function isNpmMetadataCompatibleWithCurrentHost(metadata: NpmSpecResolution): boolean {
   const hostVersion = resolveCompatibilityHostVersion();
   const installMetadata = metadata.packageOpenClaw?.install;
@@ -413,60 +374,8 @@ export function isBundledVersionNewer(bundledVersion: string, installedVersion: 
   return comparePackageUpdateVersions(bundledVersion, installedVersion) > 0;
 }
 
-function shouldFallbackClawHubToDefault(result: { ok: false; code?: string }): boolean {
-  return isUnavailableClawHubTarget(result);
-}
-
 export function shouldFallbackBetaClawHubUpdate(result: { ok: false; code?: string }): boolean {
-  return shouldFallbackClawHubToDefault(result);
-}
-
-export function describeBetaNpmFallback(params: {
-  pluginId: string;
-  betaSpec: string | undefined;
-  fallbackSpec: string;
-  result: { ok: false; code?: string; error: string };
-}): string {
-  const betaSpec = params.betaSpec ?? "the beta npm release";
-  const missingBeta = isUnavailableNpmTarget(params.result);
-  const reason = missingBeta ? "has no beta npm release" : "failed beta npm update";
-  return `Plugin "${params.pluginId}" ${reason} for ${betaSpec}; using ${params.fallbackSpec} instead. Core update can still complete.`;
-}
-
-function formatNpmSpecSelectorLabel(spec: string | undefined): string {
-  const parsed = spec ? parseRegistryNpmSpec(spec) : undefined;
-  if (!parsed) {
-    return spec ?? "unknown";
-  }
-  if (parsed.selectorKind === "none") {
-    return "@latest";
-  }
-  return `@${parsed.selector}`;
-}
-
-export function describeNpmChannelFallback(params: {
-  pluginId: string;
-  requestedSpec: string | undefined;
-  usedSpec: string;
-  result: { ok: false; code?: string; error: string };
-  verb: "used" | "would use";
-}): PluginUpdateChannelFallback {
-  const requestedSpec = params.requestedSpec ?? "unknown";
-  const requestedLabel = formatNpmSpecSelectorLabel(params.requestedSpec);
-  const usedLabel = formatNpmSpecSelectorLabel(params.usedSpec);
-  const reason = isUnavailableNpmTarget(params.result) ? "unavailable" : "failed";
-  const message =
-    reason === "unavailable"
-      ? `plugin channel fallback: ${params.pluginId} ${params.verb} ${usedLabel} because ${requestedLabel} was unavailable`
-      : `plugin channel fallback: ${params.pluginId} ${params.verb} ${usedLabel} after ${requestedLabel} failed`;
-  return {
-    requestedSpec,
-    usedSpec: params.usedSpec,
-    requestedLabel,
-    usedLabel,
-    reason,
-    message,
-  };
+  return isUnavailableClawHubTarget(result);
 }
 
 export function formatBetaChannelFallbackOutcomeSuffix(params: {
@@ -479,17 +388,6 @@ export function formatBetaChannelFallbackOutcomeSuffix(params: {
   }
   const betaTarget = params.fallbackLabel ?? "beta target";
   return ` (warning: beta channel fallback ${params.verb} ${params.fallbackSpec} because ${betaTarget} could not be used).`;
-}
-
-export function npmUpdateFailureSpec(params: {
-  effectiveSpec: string | undefined;
-  fallbackSpec: string | undefined;
-  usedFallback: boolean;
-}): string {
-  if (params.usedFallback && params.fallbackSpec) {
-    return params.fallbackSpec;
-  }
-  return params.effectiveSpec ?? params.fallbackSpec ?? "unknown";
 }
 
 export function resolveNpmSpecPackageName(spec: string | undefined): string | undefined {
@@ -546,19 +444,22 @@ export function isTrustedSourceLinkedOfficialBridgeNpmInstall(params: {
   return Boolean(officialPackageName && requestedPackageName === officialPackageName);
 }
 
-export function resolveNpmUpdateSpecs(params: {
+export async function resolveNpmUpdateSpecs(params: {
   record: PluginInstallRecord;
   specOverride?: string;
   officialSpecOverride?: string;
   updateChannel?: UpdateChannel;
   officialPackageName?: string;
   coreVersion?: string;
-}): {
+  timeoutMs?: number;
+}): Promise<{
   installSpec?: string;
   recordSpec?: string;
   fallbackSpec?: string;
   fallbackLabel?: string;
-} {
+  npmResolution?: NpmSpecResolution;
+  channelReason?: "tag-behind-latest";
+}> {
   const recordSpec = params.specOverride ?? params.record.spec ?? params.officialSpecOverride;
   if (!recordSpec) {
     return {};
@@ -568,6 +469,7 @@ export function resolveNpmUpdateSpecs(params: {
     updateChannel: params.updateChannel,
     officialPackageName: params.officialPackageName,
     coreVersion: params.coreVersion,
+    timeoutMs: params.timeoutMs,
   });
 }
 

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1456,7 +1456,7 @@ describe("updateNpmInstalledPlugins", () => {
       channel: "beta" as const,
       configuredChannel: undefined,
       registryVersion: "2026.5.3-beta.1",
-      expectedSpec: "@openclaw/codex@beta",
+      expectedSpec: "@openclaw/codex@2026.5.3-beta.1",
     },
     {
       name: "inferred stable",
@@ -1483,6 +1483,9 @@ describe("updateNpmInstalledPlugins", () => {
         installerVersion: registryVersion,
         installerResolvedSpec: `@openclaw/codex@${registryVersion}`,
       });
+      if (channel === "beta" && !configuredChannel) {
+        mockNpmViewMetadata({ name: "@openclaw/codex", version: "2026.5.2" });
+      }
 
       const result = await updatePlugin(config, "codex", {
         officialPluginUpdateChannel: channel,
@@ -1498,27 +1501,22 @@ describe("updateNpmInstalledPlugins", () => {
   );
 
   it.each([undefined, "2026.8.1-beta.3"])(
-    "retains the visible fallback for a targeted official beta update (core=%s)",
+    "selects latest before installing a targeted official update with a stale beta tag (core=%s)",
     async (coreVersion) => {
-      const requestedSpec = `@openclaw/codex@${coreVersion ?? "beta"}`;
-      installPluginFromNpmSpecMock
-        .mockResolvedValueOnce({
-          ok: false,
-          code: "npm_package_not_found",
-          error: `No matching version found for ${requestedSpec}`,
-        })
-        .mockResolvedValueOnce(
-          createSuccessfulNpmUpdateResult({
-            pluginId: "codex",
-            targetDir: "/tmp/codex",
-            version: "2026.5.3",
-            npmResolution: {
-              name: "@openclaw/codex",
-              version: "2026.5.3",
-              resolvedSpec: "@openclaw/codex@2026.5.3",
-            },
-          }),
-        );
+      mockNpmViewMetadata({ name: "@openclaw/codex", version: "2026.9.1-beta.1" });
+      mockNpmViewMetadata({ name: "@openclaw/codex", version: "2026.9.2" });
+      installPluginFromNpmSpecMock.mockResolvedValue(
+        createSuccessfulNpmUpdateResult({
+          pluginId: "codex",
+          targetDir: "/tmp/codex",
+          version: "2026.9.2",
+          npmResolution: {
+            name: "@openclaw/codex",
+            version: "2026.9.2",
+            resolvedSpec: "@openclaw/codex@2026.9.2",
+          },
+        }),
+      );
       const config = createNpmInstallConfig({
         pluginId: "codex",
         spec: "@openclaw/codex",
@@ -1531,14 +1529,10 @@ describe("updateNpmInstalledPlugins", () => {
         coreVersion,
       });
 
-      expect(npmInstallCall(0)?.spec).toBe(requestedSpec);
-      expect(result.outcomes[0]?.channelFallback).toMatchObject({
-        requestedSpec,
-        usedSpec: "@openclaw/codex",
-        reason: "unavailable",
-      });
-      expect(npmInstallCall(1)?.spec).toBe("@openclaw/codex");
+      expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+      expect(npmInstallCall()?.spec).toBe("@openclaw/codex@2026.9.2");
       expect(result.config.plugins?.installs?.codex?.spec).toBe("@openclaw/codex");
+      expect(result.config.plugins?.installs?.codex?.resolvedSpec).toBe("@openclaw/codex@2026.9.2");
     },
   );
 
@@ -1562,6 +1556,62 @@ describe("updateNpmInstalledPlugins", () => {
     expect(result.config.plugins?.installs?.acpx?.resolvedAt).toBe("2026-05-01T00:00:01.000Z");
     expect(npmInstallCall()).toBeUndefined();
   });
+
+  it.each(["@openclaw/codex", "@openclaw/codex@beta"])(
+    "converges after one beta-channel update when latest is newer and preserves %s",
+    async (spec) => {
+      const packageName = "@openclaw/codex";
+      const { config, installPath } = createNpmUpdateFixture({
+        pluginId: "codex",
+        packageName,
+        spec,
+        installedVersion: "2026.9.1-beta.1",
+      });
+      installPluginFromNpmSpecMock.mockImplementation(async () => {
+        createInstalledPackageDir({
+          name: packageName,
+          version: "2026.9.2",
+          installPath,
+        });
+        return createSuccessfulNpmUpdateResult({
+          pluginId: "codex",
+          targetDir: installPath,
+          version: "2026.9.2",
+          npmResolution: {
+            name: packageName,
+            version: "2026.9.2",
+            resolvedSpec: `${packageName}@2026.9.2`,
+          },
+        });
+      });
+      const updateOptions = {
+        updateChannel: "beta" as const,
+        syncOfficialPluginInstalls: true,
+        coreVersion: "2026.9.2",
+      };
+      mockNpmViewMetadata({ name: packageName, version: "2026.9.1-beta.1" });
+      mockNpmViewMetadata({ name: packageName, version: "2026.9.2" });
+
+      const updated = await updatePlugin(config, "codex", updateOptions);
+
+      expect(updated.outcomes[0]?.status).toBe("updated");
+      expect(npmInstallCall()?.spec).toBe(`${packageName}@2026.9.2`);
+      expect(updated.config.plugins?.installs?.codex?.spec).toBe(spec);
+      mockNpmViewMetadata({ name: packageName, version: "2026.9.1-beta.1" });
+      mockNpmViewMetadata({ name: packageName, version: "2026.9.2" });
+
+      const repeated = await updatePlugin(updated.config, "codex", updateOptions);
+
+      expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+      expect(repeated.changed).toBe(false);
+      expect(repeated.config).toBe(updated.config);
+      expect(repeated.outcomes[0]).toMatchObject({
+        status: "unchanged",
+        currentVersion: "2026.9.2",
+        nextVersion: "2026.9.2",
+      });
+    },
+  );
 
   it.each(["stable", "beta", "extended-stable"] as const)(
     "preserves official exact pins and integrity during %s bulk sync",
@@ -1784,6 +1834,9 @@ describe("updateNpmInstalledPlugins", () => {
         name: packageName,
         version: registryVersion,
       });
+      if (updateChannel === "beta") {
+        mockNpmViewMetadata({ name: packageName, version: "1.2.4" });
+      }
       installPluginFromNpmSpecMock.mockRejectedValue(new Error("installer should not run"));
 
       const result = await updatePlugin(config, pluginId, {
@@ -1792,7 +1845,7 @@ describe("updateNpmInstalledPlugins", () => {
       });
 
       expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
-      expect(runCommandWithTimeoutMock.mock.calls).toHaveLength(2);
+      expect(runCommandWithTimeoutMock.mock.calls).toHaveLength(updateChannel === "beta" ? 3 : 2);
       expect(runCommandWithTimeoutMock.mock.calls[1]?.[0]).toEqual([
         "npm",
         "view",
@@ -1822,18 +1875,6 @@ describe("updateNpmInstalledPlugins", () => {
   );
 
   it.each([
-    {
-      updateChannel: "beta" as const,
-      coreVersion: "2026.8.1-beta.3",
-      newerVersion: "2026.8.1-beta.4",
-      dryRun: false,
-    },
-    {
-      updateChannel: "beta" as const,
-      coreVersion: "2026.8.1-beta.3",
-      newerVersion: "2026.8.1-beta.4",
-      dryRun: true,
-    },
     {
       updateChannel: "extended-stable" as const,
       coreVersion: "2026.7.33",
@@ -1915,7 +1956,7 @@ describe("updateNpmInstalledPlugins", () => {
     expect(runCommandWithTimeoutMock.mock.calls[2]?.[0]).toEqual([
       "npm",
       "view",
-      "@acme/demo",
+      "@acme/demo@latest",
       "name",
       "version",
       "dist.integrity",
@@ -3787,8 +3828,10 @@ describe("updateNpmInstalledPlugins", () => {
   });
 
   it.each(["openclaw-codex-app-server", "openclaw-codex-app-server@latest"])(
-    "tries npm beta and preserves recorded intent %s",
+    "selects a newer npm beta release and preserves recorded intent %s",
     async (spec) => {
+      mockNpmViewMetadata({ name: "openclaw-codex-app-server", version: "0.2.0-beta.4" });
+      mockNpmViewMetadata({ name: "openclaw-codex-app-server", version: "0.1.9" });
       installPluginFromNpmSpecMock.mockResolvedValue(
         createSuccessfulNpmUpdateResult({
           pluginId: "openclaw-codex-app-server",
@@ -3811,7 +3854,7 @@ describe("updateNpmInstalledPlugins", () => {
       });
 
       expectNpmUpdateCall({
-        spec: "openclaw-codex-app-server@beta",
+        spec: "openclaw-codex-app-server@0.2.0-beta.4",
         expectedPluginId: "openclaw-codex-app-server",
       });
       expectCodexAppServerInstallState({
@@ -3825,23 +3868,39 @@ describe("updateNpmInstalledPlugins", () => {
 
   it.each(
     [
-      { channel: "extended-stable" as const, coreVersion: "2026.7.33" },
-      { channel: "beta" as const, coreVersion: "2026.8.1-beta.3" },
-    ].flatMap(({ channel, coreVersion }) =>
-      ["@openclaw/acpx", "@openclaw/acpx@latest"].map((spec) => ({ channel, coreVersion, spec })),
+      {
+        channel: "extended-stable" as const,
+        coreVersion: "2026.7.33",
+        selectedVersion: "2026.7.33",
+      },
+      {
+        channel: "beta" as const,
+        coreVersion: "2026.8.1-beta.3",
+        selectedVersion: "2026.8.1-beta.4",
+      },
+    ].flatMap(({ channel, coreVersion, selectedVersion }) =>
+      ["@openclaw/acpx", "@openclaw/acpx@latest"].map((spec) => ({
+        channel,
+        coreVersion,
+        selectedVersion,
+        spec,
+      })),
     ),
   )(
-    "targets the installed core for official $channel updates and preserves $spec",
-    async ({ channel, coreVersion, spec }) => {
+    "selects the official $channel release policy and preserves $spec",
+    async ({ channel, coreVersion, selectedVersion, spec }) => {
       const { config } = createNpmUpdateFixture({
         pluginId: "acpx",
         packageName: "@openclaw/acpx",
         spec,
         installedVersion: "2026.7.21",
-        registryVersion: coreVersion,
-        installerVersion: coreVersion,
-        installerResolvedSpec: `@openclaw/acpx@${coreVersion}`,
+        registryVersion: selectedVersion,
+        installerVersion: selectedVersion,
+        installerResolvedSpec: `@openclaw/acpx@${selectedVersion}`,
       });
+      if (channel === "beta") {
+        mockNpmViewMetadata({ name: "@openclaw/acpx", version: "2026.8.0" });
+      }
       const result = await updatePlugin(config, "acpx", {
         syncOfficialPluginInstalls: true,
         officialPluginUpdateChannel: channel,
@@ -3849,13 +3908,13 @@ describe("updateNpmInstalledPlugins", () => {
       });
 
       expectNpmUpdateCall({
-        spec: `@openclaw/acpx@${coreVersion}`,
+        spec: `@openclaw/acpx@${selectedVersion}`,
         expectedPluginId: "acpx",
       });
       expectRecordFields(result.config.plugins?.installs?.acpx, {
         spec,
-        version: coreVersion,
-        resolvedSpec: `@openclaw/acpx@${coreVersion}`,
+        version: selectedVersion,
+        resolvedSpec: `@openclaw/acpx@${selectedVersion}`,
       });
     },
   );
@@ -3909,14 +3968,16 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
-  it("falls back to the default npm spec when a beta tag is unavailable", async () => {
-    installPluginFromNpmSpecMock
-      .mockResolvedValueOnce({
-        ok: false,
-        code: "npm_package_not_found",
-        error: "Package not found on npm: openclaw-codex-app-server@beta.",
-      })
-      .mockResolvedValueOnce(
+  it.each([false, true])(
+    "selects latest before install when the beta tag is unavailable (dryRun=%s)",
+    async (dryRun) => {
+      runCommandWithTimeoutMock.mockResolvedValueOnce({
+        code: 1,
+        stdout: "",
+        stderr: "npm error code E404",
+      });
+      mockNpmViewMetadata({ name: "openclaw-codex-app-server", version: "0.2.6" });
+      installPluginFromNpmSpecMock.mockResolvedValue(
         createSuccessfulNpmUpdateResult({
           pluginId: "openclaw-codex-app-server",
           targetDir: "/tmp/openclaw-codex-app-server",
@@ -3928,78 +3989,33 @@ describe("updateNpmInstalledPlugins", () => {
           },
         }),
       );
-
-    const config = createCodexAppServerInstallConfig({
-      spec: "openclaw-codex-app-server",
-    });
-    const warnMessages: string[] = [];
-    const result = await updatePlugin(config, "openclaw-codex-app-server", {
-      updateChannel: "beta",
-      logger: { warn: (msg) => warnMessages.push(msg) },
-    });
-
-    expect(npmInstallCall(0)?.spec).toBe("openclaw-codex-app-server@beta");
-    expect(npmInstallCall(1)?.spec).toBe("openclaw-codex-app-server");
-    expect(npmInstallCall(1)?.config).toBe(config);
-    expect(warnMessages).toEqual([
-      'Plugin "openclaw-codex-app-server" has no beta npm release for openclaw-codex-app-server@beta; using openclaw-codex-app-server instead. Core update can still complete.',
-    ]);
-    expectCodexAppServerInstallState({
-      result,
-      spec: "openclaw-codex-app-server",
-      version: "0.2.6",
-      resolvedSpec: "openclaw-codex-app-server@0.2.6",
-    });
-    expect(result.outcomes[0]?.message).toBe(
-      "Updated openclaw-codex-app-server: unknown -> 0.2.6. (warning: beta channel fallback used openclaw-codex-app-server because openclaw-codex-app-server@beta could not be used).",
-    );
-    expect(result.outcomes[0]?.channelFallback).toEqual({
-      requestedSpec: "openclaw-codex-app-server@beta",
-      usedSpec: "openclaw-codex-app-server",
-      requestedLabel: "@beta",
-      usedLabel: "@latest",
-      reason: "unavailable",
-      message:
-        "plugin channel fallback: openclaw-codex-app-server used @latest because @beta was unavailable",
-    });
-  });
-
-  it("reports npm beta fallback as tentative during dry-run checks", async () => {
-    installPluginFromNpmSpecMock
-      .mockResolvedValueOnce({
-        ok: false,
-        code: "npm_package_not_found",
-        error: "Package not found on npm: openclaw-codex-app-server@beta.",
-      })
-      .mockResolvedValueOnce(
-        createSuccessfulNpmUpdateResult({
-          pluginId: "openclaw-codex-app-server",
-          targetDir: "/tmp/openclaw-codex-app-server",
-          version: "0.2.6",
-          npmResolution: {
-            name: "openclaw-codex-app-server",
-            version: "0.2.6",
-            resolvedSpec: "openclaw-codex-app-server@0.2.6",
-          },
-        }),
-      );
-
-    const result = await updateNpmInstalledPlugins({
-      config: createCodexAppServerInstallConfig({
+      const config = createCodexAppServerInstallConfig({
         spec: "openclaw-codex-app-server",
-      }),
-      pluginIds: ["openclaw-codex-app-server"],
-      updateChannel: "beta",
-      dryRun: true,
-    });
+      });
+      const result = await updatePlugin(config, "openclaw-codex-app-server", {
+        updateChannel: "beta",
+        dryRun,
+      });
 
-    expect(result.outcomes[0]?.message).toBe(
-      "Would update openclaw-codex-app-server: unknown -> 0.2.6. (warning: beta channel fallback would use openclaw-codex-app-server because openclaw-codex-app-server@beta could not be used).",
-    );
-    expect(result.outcomes[0]?.channelFallback?.message).toBe(
-      "plugin channel fallback: openclaw-codex-app-server would use @latest because @beta was unavailable",
-    );
-  });
+      expect(installPluginFromNpmSpecMock).toHaveBeenCalledTimes(1);
+      expect(npmInstallCall()?.spec).toBe("openclaw-codex-app-server@0.2.6");
+      expect(npmInstallCall()?.config).toBe(config);
+      expect(result.outcomes[0]?.message).toBe(
+        `${dryRun ? "Would update" : "Updated"} openclaw-codex-app-server: unknown -> 0.2.6.`,
+      );
+      if (dryRun) {
+        expect(result.config).toBe(config);
+        expect(result.changed).toBe(false);
+      } else {
+        expectCodexAppServerInstallState({
+          result,
+          spec: "openclaw-codex-app-server",
+          version: "0.2.6",
+          resolvedSpec: "openclaw-codex-app-server@0.2.6",
+        });
+      }
+    },
+  );
 
   it.each([
     { code: "incompatible_plugin_api", error: "Incompatible artifact" },
@@ -4008,6 +4024,8 @@ describe("updateNpmInstalledPlugins", () => {
     { error: "Integrity mismatch" },
     { code: "incompatible_host_version", error: "ETARGET in untrusted validation text" },
   ])("does not retry a refused beta artifact ($error)", async (failure) => {
+    mockNpmViewMetadata({ name: "openclaw-codex-app-server", version: "0.2.0-beta.4" });
+    mockNpmViewMetadata({ name: "openclaw-codex-app-server", version: "0.1.9" });
     installPluginFromNpmSpecMock.mockResolvedValue({ ok: false, ...failure });
     const result = await updatePlugin(
       createCodexAppServerInstallConfig({ spec: "openclaw-codex-app-server" }),
@@ -4568,7 +4586,7 @@ describe("updateNpmInstalledPlugins", () => {
     {
       name: "beta",
       params: { officialPluginUpdateChannel: "beta" as const },
-      expectedInstallSpec: "@openclaw/fish-audio-speech@beta",
+      expectedInstallSpec: "@openclaw/fish-audio-speech@2026.8.1",
       expectedRecordSpec: "@openclaw/fish-audio-speech",
     },
     {
@@ -4598,6 +4616,10 @@ describe("updateNpmInstalledPlugins", () => {
   ])(
     "selects the $name package line when migrating a manifest-declared legacy id",
     async ({ params, expectedInstallSpec, expectedRecordSpec }) => {
+      if (params.officialPluginUpdateChannel === "beta" && !params.specOverrides) {
+        mockNpmViewMetadata({ name: "@openclaw/fish-audio-speech", version: "2026.8.1-beta.1" });
+        mockNpmViewMetadata({ name: "@openclaw/fish-audio-speech", version: "2026.8.1" });
+      }
       installPluginFromNpmSpecMock.mockResolvedValue({
         ok: true,
         pluginId: "fish-audio-speech",
@@ -5493,6 +5515,7 @@ describe("syncPluginsForUpdateChannel", () => {
     installPluginFromClawHubMock.mockReset();
     installPluginFromGitSpecMock.mockReset();
     resolveBundledPluginSourcesMock.mockReset();
+    runCommandWithTimeoutMock.mockReset();
   });
 
   it.each([
@@ -5761,19 +5784,23 @@ describe("syncPluginsForUpdateChannel", () => {
   });
 
   it.each(["npm", "clawhub", "source-fallback"] as const)(
-    "retries the declared default after a missing beta during %s externalization",
+    "selects npm releases before install and retains ClawHub fallback during %s externalization",
     async (source) => {
       resolveBundledPluginSourcesMock.mockReturnValue(new Map());
       const pluginId = "diagnostics-otel";
       const npmSpec = "@openclaw/diagnostics-otel";
       const clawhubSpec = `clawhub:${npmSpec}`;
       const coreVersion = "2026.8.1-beta.3";
-      const clawhubBetaSpec = `${clawhubSpec}@${source === "source-fallback" ? coreVersion : "beta"}`;
+      const clawhubBetaSpec = `${clawhubSpec}@beta`;
+      if (source !== "clawhub") {
+        mockNpmViewMetadata({ name: npmSpec, version: "2026.7.1-beta.1" });
+        mockNpmViewMetadata({ name: npmSpec, version: "2026.8.0" });
+      }
       const attempts: Array<{ spec: string; expectedIntegrity?: string }> = [];
       installPluginFromNpmSpecMock.mockImplementation(
         async ({ spec, expectedIntegrity }: { spec: string; expectedIntegrity?: string }) => {
           attempts.push({ spec, expectedIntegrity });
-          return source === "source-fallback" || spec !== npmSpec
+          return source === "source-fallback"
             ? { ok: false, code: "npm_package_not_found", error: "target unavailable" }
             : createSuccessfulNpmUpdateResult({
                 pluginId,
@@ -5811,10 +5838,7 @@ describe("syncPluginsForUpdateChannel", () => {
       expect(attempts).toEqual([
         ...(source === "clawhub"
           ? []
-          : [
-              { spec: `${npmSpec}@${coreVersion}`, expectedIntegrity: undefined },
-              { spec: npmSpec, expectedIntegrity: "sha512-catalog-default" },
-            ]),
+          : [{ spec: `${npmSpec}@2026.8.0`, expectedIntegrity: undefined }]),
         ...(source === "npm" ? [] : [{ spec: clawhubBetaSpec }, { spec: clawhubSpec }]),
       ]);
       expect(result.config.plugins?.installs?.[pluginId]).toMatchObject({
@@ -5823,9 +5847,11 @@ describe("syncPluginsForUpdateChannel", () => {
         version: "2026.8.0",
       });
       expect(result.config.plugins?.load?.paths).toEqual([]);
-      expect(result.summary.warnings.join("\n")).toContain(
-        source === "npm" ? `${npmSpec}@${coreVersion}` : clawhubBetaSpec,
-      );
+      if (source === "npm") {
+        expect(result.summary.warnings).toEqual([]);
+      } else {
+        expect(result.summary.warnings.join("\n")).toContain(clawhubBetaSpec);
+      }
     },
   );
 


### PR DESCRIPTION
Closes #139527.
Related: #122321, #122378. Thanks @Conan-Scott for the detailed reproduction and recovery verification.

## What Problem This Solves

Fixes an issue where Gateway startup repeatedly reinstalls an unchanged Codex plugin and refuses readiness when the configured beta channel trails the latest stable release. The reported pairing is OpenClaw `2026.9.2`, `@openclaw/codex@beta` at `2026.9.1-beta.1`, and `@openclaw/codex@latest` at `2026.9.2`.

The previous repairs addressed obsolete bundled-install records, startup host-version context, and missing companion publications. A stale beta tag still resolves successfully, so those protections did not prevent this retained managed npm installation from being refreshed repeatedly.

## Why This Change Was Made

Core updates and managed npm plugins now share the same beta/latest version selector. Beta installs use the newest published version and install the exact inspected target while preserving the recorded selector. Healthy same-version repairs leave the inventory unchanged; metadata outages defer replacement of a healthy installed plugin, while broken payloads still require repair. Read-only health inspection stays offline.

Startup settles plugin packages before plugin state migrations consume their metadata. It rereads the final inventory, checks config identity, revalidates the current migration lease, and retains the final consistency check. The obsolete npm beta fallback and duplicate diagnostic resolver are removed. ClawHub remains an independently declared source; registry integrity, compatibility, and artifact consent checks remain in force.

## User Impact

Operators can keep `update.channel: "beta"` through stable releases without selecting an older beta package or repeatedly restarting after a no-op refresh. `openclaw update --channel beta` and managed npm plugin updates use the same version ordering. The channel documentation now states the newest-of-beta/latest policy.

Production LOC from `git diff --numstat`: **+417 / -470 (net -53)**. Tests and test support: **+1202 / -790 (net +412)**. Documentation: +26 / -20. The existing source-name count budget shrinks from 498 to 496 after deleting obsolete constants; no configuration option, dependency, version, protocol, or SQLite schema is added or changed.

## Evidence

- Focused coverage spans 1,007 tests across 19 files, including stale/newer beta selection, two-pass idempotence, registry outages, source recovery, onboarding, plugin updates, startup migration ordering, config drift, lease loss, and persisted inventory. The final startup rerun passed all 76 tests across its three files.
- The original production code fails the beta-selection/no-op and startup-order regressions for the intended reasons. For example, it selects `@openclaw/codex@beta` instead of `@openclaw/codex@2026.9.2`, reinstalls unchanged packages, and migrates against the pre-repair inventory.
- Changed TypeScript/Markdown checks passed: core and test types, lint, formatting, all unused-export scans, import cycles, schema/state guards, and the exact shrink-only budget check. The earlier full-core lint findings were corrected without new suppressions or baseline exceptions.
- Independent review findings were repaired and the ownership paths rechecked. A later claim that existing ClawHub records query npm was rejected against the source: the candidate clears the opposite registry spec before resolution.

### Packaged live proof

Provider: `blacksmith-testbox` through the repository Crabbox wrapper. Synthetic state, isolated installation, and free loopback ports; no operator Gateway or credentials.

Baseline lease: `tbx_01m1tafrghmsv3d071rkys99fg`, [run 34007845075](https://github.com/openclaw/openclaw/actions/runs/34007845075), stopped successfully. Packaged OpenClaw reports `2026.9.2 (3928bad)` and the real registry reproduced the stale beta pairing:

```text
@openclaw/codex beta=2026.9.1-beta.1 latest=2026.9.2
openclaw beta=2026.9.1 latest=2026.9.2
start 1: refreshed codex@beta; plugin migration inputs changed; exit 1; not ready
start 2: refreshed codex@beta; plugin migration inputs changed; exit 1; not ready
```

Remote live proof: Blacksmith Testbox `tbx_01m1te81gffv1jy2b0w2753760`, [run 34010595937](https://github.com/openclaw/openclaw/actions/runs/34010595937), Ubuntu/Node 24.19.0. Synthetic temporary HOME/config/state, separate npm global prefixes, free loopback ports, no account credentials. Candidate source was verified against commit `368ada9839e4133a6804c7685c8e4ef38c89f671` before building and installing its self-contained package.

Selected observed output:

```text
Registry: @openclaw/codex beta=2026.9.1-beta.1 latest=2026.9.2
Registry: openclaw beta=2026.9.1 latest=2026.9.2
Baseline: OpenClaw 2026.9.2 (3928bad)
Baseline start 1: exit=1 ready=false refresh=true migrationIdentityRefusal=true
Baseline start 2: exit=1 ready=false refresh=true migrationIdentityRefusal=true

Candidate: OpenClaw 2026.9.2 (368ada9)
Plugin "codex" refresh: tag-behind-latest; beta follows latest 2026.9.2.
Plugin "codex" refresh: newer-available (2026.9.1-beta.1 -> 2026.9.2).
Candidate start 1: ready=true failing=[] migrationIdentityRefusal=false
Candidate start 2: ready=true failing=[] refresh=false migrationIdentityRefusal=false
Managed Codex record hash unchanged between candidate starts:
5cb52927ea0746528f6e2fd5cd119fd32fbd139747ab85f91388866beda7215f

plugins inspect codex --runtime --json:
status=loaded source=npm version=2026.9.2 managedRuntimeRoot=true
runtimeFailures=[] startupFailures=[]
codex-cli 0.153.4
app-server initialize: success

openclaw update --channel beta --dry-run --json, baseline and candidate:
target.channel=beta target.tag=latest target.version=2026.9.2
```

The package helper's tarball integrity and import-graph checks passed. Candidate package SHA-256: `edf81a4ca9f975eeee8f6d3bf9bdc605806af38bc685d342c25720b80c06aa2a`. The wrapper's final command result was `exitCode: 0`, `runStatus: succeeded`. The lease was stopped successfully after proof.

The CLI proof checks target selection only. Its existing downgrade guard correctly notes that current-main schema 16 cannot be replaced by the published schema-15 package; no update or downgrade was executed. Codex initialization was credential-free, so this does not claim an authenticated model response.

The follow-up head `e511749f4acb09437245b4e6f5416ba889d9f0c5` changes only four test fixtures after the live-proof commit; production code is byte-identical. Those additional CLI/chat/channel-install suites passed all 323 tests locally with deterministic npm metadata. The schema-16 state above is pre-existing on main; this PR does not change a schema.

ClawSweeper proof follow-ups are complete: the candidate was freshly installed as a packaged npm global installation, recovered the retained release state in one startup, preserved npm source/selector intent, and retained the same authoritative record across the second start. No additional follow-up refactor is proposed: the shared resolver and removal of the obsolete fallback and diagnostic-resolution paths are included in this repair.
