### PR TITLE
fix(tooling): diagnose declaration escapes into ancestor installs

### DIFF
--- a/scripts/lib/tsdown-declaration-boundary.mts
+++ b/scripts/lib/tsdown-declaration-boundary.mts
@@ -10,6 +10,21 @@ const withinRoot = (root: string, file: string) => {
   return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
 };
 
+function findAncestorInstall(root: string, real: string): string | undefined {
+  let ancestor = path.dirname(root);
+  while (true) {
+    const install = path.join(ancestor, "node_modules");
+    if (withinRoot(install, real)) {
+      return install;
+    }
+    const parent = path.dirname(ancestor);
+    if (parent === ancestor) {
+      return undefined;
+    }
+    ancestor = parent;
+  }
+}
+
 export function createDeclarationInputBoundary(cwd: string) {
   const declared = path.resolve(cwd);
   const prefixes = [declared, fs.realpathSync(declared)];
@@ -33,8 +48,13 @@ export function createDeclarationInputBoundary(cwd: string) {
       }
       const real = fs.realpathSync.native(existing);
       if (!withinRoot(root, absolute) || !withinRoot(root, real)) {
+        // Hermetic declaration inputs must not inherit an ancestor install's exposed packages.
+        const ancestorInstall = findAncestorInstall(root, real);
+        const diagnosis = ancestorInstall
+          ? `This checkout is nested inside another install at ${ancestorInstall}; module resolution walked out of the checkout and read a package from it. Run this lane in a checkout that is not nested inside another node_modules, or repair that ancestor install to the repository's isolated layout (nodeLinker: isolated in pnpm-workspace.yaml), which keeps transitive packages out of its root rather than exposing them to nested checkouts.`
+          : `Install declaration dependencies inside ${root}; shared installs and external symlinks are unsupported.`;
         throw new Error(
-          `Declaration input escapes checkout: ${absolute} -> ${real}. Install declaration dependencies inside ${root}; shared installs and external symlinks are unsupported.`,
+          `Declaration input escapes checkout: ${absolute} -> ${real}. ${diagnosis} If the checkout is not nested inside another install, the compiled package imported a dependency it does not declare, which is the boundary violation this check exists to catch.`,
         );
       }
       return absolute;

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });

--- a/test/scripts/native-declaration-boundary.test.ts
+++ b/test/scripts/native-declaration-boundary.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, expect, it } from "vitest";
 import { portableRelativePath } from "../../scripts/lib/build-artifact-cache.mts";
 import { BoundaryInputSnapshot } from "../../scripts/lib/extension-boundary-inputs.mts";
+import { createDeclarationInputBoundary } from "../../scripts/lib/tsdown-declaration-boundary.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import {
   installNativeAncestorTypes,
@@ -14,6 +15,28 @@ import {
 } from "./native-boundary-fixture.js";
 
 const roots = useAutoCleanupTempDirTracker(afterEach);
