### PR TITLE
fix(models): preserve DeepInfra and NVIDIA catalogs on discovery failure

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -279,7 +279,7 @@ extensions/cua-computer/src/driver-client.ts	15
 extensions/cua-computer/src/driver-result.ts	9
 extensions/cua-computer/src/mcp-driver-client.ts	5
 extensions/cua-computer/src/window-actions.ts	3
-extensions/deepinfra/provider-models.ts	3
+extensions/deepinfra/provider-models.ts	2
 extensions/deepinfra/video-generation-provider.ts	2
 extensions/deepseek/provider-policy-api.ts	4
 extensions/device-pair/index.ts	6
@@ -864,7 +864,7 @@ extensions/nostr/src/nostr-profile-http.ts	1
 extensions/nostr/src/nostr-profile-import.ts	1
 extensions/nostr/src/setup-surface.ts	2
 extensions/nostr/src/types.ts	3
-extensions/nvidia/provider-catalog.ts	3
+extensions/nvidia/provider-catalog.ts	2
 extensions/oc-path/src/oc-path/find.ts	13
 extensions/oc-path/src/oc-path/jsonc/parse.ts	1
 extensions/oc-path/src/oc-path/universal.ts	4

--- a/docs/providers/deepinfra.md
+++ b/docs/providers/deepinfra.md
@@ -120,6 +120,11 @@ does not append bundled models absent from the response. Without credentials,
 the bundled catalog remains available without fetching. Explicitly configured
 models and costs remain authoritative; onboarding does not pin provider prices.
 
+The plugin's public `buildDeepInfraProvider` API keeps its advisory default:
+it retains bundled choices and uses unknown price estimates when discovery fails.
+OpenClaw's registered catalog hook explicitly selects `discoveryMode: "strict"`
+so failed or empty acquisitions reach the shared publication owner unchanged.
+
 Hosted publication uses the same native parser. It preserves metadata without
 cost for unsupported or absent schedules, retains declared zero prices, and
 leaves the previous hosted catalog intact if the native feed fails validation.

