### PR TITLE
fix(test): preserve Control UI coverage under Bun

### DIFF
--- a/ui/src/components/board/board-view.test.ts
+++ b/ui/src/components/board/board-view.test.ts
@@ -66,6 +66,10 @@ describe("openclaw-board-view", () => {
 
   it("bounds the wait for a sandbox proxy that never becomes ready", async () => {
     vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("<!doctype html><p>Ready document</p>")),
+    );
     const frameLoadFailed = vi.fn(async () => undefined);
     const view = await mount({
       context: gatewayContext(null),

--- a/ui/src/pages/chat/outbox-blob-recovery.test.ts
+++ b/ui/src/pages/chat/outbox-blob-recovery.test.ts
@@ -89,9 +89,20 @@ function seed(items: ChatQueueItem[], sessionKey = "global", version = 3) {
 async function expectBytes(host: ReturnType<typeof hostFor>, item: ChatQueueItem) {
   const result = await prepareOutboxPayload(host, item, "handoff");
   expect(result.status).toBe("ready");
-  expect(
-    result.status === "ready" ? result.update.attachments?.map(getChatAttachmentDataUrl) : [],
-  ).toEqual([dataUrl]);
+  const attachments = result.status === "ready" ? result.update.attachments : [];
+  expect(attachments).toHaveLength(1);
+  const restoredUrl = expectDefined(
+    getChatAttachmentDataUrl(expectDefined(attachments?.[0], "restored attachment")),
+    "restored attachment data URL",
+  );
+  const comma = restoredUrl.indexOf(",");
+  expect(comma).toBeGreaterThan(0);
+  const metadata = restoredUrl.slice(0, comma).split(";");
+  expect(metadata[0]).toBe("data:text/plain");
+  expect(metadata.at(-1)).toBe("base64");
+  expect(Buffer.from(restoredUrl.slice(comma + 1), "base64")).toEqual(
+    Buffer.from("complete source bytes"),
+  );
 }
 
 beforeEach(() => {

--- a/ui/src/test-helpers/control-ui-e2e-artifacts.node.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e-artifacts.node.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";

--- a/ui/src/test-helpers/mock-gateway-page.test-support.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test-support.ts
@@ -1,4 +1,3 @@
-import { Script } from "node:vm";
 import { JSDOM } from "jsdom";
 import { it } from "vitest";
 
@@ -41,9 +40,8 @@ export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
       await use({
         window: dom.window as unknown as Window & typeof globalThis,
         execute: (script) => {
-          new Script(script, { filename: `mock-gateway:${task.name}` }).runInContext(
-            dom.getInternalVMContext(),
-          );
+          // outside-only supplies the private realm's eval; never use the host's eval.
+          dom.window.eval(`${script}\n//# sourceURL=mock-gateway:${encodeURIComponent(task.name)}`);
         },
         connect: (url = "ws://mock-gateway") => {
           const socket = new dom.window.WebSocket(url);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers running the Control UI tests under Bun encountered false failures from runtime-specific data URL formatting, VM APIs, and worker environments. The board timeout fixture also lacked the successful document fetch needed to reach its intended never-ready condition.

## Why This Change Was Made

Validate restored attachment bytes and media metadata independently of optional MIME parameters. Execute the mock Gateway in JSDOM's existing private outside-only realm. Supply the board test's missing successful fetch and run the filesystem/Worker artifact tests in Vitest's native environment.

## User Impact

No production behavior changes. Existing UI coverage now checks the same attachment, isolation, timer, storage, and worker lifecycle contracts on Node and Bun.

## Evidence

- The first three repairs pass 103 focused checks on Node and 103 on true Bun, using maintained test configurations.
- The artifact owner passes all seven tests on each runtime after its environment annotation. A separate startup audit accounts for all five files and 27 tests on each runtime.
- Original Bun failures were reproduced before repair. The board probe confirmed the same bounded retry sequence on both runtimes once document fetching succeeds.
- Complete four-file changed gate passes, including types, exports, lint, and UI guards. Independent P0–P2 review is clean.
- Every original lifecycle, isolation, and timeout assertion is retained. No production source or timeout limit changes.
- The broader Bun compatibility campaign remains in progress.
