### PR TITLE
test: make suppression inventory independent of line numbers

### DIFF
--- a/test/scripts/type-suppression-inventory.test.ts
+++ b/test/scripts/type-suppression-inventory.test.ts
@@ -69,25 +69,25 @@ describe("type suppression inventory", () => {
     expect(
       report.findings
         .filter((finding) => finding.kind === "expect-error")
-        .map((finding) => `${finding.file}:${finding.line}:${finding.excerpt}`),
+        .map((finding) => `${finding.file}:${finding.excerpt}`),
     ).toEqual([
-      "extensions/openai/realtime-quicksilver-session-lifecycle.test.ts:30:@ts-expect-error JavaScript callers must still fail before reserving a native session.",
-      "src/infra/kysely-sync.types.test.ts:49:@ts-expect-error Kysely checks selected column string literals.",
-      "src/infra/kysely-sync.types.test.ts:52:@ts-expect-error Kysely checks table string literals.",
-      "src/infra/kysely-sync.types.test.ts:55:@ts-expect-error Kysely checks where-reference string literals.",
-      "src/infra/kysely-sync.types.test.ts:58:@ts-expect-error Kysely checks grouped column string literals.",
-      "src/infra/kysely-sync.types.test.ts:61:@ts-expect-error Kysely checks order references and selected aliases.",
-      "src/infra/net/fetch-guard.socks.test.ts:364:@ts-expect-error Undici's Node TLS intersection rejects its runtime-valid null timeout.",
-      "src/infra/net/fetch-guard.socks.test.ts:375:@ts-expect-error Undici's Node TLS intersection rejects its runtime-valid null timeout.",
-      "src/infra/net/fetch-guard.socks.test.ts:378:@ts-expect-error Undici's Node TLS intersection rejects its runtime-valid null timeout.",
-      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:8:@ts-expect-error Trigger eligibility is only supported for before_agent_reply.",
-      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:10:@ts-expect-error An empty trigger list cannot prove that a hook is inactive.",
-      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:28:@ts-expect-error Tool authority is only supported for before_prompt_build.",
-      "src/plugins/registry.diagnostics.test.ts:47:@ts-expect-error JavaScript plugins may omit the required supplement builder.",
-      "src/plugins/registry.diagnostics.test.ts:49:@ts-expect-error JavaScript plugins may omit the required hosted-media resolver.",
-      "src/plugins/registry.diagnostics.test.ts:51:@ts-expect-error Unknown JavaScript hook names must produce a diagnostic.",
-      "src/plugins/registry.diagnostics.test.ts:247:@ts-expect-error Untyped hook input reaches the existing rejection/coercion path.",
-      "src/plugins/registry.diagnostics.test.ts:281:@ts-expect-error Closed registration must stop before coercing untyped hook input.",
+      "extensions/openai/realtime-quicksilver-session-lifecycle.test.ts:@ts-expect-error JavaScript callers must still fail before reserving a native session.",
+      "src/infra/kysely-sync.types.test.ts:@ts-expect-error Kysely checks selected column string literals.",
+      "src/infra/kysely-sync.types.test.ts:@ts-expect-error Kysely checks table string literals.",
+      "src/infra/kysely-sync.types.test.ts:@ts-expect-error Kysely checks where-reference string literals.",
+      "src/infra/kysely-sync.types.test.ts:@ts-expect-error Kysely checks grouped column string literals.",
+      "src/infra/kysely-sync.types.test.ts:@ts-expect-error Kysely checks order references and selected aliases.",
+      "src/infra/net/fetch-guard.socks.test.ts:@ts-expect-error Undici's Node TLS intersection rejects its runtime-valid null timeout.",
+      "src/infra/net/fetch-guard.socks.test.ts:@ts-expect-error Undici's Node TLS intersection rejects its runtime-valid null timeout.",
+      "src/infra/net/fetch-guard.socks.test.ts:@ts-expect-error Undici's Node TLS intersection rejects its runtime-valid null timeout.",
+      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:@ts-expect-error Trigger eligibility is only supported for before_agent_reply.",
+      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:@ts-expect-error An empty trigger list cannot prove that a hook is inactive.",
+      "src/plugin-sdk/plugin-entry.reply-trigger.test.ts:@ts-expect-error Tool authority is only supported for before_prompt_build.",
+      "src/plugins/registry.diagnostics.test.ts:@ts-expect-error JavaScript plugins may omit the required supplement builder.",
+      "src/plugins/registry.diagnostics.test.ts:@ts-expect-error JavaScript plugins may omit the required hosted-media resolver.",
+      "src/plugins/registry.diagnostics.test.ts:@ts-expect-error Unknown JavaScript hook names must produce a diagnostic.",
+      "src/plugins/registry.diagnostics.test.ts:@ts-expect-error Untyped hook input reaches the existing rejection/coercion path.",
+      "src/plugins/registry.diagnostics.test.ts:@ts-expect-error Closed registration must stop before coercing untyped hook input.",
     ]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The suppression inventory fails after unrelated line insertions, forcing updates such as #139747 even when no suppression changed.

## Why This Change Was Made

Compare each suppression's filename and exact directive text. Ordered array equality preserves all 17 entries and duplicate counts, while the inventory still reports line numbers for diagnostics.

## User Impact

No production changes. New or changed directives and unchecked casts still fail. This independent extraction from #135599 changes one test file; production and test LOC deltas are both zero.

## Evidence

Both inventory tests, formatting, and fresh independent P2 review passed. An initial local scan hit the existing 120-second deadline under heavy host load. After the concurrent review finished, the identical command passed in 11 seconds without source, deadline, or coverage changes. Exact-head CI remains the landing gate.
