### PR TITLE
perf: reduce packaged runtime module-loading overhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
     "!dist/plugin-sdk/src/plugin-sdk/qa-channel-protocol.d.ts",
     "!dist/plugin-sdk/src/plugin-sdk/qa-lab.d.ts",
     "!dist/plugin-sdk/src/plugin-sdk/qa-runtime.d.ts",
-    "!dist/qa-runtime-*.js",
+    "!dist/qa-runtime-*",
     "docs/",
     "!docs/.generated/**",
     "!docs/.i18n/**",

--- a/scripts/check-cli-bootstrap-imports.mts
+++ b/scripts/check-cli-bootstrap-imports.mts
@@ -276,7 +276,7 @@ function listJsFiles(dirPath: string, fsImpl: typeof fs = fs): string[] {
       files.push(...listJsFiles(fullPath, fsImpl));
       continue;
     }
-    if (entry.isFile() && entry.name.endsWith(".js")) {
+    if (entry.isFile() && /\.m?js$/u.test(entry.name)) {
       files.push(fullPath);
     }
   }

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -115,16 +115,12 @@ FROM bare AS functional
 COPY --from=openclaw_package --chown=appuser:appuser openclaw-current.tgz /tmp/openclaw-current.tgz
 COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules
 COPY --chown=appuser:appuser scripts/docker/verify-fs-safe-native.mjs /tmp/verify-fs-safe-native.mjs
-# Extract the package over the prebuilt dependency tree (bundled deps ship in
-# the tarball), then run its packaged postinstall. Functional E2E lanes exercise
-# private bundled plugins too, so skip the production migration's intentionally
-# curated persisted registry in this test image. The /app/node_modules/openclaw
-# self-link preserves package self-reference imports such as
-# openclaw/plugin-sdk/*; create it after postinstall so its prune walks cannot
-# cycle through the link.
+# Complete postinstall while the image is writable; read-only runs cannot finish
+# a pending package lifecycle. Create the package self-link afterward so
+# postinstall's prune walks cannot cycle through it.
 RUN tar -xzf /tmp/openclaw-current.tgz -C /app --strip-components=1 \
  && chmod +x /app/openclaw.mjs \
- && node --input-type=module -e "import { runBundledPluginPostinstall } from '/app/scripts/postinstall-bundled-plugins.mjs'; runBundledPluginPostinstall();" \
+ && node /app/scripts/postinstall-bundled-plugins.mjs \
  && ln -sfn /app /app/node_modules/openclaw \
  && mkdir -p "$HOME/.local/bin" \
  && ln -sf /app/openclaw.mjs "$HOME/.local/bin/openclaw" \

--- a/scripts/e2e/browser-cdp-snapshot-docker.sh
+++ b/scripts/e2e/browser-cdp-snapshot-docker.sh
@@ -74,8 +74,8 @@ openclaw_e2e_eval_test_state_from_b64 \"\${OPENCLAW_TEST_STATE_SCRIPT_B64:?missi
 openclaw_e2e_write_state_env
 entry=\"\$(openclaw_e2e_resolve_entrypoint)\"
 mkdir -p /tmp/openclaw-browser-cdp
-find dist -maxdepth 1 -type f -name 'pw-ai-*.js' ! -name 'pw-ai-state-*' -exec mv {} /tmp/openclaw-browser-cdp/ \;
-if find dist -maxdepth 1 -type f -name 'pw-ai-*.js' ! -name 'pw-ai-state-*' | grep -q .; then
+find dist -maxdepth 1 -type f \( -name 'pw-ai-*.js' -o -name 'pw-ai-*.mjs' \) ! -name 'pw-ai-state-*' -exec mv {} /tmp/openclaw-browser-cdp/ \;
+if find dist -maxdepth 1 -type f \( -name 'pw-ai-*.js' -o -name 'pw-ai-*.mjs' \) ! -name 'pw-ai-state-*' | grep -q .; then
   echo 'failed to disable Playwright AI snapshot chunk for raw CDP smoke' >&2
   exit 1
 fi

--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -1143,7 +1143,7 @@ export function findDistCallGatewayModuleFiles(cwd = process.cwd()) {
   return fs.existsSync(distDir)
     ? fs
         .readdirSync(distDir)
-        .filter((name) => /^call(?:\.runtime)?-[A-Za-z0-9_-]+\.js$/u.test(name))
+        .filter((name) => /^call(?:\.runtime)?-[A-Za-z0-9_-]+\.m?js$/u.test(name))
         .toSorted((left, right) => left.localeCompare(right))
     : [];
 }