+
+it.each([true, false])(
+  "diagnoses declaration escapes with an ancestor install=%s",
+  (ancestorInstall) => {
+    const ancestor = fs.realpathSync.native(roots.make("declaration-escape-diagnosis-"));
+    const root = path.join(ancestor, ".claude/worktrees/validation");
+    fs.mkdirSync(root, { recursive: true });
+    const install = path.join(ancestor, ancestorInstall ? "node_modules" : "other/node_modules");
+    const file = path.join(install, "synthetic-package/package.json");
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, "{}");
+    const boundary = createDeclarationInputBoundary(root);
+    const diagnosis = ancestorInstall
+      ? `This checkout is nested inside another install at ${install}; module resolution walked out of the checkout and read a package from it. Run this lane in a checkout that is not nested inside another node_modules, or repair that ancestor install to the repository's isolated layout (nodeLinker: isolated in pnpm-workspace.yaml), which keeps transitive packages out of its root rather than exposing them to nested checkouts.`
+      : `Install declaration dependencies inside ${root}; shared installs and external symlinks are unsupported.`;
+    expect(() => boundary.assert(file)).toThrow(
+      new Error(
+        `Declaration input escapes checkout: ${file} -> ${file}. ${diagnosis} If the checkout is not nested inside another install, the compiled package imported a dependency it does not declare, which is the boundary violation this check exists to catch.`,
+      ),
+    );
+  },
+);
 
 function createNativeFixture(root: string, declared = root) {
   fs.mkdirSync(root, { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers running the declaration package-boundary lane in a nested checkout were told to install a dependency that was already correctly installed. The failure came from resolution reaching the parent checkout's install, so following the old advice could not repair it.

## Why This Change Was Made

The diagnostic now identifies the ancestor `node_modules` that supplied the escaped input and explains how to avoid it: run in a checkout outside another install, or repair the ancestor install to the repository's `nodeLinker: isolated` layout in `pnpm-workspace.yaml`. The existing guard, rejection conditions, and message prefix remain unchanged; unrelated escapes retain the original advice, and both branches identify undeclared imports as the boundary violation to investigate when nesting is absent.

## User Impact

Maintainers get an actionable explanation of the actual install topology instead of being sent back to reinstall a package that is already present. This only changes failure diagnostics; contaminated declaration inputs still fail and cannot be accepted.

## Evidence

Before (local paths anonymized):

```text
Declaration input escapes checkout: /workspace/openclaw/node_modules/punycode/package.json -> /workspace/openclaw/node_modules/punycode/package.json. Install declaration dependencies inside /workspace/openclaw/worktrees/validation; shared installs and external symlinks are unsupported.
```

After (local paths anonymized):

```text
Declaration input escapes checkout: /workspace/openclaw/node_modules/punycode/package.json -> /workspace/openclaw/node_modules/punycode/package.json. This checkout is nested inside another install at /workspace/openclaw/node_modules; module resolution walked out of the checkout and read a package from it. Run this lane in a checkout that is not nested inside another node_modules, or repair that ancestor install to the repository's isolated layout (nodeLinker: isolated in pnpm-workspace.yaml), which keeps transitive packages out of its root rather than exposing them to nested checkouts. If the checkout is not nested inside another install, the compiled package imported a dependency it does not declare, which is the boundary violation this check exists to catch.
```

Both live runs used `node --import ./scripts/tsx.mjs scripts/prepare-extension-package-boundary-artifacts.mts` and exited 1 on the same ancestor `punycode/package.json`, as required.

The four requested suites passed: 59 tests passed, 8 platform-specific tests skipped. The two new message assertions first failed against the original implementation. `oxfmt` on both touched files and `git diff --check` passed.

`pnpm install --frozen-lockfile` and `pnpm check:changed` passed in an independent checkout outside the parent repository, using isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH`. The copied patch was verified byte-for-byte against the candidate.

Codex autoreview of the local candidate and committed branch returned `scoped-clean` with no accepted/actionable findings at the helper's default P0 threshold.


## Also fixes red `main`

While this PR was in review, `main` went red on `check-test-types-core-2`:

```text
src/gateway/session-history-state.test.ts(398,9): error TS2353:
Object literal may only specify known properties, and
'streamErrorFallbackPending' does not exist in type 'ChatDisplayProjectionResult'.
```

#139753 renamed that projection result's `streamErrorFallbackPending` and `streamErrorFallbackRepaired` to `assistantErrorPending` and `assistantErrorRecoveryObserved`, but one call site in `src/gateway/session-history-state.test.ts` kept the old names. They were the only two stale references left in the repository. That PR's targeted CI plan never selected this shard, so the break first surfaced on a full `main` run rather than on the PR.

Repo policy is to fix a red `main` in the landing PR rather than wait it out, so the rename is applied here as a separate commit. No fix was open for it. Verified: the owning shard typechecks (exit 0), `src/gateway/session-history-state.test.ts` passes, and no reference to either old name remains.
