### PR TITLE
fix(ci): update history projection fixture fields

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

The core test typecheck fails because the pagination fixture added in #139715 still uses the projection fields renamed by #139753.

## Why This Change Was Made

Update the fixture to the current `assistantErrorPending` and `assistantErrorRecoveryObserved` fields. Both remain false for its ordinary assistant rows. All pagination inputs and assertions are unchanged; production types and behavior are unchanged.

## User Impact

Restores compilation of the existing pagination test. No user-facing, configuration, storage, or protocol changes.

## Evidence

- Reproduced TS2353 on current main with the existing gateway-root test typecheck, then passed the identical command after the two-field correction.
- All 30 existing session-history tests passed, including the interleaved pagination case.
- All 20 selected changed checks passed, including type-aware lint and the three export scans.
- Test changes are two lines replaced; production delta is zero.

This repairs the typecheck failure seen in [CI 34013357411](https://github.com/openclaw/openclaw/actions/runs/34013357411). That run also had a separate package compilation timeout, which this change does not address.
