### PR TITLE
fix: large agent rosters repeat Claude login checks during startup

### DIFF
--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -45,6 +45,20 @@ Look for:
 - `plugin load failed: dependency tree corrupted; run openclaw doctor --fix` under Channels: the channel config still exists, but plugin registration failed before the channel could load.
 - Provider 401s after re-auth: `openclaw doctor --fix` checks for stale per-agent OAuth auth shadows and removes old copies so all agents resolve the current shared profile.
 
+## Prepared model runtime publication timeout
+
+If startup reports `prepared model runtime publication (...) timed out`, the
+parenthesized detail identifies the pending stage and, during workspace
+preparation, its agent. Collect that error together with
+`openclaw gateway status --deep` and the startup logs.
+
+An `ambient credentials` stage can be waiting for a plugin's external login
+check even when the Gateway process uses little CPU. For Claude CLI, run
+`claude auth status --json` as the Gateway user with the same environment.
+Startup shares this check across workspaces; a large roster should not launch
+one native-login subprocess per agent. A successful `/health` response alone
+does not establish that model runtime publication completed.
+
 ## Split brain installs and newer config guard
 
 Use when a gateway service unexpectedly stops after an update, or logs show one `openclaw` binary is older than the version that last wrote `openclaw.json`.

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -116,6 +116,9 @@ OpenClaw release:
         through OpenClaw's direct CLI transport. OpenClaw uses a non-secret route
         marker and never reads, persists, refreshes, selects, or forwards the
         native login tokens. Claude owns the login and token refresh lifecycle.
+        Gateway startup shares the native login availability check across agent
+        workspaces using the same config and environment. Explicit catalog/auth
+        captures recheck availability for their own generation.
         Explicitly selected API-key or token credentials still use protected
         file-descriptor forwarding. Native-tool approvals remain under OpenClaw
         control. Schema-valid native calls pass through OpenClaw's canonical

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -1457,7 +1457,7 @@ describe("anthropic provider replay hooks", () => {
   ] as const)(
     "publishes native Claude auth only when its CLI reports $status",
     async ({ status, authenticated }) => {
-      probeClaudeCliAuthStatusMock.mockReturnValue({ status });
+      probeClaudeCliAuthStatusMock.mockResolvedValue({ status });
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
       const config = {};
 
@@ -1483,7 +1483,7 @@ describe("anthropic provider replay hooks", () => {
       expect(
         await provider.prepareSyntheticAuth?.({ provider: "claude-cli" } as never),
       ).toBeUndefined();
-      expect(probeClaudeCliAuthStatusMock).toHaveBeenCalledTimes(2);
+      expect(probeClaudeCliAuthStatusMock).toHaveBeenCalledOnce();
     },
   );
 

--- a/extensions/anthropic/provider-discovery.test.ts
+++ b/extensions/anthropic/provider-discovery.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+const { probeClaudeCliAuthStatus } = vi.hoisted(() => ({
+  probeClaudeCliAuthStatus: vi.fn(),
+}));
+vi.mock("./cli-auth-seam.js", () => ({ probeClaudeCliAuthStatus }));
+
+import provider from "./provider-discovery.js";
+
+afterEach(() => {
+  vi.useRealTimers();
+  probeClaudeCliAuthStatus.mockReset();
+});
+
+it("prepares native availability once for a 632-workspace roster", async () => {
+  vi.useFakeTimers();
+  const config = {
+    agents: {
+      entries: Object.fromEntries(
+        Array.from({ length: 632 }, (_, index) => [
+          `agent-${index}`,
+          { workspace: `/synthetic/workspace-${index}` },
+        ]),
+      ),
+    },
+  };
+  const env = { CLAUDE_CONFIG_DIR: "/synthetic/native-account" };
+  probeClaudeCliAuthStatus.mockImplementation(
+    () => new Promise((resolve) => setTimeout(() => resolve({ status: "missing" }), 250)),
+  );
+  let prepared = 0;
+  const publication = (async () => {
+    for (const _agent of Object.values(config.agents.entries)) {
+      await provider.prepareSyntheticAuth!({ config, env, provider: "claude-cli" });
+      prepared += 1;
+    }
+  })();
+  try {
+    await vi.advanceTimersByTimeAsync(250);
+    expect(prepared).toBe(632);
+    expect(probeClaudeCliAuthStatus).toHaveBeenCalledOnce();
+  } finally {
+    await vi.runAllTimersAsync();
+    await publication;
+  }
+});
+
+it.each(["config", "environment", "capture signal"])(
+  "reobserves native availability after a changed %s",
+  async (changed) => {
+    const config = {};
+    const env = {};
+    const signal = new AbortController().signal;
+    const input = { config, env, signal, provider: "claude-cli" };
+    probeClaudeCliAuthStatus
+      .mockResolvedValueOnce({ status: "available" })
+      .mockResolvedValueOnce({ status: "missing" });
+    expect(await provider.prepareSyntheticAuth!(input)).toMatchObject({ mode: "oauth" });
+    expect(
+      await provider.prepareSyntheticAuth!({
+        ...input,
+        ...(changed === "config" ? { config: {} } : {}),
+        ...(changed === "environment" ? { env: {} } : {}),
+        ...(changed === "capture signal" ? { signal: new AbortController().signal } : {}),
+      }),
+    ).toBeUndefined();
+    expect(probeClaudeCliAuthStatus).toHaveBeenCalledTimes(2);
+  },
+);
+
+it("joins one probe per cancellation scope and preserves a surviving capture", async () => {
+  const config = {};
+  const env = {};
+  const cancelled = new AbortController();
+  const surviving = new AbortController();
+  const reason = new Error("native preparation retired");
+  let releaseSurvivor: (() => void) | undefined;
+  probeClaudeCliAuthStatus
+    .mockResolvedValue({ status: "available" })
+    .mockImplementationOnce(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    )
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releaseSurvivor = () => resolve({ status: "available" });
+        }),
+    );
+  const prepare = (signal: AbortSignal) =>
+    provider.prepareSyntheticAuth!({ config, env, signal, provider: "claude-cli" });
+  const retired = prepare(cancelled.signal);
+  const rejection = expect(retired).rejects.toBe(reason);
+  const survivor = prepare(surviving.signal);
+  const follower = prepare(surviving.signal);
+  cancelled.abort(reason);
+  releaseSurvivor!();
+  await rejection;
+  await expect(survivor).resolves.toMatchObject({ mode: "oauth" });
+  await expect(follower).resolves.toMatchObject({ mode: "oauth" });
+  expect(probeClaudeCliAuthStatus).toHaveBeenCalledTimes(2);
+  await expect(prepare(cancelled.signal)).rejects.toBe(reason);
+  expect(probeClaudeCliAuthStatus).toHaveBeenCalledTimes(2);
+});

