### PR TITLE
refactor(tasks): retire test-only runtime registration facades

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -460,7 +460,6 @@ const config = {
     "src/plugins/interactive-registry.ts": ["exports"],
     "src/plugins/memory-state.ts": ["exports", "types"],
     "src/plugins/session-discussion-registry.ts": ["exports"],
-    "src/tasks/detached-task-runtime-state.ts": ["exports"],
     // Focused Control UI tests consume these explicit state-machine seams;
     // production uses them through their owning module/controller.
     "ui/src/pages/chat/chat-state-refresh.ts": ["exports"],

--- a/src/plugins/loader.registration.test-utils.ts
+++ b/src/plugins/loader.registration.test-utils.ts
@@ -10,10 +10,7 @@ import {
   triggerInternalHook,
 } from "../hooks/internal-hooks.js";
 import { NODE_WORKER_PRIVATE_COMMANDS } from "../infra/node-commands.js";
-import {
-  getDetachedTaskLifecycleRuntimeRegistration,
-  registerDetachedTaskLifecycleRuntime,
-} from "../tasks/detached-task-runtime-state.js";
+import { setDetachedTaskLifecycleRuntime } from "../tasks/detached-task-runtime.test-support.js";
 import { clearPluginCommands } from "./command-registry-state.js";
 import { getPluginCommandSpecs } from "./command-specs.js";
 import { registerEmbeddingProvider } from "./embedding-providers.js";
@@ -72,6 +69,7 @@ import { createEmptyPluginRegistry } from "./registry.js";
 import {
   getActivePluginChannelRegistry,
   getActivePluginRegistry,
+  requireActivePluginRegistry,
   getActivePluginRegistryKey,
   getActivePluginRegistryWorkspaceDir,
   getActivePluginRuntimeSubagentMode,
@@ -959,7 +957,7 @@ describe("loadOpenClawPlugins", () => {
   it("does not replace the active detached task runtime during non-activating loads", () => {
     useNoBundledPlugins();
     const activeRuntime = createDetachedTaskRuntimeStub("active");
-    registerDetachedTaskLifecycleRuntime("active-runtime", activeRuntime);
+    setDetachedTaskLifecycleRuntime(activeRuntime, "active-runtime");
 
     const plugin = writePlugin({
       id: "snapshot-detached-runtime",
@@ -991,7 +989,7 @@ describe("loadOpenClawPlugins", () => {
     expect(scoped.plugins.find((entry) => entry.id === "snapshot-detached-runtime")?.status).toBe(
       "loaded",
     );
-    const runtimeRegistration = getDetachedTaskLifecycleRuntimeRegistration();
+    const runtimeRegistration = requireActivePluginRegistry().detachedTaskRuntimes[0];
     expect(runtimeRegistration?.pluginId).toBe("active-runtime");
     expect(runtimeRegistration?.runtime).toBe(activeRuntime);
   });
@@ -1020,6 +1018,38 @@ describe("loadOpenClawPlugins", () => {
     expect(
       (registry.detachedTaskRuntimes[0]?.runtime as { marker?: string } | undefined)?.marker,
     ).toBe("second");
+  });
+
+  it("does not let another plugin replace the detached task runtime", () => {
+    useNoBundledPlugins();
+    const plugins = ["first-plugin", "second-plugin"].map((id) =>
+      writePlugin({
+        id,
+        body: `module.exports = { register(api) {
+          api.registerDetachedTaskRuntime({ marker: ${JSON.stringify(id)} });
+        } };`,
+      }),
+    );
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          allow: plugins.map(({ id }) => id),
+          load: { paths: plugins.map(({ dir }) => dir) },
+        },
+      },
+    });
+
+    expect(registry.detachedTaskRuntimes).toEqual([
+      { pluginId: "first-plugin", runtime: { marker: "first-plugin" } },
+    ]);
+    expect(registry.diagnostics).toContainEqual(
+      expect.objectContaining({
+        level: "error",
+        pluginId: "second-plugin",
+        message: "detached task runtime already registered by first-plugin",
+      }),
+    );
   });
 
   it("clears newly-registered detached task runtimes when plugin register fails", () => {
@@ -1055,7 +1085,7 @@ describe("loadOpenClawPlugins", () => {
     expect(registry.plugins.find((entry) => entry.id === "failing-detached-runtime")?.status).toBe(
       "error",
     );
-    expect(getDetachedTaskLifecycleRuntimeRegistration()).toBeUndefined();
+    expect(requireActivePluginRegistry().detachedTaskRuntimes[0]).toBeUndefined();
   });
 
   it("restores detached task runtime registrations after registry replacement", () => {
@@ -1093,14 +1123,18 @@ describe("loadOpenClawPlugins", () => {
     } satisfies Parameters<typeof loadOpenClawPlugins>[0];
 
     loadOpenClawPlugins(loadOptions);
-    expect(getDetachedTaskLifecycleRuntimeRegistration()?.pluginId).toBe("cached-detached-runtime");
+    expect(requireActivePluginRegistry().detachedTaskRuntimes[0]?.pluginId).toBe(
+      "cached-detached-runtime",
+    );
 
     setActivePluginRegistry(createEmptyPluginRegistry());
-    expect(getDetachedTaskLifecycleRuntimeRegistration()).toBeUndefined();
+    expect(requireActivePluginRegistry().detachedTaskRuntimes[0]).toBeUndefined();
 
     loadOpenClawPlugins(loadOptions);
 
-    expect(getDetachedTaskLifecycleRuntimeRegistration()?.pluginId).toBe("cached-detached-runtime");
+    expect(requireActivePluginRegistry().detachedTaskRuntimes[0]?.pluginId).toBe(
+      "cached-detached-runtime",
+    );
   });
 
   it("restores legacy internal hook registrations after registry replacement", async () => {
@@ -1234,7 +1268,7 @@ describe("loadOpenClawPlugins", () => {
 
   it("clears stale detached task runtime registrations on active reloads when no plugin re-registers one", () => {
     useNoBundledPlugins();
-    registerDetachedTaskLifecycleRuntime("stale-runtime", createDetachedTaskRuntimeStub("stale"));
+    setDetachedTaskLifecycleRuntime(createDetachedTaskRuntimeStub("stale"), "stale-runtime");
 
     loadOpenClawPlugins({
       cache: false,
@@ -1246,7 +1280,7 @@ describe("loadOpenClawPlugins", () => {
       },
     });
 
-    expect(getDetachedTaskLifecycleRuntimeRegistration()).toBeUndefined();
+    expect(requireActivePluginRegistry().detachedTaskRuntimes[0]).toBeUndefined();
   });
 
   it("restores memory capability public artifacts with a fresh registry after replacement", async () => {

--- a/src/tasks/detached-task-runtime-state.ts
+++ b/src/tasks/detached-task-runtime-state.ts
@@ -1,48 +1,8 @@
-import {
-  assertDirectPluginRegistrationReplacement,
-  requireActivePluginRegistry,
-  resolveDirectPluginRegistrationOwner,
-} from "../plugins/runtime.js";
-// Tracks detached task runtime state and spawned process handles.
-import type {
-  DetachedTaskLifecycleRuntime,
-  DetachedTaskLifecycleRuntimeRegistration,
-} from "./detached-task-runtime-contract.js";
-
-const getRegistrations = () => requireActivePluginRegistry().detachedTaskRuntimes;
-
-/** Registers the active detached task lifecycle runtime implementation. */
-export function registerDetachedTaskLifecycleRuntime(
-  requestedPluginId: string,
-  runtime: DetachedTaskLifecycleRuntime,
-): void {
-  const registrations = getRegistrations();
-  const pluginId = resolveDirectPluginRegistrationOwner(requestedPluginId) ?? requestedPluginId;
-  if (registrations[0]) {
-    assertDirectPluginRegistrationReplacement(registrations[0].pluginId, "detached task runtime");
-  }
-  registrations.splice(0, registrations.length, { pluginId, runtime });
-}
-
-export function getDetachedTaskLifecycleRuntimeRegistration():
-  | DetachedTaskLifecycleRuntimeRegistration
-  | undefined {
-  const registration = getRegistrations()[0];
-  if (!registration) {
-    return undefined;
-  }
-  return {
-    pluginId: registration.pluginId,
-    runtime: registration.runtime,
-  };
-}
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
+import type { DetachedTaskLifecycleRuntime } from "./detached-task-runtime-contract.js";
 
 export function getRegisteredDetachedTaskLifecycleRuntime():
   | DetachedTaskLifecycleRuntime
   | undefined {
-  return getRegistrations()[0]?.runtime;
-}
-
-export function clearDetachedTaskLifecycleRuntimeRegistration(): void {
-  getRegistrations().length = 0;
+  return requireActivePluginRegistry().detachedTaskRuntimes[0]?.runtime;
 }

--- a/src/tasks/detached-task-runtime.test-support.ts
+++ b/src/tasks/detached-task-runtime.test-support.ts
@@ -1,13 +1,14 @@
+import { requireActivePluginRegistry } from "../plugins/runtime.js";
 import type { DetachedTaskLifecycleRuntime } from "./detached-task-runtime-contract.js";
-import {
-  clearDetachedTaskLifecycleRuntimeRegistration,
-  registerDetachedTaskLifecycleRuntime,
-} from "./detached-task-runtime-state.js";
 
-export function setDetachedTaskLifecycleRuntime(runtime: DetachedTaskLifecycleRuntime): void {
-  registerDetachedTaskLifecycleRuntime("__test__", runtime);
+export function setDetachedTaskLifecycleRuntime(
+  runtime: DetachedTaskLifecycleRuntime,
+  pluginId = "__test__",
+): void {
+  const registrations = requireActivePluginRegistry().detachedTaskRuntimes;
+  registrations.splice(0, registrations.length, { pluginId, runtime });
 }
 
 export function resetDetachedTaskLifecycleRuntimeForTests(): void {
-  clearDetachedTaskLifecycleRuntimeRegistration();
+  requireActivePluginRegistry().detachedTaskRuntimes.length = 0;
 }

--- a/src/tasks/detached-task-runtime.test.ts
+++ b/src/tasks/detached-task-runtime.test.ts
@@ -1,11 +1,5 @@
 // Covers detached task runtime spawning, events, and cancellation handling.
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import { withPluginRegistrationContext } from "../plugins/runtime.js";
-import {
-  getDetachedTaskLifecycleRuntimeRegistration,
-  registerDetachedTaskLifecycleRuntime,
-} from "./detached-task-runtime-state.js";
 import {
   completeTaskRunByRunId,
   createQueuedTaskRun,
@@ -332,48 +326,6 @@ describe("detached-task-runtime", () => {
 
     resetDetachedTaskLifecycleRuntimeForTests();
     expect(getDetachedTaskLifecycleRuntime()).toBe(defaultRuntime);
-  });
-
-  it("tracks registered detached runtimes by plugin id", () => {
-    const runtime = {
-      ...getDetachedTaskLifecycleRuntime(),
-    };
-
-    registerDetachedTaskLifecycleRuntime("tests/detached-runtime", runtime);
-
-    const registration = getDetachedTaskLifecycleRuntimeRegistration();
-    expect(registration?.pluginId).toBe("tests/detached-runtime");
-    expect(registration?.runtime).toBe(runtime);
-    expect(getDetachedTaskLifecycleRuntime()).toBe(runtime);
-  });
-
-  it("replaces the active detached runtime registration", () => {
-    const first = { ...getDetachedTaskLifecycleRuntime() };
-    const second = { ...getDetachedTaskLifecycleRuntime() };
-
-    registerDetachedTaskLifecycleRuntime("first", first);
-    registerDetachedTaskLifecycleRuntime("second", second);
-
-    expect(getDetachedTaskLifecycleRuntimeRegistration()).toEqual({
-      pluginId: "second",
-      runtime: second,
-    });
-  });
-
-  it("does not let a registering plugin displace another owner's detached runtime", () => {
-    const building = createEmptyPluginRegistry();
-    const original = { ...getDetachedTaskLifecycleRuntime() };
-    const replacement = { ...getDetachedTaskLifecycleRuntime() };
-    building.detachedTaskRuntimes.push({ pluginId: "first-plugin", runtime: original });
-
-    expect(() =>
-      withPluginRegistrationContext(building, "failing-plugin", () => {
-        registerDetachedTaskLifecycleRuntime("spoofed-plugin", replacement);
-      }),
-    ).toThrow("detached task runtime already registered by first-plugin");
-    expect(building.detachedTaskRuntimes).toEqual([
-      { pluginId: "first-plugin", runtime: original },
-    ]);
   });
 
   it("falls back to legacy complete and fail hooks when a runtime has no finalizer", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Detached-task tests exercise obsolete private registration facades that have no production callers, retaining duplicate registration paths and a dead-export exception.

## Why This Change Was Made

Remove the three private facades and keep test-only registry setup in test support. Exercise foreign-owner rejection through the actual plugin loader and registration API. Preserve the live runtime getter and existing replacement, rollback, reload and non-activation coverage.

## User Impact

No public API or runtime registration behavior changes. Net removal: 13 test/support lines, 40 production lines and one Knip exception, counted separately.

## Evidence

All 211 loader/task tests pass. The new real-API ownership case fails when its registrar guard is temporarily disabled; the guard was restored unchanged. Removed-symbol searches found no remaining callers, and all three dead-export scans pass with zero entries.

The complete changed gate, deslop and independent P2 review pass. After an inherited CI inventory repair landed, the branch was rebased without changing its added/deleted lines; 211 focused tests, formatting and diff checks pass again. No runtime improvement is claimed.
