### PR TITLE
perf(tui): reuse resolved tool card display details

### DIFF
--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -13,6 +13,48 @@ function renderToolOutput(text: string, width: number) {
 }
 
 describe("ToolExecutionComponent", () => {
+  it.each([
+    {
+      tool: "read",
+      initial: { path: "before.txt", limit: 3 },
+      updated: { path: "after.txt", offset: 8 },
+      before: "first 3 lines of before.txt",
+      after: "from line 8 in after.txt",
+    },
+    {
+      tool: "custom_tool",
+      initial: { custom: "before" },
+      updated: { custom: "after" },
+      before: '{"custom":"before"}',
+      after: '{"custom":"after"}',
+    },
+  ])("keeps $tool arguments current through partial and final results", (fixture) => {
+    const component = new ToolExecutionComponent(fixture.tool, fixture.initial);
+    const render = () => component.render(120).map(normalizeTestText).join("\n");
+    expect(render()).toContain(fixture.before);
+
+    component.setArgs(fixture.updated);
+    component.setPartialResult({ content: [{ type: "text", text: "partial output" }] });
+    expect(render()).toContain(fixture.after);
+    expect(render()).not.toContain(fixture.before);
+    expect(render()).toContain("(running)");
+
+    component.setResult({ content: [{ type: "text", text: "final output" }] });
+    expect(render()).toContain(fixture.after);
+    expect(render()).toContain("final output");
+    expect(render()).not.toContain("(running)");
+  });
+
+  it("retains display redaction when rendering command arguments", () => {
+    const component = new ToolExecutionComponent("exec", {
+      command: "/opt/custom/bin/deploy --aws-key AKIDABCDEFGHIJKLMNOP1234567890",
+    });
+    const rendered = component.render(120).map(normalizeTestText).join("\n");
+
+    expect(rendered).not.toContain("AKIDABCDEFGHIJKLMNOP1234567890");
+    expect(rendered).toContain("AKIDAB...7890");
+  });
+
   it.each(
     [
       { source: "    # heading\n    command --flag", literal: "# heading" },

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -73,9 +73,7 @@ class ToolOutputComponent extends HyperlinkMarkdown {
 }
 
 // Prefer curated display summaries, then fall back to sanitized JSON args.
-function formatArgs(toolName: string, args: unknown): string {
-  const display = resolveToolDisplay({ name: toolName, args });
-  const detail = formatToolDetail(display);
+function formatArgs(args: unknown, detail: string | undefined): string {
   if (detail) {
     return tuiFormatters.sanitizeRenderableText(detail);
   }
@@ -183,7 +181,7 @@ export class ToolExecutionComponent extends Container {
     );
     this.header.setText(theme.toolTitle(theme.bold(title)));
 
-    const argLine = formatArgs(this.toolName, this.args);
+    const argLine = formatArgs(this.args, formatToolDetail(display));
     this.argsLine.setText(argLine ? theme.dim(argLine) : theme.dim(" "));
 
     const raw = extractText(this.result);


### PR DESCRIPTION
## What Problem This Solves

TUI tool cards do redundant display preparation each time arguments, partial output, completion, or expansion updates the card. This adds avoidable work while tools stream results.

## Why This Change Was Made

Reuse the display already resolved by the card's refresh method when formatting its argument detail. Keep redaction, sanitized JSON fallback, setter ordering, and fresh per-update resolution unchanged; no cache or new API. Production code shrinks by two lines.

## User Impact

Tool cards retain the same titles, arguments, output, and expansion behavior with less repeated preparation. The measured benefit is strongest for exec and JSON-fallback card construction; this does not claim faster Gateway/model turns or lower memory use.

## Evidence

Normal repository test wrapper: 94/94 tests passed across complete tool-execution, chat-log, and chat-log-run-state files. Three new card-boundary cases cover changing curated/JSON arguments, partial/final transitions, and command redaction. Independent source review and canonical P2 autoreview found no actionable findings. Tests add 42 lines.

One fixed B0/C0/C1/B1 cohort at base `6c33a2f3b9b2b1c2ca78293f178a04aaa5e637b1`, Node 26.8.1: 7 real card construction/update/render operations, 5,628 calls, 672 retained batch means. All reference/warmup frames match byte-for-byte, including ANSI; every timed operation passed its output assertion. All four processes exited 0 and closed. No terminal I/O or live Gateway was involved in this component measurement.

| Card operation | Forward median change | Reverse median change |
| --- | ---: | ---: |
| Read construction/render | -5.04% | +1.04% |
| Exec construction/render | -28.66% | -28.04% |
| JSON fallback construction/render | -18.69% | -21.77% |
| Web query updates/render | -1.57% | -6.16% |
| Large partial/final results/render | +0.54% | -1.26% |
| Expansion/recollapse/render | -1.68% | -2.05% |
| Circular/empty arguments/error/render | -1.67% | +2.73% |

All 11 adverse comparisons remain recorded (3 medians, 3 means, 5 maximum batch means). The largest adverse maximum batch mean was large-result rendering in reverse order: +30.79%/+346µs; other adverse maxima were below 0.49%. Large-result means increased 1.06%/0.049%, and the reverse circular/empty control mean increased 2.84%. Whole-process wall time changed -10.30%/+1.09%; kernel maxRSS increased about 1.18% in both comparisons. No preset percentage threshold or universal speedup claim.

All 29 normal changed-check stages passed on refreshed base `42162ca08fef99539bf7e97622ef8f33d0087d9e`, including formatting, core/test typechecks, lint, and all three Knip scans. The measured owner, tests, direct display dependencies, package manifest and lockfile were unchanged by the fast-forward; the exact two-file patch was retained without formatting edits. Numerical results above remain attributed to the original `6c33a2f3b9b2b1c2ca78293f178a04aaa5e637b1` base. Exact-head CI remains pending.

Before publication, this unchanged patch was fast-forwarded to `5b7e42bc899e72b3db598b41545fd3454e38f499` to inherit upstream #139747, the unrelated suppression-inventory CI repair. Local checks retain their `42162` attribution, and numeric results retain their stated original source pair. Required exact-head CI remains a landing gate.

Matched real-loop proof also passed before and after: the existing fake-backend PTY tool-card chronology test passed once per variant (68 other tests unselected), preserving running partial output, final tool result and surrounding assistant order. Both observed process trees closed, and the published source was restored clean. The attached pictures are inspected native Terminal **replays of captured real PTY output**, with a synthetic backend—not screenshots of a live Gateway. Two capture refusals are retained; the documented explicit local capture route succeeded without changing daemon or screen-recording permissions.

![Before: native replay of real TUI tool-card output with a fake backend](https://github.com/user-attachments/assets/4c6ab4c1-db7c-4a1c-a6a6-59dbaffd2324)

![After: native replay of the same real TUI tool-card flow with a fake backend](https://github.com/user-attachments/assets/540b7931-5e2f-4429-8fe7-11c1ef7ad6a0)