### PR TITLE
improve(agents): reuse prompt date and time formatters

### DIFF
--- a/src/agents/date-time.test.ts
+++ b/src/agents/date-time.test.ts
@@ -1,10 +1,46 @@
-// Covers date-stamp formatting fallbacks.
+// Covers prompt date/time formatting, timezone changes, and timestamp fallbacks.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { formatDateStamp } from "./date-time.js";
+import { formatDateStamp, formatUserTime, resolveUserTimezone } from "./date-time.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("resolveUserTimezone", () => {
+  it("keeps configured zones fixed while host fallback follows timezone changes", () => {
+    const RealDateTimeFormat = Intl.DateTimeFormat;
+    let hostTimezone = "UTC";
+    // Thread workers cannot change Intl's host timezone through process.env.TZ.
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(function (locales, options) {
+      return new RealDateTimeFormat(locales, {
+        ...options,
+        timeZone: options?.timeZone ?? hostTimezone,
+      });
+    });
+    for (const timezone of ["UTC", "America/New_York", "UTC"]) {
+      hostTimezone = timezone;
+      expect(resolveUserTimezone(" Asia/Tokyo ")).toBe("Asia/Tokyo");
+      for (const configured of [undefined, "", "Invalid/Timezone"]) {
+        expect(resolveUserTimezone(configured)).toBe(timezone);
+      }
+    }
+  });
+});
 
 describe("formatDateStamp", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it("follows local midnight, DST, and timezone changes across calls", () => {
+    for (const [timestamp, timezone, expected] of [
+      ["2026-03-28T22:30:00.000Z", "Europe/Vienna", "2026-03-28"],
+      ["2026-03-28T23:30:00.000Z", "Europe/Vienna", "2026-03-29"],
+      ["2026-03-29T22:30:00.000Z", "Europe/Vienna", "2026-03-30"],
+      ["2026-03-29T22:30:00.000Z", "UTC", "2026-03-29"],
+      ["2026-03-29T22:30:00.000Z", "Europe/Vienna", "2026-03-30"],
+    ] as const) {
+      expect(formatDateStamp(Date.parse(timestamp), timezone)).toBe(expected);
+    }
+    const timestamp = Date.parse("2026-03-29T22:30:00.000Z");
+    expect(() => formatDateStamp(timestamp, "Invalid/Timezone")).toThrow(RangeError);
+    expect(formatDateStamp(timestamp, "Europe/Vienna")).toBe("2026-03-30");
   });
 
   it("falls back when nowMs is outside Date range", () => {
@@ -19,5 +55,25 @@ describe("formatDateStamp", () => {
     vi.spyOn(Date, "now").mockReturnValue(8_640_000_000_000_001);
 
     expect(formatDateStamp(8_640_000_000_000_001, "UTC")).toBe("1970-01-01");
+  });
+});
+
+describe("formatUserTime", () => {
+  it("follows timestamp, timezone, and hour-format changes across calls", () => {
+    const before = new Date("2026-03-29T00:30:00.000Z");
+    const after = new Date("2026-03-29T01:30:00.000Z");
+    for (const [date, timezone, format, expectedTime] of [
+      [before, "Europe/Vienna", "12", "1:30 AM"],
+      [before, "Europe/Vienna", "24", "01:30"],
+      [after, "Europe/Vienna", "24", "03:30"],
+      [after, "UTC", "24", "01:30"],
+      [after, "Europe/Vienna", "12", "3:30 AM"],
+    ] as const) {
+      expect(formatUserTime(date, timezone, format)).toBe(
+        `Sunday, March 29th, 2026 - ${expectedTime}`,
+      );
+    }
+    expect(formatUserTime(after, "Invalid/Timezone", "12")).toBeUndefined();
+    expect(formatUserTime(after, "Europe/Vienna", "12")).toBe("Sunday, March 29th, 2026 - 3:30 AM");
   });
 });

--- a/src/agents/date-time.ts
+++ b/src/agents/date-time.ts
@@ -7,6 +7,11 @@ import { resolveDateTimestampMs } from "@openclaw/normalization-core/number-coer
 type ResolvedTimeFormat = "12" | "24";
 
 let cachedTimeFormat: ResolvedTimeFormat | undefined;
+// Retain only the latest timezone formatter for each prompt format.
+let dateStampFormatter: { timeZone: string; formatter: Intl.DateTimeFormat } | undefined;
+let userTimeFormatter:
+  | { timeZone: string; format: ResolvedTimeFormat; formatter: Intl.DateTimeFormat }
+  | undefined;
 
 function buildNormalizedTimestamp(
   timestampMs: number,
@@ -23,7 +28,7 @@ export function resolveUserTimezone(configured?: string): string {
   const trimmed = configured?.trim();
   if (trimmed) {
     try {
-      new Intl.DateTimeFormat("en-US", { timeZone: trimmed }).format(new Date());
+      getDateStampFormatter(trimmed);
       return trimmed;
     } catch {
       // ignore invalid timezone
@@ -45,16 +50,25 @@ export function resolveUserTimeFormat(preference?: "auto" | "12" | "24"): Resolv
   return cachedTimeFormat;
 }
 
-/** Format a stable YYYY-MM-DD stamp in the requested timezone. */
-export function formatDateStamp(nowMs: number, timeZone: string): string {
-  const timestampMs = resolveDateTimestampMs(nowMs);
-  const date = new Date(timestampMs);
-  const parts = new Intl.DateTimeFormat("en-US", {
+function getDateStampFormatter(timeZone: string): Intl.DateTimeFormat {
+  if (dateStampFormatter?.timeZone === timeZone) {
+    return dateStampFormatter.formatter;
+  }
+  const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone,
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
-  }).formatToParts(date);
+  });
+  dateStampFormatter = { timeZone, formatter };
+  return formatter;
+}
+
+/** Format a stable YYYY-MM-DD stamp in the requested timezone. */
+export function formatDateStamp(nowMs: number, timeZone: string): string {
+  const timestampMs = resolveDateTimestampMs(nowMs);
+  const date = new Date(timestampMs);
+  const parts = getDateStampFormatter(timeZone).formatToParts(date);
   const year = parts.find((part) => part.type === "year")?.value;
   const month = parts.find((part) => part.type === "month")?.value;
   const day = parts.find((part) => part.type === "day")?.value;
@@ -237,16 +251,24 @@ export function formatUserTime(
 ): string | undefined {
   const use24Hour = format === "24";
   try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      weekday: "long",
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: use24Hour ? "2-digit" : "numeric",
-      minute: "2-digit",
-      hourCycle: use24Hour ? "h23" : "h12",
-    }).formatToParts(date);
+    let formatter =
+      userTimeFormatter?.timeZone === timeZone && userTimeFormatter.format === format
+        ? userTimeFormatter.formatter
+        : undefined;
+    if (!formatter) {
+      formatter = new Intl.DateTimeFormat("en-US", {
+        timeZone,
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: use24Hour ? "2-digit" : "numeric",
+        minute: "2-digit",
+        hourCycle: use24Hour ? "h23" : "h12",
+      });
+      userTimeFormatter = { timeZone, format, formatter };
+    }
+    const parts = formatter.formatToParts(date);
     const map: Record<string, string> = {};
     for (const part of parts) {
       if (part.type !== "literal") {


### PR DESCRIPTION
## What Problem This Solves

Repeated prompt preparation and current-time rendering construct new timezone formatters for the same settings, adding native allocation and CPU work to agent turns.

## Why This Change Was Made

Reuse the latest date-stamp formatter and localized-time formatter, and use the date-stamp owner for configured-timezone validation. Missing or invalid configuration still resolves the host timezone on each call. Formatting options, timestamp fallbacks, and error behavior remain unchanged.

## User Impact

Prompt and current-time preparation do less repeated work. Each format retains only its latest key. Startup's local/UTC alternation still replaces the date formatter, but sharing validation removes one of its three constructions. The production change adds 22 lines.

## Evidence

On macOS with Node 26.8.1, medians of three fresh-process runs of 3,000 iterations preserved exact output hashes:

| Owner workload | Before | After | Formatter constructions per 10 warm iterations |
| --- | ---: | ---: | ---: |
| Same-zone prompt preparation | 152.3 ms | 4.62 ms | 20 → 0 |
| Startup resolver, local date, UTC date | 234.5 ms | 153.4 ms | 30 → 20 |
| Same-zone current-time formatting | 160.6 ms | 7.33 ms | 20 → 0 |
| Prompt with live host-zone fallback | 146.9 ms | 74.1 ms | 20 → 10 |

Post-GC process RSS growth in those bursts fell from 168.5 to 1.28 MiB for the same-zone prompt and from 230.0 to 168.7 MiB for alternating startup. These are local owner microbenchmarks, not whole-Gateway memory or leak claims.

Focused date, current-time, prompt-parameter, envelope, startup, and post-compaction tests pass. Real standalone Node checks cover host timezone changes, midnight/DST, invalid zones, and invalid timestamps. The worker test delegates construction to native Intl so each simulated host zone is captured by the created formatter.

The complete changed check passed, including production/test typechecking, formatting, lint and repository guards. Independent owner/caller review found no actionable findings; Codex autoreview returned scoped-clean at its P0 threshold.
