### PR TITLE
fix(test): align history fixture with projection result

### DIFF
--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
Related: #139715, #139753, #139712

## What Problem This Solves

Gateway test typechecking fails after the interleaved-history paging test and the display-projection field rename landed independently. The paging fixture still supplies retired `streamErrorFallbackPending` / `streamErrorFallbackRepaired` properties, so the core-2 CI typecheck stops with TS2353.

## Why This Change Was Made

Use the current `assistantErrorPending` / `assistantErrorRecoveryObserved` field names in that existing fixture. Both values remain false and every paging assertion is unchanged. Do not add compatibility aliases to production code to accommodate an outdated test input.

## User Impact

No runtime behavior changes. This unblocks validation of the existing history paging coverage and other PRs encountering the inherited main typecheck failure. The repair is separate from the Watch setup change.

## Evidence

- Observed failure: [core-2 CI job](https://github.com/openclaw/openclaw/actions/runs/34013378942/job/101433005946), `src/gateway/session-history-state.test.ts:398`, TS2353.
- Existing history test file: **30/30 passed**.
- Exact core-2 typecheck sequence: stripes 3/5 and 4/5, each with concurrency 2, **passed**.
- Scoped changed checks passed, including test types, lint and dead-export scans.
- Independent P3 review is scoped-clean with no accepted actionable findings.

Production delta: 0. Existing test fixture: +2/−2; no new tests, assertions, dependencies, configuration or schema changes.
