### PR TITLE
improve(skills): skip unnecessary path work for ignored watcher entries

### DIFF
--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -370,7 +370,7 @@ function isTrustedSymlinkSkillTarget(
 function shouldIgnoreSkillsWatchPath(
   watchPath: string,
   stats?: { isDirectory?: () => boolean; isSymbolicLink?: () => boolean },
-  options: { usePolling?: boolean } = {},
+  usePolling = false,
 ): boolean {
   if (DEFAULT_SKILLS_WATCH_IGNORED.some((re) => re.test(watchPath))) {
     return true;
@@ -381,7 +381,7 @@ function shouldIgnoreSkillsWatchPath(
   if (!stats) {
     return false;
   }
-  if (options.usePolling && isSkillFileWatchPath(watchPath)) {
+  if (usePolling && isSkillFileWatchPath(watchPath)) {
     return false;
   }
   // Regular files are surfaced through raw directory events below. Letting
@@ -515,8 +515,8 @@ function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
         pollInterval: 100,
       },
       ignored: (watchPath, stats) =>
-        (!isPathInside(target.path, watchPath) && !isPathInside(watchPath, target.path)) ||
-        shouldIgnoreSkillsWatchPath(watchPath, stats, { usePolling }),
+        shouldIgnoreSkillsWatchPath(watchPath, stats, usePolling) ||
+        (!isPathInside(target.path, watchPath) && !isPathInside(watchPath, target.path)),
     }),
   );
 


### PR DESCRIPTION
## What Problem This Solves

Skills watcher traversal performs path containment work for entries that its existing ignored-name and file-type rules can reject immediately. Missing skill roots make this particularly wasteful while the watcher scans their existing parent directories.

## Why This Change Was Made

Run the same cheap rejection rules before the unchanged containment checks, and pass the polling boolean directly instead of creating an options object for each callback. Missing-root ancestor traversal, symlink policy, polling, and event delivery keep their existing behavior.

## User Impact

Ignored files and directories avoid unnecessary path normalization. There is no configuration or visible behavior change.

## Evidence

All 43 focused tests passed, including a real filesystem watcher detecting a skill created beneath initially missing parents. The complete changed-file check, independent source review, and isolated autoreview passed.

A real ten-turn Gateway baseline showed recurring allocations in this callback. A source-derived synthetic comparison preserved 88 callback outcomes and reduced work for rejected regular files; unknown-stat and unrelated-directory cases showed small allocation increases, so this is not a claim of reduced whole-Gateway RSS. The callback still uses the same containment helper and dependency contracts.
