### PR TITLE
fix(test): preserve census fixture coverage under Bun

### DIFF
--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -611,7 +611,7 @@ it.skipIf(process.platform === "win32").each(["census", "corrupt-report", "timeo
     const preload = String.raw`
 import cp from "node:child_process";
 import fs from "node:fs";
-import { syncBuiltinESMExports } from "node:module";
+import { syncFixtureBuiltinExports } from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 import path from "node:path";
 if (process.argv[2] === "sentinel" && fault === "timeout") {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
@@ -651,7 +651,7 @@ if (process.argv[2] === "supervise") {
     }
     return result;
   };
-  syncBuiltinESMExports();
+  syncFixtureBuiltinExports();
 }
 `;
     // Use the actual outer namespace owner, including its cleanup on exit code 1.
@@ -664,11 +664,10 @@ if (process.argv[2] === "supervise") {
 import assert from "node:assert/strict";
 import cp from "node:child_process";
 import fs from "node:fs";
-import { syncBuiltinESMExports } from "node:module";
+import { fixturePreloadEnv, syncFixtureBuiltinExports } from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { mock } from "node:test";
-import { pathToFileURL } from "node:url";
 const timeoutFault = process.argv[2] === "timeout";
 let root, failure;
 let supervisor, ready, onReady;
@@ -684,7 +683,7 @@ if (timeoutFault) {
     supervisor.on("message", onReady);
     return supervisor;
   };
-  syncBuiltinESMExports();
+  syncFixtureBuiltinExports();
 }
 try {
   const { withCiCheckoutFixture } = await import(process.argv[1]);
@@ -694,7 +693,7 @@ try {
     fs.writeFileSync(path.join(root, "checkout.sh"), "exit 0\n");
     const preload = path.join(root, "fault.mjs");
     fs.writeFileSync(preload, "const fault = " + JSON.stringify(process.argv[2]) + ";\n" + process.argv[3]);
-    return { NODE_OPTIONS: "--import=" + pathToFileURL(preload).href };
+    return fixturePreloadEnv(preload);
   }, (report, result, stderr) => {
     throw new Error("unexpected completed report: " + JSON.stringify({ report, result, stderr }));
   }).catch(error => {
@@ -731,7 +730,7 @@ try {
     mock.timers.reset();
     supervisor?.off("message", onReady);
     cp.fork = fork;
-    syncBuiltinESMExports();
+    syncFixtureBuiltinExports();
   }
 }
 console.log(JSON.stringify({ root, outerRoot: tmpdir(), failure,
@@ -874,8 +873,7 @@ cp.spawnSync = (command, args, options) => {
   }
   return spawnSync(command, args, options);
 };
-require("node:module").syncBuiltinESMExports();
-''')
+''' + "\nrequire(" + json.dumps(sys.argv[5]) + ").syncFixtureBuiltinExports();\n")
     with subprocess.Popen([sys.executable, "-I", "-S", "-c", "import sys; sys.stdin.read()"],
                           stdin=subprocess.PIPE) as child, contextlib.ExitStack() as cleanup:
         if os.name == "nt":
@@ -932,6 +930,7 @@ print("fixture lifetime contract passed")
       ciCheckoutFixture,
       fileURLToPath(new URL("./fixtures/ci-windows-process-census.py", import.meta.url)),
       new URL("./fixtures/ci-windows-process-census.mjs", import.meta.url).href,
+      fileURLToPath(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url)),
     ],
     { encoding: "utf8", timeout: 15_000, killSignal: "SIGKILL" },
   );

--- a/test/scripts/ci-windows-process-census.test-support.ts
+++ b/test/scripts/ci-windows-process-census.test-support.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { expect, it } from "vitest";
 import { spawnOwnedVitestProcess } from "../../scripts/lib/vitest-process.mts";
 import { withCiCheckoutFixture } from "./ci-checkout.test-support.js";
+import { fixturePreloadEnv } from "./fixtures/ci-fixture-runtime.cjs";
 
 export function censusPreload(root: string, extra = "", delayed = false) {
   const preload = path.join(root, "census-preload.mjs");
@@ -14,7 +14,7 @@ export function censusPreload(root: string, extra = "", delayed = false) {
 import cp from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
-import { syncBuiltinESMExports } from "node:module";
+import { syncFixtureBuiltinExports } from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 const root = process.argv[3];
 const delayed = ` +
       JSON.stringify(delayed) +
@@ -35,11 +35,11 @@ cp.spawn = (command, args, options) => {
   }
   return child;
 };
-syncBuiltinESMExports();
+syncFixtureBuiltinExports();
 ` +
       extra,
   );
-  return { NODE_OPTIONS: `--import=${pathToFileURL(preload).href}` };
+  return fixturePreloadEnv(preload);
 }
 
 export function expectCensusClosed(root: string, actorPids: number[]) {
@@ -114,7 +114,7 @@ else if (fault !== "retire") console.log(JSON.stringify({ ready: true }));
 import assert from "node:assert/strict";
 import cp from "node:child_process";
 import fs from "node:fs";
-import { syncBuiltinESMExports } from "node:module";
+import { syncFixtureBuiltinExports } from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 import { tmpdir } from "node:os";
 import path from "node:path";
 const [moduleUrl, fault, sampler] = process.argv.slice(1);
@@ -174,7 +174,7 @@ cp.spawn = (command, args, options) => {
   }
   return child;
 };
-syncBuiltinESMExports();
+syncFixtureBuiltinExports();
 const { createWindowsProcessCensus, requestWindowsProcessCensus } = await import(moduleUrl);
 const failures = [];
 const owner = createWindowsProcessCensus({ root, token: "owned", onFailure: error => failures.push(String(error)) });
@@ -270,7 +270,7 @@ for line in sys.stdin:
   const censusSpawn = cp.spawn;
   cp.spawn = (command, args, options) => censusSpawn(command, command === "python"
     ? ["-I", "-S", "-c", ${JSON.stringify(sampler)}, root, args[2], ${JSON.stringify(fault)}] : args, options);
-  syncBuiltinESMExports();
+  syncFixtureBuiltinExports();
 }`,
           );
         },
@@ -332,7 +332,7 @@ if (mode === "supervise") {
     }
     return child;
   };
-  syncBuiltinESMExports();
+  syncFixtureBuiltinExports();
 }
 `,
         );
