### PR TITLE
fix(process): preserve log output and errors in Code Mode

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -132,6 +132,11 @@ Notes:
 - `poll`'s `timeout` waits up to that many milliseconds before returning; values above 30000 are clamped to 30000.
 - Polling is for on-demand status, not wait-loop scheduling. If the work should happen later, use cron.
 
+In [Code Mode](/tools/code-mode), `process` returns its structured details directly.
+For `action: "log"`, `output` contains the requested log page, including paging,
+retention, and input-recovery hints. Failed process actions include an `error`
+message alongside `status: "failed"`, so the agent can choose the next action.
+
 ## Examples
 
 Run a long task and poll later:

--- a/src/agents/bash-tools.process-send-keys.ts
+++ b/src/agents/bash-tools.process-send-keys.ts
@@ -20,7 +20,7 @@ export type WritableStdin = {
 };
 
 function failText(text: string): AgentToolResult<unknown> {
-  return textResult(text, { status: "failed" });
+  return textResult(text, { status: "failed", error: text });
 }
 
 export async function writeProcessStdin(stdin: WritableStdin, data: string) {

--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -27,8 +27,10 @@ import { createProcessTool } from "./bash-tools.process.js";
 import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
+  createCodeModeHarness,
   resetCodeModeTestState,
   resultDetails,
+  runUntilCompleted,
   waitUntilCompleted,
 } from "./code-mode.test-support.js";
 import type { AgentMessage, AgentToolResult } from "./runtime/index.js";
@@ -73,6 +75,16 @@ async function poll(
       ...(timeout === undefined ? {} : { timeout }),
     }),
   );
+}
+
+async function runProcessInCodeMode(args: Record<string, unknown>) {
+  const harness = createCodeModeHarness();
+  applyCodeModeCatalog({ ...harness.ctx, tools: [...harness.tools, createProcessTool()] });
+  return await runUntilCompleted({
+    execTool: expectDefined(harness.tools[0], "Code Mode exec"),
+    waitTool: expectDefined(harness.tools[1], "Code Mode wait"),
+    code: `return await process(${JSON.stringify(args)});`,
+  });
 }
 
 function resultText(result: AgentToolResult<unknown>): string {
@@ -292,6 +304,81 @@ test.each(["transformed", "blocked", "error"] as const)(
     }
   },
 );
