### PR TITLE
fix(cli): keep sessions tail responsive in large stores

### DIFF
--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -334,6 +334,54 @@ describe("sessionsTailCommand", () => {
     expect(output).not.toContain("No sessions found");
   });
 
+  it("selects a trajectory target without decoding unrelated saved prompts", async () => {
+    const runtime = makeRuntime();
+    await writeSessionEntry();
+    await appendEvents([
+      makeEvent({
+        type: "tool.result",
+        ts: "2026-05-18T12:04:21.000Z",
+        data: { name: "selected", success: true },
+      }),
+    ]);
+    for (let index = 0; index < 100; index += 1) {
+      await writeSessionEntry(`agent:main:unrelated:${index}`, {
+        sessionId: `unrelated-${index}`,
+        skillsSnapshot: {
+          prompt: `UNRELATED_TAIL_PAYLOAD_${"x".repeat(4096)}`,
+          skills: [],
+        },
+        systemPromptReport: {
+          source: "run",
+          generatedAt: 1,
+          workspaceDir: `UNRELATED_TAIL_PAYLOAD_${"y".repeat(4096)}`,
+          systemPrompt: { chars: 0, projectContextChars: 0, nonProjectContextChars: 0 },
+          injectedWorkspaceFiles: [],
+          skills: { promptChars: 0, entries: [] },
+          tools: { listChars: 0, schemaChars: 0, entries: [] },
+        },
+      });
+    }
+
+    const parse = vi.spyOn(JSON, "parse");
+    try {
+      await sessionsTailCommand(
+        { agent: "main", store: storePath, sessionKey, tail: "1" },
+        runtime,
+      );
+
+      expect(
+        parse.mock.calls.filter(
+          ([value]) => typeof value === "string" && value.includes("UNRELATED_TAIL_PAYLOAD_"),
+        ),
+      ).toHaveLength(0);
+      expect(runtimeOutput(runtime)).toContain("selected ok");
+      expect(runtime.error).not.toHaveBeenCalled();
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
   it("isolates trajectory rows by session id", async () => {
     const runtime = makeRuntime();
     await writeSessionEntry();

--- a/src/commands/sessions-tail.test.ts
+++ b/src/commands/sessions-tail.test.ts
@@ -4,8 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
+import { buildAcpDatabaseSessionKey } from "../acp/runtime/session-meta-keys.js";
+import { writeAcpSessionMetaForMigration } from "../acp/runtime/session-meta.js";
 import { ExpectedCliError } from "../cli/failure-output.js";
-import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  replaceSessionEntrySync,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
@@ -334,53 +339,89 @@ describe("sessionsTailCommand", () => {
     expect(output).not.toContain("No sessions found");
   });
 
-  it("selects a trajectory target without decoding unrelated saved prompts", async () => {
-    const runtime = makeRuntime();
-    await writeSessionEntry();
-    await appendEvents([
-      makeEvent({
-        type: "tool.result",
-        ts: "2026-05-18T12:04:21.000Z",
-        data: { name: "selected", success: true },
-      }),
-    ]);
-    for (let index = 0; index < 100; index += 1) {
-      await writeSessionEntry(`agent:main:unrelated:${index}`, {
-        sessionId: `unrelated-${index}`,
-        skillsSnapshot: {
-          prompt: `UNRELATED_TAIL_PAYLOAD_${"x".repeat(4096)}`,
-          skills: [],
+  it.each(["explicit", "running", "latest", "acp"])(
+    "selects %s sessions without decoding unrelated saved prompts",
+    async (selection) => {
+      const runtime = makeRuntime();
+      storePath = path.join(tmpDir, "state", "agents", "main", "agent", "openclaw-agent.sqlite");
+      replaceSessionEntrySync(
+        { sessionKey, storePath },
+        {
+          sessionId: "session-one",
+          updatedAt: 2,
+          status: selection === "running" ? "running" : "done",
         },
-        systemPromptReport: {
-          source: "run",
-          generatedAt: 1,
-          workspaceDir: `UNRELATED_TAIL_PAYLOAD_${"y".repeat(4096)}`,
-          systemPrompt: { chars: 0, projectContextChars: 0, nonProjectContextChars: 0 },
-          injectedWorkspaceFiles: [],
-          skills: { promptChars: 0, entries: [] },
-          tools: { listChars: 0, schemaChars: 0, entries: [] },
-        },
-      });
-    }
-
-    const parse = vi.spyOn(JSON, "parse");
-    try {
-      await sessionsTailCommand(
-        { agent: "main", store: storePath, sessionKey, tail: "1" },
-        runtime,
       );
+      if (selection === "acp") {
+        writeAcpSessionMetaForMigration({
+          sessionKey: buildAcpDatabaseSessionKey(sessionKey, "main"),
+          sessionId: "session-one",
+          now: () => 2,
+          meta: {
+            backend: "fixture",
+            agent: "main",
+            runtimeSessionName: "fixture",
+            mode: "persistent",
+            state: "running",
+            lastActivityAt: 2,
+          },
+        });
+      }
+      await appendEvents([
+        makeEvent({
+          type: "tool.result",
+          ts: "2026-05-18T12:04:21.000Z",
+          data: { name: "selected", success: true },
+        }),
+      ]);
+      for (let index = 0; index < 100; index += 1) {
+        replaceSessionEntrySync(
+          { sessionKey: `agent:main:unrelated:${index}`, storePath },
+          {
+            sessionId: `unrelated-${index}`,
+            status: "done",
+            updatedAt: selection === "acp" ? 3 : 1,
+            skillsSnapshot: {
+              prompt: `UNRELATED_TAIL_PAYLOAD_${"x".repeat(4096)}`,
+              skills: [],
+            },
+            systemPromptReport: {
+              source: "run",
+              generatedAt: 1,
+              workspaceDir: `UNRELATED_TAIL_PAYLOAD_${"y".repeat(4096)}`,
+              systemPrompt: { chars: 0, projectContextChars: 0, nonProjectContextChars: 0 },
+              injectedWorkspaceFiles: [],
+              skills: { promptChars: 0, entries: [] },
+              tools: { listChars: 0, schemaChars: 0, entries: [] },
+            },
+          },
+        );
+      }
 
-      expect(
-        parse.mock.calls.filter(
-          ([value]) => typeof value === "string" && value.includes("UNRELATED_TAIL_PAYLOAD_"),
-        ),
-      ).toHaveLength(0);
-      expect(runtimeOutput(runtime)).toContain("selected ok");
-      expect(runtime.error).not.toHaveBeenCalled();
-    } finally {
-      parse.mockRestore();
-    }
-  });
+      const parse = vi.spyOn(JSON, "parse");
+      try {
+        await sessionsTailCommand(
+          {
+            agent: "main",
+            store: storePath,
+            sessionKey: selection === "explicit" ? sessionKey : undefined,
+            tail: "1",
+          },
+          runtime,
+        );
+
+        expect(
+          parse.mock.calls.filter(
+            ([value]) => typeof value === "string" && value.includes("UNRELATED_TAIL_PAYLOAD_"),
+          ),
+        ).toHaveLength(0);
+        expect(runtimeOutput(runtime)).toContain("selected ok");
+        expect(runtime.error).not.toHaveBeenCalled();
+      } finally {
+        parse.mockRestore();
+      }
+    },
+  );
 
   it("isolates trajectory rows by session id", async () => {
     const runtime = makeRuntime();

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -1,7 +1,10 @@
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString as toOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
-import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import {
+  readAcpSessionMetaForEntry,
+  resolveSessionStorePathForAcp,
+} from "../acp/runtime/session-meta.js";
 import {
   buildAgentRunTerminalOutcomeFromLifecycleEvent,
   classifyAgentRunTerminalOutcome,
@@ -163,12 +166,17 @@ function renderEvents(events: TrajectoryEvent[], runtime: RuntimeEnv): void {
 
 function isRunningSession(selection: TailSelection): boolean {
   const cfg = getRuntimeConfig();
-  const acpMeta = readAcpSessionMeta({
-    sessionKey: resolveStoredSessionKeyForAgentStore({
-      cfg,
-      agentId: selection.agentId,
-      sessionKey: selection.key,
-    }),
+  const sessionKey = resolveStoredSessionKeyForAgentStore({
+    cfg,
+    agentId: selection.agentId,
+    sessionKey: selection.key,
+  });
+  const { agentId } = resolveSessionStorePathForAcp({ cfg, sessionKey });
+  const acpMeta = readAcpSessionMetaForEntry({
+    cfg,
+    sessionKey,
+    agentId,
+    entry: selection.entry,
   });
   return selection.entry.status === "running" || acpMeta?.state === "running";
 }

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -299,6 +299,7 @@ export async function sessionsTailCommand(
     for (const { sessionKey, entry } of listSessionEntriesReadOnly({
       agentId: target.agentId,
       storePath: target.storePath,
+      projection: "list",
     })) {
       const selection = buildTailSelection({
         agentId: target.agentId,


### PR DESCRIPTION
Closes #139671

## What Problem This Solves

Fixes an issue where operators tailing a session decoded saved prompts from unrelated sessions before seeing progress. Automatic running/latest selection also reread session entries while checking agent-runtime activity.

## Why This Change Was Made

Use the existing session metadata projection, then pass the selected entry to the existing agent-runtime metadata reader. Keep its owner resolution and session-generation checks. Full readers still return complete saved prompts. This adds no query, cache, schema, or selection policy.

## User Impact

Explicit and automatic tailing avoid unrelated saved-prompt decoding while preserving selected sessions, output, read-only access, and follow behavior.

## Evidence

- Built CLI comparison against main `e19a7694cef6d38140033f798215103dd638fafb`: explicit-key unrelated parses fall from 100 to 0 at 100 rows and 500 to 0 at 500 rows. Latest selection falls from 200 to 0 at 100 rows. Selected output is byte-for-byte unchanged.
- Increasing each saved field from 4 KiB to 64 KiB keeps the candidate count at zero.
- 33 paired CLI controls preserve selection/order, malformed/deep/NUL/canonical-key behavior, database contents/data version, and current/stale runtime identity binding across two agents.
- 90 focused tests pass. All four regression modes fail on main with 100 or 200 unrelated parses; the candidate passes. Targeted type-aware lint and formatting pass.
- Fresh source-blind acceptance passes all ten observable clauses, including complete full readers and eight follow runs across both builds, explicit/latest selection, and tail counts 0/1. Internal SQLite allocation is not measured.

Thirty-one alternating measured pairs per store size, after two warmups per build, on the same isolated Linux/Node 24.20.0 runtime. Timing uses no JSON parse spy.

| Unrelated rows | Main/candidate median wall | Main/candidate median CPU | Main/candidate median peak memory |
| --- | --- | --- | --- |
| 100 | 1538 / 1551 ms | 2038 / 2046 ms | 420244 / 420992 KiB |
| 500 | 1530 / 1537 ms | 2034 / 2031 ms | 421380 / 420856 KiB |

The 500-row CPU median is 3.416 ms lower (0.17%). This is too small to establish a reliable speedup; neither general latency nor memory reduction is claimed. The measured work reduction is elimination of unrelated prompt decoding.

Original contribution by @ly85206559, with expanded repair, regression coverage, and CLI proof.