@@ -477,7 +477,7 @@ if (mode === "supervise") {
     };
   }
   process.once("exit", code => recordBoundary({ event: "supervisor-exit", code }));
-  syncBuiltinESMExports();
+  syncFixtureBuiltinExports();
 }
 `,
           );

--- a/test/scripts/fixtures/ci-fixture-runtime.cjs
+++ b/test/scripts/fixtures/ci-fixture-runtime.cjs
@@ -1,0 +1,26 @@
+const { syncBuiltinESMExports } = require("node:module");
+const { pathToFileURL } = require("node:url");
+
+// Synthetic child fixtures replace builtin methods before loading their owners.
+exports.syncFixtureBuiltinExports = function syncFixtureBuiltinExports() {
+  if (!process.versions.bun) {
+    syncBuiltinESMExports();
+    return;
+  }
+  const { mock } = require("bun:test");
+  for (const name of ["node:child_process", "node:fs"]) {
+    const builtin = require(name);
+    mock.module(name, () => ({ ...builtin, default: builtin }));
+  }
+};
+
+/** @param {string} preload */
+exports.fixturePreloadEnv = function fixturePreloadEnv(preload) {
+  const url = pathToFileURL(preload).href;
+  if (!process.versions.bun) {
+    return { NODE_OPTIONS: `--import=${url}` };
+  }
+  // BUN_OPTIONS cannot quote paths with spaces; import the original file by URL.
+  const loader = Buffer.from(`import ${JSON.stringify(url)};`).toString("base64");
+  return { BUN_OPTIONS: `--preload=data:text/javascript;base64,${loader}` };
+};

--- a/test/scripts/fixtures/ci-platform-checkout.mjs
+++ b/test/scripts/fixtures/ci-platform-checkout.mjs
@@ -30,11 +30,15 @@ const localGit = options.localGit ?? options.performance;
 // uses .js specifiers that native Node type stripping cannot resolve.
 let getFileLockProcessStartTime;
 if (options.cancelDuringCleanup && ["supervise", "git"].includes(mode)) {
-  const { tsImport } = await import("tsx/esm/api");
-  ({ getFileLockProcessStartTime } = await tsImport(
-    "../../../src/shared/pid-alive.ts",
-    import.meta.url,
-  ));
+  if (process.versions.bun) {
+    ({ getFileLockProcessStartTime } = await import("../../../src/shared/pid-alive.ts"));
+  } else {
+    const { tsImport } = await import("tsx/esm/api");
+    ({ getFileLockProcessStartTime } = await tsImport(
+      "../../../src/shared/pid-alive.ts",
+      import.meta.url,
+    ));
+  }
 }
 const refsFile = path.join(root, "refs.json");
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where synthetic checkout and process-census tests running under Bun did not install their intended child-process fixtures. Builtin export synchronization and inherited preload arguments differ between Node and Bun.

## Why This Change Was Made

Use a test-only runtime helper to synchronize the synthetic child fixtures through each runtime's supported mechanism. Bun preloads import the original fixture URL through a space-safe data URL, and its cancellation fixture uses native TypeScript loading. Node retains its existing export synchronization and loader.

## User Impact

No production behavior changes. Developers can validate the existing checkout and process-lifetime contracts under both runtimes.

## Evidence

- The original full 74-case Bun run had 18 failures. The same ordered suite passes all 74 cases on Node and all 74 on true Bun after repair.
- Existing process identity, cleanup, timeout, and diagnostic assertions remain unchanged; actual fixture child close is verified.
- Full changed-file gate and independent P0–P2 review pass.
- A separately observed nineteenth campaign failure was not reproduced in either the original or final ordered run and is not counted as a demonstrated repair.
- Native Windows execution was not run. These macOS tests include Windows census broker coverage through a simulated sampler.
- The repository-wide Bun compatibility campaign remains in progress.
