### PR TITLE
fix(gateway): align history test fixture with projection state

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
## What Problem This Solves

Gateway history test-type validation fails after the assistant error projection state was renamed in #139753. The interleaved pagination regression fixture added in #139715 still uses the previous result fields.

## Why This Change Was Made

Update the existing fixture to the current projection result contract: `assistantErrorPending` and `assistantErrorRecoveryObserved`, both `false`. Keep its messages, pagination options, and assertions unchanged.

## User Impact

No runtime behavior changes. Maintainers can validate the Gateway history tests against the current projection contract while retaining the pagination regression coverage.

## Evidence

The canonical changed-paths typecheck selected `gateway-root` and reproduced TS2353 on the original fixture; the same command passes with this repair. All 30 existing session-history state tests pass. Targeted formatting, lint, and `git diff --check` pass.

Commands: `node scripts/run-tsgo-core-test-shards.mjs --changed-paths-json '["src/gateway/session-history-state.test.ts"]'`; `node scripts/run-vitest.mjs src/gateway/session-history-state.test.ts`.

Independent source review and isolated Codex autoreview found no actionable issue. No production code or pagination assertions change.
