### PR TITLE
fix(xai): preserve WebSocket transport behavior under Bun

### DIFF
--- a/extensions/xai/realtime-voice-bridge.ts
+++ b/extensions/xai/realtime-voice-bridge.ts
@@ -12,7 +12,6 @@ import type {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { RealtimeVoiceSessionLifecycle } from "openclaw/plugin-sdk/realtime-voice-provider";
 import { sleepWithAbort } from "openclaw/plugin-sdk/runtime-env";
-import WebSocket from "ws";
 import { resolveXaiRealtimeApiKey } from "./realtime-voice-auth.runtime.js";
 import {
   XAI_REALTIME_BASE_RECONNECT_DELAY_MS,
@@ -30,6 +29,7 @@ import {
 import { XaiRealtimeMalformedAudioError, XaiRealtimeVoiceEvents } from "./realtime-voice-events.js";
 import { XaiRealtimePlaybackMarkOverflowError } from "./realtime-voice-protocol.js";
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
+import { WebSocket } from "./ws-runtime.js";
 
 export class XaiRealtimeVoiceBridge extends XaiRealtimeVoiceEvents implements RealtimeVoiceBridge {
   readonly supportsToolResultContinuation = false;

--- a/extensions/xai/realtime-voice-outgoing-response.test.ts
+++ b/extensions/xai/realtime-voice-outgoing-response.test.ts
@@ -24,7 +24,7 @@ const { FakeWebSocket } = await vi.hoisted(async () => {
   }
   return { FakeWebSocket: MockWebSocket };
 });
-vi.mock("ws", () => ({ default: FakeWebSocket }));
+vi.mock("./ws-runtime.js", () => ({ WebSocket: FakeWebSocket }));
 
 beforeEach(() => {
   FakeWebSocket.instances = [];

--- a/extensions/xai/realtime-voice-provider.test.ts
+++ b/extensions/xai/realtime-voice-provider.test.ts
@@ -89,8 +89,8 @@ const { FakeWebSocket, isProviderAuthProfileConfiguredMock, resolveApiKeyForProv
     };
   });
 
-vi.mock("ws", () => ({
-  default: FakeWebSocket,
+vi.mock("./ws-runtime.js", () => ({
+  WebSocket: FakeWebSocket,
 }));
 
 vi.mock("openclaw/plugin-sdk/provider-auth", () => ({

--- a/extensions/xai/tts.test.ts
+++ b/extensions/xai/tts.test.ts
@@ -66,8 +66,8 @@ const { FakeWebSocket } = vi.hoisted(() => {
   return { FakeWebSocket: MockWebSocket };
 });
 
-vi.mock("ws", () => ({
-  default: FakeWebSocket,
+vi.mock("./ws-runtime.js", () => ({
+  WebSocket: FakeWebSocket,
 }));
 
 function createStreamingAudioResponse(params: {

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -6,7 +6,6 @@ import {
   asOptionalRecord,
   normalizeOptionalString as trimToUndefined,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import WebSocket from "ws";
 import { XAI_BASE_URL } from "./model-definitions.js";
 import {
   isValidXaiTtsVoice,
@@ -14,6 +13,7 @@ import {
   normalizeXaiTtsBaseUrl,
 } from "./speech-provider-metadata.js";
 import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
+import { WebSocket } from "./ws-runtime.js";
 
 const DEFAULT_TTS_MAX_BYTES = 16 * 1024 * 1024;
 const XAI_TTS_VOICE_LIST_TIMEOUT_MS = 30_000;

--- a/extensions/xai/ws-runtime.ts
+++ b/extensions/xai/ws-runtime.ts
@@ -1,0 +1,11 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type WebSocketClient from "ws";
+
+const require = createRequire(import.meta.url);
+
+// Bun's built-in ws adapter ignores maxPayload; use the plugin's declared receiver.
+export type WebSocket = WebSocketClient;
+export const WebSocket: typeof WebSocketClient = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where xAI realtime voice and streaming speech used Bun's substituted WebSocket adapter instead of the installed dependency expected by their transport limits and tests.

## Why This Change Was Made

A private plugin-owned helper resolves and loads the declared ws package synchronously. Both consumers use that constructor, preserving immediate listener setup. The three affected test suites mock the same private module boundary.

## User Impact

xAI voice and speech retain the installed WebSocket implementation's existing transport behavior under Bun. Provider APIs, configuration, and connection lifecycle ownership remain unchanged.

## Evidence

- 146 focused tests passed on Node and 146 on true Bun.
- Full build pipeline and complete changed-file checks passed; final P0–P2 review found no actionable findings.
- The pinned dependency's package entry and constructor exports were inspected directly. No new dependency or public SDK surface was added.
- Earlier build/check attempts failed during the shared pinned-pnpm launcher problem; only the successful final pipeline and stable-runtime check are counted here.
- Tests used synthetic fixtures rather than live provider calls. The wider Bun compatibility campaign remains in progress.
