### PR TITLE
fix(gateway): bound request timings across WebSocket log styles

### DIFF
--- a/src/gateway/ws-log.test.ts
+++ b/src/gateway/ws-log.test.ts
@@ -1,10 +1,12 @@
 /**
  * Gateway WebSocket log formatting tests.
  */
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { setVerbose } from "../global-state.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { loggingState } from "../logging/state.js";
 import { formatForLog, logWs, summarizeAgentEventForWsLog } from "./ws-log.js";
+import { setGatewayWsLogStyle } from "./ws-logging.js";
 
 function shouldLogWs(direction: "in" | "out", kind: string): boolean {
   let admitted = false;
@@ -17,11 +19,66 @@ function shouldLogWs(direction: "in" | "out", kind: string): boolean {
 
 afterEach(() => {
   setVerbose(false);
+  setGatewayWsLogStyle("auto");
   setLoggerOverride(null);
+  loggingState.rawConsole = null;
   resetLogger();
+  vi.restoreAllMocks();
 });
 
 describe("gateway ws log helpers", () => {
+  test.each(["optimized", "compact", "full"] as const)(
+    "bounds unanswered timing and preserves request identity across %s log changes",
+    (style) => {
+      setVerbose(style !== "optimized");
+      setGatewayWsLogStyle(style === "optimized" ? "auto" : style);
+      setLoggerOverride({ level: "silent", consoleLevel: "info" });
+      const output = vi.fn();
+      loggingState.rawConsole = { log: output, info: output, warn: output, error: output };
+      const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+      const first = { connId: `first-${style}`, id: "same", method: "health" };
+      const second = { connId: `second-${style}`, id: "same", method: "health" };
+      try {
+        logWs("in", "req", first);
+        clock.mockReturnValue(1_050);
+        logWs("in", "req", second);
+        clock.mockReturnValue(1_100);
+        output.mockClear();
+        logWs("out", "res", { ...first, ok: true });
+        expect(output).toHaveBeenLastCalledWith(expect.stringContaining("100ms"));
+        logWs("out", "res", { ...second, ok: true });
+        expect(output).toHaveBeenLastCalledWith(expect.stringContaining("50ms"));
+        logWs("out", "res", { ...first, ok: false });
+        expect(output).toHaveBeenLastCalledWith(expect.not.stringMatching(/\d+ms/));
+
+        clock.mockReturnValue(2_000);
+        logWs("in", "req", first);
+        for (let index = 0; index < 2_000; index += 1) {
+          logWs("in", "req", { ...first, id: `unanswered-${index}` });
+        }
+        clock.mockReturnValue(2_100);
+        output.mockClear();
+        logWs("out", "res", { ...first, ok: false });
+        expect(output).toHaveBeenLastCalledWith(expect.not.stringMatching(/\d+ms/));
+
+        logWs("in", "req", second);
+        setVerbose(true);
+        setGatewayWsLogStyle(style === "full" ? "compact" : "full");
+        clock.mockReturnValue(2_200);
+        logWs("out", "res", { ...second, ok: true });
+        expect(output).toHaveBeenLastCalledWith(expect.stringContaining("100ms"));
+      } finally {
+        setVerbose(style !== "optimized");
+        setGatewayWsLogStyle(style === "optimized" ? "auto" : style);
+        logWs("out", "res", { ...first, ok: true });
+        logWs("out", "res", { ...second, ok: true });
+        for (let index = 0; index < 2_000; index += 1) {
+          logWs("out", "res", { ...first, id: `unanswered-${index}`, ok: true });
+        }
+      }
+    },
+  );
+
   test("admits only useful optimized-mode frames and honors console info enablement", () => {
     setVerbose(false);
     setLoggerOverride({ level: "silent", consoleLevel: "info" });

--- a/src/gateway/ws-log.ts
+++ b/src/gateway/ws-log.ts
@@ -22,15 +22,7 @@ const WS_LOG_REDACT_OPTIONS = {
   patterns: getDefaultRedactPatterns(),
 };
 
-type WsInflightEntry = {
-  ts: number;
-  method?: string;
-  meta?: Record<string, unknown>;
-};
-
-const wsInflightCompact = new Map<string, WsInflightEntry>();
 let wsLastCompactConnId: string | undefined;
-const wsInflightOptimized = new Map<string, number>();
 const wsInflightSince = new Map<string, number>();
 const wsLog = createSubsystemLogger("gateway/ws");
 
@@ -308,39 +300,38 @@ export function logWs(
     return;
   }
   const meta = typeof metaInput === "function" ? metaInput() : metaInput;
+  const connId = typeof meta?.connId === "string" ? meta.connId : undefined;
+  const id = typeof meta?.id === "string" ? meta.id : undefined;
+  const inflightKey = connId && id ? `${connId}:${id}` : undefined;
+  let durationMs: number | undefined;
+  if (direction === "in" && kind === "req" && inflightKey) {
+    wsInflightSince.set(inflightKey, Date.now());
+    // Unanswered requests must stay bounded in every log style.
+    if (wsInflightSince.size > 2000) {
+      wsInflightSince.clear();
+    }
+  } else if (direction === "out" && kind === "res" && inflightKey) {
+    const startedAt = wsInflightSince.get(inflightKey);
+    wsInflightSince.delete(inflightKey);
+    if (startedAt !== undefined) {
+      durationMs = Date.now() - startedAt;
+    }
+  }
+
   const style = getGatewayWsLogStyle();
   if (!isVerbose()) {
-    logWsOptimized(direction, kind, meta);
+    logWsOptimized(direction, kind, meta, durationMs);
     return;
   }
 
   if (style === "compact" || style === "auto") {
-    logWsCompact(direction, kind, meta);
+    logWsCompact(direction, kind, meta, durationMs);
     return;
   }
 
-  const now = Date.now();
-  const connId = typeof meta?.connId === "string" ? meta.connId : undefined;
-  const id = typeof meta?.id === "string" ? meta.id : undefined;
   const method = typeof meta?.method === "string" ? meta.method : undefined;
   const ok = typeof meta?.ok === "boolean" ? meta.ok : undefined;
   const event = typeof meta?.event === "string" ? meta.event : undefined;
-
-  const inflightKey = connId && id ? `${connId}:${id}` : undefined;
-  if (direction === "in" && kind === "req" && inflightKey) {
-    wsInflightSince.set(inflightKey, now);
-  }
-  const durationMs =
-    direction === "out" && kind === "res" && inflightKey
-      ? (() => {
-          const startedAt = wsInflightSince.get(inflightKey);
-          if (startedAt === undefined) {
-            return undefined;
-          }
-          wsInflightSince.delete(inflightKey);
-          return now - startedAt;
-        })()
-      : undefined;
 
   const dirArrow = direction === "in" ? "←" : "→";
   const dirColor = direction === "in" ? chalk.greenBright : chalk.cyanBright;
@@ -364,21 +355,16 @@ export function logWs(
   logWsInfoLine({ prefix, statusToken, headline, durationToken, restMeta, trailing });
 }
 
-function logWsOptimized(direction: "in" | "out", kind: string, meta?: Record<string, unknown>) {
+function logWsOptimized(
+  direction: "in" | "out",
+  kind: string,
+  meta: Record<string, unknown> | undefined,
+  durationMs: number | undefined,
+) {
   const connId = typeof meta?.connId === "string" ? meta.connId : undefined;
   const id = typeof meta?.id === "string" ? meta.id : undefined;
   const ok = typeof meta?.ok === "boolean" ? meta.ok : undefined;
   const method = typeof meta?.method === "string" ? meta.method : undefined;
-
-  const inflightKey = connId && id ? `${connId}:${id}` : undefined;
-
-  if (direction === "in" && kind === "req" && inflightKey) {
-    wsInflightOptimized.set(inflightKey, Date.now());
-    if (wsInflightOptimized.size > 2000) {
-      wsInflightOptimized.clear();
-    }
-    return;
-  }
 
   if (kind === "parse-error") {
     const errorMsg = typeof meta?.error === "string" ? formatForLog(meta.error) : undefined;
@@ -397,12 +383,6 @@ function logWsOptimized(direction: "in" | "out", kind: string, meta?: Record<str
   if (direction !== "out" || kind !== "res") {
     return;
   }
-
-  const startedAt = inflightKey ? wsInflightOptimized.get(inflightKey) : undefined;
-  if (inflightKey) {
-    wsInflightOptimized.delete(inflightKey);
-  }
-  const durationMs = typeof startedAt === "number" ? Date.now() - startedAt : undefined;
 
   const shouldLog =
     ok === false || (typeof durationMs === "number" && durationMs >= DEFAULT_WS_SLOW_MS);
@@ -428,16 +408,17 @@ function logWsOptimized(direction: "in" | "out", kind: string, meta?: Record<str
   });
 }
 
-function logWsCompact(direction: "in" | "out", kind: string, meta?: Record<string, unknown>) {
-  const now = Date.now();
+function logWsCompact(
+  direction: "in" | "out",
+  kind: string,
+  meta: Record<string, unknown> | undefined,
+  durationMs: number | undefined,
+) {
   const connId = typeof meta?.connId === "string" ? meta.connId : undefined;
   const id = typeof meta?.id === "string" ? meta.id : undefined;
   const method = typeof meta?.method === "string" ? meta.method : undefined;
   const ok = typeof meta?.ok === "boolean" ? meta.ok : undefined;
-  const inflightKey = connId && id ? `${connId}:${id}` : undefined;
-
-  if (kind === "req" && direction === "in" && inflightKey) {
-    wsInflightCompact.set(inflightKey, { ts: now, method, meta });
+  if (kind === "req" && direction === "in" && connId && id) {
     return;
   }
 
@@ -458,15 +439,7 @@ function logWsCompact(direction: "in" | "out", kind: string, meta?: Record<strin
 
   const statusToken = buildWsStatusToken(kind, ok);
 
-  const startedAt =
-    kind === "res" && direction === "out" && inflightKey
-      ? wsInflightCompact.get(inflightKey)?.ts
-      : undefined;
-  if (kind === "res" && direction === "out" && inflightKey) {
-    wsInflightCompact.delete(inflightKey);
-  }
-  const durationToken =
-    typeof startedAt === "number" ? chalk.dim(`${now - startedAt}ms`) : undefined;
+  const durationToken = typeof durationMs === "number" ? chalk.dim(`${durationMs}ms`) : undefined;
 
   const headline = buildWsHeadline({
     kind,


### PR DESCRIPTION
## What Problem This Solves

Compact and full WebSocket logging retained unanswered request timing without a bound. Compact also retained unused request metadata, and switching log styles could lose a pending request's duration.

## Why This Change Was Made

Record and consume timestamps once in the shared logging owner. All three renderers use the same duration and the existing optimized-mode clear-after-2,000-entry policy. Remove the redundant maps and unused metadata records.

## User Impact

WebSocket diagnostic logging keeps bounded request timing across styles and preserves durations when the style changes. Connection/request identity, lazy metadata admission, output formatting, missing-start behavior, and the normal-mode 50 ms threshold remain intact. Production code shrinks by 27 lines.

## Evidence

The original test-only regression failed for both unbounded styles and the cross-style duration case. All 19 focused tests pass with the repair, including response consumption, connection identity, overflow and recovery. The full changed gate passed; independent review and isolated autoreview found no actionable issue.

A component probe sent 10,000 synthetic unanswered health requests per style in a fresh process, discarding console output. After forced GC, compact heap growth fell from 2,151,352 to 174,224 bytes and full growth from 1,022,568 to 239,104 bytes; optimized remained roughly flat. The first compact request metadata object was released. These are single-pair component observations, not whole-Gateway RSS or production latency claims.