--- a/scripts/e2e/lib/openai-web-search-minimal/client.mjs
+++ b/scripts/e2e/lib/openai-web-search-minimal/client.mjs
@@ -5,7 +5,7 @@ import { readTcpPortEnv } from "../env-limits.mjs";
 
 async function loadCallGateway() {
   const candidates = readdirSync("/app/dist")
-    .filter((name) => /^call(?:\.runtime)?-[A-Za-z0-9_-]+\.js$/.test(name))
+    .filter((name) => /^call(?:\.runtime)?-[A-Za-z0-9_-]+\.m?js$/.test(name))
     .toSorted();
   for (const name of candidates) {
     const mod = await import(pathToFileURL(`/app/dist/${name}`).href);

--- a/scripts/e2e/lib/systemd-sealed-service-definition/paired-mounts.mjs
+++ b/scripts/e2e/lib/systemd-sealed-service-definition/paired-mounts.mjs
@@ -21,7 +21,7 @@ try {
   // Exercise the update lifecycle's root-ownership boundary from the installed package.
   let ownsRoot;
   const bundles = (await fs.readdir("/app/dist"))
-    .filter((file) => /^update-command-service-.*\.js$/.test(file))
+    .filter((file) => /^update-command-service-.*\.m?js$/.test(file))
     .toSorted();
   for (const file of bundles) {
     const module = await import(pathToFileURL(`/app/dist/${file}`).href);

--- a/scripts/e2e/parallels/npm-update-scripts.ts
+++ b/scripts/e2e/parallels/npm-update-scripts.ts
@@ -26,7 +26,7 @@ interface NpmUpdateScriptInput {
   updateTarget: string;
 }
 
-const windowsStalePostSwapImportRegex = String.raw`node_modules\\openclaw\\dist\\[^\\]+-[A-Za-z0-9_-]+\.js`;
+const windowsStalePostSwapImportRegex = String.raw`node_modules\\openclaw\\dist\\[^\\]+-[A-Za-z0-9_-]+\.m?js`;
 const startupMigrationRestartPrefix =
   "OpenClaw plugin migration inputs changed during startup convergence;";
 const macosGuestPath =

--- a/scripts/lib/cli-startup-root-help-bundle.ts
+++ b/scripts/lib/cli-startup-root-help-bundle.ts
@@ -10,7 +10,7 @@ export function resolveCliStartupRootHelpBundleIdentity(
   distDir: string,
 ): { bundleName: string; signature: string } | null {
   for (const bundleName of readdirSync(distDir).toSorted()) {
-    if (!bundleName.startsWith("root-help-") || !bundleName.endsWith(".js")) {
+    if (!bundleName.startsWith("root-help-") || !/\.m?js$/u.test(bundleName)) {
       continue;
     }
     const bundleContents = readFileSync(path.join(distDir, bundleName), "utf8");

--- a/scripts/runtime-postbuild.mts
+++ b/scripts/runtime-postbuild.mts
@@ -48,10 +48,10 @@ const LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK = [
 ].join("\n");
 
 const ROOT = resolveRepoRoot(import.meta.url);
-const ROOT_RUNTIME_ALIAS_PATTERN = /^(?<base>.+\.(?:runtime|contract))-[A-Za-z0-9_-]+\.js$/u;
+const ROOT_RUNTIME_ALIAS_PATTERN = /^(?<base>.+\.(?:runtime|contract))-[A-Za-z0-9_-]+\.m?js$/u;
 const ROOT_STABLE_RUNTIME_ALIAS_PATTERN = /^.+\.(?:runtime|contract)\.js$/u;
 const ROOT_RUNTIME_IMPORT_SPECIFIER_PATTERN =
-  /(["'])\.\/([^"']+\.(?:runtime|contract)-[A-Za-z0-9_-]+\.js)\1/gu;
+  /(["'])\.\/([^"']+\.(?:runtime|contract)-[A-Za-z0-9_-]+\.m?js)\1/gu;
 const OFFICIAL_CHANNEL_CATALOG_OUTPUT = "dist/channel-catalog.json";
 const EXPORT_HTML_SOURCE_DIR = "src/auto-reply/reply/export-html";
 const EXPORT_HTML_OUTPUT_DIR = "dist/export-html";
@@ -544,7 +544,7 @@ export function rewriteRootRuntimeImportsToStableAliases(params: RuntimeFsParams
   }
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".js")) {
+    if (!entry.isFile() || !/\.m?js$/u.test(entry.name)) {
       continue;
     }
     if (ROOT_STABLE_RUNTIME_ALIAS_PATTERN.test(entry.name)) {
@@ -584,7 +584,10 @@ function resolveRootRuntimeCandidateByMarkers(
     return null;
   }
   const aliasBaseFileName = aliasFileName.replace(/\.js$/u, "");
-  const hashedPattern = new RegExp(`^${escapeRegExp(aliasBaseFileName)}-[A-Za-z0-9_-]+\\.js$`, "u");
+  const hashedPattern = new RegExp(
+    `^${escapeRegExp(aliasBaseFileName)}-[A-Za-z0-9_-]+\\.m?js$`,
+    "u",
+  );
   let entries;
   try {
     entries = fsImpl.readdirSync(distDir, { withFileTypes: true });

--- a/scripts/test-built-status-message-runtime.mts
+++ b/scripts/test-built-status-message-runtime.mts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { parsePackageRootArg } from "./lib/package-root-args.mts";
 
-const STATUS_MESSAGE_RUNTIME_RE = /^status-message\.runtime(?:-[A-Za-z0-9_-]+)?\.js$/u;
+const STATUS_MESSAGE_RUNTIME_RE = /^status-message\.runtime(?:-[A-Za-z0-9_-]+\.m?js|\.js)$/u;
 
 /**
  * Finds the preferred built status-message runtime bundle under dist.
@@ -40,7 +40,7 @@ function listBuiltStatusMessageRuntimeFiles(distDir: string) {
 function listFindBuiltStatusMessageRuntimeFiles(distDir: string) {
   const result = spawnSync(
     "find",
-    [distDir, "-maxdepth", "1", "-type", "f", "-name", "status-message.runtime*.js"],
+    [distDir, "-maxdepth", "1", "-type", "f", "-name", "status-message.runtime*.*js"],
     {
       encoding: "utf8",
       maxBuffer: 1024 * 1024,

--- a/src/docker-build-cache.test.ts
+++ b/src/docker-build-cache.test.ts
@@ -14,17 +14,13 @@ const dockerfilePaths = [
   "scripts/docker/install-sh-smoke/Dockerfile",
   "scripts/docker/install-sh-e2e/Dockerfile",
   "scripts/docker/install-sh-nonroot/Dockerfile",
-  "scripts/e2e/Dockerfile",
   "scripts/e2e/Dockerfile.qr-import",
 ] as const;
 const aptCacheDockerfilePaths = dockerfilePaths.filter(
-  (path) => path !== "scripts/e2e/Dockerfile.qr-import" && path !== "scripts/e2e/Dockerfile",
+  (path) => path !== "scripts/e2e/Dockerfile.qr-import",
 );
 const shellContinuationDockerfilePaths = dockerfilePaths.filter(
-  (path) =>
-    path !== "Dockerfile" &&
-    path !== "scripts/e2e/Dockerfile" &&
-    path !== "scripts/e2e/Dockerfile.qr-import",
+  (path) => path !== "Dockerfile" && path !== "scripts/e2e/Dockerfile.qr-import",
 );
 const repoFileCache = new Map<string, Promise<string>>();
 
@@ -120,32 +116,6 @@ describe("docker build cache layout", () => {
         `${path} should not have blank lines after a trailing backslash`,
       ).not.toMatch(/\\\n\s*\n/);
     }
-  });
-
-  it("keeps the shared e2e image on the packaged tarball install path", async () => {
-    const dockerfile = await readRepoFile("scripts/e2e/Dockerfile");
-
-    expect(dockerfile).not.toContain("pnpm install --frozen-lockfile");
-    expect(dockerfile).not.toContain("COPY . .");
-    expect(dockerfile).toMatch(
-      /^COPY --from=openclaw_package --chown=appuser:appuser openclaw-current\.tgz \/tmp\/openclaw-current\.tgz$/m,
-    );
-    // The dependency reify layer must key on the extracted manifest, not the
-    // per-PR tarball bytes, so warm builders skip the full npm install.
-    expect(dockerfile).toContain(
-      "COPY --from=functional-manifest --chown=appuser:appuser /tmp/openclaw-deps /tmp/openclaw-deps",
-    );
-    expect(dockerfile).toContain("npm install --omit=dev --no-fund --no-audit");
-    expect(dockerfile).not.toContain("npm install -g --prefix");
-    expect(dockerfile).toContain(
-      "COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules",
-    );
-    // Packaged prune/hotfix logic must run before the self-link exists so its
-    // walks cannot cycle through /app/node_modules/openclaw -> /app.
-    const postinstallIndex = dockerfile.indexOf("runBundledPluginPostinstall");
-    const selfLinkIndex = dockerfile.indexOf("ln -sfn /app /app/node_modules/openclaw");
-    expect(postinstallIndex).toBeGreaterThan(-1);
-    expect(selfLinkIndex).toBeGreaterThan(postinstallIndex);
   });
 
   it("copies manifests before install in the qr-import image", async () => {

--- a/src/entry.esm-resolve-fast-path.test.ts
+++ b/src/entry.esm-resolve-fast-path.test.ts
@@ -249,7 +249,7 @@ describe.skipIf(!fs.existsSync(DIST_ENTRY_PATH) || !fs.existsSync(DIST_INDEX_PAT
           `import { appendFileSync } from "node:fs";
 import { registerHooks } from "node:module";
 function recordTarget(specifier, context, nextResolve) {
-  if (specifier.startsWith(${JSON.stringify(targetPrefix)}) && specifier.endsWith(".js")) {
+  if (specifier.startsWith(${JSON.stringify(targetPrefix)}) && (specifier.endsWith(".js") || specifier.endsWith(".mjs"))) {
     appendFileSync(process.env.OPENCLAW_TEST_RESOLVER_HOOK_MARKER, specifier + "\\n");
   }
   return nextResolve(specifier, context);

--- a/src/infra/runtime-worker-url.test.ts
+++ b/src/infra/runtime-worker-url.test.ts
@@ -19,6 +19,7 @@ describe("resolveRuntimeWorkerUrl", () => {
     for (const currentModuleUrl of [
       pathToFileURL(path.join(root, "dist/agents/code-mode.js")).href,
       pathToFileURL(path.join(root, "dist/selection-abc123.js")).href,
+      pathToFileURL(path.join(root, "dist/selection-abc123.mjs")).href,
     ]) {
       expect(
         fileURLToPath(

--- a/test/e2e/qa-lab/runtime/codex-heartbeat-compaction-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-heartbeat-compaction-app-server.fixture.mjs
@@ -255,7 +255,7 @@ async function installProviderRedirect() {
   const distDir = path.join(repoRoot, "dist");
   if (proofMode === "heartbeat-upgraded-restart") {
     const compactChunks = fs.readdirSync(distDir).filter((name) => {
-      if (!name.startsWith("compact-") || !name.endsWith(".js")) {
+      if (!name.startsWith("compact-") || !/\.m?js$/u.test(name)) {
         return false;
       }
       const source = fs.readFileSync(path.join(distDir, name), "utf8");
@@ -295,7 +295,7 @@ async function installProviderRedirect() {
   }
   const hostChunks = fs
     .readdirSync(distDir)
-    .filter((name) => name.startsWith("ai-transport-host-") && name.endsWith(".js"));
+    .filter((name) => name.startsWith("ai-transport-host-") && /\.m?js$/u.test(name));
   if (hostChunks.length !== 1) {
     throw new Error(`expected one built AI transport host chunk, found ${hostChunks.length}`);
   }

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -878,6 +878,44 @@ describe("package-openclaw-for-docker", () => {
     ]);
   });
 
+  it("keeps root package exclusions in parity with reused private QA build inventory", async () => {
+    const sourceDir = createPackageSourceFixture("openclaw-package-qa-exclusions-source-");
+    const outputDir = tempDirs.make("openclaw-package-qa-exclusions-output-");
+    const { files, version } = JSON.parse(
+      fs.readFileSync(new URL("../../../../package.json", import.meta.url), "utf8"),
+    ) as { files: string[]; version: string };
+    fs.writeFileSync(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({ name: "openclaw", version, files }),
+    );
+    const publicFiles = ["dist/index.js", "dist/runtime-PUBLIC.mjs"];
+    const privateFiles = ["dist/qa-runtime-PRIVATE.js", "dist/qa-runtime-PRIVATE.mjs"];
+    fs.mkdirSync(path.join(sourceDir, "dist"));
+    for (const file of [...publicFiles, ...privateFiles]) {
+      fs.writeFileSync(path.join(sourceDir, file), "export {};\n");
+    }
+
+    // Reuse prepared outputs, as --skip-build does; npm owns the root files policy.
+    const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
+      ...skipDocsMapLifecycle,
+      prepareChangelog: async () => {},
+      restoreChangelog: async () => {},
+    });
+    const extractDir = tempDirs.make("openclaw-package-qa-exclusions-extract-");
+    await tar.x({ file: tarball, cwd: extractDir });
+    const packedDist = path.join(extractDir, "package/dist");
+    const inventory = JSON.parse(
+      fs.readFileSync(path.join(packedDist, "postinstall-inventory.json"), "utf8"),
+    ) as string[];
+    const packagedFiles = fs
+      .readdirSync(packedDist)
+      .map((file) => `dist/${file}`)
+      .toSorted();
+
+    expect(inventory).toEqual(publicFiles);
+    expect(packagedFiles).toEqual([...publicFiles, "dist/postinstall-inventory.json"].toSorted());
+  });
+
   it("omits stale hashed dist output when frozen sources expose only their own build", async () => {
     const sourceDir = createPackageSourceFixture("openclaw-package-clean-dist-source-");
     const outputDir = tempDirs.make("openclaw-package-clean-dist-output-");

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -221,7 +221,7 @@ async function resolveBuiltModule(params: {
   exportMarker: string;
 }): Promise<string> {
   for (const name of await fs.readdir(params.distDir)) {
-    if (!name.startsWith(params.prefix) || !name.endsWith(".js")) {
+    if (!name.startsWith(params.prefix) || !/\.m?js$/u.test(name)) {
       continue;
     }
     const filePath = path.join(params.distDir, name);

--- a/test/scripts/check-cli-bootstrap-imports.test.ts
+++ b/test/scripts/check-cli-bootstrap-imports.test.ts
@@ -33,7 +33,11 @@ function writeFixture(root: string, relativePath: string, source: string): void 
   writeFileSync(target, source, "utf8");
 }
 
-function writeGatewayRunChunk(root: string, source = "", distDir = "dist"): void {
+function writeGatewayRunChunk(
+  root: string,
+  source = "",
+  { distDir = "dist", chunkName = "run-gateway.js" }: { distDir?: string; chunkName?: string } = {},
+): void {
   writeFixture(root, `${distDir}/string-coerce.js`, "export const normalize = true;");
   const chunkSource = [
     'import "./string-coerce.js";',
@@ -41,7 +45,7 @@ function writeGatewayRunChunk(root: string, source = "", distDir = "dist"): void
     "function addGatewayRunCommand(cmd) { return cmd; }",
     source,
   ].join("\n");
-  writeFixture(root, `${distDir}/run-gateway.js`, chunkSource);
+  writeFixture(root, `${distDir}/${chunkName}`, chunkSource);
   writeFixture(
     root,
     `${distDir}/cli/gateway-run-chunk.json`,
@@ -49,7 +53,7 @@ function writeGatewayRunChunk(root: string, source = "", distDir = "dist"): void
       version: 1,
       chunks: [
         {
-          fileName: "run-gateway.js",
+          fileName: chunkName,
           sha256: createHash("sha256").update(chunkSource).digest("hex"),
         },
       ],
@@ -75,29 +79,36 @@ describe("check-cli-bootstrap-imports", () => {
     ).toEqual(["node:fs", "./side-effect.js", "../value.js"]);
   });
 
-  it("allows a bootstrap graph with builtins and lazy external imports", () => {
-    const root = makeTempRoot();
-    writeFixture(
-      root,
-      "dist/entry.js",
-      `import fs from "node:fs";\nimport "./cli/run-main.js";\nvoid fs;\n`,
-    );
-    writeFixture(
-      root,
-      "dist/cli/run-main.js",
-      `import "../light.js";\nexport async function run() { return import("tslog"); }\n`,
-    );
-    writeFixture(root, "dist/light.js", `import path from "node:path";\nvoid path;\n`);
-    writeGatewayRunChunk(root);
+  it.each(["run-gateway.js", "run-gateway-abc123.mjs"])(
+    "allows builtins and lazy external imports with %s and a mixed-extension graph",
+    (chunkName) => {
+      const root = makeTempRoot();
+      writeFixture(
+        root,
+        "dist/entry.js",
+        `import fs from "node:fs";\nimport "./cli/run-main.js";\nvoid fs;\n`,
+      );
+      writeFixture(
+        root,
+        "dist/cli/run-main.js",
+        `import "../light-abc123.mjs";\nexport async function run() { return import("tslog"); }\n`,
+      );
+      writeFixture(root, "dist/light-abc123.mjs", 'import "./string-coerce.js";\n');
+      writeGatewayRunChunk(root, "", { chunkName });
 
-    expect(collectCliBootstrapExternalImportErrors({ rootDir: root })).toStrictEqual([]);
-    expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toStrictEqual([]);
-  });
+      expect(collectCliBootstrapExternalImportErrors({ rootDir: root })).toStrictEqual([]);
+      expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toStrictEqual([]);
+      expect(
+        collectGatewayRunChunkBudgetErrors({ rootDir: root, legacyGatewayChunkDiscovery: true }),
+      ).toStrictEqual([]);
+    },
+  );
 
   it("reports external packages in the static bootstrap graph", () => {
     const root = makeTempRoot();
     writeFixture(root, "dist/entry.js", `import "./cli/run-main.js";\n`);
-    writeFixture(root, "dist/cli/run-main.js", `import "../heavy.js";\n`);
+    writeFixture(root, "dist/cli/run-main.js", `import "../bridge-abc123.mjs";\n`);
+    writeFixture(root, "dist/bridge-abc123.mjs", `import "./heavy.js";\n`);
     writeFixture(root, "dist/heavy.js", `import { Logger } from "tslog";\nvoid Logger;\n`);
     writeGatewayRunChunk(root);
 
@@ -131,7 +142,7 @@ describe("check-cli-bootstrap-imports", () => {
 
   it.each(["dist", "custom-output"])("reads only the owned gateway graph under %s", (distDir) => {
     const root = makeTempRoot();
-    writeGatewayRunChunk(root, "", distDir);
+    writeGatewayRunChunk(root, "", { distDir });
     const unrelatedPath = join(root, distDir, "plugins/unrelated.js");
     writeFixture(root, `${distDir}/plugins/unrelated.js`, "export const unrelated = true;");
     const reads: string[] = [];
@@ -222,36 +233,42 @@ describe("check-cli-bootstrap-imports", () => {
     },
   );
 
-  it("reports cold static imports in the gateway run chunk", () => {
+  it.each(["run-gateway.js", "run-gateway-abc123.mjs"])(
+    "reports cold static imports in %s",
+    (chunkName) => {
+      const root = makeTempRoot();
+      writeGatewayRunChunk(root, 'import "./restart-sentinel-abc123.mjs";', { chunkName });
+      writeFixture(root, "dist/restart-sentinel-abc123.mjs", "export const sentinel = true;");
+
+      expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toEqual([
+        `Gateway run chunk dist/${chunkName} static graph imports cold path "./restart-sentinel-abc123.mjs" from dist/${chunkName}.`,
+      ]);
+    },
+  );
+
+  it.each(["run-gateway.js", "run-gateway-abc123.mjs"])(
+    "reports transitive cold static imports from %s through a mixed-extension graph",
+    (chunkName) => {
+      const root = makeTempRoot();
+      writeGatewayRunChunk(root, 'import "./gateway-bridge-abc123.mjs";', { chunkName });
+      writeFixture(root, "dist/gateway-bridge-abc123.mjs", 'import "./server-close-abc123.js";');
+      writeFixture(root, "dist/server-close-abc123.js", "export const close = true;");
+
+      expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toEqual([
+        `Gateway run chunk dist/${chunkName} static graph imports cold path "./server-close-abc123.js" from dist/gateway-bridge-abc123.mjs.`,
+      ]);
+    },
+  );
+
+  it.each(["run-gateway.js", "run-gateway-abc123.mjs"])("reports an oversized %s", (chunkName) => {
     const root = makeTempRoot();
-    writeGatewayRunChunk(root, 'import "./restart-sentinel-abc123.js";');
-    writeFixture(root, "dist/restart-sentinel-abc123.js", "export const sentinel = true;");
-
-    expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toEqual([
-      'Gateway run chunk dist/run-gateway.js static graph imports cold path "./restart-sentinel-abc123.js" from dist/run-gateway.js.',
-    ]);
-  });
-
-  it("reports transitive cold static imports from the gateway run chunk graph", () => {
-    const root = makeTempRoot();
-    writeGatewayRunChunk(root, 'import "./gateway-bridge.js";');
-    writeFixture(root, "dist/gateway-bridge.js", 'import "./server-close-abc123.js";');
-    writeFixture(root, "dist/server-close-abc123.js", "export const close = true;");
-
-    expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toEqual([
-      'Gateway run chunk dist/run-gateway.js static graph imports cold path "./server-close-abc123.js" from dist/gateway-bridge.js.',
-    ]);
-  });
-
-  it("reports oversized gateway run chunks", () => {
-    const root = makeTempRoot();
-    writeGatewayRunChunk(root, "x".repeat(10));
-    const gatewayRunChunkBytes = statSync(join(root, "dist", "run-gateway.js")).size;
+    writeGatewayRunChunk(root, "x".repeat(10), { chunkName });
+    const gatewayRunChunkBytes = statSync(join(root, "dist", chunkName)).size;
 
     expect(
       collectGatewayRunChunkBudgetErrors({ rootDir: root, gatewayRunChunkMaxBytes: 50 }),
     ).toEqual([
-      `Gateway run chunk dist/run-gateway.js is ${gatewayRunChunkBytes} bytes, above budget 50 bytes.`,
+      `Gateway run chunk dist/${chunkName} is ${gatewayRunChunkBytes} bytes, above budget 50 bytes.`,
     ]);
   });
 
@@ -396,6 +413,10 @@ describe("gateway run chunk metadata", () => {
       entry: { "cli/run-main": "entry.ts" },
       outDir: "dist",
       dts: false,
+      outputOptions: {
+        entryFileNames: "[name].js",
+        chunkFileNames: "[name]-[hash].mjs",
+      },
       minify: true,
       sourcemap,
       plugins: [plugin],
@@ -404,6 +425,8 @@ describe("gateway run chunk metadata", () => {
     try {
       const chunks = readGatewayRunChunks(join(root, "dist"));
       expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.filePath).toMatch(/-[A-Za-z0-9_-]+\.mjs$/u);
+      expect(fs.existsSync(join(root, "dist/cli/run-main.js"))).toBe(true);
       expect(chunks[0]?.source).not.toContain("GATEWAY_AUTH_MODES");
       expect(collectGatewayRunChunkBudgetErrors({ rootDir: root })).toEqual([]);
       fs.appendFileSync(chunks[0]!.filePath, "\n// changed after emission\n");

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6131,10 +6131,30 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(updateRunner).toContain("--mode fallback");
   });
 
-  it("keeps private bundled plugins discoverable without persisting a curated registry", () => {
+  it("keeps the shared e2e image on the packaged tarball install path", () => {
     const dockerfile = readFileSync("scripts/e2e/Dockerfile", "utf8");
-    expect(dockerfile).toContain("runBundledPluginPostinstall");
-    expect(dockerfile).not.toContain("node /app/scripts/postinstall-bundled-plugins.mjs");
+
+    expect(dockerfile).not.toContain("pnpm install --frozen-lockfile");
+    expect(dockerfile).not.toContain("COPY . .");
+    expect(dockerfile).toMatch(
+      /^COPY --from=openclaw_package --chown=appuser:appuser openclaw-current\.tgz \/tmp\/openclaw-current\.tgz$/m,
+    );
+    // Cache registry dependencies by manifest, not by each PR's built tarball.
+    expect(dockerfile).toContain(
+      "COPY --from=functional-manifest --chown=appuser:appuser /tmp/openclaw-deps /tmp/openclaw-deps",
+    );
+    expect(dockerfile).toContain("npm install --omit=dev --no-fund --no-audit");
+    expect(dockerfile).not.toContain("npm install -g --prefix");
+    expect(dockerfile).toContain(
+      "COPY --from=functional-deps --chown=appuser:appuser /tmp/openclaw-deps/node_modules /app/node_modules",
+    );
+    // Complete the lifecycle before the self-link lets pruning cycle back into /app.
+    const postinstallIndex = dockerfile.indexOf(
+      "node /app/scripts/postinstall-bundled-plugins.mjs",
+    );
+    const selfLinkIndex = dockerfile.indexOf("ln -sfn /app /app/node_modules/openclaw");
+    expect(postinstallIndex).toBeGreaterThan(-1);
+    expect(selfLinkIndex).toBeGreaterThan(postinstallIndex);
   });
 
   it("keeps onboarding Docker E2E resource-guarded", () => {

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -946,12 +946,16 @@ describe("kitchen-sink RPC caller loading", () => {
     try {
       mkdirSync(path.join(root, "dist"));
       writeFileSync(path.join(root, "dist", "call-Abc123.js"), "");
+      writeFileSync(path.join(root, "dist", "call-Abc123.mjs"), "");
       writeFileSync(path.join(root, "dist", "call.runtime-Def456.js"), "");
+      writeFileSync(path.join(root, "dist", "call.runtime-Def456.mjs"), "");
       writeFileSync(path.join(root, "dist", "index.js"), "");
 
       expect(findDistCallGatewayModuleFiles(root)).toEqual([
         "call-Abc123.js",
+        "call-Abc123.mjs",
         "call.runtime-Def456.js",
+        "call.runtime-Def456.mjs",
       ]);
     } finally {
       rmSync(root, { recursive: true, force: true });

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -1523,14 +1523,15 @@ exit 7
     }
     expect(staleImportLine).toContain("$updateText -match 'ERR_MODULE_NOT_FOUND'");
     expect(staleImportLine).toContain(`$updateText -match '${staleImportPattern}'`);
-    expect(staleImportPattern).toBe(
-      String.raw`node_modules\\openclaw\\dist\\[^\\]+-[A-Za-z0-9_-]+\.js`,
-    );
     expect(staleImportPattern).not.toContain("node_modules\\openclaw\\dist\\");
     expect(staleImportPattern.match(/\\\\/g)).toHaveLength(4);
-    const representativeUpdateFailure = String.raw`Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'C:\Users\runner\AppData\Roaming\npm\node_modules\openclaw\dist\main-a1_B2.js' imported from C:\Users\runner\AppData\Roaming\npm\node_modules\openclaw\dist\cli.js`;
     const generatedRegex = new RegExp(staleImportPattern);
-    expect(generatedRegex.test(representativeUpdateFailure)).toBe(true);
-    expect(generatedRegex.test(String.raw`node_modules\openclaw\dist\main.js`)).toBe(false);
+    for (const extension of ["js", "mjs"]) {
+      const representativeUpdateFailure = String.raw`Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'C:\Users\runner\AppData\Roaming\npm\node_modules\openclaw\dist\main-a1_B2.${extension}' imported from C:\Users\runner\AppData\Roaming\npm\node_modules\openclaw\dist\cli.js`;
+      expect(generatedRegex.test(representativeUpdateFailure)).toBe(true);
+      expect(generatedRegex.test(String.raw`node_modules\openclaw\dist\main.${extension}`)).toBe(
+        false,
+      );
+    }
   });
 });

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -558,15 +558,22 @@ describe("runtime postbuild static assets", () => {
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "runtime-tts.runtime-AbCd1234.js"),
+      path.join(distDir, "runtime-tts.runtime-AbCd1234.mjs"),
       "export const tts = true;\n",
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "library-Other123.js"),
-      "export const x = true;\n",
+      path.join(distDir, "dispatch.contract-AbCd1234.mjs"),
+      "export const dispatch = true;\n",
       "utf8",
     );
+    for (const extension of ["js", "mjs"]) {
+      await fs.writeFile(
+        path.join(distDir, `library-Other123.${extension}`),
+        "export const x = true;\n",
+        "utf8",
+      );
+    }
 
     writeStableRootRuntimeAliases({ rootDir });
 
@@ -574,9 +581,14 @@ describe("runtime postbuild static assets", () => {
       'export * from "./runtime-model-auth.runtime-XyZ987.js";\n',
     );
     expect(await fs.readFile(path.join(distDir, "runtime-tts.runtime.js"), "utf8")).toBe(
-      'export * from "./runtime-tts.runtime-AbCd1234.js";\n',
+      'export * from "./runtime-tts.runtime-AbCd1234.mjs";\n',
     );
-    await expectPathMissing(path.join(distDir, "library.js"));
+    expect(await fs.readFile(path.join(distDir, "dispatch.contract.js"), "utf8")).toBe(
+      'export * from "./dispatch.contract-AbCd1234.mjs";\n',
+    );
+    for (const fileName of ["library.js", "runtime-tts.runtime.mjs", "dispatch.contract.mjs"]) {
+      await expectPathMissing(path.join(distDir, fileName));
+    }
   });
 
   it("refuses to rewrite stable aliases through a symlinked dist root", async () => {
@@ -601,12 +613,12 @@ describe("runtime postbuild static assets", () => {
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(path.join(rootDir, "package.json"), '{"type":"module"}\n', "utf8");
     await fs.writeFile(
-      path.join(distDir, "runtime-plugins.runtime-Hash111.js"),
+      path.join(distDir, "runtime-plugins.runtime-Hash111.mjs"),
       "function reconcile(value) { return value; }\nexport { reconcile as default };\n",
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "mixed.runtime-Hash222.js"),
+      path.join(distDir, "mixed.contract-Hash222.mjs"),
       "export const named = true;\nexport default function run() {}\n",
       "utf8",
     );
@@ -625,16 +637,23 @@ describe("runtime postbuild static assets", () => {
     const legacy = await import(
       pathToFileURL(path.join(distDir, "runtime-plugins.runtime-fLHuT7Vs.js")).href
     );
-    const mixed = await import(pathToFileURL(path.join(distDir, "mixed.runtime.js")).href);
+    const mixed = await import(pathToFileURL(path.join(distDir, "mixed.contract.js")).href);
     const namedOnly = await import(pathToFileURL(path.join(distDir, "named-only.runtime.js")).href);
 
     expect(stable.default("stable")).toBe("stable");
     expect(legacy.default("legacy")).toBe("legacy");
     expect(mixed.default).toBeTypeOf("function");
+    expect(mixed.named).toBe(true);
+    expect(namedOnly.marker).toBe("export { marker as default }");
     expect(namedOnly).not.toHaveProperty("default");
 
+    rewriteRootRuntimeImportsToStableAliases({ rootDir });
     writeStableRootRuntimeAliases({ rootDir });
     writeLegacyRootRuntimeCompatAliases({ rootDir });
+    expect(await fs.readFile(path.join(distDir, "runtime-plugins.runtime.js"), "utf8")).toBe(
+      'export * from "./runtime-plugins.runtime-Hash111.mjs";\n' +
+        'export { default } from "./runtime-plugins.runtime-Hash111.mjs";\n',
+    );
 
     const stableAfterRerun = await import(
       `${pathToFileURL(path.join(distDir, "runtime-plugins.runtime.js")).href}?rerun=1`
@@ -647,7 +666,7 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "install.runtime-Aaa111.js"),
+      path.join(distDir, "install.runtime-Aaa111.mjs"),
       "export const pluginInstall = true;\n",
       "utf8",
     );
@@ -672,7 +691,7 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "install.runtime-Aaa111.js"),
+      path.join(distDir, "install.runtime-Aaa111.mjs"),
       [
         "export const scanPackageInstallSource = true;",
         "export const scanFileInstallSource = true;",
@@ -691,7 +710,7 @@ describe("runtime postbuild static assets", () => {
     writeStableRootRuntimeAliases({ rootDir });
 
     expect(await fs.readFile(path.join(distDir, "install.runtime.js"), "utf8")).toBe(
-      'export * from "./install.runtime-Aaa111.js";\n',
+      'export * from "./install.runtime-Aaa111.mjs";\n',
     );
   });
 
@@ -705,7 +724,7 @@ describe("runtime postbuild static assets", () => {
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "runtime-model-auth.runtime-Wrap456.js"),
+      path.join(distDir, "runtime-model-auth.runtime-Wrap456.mjs"),
       'import { auth } from "./runtime-model-auth.runtime-Impl123.js";\nexport { auth };\n',
       "utf8",
     );
@@ -713,7 +732,7 @@ describe("runtime postbuild static assets", () => {
     writeStableRootRuntimeAliases({ rootDir });
 
     expect(await fs.readFile(path.join(distDir, "runtime-model-auth.runtime.js"), "utf8")).toBe(
-      'export * from "./runtime-model-auth.runtime-Wrap456.js";\n',
+      'export * from "./runtime-model-auth.runtime-Wrap456.mjs";\n',
     );
   });
 
@@ -722,7 +741,7 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "runtime-plugins.runtime-NewHash.js"),
+      path.join(distDir, "runtime-plugins.runtime-NewHash.mjs"),
       "export const ready = true;\n",
       "utf8",
     );
@@ -733,7 +752,7 @@ describe("runtime postbuild static assets", () => {
     );
     await fs.writeFile(
       path.join(distDir, "dispatch-OldHash.js"),
-      ['const lazy = () => import("./runtime-plugins.runtime-NewHash.js");', ""].join("\n"),
+      ['const lazy = () => import("./runtime-plugins.runtime-NewHash.mjs");', ""].join("\n"),
       "utf8",
     );
 
@@ -744,24 +763,32 @@ describe("runtime postbuild static assets", () => {
       ['const lazy = () => import("./runtime-plugins.runtime.js");', ""].join("\n"),
     );
     expect(await fs.readFile(path.join(distDir, "runtime-plugins.runtime.js"), "utf8")).toBe(
-      'export * from "./runtime-plugins.runtime-NewHash.js";\n',
+      'export * from "./runtime-plugins.runtime-NewHash.mjs";\n',
     );
   });
 
-  it("rewrites root runtime imports to stable aliases", async () => {
+  it.each(["js", "mjs"])("rewrites mixed runtime imports in a %s importer", async (extension) => {
     const rootDir = createTempDir("openclaw-runtime-postbuild-");
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "runtime-plugins.runtime-AbCd1234.js"),
+      path.join(distDir, "runtime-plugins.runtime-AbCd1234.mjs"),
       "export const ready = true;\n",
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "dispatch-OldHash.js"),
+      path.join(distDir, "dispatch.contract-AbCd1234.js"),
+      "export const dispatch = true;\n",
+      "utf8",
+    );
+    const importerPath = path.join(distDir, `dispatch-OldHash.${extension}`);
+    await fs.writeFile(
+      importerPath,
       [
-        'const lazy = () => import("./runtime-plugins.runtime-AbCd1234.js");',
+        'const lazy = () => import("./runtime-plugins.runtime-AbCd1234.mjs");',
+        'export { dispatch } from "./dispatch.contract-AbCd1234.js";',
         'import "./missing.runtime-Nope.js";',
+        'import "./missing.contract-Nope.mjs";',
         "",
       ].join("\n"),
       "utf8",
@@ -769,10 +796,12 @@ describe("runtime postbuild static assets", () => {
 
     rewriteRootRuntimeImportsToStableAliases({ rootDir });
 
-    expect(await fs.readFile(path.join(distDir, "dispatch-OldHash.js"), "utf8")).toBe(
+    expect(await fs.readFile(importerPath, "utf8")).toBe(
       [
         'const lazy = () => import("./runtime-plugins.runtime.js");',
+        'export { dispatch } from "./dispatch.contract.js";',
         'import "./missing.runtime-Nope.js";',
+        'import "./missing.contract-Nope.mjs";',
         "",
       ].join("\n"),
     );
@@ -783,14 +812,14 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "text-transforms.runtime-NewHash.js"),
+      path.join(distDir, "text-transforms.runtime-NewHash.mjs"),
       "export const n = true;\nexport const t = true;\n",
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "provider-runtime-NewHash.js"),
+      path.join(distDir, "provider-runtime-NewHash.mjs"),
       [
-        'import { n as applyPluginTextReplacements } from "./text-transforms.runtime-NewHash.js";',
+        'import { n as applyPluginTextReplacements } from "./text-transforms.runtime-NewHash.mjs";',
         "export { applyPluginTextReplacements };",
         "",
       ].join("\n"),
@@ -800,15 +829,15 @@ describe("runtime postbuild static assets", () => {
     rewriteRootRuntimeImportsToStableAliases({ rootDir });
     writeStableRootRuntimeAliases({ rootDir });
 
-    expect(await fs.readFile(path.join(distDir, "provider-runtime-NewHash.js"), "utf8")).toBe(
+    expect(await fs.readFile(path.join(distDir, "provider-runtime-NewHash.mjs"), "utf8")).toBe(
       [
-        'import { n as applyPluginTextReplacements } from "./text-transforms.runtime-NewHash.js";',
+        'import { n as applyPluginTextReplacements } from "./text-transforms.runtime-NewHash.mjs";',
         "export { applyPluginTextReplacements };",
         "",
       ].join("\n"),
     );
     expect(await fs.readFile(path.join(distDir, "text-transforms.runtime.js"), "utf8")).toBe(
-      'export * from "./text-transforms.runtime-NewHash.js";\n',
+      'export * from "./text-transforms.runtime-NewHash.mjs";\n',
     );
   });
 
@@ -879,7 +908,7 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "install.runtime-Aaa111.js"),
+      path.join(distDir, "install.runtime-Aaa111.mjs"),
       "export const pluginInstall = true;\n",
       "utf8",
     );
@@ -891,7 +920,7 @@ describe("runtime postbuild static assets", () => {
     await fs.writeFile(
       path.join(distDir, "install-OldHash.js"),
       [
-        'const pluginRuntime = () => import("./install.runtime-Aaa111.js");',
+        'const pluginRuntime = () => import("./install.runtime-Aaa111.mjs");',
         'const daemonRuntime = () => import("./install.runtime-Bbb222.js");',
         "",
       ].join("\n"),
@@ -902,7 +931,7 @@ describe("runtime postbuild static assets", () => {
 
     expect(await fs.readFile(path.join(distDir, "install-OldHash.js"), "utf8")).toBe(
       [
-        'const pluginRuntime = () => import("./install.runtime-Aaa111.js");',
+        'const pluginRuntime = () => import("./install.runtime-Aaa111.mjs");',
         'const daemonRuntime = () => import("./install.runtime-Bbb222.js");',
         "",
       ].join("\n"),
@@ -914,7 +943,7 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "install.runtime-Aaa111.js"),
+      path.join(distDir, "install.runtime-Aaa111.mjs"),
       [
         "export const scanPackageInstallSource = true;",
         "export const scanFileInstallSource = true;",
@@ -932,7 +961,7 @@ describe("runtime postbuild static assets", () => {
     await fs.writeFile(
       path.join(distDir, "install-OldHash.js"),
       [
-        'const pluginRuntime = () => import("./install.runtime-Aaa111.js");',
+        'const pluginRuntime = () => import("./install.runtime-Aaa111.mjs");',
         'const daemonRuntime = () => import("./install.runtime-Bbb222.js");',
         "",
       ].join("\n"),
@@ -955,20 +984,20 @@ describe("runtime postbuild static assets", () => {
     const distDir = path.join(rootDir, "dist");
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
-      path.join(distDir, "runtime-plugins.runtime-AbCd1234.js"),
+      path.join(distDir, "runtime-plugins.runtime-AbCd1234.mjs"),
       "export const ready = true;\n",
       "utf8",
     );
     await fs.writeFile(
       path.join(distDir, "runtime-plugins.runtime.js"),
-      'export * from "./runtime-plugins.runtime-AbCd1234.js";\n',
+      'export * from "./runtime-plugins.runtime-AbCd1234.mjs";\n',
       "utf8",
     );
 
     rewriteRootRuntimeImportsToStableAliases({ rootDir });
 
     expect(await fs.readFile(path.join(distDir, "runtime-plugins.runtime.js"), "utf8")).toBe(
-      'export * from "./runtime-plugins.runtime-AbCd1234.js";\n',
+      'export * from "./runtime-plugins.runtime-AbCd1234.mjs";\n',
     );
   });
 
@@ -978,7 +1007,7 @@ describe("runtime postbuild static assets", () => {
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
       path.join(distDir, "runtime-plugins.runtime.js"),
-      'export * from "./runtime-plugins.runtime-NewHash.js";\n',
+      'export * from "./runtime-plugins.runtime-NewHash.mjs";\n',
       "utf8",
     );
     await fs.writeFile(
@@ -987,7 +1016,7 @@ describe("runtime postbuild static assets", () => {
       "utf8",
     );
     await fs.writeFile(
-      path.join(distDir, "install.runtime-NewPluginHash.js"),
+      path.join(distDir, "install.runtime-NewPluginHash.mjs"),
       [
         "export const scanPackageInstallSource = true;",
         "export const scanFileInstallSource = true;",
@@ -1015,31 +1044,31 @@ describe("runtime postbuild static assets", () => {
       'export * from "./provider-dispatcher.runtime.js";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-D7SL02B2.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-Deq6Beal.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-BRVACueI.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-DX8jy7tN.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-D6FSd9v2.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-DQ-ui3nL.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-Xom5hOHq.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-tnhNR9WW.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
     expect(await fs.readFile(path.join(distDir, "install.runtime-CNHwKOIb.js"), "utf8")).toBe(
-      'export * from "./install.runtime-NewPluginHash.js";\n',
+      'export * from "./install.runtime-NewPluginHash.mjs";\n',
     );
   });
 
@@ -1049,7 +1078,7 @@ describe("runtime postbuild static assets", () => {
     await fs.mkdir(distDir, { recursive: true });
     await fs.writeFile(
       path.join(distDir, "text-transforms.runtime.js"),
-      'export * from "./text-transforms.runtime-NewHash.js";\n',
+      'export * from "./text-transforms.runtime-NewHash.mjs";\n',
       "utf8",
     );
 

--- a/test/scripts/test-built-status-message-runtime.test.ts
+++ b/test/scripts/test-built-status-message-runtime.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { findBuiltStatusMessageRuntimePath } from "../../scripts/test-built-status-message-runtime.mts";
+import { withEnv } from "../../src/test-utils/env.js";
 import { expectNoReaddirSyncDuring } from "../../src/test-utils/fs-scan-assertions.js";
 
 const tempDirs: string[] = [];
@@ -23,16 +24,30 @@ function makeDistDir(): string {
 }
 
 describe("test-built-status-message-runtime", () => {
-  it("finds the built status runtime without scanning dist in-process", () => {
+  it("prefers the hashed mjs runtime when external find is unavailable", () => {
     const distDir = makeDistDir();
     fs.writeFileSync(path.join(distDir, "status-message.runtime.js"), "export {}\n");
-    fs.writeFileSync(path.join(distDir, "status-message.runtime-abc123.js"), "export {}\n");
+    fs.writeFileSync(path.join(distDir, "status-message.runtime-abc123.mjs"), "export {}\n");
+
+    withEnv({ PATH: "" }, () => {
+      expect(findBuiltStatusMessageRuntimePath(distDir)).toBe(
+        path.join(distDir, "status-message.runtime-abc123.mjs"),
+      );
+    });
+  });
+
+  it.each([
+    "status-message.runtime-abc123.js",
+    "status-message.runtime-abc123.mjs",
+    "status-message.runtime.js",
+  ])("finds %s without scanning dist in-process", (runtimeFile) => {
+    const distDir = makeDistDir();
+    fs.writeFileSync(path.join(distDir, "status-message.runtime.js"), "export {}\n");
+    fs.writeFileSync(path.join(distDir, runtimeFile), "export {}\n");
     fs.writeFileSync(path.join(distDir, "other.js"), "export {}\n");
 
     expectNoReaddirSyncDuring(() => {
-      expect(findBuiltStatusMessageRuntimePath(distDir)).toBe(
-        path.join(distDir, "status-message.runtime-abc123.js"),
-      );
+      expect(findBuiltStatusMessageRuntimePath(distDir)).toBe(path.join(distDir, runtimeFile));
     });
   });
 });

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -215,7 +215,9 @@ describe("write-cli-startup-metadata", () => {
       });
 
       await rootHelpStarted;
-      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
       expect(startedCommands).toEqual([]);
 
       releaseRootHelp();
@@ -338,7 +340,9 @@ describe("write-cli-startup-metadata", () => {
       });
       const deadline = Date.now() + 1_000;
       while (children.length < COMMAND_HELP_RENDER_CONCURRENCY && Date.now() < deadline) {
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
       }
       expect(children.map((child) => child.commandName)).toEqual(
         DEFAULT_COMMAND_HELP_NAMES.slice(0, COMMAND_HELP_RENDER_CONCURRENCY),
@@ -426,7 +430,9 @@ describe("write-cli-startup-metadata", () => {
             tasks: "Usage: openclaw tasks\n",
           }),
         });
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
         child.stderr.write("primary browser failure\n");
         child.emit("close", 7, null);
 
@@ -1035,7 +1041,9 @@ describe("write-cli-startup-metadata", () => {
         for (const suffix of ["", "-shm", "-wal"]) {
           writeFileSync(path.join(sqliteDir, `openclaw.sqlite${suffix}`), "fixture", "utf8");
         }
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
         if (failRender) {
           throw new Error("browser help failed");
         }

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -876,52 +876,58 @@ describe("write-cli-startup-metadata", () => {
     expect(existsSync(outputPath)).toBe(false);
   });
 
-  it("selects the root-help bundle that exports the renderer", async () => {
-    const tempRoot = createTempDir("openclaw-startup-metadata-bundle-selection-");
-    const distDir = path.join(tempRoot, "dist");
-    const extensionsDir = path.join(tempRoot, "extensions");
-    const outputPath = path.join(distDir, "cli-startup-metadata.json");
-    const renderSourceRootHelpText = vi.fn(() => "Usage: source fallback\n");
+  it.each([
+    { rendererExtension: "js", helperExtension: "mjs" },
+    { rendererExtension: "mjs", helperExtension: "js" },
+  ])(
+    "selects the .$rendererExtension root-help renderer beside a .$helperExtension helper",
+    async ({ rendererExtension, helperExtension }) => {
+      const tempRoot = createTempDir("openclaw-startup-metadata-bundle-selection-");
+      const distDir = path.join(tempRoot, "dist");
+      const extensionsDir = path.join(tempRoot, "extensions");
+      const outputPath = path.join(distDir, "cli-startup-metadata.json");
+      const renderSourceRootHelpText = vi.fn(() => "Usage: source fallback\n");
 
-    writeStartupMetadataSourceSignatureFixture(tempRoot);
-    writeFixtureFile(tempRoot, "package.json", '{"type":"module"}\n');
-    writeFixtureFile(
-      distDir,
-      "root-help-live-config-fixture.js",
-      "async function loadRootHelpRenderOptionsForConfigSensitivePlugins() { return null; }\nexport { loadRootHelpRenderOptionsForConfigSensitivePlugins };\n",
-    );
-    writeFixtureFile(
-      distDir,
-      "root-help-renderer-fixture.js",
-      "async function outputRootHelp() { process.stdout.write('Usage: bundled renderer\\n'); }\nexport { outputRootHelp };\n",
-    );
+      writeStartupMetadataSourceSignatureFixture(tempRoot);
+      writeFixtureFile(tempRoot, "package.json", '{"type":"module"}\n');
+      writeFixtureFile(
+        distDir,
+        `root-help-live-config-fixture.${helperExtension}`,
+        "async function loadRootHelpRenderOptionsForConfigSensitivePlugins() { return null; }\nexport { loadRootHelpRenderOptionsForConfigSensitivePlugins };\n",
+      );
+      writeFixtureFile(
+        distDir,
+        `root-help-renderer-fixture.${rendererExtension}`,
+        `import "./root-help-live-config-fixture.${helperExtension}";\nasync function outputRootHelp() { process.stdout.write('Usage: bundled renderer\\n'); }\nexport { outputRootHelp };\n`,
+      );
 
-    await testing.writeCliStartupMetadata({
-      distDir,
-      outputPath,
-      extensionsDir,
-      sourceRootDir: tempRoot,
-      renderSourceRootHelpText,
-      renderSourceBrowserHelpText: () => "Usage: openclaw browser\n",
-      renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
-      renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
-      renderSourceSubcommandHelpTextRecord: () => ({
-        config: "Usage: openclaw config\n",
-        doctor: "Usage: openclaw doctor\n",
-        gateway: "Usage: openclaw gateway\n",
-        models: "Usage: openclaw models\n",
-        plugins: "Usage: openclaw plugins\n",
-        sessions: "Usage: openclaw sessions\n",
-        tasks: "Usage: openclaw tasks\n",
-      }),
-    });
+      await testing.writeCliStartupMetadata({
+        distDir,
+        outputPath,
+        extensionsDir,
+        sourceRootDir: tempRoot,
+        renderSourceRootHelpText,
+        renderSourceBrowserHelpText: () => "Usage: openclaw browser\n",
+        renderSourceSecretsHelpText: () => "Usage: openclaw secrets\n",
+        renderSourceNodesHelpText: () => "Usage: openclaw nodes\n",
+        renderSourceSubcommandHelpTextRecord: () => ({
+          config: "Usage: openclaw config\n",
+          doctor: "Usage: openclaw doctor\n",
+          gateway: "Usage: openclaw gateway\n",
+          models: "Usage: openclaw models\n",
+          plugins: "Usage: openclaw plugins\n",
+          sessions: "Usage: openclaw sessions\n",
+          tasks: "Usage: openclaw tasks\n",
+        }),
+      });
 
-    const written = JSON.parse(readFileSync(outputPath, "utf8")) as {
-      rootHelpText: string;
-    };
-    expect(written.rootHelpText).toBe("Usage: bundled renderer\n");
-    expect(renderSourceRootHelpText).not.toHaveBeenCalled();
-  });
+      const written = JSON.parse(readFileSync(outputPath, "utf8")) as {
+        rootHelpText: string;
+      };
+      expect(written.rootHelpText).toBe("Usage: bundled renderer\n");
+      expect(renderSourceRootHelpText).not.toHaveBeenCalled();
+    },
+  );
 
   it("renders independent startup help snapshots concurrently", async () => {
     const tempRoot = createTempDir("openclaw-startup-metadata-concurrency-");

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -812,6 +812,9 @@ const configs = [
       // and bundled hooks in one graph so runtime singletons are emitted once.
       entry: unifiedDistEntries,
       deps: unifiedDeps,
+      // Explicit ESM chunks avoid repeated package-format parsing in Node;
+      // named entrypoints retain their public .js paths.
+      outputOptions: { chunkFileNames: "[name]-[hash].mjs" },
       plugins: [createStateSchemaInlinePlugin(), createGatewayRunChunkMetadataPlugin()],
     },
     false,


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/136639 — preserve conversations under session-maintenance pressure.

## What Problem This Solves

Resolves avoidable module-loading overhead in the packaged runtime, particularly when operators use Node preload/loader hooks. Internal code-split files currently use `.js`, so Node repeatedly resolves their package format against OpenClaw's large package metadata. This surfaced while exercising Gateway startup and restart in the retention stress scenarios.

## Why This Change Was Made

Emit the unified runtime graph's internal hashed chunks as explicit ESM (`.mjs`) using tsdown's existing chunk filename option. Keep named/public `.js` entrypoints, declarations, workers, stable runtime aliases, historical hashed `.js` aliases, export allowlists, shutdown retention, and the user-loader guard unchanged. Update existing chunk consumers and their tests to recognize both extensions; preserve the existing private-QA package exclusion across either extension.

This is separate from the retention-policy change and from the small QA visibility-metadata cleanup. It adds no loader cache, Node patch, dependency, configuration option, schema, or protocol change. Production/tooling growth is six net lines; most changed lines are existing test tables and artifact-boundary coverage.

## User Impact

Internal runtime modules carry an explicit format without changing the paths users, plugins, or workers load. Preloaded user resolver hooks continue to observe module resolution. Private QA chunks remain excluded even when the canonical packer reuses a prebuilt tree.

## Evidence

- Focused tooling, worker, and canonical-packer suites: **316 passed**, with **three Windows-only cases skipped on macOS**. The normal build on `16417367fea55e1169036e47058f824138319a2f` passed in **13m 47.7s**, followed by the 23 loader tests and `node scripts/check-package-dist-imports.mjs .`. Subsequent follow-through is limited to the Docker E2E image and test consumers; the runtime build logic is unchanged.
- `node scripts/run-vitest.mjs src/entry.esm-resolve-fast-path.test.ts`: **23 passed, none skipped**, including actual built entry/index processes with synchronous preload, asynchronous loader, and split-quoted `NODE_OPTIONS`. The observer previously recognized only `.js`; all three real-process cases failed at the missing observation before it was corrected to recognize `.mjs` too. Production loader guards are unchanged.
- A real canonical npm-pack regression demonstrated that the old root exclusion omitted private `.js` files but admitted a private `.mjs` file, while the package inventory already rejected both. The same regression passes with the existing private prefix excluded independently of extension.
- Fresh independent Codex autoreview: **scoped-clean at P0** for the complete candidate, including the subsequently separated metadata change. This is the requested review threshold, not a claim that lower-priority findings were audited.
- The earlier frozen combined prototype completed all functional Linux smoke phases—archival, archive lookup/restoration, continuation, graceful restart, immediate in-flight crash recovery, and disk-pressure cleanup—with database integrity intact. Its largest measured full-lifetime gap fell from approximately 1.5 seconds to **523.265 ms**, but **the smoke still failed** the unchanged 500 ms requirement. Those timings used a preload, which deliberately disables the existing resolver optimization; they are not uninstrumented default-path measurements. Detailed qualification: https://github.com/openclaw/openclaw/pull/136639#issuecomment-5556700310.

- **Clean installed-package proof passed on Linux/Node 24.19.0:** the configured Blacksmith Testbox built the exact `16417367fea55e1169036e47058f824138319a2f` source, packed and verified the actual npm tarball, and ran `bash scripts/e2e/openai-web-search-minimal-docker.sh`. This exercises the changed private chunk locator through both the synthetic provider's success and rejection paths. Provider `blacksmith-testbox`, lease `tbx_01m1th8sdw56g6st89jmtyfrgj`, [run 34012793337](https://github.com/openclaw/openclaw/actions/runs/34012793337), command exit 0 in 318.8s. The harness deletes successful scenario logs by design; its synchronous exit result and tarball-integrity output were retained. The lease was stopped and its completed state verified.
- Built status-runtime loading and both heartbeat-fixture chunk imports passed against completed output with isolated OpenClaw state. The latter is import/shape proof only: no app-server mode, provider request, heartbeat execution, or Codex protocol claim.
- CI passed for [head `164173`](https://github.com/openclaw/openclaw/actions/runs/34012569438) and [head `2aa8cfe`](https://github.com/openclaw/openclaw/actions/runs/34015352881). [The `2686ff2` run](https://github.com/openclaw/openclaw/actions/runs/34017445224) found two stale Docker recipe assertions; both are corrected and consolidated in `f642dcd429a082876952259a752a426ccc9e8663`. That test-only follow-through leaves runtime and Dockerfile source unchanged from the Docker-tested commit. [Exact-head CI for `f642dcd`](https://github.com/openclaw/openclaw/actions/runs/34020016353) passed with no pending required checks.

### Review follow-through

The sealed-service fixture's `.js`-only selector was a real omission. Against the completed build it found zero ownership chunks while four matching `.mjs` chunks existed. Its existing selector now accepts both extensions; all unprivileged, read-only mount, and release-root ownership assertions remain unchanged.

The same audit corrected two other test consumers without adding production code: the prepared-Gateway module lookup and the raw-CDP fixture's paired removal/check globs. The prepared-Gateway regression failed before the correction with `Could not resolve built prepared-model-runtime- module`; afterward both existing model-picker scenarios passed using the isolated Gateway and synthetic Telegram API. Command: `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts`. The browser finding was verified against immutable CI artifact `dist-runtime-build` (run 34012569438, artifact 9982950836), not a changing local build: it contains `dist/pw-ai-Biu1LSh7.mjs`, and its build commit is the CI merge `d85d0e669727ebacae6f9ff9a9bf6a92eefbb9c1` with this PR's `164173` head as a parent. The artifact listing contains neither `qa-runtime-*` chunks nor `dist/plugin-sdk/qa-lab.js`, and its producer job does not enable private QA.

The consumer follow-through changes four lines across three test files. Syntax, formatting, targeted lint, the Docker boundary guard, and fresh independent Codex autoreview at P0 passed.

The complete sealed-service run also exposed a pre-existing image-initialization defect: the functional image imported only postinstall's cleanup function, leaving `.openclaw-lifecycle-pending` present. Four writable-container denial scenarios passed, but a fresh read-only container failed trying to create the lifecycle lock before reaching the service assertion. The test image now invokes the existing complete postinstall script during its writable build step; its obsolete partial-hook comment was removed. No runtime recovery code or assertion changed.

**Complete Docker proof passed after that image correction**, using the configured Blacksmith Testbox, lease `tbx_01m1tmym033x8q3v76q586vz28`, [run 34015453273](https://github.com/openclaw/openclaw/actions/runs/34015453273). The unchanged sealed-service script passed all four ownership-denial scenarios, same-UID read-only file mounts in modes `0400` and `0644`, and both paired mounts (matching release accepted, different release rejected). A fresh read-only image probe reported `pending: false`, and the raw-CDP Docker scenario passed afterward. The combined command exited 0 in **291.5s**. This tested frozen source tree `db3b0299ce9873c8d57c4bbc8726df3b3e31acdc`, including the then-uncommitted image correction. Image-fix commit [2686ff2](https://github.com/openclaw/openclaw/commit/2686ff28040e9a5af2123fbb50f53f8cf5ad6d68) retains that exact tree. The lease was stopped and its completed state verified. The image correction also passed the Docker boundary guard and fresh independent review at P0.

The final CI follow-through consolidates two overlapping Docker recipe checks into the owning tooling suite. The old checks required the partial cleanup call, and one explicitly forbade the complete postinstall entrypoint. All package-extraction, dependency-cache, and postinstall-before-self-link assertions remain; the obsolete private-registry policy assertion and duplicate case are removed. The consolidated guard was demonstrated to fail against the original partial-hook recipe, then both affected suites passed with the repaired recipe: **281 passed, two platform-specific skips**. Command: `node scripts/run-vitest.mjs src/docker-build-cache.test.ts test/scripts/docker-build-helper.test.ts`. Targeted lint, the max-lines guard, and fresh independent review at P0 also passed. This test-only consolidation removes ten lines and changes neither runtime nor Dockerfile source.

The automated data-model compatibility checkbox is not applicable to this build PR. `scripts/e2e/Dockerfile` now invokes the same pruning operation and the existing package-lifecycle marker completion in `scripts/postinstall-bundled-plugins.mjs:357-411`; it does not migrate operator state or persist a plugin registry. No SQLite schema, index, projection, retention policy, operator configuration, or user-data representation changes here. The installed-package/read-only proof above verifies that existing lifecycle contract; mixed-extension alias tests retain the stable and historical `.js` upgrade paths. ClawSweeper's source review likewise reports no migration or blocking patch defect—the remaining generic checkbox is a classification false positive, not an unimplemented data migration.

### Scope and remaining validation

This PR is not a retention stress-pass report. SCALE and MASSIVE have no accepted final-candidate result; their workloads, 4/30/60-minute budgets, 500 ms limit, and crash ordering are unchanged. Prototype measurements are not a default-loader performance comparison for this head.

The branch's aggregate local check encountered an inherited services-shard count of 721 against the 720 limit. Base and candidate have identical expanded roots. This was already repaired on `main` by https://github.com/openclaw/openclaw/pull/139645 (moves logging roots to infra, without raising the limit or dropping coverage), and the PR CI run passed. No shard-policy change is included here.
