### PR TITLE
refactor(plugins): centralize managed npm install planning

### DIFF
--- a/src/plugins/install-managed-npm-state.ts
+++ b/src/plugins/install-managed-npm-state.ts
@@ -20,7 +20,7 @@ import {
   resolvePluginNpmGenerationProjectDirPrefix,
   resolvePluginNpmProjectDir,
 } from "./install-paths.js";
-import { loadPluginInstallRuntime } from "./install-shared.js";
+import { loadPluginInstallRuntime, resolveEffectiveInstallMode } from "./install-shared.js";
 import type { PluginInstallLogger } from "./install-types.js";
 import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
@@ -517,7 +517,7 @@ export async function listManagedNpmRootPackageNames(npmRoot: string): Promise<S
   return packageNames;
 }
 
-export function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): string {
+function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): string {
   return path.join(npmRoot, "node_modules", ...packageName.split("/"));
 }
 
@@ -534,7 +534,7 @@ function resolveManagedNpmRootGenerationKey(params: {
   ].join("\n");
 }
 
-export function resolveManagedNpmRootForInstall(params: {
+function resolveManagedNpmRootForInstall(params: {
   npmBaseDir: string;
   packageName: string;
   npmResolution: NpmSpecResolution;
@@ -556,7 +556,7 @@ export function resolveManagedNpmRootForInstall(params: {
   });
 }
 
-export function resolveManagedNpmInstallRoot(params: {
+function resolveManagedNpmInstallRoot(params: {
   npmBaseDir: string;
   packageName: string;
   npmResolution: NpmSpecResolution;
@@ -620,7 +620,7 @@ async function listManagedNpmPackageDirsForPackage(params: {
   return packageDirs;
 }
 
-export async function resolveManagedNpmGenerationUseForInstall(params: {
+async function resolveManagedNpmGenerationUseForInstall(params: {
   runtime: Awaited<ReturnType<typeof loadPluginInstallRuntime>>;
   npmBaseDir: string;
   packageName: string;
@@ -652,10 +652,44 @@ export async function resolveManagedNpmGenerationUseForInstall(params: {
       return "retained-install";
     }
   }
-  if (params.requestedMode === "update") {
-    return hasNonRetainedPackageDir ? "update" : "none";
-  }
-  return "none";
+  return generationUse;
+}
+
+export async function resolveManagedNpmInstallPlan(params: {
+  runtime: Awaited<ReturnType<typeof loadPluginInstallRuntime>>;
+  npmBaseDir: string;
+  packageName: string;
+  requestedMode: "install" | "update";
+  npmResolution: NpmSpecResolution;
+}): Promise<{
+  npmRoot: string;
+  installRoot: string;
+  targetMode: "install" | "update";
+  policyMode: "install" | "update";
+}> {
+  const generationUse = await resolveManagedNpmGenerationUseForInstall(params);
+  const npmRoot = resolveManagedNpmInstallRoot({
+    ...params,
+    useGeneration: generationUse !== "none",
+  });
+  const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
+  const targetMode =
+    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
+      ? "update"
+      : await resolveEffectiveInstallMode({
+          runtime: params.runtime,
+          requestedMode: params.requestedMode,
+          targetPath: installRoot,
+        });
+  // A new artifact directory can still update an installed plugin. Conversely,
+  // reactivating a retained tree requires fresh-install policy, even for --update.
+  const policyMode =
+    generationUse === "update"
+      ? "update"
+      : generationUse === "retained-install"
+        ? "install"
+        : targetMode;
+  return { npmRoot, installRoot, targetMode, policyMode };
 }
 
 export function resolveRequiredPlatformPackageNames(

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -35,10 +35,8 @@ import {
   listNewManagedNpmRootPackageDirs,
   quarantineManagedNpmProjectRebuildArtifacts,
   removeEmptyDirectoryIfPresent,
-  resolveManagedNpmGenerationUseForInstall,
-  resolveManagedNpmInstallRoot,
+  resolveManagedNpmInstallPlan,
   resolveManagedNpmRootDependencySpecForInstall,
-  resolveManagedNpmRootPackageDir,
   resolveRequiredPlatformPackageNames,
   rollbackManagedNpmPluginInstall,
   rollbackManagedNpmRootPreparedDependency,
@@ -59,7 +57,6 @@ import {
   formatUnresolvedOpenClawPeerLinkError,
   loadPluginInstallRuntime,
   readOptionalPackageManifest,
-  resolveEffectiveInstallMode,
   runInstallSourceScan,
   sourceFamilyForInstallPolicySource,
 } from "./install-shared.js";
@@ -73,7 +70,6 @@ import type {
   PluginInstallLogger,
   PluginInstallPolicyRequest,
 } from "./install-types.js";
-import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import { isOfficialCatalogLookupPluginIdReplacement } from "./official-external-install-records.js";
 import {
   auditDeclaredOpenClawHostDependency,
@@ -111,34 +107,13 @@ export async function installPluginFromManagedNpmRoot(
   );
   const expectedPluginId = params.expectedPluginId;
   const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const generationUse = await resolveManagedNpmGenerationUseForInstall({
+  const { npmRoot, installRoot, targetMode, policyMode } = await resolveManagedNpmInstallPlan({
     runtime,
     npmBaseDir,
     packageName: params.packageName,
     requestedMode: mode,
     npmResolution: params.npmResolution,
   });
-  const npmRoot = resolveManagedNpmInstallRoot({
-    npmBaseDir,
-    packageName: params.packageName,
-    npmResolution: params.npmResolution,
-    useGeneration: generationUse !== "none",
-  });
-  const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
-  const targetMode =
-    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
-      ? "update"
-      : await resolveEffectiveInstallMode({
-          runtime,
-          requestedMode: mode,
-          targetPath: installRoot,
-        });
-  const policyMode =
-    generationUse === "update"
-      ? "update"
-      : generationUse === "retained-install"
-        ? "install"
-        : targetMode;
   const availability = await ensureInstallTargetAvailableForMode({
     runtime,
     targetPath: installRoot,

--- a/src/plugins/install-npm-pack.ts
+++ b/src/plugins/install-npm-pack.ts
@@ -11,9 +11,7 @@ import { parseRegistryNpmSpec, validateRegistryNpmSpec } from "../infra/npm-regi
 import { resolveUserPath } from "../utils.js";
 import {
   removeEmptyDirectoryIfPresent,
-  resolveManagedNpmGenerationUseForInstall,
-  resolveManagedNpmRootForInstall,
-  resolveManagedNpmRootPackageDir,
+  resolveManagedNpmInstallPlan,
   type ManagedNpmRootPreparedDependency,
 } from "./install-managed-npm-state.js";
 import { installPluginFromManagedNpmRoot } from "./install-managed-npm.js";
@@ -23,7 +21,6 @@ import {
   defaultLogger,
   emitSuccessfulPluginInstallSecurityEvent,
   loadPluginInstallRuntime,
-  resolveEffectiveInstallMode,
 } from "./install-shared.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
 import {
@@ -34,7 +31,6 @@ import {
   type PluginInstallLogger,
   type PluginNpmIntegrityDriftParams,
 } from "./install-types.js";
-import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 
 const MANAGED_NPM_PACK_ARCHIVE_DIR = "_openclaw-pack-archives";
 
@@ -206,34 +202,13 @@ export async function installPluginFromNpmPackArchive(
   }
   const packageName = packageNameResult.packageName;
   const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const generationUse = await resolveManagedNpmGenerationUseForInstall({
+  const { policyMode } = await resolveManagedNpmInstallPlan({
     runtime,
     npmBaseDir,
     packageName,
     requestedMode: mode,
     npmResolution,
   });
-  const npmProjectRoot = resolveManagedNpmRootForInstall({
-    npmBaseDir,
-    packageName,
-    npmResolution,
-    useGeneration: generationUse !== "none",
-  });
-  const installRoot = resolveManagedNpmRootPackageDir(npmProjectRoot, packageName);
-  const targetMode =
-    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
-      ? "update"
-      : await resolveEffectiveInstallMode({
-          runtime,
-          requestedMode: mode,
-          targetPath: installRoot,
-        });
-  const policyMode =
-    generationUse === "update"
-      ? "update"
-      : generationUse === "retained-install"
-        ? "install"
-        : targetMode;
 
   const result = await installPluginFromManagedNpmRoot(
     copyPluginInstallTransactionRequest(params, {

--- a/src/plugins/install-npm.ts
+++ b/src/plugins/install-npm.ts
@@ -10,11 +10,7 @@ import {
   parseRegistryNpmSpec,
 } from "../infra/npm-registry-spec.js";
 import { resolveUserPath } from "../utils.js";
-import {
-  resolveManagedNpmGenerationUseForInstall,
-  resolveManagedNpmRootForInstall,
-  resolveManagedNpmRootPackageDir,
-} from "./install-managed-npm-state.js";
+import { resolveManagedNpmInstallPlan } from "./install-managed-npm-state.js";
 import { installPluginFromManagedNpmRoot } from "./install-managed-npm.js";
 import {
   canResolveAroundCompatibilityError,
@@ -32,7 +28,6 @@ import {
   defaultLogger,
   emitSuccessfulPluginInstallSecurityEvent,
   loadPluginInstallRuntime,
-  resolveEffectiveInstallMode,
   runInstallSourceScan,
 } from "./install-shared.js";
 import { copyPluginInstallTransactionRequest } from "./install-transaction.js";
@@ -43,7 +38,6 @@ import {
   type PluginInstallLogger,
   type PluginNpmIntegrityDriftParams,
 } from "./install-types.js";
-import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 
 export async function installPluginFromNpmSpec(
   params: InstallSafetyOverrides & {
@@ -183,34 +177,13 @@ export async function installPluginFromNpmSpec(
     return { ok: false, error: driftResult.error };
   }
   const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const generationUse = await resolveManagedNpmGenerationUseForInstall({
+  const { policyMode } = await resolveManagedNpmInstallPlan({
     runtime,
     npmBaseDir,
     packageName: parsedSpec.name,
     requestedMode: mode,
     npmResolution,
   });
-  const npmRoot = resolveManagedNpmRootForInstall({
-    npmBaseDir,
-    packageName: parsedSpec.name,
-    npmResolution,
-    useGeneration: generationUse !== "none",
-  });
-  const installRoot = resolveManagedNpmRootPackageDir(npmRoot, parsedSpec.name);
-  const targetMode =
-    generationUse === "retained-install" && hasRetainedManagedNpmInstallMarker(installRoot)
-      ? "update"
-      : await resolveEffectiveInstallMode({
-          runtime,
-          requestedMode: mode,
-          targetPath: installRoot,
-        });
-  const policyMode =
-    generationUse === "update"
-      ? "update"
-      : generationUse === "retained-install"
-        ? "install"
-        : targetMode;
 
   const policyTempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npm-policy-"));
   try {


### PR DESCRIPTION
## What Problem This Solves

Registry installs, npm-pack archives, and managed npm installation repeated the same generation and policy decisions. An update into a new directory or reinstallation of a retained artifact needs consistent policy across those paths.

## Why This Change Was Made

One managed npm install planner now returns the artifact roots, filesystem operation mode, and policy mode for all three callers. The generation owner also reuses its existing decision instead of calculating it twice.

## User Impact

Install/update behavior, retained-file protection, rollback, corruption quarantine, and Gateway restart behavior remain unchanged. This independent preparation for #135599 removes 43 production lines across four files.

## Evidence

All 210 existing installer tests passed, including generated policy scripts, npm-pack installation, retained lazy imports, rollback, and quarantine. The 11 generation/mode cases passed again after the final simplification. Production and test typechecks, formatting, boundary/ratchet/dead-export guards, final typed lint, and independent P2 review passed. No tests were weakened or added to mirror the implementation.
