### PR TITLE
fix(media): avoid Bedrock PDF policy stalls in source checkouts

### DIFF
--- a/extensions/amazon-bedrock/thinking-policy.ts
+++ b/extensions/amazon-bedrock/thinking-policy.ts
@@ -1,3 +1,10 @@
+import {
+  resolveClaudeFable5ModelIdentity,
+  resolveClaudeModelIdentity,
+  resolveClaudeMythos5ModelIdentity,
+  resolveClaudeOpus5ModelIdentity,
+  resolveClaudeSonnet5ModelIdentity,
+} from "openclaw/plugin-sdk/claude-model-runtime";
 /**
  * Thinking-level policy for Claude models on Amazon Bedrock. It maps Bedrock
  * model ids to the provider SDK thinking levels that are actually supported.
@@ -6,13 +13,6 @@ import type {
   ProviderRuntimeModel,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
-import {
-  resolveClaudeFable5ModelIdentity,
-  resolveClaudeModelIdentity,
-  resolveClaudeMythos5ModelIdentity,
-  resolveClaudeOpus5ModelIdentity,
-  resolveClaudeSonnet5ModelIdentity,
-} from "openclaw/plugin-sdk/provider-model-shared";
 
 const BASE_CLAUDE_THINKING_LEVELS = [
   { id: "off" },

--- a/src/media/document-extractors.runtime.test.ts
+++ b/src/media/document-extractors.runtime.test.ts
@@ -1,9 +1,14 @@
 // Document extractor runtime tests cover lazy document extraction adapters.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  DocumentExtractionRequest,
+  DocumentExtractionResult,
+} from "../plugins/document-extractor-types.js";
+import type { resolvePluginDocumentExtractors } from "../plugins/document-extractors.runtime.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 
 const { resolvePluginDocumentExtractorsMock } = vi.hoisted(() => ({
-  resolvePluginDocumentExtractorsMock: vi.fn(),
+  resolvePluginDocumentExtractorsMock: vi.fn<typeof resolvePluginDocumentExtractors>(),
 }));
 
 vi.mock("../plugins/document-extractors.runtime.js", () => ({
@@ -11,6 +16,7 @@ vi.mock("../plugins/document-extractors.runtime.js", () => ({
 }));
 
 import { extractDocumentContent } from "./document-extractors.runtime.js";
+import { extractPdfContent } from "./pdf-extract.js";
 
 describe("extractDocumentContent", () => {
   beforeEach(() => {
@@ -118,5 +124,71 @@ describe("extractDocumentContent", () => {
     expect(resolvePluginDocumentExtractorsMock).toHaveBeenCalledTimes(2);
     expect(oldExtract).toHaveBeenCalledOnce();
     expect(newExtract).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    {
+      name: "populated optional fields",
+      password: "  retained  ",
+      pageNumbers: [2, 1],
+      callback: true,
+    },
+    { name: "empty password and pages", password: "", pageNumbers: [], callback: false },
+  ])("preserves the composed PDF request with $name", async (row) => {
+    const { password, pageNumbers, callback } = row;
+    const buffer = Buffer.from("%PDF-1.4");
+    const config = {};
+    const images: DocumentExtractionResult["images"] = [];
+    const imageError = new Error("image rendering failed");
+    const onImageExtractionError = vi.fn<(error: unknown) => void>();
+    const extract = vi.fn(async (request: DocumentExtractionRequest) => {
+      expect(request).toStrictEqual({
+        buffer,
+        mimeType: "application/pdf",
+        maxPages: 2,
+        maxPixels: 100,
+        minTextChars: 10,
+        ...(password ? { password: "  retained  " } : {}),
+        pageNumbers,
+        ...(callback ? { onImageExtractionError } : {}),
+      });
+      expect(request.buffer).toBe(buffer);
+      expect(request.pageNumbers).toBe(pageNumbers);
+      expect(request.onImageExtractionError).toBe(callback ? onImageExtractionError : undefined);
+      request.onImageExtractionError?.(imageError);
+      return { text: "pdf text", images };
+    });
+    resolvePluginDocumentExtractorsMock.mockReturnValue([
+      {
+        id: "pdf",
+        pluginId: "document-extract",
+        label: "PDF",
+        mimeTypes: ["application/pdf"],
+        extract,
+      },
+    ]);
+
+    const result = await extractPdfContent({
+      buffer,
+      maxPages: 2,
+      maxPixels: 100,
+      minTextChars: 10,
+      password,
+      pageNumbers,
+      config,
+      onImageExtractionError: callback ? onImageExtractionError : undefined,
+    });
+
+    expect(resolvePluginDocumentExtractorsMock).toHaveBeenCalledOnce();
+    expect(resolvePluginDocumentExtractorsMock.mock.calls[0]?.[0]?.config).toBe(config);
+    expect(extract).toHaveBeenCalledOnce();
+    expect(result).toStrictEqual({ text: "pdf text", images });
+    expect(result.images).toBe(images);
+    if (callback) {
+      expect(onImageExtractionError).toHaveBeenCalledOnce();
+      expect(onImageExtractionError).toHaveBeenCalledWith(imageError);
+    } else {
+      expect(onImageExtractionError).not.toHaveBeenCalled();
+    }
   });
 });

--- a/src/media/pdf-extract.ts
+++ b/src/media/pdf-extract.ts
@@ -22,18 +22,10 @@ export async function extractPdfContent(params: {
   config?: OpenClawConfig;
   onImageExtractionError?: (error: unknown) => void;
 }): Promise<PdfExtractedContent> {
+  // The document owner strips config and loader-only fields before plugin dispatch.
   const extracted = await extractDocumentContent({
-    buffer: params.buffer,
+    ...params,
     mimeType: "application/pdf",
-    maxPages: params.maxPages,
-    maxPixels: params.maxPixels,
-    minTextChars: params.minTextChars,
-    ...(params.password ? { password: params.password } : {}),
-    ...(params.pageNumbers ? { pageNumbers: params.pageNumbers } : {}),
-    ...(params.config ? { config: params.config } : {}),
-    ...(params.onImageExtractionError
-      ? { onImageExtractionError: params.onImageExtractionError }
-      : {}),
   });
   if (!extracted) {
     throw new Error(

--- a/src/plugin-sdk/claude-model-runtime.ts
+++ b/src/plugin-sdk/claude-model-runtime.ts
@@ -1,11 +1,10 @@
-/**
- * Claude model-family policy helpers for provider policy artifacts.
- *
- * Provider policy artifacts (`provider-policy-api.js`) load eagerly whenever a
- * provider is resolved, so their module graph must stay leaf-light. This
- * subpath re-exports the Claude identity and thinking helpers from their leaf
- * owners; importing them through `provider-model-shared` drags the transport
- * and compat graph into every policy load (~60s under jiti in source checkouts).
- */
-export { resolveClaudeModelIdentity, resolveClaudeMythos5ModelIdentity } from "@openclaw/llm-core";
+// Provider policy artifacts load eagerly; keep Claude identity and thinking
+// helpers on their leaf owners so policy resolution does not load transports.
+export {
+  resolveClaudeFable5ModelIdentity,
+  resolveClaudeModelIdentity,
+  resolveClaudeMythos5ModelIdentity,
+  resolveClaudeOpus5ModelIdentity,
+  resolveClaudeSonnet5ModelIdentity,
+} from "@openclaw/llm-core";
 export { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";


### PR DESCRIPTION
Related: #129652

## What Problem This Solves

Resolves a problem where PDF-tool execution with Bedrock Claude models could stall during model-policy resolution in source checkouts. The existing Bedrock PDF-tool case exceeded its 120-second timeout in three unmodified runs.

This maintainer-requested change also removes duplicate PDF request projection while preserving supported extraction behavior.

## Why This Change Was Made

The canonical document-extraction owner already filters loader/config fields and constructs the plugin request. Let the PDF adapter use that owner while retaining its fixed PDF MIME type, explicit unavailable/disabled failure, and text/images-only result.

Bedrock's eager thinking-policy module now uses the existing leaf-light Claude facade, as the Anthropic/Vertex policy siblings do. Three existing identity helpers are re-exported through that local-only facade; helper implementations and thinking policy stay unchanged. Public SDK entrypoints, export totals, configuration, dependencies, protocol, and schema are unchanged.

Production LOC: +18/-27 (net -9, including mechanical import movement). Tests: +73/-1 (net +72), extending the existing composed-owner test rather than adding a production test seam.

## User Impact

Bedrock Claude policy resolution avoids loading the broad transport dependency graph on this source-checkout path. PDF requests retain their password/page/callback behavior, and disabled extraction still returns an explicit error. No model/vendor API behavior changes are claimed.

## Evidence

- The existing Bedrock case recorded 419.409s, 175.555s, and 184.905s failures before the import repair. A local Node CPU profile localized approximately 179.8s to the nested heavy-barrel import subtree; those nested measurements are not additive. Raw profiles remain private.
- One uninstrumented, original-order `pnpm test src/agents/tools/pdf-tool.test.ts` run passed all 35 cases after the repair; the previously failing case took 330ms. No timeout increase, broader mock, cache clear, or test retry was used.
- A separate seven-file owner/sibling run passed 102 cases covering document extraction, plugin dispatch/public artifacts, Bedrock policy/discovery, and Anthropic/Vertex policy siblings.
- `pnpm test:e2e:gateway test/e2e/qa-lab/media/pdf-document-extraction-dispatch.e2e.test.ts`: one existing case passed in 438ms after its normal private-QA/DTS/AI prerequisites. This exercised actual inline PDF parsing through the registered extractor and explicit disablement—not live AWS/model calls, encrypted PDFs, or image rendering.
- Ordinary `pnpm build`: all 16 full-profile phases ran and passed, including declarations, CLI bootstrap/Gateway chunk metadata, SDK exports, UI, and final metadata. Source bytes were verified unchanged and generated outputs retained.
- The first changed gate passed 10 checks, failed formatting in the Bedrock policy file, and left 25 checks unrun. After ordinary formatting, the complete four-path changed gate passed all 36 commands on the final formatted source: core/extension production and test types, two doctor-contract files/five cases, SDK exports/budgets, scoped lint, and final static guards. The [delegated Testbox run](https://github.com/openclaw/openclaw/actions/runs/34007674986) returned payload exit 0; normal one-shot cleanup can leave its backing Actions job marked cancelled.
- The SDK budget check confirms unchanged public totals: 152 entrypoints, 4,436 exports, and 2,620 callable exports. Only local-only/all-source export counts rise by three.
- Managed precommit and separate exact-commit Codex reviews through P2 returned no findings for the pre-refresh candidate. The separate exact-successor Codex P2 review also returned no findings in all three native evidence partitions. These source reviews are distinct from the executed tests and builds above.

The runtime tests, full build, and precommit review preceded one mechanical import-order correction: the sole value import moved relative to the header and an erased type-only import, with names, module source, and policy bodies unchanged. That equivalence was independently reconstructed; the 36-check gate and separate exact-commit review cover the final formatted source. Earlier failure receipts remain retained rather than relabeled as passes.

The original exact-head [CI run 34011621752](https://github.com/openclaw/openclaw/actions/runs/34011621752) failed on three stale SOCKS test line references in the suppression inventory; 105 jobs passed and 17 were skipped. The canonical correction landed separately in #139747. This candidate was then mechanically rebased onto that fix, preserving the same four-file patch and afterimages; the earlier failing run remains retained. No healthy runtime/build/E2E proof was replayed merely for this base refresh.

Candidate commit: `9e6e2417b8ecec500de40eed0aa5222ef7467cce`. Exact-head [CI 34015067905](https://github.com/openclaw/openclaw/actions/runs/34015067905) passed (107 successful jobs, 17 skipped), and the completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139732#issuecomment-5556925982) has no findings or before-merge moves. Native landing remains pending.