+
+test.each(["running", "completed"] as const)(
+  "Code Mode reads the requested page from a %s process log",
+  async (status) => {
+    const session = createProcessSessionFixture({ id: "paged-log", backgrounded: true });
+    addSession(session);
+    appendOutput(session, "stdout", "before-page\nrequested-page\nafter-page\n");
+    if (status === "completed") {
+      markExited(session, 0, null, "completed");
+    }
+
+    const result = await runProcessInCodeMode({
+      action: "log",
+      sessionId: session.id,
+      offset: 1,
+      limit: 1,
+    });
+
+    expect(result).toMatchObject({
+      status: "completed",
+      value: { status, output: "requested-page", totalLines: 3 },
+    });
+  },
+);
+
+test("Code Mode retains the default log page limit and continuation hint", async () => {
+  const session = createProcessSessionFixture({ id: "tailed-log", backgrounded: true });
+  addSession(session);
+  appendOutput(
+    session,
+    "stdout",
+    Array.from({ length: 205 }, (_, index) => `line-${index}`).join("\n"),
+  );
+
+  const result = await runProcessInCodeMode({ action: "log", sessionId: session.id });
+
+  expect(result).toMatchObject({
+    status: "completed",
+    value: {
+      output: `${Array.from({ length: 200 }, (_, index) => `line-${index + 5}`).join("\n")}\n\n[showing last 200 of 205 lines; pass offset/limit to page]`,
+    },
+  });
+});
+
+test.each([
+  { action: "log", sessionId: "missing-process", error: "No session found for missing-process" },
+  {
+    action: "paste",
+    sessionId: "interactive-process",
+    text: "",
+    bracketed: false,
+    error: "No paste text provided.",
+  },
+  {
+    action: "send-keys",
+    sessionId: "interactive-process",
+    keys: ["up"],
+    error:
+      "Session interactive-process cursor key mode is not known yet. Poll or log until startup output appears, then retry send-keys.",
+  },
+])("Code Mode preserves actionable $action failures", async ({ error, ...args }) => {
+  const session = createProcessSessionFixture({
+    id: "interactive-process",
+    backgrounded: true,
+    cursorKeyMode: "unknown",
+  });
+  const write = vi.fn((_data: string, callback?: (error?: Error | null) => void) => callback?.());
+  session.stdin = { write, end: vi.fn() };
+  addSession(session);
+
+  const result = await runProcessInCodeMode(args);
+
+  expect(result).toMatchObject({ status: "completed", value: { status: "failed", error } });
+  expect(write).not.toHaveBeenCalled();
+});
 
 test("a retained old snapshot cannot consume a successor poll delivery", async () => {
   const session = createProcessSessionFixture({ id: "retained-poll", backgrounded: true });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -153,7 +153,7 @@ function resolvePollWaitMs(value: unknown) {
 }
 
 function failText(text: string): AgentToolResult<unknown> {
-  return textResult(text, { status: "failed" });
+  return textResult(text, { status: "failed", error: text });
 }
 
 function recordPollRetrySuggestion(sessionId: string, hasNewOutput: boolean): number | undefined {
@@ -513,25 +513,25 @@ export function createProcessTool(
             retentionCapNote(record) +
             (slice || (scopedSession ? "(no output yet)" : "(no output recorded)")) +
             defaultTailNote(totalLines, window.usingDefaultTail);
-          return textResult(
-            runtime
-              ? text + buildInputWaitHint(runtime)
-              : appendExecTimeoutRetryGuidance(text, record.exitReason),
-            {
-              ...(runtime
-                ? {
-                    status: record.exited ? "completed" : "running",
-                    sessionId: params.sessionId,
-                    name: deriveSessionName(record.command),
-                    ...runningSessionInputDetails(runtime),
-                  }
-                : finishedSessionDetails(params.sessionId, record)),
-              total: totalLines,
-              totalLines,
-              totalChars,
-              truncated: record.truncated,
-            },
-          );
+          const output = runtime
+            ? text + buildInputWaitHint(runtime)
+            : appendExecTimeoutRetryGuidance(text, record.exitReason);
+          return textResult(output, {
+            ...(runtime
+              ? {
+                  status: record.exited ? "completed" : "running",
+                  sessionId: params.sessionId,
+                  name: deriveSessionName(record.command),
+                  ...runningSessionInputDetails(runtime),
+                }
+              : finishedSessionDetails(params.sessionId, record)),
+            // Code Mode reads details, so preserve the requested page and its recovery hints.
+            output,
+            total: totalLines,
+            totalLines,
+            totalChars,
+            truncated: record.truncated,
+          });
         }
 
         case "write": {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents using Code Mode could not read a background command's requested log page: `process` returned session metadata but omitted the output. Failed process actions also lost the explanation needed to recover, such as a missing session or terminal input that was not ready.

## Why This Change Was Made

Code Mode returns the process tool's structured details to guest JavaScript. The process result now includes the existing rendered log page in `output`, with its paging, retention, and recovery hints, and failed actions include their existing diagnostic in `error`. The repair stays with the result producer and preserves process scope, polling acknowledgements, and output limits.

## User Impact

Code Mode agents can inspect retained command output and act on process errors. Direct process callers continue to receive the same text and gain the corresponding structured fields.

## Evidence

- Six regressions failed on the original production code because guest results lacked log output or error explanations; all six pass with the repair.
- 69 focused tests passed across Code Mode, process delivery, polling, input hints, and send keys. After consolidating the new cases into the existing process delivery suite, all 18 tests in that suite passed.
- Independent review found no actionable P0–P2 findings.
- Isolated live-model probe passed in direct and Code Mode with the same model and high reasoning: each started a synthetic background producer once and read offset 100 / limit 1 from its 500-line output. The stored Code Mode result contains the exact generated value in `page.output`, with Code Mode activation confirmed. Both used four assistant turns; this is behavior proof, not a benchmark score claim.
- `pnpm check:changed` passed, including formatting, core and core-test typechecks, lint, exports, and repository guards.
- `pnpm build` passed against the frozen source layout. An earlier declaration build rejected output after the test file layout changed during compilation; the clean rerun completed successfully.

CI initially found unrelated inventory line drift introduced on main by #139651. After #139747 corrected the three locations, this PR was rebased without changing its patch (`git range-diff` verified). All 21 focused delivery/send-keys tests passed again; Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34012563841).
