### PR TITLE
fix: stop Gateway shutdown waiting on abandoned setup prompts

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -243,6 +243,11 @@ An ordinary stop logs `active-work drain settled; beginning server close` before
 teardown, including after a drain timeout or failure. Diagnostics do not change
 drain budgets or the service manager's stop deadline.
 
+A client disconnect leaves interactive setup available for reconnect. A Gateway
+stop or restart closes setup prompts before draining work. Settings writes already
+in progress may finish, but setup will not wait for another answer during shutdown.
+After the Gateway starts again, reopen setup and check the saved settings.
+
 ## Query a running Gateway
 
 All query commands use WebSocket RPC.

--- a/src/gateway/gateway-wizard-cancel.e2e.test.ts
+++ b/src/gateway/gateway-wizard-cancel.e2e.test.ts
@@ -3,12 +3,24 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { WizardStartResult } from "../../packages/gateway-protocol/src/index.js";
-import { createDeferred } from "../../test/helpers/promise.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { resetConfigOverrides } from "../config/runtime-overrides.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
 import { resetAgentEventsForTest } from "../infra/agent-events.js";
+import { waitForGatewayActiveWork } from "../infra/gateway-active-work.js";
+import {
+  enqueueCommandInLane,
+  getTotalQueueSize,
+  markGatewayDraining,
+} from "../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import type { SetupWizardRunner } from "./server-methods/wizard.js";
 import { startGatewayServer } from "./server.js";
 import {
   connectGatewayClient,
@@ -43,117 +55,203 @@ function resetGatewayTestState(): void {
   clearConfigCache();
   clearSessionStoreCacheForTest();
   resetAgentEventsForTest();
+  resetCommandQueueStateForTest();
+  resetGatewayWorkAdmission();
 }
 
 afterEach(() => {
   resetGatewayTestState();
 });
 
-describe("gateway wizard cancellation lifecycle", () => {
-  it(
-    "keeps a cancelled wizard owner until settlement before allowing a replacement",
-    { timeout: GATEWAY_E2E_TIMEOUT_MS },
-    async () => {
-      const envSnapshot = captureEnv(ENV_KEYS);
-      const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wizard-cancel-home-"));
-      const stateDir = path.join(tempHome, ".openclaw");
-      const bundledPluginsDir = path.join(tempHome, "empty-bundled-plugins");
-      const token = `wizard-cancel-${process.pid}-${process.env.VITEST_POOL_ID ?? "0"}`;
-      const runnerSettled = [createDeferred(), createDeferred()] as const;
-      let runnerIndex = 0;
-
-      try {
-        await fs.mkdir(bundledPluginsDir, { recursive: true });
-        setTestEnvValue("HOME", tempHome);
-        setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
-        deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
-        setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
-        setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
-        setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
-        setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
-        setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
-        setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
-        setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPluginsDir);
-        setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
-        setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "1");
-
-        const port = await getGatewayE2ePortBlock();
-        const server = await startGatewayServer(port, {
-          bind: "loopback",
-          auth: { mode: "token", token },
-          controlUiEnabled: false,
-          wizardRunner: async (_opts, _runtime, prompter) => {
-            const settlement = runnerSettled[runnerIndex++];
-            if (!settlement) {
-              throw new Error("wizard runner started more than twice");
-            }
-            prompter.progress("working");
-            await settlement.promise;
-          },
-        });
-        try {
+async function withWizardGateway(
+  wizardRunner: SetupWizardRunner,
+  releaseRunner: () => void,
+  run: (fixture: {
+    server: Awaited<ReturnType<typeof startGatewayServer>>;
+    connect: () => ReturnType<typeof connectGatewayClient>;
+  }) => Promise<void>,
+): Promise<void> {
+  const envSnapshot = captureEnv(ENV_KEYS);
+  const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-wizard-cancel-home-"));
+  const stateDir = path.join(tempHome, ".openclaw");
+  const bundledPluginsDir = path.join(tempHome, "empty-bundled-plugins");
+  const token = `wizard-cancel-${process.pid}-${process.env.VITEST_POOL_ID ?? "0"}`;
+  const clients: Array<Awaited<ReturnType<typeof connectGatewayClient>>> = [];
+  try {
+    await fs.mkdir(bundledPluginsDir, { recursive: true });
+    setTestEnvValue("HOME", tempHome);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
+    setTestEnvValue("OPENCLAW_SKIP_CHANNELS", "1");
+    setTestEnvValue("OPENCLAW_SKIP_GMAIL_WATCHER", "1");
+    setTestEnvValue("OPENCLAW_SKIP_CRON", "1");
+    setTestEnvValue("OPENCLAW_SKIP_CANVAS_HOST", "1");
+    setTestEnvValue("OPENCLAW_SKIP_BROWSER_CONTROL_SERVER", "1");
+    setTestEnvValue("OPENCLAW_SKIP_PROVIDERS", "1");
+    setTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledPluginsDir);
+    setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+    setTestEnvValue("OPENCLAW_TEST_MINIMAL_GATEWAY", "1");
+    const port = await getGatewayE2ePortBlock();
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: false,
+      wizardRunner,
+    });
+    try {
+      await run({
+        server,
+        connect: async () => {
           const client = await connectGatewayClient({
             url: `ws://127.0.0.1:${port}`,
             token,
             clientDisplayName: "vitest-wizard-cancel",
           });
-          try {
-            const start = await client.request<WizardStartResult>("wizard.start", {
-              mode: "local",
-            });
-            expect(start).toMatchObject({ done: false, status: "running" });
+          clients.push(client);
+          return client;
+        },
+      });
+    } finally {
+      releaseRunner();
+      await Promise.all(clients.map(disconnectGatewayClient));
+      await server.close({ reason: "wizard cancellation lifecycle complete" });
+    }
+  } finally {
+    releaseRunner();
+    try {
+      await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    } finally {
+      envSnapshot.restore();
+    }
+  }
+}
 
-            await expect(
-              client.request("wizard.cancel", { sessionId: start.sessionId }),
-            ).resolves.toMatchObject({ status: "cancelled" });
-            await expect(client.request("wizard.start", { mode: "local" })).rejects.toMatchObject({
-              code: "UNAVAILABLE",
-            });
-
-            runnerSettled[0].resolve();
-            let replacement: WizardStartResult | undefined;
-            await expect
-              .poll(
-                async () => {
-                  try {
-                    replacement = await client.request<WizardStartResult>("wizard.start", {
-                      mode: "local",
-                    });
-                    return replacement.status;
-                  } catch {
-                    return "blocked";
-                  }
-                },
-                { timeout: 5_000 },
-              )
-              .toBe("running");
-            if (!replacement) {
-              throw new Error("replacement wizard did not start");
-            }
-            expect(replacement).toMatchObject({ done: false, status: "running" });
-            await expect(client.request("health", {})).resolves.toBeDefined();
-
-            await expect(
-              client.request("wizard.cancel", { sessionId: replacement.sessionId }),
-            ).resolves.toMatchObject({ status: "cancelled" });
-            runnerSettled[1].resolve();
-          } finally {
-            await disconnectGatewayClient(client);
+describe("gateway wizard cancellation lifecycle", () => {
+  it(
+    "keeps a cancelled wizard owner until settlement before allowing a replacement",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const runnerSettled = [createDeferred(), createDeferred()] as const;
+      let runnerIndex = 0;
+      await withWizardGateway(
+        async (_opts, _runtime, prompter) => {
+          const settlement = runnerSettled[runnerIndex++];
+          if (!settlement) {
+            throw new Error("wizard runner started more than twice");
           }
-        } finally {
+          prompter.progress("working");
+          await settlement.promise;
+        },
+        () => {
           runnerSettled[0].resolve();
           runnerSettled[1].resolve();
-          await server.close({ reason: "wizard cancellation lifecycle complete" });
-        }
-      } finally {
-        runnerSettled[0].resolve();
-        runnerSettled[1].resolve();
-        try {
-          await fs.rm(tempHome, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
-        } finally {
-          envSnapshot.restore();
-        }
-      }
+        },
+        async ({ connect }) => {
+          const client = await connect();
+          const start = await client.request<WizardStartResult>("wizard.start", { mode: "local" });
+          expect(start).toMatchObject({ done: false, status: "running" });
+          await expect(
+            client.request("wizard.cancel", { sessionId: start.sessionId }),
+          ).resolves.toMatchObject({ status: "cancelled" });
+          await expect(client.request("wizard.start", { mode: "local" })).rejects.toMatchObject({
+            code: "UNAVAILABLE",
+          });
+          runnerSettled[0].resolve();
+          let replacement: WizardStartResult | undefined;
+          await expect
+            .poll(
+              async () => {
+                try {
+                  replacement = await client.request<WizardStartResult>("wizard.start", {
+                    mode: "local",
+                  });
+                  return replacement.status;
+                } catch {
+                  return "blocked";
+                }
+              },
+              { timeout: 5_000 },
+            )
+            .toBe("running");
+          if (!replacement) {
+            throw new Error("replacement wizard did not start");
+          }
+          expect(replacement).toMatchObject({ done: false, status: "running" });
+          await expect(client.request("health", {})).resolves.toBeDefined();
+          await expect(
+            client.request("wizard.cancel", { sessionId: replacement.sessionId }),
+          ).resolves.toMatchObject({ status: "cancelled" });
+          runnerSettled[1].resolve();
+        },
+      );
+    },
+  );
+
+  it.each(["process drain", "server close"])(
+    "retires an abandoned reconnectable wizard before %s joins its cleanup",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async (closing) => {
+      const cleanupStarted = createDeferred();
+      const releaseCleanup = createDeferred();
+      const fixtureStop = new AbortController();
+      let submitted = false;
+      let closed = false;
+      let closingServer: Promise<void> | undefined;
+      await withWizardGateway(
+        async (_opts, _runtime, prompter) => {
+          await enqueueCommandInLane("wizard-shutdown-e2e", async () => {
+            try {
+              await prompter.text({ message: "Local model base URL", signal: fixtureStop.signal });
+              submitted = true;
+            } finally {
+              cleanupStarted.resolve();
+              await releaseCleanup.promise;
+            }
+          });
+        },
+        () => {
+          fixtureStop.abort();
+          releaseCleanup.resolve();
+        },
+        async ({ connect, server }) => {
+          const first = await connect();
+          const start = await first.request<WizardStartResult>("wizard.start", { mode: "local" });
+          expect(start.step?.type).toBe("text");
+          await disconnectGatewayClient(first);
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          const reconnected = await connect();
+          await expect(
+            reconnected.request("wizard.next", { sessionId: start.sessionId }),
+          ).resolves.toMatchObject({
+            done: false,
+            status: "running",
+            step: { id: start.step?.id },
+          });
+          await disconnectGatewayClient(reconnected);
+          expect(getTotalQueueSize()).toBe(1);
+          if (closing === "process drain") {
+            markGatewayDraining();
+          } else {
+            closingServer = server.close({ reason: "abandoned wizard proof" }).then(() => {
+              closed = true;
+            });
+          }
+          await withTestTimeout(
+            cleanupStarted.promise,
+            1_000,
+            "shutdown did not retire the abandoned prompt",
+          );
+          expect(submitted).toBe(false);
+          expect(closed).toBe(false);
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          expect(getTotalQueueSize()).toBe(1);
+          releaseCleanup.resolve();
+          expect((await waitForGatewayActiveWork(5_000)).drained).toBe(true);
+          expect(getActiveGatewayRootWorkCount()).toBe(0);
+          expect(getTotalQueueSize()).toBe(0);
+          await closingServer;
+        },
+      );
     },
   );
 });

--- a/src/gateway/server-methods/setup-admission.test.ts
+++ b/src/gateway/server-methods/setup-admission.test.ts
@@ -1,14 +1,24 @@
+import { getEventListeners } from "node:events";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { enqueueCommandInLane, getTotalQueueSize } from "../../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import {
+  beginGatewayRestartSignalAdmission,
   getActiveGatewayRootWorkCount,
+  getGatewayRestartDrainSignal,
+  markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   runWithGatewayIndependentRootWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
 } from "../../process/gateway-work-admission.js";
