### PR TITLE
test(agents): share fresh zero-usage input fixtures

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -16,6 +16,7 @@ import {
 import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../embedded-agent-runner/extensions.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { jsonResult } from "../tools/common.js";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../workspace-bootstrap-read.js";
 import * as compactionQualityModule from "./compaction-safeguard-quality.js";
@@ -2256,14 +2257,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
             api: model.api,
             provider: model.provider,
             model: model.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsageFixture(),
             stopReason: "stop",
             timestamp: 1,
           },
@@ -2341,14 +2335,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
           api: model.api,
           provider: model.provider,
           model: model.id,
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
+          usage: createZeroUsageFixture(),
           stopReason: "error",
           errorMessage: "Cannot convert undefined or null to object",
           timestamp: 1,

--- a/src/agents/agent-tools.schema.test.ts
+++ b/src/agents/agent-tools.schema.test.ts
@@ -28,20 +28,14 @@ import {
   BEFORE_TOOL_CALL_HOOK_CONTEXT,
   BEFORE_TOOL_CALL_SOURCE_TOOL,
 } from "./before-tool-call-metadata.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 const beforeToolCallTesting = {
   BEFORE_TOOL_CALL_HOOK_CONTEXT,
   BEFORE_TOOL_CALL_SOURCE_TOOL,
 };
 
