### PR TITLE
fix: avoid idle release preparation and late registry failures

### DIFF
--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -45,9 +45,9 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
   npm publication, or `pnpm release:candidate`. Keep normal CI, npm
   qualification, Docker, Package Acceptance, performance, and soak gates intact.
 - macOS app signing/notarization/appcast and Windows Hub asset promotion run
-  in parallel with or after npm publication and never delay npm. Their own
-  qualification and artifact gates still apply; Windows Hub assets remain a
-  GitHub release finalization requirement.
+  in parallel with or after npm publication and never delay npm or GitHub
+  finalization. Their own qualification and artifact gates still apply; track
+  selected platforms through verified assets and updater evidence separately.
 - Do not set GitHub secrets from unvalidated 1Password candidates. If a candidate returns 401/403, leave the existing secret alone and report the exact missing provider.
 - Use `$one-password` for secret reads/writes: one persistent tmux session, targeted items only, no secret output.
 - Watch one parent run plus compact child summaries. Avoid broad `gh run view` polling loops; REST quota is easy to burn.

--- a/.agents/skills/release-openclaw-ci/references/release-ci-notes.md
+++ b/.agents/skills/release-openclaw-ci/references/release-ci-notes.md
@@ -13,7 +13,12 @@
 
 ## Better Defaults
 
-- Run provider-secret preflight first. Require real `/models` or equivalent endpoint checks for release-blocking providers.
+- Run provider-secret preflight first. Required providers need a real completion
+  to prove inference entitlement; a successful `/models` request proves only
+  authentication. The current verifier probes inference only for Anthropic;
+  OpenAI and Fireworks remain authentication-only. Record and complete their
+  missing inference proof before expensive dispatch, using the existing live
+  provider lane with the same credential source.
 - Keep one watcher open. Use child summaries every few minutes, not every few seconds.
 - Fetch failed-job logs only after a job reaches a terminal failing state.
 - Prefer same-parent failed-job reruns when the original inputs still select the

--- a/.agents/skills/release-openclaw-maintainer/references/regular-release.md
+++ b/.agents/skills/release-openclaw-maintainer/references/regular-release.md
@@ -72,7 +72,11 @@ For a prepare-only request, stop with the candidate, evidence, limitations, and
 printed next command. Do not create/push the final tag or publish/announce.
 With publication authority and candidate success, create and push the signed
 final tag at Release SHA. Leave GitHub Release creation/finalization to the
-publish workflow.
+publish workflow. At this point start the selected macOS handoff, release-ops
+validation, and notarization preflight through [platform publication](platform-publication.md)
+while npm/plugin publication proceeds. These preparation lanes do not need a
+published GitHub page; asset promotion waits for its required release state.
+Keep their exact run/attempt identities in the handoff's publication rows.
 
 ## Publish and verify
 

--- a/.agents/skills/release-openclaw-maintainer/references/release-handoff-template.md
+++ b/.agents/skills/release-openclaw-maintainer/references/release-handoff-template.md
@@ -36,6 +36,30 @@ operator steering. Do not preserve superseded scope.
 - immutable successful children: `<run ids / artifacts or none>`
 - registry/provenance readback: `<artifact or command result>`
 
