### PR TITLE
fix(ui): make agent automations editable from Settings

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1563,6 +1563,8 @@ export const en: TranslationMap & {
       agentJobsSubtitle: "Scheduled jobs targeting this agent.",
       noJobs: "No jobs assigned.",
       runNow: "Run Now",
+      edit: "Edit",
+      editJob: "Edit {name}",
     },
     files: {
       emptyDraft: "Empty draft",

--- a/ui/src/pages/agents/panels-status-files.ts
+++ b/ui/src/pages/agents/panels-status-files.ts
@@ -9,6 +9,7 @@ import type {
   CronJob,
   CronStatus,
 } from "../../api/types.ts";
+import { pathForRoute } from "../../app-route-paths.ts";
 import { renderCronJobsPagination } from "../../components/cron-jobs-pagination.ts";
 import { renderHubTabs } from "../../components/hub-tabs.ts";
 import { icons } from "../../components/icons.ts";
@@ -265,6 +266,7 @@ export function renderAgentChannels(params: {
 }
 
 export function renderAgentCron(params: {
+  basePath: string;
   context: AgentContext;
   agentId: string;
   jobs: CronJob[];
@@ -346,6 +348,13 @@ export function renderAgentCron(params: {
                     kind: job.enabled ? "ok" : "warn",
                     label: job.enabled ? t("common.enabled") : t("common.disabled"),
                   })}
+                  <a
+                    class="btn btn--sm"
+                    href=${`${pathForRoute("cron", params.basePath)}?job=${encodeURIComponent(job.id)}`}
+                    aria-label=${t("agents.cronPanel.editJob", { name: job.name })}
+                  >
+                    ${t("agents.cronPanel.edit")}
+                  </a>
                   <button
                     class="btn btn--sm"
                     ?disabled=${!params.canRunNow || !job.enabled}

--- a/ui/src/pages/agents/view.cron-edit.test.ts
+++ b/ui/src/pages/agents/view.cron-edit.test.ts
@@ -1,0 +1,32 @@
+import { render } from "lit";
+import { expect, it } from "vitest";
+import type { CronJob } from "../../api/types.ts";
+import { createAgentViewTestProps as createProps } from "./agents-view.test-helpers.ts";
+import { renderAgents } from "./view.ts";
+
+it.each([true, false])("links agent automations to the shared editor (enabled=%s)", (enabled) => {
+  const container = document.createElement("div");
+  const job: CronJob = {
+    id: "job /?&",
+    name: "Weekly report",
+    agentId: "alpha",
+    enabled,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "Summarize notes." },
+    state: {},
+  };
+  const props = createProps({
+    activePanel: "cron",
+    selectedAgentId: "alpha",
+    basePath: "/gateway",
+  });
+  render(renderAgents({ ...props, cron: { ...props.cron, jobs: [job] } }), container);
+  const link = [...container.querySelectorAll("a")].find(
+    (entry) => entry.textContent?.trim() === "Edit",
+  );
+  expect(link?.getAttribute("href")).toBe("/gateway/automations?job=job%20%2F%3F%26");
+});

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -493,6 +493,7 @@ export function renderAgents(props: AgentsProps) {
                   ${
                     props.activePanel === "cron"
                       ? renderAgentCron({
+                          basePath: props.basePath,
                           context: buildAgentContext(
                             selectedAgent,
                             props.config.form,

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1091,6 +1091,7 @@ openclaw-session-owner-chip {
 }
 
 .btn {
+  color: inherit;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -258,6 +258,13 @@ describeCursorPolicy("Control UI cursor policy", () => {
       await page.evaluate((mode) => {
         document.documentElement.dataset.themeMode = mode;
       }, theme);
+      expect(
+        await page.locator("#new-tab-link").evaluate((element) => getComputedStyle(element).color),
+      ).toBe(
+        await page
+          .locator("#new-tab-button")
+          .evaluate((element) => getComputedStyle(element).color),
+      );
       const people = await page.locator(".sidebar-online__person").all();
       expect(people).toHaveLength(2);
       for (const person of people) {


### PR DESCRIPTION
Closes #139781

## What Problem This Solves

Fixes an issue where users opening Settings → Agents → Automations could run a job but had no way to open its editor. The community report made editing appear to be CLI-only, although the main Automations screen already supports it.

## Why This Change Was Made

Add an Edit link beside Run Now that opens the selected job in the existing Automations editor. The link preserves the configured base path and encodes the job ID. The existing editor continues to own loading, permissions, validation, and saving.

## User Impact

Users can reach editing directly from an agent's automation inventory, including for paused jobs. No new form, persistence path, configuration, or Gateway API is introduced.

## Evidence

- Regression reproduced before the fix for enabled and paused jobs; 57 focused tests now pass across `view.cron-edit.test.ts`, `view.test.ts`, and `cron-page.test.ts`.
- UI typecheck, targeted Oxfmt/Oxlint, `ui:i18n:verify`, and `ui:build` pass.
- Real Chromium + isolated Gateway: opened the agent panel, clicked Edit on a paused job, changed its name, saved, and independently read the stored job through `automations get`. The name changed and the job remained paused.
- Browser proof used the existing built Gateway with isolated temporary state and the candidate UI bundle. A fresh Gateway build encountered an unrelated Worker bundle guard failure (`yargs-parser` retained as a runtime import); no Gateway code changes are included here.
- Independent autoreview: scoped-clean at its default P0 threshold.
- Production delta: +12 lines for navigation/localized labels; regression coverage: +32 lines. Reuses the canonical editor.

Before:

![Agent automation with only Run Now](https://github.com/user-attachments/assets/c5260275-c781-4833-a222-ccd663ca2460)

After:

![Agent automation with Edit beside Run Now](https://github.com/user-attachments/assets/7fa8f4e5-78c6-480c-8a4b-c002c26081f3)
