### PR TITLE
improve(tui): release unused tool card payloads

### DIFF
--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -13,6 +13,35 @@ function renderToolOutput(text: string, width: number) {
 }
 
 describe("ToolExecutionComponent", () => {
+  it("keeps tool arguments, output, and running status independent across updates", () => {
+    const component = new ToolExecutionComponent("read", { path: "initial.txt" });
+    component.setPartialResult({ content: [{ type: "text", text: "partial output" }] });
+    component.setArgs({ path: "updated.txt" });
+    component.setExpanded(true);
+
+    let rendered = normalizeTestText(component.render(80).join("\n"));
+    expect(rendered).toContain("updated.txt");
+    expect(rendered).not.toContain("initial.txt");
+    expect(rendered).toContain("partial output");
+    expect(rendered).toContain("(running)");
+
+    component.setResult({ content: [{ type: "text", text: "final output" }] }, { isError: true });
+    component.setArgs({ path: "complete.txt" });
+    component.setExpanded(false);
+
+    rendered = normalizeTestText(component.render(80).join("\n"));
+    expect(rendered).toContain("complete.txt");
+    expect(rendered).toContain("final output");
+    expect(rendered).not.toContain("partial output");
+    expect(rendered).not.toContain("(running)");
+
+    component.setPartialResult(undefined);
+    rendered = normalizeTestText(component.render(80).join("\n"));
+    expect(rendered).toContain("complete.txt");
+    expect(rendered).toContain("(running)");
+    expect(rendered).not.toContain("final output");
+  });
+
   it.each(
     [
       { source: "    # heading\n    command --flag", literal: "# heading" },

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -73,9 +73,7 @@ class ToolOutputComponent extends HyperlinkMarkdown {
 }
 
 // Prefer curated display summaries, then fall back to sanitized JSON args.
-function formatArgs(toolName: string, args: unknown): string {
-  const display = resolveToolDisplay({ name: toolName, args });
-  const detail = formatToolDetail(display);
+function formatArgs(detail: string | undefined, args: unknown): string {
   if (detail) {
     return tuiFormatters.sanitizeRenderableText(detail);
   }
@@ -115,17 +113,13 @@ export class ToolExecutionComponent extends Container {
   private argsLine: Text;
   private output: ToolOutputComponent;
   private toolName: string;
-  private args: unknown;
-  private result?: ToolResult;
-  private expanded = false;
-  private isError = false;
+  private title = "";
   private isPartial = true;
 
   constructor(toolName: string, args: unknown) {
     super();
     this.toolName = toolName;
-    this.args = args;
-    this.box = new Box(1, 1, (line) => theme.toolPendingBg(line));
+    this.box = new Box(1, 1, theme.toolPendingBg);
     this.header = new Text("", 0, 0);
     this.argsLine = new Text("", 0, 0);
     this.output = new ToolOutputComponent("", 0, 0, markdownTheme, {
@@ -136,59 +130,50 @@ export class ToolExecutionComponent extends Container {
     this.box.addChild(this.header);
     this.box.addChild(this.argsLine);
     this.box.addChild(this.output);
-    this.refresh();
+    this.setArgs(args);
+    this.setPartialResult(undefined);
   }
 
   /** Re-renders tool arguments when streaming tool call input changes. */
   setArgs(args: unknown) {
-    this.args = args;
-    this.refresh();
+    const display = resolveToolDisplay({ name: this.toolName, args });
+    this.title = `${display.emoji} ${display.label}`;
+    this.refreshTitle();
+    const argLine = formatArgs(formatToolDetail(display), args);
+    this.argsLine.setText(argLine ? theme.dim(argLine) : theme.dim(" "));
   }
 
   /** Toggles preview/full output rendering for long tool results. */
   setExpanded(expanded: boolean) {
-    this.expanded = expanded;
-    this.refresh();
+    this.output.setExpanded(expanded);
   }
 
   /** Marks the tool call complete and renders final output. */
   setResult(result: ToolResult | undefined, opts?: { isError?: boolean }) {
-    this.result = result;
-    this.isPartial = false;
-    this.isError = Boolean(opts?.isError);
-    this.refresh();
+    this.updateResult(result, false, Boolean(opts?.isError));
   }
 
   /** Renders partial output while the tool call is still running. */
   setPartialResult(result: ToolResult | undefined) {
-    this.result = result;
-    this.isPartial = true;
-    this.refresh();
+    this.updateResult(result, true);
   }
 
-  private refresh() {
-    const bg = this.isPartial
-      ? theme.toolPendingBg
-      : this.isError
-        ? theme.toolErrorBg
-        : theme.toolSuccessBg;
-    this.box.setBgFn((line) => bg(line));
-
-    const display = resolveToolDisplay({
-      name: this.toolName,
-      args: this.args,
-    });
+  private refreshTitle() {
     const title = tuiFormatters.sanitizeRenderableLine(
-      `${display.emoji} ${display.label}${this.isPartial ? " (running)" : ""}`,
+      `${this.title}${this.isPartial ? " (running)" : ""}`,
     );
     this.header.setText(theme.toolTitle(theme.bold(title)));
+  }
 
-    const argLine = formatArgs(this.toolName, this.args);
-    this.argsLine.setText(argLine ? theme.dim(argLine) : theme.dim(" "));
-
-    const raw = extractText(this.result);
-    const text = raw.trim() ? raw : this.isPartial ? "…" : "";
-    this.output.setExpanded(this.expanded);
-    this.output.setText(text);
+  private updateResult(result: ToolResult | undefined, isPartial: boolean, isError = false) {
+    if (this.isPartial !== isPartial) {
+      this.isPartial = isPartial;
+      this.refreshTitle();
+    }
+    this.box.setBgFn(
+      isPartial ? theme.toolPendingBg : isError ? theme.toolErrorBg : theme.toolSuccessBg,
+    );
+    const raw = extractText(result);
+    this.output.setText(raw.trim() ? raw : isPartial ? "…" : "");
   }
 }


### PR DESCRIPTION
## What Problem This Solves

TUI tool cards kept complete argument and result objects in scrollback even though they displayed only prepared text and compact media summaries. Streaming updates and expansion toggles also repeatedly formatted unchanged arguments and invalidated their rendered lines.

## Why This Change Was Made

Prepare argument and result display data when each arrives, and retain the complete sanitized output in its existing component. Expansion now updates that component directly. Tool cards can release unused payload fields while preserving running/error/success states, formatting, colors, and full output expansion.

## User Impact

Tool-heavy TUI sessions retain less unused data and perform less repeated formatting. Visible output and controls remain unchanged. Production code shrinks by 15 lines.

## Evidence

- A synthetic 80-card probe retained all 80 argument, result, and details objects before the change; all became collectible afterward while the cards stayed alive. The fixture's additional retained heap fell from 42,194,208 to 248,288 bytes. This measures component ownership, not whole-Gateway memory usage.
- All 40 before/after rendered frames were byte-for-byte identical, including truecolor pending/error/success backgrounds, RTL titles, argument updates, expansion, and widths 20/80.
- 287 tests passed across tool execution, ChatLog, run state, and event handlers. Added public-setter coverage preserves output and status across interleaved updates.
- Independent source/evidence review found no actionable issue; native autoreview was scoped-clean at its default P0 threshold.
- The complete changed-file gate passed, including core/test typechecks, lint, dependency and architecture guards, dead exports, and runtime import cycles.
