### PR TITLE
perf(tooling): prepare source scan paths before sorting

### DIFF
--- a/scripts/lib/source-file-scan-cache.mts
+++ b/scripts/lib/source-file-scan-cache.mts
@@ -101,19 +101,15 @@ export async function collectSourceFileContents(params: SourceScanParams) {
       )
     )
       .flat()
-      .toSorted((left, right) =>
-        normalizeRepoPath(params.repoRoot, left).localeCompare(
-          normalizeRepoPath(params.repoRoot, right),
-        ),
-      );
+      .map((filePath) => ({ filePath, relativeFile: normalizeRepoPath(params.repoRoot, filePath) }))
+      .toSorted((left, right) => left.relativeFile.localeCompare(right.relativeFile));
 
     const readFile = params.readFile ?? fs.readFile;
     const statFile = params.statFile ?? fs.stat;
     const maxFileBytes = normalizeMaxFileBytes(params.maxFileBytes);
     return await pMap(
       files,
-      async (filePath) => {
-        const relativeFile = normalizeRepoPath(params.repoRoot, filePath);
+      async ({ filePath, relativeFile }) => {
         const stat = await statFile(filePath);
         assertSourceFileWithinLimit(relativeFile, stat.size, maxFileBytes);
         const content = await readFile(filePath, "utf8");


### PR DESCRIPTION
## What Problem This Solves

Developer source guards repeatedly calculate the same relative file paths while sorting a repository inventory. This adds avoidable work to checks that already read thousands of files.

## Why This Change Was Made

Prepare each relative path once and carry it beside the absolute file path through sorting and reading. This removes repeated path conversion without changing directory traversal, locale ordering, duplicates, cache behavior, concurrency, error propagation, or either file-size check. The change removes four tooling lines; no runtime or test lines are added.

## User Impact

Source scanning does less work, with the same complete scan and guard results. This is a developer-tooling improvement, not a Gateway latency claim.

## Evidence

The existing source-scan, export-collision, and wrapper-shadowing test files passed: 3 files, 42 tests, normal repository wrapper exit 0 with Vitest 5. Canonical P2 autoreview reported scoped-clean with no findings.

One fixed B0/C0/C1/B1 cohort ran all four workloads against base `6c55a99226ed0611ca088004c81b00fb296f1f71`; all 16 commands exited 0 and their process owners reported complete closure. Fresh processes were used for each command, without cache resets or result-driven retries.

| Workload | B0 | C0 | C1 | B1 |
| --- | ---: | ---: | ---: | ---: |
| Source scanner owner | 936.3 ms | 194.9 ms | 200.6 ms | 245.9 ms |
| UI scanner owner | 166.4 ms | 52.0 ms | 52.4 ms | 62.9 ms |
| Complete wrapper-shadowing guard | 3285.0 ms | 3280.2 ms | 3284.2 ms | 3600.8 ms |
| Complete web-fetch boundary guard | 492.8 ms | 453.0 ms | 458.5 ms | 517.4 ms |

B0 was the first filesystem scan, so its much larger scanner times are not a clean estimate of the patch benefit. With the filesystem already warm, C1 versus B1 reduced scanner-owner elapsed time by 18.4% for source files and 16.7% for UI files. Full wrapper-guard differences were only 0.15% in the forward order and 8.79% in reverse; complete web-fetch guard differences were 8.09% and 11.38%. These are descriptive single observations per phase, not statistically established throughput or tail-latency gains. The scanner-owner timer excludes serialization and writing the comparison artifact; complete guard timings include process startup and shutdown.

All four phases returned byte-identical full scanner JSON, including absolute paths, relative paths, content, and ordering: 16,732 source rows (192,629,854 bytes per output) and 2,802 UI rows (32,884,112 bytes). Both complete guards also retained identical stdout, stderr, and exit status. An independent streaming byte comparison rechecked these retained outputs; no benchmark was rerun.

The candidate was fast-forwarded to `42162ca08fef99539bf7e97622ef8f33d0087d9e` without conflict. Scanner, relevant guard/test owners, and package/lock/workspace manifests did not drift; the exact four-line reduction remains unchanged. The numeric evidence above remains attributed to the original measured base and corpus.

Current-base `pnpm install --frozen-lockfile` passed with an independent dependency directory (pnpm 12.3.4, Vitest 5). All 17 commands in the normal changed gate passed at this refreshed base, including script typechecking, targeted lint/formatting, wrapper shadowing, both wildcard guards, coercion and source-boundary checks. No checks were skipped or weakened.

Before publication, the unchanged scanner patch was fast-forwarded to `5b7e42bc899e72b3db598b41545fd3454e38f499` to include upstream #139747, which repairs an unrelated CI inventory failure. The local 17-check run remains attributed to `42162`; the fixed numerical corpus remains attributed to `6c55`. Required exact-head CI will validate the published head.

Review checklist clarification: migration/upgrade proof is not applicable. This patch changes only transient path preparation in a process-local `Map<string, Promise<SourceFileContent[]>>`; it adds no storage writes, schema, persisted format, configuration, or upgrade path. The returned `{ filePath, relativeFile, content }` records, duplicate ordering, error behavior and file-size bounds are unchanged, verified by the 42 existing tests and complete byte-for-byte scanner/guard outputs above. The review prose reaches the same conclusion; its residual data-model checklist item is therefore skipped with this source-based explanation.
