### PR TITLE
fix(test): make process registration fixtures work under Bun

### DIFF
--- a/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.procfs.test.ts
@@ -1,11 +1,10 @@
-import { ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { PassThrough } from "node:stream";
 import { createPluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-store-runtime";
 import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
 import { prepareCodexAppServerProcessRegistration } from "./transport-process-registration.js";
+import { RegistrationTestChildProcess } from "./transport-process-registration.test-support.js";
 import { readCodexAppServerProcessSnapshot } from "./transport-process-snapshot.js";
 
 const procfs = vi.hoisted(() => ({ files: new Map<string, string | Error | (() => string)>() }));
@@ -131,26 +130,11 @@ describe("Codex registration procfs boundary", () => {
     "registers a direct child despite an unreadable unrelated process only with usable ownership: %s",
     async (mode, ctx) => {
       addProcess(child.pid, process.pid);
-      const stdin = new PassThrough();
-      const stdout = new PassThrough();
-      const stderr = new PassThrough();
-      const spawned = Object.assign(new ChildProcess(), {
-        pid: child.pid,
-        stdin,
-        stdout,
-        stderr,
-        stdio: [stdin, stdout, stderr, null, null] as [
-          PassThrough,
-          PassThrough,
-          PassThrough,
-          null,
-          null,
-        ],
-      });
+      const spawned = new RegistrationTestChildProcess(child.pid);
       ctx.onTestFinished(() => {
-        stdin.destroy();
-        stdout.destroy();
-        stderr.destroy();
+        spawned.stdin.destroy();
+        spawned.stdout.destroy();
+        spawned.stderr.destroy();
         spawned.removeAllListeners();
       });
       const register = await prepareCodexAppServerProcessRegistration();

--- a/extensions/codex/src/app-server/transport-process-registration.test-support.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test-support.ts
@@ -1,0 +1,28 @@
+import { ChildProcess } from "node:child_process";
+import { PassThrough } from "node:stream";
+
+export class RegistrationTestChildProcess extends ChildProcess {
+  override pid!: number;
+  override stdin!: PassThrough;
+  override stdout!: PassThrough;
+  override stderr!: PassThrough;
+  override stdio!: [PassThrough, PassThrough, PassThrough, null, null];
+
+  constructor(pid: number) {
+    super();
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const stdio: RegistrationTestChildProcess["stdio"] = [stdin, stdout, stderr, null, null];
+    // Bun inherits getter-only stdio properties. Define the fixture's own mutable
+    // fields instead of assigning through those accessors.
+    for (const [key, value] of Object.entries({ pid, stdin, stdout, stderr, stdio })) {
+      Object.defineProperty(this, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+    }
+  }
+}

--- a/extensions/codex/src/app-server/transport-process-registration.test.ts
+++ b/extensions/codex/src/app-server/transport-process-registration.test.ts
@@ -1,9 +1,7 @@
-import { ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { PassThrough } from "node:stream";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { terminateCodexAppServerOrphan } from "./transport-process-containment.js";
@@ -11,6 +9,7 @@ import {
   createCodexAppServerProcessReaperService,
   prepareCodexAppServerProcessRegistration,
 } from "./transport-process-registration.js";
+import { RegistrationTestChildProcess } from "./transport-process-registration.test-support.js";
 import {
   ProcessInspectionError,
   readCodexAppServerProcessCommand,
@@ -190,24 +189,7 @@ describe("Codex process registration", () => {
       if (mode === "windows") {
         vi.spyOn(process, "platform", "get").mockReturnValue("win32");
       }
-      const stdin = new PassThrough();
-      const stdout = new PassThrough();
-      const stderr = new PassThrough();
-      // The typed stdio tuple makes this fixture structurally a
-      // ChildProcessWithoutNullStreams without widening casts.
-      const spawned = Object.assign(new ChildProcess(), {
-        pid: child.pid,
-        stdin,
-        stdout,
-        stderr,
-        stdio: [stdin, stdout, stderr, null, null] as [
-          PassThrough,
-          PassThrough,
-          PassThrough,
-          null,
-          null,
-        ],
-      });
+      const spawned = new RegistrationTestChildProcess(child.pid);
       ctx.onTestFinished(() => {
         spawned.stdin.destroy();
         spawned.stdout.destroy();


### PR DESCRIPTION
## What Problem This Solves

Fixes 14 Bun failures in process-registration tests where fixture setup assigned through inherited getter-only ChildProcess stream properties before reaching the ownership assertions.

## Why This Change Was Made

A shared test-only ChildProcess subclass defines its own mutable PID and non-null stream fields. It retains ChildProcess/EventEmitter behavior and the existing cleanup, replacing duplicated Object.assign fixture setup.

## User Impact

Developers can run the existing process-registration and procfs boundary tests under both Node and Bun. Production registration, process inspection, and cleanup authority are unchanged.

## Evidence

- 39 focused tests passed on Node and 39 on true Bun; all 14 original fixture failures are resolved.
- Complete changed-file gate passed; independent P0–P2 review found no actionable findings.
- Existing registration, ownership, and lifecycle assertions remain unchanged. The non-null stream tuple is explicitly typed without the previous tuple casts.
- The wider Bun compatibility campaign remains in progress.