-import { withSetupMigrationTargetLock } from "../../wizard/setup.migration-snapshot.js";
+import { WizardCancelledError } from "../../wizard/prompts.js";
+import { WizardSession } from "../../wizard/session.js";
+import * as setupMigration from "../../wizard/setup.migration-snapshot.js";
+import { GatewayConnectionWork } from "../server-connection-work.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -82,18 +92,16 @@ describe("setup admission", () => {
 
   it("holds an admitted session lease until its runner settles", async () => {
     const settled = createDeferred();
-    const session = await createAdmittedWizardSession(() => ({
-      whenSettled: () => settled.promise,
-    }));
+    const session = await createAdmittedWizardSession(
+      () => new WizardSession(() => settled.promise),
+    );
 
     await expect(
-      createAdmittedWizardSession(() => ({ whenSettled: () => Promise.resolve() })),
+      createAdmittedWizardSession(() => new WizardSession(async () => {})),
     ).resolves.toBeUndefined();
     settled.resolve();
     await whenAdmittedWizardSessionSettled(session!);
-    const next = await createAdmittedWizardSession(() => ({
-      whenSettled: () => Promise.resolve(),
-    }));
+    const next = await createAdmittedWizardSession(() => new WizardSession(async () => {}));
     expect(next).toBeDefined();
     await whenAdmittedWizardSessionSettled(next!);
   });
