### PR TITLE
improve(slack): avoid repeated authored-text prefix copies

### DIFF
--- a/extensions/slack/src/authored-text.test.ts
+++ b/extensions/slack/src/authored-text.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { resolveSlackAuthoredTextPlacement } from "./authored-text.js";
+
+describe("resolveSlackAuthoredTextPlacement", () => {
+  it.each([
+    {
+      name: "matches consecutive fragments after unrelated text",
+      text: "First second",
+      fragments: ["Before", "First", "second", "After"],
+      expected: "blocks",
+    },
+    {
+      name: "normalizes whitespace and skips empty fragments",
+      text: "  First\n second\tthird \u00a0🚀  ",
+      fragments: ["\t", " First ", "", " second\tthird ", " \u00a0🚀", "After"],
+      expected: "blocks",
+    },
+    {
+      name: "does not match a suffix inside the first fragment",
+      text: "First second",
+      fragments: ["Before First", "second"],
+      expected: "outside-blocks",
+    },
+    {
+      name: "does not match a prefix inside the final fragment",
+      text: "First second",
+      fragments: ["First", "second After"],
+      expected: "outside-blocks",
+    },
+    {
+      name: "requires a separator between fragments",
+      text: "Firstsecond",
+      fragments: ["First", "second"],
+      expected: "outside-blocks",
+    },
+    {
+      name: "does not skip intervening visible text",
+      text: "First second",
+      fragments: ["First", "Between", "second"],
+      expected: "outside-blocks",
+    },
+    {
+      name: "restarts after a partially matching sequence",
+      text: "First second",
+      fragments: ["First", "First", "second"],
+      expected: "blocks",
+    },
+  ])("$name", ({ text, fragments, expected }) => {
+    expect(resolveSlackAuthoredTextPlacement({ text, renderedTextFragments: fragments })).toBe(
+      expected,
+    );
+    expect(
+      resolveSlackAuthoredTextPlacement({
+        text,
+        interactive: {
+          blocks: fragments.flatMap((fragment) => [
+            { type: "text" as const, text: fragment },
+            { type: "buttons" as const, buttons: [{ label: "Continue", value: "continue" }] },
+          ]),
+        },
+      }),
+    ).toBe(expected);
+  });
+});

--- a/extensions/slack/src/authored-text.ts
+++ b/extensions/slack/src/authored-text.ts
@@ -24,17 +24,27 @@ function isSlackAuthoredTextRepresentedInFragments(
 ): boolean {
   const target = normalizeComparableSlackText(text);
   const fragments = rawFragments.map(normalizeComparableSlackText).filter(Boolean);
+  let remainingLength = fragments.reduce((length, fragment) => length + fragment.length + 1, -1);
   // Legacy inline controls split surrounding text into multiple interactive text blocks.
-  for (let start = 0; start < fragments.length; start += 1) {
-    let combined = "";
-    for (let end = start; end < fragments.length; end += 1) {
-      combined = normalizeComparableSlackText(`${combined} ${fragments[end]}`);
-      if (combined === target) {
-        return true;
-      }
-      if (combined.length > target.length) {
+  for (const [start, firstFragment] of fragments.entries()) {
+    if (remainingLength < target.length) {
+      break;
+    }
+    remainingLength -= firstFragment.length + 1;
+    let offset = 0;
+    for (let end = start; ; end += 1) {
+      const fragment = fragments[end];
+      if (fragment === undefined || !target.startsWith(fragment, offset)) {
         break;
       }
+      offset += fragment.length;
+      if (offset === target.length) {
+        return true;
+      }
+      if (target[offset] !== " ") {
+        break;
+      }
+      offset += 1;
     }
   }
   return false;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Preparing Slack replies with authored text and rendered blocks repeatedly copies and normalizes growing text prefixes to decide whether that text is already visible. Large structured replies can spend unnecessary CPU and temporary memory on these comparisons.

## Why This Change Was Made

Compare already-normalized fragments directly against the target at an offset, stop on a mismatch, and stop trying later starts once the remaining text cannot fit the target. Matching still requires complete consecutive fragments joined by one normalized space; the existing producer facts and legacy interactive path remain intact.

## User Impact

Slack reply preparation uses less temporary memory and comparison work, especially with many rendered fragments. Text placement, message content, controls, and delivery order remain unchanged.

## Evidence

Before/after public-owner probes produced identical placement results for 455 synthetic cases through both rendered-fragment and legacy-interactive inputs, plus four default/producer-fact cases. Seven focused tests cover full-fragment boundaries, required separators, normalization, consecutive text, and later matching starts.

On Node 26.8.1, median times for 100 comparisons of 50 synthetic 1,000-character fragments were:

| Input | Before | After |
| --- | ---: | ---: |
| Complete match | 14.7 ms | 4.5 ms |
| Unrelated target | 239.7 ms | 2.7 ms |
| Repeated prefix, final mismatch | 240.0 ms | 3.4 ms |

One allocation-sampling run of 100 comparisons showed over 99.7% fewer sampled allocated bytes for both mismatch cases. A separate warmed, alternating comparison of short three-fragment replies improved in all eight pairs, with median time falling from 72.0 to 35.5 ms per 100,000 calls. These are synthetic owner measurements; sampled allocations include collected objects and do not establish whole-Gateway retained-heap or RSS gains.

Owner, reply-builder, and outbound-payload suites passed: **60 tests in 3 files**. The complete required changed gate passed, including extension production/test typechecks, lint, plugin boundary declarations, and repository guards. Independent source review and native autoreview found no actionable issue; native review returned `scoped-clean` at its default P0 threshold.
