### PR TITLE
improve(ui): reuse Settings search schema preparation

### DIFF
--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -258,6 +258,60 @@ describe("findSettingsSearchBlocks", () => {
     ]);
   });
 
+  it("refreshes prepared schema tiers while searching current draft keys and access", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        mcp: {
+          type: "object",
+          properties: {
+            servers: {
+              type: "object",
+              additionalProperties: {
+                type: "object",
+                properties: { command: { type: "string" } },
+              },
+            },
+          },
+        },
+      },
+    };
+    const servers: Record<string, { command: string }> = {};
+    const params = {
+      query: "zephyr",
+      schema,
+      value: { mcp: { servers } },
+      uiHints: { "mcp.servers.*.command": { advanced: false } },
+    };
+    expect(findSettingsSearchBlocks(params)).toEqual([]);
+    servers.zephyr = { command: "node" };
+    const common = {
+      routeId: "mcp",
+      label: "MCP",
+      search: "?section=mcp",
+      hash: "#config-section-mcp",
+    };
+    expect(findSettingsSearchBlocks(params)).toEqual([common]);
+    expect(findSettingsSearchBlocks({ ...params, canAdmin: false })).toEqual([]);
+    expect(findSettingsSearchBlocks(params)).toEqual([common]);
+    expect(findSettingsSearchBlocks({ ...params, uiHints: {} })).toEqual([
+      { ...common, search: "?section=mcp&advanced=1" },
+    ]);
+    expect(findSettingsSearchBlocks(params)).toEqual([common]);
+    expect(
+      findSettingsSearchBlocks({
+        ...params,
+        schema: {
+          type: "object",
+          properties: { mcp: { type: "object", properties: { endpoint: { type: "string" } } } },
+        },
+      }),
+    ).toEqual([]);
+    expect(findSettingsSearchBlocks(params)).toEqual([common]);
+    delete servers.zephyr;
+    expect(findSettingsSearchBlocks(params)).toEqual([]);
+  });
+
   it("finds existing update checks and channel controls on the curated Updates page", () => {
     const updateSchema = {
       type: "object",

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -48,6 +48,17 @@ const CURATED_ROUTE_VISIBLE_KEYS: Partial<Record<string, () => readonly string[]
   updates: () => ["channel", "checkOnStart", "auto"],
 };
 
+const preparedSectionsBySchema = new WeakMap<
+  JsonSchema,
+  {
+    hints: ConfigUiHints;
+    sections: Map<
+      string,
+      { schema: JsonSchema; tiers: ReturnType<typeof splitConfigSchemaByTier> }
+    >;
+  }
+>();
+
 function visibleSectionSchema(routeId: string, sectionSchema: JsonSchema): JsonSchema {
   const visibleKeys = CURATED_ROUTE_VISIBLE_KEYS[routeId];
   const properties = sectionSchema.properties;
@@ -98,6 +109,13 @@ export function findSettingsSearchBlocks(params: {
   if (!schema || schemaType(schema) !== "object" || !schema.properties) {
     return matches;
   }
+  let prepared = preparedSectionsBySchema.get(schema);
+  // Schema responses replace both objects. Keep only the current hint revision;
+  // draft values, query text, locale, and route visibility are evaluated below.
+  if (!prepared || prepared.hints !== params.uiHints) {
+    prepared = { hints: params.uiHints, sections: new Map() };
+    preparedSectionsBySchema.set(schema, prepared);
+  }
   const value = params.value ?? {};
   for (const [key, rawSectionSchema] of Object.entries(schema.properties)) {
     const routeId = configPageForSection(key);
@@ -110,16 +128,24 @@ export function findSettingsSearchBlocks(params: {
     ) {
       continue;
     }
-    const sectionSchema =
-      key === "wizard"
-        ? setupVisibleSchema(rawSectionSchema)
-        : visibleSectionSchema(routeId, rawSectionSchema);
+    let section = prepared.sections.get(key);
+    if (!section) {
+      const sectionSchema =
+        key === "wizard"
+          ? setupVisibleSchema(rawSectionSchema)
+          : visibleSectionSchema(routeId, rawSectionSchema);
+      section = {
+        schema: sectionSchema,
+        tiers: splitConfigSchemaByTier({
+          schema: sectionSchema,
+          path: [key],
+          hints: params.uiHints,
+        }),
+      };
+      prepared.sections.set(key, section);
+    }
+    const { schema: sectionSchema, tiers: tierSplit } = section;
     const meta = SECTION_META[key];
-    const tierSplit = splitConfigSchemaByTier({
-      schema: sectionSchema,
-      path: [key],
-      hints: params.uiHints,
-    });
     const matchesTier = (tierSchema: JsonSchema | null) =>
       Boolean(
         tierSchema &&


### PR DESCRIPTION
## What Problem This Solves

Settings search rebuilt common and advanced schema projections for every keystroke and sidebar refresh.

## Why This Change Was Made

Prepare visible sections once for the current schema and hints, retaining only the latest hints generation for each weakly held schema. Queries, draft keys, permissions, native-device capability, locale labels, and result destinations remain live.

## User Impact

Repeated Settings searches do less temporary allocation and CPU work. Two runs per version of a synthetic 1,728-field, 256-query workload showed 68.6% less sampled allocation and 58.8% less user CPU with identical result digests. Preparation retained about 61 KB more heap. This small cache tradeoff is UI evidence, not Gateway RSS evidence.

## Evidence

All 67 focused Settings search, sidebar, and navigation tests passed. The complete changed gate and standard UI build passed. Independent review and isolated autoreview found no actionable issue.

The built UI passed English dynamic-draft-key search and actual Spanish locale switching before and after. The corresponding captures are byte-identical. Both screenshots below contain only synthetic fixture and version data; the result remains visually unchanged.

Before:

![Settings search before](https://github.com/user-attachments/assets/0ee73e9f-adaa-43c1-b872-7d47a1874d9e)

After:

![Settings search after](https://github.com/user-attachments/assets/52350f6c-f97c-43d5-8459-0006f07ae8e1)
