### PR TITLE
fix(test): align recovery and history fixtures with runtime contracts

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });

--- a/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-repeated-request-recovery.e2e.test.ts
@@ -27,6 +27,7 @@ type GatewayChatRun = {
   runId?: unknown;
   status?: unknown;
   stopReason?: unknown;
+  endedAt?: unknown;
 };
 
 type GatewayChatMessage = {
@@ -41,12 +42,16 @@ type GatewayChatHistory = {
 type MockRequestSnapshot = {
   cursor?: unknown;
   prompt?: unknown;
+  allInputText?: unknown;
+  model?: unknown;
   outcome?: unknown;
   errorCode?: unknown;
 };
 
 type ClassifiedMockRequest = {
   cursor: unknown;
+  model: unknown;
+  continuation: boolean;
   prompt: "recovery" | "queued" | "other" | "missing";
   outcome: unknown;
   errorCode: unknown;
@@ -228,13 +233,20 @@ async function readClassifiedMockRequests(mockBaseUrl: string): Promise<Classifi
   return fetch(`${mockBaseUrl}/debug/requests`)
     .then((response) => response.json() as Promise<MockRequestSnapshot[]>)
     .then((records) =>
-      records.map(({ cursor, prompt, outcome, errorCode }) => ({
+      records.map(({ cursor, prompt, allInputText, model, outcome, errorCode }) => ({
         cursor,
+        model,
+        continuation:
+          typeof prompt === "string" &&
+          !prompt.includes(RECOVERY_PROMPT) &&
+          !prompt.includes(QUEUED_PROMPT) &&
+          typeof allInputText === "string" &&
+          allInputText.includes(RECOVERY_PROMPT),
         prompt:
           typeof prompt === "string"
             ? prompt.includes(QUEUED_PROMPT)
               ? "queued"
-              : prompt.includes(RECOVERY_PROMPT)
+              : typeof allInputText === "string" && allInputText.includes(RECOVERY_PROMPT)
                 ? "recovery"
                 : "other"
             : "missing",
@@ -286,7 +298,7 @@ async function readFailureEvidence(params: {
 
 describe("Gateway repeated-request provider timeout", () => {
   it(
-    "lets the provider timeout terminate the stalled attempt before draining one queued followup",
+    "continues after a provider timeout and settles failure before draining one queued followup",
     { timeout: 510_000 },
     async () => {
       gatewayOwner = createQaLiveLaneGateway();
@@ -364,16 +376,14 @@ describe("Gateway repeated-request provider timeout", () => {
       expect(queued).toMatchObject({ status: "started" });
       expect(typeof queued.runId).toBe("string");
 
+      // The provider deadline starts before model-call observation, so its diagnostic
+      // duration can be shorter than timeoutSeconds. The failure kind owns timeout evidence.
       const events = await waitForStability(
         gateway,
         baselineSeq,
         (records) =>
           records.some(
-            (event) =>
-              event.type === "model.call.error" &&
-              event.failureKind === "timeout" &&
-              typeof event.durationMs === "number" &&
-              event.durationMs >= MODEL_REQUEST_ALLOWANCE_SECONDS * 1_000,
+            (event) => event.type === "model.call.error" && event.failureKind === "timeout",
           ),
         350_000,
       );
@@ -399,7 +409,10 @@ describe("Gateway repeated-request provider timeout", () => {
         { runId: active.runId, timeoutMs: 30_000 },
         { timeoutMs: 35_000 },
       )) as GatewayChatRun;
-      expect(activeTerminal.status).not.toBe("ok");
+      expect(activeTerminal).toMatchObject({
+        status: "error",
+        endedAt: expect.any(Number),
+      });
 
       const history = await waitForQueuedReply(gateway, sessionKey).catch(
         async (error: unknown) => {
@@ -423,9 +436,19 @@ describe("Gateway repeated-request provider timeout", () => {
         throw new Error("mock provider request evidence unavailable");
       }
       const requests = await readClassifiedMockRequests(mockBaseUrl);
-      expect(
-        requests.filter((request) => request.prompt === "recovery").length,
-      ).toBeGreaterThanOrEqual(5);
+      const recoveryRequests = requests.filter((request) => request.prompt === "recovery");
+      expect(recoveryRequests.length).toBeGreaterThanOrEqual(5);
+      expect(recoveryRequests[0]?.model).toBe("gpt-5.6-luna");
+      expect(recoveryRequests[1]?.model).toBe(recoveryRequests[0]?.model);
+      expect(recoveryRequests).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            continuation: true,
+            outcome: "error",
+            errorCode: "response_failed_no_details",
+          }),
+        ]),
+      );
       expect(requests.filter((request) => request.prompt === "queued")).toEqual([
         expect.objectContaining({ outcome: "success" }),
       ]);

--- a/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-message-tool-failure-settlement.e2e.test.ts
@@ -13,6 +13,8 @@ const SENDER_ID = 777;
 const FAILURE_TEXT =
   "⚠️ mock-openai/gpt-5.6-luna-alt request failed (provider internal error, HTTP 500). This is usually temporary — try again shortly.";
 const RAW_ERROR_CANARY = "untrusted-provider-detail-qa-canary";
+const REQUEST_TEXT =
+  "Please investigate this request. This turn should visibly settle even if the agent fails.";
 
 async function readRequest(req: IncomingMessage): Promise<JsonObject> {
   let text = "";
@@ -29,6 +31,7 @@ function succeed(res: ServerResponse, result: unknown = true) {
 test("visibly settles a message-tool-only Telegram turn after a provider failure", async () => {
   const pendingPolls = new Set<ServerResponse>();
   const telegramSends: JsonObject[] = [];
+  const providerBodies: JsonObject[] = [];
   let providerRequests = 0;
   let updateDelivered = false;
 
@@ -39,7 +42,7 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
       date: 1_754_000_000,
       chat: { id: CHAT_ID, type: "supergroup", title: "QA" },
       from: { id: SENDER_ID, is_bot: false, first_name: "QA" },
-      text: "Please investigate this request. This turn should visibly settle even if the agent fails.",
+      text: REQUEST_TEXT,
     },
   };
 
@@ -47,7 +50,17 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
     const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
     if (pathname.startsWith("/v1/")) {
       providerRequests += 1;
-      writeJson(res, 500, { error: { message: `provider returned HTTP 500 ${RAW_ERROR_CANARY}` } });
+      const body = await readRequest(req);
+      const isModelRequest = pathname === "/v1/responses";
+      if (isModelRequest) {
+        providerBodies.push(body);
+      }
+      // Allow one continuation, then advertise an outage beyond the recovery window.
+      const retryHint =
+        !isModelRequest || providerBodies.length > 1 ? "; Retry-After: 120 seconds" : "";
+      writeJson(res, 500, {
+        error: { message: `provider returned HTTP 500 ${RAW_ERROR_CANARY}${retryHint}` },
+      });
       return;
     }
 
@@ -170,6 +183,9 @@ test("visibly settles a message-tool-only Telegram turn after a provider failure
               sends: [{ chatId: String(CHAT_ID), silent: true, text: FAILURE_TEXT }],
             });
           expect(providerRequests).toBeGreaterThan(0);
+          expect(providerBodies[1]?.model).toBe(providerBodies[0]?.model);
+          expect(JSON.stringify(providerBodies[1]?.input)).toContain(REQUEST_TEXT);
+          expect(providerBodies[1]?.input).not.toEqual(providerBodies[0]?.input);
           expect(telegramSends.map((send) => send.text).join("\n")).not.toContain(RAW_ERROR_CANARY);
         } finally {
           await stopQaGatewayFixture(gatewayOwner);

--- a/test/plugin-cron-registry-owner.e2e.test.ts
+++ b/test/plugin-cron-registry-owner.e2e.test.ts
@@ -152,8 +152,9 @@ async function startMockModelServer(rejectModel?: string): Promise<MockModelServ
       const body = await readJsonRequest(req);
       requests.push({ body });
       if (rejectModel && body.model === rejectModel) {
-        res.writeHead(503, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: { message: "Model temporarily unavailable" } }));
+        // Missing models advance fallback; transient outages first recover on the same model.
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: { code: "model_not_found", message: "Model not found" } }));
         return;
       }
       writeModelResponse(res, requests.length);


### PR DESCRIPTION
Related: #139753, #139715

## What Problem This Solves

Resolves false runtime-validation failures after bounded same-model recovery became the default. Provider-selection fixtures spend their deadlines retrying a temporary outage, Telegram settlement waits for an outage that has not become terminal, and the repeated-request test rejects a real timeout because its diagnostic duration starts later than the timeout clock.

Also repairs the Gateway history fixture interaction between #139715 and #139753: the paging fixture still supplied the two old projection-state field names after the projection contract renamed them, causing the required core test-type stripe to fail.

## Why This Change Was Made

Use `model_not_found` to exercise selected-provider and fallback-provider hooks directly. The Telegram fixture still returns HTTP 500 and permits one real continuation, then supplies a provider retry hint beyond the existing recovery window. It preserves the exact detailed error reply and raw-error redaction, and verifies that continuation retains the request on the same model.

Recognize the repeated-request timeout from its explicit diagnostic classification, require a terminal error with `endedAt`, and classify continuation requests from their retained transcript. Keep the existing stall guard, no forced recovery, and exactly one successful queued followup. All timeout budgets remain unchanged.

Rename the history fixture's two obsolete keys to `assistantErrorPending` and `assistantErrorRecoveryObserved`, preserving their `false` values and every pagination assertion.

## User Impact

No runtime behavior changes. Maintainer validation exercises the current continuation, settlement, and projection contracts. The separate intermittent port collision did not reproduce locally; port allocation remains unchanged and no repair is claimed for it.

## Evidence

On the unchanged original base, both selected-provider cases exceeded their existing 45-second deadlines and Telegram made 18 provider requests without a settlement send. The hosted repeated-request failure recorded an explicit timeout at 89,950 ms; its duration was shorter than the request deadline because the clocks begin at different boundaries.

All five focused runtime E2E tests passed on reviewed head `85cc7c34e37`, including the 429.9-second repeated-request run. The second rebase was patch-identical and retained the exercised retry, timeout, mock-provider, and Telegram delivery implementations. Nearby optional widget-authoring forwarding is unused by these fixtures; Telegram import changes only removed a re-export layer.

The Gateway-root typecheck reproduces TS2353 before the two-key correction and passes afterward. All 30 history tests pass before and after with unchanged assertions. The formerly failing suppression-inventory test passes 2/2 after incorporating main's correction from #139747.

Full `check:changed`, formatting, and `git diff --check` pass. Independent review of the recovery repairs and a fresh review of the two-key correction have no actionable findings through P2. Fresh CI on the final pushed head remains the merge gate.
