### PR TITLE
fix(infra): release completed task data from warm workers

### DIFF
--- a/src/infra/worker-task-pool.reply-retention.test-support.ts
+++ b/src/infra/worker-task-pool.reply-retention.test-support.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { setImmediate } from "node:timers/promises";
+import { WorkerTaskPool } from "./worker-task-pool.js";
+import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-support.js";
+
+const gc = globalThis.gc;
+assert.ok(gc, "The retention child requires --expose-gc");
+const pool = new WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>({
+  workerUrl: new URL("./worker-task-pool.test-support.ts", import.meta.url),
+  maxWorkers: 1,
+  idleTimeoutMs: 0,
+});
+
+async function receiveFirstReply() {
+  const result = await pool.run(
+    { label: "first reply", buffer: new ArrayBuffer(4) },
+    { timeoutMs: 10_000 },
+  );
+  assert.equal(result.label, "first reply");
+  assert.equal(result.buffer?.byteLength, 4);
+  return { reference: new WeakRef(result), threadId: result.threadId };
+}
+
+try {
+  const { reference, threadId } = await receiveFirstReply();
+  const control = new WeakRef({ unowned: true });
+  for (let pass = 0; pass < 8; pass += 1) {
+    await setImmediate();
+    gc();
+  }
+  assert.equal(control.deref(), undefined, "Unowned control must collect");
+  assert.equal(reference.deref(), undefined, "Warm worker retained its first completed reply");
+  const next = await pool.run({ label: "warm worker" }, { timeoutMs: 10_000 });
+  assert.equal(next.threadId, threadId, "The worker must remain reusable during collection");
+  assert.equal(next.previousBufferBytes, 0, "The same worker must retain its transferred marker");
+} finally {
+  await pool.close();
+}

--- a/src/infra/worker-task-pool.test.ts
+++ b/src/infra/worker-task-pool.test.ts
@@ -1,18 +1,29 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { channel } from "node:diagnostics_channel";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
-import { Worker } from "node:worker_threads";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Worker } from "node:worker_threads";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WorkerTaskPool } from "./worker-task-pool.js";
 import type { PoolFixtureInput, PoolFixtureResult } from "./worker-task-pool.test-support.js";
 
 const workerUrl = new URL("./worker-task-pool.test-support.ts", import.meta.url);
 const pools: WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>[] = [];
