### PR TITLE
improve(matrix): avoid spoiler parsing for ordinary replies

### DIFF
--- a/extensions/matrix/src/matrix/format-profile.ts
+++ b/extensions/matrix/src/matrix/format-profile.ts
@@ -1,10 +1,6 @@
 // Matrix helper module declares formatting capabilities and shared projections.
 import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
-import {
-  convertMarkdownTables,
-  FormatCapabilityProfile,
-  renderMarkdownWithMarkers,
-} from "openclaw/plugin-sdk/text-chunking";
+import { convertMarkdownTables, FormatCapabilityProfile } from "openclaw/plugin-sdk/text-chunking";
 
 export type MatrixSpoilerMarkers = { open: string; close: string; padding: string };
 export type MatrixSpoilerProtection = { markdown: string; markers?: MatrixSpoilerMarkers };
@@ -53,12 +49,7 @@ export function isMarkdownEscaped(markdown: string, index: number): boolean {
 }
 
 export function projectMatrixMarkdown(markdown: string): string {
-  const normalized = (markdown ?? "").replace(/\r\n?/gu, "\n");
-  return renderMarkdownWithMarkers(
-    { text: normalized, styles: [], links: [] },
-    { styleMarkers: {}, escapeText: (text) => text },
-    MATRIX_FORMAT_PROFILE,
-  );
+  return (markdown ?? "").replace(/\r\n?/gu, "\n");
 }
 
 export function renderMatrixMarkdownTables(markdown: string, mode: MarkdownTableMode): string {

--- a/extensions/matrix/src/matrix/format-spoiler-ranges.ts
+++ b/extensions/matrix/src/matrix/format-spoiler-ranges.ts
@@ -152,6 +152,9 @@ export function findMatrixMarkdownMetadataRanges(
 
 export function findMatrixSpoilerDelimiterOffsets(markdown: string): number[] {
   const projected = projectMatrixMarkdown(markdown);
+  if (!projected.includes("||")) {
+    return [];
+  }
   const tokens = spoilerParser.parse(projected, {});
   const lineStarts = [0];
   for (let index = 0; index < projected.length; index += 1) {
@@ -195,6 +198,9 @@ export function findMatrixSpoilerDelimiterOffsets(markdown: string): number[] {
 
 export function hasMatrixSpoilerMetadataCollision(markdown: string): boolean {
   const projected = projectMatrixMarkdown(markdown);
+  if (!projected.includes("||")) {
+    return false;
+  }
   const ordinary = new Set(findMatrixSpoilerDelimiterOffsets(projected));
   const underlineTags = [...tokenizeHtmlTags(projected)].filter(
     (tag) => (tag.name === "u" || tag.name === "ins") && !isMarkdownEscaped(projected, tag.start),

--- a/extensions/matrix/src/matrix/format.test.ts
+++ b/extensions/matrix/src/matrix/format.test.ts
@@ -285,9 +285,10 @@ describe("markdownToMatrixHtml", () => {
     expect(html).toBe("<p>alt</p>");
   });
 
-  it("preserves line breaks", () => {
-    const html = markdownToMatrixHtml("line1\nline2");
-    expect(html).toBe("<p>line1<br>\nline2</p>");
+  it.each(["\n", "\r\n", "\r"])("preserves %j line breaks in text and HTML", (newline) => {
+    const markdown = `line1${newline}line2`;
+    expect(markdownToMatrixBody(markdown)).toBe("line1\nline2");
+    expect(markdownToMatrixHtml(markdown)).toBe("<p>line1<br>\nline2</p>");
   });
 
   it("compacts loose ordered lists without paragraph tags", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Formatting ordinary Matrix replies and streaming previews repeatedly parses the same text for spoiler metadata even when no spoiler delimiter exists. This adds substantial temporary allocation and CPU work to normal replies.

## Why This Change Was Made

Skip spoiler analysis when normalized source has no adjacent literal pipes, and replace an empty-IR rendering pass with its existing newline normalization. Messages containing literal `||` retain the complete existing code, table, escape, metadata, and spoiler handling.

## User Impact

Matrix replies without spoiler delimiters require less formatting work. Body, HTML, mention, and chunk behavior remain unchanged; this does not alter Matrix transport or the public Plugin SDK.

## Evidence

An isolated Node 26.8.1 formatter probe preserved exact body, HTML, and mention output for 28 synthetic cases, including CR/CRLF, Unicode, literal code pipes, encoded pipes, escaped delimiters, tables, and real spoilers. A plain body now invokes MarkdownIt zero times instead of five; HTML invokes it once instead of six.

For 100 body-plus-HTML renders, five-sample median times were:

| Synthetic input | Before | After |
| --- | ---: | ---: |
| 1,775-character prose | 142.6 ms | 7.9 ms |
| 1,750-character Markdown | 1,466.2 ms | 34.7 ms |
| 590-character spoiler control | 287.3 ms | 278.7 ms |

One allocation-sampling run of 200 renders per workload showed about 99.5% fewer sampled allocated bytes for the Markdown case; the spoiler control stayed roughly flat. These are synthetic formatter measurements from separate processes, not whole-Gateway retained-heap or RSS results.

Focused formatter, send, and preparation suites passed: **163 tests in 3 files**. The existing newline test now covers LF, CRLF, and CR through both body and HTML output. The complete required changed gate passed, including extension production/test typechecks, lint, plugin boundary declarations, and repository guards. Independent source review and native autoreview found no actionable issue; native review returned `scoped-clean` at its default P0 threshold.
