### PR TITLE
improve(tui): defer editor snapshots until autocomplete confirmation

### DIFF
--- a/src/tui/components/custom-editor.ts
+++ b/src/tui/components/custom-editor.ts
@@ -116,19 +116,19 @@ export class CustomEditor extends Editor {
     }
 
     const keybindings = getKeybindings();
-    const cursor = this.getCursor();
-    const lines = this.getLines();
-    const cursorAtEnd =
-      cursor.line === lines.length - 1 && cursor.col === (lines[cursor.line]?.length ?? 0);
     if (
-      cursorAtEnd &&
       this.isShowingAutocomplete() &&
       keybindings.matches(data, "tui.select.confirm") &&
-      keybindings.matches(data, "tui.input.submit") &&
-      this.shouldSubmitAutocomplete?.(this.getText())
+      keybindings.matches(data, "tui.input.submit")
     ) {
-      // Exact argument already present: close the picker so this Enter reaches submit.
-      this.setText(this.getText());
+      const cursor = this.getCursor();
+      const lines = this.getLines();
+      const cursorAtEnd =
+        cursor.line === lines.length - 1 && cursor.col === (lines[cursor.line]?.length ?? 0);
+      if (cursorAtEnd && this.shouldSubmitAutocomplete?.(this.getText())) {
+        // Exact argument already present: close the picker so this Enter reaches submit.
+        this.setText(this.getText());
+      }
     }
 
     if (keybindings.matches(data, "tui.input.submit") && this.onSubmit) {


### PR DESCRIPTION
## What Problem This Solves

Ordinary typing and cursor movement in the TUI copied the draft's entire line-reference array and created a cursor snapshot for an autocomplete-only submission check. The unnecessary work grew with the number of draft lines.

## Why This Change Was Made

Read those snapshots only when autocomplete is visible and the input matches both confirmation and submission. Preserve the existing end-of-draft and exact-completion checks, followed by the same editing and submission paths.

## User Impact

Editing long drafts avoids the extra draft-sized copy for ordinary keys. Autocomplete, multiline input, paste handling, and shortcuts keep their existing behavior. Production LOC is unchanged, and the existing tests provide behavior coverage.

## Evidence

- Four synthetic runs each sent 2,000 cursor keys through a 1,000-line, 50,999-character draft. Each run went from 2,000 line-array copies, two million copied references, and 2,000 cursor records to zero. Active completion confirmation still takes one snapshot.
- Before/after outcomes were byte-identical for ordinary editing, newline insertion, bracketed paste/submission, hotkeys, AltGr/key releases, exact single-Enter completion, multiple-match acceptance, and ordinary command submission. Final draft text and cursor positions also matched. These are component allocation and behavior measurements, not process heap/RSS or production latency measurements.
- All 58 existing editor and submission-handler tests passed. No implementation-spy test or new production seam was added.
- Independent source/evidence review found no actionable issue; native autoreview was scoped-clean at its default P0 threshold.
- The complete changed-file gate passed, including core/test typechecks, lint, dependency and architecture guards, dead exports, and runtime import cycles.
