### PR TITLE
refactor(gateway): simplify placement and lifecycle owners

### DIFF
--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -131,11 +131,7 @@ export function createRestartSafeChatRequest(params: {
     return undefined;
   }
   return {
-    fingerprint: fingerprintRestartSafeChatRequest({
-      message: params.message,
-      mentions: params.mentions,
-      senderIsOwner: params.senderIsOwner,
-    }),
+    fingerprint: fingerprintRestartSafeChatRequest(params),
   };
 }
 

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -1,6 +1,4 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-// Gateway session lifecycle state projection.
-// Converts agent run lifecycle events into session row/store status updates.
 import { normalizeOptionalString as normalizeLifecycleRunId } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SessionRunStatus } from "../../packages/gateway-protocol/src/schema/sessions-row.js";
@@ -90,7 +88,7 @@ function isFiniteTimestamp(value: unknown): value is number {
 }
 
 function resolveLifecyclePhase(event: Pick<LifecycleEventLike, "data">): LifecyclePhase | null {
-  const phase = typeof event.data?.phase === "string" ? event.data.phase : "";
+  const phase = event.data?.phase;
   return phase === "start" || phase === "end" || phase === "error" ? phase : null;
 }
 
@@ -102,9 +100,8 @@ const SESSION_STATUS_BY_TERMINAL_CLASSIFICATION = {
 } as const satisfies Record<ReturnType<typeof classifyAgentRunTerminalOutcome>, SessionRunStatus>;
 
 function resolveTerminalOutcome(event: LifecycleEventLike): AgentRunTerminalOutcome {
-  const phase = resolveLifecyclePhase(event);
   return buildAgentRunTerminalOutcomeFromLifecycleEvent({
-    phase: phase === "error" ? "error" : "end",
+    phase: event.data?.phase === "error" ? "error" : "end",
     data: event.data,
     endedAt: event.data?.endedAt ?? event.ts,
   });
@@ -459,18 +456,17 @@ export async function persistGatewaySessionLifecycleEvent(params: {
           error: resolveTerminalOutcome(params.event).error,
         };
       }
-      const recoveryTerminalRunId = normalizeLifecycleRunId(params.event.runId);
       const recoveryTerminalIsCurrent =
         params.event.mainSessionRestartRecovery === true &&
         params.event.lifecycleGeneration === getAgentEventLifecycleGeneration() &&
-        recoveryTerminalRunId !== undefined &&
+        eventRunId !== undefined &&
         (phase === "end" || phase === "error");
       const terminalOutcome = recoveryTerminalIsCurrent
         ? resolveSettledLifecycleTerminalOutcome(params.event)
         : undefined;
-      if (terminalOutcome && recoveryTerminalRunId && Object.keys(patch).length > 0) {
+      if (terminalOutcome && eventRunId && Object.keys(patch).length > 0) {
         terminalRecovery = {
-          runId: recoveryTerminalRunId,
+          runId: eventRunId,
           outcome: terminalOutcome,
         };
       }

--- a/src/gateway/worker-environments/placement-dispatch-failure.ts
+++ b/src/gateway/worker-environments/placement-dispatch-failure.ts
@@ -20,7 +20,7 @@ export type WorkerActiveDispatchPlacement = Extract<
   WorkerSessionPlacementRecord,
   { state: "active" }
 >;
-export type WorkerFailedDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "failed" }>;
+type WorkerFailedDispatchPlacement = Extract<WorkerDispatchPlacement, { state: "failed" }>;
 export type WorkerProvisioningDispatchPlacement = Extract<
   WorkerDispatchPlacement,
   { state: "provisioning" }
@@ -354,9 +354,8 @@ export function createPlacementFailureActions(deps: {
         .listPendingWorkspaceResults()
         .some((result) => result.sessionId === placement.sessionId)
     ) {
-      // Match successful live teardown below: retained conflicts do not block reclaim.
-      // Their durable reports and staged refs survive redispatch and remain independently
-      // consulted by reclaim/publication; only pending results block this idle retirement.
+      // Retained conflict reports and staged refs survive redispatch; only pending results
+      // block idle retirement. Reclaim and publication still consult retained conflicts.
       placements.transition({
         sessionId: reconciling.sessionId,
         from: "reconciling",

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -10,7 +10,10 @@ import {
   type WorkerDispatchPlacement,
   type WorkerDispatchPlacementStore,
 } from "./placement-dispatch-failure.js";
-import { resolvePriorWorkspaceResultConflict } from "./placement-dispatch-pending-results.js";
+import {
+  type PlacementRecoveryDeps,
+  resolvePriorWorkspaceResultConflict,
+} from "./placement-dispatch-pending-results.js";
 import { createPlacementRecoveryActions } from "./placement-dispatch-recovery.js";
 import {
   createWorkerPlacementDispatchStartup,
@@ -48,15 +51,10 @@ import { deriveEnvironmentIntent } from "./service-contract.js";
 import type { WorkerEnvironmentService } from "./service.js";
 import { isFailedWorkerPlacementEnvironmentGone } from "./session-placement-lifecycle.js";
 import { WorkerTunnelOwnerDisconnectedError } from "./tunnel-contract.js";
-import type {
-  WorkerWorkspaceRecoveryFailureReport,
-  WorkspaceResultConflictLookup,
-} from "./workspace-conflicts.js";
 import {
   verifyReconciledWorkspaceFinal,
   WorkerWorkspaceFinalFenceError,
 } from "./workspace-finalize.js";
-import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   finalizeWorkspaceResultConflicts,
@@ -78,52 +76,36 @@ type WorkerLocalDispatchBarrier = (params: {
   startDispatch: () => WorkerDispatchPlacement;
 }) => Promise<WorkerDispatchPlacement>;
 
-type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers & {
-  placements: WorkerDispatchPlacementStore;
-  environments: WorkerDispatchEnvironmentService &
-    Pick<WorkerEnvironmentService, "recordError"> &
-    Partial<Pick<WorkerEnvironmentService, "requiresNodeEnrollment">>;
-  isShuttingDown?: () => boolean;
-  runnerAvailability: WorkerPlacementRunnerAvailabilityReader;
-  runLocalBarrier: WorkerLocalDispatchBarrier;
-  runRecoveryBarrier: WorkerPlacementRecoveryBarrier;
-  runActivationBarrier: WorkerActivationBarrier;
-  runMoveBarrier: WorkerPlacementMoveBarrier;
-  resolveMoveDestination: (
-    identity: Pick<WorkerPlacementMoveRequest, "sessionId" | "sessionKey" | "agentId">,
-    target: WorkerPlacementMoveRequest["target"],
-  ) => Promise<WorkerPlacementMoveDestination | undefined>;
-  onActivated?: (request: WorkerPlacementDispatchRequest) => void;
-  workspaceOperations: WorkerWorkspaceOperationCoordinator;
-  resolveWorkspacePath: (params: {
-    sessionId: string;
-    sessionKey: string;
-    agentId: string;
-  }) => Promise<string>;
-  reportWorkspaceResultConflict: (
-    params: { sessionId: string; sessionKey: string; agentId: string } & (
-      | { paths: string[]; stagedResultRef: string; totalCount: number }
-      | { cleared: true }
-    ),
-  ) => Promise<void>;
-  reportWorkspaceResultRecoveryFailure?: (
-    recovery: WorkerWorkspaceRecoveryFailureReport,
-  ) => Promise<void>;
-  resolveWorkspaceResultConflict: (params: {
-    sessionId: string;
-    sessionKey: string;
-    agentId: string;
-  }) => Promise<WorkspaceResultConflictLookup>;
-  prepareAcceptedWorkspacePublication?: (
-    claim: import("./placement-store.js").WorkerSessionTurnClaim,
-  ) => Promise<void>;
-  publishAcceptedWorkspace?: (
-    claim: import("./placement-store.js").WorkerSessionTurnClaim,
-  ) => Promise<void>;
-  resolveGitAuthor?: (agentId: string) => { name?: string; email?: string } | undefined;
-  resolveDevicePlacementRequirement?: WorkerDevicePlacementRequirementResolver;
-  isCurrentNodePlacement?: WorkerNodePlacementAuthority;
-};
+type WorkerPlacementDispatchOptions = WorkerPlacementReclaimBarriers &
+  Pick<
+    PlacementRecoveryDeps,
+    | "workspaceOperations"
+    | "resolveWorkspacePath"
+    | "reportWorkspaceResultConflict"
+    | "reportWorkspaceResultRecoveryFailure"
+    | "resolveWorkspaceResultConflict"
+    | "prepareAcceptedWorkspacePublication"
+    | "publishAcceptedWorkspace"
+  > & {
+    placements: WorkerDispatchPlacementStore;
+    environments: WorkerDispatchEnvironmentService &
+      Pick<WorkerEnvironmentService, "recordError"> &
+      Partial<Pick<WorkerEnvironmentService, "requiresNodeEnrollment">>;
+    isShuttingDown?: () => boolean;
+    runnerAvailability: WorkerPlacementRunnerAvailabilityReader;
+    runLocalBarrier: WorkerLocalDispatchBarrier;
+    runRecoveryBarrier: WorkerPlacementRecoveryBarrier;
+    runActivationBarrier: WorkerActivationBarrier;
+    runMoveBarrier: WorkerPlacementMoveBarrier;
+    resolveMoveDestination: (
+      identity: Pick<WorkerPlacementMoveRequest, "sessionId" | "sessionKey" | "agentId">,
+      target: WorkerPlacementMoveRequest["target"],
+    ) => Promise<WorkerPlacementMoveDestination | undefined>;
+    onActivated?: (request: WorkerPlacementDispatchRequest) => void;
+    resolveGitAuthor?: (agentId: string) => { name?: string; email?: string } | undefined;
+    resolveDevicePlacementRequirement?: WorkerDevicePlacementRequirementResolver;
+    isCurrentNodePlacement?: WorkerNodePlacementAuthority;
+  };
 
 export function createWorkerPlacementDispatchService(options: WorkerPlacementDispatchOptions) {
   const { environments, placements } = options;
@@ -136,23 +118,9 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
   });
 
   const recovery = createPlacementRecoveryActions({
-    environments,
+    ...options,
     failure,
-    placements,
-    resolveWorkspacePath: options.resolveWorkspacePath,
-    reportWorkspaceResultConflict: options.reportWorkspaceResultConflict,
-    ...(options.reportWorkspaceResultRecoveryFailure
-      ? { reportWorkspaceResultRecoveryFailure: options.reportWorkspaceResultRecoveryFailure }
-      : {}),
-    resolveWorkspaceResultConflict: options.resolveWorkspaceResultConflict,
     recoverPlacementMoves: (environmentId) => moveService.recoverAll(environmentId),
-    workspaceOperations: options.workspaceOperations,
-    ...(options.prepareAcceptedWorkspacePublication
-      ? { prepareAcceptedWorkspacePublication: options.prepareAcceptedWorkspacePublication }
-      : {}),
-    ...(options.publishAcceptedWorkspace
-      ? { publishAcceptedWorkspace: options.publishAcceptedWorkspace }
-      : {}),
   });
 
   const dispatch = async (

--- a/src/gateway/worker-environments/placement-projector.ts
+++ b/src/gateway/worker-environments/placement-projector.ts
@@ -147,46 +147,10 @@ export function projectWorkerSessionPlacement(
         remoteWorkspaceDir: record.remoteWorkspaceDir,
       };
     case "active":
-      return {
-        state: "active",
-        ...timing,
-        ...identity,
-        environmentId: record.environmentId,
-        activeOwnerEpoch: record.activeOwnerEpoch,
-        workerBundleHash: record.workerBundleHash,
-        workspaceBaseManifestRef: record.workspaceBaseManifestRef,
-        remoteWorkspaceDir: record.remoteWorkspaceDir,
-        ...(record.lastTranscriptAckCursor !== null
-          ? { lastTranscriptAckCursor: record.lastTranscriptAckCursor }
-          : {}),
-        ...(record.lastLiveEventAckCursor !== null
-          ? { lastLiveEventAckCursor: record.lastLiveEventAckCursor }
-          : {}),
-        ...(diskSpace ? { diskSpace } : {}),
-        ...(runner ? { runner } : {}),
-        ...conflict,
-      };
     case "draining":
-      return {
-        state: "draining",
-        ...timing,
-        ...identity,
-        environmentId: record.environmentId,
-        activeOwnerEpoch: record.activeOwnerEpoch,
-        workerBundleHash: record.workerBundleHash,
-        workspaceBaseManifestRef: record.workspaceBaseManifestRef,
-        remoteWorkspaceDir: record.remoteWorkspaceDir,
-        ...(record.lastTranscriptAckCursor !== null
-          ? { lastTranscriptAckCursor: record.lastTranscriptAckCursor }
-          : {}),
-        ...(record.lastLiveEventAckCursor !== null
-          ? { lastLiveEventAckCursor: record.lastLiveEventAckCursor }
-          : {}),
-        ...conflict,
-      };
     case "reconciling":
       return {
-        state: "reconciling",
+        state: record.state,
         ...timing,
         ...identity,
         environmentId: record.environmentId,
@@ -200,11 +164,13 @@ export function projectWorkerSessionPlacement(
         ...(record.lastLiveEventAckCursor !== null
           ? { lastLiveEventAckCursor: record.lastLiveEventAckCursor }
           : {}),
+        ...(record.state === "active" && diskSpace ? { diskSpace } : {}),
+        ...(record.state === "active" && runner ? { runner } : {}),
         ...conflict,
       };
     case "reclaimed":
-      return {
-        state: "reclaimed",
+    case "failed": {
+      const retained = {
         ...timing,
         ...identity,
         ...(record.environmentId ? { environmentId: record.environmentId } : {}),
@@ -221,31 +187,17 @@ export function projectWorkerSessionPlacement(
           ? { lastLiveEventAckCursor: record.lastLiveEventAckCursor }
           : {}),
         ...conflict,
-        ...terminal,
       };
-    case "failed":
-      return {
-        state: "failed",
-        ...timing,
-        ...identity,
-        ...(record.environmentId ? { environmentId: record.environmentId } : {}),
-        ...(record.activeOwnerEpoch !== null ? { activeOwnerEpoch: record.activeOwnerEpoch } : {}),
-        ...(record.workspaceBaseManifestRef
-          ? { workspaceBaseManifestRef: record.workspaceBaseManifestRef }
-          : {}),
-        ...(record.remoteWorkspaceDir ? { remoteWorkspaceDir: record.remoteWorkspaceDir } : {}),
-        ...(record.workerBundleHash ? { workerBundleHash: record.workerBundleHash } : {}),
-        ...(record.lastTranscriptAckCursor !== null
-          ? { lastTranscriptAckCursor: record.lastTranscriptAckCursor }
-          : {}),
-        ...(record.lastLiveEventAckCursor !== null
-          ? { lastLiveEventAckCursor: record.lastLiveEventAckCursor }
-          : {}),
-        ...conflict,
-        recoveryError: record.recoveryError,
-        ...(failedRecoveryAction ? { recoveryAction: failedRecoveryAction } : {}),
-        ...terminal,
-      };
+      return record.state === "failed"
+        ? {
+            state: "failed",
+            ...retained,
+            recoveryError: record.recoveryError,
+            ...(failedRecoveryAction ? { recoveryAction: failedRecoveryAction } : {}),
+            ...terminal,
+          }
+        : { state: "reclaimed", ...retained, ...terminal };
+    }
   }
   // Exhaustive over placement states; the return satisfies consistent-return.
   return record satisfies never;

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -1,10 +1,3 @@
-import type {
-  WorkerPortalParams,
-  WorkerSessionsSendParams,
-  WorkerSessionsSpawnParams,
-  WorkerSessionToolResult,
-} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
-import type { WorkerSkillWorkshopParams } from "../../../packages/gateway-protocol/src/schema/worker-skill-workshop.js";
 import { onSessionIdentityMutation } from "../../config/sessions/session-accessor.js";
 import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { withTimeout } from "../../infra/fs-safe.js";
@@ -12,7 +5,6 @@ import { isSqliteLockError } from "../../infra/sqlite-transaction.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
 import type { WorkerExecutionMode, WorkerProfile } from "../../plugins/types.js";
 import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
-import type { WorkerConnectionIdentity } from "./admission.js";
 import { workerBootstrapOperationTimeoutMs } from "./bootstrap.js";
 import type { WorkerInstallationArtifact } from "./bundle.js";
 import { createWorkerCredentialBroker } from "./credential-broker.js";
@@ -97,33 +89,7 @@ type WorkerEnvironmentServiceOptions = WorkerProviderLifecycleInputOptions & {
   executeInference: WorkerInferenceExecutor;
   inferenceStore?: WorkerInferenceStore;
   placementStore?: WorkerSessionPlacementGate;
-  executeSessionTool?: (
-    params:
-      | {
-          identity: WorkerConnectionIdentity;
-          toolName: "skill_workshop";
-          request: WorkerSkillWorkshopParams;
-          signal?: AbortSignal;
-        }
-      | {
-          identity: WorkerConnectionIdentity;
-          toolName: "sessions_spawn";
-          request: WorkerSessionsSpawnParams;
-          signal?: AbortSignal;
-        }
-      | {
-          identity: WorkerConnectionIdentity;
-          toolName: "sessions_send";
-          request: WorkerSessionsSendParams;
-          signal?: AbortSignal;
-        }
-      | {
-          identity: WorkerConnectionIdentity;
-          toolName: "portal";
-          request: WorkerPortalParams;
-          signal?: AbortSignal;
-        },
-  ) => Promise<WorkerSessionToolResult>;
+  executeSessionTool?: Parameters<typeof createWorkerTurnRpc>[0]["executeSessionTool"];
 };
 
 export type WorkerEnvironmentReconcileCore = (
@@ -293,13 +259,10 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   };
 
   const credentialBroker = createWorkerCredentialBroker({
+    ...options,
     store,
     prepareInstallation,
     tunnelManager: tunnelLifecycle,
-    workerCredentialTtlMs: options.workerCredentialTtlMs,
-    generateWorkerCredential: options.generateWorkerCredential,
-    liveEvents: options.liveEvents,
-    placementStore: options.placementStore,
     now,
     isStopping: () => stopping,
     cancelInferenceEnvironment: (environmentId) => inference.cancelEnvironment(environmentId),
@@ -310,22 +273,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   });
 
   const providerLifecycle = createWorkerProviderLifecycle({
+    ...options,
     store,
-    getConfig: options.getConfig,
-    resolveProvider: options.resolveProvider,
     prepareInstallation,
-    bootstrapWorker: options.bootstrapWorker,
-    resolveSshIdentity: options.resolveSshIdentity,
-    ensureNodeWorkerBundle: options.ensureNodeWorkerBundle,
-    prepareNodeBootstrap: options.prepareNodeBootstrap,
-    projectNamespace: options.projectNamespace,
-    prepareNodeRuntime: options.prepareNodeRuntime,
-    closeNodeRuntime: options.closeNodeRuntime,
-    prepareNodeEnrollment: options.prepareNodeEnrollment,
-    closeNodeEnrollment: options.closeNodeEnrollment,
-    retireNodeEnrollment: options.retireNodeEnrollment,
-    placementStore: options.placementStore,
-    providerCallTimeoutMs: options.providerCallTimeoutMs,
     tunnelManager: tunnelLifecycle,
     credentialBroker,
     callBootstrap,
@@ -341,12 +291,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   });
 
   const environmentAccess = createWorkerEnvironmentAccess({
+    ...options,
     store,
-    getConfig: options.getConfig,
     prepareCurrentBundle: async () => await prepareInstallation("bundle"),
-    tunnelManager: options.tunnelManager,
-    nodeTunnelManager: options.nodeTunnelManager,
-    nodeDesktopCarrier: options.nodeDesktopCarrier,
     now,
     identityResolverFor: providerLifecycle.identityResolverFor,
     inState,
@@ -357,13 +304,9 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
   });
 
   const turnRpc = createWorkerTurnRpc({
+    ...options,
     store,
     prepareInstallation,
-    applyTranscriptCommit: options.applyTranscriptCommit,
-    liveEvents: options.liveEvents,
-    placementStore: options.placementStore,
-    executeSessionTool: options.executeSessionTool,
-    executeComputer: options.executeComputer,
     inference,
     isStopping: () => stopping,
     now,

--- a/src/gateway/worker-environments/worker-turn-launcher.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher.ts
@@ -121,7 +121,6 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
         currentEnvironment.attachedSessionIds.length !== 1 ||
         currentEnvironment.attachedSessionIds[0] !== placement.sessionId ||
         (sandbox.backendId === "node" &&
-          "placementNodeId" in sandbox &&
           currentEnvironment.nodeDeviceId !== sandbox.placementNodeId)
       ) {
         throw new Error("Remote-exec environment changed while preparing its sandbox");
@@ -335,6 +334,5 @@ export function createWorkerSessionTurnPlacementProvider(options: WorkerTurnLaun
       }
     },
   };
-  provider satisfies SessionPlacementAdmissionProvider;
   return provider;
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of duplicated wiring, projection fields, and redundant checks around Gateway placement and restart lifecycle owners. Context: #139437, #139455, #139439, and #139519. These landings supply the review scope; this PR preserves their behavior.

## Why This Change Was Made

Reuse the existing owners' types and typed options, share identical placement projection fields, and remove checks already guaranteed by their producer. Net production reduction after the landing rebase: **148 lines** across seven files. No tests are changed or deleted.

| Work-order category | Change and final source location |
| --- | --- |
| 1. Dead code / unused exports | Make `WorkerFailedDispatchPlacement` module-local at `src/gateway/worker-environments/placement-dispatch-failure.ts:23`. `rg` across `src/` and `extensions/` finds only its definition and use inside that module. No unreferenced runtime function was found that could honestly be deleted. |
| 2. Duplicate guards | `src/gateway/session-lifecycle-state.ts:90`: the three strict phase comparisons already reject non-string values. `src/gateway/worker-environments/worker-turn-launcher.ts:123`: remove the property probe after the `node` discriminator; `placement-sandbox.ts:18` and its node return at `:126` guarantee `placementNodeId`. All current-owner checks remain. |
| 3. Types, wrappers, and locals | Reuse `PlacementRecoveryDeps` at `placement-dispatch.ts:76` and the existing turn-RPC callback type at `service.ts:92`; both replace verbatim duplicate definitions. Remove the already-satisfied provider type expression at `worker-turn-launcher.ts:337`. Simplify terminal phase selection at `session-lifecycle-state.ts:102` and reuse the run ID normalized at `:430` for recovery at `:459`. Paths without a prefix in this row are under `src/gateway/worker-environments/`, except `session-lifecycle-state.ts`, which is under `src/gateway/`. |
| 4. Comments | Remove the module-purpose narration above the lifecycle imports and tighten the retained-conflict invariant at `placement-dispatch-failure.ts:357` to two lines. |
| 5. Compatibility | **None removed.** The retained candidates and their contracts are listed below. |
| 6. Option/object duplication | Pass typed options through the recovery factory at `placement-dispatch.ts:117` and service factories at `service.ts:261`, `:275`, `:293`, and `:306`, retaining explicit local overrides. Use the existing fingerprint input at `src/gateway/server-methods/chat-restart-recovery.ts:134`. Share identical projection fields at `placement-projector.ts:149` and `:173`, retaining active-only samples and failed-only error/action fields. Worker filenames in this row are under `src/gateway/worker-environments/`. |
| 7. Test-support seams | None removed or added. All existing tests and fixtures remain byte-for-byte unchanged. |

The factory consumers read named properties; none enumerates or persists the extra options. The provider lifecycle's downstream spreads were traced through `provider-owner-lifecycle.ts`, `provider-node-provisioning.ts`, and `provider-intent.ts`, which also consume named fields only.

Retained candidates:

- Missing persisted `profileSnapshot.executionMode` and optional `requiresNodeEnrollment`: introduced in `8a1ff3966b7` (#127752); optional service/provider contracts and the SSH-backed provider path documented in `docs/gateway/cloud-workers.md` still apply.
- `retireMismatchedWorkerLease`: introduced in `2fc85bdc1bd` (#125384) to fence persisted transport mismatches; reconciliation still invokes it before adoption.
- Device, placement, claim, and environment validation around awaits: these enforce current authority after provisioning, workspace work, and activation barriers.
- Lifecycle event reconstruction: `lifecycleGeneration` and `mainSessionRestartRecovery` are non-enumerable in `src/infra/agent-events.ts`; ordinary spread loses them (history `d179dc3e27e`).
- Restart recovery's `terminalized` flag: the session patch API can return an existing entry when its callback declines the patch, so a returned entry alone does not prove acceptance.
- Transcript writer-fence checks: callbacks run between checks; the synchronous pre-commit check remains necessary (history `118ff477a19`).
- Timestamp fallback for missing/different run identity: protects late lifecycle events (history `678a3c18a94`). The `snapshotPatch` rebuild also preserves own-property presence for an invalid phase.
- The lifecycle `storedEntry as SessionEntry` cast is redundant, but removing it requires an accompanying edit to `config/assertion-safety-baseline.txt`, outside the requested hard boundary. The initial changed check caught that requirement; the final candidate retains the cast and changes no baseline.
- The restart-recovery wrapper has a production consumer outside the enumerated cleanup owners. The startup transition observer and its fixture remain; removing that injection would create test churn for little reduction. The inference drain cast preserves an intentionally non-enumerable internal control (history `b4104e29b5f`).

## User Impact

Behavior: **none**. State transitions, current-owner/epoch/generation/claim fencing, guard order, teardown and restart sequencing, errors and log text, public RPC fields, SQLite schema, and persisted record fields are preserved. Retained conflict reports and staged results continue to survive redispatch. No changelog or documentation changes.

| LOC | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 64 | 212 | **-148** |
| Tests / test support | 0 | 0 | 0 |
| Total | 64 | 212 | **-148** |

## Evidence

The Gateway scope and direct caller tests passed; the complete session/config scope passed on a separate unchanged rerun. Two Windows-only workspace-quiescence tests skip on macOS, as in the baseline.

Commands (an isolated filesystem module cache was used for runtime runs):

```sh
node scripts/run-vitest.mjs \
  src/gateway/worker-environments \
  src/gateway/session-lifecycle*.test.ts \
  src/gateway/server-session-lifecycle-events.test.ts \
  src/gateway/server-methods/chat-send-dispatch-errors.test.ts \
  src/gateway/server-methods/chat-send-pre-admission.test.ts \
  src/gateway/server-methods/sessions-read-cache.test.ts \
  src/gateway/server.sessions.placement-projection.test.ts \
  src/gateway/server-worker-placement-startup.test.ts \
  src/gateway/server-worker-placement-startup-cleanup.test.ts \
  src/gateway/server-chat.agent-events.test.ts \
  src/gateway/server-runtime-subscriptions.test.ts \
  src/gateway/server-worker-placement-cancel.test.ts \
  src/gateway/server.chat.gateway-server-chat.test.ts \
  src/config/sessions
node scripts/run-vitest.mjs src/config/sessions/session-transcript-reconcile.lifecycle.test.ts
node scripts/run-vitest.mjs src/config/sessions
node scripts/check-changed.mjs
```

Gateway result from the expanded run:

```text
 Test Files  157 passed | 1 skipped (158)
      Tests  2320 passed | 2 skipped (2322)
   Start at  20:52:27
   Duration  344.64s (tests 78%, transform 16%, import 5%, worker 1%)
```

The first combined run had one timeout in `session-transcript-reconcile.lifecycle.test.ts`, in the `preflight-begin` startup-cleanup case. Its 64-database cache-pressure fixture took 31.024 seconds against an unchanged 30-second limit, versus 6.291 seconds in the passing baseline. The host load average was 60–100 during the investigation. The unchanged whole-file probe passed all 11 tests, and the unchanged full config rerun passed with normal runner settings and no overlapping check; the same case took 6.590 seconds. This is consistent with resource contention; no timeout, assertion, fixture, or production change was made for it.

Focused retry tail (exit 0):

```text

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  21:02:10
   Duration  145.13s (tests 77%, transform 20%, import 2%, worker 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 152.51s
```

Complete config rerun tail (exit 0):

```text
 ✓ |runtime-config| src/config/sessions/cleanup-service.agent-purge.test.ts > purgeAgentSessionStoreEntries > records a bounded warning and failure fact when storage purge fails 145ms

 Test Files  127 passed (127)
      Tests  1553 passed (1553)
   Start at  21:05:24
   Duration  221.62s (tests 84%, transform 10%, import 3%, worker 3%)

[vitest-workers] verifying completed generation before cleanup
```

`node scripts/check-changed.mjs` completed with exit 0, including core and test types, lint, all guards, and all three Knip scans:

```text
[deadcode] Knip script unused-export scan passed with 0 entries.
[deadcode] Knip production unused-export scan passed with 0 entries.
[deadcode] Knip full-tree unused-export scan passed with 0 entries.
```

Actual command tail:

```text
[check:changed] runtime sidecar loader guard
$ node --import ./scripts/tsx.mjs scripts/check-runtime-sidecar-loaders.mts
runtime-sidecar-loaders: local runtime sidecar loaders look OK.

[check:changed] runtime import cycles
$ node --import ./scripts/tsx.mjs scripts/check-import-cycles.ts
Import cycle check: 0 runtime value cycle(s).

[check:changed] webhook body guard
$ node --import ./scripts/tsx.mjs scripts/check-webhook-auth-body-order.mts

[check:changed] pairing store guard
$ node --import ./scripts/tsx.mjs scripts/check-no-pairing-store-group-auth.mts

[check:changed] pairing account guard
$ node --import ./scripts/tsx.mjs scripts/check-pairing-account-scope.mts
```

Additional before/after projection comparison:

```text
PASS: 7680 before/after placement projections; values, omitted fields, and serialized key order identical across all 10 states.
```

Fresh Codex autoreview of the final candidate, with the requested reasoning/service settings and P0–P2 scope:

```text
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
overall: patch is correct (0.93)
The final diff and supplied contracts show no actionable P0–P2 defects. Option forwarding preserves named dependencies and explicit overrides; projector consolidation preserves output shapes; the removed checks are redundant under the supplied contracts. No concrete authority, state-transition, persistence, or security regression is demonstrated.
```

Original reviewed diff (before the landing rebase):

```text
.../server-methods/chat-restart-recovery.ts        |  6 +-
 src/gateway/session-lifecycle-state.ts             | 14 ++--
 .../placement-dispatch-failure.ts                  |  7 +-
 .../worker-environments/placement-dispatch.ts      | 98 +++++++---------------
 .../worker-environments/placement-projector.ts     | 78 ++++-------------
 src/gateway/worker-environments/service.ts         | 67 ++-------------
 .../worker-environments/worker-turn-launcher.ts    |  2 -
 7 files changed, 61 insertions(+), 211 deletions(-)
```

Production-only count, using the work order exclusions:

```sh
git diff --numstat origin/main...HEAD -- 'src/**' \
  ':!**/*.test.ts' ':!**/*.test-support.ts' \
  ':!**/*.test-harness.ts' ':!**/*.test-fixtures.ts'
```

```text
Production: +61 -211 = -150 net lines
```

The coordinator reviewed and accepted the original committed patch and authorized landing. The landing rebase described below preserves that cleanup.

Exact-head CI attachment:

```text
ATTACHED run=34010886414 url=https://github.com/openclaw/openclaw/actions/runs/34010886414
```

Verified with `node scripts/watch-pr-ci.mjs 139720 b00e7c9329ed2901af04c62d8d3aa183ce71daef --repo openclaw/openclaw --attach-timeout 300 --timeout 1 --interval 30`. The initial attachment-only watcher expired after attachment. The subsequent completion watcher returned **GREEN** for that exact head, with CI run 34010886414 successful.


## Landing rebase and proof

The original exact-head CI passed and native prepare completed. Before merge dispatch, #139582 landed and made `placement-dispatch.ts` conflict. Native merge stopped before recording an intent or sending a merge request.

Rebased onto main `9596eab05de` as `ad1669aeff999b9302edfd89b3c917b7bb84559d`. The resolution combines the existing conflict-lookup helper import with the cleanup's `PlacementRecoveryDeps` import and preserves the `Pick` so it inherits main's updated `WorkspaceResultConflictLookup` contract. The sibling helper call remains intact. The range diff contains only those mechanical adaptations; tests remain unchanged. The import formatting changes the final reduction to 148 production lines (+64/-212).

Rebase proof passed:

```sh
node scripts/run-vitest.mjs src/gateway/worker-environments src/gateway/session-lifecycle-run-failure.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/server-methods/chat-send-dispatch-errors.test.ts src/gateway/server-methods/chat-send-pre-admission.test.ts
node scripts/check-changed.mjs
```

147 test files passed, one skipped; 1,922 tests passed, two skipped. The requested `chat-restart-recovery.test.ts` path does not exist; its existing dispatch-error and pre-admission consumer suites provide that coverage. An isolated filesystem module cache was used. Changed checks passed, including typechecks, lint, all three dead-export scans, and guards. The CI watcher for run 34012072158 then stopped at the unrelated suppression-inventory line-number assertion (expected 363/374/377, received 364/375/378). Fix #139747 landed as `5b7e42bc899e72b3db598b41545fd3454e38f499`; the next scheduled check detected its merge after 241 seconds.

Rebased again without conflicts to `307c85be5db74e51cbfac2836b8ceff7113cd859`. `git range-diff` confirms the cleanup patch is unchanged by this second rebase. The same focused proof passed again (147 files and 1,922 tests passed; one file and two tests skipped), and `node scripts/check-changed.mjs` passed again. Final exact-head CI returned **GREEN**: [run 34013058132](https://github.com/openclaw/openclaw/actions/runs/34013058132), head `307c85be5db74e51cbfac2836b8ceff7113cd859`. The completion watch took approximately 25 minutes. ClawSweeper completed its review of this head with no findings.