@@ -108,7 +116,7 @@ describe("setup admission", () => {
           await continueAfterStart.promise;
           await enqueueCommandInLane("setup-post-start-proof", async () => undefined);
         })();
-        return { whenSettled: () => runner! };
+        return new WizardSession(() => runner!);
       }),
     );
 
@@ -120,15 +128,378 @@ describe("setup admission", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(0);
   });
 
+  it.each(["process drain", "server close"])(
+    "settles an abandoned prompt before %s releases its runtime",
+    async (closing) => {
+      const work = new GatewayConnectionWork();
+      const disconnected = work.registerConnection(() => {});
+      const cleanupStarted = createDeferred();
+      const finishCleanup = createDeferred();
+      const session = await work.track(() =>
+        runWithGatewayIndependentRootWorkAdmission(() =>
+          createAdmittedWizardSession(
+            () =>
+              new WizardSession(async (prompter) => {
+                await enqueueCommandInLane("setup-shutdown-proof", async () => {
+                  try {
+                    await prompter.text({ message: "Local model base URL" });
+                  } finally {
+                    cleanupStarted.resolve();
+                    await finishCleanup.promise;
+                  }
+                });
+              }),
+          ),
+        ),
+      );
+      if (!session) {
+        throw new Error("expected an admitted wizard");
+      }
+      try {
+        expect((await session.next()).step?.type).toBe("text");
+        disconnected();
+        expect(session.getStatus()).toBe("running");
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        expect(getTotalQueueSize()).toBe(1);
+
+        if (closing === "process drain") {
+          markGatewayRestartDraining();
+        } else {
+          work.beginClose();
+        }
+        expect(session.signal.aborted).toBe(true);
+        await cleanupStarted.promise;
+        expect(session.getStatus()).not.toBe("cancelled");
+        expect(session.cancel()).toBe(false);
+        expect(session.isSettled()).toBe(false);
+        expect(getActiveGatewayRootWorkCount()).toBe(1);
+        expect(getTotalQueueSize()).toBe(1);
+        await expect(runExclusiveSystemAgentSetupActivation(async () => {})).rejects.toThrow(
+          "setup is already in progress",
+        );
+        let drained = false;
+        const drain = work.drain().then(() => {
+          drained = true;
+        });
+        await Promise.resolve();
+        expect(drained).toBe(false);
+
+        finishCleanup.resolve();
+        await whenAdmittedWizardSessionSettled(session);
+        await drain;
+        expect(await session.next()).toMatchObject({ done: true, status: "error" });
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        expect(getTotalQueueSize()).toBe(0);
+        await expect(runExclusiveSystemAgentSetupActivation(async () => "released")).resolves.toBe(
+          "released",
+        );
+      } finally {
+        disconnected();
+        session.cancel();
+        finishCleanup.resolve();
+        await whenAdmittedWizardSessionSettled(session);
+        await work.drain();
+      }
+    },
+  );
+
+  it.each([
+    ["already waiting", "outro"],
+    ["after write", "outro"],
+    ["already waiting", "confirm"],
+    ["after write", "confirm"],
+  ] as const)(
+    "preserves committed work and ends unavailable %s %s at shutdown",
+    async (when, prompt) => {
+      const finishWrite = createDeferred();
+      const prompting = createDeferred();
+      let written = false;
+      let answered = false;
+      const session = await runWithGatewayIndependentRootWorkAdmission(() =>
+        createAdmittedWizardSession(
+          () =>
+            new WizardSession(async (prompter, _signal, owner) => {
+              owner.lockCancellation();
+              await finishWrite.promise;
+              written = true;
+              prompting.resolve();
+              if (prompt === "outro") {
+                await prompter.outro("Channels updated.");
+              } else {
+                await prompter.confirm({
+                  message: "Configure another account?",
+                  initialValue: true,
+                });
+              }
+              answered = true;
+            }),
+        ),
+      );
+      if (!session) {
+        throw new Error("expected an admitted wizard");
+      }
+      try {
+        if (when === "already waiting") {
+          finishWrite.resolve();
+          await prompting.promise;
+        }
+        markGatewayRestartDraining();
+        expect(session.signal.aborted).toBe(false);
+        expect(session.getStatus()).not.toBe("cancelled");
+        if (when === "after write") {
+          expect(written).toBe(false);
+          expect(session.isSettled()).toBe(false);
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          finishWrite.resolve();
+          await prompting.promise;
+        }
+        expect(session.getCurrentStep()).toBeUndefined();
+        await whenAdmittedWizardSessionSettled(session);
+        expect(written).toBe(true);
+        expect(answered).toBe(false);
+        expect(await session.next()).toMatchObject({ done: true, status: "error" });
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+      } finally {
+        finishWrite.resolve();
+        await prompting.promise;
+        const pending = session.getCurrentStep();
+        if (pending) {
+          await session.answer(pending.id, undefined);
+        }
+        await whenAdmittedWizardSessionSettled(session);
+      }
+    },
+  );
+
+  it("keeps a prompt resumable across disconnect and reversible admission fences", async () => {
+    const work = new GatewayConnectionWork();
+    const disconnect = work.registerConnection(() => {});
+    let submitted: string | undefined;
+    const session = await work.track(() =>
+      createAdmittedWizardSession(
+        () =>
+          new WizardSession(async (prompter) => {
+            submitted = await prompter.text({ message: "Local model base URL" });
+          }),
+      ),
+    );
+    if (!session) {
+      throw new Error("expected an admitted wizard");
+    }
+    try {
+      const step = (await session.next()).step;
+      if (!step) {
+        throw new Error("expected a pending prompt");
+      }
+      disconnect();
+      expect(beginGatewayRestartSignalAdmission()?.rollback()).toBe(true);
+      const suspension = tryBeginGatewaySuspendAdmission(() => {});
+      expect(suspension?.drain()).toBe(true);
+      expect(suspension?.release()).toBe(true);
+      expect(session.signal.aborted).toBe(false);
+      expect((await session.next()).step?.id).toBe(step.id);
+      await session.answer(step.id, "http://127.0.0.1:11434");
+      await whenAdmittedWizardSessionSettled(session);
+      expect(submitted).toBe("http://127.0.0.1:11434");
+      expect(session.getStatus()).toBe("done");
+    } finally {
+      disconnect();
+      session.cancel();
+      await whenAdmittedWizardSessionSettled(session);
+      await work.drain();
+    }
+  });
+
+  it.each([false, true])(
+    "does not construct a wizard after drain wins target-lock acquisition (reset=%s)",
+    async (reset) => {
+      const create = vi.fn(() => new WizardSession(async () => {}));
+      const pending = createAdmittedWizardSession(create);
+      const rejected = expect(pending).rejects.toThrow("draining");
+      markGatewayRestartDraining();
+      if (reset) {
+        resetGatewayWorkAdmission();
+      }
+      await rejected;
+      expect(create).not.toHaveBeenCalled();
+      resetGatewayWorkAdmission();
+      const fresh = await createAdmittedWizardSession(create);
+      expect(fresh).toBeDefined();
+      await whenAdmittedWizardSessionSettled(fresh!);
+    },
+  );
+
+  it.each([false, true])(
+    "closes a wizard when construction races drain (target lock=%s)",
+    async (lockSetupTarget) => {
+      const session = await createAdmittedWizardSession(
+        () =>
+          new WizardSession(async (prompter) => {
+            markGatewayRestartDraining();
+            await prompter.text({ message: "Local model base URL" });
+          }),
+        lockSetupTarget,
+      );
+      if (!session) {
+        throw new Error("expected an admitted wizard");
+      }
+      try {
+        await whenAdmittedWizardSessionSettled(session);
+        expect(session.getStatus()).toBe("error");
+      } finally {
+        session.cancel();
+        await whenAdmittedWizardSessionSettled(session);
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves committed work's result without further input (failure=%s)",
+    async (failWrite) => {
+      const finishWrite = createDeferred();
+      const session = await createAdmittedWizardSession(
+        () =>
+          new WizardSession(async (_prompter, _signal, owner) => {
+            owner.lockCancellation();
+            await finishWrite.promise;
+            if (failWrite) {
+              throw new Error("settings write failed");
+            }
+            owner.setModelActivation({ modelRef: "ollama/local-model" });
+          }),
+      );
+      if (!session) {
+        throw new Error("expected an admitted wizard");
+      }
+      try {
+        markGatewayRestartDraining();
+        expect(session.signal.aborted).toBe(false);
+        finishWrite.resolve();
+        await whenAdmittedWizardSessionSettled(session);
+        expect(await session.next()).toMatchObject({
+          done: true,
+          ...(failWrite
+            ? { status: "error", error: "Error: settings write failed" }
+            : { status: "done", modelActivation: { modelRef: "ollama/local-model" } }),
+        });
+      } finally {
+        finishWrite.resolve();
+        await whenAdmittedWizardSessionSettled(session);
+      }
+    },
+  );
+
+  it("does not report classic setup's saved settings as user cancellation", async () => {
+    const configPath = path.join(mocks.stateDir, "openclaw.json");
+    const saved = '{"gateway":{"mode":"remote"}}';
+    const session = await createAdmittedWizardSession(
+      () =>
+        new WizardSession(async (prompter) => {
+          await fs.writeFile(configPath, saved);
+          await prompter.outro("Remote Gateway configured.");
+        }),
+    );
+    if (!session) {
+      throw new Error("expected an admitted wizard");
+    }
+    try {
+      expect((await session.next()).step?.type).toBe("note");
+      markGatewayRestartDraining();
+      await whenAdmittedWizardSessionSettled(session);
+      expect(await fs.readFile(configPath, "utf8")).toBe(saved);
+      expect(await session.next()).toMatchObject({ done: true, status: "error" });
+    } finally {
+      session.cancel();
+      await whenAdmittedWizardSessionSettled(session);
+    }
+  });
+
+  it("keeps shutdown error provenance when a provider maps closed input to cancellation", async () => {
+    const session = await createAdmittedWizardSession(
+      () =>
+        new WizardSession(async (prompter, _signal, owner) => {
+          owner.lockCancellation();
+          try {
+            await prompter.text({ message: "Provider sign-in code" });
+          } catch {
+            throw new WizardCancelledError("provider input cancelled");
+          }
+        }),
+    );
+    if (!session) {
+      throw new Error("expected an admitted wizard");
+    }
+    try {
+      await session.next();
+      markGatewayRestartDraining();
+      await whenAdmittedWizardSessionSettled(session);
+      expect(await session.next()).toMatchObject({
+        done: true,
+        status: "error",
+        error: expect.stringContaining("Gateway is shutting down"),
+      });
+    } finally {
+      const pending = session.getCurrentStep();
+      if (pending) {
+        await session.answer(pending.id, undefined);
+      }
+      await whenAdmittedWizardSessionSettled(session);
+    }
+  });
+
+  it.each([false, true])(
+    "releases its drain listener and root even when target-lock cleanup fails (%s)",
+    async (failCleanup) => {
+      const finish = createDeferred();
+      const drainSignal = getGatewayRestartDrainSignal();
+      const priorListeners = getEventListeners(drainSignal, "abort").length;
+      const releaseError = new Error("target-lock release failed");
+      const lock = failCleanup
+        ? vi
+            .spyOn(setupMigration, "withSetupMigrationTargetLock")
+            .mockImplementationOnce(async (_stateDir, run) => {
+              await run();
+              throw releaseError;
+            })
+        : undefined;
+      let session: WizardSession | undefined;
+      try {
+        session = await runWithGatewayIndependentRootWorkAdmission(() =>
+          createAdmittedWizardSession(() => new WizardSession(() => finish.promise)),
+        );
+        if (!session) {
+          throw new Error("expected an admitted wizard");
+        }
+        expect(getEventListeners(drainSignal, "abort")).toHaveLength(priorListeners + 1);
+        finish.resolve();
+        const settlement = whenAdmittedWizardSessionSettled(session);
+        if (failCleanup) {
+          await expect(settlement).rejects.toBe(releaseError);
+        } else {
+          await settlement;
+        }
+        expect(getEventListeners(drainSignal, "abort")).toHaveLength(priorListeners);
+        expect(getActiveGatewayRootWorkCount()).toBe(0);
+        const fresh = await createAdmittedWizardSession(() => new WizardSession(async () => {}));
+        expect(fresh).toBeDefined();
+        await whenAdmittedWizardSessionSettled(fresh!);
+      } finally {
+        finish.resolve();
+        if (session) {
+          await whenAdmittedWizardSessionSettled(session).catch(() => {});
+        }
+        lock?.mockRestore();
+      }
+    },
+  );
+
   it("releases an admitted session lease when construction fails", async () => {
     await expect(
       createAdmittedWizardSession(() => {
         throw new Error("construction failed");
       }),
     ).rejects.toThrow("construction failed");
-    const recovered = await createAdmittedWizardSession(() => ({
-      whenSettled: () => Promise.resolve(),
-    }));
+    const recovered = await createAdmittedWizardSession(() => new WizardSession(async () => {}));
     expect(recovered).toBeDefined();
     await whenAdmittedWizardSessionSettled(recovered!);
   });
@@ -136,16 +507,14 @@ describe("setup admission", () => {
   it("reserves wizard admission while setup waits to acquire its target lock", async () => {
     const lockAcquired = createDeferred();
     const releaseLock = createDeferred();
-    const lockOwner = withSetupMigrationTargetLock(mocks.stateDir, async () => {
+    const lockOwner = setupMigration.withSetupMigrationTargetLock(mocks.stateDir, async () => {
       lockAcquired.resolve();
       await releaseLock.promise;
     });
     await lockAcquired.promise;
 
-    const setupAttempt = createAdmittedWizardSession(() => ({
-      whenSettled: () => Promise.resolve(),
-    }));
-    const channelFactory = vi.fn(() => ({ whenSettled: () => Promise.resolve() }));
+    const setupAttempt = createAdmittedWizardSession(() => new WizardSession(async () => {}));
+    const channelFactory = vi.fn(() => new WizardSession(async () => {}));
     await expect(createAdmittedWizardSession(channelFactory, false)).resolves.toBeUndefined();
     expect(channelFactory).not.toHaveBeenCalled();
     await expect(setupAttempt).resolves.toBeUndefined();
@@ -157,7 +526,7 @@ describe("setup admission", () => {
   it("rejects Gateway setup while the canonical onboarding target lock is held", async () => {
     const lockAcquired = createDeferred();
     const releaseLock = createDeferred();
-    const lockOwner = withSetupMigrationTargetLock(mocks.stateDir, async () => {
+    const lockOwner = setupMigration.withSetupMigrationTargetLock(mocks.stateDir, async () => {
       lockAcquired.resolve();
       await releaseLock.promise;
     });

--- a/src/gateway/server-methods/setup-admission.ts
+++ b/src/gateway/server-methods/setup-admission.ts
@@ -4,7 +4,12 @@ import {
   GatewayErrorDetailCodes,
 } from "../../../packages/gateway-protocol/src/schema/error-codes.js";
 import { resolveStateDir } from "../../config/paths.js";
-import { retainGatewayRootWorkAdmissionContinuation } from "../../process/gateway-work-admission.js";
+import {
+  getGatewayRestartDrainSignal,
+  retainGatewayRootWorkAdmissionContinuation,
+} from "../../process/gateway-work-admission.js";
+import { getAsyncWorkSignal, trackAsyncWork } from "../../shared/async-work-scope.js";
+import type { WizardSession } from "../../wizard/session.js";
 import {
   SetupTargetLockedError,
   withSetupMigrationTargetLock,
@@ -56,37 +61,59 @@ export function whenAdmittedWizardSessionSettled(session: {
   return wizardSessionAdmissionSettlements.get(session) ?? session.whenSettled();
 }
 
-export async function createAdmittedWizardSession<T extends { whenSettled(): Promise<unknown> }>(
-  createSession: () => T,
+export async function createAdmittedWizardSession(
+  createSession: () => WizardSession,
   lockSetupTarget = true,
-): Promise<T | undefined> {
+): Promise<WizardSession | undefined> {
   if (wizardSessionInProgress) {
     return undefined;
   }
   wizardSessionInProgress = true;
+  // Capture this generation before target-lock acquisition can yield or reset.
+  const gatewaySignal = getAsyncWorkSignal();
+  const drainSignal = getGatewayRestartDrainSignal();
+  const signal = gatewaySignal ? AbortSignal.any([gatewaySignal, drainSignal]) : drainSignal;
+  let removeCloseListener: (() => void) | undefined;
+  let releaseGatewayWork: (() => void) | null = null;
   const releaseSession = () => {
+    removeCloseListener?.();
+    releaseGatewayWork?.();
     wizardSessionInProgress = false;
   };
   try {
+    const create = () => {
+      signal.throwIfAborted();
+      const session = createSession();
+      const close = () =>
+        session.close(
+          new Error("Gateway is shutting down; restart it before continuing setup.", {
+            cause: signal.reason,
+          }),
+        );
+      signal.addEventListener("abort", close, { once: true });
+      removeCloseListener = () => signal.removeEventListener("abort", close);
+      // Construction can commit or close the Gateway before the listener exists.
+      if (signal.aborted) {
+        close();
+      }
+      return session;
+    };
     let admissionSettled: Promise<unknown> | undefined;
     const session = lockSetupTarget
-      ? await new Promise<T>((resolve, reject) => {
+      ? await new Promise<WizardSession>((resolve, reject) => {
           admissionSettled = runExclusiveSystemAgentSetupActivation(async () => {
-            const createdSession = createSession();
+            const createdSession = create();
             resolve(createdSession);
             await createdSession.whenSettled();
           });
           void admissionSettled.catch(reject);
         })
-      : createSession();
-    const settled = admissionSettled ?? session.whenSettled();
+      : create();
+    const settled = trackAsyncWork(() => admissionSettled ?? session.whenSettled());
     wizardSessionAdmissionSettlements.set(session, settled);
     // The runner outlives its start RPC and inherits that request's admission.
     // Keep the root live so later prompts and post-auth probes remain subordinate work.
-    const releaseGatewayWork = retainGatewayRootWorkAdmissionContinuation();
-    if (releaseGatewayWork) {
-      void settled.then(releaseGatewayWork, releaseGatewayWork);
-    }
+    releaseGatewayWork = retainGatewayRootWorkAdmissionContinuation();
     void settled.then(releaseSession, releaseSession);
     return session;
   } catch (error) {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -264,6 +264,7 @@ export class WizardSession {
   private deliveredProgressStepIds = new Set<string>();
   private stepDeferred: Deferred<WizardStep | null> | null = null;
   private cancellationLocked = false;
+  private inputClosedError: Error | undefined;
   private settled = false;
   private pendingExternalUrl: string | undefined;
   private answerDeferred = new Map<
@@ -395,7 +396,7 @@ export class WizardSession {
   }
 
   cancel(): boolean {
-    if (this.status !== "running" || this.cancellationLocked) {
+    if (this.status !== "running" || this.cancellationLocked || this.inputClosedError) {
       return false;
     }
     this.status = "cancelled";
@@ -406,6 +407,18 @@ export class WizardSession {
     this.deliveredProgressStepIds.clear();
     this.resolveStep(null);
     return true;
+  }
+
+  /** Close client input without interrupting an operation past its commit point. */
+  close(error: Error): void {
+    if (this.status !== "running") {
+      return;
+    }
+    this.inputClosedError ??= error;
+    if (!this.cancellationLocked) {
+      this.abortController.abort(this.inputClosedError);
+    }
+    this.rejectPendingAnswers(this.inputClosedError);
   }
 
   /** The underlying mutation crossed its durable commit point and must finish. */
@@ -478,12 +491,15 @@ export class WizardSession {
       if (this.status !== "running") {
         return;
       }
-      if (err instanceof WizardCancelledError) {
+      // A provider may translate an aborted prompt into user cancellation.
+      // The recorded host closure still owns that outcome, including after writes.
+      const error = err instanceof WizardCancelledError ? (this.inputClosedError ?? err) : err;
+      if (error instanceof WizardCancelledError) {
         this.status = "cancelled";
-        this.error = err.message;
+        this.error = error.message;
       } else {
         this.status = "error";
-        this.error = String(err);
+        this.error = String(error);
       }
     } finally {
       this.settled = true;
@@ -497,10 +513,10 @@ export class WizardSession {
     }
   }
 
-  private rejectPendingAnswers() {
+  private rejectPendingAnswers(error: Error = new WizardCancelledError()) {
     this.currentStep = null;
     for (const pending of this.answerDeferred.values()) {
-      pending.deferred.reject(new WizardCancelledError());
+      pending.deferred.reject(error);
     }
     this.answerDeferred.clear();
   }
@@ -512,6 +528,9 @@ export class WizardSession {
   ): Promise<unknown> {
     if (this.status !== "running") {
       throw new Error("wizard: session not running");
+    }
+    if (this.inputClosedError) {
+      throw this.inputClosedError;
     }
     signal?.throwIfAborted();
     const deferred = createDeferredCore<unknown>();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where stopping or restarting a Gateway could wait for the full drain budget after an operator left an interactive setup prompt unanswered. Shutdown had already stopped accepting answers, while the wizard still retained its work and setup-lock ownership.

## Why This Change Was Made

Wizard admission now binds to the existing Gateway generation and committed drain signal before setup-lock acquisition can yield. Shutdown closes the prompt input lifetime, and the Gateway tracks the existing settlement promise until the runner and target-lock cleanup finish. Ordinary socket disconnects remain reconnectable.

Lifecycle closure is distinct from user cancellation. Writes past their cancellation lock finish normally; pending and future prompts stop waiting for a client that cannot answer. Classic setup can already have saved settings without taking that cancellation lock, so shutdown records its own error rather than claiming a user cancellation. Genuine later write failures retain their diagnostic.

## User Impact

An abandoned setup prompt no longer strands Gateway stop or restart. After the Gateway starts again, operators can reopen setup and inspect their saved settings. Configuration, persistence formats, protocol versions and drain budgets are unchanged.

Production grows by 46 lines across the two existing owners; tests grow by 467 lines, including reuse of the existing Gateway fixture, and docs by 5. The new input lifetime and exact cleanup binding require that production growth; there is no new run-loop layer or duplicate shutdown path.

## Evidence

- Captured four failing owner regressions on unchanged code, then additional failing cases for an unlocked real settings write followed by an outro and a provider translating closure into cancellation.
- Final focused run: 131 tests passed across seven files, including real Gateway WebSocket disconnect/reconnect followed by process drain and direct server close. Original file order and the existing 90-second timeout were preserved. The final combined replay completed the two shutdown cases in 504ms and 433ms.
- The first cold integration run timed out the existing cancellation baseline during heavy transform/import work. The full original-order replay passed unchanged; its existing baseline completed in 14.4 seconds. The documented source-fixture mode avoids rebuilding unrelated private-QA artifacts and still starts the real source Gateway.
- The complete changed-file gate passed: core and test types, formatting, lint, dead exports and selected ownership/schema/import guards.
- Independent review is clean through P2. Exact-head CI passed all 132 checks, with 42 intentional skips and a successful `openclaw/ci-gate`. The latest ClawSweeper review has no findings or before-merge actions.
- Prior CI exposed an unrelated stale session-history test fixture already repaired in main by #139794; this branch includes that fix through rebase. An unrelated profiler test timed out on the old run; its unchanged file passed 34/34 in 19.38 seconds under the original timeout. No product or test timeout was increased.

## Native live proof

[Crabbox run 34014138751](https://github.com/openclaw/openclaw/actions/runs/34014138751), provider `blacksmith-testbox`, lease `tbx_01m1tk40syn8mwrdr3k0v0am0p`. A real Tauri app opened the Ollama setup wizard and left the Local only choice unanswered. Native tray Stop completed in **1.241 seconds**, with the real Gateway process gone and its health port closed; tray Start restored it in **4.128 seconds**. The CLI receipt was `gateway stop --json --force`, non-TTY stdin/stdout, exit 0, `ok:true`, `result:stopped`.

This combined candidate used base `883d4d65bad1791755c203a8dfd854e14b4f6e33` with the reviewed changes from this PR and #139664; the two setup runtime owner files are byte-identical to this PR head. Native GUI proof is Linux; no macOS/Windows service-manager claim is made. Screenshots contain only synthetic task data.

Pending real provider prompt:

![Unanswered local model setup prompt](https://github.com/user-attachments/assets/b904546f-8e75-48a1-99d8-fa47c74b18fd)

After native Stop:

![Gateway stopped and app standing by](https://github.com/user-attachments/assets/4131194d-8e06-4ee9-b192-e916e4145991)
