### PR TITLE
improve(heartbeat): reuse enrolled targets for individual wakes

### DIFF
--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -23,7 +23,6 @@ import {
   type HeartbeatRunResult,
   type HeartbeatWakeHandler,
   type HeartbeatWakeIntent,
-  type HeartbeatWakeRequest,
   isRetryableHeartbeatSkipReason,
   setHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
@@ -206,26 +205,6 @@ export function startHeartbeatRunner(opts: {
     const requestedTargetAgentId =
       requestedAgentId ??
       (requestedSessionKey ? resolveAgentIdFromSessionKey(requestedSessionKey) : undefined);
-    const allowsUnscheduledTarget =
-      requestedTargetAgentId !== undefined &&
-      isConfiguredHeartbeatAgent(wakeConfig, requestedTargetAgentId) &&
-      isTargetedUnscheduledWake({
-        source: params.source,
-        intent,
-        reason,
-        agentId: requestedAgentId,
-        sessionKey: requestedSessionKey,
-      });
-    const enrolledAgents = Array.from(state.agents.values()).filter(
-      (agent) => agent.intervalMs !== undefined,
-    );
-    if (enrolledAgents.length === 0 && !allowsUnscheduledTarget) {
-      return {
-        status: "skipped",
-        reason: "disabled",
-      } satisfies HeartbeatRunResult;
-    }
-
     const isInterval = reason === "interval";
     const startedAt = Date.now();
     const now = startedAt;
@@ -327,8 +306,20 @@ export function startHeartbeatRunner(opts: {
       let targetAgent = state.agents.get(targetAgentId);
       // A user-present targeted event may wake an unscheduled agent once. It
       // must not enroll that agent in the recurring heartbeat scheduler.
-      if (targetAgent?.intervalMs === undefined && !allowsUnscheduledTarget) {
-        return { status: "skipped", reason: "disabled" };
+      if (targetAgent?.intervalMs === undefined) {
+        const allowsUnscheduledTarget =
+          requestedTargetAgentId !== undefined &&
+          isConfiguredHeartbeatAgent(wakeConfig, requestedTargetAgentId) &&
+          isTargetedUnscheduledWake({
+            source: params.source,
+            intent,
+            reason,
+            agentId: requestedAgentId,
+            sessionKey: requestedSessionKey,
+          });
+        if (!allowsUnscheduledTarget) {
+          return { status: "skipped", reason: "disabled" };
+        }
       }
       if (!targetAgent) {
         targetAgent = createAgentState(targetAgentId, now);
@@ -341,6 +332,16 @@ export function startHeartbeatRunner(opts: {
       return outcome.ran
         ? { status: "ran", durationMs: Date.now() - startedAt }
         : (outcome.result ?? { status: "skipped", reason: "not-due" });
+    }
+
+    const enrolledAgents = Array.from(state.agents.values()).filter(
+      (agent) => agent.intervalMs !== undefined,
+    );
+    if (enrolledAgents.length === 0) {
+      return {
+        status: "skipped",
+        reason: "disabled",
+      } satisfies HeartbeatRunResult;
     }
 
     // Agent state is disjoint; concurrent broadcast dispatch prevents a slow
@@ -381,19 +382,7 @@ export function startHeartbeatRunner(opts: {
     );
   };
 
-  const wakeHandler: HeartbeatWakeHandler = async (params: HeartbeatWakeRequest) =>
-    run({
-      reason: params.reason,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      heartbeat: params.heartbeat,
-      scheduledEveryMs: params.scheduledEveryMs,
-      tasks: params.tasks,
-      retainedWork: params.retainedWork,
-      source: params.source,
-      intent: params.intent,
-    });
-  const disposeWakeHandler = setHeartbeatWakeHandler(wakeHandler);
+  const disposeWakeHandler = setHeartbeatWakeHandler(run);
   updateConfig(state.cfg);
 
   const cleanup = () => {


### PR DESCRIPTION
## What Problem This Solves

Targeted heartbeat wakes for an already-enrolled agent rebuilt the configured-agent list and copied the recurring-agent roster on every dispatch.

## Why This Change Was Made

Use the existing enrollment map directly, resolve the unchanged unscheduled-wake rules only for unenrolled targets, and build the recurring roster only for broadcasts. Remove the redundant handler wrapper because request enqueueing and dispatch already own separate top-level request records.

## User Impact

Targeted wakes avoid repeated roster work, especially with many configured agents. Disabled cadence, unknown targets, reload accounting, broadcasts, request ownership, and wake outcomes keep their existing behavior.

## Evidence

- All 97 focused heartbeat tests pass before and after the change.
- A synthetic probe through the real request queue and scheduler preserved all six scenarios, including caller request mutation before dispatch and during execution.
- For 500 targeted wakes with 512 configured agents, sampled allocations fell from 125.6 MB to 9.2 MB. This is one before/after sample through the real queue and scheduler with an injected executor. Single-agent timing was noisy and did not improve; no whole-Gateway RSS improvement is claimed.
- The complete changed-file gate passed, including formatting, core/test typechecks, lint, dead exports, and repository guards. Independent and isolated reviews found no actionable issues.
