### PR TITLE
refactor(test): reuse shared child close waits

### DIFF
--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -28,7 +28,7 @@ import {
   translateNativeEntries,
 } from "../../scripts/control-ui-i18n.ts";
 import { collectControlUiRawCopyFromSource } from "../../scripts/lib/control-ui-i18n-raw-copy.ts";
-import { waitForPidFile } from "../helpers/process-wait.js";
+import { waitForChildClose, waitForPidFile } from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 
 vi.mock("../../scripts/lib/sleep.mjs", () => ({ sleep: async () => {} }));
@@ -357,21 +357,6 @@ async function waitForProcessExit(pid: number, timeoutMs = 1_000): Promise<void>
     });
   }
   throw new Error(`process ${pid} was still alive after ${timeoutMs}ms`);
-}
-
-async function waitForChildClose(
-  child: ReturnType<typeof spawn>,
-  timeoutMs = 2_000,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  return await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error("child did not close before timeout"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timeout);
-      resolve({ code, signal });
-    });
-  });
 }
 
 describe("control-ui-i18n process runner", () => {
@@ -782,7 +767,7 @@ describe("control-ui-i18n process runner", () => {
 
           runner.kill("SIGTERM");
 
-          await expect(waitForChildClose(runner)).resolves.toEqual({
+          await expect(waitForChildClose(runner, 2_000)).resolves.toEqual({
             code: null,
             signal: "SIGTERM",
           });

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -41,6 +41,7 @@ import {
   validateDockerCandidateEnvironment,
   writeRunSummary,
 } from "../../scripts/test-docker-all.mts";
+import { waitForChildClose } from "../helpers/process-wait.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { copyDockerSchedulerHarness } from "./docker-all-harness.test-support.js";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -335,20 +336,6 @@ async function runReadyTimedCommand<T>(
     fireDeadline();
     await command;
   }
-}
-
-async function waitForChildClose(child: ReturnType<typeof spawn>, timeoutMs = 5_000) {
-  return await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error("child did not close before timeout"));
-      }, timeoutMs);
-      child.once("close", (code, signal) => {
-        clearTimeout(timeout);
-        resolve({ code, signal });
-      });
-    },
-  );
 }
 
 describe("scripts/test-docker-all scheduler", () => {

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -68,6 +68,7 @@ import {
   resolveWindowsTaskkillPath,
 } from "../../scripts/lib/windows-taskkill.mjs";
 import { formatGatewayClientRequestErrorJson } from "../../src/gateway/call.js";
+import { waitForChildClose } from "../helpers/process-wait.js";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
@@ -2254,20 +2255,6 @@ async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 
     }
     await realDelay(25);
   }