--- a/docs/providers/deepinfra.md
+++ b/docs/providers/deepinfra.md
@@ -110,13 +110,15 @@ retention and priority/flex rates are separate contracts and are not included in
 standard estimates. See DeepInfra's [prompt caching](https://docs.deepinfra.com/chat/prompt-caching)
 and [cache retention](https://docs.deepinfra.com/chat/prompt-cache-retention) docs.
 
-Missing, malformed, or unavailable native prices never restore the projection's
-flat prices. Models remain selectable; the required runtime zero-cost placeholder
-means unknown, not verified free billing. If metadata discovery fails, OpenClaw
-keeps bundled model metadata and applies any available native prices. The complete
-bundled fallback, including prices, is used only when both sources fail or live
-discovery is skipped. Onboarding adds the model alias without pinning provider
-prices, and explicitly configured model costs remain authoritative.
+Missing or unsupported individual price schedules use the required runtime
+zero-cost placeholder, which means unknown, not verified free billing. A failed
+metadata or native pricing request marks chat discovery unavailable and retains
+the last successful catalog for the same provider configuration and credentials.
+A successful empty model response clears discovered chat models even when pricing
+is unavailable. Live discovery
+does not append bundled models absent from the response. Without credentials,
+the bundled catalog remains available without fetching. Explicitly configured
+models and costs remain authoritative; onboarding does not pin provider prices.
 
 Hosted publication uses the same native parser. It preserves metadata without
 cost for unsupported or absent schedules, retains declared zero prices, and

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -82,12 +82,12 @@ from model names. Unknown IDs can still be configured explicitly; listing alone
 does not prove chat compatibility. This is not a complete automatic catalog of
 every NVIDIA model.
 
-Both public fetches use fixed HTTPS hosts and send no credentials. If the
-featured feed fails, available bundled chat models still appear. If the
-inventory is unavailable or malformed, browse and setup retain the bundled
-fallback, while the fresh-live catalog stays empty. A successful empty inventory
-does not restore stale bundled entries. Without NVIDIA auth, browsing uses the
-bundled catalog without fetching.
+Both public fetches use fixed HTTPS hosts and send no credentials. A failed
+inventory or featured request marks discovery unavailable and retains the last
+successful catalog for the same provider configuration and credentials. Failed
+featured metadata cannot silently remove previously discovered models. A
+successful empty inventory clears discovered models, even if the featured feed
+fails. Without NVIDIA auth, browsing uses the bundled catalog without fetching.
 
 ## Nemotron 3.5 Lightning
 

--- a/extensions/deepinfra/index.test.ts
+++ b/extensions/deepinfra/index.test.ts
@@ -7,18 +7,9 @@ import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-cata
 import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import deepinfraPlugin from "./index.js";
-import { DEEPINFRA_MODEL_CATALOG } from "./provider-models.js";
 
 const DEEPINFRA_MODELS_URL =
   "https://api.deepinfra.com/v1/openai/models?sort_by=openclaw&filter=with_meta";
-
-function buildSyntheticDeepInfraEntries(count: number) {
-  return Array.from({ length: count }, (_unused, index) => ({
-    provider: "deepinfra",
-    id: `synthetic/model-${index}`,
-    name: `synthetic/model-${index}`,
-  }));
-}
 
 function buildDeepInfraCatalogContext(): ProviderCatalogContext {
   return {
@@ -85,161 +76,69 @@ async function withLiveDiscoveryTestEnv(
   mockFetch: ReturnType<typeof vi.fn>,
   runAssertions: () => Promise<void>,
 ) {
-  const env = { ...process.env };
-  delete process.env.NODE_ENV;
-  delete process.env.VITEST;
-  delete process.env.DEEPINFRA_API_KEY;
   vi.stubGlobal("fetch", mockFetch);
 
   try {
     await runAssertions();
   } finally {
-    for (const key of ["NODE_ENV", "VITEST", "DEEPINFRA_API_KEY"]) {
-      if (env[key] === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = env[key];
-      }
-    }
     vi.unstubAllGlobals();
   }
 }
 
-describe("deepinfra augmentModelCatalog", () => {
-  it("returns the discovered (static under VITEST) catalog when nothing is configured", async () => {
-    clearLiveCatalogCacheForTests();
-    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
-
-    const entries = (await provider.augmentModelCatalog?.({ entries: [] } as never)) ?? [];
-
-    expect(entries.map((entry) => entry.id)).toEqual(
-      DEEPINFRA_MODEL_CATALOG.map((model) => model.id),
-    );
-    for (const entry of entries) {
-      expect(entry.provider).toBe("deepinfra");
-    }
-  });
-
-  it("preserves configured entries and appends discovered entries that are not already configured", async () => {
-    clearLiveCatalogCacheForTests();
-    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
-
-    const entries =
-      (await provider.augmentModelCatalog?.({
-        entries: [],
-        config: {
-          models: {
-            providers: {
-              deepinfra: {
-                models: [
+describe("deepinfra capability registration", () => {
+  it.each([
+    ...["metadata", "pricing"].flatMap((scenario) =>
+      [401, 403, 503].map((status) => ({ scenario, status })),
+    ),
+    ...[200, 401, 503].map((status) => ({ scenario: "empty", status })),
+  ])(
+    "reports public $scenario HTTP $status without rejecting inference credentials",
+    async ({ scenario, status }) => {
+      const healthyFetch = mockDiscoveryFetch();
+      const mockFetch = vi.fn(async (url: string) => {
+        const metadata = url === DEEPINFRA_MODELS_URL;
+        if (scenario === "empty" && metadata) {
+          return jsonResponse({ data: [] });
+        }
+        if (
+          (scenario === "metadata" && metadata) ||
+          (scenario === "pricing" && !metadata) ||
+          (scenario === "empty" && !metadata && status !== 200)
+        ) {
+          return new Response("unavailable", { status });
+        }
+        return healthyFetch(url);
+      });
+      const provider = await registerSingleProviderPlugin(deepinfraPlugin);
+      await withLiveDiscoveryTestEnv(mockFetch, async () => {
+        const result = await provider.catalog?.run(buildDeepInfraCatalogContext());
+        const rejected = status === 401 || status === 403;
+        expect(result).toEqual(
+          scenario === "empty"
+            ? {
+                provider: {
+                  baseUrl: "https://api.deepinfra.com/v1/openai",
+                  api: "openai-completions",
+                  apiKey: "profile-key",
+                  models: [],
+                },
+                outcomes: [{ provider: "deepinfra", status: "ready" }],
+              }
+            : {
+                providers: {},
+                outcomes: [
                   {
-                    id: "zai-org/GLM-5.1",
-                    name: "GLM-5.1 custom",
-                    input: ["text"],
-                    reasoning: true,
-                    contextWindow: 202752,
+                    provider: "deepinfra",
+                    status: rejected ? "auth-rejected" : "unavailable",
+                    ...(rejected ? { rejectionScope: "catalog" } : {}),
                   },
                 ],
               },
-            },
-          },
-        },
-      } as never)) ?? [];
-
-    const glmEntry = entries.find((entry) => entry.id === "zai-org/GLM-5.1");
-    expect(glmEntry?.name).toBe("GLM-5.1 custom");
-    expect(entries.filter((entry) => entry.id === "zai-org/GLM-5.1")).toHaveLength(1);
-    expect(entries.length).toBe(DEEPINFRA_MODEL_CATALOG.length);
-  });
-
-  it("uses config-backed API keys to enable live model catalog augmentation", async () => {
-    clearLiveCatalogCacheForTests();
-    const mockFetch = mockDiscoveryFetch("config/live-model");
-    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
-
-    await withLiveDiscoveryTestEnv(mockFetch, async () => {
-      const entries =
-        (await provider.augmentModelCatalog?.({
-          entries: [],
-          env: {},
-          config: {
-            models: {
-              providers: {
-                deepinfra: {
-                  apiKey: { source: "env", provider: "default", id: "CUSTOM_DEEPINFRA_KEY" },
-                },
-              },
-            },
-          },
-        } as never)) ?? [];
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(entries.map((entry) => entry.id)).toContain("config/live-model");
-    });
-  });
-
-  it("still runs live discovery when ctx.entries includes custom DeepInfra rows", async () => {
-    clearLiveCatalogCacheForTests();
-    const mockFetch = mockDiscoveryFetch("custom/live-model");
-    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
-
-    const seededDeepInfraCount = DEEPINFRA_MODEL_CATALOG.length + 5;
-    await withLiveDiscoveryTestEnv(mockFetch, async () => {
-      const entries =
-        (await provider.augmentModelCatalog?.({
-          entries: [
-            ...buildSyntheticDeepInfraEntries(seededDeepInfraCount),
-            { provider: "openai", id: "noise", name: "noise" },
-          ],
-          config: {
-            models: {
-              providers: {
-                deepinfra: {
-                  apiKey: "sk-test",
-                  models: [
-                    {
-                      id: "zai-org/GLM-5.1",
-                      name: "configured override",
-                      input: ["text"],
-                      reasoning: true,
-                      contextWindow: 202752,
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        } as never)) ?? [];
-
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(entries[0]).toEqual({
-        provider: "deepinfra",
-        id: "zai-org/GLM-5.1",
-        name: "configured override",
-        input: ["text"],
-        reasoning: true,
-        contextWindow: 202752,
+        );
       });
-      expect(entries.map((entry) => entry.id)).toContain("custom/live-model");
-    });
-  });
+    },
+  );
 
-  it("still fetches when ctx.entries has exactly the static catalog length (static-fallback case)", async () => {
-    clearLiveCatalogCacheForTests();
-    const provider = await registerSingleProviderPlugin(deepinfraPlugin);
-
-    const entries =
-      (await provider.augmentModelCatalog?.({
-        entries: buildSyntheticDeepInfraEntries(DEEPINFRA_MODEL_CATALOG.length),
-      } as never)) ?? [];
-
-    expect(entries.map((entry) => entry.id)).toEqual(
-      DEEPINFRA_MODEL_CATALOG.map((model) => model.id),
-    );
-  });
-});
-
-describe("deepinfra capability registration", () => {
   it("registers all DeepInfra-backed OpenClaw provider surfaces", () => {
     const captured = createCapturedPluginRegistration();
     deepinfraPlugin.register(captured.api);
@@ -282,10 +181,8 @@ describe("deepinfra capability registration", () => {
         cacheWrite: 0,
       });
       expect(result?.provider.apiKey).toBe("profile-key");
-      expect(result.provider.models.map((model) => model.id)).toEqual([
-        "profile/live-model",
-        ...DEEPINFRA_MODEL_CATALOG.map((model) => model.id),
-      ]);
+      expect(result.outcomes).toEqual([{ provider: "deepinfra", status: "ready" }]);
+      expect(result.provider.models.map((model) => model.id)).toEqual(["profile/live-model"]);
     });
   });
 });

--- a/extensions/deepinfra/index.ts
+++ b/extensions/deepinfra/index.ts
@@ -1,9 +1,5 @@
 // Deepinfra plugin entrypoint registers its OpenClaw integration.
-import {
-  type ProviderCatalogContext,
-  type ConfiguredProviderCatalogEntry,
-  readConfiguredProviderCatalogEntries,
-} from "openclaw/plugin-sdk/provider-catalog-shared";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import {
@@ -18,9 +14,7 @@ import { applyDeepInfraConfig } from "./onboard.js";
 import { buildDeepInfraApiKeyCatalog, buildStaticDeepInfraProvider } from "./provider-catalog.js";
 import {
   DEEPINFRA_DEFAULT_MODEL_REF,
-  discoverDeepInfraModels,
   getDeepInfraSurfaceFallbackCatalog,
-  hasDeepInfraApiKey,
 } from "./provider-models.js";
 import { buildDeepInfraSpeechProvider } from "./speech-provider.js";
 import {
@@ -68,38 +62,6 @@ export default defineSingleProviderPluginEntry({
       order: "simple",
       run: (ctx: ProviderCatalogContext) => buildDeepInfraApiKeyCatalog(ctx),
       staticRun: async () => ({ provider: buildStaticDeepInfraProvider() }),
-    },
-    augmentModelCatalog: async ({ config, env, agentDir }) => {
-      const configured = readConfiguredProviderCatalogEntries({
-        config,
-        providerId: PROVIDER_ID,
-      });
-      // Gate dynamic discovery on the user having configured a DeepInfra API
-      // key (env var, config SecretInput, or auth-profile store).
-      // Pre-auth flows keep the curated manifest fallback so the model picker
-      // stays tight and startup stays offline-friendly.
-      const hasApiKey = hasDeepInfraApiKey({ env, agentDir, config });
-      const seen = new Set(configured.map((entry) => entry.id));
-      const discovered = await discoverDeepInfraModels({ hasApiKey, env, agentDir });
-      const merged: ConfiguredProviderCatalogEntry[] = [...configured];
-      for (const model of discovered) {
-        if (seen.has(model.id)) {
-          continue;
-        }
-        seen.add(model.id);
-        const input = model.input;
-        merged.push({
-          provider: PROVIDER_ID,
-          id: model.id,
-          name: model.name ?? model.id,
-          ...(typeof model.contextWindow === "number" && model.contextWindow > 0
-            ? { contextWindow: model.contextWindow }
-            : {}),
-          ...(typeof model.reasoning === "boolean" ? { reasoning: model.reasoning } : {}),
-          ...(input && input.length > 0 ? { input } : {}),
-        });
-      }
-      return merged;
     },
     normalizeConfig: ({ providerConfig }) => providerConfig,
     normalizeTransport: ({ api, baseUrl }) =>

--- a/extensions/deepinfra/provider-catalog.ts
+++ b/extensions/deepinfra/provider-catalog.ts
@@ -25,8 +25,12 @@ export async function buildDeepInfraProvider(options?: {
   hasApiKey?: boolean;
   env?: NodeJS.ProcessEnv;
   agentDir?: string;
+  discoveryMode?: "strict";
 }): Promise<ModelProviderConfig> {
-  const models = await discoverDeepInfraModels(options);
+  const models = await discoverDeepInfraModels({
+    ...options,
+    discoveryMode: options?.discoveryMode ?? "advisory",
+  });
   return {
     baseUrl: DEEPINFRA_BASE_URL,
     api: "openai-completions",
@@ -46,6 +50,7 @@ export function buildDeepInfraApiKeyCatalog(
         buildProvider: () =>
           buildDeepInfraProvider({
             hasApiKey: true,
+            discoveryMode: "strict",
             env: ctx.env,
             agentDir: ctx.agentDir,
           }),

--- a/extensions/deepinfra/provider-catalog.ts
+++ b/extensions/deepinfra/provider-catalog.ts
@@ -1,4 +1,5 @@
 // Deepinfra provider module implements model/runtime integration.
+import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {
   buildSingleProviderApiKeyCatalog,
   type ProviderCatalogContext,
@@ -36,16 +37,18 @@ export async function buildDeepInfraProvider(options?: {
 export function buildDeepInfraApiKeyCatalog(
   ctx: ProviderCatalogContext,
 ): Promise<ProviderCatalogResult> {
-  return buildSingleProviderApiKeyCatalog({
-    ctx,
+  return runLiveProviderCatalog({
     providerId: "deepinfra",
-    // The shared API-key helper already resolved env/profile credentials.
-    // Pass that fact into discovery so profile-only setups get the live catalog.
-    buildProvider: () =>
-      buildDeepInfraProvider({
-        hasApiKey: true,
-        env: ctx.env,
-        agentDir: ctx.agentDir,
+    run: () =>
+      buildSingleProviderApiKeyCatalog({
+        ctx,
+        providerId: "deepinfra",
+        buildProvider: () =>
+          buildDeepInfraProvider({
+            hasApiKey: true,
+            env: ctx.env,
+            agentDir: ctx.agentDir,
+          }),
       }),
   });
 }

--- a/extensions/deepinfra/provider-models.pricing.test.ts
+++ b/extensions/deepinfra/provider-models.pricing.test.ts
@@ -1,5 +1,6 @@
 import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDeepInfraProvider } from "./api.js";
 import { DEEPINFRA_MODEL_CATALOG, discoverDeepInfraModels } from "./provider-models.js";
 
 const DEEPINFRA_MODELS_URL =
@@ -32,6 +33,49 @@ async function withFetchPathTest(mockFetch: ReturnType<typeof vi.fn>, run: () =>
 }
 
 describe("DeepInfra native runtime prices", () => {
+  it.each([
+    { metadata: 503, pricing: 503, empty: false },
+    { metadata: 503, pricing: 200, empty: false },
+    { metadata: 200, pricing: 503, empty: false },
+    { metadata: 200, pricing: 200, empty: true },
+  ])("keeps the public builder advisory for $metadata/$pricing empty=$empty", async (scenario) => {
+    const mockFetch = vi.fn(async (url: string) => {
+      const metadata = url === DEEPINFRA_MODELS_URL;
+      const status = metadata ? scenario.metadata : scenario.pricing;
+      if (status !== 200) {
+        return new Response("unavailable", { status });
+      }
+      return jsonResponse(
+        metadata
+          ? { data: scenario.empty ? [] : [makeAgentModelEntry({ id: "fixture/public-model" })] }
+          : [
+              {
+                model_name: "fixture/public-model",
+                pricing: {
+                  type: "tokens",
+                  cents_per_input_token: 0.0002,
+                  cents_per_output_token: 0.001,
+                },
+              },
+            ],
+      );
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const provider = await buildDeepInfraProvider({ hasApiKey: true });
+      expect(provider.models.map((model) => model.id)).toEqual(
+        expect.arrayContaining(DEEPINFRA_MODEL_CATALOG.map((model) => model.id)),
+      );
+      if (scenario.metadata === 200 && !scenario.empty) {
+        expect(provider.models.find((model) => model.id === "fixture/public-model")?.cost).toEqual({
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+        });
+      }
+    });
+  });
+
   it("rejects failed metadata even when native pricing succeeds", async () => {
     const seedId = DEEPINFRA_MODEL_CATALOG[0]!.id;
     const mockFetch = vi.fn(async (url: string) => {

--- a/extensions/deepinfra/provider-models.pricing.test.ts
+++ b/extensions/deepinfra/provider-models.pricing.test.ts
@@ -27,16 +27,13 @@ afterEach(() => {
 });
 
 async function withFetchPathTest(mockFetch: ReturnType<typeof vi.fn>, run: () => Promise<void>) {
-  vi.stubEnv("NODE_ENV", undefined);
-  vi.stubEnv("VITEST", undefined);
   vi.stubGlobal("fetch", mockFetch);
   await run();
 }
 
 describe("DeepInfra native runtime prices", () => {
-  it("keeps native prices with static metadata when metadata discovery fails", async () => {
+  it("rejects failed metadata even when native pricing succeeds", async () => {
     const seedId = DEEPINFRA_MODEL_CATALOG[0]!.id;
-    const nativeCost = { input: 1, output: 5, cacheRead: 0.2, cacheWrite: 0 };
     const mockFetch = vi.fn(async (url: string) => {
       if (url === DEEPINFRA_MODELS_URL) {
         return new Response("unavailable", { status: 503 });
@@ -56,23 +53,15 @@ describe("DeepInfra native runtime prices", () => {
       );
     });
     await withFetchPathTest(mockFetch, async () => {
-      const offline = await discoverDeepInfraModels({ hasApiKey: false });
+      await discoverDeepInfraModels({ hasApiKey: false });
       expect(mockFetch).not.toHaveBeenCalled();
-      const models = await discoverDeepInfraModels({ hasApiKey: true });
-      expect(models.map((model) => model.id)).toEqual(offline.map((model) => model.id));
-      expect(models[0]?.cost).toEqual(nativeCost);
-      for (const [index, model] of models.entries()) {
-        expect(model).toEqual({
-          ...offline[index],
-          cost: index === 0 ? nativeCost : { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        });
-      }
+      await expect(discoverDeepInfraModels({ hasApiKey: true })).rejects.toThrow("HTTP 503");
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 
   it.each(["unavailable", "malformed", "absent"])(
-    "keeps metadata with unknown costs when native pricing is %s and recovers without refetching metadata",
+    "rejects %s native pricing and recovers without refetching metadata",
     async (failure) => {
       let nativeCalls = 0;
       const mockFetch = vi.fn(async (url: string) => {
@@ -111,18 +100,14 @@ describe("DeepInfra native runtime prices", () => {
         ]);
       });
       await withFetchPathTest(mockFetch, async () => {
-        const unknown = await discoverDeepInfraModels({ hasApiKey: true });
-        expect(unknown[0]).toMatchObject({
-          id: "fixture/recovered",
-          contextWindow: 131072,
-          maxTokens: 65536,
-        });
-        expect(
-          unknown.every((model) => Object.values(model.cost).every((rate) => rate === 0)),
-        ).toBe(true);
+        await expect(discoverDeepInfraModels({ hasApiKey: true })).rejects.toThrow(
+          failure === "unavailable"
+            ? "HTTP 503"
+            : "Native DeepInfra pricing is malformed or has no usable schedules",
+        );
         const recovered = await discoverDeepInfraModels({ hasApiKey: true });
         expect(recovered[0]?.cost).toEqual({ input: 2, output: 10, cacheRead: 0, cacheWrite: 0 });
-        expect(recovered.map((model) => model.id)).toEqual(unknown.map((model) => model.id));
+        expect(recovered.map((model) => model.id)).toEqual(["fixture/recovered"]);
         expect(await discoverDeepInfraModels({ hasApiKey: true })).toEqual(recovered);
         expect(mockFetch).toHaveBeenCalledTimes(3);
       });

--- a/extensions/deepinfra/provider-models.proxy.test.ts
+++ b/extensions/deepinfra/provider-models.proxy.test.ts
@@ -48,7 +48,12 @@ describe("DeepInfra model discovery proxy policy", () => {
           release,
         };
       });
-      await discoverDeepInfraModels({ hasApiKey: true, env: {} });
+      const acquisition = discoverDeepInfraModels({ hasApiKey: true, env: {} });
+      if (scenario === "success") {
+        await expect(acquisition).resolves.toMatchObject([{ id: "fixture/chat" }]);
+      } else {
+        await expect(acquisition).rejects.toThrow();
+      }
       expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
       expect(new Set(fetchWithSsrFGuardMock.mock.calls.map(([request]) => request.url))).toEqual(
         new Set([

--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -13,7 +13,6 @@ import {
   DEEPINFRA_MODEL_CATALOG,
   discoverDeepInfraModels,
   discoverDeepInfraSurfaces,
-  hasDeepInfraApiKey,
 } from "./provider-models.js";
 
 const DEEPINFRA_MODELS_URL =
@@ -141,64 +140,33 @@ describe("buildDeepInfraModelDefinition", () => {
   });
 });
 
-describe("hasDeepInfraApiKey", () => {
-  it("returns true via env var, false on missing / blank", () => {
-    expect(hasDeepInfraApiKey({ env: { DEEPINFRA_API_KEY: "sk-x" } })).toBe(true);
-    expect(hasDeepInfraApiKey({ env: { DEEPINFRA_API_KEY: "" } })).toBe(false);
-    expect(hasDeepInfraApiKey({ env: { DEEPINFRA_API_KEY: "   " } })).toBe(false);
-    expect(hasDeepInfraApiKey({ env: {} })).toBe(false);
-  });
-
-  it("falls back to the auth-profile store when no env var is set", () => {
-    isProviderApiKeyConfiguredMock.mockReturnValue(true);
-
-    expect(hasDeepInfraApiKey({ env: {}, agentDir: "/tmp/openclaw-agent" })).toBe(true);
-
-    expect(isProviderApiKeyConfiguredMock).toHaveBeenCalledTimes(1);
-    expect(isProviderApiKeyConfiguredMock).toHaveBeenCalledWith({
-      provider: "deepinfra",
-      agentDir: "/tmp/openclaw-agent",
+describe("DeepInfra pre-auth discovery", () => {
+  it.each([
+    { key: "sk-fixture", live: true },
+    { key: "", live: false },
+    { key: "   ", live: false },
+    { key: undefined, live: false },
+  ])("discovers only with a configured environment key: $live", async ({ key, live }) => {
+    const mockFetch = mockProjectionFetch(() => jsonResponse({ data: [makeAgentModelEntry()] }));
+    await withFetchPathTest(mockFetch, {}, async () => {
+      expect((await discoverDeepInfraSurfaces({ env: { DEEPINFRA_API_KEY: key } })).live).toBe(
+        live,
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(live ? 1 : 0);
     });
+    if (live) {
+      expect(isProviderApiKeyConfiguredMock).not.toHaveBeenCalled();
+    }
   });
 
-  it("accepts config-backed provider API keys before probing the profile store", () => {
-    expect(
-      hasDeepInfraApiKey({
-        env: {},
-        agentDir: "/tmp/openclaw-agent",
-        config: {
-          models: {
-            providers: {
-              deepinfra: {
-                apiKey: { source: "env", provider: "default", id: "CUSTOM_DEEPINFRA_KEY" },
-              },
-            },
-          },
-        },
-      }),
-    ).toBe(true);
-
-    expect(isProviderApiKeyConfiguredMock).not.toHaveBeenCalled();
-  });
-
-  it("short-circuits on env var and skips the profile-store probe", () => {
+  it("discovers with a saved profile when the environment has no key", async () => {
     isProviderApiKeyConfiguredMock.mockReturnValue(true);
-
-    expect(
-      hasDeepInfraApiKey({
-        env: { DEEPINFRA_API_KEY: "sk-x" },
-        agentDir: "/tmp/openclaw-agent",
-      }),
-    ).toBe(true);
-
-    expect(isProviderApiKeyConfiguredMock).not.toHaveBeenCalled();
-  });
-
-  it("returns false when env is empty and the auth-profile store has no deepinfra profile", () => {
-    isProviderApiKeyConfiguredMock.mockReturnValue(false);
-
-    expect(hasDeepInfraApiKey({ env: {}, agentDir: "/tmp/openclaw-agent" })).toBe(false);
-
+    const mockFetch = mockProjectionFetch(() => jsonResponse({ data: [makeAgentModelEntry()] }));
+    await withFetchPathTest(mockFetch, {}, async () => {
+      expect(
+        (await discoverDeepInfraSurfaces({ env: {}, agentDir: "/tmp/openclaw-agent" })).live,
+      ).toBe(true);
+    });
     expect(isProviderApiKeyConfiguredMock).toHaveBeenCalledWith({
       provider: "deepinfra",
       agentDir: "/tmp/openclaw-agent",

--- a/extensions/deepinfra/provider-models.test.ts
+++ b/extensions/deepinfra/provider-models.test.ts
@@ -59,25 +59,11 @@ function expectedStaticChatCatalog() {
   return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
 }
 
-function expectedLiveChatCatalog(liveModels: ReturnType<typeof expectedStaticChatCatalog>) {
-  const liveIds = new Set(liveModels.map((model) => model.id));
-  return [
-    ...liveModels,
-    ...expectedStaticChatCatalog()
-      .filter((model) => !liveIds.has(model.id))
-      .map((model) =>
-        Object.assign(model, { cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } }),
-      ),
-  ];
-}
-
 async function withFetchPathTest(
   mockFetch: ReturnType<typeof vi.fn>,
   envOverrides: Record<string, string | undefined>,
   runAssertions: () => Promise<void>,
 ) {
-  vi.stubEnv("NODE_ENV", undefined);
-  vi.stubEnv("VITEST", undefined);
   for (const [key, value] of Object.entries(envOverrides)) {
     vi.stubEnv(key, value);
   }
@@ -220,9 +206,9 @@ describe("hasDeepInfraApiKey", () => {
   });
 });
 
-describe("discoverDeepInfraModels (chat-only shim)", () => {
-  it("returns static catalog in test environment", async () => {
-    const models = await discoverDeepInfraModels({ env: { VITEST: "true" } });
+describe("discoverDeepInfraModels", () => {
+  it("returns static catalog without credentials", async () => {
+    const models = await discoverDeepInfraModels({ hasApiKey: false });
     const modelIds = models.map((m) => m.id);
     const streamingUsageIncompatibleModelIds = models
       .filter((m) => !m.compat?.supportsUsageInStreaming)
@@ -249,20 +235,18 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
       expect(fetchSignal).toBeInstanceOf(AbortSignal);
       expect(fetchHeaders).toBeInstanceOf(Headers);
       expect((fetchHeaders as Headers).get("Accept")).toBe("application/json");
-      expect(models).toEqual(
-        expectedLiveChatCatalog([
-          {
-            id: "openai/gpt-oss-120b",
-            name: "openai/gpt-oss-120b",
-            reasoning: true,
-            input: ["text", "image"],
-            contextWindow: 131072,
-            maxTokens: 65536,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            compat: { supportsUsageInStreaming: true },
-          },
-        ]),
-      );
+      expect(models).toEqual([
+        {
+          id: "openai/gpt-oss-120b",
+          name: "openai/gpt-oss-120b",
+          reasoning: true,
+          input: ["text", "image"],
+          contextWindow: 131072,
+          maxTokens: 65536,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          compat: { supportsUsageInStreaming: true },
+        },
+      ]);
     });
   });
 
@@ -369,7 +353,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
       const models = await discoverDeepInfraModels();
       expect(models.map((m) => m.id)).toEqual(
-        expectedLiveChatCatalog([
+        [
           {
             id: "openai/gpt-oss-120b",
             name: "openai/gpt-oss-120b",
@@ -380,7 +364,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: { supportsUsageInStreaming: true },
           },
-        ]).map((model) => model.id),
+        ].map((model) => model.id),
       );
     });
   });
@@ -395,43 +379,60 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
     });
   });
 
-  it("falls back to the complete static catalog when both sources fail", async () => {
+  it("rejects a chat acquisition when both sources fail", async () => {
     const mockFetch = vi.fn().mockRejectedValue(new Error("network error"));
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
-      const models = await discoverDeepInfraModels();
-      expect(models).toEqual(expectedStaticChatCatalog());
+      await expect(discoverDeepInfraModels()).rejects.toThrow();
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 
-  it("falls back to the static catalog on non-2xx HTTP responses", async () => {
+  it("rejects non-2xx metadata despite successful pricing", async () => {
     const mockFetch = mockProjectionFetch(
       vi.fn().mockResolvedValue(new Response("", { status: 503 })),
     );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
-      const models = await discoverDeepInfraModels();
-      expect(models.map((m) => m.id)).toEqual(expectedStaticChatCatalog().map((model) => model.id));
+      await expect(discoverDeepInfraModels()).rejects.toThrow("HTTP 503");
     });
   });
 
-  it("falls back without caching malformed successful model list payloads", async () => {
+  it.each([
+    {
+      payload: { data: {} },
+      error: "Live model catalog response must be an array or { data: [] }",
+    },
+    {
+      payload: { data: [{ id: "broken/model", metadata: true }] },
+      error: "metadata discovery unavailable",
+    },
+    {
+      payload: { data: [{ id: "broken/model", metadata: { tags: "chat" } }] },
+      error: "metadata discovery unavailable",
+    },
+    {
+      payload: { data: [{ id: "broken/model", metadata: { tags: [42] } }] },
+      error: "metadata discovery unavailable",
+    },
+    {
+      payload: { data: [makeAgentModelEntry(), { id: "broken/model", metadata: { tags: [42] } }] },
+      error: "metadata discovery unavailable",
+    },
+  ])("rejects malformed model payloads without caching them: %j", async ({ payload, error }) => {
     const mockFetch = mockProjectionFetch(
       vi
         .fn()
-        .mockResolvedValueOnce(jsonResponse({ data: {} }))
+        .mockResolvedValueOnce(jsonResponse(payload))
         .mockResolvedValueOnce(
           jsonResponse({ data: [makeAgentModelEntry({ id: "recovered/model" })] }),
         ),
     );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
+      await expect(discoverDeepInfraModels()).rejects.toThrow(error);
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(
-        expectedStaticChatCatalog().map((model) => model.id),
-      );
-      expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(
-        expectedLiveChatCatalog([
+        [
           {
             id: "recovered/model",
             name: "recovered/model",
@@ -442,7 +443,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
             cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
             compat: { supportsUsageInStreaming: true },
           },
-        ]).map((model) => model.id),
+        ].map((model) => model.id),
       );
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
@@ -459,7 +460,7 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
     );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
-      const expectedIds = expectedLiveChatCatalog([
+      const expectedIds = [
         {
           id: "first/model",
           name: "first/model",
@@ -470,14 +471,14 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           compat: { supportsUsageInStreaming: true },
         },
-      ]).map((model) => model.id);
+      ].map((model) => model.id);
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(expectedIds);
       expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(expectedIds);
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 
-  it("does not cache successful responses that produce no live catalog rows", async () => {
+  it("retains and caches a successful empty catalog", async () => {
     const mockFetch = mockProjectionFetch(
       vi
         .fn()
@@ -488,24 +489,9 @@ describe("discoverDeepInfraModels (chat-only shim)", () => {
     );
 
     await withFetchPathTest(mockFetch, { DEEPINFRA_API_KEY: "sk-test" }, async () => {
-      expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(
-        expectedStaticChatCatalog().map((model) => model.id),
-      );
-      expect((await discoverDeepInfraModels()).map((m) => m.id)).toEqual(
-        expectedLiveChatCatalog([
-          {
-            id: "recovered/model",
-            name: "recovered/model",
-            reasoning: true,
-            input: ["text", "image"],
-            contextWindow: 131072,
-            maxTokens: 65536,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-            compat: { supportsUsageInStreaming: true },
-          },
-        ]).map((model) => model.id),
-      );
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(await discoverDeepInfraModels()).toEqual([]);
+      expect(await discoverDeepInfraModels()).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -1,11 +1,7 @@
 import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 // Deepinfra provider module implements model/runtime integration.
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
-import {
-  fetchLiveProviderModelRows,
-  getCachedLiveProviderModelRows,
-  LiveModelCatalogHttpError,
-} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { fetchLiveProviderModelRows } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {
   buildManifestModelProviderConfig,
   getCachedLiveCatalogValue,
@@ -14,7 +10,7 @@ import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-s
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
-import { asPositiveSafeInteger } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { asPositiveSafeInteger, isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   DEEPINFRA_BASE_URL,
   DEEPINFRA_TTS_FALLBACK_CATALOG,
@@ -103,18 +99,22 @@ function entryToSurfaceModel(entry: DeepInfraAgentModelEntry): DeepInfraSurfaceM
     return null;
   }
   const metadata = entry.metadata;
-  if (!metadata) {
+  if (metadata === null) {
     return null;
   }
-  const tags = Array.isArray(metadata.tags)
-    ? metadata.tags.filter((t): t is string => typeof t === "string")
-    : [];
+  if (
+    !isRecord(metadata) ||
+    !Array.isArray(metadata.tags) ||
+    metadata.tags.some((tag) => typeof tag !== "string")
+  ) {
+    throw new Error("DeepInfra model metadata discovery unavailable.");
+  }
   const pricing: DeepInfraAgentModelPricing = metadata.pricing ?? {};
   return {
     id,
     name: id,
     description: metadata.description ?? undefined,
-    tags,
+    tags: metadata.tags,
     contextWindow: asPositiveSafeInteger(metadata.context_length),
     maxTokens: asPositiveSafeInteger(metadata.max_tokens),
     pricing,
@@ -155,10 +155,6 @@ function bucketBySurface(models: DeepInfraSurfaceModel[]): DeepInfraDiscoveredCa
     }
   }
   return catalog;
-}
-
-function hasDeepInfraSurfaceModelRows(rows: readonly unknown[]): boolean {
-  return rows.some((entry) => entryToSurfaceModel(entry as DeepInfraAgentModelEntry) !== null);
 }
 
 // Static fallback. Chat rows live in openclaw.plugin.json (manifest-validated);
@@ -288,8 +284,7 @@ function manifestFallbackCatalog(): DeepInfraDiscoveredCatalog {
 }
 
 // Sync per-surface fallback for the (sync) register callback. Media providers
-// register with these defaults; live discovery feeds the chat surface via
-// augmentModelCatalog and the catalog seams for image/video-gen.
+// register with these defaults; live discovery feeds the chat, image, and video catalog hooks.
 export function getDeepInfraSurfaceFallbackCatalog(): DeepInfraDiscoveredCatalog {
   return manifestFallbackCatalog();
 }
@@ -364,92 +359,80 @@ export function hasDeepInfraApiKey(options?: {
 
 function canDiscoverDeepInfra(options?: DeepInfraDiscoveryOptions): boolean {
   const env = options?.env ?? process.env;
-  if (env.NODE_ENV === "test" || env.VITEST) {
-    return false;
-  }
   return options?.hasApiKey ?? hasDeepInfraApiKey({ env, agentDir: options?.agentDir });
 }
 
-// Keep pre-auth and tests offline; successful discovery shares the five-minute live catalog cache.
+// Keep pre-auth offline; successful discovery shares the five-minute live catalog cache.
 export async function discoverDeepInfraSurfaces(
   options?: DeepInfraDiscoveryOptions,
 ): Promise<DeepInfraDiscoveredCatalog> {
-  return canDiscoverDeepInfra(options) ? loadDeepInfraSurfaces() : manifestFallbackCatalog();
+  if (canDiscoverDeepInfra(options)) {
+    try {
+      return await loadDeepInfraSurfaces();
+    } catch (error) {
+      log.warn(`Model metadata discovery unavailable: ${String(error)}`);
+    }
+  }
+  return manifestFallbackCatalog();
 }
 
 async function loadDeepInfraSurfaces(): Promise<DeepInfraDiscoveredCatalog> {
-  try {
-    const data = await getCachedLiveProviderModelRows({
-      providerId: "deepinfra",
-      endpoint: DEEPINFRA_MODELS_URL,
-      timeoutMs: DISCOVERY_TIMEOUT_MS,
-      ttlMs: DISCOVERY_CACHE_TTL_MS,
-      buildRequestHeaders: () => ({ Accept: "application/json" }),
-      auditContext: "deepinfra-model-discovery",
-      shouldCacheRows: hasDeepInfraSurfaceModelRows,
-      fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
-    });
-    if (data.length === 0) {
-      log.warn("No models found from DeepInfra agent-projection endpoint, using static catalog");
-      return manifestFallbackCatalog();
-    }
-    const seenIds = new Set<string>();
-    const surfaceModels: DeepInfraSurfaceModel[] = [];
-    for (const entry of data) {
-      const model = entryToSurfaceModel(entry as DeepInfraAgentModelEntry);
-      if (!model || seenIds.has(model.id)) {
-        continue;
+  return getCachedLiveCatalogValue({
+    keyParts: ["deepinfra", "surfaces", DEEPINFRA_MODELS_URL],
+    ttlMs: DISCOVERY_CACHE_TTL_MS,
+    load: async () => {
+      const data = await fetchLiveProviderModelRows({
+        providerId: "deepinfra",
+        endpoint: DEEPINFRA_MODELS_URL,
+        timeoutMs: DISCOVERY_TIMEOUT_MS,
+        buildRequestHeaders: () => ({ Accept: "application/json" }),
+        auditContext: "deepinfra-model-discovery",
+        fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
+      });
+      const seenIds = new Set<string>();
+      const surfaceModels: DeepInfraSurfaceModel[] = [];
+      for (const entry of data) {
+        const model = entryToSurfaceModel(entry as DeepInfraAgentModelEntry);
+        if (!model || seenIds.has(model.id)) {
+          continue;
+        }
+        seenIds.add(model.id);
+        surfaceModels.push(model);
       }
-      seenIds.add(model.id);
-      surfaceModels.push(model);
-    }
-    if (surfaceModels.length === 0) {
-      return manifestFallbackCatalog();
-    }
-    return bucketBySurface(surfaceModels);
-  } catch (error) {
-    if (error instanceof LiveModelCatalogHttpError) {
-      log.warn(`Failed to discover models: HTTP ${error.status}, using static catalog`);
-      return manifestFallbackCatalog();
-    }
-    log.warn(`Discovery failed: ${String(error)}, using static catalog`);
-    return manifestFallbackCatalog();
-  }
+      if (data.length > 0 && surfaceModels.length === 0) {
+        throw new Error("DeepInfra model metadata discovery unavailable.");
+      }
+      return bucketBySurface(surfaceModels);
+    },
+  });
 }
 
 async function discoverDeepInfraPricing() {
-  try {
-    return await getCachedLiveCatalogValue({
-      keyParts: ["deepinfra", "native-pricing", DEEPINFRA_PRICING_URL],
-      ttlMs: DISCOVERY_CACHE_TTL_MS,
-      load: async () => {
-        const rows = await fetchLiveProviderModelRows({
-          providerId: "deepinfra",
-          endpoint: DEEPINFRA_PRICING_URL,
-          timeoutMs: DISCOVERY_TIMEOUT_MS,
-          buildRequestHeaders: () => ({ Accept: "application/json" }),
-          auditContext: "deepinfra-pricing-discovery",
-          fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
-          readRows: (body) => {
-            if (!Array.isArray(body)) {
-              throw new Error("Native DeepInfra pricing response must be an array");
-            }
-            return body;
-          },
-        });
-        const prices = parseDeepInfraPricingCatalog(rows);
-        if (!prices) {
-          throw new Error("Native DeepInfra pricing is malformed or has no usable schedules");
-        }
-        return prices;
-      },
-    });
-  } catch (error) {
-    log.warn(
-      `Native pricing unavailable: ${String(error)}. Keeping model metadata with unknown estimates; retry discovery or configure explicit model costs.`,
-    );
-    return undefined;
-  }
+  return await getCachedLiveCatalogValue({
+    keyParts: ["deepinfra", "native-pricing", DEEPINFRA_PRICING_URL],
+    ttlMs: DISCOVERY_CACHE_TTL_MS,
+    load: async () => {
+      const rows = await fetchLiveProviderModelRows({
+        providerId: "deepinfra",
+        endpoint: DEEPINFRA_PRICING_URL,
+        timeoutMs: DISCOVERY_TIMEOUT_MS,
+        buildRequestHeaders: () => ({ Accept: "application/json" }),
+        auditContext: "deepinfra-pricing-discovery",
+        fetchGuard: (params) => fetchWithSsrFGuard(withTrustedEnvProxyGuardedFetchMode(params)),
+        readRows: (body) => {
+          if (!Array.isArray(body)) {
+            throw new Error("Native DeepInfra pricing response must be an array");
+          }
+          return body;
+        },
+      });
+      const prices = parseDeepInfraPricingCatalog(rows);
+      if (!prices) {
+        throw new Error("Native DeepInfra pricing is malformed or has no usable schedules");
+      }
+      return prices;
+    },
+  });
 }
 
 export async function discoverDeepInfraModels(
@@ -459,37 +442,36 @@ export async function discoverDeepInfraModels(
     return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
   }
   // Resolve auth once and load independent public facts concurrently within the discovery deadline.
-  // Media-only discovery continues to use just the agent projection.
-  const [catalog, prices] = await Promise.all([
+  // Finish both request releases before publishing; media only loads the projection.
+  const [metadata, pricing] = await Promise.allSettled([
     loadDeepInfraSurfaces(),
     discoverDeepInfraPricing(),
   ]);
-  if (!catalog.live && !prices) {
-    return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
+  if (metadata.status === "rejected") {
+    throw metadata.reason;
   }
-  const chatModels = catalog.chat.length > 0 ? catalog.chat : [...catalog.chat, ...catalog.vlm];
-  // Static surface rows omit chat compatibility metadata; keep the complete
-  // manifest seeds when metadata fails, then attach any available native prices.
-  const liveModels = catalog.live ? chatModels.map(chatSurfaceModelToModelDefinition) : [];
-  const seen = new Set(liveModels.map((model) => model.id));
-  const manifestModels = DEEPINFRA_MODEL_CATALOG.filter((model) => {
-    const unseen = !seen.has(model.id);
-    seen.add(model.id);
-    return unseen;
-  });
-  const models = [...liveModels, ...manifestModels];
-  const unknownPrices = models.filter((model) => !prices?.has(model.id)).length;
-  if (prices && unknownPrices > 0) {
+  const catalog = metadata.value;
+  const chatModels = catalog.chat.length > 0 ? catalog.chat : catalog.vlm;
+  // No price schedule is needed to publish an authoritative empty chat inventory.
+  if (chatModels.length === 0) {
+    return [];
+  }
+  if (pricing.status === "rejected") {
+    throw pricing.reason;
+  }
+  const prices = pricing.value;
+  const models = chatModels.map(chatSurfaceModelToModelDefinition);
+  const unknownPrices = models.filter((model) => !prices.has(model.id)).length;
+  if (unknownPrices > 0) {
     log.warn(
       `Native pricing unavailable or qualified for ${unknownPrices} models; keeping metadata with unknown estimates. Configure explicit model costs if needed.`,
     );
   }
-  // Price appended seeds too: a missing projection row must not revive stale bundled costs.
   // Runtime requires zeros for unknown prices; this is not evidence of free billing.
   return models.map((model) =>
     buildDeepInfraModelDefinition({
       ...model,
-      cost: prices?.get(model.id) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      cost: prices.get(model.id) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     }),
   );
 }

--- a/extensions/deepinfra/provider-models.ts
+++ b/extensions/deepinfra/provider-models.ts
@@ -8,7 +8,6 @@ import {
 } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
-import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { asPositiveSafeInteger, isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
@@ -44,11 +43,7 @@ type DeepInfraDiscoveryOptions = {
   hasApiKey?: boolean;
   env?: NodeJS.ProcessEnv;
   agentDir?: string;
-};
-
-type DeepInfraAuthConfig = {
-  secrets?: { defaults?: { env?: string; file?: string; exec?: string } };
-  models?: { providers?: Record<string, { apiKey?: unknown } | undefined> };
+  discoveryMode?: "strict" | "advisory";
 };
 
 type DeepInfraAgentModelPricing = DeepInfraSurfaceModel["pricing"];
@@ -113,7 +108,7 @@ function entryToSurfaceModel(entry: DeepInfraAgentModelEntry): DeepInfraSurfaceM
   return {
     id,
     name: id,
-    description: metadata.description ?? undefined,
+    description: typeof metadata.description === "string" ? metadata.description : undefined,
     tags: metadata.tags,
     contextWindow: asPositiveSafeInteger(metadata.context_length),
     maxTokens: asPositiveSafeInteger(metadata.max_tokens),
@@ -330,36 +325,16 @@ function chatSurfaceModelToModelDefinition(
   };
 }
 
-// Gate dynamic discovery on key presence: pre-auth keeps the picker tight and
-// avoids a useless network call. The endpoint itself is unauthenticated.
-// Accepts env-var keys and auth-profile-store keys via the shared
-// `isProviderApiKeyConfigured` helper (covers SecretRef / `OPENCLAW_LIVE_*`
-// indirection too).
-export function hasDeepInfraApiKey(options?: {
-  env?: NodeJS.ProcessEnv;
-  agentDir?: string;
-  config?: DeepInfraAuthConfig;
-}): boolean {
+function canDiscoverDeepInfra(options?: DeepInfraDiscoveryOptions): boolean {
+  if (options?.hasApiKey !== undefined) {
+    return options.hasApiKey;
+  }
   const env = options?.env ?? process.env;
   const fromEnv = env.DEEPINFRA_API_KEY;
-  if (typeof fromEnv === "string" && fromEnv.trim() !== "") {
-    return true;
-  }
-  const providers = options?.config?.models?.providers;
-  for (const [providerId, provider] of Object.entries(providers ?? {})) {
-    if (
-      providerId.trim().toLowerCase() === "deepinfra" &&
-      hasConfiguredSecretInput(provider?.apiKey, options?.config?.secrets?.defaults)
-    ) {
-      return true;
-    }
-  }
-  return isProviderApiKeyConfigured({ provider: "deepinfra", agentDir: options?.agentDir });
-}
-
-function canDiscoverDeepInfra(options?: DeepInfraDiscoveryOptions): boolean {
-  const env = options?.env ?? process.env;
-  return options?.hasApiKey ?? hasDeepInfraApiKey({ env, agentDir: options?.agentDir });
+  return (
+    (typeof fromEnv === "string" && fromEnv.trim() !== "") ||
+    isProviderApiKeyConfigured({ provider: "deepinfra", agentDir: options?.agentDir })
+  );
 }
 
 // Keep pre-auth offline; successful discovery shares the five-minute live catalog cache.
@@ -441,6 +416,7 @@ export async function discoverDeepInfraModels(
   if (!canDiscoverDeepInfra(options)) {
     return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
   }
+  const strict = options?.discoveryMode !== "advisory";
   // Resolve auth once and load independent public facts concurrently within the discovery deadline.
   // Finish both request releases before publishing; media only loads the projection.
   const [metadata, pricing] = await Promise.allSettled([
@@ -448,20 +424,29 @@ export async function discoverDeepInfraModels(
     discoverDeepInfraPricing(),
   ]);
   if (metadata.status === "rejected") {
-    throw metadata.reason;
+    if (strict) {
+      throw metadata.reason;
+    }
+    if (pricing.status === "rejected") {
+      return DEEPINFRA_MODEL_CATALOG.map(buildDeepInfraModelDefinition);
+    }
   }
-  const catalog = metadata.value;
-  const chatModels = catalog.chat.length > 0 ? catalog.chat : catalog.vlm;
+  const catalog = metadata.status === "fulfilled" ? metadata.value : undefined;
+  const chatModels = catalog ? (catalog.chat.length > 0 ? catalog.chat : catalog.vlm) : [];
   // No price schedule is needed to publish an authoritative empty chat inventory.
-  if (chatModels.length === 0) {
+  if (strict && chatModels.length === 0) {
     return [];
   }
-  if (pricing.status === "rejected") {
+  if (strict && pricing.status === "rejected") {
     throw pricing.reason;
   }
-  const prices = pricing.value;
+  const prices = pricing.status === "fulfilled" ? pricing.value : undefined;
   const models = chatModels.map(chatSurfaceModelToModelDefinition);
-  const unknownPrices = models.filter((model) => !prices.has(model.id)).length;
+  if (!strict) {
+    const discovered = new Set(models.map((model) => model.id));
+    models.push(...DEEPINFRA_MODEL_CATALOG.filter((model) => !discovered.has(model.id)));
+  }
+  const unknownPrices = models.filter((model) => !prices?.has(model.id)).length;
   if (unknownPrices > 0) {
     log.warn(
       `Native pricing unavailable or qualified for ${unknownPrices} models; keeping metadata with unknown estimates. Configure explicit model costs if needed.`,
@@ -471,7 +456,7 @@ export async function discoverDeepInfraModels(
   return models.map((model) =>
     buildDeepInfraModelDefinition({
       ...model,
-      cost: prices.get(model.id) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      cost: prices?.get(model.id) ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     }),
   );
 }

--- a/extensions/deepinfra/surface-model-catalogs.test.ts
+++ b/extensions/deepinfra/surface-model-catalogs.test.ts
@@ -58,29 +58,12 @@ function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
 }
 
 async function withLiveFetch(mockFetch: ReturnType<typeof vi.fn>, run: () => Promise<void>) {
-  const env = { ...process.env };
-  delete process.env.NODE_ENV;
-  delete process.env.VITEST;
-  process.env.DEEPINFRA_API_KEY = "sk-test";
+  vi.stubEnv("DEEPINFRA_API_KEY", "sk-test");
   vi.stubGlobal("fetch", mockFetch);
   try {
     await run();
   } finally {
-    if (env.NODE_ENV !== undefined) {
-      process.env.NODE_ENV = env.NODE_ENV;
-    } else {
-      delete process.env.NODE_ENV;
-    }
-    if (env.VITEST !== undefined) {
-      process.env.VITEST = env.VITEST;
-    } else {
-      delete process.env.VITEST;
-    }
-    if (env.DEEPINFRA_API_KEY !== undefined) {
-      process.env.DEEPINFRA_API_KEY = env.DEEPINFRA_API_KEY;
-    } else {
-      delete process.env.DEEPINFRA_API_KEY;
-    }
+    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
   }
 }
@@ -112,12 +95,12 @@ describe("listDeepInfraImageGenCatalog", () => {
     });
   });
 
-  it("returns null under VITEST even with a key (static fallback owns offline)", async () => {
-    // The default VITEST env path makes discoverDeepInfraSurfaces emit the
-    // manifest fallback (live=false), and the catalog provider rejects
-    // non-live results so it cannot serve stale offline data as "live".
-    const result = await listDeepInfraImageGenCatalog(withKeyCtx());
-    expect(result).toBeNull();
+  it("does not publish fallback models as live after an acquisition failure", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response("unavailable", { status: 503 }));
+    await withLiveFetch(mockFetch, async () => {
+      await expect(listDeepInfraImageGenCatalog(withKeyCtx())).resolves.toBeNull();
+      await expect(listDeepInfraVideoGenCatalog(withKeyCtx())).resolves.toBeNull();
+    });
   });
 
   it("projects discovered image-gen entries when a key is configured and discovery is live", async () => {

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -94,19 +94,38 @@ function buildCatalogContext(apiKey?: string) {
   };
 }
 
-function buildAugmentCatalogContext(apiKey?: string) {
-  const env = { ...process.env };
-  if (!apiKey) {
-    delete env.NVIDIA_API_KEY;
-  }
-  return {
-    ...buildCatalogContext(apiKey),
-    env,
-    entries: [],
-  };
-}
-
 describe("nvidia provider hooks", () => {
+  it.each([401, 403, 503])(
+    "reports public catalog HTTP %s without rejecting inference credentials",
+    async (status) => {
+      mockFeaturedCatalogResponse({ error: "unavailable" }, status);
+      const provider = await registerNvidiaProvider();
+      const rejected = status === 401 || status === 403;
+      await expect(provider.catalog?.run(buildCatalogContext("nvapi-test"))).resolves.toEqual({
+        providers: {},
+        outcomes: [
+          {
+            provider: "nvidia",
+            status: rejected ? "auth-rejected" : "unavailable",
+            ...(rejected ? { rejectionScope: "catalog" } : {}),
+          },
+        ],
+      });
+      for (const [request] of ssrfRuntimeMocks.fetchWithSsrFGuard.mock.calls) {
+        expect(new Headers(request.init.headers).has("authorization")).toBe(false);
+      }
+    },
+  );
+
+  it("publishes ready for successful empty inventory", async () => {
+    mockFeaturedCatalogResponse({ "featured-models": [] });
+    const provider = await registerNvidiaProvider();
+    await expect(provider.catalog?.run(buildCatalogContext("nvapi-test"))).resolves.toMatchObject({
+      provider: { apiKey: "nvapi-test", models: [] },
+      outcomes: [{ provider: "nvidia", status: "ready" }],
+    });
+  });
+
   it("registers the nvidia provider with correct metadata", async () => {
     const provider = await registerNvidiaProvider();
 
@@ -210,70 +229,6 @@ describe("nvidia provider hooks", () => {
 
     // NVIDIA uses standard streaming without custom wrappers
     expect(provider.wrapStreamFn).toBeUndefined();
-  });
-
-  it("surfaces the bundled NVIDIA models without fetching when no NVIDIA API token is available", async () => {
-    const provider = await registerNvidiaProvider();
-
-    const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext());
-
-    expect(entries?.map((entry) => entry.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "nvidia/nemotron-3.5-lightning-30b-a3b",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "z-ai/glm-5.2",
-      "moonshotai/kimi-k2.6",
-      "minimaxai/minimax-m3",
-      "deepseek-ai/deepseek-v4-pro",
-    ]);
-    expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
-  });
-
-  it("surfaces the bundled NVIDIA models when authenticated live discovery fails", async () => {
-    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
-    const provider = await registerNvidiaProvider();
-
-    const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
-
-    expect(entries?.map((entry) => entry.id)).toEqual([
-      "nvidia/nemotron-3-ultra-550b-a55b",
-      "nvidia/nemotron-3.5-lightning-30b-a3b",
-      "nvidia/nemotron-3-super-120b-a12b",
-      "z-ai/glm-5.2",
-      "moonshotai/kimi-k2.6",
-      "minimaxai/minimax-m3",
-      "deepseek-ai/deepseek-v4-pro",
-    ]);
-    expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
-  });
-
-  it("surfaces republished NVIDIA featured models via augmentModelCatalog", async () => {
-    mockFeaturedCatalogResponse({
-      "featured-models": [
-        {
-          model: "minimaxai/minimax-m3",
-          "model-name": "Minimax M3",
-          context: 196608,
-          "max-output": 8192,
-        },
-        {
-          model: "qwen/qwen3.5-397b-a17b",
-          "model-name": "Qwen3.5 397B A17B",
-          context: 262144,
-          "max-output": 32768,
-        },
-      ],
-    });
-    const provider = await registerNvidiaProvider();
-
-    const entries = await provider.augmentModelCatalog?.(buildAugmentCatalogContext("nvapi-test"));
-
-    expect(entries?.map((entry) => entry.id)).toEqual([
-      "minimaxai/minimax-m3",
-      "qwen/qwen3.5-397b-a17b",
-    ]);
   });
 
   it("opts into literal provider-prefix preservation", async () => {

--- a/extensions/nvidia/index.ts
+++ b/extensions/nvidia/index.ts
@@ -2,39 +2,9 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyNvidiaConfig, NVIDIA_DEFAULT_MODEL_REF } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
-import {
-  buildLiveNvidiaProvider,
-  buildSelectableNvidiaProvider,
-  buildSelectableLiveNvidiaProvider,
-} from "./provider-catalog.js";
+import { buildLiveNvidiaProvider, buildSelectableNvidiaProvider } from "./provider-catalog.js";
 
 const PROVIDER_ID = "nvidia";
-
-function hasNvidiaApiToken(ctx: {
-  env: NodeJS.ProcessEnv;
-  resolveProviderApiKey?: (providerId?: string) => { apiKey: string | undefined };
-}) {
-  return Boolean(
-    ctx.resolveProviderApiKey?.(PROVIDER_ID).apiKey?.trim() || ctx.env.NVIDIA_API_KEY?.trim(),
-  );
-}
-
-async function buildNvidiaCatalogModels(ctx: {
-  env: NodeJS.ProcessEnv;
-  resolveProviderApiKey?: (providerId?: string) => { apiKey: string | undefined };
-}) {
-  const provider = hasNvidiaApiToken(ctx)
-    ? await buildLiveNvidiaProvider()
-    : buildSelectableNvidiaProvider();
-  return provider.models.map((model) => ({
-    provider: PROVIDER_ID,
-    id: model.id,
-    name: model.name ?? model.id,
-    contextWindow: model.contextWindow,
-    reasoning: model.reasoning,
-    input: model.input,
-  }));
-}
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
@@ -50,10 +20,10 @@ export default defineSingleProviderPluginEntry({
       applyConfig: applyNvidiaConfig,
     },
     catalog: {
-      buildProvider: buildSelectableLiveNvidiaProvider,
+      discoveryMode: "strict",
+      buildProvider: buildLiveNvidiaProvider,
       buildStaticProvider: buildSelectableNvidiaProvider,
     },
-    augmentModelCatalog: buildNvidiaCatalogModels,
     wizard: {
       setup: {
         choiceId: "nvidia-api-key",

--- a/extensions/nvidia/nvidia.live.test.ts
+++ b/extensions/nvidia/nvidia.live.test.ts
@@ -1,12 +1,12 @@
 import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
 import { describe, expect, it } from "vitest";
-import { buildSelectableLiveNvidiaProvider } from "./provider-catalog.js";
+import { buildLiveNvidiaProvider } from "./provider-catalog.js";
 
 const describeLive = isLiveTestEnabled() ? describe : describe.skip;
 
 describeLive("NVIDIA public catalog live", () => {
   it("finds Lightning outside the featured feed without offering non-chat inventory", async () => {
-    const provider = await buildSelectableLiveNvidiaProvider();
+    const provider = await buildLiveNvidiaProvider();
     expect(
       provider.models.find((model) => model.id === "nvidia/nemotron-3.5-lightning-30b-a3b"),
     ).toMatchObject({

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -6,7 +6,6 @@ import {
   buildLiveNvidiaProvider,
   buildNvidiaProvider,
   buildSelectableNvidiaProvider,
-  buildSelectableLiveNvidiaProvider,
 } from "./provider-catalog.js";
 
 const NVIDIA_FEATURED_MODELS_URL =
@@ -214,41 +213,36 @@ describe("nvidia provider catalog", () => {
     ]);
   });
 
-  it("uses known live models when the featured feed fails", async () => {
+  it("rejects an incomplete acquisition when the featured feed fails", async () => {
     mockInventoryAndFeatured({
       ids: ["nvidia/nemotron-3-ultra-550b-a55b"],
       featured: [],
       featuredStatus: 503,
     });
 
-    const provider = await buildSelectableLiveNvidiaProvider();
-
-    expect(provider.models).toMatchObject([
-      {
-        id: "nvidia/nemotron-3-ultra-550b-a55b",
-        reasoning: true,
-        params: { chat_template_kwargs: { enable_thinking: false, force_nonempty_content: true } },
-      },
-    ]);
-    expect(provider.models).toHaveLength(1);
+    await expect(buildLiveNvidiaProvider()).rejects.toThrow("HTTP 503");
   });
 
-  it("does not turn an empty authoritative inventory into a bundled fallback", async () => {
-    mockInventoryAndFeatured({
-      ids: [],
-      featured: [
-        {
-          model: "z-ai/glm-5.2",
-          "model-name": "Stale featured model",
-          context: 202752,
-          "max-output": 8192,
-        },
-      ],
-    });
+  it.each([200, 503])(
+    "keeps empty inventory authoritative with featured HTTP %s",
+    async (featuredStatus) => {
+      mockInventoryAndFeatured({
+        ids: [],
+        featuredStatus,
+        featured: [
+          {
+            model: "z-ai/glm-5.2",
+            "model-name": "Stale featured model",
+            context: 202752,
+            "max-output": 8192,
+          },
+        ],
+      });
 
-    expect((await buildLiveNvidiaProvider()).models).toEqual([]);
-    expect((await buildSelectableLiveNvidiaProvider()).models).toEqual([]);
-  });
+      expect((await buildLiveNvidiaProvider()).models).toEqual([]);
+      expect((await buildLiveNvidiaProvider()).models).toEqual([]);
+    },
+  );
 
   it("does not treat featured rows as fresh inventory when model discovery fails", async () => {
     mockInventoryAndFeatured({
@@ -259,10 +253,7 @@ describe("nvidia provider catalog", () => {
       ],
     });
 
-    expect((await buildLiveNvidiaProvider()).models.map((model) => model.id)).toEqual(
-      EXPECTED_SELECTABLE_MODELS.map((model) => model.id),
-    );
-    expect((await buildSelectableLiveNvidiaProvider()).models).toEqual([]);
+    await expect(buildLiveNvidiaProvider()).rejects.toThrow("HTTP 503");
   });
 
   it("builds the bundled NVIDIA provider defaults", () => {
@@ -418,42 +409,6 @@ describe("nvidia provider catalog", () => {
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("falls back to the bundled catalog when live discovery is unavailable", async () => {
-    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
-
-    const provider = await buildLiveNvidiaProvider();
-
-    expect(provider.models.map((model) => model.id)).toEqual(
-      EXPECTED_SELECTABLE_MODELS.map((model) => model.id),
-    );
-  });
-
-  it("uses only selectable live catalog rows when the featured catalog returns models", async () => {
-    mockFeaturedCatalogResponse({
-      "featured-models": [
-        {
-          model: "z-ai/glm-5.2",
-          "model-name": "GLM 5.2",
-          context: 202752,
-          "max-output": 8192,
-        },
-        {
-          model: "nemotron-3-super-120b-a12b",
-          "model-name": "Nemotron 3 Super 120B",
-          context: 262144,
-          "max-output": 8192,
-        },
-      ],
-    });
-
-    const provider = await buildSelectableLiveNvidiaProvider();
-
-    expect(provider.models.map((model) => model.id)).toEqual([
-      "z-ai/glm-5.2",
-      "nvidia/nemotron-3-super-120b-a12b",
-    ]);
-  });
-
   it("restores bundled legacy models when NVIDIA republishes them in its featured catalog", async () => {
     mockFeaturedCatalogResponse({
       "featured-models": [
@@ -473,14 +428,12 @@ describe("nvidia provider catalog", () => {
     });
 
     const live = await buildLiveNvidiaProvider();
-    const selectableLive = await buildSelectableLiveNvidiaProvider();
     const republishedIds = [
       "minimaxai/minimax-m3",
       ...EXPECTED_DEPRECATED_MODELS.map((model) => model.id),
     ];
 
     expect(live.models.map((model) => model.id)).toEqual(republishedIds);
-    expect(selectableLive.models.map((model) => model.id)).toEqual(republishedIds);
   });
 
   it("maps a republished Qwen model from NVIDIA's current featured catalog", async () => {
@@ -520,14 +473,6 @@ describe("nvidia provider catalog", () => {
       { id: "deepseek-ai/deepseek-v4-pro", contextWindow: 262_144, maxTokens: 16_384 },
       { id: "qwen/qwen3.5-397b-a17b", contextWindow: 262_144, maxTokens: 16_384 },
     ]);
-  });
-
-  it("returns no selectable live rows when live discovery is unavailable", async () => {
-    mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
-
-    const provider = await buildSelectableLiveNvidiaProvider();
-
-    expect(provider.models.map((model) => model.id)).toEqual([]);
   });
 
   it("ignores malformed featured catalog rows and keeps valid entries", async () => {
@@ -603,12 +548,8 @@ describe("nvidia provider catalog", () => {
       ],
     });
 
-    const first = await buildLiveNvidiaProvider();
+    await expect(buildLiveNvidiaProvider()).rejects.toThrow("no usable model metadata");
     const second = await buildLiveNvidiaProvider();
-
-    expect(first.models).toMatchObject([
-      { id: "z-ai/glm-5.2", name: "GLM 5.2", contextWindow: 202752 },
-    ]);
     expect(second.models).toMatchObject([
       { id: "z-ai/glm-5.2", name: "Updated GLM 5.2", contextWindow: 262144 },
     ]);

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -97,101 +97,98 @@ export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
   const provider = buildNvidiaProvider();
   return {
     ...provider,
-    models:
-      (await loadNvidiaLiveModels(provider.models)) ??
-      filterSelectableNvidiaModels(provider.models),
-  };
-}
-
-export async function buildSelectableLiveNvidiaProvider(): Promise<ModelProviderConfig> {
-  const provider = buildNvidiaProvider();
-  return {
-    ...provider,
-    models: (await loadNvidiaLiveModels(provider.models)) ?? [],
+    models: await loadNvidiaLiveModels(provider.models),
   };
 }
 
 async function loadNvidiaLiveModels(
   bundledModels: ModelDefinitionConfig[],
-): Promise<ModelDefinitionConfig[] | null> {
-  try {
-    const [rows, featured] = await Promise.all([
-      getCachedLiveProviderModelRows({
-        providerId: "nvidia",
-        endpoint: NVIDIA_MODELS_URL,
-        requireHttps: true,
-        readRows: (payload) => {
-          if (!isRecord(payload) || !Array.isArray(payload.data)) {
-            throw new Error("NVIDIA model inventory must contain data[]");
-          }
-          if (payload.data.some((row) => !readLiveModelCatalogStringField(row, "id"))) {
-            throw new Error("NVIDIA model inventory contains a row without an id");
-          }
-          return payload.data;
-        },
-      }),
-      loadNvidiaFeaturedModels(),
-    ]);
-    const available = new Set(rows.map((row) => readLiveModelCatalogStringField(row, "id")));
-    const known = new Map(bundledModels.map((model) => [model.id, model]));
-    // /models includes embeddings and other non-chat endpoints without capabilities.
-    // Only exact known chat metadata or the vendor's featured chat rows are selectable.
-    const ranked = new Map(
-      (featured ?? []).map((model) => {
-        const bundled = known.get(model.id);
-        return [
-          model.id,
-          bundled
-            ? {
-                ...bundled,
-                name: model.name,
-                contextWindow: model.contextWindow,
-                maxTokens: model.maxTokens,
-              }
-            : model,
-        ];
-      }),
-    );
-    for (const [id, model] of known) {
-      if (!ranked.has(id)) {
-        ranked.set(id, model);
-      }
-    }
-    // A fresh inventory can restore a republished legacy id, but a stale featured
-    // recommendation cannot restore an id the inference endpoint no longer lists.
-    return [...ranked.values()].filter((model) => available.has(model.id));
-  } catch {
-    return null;
+): Promise<ModelDefinitionConfig[]> {
+  const [inventory, featured] = await Promise.allSettled([
+    getCachedLiveProviderModelRows({
+      providerId: "nvidia",
+      endpoint: NVIDIA_MODELS_URL,
+      requireHttps: true,
+      readRows: (payload) => {
+        if (!isRecord(payload) || !Array.isArray(payload.data)) {
+          throw new Error("NVIDIA model inventory must contain data[]");
+        }
+        if (payload.data.some((row) => !readLiveModelCatalogStringField(row, "id"))) {
+          throw new Error("NVIDIA model inventory contains a row without an id");
+        }
+        return payload.data;
+      },
+    }),
+    loadNvidiaFeaturedModels(),
+  ]);
+  if (inventory.status === "rejected") {
+    throw inventory.reason;
   }
+  // Empty inference inventory is authoritative even when featured metadata is unavailable.
+  if (inventory.value.length === 0) {
+    return [];
+  }
+  if (featured.status === "rejected") {
+    throw featured.reason;
+  }
+  const available = new Set(
+    inventory.value.map((row) => readLiveModelCatalogStringField(row, "id")),
+  );
+  const known = new Map(bundledModels.map((model) => [model.id, model]));
+  // /models includes embeddings and other non-chat endpoints without capabilities.
+  // Only exact known chat metadata or the vendor's featured chat rows are selectable.
+  const ranked = new Map(
+    featured.value.map((model) => {
+      const bundled = known.get(model.id);
+      return [
+        model.id,
+        bundled
+          ? {
+              ...bundled,
+              name: model.name,
+              contextWindow: model.contextWindow,
+              maxTokens: model.maxTokens,
+            }
+          : model,
+      ];
+    }),
+  );
+  for (const [id, model] of known) {
+    if (!ranked.has(id)) {
+      ranked.set(id, model);
+    }
+  }
+  // A fresh inventory can restore a republished legacy id, but a stale featured
+  // recommendation cannot restore an id the inference endpoint no longer lists.
+  return [...ranked.values()].filter((model) => available.has(model.id));
 }
 
-async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {
-  try {
-    const rows = await getCachedLiveProviderModelRows({
-      providerId: "nvidia",
-      endpoint: NVIDIA_FEATURED_MODELS_URL,
-      timeoutMs: FEATURED_MODEL_FETCH_TIMEOUT_MS,
-      ttlMs: FEATURED_MODEL_CACHE_TTL_MS,
-      requireHttps: true,
-      policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(NVIDIA_FEATURED_MODELS_URL),
-      // The featured catalog is an NVIDIA-owned CloudFront URL. Some resolvers
-      // stall for seconds on the default all-family lookup; IPv4 pinning keeps
-      // the guarded fixed-host fetch on the fast path.
-      lookupFn: lookupNvidiaFeaturedModelHostname,
-      auditContext: "nvidia-featured-model-catalog",
-      shouldCacheRows: (modelRows) => parseNvidiaFeaturedModels(modelRows) !== null,
-      readRows: (payload) => {
-        if (!payload || typeof payload !== "object") {
-          return [];
-        }
-        const featuredRows = (payload as { "featured-models"?: unknown })["featured-models"];
-        return Array.isArray(featuredRows) ? featuredRows : [];
-      },
-    });
-    return parseNvidiaFeaturedModels(rows);
-  } catch {
-    return null;
+async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[]> {
+  const rows = await getCachedLiveProviderModelRows({
+    providerId: "nvidia",
+    endpoint: NVIDIA_FEATURED_MODELS_URL,
+    timeoutMs: FEATURED_MODEL_FETCH_TIMEOUT_MS,
+    ttlMs: FEATURED_MODEL_CACHE_TTL_MS,
+    requireHttps: true,
+    policy: ssrfPolicyFromHttpBaseUrlAllowedHostname(NVIDIA_FEATURED_MODELS_URL),
+    // The featured catalog is an NVIDIA-owned CloudFront URL. Some resolvers
+    // stall for seconds on the default all-family lookup; IPv4 pinning keeps
+    // the guarded fixed-host fetch on the fast path.
+    lookupFn: lookupNvidiaFeaturedModelHostname,
+    auditContext: "nvidia-featured-model-catalog",
+    shouldCacheRows: (modelRows) => parseNvidiaFeaturedModels(modelRows) !== null,
+    readRows: (payload) => {
+      if (!isRecord(payload) || !Array.isArray(payload["featured-models"])) {
+        throw new Error("NVIDIA featured catalog must contain featured-models[]");
+      }
+      return payload["featured-models"];
+    },
+  });
+  const models = parseNvidiaFeaturedModels(rows);
+  if (!models) {
+    throw new Error("NVIDIA featured catalog contains no usable model metadata");
   }
+  return models;
 }
 
 function parseNvidiaFeaturedModels(rows: readonly unknown[]): ModelDefinitionConfig[] | null {
@@ -199,7 +196,7 @@ function parseNvidiaFeaturedModels(rows: readonly unknown[]): ModelDefinitionCon
     .slice(0, FEATURED_MODEL_MAX_ROWS)
     .map(parseNvidiaFeaturedModel)
     .filter((model) => model !== null);
-  return models.length > 0 ? models : null;
+  return rows.length === 0 || models.length > 0 ? models : null;
 }
 
 function applyNvidiaModelDefaults(models: ModelDefinitionConfig[]): ModelDefinitionConfig[] {


### PR DESCRIPTION
Related: #136257, #139357, #139649. AI-assisted.

## What Problem This Solves

Two catalog providers could lose learned models or report success after failed refreshes. Empty discovery could restore starters, and an optional featured feed could remove a model still present in inference inventory.

## Why This Change Was Made

Both plugins use the shared acquisition owner, removing duplicate fetches and a live builder. Validated metadata retains original HTTP failures for strict discovery, while the published builder keeps its advisory defaults. Optional pricing and featured metadata remain separate from membership.

## User Impact

Failures retain compatible inventory with an explicit outcome. Successful empty results stay empty through later failure. Account changes retire old learned rows. Public metadata neither rejects credentials nor claims profile attribution. Explicit models and request defaults remain unchanged.

Consumers: both registered catalog hooks and their metadata caches now distinguish failure, empty membership, and optional enrichment.

## Evidence

Regressions reproduced hidden failures, restored starters, and featured-feed loss. Compiled checks covered retention, recovery, empty results, account changes, and helper compatibility. The final correction passed 52 checks. Public feeds returned inventory and pricing; request records confirmed anonymous discovery. Cache expiry used controlled clock changes. Picker appearance and real inference were not tested.
