### PR TITLE
improve(agents): collect tool schema search text in one pass

### DIFF
--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -3,25 +3,32 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
 /** Collects property names and descriptions from a JSON-Schema-shaped value. */
 export function readParameterText(parameters: unknown, depth = 0): string {
-  if (depth > 4 || !isRecord(parameters)) {
-    return "";
-  }
   const parts: string[] = [];
+  collectParameterText(parameters, depth, parts);
+  return parts.join(" ");
+}
+
+function collectParameterText(parameters: unknown, depth: number, parts: string[]): void {
+  if (depth > 4 || !isRecord(parameters)) {
+    return;
+  }
   const description = parameters.description;
-  if (typeof description === "string") {
+  if (typeof description === "string" && description) {
     parts.push(description);
   }
   const properties = parameters.properties;
   if (isRecord(properties)) {
     for (const [name, child] of Object.entries(properties)) {
-      parts.push(name, readParameterText(child, depth + 1));
+      if (name) {
+        parts.push(name);
+      }
+      collectParameterText(child, depth + 1, parts);
     }
   }
   const items = parameters.items;
   if (items !== undefined) {
-    parts.push(readParameterText(items, depth + 1));
+    collectParameterText(items, depth + 1, parts);
   }
-  return parts.filter(Boolean).join(" ");
 }
 
 /** BM25 term-frequency saturation. Standard Okapi default. */

--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -873,24 +873,36 @@ describe("Tool Search catalog indexing", () => {
     ]);
   });
 
-  it("rebuilds the search index when a parameter description changes in place", async () => {
-    const parameters = {
-      type: "object",
-      description: "Search an orchard",
-      properties: {},
-    };
-    const { runtime } = createRuntime([fakeTool("indexed_resource", parameters as never)]);
+  it.each(["root", "property", "items"])(
+    "rebuilds the search index when a %s description changes in place",
+    async (location) => {
+      const described = {
+        type: "object",
+        description: "Search an orchard",
+        properties: {},
+      };
+      const parameters =
+        location === "root"
+          ? described
+          : location === "property"
+            ? { type: "object", properties: { resource: described } }
+            : {
+                type: "object",
+                properties: { resources: { type: "array", items: described } },
+              };
+      const { runtime } = createRuntime([fakeTool("indexed_resource", parameters as never)]);
 
-    await expect(runtime.search("orchard")).resolves.toEqual([
-      expect.objectContaining({ name: "indexed_resource" }),
-    ]);
-    parameters.description = "Search a meteor";
+      await expect(runtime.search("orchard")).resolves.toEqual([
+        expect.objectContaining({ name: "indexed_resource" }),
+      ]);
+      described.description = "Search a meteor";
 
-    await expect(runtime.search("meteor")).resolves.toEqual([
-      expect.objectContaining({ name: "indexed_resource" }),
-    ]);
-    await expect(runtime.search("orchard")).resolves.toEqual([]);
-  });
+      await expect(runtime.search("meteor")).resolves.toEqual([
+        expect.objectContaining({ name: "indexed_resource" }),
+      ]);
+      await expect(runtime.search("orchard")).resolves.toEqual([]);
+    },
+  );
 });
 
 describe("Tool Search network error boundaries", () => {


### PR DESCRIPTION
## What Problem This Solves

Repeated Tool Search queries allocate unnecessary temporary text for nested tool metadata, even when their existing search index can be reused.

## Why This Change Was Made

Collect parameter names and descriptions into one array and join once, instead of allocating and joining text at every recursive level. The existing depth limit, ordering, empty-string handling, and property-value snapshot behavior remain intact. Cache checks still read current metadata so schema changes in place remain searchable.

## User Impact

Tool Search performs less temporary allocation while preserving ranking and current schema descriptions. The change adds seven production lines and extends the existing mutation test to nested properties and array items.

## Evidence

On macOS with Node 26.8.1, medians of three fresh-process runs preserved exact text and search-result hashes. Heap sampling included collected objects and ran separately from timing:

| Owner workload | Sampled allocations before | After |
| --- | ---: | ---: |
| 8,000 nested text collections | 207.0 MiB | 59.1 MiB |
| 300 warm searches over 64 tools | 196.0 MiB | 97.0 MiB |
| 40 fresh indexes over 64 tools | 260.6 MiB | 251.3 MiB |

These are sampled temporary allocations, not retained memory. Settled RSS results were mixed, and baseline wall-clock timings varied; no precise latency or whole-Gateway memory improvement is claimed.

All 43 ranking tests and nine catalog-indexing tests pass, including root/property/items metadata changed in place. Standalone before/after checks also preserve exact whitespace, depth cutoff, property getter ordering, and removal of stale search terms.

The complete changed check passed, including production/test typechecking, formatting, lint and repository guards. Independent owner/caller review found no actionable findings, and Codex autoreview returned scoped-clean at its P0 threshold.

Existing synthetic measurements used three fresh-process replicates per version and workload on macOS / Node 26.8.1. Values below are medians (minimum–maximum). “RSS after GC” is absolute process RSS after the timed loop and explicit GC; “RSS delta” subtracts that replicate's post-warmup, pre-loop RSS. Both are measured before the separate allocation-sampling loop.

| Workload | Version | Elapsed seconds | RSS after GC, MiB | RSS delta, MiB |
| --- | --- | ---: | ---: | ---: |
| 8,000 nested text collections | Before | 0.0458 (0.0408–0.1347) | 518.97 (485.25–538.62) | 0.34 (0.12–1.22) |
| 8,000 nested text collections | After | 0.0328 (0.0320–0.0331) | 479.27 (470.53–482.20) | 6.09 (5.97–6.86) |
| 300 warm searches / 64 tools | Before | 0.1219 (0.0832–0.1527) | 489.53 (480.23–533.56) | 1.19 (0.84–1.28) |
| 300 warm searches / 64 tools | After | 0.0390 (0.0355–0.0512) | 523.53 (471.22–549.48) | 0.42 (0.16–1.17) |
| 40 fresh indexes / 64 tools | Before | 0.1617 (0.1032–0.3528) | 491.36 (489.34–492.80) | 0.61 (0.58–0.72) |
| 40 fresh indexes / 64 tools | After | 0.1187 (0.1076–0.1475) | 522.77 (493.28–534.02) | 0.05 (0.05–0.53) |

Timing includes the async loop and output hash/JSON sink, with 10 warmup operations excluded. These short runs have substantial timing and process-RSS variability; the medians do not establish a precise latency improvement or a whole-Gateway memory reduction. RSS growth was higher for the collector after this patch. Every RSS delta was positive (0.0469–6.8594 MiB); post-GC heap deltas were negative in both versions (−746.5 to −125.4 KiB), which does not establish retained-memory savings either.

The supported result is lower sampled temporary allocation: median 207.03→59.12 MiB for text collection, 196.04→96.99 MiB for warm searches, and 260.65→251.33 MiB for fresh indexes. Sampling used a separate loop at 16 KiB intervals and included objects collected by major and minor GC. Exact text/search-result hashes matched across all measured versions and replicates. These are the existing measurements; no new benchmark was run for this clarification.