-}
-
-async function waitForChildClose(child: ReturnType<typeof spawn>, timeoutMs = 3_000) {
-  return await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve, reject) => {
-      const timeout = setTimeout(() => {
-        reject(new Error("child did not close before timeout"));
-      }, timeoutMs);
-      child.once("close", (code, signal) => {
-        clearTimeout(timeout);
-        resolve({ code, signal });
-      });
-    },
-  );
 }
 
 function isProcessAlive(pid: number) {

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -17,7 +17,7 @@ import {
   runSingleCheck,
   selectChecksForShard,
 } from "../../scripts/run-additional-boundary-checks.mts";
-import { waitForFile, waitForPidFile } from "../helpers/process-wait.js";
+import { waitForChildClose, waitForFile, waitForPidFile } from "../helpers/process-wait.js";
 
 function createOutputBuffer() {
   const chunks: string[] = [];
@@ -85,21 +85,6 @@ async function waitForNotRunning(pid: number, timeoutMs: number): Promise<void> 
     await sleep(5);
   }
   throw new Error(`process still running: ${pid}`);
-}
-
-async function waitForChildClose(
-  child: ReturnType<typeof spawn>,
-  timeoutMs: number,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  return await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error("child did not close before timeout"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timeout);
-      resolve({ code, signal });
-    });
-  });
 }
 
 describe("run-additional-boundary-checks", () => {

--- a/test/scripts/write-cli-startup-metadata.test.ts
+++ b/test/scripts/write-cli-startup-metadata.test.ts
@@ -7,7 +7,7 @@ import { PassThrough } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { testing } from "../../scripts/write-cli-startup-metadata.ts";
-import { waitForPidFile } from "../helpers/process-wait.js";
+import { waitForChildClose, waitForPidFile } from "../helpers/process-wait.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 vi.mock("node:child_process", async (importOriginal) => {
@@ -109,21 +109,6 @@ async function waitForProcessExit(
   throw new Error(`process ${pid} was still alive after ${timeoutMs}ms`);
 }
 
-async function waitForChildClose(
-  child: ReturnType<typeof spawn>,
-  timeoutMs = LOAD_SENSITIVE_PROCESS_TIMEOUT_MS,
-): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
-  return await new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      reject(new Error("child did not close before timeout"));
-    }, timeoutMs);
-    child.once("close", (code, signal) => {
-      clearTimeout(timeout);
-      resolve({ code, signal });
-    });
-  });
-}
-
 describe("write-cli-startup-metadata", () => {
   const { createTempDir } = createScriptTestHarness();
 
@@ -215,7 +200,9 @@ describe("write-cli-startup-metadata", () => {
       });
 
       await rootHelpStarted;
-      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
       expect(startedCommands).toEqual([]);
 
       releaseRootHelp();
@@ -338,7 +325,9 @@ describe("write-cli-startup-metadata", () => {
       });
       const deadline = Date.now() + 1_000;
       while (children.length < COMMAND_HELP_RENDER_CONCURRENCY && Date.now() < deadline) {
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
       }
       expect(children.map((child) => child.commandName)).toEqual(
         DEFAULT_COMMAND_HELP_NAMES.slice(0, COMMAND_HELP_RENDER_CONCURRENCY),
@@ -426,7 +415,9 @@ describe("write-cli-startup-metadata", () => {
             tasks: "Usage: openclaw tasks\n",
           }),
         });
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
         child.stderr.write("primary browser failure\n");
         child.emit("close", 7, null);
 
@@ -737,10 +728,12 @@ describe("write-cli-startup-metadata", () => {
 
         runner.kill("SIGTERM");
 
-        await expect(waitForChildClose(runner)).resolves.toEqual({
-          code: null,
-          signal: "SIGTERM",
-        });
+        await expect(waitForChildClose(runner, LOAD_SENSITIVE_PROCESS_TIMEOUT_MS)).resolves.toEqual(
+          {
+            code: null,
+            signal: "SIGTERM",
+          },
+        );
         await waitForProcessExit(grandchildPid);
         const renderStateDir = readFileSync(renderStatePath, "utf8");
         expect(existsSync(renderStateDir)).toBe(false);
@@ -1029,7 +1022,9 @@ describe("write-cli-startup-metadata", () => {
         for (const suffix of ["", "-shm", "-wal"]) {
           writeFileSync(path.join(sqliteDir, `openclaw.sqlite${suffix}`), "fixture", "utf8");
         }
-        await new Promise((resolve) => setImmediate(resolve));
+        await new Promise((resolve) => {
+          setImmediate(resolve);
+        });
         if (failRender) {
           throw new Error("browser help failed");
         }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Five script test suites maintain separate copies of the same child-close waiter, making shared test maintenance more repetitive and prone to drift.

## Why This Change Was Made

Reuse the existing test helper while preserving every subscription position, timeout, signal, delay, assertion and cleanup path. The i18n and startup-metadata callers explicitly retain their previous timeout defaults. Four existing startup-metadata Promise executors also receive block bodies to satisfy lint without changing their scheduled callbacks.

## User Impact

No user-visible or runtime behavior changes. Test support shrinks by **61 lines**; the shared helper and production scripts are unchanged. This is a maintenance refactor, not a flake fix.

## Evidence

- The same five existing synthetic process cases passed before and after the helper consolidation, with one selected case per file and 220 intentional filtered skips in each run.
- The initial changed-check invocation passed 15 stages, including root test types, i18n verification and scripts lint. Its final changed-test lint exposed four inherited executor-return warnings. After the four brace-only corrections, all five affected startup-metadata invocations and final changed-test lint passed. **No fresh full 16-stage rerun was performed.**
- Final scoped formatting and `git diff --check` passed. Source comparison confirms that the final delta after the five-case comparison consists only of those four executor brace changes; the close-case call sites and behavior remain unchanged.
- Final managed source review completed two passes with no actionable findings. Dependencies were checkout-owned and matched the frozen lockfile. No new tests, live-provider calls or full Docker/product builds were needed.

Required PR CI for committed head `56beef418e715a901c8ed674cf96cc21d1694767` and native landing validation remain pending.
