### PR TITLE
fix(pr): avoid false trust-anchor refusals on macOS

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -147,9 +147,12 @@ elif common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolu
         if [ -n "$anchor_wrapper_revision" ] && [ -n "$anchor_git_root" ] &&
           anchor_exec_dir=$(mktemp -d "${TMPDIR:-/tmp}/openclaw-pr-anchor.XXXXXX" 2>/dev/null); then
           anchor_extraction_valid=0
+          # BSD tar can stop at the end marker before Git finishes writing padding,
+          # causing SIGPIPE under pipefail. Require producer completion before reading.
           if git -C "$anchor_git_root" archive "$anchor_commit" -- \
-            "${anchor_components[@]}" 2>/dev/null |
-            tar -x -C "$anchor_exec_dir" 2>/dev/null; then
+            "${anchor_components[@]}" > "$anchor_exec_dir/anchor.tar" 2>/dev/null &&
+            tar -xf "$anchor_exec_dir/anchor.tar" -C "$anchor_exec_dir" 2>/dev/null; then
+            rm "$anchor_exec_dir/anchor.tar"
             anchor_extraction_valid=1
             anchor_verified_entries=0
             # Verify every extracted file byte-matches its anchor blob so an

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -587,6 +587,92 @@ describe("scripts/pr wrappers", () => {
     expect(result.stderr).not.toContain("Refusing to silently substitute");
   });
 
