### PR TITLE
refactor(plugins): simplify diagnostics and state wrappers

### DIFF
--- a/src/plugins/loader-records.ts
+++ b/src/plugins/loader-records.ts
@@ -150,10 +150,7 @@ export function recordPluginConfiguredUnavailable(params: {
 export function formatAutoEnabledActivationReason(
   reasons: readonly string[] | undefined,
 ): string | undefined {
-  if (!reasons || reasons.length === 0) {
-    return undefined;
-  }
-  return reasons.join("; ");
+  return reasons?.length ? reasons.join("; ") : undefined;
 }
 
 // A plugin-thrown error may expose throwing `cause`/`code` accessors; diagnostics inside the
@@ -271,12 +268,9 @@ export function formatPluginFailureSummary(failedPlugins: PluginRecord[]): strin
   const grouped = new Map<NonNullable<PluginRecord["failurePhase"]>, string[]>();
   for (const plugin of failedPlugins) {
     const phase = plugin.failurePhase ?? "load";
-    const ids = grouped.get(phase);
-    if (ids) {
-      ids.push(plugin.id);
-      continue;
-    }
-    grouped.set(phase, [plugin.id]);
+    const ids = grouped.get(phase) ?? [];
+    ids.push(plugin.id);
+    grouped.set(phase, ids);
   }
   return [...grouped.entries()].map(([phase, ids]) => `${phase}: ${ids.join(", ")}`).join("; ");
 }

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -6,14 +6,11 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import {
   createPluginBlobStore,
   type OpenBlobStoreOptions,
-  type PluginBlobStore,
 } from "../plugin-state/plugin-blob-store.js";
 import {
   createPluginStateKeyedStore,
   createPluginStateSyncKeyedStore,
   type OpenKeyedStoreOptions,
-  type PluginStateKeyedStore,
-  type PluginStateSyncKeyedStore,
 } from "../plugin-state/plugin-state-store.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { formatPluginTrustRefusal } from "./plugin-trust.js";
@@ -219,19 +216,15 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
           const baseState = getRuntimeProperty();
           return {
             ...baseState,
-            openBlobStore: <TMetadata>(
-              options: OpenBlobStoreOptions,
-            ): PluginBlobStore<TMetadata> => {
+            openBlobStore: <TMetadata>(options: OpenBlobStoreOptions) => {
               assertTrustedPluginRuntime("openBlobStore");
               return createPluginBlobStore<TMetadata>(pluginId, options);
             },
-            openKeyedStore: <T>(options: OpenKeyedStoreOptions): PluginStateKeyedStore<T> => {
+            openKeyedStore: <T>(options: OpenKeyedStoreOptions) => {
               assertTrustedPluginRuntime("openKeyedStore");
               return createPluginStateKeyedStore<T>(pluginId, options);
             },
-            openSyncKeyedStore: <T>(
-              options: OpenKeyedStoreOptions,
-            ): PluginStateSyncKeyedStore<T> => {
+            openSyncKeyedStore: <T>(options: OpenKeyedStoreOptions) => {
               assertTrustedPluginRuntime("openSyncKeyedStore");
               return createPluginStateSyncKeyedStore<T>(pluginId, options);
             },


### PR DESCRIPTION
## What Problem This Solves

Plugin diagnostics and state-store wrappers carry redundant branches and type declarations that make their owners harder to maintain.

## Why This Change Was Made

Failure diagnostics share one grouping path while preserving phase and plugin order. State-store wrappers infer return types from their typed factories and retain the runtime interface check.

## User Impact

No runtime behavior or public API changes. This independent extraction from #135599 removes 13 production lines across two files.

## Evidence

349 comparisons of the actual diagnostic helpers produced identical output. The complete registry-runtime module compiled to byte-identical JavaScript. The full changed-file gate and independent review passed, including production/test typechecks, typed lint, unused-export scans, and architecture/storage guards. No tests were added for the behavior-preserving cleanup.
