### PR TITLE
test(daemon): reuse scoped environment helper

### DIFF
--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -4,7 +4,7 @@ import { PassThrough } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PortListener } from "../infra/ports-types.js";
-import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
 import type { ExecResult } from "./exec-file.js";
 import {
@@ -276,33 +276,6 @@ function launchAgentControlFixture(
   overrides: Omit<LaunchAgentControlFixture, "env" | "stdout"> = {},
 ): LaunchAgentControlFixture {
   return { env, stdout: new PassThrough(), ...overrides };
-}
-
-async function withProcessEnv<T>(
-  overrides: Record<string, string | undefined>,
-  fn: () => Promise<T>,
-): Promise<T> {
-  const previous = new Map<string, string | undefined>();
-  for (const key of Object.keys(overrides)) {
-    previous.set(key, process.env[key]);
-    const value = overrides[key];
-    if (value === undefined) {
-      deleteTestEnvValue(key);
-    } else {
-      setTestEnvValue(key, value);
-    }
-  }
-  try {
-    return await fn();
-  } finally {
-    for (const [key, value] of previous) {
-      if (value === undefined) {
-        deleteTestEnvValue(key);
-      } else {
-        setTestEnvValue(key, value);
-      }
-    }
-  }
 }
 
 async function runStopLaunchAgentWithFakeTimers(args: Parameters<typeof stopLaunchAgent>[0]) {
@@ -773,7 +746,7 @@ describe("launchd process ancestry guards", () => {
         getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
       }
 
-      const result = await withProcessEnv(
+      const result = await withEnvAsync(
         {
           LAUNCH_JOB_LABEL: undefined,
           LAUNCH_JOB_NAME: undefined,
@@ -818,7 +791,7 @@ describe("launchd process ancestry guards", () => {
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
 
-      await withProcessEnv(
+      await withEnvAsync(
         {
           LAUNCH_JOB_LABEL: undefined,
           LAUNCH_JOB_NAME: undefined,
@@ -846,7 +819,7 @@ describe("launchd process ancestry guards", () => {
     const serviceId = `${domain}/ai.openclaw.gateway`;
     getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -879,7 +852,7 @@ describe("launchd process ancestry guards", () => {
       state.serviceStates.set(serviceId, "running");
       getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
 
-      await withProcessEnv(
+      await withEnvAsync(
         {
           LAUNCH_JOB_LABEL: undefined,
           LAUNCH_JOB_NAME: undefined,
@@ -913,7 +886,7 @@ describe("launchd process ancestry guards", () => {
     state.serviceStates.set(legacyServiceId, "running");
     getSelfAndAncestorPidsSync.mockReturnValue(new Set([process.pid, process.ppid, 4242]));
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -1794,7 +1767,7 @@ describe("launchd uninstall", () => {
     const previous = "RunAtLoad=true";
     state.files.set(plistPath, previous);
 
-    await withProcessEnv({ XPC_SERVICE_NAME: "ai.openclaw.gateway" }, async () => {
+    await withEnvAsync({ XPC_SERVICE_NAME: "ai.openclaw.gateway" }, async () => {
       await expect(uninstallLaunchAgent({ env, stdout: new PassThrough() })).rejects.toThrow(
         "Refusing to uninstall LaunchAgent ai.openclaw.gateway from inside ai.openclaw.gateway",
       );
@@ -1912,7 +1885,7 @@ describe("launchd install", () => {
   it("refuses an in-band reinstall before booting out its own LaunchAgent", async () => {
     const env = createDefaultLaunchdEnv();
 
-    await withProcessEnv({ XPC_SERVICE_NAME: "ai.openclaw.gateway" }, async () => {
+    await withEnvAsync({ XPC_SERVICE_NAME: "ai.openclaw.gateway" }, async () => {
       await expect(
         installLaunchAgent({
           env,
@@ -1931,7 +1904,7 @@ describe("launchd install", () => {
   it("refuses an in-band label migration before mutating either LaunchAgent", async () => {
     const env = createDefaultLaunchdEnv();
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         XPC_SERVICE_NAME: "0",
         OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
@@ -2683,7 +2656,7 @@ describe("launchd install", () => {
     "refuses in-band LaunchAgent stop before any native mutation (disable=%s)",
     async (disable) => {
       const env = createDefaultLaunchdEnv();
-      await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () => {
+      await withEnvAsync({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () => {
         await expect(stopLaunchAgent({ env, stdout: new PassThrough(), disable })).rejects.toThrow(
           "Refusing to stop LaunchAgent ai.openclaw.gateway from inside the same launchd service",
         );
@@ -2696,7 +2669,7 @@ describe("launchd install", () => {
     const env = createDefaultLaunchdEnv();
     state.disableCode = 0;
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
       },
@@ -2716,7 +2689,7 @@ describe("launchd install", () => {
   it("does not park an external LaunchAgent", async () => {
     const env = createDefaultLaunchdEnv();
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -2746,7 +2719,7 @@ describe("launchd install", () => {
       value: Promise.resolve(false),
     });
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: "ai.openclaw.gateway",
       },
@@ -2767,7 +2740,7 @@ describe("launchd install", () => {
   it("refuses in-band LaunchAgent stop when XPC_SERVICE_NAME is inherited", async () => {
     const env = createDefaultLaunchdEnv();
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -2794,7 +2767,7 @@ describe("launchd install", () => {
     let output = "";
     const stdout = capturePassThroughOutput((text) => (output += text));
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -2957,7 +2930,7 @@ describe("launchd install", () => {
     });
     probePortUsage.mockResolvedValue("busy");
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -3792,7 +3765,7 @@ describe("launchd install", () => {
   it("hands restart off to a detached helper when invoked from the current LaunchAgent", async () => {
     const env = createDefaultLaunchdEnv();
 
-    const result = await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+    const result = await withEnvAsync({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
       restartLaunchAgent(launchAgentControlFixture(env)),
     );
 
@@ -3813,7 +3786,7 @@ describe("launchd install", () => {
       "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
     ]);
 
-    const result = await withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+    const result = await withEnvAsync({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
       restartLaunchAgent(launchAgentControlFixture(env)),
     );
 
@@ -3835,7 +3808,7 @@ describe("launchd install", () => {
     });
 
     await expect(
-      withProcessEnv({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
+      withEnvAsync({ LAUNCH_JOB_LABEL: "ai.openclaw.gateway" }, async () =>
         restartLaunchAgent({
           env,
           stdout: new PassThrough(),
@@ -3847,7 +3820,7 @@ describe("launchd install", () => {
   it("hands restart off when XPC_SERVICE_NAME is inherited", async () => {
     const env = createDefaultLaunchdEnv();
 
-    const result = await withProcessEnv(
+    const result = await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -3874,7 +3847,7 @@ describe("launchd install", () => {
     state.kickstartError = "Could not find service";
     state.kickstartFailuresRemaining = 1;
 
-    const result = await withProcessEnv(
+    const result = await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -3906,7 +3879,7 @@ describe("launchd install", () => {
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const serviceId = `${domain}/ai.openclaw.gateway`;
 
-    const result = await withProcessEnv(
+    const result = await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,
@@ -3932,7 +3905,7 @@ describe("launchd install", () => {
   it("does not hand restart off for unrelated inherited XPC service names", async () => {
     const env = createDefaultLaunchdEnv();
 
-    await withProcessEnv(
+    await withEnvAsync(
       {
         LAUNCH_JOB_LABEL: undefined,
         LAUNCH_JOB_NAME: undefined,


### PR DESCRIPTION
Related: #135868, #139694

## What Problem This Solves

The LaunchAgent suite maintains a private copy of the shared asynchronous environment fixture, so future restoration fixes could reach one implementation and miss the other. This is the required follow-up to test-deslop stage 2 of the maintainer-requested #135868 campaign, in the daemon neighborhood of concern D (§1 and §5 of the decision brief).

## Why This Change Was Made

Use the already imported `withEnvAsync` for every scoped environment callback and remove the duplicate `withProcessEnv` implementation and unused setter/deleter imports. All overrides, callbacks, assertions, return values, and tests remain unchanged. Both implementations restore the supplied keys in `finally`; the shared helper already has independent restoration coverage.

## User Impact

No runtime behavior change. One test file loses 27 lines (+23/-50), from 4,030 to 4,003. Production, tooling, and docs are +0/-0; no tests or baseline entries are deleted. This would bring the lane's landed reduction to 292 test lines. The original supplied +94 campaign tally would be -198; including the separately assigned +412 Crabbox-wrapper target, the expanded tracked tally would be +214 before other lanes' changes.

## Evidence

The paired standard daemon-directory runs use baseline `932886441a3` and the same repository routing:

| Run | Files | Cases | Passed / skipped | Vitest time | Wrapper time |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before | 40 | 1,353 | 1,344 / 9 | 34.01s | 39.88s |
| After | 40 | 1,353 | 1,344 / 9 | 39.73s | 45.00s |

Both runs passed. The standard suite excludes explicitly named optional native E2E files. All 10 existing `src/test-utils/env.test.ts` cases also passed (1.09s). Cache and host load differed; timings are not a performance claim.

The removed helper's contract remains covered by `src/test-utils/env.test.ts:88` (async rejection restores prior values), `:102` (callback result and successful restoration), and `:112` (temporary deletion restores the original value). The complete LaunchAgent suite continues to exercise every original environment override and lifecycle assertion through the canonical helper at `src/test-utils/env.ts:140`. No test case or assertion was removed.

Full changed checks passed, including the services type graph, all selected guards, all three dead-export scans, formatting and lint. Fresh local and committed-branch Codex reviews are scoped-clean through P2 (no actionable findings, confidence 0.99). Branch review used 4a81b501d597; the published landing candidate is af40e3430d5e after the required main refreshes with byte-identical changed test, canonical helper, inspected owners and lockfile. Exact-head CI [34012004702](https://github.com/openclaw/openclaw/actions/runs/34012004702) passed on af40e3430d5e. Native Testbox-backed prepare completed on the same unchanged head.

ClawSweeper [reviewed af40e3430d5e](https://github.com/openclaw/openclaw/pull/139743#issuecomment-5556976467) with no findings, no before-merge requirements, and no rank-up moves to apply.