--- a/extensions/anthropic/provider-discovery.test.ts
+++ b/extensions/anthropic/provider-discovery.test.ts
@@ -26,18 +26,21 @@ it("prepares native availability once for a 632-workspace roster", async () => {
   };
   const env = { CLAUDE_CONFIG_DIR: "/synthetic/native-account" };
   probeClaudeCliAuthStatus.mockImplementation(
-    () => new Promise((resolve) => setTimeout(() => resolve({ status: "missing" }), 250)),
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => resolve({ status: "missing" }), 250);
+      }),
   );
-  let prepared = 0;
+  const prepared = new Set<string>();
   const publication = (async () => {
-    for (const _agent of Object.values(config.agents.entries)) {
+    for (const agentId of Object.keys(config.agents.entries)) {
       await provider.prepareSyntheticAuth!({ config, env, provider: "claude-cli" });
-      prepared += 1;
+      prepared.add(agentId);
     }
   })();
   try {
     await vi.advanceTimersByTimeAsync(250);
-    expect(prepared).toBe(632);
+    expect(prepared.size).toBe(632);
     expect(probeClaudeCliAuthStatus).toHaveBeenCalledOnce();
   } finally {
     await vi.runAllTimersAsync();
@@ -80,7 +83,7 @@ it("joins one probe per cancellation scope and preserves a surviving capture", a
     .mockImplementationOnce(
       ({ signal }: { signal: AbortSignal }) =>
         new Promise((_, reject) => {
-          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+          signal.addEventListener("abort", () => reject(reason), { once: true });
         }),
     )
     .mockImplementationOnce(

--- a/extensions/anthropic/provider-discovery.ts
+++ b/extensions/anthropic/provider-discovery.ts
@@ -3,34 +3,38 @@
  * synthetic auth for catalog/runtime discovery without full Anthropic registration.
  */
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { probeClaudeCliAuthStatus } from "./cli-auth-seam.js";
 import { CLAUDE_CLI_BACKEND_ID, CLAUDE_CLI_NATIVE_AUTH_MARKER } from "./cli-constants.js";
 
-export async function prepareClaudeCliSyntheticAuth(
-  config: object | undefined,
-  params?: { env?: NodeJS.ProcessEnv; signal?: AbortSignal },
-) {
-  params?.signal?.throwIfAborted();
-  if (!config) {
-    return undefined;
-  }
-  if ((await probeClaudeCliAuthStatus(params)).status !== "available") {
-    return undefined;
-  }
-  return {
-    apiKey: CLAUDE_CLI_NATIVE_AUTH_MARKER,
-    source: "Claude CLI native auth",
-    mode: "oauth" as const,
-  };
-}
+type NativeAvailability = ReturnType<typeof probeClaudeCliAuthStatus>;
+const availability = new WeakMap<object, WeakMap<object, WeakMap<object, NativeAvailability>>>();
 
 const anthropicProviderDiscovery: ProviderPlugin = {
   id: CLAUDE_CLI_BACKEND_ID,
   label: "Claude CLI",
   docsPath: "/providers/models",
   auth: [],
-  prepareSyntheticAuth: ({ config, provider, ...params }) =>
-    prepareClaudeCliSyntheticAuth(provider === CLAUDE_CLI_BACKEND_ID ? config : undefined, params),
+  async prepareSyntheticAuth({ config, provider, env = process.env, signal }) {
+    signal?.throwIfAborted();
+    if (!config || normalizeLowercaseStringOrEmpty(provider) !== CLAUDE_CLI_BACKEND_ID) {
+      return undefined;
+    }
+    const environments =
+      availability.get(config) ?? new WeakMap<object, WeakMap<object, NativeAvailability>>();
+    availability.set(config, environments);
+    const captures = environments.get(env) ?? new WeakMap<object, NativeAvailability>();
+    environments.set(env, captures);
+    // Native login is independent of workspace; fresh captures and cancellation own their probes.
+    const owner = signal ?? config;
+    const pending = captures.get(owner) ?? probeClaudeCliAuthStatus({ env, signal });
+    captures.set(owner, pending);
+    const result = await pending;
+    signal?.throwIfAborted();
+    return result.status === "available"
+      ? { apiKey: CLAUDE_CLI_NATIVE_AUTH_MARKER, source: "Claude CLI native auth", mode: "oauth" }
+      : undefined;
+  },
 };
 
 export default anthropicProviderDiscovery;

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -52,7 +52,7 @@ import {
 import { acceptsAnthropicLiveModelContract } from "./live-model-contract-gate.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
-import { prepareClaudeCliSyntheticAuth } from "./provider-discovery.js";
+import anthropicProviderDiscovery from "./provider-discovery.js";
 import {
   createClaudeSessionNodeInvokePolicies,
   registerClaudeSessionDiscovery,
@@ -872,11 +872,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
       );
     },
     normalizeResolvedModel: (ctx) => normalizeAnthropicResolvedModel(ctx),
-    prepareSyntheticAuth: ({ config, provider, env, signal }) =>
-      prepareClaudeCliSyntheticAuth(
-        normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID ? config : undefined,
-        { env, signal },
-      ),
+    prepareSyntheticAuth: anthropicProviderDiscovery.prepareSyntheticAuth,
     ...buildProviderReplayFamilyHooks({ family: "native-anthropic-by-model" }),
     isModernModelRef: ({ provider, modelId }) =>
       matchesAnthropicModernModel(modelId) &&

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -439,6 +439,7 @@ async function buildSnapshotBatch(
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
   includeCredentialProviders = catalogMode === "live",
+  onStage?: (stage: string) => void,
 ): Promise<PreparedModelRuntimeBuildResult[]> {
   const generations = groupBuildCandidates(candidates, (candidate) => candidate.pluginGeneration);
   const fresh = generations.get(undefined) ?? [];
@@ -506,6 +507,7 @@ async function buildSnapshotBatch(
         preferBuiltPluginArtifacts,
         includeCredentialProviders,
         getConfiguredHarnessRuntimes,
+        onStage,
       },
       prepareInboundPluginRegistry ? loadInboundPluginRegistry : undefined,
       pluginGeneration,
@@ -527,6 +529,7 @@ async function buildSnapshotBatch(
   }
   const workspaceFactsMs = performance.now() - workspaceFactsStartedAt;
   const catalogSourceStartedAt = performance.now();
+  onStage?.("agent catalog sources");
   const catalogSources = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeCatalogSource>();
   if (catalogMode === "live") {
     const sourceCandidatesByAgentDir = groupBuildCandidates(
@@ -573,6 +576,7 @@ async function buildSnapshotBatch(
   const preparedCatalogs = new Map<PreparedModelRuntimeInput, PreparedModelRuntimeCatalogFacts>();
   let runtimeRegistryCount = 0;
   const registryStartedAt = performance.now();
+  onStage?.("model registries");
   if (catalogMode === "live") {
     // Explicit live owners still request the complete inventory. Keep those builds sequential
     // instead of multiplying heap and GC pressure when a command names several agents.
@@ -686,6 +690,7 @@ export function startSerializedSnapshotBuildBatch(
   completion: Promise<void>;
 } {
   const agentDirs = [...new Set(candidates.map(({ input }) => input.agentDir))];
+  let stage = "previous generation completion";
   const previousBuildCompletions = agentDirs
     .map((agentDir) => agentBuildCompletions.get(agentDir))
     .filter((completion) => completion !== undefined);
@@ -698,23 +703,22 @@ export function startSerializedSnapshotBuildBatch(
       // retired owner cannot start expensive workspace preparation ahead of its replacement.
       assertPreparedModelRuntimeCandidatesCurrent(candidates);
     }
-    return {
-      actualBuild: buildSnapshotBatch(
-        candidates,
-        catalogMode,
-        agentBuildCompletions,
-        pluginMetadataSnapshot,
-        onBuildStats,
-        includeCredentialProviders,
-      ),
-    };
-  })();
-  const completion = startBuild
-    .then(({ actualBuild }) => actualBuild)
-    .then(
-      () => undefined,
-      () => undefined,
+    return await buildSnapshotBatch(
+      candidates,
+      catalogMode,
+      agentBuildCompletions,
+      pluginMetadataSnapshot,
+      onBuildStats,
+      includeCredentialProviders,
+      (nextStage) => {
+        stage = nextStage;
+      },
     );
+  })();
+  const completion = startBuild.then(
+    () => undefined,
+    () => undefined,
+  );
   for (const agentDir of agentDirs) {
     agentBuildCompletions.set(agentDir, completion);
     void completion.then(() => {
@@ -725,9 +729,9 @@ export function startSerializedSnapshotBuildBatch(
   }
   return {
     pending: runAbortableTimeout(
-      async () => (await startBuild).actualBuild,
+      () => startBuild,
       buildTimeoutMs,
-      "prepared model runtime publication",
+      () => `prepared model runtime publication (${stage})`,
     ),
     completion,
   };

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -282,7 +282,7 @@ describe("prepared build candidate lifetime", () => {
       const builds = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuildBatch");
       const first = acquire(input);
       const timedOut = expect(first).rejects.toThrow(
-        "prepared model runtime publication timed out",
+        "prepared model runtime publication (ambient credentials; agent standalone) timed out",
       );
       let retry: ReturnType<typeof acquire> | undefined;
       try {
@@ -320,13 +320,13 @@ describe("prepared build candidate lifetime", () => {
     const builds = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuildBatch");
     try {
       await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
-        "prepared model runtime publication timed out",
+        "prepared model runtime publication (agent catalog sources) timed out",
       );
       await expect(prepareModelRuntimeSnapshot(input)).rejects.toThrow(
-        "prepared model runtime publication timed out",
+        "prepared model runtime publication (agent catalog sources) timed out",
       );
       await expect(publishPreparedModelRuntimeSnapshot(input)).rejects.toThrow(
-        "prepared model runtime publication timed out",
+        "prepared model runtime publication (agent catalog sources) timed out",
       );
       expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
 

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -161,6 +161,7 @@ export async function prepareWorkspaceBuildGroup(
     includeCredentialProviders?: boolean;
     getConfiguredHarnessRuntimes?: () => readonly string[];
     basePluginIds?: readonly string[];
+    onStage?: (stage: string) => void;
   } = {},
   loadInboundPluginRegistry?: PreparedInboundRegistryLoader,
   reusablePluginGeneration?: PreparedModelRuntimePluginGeneration,
@@ -183,6 +184,9 @@ export async function prepareWorkspaceBuildGroup(
     throw new Error("prepared model runtime workspace group is empty");
   }
   const env = input.env ?? process.env;
+  const reportStage = (stage: string) =>
+    options.onStage?.(`${stage}; agent ${input.agentId ?? "standalone"}`);
+  reportStage("workspace plugins");
   const pluginMetadataStartedAt = performance.now();
   const pluginMetadataSnapshot =
     preparedPluginMetadataSnapshot ??
@@ -279,6 +283,7 @@ export async function prepareWorkspaceBuildGroup(
       ]),
     ].toSorted((left, right) => left.localeCompare(right));
     const staticProviderCatalogStartedAt = performance.now();
+    reportStage("static provider catalog");
     let preparedStaticProviderCatalog = reusablePluginGeneration
       ? reusablePluginGeneration.preparedStaticProviderCatalog
       : catalogMode === "static"
@@ -319,6 +324,7 @@ export async function prepareWorkspaceBuildGroup(
     const preparedSyntheticAuthProviders = preparedStaticProviderCatalog?.providers ?? [];
     // Static Gateway publication consumes discovery entrypoints; the run owns activation.
     const ambientCredentialsStartedAt = performance.now();
+    reportStage("ambient credentials");
     const ambientCredentials = await prepareAmbientAgentCredentialsForDiscovery({
       config: input.config,
       env,
@@ -352,6 +358,7 @@ export async function prepareWorkspaceBuildGroup(
     });
     const ambientCredentialsMs = performance.now() - ambientCredentialsStartedAt;
     const agentFactsStartedAt = performance.now();
+    reportStage("agent facts");
     const agentBaseFacts = inputs.map((candidate) =>
       withAgentRosterFactsBatch(candidate.config, () =>
         prepareAgentFacts(
@@ -365,6 +372,7 @@ export async function prepareWorkspaceBuildGroup(
     );
     const agentFactsMs = performance.now() - agentFactsStartedAt;
     const configuredProjectionStartedAt = performance.now();
+    reportStage("configured model projection");
     const providerStaticModels =
       reusablePluginGeneration?.providerStaticModels ??
       (catalogMode === "static"

--- a/src/node-host/with-timeout.test.ts
+++ b/src/node-host/with-timeout.test.ts
@@ -5,7 +5,25 @@ import { runAbortableTimeout } from "./with-timeout.js";
 
 describe("runAbortableTimeout", () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("names the operation pending when the deadline fires", async () => {
+    vi.useFakeTimers();
+    let stage = "queued";
+    const pending = runAbortableTimeout(
+      () => new Promise<never>(() => {}),
+      30,
+      () => `publication: ${stage}`,
+    );
+    const result = Promise.allSettled([pending]);
+    stage = "credentials";
+    await vi.advanceTimersByTimeAsync(30);
+    expect(await result).toEqual([
+      { status: "rejected", reason: new Error("publication: credentials timed out") },
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("caps huge finite timeoutMs before scheduling the timer", async () => {

--- a/src/node-host/with-timeout.ts
+++ b/src/node-host/with-timeout.ts
@@ -1,18 +1,12 @@
 /** Timeout wrapper for node-host operations using AbortSignal cancellation. */
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
-import { toErrorObject } from "../infra/errors.js";
+import { createDeferredCore } from "../shared/deferred.js";
 
-/**
- * AbortSignal-based timeout wrapper for node-host operations.
- *
- * The wrapper races work against an abort promise, clears timers/listeners on
- * completion, and preserves object-shaped abort reasons as Error properties.
- */
-/** Run work with an optional timeout and AbortSignal. */
+/** Run bounded work; dynamic labels identify the stage pending at the deadline. */
 export async function runAbortableTimeout<T>(
   work: (signal: AbortSignal | undefined, resetTimeout: () => void) => Promise<T>,
   timeoutMs?: number,
-  label?: string,
+  label?: string | (() => string),
 ): Promise<T> {
   const resolved = timeoutMs === undefined ? undefined : resolveTimerTimeoutMs(timeoutMs, 1);
   if (!resolved) {
@@ -20,40 +14,31 @@ export async function runAbortableTimeout<T>(
   }
 
   const abortCtrl = new AbortController();
-  const timeoutError = new Error(`${label ?? "request"} timed out`);
   let timer: ReturnType<typeof setTimeout> | undefined;
   let settled = false;
   const resetTimeout = () => {
     if (settled || abortCtrl.signal.aborted) {
       return;
     }
-    if (timer) {
-      clearTimeout(timer);
-    }
-    timer = setTimeout(() => abortCtrl.abort(timeoutError), resolved);
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      const operation = typeof label === "function" ? label() : (label ?? "request");
+      abortCtrl.abort(new Error(`${operation} timed out`));
+    }, resolved);
     timer.unref?.();
   };
   resetTimeout();
 
-  let abortListener: (() => void) | undefined;
-  const abortPromise: Promise<never> = abortCtrl.signal.aborted
-    ? Promise.reject(toErrorObject(abortCtrl.signal.reason ?? timeoutError, "Non-Error rejection"))
-    : new Promise((_, reject) => {
-        abortListener = () =>
-          reject(toErrorObject(abortCtrl.signal.reason ?? timeoutError, "Non-Error rejection"));
-        abortCtrl.signal.addEventListener("abort", abortListener, { once: true });
-      });
+  const aborted = createDeferredCore<never>();
+  const abortListener = () => aborted.reject(abortCtrl.signal.reason);
+  abortCtrl.signal.addEventListener("abort", abortListener, { once: true });
 
   try {
-    return await Promise.race([work(abortCtrl.signal, resetTimeout), abortPromise]);
+    return await Promise.race([work(abortCtrl.signal, resetTimeout), aborted.promise]);
   } finally {
     settled = true;
-    if (timer) {
-      clearTimeout(timer);
-    }
-    if (abortListener) {
-      // Remove the listener even when work wins the race to avoid retaining closures.
-      abortCtrl.signal.removeEventListener("abort", abortListener);
-    }
+    clearTimeout(timer);
+    // Work may finish first; its signal must not retain the pending rejection.
+    abortCtrl.signal.removeEventListener("abort", abortListener);
   }
 }


### PR DESCRIPTION
Related: #139583. Reported by @609NFT.

## What Problem This Solves

Fixes an issue where a Gateway with a large agent roster fails startup with a prepared model runtime publication timeout while the main process appears idle. The reproduction uses 632 distinct workspaces and a synthetic Claude CLI whose native-login status check takes 250 ms; no real accounts or credentials are involved.

## Why This Change Was Made

The 9.2 asynchronous native-login change (#137071, 2640154bcf8) removed the Anthropic plugin's config-wide availability observation. The generic preparation cache correctly separates workspace generations, so static startup repeated the same native-login subprocess for each workspace, sequentially. The reproduced idle interval contains continuing subprocess probes, not a lost wake-up.

The Anthropic discovery owner now shares one observation for an exact config, environment, and capture signal. Runtime registration uses that same hook. A fresh capture rechecks native availability, and cancellation remains isolated. Generic workspace/plugin auth scopes and existing bounded catalog concurrency remain unchanged. Native-login work is constant per observation; iterating the roster remains linear.

Publication timeout diagnostics now name the pending stage and workspace agent. Completion still tracks the actual build after a deadline, preventing replacement work from overlapping a timed-out generation. The timeout helper removes unreachable abort-state handling while the publication wrapper removes an intermediate promise container.

## User Impact

Large rosters no longer spend their startup budget repeating one host's Claude login check. A remaining publication stall identifies the pending preparation stage. The separate costs in plugin registration, schema preflight, and Control UI asset retention are outside this repair.

## Evidence

Paired installed-package proof on Blacksmith Testbox `tbx_01m1th03eya2s4f285g624eh6p`, [run 34012614304](https://github.com/openclaw/openclaw/actions/runs/34012614304), lease stopped. Both packages ran on Node 24.19.0 with 4 reported CPUs, the same isolated synthetic state, 632 distinct agents/workspaces, and the same 250 ms `claude auth status --json` fixture returning `loggedIn: false`. The expected first-boot plugin convergence barrier was completed before measuring. Candidate used the canonical build/package command and was installed through npm into a separate prefix.

| Observation | Published 2026.9.2 | Installed candidate |
| --- | ---: | ---: |
| Native-login subprocesses | 414 | 1 |
| Model-runtime publication | 138.156 s, timed out | 21.5104 s, completed |
| Gateway ready | No | 88.903 s |
| Health probe | 200 while publication remained pending | 200 after ready |
| Process result | Startup failure, exit 1 | Clean shutdown, exit 0 |
| Sampled peak RSS | 1,586.18 MiB | 1,889.31 MiB |

The candidate peak includes successful post-ready initialization, which the failing baseline never reached; ready RSS was 1,667.5 MiB. These measurements establish startup recovery, not a memory-reduction claim.

Live-proof transcript (synthetic data only):

```text
source: 1783a5839d1c60f152355a29a87d09e51fd24f97
materialized source tree: 3a0346d84a7a654329b4eb7e9e6143e4ab16b391
installed build-info commit: 1783a5839d1c60f152355a29a87d09e51fd24f97
candidate tarball SHA256: 116fa75f00123a59faa37bff9dca7a7046baed54a61e25c087807c74e60eed59
before: agents=632 workspaces=632 probes=414 publicationMs=138156
before: prepared model runtime publication timed out; ready=false; exit=1
after: agents=632 workspaces=632 probes=1 publicationMs=21510.4
after: ready=true health=200 timeout=false; clean exit=0
SUITE pass=true
```

The later commit `8cb178e88f6e25a3614285c99ffe850078a2a1ab` changes only regression-test lint; all production bytes match the paired package proof. Final-head verification passed on Blacksmith Testbox `tbx_01m1tj6k87c86sm6d6ewxs0hgm`, [run 34013469101](https://github.com/openclaw/openclaw/actions/runs/34013469101), lease stopped. The exact-head build, canonical package check, npm installation, focused extension lint, and 632-agent startup all passed: publication **21.8909 s**, **one probe**, ready at **90.786 s**, HTTP **200**, clean exit **0**, sampled peak RSS **1,661.27 MiB**. Materialized tree: `03a19a90417b898f15bde5be054b901f0c85f4f6`. Installed build-info commit: `8cb178e88f6e25a3614285c99ffe850078a2a1ab`. Candidate tarball SHA256: `9fe3e87b3eee27fdfa3edc9c738ab86705a137d6463ff32eae8dc0fe3d8cad71`. All three task-owned proof leases are stopped.

Validation:

- The 632-workspace owner regression under fake timers failed before the fix: only one preparation completed after 250 ms. Afterward all 632 complete with one probe.
- Focused Anthropic, generic synthetic-auth scope, publication lifecycle, supersession, cancellation, and timeout-stage tests pass. The test-only lint repair retains all five new regression cases.
- Local changed-file checks passed types, dead exports, core lint, and the remaining architecture guards. Local extension lint encountered an ancestor dependency outside the worktree; the same focused extension-lint gate passed on the flat final-head Testbox checkout.
- Independent local and branch autoreviews found no actionable P0/P1 defects. CI first exposed three test-only lint errors, now fixed. Main's unrelated projection-fixture mismatch was repaired in #139794. A refreshed merge snapshot (`75ebc4a5b25a9842f94ea7a3ddc86192551dfe56`) includes that repair; [exact-head CI run 34015360518](https://github.com/openclaw/openclaw/actions/runs/34015360518) and required `openclaw/ci-gate` passed on `8cb178e88f6e25a3614285c99ffe850078a2a1ab`.
- `git diff --numstat`: production **70 added / 73 removed (net -3)**; tests **133 added / 6 removed (net +127)**; docs **17 added / 0 removed**.

The reproduction uses synthetic state shaped like the reported roster, not the reporter's private state. It establishes repeated native-login discovery as a concrete 9.2 regression; it does not claim a permanently unresolved promise was observed. ClawSweeper's requested packaged timing and RSS evidence is supplied above; no source findings were raised.

NO-FOLLOW-UP: This repair already consolidates the duplicated Anthropic hooks; the remaining cache dimensions protect distinct ownership boundaries.
