### PR TITLE
fix: avoid unrelated prompt decoding in session detail reads

### DIFF
--- a/src/gateway/server-methods/sessions-read-by-key.ts
+++ b/src/gateway/server-methods/sessions-read-by-key.ts
@@ -38,6 +38,7 @@ export const sessionByKeyReadHandlers: GatewayRequestHandlers = {
     const { target, storePath, store, entry } = loadSessionEntriesForTarget({
       key,
       cfg,
+      includeStoreChildEntries: true,
       ...(requestedAgent.agentId ? { agentId: requestedAgent.agentId } : {}),
     });
     const boundaryFilter = createRoleVisibilityFilter(client, cfg);

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import * as pluginHostState from "../../plugins/host-hook-state.js";
 import { recordAgentProvenance } from "../../state/agent-provenance.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -324,6 +325,70 @@ test("sessions.resolve preserves presentation facts on unique and ambiguous wire
       ],
     },
   });
+});
+
+test("sessions.describe retains full target and child metadata without decoding unrelated prompts", async () => {
+  const agentId = "main";
+  const sessionKey = "agent:main:describe-target";
+  const storePath = resolveStorePath(undefined, { agentId });
+  const updatedAt = Date.now();
+  const skillsSnapshot = { prompt: "complete target prompt", skills: [] };
+  await upsertSessionEntryCore(
+    { agentId, sessionKey, storePath },
+    { sessionId: "describe-target", updatedAt, label: "Target", skillsSnapshot },
+  );
+  for (const [name, relation] of [
+    ["child-b", "spawnedBy"],
+    ["child-a", "parentSessionKey"],
+  ] as const) {
+    await upsertSessionEntryCore(
+      { agentId, sessionKey: `agent:main:${name}`, storePath },
+      { sessionId: name, updatedAt, status: "running", [relation]: sessionKey },
+    );
+  }
+  const unrelatedPrompt = "unrelated describe prompt".repeat(512);
+  for (let index = 0; index < 4; index++) {
+    await upsertSessionEntryCore(
+      { agentId, sessionKey: `agent:main:unrelated-${index}`, storePath },
+      {
+        sessionId: `unrelated-${index}`,
+        updatedAt,
+        skillsSnapshot: { prompt: unrelatedPrompt, skills: [] },
+      },
+    );
+  }
+  await directSessionReq("sessions.describe", { key: sessionKey });
+  const parse = JSON.parse;
+  let unrelatedDecodes = 0;
+  const parsed = vi.spyOn(JSON, "parse").mockImplementation((value, reviver) => {
+    if (typeof value === "string" && value.includes(unrelatedPrompt)) unrelatedDecodes++;
+    return parse(value, reviver);
+  });
+  const projected = vi.spyOn(pluginHostState, "projectPluginSessionExtensionsSync");
+  try {
+    const described = await directSessionReq("sessions.describe", { key: sessionKey });
+    expect(described).toMatchObject({
+      ok: true,
+      payload: {
+        session: {
+          key: sessionKey,
+          sessionId: "describe-target",
+          label: "Target",
+          childSessions: ["agent:main:child-a", "agent:main:child-b"],
+        },
+      },
+    });
+    expect(projected).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey,
+        entry: expect.objectContaining({ skillsSnapshot }),
+      }),
+    );
+    expect(unrelatedDecodes).toBe(0);
+  } finally {
+    projected.mockRestore();
+    parsed.mockRestore();
+  }
 });
 
 test("unknown-agent session reads return missing results without provisioning an agent", async () => {

--- a/src/gateway/server-methods/sessions-read.test.ts
+++ b/src/gateway/server-methods/sessions-read.test.ts
@@ -361,7 +361,9 @@ test("sessions.describe retains full target and child metadata without decoding 
   const parse = JSON.parse;
   let unrelatedDecodes = 0;
   const parsed = vi.spyOn(JSON, "parse").mockImplementation((value, reviver) => {
-    if (typeof value === "string" && value.includes(unrelatedPrompt)) unrelatedDecodes++;
+    if (typeof value === "string" && value.includes(unrelatedPrompt)) {
+      unrelatedDecodes++;
+    }
     return parse(value, reviver);
   });
   const projected = vi.spyOn(pluginHostState, "projectPluginSessionExtensionsSync");

--- a/src/gateway/server-methods/sessions-shared.ts
+++ b/src/gateway/server-methods/sessions-shared.ts
@@ -153,15 +153,20 @@ export function loadSessionEntriesForTarget(params: {
   key: string;
   cfg: OpenClawConfig;
   agentId?: string;
+  includeStoreChildEntries?: boolean;
 }) {
   const target = resolveGatewaySessionStoreTargetWithStore({
     cfg: params.cfg,
     key: params.key,
     clone: false,
+    exactRead: true,
+    includeStoreChildEntries: params.includeStoreChildEntries,
     ...(params.agentId ? { agentId: params.agentId } : {}),
   });
   const store = target.store;
-  const entry = resolveCanonicalSessionEntryFromStoreKeys(store, target.storeKeys);
+  const entry = isInternalSessionEffectsKey(target.canonicalKey)
+    ? undefined
+    : resolveCanonicalSessionEntryFromStoreKeys(store, target.storeKeys);
   return { target, storePath: target.storePath, store, entry };
 }
 

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where loading one session's details repeatedly decodes saved prompts from unrelated sessions in the same agent store. The unnecessary synchronous work grows with the rest of the agent's session history.

## Why This Change Was Made

Use the existing exact session reader, retaining the complete requested entry and its direct children for `sessions.describe`. The shared single-session loader also stops enumerating unrelated entries for transcript reads and Control UI previews, while preserving internal-entry hiding. No new cache, storage representation, schema, configuration, or protocol is introduced.

The PR also aligns a pagination test fixture with projection result fields already renamed on main, fixing the observed CI type error while retaining all pagination assertions.

## User Impact

Session details retain their full metadata, plugin projection inputs, and ordered child links while avoiding unrelated prompt decoding. The production change is seven added lines and one removed line; it routes the existing full-entry and child-read contracts through the single-session owner.

## Evidence

- The permanent regression fails on the original production code with four unrelated prompt decodes and passes with zero after the repair. It also checks the complete target prompt reaches the plugin projector and that both persisted child relationship forms remain ordered correctly.
- An earlier isolated diagnostic observed 480 unrelated row decodes (15,819,300 bytes) across six warmed handler calls before the change, and zero afterward. Those instrumented observations establish eliminated work, not end-to-end latency.
- The refreshed session-read, visibility, single-row cache, Swarm, and history-state suites pass: 80 tests across five files.
- The full four-file changed-code gate passes on the final source tree, including core and core-test type checking, lint, storage guards, and runtime import-cycle checks.
- Independent P2 review of the complete four-file candidate found no actionable issue.
- Separately built baseline and candidate Gateways passed the real WebSocket workflow in an isolated mock-provider environment, with two authenticated clients, small and large stores, full target-row equality, both direct-child relationship forms, transcript previews, and successful cleanup. Both canonical full typed builds passed; an independent artifact review verified source/build identity and unchanged runtime output fingerprints. This native comparison was captured at `1115779843dc`, before the final main refresh; both changed production files are byte-identical on the refreshed candidate, which separately passed the tests and full gate above.

The synthetic loopback run also triggered automatic restart recovery for the seeded running children. Its timing tails are therefore not used as causal performance evidence; this PR claims eliminated unrelated decoding and preserved behavior, not a production latency or event-loop-stall percentage.
