### PR TITLE
improve(media): avoid retaining whole text attachments for short extracts

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -2165,6 +2165,26 @@ describe("applyMediaUnderstanding", () => {
     expectPolicyRejectedFileApplied({ ctx, result, mime: "application/pdf" });
   });
 
+  it("keeps cached attachment bytes intact when a PDF extractor mutates its input", async () => {
+    const original = Buffer.from("%PDF-1.7\nfixture");
+    const mediaPath = await createTempMediaFile({ fileName: "mutable.pdf", content: original });
+    const { MediaAttachmentCache } = await import("./attachments.cache.js");
+    const pdf = await import("../media/pdf-extract.js");
+    const getBuffer = vi.spyOn(MediaAttachmentCache.prototype, "getBuffer");
+    const extract = vi.spyOn(pdf, "extractPdfContent").mockImplementation(async ({ buffer }) => {
+      buffer.fill(0);
+      return { text: "extracted PDF", images: [] };
+    });
+    try {
+      const { ctx } = await applyWithDisabledMedia({ body: "<media:file>", mediaPath });
+      expect(ctx.Body).toContain("extracted PDF");
+      expect((await getBuffer.mock.results[0]?.value)?.buffer).toEqual(original);
+    } finally {
+      extract.mockRestore();
+      getBuffer.mockRestore();
+    }
+  });
+
   it("respects configured allowedMimes for text-like attachments", async () => {
     const tsvText = "a\tb\tc\n1\t2\t3";
     const tsvPath = await createTempMediaFile({

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -236,8 +236,9 @@ async function classifyFileAttachment(params: {
   try {
     const { allowedMimesConfigured: _allowedMimesConfigured, ...baseLimits } = limits;
     extracted = await extractFileContentFromBuffer({
-      // Extractor plugins receive owned mutable bytes, never the attachment cache's buffer.
-      buffer: Buffer.from(bufferResult.buffer),
+      // Text decoding is read-only; PDF extractor plugins still receive owned mutable bytes.
+      buffer:
+        mimeType === "application/pdf" ? Buffer.from(bufferResult.buffer) : bufferResult.buffer,
       filename: bufferResult.fileName,
       limits: { ...baseLimits, allowedMimes },
       config: cfg,

--- a/src/media/input-files.extract.test.ts
+++ b/src/media/input-files.extract.test.ts
@@ -1,9 +1,11 @@
 // Regression: input_file callers declare their MIME; a cosmetic filename must
 // not reroute classification past an operator-configured allowlist.
 import { classifyAttachmentBytes } from "@openclaw/media-core/attachment-classify";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_INPUT_IMAGE_MIMES,
+  extractFileContentFromBuffer,
   extractFileContentFromSource,
   extractImageContentFromSource,
   resolveInputFileLimits,
@@ -160,5 +162,63 @@ describe("extractFileContentFromSource", () => {
     });
 
     expect(result.text).toContain('"revenue"');
+  });
+});
+
+describe("file text output limits", () => {
+  const unicodeText = `\ufeff${"é".repeat(8190)}🙂\ufefftail`;
+  const asciiPrefix = Buffer.alloc(16_383, "a");
+  it.each([
+    { name: "UTF-8 Unicode and BOMs", charset: "utf-8", buffer: Buffer.from(unicodeText) },
+    {
+      name: "UTF-16LE Unicode and BOMs",
+      charset: "utf-16le",
+      buffer: Buffer.from(unicodeText, "utf16le"),
+    },
+    {
+      name: "UTF-16BE Unicode and BOMs",
+      charset: "utf-16be",
+      buffer: Buffer.from(unicodeText, "utf16le").swap16(),
+    },
+    {
+      name: "Windows-1252",
+      charset: "windows-1252",
+      buffer: Buffer.concat([asciiPrefix, Buffer.from([0x80, 0x21])]),
+    },
+    {
+      name: "unsupported charset fallback",
+      charset: "unsupported-encoding",
+      buffer: Buffer.from(unicodeText),
+      fallback: "utf-8",
+    },
+    {
+      name: "incomplete UTF-8 at EOF",
+      charset: "utf-8",
+      buffer: Buffer.concat([asciiPrefix, Buffer.from([0xf0, 0x9f])]),
+    },
+    {
+      name: "ISO-2022-JP shift state",
+      charset: "iso-2022-jp",
+      buffer: Buffer.concat([
+        Buffer.alloc(16_382, "a"),
+        Buffer.from([0x1b, 0x24, 0x42, 0x24, 0x22, 0x1b, 0x28, 0x42]),
+      ]),
+    },
+    {
+      name: "incomplete ISO-2022-JP escape at EOF",
+      charset: "iso-2022-jp",
+      buffer: Buffer.concat([asciiPrefix, Buffer.from([0x1b, 0x28])]),
+    },
+  ])("preserves full-decoding prefixes for $name", async ({ charset, buffer, fallback }) => {
+    const decoded = new TextDecoder(fallback ?? charset).decode(buffer);
+    for (const maxChars of [0, 1, 8191, 8192, 16_384.9, Infinity]) {
+      const result = await extractFileContentFromBuffer({
+        buffer,
+        charset,
+        classification: { class: "text", mime: "text/plain" },
+        limits: resolveInputFileLimits({ maxChars }),
+      });
+      expect(result.text, `maxChars=${maxChars}`).toBe(truncateUtf16Safe(decoded, maxChars));
+    }
   });
 });

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -243,12 +243,23 @@ async function fetchWithGuard(params: {
   }
 }
 
-function decodeTextContent(buffer: Buffer, charset: string | undefined): string {
+function decodeTextContent(buffer: Buffer, charset: string | undefined, maxChars: number): string {
   const encoding = normalizeOptionalLowercaseString(charset) || "utf-8";
+  const limit = Math.max(0, Math.floor(maxChars));
+  const decode = (label: string) => {
+    const decoder = new TextDecoder(label);
+    let text = "";
+    for (let offset = 0; offset < buffer.length && text.length < limit; offset += 16_384) {
+      const end = Math.min(offset + 16_384, buffer.length);
+      // Preserve charset state across chunks; only actual EOF flushes incomplete bytes.
+      text += decoder.decode(buffer.subarray(offset, end), { stream: end < buffer.length });
+    }
+    return truncateUtf16Safe(text, limit);
+  };
   try {
-    return new TextDecoder(encoding).decode(buffer);
+    return decode(encoding);
   } catch {
-    return new TextDecoder("utf-8").decode(buffer);
+    return decode("utf-8");
   }
 }
 
@@ -408,7 +419,7 @@ export async function extractFileContentFromSource(params: {
   });
 }
 
-/** Extracts owned bytes after shared size and MIME checks; no source encoding is required. */
+/** Extracts text from borrowed bytes or PDFs from owned bytes after shared size and MIME checks. */
 export async function extractFileContentFromBuffer(params: {
   buffer: Buffer;
   filename?: string;
@@ -462,6 +473,6 @@ export async function extractFileContentFromBuffer(params: {
     };
   }
 
-  const text = truncateUtf16Safe(decodeTextContent(buffer, charset), limits.maxChars);
+  const text = decodeTextContent(buffer, charset, limits.maxChars);
   return { filename, text };
 }


### PR DESCRIPTION
## What Problem This Solves

Large text attachments were fully decoded and copied before OpenClaw kept only their configured text prefix. Retaining that prefix could keep the entire decoded document's backing memory alive.

## Why This Change Was Made

Decode in bounded chunks up to the existing character limit and borrow cached text bytes for read-only decoding. Charset state, actual EOF handling, UTF-8 fallback, and surrogate-safe truncation remain intact. PDF extractor plugins continue receiving independently owned buffers.

## User Impact

Short extracts from large text documents retain less memory. Existing output limits, text content, MIME policy, and PDF buffer ownership are preserved.

## Evidence

- All 155 focused tests passed across input-file extraction, fetch limits, PDF delegation, and inbound media application.
- Added decoding parity coverage for Unicode, BOMs, legacy charset state, malformed EOF, and character limits, plus a PDF mutation-isolation test.
- Full changed checks, independent decoder review, and isolated autoreview passed.
- A synthetic probe retaining four 60,000-character prefixes from 8 MiB ASCII documents removed 32 MiB of external string backing, with about 31.7 MiB less combined retained heap and external memory. Output hashes were identical. This measures the text-extraction owner, not whole-Gateway memory.
