### PR TITLE
fix(gateway): preserve the assistant tail before retry cleanup

### DIFF
--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1066,6 +1066,12 @@ describe("agent event handler", () => {
               { phase: "error", error: "retryable failure" },
               { seq: 50 },
             );
+            expect(
+              frames
+                .filter((frame) => frame.event === "chat" && frame.payload.state === "delta")
+                .map((frame) => frame.payload.deltaText)
+                .join(""),
+            ).toBe(`${expected} failed tail`);
           } else if (terminal === "clearRun") {
             chatRunState.clearRun(runId);
           } else {

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1653,8 +1653,10 @@ export function createAgentEventHandler({
       }
     } else {
       const itemPhase = isItemEvent && typeof evt.data?.phase === "string" ? evt.data.phase : "";
+      // The runtime error frame drains this text before retry cleanup retires its group.
       if (
-        itemPhase === "start" &&
+        (itemPhase === "start" ||
+          (lifecyclePhase === "error" && evt.data.completionSource !== "reply-dispatch")) &&
         (isControlUiVisible || hasSessionMessageSubscribers) &&
         !isAborted
       ) {
@@ -1760,18 +1762,6 @@ export function createAgentEventHandler({
         if (evt.data.completionSource !== "reply-dispatch") {
           // Runtime retries isolate failed text; reply-dispatch retains its
           // post-hook payloads and abort state until its own completion settles.
-          if (sessionKey) {
-            flushBufferedChatDeltaIfNeeded(
-              sessionKey,
-              sessionAgentId,
-              clientRunId,
-              evt.runId,
-              evt.seq,
-              {
-                controlUiVisible: isControlUiVisible,
-              },
-            );
-          }
           chatRunState.clearRun(clientRunId);
         }
         scheduleTerminalLifecycleError(evt, { skipChatErrorFinal, restartRecoveryState });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a retryable runtime error could discard the last buffered assistant text before subscribers received it. A queued chat delta could be cancelled when retry cleanup retired its text group.

## Why This Change Was Made

The error lifecycle frame was sent before the pending text was flushed. With a frame already in flight, the later flush stayed coalesced until the same group was cleared. Move the flush to the existing pre-event boundary so the error frame drains the text before cleanup. Delete the later duplicate flush.

Reply-dispatch finalization, abort checks, subscriber visibility and canonical item-aware text merging stay with their existing owners. No configuration, protocol, storage, or dependency changes. Production net **−10**; tests **+6**.

## User Impact

Subscribers retain the failed attempt’s final text before retry state resets. The next attempt still starts with an independent text group; terminal and cancellation behavior are unchanged.

## Evidence

- Extended the existing held-socket regression at the actual agent-event owner. The new tail assertion fails on the current baseline before the production repair.
- Final current-owner proof: **255 tests passed**, including 244 event/transport/live-text siblings and 11 existing canonical merge/cap cases; zero skips in the GREEN run.
- Complete two-path changed gate passed, including declarations, lint, dead exports and boundary checks. Fresh independent managed review completed without findings and with unchanged source hashes.
- An isolated real Gateway + local streaming-provider + Chromium ordinary-retry smoke passed. It emitted the complete tail, made two provider requests and completed the final response. Its captures are synthetic-only. This is ordinary retry smoke, **not** browser reproduction of the held-socket race; deterministic race proof is the owner-boundary test above.
- Source tracing confirmed the non-deferred runtime-error producer through Talk consult and the shared session-message subscriber path. No live voice/provider-account execution is claimed.
- Current-main item-aware merge/cap changes from #139507 were independently inspected and retained. Earlier baseline test-partition failure was resolved through the existing #139645 fix, not by changing limits or weakening tests.

No operator Gateway, production state, model-account credentials, or native-device behavior was changed or tested. Hosted CI must pass before landing.
