### PR TITLE
improve(plugins): avoid broad runtime loading for supplied hooks

### DIFF
--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -213,7 +213,7 @@ export function createLazyPluginRuntime(params: {
   const getRuntimeProperty = (prop: PropertyKey, ...receiver: [] | [unknown]): unknown => {
     // Prepared metadata and host facades must not initialize broad runtime services.
     if (!resolvedRuntime) {
-      if (prop === "gateway" || prop === "nodes" || prop === "subagent") {
+      if (prop === "gateway" || prop === "hooks" || prop === "nodes" || prop === "subagent") {
         const value = params.runtimeOptions?.[prop];
         if (value !== undefined) {
           return value;

--- a/src/plugins/loader.runtime-registry.test.ts
+++ b/src/plugins/loader.runtime-registry.test.ts
@@ -347,6 +347,9 @@ it("keeps an empty scoped handle load from replacing the root registry", () => {
 
 it("keeps version and injected instance surfaces independent of the broad runtime module", () => {
   const gateway = {} as PluginRuntime["gateway"];
+  const hooks = {
+    dispatchHookAgentTurn: vi.fn<PluginRuntime["hooks"]["dispatchHookAgentTurn"]>(),
+  };
   const nodes = {} as PluginRuntime["nodes"];
   const subagent = {} as PluginRuntime["subagent"];
   const loadPluginModule = vi.fn((_modulePath: string): unknown => {
@@ -354,7 +357,7 @@ it("keeps version and injected instance surfaces independent of the broad runtim
   });
   const runtime = createLazyPluginRuntime({
     loadPluginModule,
-    runtimeOptions: { gateway, nodes, subagent },
+    runtimeOptions: { gateway, hooks, nodes, subagent },
   });
 
   expect(runtime.version).toBe(VERSION);
@@ -393,6 +396,7 @@ it("keeps version and injected instance surfaces independent of the broad runtim
   }
   for (const [key, instance] of [
     ["gateway", gateway],
+    ["hooks", hooks],
     ["nodes", nodes],
     ["subagent", subagent],
   ] as const) {

--- a/src/plugins/registry-runtime.hooks.test.ts
+++ b/src/plugins/registry-runtime.hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { createLazyPluginRuntime } from "./loader-module-runtime.js";
 import { createPluginRegistry } from "./registry.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
-import { createPluginRuntime } from "./runtime/index.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { createPluginRecord } from "./status.test-fixtures.js";
 
@@ -13,6 +13,15 @@ const hookTurn = {
   externalContentSource: "email",
   deliver: false,
 } satisfies Parameters<PluginRuntime["hooks"]["dispatchHookAgentTurn"]>[0];
+
+function createHookRuntime(hooks: PluginRuntime["hooks"]): PluginRuntime {
+  return createLazyPluginRuntime({
+    runtimeOptions: { hooks },
+    loadPluginModule: () => {
+      throw new Error("Prepared hooks must not load the broad runtime");
+    },
+  });
+}
 
 describe("plugin runtime hook dispatch ownership", () => {
   it.each([
@@ -26,7 +35,7 @@ describe("plugin runtime hook dispatch ownership", () => {
     });
     const builder = createPluginRegistry({
       logger: { info() {}, warn() {}, error() {}, debug() {} },
-      runtime: createPluginRuntime({ hooks: { dispatchHookAgentTurn } }),
+      runtime: createHookRuntime({ dispatchHookAgentTurn }),
       activateGlobalSideEffects: false,
     });
     const record = createPluginRecord({ id: "trusted-mail", ...ownership });
@@ -48,7 +57,7 @@ describe("plugin runtime hook dispatch ownership", () => {
     }));
     const builder = createPluginRegistry({
       logger: { info() {}, warn() {}, error() {}, debug() {} },
-      runtime: createPluginRuntime({ hooks: { dispatchHookAgentTurn } }),
+      runtime: createHookRuntime({ dispatchHookAgentTurn }),
       activateGlobalSideEffects: false,
     });
     const record = createPluginRecord({ id: "untrusted-mail", origin: "workspace" });


### PR DESCRIPTION
## What Problem This Solves

Reading an already supplied hook dispatch facade requested the broad plugin runtime module and constructed its runtime object before returning that same facade. This affected the IMAP watcher's first admitted message dispatch and coupled hook access to unrelated runtime services.

## Why This Change Was Made

Route injected hooks through the existing lazy facade branch alongside Gateway, nodes, and subagents. Registry trust and identity checks and the Gateway lifetime resolver remain in place. Absent hooks and later runtime materialization retain their existing behavior.

## User Impact

Plugins can use supplied hooks without first loading unrelated runtime services. Hook dispatch ownership and behavior remain unchanged.

## Evidence

- The existing injected-property table and three scoped hook identity/trust tests exercise this path without a broad runtime loader. All four failed on the original code at the unexpected load; both complete focused files now pass all 31 tests.
- A synthetic owner probe confirms first supplied-hook access drops from one module-loader request and factory call to zero. Absent injection and later materialization still invoke the factory once.
- Independent review and isolated autoreview through P2 found no actionable issues.
- The full build, isolated built IMAP entrypoint profile, and complete changed checks passed.
