### PR TITLE
test(ai): share fresh zero-usage input fixtures

### DIFF
--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -3,6 +3,7 @@ import { convertMessages } from "./openai-completions-messages.js";
 import type { ProviderContext, ProviderModel } from "./provider-types.js";
 import { resolveOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
 import type { AssistantMessage, Context, Model } from "./types.js";
+import { createZeroUsage } from "./usage.test-support.js";
 
 const model: Model<"openai-completions"> = {
   id: "test-model",
@@ -17,14 +18,7 @@ const model: Model<"openai-completions"> = {
   maxTokens: 4_096,
 };
 
-const emptyUsage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
+const emptyUsage = createZeroUsage();
 
 describe("convertMessages assistant text replay", () => {
   it("serializes advertised video in ordered Chat Completions user content", () => {

--- a/packages/ai/src/providers/anthropic-usage.test.ts
+++ b/packages/ai/src/providers/anthropic-usage.test.ts
@@ -1,21 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   applyAnthropicMessageDeltaUsage,
   applyAnthropicMessageStartUsage,
   readAnthropicCacheWriteUsage,
   readLastAnthropicIterationUsage,
 } from "./anthropic-usage.js";
-
-function emptyUsage() {
-  return {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 0,
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-  };
-}
 
 describe("readAnthropicCacheWriteUsage", () => {
   it("reads independent 5-minute and 1-hour cache-write buckets", () => {
@@ -121,7 +111,7 @@ describe("applyAnthropicMessageDeltaUsage", () => {
   it.each([{ cache_read_input_tokens: 128 }, { cache_creation_input_tokens: 128 }])(
     "settles usage after a zero-placeholder start with one cache counter: %j",
     (cacheUsage) => {
-      const usage = emptyUsage();
+      const usage = createZeroUsage();
       const start = applyAnthropicMessageStartUsage(usage, { input_tokens: 0, output_tokens: 0 });
 
       applyAnthropicMessageDeltaUsage(
@@ -144,7 +134,7 @@ describe("applyAnthropicMessageDeltaUsage", () => {
     { cache_read_input_tokens: "malformed" },
     { cache_creation_input_tokens: "malformed" },
   ])("keeps context unavailable for missing or malformed cache evidence: %j", (cacheUsage) => {
-    const usage = emptyUsage();
+    const usage = createZeroUsage();
     const start = applyAnthropicMessageStartUsage(usage, { input_tokens: 0, output_tokens: 0 });
 
     applyAnthropicMessageDeltaUsage(
@@ -157,7 +147,7 @@ describe("applyAnthropicMessageDeltaUsage", () => {
   });
 
   it("sums compaction and message iterations for billed usage", () => {
-    const usage = emptyUsage();
+    const usage = createZeroUsage();
 
     applyAnthropicMessageDeltaUsage(
       usage,
@@ -197,7 +187,7 @@ describe("applyAnthropicMessageDeltaUsage", () => {
   });
 
   it("keeps top-level billing when compaction iterations are malformed", () => {
-    const usage = emptyUsage();
+    const usage = createZeroUsage();
 
     applyAnthropicMessageDeltaUsage(
       usage,
@@ -230,7 +220,7 @@ describe("applyAnthropicMessageDeltaUsage", () => {
   });
 
   it("keeps the message-start snapshot when the delta reports no usage", () => {
-    const usage = emptyUsage();
+    const usage = createZeroUsage();
     const messageStartPromptUsage = applyAnthropicMessageStartUsage(usage, {
       input_tokens: 12,
       output_tokens: 0,
@@ -251,7 +241,7 @@ describe("applyAnthropicMessageDeltaUsage", () => {
   });
 
   it("still reports unavailable context for an empty delta usage object", () => {
-    const usage = emptyUsage();
+    const usage = createZeroUsage();
     const messageStartPromptUsage = applyAnthropicMessageStartUsage(usage, {
       input_tokens: 12,
       output_tokens: 0,

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -24,6 +24,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
+import { createZeroUsage } from "../usage.test-support.js";
 import { streamAnthropic, streamSimpleAnthropic } from "./anthropic.js";
 
 function createSseResponse(events: Record<string, unknown>[] = []): Response {
@@ -73,14 +74,7 @@ function makeAnthropicAssistantMessage(
     model: "claude-sonnet-4-6",
     stopReason: "stop",
     timestamp: 0,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     content,
     ...overrides,
   };

--- a/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
@@ -9,6 +9,7 @@ import {
 import { OPENAI_RESPONSES_REASONING_REPLAY_META_KEY } from "../transports/openai-responses-contracts.js";
 import { withProviderAcceptanceObserver } from "../transports/transport-stream-shared.js";
 import type { AssistantMessage, Context, Model } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   closeOpenAICodexWebSocketSessions,
   resetOpenAICodexWebSocketStateForTest,
@@ -64,14 +65,7 @@ function createReplayContext(kind: "compaction" | "mixed"): Context {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 1,
   };

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -5,6 +5,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
   closeOpenAICodexWebSocketSessions,
@@ -515,14 +516,7 @@ describe("streamOpenAICodexResponses transport", () => {
             api: "openai-chatgpt-responses",
             provider: model.provider,
             model: model.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -52,6 +52,7 @@ import {
   resolveOpenAICompletionsCompat,
   type ResolvedOpenAICompletionsCompat,
 } from "../transports/openai-completions-compat.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { streamOpenAICompletions } from "./openai-completions.js";
 
 const baseModel: Model<"openai-completions"> = {
@@ -944,14 +945,7 @@ describe("OpenAI-compatible completions compatibility", () => {
         },
         { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
       ],
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "toolUse",
       timestamp: 2,
     };

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -81,6 +81,7 @@ vi.mock("openai", () => {
   return { default: MockOpenAI };
 });
 
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   streamOpenAICompletions,
   streamSimpleOpenAICompletions,
@@ -695,14 +696,7 @@ describe("OpenAI-compatible completions params", () => {
             api: model.api,
             provider: model.provider,
             model: model.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             content: [{ type: "toolCall", id: "call_plan", name: "update_plan", arguments: {} }],
             timestamp: 1,
@@ -749,14 +743,7 @@ describe("OpenAI-compatible completions params", () => {
             api: model.api,
             provider: model.provider,
             model: model.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             content: [{ type: "toolCall", id: "call_husk", name: "screenshot", arguments: {} }],
             timestamp: 1,
@@ -805,14 +792,7 @@ describe("OpenAI-compatible completions params", () => {
             api: model.api,
             provider: model.provider,
             model: model.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             content: [{ type: "toolCall", id: "call_shot", name: "screenshot", arguments: {} }],
             timestamp: 1,
@@ -1170,14 +1150,7 @@ describe("OpenAI-compatible completions params", () => {
             api: "openai-completions",
             provider: "xiaomi",
             model: "mimo-v2.5-pro",
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             content: [
               {

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -13,6 +13,7 @@ import {
 import { isInvalidEncryptedContentError } from "../transports/openai-responses-replay-internal.js";
 import { processResponsesStream } from "../transports/openai-responses-stream-internal.js";
 import type { AssistantMessage, AssistantMessageEvent, Context, Model, Tool } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { AssistantMessageEventStream } from "../utils/event-stream.js";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "../utils/system-prompt-cache-boundary.js";
 import {
@@ -105,14 +106,7 @@ function createAssistantOutput(): AssistantMessage {
     api: nativeOpenAIModel.api,
     provider: nativeOpenAIModel.provider,
     model: nativeOpenAIModel.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 0,
     content: [],
@@ -453,14 +447,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "stop",
             timestamp: 1,
             content: [
@@ -518,14 +505,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "stop",
             timestamp: 1,
             content: [
@@ -565,14 +545,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [
@@ -653,14 +626,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [{ type: "toolCall", id: "call_plan", name: "update_plan", arguments: {} }],
@@ -698,14 +664,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [
@@ -747,14 +706,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [{ type: "toolCall", id: "call_audio", name: "audio", arguments: {} }],
@@ -820,14 +772,7 @@ describe("convertResponsesMessages", () => {
             api: nativeOpenAIModel.api,
             provider: nativeOpenAIModel.provider,
             model: nativeOpenAIModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "stop",
             timestamp: 1,
             content: [
@@ -3573,14 +3518,7 @@ describe("Azure OpenAI Responses content type support", () => {
             api: azureModel.api,
             provider: azureModel.provider,
             model: azureModel.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "stop",
             timestamp: 1,
             content: [

--- a/packages/ai/src/providers/transform-messages.test.ts
+++ b/packages/ai/src/providers/transform-messages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { transformProviderMessages } from "../provider-transcript-transform.js";
 import type { ProviderMessage, ProviderModel } from "../provider-types.js";
 import type { Message, Model, ToolResultMessage } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { transformMessages } from "./transform-messages.js";
 
 const model: Model<"openai-completions"> = {
@@ -27,14 +28,7 @@ describe("transformMessages", () => {
         api: model.api,
         provider: model.provider,
         model: model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsage(),
         stopReason: "stop",
         timestamp: 2,
       },
@@ -155,14 +149,7 @@ describe("transformMessages", () => {
         api: model.api,
         provider: model.provider,
         model: async ? "source-model" : model.id,
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsage(),
         stopReason: "toolUse",
         timestamp: 1,
       };

--- a/packages/ai/src/transports/anthropic-compaction-replay.test.ts
+++ b/packages/ai/src/transports/anthropic-compaction-replay.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   buildAnthropicReplayPlan,
   createCompactionCapture,
@@ -39,14 +40,7 @@ function assistant(texts: string[]): AssistantMessage {
     api: "anthropic-messages",
     provider: "anthropic",
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 1,
   };

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -11,6 +11,7 @@ import {
   getAiTransportHost,
   type AiInlineContentBlock,
 } from "../host.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import { createCompactionCapture } from "./anthropic-compaction-replay.js";
 import { resolveCompactionReplayPressure } from "./provider-compaction-replay.js";
@@ -313,14 +314,7 @@ function makeSonnet5PrefillContext(): AnthropicStreamContext {
         api: "anthropic-messages",
         provider: "anthropic",
         model: "claude-sonnet-5",
-        usage: {
-          input: 0,
-          output: 0,
-          cacheRead: 0,
-          cacheWrite: 0,
-          totalTokens: 0,
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-        },
+        usage: createZeroUsage(),
         stopReason: "stop",
         timestamp: 1,
       },
@@ -692,14 +686,7 @@ describe("anthropic transport stream", () => {
       api: "anthropic-messages",
       provider: "anthropic",
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop",
       timestamp: 1,
     };
@@ -3529,14 +3516,7 @@ describe("anthropic transport stream", () => {
             model: "claude-sonnet-4-6",
             stopReason: "toolUse",
             timestamp: 0,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             content: [{ type: "toolCall", id: "tool_1", name: "screenshot", arguments: {} }],
           },
           {

--- a/packages/ai/src/transports/openai-completions-params.test.ts
+++ b/packages/ai/src/transports/openai-completions-params.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Model } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { buildOpenAICompletionsParams } from "./openai-completions-params.js";
 import { makeCompletionsModel } from "./openai-completions.test-support.js";
 
@@ -219,14 +220,7 @@ describe("openai completions params", () => {
             api: "openai-completions",
             provider: "vllm",
             model: "qwen3-5-122b-a10b-nvfp4",
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsage(),
             stopReason: "aborted",
             timestamp: 2,
           },

--- a/packages/ai/src/transports/openai-completions-replay.google-signatures.test.ts
+++ b/packages/ai/src/transports/openai-completions-replay.google-signatures.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Model } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { buildOpenAICompletionsParams } from "./openai-completions-params.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
@@ -23,14 +24,7 @@ function geminiToolReplayContext(
     api: options.sourceApi ?? model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "toolUse",
     timestamp: 1,
     content: [

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-and-buffering.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   createAssistantOutput,
@@ -182,14 +183,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };
@@ -301,14 +295,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };

--- a/packages/ai/src/transports/openai-completions-stream.reasoning-details.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.reasoning-details.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   type OpenAICompletionsOutput,
@@ -25,14 +26,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };
@@ -99,14 +93,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };
@@ -287,14 +274,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };

--- a/packages/ai/src/transports/openai-completions-stream.tool-assembly.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.tool-assembly.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   createAssistantOutput,
@@ -24,14 +25,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };

--- a/packages/ai/src/transports/openai-completions-stream.usage.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.usage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import { processCompletionsStream } from "./openai-completions-stream.js";
 import {
   type CapturedStreamEvent,
@@ -154,14 +155,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };
@@ -344,14 +338,7 @@ describe("openai completions stream", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsage(),
       stopReason: "stop" as const,
       timestamp: Date.now(),
     };

--- a/packages/ai/src/transports/openai-completions.test-support.ts
+++ b/packages/ai/src/transports/openai-completions.test-support.ts
@@ -7,6 +7,7 @@ import {
   type AiProviderRequestPolicyInput,
 } from "../host.js";
 import type { Model } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { buildOpenAICompletionsParams } from "./openai-completions-params.js";
 import type { processCompletionsStream } from "./openai-completions-stream.js";
 
@@ -208,14 +209,7 @@ export function createAssistantOutput(model: Model<"openai-completions">): OpenA
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: Date.now(),
   };

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -7,6 +7,7 @@ import type {
 } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
   suppressOpenAIResponsesCompaction,
@@ -40,14 +41,7 @@ function createOutput(): AssistantMessage {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
+++ b/packages/ai/src/transports/openai-responses-prompt-observer.test.ts
@@ -51,6 +51,7 @@ vi.mock("openai", () => {
   return { default: createClient("openai"), AzureOpenAI: createClient("azure") };
 });
 
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   createAzureOpenAIResponsesTransportStreamFn,
   createOpenAIResponsesTransportStreamFn,
@@ -150,14 +151,7 @@ function createCompactionContext(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 1,
   };
@@ -193,14 +187,7 @@ function createOrphanedToolOutputCompactionContext(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 1,
   };

--- a/packages/ai/src/transports/openai-responses-reasoning-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-reasoning-replay.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { buildOpenAIResponsesReasoningReplayMetadata } from "./openai-responses-compaction-replay.js";
 import { convertResponsesMessages } from "./openai-responses-replay-internal.js";
 
@@ -25,14 +26,7 @@ function createAssistant(content: AssistantMessage["content"]): AssistantMessage
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/packages/ai/src/transports/openai-responses-retained-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-retained-compaction-replay.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Context, Model, ProviderReplayState } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   buildOpenAIResponsesCompactionReplayPlan,
   buildOpenAIResponsesReasoningReplayMetadata,
@@ -41,14 +42,7 @@ function createAssistant(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 0,
     ...(providerReplay ? { providerReplay } : {}),

--- a/packages/ai/src/transports/openai-responses-stream-activity.test.ts
+++ b/packages/ai/src/transports/openai-responses-stream-activity.test.ts
@@ -4,6 +4,7 @@
 // transports.
 import { describe, expect, it, vi } from "vitest";
 import type { AssistantMessage, Model } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import { onLlmRequestActivity } from "../utils/llm-request-activity.js";
 import {
   processResponsesStream,
@@ -30,14 +31,7 @@ function createOutput(): AssistantMessage {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/packages/ai/src/transports/openai-responses-stream-parity.test-helpers.ts
+++ b/packages/ai/src/transports/openai-responses-stream-parity.test-helpers.ts
@@ -1,4 +1,5 @@
 import type { AssistantMessage, AssistantMessageEvent, Model } from "@openclaw/llm-core";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   processResponsesStream as processTransportStream,
   type OpenAIResponsesStreamEvent,
@@ -56,14 +57,7 @@ function createOutput(): AssistantMessage {
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "stop",
     timestamp: 0,
   };

--- a/packages/ai/src/transports/provider-compaction-replay.test.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, Context, Model, ProviderReplayState } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   createCompactionCapture,
   buildAnthropicReplayPlan,
@@ -45,14 +46,7 @@ function createAssistant(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "toolUse",
     timestamp: 0,
     providerReplay: {

--- a/packages/ai/src/usage.test-support.ts
+++ b/packages/ai/src/usage.test-support.ts
@@ -1,0 +1,10 @@
+export function createZeroUsage() {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}

--- a/packages/ai/src/utils/overflow.test.ts
+++ b/packages/ai/src/utils/overflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantMessage } from "../types.js";
+import { createZeroUsage } from "../usage.test-support.js";
 import {
   isConfiguredContextSizeOverflowError,
   isContextOverflow,
@@ -13,14 +14,7 @@ function errorMessage(message: string): AssistantMessage {
     api: "test-api",
     provider: "test-provider",
     model: "test-model",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsage(),
     stopReason: "error",
     errorMessage: message,
     timestamp: 1,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

AI-package tests repeat complete zero-usage inputs across provider and transport scenarios.

## Why This Change Was Made

Share fresh literals through a package-owned test-support factory and remove the redundant local Anthropic wrapper. Preserve field order, absent optional counters, fresh nested cost objects, original allocation locations and deliberately shared constants. Independent expected outputs and sparse/nonzero fixtures remain explicit.

## User Impact

No production, export or provider behavior changes. Net 283 test/support lines removed across 27 files.

## Evidence

All 1,027 baseline identities and pass outcomes remain; the final 1,075 tests include 48 usage/pricing siblings. Expanded-source and runtime fixture equivalence checks pass for all 45 original inputs, including graph, descriptor, key-order, absence and freshness checks.

The complete changed gate, formatting/diff checks, deslop and independent P2 review pass. Timing samples include different suite sets; no runtime improvement is claimed.
