### PR TITLE
refactor(plugins): remove repetitive policy headers

### DIFF
--- a/extensions/deepinfra/provider-policy-api.ts
+++ b/extensions/deepinfra/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Deepinfra API module exposes the plugin public contract.
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 
 /**

--- a/extensions/deepseek/provider-policy-api.ts
+++ b/extensions/deepseek/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Deepseek API module exposes the plugin public contract.
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { DEEPSEEK_MODEL_CATALOG } from "./models.js";

--- a/extensions/fireworks/provider-policy-api.ts
+++ b/extensions/fireworks/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Fireworks API module exposes the plugin public contract.
 import { resolveFireworksThinkingProfile } from "./thinking-policy.js";
 
 export function resolveThinkingProfile(params: {

--- a/extensions/github-copilot/provider-policy-api.ts
+++ b/extensions/github-copilot/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Github Copilot API module exposes the plugin public contract.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
 import { resolveCopilotThinkingLevelMap } from "./model-metadata.js";
 

--- a/extensions/google/provider-policy-api.ts
+++ b/extensions/google/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Google API module exposes the plugin public contract.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-types";
 import { normalizeGoogleProviderConfig, resolveGoogleThinkingProfile } from "./provider-policy.js";

--- a/extensions/ollama/provider-policy-api.ts
+++ b/extensions/ollama/provider-policy-api.ts
@@ -3,7 +3,6 @@ import {
   findNormalizedProviderValue,
   normalizeProviderId,
 } from "@openclaw/model-catalog-core/provider-id";
-// Ollama API module exposes the plugin public contract.
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderNormalizeResolvedModelContext,

--- a/extensions/openai/provider-policy-api.ts
+++ b/extensions/openai/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Openai API module exposes the plugin public contract.
 import type { ProviderDefaultThinkingPolicyContext } from "openclaw/plugin-sdk/core";
 import type { ProviderNormalizeResolvedModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import type {

--- a/extensions/opencode/provider-policy-api.ts
+++ b/extensions/opencode/provider-policy-api.ts
@@ -1,5 +1,4 @@
 import { resolveClaudeThinkingProfile } from "openclaw/plugin-sdk/claude-model-runtime";
-// Opencode API module exposes the plugin public contract.
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,

--- a/extensions/openrouter/provider-policy-api.ts
+++ b/extensions/openrouter/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Openrouter API module exposes the plugin public contract.
 import { resolveOpenRouterThinkingProfile } from "./thinking-policy.js";
 
 export function resolveThinkingProfile(params: { provider?: string; modelId: string }) {

--- a/extensions/vllm/provider-policy-api.ts
+++ b/extensions/vllm/provider-policy-api.ts
@@ -1,2 +1,1 @@
-// Vllm API module exposes the plugin public contract.
 export { resolveThinkingProfile } from "./thinking-policy.js";

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -1,4 +1,3 @@
-// Xai API module exposes the plugin public contract.
 import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Eleven provider-policy modules contain the same generic sentence stating that the module exposes its plugin contract. Two copies now sit between imports. These comments repeat the filename without explaining a constraint.

## Why This Change Was Made

Remove those eleven sentences while preserving every other source byte. Keep the neighboring comments that explain cold loading, provider registration, route ownership, and compatibility constraints. The comments originated in documentation passes; no maintained generator or consumer requires them.

## User Impact

No behavior, export, configuration, or dependency changes. Production files lose eleven comment lines; executable-code and test deltas are zero.

## Evidence

- All 21 modules in this artifact family were inspected; the ten unmodified siblings and each changed file's remainder are byte-for-byte unchanged.
- All 25 selected changed-check stages passed, including both plugin typecheck lanes, formatting/lint, import and export guards, and five existing doctor contract tests across two files.
- No new tests or provider calls were added for this comment-only cleanup.
- Final independent source review found no actionable issues in the frozen comment-only patch.
