### PR TITLE
fix(test): verify UI object lifetimes under Bun

### DIFF
--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment node
 // Control UI tests cover build chat items behavior.
-import { setImmediate } from "node:timers/promises";
 import { queryObjects } from "node:v8";
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
@@ -10,6 +9,7 @@ import type { MessageGroup } from "../../lib/chat/chat-types.ts";
 import { normalizeMessage } from "../../lib/chat/message-normalizer.ts";
 import { summarizeToolGroup } from "../../lib/chat/tool-call-grouping.ts";
 import * as toolCards from "../../lib/chat/tool-cards.ts";
+import { collectGarbageForTest } from "../../test-helpers/garbage-collection.ts";
 import { coalesceAgentRunFrames } from "./chat-agent-run-grouping.ts";
 import * as threadItems from "./chat-thread-items.ts";
 import {
@@ -4856,19 +4856,27 @@ describe("tool expansion state", () => {
     const paneId = "released-pane";
     const sessionKey = "released-session";
     const populatePane = () => {
-      const items = buildCachedChatItems(
-        createProps({ paneId, sessionKey, messages: [new TranscriptMessage()] }),
-      );
+      const message = new TranscriptMessage();
+      const items = buildCachedChatItems(createProps({ paneId, sessionKey, messages: [message] }));
       syncToolCardExpansionState(sessionKey, items, true);
+      return {
+        messageReference: new WeakRef(message),
+        collectionControl: new WeakRef({ unowned: true }),
+      };
     };
     try {
-      populatePane();
-      expect(queryObjects(TranscriptMessage)).toBe(1);
+      const { messageReference, collectionControl } = populatePane();
+      await collectGarbageForTest(() => {
+        expect(queryObjects(TranscriptMessage)).toBe(1);
+      });
+      expect(collectionControl.deref()).toBeUndefined();
+      expect(messageReference.deref() !== undefined).toBe(true);
 
       resetChatThreadState(paneId);
-      await setImmediate();
-
-      expect(queryObjects(TranscriptMessage)).toBe(0);
+      await collectGarbageForTest(() => {
+        expect(queryObjects(TranscriptMessage)).toBe(0);
+      });
+      expect(messageReference.deref()).toBeUndefined();
       expect([...getExpandedToolCards(sessionKey).values()]).toEqual([true]);
     } finally {
       resetChatThreadState();

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -1,9 +1,9 @@
 /* @vitest-environment jsdom */
 
-import { setImmediate } from "node:timers/promises";
 import { queryObjects } from "node:v8";
 import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { collectGarbageForTest } from "../../test-helpers/garbage-collection.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { MAX_CACHED_CHAT_SESSIONS } from "./session-cache.ts";
 import {
@@ -278,7 +278,7 @@ describe("persistent chat session snapshots", () => {
     store.write(sessionKey, snapshot("persisted"));
     await store.flush();
 
-    const evicted = await (async () => {
+    const { evicted, collectionControl } = await (async () => {
       const hydrated = await store.read(sessionKey);
       if (!hydrated) {
         throw new Error("expected hydrated snapshot");
@@ -289,7 +289,10 @@ describe("persistent chat session snapshots", () => {
         { sessionKey },
         hydrated,
       );
-      return new WeakRef(hydrated);
+      return {
+        evicted: new WeakRef(hydrated),
+        collectionControl: new WeakRef({ unowned: true }),
+      };
     })();
     for (let index = 0; index < MAX_CACHED_CHAT_SESSIONS; index += 1) {
       cacheChatSessionSnapshot(
@@ -301,10 +304,10 @@ describe("persistent chat session snapshots", () => {
     }
     await store.flush();
     expect(memoryCache.has(sessionKey)).toBe(false);
-    // Weak references keep their target alive for the current job. Move to the
-    // next turn before the V8 heap census forces a complete collection.
-    await setImmediate();
-    queryObjects(SessionSnapshotStore);
+    await collectGarbageForTest(() => {
+      queryObjects(SessionSnapshotStore);
+    });
+    expect(collectionControl.deref()).toBeUndefined();
     expect(evicted.deref()).toBeUndefined();
     expect(store.readSavedAt("agent:main:newer-0")).not.toBeNull();
   });

--- a/ui/src/test-helpers/garbage-collection.ts
+++ b/ui/src/test-helpers/garbage-collection.ts
@@ -1,0 +1,13 @@
+import { setImmediate } from "node:timers/promises";
+
+declare const Bun: { gc(force: boolean): void };
+
+export async function collectGarbageForTest(collectInNode: () => void): Promise<void> {
+  // WeakRef targets stay alive for the current job, even without a strong owner.
+  await setImmediate();
+  if (process.versions.bun) {
+    Bun.gc(true);
+  } else {
+    collectInNode();
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes memory-regression tests that depended on Node's V8 heap census when running under Bun, leaving the Bun test run unable to verify the intended object lifetimes.

## Why This Change Was Made

A test-only collection helper advances beyond the current WeakRef job, then uses the existing Node collection/census path or Bun's native forced collection. The tests track the exact fixture objects and include unowned controls that prove collection happened.

## User Impact

Developers can verify that closed chat panes and evicted snapshots release their objects under Bun. Production retention behavior is unchanged.

## Evidence

- All 274 focused tests passed on Node and 274 on true Bun.
- Restoring each historical strong-reference edge made both selected Bun leak tests fail at the retained-object assertions while collection controls passed. Those temporary production mutations were fully restored.
- Complete changed-file gate and P0–P2 review passed.
- Bun verifies the exact fixture lifetimes; Node also retains its broader real constructor census. No claim of a Bun-wide constructor census is made.
- Runs used the maintained UI unit configuration, one worker, and the supported disabled filesystem module cache. No tooling overlay or production changes were retained.
- The wider Bun compatibility campaign remains in progress.
