### PR TITLE
fix(test): derive neutral history projection state

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -5,6 +5,7 @@ import { createHash } from "node:crypto";
 import { describe, expect, test, vi } from "vitest";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../agents/stream-message-shared.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
+import { projectChatDisplayMessagesWithState } from "./chat-display-projection.js";
 import { buildSessionHistorySnapshot, SessionHistorySseState } from "./session-history-state.js";
 import * as sessionTranscriptReaders from "./session-transcript-readers.js";
 
@@ -393,10 +394,8 @@ describe("SessionHistorySseState", () => {
     const { history } = buildSessionHistorySnapshot({
       rawMessages: [],
       projection: {
+        ...projectChatDisplayMessagesWithState([]),
         messages,
-        turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
## What Problem This Solves

The core test typecheck fails because one history-pagination fixture still constructs retired projection-state fields. #139715 added the fixture; #139753 later renamed those fields and migrated production callers but missed this test.

## Why This Change Was Made

Build the fixture's neutral state through the existing public `projectChatDisplayMessagesWithState([])` producer, then override only its deliberately interleaved messages. This removes copied state fields without adding a test helper or changing production code.

## User Impact

Restores the test typecheck while retaining the same pagination regression. Runtime behavior does not change. The sequence `[1,2,2,3,undefined,4,3,4]`, one-message limit, full page assertion, cursor and `hasMore` checks are unchanged. Net test delta is −1 line.

## Evidence

The original before-fix gate reports TS2353 at `session-history-state.test.ts:398` for `streamErrorFallbackPending`; that failure is retained. After the fixture repair:

- The complete history-state test file passed 30/30 tests through the normal wrapper.
- All 20 normal changed checks passed, including the formerly failing gateway-root test type graph. No checks were skipped.
- Canonical managed P2 review completed one scoped-clean pass with no findings.
- `git diff --check` passed.

This is a necessary main CI repair, not a measured runtime performance claim.
