### PR TITLE
improve(test): avoid repeated Doctor fixture bootstraps

### DIFF
--- a/src/commands/doctor-plugin-install-config.process.test.ts
+++ b/src/commands/doctor-plugin-install-config.process.test.ts
@@ -21,7 +21,7 @@ beforeAll(() => {
   runtimeRoot = createBuiltRuntime(fs.realpathSync(tempDirs.make("doctor-plugin-config-runtime-")));
 });
 
-function createDoctorFixture() {
+async function createDoctorFixture() {
   const root = fs.realpathSync(tempDirs.make("doctor-plugin-config-"));
   const stateDir = path.join(root, "state");
   const configPath = path.join(stateDir, "openclaw.json");
@@ -39,16 +39,15 @@ function createDoctorFixture() {
     OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
     NO_COLOR: "1",
   };
-  fs.writeFileSync(
-    configPath,
-    JSON.stringify({
-      gateway: { mode: "local", auth: { mode: "none" } },
-      plugins: { enabled: false },
-    }),
-  );
-  const bootstrap = runBuiltRuntime(runtimeRoot, env, doctorArgs, 60_000);
-  expect(bootstrap.status, `${bootstrap.stdout}\n${bootstrap.stderr}`).toBe(0);
-  const config = JSON.parse(fs.readFileSync(configPath, "utf8")) as OpenClawConfig;
+  const config: OpenClawConfig = {
+    gateway: { mode: "local", auth: { mode: "none" } },
+    plugins: { enabled: false },
+    agents: { entries: { main: {} } },
+    meta: { migrations: { modelPolicyAllowlist: true } },
+  };
+  fs.writeFileSync(configPath, JSON.stringify(config));
+  // Start from current config and an existing index; the cases below own Doctor execution.
+  await writePersistedInstalledPluginIndexInstallRecords({}, { stateDir, env, config });
   return { root, stateDir, configPath, env, config };
 }
 
@@ -56,7 +55,7 @@ describe("Doctor retired plugin install config", () => {
   it.each(["empty", "populated", "included", "empty-included"] as const)(
     "removes %s legacy records after preserving the canonical install index",
     async (kind) => {
-      const { root, stateDir, configPath, env, config } = createDoctorFixture();
+      const { root, stateDir, configPath, env, config } = await createDoctorFixture();
       const empty = kind === "empty" || kind === "empty-included";
       const included = kind === "included" || kind === "empty-included";
       const durable = { source: "path" as const, installPath: path.join(root, "current-plugin") };
@@ -103,7 +102,7 @@ describe("Doctor retired plugin install config", () => {
   );
 
   it("preserves records when plain Doctor gains config-write consent after preflight", async () => {
-    const { root, stateDir, configPath, env, config } = createDoctorFixture();
+    const { root, stateDir, configPath, env, config } = await createDoctorFixture();
     const legacy = { source: "path" as const, installPath: path.join(root, "missing-plugin") };
     const candidate = { ...config, plugins: { ...config.plugins, installs: { imported: legacy } } };
     fs.writeFileSync(configPath, JSON.stringify({ ...candidate, unknownKey: true }));
@@ -145,8 +144,8 @@ describe("Doctor retired plugin install config", () => {
     });
   }, 90_000);
 
-  it("leaves malformed source records untouched before other config repairs", () => {
-    const { configPath, env, config } = createDoctorFixture();
+  it("leaves malformed source records untouched before other config repairs", async () => {
+    const { configPath, env, config } = await createDoctorFixture();
     const raw = JSON.stringify({
       ...config,
       unknownKey: true,
@@ -161,7 +160,7 @@ describe("Doctor retired plugin install config", () => {
   }, 90_000);
 
   it("does not replay source records after later registry cleanup", async () => {
-    const { root, stateDir, configPath, env, config } = createDoctorFixture();
+    const { root, stateDir, configPath, env, config } = await createDoctorFixture();
     const legacy = { source: "path", installPath: path.join(root, "missing-plugin") };
     fs.writeFileSync(
       configPath,
@@ -211,7 +210,7 @@ describe("Doctor retired plugin install config", () => {
   }, 90_000);
 
   it("preserves enabled custom-path plugin settings before stale-config repair", async () => {
-    const { root, stateDir, configPath, env, config } = createDoctorFixture();
+    const { root, stateDir, configPath, env, config } = await createDoctorFixture();
     const pluginDir = path.join(root, "custom-plugin");
     fs.mkdirSync(pluginDir);
     fs.writeFileSync(


### PR DESCRIPTION
## What Problem This Solves

The retired plugin-config migration suite launches a full Doctor process to prepare each of eight fixtures, then launches the processes that actually exercise migration, repeatability, validation, and consent. These eight setup processes add roughly31 seconds to the suite.

## Why This Change Was Made

Prepare the fixture's current agent roster, migration marker, and empty canonical installed-plugin index directly using the existing config and index writer. An original-bootstrap diagnostic confirmed those preconditions. The cases retain all20 substantive repair, repeat, validation, and contribution subprocess invocations and their assertions.

## User Impact

The same eight migration scenarios complete sooner. Production code, schemas, test counts, shard counts, timeouts, and process isolation are unchanged. This is one test file, +16/-17 lines.

## Evidence

[Paired Linux proof](https://github.com/openclaw/openclaw/actions/runs/34010209921) ran both variants serially on one four-CPU machine with separate dependencies, build outputs, caches, and fixture homes. Node24.19.0 and pnpm12.3.4; all eight case names and passing results match.

| Measurement | Before | After |
| --- | ---: | ---: |
| Test-command wall time | 99.29s | 68.50s |
| Vitest duration | 96.21s | 65.35s |
| User CPU | 123.04s | 81.94s |
| Separate runtime prebuild | 29.52s | 28.99s |

The test command saved30.79 seconds (31.0%); every case improved. Peak RSS changed only+0.2%. The owned test machine completed and stopped; source hashes and cleanup were verified.

The initial Mac baseline passed five cases and timed out in three under contention, so it is not used for the speed comparison. The isolated Linux baseline and candidate both passed all eight. Formatting, complete changed-file checks, and managed review throughP2 passed. After rebasing onto main, the candidate file still matches the exact Linux-tested hash.
