### PR TITLE
fix(models): report Google and Copilot catalog failures

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -521,7 +521,6 @@ extensions/google/index.ts	1
 extensions/google/music-generation-provider.ts	1
 extensions/google/oauth-token-shared.ts	1
 extensions/google/onboard.ts	3
-extensions/google/provider-catalog.ts	2
 extensions/google/provider-registration.ts	2
 extensions/google/realtime-voice-provider.ts	6
 extensions/google/transport-stream.ts	15

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -268,10 +268,10 @@ configured default model is never replaced.
     (e.g. 400k for the gpt-5.x series, 1M for the internal
     `claude-opus-*-1m` variants).
 
-    The bundled static catalog stays as the visible fallback when discovery
-    is disabled, the user has no GitHub auth profile, runtime authentication
-    fails, or the `/models` HTTPS call errors. To opt out and rely entirely
-    on the static manifest catalog (offline / air-gapped scenarios):
+    Failed refreshes report the failure and retain the last successful inventory,
+    or bundled models before the first success. A successful empty response clears
+    discovered models. Disabled discovery or missing credentials makes no live
+    request. To use only bundled models (offline / air-gapped scenarios):
 
     ```json5
     {

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -67,8 +67,9 @@ the Gateway already runs inside a managed Google Cloud environment.
     catalog from the Gemini `models.list` API. Newly released Gemini 3 Pro, Flash,
     and Flash-Lite variants therefore appear in
     `openclaw models list --provider google` without waiting for an OpenClaw
-    release. If discovery is unavailable, OpenClaw keeps the bundled fallback
-    catalog.
+    release. Failed refreshes report the failure and retain the last successful
+    inventory, or bundled models before the first success. A successful empty
+    response clears discovered models. Vertex uses its separate static catalog.
 
   </Tab>
 

--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -103,6 +103,7 @@ describe("resolveFirstGithubToken", () => {
     expect(result).toEqual({
       githubToken: "profile-token",
       hasProfile: true,
+      profileId: "github-copilot:github",
     });
   });
 
@@ -177,7 +178,11 @@ describe("resolveFirstGithubToken", () => {
         },
         env: {},
       }),
-    ).resolves.toEqual({ githubToken: testCase.expectedToken, hasProfile: true });
+    ).resolves.toEqual({
+      githubToken: testCase.expectedToken,
+      hasProfile: true,
+      ...(testCase.expectedToken ? { profileId: "github-copilot:preferred" } : {}),
+    });
   });
 
   it.each([
@@ -188,6 +193,7 @@ describe("resolveFirstGithubToken", () => {
         githubToken: "durable-github-token",
         githubDomain: "github.com",
         hasProfile: true,
+        profileId: "github-copilot:preferred",
       },
     },
     {
@@ -197,6 +203,7 @@ describe("resolveFirstGithubToken", () => {
         githubToken: "durable-github-token",
         githubDomain: "acme.ghe.com",
         hasProfile: true,
+        profileId: "github-copilot:preferred",
       },
     },
     {
@@ -311,6 +318,7 @@ describe("resolveFirstGithubToken", () => {
     await expect(resolveFirstGithubToken({ config: {}, env: {} })).resolves.toEqual({
       githubToken: "first-token",
       hasProfile: true,
+      profileId: "github-copilot:first",
     });
     expect(store.usageStats["github-copilot:first"].cooldownUntil).toBe(expiredCooldown);
   });
@@ -342,7 +350,11 @@ describe("resolveFirstGithubToken", () => {
         env: {},
         profileId: "github-copilot:preferred",
       }),
-    ).resolves.toEqual({ githubToken: "preferred-token", hasProfile: true });
+    ).resolves.toEqual({
+      githubToken: "preferred-token",
+      hasProfile: true,
+      profileId: "github-copilot:preferred",
+    });
   });
 
   it("uses environment direct auth without falling back to config or the first profile", async () => {
@@ -625,6 +637,7 @@ describe("resolveFirstGithubToken", () => {
     expect(result).toEqual({
       githubToken: "resolved-profile-token",
       hasProfile: true,
+      profileId: "github-copilot:github",
     });
     expect(resolveRequiredConfiguredSecretRefInputStringMock).toHaveBeenCalledWith({
       config,

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -1,4 +1,3 @@
-// Github Copilot plugin module implements auth behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ProviderPrepareDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
@@ -27,6 +26,7 @@ export async function resolveFirstGithubToken(params: {
   githubToken: string;
   githubDomain?: string;
   hasProfile: boolean;
+  profileId?: string;
 }> {
   const authStore = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
@@ -103,6 +103,7 @@ export async function resolveFirstGithubToken(params: {
       ...parsed,
       githubDomain: parsed.githubDomain ?? PUBLIC_GITHUB_COPILOT_DOMAIN,
       hasProfile,
+      profileId,
     };
   }
   if (profile?.type !== "token") {
@@ -114,5 +115,5 @@ export async function resolveFirstGithubToken(params: {
     value: profile.tokenRef,
     path: `providers.github-copilot.authProfiles.${profileId ?? "default"}.tokenRef`,
   });
-  return { githubToken: (resolved ?? profile.token ?? "").trim(), hasProfile };
+  return { githubToken: (resolved ?? profile.token ?? "").trim(), hasProfile, profileId };
 }

--- a/extensions/github-copilot/dynamic-models.ts
+++ b/extensions/github-copilot/dynamic-models.ts
@@ -6,6 +6,10 @@ import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  LiveModelCatalogHttpError,
+  runLiveProviderCatalog,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { resolveFirstGithubToken } from "./auth.js";
 import { resolveGithubCopilotDomain } from "./domain.js";
@@ -15,6 +19,7 @@ import {
   isCopilotCatalogModelVisible,
   resolveCopilotForwardCompatModel,
 } from "./models.js";
+import { CopilotRuntimeAuthError } from "./runtime-auth-error.js";
 import { buildCopilotRuntimeHeaders } from "./runtime-identity.js";
 
 type GithubCopilotCatalogContext = {
@@ -37,10 +42,6 @@ function dynamicModelScope(
       : "unscoped";
 }
 
-async function loadGithubCopilotRuntime() {
-  return await import("./register.runtime.js");
-}
-
 export function createGithubCopilotDynamicModelHooks(params: {
   discoveryEnabled(config?: OpenClawConfig): boolean;
 }) {
@@ -49,84 +50,86 @@ export function createGithubCopilotDynamicModelHooks(params: {
     Map<string, ReadonlyMap<string, ProviderRuntimeModel>>
   >();
 
-  async function resolveCatalog(ctx: GithubCopilotCatalogContext) {
+  async function resolveCatalogAuth(ctx: GithubCopilotCatalogContext) {
     if (!params.discoveryEnabled(ctx.config)) {
       return null;
     }
-    const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotRuntimeAuth } =
-      await loadGithubCopilotRuntime();
-    const { githubToken, githubDomain, hasProfile } = await resolveFirstGithubToken({
-      agentDir: ctx.agentDir,
+    const auth = await resolveFirstGithubToken(ctx);
+    return auth.githubToken ? auth : null;
+  }
+
+  async function loadCatalog(
+    ctx: GithubCopilotCatalogContext,
+    auth: Awaited<ReturnType<typeof resolveFirstGithubToken>>,
+    headers: ReturnType<typeof buildCopilotRuntimeHeaders>,
+  ) {
+    const { resolveCopilotRuntimeAuth } = await import("./register.runtime.js");
+    const { apiKey: copilotApiToken, baseUrl } = await resolveCopilotRuntimeAuth({
+      githubToken: auth.githubToken,
       env: ctx.env,
-      ...(ctx.config ? { config: ctx.config } : {}),
-      ...(ctx.profileId ? { profileId: ctx.profileId } : {}),
-      ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
+      githubDomain: resolveGithubCopilotDomain({
+        env: ctx.env,
+        explicit: auth.githubDomain,
+        config: ctx.config,
+      }),
+    }).catch((error: unknown) => {
+      if (error instanceof CopilotRuntimeAuthError && error.status !== undefined) {
+        throw new LiveModelCatalogHttpError(PROVIDER_ID, error.status);
+      }
+      throw error;
     });
-    if (!hasProfile && !githubToken) {
-      return null;
-    }
-    let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
-    let copilotApiToken: string | undefined;
-    if (githubToken) {
-      try {
-        const auth = await resolveCopilotRuntimeAuth({
-          githubToken,
-          env: ctx.env,
-          githubDomain: resolveGithubCopilotDomain({
-            env: ctx.env,
-            explicit: githubDomain,
-            config: ctx.config,
-          }),
-        });
-        baseUrl = auth.baseUrl;
-        copilotApiToken = auth.apiKey;
-      } catch {
-        baseUrl = DEFAULT_COPILOT_API_BASE_URL;
-      }
-    }
-    // Live metadata follows account entitlements and context limits. Static
-    // manifest models remain the visible fallback when exchange or discovery fails.
-    let discoveredModels: Awaited<ReturnType<typeof fetchCopilotModelCatalog>> = [];
-    if (copilotApiToken) {
-      const headers = buildCopilotRuntimeHeaders({ config: ctx.config });
-      try {
-        discoveredModels = await getCachedLiveCatalogValue({
-          keyParts: [
-            PROVIDER_ID,
-            "models",
-            baseUrl,
-            copilotApiToken,
-            headers["Copilot-Integration-Id"],
-          ],
-          load: async () => await fetchCopilotModelCatalog({ copilotApiToken, baseUrl, headers }),
-        });
-      } catch {
-        discoveredModels = [];
-      }
-    }
-    return { baseUrl, models: discoveredModels };
+    const models = await getCachedLiveCatalogValue({
+      keyParts: [
+        PROVIDER_ID,
+        "models",
+        baseUrl,
+        copilotApiToken,
+        headers["Copilot-Integration-Id"],
+      ],
+      load: async () => await fetchCopilotModelCatalog({ copilotApiToken, baseUrl, headers }),
+    });
+    return { baseUrl, models };
   }
 
   async function runCatalog(ctx: ProviderCatalogContext): Promise<ProviderCatalogResult> {
-    const catalog = await resolveCatalog(ctx);
-    return catalog
-      ? {
+    const auth = await resolveCatalogAuth(ctx);
+    if (!auth) {
+      return null;
+    }
+    const headers = buildCopilotRuntimeHeaders({ config: ctx.config });
+    return await runLiveProviderCatalog({
+      providerId: PROVIDER_ID,
+      profileId: auth.profileId,
+      run: async () => {
+        const catalog = await loadCatalog(ctx, auth, headers);
+        return {
           provider: {
             ...catalog,
             models: catalog.models.filter(isCopilotCatalogModelVisible),
           },
-        }
-      : null;
+        };
+      },
+    });
   }
 
   async function prepareDynamicModel(ctx: ProviderPrepareDynamicModelContext): Promise<void> {
-    const catalog = await resolveCatalog({
+    const catalogContext: GithubCopilotCatalogContext = {
       agentDir: ctx.agentDir,
       env: process.env,
-      ...(ctx.config ? { config: ctx.config } : {}),
-      ...(ctx.authProfileId ? { profileId: ctx.authProfileId } : {}),
-      ...(ctx.authProfileMode ? { authProfileMode: ctx.authProfileMode } : {}),
-    });
+      config: ctx.config,
+      profileId: ctx.authProfileId,
+      authProfileMode: ctx.authProfileMode,
+    };
+    const auth = await resolveCatalogAuth(catalogContext);
+    // Request preparation can fall back to forward-compatible metadata without
+    // claiming that live catalog discovery succeeded.
+    const catalog = auth
+      ? await loadCatalog(
+          catalogContext,
+          auth,
+          buildCopilotRuntimeHeaders({ config: ctx.config }),
+        ).catch(() => null)
+      : null;
     const models = new Map<string, ProviderRuntimeModel>();
     if (catalog) {
       for (const model of catalog.models) {

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -14,13 +14,13 @@ import type {
   OpenClawPluginApi,
   ProviderAuthResult,
   ProviderCatalogResult,
-  UnifiedModelCatalogEntry,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import type { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { runGitHubCopilotDeviceFlow } from "./login.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { CopilotRuntimeAuthError } from "./runtime-auth-error.js";
 
 const mocks = vi.hoisted(() => ({
   fetchWithSsrFGuard: vi.fn<typeof fetchWithSsrFGuard>(async (params) => ({
@@ -72,9 +72,6 @@ type GithubCopilotTestProvider = RegisteredProvider & {
   preferRuntimeResolvedModel: NonNullable<RegisteredProvider["preferRuntimeResolvedModel"]>;
   prepareRuntimeAuth: NonNullable<RegisteredProvider["prepareRuntimeAuth"]>;
   resolveThinkingProfile: NonNullable<RegisteredProvider["resolveThinkingProfile"]>;
-};
-type GithubCopilotTestModelCatalogProvider = {
-  liveCatalog: (ctx: unknown) => Promise<readonly UnifiedModelCatalogEntry[] | null | undefined>;
 };
 
 afterEach(async () => {
@@ -161,11 +158,8 @@ function requireFirstMockArg<T>(
   return call[0];
 }
 
-function registerProviderAndCatalogWithPluginConfig(pluginConfig: Record<string, unknown>) {
+function registerProviderWithPluginConfig(pluginConfig: Record<string, unknown>) {
   const registerProviderMock = vi.fn<OpenClawPluginApi["registerProvider"]>();
-  const registerModelCatalogProviderMock =
-    vi.fn<OpenClawPluginApi["registerModelCatalogProvider"]>();
-
   plugin.register(
     createTestPluginApi({
       id: "github-copilot",
@@ -175,26 +169,13 @@ function registerProviderAndCatalogWithPluginConfig(pluginConfig: Record<string,
       pluginConfig,
       runtime: {} as never,
       registerProvider: registerProviderMock,
-      registerModelCatalogProvider: registerModelCatalogProviderMock,
     }),
   );
-
   expect(registerProviderMock).toHaveBeenCalledTimes(1);
-  expect(registerModelCatalogProviderMock).toHaveBeenCalledTimes(1);
-  return {
-    provider: requireFirstMockArg(
-      registerProviderMock,
-      "provider registration",
-    ) as GithubCopilotTestProvider,
-    modelCatalogProvider: requireFirstMockArg(
-      registerModelCatalogProviderMock,
-      "model catalog provider registration",
-    ) as GithubCopilotTestModelCatalogProvider,
-  };
-}
-
-function registerProviderWithPluginConfig(pluginConfig: Record<string, unknown>) {
-  return registerProviderAndCatalogWithPluginConfig(pluginConfig).provider;
+  return requireFirstMockArg(
+    registerProviderMock,
+    "provider registration",
+  ) as GithubCopilotTestProvider;
 }
 
 describe("github-copilot plugin", () => {
@@ -862,6 +843,10 @@ describe("github-copilot plugin", () => {
   });
 
   it("uses live plugin config to re-enable discovery after startup disable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<typeof fetch>(async () => Response.json({ data: [] })),
+    );
     mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
       apiKey: "gh_test_token",
       baseUrl: "https://api.githubcopilot.live",
@@ -895,6 +880,7 @@ describe("github-copilot plugin", () => {
         baseUrl: "https://api.githubcopilot.live",
         models: [],
       },
+      outcomes: [{ provider: "github-copilot", status: "ready" }],
     });
   });
 
@@ -971,44 +957,49 @@ describe("github-copilot plugin", () => {
     ).toEqual(["eligible", "chat-only"]);
   });
 
-  it("dual-publishes unified live catalog rows with existing discovery semantics", async () => {
-    mocks.resolveCopilotRuntimeAuth.mockResolvedValueOnce({
-      apiKey: "gh_test_token",
-      baseUrl: "https://api.githubcopilot.live",
-    });
-    const { modelCatalogProvider } = registerProviderAndCatalogWithPluginConfig({
-      discovery: { enabled: false },
-    });
-
-    const result = await modelCatalogProvider.liveCatalog({
-      config: {
-        plugins: {
-          entries: {
-            "github-copilot": {
-              config: {
-                discovery: { enabled: true },
-              },
-            },
-          },
+  it.each([
+    { stage: "user", status: 401, expected: "auth-rejected" },
+    { stage: "user", status: 503, expected: "unavailable" },
+    { stage: "models", status: 403, expected: "auth-rejected" },
+    { stage: "models", status: 503, expected: "unavailable" },
+    { stage: "models", status: 200, expected: "ready" },
+  ])(
+    "records the catalog attempt at $stage with HTTP $status",
+    async ({ stage, status, expected }) => {
+      const agentDir = await createAgentDir();
+      writeExistingCopilotTokenProfile(agentDir);
+      const provider = registerProviderWithPluginConfig({});
+      mocks.resolveCopilotRuntimeAuth.mockReset();
+      if (stage === "user") {
+        mocks.resolveCopilotRuntimeAuth.mockRejectedValue(
+          new CopilotRuntimeAuthError({ reason: "http_error", status }),
+        );
+      } else {
+        mocks.resolveCopilotRuntimeAuth.mockResolvedValue({
+          apiKey: "catalog-attempt-token",
+          baseUrl: `https://api.githubcopilot.attempt-${status}`,
+        });
+      }
+      const fetchMock = vi.fn<typeof fetch>(async () => Response.json({ data: [] }, { status }));
+      vi.stubGlobal("fetch", fetchMock);
+      const result = await provider.catalog.run({ config: {}, agentDir, env: {} });
+      expect(result?.outcomes).toEqual([
+        {
+          provider: "github-copilot",
+          profileId: "github-copilot:github",
+          status: expected,
+          ...(expected === "auth-rejected" ? { rejectionScope: "catalog" } : {}),
         },
-      },
-      agentDir: "/tmp/agent",
-      env: { GH_TOKEN: "gh_test_token" },
-      resolveProviderApiKey: () => ({ apiKey: "gh_test_token" }),
-      resolveProviderAuth: () => ({
-        apiKey: "gh_test_token",
-        mode: "token",
-        source: "env",
-      }),
-    } as never);
-
-    expect(mocks.resolveCopilotRuntimeAuth).toHaveBeenCalledWith({
-      githubToken: "gh_test_token",
-      env: { GH_TOKEN: "gh_test_token" },
-      githubDomain: "github.com",
-    });
-    expect(result).toEqual([]);
-  });
+      ]);
+      expect(mocks.resolveCopilotRuntimeAuth).toHaveBeenCalledOnce();
+      expect(fetchMock).toHaveBeenCalledTimes(stage === "user" ? 0 : 1);
+      if (expected === "ready") {
+        expect(result && "provider" in result ? result.provider.models : undefined).toEqual([]);
+      } else {
+        expect(result && "providers" in result ? result.providers : undefined).toEqual({});
+      }
+    },
+  );
 
   it("offers to reuse an existing token profile during interactive onboarding", async () => {
     const provider = registerProviderWithPluginConfig({});

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -56,7 +56,6 @@ vi.mock("./register.runtime.js", () => ({
 import plugin from "./index.js";
 
 const tempDirs: string[] = [];
-type RegisteredEmbeddingProvider = Parameters<OpenClawPluginApi["registerEmbeddingProvider"]>[0];
 type RegisteredProvider = Parameters<OpenClawPluginApi["registerProvider"]>[0];
 type GithubCopilotTestProvider = RegisteredProvider & {
   auth: Array<{
@@ -147,33 +146,18 @@ function writeExistingCopilotTokenProfile(agentDir: string) {
   );
 }
 
-function requireFirstMockArg<T>(
-  mock: { mock: { calls: Array<[T, ...unknown[]]> } },
-  label: string,
-) {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`Expected ${label}`);
-  }
-  return call[0];
-}
-
 function registerProviderWithPluginConfig(pluginConfig: Record<string, unknown>) {
   const registerProviderMock = vi.fn<OpenClawPluginApi["registerProvider"]>();
   plugin.register(
     createTestPluginApi({
       id: "github-copilot",
-      name: "GitHub Copilot",
-      source: "test",
-      config: {},
       pluginConfig,
-      runtime: {} as never,
       registerProvider: registerProviderMock,
     }),
   );
   expect(registerProviderMock).toHaveBeenCalledTimes(1);
-  return requireFirstMockArg(
-    registerProviderMock,
+  return expectDefined(
+    registerProviderMock.mock.calls[0]?.[0],
     "provider registration",
   ) as GithubCopilotTestProvider;
 }
@@ -564,8 +548,8 @@ describe("github-copilot plugin", () => {
     );
 
     expect(registerEmbeddingProviderMock).toHaveBeenCalledTimes(1);
-    const adapter = requireFirstMockArg<RegisteredEmbeddingProvider>(
-      registerEmbeddingProviderMock,
+    const adapter = expectDefined(
+      registerEmbeddingProviderMock.mock.calls[0]?.[0],
       "embedding provider registration",
     );
     expect(adapter.id).toBe("github-copilot");

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -6,8 +6,6 @@ import {
   type ProviderAuthContext,
   type ProviderAuthResult,
   type ProviderAuthMethodNonInteractiveContext,
-  type UnifiedModelCatalogEntry,
-  type UnifiedModelCatalogProviderContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   applyAuthProfileConfig,
@@ -423,27 +421,6 @@ export default definePluginEntry({
       discoveryEnabled: (config) => resolveCurrentPluginConfig(config).discovery?.enabled !== false,
     });
 
-    async function runGithubCopilotUnifiedLiveCatalog(
-      ctx: UnifiedModelCatalogProviderContext,
-    ): Promise<UnifiedModelCatalogEntry[] | null> {
-      const result = await dynamicModels.runCatalog(ctx);
-      if (!result || !("provider" in result)) {
-        return null;
-      }
-      return (result.provider.models ?? []).map((model) => {
-        const entry: UnifiedModelCatalogEntry = {
-          kind: "text",
-          provider: PROVIDER_ID,
-          model: model.id,
-          source: "live",
-        };
-        if (model.name) {
-          entry.label = model.name;
-        }
-        return entry;
-      });
-    }
-
     async function promptForEnterpriseDomain(ctx: ProviderAuthContext): Promise<string | null> {
       // COPILOT_GITHUB_DOMAIN is authoritative for every runtime routing path
       // (token refresh, usage, completions). Honor it here too when it is set so
@@ -757,11 +734,6 @@ export default definePluginEntry({
           }),
         );
       },
-    });
-    api.registerModelCatalogProvider({
-      provider: PROVIDER_ID,
-      kinds: ["text"],
-      liveCatalog: runGithubCopilotUnifiedLiveCatalog,
     });
   },
 });

--- a/extensions/github-copilot/models.ts
+++ b/extensions/github-copilot/models.ts
@@ -1,8 +1,8 @@
-// Github Copilot plugin module implements models behavior.
 import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/core";
+import { LiveModelCatalogHttpError } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { readProviderJsonArrayFieldResponse } from "openclaw/plugin-sdk/provider-http";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
@@ -323,8 +323,7 @@ type FetchCopilotModelCatalogParams = {
  * without manifest churn.
  *
  * Filters out non-chat objects (embeddings, routers) and internal router ids.
- * On any HTTP/parse failure the caller should fall back to the static manifest
- * catalog; this function throws so the caller decides the recovery shape.
+ * Failures propagate so the catalog owner can publish a truthful outcome.
  */
 export async function fetchCopilotModelCatalog(
   params: FetchCopilotModelCatalogParams,
@@ -353,9 +352,9 @@ export async function fetchCopilotModelCatalog(
       signal: params.signal ?? controller?.signal,
     });
     if (!res.ok) {
-      // Static catalog fallback never consumes this body, so release the transport before cleanup.
+      // Failed discovery never consumes this body, so release the transport before cleanup.
       await res.body?.cancel().catch(() => undefined);
-      throw new Error(`Copilot /models fetch failed: HTTP ${res.status}`);
+      throw new LiveModelCatalogHttpError(PROVIDER_ID, res.status);
     }
     const data = await readProviderJsonArrayFieldResponse(res, "Copilot /models", "data");
     const seen = new Set<string>();

--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -225,21 +225,49 @@ describe("google provider catalog", () => {
     }
   });
 
-  it("falls back to bundled rows when live discovery is unusable", async () => {
+  it.each([{}, { models: [] }, { models: [{ name: "models/gemini-3.6-flash" }] }])(
+    "preserves a successful empty text inventory: %j",
+    async (body) => {
+      const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async ({ url }) => ({
+        response: Response.json(body),
+        finalUrl: url,
+        release: async () => undefined,
+      }));
+
+      const provider = await buildGoogleLiveCatalogProvider({
+        apiKey: "GEMINI_API_KEY",
+        discoveryApiKey: "resolved-google-key",
+        fetchGuard,
+      });
+
+      expect(provider.models).toEqual([]);
+    },
+  );
+
+  it.each([401, 403, 503])("preserves HTTP %i for the catalog outcome owner", async (status) => {
+    const release = vi.fn(async () => undefined);
     const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async ({ url }) => ({
-      response: Response.json({ models: [{ name: "models/gemini-3.6-flash" }] }),
+      response: new Response(null, { status }),
       finalUrl: url,
-      release: async () => undefined,
+      release,
     }));
-
-    const provider = await buildGoogleLiveCatalogProvider({
-      apiKey: "GEMINI_API_KEY",
-      discoveryApiKey: "resolved-google-key",
-      fetchGuard,
-    });
-
-    expect(provider.models.map((model) => model.id)).toEqual(
-      buildGoogleStaticCatalogProvider().models.map((model) => model.id),
-    );
+    await expect(
+      buildGoogleLiveCatalogProvider({ apiKey: "google-key", fetchGuard }),
+    ).rejects.toMatchObject({ status });
+    expect(release).toHaveBeenCalledOnce();
   });
+
+  it.each([null, { models: "invalid" }, { models: [null] }])(
+    "rejects a malformed inventory: %j",
+    async (body) => {
+      const fetchGuard: LiveModelCatalogFetchGuard = async ({ url }) => ({
+        response: Response.json(body),
+        finalUrl: url,
+        release: async () => undefined,
+      });
+      await expect(
+        buildGoogleLiveCatalogProvider({ apiKey: "google-key", fetchGuard }),
+      ).rejects.toThrow("invalid model");
+    },
+  );
 });

