### PR TITLE
fix: clear stale failures and duplicate answers after model fallback

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2749,7 +2749,7 @@ src/gateway/channel-health-monitor.ts	6
 src/gateway/channel-thaw-restart.ts	1
 src/gateway/chat-attachments.ts	4
 src/gateway/chat-display-projection.canvas.ts	14
-src/gateway/chat-display-projection.core.ts	6
+src/gateway/chat-display-projection.core.ts	5
 src/gateway/chat-display-projection.helpers.ts	10
 src/gateway/chat-display-projection.history.ts	1
 src/gateway/chat-display-projection.sanitize.ts	15

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -93,6 +93,8 @@ When a later probe succeeds and the session returns to the selected primary, Ope
 
 These notices are operational messages, not assistant content. They deliver once per state change outside group and channel conversations, including side-effect-only turns when feasible, but repeated turn-local fallback transitions do not repeat them. Group and channel conversations suppress the visible notices while retaining the same fallback state and lifecycle events. Delivery bypasses normal source-reply suppression, does not consume the first assistant reply slot for threaded channels, and is excluded from text-to-speech.
 
+When a fallback answers, the Control UI shows the successful answer once and removes empty failed-attempt placeholders from that same run. The raw transcript retains the failed attempts for troubleshooting. Failed turns and attempts that produced partial visible output remain visible.
+
 ## Auth storage (keys + OAuth)
 
 OpenClaw uses **auth profiles** for both API keys and OAuth tokens.

--- a/src/agents/tools/embedded-gateway-stub.history.test.ts
+++ b/src/agents/tools/embedded-gateway-stub.history.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import * as serverConstants from "../../gateway/server-constants.js";
-import { readChatHistoryMessageId } from "../../gateway/server-methods/chat-history-pages.js";
+import { readChatHistoryMessageId } from "../../gateway/session-history-tail.js";
 import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createEmbeddedCallGateway } from "./embedded-gateway-stub.js";
 import { createSessionsHistoryTool } from "./sessions-history-tool.js";

--- a/src/gateway/chat-display-projection.core.ts
+++ b/src/gateway/chat-display-projection.core.ts
@@ -9,7 +9,9 @@ import {
   readNestedToolActivity,
   nestedToolActivityContent,
 } from "../sessions/nested-tool-activity.js";
+import { readSessionTranscriptRunId } from "../sessions/transcript-events.js";
 import { formatProviderRefusalText } from "../shared/assistant-error-format.js";
