### PR TITLE
test(android): await gateway trust lifecycle publication

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -605,8 +605,8 @@ class GatewayBootstrapAuthTest {
 
       runtime.acceptGatewayTrustPrompt()
 
-      assertEquals("ab".repeat(32), prefs.loadGatewayTlsFingerprint(endpoint.stableId))
       assertEquals("setup-bootstrap-token", waitForDesiredBootstrapToken(runtime, "nodeSession"))
+      assertEquals("ab".repeat(32), prefs.loadGatewayTlsFingerprint(endpoint.stableId))
       assertEquals("ab".repeat(32), runtime.gatewayControlPage.value?.tlsFingerprintSha256)
       assertNull(desiredBootstrapToken(runtime, "operatorSession"))
     }
@@ -633,6 +633,7 @@ class GatewayBootstrapAuthTest {
       assertEquals(oldFingerprint, prefs.loadGatewayTlsFingerprint(endpoint.stableId))
 
       runtime.declineGatewayTrustPrompt()
+      withTimeout(500) { runtime.pendingGatewayTrust.first { it == null } }
 
       assertEquals(oldFingerprint, prefs.loadGatewayTlsFingerprint(endpoint.stableId))
 
@@ -643,6 +644,9 @@ class GatewayBootstrapAuthTest {
       waitForGatewayTrustPrompt(runtime)
       runtime.acceptGatewayTrustPrompt()
 
+      val desired = waitForDesiredConnection(runtime, "nodeSession")
+      val tls = readField<GatewayTlsParams>(desired, "tls")
+      assertEquals(newFingerprint, tls.expectedFingerprint)
       assertEquals(newFingerprint, prefs.loadGatewayTlsFingerprint(endpoint.stableId))
     }
 


### PR DESCRIPTION
## What Problem This Solves

Android trust tests can read an old certificate pin or a prior prompt when acceptance or dismissal queues behind the connection lifecycle mutex.

## Why This Change Was Made

The tests wait for prompt dismissal before reconnecting, then observe the accepted node connection before checking the saved pin. The adjacent explicit setup-auth test uses the same publication ordering.

## User Impact

No production changes. Pre-confirmation pin checks and existing wait bounds remain intact. This separate test repair was identified while validating #135599.

## Evidence

[CI failure](https://github.com/openclaw/openclaw/actions/runs/34011968221/job/101429393157) showed the changed-fingerprint test reading the old pin. All 54 GatewayBootstrapAuthTest cases passed through `:app:testThirdPartyDebugUnitTest --tests ai.openclaw.app.GatewayBootstrapAuthTest`, and `:app:ktlintCheck` passed. Independent P2 review found no actionable issues. Production LOC: 0; tests: +4.