+## Publication surfaces
+
+Keep one row per selected surface, with its exact run/attempt or immutable
+receipt, current state, and next action. Remove unselected rows rather than
+reporting them as passed. Stable/full includes macOS unless explicitly scoped
+out; extended-stable does not inherit ClawHub, GitHub Release, or native apps.
+
+| Surface                 | Evidence and state                                                   | Next action or blocker |
+| ----------------------- | -------------------------------------------------------------------- | ---------------------- |
+| Core and plugin npm     | `<version, selectors, parent/child receipts>`                        | `<action>`             |
+| Docker                  | `<digests, aliases, run/attempt>`                                    | `<action>`             |
+| ClawHub                 | `<child and postpublish verification receipts>`                      | `<action>`             |
+| GitHub Release / Latest | `<release URL, draft/prerelease/latest readback>`                    | `<action>`             |
+| macOS                   | `<handoff, validation, notarized preflight, promotion run/attempts>` | `<action>`             |
+| Stable appcast          | `<signed artifact, main commit/PR, public feed readback>`            | `<action>`             |
+| Other selected apps     | `<platform, exact source, publication proof>`                        | `<action>`             |
+| Stable main closeout    | `<PR, shipped metadata, immutable closeout manifest>`                | `<action>`             |
+
+A successful publish parent does not complete detached ClawHub verification or
+macOS. Preserve their exact identities and advance ready independent work while
+another surface waits. Staging is not public ClawHub byte verification; npm
+`latest` is not GitHub Latest verification. Use the owning platform/recovery
+reference for commands rather than redispatching the release parent.
+
 ## Phase
 
 - conceptual phase: `<beta-publish | postpublish-confidence | stable-publish>`
@@ -64,8 +88,9 @@ operator steering. Do not preserve superseded scope.
   cancels them explicitly
 - postpublish-confidence failure: do not retroactively unpublish the beta;
   admit a confirmed product fix to the next beta