-const workers: Worker[] = [];
-const workerChannel = channel("worker_threads");
-const trackWorker = (message: unknown) => workers.push((message as { worker: Worker }).worker);
+const workers = vi.hoisted(() => [] as Worker[]);
+
+vi.mock("node:worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:worker_threads")>();
+  return {
+    ...actual,
+    Worker: class extends actual.Worker {
+      constructor(...args: ConstructorParameters<typeof actual.Worker>) {
+        super(...args);
+        // Observe real workers even on runtimes without worker diagnostics events.
+        workers.push(this);
+      }
+    },
+  };
+});
 
 function createPool(
   options: ConstructorParameters<typeof WorkerTaskPool<PoolFixtureInput, PoolFixtureResult>>[0] = {
@@ -27,10 +38,8 @@ function createPool(
   return pool;
 }
 
-beforeEach(() => workerChannel.subscribe(trackWorker));
 afterEach(async () => {
   await Promise.all(pools.splice(0).map((pool) => pool.close()));
-  workerChannel.unsubscribe(trackWorker);
   for (const worker of workers.splice(0)) {
     expect(worker.threadId).toBe(-1);
   }
@@ -262,16 +271,24 @@ describe("worker task pool", () => {
     expect(stdout.trim()).toBe("finished");
   }, 20_000);
 
-  it("releases parent inputs while their worker copies are still executing", async () => {
-    await promisify(execFile)(
-      process.execPath,
-      [
-        "--expose-gc",
-        "--import",
-        "tsx",
-        fileURLToPath(new URL("./worker-task-pool.retention.test-support.ts", import.meta.url)),
-      ],
-      { timeout: 20_000 },
-    );
-  }, 25_000);
+  it.each([
+    {
+      name: "releases parent inputs while their worker copies are still executing",
+      entrypoint: new URL("./worker-task-pool.retention.test-support.ts", import.meta.url),
+    },
+    {
+      name: "releases delivered replies while their worker remains warm",
+      entrypoint: new URL("./worker-task-pool.reply-retention.test-support.ts", import.meta.url),
+    },
+  ])(
+    "$name",
+    async ({ entrypoint }) => {
+      await promisify(execFile)(
+        process.execPath,
+        ["--expose-gc", "--import", "tsx", fileURLToPath(entrypoint)],
+        { timeout: 20_000 },
+      );
+    },
+    25_000,
+  );
 });

--- a/src/infra/worker-task-pool.ts
+++ b/src/infra/worker-task-pool.ts
@@ -126,6 +126,26 @@ export class WorkerTaskPool<Input, Output> {
     }
   }
 
+  // Worker listeners outlive tasks; their creation scope must not retain an async task frame.
+  private createWorker(slot: Slot<Input, Output>): Worker {
+    const worker = new Worker(this.options.workerUrl, {
+      execArgv: this.options.workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : [],
+      ...this.options.workerOptions,
+    });
+    slot.worker = worker;
+    worker.on("message", (message: unknown) => this.receive(slot, message));
+    worker.on("error", (error) =>
+      this.fail(slot, new WorkerTaskError(String(error), "unavailable")),
+    );
+    worker.on("messageerror", (error) =>
+      this.fail(slot, new WorkerTaskError(String(error), "unavailable")),
+    );
+    worker.once("exit", (code) =>
+      this.fail(slot, new WorkerTaskError(`worker exited with code ${code}`, "unavailable")),
+    );
+    return worker;
+  }
+
   private async start(slot: Slot<Input, Output>, task: Task<Input, Output>): Promise<void> {
     // Execution owns the input now; retaining it on task duplicates the worker's clone.
     const taskInput = task.input!;
@@ -145,26 +165,10 @@ export class WorkerTaskPool<Input, Output> {
       return;
     }
     try {
-      if (!slot.worker) {
-        const worker = new Worker(this.options.workerUrl, {
-          execArgv: this.options.workerUrl.pathname.endsWith(".ts") ? ["--import", "tsx"] : [],
-          ...this.options.workerOptions,
-        });
-        slot.worker = worker;
-        worker.on("message", (message: unknown) => this.receive(slot, message));
-        worker.on("error", (error) =>
-          this.fail(slot, new WorkerTaskError(String(error), "unavailable")),
-        );
-        worker.on("messageerror", (error) =>
-          this.fail(slot, new WorkerTaskError(String(error), "unavailable")),
-        );
-        worker.once("exit", (code) =>
-          this.fail(slot, new WorkerTaskError(`worker exited with code ${code}`, "unavailable")),
-        );
-      }
+      const worker = slot.worker ?? this.createWorker(slot);
       const transferList = task.options.transferList?.(input);
       if (!task.done) {
-        slot.worker.postMessage({ input }, transferList);
+        worker.postMessage({ input }, transferList);
       }
     } catch (error) {
       this.fail(slot, new WorkerTaskError(String(error), "unavailable"));


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a warm execution worker could retain completed task data under Bun after the caller had finished using the result.

## Why This Change Was Made

Create persistent Worker listeners outside the asynchronous per-task frame. The listeners keep their existing lifecycle owner without retaining the first task's input or delivered reply. Scheduling, cancellation, result validation, and worker reuse remain unchanged.

## User Impact

Long-lived worker pools can release completed tool inputs and replies while keeping the worker available for the next task.

## Evidence

- 17 focused tests pass on Node and 17 on true Bun, covering the pool and its QuickJS caller.
- The existing QuickJS retention test and the new four-byte reply retention regression failed before repair. Unowned collection controls passed, demonstrating actual retained references.
- The repaired regression verifies collection while the same worker remains warm and reusable.
- Tests observe real Worker construction on both runtimes, preserving lifecycle assertions where Bun omits Node's diagnostics event.
- Full build and complete changed-file gate pass. Independent P0–P2 review found no actionable findings.
- The rebase is patch-identical. No full-repository Bun pass is claimed.