+  itPosix("materializes the anchor when tar stops before the producer's trailing padding", () => {
+    const fixture = makeMismatchedWrapperRepo();
+    parkCanonicalOffAnchor(fixture);
+    const git = join(fixture.bin, "git");
+    writeFileSync(
+      git,
+      `#!/bin/sh
+"$OPENCLAW_TEST_GIT" "$@" || exit
+if [ "$3" = archive ]; then
+  # Valid zero padding exceeds a pipe buffer even when tar has read every entry.
+  dd if=/dev/zero bs=65536 count=32 2>/dev/null
+fi
+`,
+    );
+    chmodSync(git, 0o755);
+    const result = spawnSync(join(fixture.linked, "scripts/pr"), ["unknown-command"], {
+      cwd: fixture.linked,
+      encoding: "utf8",
+      env: { ...fixture.env, OPENCLAW_TEST_GIT: resolveCommand("git") },
+    });
+    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(2);
+    expect(result.stderr).toContain("running wrapper code materialized from");
+    expect(result.stdout).toContain("Usage:");
+    expect(result.stderr).not.toContain("Refusing to silently substitute");
+  });
+
+  itPosix.each(["producer failure", "truncated archive", "reader failure"])(
+    "refuses anchor extraction on %s",
+    (failure) => {
+      const fixture = makeMismatchedWrapperRepo();
+      parkCanonicalOffAnchor(fixture);
+      const git = join(fixture.bin, "git");
+      writeFileSync(
+        git,
+        `#!/bin/sh
+if [ "$3" = archive ]; then
+  if [ "$OPENCLAW_TEST_FAILURE" = 'truncated archive' ]; then
+    "$OPENCLAW_TEST_GIT" "$@" > "$OPENCLAW_TEST_ARCHIVE" || exit
+    dd if="$OPENCLAW_TEST_ARCHIVE" bs=512 count=3 2>/dev/null
+    exit
+  fi
+  "$OPENCLAW_TEST_GIT" "$@" || exit
+  if [ "$OPENCLAW_TEST_FAILURE" = 'producer failure' ]; then
+    exit 42
+  fi
+  exit 0
+fi
+exec "$OPENCLAW_TEST_GIT" "$@"
+`,
+      );
+      chmodSync(git, 0o755);
+      const tar = join(fixture.bin, "tar");
+      writeFileSync(
+        tar,
+        `#!/bin/sh
+printf 'started\\n' >> "$OPENCLAW_TEST_READER_LOG"
+"$OPENCLAW_TEST_TAR" "$@" || exit
+if [ "$OPENCLAW_TEST_FAILURE" = 'reader failure' ]; then
+  exit 42
+fi
+`,
+      );
+      chmodSync(tar, 0o755);
+      const readerLog = join(fixture.root, "reader.log");
+      const result = spawnSync(join(fixture.linked, "scripts/pr"), ["unknown-command"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: {
+          ...fixture.env,
+          OPENCLAW_TEST_GIT: resolveCommand("git"),
+          OPENCLAW_TEST_TAR: resolveCommand("tar"),
+          OPENCLAW_TEST_FAILURE: failure,
+          OPENCLAW_TEST_ARCHIVE: join(fixture.root, "complete.tar"),
+          OPENCLAW_TEST_READER_LOG: readerLog,
+        },
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(result.stderr).toContain("Refusing to silently substitute");
+      expect(result.stderr).not.toContain("running wrapper code materialized from");
+      expect(existsSync(readerLog)).toBe(failure !== "producer failure");
+      expect(
+        readdirSync(fixture.root).filter((name) => name.startsWith("openclaw-pr-anchor.")),
+      ).toEqual([]);
+    },
+  );
+
   itPosix("executes extracted helpers through a symlinked temporary root", () => {
     const fixture = makeMismatchedWrapperRepo({ realModules: true });
     // Exercise the wrapper's own helper path, not a physical path reconstructed by the test.
@@ -756,38 +842,49 @@ describe("scripts/pr wrappers", () => {
     },
   );
 
-  itPosix("refuses an extracted anchor with a tampered dependency", () => {
-    const fixture = makeMismatchedWrapperRepo({ realModules: true });
-    advanceAnchorReviewDependency(fixture);
-    parkCanonicalOffAnchor(fixture);
-    const tar = join(fixture.bin, "tar");
-    writeFileSync(
-      tar,
-      `#!/bin/sh
+  itPosix.each(["tampered", "missing"])(
+    "refuses an extracted anchor with a %s dependency",
+    (fault) => {
+      const fixture = makeMismatchedWrapperRepo({ realModules: true });
+      advanceAnchorReviewDependency(fixture);
+      parkCanonicalOffAnchor(fixture);
+      const tar = join(fixture.bin, "tar");
+      writeFileSync(
+        tar,
+        `#!/bin/sh
 "$OPENCLAW_TEST_TAR" "$@" || exit
 while [ "$#" -gt 0 ]; do
   if [ "$1" = "-C" ]; then
-    printf '\\n// tampered\\n' >> "$2/scripts/lib/anchor-review-record.mjs"
+    if [ "$OPENCLAW_TEST_FAULT" = missing ]; then
+      rm "$2/scripts/lib/anchor-review-record.mjs"
+    else
+      printf '\\n// tampered\\n' >> "$2/scripts/lib/anchor-review-record.mjs"
+    fi
     exit
   fi
   shift
 done
 exit 99
 `,
-    );
-    chmodSync(tar, 0o755);
-    const result = spawnSync(join(fixture.linked, "scripts/pr"), ["unknown-command"], {
-      cwd: fixture.linked,
-      encoding: "utf8",
-      env: { ...fixture.env, OPENCLAW_TEST_TAR: resolveCommand("tar") },
-    });
-    expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
-    expect(result.stderr).toContain("Refusing to silently substitute");
-    expect(result.stderr).not.toContain("running wrapper code materialized from");
-    expect(
-      readdirSync(fixture.root).filter((name) => name.startsWith("openclaw-pr-anchor.")),
-    ).toEqual([]);
-  });
+      );
+      chmodSync(tar, 0o755);
+      const result = spawnSync(join(fixture.linked, "scripts/pr"), ["unknown-command"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: {
+          ...fixture.env,
+          OPENCLAW_TEST_TAR: resolveCommand("tar"),
+          OPENCLAW_TEST_FAULT: fault,
+        },
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(result.stderr).toContain("Refusing to silently substitute");
+      expect(result.stderr).not.toContain("running wrapper code materialized from");
+      expect(
+        readdirSync(fixture.root).filter((name) => name.startsWith("openclaw-pr-anchor.")),
+      ).toEqual([]);
+    },
+  );
 
   it("routes a mismatched landing subcommand through the materialized anchor", () => {
     const fixture = makeMismatchedWrapperRepo();


### PR DESCRIPTION
Related: #139063

## What Problem This Solves

Resolves a problem where maintainers landing a PR on macOS could receive a misleading refusal to substitute the trusted `origin/main` wrapper, even though every expected anchor file had extracted correctly. The failure occurs when neither the PR worktree nor the canonical checkout matches the fetched wrapper anchor.

## Why This Change Was Made

The wrapper piped `git archive` into tar under `pipefail`. BSD tar can finish at the logical archive end marker while the producer still writes trailing padding, producing SIGPIPE (141) after a successful extraction. The wrapper now fully materializes the archive inside its existing private temporary directory and requires Git success before extraction, followed by tar success and the unchanged per-blob hash validation before exec.

The temporary archive is removed after extraction, and failed materialization, extraction, or validation retains refusal and directory cleanup. This uses portable tar options rather than a BSD-specific environment setting or accepting exit 141. Trust guards, checksum validation, third-party dependency selection, package-age policy, and user configuration are unchanged.

## User Impact

Maintainers can continue native PR preparation and landing when wrapper versions differ without a false trust-anchor refusal caused by tar's early completion. Incomplete or modified anchors remain rejected. There is no change to the OpenClaw runtime, public configuration, or package dependencies.

## Evidence

- Reconstructed the historical 1,064,960-byte full anchor archive and verified all 114 expected blobs. The unmodified pipeline succeeded in this diagnostic run; adding valid trailing zero padding beyond pipe capacity deterministically reproduced producer **141**, reader **0**, with all 114 extracted blobs still hash-identical using stock macOS `/usr/bin/tar`.
- The new trailing-padding regression failed against the original wrapper with the misleading refusal, then passed with the owner-level repair. Controls cover producer failure after a complete archive, truncation, reader failure after extraction, and missing/tampered extracted dependencies.
- `node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts`: **68 tests passed**, including materialized helper execution, dependency ownership, canonical substitution, and landing-command routing.
- `node scripts/check-changed.mjs -- scripts/pr test/scripts/pr-wrappers.test.ts`: passed, including typechecking, script/test lint, formatting, and dependency guards.
- `/bin/bash -n scripts/pr` and `git diff --check`: passed.
- Independent autoreview: scoped-clean through P2, no actionable findings.

Production change: net +3 lines. No timeout increases, relaxed assertions, new dependencies, `node_modules` edits, or policy bypasses.

The first hosted run exposed an unrelated existing Gateway fixture type error (`streamErrorFallbackPending` at `src/gateway/session-history-state.test.ts:398`). After #139794 repaired that baseline on main, this branch was rebased onto it. `git range-diff` confirms the archive repair is patch-identical, and both changed files are byte-identical to the locally tested and reviewed versions. [Fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34014775589) passed at `460b1649f8e9b7f97489640c1dd4b092887745d2`, including `openclaw/ci-gate`, with no failed jobs. [ClawSweeper's completed review](https://github.com/openclaw/openclaw/pull/139795#issuecomment-5557253898) has no findings or before-merge actions.

The native review workflow also successfully materialized and selected the verified main anchor on macOS during this PR's own review initialization, without a tar environment override.
