### PR TITLE
fix(android): keep settings and skill details readable at large text sizes

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ChannelsSettingsScreen.kt
@@ -4,7 +4,7 @@ import ai.openclaw.app.GatewayChannelSummary
 import ai.openclaw.app.GatewayChannelsSummary
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
-import ai.openclaw.app.ui.design.ClawDetailRow
+import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawListPanel
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawStatus
@@ -78,7 +78,7 @@ internal fun ChannelsSettingsScreen(
 
 @Composable
 private fun ChannelRow(channel: GatewayChannelSummary) {
-  ClawDetailRow(
+  ClawListItem(
     title = channel.label,
     subtitle = channelSubtitle(channel),
     leading = { ClawTextBadge(text = channelBadge(channel.label)) },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CronJobManagementPanel.kt
@@ -11,8 +11,8 @@ import ai.openclaw.app.GatewayCronRunSummary
 import ai.openclaw.app.GatewayCronScheduleEdit
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.resolveNativeText
-import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconBadge
+import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawListPanel
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPrimaryButton
@@ -635,7 +635,7 @@ private fun CronRunHistoryPanel(
 @Composable
 private fun CronRunHistoryRow(run: GatewayCronRunSummary) {
   val status = cronRunStatus(run.status)
-  ClawDetailRow(
+  ClawListItem(
     title = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.SHORT).format(Date(run.ts)),
     subtitle = cronRunSubtitle(run),
     leading = { ClawIconBadge(icon = Icons.Default.Schedule) },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/NodesDevicesSettingsScreen.kt
@@ -12,7 +12,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.canApproveGatewayDevicePairing
 import ai.openclaw.app.currentAppLanguage
 import ai.openclaw.app.i18n.nativeString
-import ai.openclaw.app.ui.design.ClawDetailRow
+import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawSecondaryButton
 import ai.openclaw.app.ui.design.ClawStatus
@@ -489,7 +489,7 @@ private fun DeviceListRow(
   statusText: String,
   status: ClawStatus,
 ) {
-  ClawDetailRow(
+  ClawListItem(
     title = title,
     subtitle = subtitle,
     leading = { ClawTextBadge(text = badge) },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -48,7 +48,6 @@ import ai.openclaw.app.photoReadPermissionsForRequest
 import ai.openclaw.app.reconcileRestoredAction
 import ai.openclaw.app.setAppLanguage
 import ai.openclaw.app.ui.design.ClawAgentAvatar
-import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconBadge
 import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawListPanel
@@ -2741,7 +2740,7 @@ private fun SessionToolCallsPanel(toolCalls: List<ChatPendingToolCall>) {
 @Composable
 private fun ApprovalListRow(toolCall: ChatPendingToolCall) {
   val hasIssue = toolCall.isError == true
-  ClawDetailRow(
+  ClawListItem(
     title = approvalActionName(toolCall.name),
     subtitle = approvalSubtitle(toolCall, hasIssue),
     leading = { ClawIconBadge(icon = Icons.Default.Lock) },
@@ -2774,7 +2773,7 @@ internal fun usageRefreshVisible(
 @Composable
 private fun UsageProviderListRow(provider: GatewayUsageProviderSummary) {
   val hasIssue = provider.error != null
-  ClawDetailRow(
+  ClawListItem(
     title = provider.displayName,
     subtitle = usageProviderSubtitle(provider),
     leading = { ClawTextBadge(text = provider.displayName.uppercaseFirstGraphemeOrNull() ?: "U") },
@@ -2787,7 +2786,7 @@ private fun CronJobListRow(
   job: GatewayCronJobSummary,
   onClick: () -> Unit,
 ) {
-  ClawDetailRow(
+  ClawListItem(
     title = job.name,
     subtitle = cronJobSubtitle(job),
     modifier = Modifier.clickable(onClickLabel = nativeString("Open automation detail"), onClick = onClick),
@@ -2963,7 +2962,7 @@ private fun AgentListRow(
   agent: GatewayAgentSummary,
   isDefault: Boolean,
 ) {
-  ClawDetailRow(
+  ClawListItem(
     title = agent.name?.takeIf { it.isNotBlank() } ?: agent.id,
     subtitle = if (isDefault) nativeString("Default assistant") else nativeString("Ready"),
     leading = {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -28,6 +28,7 @@ import ai.openclaw.app.ui.design.AgentAvatarSource
 import ai.openclaw.app.ui.design.ClawAgentAvatar
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import ai.openclaw.app.ui.design.ClawEmptyState
+import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPlainIconButton
 import ai.openclaw.app.ui.design.ClawPrimaryButton
@@ -1905,35 +1906,27 @@ private fun SettingsListRow(
   onClick: () -> Unit,
 ) {
   val localizedTitle = title.resolveNativeTextResource()
-  val localizedValue = value.resolveNativeTextResource()
-  Row(
-    modifier =
-      Modifier
-        .fillMaxWidth()
-        .heightIn(min = 54.dp)
-        .clip(RoundedCornerShape(ClawTheme.radii.row))
-        .clickable(onClick = onClick)
-        .padding(horizontal = 0.dp, vertical = 7.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(10.dp),
-  ) {
-    Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = ClawTheme.colors.text)
-    Text(text = localizedTitle, style = ClawTheme.type.body, color = ClawTheme.colors.text, modifier = Modifier.weight(1f), maxLines = 1)
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
-      if (localizedValue.isNotBlank()) {
-        Text(text = localizedValue, style = ClawTheme.type.caption.copy(fontSize = 13.sp, lineHeight = 17.sp), color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
+  ClawListItem(
+    title = localizedTitle,
+    subtitle = value.resolveNativeTextResource().takeIf { it.isNotBlank() },
+    leading = {
+      Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = ClawTheme.colors.text)
+    },
+    trailing = {
+      Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+        status?.let { active ->
+          Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(if (active) ClawTheme.colors.success else ClawTheme.colors.textSubtle))
+        }
+        Icon(
+          imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+          contentDescription = settingsRowDisclosureDescription(localizedTitle, opensRoute = opensRoute),
+          modifier = Modifier.size(17.dp),
+          tint = ClawTheme.colors.text,
+        )
       }
-      status?.let { active ->
-        Box(modifier = Modifier.size(4.5.dp).clip(CircleShape).background(if (active) ClawTheme.colors.success else ClawTheme.colors.textSubtle))
-      }
-      Icon(
-        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-        contentDescription = settingsRowDisclosureDescription(localizedTitle, opensRoute = opensRoute),
-        modifier = Modifier.size(17.dp),
-        tint = ClawTheme.colors.text,
-      )
-    }
-  }
+    },
+    onClick = onClick,
+  )
 }
 
 internal fun settingsRowDisclosureDescription(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SkillsSettingsScreen.kt
@@ -9,8 +9,8 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.isClawHubSkillInstalled
 import ai.openclaw.app.isClawHubSkillOperationActive
-import ai.openclaw.app.ui.design.ClawDetailRow
 import ai.openclaw.app.ui.design.ClawIconButton
+import ai.openclaw.app.ui.design.ClawListItem
 import ai.openclaw.app.ui.design.ClawListPanel
 import ai.openclaw.app.ui.design.ClawPanel
 import ai.openclaw.app.ui.design.ClawPill
@@ -489,7 +489,7 @@ private fun SkillListRow(
   onClick: () -> Unit,
   onSkillEnabledChange: (String, Boolean) -> Unit,
 ) {
-  ClawDetailRow(
+  ClawListItem(
     title = skill.name,
     subtitle = skillSubtitle(skill),
     modifier = Modifier.clickable(onClickLabel = nativeString("Open skill detail"), onClick = onClick),
@@ -573,7 +573,7 @@ private fun ClawHubSkillSearchPanel(
           // An install-only row never opens a review dialog, so the warning has to show here.
           nativeString("Not scanned by ClawHub").takeIf { skill.isUnscannedSource },
         )
-      ClawDetailRow(
+      ClawListItem(
         title = skill.displayName,
         subtitle = subtitleParts.joinToString(" · "),
         leading = { ClawTextBadge(text = skillBadge(skill.displayName)) },

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
@@ -436,7 +436,7 @@ internal fun ClawIconBadge(
   }
 }
 
-/** Reusable one-line list row with optional subtitle, metadata, slots, and click handling. */
+/** Keeps labels and metadata in one wrapping column beside fixed-width row controls. */
 @Composable
 internal fun ClawListItem(
   title: String,
@@ -470,21 +470,14 @@ internal fun ClawListItem(
         text = title,
         style = ClawTheme.type.body,
         color = ClawTheme.colors.text,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
       )
-      if (subtitle != null) {
+      listOfNotNull(subtitle, metadata).forEach { detail ->
         Text(
-          text = subtitle,
+          text = detail,
           style = ClawTheme.type.caption,
-          color = ClawTheme.colors.textSubtle,
-          maxLines = 1,
-          overflow = TextOverflow.Ellipsis,
+          color = ClawTheme.colors.textMuted,
         )
       }
-    }
-    if (metadata != null) {
-      Text(text = metadata, style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle, maxLines = 1)
     }
     trailing?.invoke()
   }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -371,33 +372,6 @@ internal fun <T> ClawSeparatedColumn(
   }
 }
 
-/** Two-line settings/detail row with caller-provided leading and trailing slots. */
-@Composable
-internal fun ClawDetailRow(
-  title: String,
-  subtitle: String,
-  modifier: Modifier = Modifier,
-  leading: @Composable () -> Unit,
-  trailing: @Composable () -> Unit,
-) {
-  Row(
-    modifier =
-      modifier
-        .fillMaxWidth()
-        .heightIn(min = ClawTheme.spacing.row)
-        .padding(vertical = 6.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs),
-  ) {
-    leading()
-    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-      Text(text = title, style = ClawTheme.type.body, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
-      Text(text = subtitle, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-    }
-    trailing()
-  }
-}
-
 /** Circular text badge used for compact numeric or initials-style row marks. */
 @Composable
 internal fun ClawTextBadge(
@@ -436,7 +410,7 @@ internal fun ClawIconBadge(
   }
 }
 
-/** Keeps labels and metadata in one wrapping column beside fixed-width row controls. */
+/** Keeps labels together and flows controls below when their intrinsic widths cannot fit. */
 @Composable
 internal fun ClawListItem(
   title: String,
@@ -454,29 +428,36 @@ internal fun ClawListItem(
       modifier.clickable(onClick = onClick)
     }
 
-  Row(
+  FlowRow(
     modifier =
       rowModifier
         .fillMaxWidth()
         .heightIn(min = ClawTheme.spacing.touchTarget)
         .clip(RoundedCornerShape(ClawTheme.radii.row))
         .padding(vertical = 6.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs),
+    horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs, Alignment.End),
+    verticalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs),
+    itemVerticalAlignment = Alignment.CenterVertically,
   ) {
-    leading?.invoke()
-    Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-      Text(
-        text = title,
-        style = ClawTheme.type.body,
-        color = ClawTheme.colors.text,
-      )
-      listOfNotNull(subtitle, metadata).forEach { detail ->
+    Row(
+      modifier = Modifier.weight(1f),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs),
+    ) {
+      leading?.invoke()
+      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
         Text(
-          text = detail,
-          style = ClawTheme.type.caption,
-          color = ClawTheme.colors.textMuted,
+          text = title,
+          style = ClawTheme.type.body,
+          color = ClawTheme.colors.text,
         )
+        listOfNotNull(subtitle, metadata).forEach { detail ->
+          Text(
+            text = detail,
+            style = ClawTheme.type.caption,
+            color = ClawTheme.colors.textMuted,
+          )
+        }
       }
     }
     trailing?.invoke()

--- a/apps/android/app/src/test/java/ai/openclaw/app/i18n/NativeStringsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/i18n/NativeStringsTest.kt
@@ -1,5 +1,8 @@
 package ai.openclaw.app.i18n
 
+import ai.openclaw.app.AppearanceThemeMode
+import ai.openclaw.app.ui.appearanceThemeModeForLabel
+import ai.openclaw.app.ui.appearanceThemeOptions
 import android.content.Context
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
@@ -21,6 +24,20 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [31])
 class NativeStringsTest {
+  @Test
+  fun appearanceThemeModesUseTheAppLanguage() {
+    NativeStringResources.install(RuntimeEnvironment.getApplication())
+    try {
+      NativeStringResources.setApplicationLocales(LocaleListCompat.forLanguageTags("fr"))
+
+      assertEquals(listOf("Système", "Sombre", "Clair"), appearanceThemeOptions())
+      assertEquals(AppearanceThemeMode.Dark, appearanceThemeModeForLabel("Sombre"))
+      assertEquals(AppearanceThemeMode.Light, appearanceThemeModeForLabel("Clair"))
+    } finally {
+      NativeStringResources.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+    }
+  }
+
   @Test
   fun sourceFallbackFormatsNestedKotlinInterpolations() {
     assertEquals(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
@@ -11,8 +11,16 @@ import ai.openclaw.app.i18n.verbatimText
 import android.content.Context
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ChatBubbleOutline
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyDescendant
@@ -26,7 +34,11 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import org.junit.Assert.assertEquals
@@ -39,6 +51,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
 import org.robolectric.util.ReflectionHelpers
 import java.util.UUID
 
@@ -127,39 +140,72 @@ class CommandPaletteLogicTest {
     assertTrue(commandItems(query = nativeString("Sign Out"), desktopObserveAvailable = true, providerSubtitle = "Ready").isEmpty())
   }
 
+  @Test
+  @GraphicsMode(GraphicsMode.Mode.NATIVE)
+  @Config(qualifiers = "fr-w320dp-h800dp-420dpi")
+  fun settingsRowsKeepLocalizedTitlesAndStatusesReadable() {
+    val fontScale = mutableStateOf(1f)
+    val title = nativeString("Providers & Models")
+    val value = nativeString("Review readiness")
+    assertTrue(title.startsWith("Fournisseurs"))
+    withShell(HomeDestination.Settings, Modifier.width(320.dp), { fontScale.value }) { backDispatcher, assertRuntimeUnchanged ->
+      for (scale in listOf(1f, 2f)) {
+        composeRule.runOnIdle { fontScale.value = scale }
+        composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex)).performScrollToNode(hasText(title))
+        for (label in listOf(title, value)) {
+          val layouts = mutableListOf<TextLayoutResult>()
+          composeRule
+            .onNodeWithText(label, useUnmergedTree = true)
+            .assertIsDisplayed()
+            .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
+          val layout = layouts.single()
+          // Paragraph width can exceed a tight Text node even when every glyph fits.
+          assertFalse("$label must retain every line", layout.multiParagraph.didExceedMaxLines)
+          assertTrue("$label must fit vertically", layout.multiParagraph.height <= layout.size.height + 1f)
+          assertTrue("$label must fit horizontally", (0 until layout.lineCount).all { layout.getLineLeft(it) >= -1f && layout.getLineRight(it) <= layout.size.width + 1f })
+          assertTrue("$scale: $label must not be ellipsized", (0 until layout.lineCount).none(layout::isLineEllipsized))
+          assertEquals(label.length, layout.getLineEnd(layout.lineCount - 1, visibleEnd = true))
+        }
+        assertRuntimeUnchanged()
+      }
+      composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex)).performScrollToNode(hasText(nativeString("Appearance")))
+      composeRule.onNodeWithContentDescription(settingsRowDisclosureDescription(nativeString("Appearance"), opensRoute = true)).performClick()
+      composeRule.onNodeWithText(nativeString("Theme family")).assertIsDisplayed()
+      composeRule.runOnIdle { backDispatcher.onBackPressed() }
+      composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex)).performScrollToNode(hasText(nativeString("Licenses")))
+      assertEquals(
+        listOf(nativeString("Licenses")),
+        composeRule
+          .onNodeWithText(nativeString("Licenses"))
+          .fetchSemanticsNode()
+          .config[SemanticsProperties.Text]
+          .map { it.text },
+      )
+      composeRule.onNodeWithText(nativeString("Licenses")).performClick()
+      composeRule.onNodeWithText(nativeString("OpenClaw appreciates its partners in the open-source community.")).assertIsDisplayed()
+      assertRuntimeUnchanged()
+    }
+  }
+
   private fun verifyAppearanceSearch(origin: HomeDestination) {
-    val app = RuntimeEnvironment.getApplication() as NodeApp
-    val originalRuntime = app.peekRuntime()
-    val prefs = SecurePrefs(app, app.getSharedPreferences("settings-search-${UUID.randomUUID()}", Context.MODE_PRIVATE))
-    val viewModel = MainViewModel(app, prefs, SavedStateHandle())
-    val models = ViewModelStore().apply { put("settings-search", viewModel) }
     val fromSettings = origin == HomeDestination.Settings
     val originTag = if (fromSettings) "sidebar-open-settings" else "sidebar-open-overview"
     val searchDescription = if (fromSettings) nativeString("Search settings") else nativeString("Search")
     val appearance = nativeString("Appearance")
-    lateinit var backDispatcher: OnBackPressedDispatcher
+    withShell(origin) { backDispatcher, assertRuntimeUnchanged ->
+      fun assertOrigin() {
+        composeRule.onNode(hasSetTextAction()).assertDoesNotExist()
+        composeRule.onNodeWithTag(originTag).assertIsDisplayed()
+        composeRule.onNodeWithText(nativeString("Theme family")).assertDoesNotExist()
+        assertRuntimeUnchanged()
+      }
 
-    fun assertOrigin() {
-      composeRule.onNode(hasSetTextAction()).assertDoesNotExist()
-      composeRule.onNodeWithTag(originTag).assertIsDisplayed()
-      composeRule.onNodeWithText(nativeString("Theme family")).assertDoesNotExist()
-      composeRule.runOnIdle { assertSame("Settings discovery must preserve the process runtime owner", originalRuntime, app.peekRuntime()) }
-    }
-
-    fun searchAppearance() {
-      composeRule.onNodeWithContentDescription(searchDescription).performClick()
-      composeRule.onNode(hasSetTextAction()).performTextReplacement(appearance)
-      composeRule.runOnIdle { assertSame("Opening and filtering search must not create a runtime", originalRuntime, app.peekRuntime()) }
-    }
-
-    try {
-      viewModel.requestHomeDestination(origin)
-      composeRule.setContent {
-        backDispatcher = checkNotNull(LocalOnBackPressedDispatcherOwner.current).onBackPressedDispatcher
-        ShellScreen(viewModel = viewModel)
+      fun searchAppearance() {
+        composeRule.onNodeWithContentDescription(searchDescription).performClick()
+        composeRule.onNode(hasSetTextAction()).performTextReplacement(appearance)
+        assertRuntimeUnchanged()
       }
       assertOrigin()
-
       searchAppearance()
       if (fromSettings) {
         composeRule.onNodeWithContentDescription(nativeString("Close search")).performClick()
@@ -167,11 +213,9 @@ class CommandPaletteLogicTest {
         composeRule.runOnIdle { backDispatcher.onBackPressed() }
       }
       assertOrigin()
-
       searchAppearance()
       composeRule.onNodeWithText(nativeString("No actions found")).assertDoesNotExist()
-      // Settings Home remains composed below the palette. Match a non-editable
-      // result in the query's scroll container, not the query editor itself.
+      // Settings Home remains below the palette; scope the result to its query container.
       val searchResults = hasScrollAction() and hasAnyDescendant(hasSetTextAction())
       composeRule
         .onNode(hasText(appearance) and hasClickAction() and hasSetTextAction().not() and hasAnyAncestor(searchResults))
@@ -180,14 +224,40 @@ class CommandPaletteLogicTest {
         .performClick()
       composeRule.onNode(hasSetTextAction()).assertDoesNotExist()
       composeRule.onNodeWithText(nativeString("Theme family")).assertIsDisplayed()
-      composeRule.runOnIdle { assertSame("Opening local Appearance must not create a runtime", originalRuntime, app.peekRuntime()) }
-
+      assertRuntimeUnchanged()
       if (fromSettings) {
         composeRule.runOnIdle { backDispatcher.onBackPressed() }
       } else {
         composeRule.onNodeWithContentDescription(nativeString("Back")).performClick()
       }
       assertOrigin()
+    }
+  }
+
+  private fun withShell(
+    origin: HomeDestination,
+    modifier: Modifier = Modifier,
+    fontScale: () -> Float = { 1f },
+    verify: (OnBackPressedDispatcher, () -> Unit) -> Unit,
+  ) {
+    val app = RuntimeEnvironment.getApplication() as NodeApp
+    val originalRuntime = app.peekRuntime()
+    val prefs = SecurePrefs(app, app.getSharedPreferences("settings-search-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+    val models = ViewModelStore().apply { put("settings-search", viewModel) }
+    lateinit var backDispatcher: OnBackPressedDispatcher
+    try {
+      viewModel.requestHomeDestination(origin)
+      composeRule.setContent {
+        backDispatcher = checkNotNull(LocalOnBackPressedDispatcherOwner.current).onBackPressedDispatcher
+        DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale())) {
+          ShellScreen(viewModel = viewModel, modifier = modifier)
+        }
+      }
+      composeRule.waitForIdle()
+      verify(backDispatcher) {
+        composeRule.runOnIdle { assertSame("Local Settings must preserve the process runtime owner", originalRuntime, app.peekRuntime()) }
+      }
     } finally {
       try {
         models.clear()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -122,9 +122,11 @@ class SettingsScreensContrastTest {
       }
     }
     composeRule.runOnIdle { model.connect(gateway.endpoint) }
+    // Both screens retain visible data during refresh; wait for completion before measuring.
     try {
       composeRule.waitUntil(10_000) {
-        composeRule.onAllNodesWithText("Enabled").fetchSemanticsNodes().isNotEmpty()
+        composeRule.onAllNodesWithText("Enabled").fetchSemanticsNodes().isNotEmpty() &&
+          model.isConnected.value && !model.cronRefreshing.value && model.cronStatus.value.enabled
       }
     } finally {
       File(evidence, "cron-readiness.json").writeText(
@@ -140,7 +142,6 @@ class SettingsScreensContrastTest {
           .toString(2),
       )
     }
-    assertTrue(model.isConnected.value && !model.cronRefreshing.value && model.cronStatus.value.enabled)
     assertTrue(gateway.methods.containsAll(listOf("cron.status", "cron.list")))
 
     fun observe(
@@ -188,13 +189,11 @@ class SettingsScreensContrastTest {
     }
     composeRule.runOnIdle { route.value = SettingsRoute.Approvals }
     composeRule.waitUntil(10_000) {
-      composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty()
+      composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty() &&
+        !model.execApprovalsRefreshing.value && model.execApprovals.value
+          .singleOrNull()
+          ?.commandPreview == "echo"
     }
-    assertTrue(
-      !model.execApprovalsRefreshing.value && model.execApprovals.value
-        .singleOrNull()
-        ?.commandPreview == "echo",
-    )
     composeRule
       .onNodeWithText("Deny")
       .performScrollTo()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SkillsSettingsScreenTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SkillsSettingsScreenTest.kt
@@ -6,6 +6,7 @@ import ai.openclaw.app.NodeApp
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.closeNodeRuntimeTestFixture
 import ai.openclaw.app.ui.design.ClawDesignTheme
 import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
@@ -77,7 +78,7 @@ class SkillsSettingsScreenTest {
     } finally {
       viewModels.clear()
       runtimeField.set(app, originalRuntime)
-      runtime.disconnect()
+      closeNodeRuntimeTestFixture(runtime)
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
@@ -3,11 +3,16 @@ package ai.openclaw.app.ui.design
 import ai.openclaw.app.AppearanceThemeFamily
 import ai.openclaw.app.GatewaySummaryState
 import ai.openclaw.app.appearanceAccentPalette
+import ai.openclaw.app.i18n.NativeStringResources
+import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.i18n.nativeText
+import ai.openclaw.app.parseClawHubSearchResults
 import ai.openclaw.app.ui.SettingsRefreshControls
 import ai.openclaw.app.ui.SettingsSummaryContent
 import ai.openclaw.app.ui.chat.ChatMarkdown
+import android.graphics.Bitmap
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,8 +36,10 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toPixelMap
@@ -56,6 +63,10 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import kotlinx.serialization.json.Json
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -63,8 +74,11 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
+import java.io.File
+import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [36], qualifiers = "w360dp-h800dp-mdpi")
@@ -74,6 +88,148 @@ class ClawComponentsTest {
   val composeRule = createComposeRule()
 
   @Test
+  fun detailRowKeepsInstallOnlyTrustWarningVisible() {
+    val results =
+      parseClawHubSearchResults(
+        """{"results":[{"slug":"weather","installRef":"skills-sh:openclaw/skills/weather","installOnly":true,"trustState":"not-scanned-by-clawhub","displayName":"Weather"},{"slug":"pdf","installRef":"skills-sh:openai/skills/pdf","installOnly":true,"trustState":"not-scanned-by-clawhub","displayName":"Pdf"}]}""",
+        Json,
+      )
+    assertEquals("Both install-only result fixtures must render", 2, results.size)
+    val current = mutableStateOf(Triple("", "", ""))
+    val width = mutableStateOf(320.dp)
+    val fontScale = mutableStateOf(1f)
+    val evidence = File("build/outputs/detail-row-required-subtitle", UUID.randomUUID().toString())
+    check(!evidence.exists() && evidence.mkdirs())
+    val observations = JSONArray()
+    val failures = mutableListOf<String>()
+
+    // These English/French fixture words may break at source spacing or punctuation, not inside letters.
+    fun intraWordBreaks(
+      text: String,
+      layout: TextLayoutResult,
+      start: Int,
+      end: Int,
+    ): List<Int> =
+      (0 until layout.lineCount - 1)
+        .map { layout.getLineEnd(it, visibleEnd = true) }
+        .filter { it > start && it < end && text[it - 1].isLetterOrDigit() && text[it].isLetterOrDigit() }
+    NativeStringResources.install(RuntimeEnvironment.getApplication())
+    try {
+      composeRule.setContent {
+        DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale.value)) {
+          ClawDesignTheme(dark = false) {
+            LazyColumn(Modifier.width(width.value)) {
+              item {
+                ClawListPanel(items = listOf(current.value), modifier = Modifier.testTag("detail-result-panel")) { row ->
+                  ClawListItem(
+                    title = row.first,
+                    subtitle = row.second,
+                    leading = { ClawTextBadge(row.first.take(1).uppercase()) },
+                    trailing = { ClawSecondaryButton(text = row.third, onClick = {}) },
+                  )
+                }
+              }
+            }
+          }
+        }
+      }
+      for (language in listOf("en", "fr")) {
+        NativeStringResources.setApplicationLocales(LocaleListCompat.forLanguageTags(language))
+        val warning = nativeString("Not scanned by ClawHub")
+        for (result in results) {
+          val subtitle =
+            listOfNotNull(
+              result.summary,
+              result.reference,
+              result.version?.let { nativeString("Version \$it", it) },
+              warning.takeIf { result.isUnscannedSource },
+            ).joinToString(" · ")
+          for ((rowWidth, scale) in listOf(320.dp to 1f, 280.dp to 1f, 280.dp to 2f)) {
+            val name = "${result.slug}-$language-${rowWidth.value.toInt()}-${scale.toInt()}"
+            composeRule.runOnIdle {
+              current.value = Triple(result.displayName, subtitle, nativeString("Install"))
+              width.value = rowWidth
+              fontScale.value = scale
+            }
+            val panel = composeRule.onNodeWithTag("detail-result-panel").performScrollTo()
+            val layouts = mutableListOf<TextLayoutResult>()
+            composeRule
+              .onNodeWithText(subtitle, useUnmergedTree = true)
+              .assertIsDisplayed()
+              .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
+            val layout = layouts.single()
+            val titleLayouts = mutableListOf<TextLayoutResult>()
+            val titleNode = composeRule.onNodeWithText(result.displayName, useUnmergedTree = true)
+            titleNode.assertIsDisplayed().performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(titleLayouts)) }
+            val titleLayout = titleLayouts.single()
+            val titleBounds = titleNode.fetchSemanticsNode().boundsInRoot
+            val subtitleBounds = composeRule.onNodeWithText(subtitle, useUnmergedTree = true).fetchSemanticsNode().boundsInRoot
+            val controlBounds =
+              composeRule
+                .onNodeWithText(current.value.third)
+                .assertIsDisplayed()
+                .assertHasClickAction()
+                .fetchSemanticsNode()
+                .boundsInRoot
+            val titleComplete =
+              titleLayout.getLineEnd(titleLayout.lineCount - 1, visibleEnd = true) == result.displayName.length &&
+                (0 until titleLayout.lineCount).none(titleLayout::isLineEllipsized)
+            val titleBreaks = intraWordBreaks(result.displayName, titleLayout, 0, result.displayName.length)
+            val visibleEnd = layout.getLineEnd(layout.lineCount - 1, visibleEnd = true)
+            val ellipsized = (0 until layout.lineCount).any(layout::isLineEllipsized)
+            val warningStart = subtitle.indexOf(warning)
+            val complete = warningStart >= 0 && visibleEnd >= warningStart + warning.length && !ellipsized
+            val warningBreaks = intraWordBreaks(subtitle, layout, warningStart, warningStart + warning.length)
+            File(evidence, "$name.png").outputStream().use { stream ->
+              check(panel.captureToImage().asAndroidBitmap().compress(Bitmap.CompressFormat.PNG, 100, stream))
+            }
+            observations.put(
+              JSONObject()
+                .put("case", name)
+                .put("title", result.displayName)
+                .put("titleComplete", titleComplete)
+                .put("titleLineEnds", JSONArray((0 until titleLayout.lineCount).map { titleLayout.getLineEnd(it, visibleEnd = true) }))
+                .put("titleIntraWordBreaks", JSONArray(titleBreaks))
+                .put("warningIntraWordBreaks", JSONArray(warningBreaks))
+                .put("subtitleLineEnds", JSONArray((0 until layout.lineCount).map { layout.getLineEnd(it, visibleEnd = true) }))
+                .put("titleTop", titleBounds.top)
+                .put("subtitleBottom", subtitleBounds.bottom)
+                .put("controlTop", controlBounds.top)
+                .put("controlBottom", controlBounds.bottom)
+                .put("reference", result.reference)
+                .put("subtitle", subtitle)
+                .put("warning", warning)
+                .put("warningStart", warningStart)
+                .put("warningEnd", warningStart + warning.length)
+                .put("lineCount", layout.lineCount)
+                .put("visibleEnd", visibleEnd)
+                .put("ellipsized", ellipsized)
+                .put("didExceedMaxLines", layout.multiParagraph.didExceedMaxLines)
+                .put("layoutWidthPx", layout.size.width)
+                .put("layoutHeightPx", layout.size.height)
+                .put("warningComplete", complete),
+            )
+            File(evidence, "observations.json").writeText(observations.toString(2))
+            if (!complete) failures += "$name: warning [$warningStart, ${warningStart + warning.length}), visibleEnd=$visibleEnd, ellipsized=$ellipsized"
+            if (!titleComplete || titleBreaks.isNotEmpty() || warningBreaks.isNotEmpty()) {
+              failures += "$name: titleComplete=$titleComplete, title word breaks=$titleBreaks, warning word breaks=$warningBreaks"
+            }
+            if (language == "fr" && rowWidth == 280.dp && scale == 2f && controlBounds.top < subtitleBounds.bottom) {
+              failures += "$name: Installer must move below the text"
+            }
+            if (rowWidth == 320.dp && scale == 1f && !(controlBounds.top < subtitleBounds.bottom && controlBounds.bottom > titleBounds.top)) {
+              failures += "$name: fitting normal controls must stay beside the text"
+            }
+          }
+        }
+      }
+      assertTrue("Required install-only warning must stay visible:\n${failures.joinToString("\n")}", failures.isEmpty())
+    } finally {
+      NativeStringResources.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+    }
+  }
+
+  @Test
   fun listItemKeepsCompleteLabelsAtNarrowWidthsAndLargeText() {
     val cases =
       listOf(
@@ -81,6 +237,7 @@ class ClawComponentsTest {
         ListRowCase("Fournisseurs et modèles", "Vérifier l’état de préparation", slots = ListRowSlots.Settings),
         ListRowCase("Microphone USB du bureau", "Microphone externe", "Session suivante", ListRowSlots.Microphone),
         ListRowCase("Passerelle principale du bureau", "gateway.example.test:18789", slots = ListRowSlots.Gateway),
+        ListRowCase("Analyse des documents", "Configuration de la compétence", slots = ListRowSlots.Skill),
       )
     val current = mutableStateOf(cases.first())
     val width = mutableStateOf(320.dp)
@@ -98,6 +255,12 @@ class ClawComponentsTest {
             item {
               ClawListItem(
                 title = row.title,
+                modifier =
+                  if (row.slots == ListRowSlots.Skill) {
+                    Modifier.clickable(onClickLabel = "Open skill detail") { rowClicks++ }
+                  } else {
+                    Modifier
+                  },
                 subtitle = row.subtitle,
                 metadata = row.metadata,
                 leading =
@@ -107,6 +270,8 @@ class ClawComponentsTest {
                     {
                       if (row.slots == ListRowSlots.Settings) {
                         Icon(Icons.Default.Cloud, null, Modifier.size(20.dp))
+                      } else if (row.slots == ListRowSlots.Skill) {
+                        ClawTextBadge("A")
                       } else {
                         ClawIconBadge(if (row.slots == ListRowSlots.Microphone) Icons.Default.Mic else Icons.Default.Cloud)
                       }
@@ -139,11 +304,21 @@ class ClawComponentsTest {
                           }
                         }
 
+                        ListRowSlots.Skill -> {
+                          Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                            ClawStatusPill(text = "Setup", status = ClawStatus.Warning)
+                            Switch(connected.value, {
+                              connected.value = it
+                              connectionClicks++
+                            }, Modifier.testTag("skill-enabled"))
+                          }
+                        }
+
                         ListRowSlots.None -> {}
                       }
                     }
                   },
-                onClick = { rowClicks++ },
+                onClick = if (row.slots == ListRowSlots.Skill) null else ({ rowClicks++ }),
               )
             }
           }
@@ -158,7 +333,7 @@ class ClawComponentsTest {
             width.value = rowWidth
             fontScale.value = scale
           }
-          val labels = listOfNotNull(row.title, row.subtitle, row.metadata, "Oublier".takeIf { row.slots == ListRowSlots.Gateway })
+          val labels = listOfNotNull(row.title, row.subtitle, row.metadata, "Oublier".takeIf { row.slots == ListRowSlots.Gateway }, "Setup".takeIf { row.slots == ListRowSlots.Skill })
           for (label in labels) {
             val layouts = mutableListOf<TextLayoutResult>()
             composeRule
@@ -173,6 +348,16 @@ class ClawComponentsTest {
             assertTrue("${row.slots}/$rowWidth/$scale: $label must fit horizontally", (0 until layout.lineCount).all { layout.getLineLeft(it) >= -1f && layout.getLineRight(it) <= layout.size.width + 1f })
             assertTrue("$label must not be ellipsized", (0 until layout.lineCount).none(layout::isLineEllipsized))
             assertEquals(label.length, layout.getLineEnd(layout.lineCount - 1, visibleEnd = true))
+          }
+          if (row.slots == ListRowSlots.Skill) {
+            assertEquals(
+              "Open skill detail",
+              composeRule
+                .onNodeWithText(row.title)
+                .fetchSemanticsNode()
+                .config[SemanticsActions.OnClick]
+                .label,
+            )
           }
           val beforeRowClicks = rowClicks
           val beforeForgetClicks = forgetClicks
@@ -196,16 +381,18 @@ class ClawComponentsTest {
             assertEquals(beforeForgetClicks, forgetClicks)
             assertEquals(beforeConnectionClicks, connectionClicks)
           }
-          if (row.slots == ListRowSlots.Gateway) {
-            composeRule.onNodeWithText("Oublier").performScrollTo().performClick()
+          if (row.slots == ListRowSlots.Gateway || row.slots == ListRowSlots.Skill) {
+            if (row.slots == ListRowSlots.Gateway) {
+              composeRule.onNodeWithText("Oublier").performScrollTo().performClick()
+            }
             composeRule
-              .onNodeWithTag("gateway-connection")
+              .onNodeWithTag(if (row.slots == ListRowSlots.Gateway) "gateway-connection" else "skill-enabled")
               .performScrollTo()
               .assertIsDisplayed()
               .performClick()
             composeRule.runOnIdle {
               assertEquals("Trailing controls must not activate the row", beforeRowClicks + 1, rowClicks)
-              assertEquals(beforeForgetClicks + 1, forgetClicks)
+              assertEquals(beforeForgetClicks + if (row.slots == ListRowSlots.Gateway) 1 else 0, forgetClicks)
               assertEquals(beforeConnectionClicks + 1, connectionClicks)
             }
           }
@@ -214,7 +401,7 @@ class ClawComponentsTest {
     }
   }
 
-  private enum class ListRowSlots { None, Settings, Microphone, Gateway }
+  private enum class ListRowSlots { None, Settings, Microphone, Gateway, Skill }
 
   private data class ListRowCase(
     val title: String,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
@@ -7,17 +7,27 @@ import ai.openclaw.app.i18n.nativeText
 import ai.openclaw.app.ui.SettingsRefreshControls
 import ai.openclaw.app.ui.SettingsSummaryContent
 import ai.openclaw.app.ui.chat.ChatMarkdown
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Cloud
+import androidx.compose.material.icons.filled.Mic
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.mutableStateOf
@@ -28,13 +38,17 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -43,6 +57,7 @@ import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -57,6 +72,156 @@ import org.robolectric.annotation.GraphicsMode
 class ClawComponentsTest {
   @get:Rule
   val composeRule = createComposeRule()
+
+  @Test
+  fun listItemKeepsCompleteLabelsAtNarrowWidthsAndLargeText() {
+    val cases =
+      listOf(
+        ListRowCase("Fournisseurs et modèles", "Vérifier l’état de préparation"),
+        ListRowCase("Fournisseurs et modèles", "Vérifier l’état de préparation", slots = ListRowSlots.Settings),
+        ListRowCase("Microphone USB du bureau", "Microphone externe", "Session suivante", ListRowSlots.Microphone),
+        ListRowCase("Passerelle principale du bureau", "gateway.example.test:18789", slots = ListRowSlots.Gateway),
+      )
+    val current = mutableStateOf(cases.first())
+    val width = mutableStateOf(320.dp)
+    val fontScale = mutableStateOf(1f)
+    val connected = mutableStateOf(false)
+    var rowClicks = 0
+    var forgetClicks = 0
+    var connectionClicks = 0
+    composeRule.setContent {
+      val row = current.value
+      DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale.value)) {
+        ClawDesignTheme {
+          // SettingsShellScreen and SettingsDetailFrame give rows scrollable height.
+          LazyColumn(Modifier.width(width.value)) {
+            item {
+              ClawListItem(
+                title = row.title,
+                subtitle = row.subtitle,
+                metadata = row.metadata,
+                leading =
+                  if (row.slots == ListRowSlots.None) {
+                    null
+                  } else {
+                    {
+                      if (row.slots == ListRowSlots.Settings) {
+                        Icon(Icons.Default.Cloud, null, Modifier.size(20.dp))
+                      } else {
+                        ClawIconBadge(if (row.slots == ListRowSlots.Microphone) Icons.Default.Mic else Icons.Default.Cloud)
+                      }
+                    }
+                  },
+                trailing =
+                  if (row.slots == ListRowSlots.None) {
+                    null
+                  } else {
+                    {
+                      when (row.slots) {
+                        ListRowSlots.Settings -> {
+                          Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+                            Box(Modifier.size(4.5.dp).background(ClawTheme.colors.success))
+                            Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Ouvrir ${row.title}", Modifier.size(17.dp))
+                          }
+                        }
+
+                        ListRowSlots.Microphone -> {
+                          Icon(Icons.Default.Check, "Sélectionné", Modifier.size(18.dp))
+                        }
+
+                        ListRowSlots.Gateway -> {
+                          Row {
+                            Switch(connected.value, {
+                              connected.value = it
+                              connectionClicks++
+                            }, Modifier.testTag("gateway-connection"))
+                            TextButton(onClick = { forgetClicks++ }) { Text("Oublier") }
+                          }
+                        }
+
+                        ListRowSlots.None -> {}
+                      }
+                    }
+                  },
+                onClick = { rowClicks++ },
+              )
+            }
+          }
+        }
+      }
+    }
+    for (row in cases) {
+      for (scale in listOf(1f, 2f)) {
+        for (rowWidth in listOf(320.dp, 280.dp)) {
+          composeRule.runOnIdle {
+            current.value = row
+            width.value = rowWidth
+            fontScale.value = scale
+          }
+          val labels = listOfNotNull(row.title, row.subtitle, row.metadata, "Oublier".takeIf { row.slots == ListRowSlots.Gateway })
+          for (label in labels) {
+            val layouts = mutableListOf<TextLayoutResult>()
+            composeRule
+              .onNodeWithText(label, useUnmergedTree = true)
+              .performScrollTo()
+              .assertIsDisplayed()
+              .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
+            val layout = layouts.single()
+            // Paragraph width can exceed a tight Text node even when every glyph fits.
+            assertFalse("${row.slots}/$rowWidth/$scale: $label must retain every line", layout.multiParagraph.didExceedMaxLines)
+            assertTrue("$label must fit vertically", layout.multiParagraph.height <= layout.size.height + 1f)
+            assertTrue("${row.slots}/$rowWidth/$scale: $label must fit horizontally", (0 until layout.lineCount).all { layout.getLineLeft(it) >= -1f && layout.getLineRight(it) <= layout.size.width + 1f })
+            assertTrue("$label must not be ellipsized", (0 until layout.lineCount).none(layout::isLineEllipsized))
+            assertEquals(label.length, layout.getLineEnd(layout.lineCount - 1, visibleEnd = true))
+          }
+          val beforeRowClicks = rowClicks
+          val beforeForgetClicks = forgetClicks
+          val beforeConnectionClicks = connectionClicks
+          if (row.slots == ListRowSlots.Settings) {
+            composeRule.onNodeWithContentDescription("Ouvrir ${row.title}").assertHasClickAction()
+            composeRule
+              .onNodeWithContentDescription("Ouvrir ${row.title}", useUnmergedTree = true)
+              .performScrollTo()
+              .performClick()
+          } else {
+            composeRule.onNodeWithText(row.title).assertHasClickAction()
+            // A merged row's center can be a trailing button; touch the title itself.
+            composeRule
+              .onNodeWithText(row.title, useUnmergedTree = true)
+              .performScrollTo()
+              .performClick()
+          }
+          composeRule.runOnIdle {
+            assertEquals("${row.slots}/$rowWidth/$scale: one row callback", beforeRowClicks + 1, rowClicks)
+            assertEquals(beforeForgetClicks, forgetClicks)
+            assertEquals(beforeConnectionClicks, connectionClicks)
+          }
+          if (row.slots == ListRowSlots.Gateway) {
+            composeRule.onNodeWithText("Oublier").performScrollTo().performClick()
+            composeRule
+              .onNodeWithTag("gateway-connection")
+              .performScrollTo()
+              .assertIsDisplayed()
+              .performClick()
+            composeRule.runOnIdle {
+              assertEquals("Trailing controls must not activate the row", beforeRowClicks + 1, rowClicks)
+              assertEquals(beforeForgetClicks + 1, forgetClicks)
+              assertEquals(beforeConnectionClicks + 1, connectionClicks)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private enum class ListRowSlots { None, Settings, Microphone, Gateway }
+
+  private data class ListRowCase(
+    val title: String,
+    val subtitle: String,
+    val metadata: String? = null,
+    val slots: ListRowSlots = ListRowSlots.None,
+  )
 
   @Test
   fun gatewaySummaryShowsFailuresWithoutInventingDataAndRetainsLoadedSnapshots() {
@@ -102,6 +267,9 @@ class ClawComponentsTest {
           Column(Modifier.width(320.dp).verticalScroll(rememberScrollState()).padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             ClawSegmentedControl(options = listOf("Segment", "Other"), selected = "Segment", onSelect = {})
             ClawPill(text = "Pill", selected = true, onClick = {})
+            ClawPanel(Modifier.testTag("list-item-panel")) {
+              ClawListItem(title = "Row title", subtitle = "Row subtitle", metadata = "Row metadata")
+            }
             Surface(
               modifier = Modifier.testTag("primary-container"),
               color = MaterialTheme.colorScheme.primaryContainer,
@@ -142,6 +310,9 @@ class ClawComponentsTest {
       mapOf(
         "Segment" to null,
         "Pill" to null,
+        "Row title" to "list-item-panel",
+        "Row subtitle" to "list-item-panel",
+        "Row metadata" to "list-item-panel",
         "Primary container" to "primary-container",
         "Secondary container" to "secondary-container",
         "Primary button" to null,


### PR DESCRIPTION
Related: #134939

## What Problem This Solves

Fixes an issue where Android Settings labels and important details are cut off on narrow screens or with larger text. This includes the “Not scanned by ClawHub” warning on install-only skill results. Longer translated labels can also be squeezed into unreadable word fragments beside fixed controls.

## Why This Change Was Made

Settings and detail rows now use one shared list-row component. Its text stays complete, and Compose moves controls below when they cannot fit alongside it. This removes duplicate layouts rather than adding screen-width thresholds or shrinking text. Captions use the existing readable panel color.

Navigation, localized disclosure labels, enabled states and independent control callbacks are preserved. There is no configuration, storage, dependency or protocol change. The related screenshot fixture now uses the existing joined runtime/database cleanup helper instead of disconnecting without closing its resources.

## User Impact

Shared settings and skill-detail rows remain readable at larger text sizes. Required warnings no longer disappear behind single-line ellipses, and controls retain their own actions. This is a shared layout repair, not a change to skill installation or trust policy.

## Evidence

**The final installed comparison and visual review are complete for this shared-row change. The previous installed-verification hold is resolved.**

Source: `34be184fd0a81d5f43120c7c08a5a4d635889d06`, compared with main `87ceec92ecdcbf259c6f0a0d7c3a45f49e8d9e98`, including the caption repair #139931.

- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34026917846), including all Android tests, Play/Wear builds and the required CI gate.
- The local unfiltered Play suite passed **2,788 tests**, with **10 wear-shared tests**. The focused row/caller/localization/lifecycle suites passed **223 tests**, and all **155 caption contrast measurements** passed. Changed-file checks, Kotlin lint, and independent/isolated Codex reviews passed.
- A fresh [isolated Testbox comparison](https://github.com/openclaw/openclaw/actions/runs/34027244708) built and verified both complete APKs, then performed one same-device update without clearing app data. **All ten installed cases passed**: French/light setup, original-width/normal text, 320dp/normal text and 320dp/2x text, navigation, Forget/Cancel, and restoration. The separate read-only Skills case passed all three display profiles, with the warning readable and Install disabled.
- All **19,194 evidence files** were retained and verified. The maintainer agent visually inspected the full **21 primary, 36 navigation/action, and three onboarding/restoration PNGs**. Display size, text scale, app language and effective theme were restored; the owned emulator, service processes and ports closed; the Testbox was stopped after the complete download. Foreground proof/export/receipt exits were all zero.

The installed captures below are unmodified full screenshots with synthetic data. Layout comparisons use the requested profile; ordinary navigation/cancel actions restore the original profile first. No skill installation, admin action, hardware microphone change, inactive Gateway toggle, chat send or model-provider execution is claimed. In the large-text Skills capture, the bottom seven pixels of the disabled button fall below the scrolling viewport: its warning and label are readable, but a further-scroll/full-border reveal was not observed.

Earlier incomplete media and harness-failure attempts remain excluded from acceptance. The previous hosted test failure was a readiness race: retained data could appear while refreshing. Its existing conditions now run inside the same 10-second waits; contrast, terminal-notice and action assertions are unchanged.

The [latest Claw review](https://github.com/openclaw/openclaw/pull/139789#issuecomment-5557268404) confirms the earlier installed-proof hold is resolved and reports no patch finding. Its remaining image-fetch note is a limitation of that review environment: the maintainer agent inspected the actual full local captures listed above. No separate human visual review is claimed; the disclosed viewport crop remains a limitation, not a claim of full border visibility.

Production: **+57/-91, net -34 lines**. Tests: **+484/-39**. One adaptive row owner replaces duplicate layouts; no test-only production API is added.

### Installed comparison: French, 320dp, 2x text

| Before | After |
| --- | --- |
| ![Before: settings labels are clipped beside their status text](https://github.com/user-attachments/assets/428f7d95-e8f5-4b9f-8ab7-30de57aadbe3) | ![After: complete settings labels and status text wrap without shrinking](https://github.com/user-attachments/assets/764203d1-74ab-4679-ad6b-1eef34eafb60) |
| ![Before: the paired Gateway identity is truncated beside controls](https://github.com/user-attachments/assets/31088b22-fc1a-42fa-ac53-680ce6524233) | ![After: the complete Gateway identity is above its existing controls](https://github.com/user-attachments/assets/1baea3ca-85b3-4f78-a427-e1cc748f6147) |

### Installed Skills warning: 320dp

| Normal text | 2x text |
| --- | --- |
| ![Read-only Skills result with complete warning and disabled Install](https://github.com/user-attachments/assets/5f83b2b4-b4ac-488d-b437-fc6794d3257b) | ![Large-text Skills warning and disabled Install label; lower button border is below the scroll viewport](https://github.com/user-attachments/assets/bd50b323-968b-4516-bc81-eb6e9611efa5) |

### Component regression: French, 280dp, 2x text

The twelve rendered install-only cases preserve complete warnings and independent control behavior. The original fixture ordering also passes with joined runtime/database cleanup.

![Before: synthetic component render, French 280dp at 2x text size](https://github.com/user-attachments/assets/7d848e62-55da-4a0e-9c0c-bdf215a12ba3)

![After: synthetic component render, French 280dp at 2x text size](https://github.com/user-attachments/assets/41369e4b-dbfe-4779-88d8-525ec544e144)

## Follow-ups from the app-wide audit

Separate, pre-existing voice-provider summary cards, section descriptions/manual security selectors, and title/status app-bar layouts still show truncation or awkward wrapping at large text sizes. Those owners are recorded for follow-up; this PR does not claim whole-app typography is finished.
