### PR TITLE
test(cron): share neutral scheduler state fixtures

### DIFF
--- a/src/cron/service.cross-tick-admission-lifecycle.test.ts
+++ b/src/cron/service.cross-tick-admission-lifecycle.test.ts
@@ -1,8 +1,8 @@
 // Cross-tick lifecycle regressions cover delayed capacity wakes and activation skips.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../test/helpers/promise.js";
@@ -17,7 +17,6 @@ import {
 } from "../process/gateway-work-admission.js";
 import { start, stop } from "./service/ops-lifecycle.js";
 import { run } from "./service/ops-run.js";
-import { createCronServiceState } from "./service/state.js";
 import { onTimer } from "./service/timer.test-support.js";
 import * as cronStoreModule from "./store.js";
 import type { CronJob } from "./types.js";
@@ -46,13 +45,9 @@ describe("cron service cross-tick admission lifecycle", () => {
     });
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => nowMs,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     await start(state);
@@ -127,13 +122,9 @@ describe("cron service cross-tick admission lifecycle", () => {
     const releaseDirectB = createDeferred<{ status: "ok"; summary: string }>();
     let pendingStartCount = 0;
     const releasePending = createDeferred<{ status: "ok"; summary: string }>();
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => t0,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
         switch (job.id) {
           case scheduledA.id:
@@ -249,13 +240,9 @@ describe("cron service cross-tick admission lifecycle", () => {
     const pendingStarted = createDeferred();
     const directRootRetired = createDeferred();
     const subordinateResult = createDeferred<unknown>();
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => t0,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
         switch (job.id) {
           case scheduledA.id:
@@ -345,13 +332,9 @@ describe("cron service cross-tick admission lifecycle", () => {
       expect(job.id).toBe(pending.id);
       return { status: "ok" as const, summary: "pending" };
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => t0,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 1;

--- a/src/cron/service.cross-tick-admission.test.ts
+++ b/src/cron/service.cross-tick-admission.test.ts
@@ -1,8 +1,8 @@
 // Scheduled work must use free shared-admission slots across timer ticks (#119083).
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../test/helpers/promise.js";
@@ -13,7 +13,6 @@ import {
 } from "../process/gateway-work-admission.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { stop } from "./service/ops-lifecycle.js";
-import { createCronServiceState } from "./service/state.js";
 import { onTimer } from "./service/timer.test-support.js";
 import { loadCronStore, saveCronStore } from "./store.js";
 import { cronStoreKey } from "./store/key.js";
@@ -71,13 +70,9 @@ describe("cron service cross-tick bounded admission", () => {
         active -= 1;
       }
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 2;
@@ -157,13 +152,9 @@ describe("cron service cross-tick bounded admission", () => {
         active -= 1;
       }
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 2;
@@ -279,13 +270,9 @@ describe("cron service cross-tick bounded admission", () => {
         active -= 1;
       }
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => t0,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 2;
@@ -349,10 +336,8 @@ describe("cron service cross-tick bounded admission", () => {
       expect(job.id).toBe(pending.id);
       return { status: "ok" as const, summary: "pending done" };
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => {
         nowCalls += 1;
         // The third scheduler time read occurs after due-job collection and
@@ -376,8 +361,6 @@ describe("cron service cross-tick bounded admission", () => {
         }
         return t0;
       },
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 1;
@@ -442,13 +425,9 @@ describe("cron service cross-tick bounded admission", () => {
         active -= 1;
       }
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => Date.now(),
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 2;

--- a/src/cron/service.unresolved-next-run.test.ts
+++ b/src/cron/service.unresolved-next-run.test.ts
@@ -1,9 +1,9 @@
 // Next-run regression tests cover unresolved next-run state after service updates.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDefaultIsolatedRunner,
   createIsolatedRegressionJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../test/helpers/cron/service-regression-fixtures.js";
 import * as schedule from "./schedule.js";
@@ -29,13 +29,9 @@ function createIssue66019State(params: {
   nowMs: () => number;
   runIsolatedAgentJob: Parameters<typeof createCronServiceState>[0]["runIsolatedAgentJob"];
 }) {
-  return createCronServiceState({
-    cronEnabled: true,
+  return createCronRegressionState({
     storePath: params.storePath,
-    log: noopLogger,
     nowMs: params.nowMs,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: params.runIsolatedAgentJob,
   });
 }

--- a/src/cron/service/failure-alerts.persistence.test.ts
+++ b/src/cron/service/failure-alerts.persistence.test.ts
@@ -1,8 +1,8 @@
 // Failure alerts must describe only cron outcomes that survived durable persistence.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -47,13 +47,9 @@ function createAlertState(params: {
   nowMs: () => number;
   sendCronFailureAlert: SendCronFailureAlert;
 }) {
-  return createCronServiceState({
-    cronEnabled: true,
+  return createCronRegressionState({
     storePath: params.storePath,
-    log: noopLogger,
     nowMs: params.nowMs,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     sendCronFailureAlert: params.sendCronFailureAlert,
     runIsolatedAgentJob: vi.fn(),
   });

--- a/src/cron/service/ops.regression.test.ts
+++ b/src/cron/service/ops.regression.test.ts
@@ -1,6 +1,7 @@
 // Cron ops regression tests cover service operation regressions.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createAbortAwareIsolatedRunner,
   createDueIsolatedJob,
   createIsolatedRegressionJob,
@@ -90,13 +91,9 @@ describe("cron service ops regressions", () => {
     const runnerStarted = createDeferred();
     const finished = createDeferred();
     let terminalEvent: CronEvent | undefined;
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         runnerStarted.resolve();
         await enterRunner.promise;
@@ -150,13 +147,9 @@ describe("cron service ops regressions", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
     const finished = createDeferred<CronEvent>();
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
       onEvent: (event) => {
         if (event.jobId === job.id && event.action === "finished") {
@@ -180,12 +173,8 @@ describe("cron service ops regressions", () => {
   it("repairs missing job state during startup", async () => {
     const scheduledAt = Date.now() + 60_000;
     const store = opsRegressionFixtures.makeStorePath();
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
     });
     const job = createIsolatedRegressionJob({
@@ -254,12 +243,8 @@ describe("cron service ops regressions", () => {
         ),
     );
 
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent: (evt: CronEvent) => {
         events.push(evt);
@@ -330,13 +315,9 @@ describe("cron service ops regressions", () => {
       );
     });
 
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent: (evt: CronEvent) => {
         if (evt.jobId === job.id && evt.action === "finished") {
@@ -597,13 +578,9 @@ describe("cron service ops regressions", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
     const runIsolatedAgentJob = vi.fn().mockResolvedValue({ status: "ok", summary: "ok" });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -655,13 +632,9 @@ describe("cron service ops regressions", () => {
         activeRuns -= 1;
       }
     });
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent: (evt) => {
         if (evt.action === "finished" && evt.jobId === second.id && evt.status === "ok") {
@@ -719,14 +692,10 @@ describe("cron service ops regressions", () => {
     const terminal = createDeferred();
     const events: CronEvent[] = [];
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       cronConfig: { triggers: { enabled: true } },
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       evaluateCronTrigger: vi.fn(async () => ({
         kind: "evaluated" as const,
         fire: false,
@@ -786,13 +755,9 @@ describe("cron service ops regressions", () => {
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
     const events: CronEvent[] = [];
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent: (evt) => events.push(evt),
     });
@@ -857,13 +822,9 @@ describe("cron service ops regressions", () => {
     const releaseProvider = createDeferred();
     const providerExited = createDeferred();
     const events: CronEvent[] = [];
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
         if (!abortSignal) {
           throw new Error("expected isolated cron abort signal");
@@ -959,13 +920,9 @@ describe("cron service ops regressions", () => {
     let dispatchCount = 0;
     let inFlight = 0;
     let peakInFlight = 0;
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ abortSignal }) => {
         dispatchCount += 1;
         inFlight += 1;

--- a/src/cron/service/ops.run-admission-capacity.test.ts
+++ b/src/cron/service/ops.run-admission-capacity.test.ts
@@ -1,8 +1,8 @@
 // Capacity-edge regressions cover stopped direct runs and saturated scheduled work.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -14,20 +14,19 @@ import { inspectActiveCronRunReceipt } from "../store/run-receipt-store.js";
 import { stop } from "./ops-lifecycle.js";
 import { update } from "./ops-mutations.js";
 import { run } from "./ops-run.js";
-import { createCronServiceState } from "./state.js";
 import { onTimer } from "./timer.test-support.js";
 
 const capacityFixtures = setupCronRegressionFixtures({
   prefix: "cron-service-run-admission-capacity-",
 });
 
-type CronStateParams = Parameters<typeof createCronServiceState>[0] & {
+type CronStateParams = Parameters<typeof createCronRegressionState>[0] & {
   testAdmissionLimit?: number;
 };
 
 function createAdmissionTestState(params: CronStateParams) {
   const { testAdmissionLimit, ...stateParams } = params;
-  const state = createCronServiceState(stateParams);
+  const state = createCronRegressionState(stateParams);
   if (testAdmissionLimit !== undefined) {
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - testAdmissionLimit;
   }
@@ -53,13 +52,9 @@ describe("cron service run admission capacity edges", () => {
     const activeStarted = createDeferred();
     const releaseActive = createDeferred<{ status: "ok"; summary: string }>();
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ job: runningJob }: { job: { id: string } }) => {
         if (runningJob.id === activeJob.id) {
           activeStarted.resolve();
@@ -112,13 +107,9 @@ describe("cron service run admission capacity edges", () => {
       return { status: "ok" as const, summary: "should not run" };
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 

--- a/src/cron/service/ops.run-admission-cleanup.test.ts
+++ b/src/cron/service/ops.run-admission-cleanup.test.ts
@@ -2,8 +2,8 @@
 import { Worker } from "node:worker_threads";
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -23,7 +23,6 @@ import { start, stop } from "./ops-lifecycle.js";
 import { update } from "./ops-mutations.js";
 import { enqueueRun, run } from "./ops-run.js";
 import { runWithCronAdmission } from "./run-admission.js";
-import { createCronServiceState } from "./state.js";
 import { runMissedJobs } from "./timer.js";
 import { onTimer } from "./timer.test-support.js";
 
@@ -75,13 +74,9 @@ describe("cron service run admission cleanup", () => {
     const runnerStarted = createDeferred();
     const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
     let ownerAvailable = true;
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => startedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       isAgentAvailable: () => ownerAvailable,
       runIsolatedAgentJob: vi.fn(async () => {
         runnerStarted.resolve();
@@ -118,13 +113,9 @@ describe("cron service run admission cleanup", () => {
     const runnerStarted = createDeferred();
     const releaseRun = createDeferred<{ status: "error"; error: string }>();
     let ownerAvailable = true;
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => startedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       isAgentAvailable: () => ownerAvailable,
       runIsolatedAgentJob: vi.fn(async () => {
         runnerStarted.resolve();
@@ -174,13 +165,9 @@ describe("cron service run admission cleanup", () => {
       const before = await loadCronStore(store.storePath);
       const onEvent = vi.fn();
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => dueAt,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
         onEvent,
       });
@@ -234,13 +221,9 @@ describe("cron service run admission cleanup", () => {
     await blockerStarted.promise;
     let authorityActive = true;
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -286,13 +269,9 @@ describe("cron service run admission cleanup", () => {
         summary: string;
         triggerEval?: { fired: false; stateChanged: false };
       }>();
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => startedAt,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => {
           runnerStarted.resolve();
           return await releaseRun.promise;
@@ -334,13 +313,9 @@ describe("cron service run admission cleanup", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
     const runnerStarted = createDeferred();
     const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => startedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         runnerStarted.resolve();
         return await releaseRun.promise;
@@ -420,13 +395,9 @@ describe("cron service run admission cleanup", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -472,13 +443,9 @@ describe("cron service run admission cleanup", () => {
     const store = opsRegressionFixtures.makeStorePath();
     const releaseFirst = createDeferred();
     const executionOrder: string[] = [];
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => 0,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
     });
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - 1;
@@ -526,13 +493,9 @@ describe("cron service run admission cleanup", () => {
 
       let now = dueAt;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
       let reservationPersisted = false;
@@ -591,13 +554,9 @@ describe("cron service run admission cleanup", () => {
     let now = dueAt;
     let restart: Promise<void> | undefined;
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     const stopObserving = observeCronJobWrites(job.id, ({ queuedAtMs, runningAtMs }) => {
@@ -649,13 +608,9 @@ describe("cron service run admission cleanup", () => {
 
     let restart: Promise<void> | undefined;
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent: (event) => {
         if (event.action === "started" && !restart) {
@@ -695,13 +650,9 @@ describe("cron service run admission cleanup", () => {
       });
       await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => dueAt,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
       });
       let reservationPersisted = false;
@@ -756,13 +707,9 @@ describe("cron service run admission cleanup", () => {
 
       let now = dueAt;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
       let reservationPersisted = false;
@@ -815,13 +762,9 @@ describe("cron service run admission cleanup", () => {
 
       let now = dueAt;
       const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
       let reservationPersisted = false;
@@ -881,13 +824,9 @@ describe("cron service run admission cleanup", () => {
       await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
       let now = dueAt;
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
       });
       let reservationPersisted = false;

--- a/src/cron/service/ops.run-admission.test.ts
+++ b/src/cron/service/ops.run-admission.test.ts
@@ -1,8 +1,8 @@
 // Shared cron run-admission regressions cover cross-trigger limits and queued-run cleanup.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -24,20 +24,19 @@ import { recomputeNextRunsForMaintenance } from "./jobs-scheduling.js";
 import { remove, update } from "./ops-mutations.js";
 import { list } from "./ops-read.js";
 import { enqueueRun, run } from "./ops-run.js";
-import { createCronServiceState } from "./state.js";
 import { onTimer } from "./timer.test-support.js";
 
 const opsRegressionFixtures = setupCronRegressionFixtures({
   prefix: "cron-service-run-admission-",
 });
 
-type CronStateParams = Parameters<typeof createCronServiceState>[0] & {
+type CronStateParams = Parameters<typeof createCronRegressionState>[0] & {
   testAdmissionLimit?: number;
 };
 
 function createAdmissionTestState(params: CronStateParams) {
   const { testAdmissionLimit, ...stateParams } = params;
-  const state = createCronServiceState(stateParams);
+  const state = createCronRegressionState(stateParams);
   if (testAdmissionLimit !== undefined) {
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - testAdmissionLimit;
   }
@@ -78,12 +77,8 @@ describe("cron service run admission", () => {
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
     const onEvent = vi.fn();
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent,
     });
@@ -123,13 +118,9 @@ describe("cron service run admission", () => {
     let peakActive = 0;
     const completed = new Set<string>();
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 4,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: { id: string } }) => {
         active += 1;
         peakActive = Math.max(peakActive, active);
@@ -185,13 +176,9 @@ describe("cron service run admission", () => {
       return await releaseCompleting.promise;
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 2,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     inspectActiveCronRunReceipt({ storePath: store.storePath, jobId: failingJob.id });
@@ -259,13 +246,9 @@ describe("cron service run admission", () => {
       return { status: "ok" as const, summary: "should not run" };
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -331,13 +314,9 @@ describe("cron service run admission", () => {
         return { status: "ok" as const, summary: "replacement" };
       });
       const state = createAdmissionTestState({
-        cronEnabled: true,
         storePath: store.storePath,
         testAdmissionLimit: 1,
-        log: noopLogger,
         nowMs: () => dueAt,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
 
@@ -416,14 +395,10 @@ describe("cron service run admission", () => {
       return { status: "ok" as const, summary: "stale stream batch" };
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
       cronConfig: { triggers: { enabled: true } },
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -473,14 +448,10 @@ describe("cron service run admission", () => {
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "ran" }));
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
       cronConfig: { triggers: { enabled: true } },
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -527,14 +498,10 @@ describe("cron service run admission", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [streamJob] });
 
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
       cronConfig: { triggers: { enabled: true } },
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
     });
 
@@ -568,14 +535,10 @@ describe("cron service run admission", () => {
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const, summary: "ran" }));
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
       cronConfig: { triggers: { enabled: true } },
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -624,13 +587,9 @@ describe("cron service run admission", () => {
       return { status: "ok" as const, summary: "should not run" };
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -676,12 +635,8 @@ describe("cron service run admission", () => {
     let edited = false;
     let persistedStatusAtEvent: string | undefined;
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       sendCronFailureAlert,
       runIsolatedAgentJob: vi.fn(),
       onEvent: (event) => {
@@ -740,13 +695,9 @@ describe("cron service run admission", () => {
       return { status: "ok" as const, summary: "replacement" };
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -789,12 +740,8 @@ describe("cron service run admission", () => {
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -828,12 +775,8 @@ describe("cron service run admission", () => {
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
     const onEvent = vi.fn();
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
       onEvent,
     });
@@ -860,12 +803,8 @@ describe("cron service run admission", () => {
 
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -903,13 +842,9 @@ describe("cron service run admission", () => {
       return await releaseWaiting.promise;
     });
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -960,13 +895,9 @@ describe("cron service run admission", () => {
     const waitingStarted = createDeferred();
     const releaseWaiting = createDeferred<{ status: "ok"; summary: string }>();
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ job: runningJob }: { job: { id: string } }) => {
         if (runningJob.id === activeJob.id) {
           activeStarted.resolve();
@@ -1025,12 +956,8 @@ describe("cron service run admission", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
     const state = createAdmissionTestState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
     });
     const realLoad = cronStoreModule.loadCronJobsStoreWithConfigJobs;

--- a/src/cron/service/ops.run-execution-binding.test.ts
+++ b/src/cron/service/ops.run-execution-binding.test.ts
@@ -1,8 +1,8 @@
 // Focused proof that manual cron admission binds exact owner-native rows.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import type { AdmittedRunContext } from "../../agents/admitted-run-context.js";
@@ -25,7 +25,6 @@ import {
   prepareCronRunReceiptClaim,
 } from "../store/run-receipt-store.js";
 import { run } from "./ops-run.js";
-import { createCronServiceState } from "./state.js";
 import {
   createCronOwnerExecutionIdentityAdmission,
   tryCreateCronTaskRunHandle,
@@ -78,13 +77,9 @@ describe("cron run execution binding", () => {
             return { status: "ok" as const };
           },
         );
-        const state = createCronServiceState({
-          cronEnabled: true,
+        const state = createCronRegressionState({
           storePath: store.storePath,
-          log: noopLogger,
           nowMs: () => dueAt,
-          enqueueSystemEvent: vi.fn(),
-          requestHeartbeat: vi.fn(),
           runIsolatedAgentJob,
         });
 
@@ -149,13 +144,9 @@ describe("cron run execution binding", () => {
           agentId: "main",
         };
         await saveCronStore(store.storePath, { version: 1, jobs: [job] });
-        const state = createCronServiceState({
-          cronEnabled: true,
+        const state = createCronRegressionState({
           storePath: store.storePath,
-          log: noopLogger,
           nowMs: () => dueAt,
-          enqueueSystemEvent: vi.fn(),
-          requestHeartbeat: vi.fn(),
           runIsolatedAgentJob: vi.fn(),
         });
         const prepared = prepareCronRunReceiptClaim({

--- a/src/cron/service/ops.update.disable-and-list.test.ts
+++ b/src/cron/service/ops.update.disable-and-list.test.ts
@@ -1,23 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  noopLogger,
+  createCronRegressionState,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { add, update } from "./ops-mutations.js";
 import { list } from "./ops-read.js";
-import { createCronServiceState } from "./state.js";
 
 const fixtures = setupCronRegressionFixtures({ prefix: "cron-disable-list-" });
 
 describe("cron service ops: disable + list round-trip", () => {
   it("keeps a disabled job available to --all and restores it after enable", async () => {
     const { storePath } = fixtures.makeStorePath();
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath,
-      log: noopLogger,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
     });
 

--- a/src/cron/service/run-admission-conflict.test.ts
+++ b/src/cron/service/run-admission-conflict.test.ts
@@ -1,7 +1,7 @@
 import { expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import {
@@ -24,7 +24,6 @@ import {
   persistQueuedCronRunReservations,
   reserveQueuedCronRun,
 } from "./run-admission.js";
-import { createCronServiceState } from "./state.js";
 import { onTimer } from "./timer.test-support.js";
 
 const fixtures = setupCronRegressionFixtures({ prefix: "cron-admission-conflict-" });
@@ -50,13 +49,9 @@ it("recovers an ownerless queued lease on a live sibling without restart", async
   const now = Date.parse("2026-08-13T15:30:00.000Z");
   const job = createDueIsolatedJob({ id: "queued-owner-exit", nowMs: now, nextRunAtMs: now });
   await saveCronStore(store.storePath, { version: 1, jobs: [job] });
-  const owner = createCronServiceState({
-    cronEnabled: true,
+  const owner = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
   });
   await list(owner);
@@ -72,13 +67,9 @@ it("recovers an ownerless queued lease on a live sibling without restart", async
   releaseLocalCronRunReceiptOwnership(reserved.runReceipt);
 
   const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-  const sibling = createCronServiceState({
-    cronEnabled: true,
+  const sibling = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now + 1,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob,
   });
   await onTimer(sibling);
@@ -101,13 +92,9 @@ it("recovers a dead running owner on timer refresh without an admission conflict
   const receipt = claimReceipt(store.storePath, job, now);
   releaseLocalCronRunReceiptOwnership(receipt);
   const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-  const sibling = createCronServiceState({
-    cronEnabled: true,
+  const sibling = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now + 1,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob,
   });
 
@@ -154,13 +141,9 @@ it("preserves foreign state while retrying an unrelated reservation", async () =
     nextRunAtMs: now,
   });
   await saveCronStore(store.storePath, { version: 1, jobs: [foreignJob, pendingJob] });
-  const state = createCronServiceState({
-    cronEnabled: true,
+  const state = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
   });
   await list(state);
@@ -238,13 +221,9 @@ it("rejects a stale reservation plan after the job already finalized", async () 
     nextRunAtMs: now,
   });
   await saveCronStore(store.storePath, { version: 1, jobs: [planned] });
-  const state = createCronServiceState({
-    cronEnabled: true,
+  const state = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now + 1,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
   });
   await list(state);
@@ -280,13 +259,9 @@ it("terminalizes an owned reservation after another gateway deletes the job", as
     nextRunAtMs: now,
   });
   await saveCronStore(store.storePath, { version: 1, jobs: [job] });
-  const state = createCronServiceState({
-    cronEnabled: true,
+  const state = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(),
   });
   await list(state);
@@ -326,13 +301,9 @@ it("retires a reservation when its row disappears during the post-commit reload"
     nextRunAtMs: now,
   });
   await saveCronStore(store.storePath, { version: 1, jobs: [job] });
-  const state = createCronServiceState({
-    cronEnabled: true,
+  const state = createCronRegressionState({
     storePath: store.storePath,
-    log: noopLogger,
     nowMs: () => now,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: vi.fn(),
   });
   await list(state);

--- a/src/cron/service/runtime-store.test.ts
+++ b/src/cron/service/runtime-store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
   noopLogger,
   setupCronRegressionFixtures,
@@ -25,7 +26,6 @@ import { readCronTaskRunHistoryPage } from "../task-run-history.js";
 import type { CronStoredJob } from "../types.js";
 import { stop } from "./ops-lifecycle.js";
 import { applyCronRuntimeRowsToState, commitCronRuntimeRows } from "./runtime-store.js";
-import { createCronServiceState } from "./state.js";
 import { armTimer } from "./timer.js";
 
 const runtimeStoreFixtures = setupCronRegressionFixtures({ prefix: "cron-runtime-store-" });
@@ -75,12 +75,8 @@ describe("cron runtime row publication", () => {
     const before = database
       .prepare("SELECT * FROM cron_jobs WHERE store_key = ? ORDER BY sort_order")
       .all(storeKey);
-    const state = createCronServiceState({
+    const state = createCronRegressionState({
       storePath,
-      cronEnabled: true,
-      log: noopLogger,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
     });
     // A large missing-ID set must not hit SQLite's bound-parameter limit or widen the read.
@@ -276,13 +272,9 @@ describe("cron runtime row publication", () => {
       nowMs: now,
       nextRunAtMs: now + 60_000,
     });
-    const state = createCronServiceState({
+    const state = createCronRegressionState({
       storePath: "/tmp/runtime-store-import.json",
-      cronEnabled: true,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
     });
     state.store = { version: 1, jobs: [resident] };

--- a/src/cron/service/timer-catchup-concurrency.test.ts
+++ b/src/cron/service/timer-catchup-concurrency.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -43,13 +43,9 @@ describe("cron startup catch-up concurrency", () => {
       await saveCronStore(storePath, { version: 1, jobs: [selected, deferred] });
       const started = createDeferred();
       const release = createDeferred();
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         maxMissedJobsPerRestart: 1,
         missedJobStaggerMs: 5_000,
         runIsolatedAgentJob: vi.fn(async ({ job }) => {
@@ -126,13 +122,9 @@ describe("cron startup catch-up concurrency", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [selected, deferred] });
     const selectedStarted = createDeferred();
     const releaseSelected = createDeferred<{ status: "ok"; summary: string }>();
-    const firstState = createCronServiceState({
-      cronEnabled: true,
+    const firstState = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => startNow,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       maxMissedJobsPerRestart: 1,
       missedJobStaggerMs: 5_000,
       runIsolatedAgentJob: vi.fn(async ({ job }) => {
@@ -148,13 +140,9 @@ describe("cron startup catch-up concurrency", () => {
     try {
       await selectedStarted.promise;
       const foreignNow = startNow + 1;
-      const foreignState = createCronServiceState({
-        cronEnabled: true,
+      const foreignState = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => foreignNow,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const, summary: "foreign" })),
       });
       await expect(runCronJob(foreignState, deferred.id, "force")).resolves.toEqual({

--- a/src/cron/service/timer-outcome-finalization.receipts.test.ts
+++ b/src/cron/service/timer-outcome-finalization.receipts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
   noopLogger,
   setupCronRegressionFixtures,
@@ -74,13 +75,9 @@ describe("cron outcome receipt finalization", () => {
       await saveCronStore(store.storePath, { version: 1, jobs: [retired, current] });
       const retiredReceipt = claimReceipt(store.storePath, retired, startedAt);
       const currentReceipt = claimReceipt(store.storePath, current, startedAt);
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => startedAt,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(),
       });
       const taskRunId = tryCreateCronTaskRunHandle({
@@ -177,13 +174,9 @@ describe("cron outcome receipt finalization", () => {
     edited.jobs.find((job) => job.id === current.id)!.name = "authoritative edited name";
     await saveCronStore(store.storePath, edited);
     const events: Array<{ action: string; jobId: string; job?: CronJob }> = [];
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => startedAt + 2,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
       onEvent: (event) => events.push(event),
     });
@@ -229,14 +222,10 @@ describe("cron outcome receipt finalization", () => {
     job.trigger = { script: "return false" };
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       cronConfig: { triggers: { enabled: true } },
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       evaluateCronTrigger: vi.fn(async () => ({ kind: "evaluated" as const, fire: false })),
       runIsolatedAgentJob,
     });
@@ -269,13 +258,9 @@ describe("cron outcome receipt finalization", () => {
     imported.state.nextRunAtMs = undefined;
     await saveCronStore(store.storePath, { version: 1, jobs: [completed, imported] });
     const receipt = claimReceipt(store.storePath, completed, startedAt);
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => startedAt + 1,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
     });
 

--- a/src/cron/service/timer.batch-finalization.test.ts
+++ b/src/cron/service/timer.batch-finalization.test.ts
@@ -2,6 +2,7 @@
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createDueIsolatedJob,
   noopLogger,
   setupCronRegressionFixtures,
@@ -46,13 +47,9 @@ function createBatchState(params: {
   onEvent?: Parameters<typeof createCronServiceState>[0]["onEvent"];
   isAgentAvailable?: Parameters<typeof createCronServiceState>[0]["isAgentAvailable"];
 }) {
-  const state = createCronServiceState({
-    cronEnabled: true,
+  const state = createCronRegressionState({
     storePath: params.storePath,
-    log: noopLogger,
     nowMs: () => params.nowMs,
-    enqueueSystemEvent: vi.fn(),
-    requestHeartbeat: vi.fn(),
     runIsolatedAgentJob: params.runIsolatedAgentJob,
     isAgentAvailable: params.isAgentAvailable,
     maxMissedJobsPerRestart: 40,
@@ -169,13 +166,9 @@ describe("cron batch outcome finalization", () => {
         status: "ok" as const,
         summary: "finished before terminal store failure",
       }));
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
         onEvent: (event) => events.push(event),
       });
@@ -220,13 +213,9 @@ describe("cron batch outcome finalization", () => {
         expect(events.filter((event) => event.action === "finished")).toEqual([]);
 
         database.exec(`DROP TRIGGER IF EXISTS ${triggerName}`);
-        recoveryState = createCronServiceState({
-          cronEnabled: true,
+        recoveryState = createCronRegressionState({
           storePath: store.storePath,
-          log: noopLogger,
           nowMs: () => startedAt + 1,
-          enqueueSystemEvent: vi.fn(),
-          requestHeartbeat: vi.fn(),
           runIsolatedAgentJob,
           onEvent: (event) => events.push(event),
         });
@@ -570,13 +559,9 @@ describe("cron batch outcome finalization", () => {
     job.state.runningAtMs = dueAt;
     await saveCronStore(store.storePath, { version: 1, jobs: [job] });
 
-    const state = createCronServiceState({
-      cronEnabled: true,
+    const state = createCronRegressionState({
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => dueAt + 10,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(),
     });
     const database = openOpenClawStateDatabase().db;

--- a/src/cron/service/timer.heartbeat-timeout-watchdog.test.ts
+++ b/src/cron/service/timer.heartbeat-timeout-watchdog.test.ts
@@ -1,14 +1,14 @@
 // Integration regressions for cron-owned heartbeat watchdog handoffs.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createIsolatedRegressionJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
-import { createCronServiceState, type CronServiceDeps } from "./state.js";
+import type { CronServiceDeps } from "./state.js";
 import { onTimer } from "./timer.test-support.js";
 
 const heartbeatWatchdogFixtures = setupCronRegressionFixtures({
@@ -62,14 +62,10 @@ describe("cron heartbeat watchdog", () => {
           await releaseHeartbeat.promise;
           return { status: "ran" as const, durationMs: 1 };
         };
-        const state = createCronServiceState({
-          cronEnabled: true,
+        const state = createCronRegressionState({
           storePath: store.storePath,
-          log: noopLogger,
           nowMs: () => Date.now(),
           defaultAgentId: "main",
-          enqueueSystemEvent: vi.fn(),
-          requestHeartbeat: vi.fn(),
           resolveHeartbeatTimeoutMs: vi.fn(() => undefined),
           requestHeartbeatAndWait:
             vi.fn<NonNullable<CronServiceDeps["requestHeartbeatAndWait"]>>(runHeartbeat),
@@ -117,14 +113,10 @@ describe("cron heartbeat watchdog", () => {
       vi.setSystemTime(scheduledAt);
       const triggerStarted = createDeferred();
       const resolveHeartbeatTimeoutMs = vi.fn(() => 15 * 60_000);
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => Date.now(),
         defaultAgentId: "main",
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runHeartbeatOnce: vi.fn(async () => ({ status: "ran" as const, durationMs: 1 })),
         resolveHeartbeatTimeoutMs,
         evaluateCronTrigger: vi.fn(async () => {

--- a/src/cron/service/timer.regression.test.ts
+++ b/src/cron/service/timer.regression.test.ts
@@ -1,6 +1,7 @@
 // Timer regression tests cover historical cron timer scheduling failures.
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createAbortAwareIsolatedRunner,
   createDefaultIsolatedRunner,
   createDueIsolatedJob,
@@ -45,7 +46,7 @@ import { resetActiveCronTaskRunsForTests } from "./active-run-cancellation.test-
 import { computeJobNextRunAtMs, recomputeNextRunsForMaintenance } from "./jobs-scheduling.js";
 import { stop } from "./ops-lifecycle.js";
 import { run as runManualCronJob } from "./ops-run.js";
-import { createCronServiceState as createBaseCronServiceState, type CronEvent } from "./state.js";
+import type { CronEvent } from "./state.js";
 import { executeJobCore } from "./timer-execution.js";
 import { applyJobResult, executeJobCoreWithTimeout, runMissedJobs } from "./timer.js";
 import { onTimer } from "./timer.test-support.js";
@@ -55,13 +56,13 @@ const timerRegressionFixtures = setupCronRegressionFixtures({
   prefix: "cron-service-timer-regressions-",
 });
 
-type CronStateParams = Parameters<typeof createBaseCronServiceState>[0] & {
+type CronStateParams = Parameters<typeof createCronRegressionState>[0] & {
   testAdmissionLimit?: number;
 };
 
 function createCronServiceState(params: CronStateParams) {
   const { testAdmissionLimit, ...stateParams } = params;
-  const state = createBaseCronServiceState(stateParams);
+  const state = createCronRegressionState(stateParams);
   if (testAdmissionLimit !== undefined) {
     state.runAdmission.active = DEFAULT_CRON_MAX_CONCURRENT_RUNS - testAdmissionLimit;
   }
@@ -110,11 +111,7 @@ describe("cron service timer regressions", () => {
     const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
     const store = timerRegressionFixtures.makeStorePath();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
 
@@ -172,12 +169,8 @@ describe("cron service timer regressions", () => {
         })
         .mockResolvedValueOnce({ status: "ok", summary: "done", delivered: true });
       const state = createCronServiceState({
-        cronEnabled: true,
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob,
       });
 
@@ -254,12 +247,8 @@ describe("cron service timer regressions", () => {
       },
     });
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => firedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -304,12 +293,8 @@ describe("cron service timer regressions", () => {
       error: "429 rate limit exceeded",
     });
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -377,12 +362,8 @@ describe("cron service timer regressions", () => {
     let now = scheduledAt;
     let fireCount = 0;
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         now += 7;
         fireCount += 1;
@@ -416,12 +397,8 @@ describe("cron service timer regressions", () => {
 
     let now = scheduledAt;
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         now += 100;
         return { status: "ok" as const, summary: "done" };
@@ -452,12 +429,8 @@ describe("cron service timer regressions", () => {
     let now = scheduledAt;
     const deferredRun = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         const result = await deferredRun.promise;
         now += 5;
@@ -512,12 +485,8 @@ describe("cron service timer regressions", () => {
     const runnerStarted = createDeferred();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
         onExecutionStarted?.();
         runnerStarted.resolve();
@@ -620,12 +589,8 @@ describe("cron service timer regressions", () => {
       },
     );
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -672,12 +637,8 @@ describe("cron service timer regressions", () => {
       let now = scheduledAt;
       const abortAwareRunner = createAbortAwareIsolatedRunner();
       const state = createCronServiceState({
-        cronEnabled: true,
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async (params) => {
           const result = await abortAwareRunner.runIsolatedAgentJob(params);
           now += 5;
@@ -718,12 +679,8 @@ describe("cron service timer regressions", () => {
     const cleanupTimedOutAgentRun = vi.fn(async () => {});
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       cleanupTimedOutAgentRun,
       runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
         onExecutionStarted?.();
@@ -798,12 +755,8 @@ describe("cron service timer regressions", () => {
     });
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       cleanupTimedOutAgentRun,
       runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
         onExecutionStarted?.();
@@ -879,12 +832,8 @@ describe("cron service timer regressions", () => {
     let observedAbortSignal: AbortSignal | undefined;
     const finishRunner = createDeferred();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
         observedAbortSignal = abortSignal;
         runnerEntered.resolve();
@@ -947,12 +896,8 @@ describe("cron service timer regressions", () => {
     const runnerEntered = createDeferred();
     const finishRunner = createDeferred();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ abortSignal, onExecutionStarted }) => {
         // Report the resolved run identity the same way the real runner does,
         // then hang past the wall-clock watchdog so the timer-built timeout
@@ -1025,12 +970,8 @@ describe("cron service timer regressions", () => {
     const runnerEntered = createDeferred();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ onExecutionStarted }) => {
         onExecutionStarted?.({
           jobId: cronJob.id,
@@ -1146,12 +1087,8 @@ describe("cron service timer regressions", () => {
       let now = scheduledAt;
       const abortAwareRunner = createAbortAwareIsolatedRunner();
       const state = createCronServiceState({
-        cronEnabled: true,
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(async (params) => {
           const result = await abortAwareRunner.runIsolatedAgentJob(params);
           now += 5;
@@ -1187,12 +1124,8 @@ describe("cron service timer regressions", () => {
     await saveCronStore(store.storePath, { version: 1, jobs: [cronJob] });
 
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => scheduledAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => ({
         status: "ok" as const,
         summary: "work completed",
@@ -1230,12 +1163,8 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
         observedAbortSignal = abortSignal;
@@ -1288,12 +1217,8 @@ describe("cron service timer regressions", () => {
     const started = createDeferred();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         started.resolve();
         return await runnerResult.promise;
@@ -1792,13 +1717,9 @@ describe("cron service timer regressions", () => {
     const entered = createDeferred();
     const release = createDeferred<{ status: "ok"; notify: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       cronConfig: { triggers: { enabled: true } },
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => scheduledAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
       runScriptJob: vi.fn(async () => {
         entered.resolve();
@@ -1842,12 +1763,8 @@ describe("cron service timer regressions", () => {
 
     const runIsolatedAgentJob = vi.fn(createDefaultIsolatedRunner());
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => scheduledAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -1915,12 +1832,8 @@ describe("cron service timer regressions", () => {
     const entered = createDeferred();
     const release = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => scheduledAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async () => {
         entered.resolve();
         return await release.promise;
@@ -1962,9 +1875,7 @@ describe("cron service timer regressions", () => {
     let stoppedInjected = false;
     const runIsolatedAgentJob = vi.fn(createDefaultIsolatedRunner());
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => {
         if (stopOnNextClockRead && !stoppedInjected) {
           stoppedInjected = true;
@@ -1972,8 +1883,6 @@ describe("cron service timer regressions", () => {
         }
         return scheduledAt;
       },
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -2080,13 +1989,9 @@ describe("cron service timer regressions", () => {
     let now = dueAt;
     const events: CronEvent[] = [];
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onEvent: (evt) => {
         events.push(evt);
       },
@@ -2133,13 +2038,9 @@ describe("cron service timer regressions", () => {
     const secondStarted = createDeferred();
     const releaseSecond = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: { id: string } }) => {
         if (job.id === first.id) {
           firstStarted.resolve();
@@ -2221,13 +2122,9 @@ describe("cron service timer regressions", () => {
       return { status: "ok" as const, summary: "should not run" };
     });
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
 
@@ -2293,13 +2190,9 @@ describe("cron service timer regressions", () => {
     const serviceLockHeld = createDeferred();
     const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => dueAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob,
     });
     let currentOperation = state.op;
@@ -2358,13 +2251,9 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 2,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async () => {
         startedCount += 1;
@@ -2426,13 +2315,9 @@ describe("cron service timer regressions", () => {
     const timeoutNotified = createDeferred();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 2,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout: () => timeoutNotified.resolve(),
       runIsolatedAgentJob: vi.fn(
         async ({
@@ -2500,13 +2385,9 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
         if (job.id === first.id) {
@@ -2569,13 +2450,9 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
         if (job.id === first.id) {
@@ -2640,13 +2517,9 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async ({ job }: { job: CronJob }) => {
         if (job.id === manualJob.id) {
@@ -2716,12 +2589,8 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async ({ job }) => {
         if (job.id === manualJob.id) {
@@ -2780,12 +2649,8 @@ describe("cron service timer regressions", () => {
     const runStarted = createDeferred();
     const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => scheduledAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: async () => {
         runStarted.resolve();
         return await releaseRun.promise;
@@ -2857,12 +2722,8 @@ describe("cron service timer regressions", () => {
     const runStarted = createDeferred();
     const releaseRun = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
-      log: noopLogger,
       nowMs: () => scheduledAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: async () => {
         runStarted.resolve();
         return await releaseRun.promise;
@@ -2934,13 +2795,9 @@ describe("cron service timer regressions", () => {
     const onIsolatedAgentSetupTimeout = vi.fn();
     const runnerResult = createDeferred<{ status: "ok"; summary: string }>();
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: store.storePath,
       testAdmissionLimit: 1,
-      log: noopLogger,
       nowMs: () => now,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       onIsolatedAgentSetupTimeout,
       runIsolatedAgentJob: vi.fn(async ({ job, onExecutionStarted }) => {
         if (job.id === manualJob.id) {
@@ -3279,12 +3136,8 @@ describe("cron service timer regressions", () => {
   it("resets the auto-disable streak after a successful recurring run", () => {
     const startedAt = Date.parse("2026-08-01T13:00:00.000Z");
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: "/tmp/cron-consecutive-failure-reset.json",
-      log: noopLogger,
       nowMs: () => startedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
     const job = createIsolatedRegressionJob({
@@ -3328,12 +3181,8 @@ describe("cron service timer regressions", () => {
     const startedAt = Date.parse("2026-08-01T14:00:00.000Z");
     const deferredNotifications: Array<() => void> = [];
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: "/tmp/cron-non-owning-failure.json",
-      log: noopLogger,
       nowMs: () => startedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
     const job = createIsolatedRegressionJob({
@@ -3362,12 +3211,8 @@ describe("cron service timer regressions", () => {
     const startedAt = Date.parse("2026-03-02T12:00:00.000Z");
     const endedAt = startedAt + 50;
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: "/tmp/cron-30905-success.json",
-      log: noopLogger,
       nowMs: () => endedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
     const job = createIsolatedRegressionJob({
@@ -3400,12 +3245,8 @@ describe("cron service timer regressions", () => {
     const startedAt = Date.parse("2026-03-02T12:05:00.000Z");
     const endedAt = startedAt + 25;
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: "/tmp/cron-30905-error.json",
-      log: noopLogger,
       nowMs: () => endedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
     const job = createIsolatedRegressionJob({
@@ -3439,12 +3280,8 @@ describe("cron service timer regressions", () => {
     const startedAt = Date.parse("2026-04-13T15:40:00.000Z");
     const endedAt = startedAt + 50;
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: "/tmp/cron-66019-success.json",
-      log: noopLogger,
       nowMs: () => endedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
     const job = createIsolatedRegressionJob({
@@ -3480,12 +3317,8 @@ describe("cron service timer regressions", () => {
     const startedAt = Date.parse("2026-04-13T15:45:00.000Z");
     const endedAt = startedAt + 25;
     const state = createCronServiceState({
-      cronEnabled: true,
       storePath: "/tmp/cron-66019-error.json",
-      log: noopLogger,
       nowMs: () => endedAt,
-      enqueueSystemEvent: vi.fn(),
-      requestHeartbeat: vi.fn(),
       runIsolatedAgentJob: createDefaultIsolatedRunner(),
     });
     const job = createIsolatedRegressionJob({

--- a/src/cron/service/timer.timeout-watchdog.test.ts
+++ b/src/cron/service/timer.timeout-watchdog.test.ts
@@ -2,8 +2,8 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import {
+  createCronRegressionState,
   createIsolatedRegressionJob,
-  noopLogger,
   setupCronRegressionFixtures,
 } from "../../../test/helpers/cron/service-regression-fixtures.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
@@ -16,7 +16,7 @@ import type {
   CronAgentExecutionStarted,
   CronJob,
 } from "../types.js";
-import { createCronServiceState, type CronServiceDeps } from "./state.js";
+import type { CronServiceDeps } from "./state.js";
 import { onTimer } from "./timer.test-support.js";
 
 const timerRegressionFixtures = setupCronRegressionFixtures({
@@ -65,14 +65,10 @@ describe("cron service timer regressions", () => {
       const heartbeatStarted = createDeferred();
       let abortObserved = false;
       const resolveHeartbeatTimeoutMs = vi.fn(() => 15 * 60_000);
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => Date.now(),
         defaultAgentId: "main",
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         resolveHeartbeatTimeoutMs,
         requestHeartbeatAndWait: vi.fn<NonNullable<CronServiceDeps["requestHeartbeatAndWait"]>>(
           async (_wake, { abortSignal }) => {
@@ -141,14 +137,10 @@ describe("cron service timer regressions", () => {
       vi.setSystemTime(scheduledAt);
       const heartbeatStarted = createDeferred();
       const resolveHeartbeatTimeoutMs = vi.fn(() => 15 * 60_000);
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => Date.now(),
         defaultAgentId: "main",
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         resolveHeartbeatTimeoutMs,
         runHeartbeatOnce: vi.fn(() => {
           heartbeatStarted.resolve();
@@ -206,13 +198,9 @@ describe("cron service timer regressions", () => {
       let abortReason: unknown;
       const started = createDeferred();
 
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         runIsolatedAgentJob: vi.fn(
           async ({
             abortSignal,
@@ -294,13 +282,9 @@ describe("cron service timer regressions", () => {
       const started = createDeferred();
       let abortObserved = false;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
         runIsolatedAgentJob: vi.fn(
           async ({
@@ -375,13 +359,9 @@ describe("cron service timer regressions", () => {
       let abortObserved = false;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
       const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
         onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
@@ -449,13 +429,9 @@ describe("cron service timer regressions", () => {
       await laneEntered.promise;
 
       const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun: vi.fn(async () => {}),
         onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(async ({ onLaneWait }) => {
@@ -512,13 +488,9 @@ describe("cron service timer regressions", () => {
       let now = scheduledAt;
       const started = createDeferred();
       const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun: vi.fn(async () => {}),
         onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(async ({ abortSignal }: { abortSignal?: AbortSignal }) => {
@@ -565,13 +537,9 @@ describe("cron service timer regressions", () => {
       let abortReason: unknown;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
       const onIsolatedAgentSetupTimeout = vi.fn();
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
         onIsolatedAgentSetupTimeout,
         runIsolatedAgentJob: vi.fn(
@@ -675,13 +643,9 @@ describe("cron service timer regressions", () => {
       const started = createDeferred();
       let abortObserved = false;
       const cleanupTimedOutAgentRun = vi.fn(async () => {});
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
         runIsolatedAgentJob: vi.fn(
           async ({
@@ -783,13 +747,9 @@ describe("cron service timer regressions", () => {
         const started = createDeferred();
         let abortObserved = false;
         const cleanupTimedOutAgentRun = vi.fn(async () => {});
-        const state = createCronServiceState({
-          cronEnabled: true,
+        const state = createCronRegressionState({
           storePath: store.storePath,
-          log: noopLogger,
           nowMs: () => now,
-          enqueueSystemEvent: vi.fn(),
-          requestHeartbeat: vi.fn(),
           cleanupTimedOutAgentRun,
           runIsolatedAgentJob: vi.fn(
             async ({
@@ -881,13 +841,9 @@ describe("cron service timer regressions", () => {
       const sendCronFailureAlert = vi.fn<NonNullable<CronServiceDeps["sendCronFailureAlert"]>>(
         async () => {},
       );
-      const state = createCronServiceState({
-        cronEnabled: true,
+      const state = createCronRegressionState({
         storePath: store.storePath,
-        log: noopLogger,
         nowMs: () => now,
-        enqueueSystemEvent: vi.fn(),
-        requestHeartbeat: vi.fn(),
         cleanupTimedOutAgentRun,
         sendCronFailureAlert,
         runIsolatedAgentJob: vi.fn(

--- a/test/helpers/cron/service-regression-fixtures.ts
+++ b/test/helpers/cron/service-regression-fixtures.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { clearSessionStoreCacheForTest } from "../../../src/config/sessions/store-writer-state.js";
 import { createRunningCronServiceState } from "../../../src/cron/service.test-harness.js";
-import type { CronServiceDeps } from "../../../src/cron/service/state.js";
+import { createCronServiceState, type CronServiceDeps } from "../../../src/cron/service/state.js";
 import type { CronJob, CronJobState } from "../../../src/cron/types.js";
 import { resetAgentEventsForTest } from "../../../src/infra/agent-events.js";
 import { getTotalQueueSize } from "../../../src/process/command-queue.js";
@@ -19,7 +19,9 @@ const TOP_OF_HOUR_STAGGER_MS = 5 * 60 * 1_000;
 async function waitForCommandQueueIdle(timeoutMs: number): Promise<void> {
   const deadlineAt = Date.now() + timeoutMs;
   while (getTotalQueueSize() > 0 && Date.now() < deadlineAt) {
-    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 10);
+    });
   }
 }
 
@@ -30,6 +32,21 @@ export const noopLogger = {
   debug: () => {},
   trace: () => {},
 };
+
+type CronRegressionDefaults = "cronEnabled" | "log" | "enqueueSystemEvent" | "requestHeartbeat";
+
+export function createCronRegressionState(
+  deps: Omit<CronServiceDeps, CronRegressionDefaults> &
+    Partial<Pick<CronServiceDeps, CronRegressionDefaults>>,
+) {
+  return createCronServiceState({
+    cronEnabled: true,
+    log: noopLogger,
+    enqueueSystemEvent: vi.fn(),
+    requestHeartbeat: vi.fn(),
+    ...deps,
+  });
+}
 
 export function setupCronRegressionFixtures(options?: { prefix?: string; baseTimeIso?: string }) {
   let fixtureRoot = "";
@@ -107,7 +124,7 @@ export function createDefaultIsolatedRunner(): CronServiceDeps["runIsolatedAgent
 
 export function createAbortAwareIsolatedRunner(summary = "late") {
   let observedAbortSignal: AbortSignal | undefined;
-  const started = createDeferred<void>();
+  const started = createDeferred();
   const runIsolatedAgentJob = vi.fn(async ({ abortSignal, onExecutionStarted }) => {
     observedAbortSignal = abortSignal;
     started.resolve();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Cron regression suites repeat the same four dependency defaults at 135 state-construction sites, obscuring the clocks, runners and ownership details that distinguish each scenario.

## Why This Change Was Made

Use a neutral factory in the existing regression-fixture module. It calls the real state constructor and creates fresh event/heartbeat mocks for each invocation. Store paths, clocks, runners, admission transforms, authority callbacks, SQL, timing and cleanup remain explicit. Disabled/custom/sparse inputs retain their original values; the existing running-state fixture is unchanged.

## User Impact

No production scheduler or persistence behavior changes. Net 527 test/support lines removed across 18 test files and one existing helper. All 275 affected cases remain selected.

## Evidence

Before/after runtime inventories contain the same 275 case identities. Full test-body AST comparison, expanding only the shared defaults, preserves all callbacks, assertions, state mutations, timing and cleanup statements. Existing scheduler siblings pass. A temporary diagnostic verified real initial state, fresh mocks/collections and explicit override identities, then was removed.

The complete changed gate, targeted helper lint, formatting/diff checks, deslop and final independent P2 review pass, along with all 275 affected cases and seven existing scheduler siblings. Three import/helper lint issues were corrected without changing timing or assertions. No runtime improvement is claimed from the timing samples.