--- a/extensions/google/provider-catalog.test.ts
+++ b/extensions/google/provider-catalog.test.ts
@@ -235,12 +235,19 @@ describe("google provider catalog", () => {
       }));
 
       const provider = await buildGoogleLiveCatalogProvider({
+        discoveryMode: "strict",
         apiKey: "GEMINI_API_KEY",
         discoveryApiKey: "resolved-google-key",
         fetchGuard,
       });
 
       expect(provider.models).toEqual([]);
+      const advisory = await buildGoogleLiveCatalogProvider({
+        apiKey: "GEMINI_API_KEY",
+        discoveryApiKey: "resolved-google-key",
+        fetchGuard,
+      });
+      expect(advisory.models).toEqual(buildGoogleStaticCatalogProvider().models);
     },
   );
 
@@ -252,9 +259,11 @@ describe("google provider catalog", () => {
       release,
     }));
     await expect(
-      buildGoogleLiveCatalogProvider({ apiKey: "google-key", fetchGuard }),
+      buildGoogleLiveCatalogProvider({ discoveryMode: "strict", apiKey: "google-key", fetchGuard }),
     ).rejects.toMatchObject({ status });
     expect(release).toHaveBeenCalledOnce();
+    const advisory = await buildGoogleLiveCatalogProvider({ apiKey: "google-key", fetchGuard });
+    expect(advisory.models).toEqual(buildGoogleStaticCatalogProvider().models);
   });
 
   it.each([null, { models: "invalid" }, { models: [null] }])(
@@ -266,7 +275,11 @@ describe("google provider catalog", () => {
         release: async () => undefined,
       });
       await expect(
-        buildGoogleLiveCatalogProvider({ apiKey: "google-key", fetchGuard }),
+        buildGoogleLiveCatalogProvider({
+          discoveryMode: "strict",
+          apiKey: "google-key",
+          fetchGuard,
+        }),
       ).rejects.toThrow("invalid model");
     },
   );

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -146,6 +146,7 @@ function parseGoogleLiveModels(rows: readonly unknown[]): ModelDefinitionConfig[
 }
 
 export async function buildGoogleLiveCatalogProvider(params: {
+  discoveryMode?: "strict";
   apiKey?: string;
   discoveryApiKey?: string;
   fetchGuard?: LiveModelCatalogFetchGuard;
@@ -153,7 +154,6 @@ export async function buildGoogleLiveCatalogProvider(params: {
 }): Promise<ModelProviderConfig> {
   const { models, ...providerConfig } = buildGoogleStaticCatalogProvider();
   return await buildLiveModelProviderConfig({
-    discoveryMode: "strict",
     providerId: "google",
     endpoint: GOOGLE_GEMINI_MODELS_ENDPOINT,
     providerConfig,

--- a/extensions/google/provider-catalog.ts
+++ b/extensions/google/provider-catalog.ts
@@ -1,6 +1,5 @@
-// Google provider module implements model/runtime integration.
 import {
-  getCachedLiveProviderModelRows,
+  buildLiveModelProviderConfig,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import type {
@@ -8,6 +7,7 @@ import type {
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
+  asOptionalRecord,
   asPositiveSafeInteger,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -76,11 +76,11 @@ export function buildGoogleStaticCatalogProvider(): ModelProviderConfig {
 }
 
 function readGoogleLiveModels(body: unknown): readonly unknown[] {
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return [];
+  const record = asOptionalRecord(body);
+  if (!record || (record.models !== undefined && !Array.isArray(record.models))) {
+    throw new Error("Google models.list returned an invalid model list");
   }
-  const models = (body as { models?: unknown }).models;
-  return Array.isArray(models) ? models : [];
+  return record.models ?? [];
 }
 
 function googleLiveModelInput(id: string): ModelDefinitionConfig["input"] {
@@ -95,10 +95,10 @@ function googleLiveModelInput(id: string): ModelDefinitionConfig["input"] {
 }
 
 function buildGoogleLiveModel(row: unknown): ModelDefinitionConfig | undefined {
-  if (!row || typeof row !== "object" || Array.isArray(row)) {
-    return undefined;
+  const record = asOptionalRecord(row);
+  if (!record) {
+    throw new Error("Google models.list returned an invalid model row");
   }
-  const record = row as Record<string, unknown>;
   const resourceName = normalizeOptionalString(record.name);
   const id = resourceName?.startsWith("models/") ? resourceName.slice("models/".length) : undefined;
   const methods = record.supportedGenerationMethods;
@@ -151,40 +151,23 @@ export async function buildGoogleLiveCatalogProvider(params: {
   fetchGuard?: LiveModelCatalogFetchGuard;
   signal?: AbortSignal;
 }): Promise<ModelProviderConfig> {
-  const fallback = {
-    ...buildGoogleStaticCatalogProvider(),
-    ...(params.apiKey ? { apiKey: params.apiKey } : {}),
-  };
-  try {
-    const rows = await getCachedLiveProviderModelRows({
-      providerId: "google",
-      endpoint: GOOGLE_GEMINI_MODELS_ENDPOINT,
-      apiKey: params.apiKey,
-      discoveryApiKey: params.discoveryApiKey,
-      fetchGuard: params.fetchGuard,
-      signal: params.signal,
-      ttlMs: GOOGLE_GEMINI_MODELS_CACHE_TTL_MS,
-      auditContext: "google-model-discovery",
-      readRows: readGoogleLiveModels,
-      buildRequestHeaders: ({ discoveryApiKey, apiKey }) => ({
-        Accept: "application/json",
-        ...((discoveryApiKey ?? apiKey) ? { "x-goog-api-key": discoveryApiKey ?? apiKey } : {}),
-      }),
-      shouldCacheRows: (modelRows) => parseGoogleLiveModels(modelRows).length > 0,
-    });
-    const models = parseGoogleLiveModels(rows);
-    if (models.length === 0) {
-      return fallback;
-    }
-    return {
-      ...fallback,
-      models,
-    };
-  } catch {
-    // Discovery is advisory. Offline setup, expired credentials, and transient
-    // provider failures retain the bundled catalog instead of hiding Google.
-    return fallback;
-  }
+  const { models, ...providerConfig } = buildGoogleStaticCatalogProvider();
+  return await buildLiveModelProviderConfig({
+    discoveryMode: "strict",
+    providerId: "google",
+    endpoint: GOOGLE_GEMINI_MODELS_ENDPOINT,
+    providerConfig,
+    models,
+    ...params,
+    ttlMs: GOOGLE_GEMINI_MODELS_CACHE_TTL_MS,
+    auditContext: "google-model-discovery",
+    readRows: readGoogleLiveModels,
+    buildRequestHeaders: ({ discoveryApiKey, apiKey }) => ({
+      Accept: "application/json",
+      ...((discoveryApiKey ?? apiKey) ? { "x-goog-api-key": discoveryApiKey ?? apiKey } : {}),
+    }),
+    projectRows: parseGoogleLiveModels,
+  });
 }
 
 export function buildGoogleVertexStaticCatalogProvider(): ModelProviderConfig {

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -1,9 +1,9 @@
-// Google provider module implements model/runtime integration.
 import type {
   OpenClawPluginApi,
   ProviderReasoningOutputModeContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeGoogleModelId } from "./model-id.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL, applyGoogleGeminiModelDefault } from "./onboard.js";
@@ -108,15 +108,18 @@ export function buildGoogleProvider(): ProviderPlugin {
         if (!auth.apiKey) {
           return null;
         }
-        return {
-          providers: {
-            google: await buildGoogleLiveCatalogProvider({
-              apiKey: auth.apiKey,
-              discoveryApiKey: auth.discoveryApiKey,
-            }),
-            "google-vertex": buildGoogleVertexStaticCatalogProvider(),
-          },
-        };
+        return await runLiveProviderCatalog({
+          providerId: "google",
+          profileId: auth.profileId,
+          run: async () => ({
+            providers: {
+              google: await buildGoogleLiveCatalogProvider({
+                apiKey: auth.apiKey,
+                discoveryApiKey: auth.discoveryApiKey,
+              }),
+            },
+          }),
+        });
       },
     },
     normalizeModelId: ({ modelId }) => normalizeGoogleModelId(modelId),

--- a/extensions/google/provider-registration.ts
+++ b/extensions/google/provider-registration.ts
@@ -114,6 +114,7 @@ export function buildGoogleProvider(): ProviderPlugin {
           run: async () => ({
             providers: {
               google: await buildGoogleLiveCatalogProvider({
+                discoveryMode: "strict",
                 apiKey: auth.apiKey,
                 discoveryApiKey: auth.discoveryApiKey,
               }),

--- a/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
@@ -306,7 +306,7 @@ export function describeGithubCopilotProviderDiscoveryContract(params: {
       ).resolves.toBeNull();
     });
 
-    it("keeps profile-only catalog fallback provider-owned", async () => {
+    it("reports an unavailable profile catalog without replacing inventory", async () => {
       setGithubCopilotProfileSnapshot();
 
       await expect(
@@ -314,14 +314,15 @@ export function describeGithubCopilotProviderDiscoveryContract(params: {
           provider: state.githubCopilotProvider!,
         }),
       ).resolves.toEqual({
-        provider: {
-          baseUrl: "https://api.individual.githubcopilot.com",
-          models: [],
-        },
+        providers: {},
+        outcomes: [
+          { provider: "github-copilot", profileId: "github-copilot:github", status: "unavailable" },
+        ],
       });
     });
 
     it("keeps env-token base URL resolution provider-owned", async () => {
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(Response.json({ data: [] }));
       resolveCopilotRuntimeAuthMock.mockResolvedValueOnce({
         apiKey: "copilot-api-token",
         source: "validated:https://api.github.com/copilot_internal/user",
@@ -341,6 +342,7 @@ export function describeGithubCopilotProviderDiscoveryContract(params: {
           baseUrl: "https://copilot-proxy.example.com",
           models: [],
         },
+        outcomes: [{ provider: "github-copilot", status: "ready" }],
       });
       const copilotCall = requireRecord(
         resolveCopilotRuntimeAuthMock.mock.calls.at(0)?.[0],


### PR DESCRIPTION
Related: #136257. AI-assisted.

## What Problem This Solves

Two bundled model providers hid discovery failures, replacing learned models with starter rows or empty inventory. One also replaced a successful empty response with bundled models.

## Why This Change Was Made

Both plugins use the shared catalog-outcome owner. Registered acquisition is strict while released helper defaults remain advisory. Credentials are resolved once, preserving the selected profile and HTTP status. Duplicate catalog production is removed; request-time fallback and credential/header validation remain intact.

## User Impact

Failed refreshes retain compatible successful inventory with a rejection or unavailable outcome. Successful empty results are authoritative. Missing credentials and disabled discovery make no request.

Consumers: the two catalog hooks now publish real acquisition outcomes without replacing valid inventory on failure.

## Evidence

Built baseline checks hid service failures and restored ten rows after empty discovery. Fourteen regressions failed before repair; all 156 focused checks passed. Built API/Gateway checks covered failures, recovery, empty results, static siblings, credential provenance, account switching, and request limits. Four synthetic completions checked request behavior. A header credential reference still fails refresh on both versions; shared materialization remains a separate issue. Endpoints and credentials were synthetic; live inference was not tested.