-const TEST_USAGE = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
+const TEST_USAGE = createZeroUsageFixture();
 
 describe("direct exec tool schema", () => {
   it("keeps model-facing descriptions compact without hiding runtime constraints", () => {

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -99,6 +99,7 @@ import {
   captureRoutingDecisionWork,
   createModelRoutingTestAdmission,
 } from "../test-helpers/model-routing-decision-e2e-fixtures.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
 import { prepareClaudeCliSkillsPlugin } from "./claude-skills-plugin.js";
 import { executePluginOwnedProcess } from "./execute-plugin.js";
@@ -2027,14 +2028,7 @@ describe("prepareCliRunContext", () => {
         api: "responses",
         provider: "test-cli",
         model: "test-model",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "stop",
         timestamp: 2,
       },
@@ -6017,14 +6011,7 @@ describe("prepareCliRunContext", () => {
         api: "responses",
         provider: "test-cli",
         model: "test-model",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "stop",
         timestamp: 2,
       },

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -26,6 +26,7 @@ import {
 } from "./code-mode.test-support.js";
 import { Agent } from "./runtime/index.js";
 import { createReadTool } from "./sessions/tools/read.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 import { isToolResultError, readToolResultDetails } from "./tool-result-error.js";
 import { jsonResult, ToolInputError, type AnyAgentTool } from "./tools/common.js";
 
@@ -49,14 +50,7 @@ function createAssistant(content: AssistantMessage["content"]): AssistantMessage
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: content.some((entry) => entry.type === "toolCall") ? "toolUse" : "stop",
     timestamp: Date.now(),
   };

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -7,6 +7,7 @@ import {
   projectCompactionMessagesForPlanning,
 } from "./compaction-planning.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 describe("compaction token accounting sanitization", () => {
   it("projects worker inputs to planning-safe messages before cloning", () => {
@@ -130,14 +131,7 @@ describe("compaction token accounting sanitization", () => {
             },
           },
         ],
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "toolUse",
         timestamp: 1,
       },
@@ -215,14 +209,7 @@ describe("compaction token accounting sanitization", () => {
         provider: "openai",
         model: "gpt-5.6-luna",
         content: [{ type: "toolCall", id: "call_late", name: "read", arguments: { path: "x" } }],
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "toolUse",
         timestamp: 9,
       } satisfies AgentMessage,

--- a/src/agents/embedded-agent-helpers/assistant-message-failures.test.ts
+++ b/src/agents/embedded-agent-helpers/assistant-message-failures.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { classifyAssistantFailoverReason } from "./assistant-message-failures.js";
 
 describe("classifyAssistantFailoverReason", () => {
@@ -7,14 +8,7 @@ describe("classifyAssistantFailoverReason", () => {
     api: "openai-completions" as const,
     provider: "opencode-go",
     model: "deepseek-v4-flash",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "error" as const,
     errorMessage: "opencode-go stream timed out after provider-owned SSE boundary stalled",
     content: [],
@@ -60,14 +54,7 @@ describe("classifyAssistantFailoverReason", () => {
         api: "openai-completions",
         provider: "openai",
         model: "some-model-id",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "error",
         errorMessage: "400 Param Incorrect",
         errorCode: "400",

--- a/src/agents/embedded-agent-helpers/openai.test.ts
+++ b/src/agents/embedded-agent-helpers/openai.test.ts
@@ -2,16 +2,10 @@
 import type { AssistantMessage, ToolResultMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import type { AgentMessage } from "../runtime/index.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { normalizeOpenAIResponsesToolCallIds } from "./openai.js";
 
-const ZERO_USAGE = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-} as const;
+const ZERO_USAGE = createZeroUsageFixture();
 
 function buildAssistantToolCall(rawId: string): AssistantMessage {
   return {

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -7,6 +7,7 @@ import {
   testing as extraParamsTesting,
   type WrapProviderStreamFnParams,
 } from "./embedded-agent-runner/extra-params.test-support.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 vi.mock("../plugins/provider-hook-runtime.js", () => ({
   clearProviderRuntimePluginCacheForTest: vi.fn(),
@@ -855,14 +856,7 @@ describe("applyExtraParamsToAgent", () => {
       api: "openai-completions",
       provider: "opencode",
       model: "xiaomi/mimo-v2-pro",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: 1,
     } as const;

--- a/src/agents/embedded-agent-runner/replay-history.test.ts
+++ b/src/agents/embedded-agent-runner/replay-history.test.ts
@@ -8,6 +8,7 @@ import {
   INTERNAL_RUNTIME_CONTEXT_END,
   OPENCLAW_RUNTIME_CONTEXT_NOTICE,
 } from "../internal-runtime-context.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { normalizeAssistantReplayContent } from "./replay-history.js";
 
 // Preface of carriers persisted before the stable system prompt explained the markers.
@@ -60,14 +61,7 @@ function openclawTranscriptAssistant(model: "delivery-mirror" | "gateway-injecte
     api: OPENCLAW_TRANSCRIPT_ARTIFACT_API,
     provider: "openclaw",
     model,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: 0,
   } as unknown as AgentMessage;

--- a/src/agents/embedded-agent-runner/run/attempt-transcript-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-transcript-recovery.test.ts
@@ -4,6 +4,7 @@ import { openOpenClawAgentDatabase } from "../../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/session-manager.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { stripSessionsYieldArtifacts } from "./attempt-sessions-yield.js";
 import {
   normalizeCompactionRecoveryTranscriptTail,
@@ -32,14 +33,7 @@ it.each(["yield", "precheck", "compaction"])(
         stopReason: "error",
         errorMessage: MID_TURN_PRECHECK_ERROR_MESSAGE,
         timestamp: 2,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
       };
       sessionManager.appendMessage(user);
       sessionManager.appendMessage(error);

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-continuation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-continuation.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../code-mode.test-support.js";
 import { Agent, type AgentTool } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/session-manager.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { isToolResultError } from "../../tool-result-error.js";
 import { jsonResult } from "../../tools/common.js";
 import {
@@ -47,14 +48,7 @@ function streamAssistant(content: AssistantMessage["content"]) {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: content.some((entry) => entry.type === "toolCall") ? "toolUse" : "stop",
     timestamp: Date.now(),
   };

--- a/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "../../../llm/types.js";
 import type { AgentMessage } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/session-manager.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { stripSessionsYieldArtifacts } from "./attempt-sessions-yield.js";
 
 const SESSIONS_YIELD_INTERRUPT_CUSTOM_TYPE = "openclaw.sessions_yield_interrupt";
@@ -13,14 +14,7 @@ function makeAssistantMessage(overrides: Partial<AssistantMessage> = {}): Assist
     api: "openai-responses",
     provider: "openai",
     model: "test-model",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: Date.now(),
     ...overrides,

--- a/src/agents/embedded-agent-runner/run/attempt.stop-reason-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.stop-reason-recovery.test.ts
@@ -6,6 +6,7 @@ import {
   type Model,
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { wrapStreamFnHandleSensitiveStopReason } from "./attempt-stop-reason-recovery.js";
 
 const anthropicModel = {
@@ -30,14 +31,7 @@ describe("wrapStreamFnHandleSensitiveStopReason", () => {
             api: anthropicModel.api,
             provider: anthropicModel.provider,
             model: anthropicModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsageFixture(),
             stopReason: "error",
             errorMessage: "Unhandled stop reason: sensitive",
             timestamp: Date.now(),

--- a/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts
@@ -14,6 +14,7 @@ import type { createOpenClawCodingTools } from "../../agent-tools.js";
 import { Agent, type AgentEvent, type AgentTool } from "../../runtime/index.js";
 import { getInternalToolExecutionPreparer } from "../../runtime/internal-hooks.js";
 import { SessionManager } from "../../sessions/session-manager.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { TOOL_EXECUTION_GATED_MESSAGE } from "../../tool-policy-shared.js";
 import { isToolResultError } from "../../tool-result-error.js";
 import type { ToolSearchCatalogRef } from "../../tool-search.js";
@@ -152,14 +153,7 @@ describe("runEmbeddedAttempt tool-search catalog cleanup", () => {
                 api: options.model.api,
                 provider: options.model.provider,
                 model: options.model.id,
-                usage: {
-                  input: 0,
-                  output: 0,
-                  cacheRead: 0,
-                  cacheWrite: 0,
-                  totalTokens: 0,
-                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-                },
+                usage: createZeroUsageFixture(),
                 stopReason: turn === 1 ? "toolUse" : "stop",
                 timestamp: Date.now(),
               };

--- a/src/agents/embedded-agent-runner/run/failover-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.test.ts
@@ -2,6 +2,7 @@
 // profile rotation, fallback model escalation, and user-visible errors.
 import { describe, expect, it } from "vitest";
 import { classifyAssistantFailoverReason } from "../../embedded-agent-helpers.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { mergeRetryFailoverReason, resolveRunFailoverDecision } from "./failover-policy.js";
 
 describe("resolveRunFailoverDecision", () => {
@@ -362,14 +363,7 @@ describe("resolveRunFailoverDecision", () => {
       api: "openai-completions" as const,
       provider: "opencode-go",
       model: "deepseek-v4-flash",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "error" as const,
       errorMessage: "opencode-go stream timed out after provider-owned SSE boundary stalled",
       content: [],

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -3,6 +3,7 @@
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { resolveRetryAfterMs } from "../../failover/retry-evidence.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import type { NormalizedUsage } from "../../usage.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "../usage-accumulator.js";
 import {
@@ -52,14 +53,7 @@ function makeAssistantMessage(
     api: "responses",
     provider: "openai",
     model: "gpt-5.4",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     role: "assistant",
     content,
     timestamp: Date.now(),

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.test.ts
@@ -3,6 +3,7 @@ import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,
 } from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import {
   resolveEmptyResponseRetryInstruction,
   resolveReasoningOnlyRetryInstruction,
@@ -149,14 +150,7 @@ describe("incomplete-turn recovery policy", () => {
         provider: "anthropic",
         model: "claude-opus-4.7",
         content: [],
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
       }),
     },
     {

--- a/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/run/message-tool-terminal.test.ts
@@ -3,6 +3,7 @@
 // the run before the model can observe the tool result.
 import type { Agent, AfterToolCallContext } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 
 async function recordsDeliveredSourceReply(params: {
@@ -475,14 +476,7 @@ function createToolCallAssistant(
     api: "openai-responses",
     provider: "openai",
     model: "gpt-5.5",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "toolUse",
     timestamp: 0,
   };

--- a/src/agents/embedded-agent-runner/run/terminal-outcome.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-outcome.test.ts
@@ -4,6 +4,7 @@ import {
   createAgentRunRestartAbortError,
   createAgentRunSupersededAbortError,
 } from "../../run-termination.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import {
   isEmbeddedRunTerminalAbort,
   isEmbeddedRunTerminalInterrupted,
@@ -31,14 +32,7 @@ function makeAssistant(stopReason: AssistantMessage["stopReason"]): AssistantMes
     api: "responses",
     provider: "openai",
     model: "gpt-5.4",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     role: "assistant",
     content: [],
     timestamp: 0,

--- a/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-preparation.test.ts
@@ -2,6 +2,7 @@ import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { createTestAdmittedRunContext } from "../../admitted-run-context.test-support.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 import {
   markCoreTtsAttemptResult,
   markCoreTtsToolResult,
@@ -29,14 +30,7 @@ function assistantMessage(stopReason: AssistantMessage["stopReason"] = "stop"): 
     api: "responses",
     provider: "openai",
     model: "gpt-5.4",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     role: "assistant",
     content: [
       {

--- a/src/agents/embedded-agent-runner/run/tool-loop-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/tool-loop-recovery.test.ts
@@ -3,6 +3,7 @@ import { Type } from "typebox";
 import { describe, expect, it, vi } from "vitest";
 import { markCodeModeControlTool } from "../../code-mode-control-tools.js";
 import type { AgentTool } from "../../runtime/index.js";
+import { createZeroUsageFixture } from "../../test-helpers/usage-fixtures.js";
 
 const mocks = vi.hoisted(() => ({
   attachedLifecycles: [] as Array<{
@@ -76,14 +77,7 @@ describe("tool-loop recovery batch admission", () => {
         api: "openai-responses",
         provider: "test",
         model: "test",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "toolUse",
         timestamp: 1,
       },
@@ -102,14 +96,7 @@ describe("tool-loop recovery batch admission", () => {
         api: "openai-responses",
         provider: "test",
         model: "test",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "toolUse",
         timestamp: 2,
       },

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 
 const { requestPreparedCompactionMock } = vi.hoisted(() => ({
   requestPreparedCompactionMock: vi.fn(),
@@ -37,14 +38,7 @@ function createSession() {
     api: "openai-responses",
     provider: "xai",
     model: "grok-4.5",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: 2,
   });

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -4,6 +4,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { castAgentMessage, castAgentMessages } from "../test-helpers/agent-message-fixtures.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { stripStaleThinkingSignaturesForCompactionReplay } from "../thinking-signatures.js";
 import {
   assessLastAssistantMessage,
@@ -444,14 +445,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
       api: "anthropic-messages",
       provider: "anthropic",
       model: "claude-sonnet-4-6",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       timestamp: 0,
       ...overrides,
     }) as AssistantMessage;
@@ -969,14 +963,7 @@ describe("wrapAnthropicStreamWithRecovery", () => {
       api: "anthropic-messages",
       provider: "anthropic",
       model: "claude-sonnet-4-6",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: Date.now(),
     }) as AssistantMessage;

--- a/src/agents/embedded-agent-utils.test.ts
+++ b/src/agents/embedded-agent-utils.test.ts
@@ -16,6 +16,7 @@ import {
   promoteThinkingTagsToBlocks,
   stripDowngradedToolCallText,
 } from "./embedded-agent-utils.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 const REFERENCE_THINKING_TAG_NAME_PATTERN = String.raw`(?:(?:antml:|mm:)?(?:think(?:ing)?|thought)|antthinking)`;
 const REFERENCE_THINKING_TAG_OPEN_RE = new RegExp(
@@ -74,14 +75,7 @@ function makeAssistantMessage(
     api: "responses",
     provider: "openai",
     model: "gpt-5",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     ...message,
   } as unknown as AssistantMessage;

--- a/src/agents/harness/lifecycle.test.ts
+++ b/src/agents/harness/lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
   type DiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import type { EmbeddedRunAttemptResult } from "../embedded-agent-runner/run/types.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import {
   getCoreTtsAttemptResultMediaUrls,
   markCoreTtsAttemptResult,
@@ -75,14 +76,7 @@ function createFinalAssistant(): NonNullable<EmbeddedRunAttemptResult["lastAssis
     api: "openai-responses",
     provider: "openai",
     model: "gpt-5.5",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -63,6 +63,7 @@ import {
   setActiveEmbeddedRun,
 } from "../embedded-agent-runner/runs.js";
 import { createEmbeddedRunHandle } from "../embedded-agent-runner/runs.test-support.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { getGatewayToolCallerIdentity } from "../tools/gateway-caller-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import type { SystemAgentToolOptions } from "../tools/system-agent-tool.js";
@@ -355,14 +356,7 @@ function createFinalAssistant(): NonNullable<EmbeddedRunAttemptResult["lastAssis
     api: "openai-responses",
     provider: "openai",
     model: "gpt-5.5",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/src/agents/harness/settled-turn-finalization-result.test.ts
+++ b/src/agents/harness/settled-turn-finalization-result.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage } from "../../llm/types.js";
 import type { EmbeddedRunAttemptResult } from "../embedded-agent-runner/run/types.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { EmptySettledTurnFinalizationError } from "./settled-turn-finalization-outcome.js";
 import {
   assertSettledTurnFinalizationResult,
@@ -18,14 +19,7 @@ function assistantMessage(
     api: "openai-responses",
     provider: "openai",
     model: "gpt-5.5",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason,
     timestamp: 0,
   };

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -4,6 +4,7 @@ import type { AssistantMessage, Model, ToolResultMessage } from "openclaw/plugin
 import { stream } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 function buildModel(): Model<"openai-responses"> {
   return {
@@ -53,14 +54,7 @@ function extractInputMessages(input: unknown[]) {
   );
 }
 
-const ZERO_USAGE = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-} as const;
+const ZERO_USAGE = createZeroUsageFixture();
 
 function buildReasoningPart(id = "rs_test") {
   return {

--- a/src/agents/openai-thinking-contract.test.ts
+++ b/src/agents/openai-thinking-contract.test.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it } from "vitest";
 import { resolveEmbeddedAgentStream } from "./embedded-agent-runner/stream-resolution.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 type ResponsesModel = Model<"openai-responses"> | Model<"openai-chatgpt-responses">;
 
@@ -317,14 +318,7 @@ function createAssistantMessage(model: ResponsesModel): AssistantMessage {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/src/agents/openai-transport-stream.base.test.ts
+++ b/src/agents/openai-transport-stream.base.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./openai-transport-stream.test-harness.js";
 import { testing } from "./openai-transport-stream.test-support.js";
 import { attachModelProviderRequestTransport } from "./provider-request-config.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 describe("openai transport stream", () => {
   it("keeps bounded redacted diagnostics UTF-16 well-formed", () => {
@@ -247,14 +248,7 @@ describe("openai transport stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: Date.now(),
     };

--- a/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
+++ b/src/agents/openai-transport-stream.deepseek-and-shaping.test.ts
@@ -8,6 +8,7 @@ import {
   makeResponsesModel,
 } from "./openai-transport-stream.test-harness.js";
 import { testing } from "./openai-transport-stream.test-support.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 describe("openai transport stream", () => {
   it("carries the system prompt via top-level instructions for xAI responses providers", () => {
@@ -575,14 +576,7 @@ describe("openai transport stream", () => {
             api: "openai-chatgpt-responses",
             provider: "openai",
             model: "gpt-5.4",
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsageFixture(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [

--- a/src/agents/openai-transport-stream.replay-and-tools.test.ts
+++ b/src/agents/openai-transport-stream.replay-and-tools.test.ts
@@ -11,6 +11,7 @@ import {
   expectRecordFields,
 } from "./openai-transport-stream.test-harness.js";
 import { testing } from "./openai-transport-stream.test-support.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 type ReplayContextSpec = {
   source?: Pick<Model, "api" | "id" | "provider">;
@@ -71,14 +72,7 @@ function replayContext(spec: ReplayContextSpec) {
       api: spec.source?.api ?? spec.api ?? "openai-responses",
       provider: spec.source?.provider ?? spec.provider ?? "openai",
       model: spec.source?.id ?? spec.model ?? "gpt-5.5",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: spec.stopReason ?? "toolUse",
       timestamp: 1,
       content,

--- a/src/agents/openai-transport-stream.test-harness.ts
+++ b/src/agents/openai-transport-stream.test-harness.ts
@@ -3,6 +3,7 @@ import type { MutableAssistantOutput } from "@openclaw/ai/transports";
 import type { Api, Model } from "openclaw/plugin-sdk/llm";
 import { expect } from "vitest";
 import { testing } from "./openai-transport-stream.test-support.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 export const buildOpenAIResponsesParams: typeof testing.buildOpenAIResponsesParams =
   testing.buildOpenAIResponsesParams;
@@ -69,14 +70,7 @@ export function createAssistantOutput(model: Model<"openai-completions">): Mutab
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: Date.now(),
   };
@@ -91,14 +85,7 @@ export function createResponsesAssistantOutput(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: Date.now(),
   };

--- a/src/agents/openai-transport-stream.usage-and-calls.test.ts
+++ b/src/agents/openai-transport-stream.usage-and-calls.test.ts
@@ -4,6 +4,7 @@ import {
   makeResponsesModel,
   expectRecordFields,
 } from "./openai-transport-stream.test-harness.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 
 describe("openai transport stream", () => {
   it("serializes raw string tool-call arguments without double-encoding them", () => {
@@ -20,14 +21,7 @@ describe("openai transport stream", () => {
             api: "openai-responses",
             provider: "openai",
             model: "gpt-5.4",
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsageFixture(),
             stopReason: "stop",
             timestamp: 1,
             content: [

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -14,6 +14,7 @@ import { finalizeRuntimePromptImages } from "../../media/runtime-prompt-image-pr
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
 import { disposeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 
 const thinkingMocks = vi.hoisted(() => ({
   resolveThinkingDefaultForModel: vi.fn(() => "medium"),
@@ -144,14 +145,7 @@ function createAssistantError(errorMessage: string): AssistantMessage {
     api: testModel.api,
     provider: testModel.provider,
     model: testModel.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "error",
     errorMessage,
     timestamp: 1,
@@ -280,14 +274,7 @@ function createSessionManagerWithPersistedAssistantMessages(
         api: "messages",
         provider: "anthropic",
         model: "sonnet-4.6",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: message.stopReason ?? "stop",
         timestamp: Date.now(),
       },
@@ -369,14 +356,7 @@ describe("AgentSession tree navigation", () => {
       api: testModel.api,
       provider: testModel.provider,
       model: testModel.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: 3,
     });
@@ -389,14 +369,7 @@ describe("AgentSession tree navigation", () => {
         api: testModel.api,
         provider: testModel.provider,
         model: testModel.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "stop",
         timestamp: 4,
       }),
@@ -824,14 +797,7 @@ describe("createAgentSession tool defaults", () => {
         api: testModel.api,
         provider: testModel.provider,
         model: testModel.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "toolUse",
         timestamp: Date.now(),
       },
@@ -874,14 +840,7 @@ describe("createAgentSession tool defaults", () => {
         api: testModel.api,
         provider: testModel.provider,
         model: testModel.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "toolUse",
         timestamp: Date.now(),
       },

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { CURRENT_SESSION_VERSION, SessionManager } from "./session-manager.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -28,14 +29,7 @@ function buildAssistantMessage(text: string) {
     api: "messages" as const,
     provider: "anthropic" as const,
     model: "sonnet-4.6" as const,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop" as const,
     timestamp: Date.now(),
   };

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { redactIdentifier } from "../../logging/redact-identifier.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import {
   buildSessionContext,
   CURRENT_SESSION_VERSION,
@@ -72,20 +73,7 @@ describe("SessionManager.open", () => {
       api: "openai-responses",
       provider: "openai",
       model: "gpt-5.5",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          total: 0,
-        },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: Date.now(),
     });
@@ -587,14 +575,7 @@ describe("SessionManager.open", () => {
         api: "openai-responses",
         provider: "openai",
         model: "gpt-5.5",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: "stop",
         timestamp: Date.now(),
       }),
@@ -945,14 +926,7 @@ function buildAssistantMessage(text: string) {
     api: "messages" as const,
     provider: "anthropic" as const,
     model: "sonnet-4.6" as const,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop" as const,
     timestamp: Date.now(),
   };

--- a/src/agents/sessions/session-manager.tool-result-replay.test.ts
+++ b/src/agents/sessions/session-manager.tool-result-replay.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { Context, Message, Model } from "../../llm/types.js";
 import type { AgentMessage } from "../runtime/index.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { parseSessionEntries, SessionManager } from "./session-manager.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -63,14 +64,7 @@ async function writeSessionWithToolResultContent(
         model: "claude-sonnet-4-6",
         stopReason: "toolUse",
         timestamp: 2,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
       },
     },
@@ -123,14 +117,7 @@ async function writeSessionWithAssistantContent(
         model: "claude-sonnet-4-6",
         stopReason: "stop",
         timestamp: 2,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         content,
       },
     },

--- a/src/agents/sessions/session-manager.user-idempotency.test.ts
+++ b/src/agents/sessions/session-manager.user-idempotency.test.ts
@@ -8,6 +8,7 @@ import {
   loadTranscriptEvents,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { SessionManager } from "./session-manager.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -19,14 +20,7 @@ function buildAssistantMessage(text: string) {
     api: "messages" as const,
     provider: "anthropic" as const,
     model: "sonnet-4.6" as const,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop" as const,
     timestamp: Date.now(),
   };

--- a/src/agents/test-helpers/usage-fixtures.ts
+++ b/src/agents/test-helpers/usage-fixtures.ts
@@ -6,18 +6,22 @@
  */
 import type { Usage } from "openclaw/plugin-sdk/llm";
 
-/** Usage fixture with every token and cost counter set to zero. */
-export const ZERO_USAGE_FIXTURE: Usage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: {
+export function createZeroUsageFixture(): Usage {
+  return {
     input: 0,
     output: 0,
     cacheRead: 0,
     cacheWrite: 0,
-    total: 0,
-  },
-};
+    totalTokens: 0,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 0,
+    },
+  };
+}
+
+/** Usage fixture with every token and cost counter set to zero. */
+export const ZERO_USAGE_FIXTURE: Usage = createZeroUsageFixture();

--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -22,6 +22,7 @@ import {
 } from "../secrets/runtime-degraded-state.js";
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 import {
   addClientToolsToToolCatalog,
   compactToolSearchCatalogEntry,
@@ -345,14 +346,7 @@ describe("Tool Search dispatcher argument preparation", () => {
         api: model.api,
         provider: model.provider,
         model: model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsageFixture(),
         stopReason: content.some((item) => item.type === "toolCall") ? "toolUse" : "stop",
         timestamp: 1,
       };

--- a/src/agents/tool-search.mcp-error.test.ts
+++ b/src/agents/tool-search.mcp-error.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
 import { runAgentLoop, type AgentEvent, type AgentMessage } from "./runtime/index.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 import { isToolResultError } from "./tool-result-error.js";
 import {
   applyToolSearchCatalog,
@@ -34,14 +35,7 @@ const model: Model = {
   maxTokens: 1000,
 };
 
-const testUsage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
+const testUsage = createZeroUsageFixture();
 
 function makeMcpRuntime(result: CallToolResult): SessionMcpRuntime {
   const tool = {

--- a/src/agents/transport-message-transform.async.test.ts
+++ b/src/agents/transport-message-transform.async.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import type { Context, Model } from "../llm/types.js";
+import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 
 it.each([
@@ -23,14 +24,7 @@ it.each([
     model: "async-model",
     api: "openai-responses",
     timestamp: 0,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
   };
   const messages: Context["messages"] = [
     {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Agent tests repeat complete zero-usage input objects, adding fixture code without adding distinct scenarios.

## Why This Change Was Made

Use a fresh zero-argument fixture factory for 57 audited inputs. Preserve every allocation location, property order and omitted optional field. The existing singleton remains one shared initialization-time result for its unchanged consumers. Expected, sparse and nonzero usage remains explicit.

## User Impact

No production behavior changes or scenarios removed. Net 359 test/support lines removed across 43 files.

## Evidence

All 1,509 affected/sibling tests across 46 files pass. Whole-file reconstruction and runtime graph/JSON-order checks preserve the original inputs and test bodies. Fresh outer/cost objects remain independent of the singleton; two obsolete const assertions had no narrowing-dependent consumers.

The complete changed gate, formatting/diff checks, deslop and final independent P2 review pass. No overall runtime improvement is claimed.