+import { isTranscriptOnlyOpenClawAssistantMessage } from "../shared/transcript-only-openclaw-assistant.js";
 import {
   DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS,
   extractAssistantTextForSilentCheck,
@@ -43,7 +45,7 @@ type ChatDisplayProjectionOptions = {
   resolveCurrentUserProfileDisplay?: CurrentUserProfileDisplayResolver;
   stripEnvelope?: boolean;
   turnBoundaryPending?: boolean;
-  streamErrorFallbackPending?: boolean;
+  assistantErrorPending?: boolean;
 };
 
 /** Keep profile display reads local to one history page or event projection operation. */
@@ -109,8 +111,8 @@ function projectCurrentUserProfileAvatars(
 type ChatDisplayProjectionResult = {
   messages: Array<Record<string, unknown>>;
   turnBoundaryPending: boolean;
-  streamErrorFallbackPending: boolean;
-  streamErrorFallbackRepaired: boolean;
+  assistantErrorPending: boolean;
+  assistantErrorRecoveryObserved: boolean;
 };
 
 const GATEWAY_ASSISTANT_ERROR_FALLBACK_TEXT = "The agent run failed before producing a reply.";
@@ -227,21 +229,51 @@ function hasVisibleAssistantDisplayContent(message: Record<string, unknown>): bo
   if (hasAssistantDisplayableNonTextContent(sanitized)) {
     return true;
   }
-  const text = extractAssistantTextForSilentCheck(sanitized);
-  return Boolean(text?.trim()) && !isSuppressedControlReplyText(text ?? "");
+  return hasVisibleAssistantReplyText(sanitized);
 }
 
-function projectRepairedStreamErrorFallbackMessages(
+function hasVisibleAssistantReplyText(message: Record<string, unknown>): boolean {
+  const texts = Array.isArray(message.content)
+    ? message.content.flatMap((block) => {
+        const entry = asOptionalRecord(block);
+        return isAssistantTextContentType(entry?.type) ? [entry?.text] : [];
+      })
+    : [message.content];
+  return [...texts, message.text].some((text) => {
+    if (typeof text !== "string") {
+      return false;
+    }
+    const visible = text.trim();
+    return (
+      visible.length > 0 &&
+      visible !== STREAM_ERROR_FALLBACK_TEXT &&
+      !isSuppressedControlReplyText(visible)
+    );
+  });
+}
+
+export function isPendingAssistantError(value: unknown): boolean {
+  const message = asOptionalRecord(value);
+  return (
+    message?.role === "assistant" &&
+    message.stopReason === "error" &&
+    (isPureStreamErrorFallbackAssistantMessage(message) ||
+      (Boolean(readSessionTranscriptRunId(message)) &&
+        !hasAssistantDisplayableNonTextContent(message) &&
+        !hasVisibleAssistantDisplayContent(message)))
+  );
+}
+
+function projectRecoveredAssistantErrors(
   messages: Array<Record<string, unknown>>,
   initialPending = false,
 ): {
   messages: Array<Record<string, unknown>>;
   pending: boolean;
-  repaired: boolean;
+  recoveryObserved: boolean;
 } {
-  let pending = initialPending;
-  let repaired = false;
-  let changed = false;
+  let unseenPending = initialPending;
+  let recoveryObserved = false;
   let pendingIndexes: number[] = [];
   const repairedIndexes = new Set<number>();
   for (let index = 0; index < messages.length; index++) {
@@ -250,32 +282,48 @@ function projectRepairedStreamErrorFallbackMessages(
       continue;
     }
     if (message.role === "user") {
-      pending = false;
+      unseenPending = false;
       pendingIndexes = [];
       continue;
     }
-    if (isPureStreamErrorFallbackAssistantMessage(message)) {
-      pending = true;
+    if (isPendingAssistantError(message)) {
       pendingIndexes.push(index);
       continue;
     }
-    if (!pending || !hasVisibleAssistantDisplayContent(message)) {
+    if (
+      (!unseenPending && pendingIndexes.length === 0) ||
+      !hasVisibleAssistantDisplayContent(message)
+    ) {
       continue;
     }
-    repaired = true;
-    pending = false;
-    if (pendingIndexes.length > 0) {
-      changed = true;
-      for (const pendingIndex of pendingIndexes) {
-        repairedIndexes.add(pendingIndex);
+    // An incremental reader carries only a pending bit. It must reload raw
+    // history before deciding which previously emitted failures were recovered.
+    recoveryObserved ||= unseenPending;
+    unseenPending = false;
+    const completedRunId =
+      (message.stopReason === "stop" || message.stopReason === "length") &&
+      !isTranscriptOnlyOpenClawAssistantMessage(message)
+        ? readSessionTranscriptRunId(message)
+        : undefined;
+    pendingIndexes = pendingIndexes.filter((pendingIndex) => {
+      const failedRunId = readSessionTranscriptRunId(messages[pendingIndex]);
+      // Unattributed legacy stream sentinels retain their existing turn-local
+      // repair. Runtime attempt failures require completion of the exact run.
+      if (failedRunId && failedRunId !== completedRunId) {
+        return true;
       }
-      pendingIndexes = [];
-    }
+      repairedIndexes.add(pendingIndex);
+      recoveryObserved = true;
+      return false;
+    });
   }
   return {
-    messages: changed ? messages.filter((_, index) => !repairedIndexes.has(index)) : messages,
-    pending,
-    repaired,
+    messages:
+      repairedIndexes.size > 0
+        ? messages.filter((_, index) => !repairedIndexes.has(index))
+        : messages,
+    pending: unseenPending || pendingIndexes.length > 0,
+    recoveryObserved,
   };
 }
 
@@ -294,28 +342,7 @@ function projectEmptyAssistantErrorMessages(
     }
     const sanitized = sanitizeChatHistoryMessage(message, Number.MAX_SAFE_INTEGER)
       .message as Record<string, unknown>;
-    const visibleTexts: string[] = [];
-    if (typeof sanitized.content === "string") {
-      visibleTexts.push(sanitized.content);
-    } else if (Array.isArray(sanitized.content)) {
-      for (const block of sanitized.content) {
-        if (!block || typeof block !== "object" || Array.isArray(block)) {
-          continue;
-        }
-        const entry = block as { type?: unknown; text?: unknown };
-        if (isAssistantTextContentType(entry.type) && typeof entry.text === "string") {
-          visibleTexts.push(entry.text);
-        }
-      }
-    }
-    if (typeof sanitized.text === "string") {
-      visibleTexts.push(sanitized.text);
-    }
-    const nonEmptyVisibleTexts = visibleTexts.map((text) => text.trim()).filter(Boolean);
-    const hasVisibleReplyText = nonEmptyVisibleTexts.some(
-      (text) => text !== STREAM_ERROR_FALLBACK_TEXT && !isSuppressedControlReplyText(text),
-    );
-    if (!shouldDropAssistantHistoryMessage(sanitized) && hasVisibleReplyText) {
+    if (!shouldDropAssistantHistoryMessage(sanitized) && hasVisibleAssistantReplyText(sanitized)) {
       changed = true;
       return sanitizeAssistantErrorDisplayMessage(message);
     }
@@ -367,11 +394,11 @@ export function projectChatDisplayMessagesWithState(
       ? projectedActivity
       : stripEnvelopeFromMessages(projectedActivity);
   const mirrored = mirrorMessageToolVisibleReplies(source);
-  const repairedStreamErrors = projectRepairedStreamErrorFallbackMessages(
+  const recoveredErrors = projectRecoveredAssistantErrors(
     toProjectedMessages(mirrored),
-    options?.streamErrorFallbackPending,
+    options?.assistantErrorPending,
   );
-  const projectedErrors = projectEmptyAssistantErrorMessages(repairedStreamErrors.messages);
+  const projectedErrors = projectEmptyAssistantErrorMessages(recoveredErrors.messages);
   const filtered = filterVisibleProjectedHistoryMessages(
     projectSessionsSendInterSessionMessages(
       toProjectedMessages(
@@ -392,8 +419,8 @@ export function projectChatDisplayMessagesWithState(
       options?.resolveCurrentUserProfileDisplay,
     ),
     turnBoundaryPending: filtered.turnBoundaryPending,
-    streamErrorFallbackPending: repairedStreamErrors.pending,
-    streamErrorFallbackRepaired: repairedStreamErrors.repaired,
+    assistantErrorPending: recoveredErrors.pending,
+    assistantErrorRecoveryObserved: recoveredErrors.recoveryObserved,
   };
 }
 

--- a/src/gateway/chat-display-projection.reconciliation.test.ts
+++ b/src/gateway/chat-display-projection.reconciliation.test.ts
@@ -1,0 +1,95 @@
+import { assert, describe, expect, it } from "vitest";
+import {
+  createSessionProjection,
+  hasSessionProjectionAcceptedFinal,
+  readSessionMessageIdentity,
+  reduceSessionProjection,
+  reduceSessionProjectionRunEvent,
+} from "../../packages/gateway-client/src/session-projection.js";
+import { projectChatDisplayMessages } from "./chat-display-projection.js";
+
+const runId = "fallback-run";
+const scope = { sessionKey: "agent:main:fallback-reconciliation" };
+const user = {
+  role: "user",
+  content: [{ type: "text", text: "Reply with exactly: RECOVERY_OK" }],
+  __openclaw: { id: "user", seq: 1, idempotencyKey: `${runId}:user` },
+};
+const failed = {
+  role: "assistant",
+  content: [],
+  stopReason: "error",
+  errorMessage: "The selected model is not supported by this account.",
+  __openclaw: { id: "failed-attempt", seq: 2, runId },
+};
+const answer = {
+  role: "assistant",
+  content: [{ type: "text", text: "RECOVERY_OK" }],
+  stopReason: "stop",
+  __openclaw: { id: "successful-attempt", seq: 3, runId },
+};
+
+describe("recovered fallback history reconciliation", () => {
+  it("adopts the live answer once after a failed attempt and accepts the later status final", () => {
+    const rawHistory = structuredClone([user, failed, answer]);
+    const history = projectChatDisplayMessages(rawHistory);
+    let projection = createSessionProjection(scope, history);
+    const liveAnswer = { role: "assistant", content: answer.content };
+    const fallbackNotice = {
+      role: "assistant",
+      content: [{ type: "text", text: "Model fallback: the backup model answered." }],
+      stopReason: "stop",
+    };
+
+    // The live Gateway publishes persisted attempts before the answer final,
+    // then a separate status final without a durable message identity.
+    for (const message of [liveAnswer, fallbackNotice]) {
+      const transition = reduceSessionProjectionRunEvent(projection, {
+        state: "final",
+        runId,
+        message,
+      });
+      assert(transition);
+      projection = reduceSessionProjection(transition.projection, {
+        type: "messagePersisted",
+        message,
+        envelope: { runId },
+      });
+    }
+    projection = reduceSessionProjection(projection, {
+      type: "snapshotLoaded",
+      messages: projectChatDisplayMessages(rawHistory),
+    });
+
+    expect(projection.messages).toEqual([user, answer]);
+    expect(projection.runs[runId]).toMatchObject({ status: "completed", message: liveAnswer });
+    expect(hasSessionProjectionAcceptedFinal(projection.runs[runId], fallbackNotice)).toBe(true);
+    expect(rawHistory).toEqual([user, failed, answer]);
+  });
+
+  it("preserves distinct durable answers even when one run produced identical text", () => {
+    const secondAnswer = {
+      ...answer,
+      __openclaw: { id: "second-answer", seq: 4, runId },
+    };
+    const rawHistory = [user, failed, answer, secondAnswer];
+    const history = projectChatDisplayMessages(rawHistory);
+    let projection = createSessionProjection(scope, history);
+    projection = reduceSessionProjection(projection, {
+      type: "messagePersisted",
+      message: secondAnswer,
+      envelope: { runId },
+    });
+    projection = reduceSessionProjection(projection, {
+      type: "snapshotLoaded",
+      messages: projectChatDisplayMessages(rawHistory),
+    });
+
+    expect(projection.messages).toEqual([user, answer, secondAnswer]);
+    expect(projection.messages.map((message) => readSessionMessageIdentity(message)?.id)).toEqual([
+      "user",
+      "successful-attempt",
+      "second-answer",
+    ]);
+  });
+});

--- a/src/gateway/chat-display-projection.recovery.test.ts
+++ b/src/gateway/chat-display-projection.recovery.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { projectChatDisplayMessages } from "./chat-display-projection.js";
+import { SessionHistorySseState } from "./session-history-state.js";
+
+const user = { role: "user", content: "hello", __openclaw: { seq: 1 } };
+const failed = {
+  role: "assistant",
+  provider: "openai",
+  model: "primary",
+  content: [],
+  stopReason: "error",
+  errorMessage: "model unavailable",
+  __openclaw: { id: "failed", seq: 2, runId: "run-a" },
+};
+const answer = {
+  role: "assistant",
+  provider: "openai",
+  model: "backup",
+  content: [{ type: "text", text: "Recovered answer" }],
+  stopReason: "stop",
+  __openclaw: { id: "answer", seq: 3, runId: "run-a" },
+};
+
+function projectedIds(messages: unknown[]) {
+  return projectChatDisplayMessages(messages).map((message) => message["__openclaw"]);
+}
+
+describe("recovered assistant errors", () => {
+  it.each([
+    { content: [] },
+    { content: "" },
+    { content: [{ type: "text", text: "  " }] },
+    { content: [{ type: "thinking", thinking: "private reasoning" }] },
+  ])("retires a non-visible failed attempt after its run answers: %j", ({ content }) => {
+    const failure = { ...failed, content };
+    const raw = [user, failure, answer];
+    const original = structuredClone(raw);
+    expect(projectedIds(raw)).toEqual([user["__openclaw"], answer["__openclaw"]]);
+    expect(raw).toEqual(original);
+  });
+
+  it.each([
+    { ...answer, __openclaw: { ...answer["__openclaw"], runId: "run-b" } },
+    { ...answer, __openclaw: { id: "answer", seq: 3 } },
+    { ...answer, provider: "openclaw", model: "gateway-injected" },
+    { ...answer, stopReason: "toolUse" },
+    { ...answer, stopReason: "error" },
+    { ...answer, stopReason: "aborted" },
+    { ...answer, display: false },
+  ])("keeps the failure without a successful runtime answer from its own run: %j", (later) => {
+    expect(projectedIds([user, failed, later])).toContainEqual(failed["__openclaw"]);
+  });
+
+  it("keeps an unattributed failure and failures separated by a new user turn", () => {
+    const unattributed = { ...failed, __openclaw: { id: "failed", seq: 2 } };
+    expect(projectedIds([user, unattributed, answer])).toContainEqual(unattributed["__openclaw"]);
+    expect(projectedIds([user, failed, { ...user, content: "next turn" }, answer])).toContainEqual(
+      failed["__openclaw"],
+    );
+    expect(projectedIds([user, failed])).toContainEqual(failed["__openclaw"]);
+  });
+
+  it.each([
+    { content: [{ type: "text", text: "A partial answer" }] },
+    { content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }] },
+    { content: [{ type: "attachment", attachment: { kind: "document", label: "report.txt" } }] },
+  ])("preserves failed attempts that already produced visible content: %j", ({ content }) => {
+    expect(projectedIds([user, { ...failed, content }, answer])).toContainEqual(
+      failed["__openclaw"],
+    );
+  });
+
+  it("preserves partial content even when a redundant text field is empty", () => {
+    const partial = { ...failed, text: "", content: [{ type: "text", text: "Partial reply" }] };
+    expect(projectChatDisplayMessages([user, partial, answer])[1]).toMatchObject({
+      content: [{ type: "text", text: "Partial reply" }],
+    });
+  });
+
+  it("repairs only matching attempts when run identities interleave", () => {
+    const other = { ...failed, __openclaw: { id: "other", seq: 3, runId: "run-b" } };
+    expect(projectedIds([user, failed, other, answer])).toEqual([
+      user["__openclaw"],
+      other["__openclaw"],
+      answer["__openclaw"],
+    ]);
+  });
+
+  it("retires the empty failure when its fallback answer reaches the output limit", () => {
+    expect(projectedIds([user, failed, { ...answer, stopReason: "length" }])).toEqual([
+      user["__openclaw"],
+      answer["__openclaw"],
+    ]);
+  });
+
+  it.each([false, true])(
+    "refreshes earlier SSE history after recovery (initial error: %s)",
+    (initial) => {
+      const state = SessionHistorySseState.fromRawSnapshot({
+        target: { sessionId: "session", sessionKey: "agent:main:test" },
+        rawMessages: initial ? [user, failed] : [user],
+      });
+      if (!initial) {
+        expect(
+          state.appendInlineMessage({ message: failed, messageSeq: 2 })?.message,
+        ).toMatchObject({
+          stopReason: "error",
+        });
+      }
+      expect(state.appendInlineMessage({ message: answer, messageSeq: 3 })).toEqual({
+        shouldRefresh: true,
+      });
+    },
+  );
+});

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -2,6 +2,7 @@
 export { augmentChatHistoryWithCanvasBlocks } from "./chat-display-projection.canvas.js";
 export {
   createCurrentUserProfileMessageProjector,
+  isPendingAssistantError,
   projectChatDisplayMessage,
   projectChatDisplayMessages,
   projectChatDisplayMessagesWithState,

--- a/src/gateway/server-methods/chat-history-delta.test.ts
+++ b/src/gateway/server-methods/chat-history-delta.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { STREAM_ERROR_FALLBACK_TEXT } from "../../agents/stream-message-shared.js";
 import {
   appendTranscriptMessage,
   replaceSessionEntry,
@@ -9,6 +10,7 @@ import {
 import { readTranscriptDisplayDelta } from "../../config/sessions/session-accessor.sqlite-history-events.js";
 import { buildGatewaySessionSnapshot } from "../session-event-payload.js";
 import { readChatHistoryDelta } from "./chat-history-delta.js";
+import { readChatHistoryPage } from "./chat-history-pages.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const maxBytes = 1_000_000;
@@ -20,8 +22,7 @@ const sessionSnapshot = buildGatewaySessionSnapshot({
   sessionRow: { key: sessionKey, sessionId, kind: "direct", updatedAt: 42 },
 });
 
-async function readContents(contents: string[], requestedMaxBytes?: number) {
-  const byteLimit = Math.min(requestedMaxBytes ?? maxBytes, maxBytes);
+async function createTranscript() {
   const scope = {
     agentId: "main",
     sessionKey,
@@ -34,6 +35,12 @@ async function readContents(contents: string[], requestedMaxBytes?: number) {
   if (head.kind !== "page") {
     throw new Error("Expected an initial transcript cursor");
   }
+  return { scope, cursor: head.cursor };
+}
+
+async function readContents(contents: string[], requestedMaxBytes?: number) {
+  const byteLimit = Math.min(requestedMaxBytes ?? maxBytes, maxBytes);
+  const { scope, cursor } = await createTranscript();
   for (const [index, content] of contents.entries()) {
     await appendTranscriptMessage(scope, {
       eventId: `result-${index}`,
@@ -49,7 +56,7 @@ async function readContents(contents: string[], requestedMaxBytes?: number) {
     });
   }
   const raw = readTranscriptDisplayDelta(scope, {
-    cursor: head.cursor,
+    cursor,
     maxBytes: byteLimit,
     maxEvents: 200,
   });
@@ -65,7 +72,7 @@ async function readContents(contents: string[], requestedMaxBytes?: number) {
   expect(JSON.stringify(raw.events)).toContain("PRIVATE_REPLAY");
   return readChatHistoryDelta({
     agentId: "main",
-    cursor: head.cursor,
+    cursor,
     maxBytes: requestedMaxBytes,
     scope,
     sessionKey,
@@ -121,4 +128,132 @@ describe("chat history delta display budget", () => {
       expect(serialized).not.toContain("PRIVATE_UPSTREAM");
     },
   );
+});
+
+const failedAssistant = {
+  role: "assistant",
+  provider: "openai",
+  model: "primary",
+  content: [],
+  stopReason: "error",
+  errorMessage: "model unavailable",
+  __openclaw: { runId: "run-recovery" },
+};
+const recoveredAssistant = {
+  role: "assistant",
+  provider: "openai",
+  model: "backup",
+  content: [{ type: "text", text: "Recovered answer" }],
+  stopReason: "stop",
+  __openclaw: { runId: "run-recovery" },
+};
+
+type TranscriptScope = Awaited<ReturnType<typeof createTranscript>>["scope"];
+
+function readDelta(scope: TranscriptScope, cursor: string) {
+  return readChatHistoryDelta({ agentId: "main", cursor, scope, sessionKey, sessionSnapshot });
+}
+
+function readTail(scope: TranscriptScope, offset?: number) {
+  return readChatHistoryPage({
+    entry: { sessionId, updatedAt: 42 },
+    provider: "openai",
+    sessionId,
+    storePath: scope.storePath,
+    sessionAgentId: "main",
+    canonicalKey: sessionKey,
+    max: 20,
+    maxHistoryBytes: maxBytes,
+    effectiveMaxChars: 10_000,
+    offset,
+    messageId: undefined,
+    ignoreCliSessionImports: true,
+  });
+}
+
+describe("chat history recovery cursor eligibility", () => {
+  it.each([undefined, 0])(
+    "keeps refreshes authoritative while a tail error can recover (offset=%s)",
+    async (offset) => {
+      const { scope, cursor } = await createTranscript();
+      await appendTranscriptMessage(scope, {
+        eventId: "failed-attempt",
+        message: failedAssistant,
+      });
+      expect(readDelta(scope, cursor)).toEqual({ kind: "reset" });
+
+      const pending = await readTail(scope, offset);
+      expect(pending.messages).toContainEqual(
+        expect.objectContaining({ __openclaw: expect.objectContaining({ id: "failed-attempt" }) }),
+      );
+      expect(pending).not.toHaveProperty("deltaCursor");
+
+      await appendTranscriptMessage(scope, {
+        eventId: "recovered-answer",
+        message: recoveredAssistant,
+      });
+      const recovered = await readTail(scope, offset);
+      expect(recovered.messages).toEqual([
+        expect.objectContaining({
+          __openclaw: expect.objectContaining({ id: "recovered-answer" }),
+        }),
+      ]);
+      expect(recovered.deltaCursor).toEqual(expect.any(String));
+      if (!recovered.deltaCursor) {
+        throw new Error("Recovered history must resume incremental updates");
+      }
+
+      await appendTranscriptMessage(scope, {
+        eventId: "next-user",
+        message: { role: "user", content: "next turn" },
+      });
+      await appendTranscriptMessage(scope, {
+        eventId: "next-answer",
+        message: { ...recoveredAssistant, __openclaw: { runId: "run-next" } },
+      });
+      expect(readDelta(scope, recovered.deltaCursor)).toMatchObject({
+        kind: "delta",
+        deltaCursor: expect.any(String),
+        messages: [{ messageId: "next-user" }, { messageId: "next-answer" }],
+      });
+    },
+  );
+
+  it.each([
+    ["empty provider failure", failedAssistant],
+    [
+      "legacy stream placeholder",
+      {
+        ...failedAssistant,
+        content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
+      },
+    ],
+  ])("resets a single delta containing %s and its recovered answer", async (_name, failure) => {
+    const { scope, cursor } = await createTranscript();
+    await appendTranscriptMessage(scope, { eventId: "failed-attempt", message: failure });
+    await appendTranscriptMessage(scope, {
+      eventId: "recovered-answer",
+      message: recoveredAssistant,
+    });
+
+    expect(readDelta(scope, cursor)).toEqual({ kind: "reset" });
+    const recovered = await readTail(scope);
+    expect(recovered.messages).toEqual([
+      expect.objectContaining({ __openclaw: expect.objectContaining({ id: "recovered-answer" }) }),
+    ]);
+    expect(recovered.deltaCursor).toEqual(expect.any(String));
+  });
+
+  it("retains incremental delivery for failed attempts with visible partial output", async () => {
+    const { scope, cursor } = await createTranscript();
+    await appendTranscriptMessage(scope, {
+      eventId: "partial-failure",
+      message: { ...failedAssistant, content: [{ type: "text", text: "Partial answer" }] },
+    });
+    expect(readDelta(scope, cursor)).toMatchObject({
+      kind: "delta",
+      messages: [{ messageId: "partial-failure" }],
+    });
+    expect((await readTail(scope)).deltaCursor).toEqual(expect.any(String));
+  });
 });

--- a/src/gateway/server-methods/chat-history-delta.ts
+++ b/src/gateway/server-methods/chat-history-delta.ts
@@ -71,7 +71,7 @@ export function readChatHistoryDelta(params: {
   }
 
   let projectionState: SessionMessageProjectionState = {
-    streamErrorFallbackPending: false,
+    assistantErrorPending: false,
     turnBoundaryPending: false,
   };
   const projectCurrentUserProfile = createCurrentUserProfileMessageProjector(
@@ -97,6 +97,11 @@ export function readChatHistoryDelta(params: {
       sessionSnapshot: params.sessionSnapshot,
     });
     projectionState = projected.projectionState;
+    // Recovery can remove this row from history, which an append-only delta cannot express.
+    // Keep the last accepted cursor before the error and let a full tail own reconciliation.
+    if (projectionState.assistantErrorPending) {
+      return { kind: "reset" };
+    }
     if (projected.payload) {
       messagesBytes += jsonUtf8BytesOrInfinity(projected.payload) + (messages.length > 0 ? 1 : 0);
       if (messagesBytes > maxBytes) {

--- a/src/gateway/server-methods/chat-history-handler.cli-import.test.ts
+++ b/src/gateway/server-methods/chat-history-handler.cli-import.test.ts
@@ -10,8 +10,8 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { readChatHistoryMessageId } from "../session-history-tail.js";
 import { chatHistoryHandlers } from "./chat-history-handler.js";
-import { readChatHistoryMessageId } from "./chat-history-pages.js";
 
 type HistoryPage = {
   messages: unknown[];

--- a/src/gateway/server-methods/chat-history-pages.recovery.test.ts
+++ b/src/gateway/server-methods/chat-history-pages.recovery.test.ts
@@ -1,0 +1,189 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  appendTranscriptMessage,
+  replaceSessionEntry,
+  replaceTranscriptEvents,
+} from "../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { readChatHistoryMessageId } from "../session-history-tail.js";
+import * as anchorReader from "../session-transcript-anchor-reader.js";
+import { readSessionMessagesAsync } from "../session-transcript-readers.js";
+import { readChatHistoryPage } from "./chat-history-pages.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+const user = { role: "user", content: "Question" };
+const failed = {
+  role: "assistant",
+  content: [],
+  stopReason: "error",
+  errorMessage: "The selected model is unavailable.",
+  __openclaw: { runId: "recovered-run" },
+};
+const answer = {
+  role: "assistant",
+  content: [{ type: "text", text: "Recovered answer" }],
+  stopReason: "stop",
+  __openclaw: { runId: "recovered-run" },
+};
+
+type PageOptions = Pick<Parameters<typeof readChatHistoryPage>[0], "offset" | "messageId"> & {
+  maxHistoryBytes?: number;
+};
+
+async function withTranscript(
+  messages: Array<[id: string, message: Record<string, unknown>]>,
+  use: (fixture: {
+    append: (id: string, message: Record<string, unknown>) => Promise<unknown>;
+    read: (options: PageOptions) => ReturnType<typeof readChatHistoryPage>;
+    raw: () => ReturnType<typeof readSessionMessagesAsync>;
+  }) => Promise<void>,
+) {
+  await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionKey: "agent:main:page-recovery",
+      sessionId: "page-recovery",
+      storePath: path.join(state.sessionsDir(), "sessions.json"),
+    };
+    const entry = { sessionId: scope.sessionId, updatedAt: 1 };
+    await replaceSessionEntry(scope, entry);
+    await replaceTranscriptEvents(scope, [
+      { type: "session", version: 3, id: scope.sessionId },
+      ...messages.map(([id, message], index) => ({
+        type: "message",
+        id,
+        parentId: messages[index - 1]?.[0] ?? null,
+        message,
+      })),
+    ]);
+    await use({
+      append: (id, message) => appendTranscriptMessage(scope, { eventId: id, message }),
+      read: (options) =>
+        readChatHistoryPage({
+          entry,
+          provider: "openai",
+          sessionId: scope.sessionId,
+          storePath: scope.storePath,
+          sessionAgentId: scope.agentId,
+          canonicalKey: scope.sessionKey,
+          max: 1,
+          maxHistoryBytes: 100_000,
+          effectiveMaxChars: 10_000,
+          ignoreCliSessionImports: true,
+          ...options,
+        }),
+      raw: () => readSessionMessagesAsync(scope, { mode: "full", reason: "recovery immutability" }),
+    });
+  });
+}
+
+describe("historical page recovery context", () => {
+  it.each([
+    { offset: 1, messageId: undefined, expectedIds: ["user"] },
+    { offset: undefined, messageId: "failed", expectedIds: [] },
+  ])(
+    "omits a recovered failure outside the newer page (offset=$offset, anchor=$messageId)",
+    async ({ expectedIds, ...options }) => {
+      await withTranscript(
+        [
+          ["user", user],
+          ["failed", failed],
+          ["answer", answer],
+        ],
+        async ({ read, raw }) => {
+          const original = await raw();
+          const page = await read(options);
+
+          expect(page.messages.map(readChatHistoryMessageId)).toEqual(expectedIds);
+          if (options.offset !== undefined) {
+            expect(page.pagination).toEqual({ offset: 1, totalMessages: 3, rawPageMessages: 2 });
+          }
+          expect(await raw()).toEqual(original);
+        },
+      );
+    },
+  );
+
+  it("does not use a later turn to hide an unrecovered historical failure", async () => {
+    await withTranscript(
+      [
+        ["user", user],
+        ["failed", failed],
+        ["next-user", user],
+        ["answer", answer],
+      ],
+      async ({ read }) => {
+        const page = await read({ offset: 2, messageId: undefined });
+        expect(page.messages).toEqual([
+          expect.objectContaining({
+            stopReason: "error",
+            __openclaw: expect.objectContaining({ id: "failed" }),
+          }),
+        ]);
+      },
+    );
+  });
+
+  it("keeps original page boundaries when messages append during recovery lookahead", async () => {
+    await withTranscript(
+      [
+        ["user", user],
+        ["failed", failed],
+        ["answer", answer],
+      ],
+      async ({ append, read }) => {
+        const readAround = anchorReader.readSessionMessagesAroundIdWithStatsAsync;
+        vi.spyOn(anchorReader, "readSessionMessagesAroundIdWithStatsAsync").mockImplementationOnce(
+          async (scope, options) => {
+            await append("next-user", user);
+            await append("next-answer", { ...answer, __openclaw: { runId: "next-run" } });
+            return readAround(scope, options);
+          },
+        );
+
+        const page = await read({ offset: 1, messageId: undefined });
+
+        expect(page.messages.map(readChatHistoryMessageId)).toEqual(["user"]);
+        expect(page.pagination).toEqual({ offset: 1, totalMessages: 3, rawPageMessages: 2 });
+      },
+    );
+  });
+
+  it("keeps the failure when newer recovery evidence exceeds the read byte budget", async () => {
+    await withTranscript(
+      [
+        ["user", user],
+        ["failed", failed],
+        ["answer", answer],
+      ],
+      async ({ read }) => {
+        const page = await read({ offset: 1, messageId: undefined, maxHistoryBytes: 1 });
+        expect(page.messages.map(readChatHistoryMessageId)).toEqual(["failed"]);
+      },
+    );
+  });
+
+  it.each([
+    { offset: 1, messageId: undefined, expectedReads: 0 },
+    { offset: undefined, messageId: "answer", expectedReads: 1 },
+  ])(
+    "does not read recovery context for an ordinary page (offset=$offset, anchor=$messageId)",
+    async ({ expectedReads, ...options }) => {
+      await withTranscript(
+        [
+          ["user", user],
+          ["answer", answer],
+          ["next-user", user],
+        ],
+        async ({ read }) => {
+          const reads = vi.spyOn(anchorReader, "readSessionMessagesAroundIdWithStatsAsync");
+          const page = await read(options);
+          expect(page.messages.map(readChatHistoryMessageId)).toEqual(["answer"]);
+          expect(reads).toHaveBeenCalledTimes(expectedReads);
+        },
+      );
+    },
+  );
+});

--- a/src/gateway/server-methods/chat-history-pages.ts
+++ b/src/gateway/server-methods/chat-history-pages.ts
@@ -4,6 +4,7 @@ import {
   dropPreSessionStartAnnouncePairs,
   isHeartbeatHistoryTurnBoundaryMessage,
   projectChatDisplayMessages,
+  projectChatDisplayMessagesWithState,
   augmentChatHistoryWithCanvasBlocks,
 } from "../chat-display-projection.js";
 import {
@@ -14,6 +15,8 @@ import {
 import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import {
   dropChatHistoryOverreadContextMessage,
+  readChatHistoryMessageId,
+  readChatHistoryRecoveryContext,
   readChatHistoryMessageSeq,
   readIncrementalChatHistoryTail,
   type IncrementalChatHistoryTail,
@@ -24,11 +27,6 @@ import {
   type ReadRecentSessionMessagesResult,
 } from "../session-transcript-readers.js";
 import type { loadSessionEntry } from "../session-utils.js";
-
-export function readChatHistoryMessageId(message: unknown): string | undefined {
-  const metadata = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
-  return typeof metadata?.id === "string" ? metadata.id : undefined;
-}
 
 type ChatHistoryPage = {
   activeLeafEntryId?: string | null;
@@ -316,14 +314,35 @@ export async function readChatHistoryPage(params: {
           max,
           Math.max(readPage.messages.length, readPage.totalMessages > pageOffset ? 1 : 0),
         );
-    const projected = incrementalTail
-      ? incrementalTail.projected
-      : projectChatDisplayMessages(localMessages, {
-          includeCommentaryFallbacks: true,
-          maxChars: effectiveMaxChars,
-          resolveCurrentUserProfileDisplay,
-          turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
-        });
+    const project = (messages: unknown[]) =>
+      projectChatDisplayMessagesWithState(messages, {
+        includeCommentaryFallbacks: true,
+        maxChars: effectiveMaxChars,
+        resolveCurrentUserProfileDisplay,
+        turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(overreadContextMessage),
+      });
+    const projection = incrementalTail?.projection ?? project(localMessages);
+    let projected = incrementalTail?.projected ?? projection.messages;
+    const newestPageSeq = readChatHistoryMessageSeq(localMessages.at(-1));
+    if (
+      !incrementalTail &&
+      pageOffset > 0 &&
+      newestPageSeq !== undefined &&
+      projection.assistantErrorPending
+    ) {
+      const recoveryContext = await readChatHistoryRecoveryContext({
+        messages: localMessages,
+        project,
+        readScope,
+        displaySource: readPage.displaySource,
+        maxBytes: maxHistoryBytes,
+      });
+      if (recoveryContext.length > 0) {
+        projected = project([...localMessages, ...recoveryContext]).messages.filter(
+          (message) => (readChatHistoryMessageSeq(message) ?? Infinity) <= newestPageSeq,
+        );
+      }
+    }
     const windowed = messageId
       ? capChatHistoryAroundMessage({
           messages: projected,
@@ -339,7 +358,9 @@ export async function readChatHistoryPage(params: {
       ...(isTailPage
         ? {
             activeLeafEntryId: resolveChatHistoryActiveLeafEntryId(readPage),
-            ...(readPage.transcriptSource === "active" && readPage.deltaCursor
+            ...(readPage.transcriptSource === "active" &&
+            readPage.deltaCursor &&
+            !incrementalTail?.projection.assistantErrorPending
               ? { deltaCursor: readPage.deltaCursor }
               : {}),
           }
@@ -435,7 +456,9 @@ export async function readChatHistoryPage(params: {
   }
   return {
     activeLeafEntryId,
-    ...(readPage.transcriptSource === "active" && readPage.deltaCursor
+    ...(readPage.transcriptSource === "active" &&
+    readPage.deltaCursor &&
+    !incrementalTail.projection.assistantErrorPending
       ? { deltaCursor: readPage.deltaCursor }
       : {}),
     messages: augmentChatHistoryWithCanvasBlocks(incrementalTail.projected),

--- a/src/gateway/server-methods/chat-message-get-handler.test.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.test.ts
@@ -1,0 +1,93 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  appendTranscriptMessage,
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import { chatMessageGetHandlers } from "./chat-message-get-handler.js";
+
+describe("chat.message.get recovery visibility", () => {
+  it("hides recovered empty failures while retaining unresolved, partial, and successful replies", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const scope = {
+        agentId: "main",
+        sessionKey: "agent:main:message-recovery",
+        sessionId: "message-recovery",
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      await appendTranscriptMessage(scope, {
+        eventId: "user",
+        message: { role: "user", content: "hello" },
+      });
+      const failure = {
+        role: "assistant",
+        provider: "openai",
+        model: "primary",
+        content: [],
+        stopReason: "error",
+        errorMessage: "model unavailable",
+        __openclaw: { runId: "run-recovery" },
+      };
+      await appendTranscriptMessage(scope, { eventId: "failed", message: failure });
+      const respond = vi.fn();
+      const context = createDirectChatContext();
+      const lookup = async (messageId: string) => {
+        respond.mockClear();
+        await expectDefined(
+          chatMessageGetHandlers["chat.message.get"],
+          "message handler",
+        )({
+          params: { sessionKey: scope.sessionKey, messageId },
+          context,
+          req: { type: "req", id: "message-recovery", method: "chat.message.get" },
+          client: null,
+          isWebchatConnect: () => false,
+          respond,
+        });
+      };
+      await lookup("failed");
+      expect(respond).toHaveBeenCalledWith(true, expect.objectContaining({ ok: true }));
+
+      await appendTranscriptMessage(scope, {
+        eventId: "answer",
+        message: {
+          ...failure,
+          model: "backup",
+          stopReason: "stop",
+          errorMessage: undefined,
+          content: [{ type: "text", text: "Recovered answer" }],
+        },
+      });
+      const persisted = await loadTranscriptEvents(scope);
+      await lookup("failed");
+      expect(respond).toHaveBeenCalledWith(true, { ok: false, unavailableReason: "not_found" });
+      await lookup("answer");
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          ok: true,
+          message: expect.objectContaining({
+            content: [{ type: "text", text: "Recovered answer" }],
+          }),
+        }),
+      );
+      expect(await loadTranscriptEvents(scope)).toEqual(persisted);
+
+      await appendTranscriptMessage(scope, {
+        eventId: "partial",
+        message: { ...failure, content: [{ type: "text", text: "Partial answer" }] },
+      });
+      await lookup("partial");
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          ok: true,
+          message: expect.objectContaining({ content: [{ type: "text", text: "Partial answer" }] }),
+        }),
+      );
+    });
+  });
+});

--- a/src/gateway/server-methods/chat-message-get-handler.ts
+++ b/src/gateway/server-methods/chat-message-get-handler.ts
@@ -12,14 +12,16 @@ import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
 import {
   augmentChatHistoryWithCanvasBlocks,
   dropPreSessionStartAnnouncePairs,
+  isPendingAssistantError,
   projectChatDisplayMessage,
 } from "../chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "../current-user-profile-display.js";
 import { MAX_PAYLOAD_BYTES } from "../server-constants.js";
+import { readChatHistoryMessageId } from "../session-history-tail.js";
 import { readSessionMessagesAroundIdWithStatsAsync } from "../session-transcript-anchor-reader.js";
 import { readSessionMessageByIdAsync } from "../session-transcript-readers.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
-import { readChatHistoryMessageId } from "./chat-history-pages.js";
+import { readChatHistoryPage } from "./chat-history-pages.js";
 import { resolveRequestedChatAgentId, validateChatSelectedAgent } from "./chat-origin-routing.js";
 import { projectPendingInputMessage } from "./chat-pending-inputs.js";
 import { normalizeOptionalChatText as normalizeOptionalText } from "./chat-text-normalization.js";
@@ -29,13 +31,33 @@ import { assertValidParams } from "./validation.js";
 async function isChatMessageIdVisibleAfterHistoryFilters(params: {
   sessionId: string;
   storePath: string | undefined;
-  sessionEntry?: { sessionFile?: string; sessionId?: string };
+  sessionEntry: ReturnType<typeof loadGatewaySessionEntryReadOnly>["entry"];
   sessionKey: string;
-  agentId?: string;
+  agentId: string;
+  message: unknown;
   messageId: string;
   sessionStartedAt?: number;
   allowResetArchiveFallback?: boolean;
 }): Promise<boolean> {
+  if (isPendingAssistantError(params.message)) {
+    // A recovered attempt remains stored but no longer belongs to visible history.
+    // Reuse the anchored history owner; ordinary message lookups stay on the exact-ID path.
+    const page = await readChatHistoryPage({
+      entry: params.sessionEntry,
+      provider: undefined,
+      sessionId: params.sessionId,
+      storePath: params.storePath,
+      sessionAgentId: params.agentId,
+      canonicalKey: params.sessionKey,
+      max: 1,
+      maxHistoryBytes: MAX_PAYLOAD_BYTES,
+      effectiveMaxChars: MAX_PAYLOAD_BYTES,
+      offset: undefined,
+      messageId: params.messageId,
+      ignoreCliSessionImports: true,
+    });
+    return page.messages.some((message) => readChatHistoryMessageId(message) === params.messageId);
+  }
   if (params.sessionStartedAt === undefined) {
     return true;
   }
@@ -159,6 +181,7 @@ export const chatMessageGetHandlers: GatewayRequestHandlers = {
       sessionEntry: entry,
       sessionKey,
       agentId: sessionAgentId,
+      message: resolved.message,
       messageId,
       sessionStartedAt:
         typeof entry?.sessionStartedAt === "number" ? entry.sessionStartedAt : undefined,

--- a/src/gateway/session-history-state.ts
+++ b/src/gateway/session-history-state.ts
@@ -22,7 +22,7 @@ import {
   readSessionMessagesWithSourceAsync,
 } from "./session-transcript-readers.js";
 
-// Session history state owns the SSE-friendly projection of transcript JSONL:
+// Session history state owns the SSE-friendly transcript projection:
 // raw messages are projected for display, paginated by transcript seq, then
 // incrementally updated until cursor/window semantics require a full refresh.
 type SessionHistoryTranscriptMeta = {
@@ -46,7 +46,7 @@ type SessionHistorySnapshot = {
   history: PaginatedSessionHistory;
   rawTranscriptSeq: number;
   turnBoundaryPending: boolean;
-  streamErrorFallbackPending: boolean;
+  assistantErrorPending: boolean;
 };
 
 type InlineSessionHistoryAppend = {
@@ -256,7 +256,7 @@ export function buildSessionHistorySnapshot(params: {
       resolveMessageSeq(rawHistoryMessages.at(-1)) ??
       rawHistoryMessages.length,
     turnBoundaryPending: projected.turnBoundaryPending,
-    streamErrorFallbackPending: projected.streamErrorFallbackPending,
+    assistantErrorPending: projected.assistantErrorPending,
   };
 }
 
@@ -269,7 +269,7 @@ export class SessionHistorySseState {
   private sentHistory: PaginatedSessionHistory;
   private rawTranscriptSeq: number;
   private turnBoundaryPending: boolean;
-  private streamErrorFallbackPending: boolean;
+  private assistantErrorPending: boolean;
   private transcriptPath: string | undefined;
 
   static fromRawSnapshot(params: SessionHistoryStateSnapshot): SessionHistorySseState {
@@ -285,7 +285,7 @@ export class SessionHistorySseState {
     this.sentHistory = snapshot.history;
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.turnBoundaryPending = snapshot.turnBoundaryPending;
-    this.streamErrorFallbackPending = snapshot.streamErrorFallbackPending;
+    this.assistantErrorPending = snapshot.assistantErrorPending;
     this.transcriptPath = normalizeTranscriptPathForComparison(params.transcriptPath);
   }
 
@@ -336,11 +336,11 @@ export class SessionHistorySseState {
       includeCommentaryFallbacks: true,
       maxChars: this.maxChars,
       turnBoundaryPending: hadPendingTurnBoundary,
-      streamErrorFallbackPending: this.streamErrorFallbackPending,
+      assistantErrorPending: this.assistantErrorPending,
     });
     this.turnBoundaryPending = nextProjection.turnBoundaryPending;
-    this.streamErrorFallbackPending = nextProjection.streamErrorFallbackPending;
-    if (nextProjection.streamErrorFallbackRepaired) {
+    this.assistantErrorPending = nextProjection.assistantErrorPending;
+    if (nextProjection.assistantErrorRecoveryObserved) {
       // Keep only the pending bit here: retaining raw transcript context would
       // undo the bounded SSE memory contract. The caller rereads canonical
       // history so full projection can remove the already-emitted placeholder.
@@ -429,7 +429,7 @@ export class SessionHistorySseState {
     const snapshot = this.buildSnapshot(rawSnapshot);
     this.rawTranscriptSeq = snapshot.rawTranscriptSeq;
     this.turnBoundaryPending = snapshot.turnBoundaryPending;
-    this.streamErrorFallbackPending = snapshot.streamErrorFallbackPending;
+    this.assistantErrorPending = snapshot.assistantErrorPending;
     this.transcriptPath = normalizeTranscriptPathForComparison(rawSnapshot.transcriptPath);
     this.sentHistory = snapshot.history;
     return snapshot.history;

--- a/src/gateway/session-history-tail.ts
+++ b/src/gateway/session-history-tail.ts
@@ -8,6 +8,7 @@ import {
   projectChatDisplayMessagesWithState,
 } from "./chat-display-projection.js";
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
+import { readSessionMessagesAroundIdWithStatsAsync } from "./session-transcript-anchor-reader.js";
 import {
   readRecentSessionMessagesWithStatsAsync,
   readSessionMessagesPageWithStatsAsync,
@@ -18,6 +19,11 @@ import {
 const SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES = 8_000;
 const SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES = 100;
 const SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_CHUNK_MESSAGES = 400;
+
+export function readChatHistoryMessageId(message: unknown): string | undefined {
+  const id = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"])?.id;
+  return typeof id === "string" && id ? id : undefined;
+}
 
 export function readChatHistoryMessageSeq(message: unknown): number | undefined {
   const metadata = asOptionalRecord(asOptionalRecord(message)?.["__openclaw"]);
@@ -60,6 +66,82 @@ export type IncrementalChatHistoryTail = {
   rawPageMessages: number;
   readPage: ReadRecentSessionMessagesResult;
 };
+
+async function readAdjacentChatHistoryMessages(params: {
+  anchorId: string;
+  direction: "older" | "newer";
+  limit: number;
+  readScope: SessionTranscriptReadScope;
+  displaySource: string | undefined;
+}): Promise<unknown[]> {
+  // Anchor lookup and positioning share one snapshot; numeric offsets drift on appends.
+  const page = await readSessionMessagesAroundIdWithStatsAsync(params.readScope, {
+    messageId: params.anchorId,
+    maxMessages: params.limit * 2 + 1,
+    allowResetArchiveFallback: true,
+  });
+  if (!page.found || page.displaySource !== params.displaySource) {
+    throw new SessionTranscriptProjectionUnavailableError(params.readScope.sessionId);
+  }
+  const anchorIndex = page.messages.findIndex(
+    (message) => readChatHistoryMessageId(message) === params.anchorId,
+  );
+  if (anchorIndex < 0) {
+    throw new SessionTranscriptProjectionUnavailableError(params.readScope.sessionId);
+  }
+  return params.direction === "newer"
+    ? page.messages.slice(anchorIndex + 1, anchorIndex + 1 + params.limit)
+    : page.messages.slice(Math.max(0, anchorIndex - params.limit), anchorIndex);
+}
+
+/** Resolve only the newer turn context a historical page needs to classify its pending error. */
+export async function readChatHistoryRecoveryContext(params: {
+  messages: unknown[];
+  project: (messages: unknown[]) => ReturnType<typeof projectChatDisplayMessagesWithState>;
+  readScope: SessionTranscriptReadScope;
+  displaySource: string | undefined;
+  maxBytes: number;
+}): Promise<unknown[]> {
+  const context: unknown[] = [];
+  let anchorId = readChatHistoryMessageId(params.messages.at(-1));
+  let scannedBytes = 0;
+  while (anchorId && context.length < SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES) {
+    const chunkSize = Math.min(
+      SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES,
+      SILENT_CHAT_HISTORY_TAIL_SCAN_MAX_MESSAGES - context.length,
+    );
+    const newer = await readAdjacentChatHistoryMessages({
+      anchorId,
+      direction: "newer",
+      limit: chunkSize,
+      readScope: params.readScope,
+      displaySource: params.displaySource,
+    });
+    if (newer.length === 0) {
+      break;
+    }
+    let boundaryReached = false;
+    for (const message of newer) {
+      scannedBytes += Buffer.byteLength(JSON.stringify(message), "utf8");
+      if (scannedBytes > params.maxBytes) {
+        return context;
+      }
+      context.push(message);
+      if (asOptionalRecord(message)?.role === "user") {
+        boundaryReached = true;
+        break;
+      }
+    }
+    if (
+      boundaryReached ||
+      !params.project([...params.messages, ...context]).assistantErrorPending
+    ) {
+      break;
+    }
+    anchorId = readChatHistoryMessageId(context.at(-1));
+  }
+  return context;
+}
 
 /** Scans indexed transcript records until one bounded visible history page is filled. */
 export async function readIncrementalChatHistoryTail(params: {
@@ -104,10 +186,13 @@ export async function readIncrementalChatHistoryTail(params: {
     readPage.messages,
     overreadContextMessage,
   );
+  let recoveryContext: unknown[] | undefined = offset === 0 ? [] : undefined;
+  const newestPageSeq = readChatHistoryMessageSeq(rawMessages.at(-1));
   const project = (
     messages = rawMessages,
     contextMessage = overreadContextMessage,
     resolveProfileDisplay = true,
+    newerContext = recoveryContext ?? [],
   ) => {
     const filteredRawMessages =
       sessionStartedAt === undefined
@@ -119,12 +204,20 @@ export async function readIncrementalChatHistoryTail(params: {
             ),
             contextMessage,
           );
-    const projection = projectChatDisplayMessagesWithState(filteredRawMessages, {
-      includeCommentaryFallbacks: true,
-      maxChars: params.effectiveMaxChars,
-      ...(resolveProfileDisplay ? { resolveCurrentUserProfileDisplay } : {}),
-      turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(contextMessage),
-    });
+    const projection = projectChatDisplayMessagesWithState(
+      newerContext.length > 0 ? [...filteredRawMessages, ...newerContext] : filteredRawMessages,
+      {
+        includeCommentaryFallbacks: true,
+        maxChars: params.effectiveMaxChars,
+        ...(resolveProfileDisplay ? { resolveCurrentUserProfileDisplay } : {}),
+        turnBoundaryPending: isHeartbeatHistoryTurnBoundaryMessage(contextMessage),
+      },
+    );
+    if (newerContext.length > 0) {
+      projection.messages = projection.messages.filter(
+        (message) => (readChatHistoryMessageSeq(message) ?? Infinity) <= (newestPageSeq ?? -1),
+      );
+    }
     const projected =
       offset === 0
         ? projection.messages.length > params.max
@@ -133,7 +226,25 @@ export async function readIncrementalChatHistoryTail(params: {
         : capOffsetChatHistoryProjectedMessages(projection.messages, params.max);
     return { filteredRawMessages, projected, projection };
   };
-  let result = project();
+  const projectWindow = async () => {
+    const result = project();
+    if (
+      recoveryContext !== undefined ||
+      newestPageSeq === undefined ||
+      !result.projection.assistantErrorPending
+    ) {
+      return result;
+    }
+    recoveryContext = await readChatHistoryRecoveryContext({
+      messages: result.filteredRawMessages,
+      project: (messages) => project(messages, overreadContextMessage, true, []).projection,
+      readScope: params.readScope,
+      displaySource: readPage.displaySource,
+      maxBytes: params.maxBytes,
+    });
+    return project();
+  };
+  let result = await projectWindow();
   let estimatedVisibleMessages = result.projected.length;
   let projectionDirty = false;
   let scanLimit = rawHistoryWindowMessages;
@@ -141,7 +252,7 @@ export async function readIncrementalChatHistoryTail(params: {
   let nextChunkMessages = SILENT_CHAT_HISTORY_TAIL_SCAN_CHUNK_MESSAGES;
   while (offset + rawPageMessages < readPage.totalMessages) {
     if (projectionDirty && estimatedVisibleMessages >= params.max) {
-      result = project();
+      result = await projectWindow();
       projectionDirty = false;
       estimatedVisibleMessages = result.projected.length;
     }
@@ -155,11 +266,24 @@ export async function readIncrementalChatHistoryTail(params: {
       break;
     }
     const chunkMessages = Math.min(nextChunkMessages, scanLimit - rawPageMessages);
-    const page = await readSessionMessagesPageWithStatsAsync(params.readScope, {
-      offset: offset + rawPageMessages,
-      maxMessages: chunkMessages + 1,
-      allowResetArchiveFallback: true,
-    });
+    const oldestId = readChatHistoryMessageId(rawMessages[0]);
+    const page =
+      offset > 0 && recoveryContext !== undefined && oldestId
+        ? {
+            ...readPage,
+            messages: await readAdjacentChatHistoryMessages({
+              anchorId: oldestId,
+              direction: "older",
+              limit: chunkMessages + 1,
+              readScope: params.readScope,
+              displaySource: readPage.displaySource,
+            }),
+          }
+        : await readSessionMessagesPageWithStatsAsync(params.readScope, {
+            offset: offset + rawPageMessages,
+            maxMessages: chunkMessages + 1,
+            allowResetArchiveFallback: true,
+          });
     // Separate awaits may cross a destructive rewrite, even when a page is empty.
     // Let the existing retryable history response request one coherent snapshot.
     if (page.displaySource !== readPage.displaySource) {
@@ -175,8 +299,8 @@ export async function readIncrementalChatHistoryTail(params: {
     rawMessages = chunkRawMessages.concat(rawMessages);
     overreadContextMessage = contextMessage;
     // Count fresh rows once; the authoritative whole-window projection preserves cross-chunk facts.
-    estimatedVisibleMessages += project(chunkRawMessages, contextMessage, false).projection.messages
-      .length;
+    estimatedVisibleMessages += project(chunkRawMessages, contextMessage, false, []).projection
+      .messages.length;
     projectionDirty = true;
     scannedBytes += Buffer.byteLength(JSON.stringify(page.messages), "utf8");
     if (rawPageMessages > rawHistoryWindowMessages && scannedBytes >= params.maxBytes) {
@@ -189,7 +313,7 @@ export async function readIncrementalChatHistoryTail(params: {
     );
   }
   if (projectionDirty) {
-    result = project();
+    result = await projectWindow();
   }
   return {
     overreadContextMessage,

--- a/src/gateway/session-transcript-message.ts
+++ b/src/gateway/session-transcript-message.ts
@@ -9,7 +9,7 @@ import {
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 
 export type SessionMessageProjectionState = {
-  streamErrorFallbackPending: boolean;
+  assistantErrorPending: boolean;
   turnBoundaryPending: boolean;
 };
 
@@ -75,16 +75,16 @@ export function projectSessionMessagePayload(params: {
   });
   const projected = params.projectionState
     ? projectChatDisplayMessagesWithState([rawMessage], {
-        streamErrorFallbackPending: params.projectionState.streamErrorFallbackPending,
+        assistantErrorPending: params.projectionState.assistantErrorPending,
         turnBoundaryPending: params.projectionState.turnBoundaryPending,
       })
     : {
         messages: [projectChatDisplayMessage(rawMessage)],
-        streamErrorFallbackPending: false,
+        assistantErrorPending: false,
         turnBoundaryPending: false,
       };
   const projectionState = {
-    streamErrorFallbackPending: projected.streamErrorFallbackPending,
+    assistantErrorPending: projected.assistantErrorPending,
     turnBoundaryPending: projected.turnBoundaryPending,
   };
   const message = projected.messages[0];


### PR DESCRIPTION
Related: #139410

## What Problem This Solves

Fixes an issue where Control UI users saw “The agent run failed before producing a reply.” and a duplicate `×2` answer after a model fallback had already succeeded. Reloading or opening older history could preserve or reintroduce the stale failure.

## Why This Change Was Made

The transcript correctly stored one failed attempt and one successful answer with the same run identity. Keeping the empty failure in display history made the live answer ambiguous to the shared client reconciler. The Gateway now retires empty failed attempts only after a visible successful runtime answer from that exact run, using one projection flow for legacy stream errors and provider failures.

Raw transcript diagnostics, partial replies, structured output, unrelated runs, and unresolved failures remain intact. Incremental history requests reset while recovery can remove a previously displayed row. Historical pages and exact-message lookup share bounded recovery context so navigating history follows the same visibility rule. Ordinary successful turns retain the existing fast path.

## User Impact

A successful fallback displays its answer once, without a stale failed-attempt placeholder. Follow-up messages and reloads remain usable. No configuration, transcript migration, or protocol change is required.

## Evidence

- Reproduced the original defect in a real isolated Gateway and Chromium using an injected first-request model restriction, followed by real OpenAI fallback and follow-up responses. Raw SQLite records confirmed one stored answer.
- The core regression suite failed on the original source for the intended recovery and reconciliation failures.
- 188 focused tests passed across 15 files, covering matching run identity, length-limited completion, unresolved and partial failures, shared client reconciliation, SSE refresh, delta cursors, historical page boundaries, concurrent appends, exact-message lookup, access restrictions, and raw transcript preservation.
- The final full build and complete changed-file gate passed. The real Gateway/browser rerun showed one answer, no stale failure or duplicate badge, a successful follow-up, and clean history after reload. Independent review is clean through P2. Sanitized [before/after captures](https://github.com/openclaw/openclaw/pull/139753#issuecomment-5556983634) show the result.

Recovery lookahead retains the existing message and byte limits; insufficient evidence preserves a failure. An opaque cursor cached before this fix and already past a failure is corrected by the next full history read.

The first CI run exposed an unrelated suppression-inventory line-number mismatch, already fixed on main by #139747. The branch was rebased onto that fix; `git range-diff` confirmed the reviewed patch is unchanged.

The PR review reported no actionable code findings but could not inspect the linked media. Both uploaded images are reachable: a one-byte ranged GET returns HTTP 206 for each. HEAD follows a GET-signed storage redirect and returns 403, so it is not a valid reachability check here. The sanitized originals were visually inspected before upload; the live run also asserted no stale failure or duplicate badge before and after reload.

![Before: stale failure and duplicate answer](https://github.com/user-attachments/assets/149cf838-bd4d-476b-993d-7d8949b9ae12)

![After: one answer and successful follow-up](https://github.com/user-attachments/assets/dece4bb0-b45d-4bde-82a8-e2269e37dcb5)