-- external approval or permission blocker: stop with the exact job, URL,
-  missing permission, and required operator action
+- external approval or permission blocker: pause that surface with the exact
+  job, URL, enforced rule, and required owner action; continue independent
+  authorized work. Do not invent another consent step for an approved release.
 
 Do not scan moving `main`, add optional backports, dispatch a replacement
 validation parent, automatically rerun `all`, or repeat completed phases unless

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -1983,6 +1983,17 @@ async function main() {
     : "";
   const localGeneratedCheck = runLocalGeneratedCheckIfNeeded(options);
 
+  // Discover invalid plugin inputs and registry failures before starting expensive validation.
+  // Publishers rebuild these read-only plans; this snapshot never authorizes publication.
+  const pluginNpmPlan = await collectPluginPlanWithRetry(
+    "scripts/plugin-npm-release-plan.ts",
+    options,
+  );
+  const pluginClawHubPlan = await collectPluginPlanWithRetry(
+    "scripts/plugin-clawhub-release-plan.ts",
+    options,
+  );
+
   if (!options.fullReleaseRunId && !options.skipDispatch) {
     const workflowFile = "full-release-validation.yml";
     const targetContextRef = releaseBranchForTag(options.tag);
@@ -2218,14 +2229,6 @@ async function main() {
     npmRun.runAttempt,
     targetSha,
     fullValidationEvidence.coveragePolicy,
-  );
-  const pluginNpmPlan = await collectPluginPlanWithRetry(
-    "scripts/plugin-npm-release-plan.ts",
-    options,
-  );
-  const pluginClawHubPlan = await collectPluginPlanWithRetry(
-    "scripts/plugin-clawhub-release-plan.ts",
-    options,
   );
   const publishCommand = buildPublishCommand(
     {

--- a/scripts/release-preflight.mts
+++ b/scripts/release-preflight.mts
@@ -274,7 +274,8 @@ async function runTaskGraph({
   const taskFailures: FailedTask[] = [];
   const skipped: SkippedTask[] = [];
 
-  while (pending.size > 0) {
+  const running = new Map<string, Promise<{ task: RunnableTask; status: number }>>();
+  while (pending.size > 0 || running.size > 0) {
     for (const [taskId, task] of pending) {
       const failedDependency = task.after.find(
         (dependencyId) => selectedIds.has(dependencyId) && failedIds.has(dependencyId),
@@ -287,32 +288,38 @@ async function runTaskGraph({
       pending.delete(taskId);
     }
 
-    const ready = [...pending.values()].filter((task) =>
-      task.after.every(
-        (dependencyId) => !selectedIds.has(dependencyId) || completed.has(dependencyId),
-      ),
-    );
-    if (ready.length === 0) {
+    for (const [taskId, task] of pending) {
+      if (running.size >= jobs) {
+        break;
+      }
+      if (
+        !task.after.every(
+          (dependencyId) => !selectedIds.has(dependencyId) || completed.has(dependencyId),
+        )
+      ) {
+        continue;
+      }
+      pending.delete(taskId);
+      running.set(
+        taskId,
+        runCommand(task).then((status) => ({ task, status })),
+      );
+    }
+    if (running.size === 0) {
       if (pending.size === 0) {
         break;
       }
       throw new Error(`release preflight task graph is blocked: ${[...pending.keys()].join(", ")}`);
     }
 
-    for (let index = 0; index < ready.length; index += jobs) {
-      const batch = ready.slice(index, index + jobs);
-      const results = await Promise.all(
-        batch.map(async (task) => ({ task, status: await runCommand(task) })),
-      );
-      for (const { task, status } of results) {
-        pending.delete(task.id);
-        if (status === 0) {
-          completed.add(task.id);
-        } else {
-          failedIds.add(task.id);
-          taskFailures.push({ ...task, status });
-        }
-      }
+    // Refill each freed worker and release dependents without waiting for an unrelated batch.
+    const { task, status } = await Promise.race(running.values());
+    running.delete(task.id);
+    if (status === 0) {
+      completed.add(task.id);
+    } else {
+      failedIds.add(task.id);
+      taskFailures.push({ ...task, status });
     }
   }
 

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -92,14 +92,20 @@ async function withGithubApiTimeoutEnv<T>(value: string, fn: () => Promise<T>): 
 
 describe("release candidate checklist", () => {
   it.each([
-    { tag: "v2026.9.1", pin: "2026.9.1", expected: "passed" },
-    { tag: "v2026.9.1", pin: "2026.7.4", expected: "warning" },
-    { tag: "v2026.9.1-1", pin: "2026.9.1", expected: "passed" },
-    { tag: "v2026.9.1-beta.1", pin: "2026.7.4", expected: undefined },
-    { tag: "v2026.9.1-alpha.1", pin: "2026.7.4", expected: undefined },
+    { tag: "v2026.9.1", pin: "2026.9.1", expected: "passed", failedRegistry: "" },
+    { tag: "v2026.9.1", pin: "2026.7.4", expected: "warning", failedRegistry: "" },
+    { tag: "v2026.9.1-1", pin: "2026.9.1", expected: "passed", failedRegistry: "" },
+    { tag: "v2026.9.1-beta.1", pin: "2026.7.4", expected: undefined, failedRegistry: "" },
+    { tag: "v2026.9.1-alpha.1", pin: "2026.7.4", expected: undefined, failedRegistry: "" },
+    ...["npm", "clawhub"].map((failedRegistry) => ({
+      tag: "v2026.9.1",
+      pin: "2026.9.1",
+      expected: "passed",
+      failedRegistry,
+    })),
   ])(
-    "records advisory Android pin evidence for $tag ($pin): $expected",
-    async ({ tag, pin, expected }) => {
+    "preflights registries ($failedRegistry) before validation and records Android evidence for $tag ($pin)",
+    async ({ tag, pin, expected, failedRegistry }) => {
       const { root: targetRoot, git } = candidateGitFixture({
         "package.json": JSON.stringify({ version: tag.slice(1) }),
         "apps/android/version.json": JSON.stringify({ version: pin, versionCode: 2026070401 }),
@@ -126,6 +132,10 @@ describe("release candidate checklist", () => {
           ? ["--workflow-ref", "tideclaw/alpha/2026-09-01-1200Z"]
           : ["--publish-workflow-ref", publishWorkflowRef]),
       ]);
+      if (failedRegistry) {
+        options.fullReleaseRunId = "";
+        options.skipDispatch = false;
+      }
       options.outputDir = join(targetRoot, "evidence");
       mkdirSync(join(options.outputDir, "npm-preflight"), { recursive: true });
       writeFileSync(join(options.outputDir, "npm-preflight", "openclaw.tgz"), "fixture");
@@ -134,6 +144,7 @@ describe("release candidate checklist", () => {
       const android =
         source.match(/^function checkCandidateAndroidVersion\([\s\S]*?^\}/mu)?.[0] ?? "";
       const log = vi.fn();
+      const stages: string[] = [];
       const toolingSha = "b".repeat(40);
       const npmManifest = {
         tarballName: "openclaw.tgz",
@@ -143,7 +154,7 @@ describe("release candidate checklist", () => {
         pluginSdkApi: {},
       };
       // Run the real coordinator and evidence writers; unrelated remote release gates are fixtures.
-      await runInNewContext(stripTypeScriptTypes(`${android}\n${main}\nmain();`), {
+      const completion = runInNewContext(stripTypeScriptTypes(`${android}\n${main}\nmain();`), {
         process: { argv: [], cwd: () => targetRoot, env: {} },
         console: { log, warn: log },
         TOOLING_ROOT: "/trusted/tooling",
@@ -175,10 +186,20 @@ describe("release candidate checklist", () => {
         validateCandidateReleaseNotes: () => ({ status: "passed" }),
         validateCandidateChangelogProvenance: () => ({ status: "passed", shippedBaselines: [] }),
         runLocalGeneratedCheckIfNeeded: () => ({ status: "skipped" }),
-        waitForSuccessfulRun: async () => ({
-          run: { headSha: targetSha, runAttempt: 1 },
-          source: { workflowRef: options.workflowRef },
-        }),
+        releaseBranchForTag,
+        fullReleaseTrustedWorkflowFields: () => ({}),
+        readFileSync: () => "fixture workflow",
+        dispatchWorkflow: () => {
+          stages.push("dispatch");
+          return "111";
+        },
+        waitForSuccessfulRun: async () => {
+          stages.push("wait");
+          return {
+            run: { headSha: targetSha, runAttempt: 1 },
+            source: { workflowRef: options.workflowRef },
+          };
+        },
         downloadArtifact: () => {},
         readJson: (file: string) => (file.endsWith("preflight-manifest.json") ? npmManifest : {}),
         validateFullReleaseValidationEvidence: () => ({ source: "direct" }),
@@ -193,7 +214,13 @@ describe("release candidate checklist", () => {
         preflightDependencyTarballs,
         runParallelsIfNeeded: async () => ({ status: "skipped" }),
         runTelegramIfNeeded: async () => ({ status: "skipped" }),
-        collectPluginPlanWithRetry: async () => ({ all: [] }),
+        collectPluginPlanWithRetry: async (script: string) => {
+          stages.push(script);
+          if (failedRegistry && script === `scripts/plugin-${failedRegistry}-release-plan.ts`) {
+            throw new Error(`${failedRegistry} registry unavailable`);
+          }
+          return { all: [] };
+        },
         buildPublishCommand,
         formatJsonValue: String,
         formatShippedBaselineExclusions: () => "",
@@ -204,6 +231,20 @@ describe("release candidate checklist", () => {
         mkdirSync,
         writeFileSync,
       });
+      if (failedRegistry) {
+        await expect(completion).rejects.toThrow(`${failedRegistry} registry unavailable`);
+        expect(stages).not.toContain("dispatch");
+        expect(stages).not.toContain("wait");
+        expect(existsSync(join(options.outputDir, "release-candidate-evidence.json"))).toBe(false);
+        expect(log.mock.calls.flat().join("\n")).not.toContain("publish command:");
+        return;
+      }
+      await completion;
+      expect(stages.slice(0, 3)).toEqual([
+        "scripts/plugin-npm-release-plan.ts",
+        "scripts/plugin-clawhub-release-plan.ts",
+        "wait",
+      ]);
       const evidence = JSON.parse(
         readFileSync(join(options.outputDir, "release-candidate-evidence.json"), "utf8"),
       );

--- a/test/scripts/release-preflight.test.ts
+++ b/test/scripts/release-preflight.test.ts
@@ -37,7 +37,11 @@ afterEach(() => {
   cleanupTempDirs(tempDirs);
 });
 
-function makeFakePnpm(): { binDir: string; eventsPath: string; logPath: string } {
+function makeFakePnpm(waitFor?: { command: string; event: string }): {
+  binDir: string;
+  eventsPath: string;
+  logPath: string;
+} {
   const root = makeTempDir(tempDirs, "openclaw-release-preflight-");
   const binDir = join(root, "bin");
   const eventsPath = join(root, "pnpm-events.log");
@@ -48,11 +52,22 @@ function makeFakePnpm(): { binDir: string; eventsPath: string; logPath: string }
     writeFileSync(
       binPath,
       `#!${process.execPath}
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 
 const command = ${JSON.stringify(bin)} + " " + process.argv.slice(2).join(" ");
 appendFileSync(process.env.OPENCLAW_RELEASE_PREFLIGHT_PNPM_LOG, command + "\\n");
 appendFileSync(process.env.OPENCLAW_RELEASE_PREFLIGHT_PNPM_EVENTS, "start " + command + "\\n");
+const waitFor = ${JSON.stringify(waitFor ?? null)};
+if (waitFor?.command === command) {
+  const deadline = Date.now() + 3000;
+  while (!readFileSync(process.env.OPENCLAW_RELEASE_PREFLIGHT_PNPM_EVENTS, "utf8").split("\\n").includes(waitFor.event)) {
+    if (Date.now() >= deadline) {
+      console.error("Ready work did not start while another command held a worker");
+      process.exit(9);
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+}
 const delayMs = Number(process.env.OPENCLAW_RELEASE_PREFLIGHT_DELAY_MS ?? "0");
 if (delayMs > 0) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
@@ -268,6 +283,50 @@ describe("scripts/release-preflight.mjs", () => {
     expect(events.indexOf("end pnpm plugin-sdk:sync-exports")).toBeLessThan(
       events.indexOf("start node --import tsx scripts/generate-plugin-inventory-doc.mts --write"),
     );
+  });
+
+  it.each([
+    {
+      args: ["--check", "--scope", "config", "--jobs", "2"],
+      command: "pnpm config:schema:check",
+      event: "start pnpm config:docs:check",
+    },
+    {
+      args: ["--fix", "--jobs", "4"],
+      command: "pnpm ui:i18n:sync",
+      event: "start pnpm plugin-sdk:sync-exports",
+    },
+  ])(
+    "starts ready work without waiting for an unrelated command: $command",
+    ({ args, command, event }) => {
+      const fakePnpm = makeFakePnpm({ command, event });
+      const result = runPreflight(args, fakePnpm, {}, makeReleaseFixture());
+      expect(result.status, result.stderr).toBe(0);
+      const events = readPnpmLog(fakePnpm.eventsPath);
+      expect(events.indexOf(event)).toBeLessThan(events.indexOf(`end ${command}`));
+    },
+  );
+
+  it("skips failed generator descendants while completing unrelated generators", () => {
+    const fakePnpm = makeFakePnpm();
+    const result = runPreflight(
+      ["--fix", "--jobs", "4"],
+      fakePnpm,
+      {
+        OPENCLAW_RELEASE_PREFLIGHT_FAIL_COMMANDS:
+          "node --import tsx scripts/sync-plugin-versions.ts",
+      },
+      makeReleaseFixture(),
+    );
+    expect(result.status).toBe(1);
+    const commands = readPnpmLog(fakePnpm.logPath);
+    expect(commands).toContain("pnpm config:docs:gen");
+    expect(commands).not.toContain("pnpm channels:catalog:gen");
+    expect(commands).not.toContain("pnpm plugin-sdk:sync-exports");
+    expect(commands).not.toContain(
+      "node --import tsx scripts/generate-plugin-inventory-doc.mts --write",
+    );
+    expect(result.stderr).toContain("skipped because plugin-versions failed");
   });
 
   it("runs only version-owned generators and checks for version prep", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary release preparation waits: idle workers wait for an unrelated slow command to finish a batch, while npm and ClawHub planner errors are discovered only after expensive validation and package smoke work. Release instructions also retain an obsolete Windows finalization blocker and can lose detached macOS, ClawHub, appcast, and Latest verification work between handoffs.

## Why This Change Was Made

The existing preflight task graph now refills each available worker and releases dependency-ready generators immediately, keeping the same concurrency cap, generator ordering constraints, failure propagation, and complete check roster. The candidate helper collects its existing read-only npm and ClawHub plans before FRV dispatch/wait. Publishers still regenerate authoritative plans immediately before publication; the earlier snapshot grants no publish authority.

The existing release skills now start selected macOS preparation alongside npm/plugin publication after tagging, track each requested publication surface and its next action separately, and match the current detached Windows policy. Provider notes distinguish authentication from actual inference entitlement. No new flags, configuration, dependencies, skipped gates, version changes, or publication operations.

## User Impact

Release preparation makes use of available workers, and registry planner failures stop the candidate before a new expensive validation dispatch or an unnecessary wait. Release operators retain exact per-surface evidence and can finish independent work while another platform waits, including macOS by default for stable/full releases without another consent step.

## Evidence

- Preflight: 21 focused tests passed through the real CLI with controlled child commands. Two new barrier scenarios fail on the original batching implementation because ready work cannot start until the unrelated held command exits; they pass with immediate refill. Existing worker-cap, generator dependency, manual metadata, complete-check, and failure-reporting cases remain green. Added failed-parent coverage proves descendants are skipped while unrelated generators finish.
- Candidate: 119 focused tests passed. Seven existing/extended coordinator replay scenarios fail before the change; both npm and ClawHub planner failures originally dispatch/wait for validation before failing. Afterward they emit no validation dispatch/wait, green evidence, or publish command. Proof uses the real coordinator/evidence writers and temporary Git fixtures with controlled remote dependencies; no live publication was attempted.
- Changed checks passed scripts/test-root typechecks, script erasability, production lint, repository guards, and formatting. Test lint found one redundant default assignment; it was removed and the exact failed lint check passed on rerun.
- Skill links resolve; `git diff --check` passes. Independent Codex review found no actionable P0–P2 defects.

Commands: `node scripts/run-vitest.mjs test/scripts/release-preflight.test.ts`; `node scripts/run-vitest.mjs test/scripts/release-candidate-checklist.test.ts`; scoped `node scripts/check-changed.mjs -- <changed paths>`.

Limits: this does not promise a measured end-to-end release duration or parallelize synchronous registry planner subprocesses. Candidate bootstrap/trusted-publisher lists retain their existing semantics; publication rechecks remain authoritative. Named follow-up: upgrade the existing OpenAI and Fireworks credential preflight from authentication-only checks to bounded real completions; this PR documents that gap without claiming it is fixed.

CI note: the first head failed only the pre-existing gateway fixture type mismatch, with `openclaw/ci-gate` failing as its aggregate. Rebased onto the existing main repair https://github.com/openclaw/openclaw/pull/139794; every release-patch file remains byte-identical. Exact-head CI is rerunning; the unrelated repair is not part of this PR's introduced diff.

Final CI: https://github.com/openclaw/openclaw/actions/runs/34014959420 passed on the refreshed head (attempt 2). Only the failed gateway integration job was retried; the unchanged fixture’s client-observation race was independently repaired and landed in https://github.com/openclaw/openclaw/pull/139820. No release-tooling source change or weakened gate was needed for that retry.
