### PR TITLE
improve(gateway): reduce memory used to page session history

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -384,6 +384,28 @@ describe("SessionHistorySseState", () => {
     expect(oldest.nextCursor).toBeUndefined();
   });
 
+  test("closes interleaved pages across unsequenced rows without admitting older duplicate groups", () => {
+    const messages = [1, 2, 2, 3, undefined, 4, 3, 4].map((seq, index) => ({
+      role: "assistant" as const,
+      content: textContent(`Projected row ${index}`),
+      __openclaw: seq === undefined ? undefined : { seq },
+    }));
+    const { history } = buildSessionHistorySnapshot({
+      rawMessages: [],
+      projection: {
+        messages,
+        turnBoundaryPending: false,
+        streamErrorFallbackPending: false,
+        streamErrorFallbackRepaired: false,
+      },
+      limit: 1,
+    });
+
+    expect(history.messages).toEqual(messages.slice(3));
+    expect(history.nextCursor).toBe("3");
+    expect(history.hasMore).toBe(true);
+  });
+
   test("keeps commentary fallback rows reachable across cursor pages and SSE state", () => {
     const rawMessages = [
       userTextMessage("check the workspace", 1),

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -192,22 +192,22 @@ function paginateSessionMessages(
   let start = typeof limit === "number" && limit > 0 ? Math.max(0, endExclusive - limit) : 0;
   // Projection can interleave several rows from the same transcript records.
   // Close the page over their seq groups because the public cursor cannot split one.
-  const pageSeqs = new Set(
-    messages.slice(start, endExclusive).map(resolveMessageSeq).filter(Boolean),
-  );
-  const gapSeqs = new Set<number>();
-  for (let index = start - 1; index >= 0; index--) {
-    const seq = resolveMessageSeq(messages[index]);
-    if (seq === undefined) {
-      continue;
+  if (start > 0) {
+    const pageSeqs = new Set<number>();
+    let indexedStart = endExclusive;
+    for (let index = start - 1; index >= 0; index--) {
+      // Index only admitted intervals; unrelated older gaps need no retained sequence set.
+      while (indexedStart > start) {
+        const pageSeq = resolveMessageSeq(messages[--indexedStart]);
+        if (pageSeq !== undefined) {
+          pageSeqs.add(pageSeq);
+        }
+      }
+      const seq = resolveMessageSeq(messages[index]);
+      if (seq !== undefined && pageSeqs.has(seq)) {
+        start = index;
+      }
     }
-    gapSeqs.add(seq);
-    if (!pageSeqs.has(seq)) {
-      continue;
-    }
-    start = index;
-    gapSeqs.forEach((gapSeq) => pageSeqs.add(gapSeq));
-    gapSeqs.clear();
   }
   const paginatedMessages = messages.slice(start, endExclusive);
   const firstSeq = resolveMessageSeq(paginatedMessages[0]);


### PR DESCRIPTION
## What Problem This Solves

History pagination kept sequence IDs for every older row it scanned, including rows that never entered the returned page. Full-history snapshots also built temporary arrays and sequence sets that were never used.

## Why This Change Was Made

Track only sequences inside the admitted page and index newly included intervals as interleaved groups expand it. Full pages skip this bookkeeping. Existing cursor behavior, message order, and transitive group closure are preserved.

## User Impact

Paging long session histories uses less temporary memory and CPU. Returned messages, cursors, and persistent storage behavior are unchanged.

## Evidence

- All 32 focused tests passed across history state, REST/SSE pagination, and full-history retention. A new case covers transitive groups across an unsequenced row while excluding older unrelated duplicate groups.
- Full changed checks, independent correctness review, and isolated autoreview passed.
- For a synthetic 50,000-row history, sampled allocations across twelve calls fell from 75.0 MB to 19.1 MB for full pages and from 46.3 MB to 14.5 MB for one-row pages. Full result comparisons matched and caller inputs stayed unchanged.
- A warmed same-process comparison reduced CPU time for full, bounded, and heavily interleaved pages. These measurements isolate the history helper and do not establish whole-Gateway memory or RSS savings.
