### PR TITLE
fix(gateway): stop input downloads after HTTP clients disconnect

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -238,6 +238,8 @@ Set `stream: true` to receive Server-Sent Events:
 
 Failed agent runs, including whole-agent timeouts, return an error instead of a successful completion. A streaming failure emits an `error` object followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
 
+Disconnecting the HTTP client cancels active source-URL downloads and the agent run. If cancellation happens while preparing input, the Gateway releases that download and does not start another input download or the agent run. This applies to both streaming and non-streaming requests.
+
 ## Open WebUI quick setup
 
 - Base URL: `http://127.0.0.1:18789/v1`

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -245,6 +245,8 @@ Event types currently emitted: `response.created`, `response.in_progress`, `resp
 
 Failed agent runs, including whole-agent timeouts, return a failed response. Streaming failures emit `response.failed` followed by `[DONE]`; partial content may already have reached the client. Timeout settings follow the [agent loop](/concepts/agent-loop#timeouts).
 
+Disconnecting the HTTP client cancels active source-URL downloads and the agent run. If cancellation happens while preparing input, the Gateway releases that download and does not start another input download or the agent run. This applies to both streaming and non-streaming requests.
+
 ## Usage
 
 `usage` is populated when the underlying provider reports token counts. OpenClaw normalizes common OpenAI-style aliases before those counters reach downstream status/session surfaces, including `input_tokens` / `output_tokens` and `prompt_tokens` / `completion_tokens`.

--- a/src/gateway/http-common.fuzz.test.ts
+++ b/src/gateway/http-common.fuzz.test.ts
@@ -374,17 +374,16 @@ describe("fuzz: watchClientDisconnect", () => {
         expect(s.listenerCount("close")).toBe(1);
       }
 
-      // Fire close on every unique socket; invariants: callback fires once per
-      // close, controller becomes aborted (regardless of whether it started so).
-      let expectedCallbackCalls = 0;
+      // One closed socket releases all socket watchers; later socket closes
+      // cannot repeat the callback, including with a pre-aborted controller.
       for (const s of uniqueSockets) {
         s.emit("close");
-        expectedCallbackCalls += 1;
+        expect(s.listenerCount("close")).toBe(0);
       }
       if (uniqueSockets.size > 0) {
         expect(controller.signal.aborted).toBe(true);
         if (onDisconnect) {
-          expect(onDisconnect).toHaveBeenCalledTimes(expectedCallbackCalls);
+          expect(onDisconnect).toHaveBeenCalledTimes(1);
         }
       } else {
         expect(controller.signal.aborted).toBe(preAborted);

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -515,13 +515,23 @@ describe("watchClientDisconnect", () => {
     expect(typeof resOnCall[1]).toBe("function");
   });
 
-  it("cleanup detaches the close listener from each socket", () => {
-    const socket = new EventEmitter();
-    const { req, res } = makeMockHttpReqRes(socket, null);
-    const controller = new AbortController();
-    const cleanup = watchClientDisconnect(req, res, controller);
-    expect(socket.listenerCount("close")).toBe(1);
-    cleanup();
-    expect(socket.listenerCount("close")).toBe(0);
-  });
+  it.each(["cleanup", "response completion"])(
+    "keeps completed work un-aborted after %s",
+    (phase) => {
+      const socket = new EventEmitter();
+      const { req, res } = makeMockHttpReqRes(socket, null);
+      const controller = new AbortController();
+      const cleanup = watchClientDisconnect(req, res, controller);
+      expect(socket.listenerCount("close")).toBe(1);
+      if (phase === "cleanup") {
+        cleanup();
+      } else {
+        res.emit("finish");
+      }
+      expect(socket.listenerCount("close")).toBe(0);
+      socket.emit("close");
+      expect(controller.signal.aborted).toBe(false);
+      res.emit("close");
+    },
+  );
 });

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -230,20 +230,29 @@ export function watchClientDisconnect(
   if (sockets.length === 0) {
     return () => {};
   }
+  const stopWatchingDisconnect = () => {
+    for (const socket of sockets) {
+      socket.off("close", handleClose);
+    }
+    res.off("finish", stopWatchingDisconnect);
+  };
   const handleClose = () => {
+    stopWatchingDisconnect();
     onDisconnect?.();
     if (!abortController.signal.aborted) {
       abortController.abort(new ClientDisconnectError());
     }
   };
   const stopWatchingResponseErrors = () => {
+    stopWatchingDisconnect();
     res.off("error", handleClose);
     res.off("close", stopWatchingResponseErrors);
   };
-  // Finalizers release socket watchers before res.end(); keep its error
-  // listener until close so a failed flush cannot become process-fatal.
+  // Completed responses release socket watchers; keep response errors handled
+  // until close so a failed flush cannot become process-fatal.
   res.on("error", handleClose);
   res.once("close", stopWatchingResponseErrors);
+  res.once("finish", stopWatchingDisconnect);
   if (res.destroyed || sockets.some((socket) => socket.destroyed)) {
     handleClose();
     return () => {};
@@ -251,9 +260,5 @@ export function watchClientDisconnect(
   for (const socket of sockets) {
     socket.on("close", handleClose);
   }
-  return () => {
-    for (const socket of sockets) {
-      socket.off("close", handleClose);
-    }
-  };
+  return stopWatchingDisconnect;
 }

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -588,7 +588,9 @@ function resolveActiveTurnContext(messagesUnknown: unknown): ActiveTurnContext {
 async function resolveImagesForRequest(
   activeTurnContext: Pick<ActiveTurnContext, "imageUrls">,
   limits: ResolvedOpenAiChatCompletionsLimits,
+  signal: AbortSignal,
 ): Promise<ImageContent[]> {
+  signal.throwIfAborted();
   if (activeTurnContext.imageUrls.kind === "invalid") {
     throw new Error("image_url part is missing a valid URL");
   }
@@ -613,7 +615,7 @@ async function resolveImagesForRequest(
       }
     }
 
-    const image = await extractImageContentFromSource(source, limits.images);
+    const image = await extractImageContentFromSource(source, limits.images, signal);
     totalBytes += estimateBase64DecodedBytes(image.data);
     if (totalBytes > limits.maxTotalImageBytes) {
       throw new Error(
@@ -834,6 +836,10 @@ export async function handleOpenAiHttpRequest(
   if (!handled) {
     return true;
   }
+  const abortController = new AbortController();
+  // The signal owns preparation; SSE installs presentation cleanup below.
+  let onDisconnect = () => {};
+  watchClientDisconnect(req, res, abortController, () => onDisconnect());
   const modelOverrideAuth = authorizeOpenAiCompatibleHttpModelOverride(req, handled.requestAuth);
   if (!modelOverrideAuth.allowed) {
     sendMissingScopeForbidden(res, modelOverrideAuth.missingScope);
@@ -989,8 +995,11 @@ export async function handleOpenAiHttpRequest(
   }
   let images: ImageContent[];
   try {
-    images = await resolveImagesForRequest(activeTurnContext, limits);
+    images = await resolveImagesForRequest(activeTurnContext, limits, abortController.signal);
   } catch (err) {
+    if (abortController.signal.aborted) {
+      return true;
+    }
     logWarn(`openai-compat: invalid image_url content: ${String(err)}`);
     sendInvalidRequest(res, "Invalid image_url content in `messages`.");
     return true;
@@ -1005,7 +1014,6 @@ export async function handleOpenAiHttpRequest(
   const created = Math.floor(Date.now() / 1000);
   const streamIdentity = { runId, model, created };
   const deps = createDefaultDeps();
-  const abortController = new AbortController();
   const mergedExtraSystemPrompt = [prompt.extraSystemPrompt, toolChoicePrompt]
     .filter((part): part is string => Boolean(part))
     .join("\n\n");
@@ -1033,7 +1041,6 @@ export async function handleOpenAiHttpRequest(
     : commandInput;
 
   if (!stream) {
-    const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
     try {
       const result = await agentCommandFromGatewayIngress(
         gatewayCommandInput,
@@ -1131,8 +1138,6 @@ export async function handleOpenAiHttpRequest(
       sendJson(res, 500, {
         error: { message: "internal error", type: "api_error" },
       });
-    } finally {
-      stopWatchingDisconnect();
     }
     return true;
   }
@@ -1153,7 +1158,6 @@ export async function handleOpenAiHttpRequest(
   let observedTerminalLifecycle = false;
   let terminalStreamError: { message: string; type: string; code?: string } | undefined;
   let terminalLifecyclePhase: "end" | "error" = "end";
-  let stopWatchingDisconnect = () => {};
 
   const maybeFinalize = () => {
     if (closed || finalizeScheduled || !finalizeRequested) {
@@ -1202,7 +1206,6 @@ export async function handleOpenAiHttpRequest(
         });
       }
       closed = true;
-      stopWatchingDisconnect();
       unsubscribe();
       if (!wroteStopChunk) {
         writeAssistantFinishChunk(res, {
@@ -1292,7 +1295,6 @@ export async function handleOpenAiHttpRequest(
       return;
     }
     closed = true;
-    stopWatchingDisconnect();
     unsubscribe();
     writeSse(res, { error });
     writeDone(res);
@@ -1311,11 +1313,11 @@ export async function handleOpenAiHttpRequest(
   res.once("finish", releaseStreamRootWork);
   res.once("close", releaseStreamRootWork);
 
-  stopWatchingDisconnect = watchClientDisconnect(req, res, abortController, () => {
+  onDisconnect = () => {
     closed = true;
     unsubscribe();
     releaseStreamRootWork();
-  });
+  };
 
   writeAssistantRoleChunk(res, streamIdentity);
 

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -463,6 +463,10 @@ export async function handleOpenResponsesHttpRequest(
   if (!handled) {
     return true;
   }
+  const abortController = new AbortController();
+  // The signal owns preparation; SSE installs presentation cleanup below.
+  let onDisconnect = () => {};
+  watchClientDisconnect(req, res, abortController, () => onDisconnect());
   const modelOverrideAuth = authorizeOpenAiCompatibleHttpModelOverride(req, handled.requestAuth);
   if (!modelOverrideAuth.allowed) {
     sendMissingScopeForbidden(res, modelOverrideAuth.missingScope);
@@ -528,6 +532,7 @@ export async function handleOpenResponsesHttpRequest(
     }
   };
   try {
+    abortController.signal.throwIfAborted();
     if (Array.isArray(payload.input)) {
       for (const item of payload.input) {
         if (item.type === "message" && typeof item.content !== "string") {
@@ -551,7 +556,11 @@ export async function handleOpenResponsesHttpRequest(
                       data: source.data,
                       mediaType: source.media_type,
                     };
-              const image = await extractImageContentFromSource(imageSource, limits.images);
+              const image = await extractImageContentFromSource(
+                imageSource,
+                limits.images,
+                abortController.signal,
+              );
               images.push(image);
               continue;
             }
@@ -568,6 +577,7 @@ export async function handleOpenResponsesHttpRequest(
                       filename: source.filename,
                     },
               limits: limits.files,
+              signal: abortController.signal,
             });
             const rawText = file.text;
             if (rawText?.trim()) {
@@ -602,6 +612,9 @@ export async function handleOpenResponsesHttpRequest(
       }
     }
   } catch (err) {
+    if (abortController.signal.aborted) {
+      return true;
+    }
     logWarn(`openresponses: request parsing failed: ${String(err)}`);
     sendInvalidRequest(res, "invalid request");
     return true;
@@ -707,7 +720,6 @@ export async function handleOpenResponsesHttpRequest(
     storeResponseSession(responseId, sessionKey, responseSessionScope);
   const outputItemId = `msg_${randomUUID()}`;
   const deps = createDefaultDeps();
-  const abortController = new AbortController();
   const streamMaxTokens =
     typeof payload.max_output_tokens === "number" ? payload.max_output_tokens : undefined;
   const streamTemperature =
@@ -723,7 +735,6 @@ export async function handleOpenResponsesHttpRequest(
       : undefined;
 
   if (!stream) {
-    const stopWatchingDisconnect = watchClientDisconnect(req, res, abortController);
     try {
       const result = await runResponsesAgentCommand({
         message: prompt.message,
@@ -854,8 +865,6 @@ export async function handleOpenResponsesHttpRequest(
       }
       rememberResponseSession();
       sendJson(res, 500, createFailedResponse({ code: "api_error", message: "internal error" }));
-    } finally {
-      stopWatchingDisconnect();
     }
     return true;
   }
@@ -874,7 +883,6 @@ export async function handleOpenResponsesHttpRequest(
   let unrepresentableAssistantReplacement = false;
   let closed = false;
   let unsubscribe = () => {};
-  let stopWatchingDisconnect = () => {};
   let finalUsage: Usage | undefined;
   let finalizeRequested: { status: ResponseResource["status"]; errorMessage?: string } | null =
     null;
@@ -926,7 +934,6 @@ export async function handleOpenResponsesHttpRequest(
       }
       streamedAssistantText = finalText;
       closed = true;
-      stopWatchingDisconnect();
       unsubscribe();
 
       writeSseEvent(res, {
@@ -1023,7 +1030,6 @@ export async function handleOpenResponsesHttpRequest(
     }
     // Failure is terminal even when an earlier lifecycle event is waiting for usage.
     closed = true;
-    stopWatchingDisconnect();
     unsubscribe();
     writeSseEvent(res, { type: "response.failed", response });
     writeDone(res);
@@ -1164,11 +1170,11 @@ export async function handleOpenResponsesHttpRequest(
   res.once("finish", releaseStreamRootWork);
   res.once("close", releaseStreamRootWork);
 
-  stopWatchingDisconnect = watchClientDisconnect(req, res, abortController, () => {
+  onDisconnect = () => {
     closed = true;
     unsubscribe();
     releaseStreamRootWork();
-  });
+  };
 
   void (async () => {
     try {

--- a/src/gateway/server-http.openai-compat.test.ts
+++ b/src/gateway/server-http.openai-compat.test.ts
@@ -1,8 +1,13 @@
 // Gateway OpenAI-compatible route tests cover config reload and root-mounted behavior.
+import { once } from "node:events";
+import http, { type Server, type ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
 import { agentCommandFromGatewayIngress } from "../commands/agent.js";
 import { setRuntimeConfigSnapshot } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { fetchWithRuntimeDispatcher } from "../infra/net/runtime-fetch.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import {
   AUTH_NONE,
   AUTH_TOKEN,
@@ -248,4 +253,174 @@ describe("gateway OpenAI-compatible HTTP routes", () => {
       });
     },
   );
+});
+
+const IMAGE_BYTES = Buffer.from(PNG_IMAGE_BASE64, "base64");
+const SOURCE_ORIGIN = "https://cdn.example.com";
+const inputCases = [
+  { name: "chat image", path: "/v1/chat/completions", kind: "image" },
+  { name: "response image", path: "/v1/responses", kind: "image" },
+  { name: "response file", path: "/v1/responses", kind: "file" },
+] as const;
+
+async function listen(server: Server): Promise<string> {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected a fixture HTTP listener");
+  }
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Server): Promise<void> {
+  server.closeAllConnections();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function requestBody(input: { path: string; kind: "image" | "file" }, stream: boolean) {
+  const urls = ["first", "second"].map((name) => `${SOURCE_ORIGIN}/${name}`);
+  return {
+    model: "openclaw/main",
+    stream,
+    ...(input.path === "/v1/chat/completions"
+      ? {
+          messages: [
+            {
+              role: "user",
+              content: urls.map((url) => ({ type: "image_url", image_url: { url } })),
+            },
+          ],
+        }
+      : {
+          input: [
+            {
+              type: "message",
+              role: "user",
+              content: urls.map((url) => ({
+                type: input.kind === "image" ? "input_image" : "input_file",
+                source: { type: "url", url },
+              })),
+            },
+          ],
+        }),
+  };
+}
+
+describe("HTTP media preparation cancellation", () => {
+  it.each(
+    inputCases.flatMap(({ name, path, kind }) =>
+      [false, true].flatMap((stream) =>
+        (["complete", "before headers", "during body"] as const).map((phase) => ({
+          name,
+          path,
+          kind,
+          stream,
+          phase,
+        })),
+      ),
+    ),
+  )("$name stream=$stream: $phase", async (testCase) => {
+    const initialRoots = getActiveGatewayRootWorkCount();
+    const firstStarted = createDeferredCore();
+    const firstHeaders = createDeferredCore();
+    const requestClosed = createDeferredCore();
+    const requestedSources: string[] = [];
+    const bytes = testCase.kind === "image" ? IMAGE_BYTES : Buffer.from("fixture file text");
+    let firstResponse: ServerResponse | undefined;
+    let firstCanceled = false;
+    const upstream = http.createServer((req, res) => {
+      requestedSources.push(req.url ?? "");
+      res.setHeader("Content-Type", testCase.kind === "image" ? "image/png" : "text/plain");
+      if (req.url !== "/first" || testCase.phase === "complete") {
+        res.end(bytes);
+        return;
+      }
+      firstResponse = res;
+      res.once("close", () => {
+        firstCanceled = !res.writableFinished;
+      });
+      if (testCase.phase === "during body") {
+        res.write(bytes.subarray(0, 4));
+      }
+      firstStarted.resolve();
+    });
+    const upstreamOrigin = await listen(upstream);
+    // Remap only the fixture origin; actual Undici owns request/body cancellation.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      if (url.origin !== SOURCE_ORIGIN) {
+        throw new Error(`Unexpected fixture fetch: ${url.origin}`);
+      }
+      const response = await fetchWithRuntimeDispatcher(`${upstreamOrigin}${url.pathname}`, init);
+      if (url.pathname === "/first") {
+        firstHeaders.resolve();
+      }
+      return response;
+    });
+    vi.mocked(agentCommandFromGatewayIngress).mockClear();
+    try {
+      await withGatewayServer({
+        prefix: "http-media-preparation",
+        resolvedAuth: AUTH_TOKEN,
+        overrides: { openAiChatCompletionsEnabled: true, openResponsesEnabled: true },
+        run: async (server) => {
+          const config: OpenClawConfig = {
+            agents: { entries: { main: {} } },
+            gateway: {
+              http: {
+                endpoints: {
+                  chatCompletions: { images: { allowUrl: true } },
+                  responses: { images: { allowUrl: true }, files: { allowUrl: true } },
+                },
+              },
+            },
+          };
+          setRuntimeConfigSnapshot(config, config);
+          server.on("request", (_req, res) => res.once("close", requestClosed.resolve));
+          const origin = await listen(server);
+          const client = http.request(`${origin}${testCase.path}`, {
+            method: "POST",
+            headers: { authorization: "Bearer test-token", "content-type": "application/json" },
+          });
+          client.on("error", () => {});
+          const completed = testCase.phase === "complete" ? once(client, "response") : undefined;
+          client.end(JSON.stringify(requestBody(testCase, testCase.stream)));
+          try {
+            if (completed) {
+              const [response] = await completed;
+              const chunks: Buffer[] = [];
+              for await (const chunk of response) {
+                chunks.push(Buffer.from(chunk));
+              }
+              expect(response.statusCode).toBe(200);
+              expect(Buffer.concat(chunks).toString()).toContain("image accepted");
+              expect(requestedSources).toEqual(["/first", "/second"]);
+              expect(agentCommandFromGatewayIngress).toHaveBeenCalledTimes(1);
+            } else {
+              await firstStarted.promise;
+              if (testCase.phase === "during body") {
+                await firstHeaders.promise;
+              }
+              client.destroy();
+              await requestClosed.promise;
+              await vi.waitFor(() => expect(firstCanceled).toBe(true), { timeout: 1_000 });
+              expect(requestedSources).toEqual(["/first"]);
+              expect(agentCommandFromGatewayIngress).not.toHaveBeenCalled();
+            }
+          } finally {
+            client.destroy();
+            firstResponse?.destroy();
+            await close(server);
+            await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(initialRoots));
+          }
+        },
+      });
+    } finally {
+      fetchSpy.mockRestore();
+      await close(upstream);
+    }
+  });
 });

--- a/src/media/input-files.fetch-guard.test.ts
+++ b/src/media/input-files.fetch-guard.test.ts
@@ -368,6 +368,43 @@ describe("HEIC input image normalization", () => {
 });
 
 describe("guarded input file URL fetches", () => {
+  it.each(["image", "file"] as const)(
+    "does not start %s processing after cancellation during fetch release",
+    async (kind) => {
+      const controller = new AbortController();
+      const reason = new Error("HTTP request ended during download cleanup");
+      const source = { type: "url" as const, url: "https://example.com/input" };
+      const release = mockUrlFetchResponse({
+        source,
+        fetchedContentType: kind === "image" ? "image/png" : "application/pdf",
+        fetchedBody:
+          kind === "image"
+            ? Buffer.from(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO2N4j8AAAAASUVORK5CYII=",
+                "base64",
+              )
+            : Buffer.from("%PDF-1.4\n"),
+      });
+      release?.mockImplementationOnce(async () => controller.abort(reason));
+
+      const extraction =
+        kind === "image"
+          ? extractImageContentFromSource(
+              source,
+              createImageSourceLimits(["image/png"], true),
+              controller.signal,
+            )
+          : extractFileContentFromSource({
+              source,
+              limits: createFileSourceLimits(["application/pdf"], true),
+              signal: controller.signal,
+            });
+      await expect(extraction).rejects.toBe(reason);
+      expect(kind === "image" ? detectMimeMock : extractPdfContentMock).not.toHaveBeenCalled();
+      expect(release).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it("releases a rejected fetch without waiting for its capture tee", async () => {
     const response = new Response("server error", { status: 503 });
     const capture = response.clone();

--- a/src/media/input-files.ts
+++ b/src/media/input-files.ts
@@ -13,7 +13,6 @@ import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { cancelUnreadResponseBody, readResponseWithLimit } from "../infra/http-body.js";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
-import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import { logWarn } from "../logger.js";
 import { convertHeicToJpeg } from "./media-services.js";
 import { extractPdfContent, type PdfExtractedImage } from "./pdf-extract.js";
@@ -35,17 +34,17 @@ type InputPdfLimits = {
   minTextChars: number;
 };
 
-/** Resolved input_file limits with normalized MIME allowlist and PDF sub-limits. */
-export type InputFileLimits = {
+type InputSourceLimits = {
   allowUrl: boolean;
   urlAllowlist?: string[];
   allowedMimes: Set<string>;
   maxBytes: number;
-  maxChars: number;
   maxRedirects: number;
   timeoutMs: number;
-  pdf: InputPdfLimits;
 };
+
+/** Resolved input_file limits with normalized MIME allowlist and PDF sub-limits. */
+export type InputFileLimits = InputSourceLimits & { maxChars: number; pdf: InputPdfLimits };
 
 /** Optional config shape accepted by input_file limit resolution. */
 export type InputFileLimitsConfig = {
@@ -63,14 +62,7 @@ export type InputFileLimitsConfig = {
 };
 
 /** Resolved input_image limits with normalized MIME allowlist and URL fetch controls. */
-export type InputImageLimits = {
-  allowUrl: boolean;
-  urlAllowlist?: string[];
-  allowedMimes: Set<string>;
-  maxBytes: number;
-  maxRedirects: number;
-  timeoutMs: number;
-};
+export type InputImageLimits = InputSourceLimits;
 
 /** Supported input_image source variants before base64 decoding or guarded URL fetch. */
 export type InputImageSource =
@@ -197,23 +189,26 @@ export function resolveInputFileLimits(config?: InputFileLimitsConfig): InputFil
 }
 
 /** Fetches an input source URL through SSRF, redirect, timeout, and byte-limit guards. */
-async function fetchWithGuard(params: {
-  url: string;
-  maxBytes: number;
-  timeoutMs: number;
-  maxRedirects: number;
-  policy?: SsrFPolicy;
-  auditContext?: string;
-}): Promise<InputFetchResult> {
+async function fetchWithGuard(
+  url: string,
+  limits: InputSourceLimits,
+  kind: "input_image" | "input_file",
+  signal?: AbortSignal,
+): Promise<InputFetchResult> {
+  if (!limits.allowUrl) {
+    throw new Error(`${kind} URL sources are disabled by config`);
+  }
   const { response, release } = await fetchWithSsrFGuard({
-    url: params.url,
-    maxRedirects: params.maxRedirects,
-    timeoutMs: params.timeoutMs,
-    policy: params.policy,
-    auditContext: params.auditContext,
+    url,
+    maxRedirects: limits.maxRedirects,
+    timeoutMs: limits.timeoutMs,
+    signal,
+    policy: { allowPrivateNetwork: false, hostnameAllowlist: limits.urlAllowlist },
+    auditContext: `openresponses.${kind}`,
     init: { headers: { "User-Agent": "OpenClaw-Gateway/1.0" } },
   });
 
+  let result: InputFetchResult;
   try {
     if (!response.ok) {
       await cancelUnreadResponseBody(response);
@@ -227,20 +222,23 @@ async function fetchWithGuard(params: {
       await cancelUnreadResponseBody(response);
       throw err;
     }
-    if (contentLength !== null && contentLength > params.maxBytes) {
+    if (contentLength !== null && contentLength > limits.maxBytes) {
       await cancelUnreadResponseBody(response);
       throw new Error(
-        `Content too large: ${contentLength} bytes (limit: ${params.maxBytes} bytes)`,
+        `Content too large: ${contentLength} bytes (limit: ${limits.maxBytes} bytes)`,
       );
     }
 
-    const buffer = await readResponseWithLimit(response, params.maxBytes);
+    const buffer = await readResponseWithLimit(response, limits.maxBytes);
 
     const contentType = response.headers.get("content-type") ?? undefined;
-    return { buffer, contentType };
+    result = { buffer, contentType };
   } finally {
     await release();
   }
+  // Successful downloads can finish transport cleanup after their caller canceled.
+  signal?.throwIfAborted();
+  return result;
 }
 
 function decodeTextContent(buffer: Buffer, charset: string | undefined, maxChars: number): string {
@@ -326,7 +324,9 @@ export async function normalizeInputImageBuffer(params: {
 export async function extractImageContentFromSource(
   source: InputImageSource,
   limits: InputImageLimits,
+  signal?: AbortSignal,
 ): Promise<InputImageContent> {
+  signal?.throwIfAborted();
   let buffer: Buffer;
   let mimeType: string | undefined;
   let canonicalData: string | undefined;
@@ -339,26 +339,14 @@ export async function extractImageContentFromSource(
     buffer = Buffer.from(canonicalData, "base64");
     mimeType = normalizeMimeType(source.mediaType) ?? "image/png";
   } else if (source.type === "url") {
-    if (!limits.allowUrl) {
-      throw new Error("input_image URL sources are disabled by config");
-    }
-    const result = await fetchWithGuard({
-      url: source.url,
-      maxBytes: limits.maxBytes,
-      timeoutMs: limits.timeoutMs,
-      maxRedirects: limits.maxRedirects,
-      policy: {
-        allowPrivateNetwork: false,
-        hostnameAllowlist: limits.urlAllowlist,
-      },
-      auditContext: "openresponses.input_image",
-    });
+    const result = await fetchWithGuard(source.url, limits, "input_image", signal);
     buffer = result.buffer;
     mimeType = parseContentType(result.contentType).mimeType;
   } else {
     throw new Error(`Unsupported input_image source type: ${(source as { type: string }).type}`);
   }
   const image = await normalizeInputImageBuffer({ buffer, mimeType, limits });
+  signal?.throwIfAborted();
   // Conversions replace the buffer; unchanged bytes already have validated base64.
   const data =
     image.buffer === buffer && canonicalData ? canonicalData : image.buffer.toString("base64");
@@ -370,8 +358,10 @@ export async function extractFileContentFromSource(params: {
   source: InputFileSource;
   limits: InputFileLimits;
   config?: OpenClawConfig;
+  signal?: AbortSignal;
 }): Promise<InputFileExtractResult> {
-  const { source, limits } = params;
+  const { source, limits, signal } = params;
+  signal?.throwIfAborted();
   const filename = source.filename || "file";
 
   let buffer: Buffer;
@@ -389,27 +379,14 @@ export async function extractFileContentFromSource(params: {
     charset = parsed.charset;
     buffer = Buffer.from(canonicalData, "base64");
   } else {
-    if (!limits.allowUrl) {
-      throw new Error("input_file URL sources are disabled by config");
-    }
-    const result = await fetchWithGuard({
-      url: source.url,
-      maxBytes: limits.maxBytes,
-      timeoutMs: limits.timeoutMs,
-      maxRedirects: limits.maxRedirects,
-      policy: {
-        allowPrivateNetwork: false,
-        hostnameAllowlist: limits.urlAllowlist,
-      },
-      auditContext: "openresponses.input_file",
-    });
+    const result = await fetchWithGuard(source.url, limits, "input_file", signal);
     const parsed = parseContentType(result.contentType);
     mimeType = parsed.mimeType;
     charset = parsed.charset;
     buffer = result.buffer;
   }
 
-  return await extractFileContentFromBuffer({
+  const extracted = await extractFileContentFromBuffer({
     buffer,
     filename,
     mimeType,
@@ -417,6 +394,8 @@ export async function extractFileContentFromSource(params: {
     limits,
     config: params.config,
   });
+  signal?.throwIfAborted();
+  return extracted;
 }
 
 /** Extracts text from borrowed bytes or PDFs from owned bytes after shared size and MIME checks. */


### PR DESCRIPTION
Closes #139774. Related: #116337.

## What Problem This Solves

Fixes an issue where clients disconnecting from `/v1/chat/completions` or `/v1/responses` during an input URL download leave that download running, and the Gateway can continue preparing later inputs after the HTTP response is gone.

## Why This Change Was Made

Both endpoints now establish one request cancellation signal before input preparation and carry it through shared guarded URL acquisition into agent execution. The existing HTTP response owner disposes disconnect watchers at completion while retaining response-error handling until close. Successful download release and input processing settlement check cancellation before further work starts.

Image and file URL acquisition now share their limit and lifecycle handling, removing duplicated branches. Production changes total **+80/−88 (net −8)**; tests **+235/−14 (net +221)**; docs **+4**.

## User Impact

Streaming and non-streaming clients can cancel active URL downloads without leaving later preparation or agent dispatch running. Connected requests retain their existing output and limits. No configuration, protocol, persistence, authentication, SDK export, or extraction-capacity policy changes.

This credits @zhangguiping-xydt's earlier request-cancellation work in #116337. That PR additionally proposes cancellable document workers and a new saturation policy. It remains open for those decisions; this change does not claim to stop an already-running codec or replace that entire proposal.

## Evidence

Candidate: `90a2bb9d2a6a21814bcf2b052ce27fc3c8d64cc5`, based on main `e19a7694cef6d38140033f798215103dd638fafb`.

- Before: real inbound/outbound HTTP with installed Undici reproduced **12 failures and 6 passing connected controls** on `95f963e342ab476912c23c0e7fb9660c69bb9980`. Two cancellation-during-release cases failed independently. The affected production owners remained unchanged through main `391550bbd9afa8c8df2f324422ab46a4b01296ec`.
- Current candidate: **457 tests passed across 15 owner/sibling files**, including both complete compatibility API suites, URL headers/body cancellation, successive inputs, release races, keepalive/response errors, the disconnect fuzz matrix, and sibling embedding/tool/MCP/artifact/workspace routes. This also covers main's newer bounded text decoder and its eight added regression rows.
- The complete changed gate passed on the original repair. Following current-main integration, production and Gateway-root test types, formatting, type-aware lint, and diff checks passed again on this exact candidate.
- The original exact candidate passed a full `pnpm build`, including declarations and SDK export checks. The current head passed the repository `sourcePerformance` runtime build and actual UI build; `dist/build-info.json` records this candidate SHA.
- Fresh managed complete-source Codex review on this exact candidate completed **three P0–P2 passes with no actionable findings**. All ten complete changed files were included in every pass, plus current full owner/dependency context.

The first hosted run, [34014746607](https://github.com/openclaw/openclaw/actions/runs/34014746607), caught two failures. Main's history-fixture type error was already repaired by #139794 and is included here. The disconnect fuzz oracle still expected a callback for each socket after the first socket had already released all watchers. Its original local run reproduced **1 failure / 8 controls**; the existing test now checks listener cleanup and a single socket-disconnect callback, including pre-aborted controllers. All **48 fuzz/helper tests**, targeted lint, and an independent P0–P2 correction review passed before integration. No failure was skipped or rerun unchanged.

The HTTP proof uses real loopback sockets and actual Undici. Address approval and agent execution are synthetic fixture boundaries; it is not an authenticated provider/channel run. Direct Node24.20.0 HTTP/AbortController and Undici8.10.2 source inspection supports response-finish/close ownership, body cancellation, and abort-reason propagation.

The focused test commands were:

```sh
node scripts/run-vitest.mjs src/gateway/http-common.fuzz.test.ts src/gateway/http-common.test.ts src/gateway/openai-http.test.ts src/gateway/openresponses-http.test.ts src/gateway/server-http.openai-compat.test.ts src/infra/net/fetch-guard.release.test.ts src/infra/net/guarded-body-stream.test.ts src/media/input-files.extract.test.ts src/media/input-files.fetch-guard.test.ts
node scripts/run-vitest.mjs src/gateway/embeddings-http.test.ts src/gateway/mcp-app-standalone-cancellation.test.ts src/gateway/server-http.node-workspace-transfer.test.ts src/gateway/tools-invoke-http.abort.test.ts src/gateway/worker-environments/node-workspace-transfer-revocation.test.ts src/gateway/worker-environments/worker-bootstrap-artifact-transfer.test.ts
```
