### PR TITLE
fix(test): isolate Copilot catalog discovery fixtures

### DIFF
--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -891,10 +891,10 @@ describe("github-copilot plugin", () => {
     });
     expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
       "https://copilot-reenabled.test/models",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({ Authorization: "Bearer gh_test_token" }),
-      }),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer gh_test_token",
     );
   });
 
@@ -1024,10 +1024,10 @@ describe("github-copilot plugin", () => {
     ]);
     expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
       "https://copilot-unified.test/models",
-      expect.objectContaining({
-        method: "GET",
-        headers: expect.objectContaining({ Authorization: "Bearer gh_test_token" }),
-      }),
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+      "Bearer gh_test_token",
     );
   });
 

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -1,4 +1,3 @@
-// Github Copilot tests cover index plugin behavior.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -56,7 +55,6 @@ vi.mock("./register.runtime.js", () => ({
 import plugin from "./index.js";
 
 const tempDirs: string[] = [];
-type RegisteredEmbeddingProvider = Parameters<OpenClawPluginApi["registerEmbeddingProvider"]>[0];
 type RegisteredProvider = Parameters<OpenClawPluginApi["registerProvider"]>[0];
 type GithubCopilotTestProvider = RegisteredProvider & {
   auth: Array<{
@@ -150,17 +148,6 @@ function writeExistingCopilotTokenProfile(agentDir: string) {
   );
 }
 
-function requireFirstMockArg<T>(
-  mock: { mock: { calls: Array<[T, ...unknown[]]> } },
-  label: string,
-) {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`Expected ${label}`);
-  }
-  return call[0];
-}
-
 function registerProviderAndCatalogWithPluginConfig(pluginConfig: Record<string, unknown>) {
   const registerProviderMock = vi.fn<OpenClawPluginApi["registerProvider"]>();
   const registerModelCatalogProviderMock =
@@ -182,14 +169,14 @@ function registerProviderAndCatalogWithPluginConfig(pluginConfig: Record<string,
   expect(registerProviderMock).toHaveBeenCalledTimes(1);
   expect(registerModelCatalogProviderMock).toHaveBeenCalledTimes(1);
   return {
-    provider: requireFirstMockArg(
-      registerProviderMock,
+    provider: expectDefined(
+      registerProviderMock.mock.calls[0],
       "provider registration",
-    ) as GithubCopilotTestProvider,
-    modelCatalogProvider: requireFirstMockArg(
-      registerModelCatalogProviderMock,
+    )[0] as GithubCopilotTestProvider,
+    modelCatalogProvider: expectDefined(
+      registerModelCatalogProviderMock.mock.calls[0],
       "model catalog provider registration",
-    ) as GithubCopilotTestModelCatalogProvider,
+    )[0] as GithubCopilotTestModelCatalogProvider,
   };
 }
 
@@ -583,8 +570,8 @@ describe("github-copilot plugin", () => {
     );
 
     expect(registerEmbeddingProviderMock).toHaveBeenCalledTimes(1);
-    const adapter = requireFirstMockArg<RegisteredEmbeddingProvider>(
-      registerEmbeddingProviderMock,
+    const [adapter] = expectDefined(
+      registerEmbeddingProviderMock.mock.calls[0],
       "embedding provider registration",
     );
     expect(adapter.id).toBe("github-copilot");
@@ -864,8 +851,14 @@ describe("github-copilot plugin", () => {
   it("uses live plugin config to re-enable discovery after startup disable", async () => {
     mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
       apiKey: "gh_test_token",
-      baseUrl: "https://api.githubcopilot.live",
+      baseUrl: "https://copilot-reenabled.test",
     });
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        data: [{ id: "reenabled-model", model_picker_enabled: true, policy: { state: "enabled" } }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
     const provider = registerProviderWithPluginConfig({ discovery: { enabled: false } });
 
     const result = await provider.catalog.run({
@@ -892,10 +885,17 @@ describe("github-copilot plugin", () => {
     });
     expect(result).toEqual({
       provider: {
-        baseUrl: "https://api.githubcopilot.live",
-        models: [],
+        baseUrl: "https://copilot-reenabled.test",
+        models: [expect.objectContaining({ id: "reenabled-model" })],
       },
     });
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      "https://copilot-reenabled.test/models",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer gh_test_token" }),
+      }),
+    );
   });
 
   it("publishes only picker-visible, policy-enabled tool models in the live catalog", async () => {
@@ -974,8 +974,14 @@ describe("github-copilot plugin", () => {
   it("dual-publishes unified live catalog rows with existing discovery semantics", async () => {
     mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
       apiKey: "gh_test_token",
-      baseUrl: "https://api.githubcopilot.live",
+      baseUrl: "https://copilot-unified.test",
     });
+    const fetchMock = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        data: [{ id: "unified-model", model_picker_enabled: true, policy: { state: "enabled" } }],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
     const { modelCatalogProvider } = registerProviderAndCatalogWithPluginConfig({
       discovery: { enabled: false },
     });
@@ -1007,7 +1013,22 @@ describe("github-copilot plugin", () => {
       env: { GH_TOKEN: "gh_test_token" },
       githubDomain: "github.com",
     });
-    expect(result).toEqual([]);
+    expect(result).toEqual([
+      {
+        kind: "text",
+        provider: "github-copilot",
+        model: "unified-model",
+        label: "unified-model",
+        source: "live",
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
+      "https://copilot-unified.test/models",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer gh_test_token" }),
+      }),
+    );
   });
 
   it("offers to reuse an existing token profile during interactive onboarding", async () => {

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -889,13 +889,19 @@ describe("github-copilot plugin", () => {
         models: [expect.objectContaining({ id: "reenabled-model" })],
       },
     });
-    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
-      "https://copilot-reenabled.test/models",
-      expect.objectContaining({ method: "GET" }),
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = new Request(
+      ...expectDefined(fetchMock.mock.calls[0], "Copilot catalog request"),
     );
-    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
-      "Bearer gh_test_token",
-    );
+    expect({
+      url: request.url,
+      method: request.method,
+      authorization: request.headers.get("authorization"),
+    }).toEqual({
+      url: "https://copilot-reenabled.test/models",
+      method: "GET",
+      authorization: "Bearer gh_test_token",
+    });
   });
 
   it("publishes only picker-visible, policy-enabled tool models in the live catalog", async () => {
@@ -1022,13 +1028,19 @@ describe("github-copilot plugin", () => {
         source: "live",
       },
     ]);
-    expect(fetchMock).toHaveBeenCalledExactlyOnceWith(
-      "https://copilot-unified.test/models",
-      expect.objectContaining({ method: "GET" }),
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const request = new Request(
+      ...expectDefined(fetchMock.mock.calls[0], "Copilot catalog request"),
     );
-    expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
-      "Bearer gh_test_token",
-    );
+    expect({
+      url: request.url,
+      method: request.method,
+      authorization: request.headers.get("authorization"),
+    }).toEqual({
+      url: "https://copilot-unified.test/models",
+      method: "GET",
+      authorization: "Bearer gh_test_token",
+    });
   });
 
   it("offers to reuse an existing token profile during interactive onboarding", async () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where two Copilot discovery tests could pass after an unintended network request failed. Their empty-catalog expectations accepted the error fallback without proving that enabled discovery actually returned models.

## Why This Change Was Made

Give each existing case a local fetch fixture and its own reserved test endpoint. Require one authenticated GET and a nonempty discovered model or exact unified catalog row. Separate endpoint identities prevent a cached result from satisfying the second case without making its request.

Also reuse the already-imported typed call guard at three registration reads, removing the duplicate generic reader and unused type alias. Registration call counts, missing-call rejection and original argument identity remain intact.

## User Impact

No production behavior or public API changes. The tests now fail when discovery silently returns an empty result and run without relying on external network failures. All 46 existing index test definitions remain; four transport assertion sites supplement the original 130 assertion sites.

## Evidence

An external no-network probe ran the original two cases: both tests passed, but the probe recorded and blocked two unstubbed requests. The repaired pair passed with zero intercepted requests. No external connection was permitted by that probe.

After the fixture repair, the full index and usage suites passed 59/59; the same suites passed 59/59 again after the reader cleanup, with identical reported cases and outcomes. Both native runs used the same credential-free child environment. The independent review through P2 is clean. Production delta is zero; the combined test change is +59/-26.

Request checks normalize the complete captured Fetch call. Equivalent string, URL and Request inputs, default GET and header representations produce the same asserted endpoint, method and authorization. A controlled Request-input variant failed the two original call-shape assertions and passed both semantic assertions, with no intercepted requests. The native equivalence probe also preserved all eight headers and abort propagation. Original production bytes were restored before the final 59/59 run.

The final normal 19-stage changed gate passed, including extension test types, all three dead-export scans and lint. Testbox [run 34013298524](https://github.com/openclaw/openclaw/actions/runs/34013298524) completed its command successfully; the one-shot lease, temporary source capsule and recorded local processes were cleaned up. A focused independent review confirmed the correction.

The branch includes the existing [Gateway fixture correction #139794](https://github.com/openclaw/openclaw/pull/139794), which fixes the unrelated core-test type failure seen in an earlier CI run. This mechanical main refresh preserves the reviewed binary patch, Copilot owner files and dependency manifests exactly.

Follow-up: the shared SDK discovery contract's `keeps env-token base URL resolution provider-owned` case has a separate unstubbed-fetch fixture. It is source-identified and remains outside this change; no test or fix is claimed for it here.
