### PR TITLE
fix(net): preserve installed HTTP dispatcher behavior under Bun

### DIFF
--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -23,9 +23,9 @@ export function getPlaywrightUserAgent() { return getUserAgent(); }`;
 const UNDICI_REQUIRE_BOOTSTRAP = [
   'import { createRequire } from "node:module";',
   "const requireUndici = createRequire(import.meta.url);\n",
-  'return requireUndici("undici") as typeof import("undici");',
+  'return requireUndici("undici/index.js") as typeof import("undici");',
 ] as const;
-const WORKER_UNDICI_IMPORT = 'import * as bundledUndici from "undici";';
+const WORKER_UNDICI_IMPORT = 'import * as bundledUndici from "undici/index.js";';
 
 export function resolveWorkerDeployGeneratorInputs(rootDir = process.cwd()) {
   const playwrightRoot = fs.realpathSync(path.resolve(rootDir, "node_modules/playwright-core"));

--- a/src/infra/net/undici-dispatcher-options.ts
+++ b/src/infra/net/undici-dispatcher-options.ts
@@ -27,7 +27,8 @@ export function loadUndiciModule(
   ) {
     return override as typeof import("undici");
   }
-  return requireUndici("undici") as typeof import("undici");
+  // Bun substitutes a partial built-in for bare undici; require the installed API.
+  return requireUndici("undici/index.js") as typeof import("undici");
 }
 
 function createHttp1ProxyClient(origin: URL, poolOptions: object): import("undici").Dispatcher {

--- a/src/infra/net/undici-runtime.test.ts
+++ b/src/infra/net/undici-runtime.test.ts
@@ -131,6 +131,19 @@ function invokeProxyClientFactory(options: Record<string, unknown>): void {
   clientFactory(new URL("https://127.0.0.1:8443"), { connect: proxyConnect });
 }
 
+describe("installed dispatcher lifecycle", () => {
+  it.each([
+    ["close", "closed"],
+    ["destroy", "destroyed"],
+  ] as const)("supports %s without a runtime override", async (method, state) => {
+    const dispatcher = createHttp1Agent();
+
+    await dispatcher[method]();
+
+    expect(dispatcher[state]).toBe(true);
+  });
+});
+
 describe("undici dispatcher errors", () => {
   it.each([
     {

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -94,12 +94,12 @@ export async function createAttachedBrowserToolRuntime(params) {
 
     const transformed = plugin.transform.call({ error: fail }, source, dispatcherPath);
 
-    expect(transformed).toContain('import * as bundledUndici from "undici";');
+    expect(transformed).toContain('import * as bundledUndici from "undici/index.js";');
     expect(transformed).toContain("return bundledUndici;");
     expect(transformed).toContain('return override as typeof import("undici");');
     expect(transformed).not.toContain('import { createRequire } from "node:module";');
     expect(transformed).not.toContain("const requireUndici = createRequire(import.meta.url);");
-    expect(transformed).not.toContain('requireUndici("undici")');
+    expect(transformed).not.toContain('requireUndici("undici/index.js")');
   });
 
   it("leaves fs-safe native package resolution to the dependency", () => {
@@ -120,7 +120,10 @@ export async function createAttachedBrowserToolRuntime(params) {
     expect(() =>
       plugin.transform.call(
         { error: fail },
-        source.replace('return requireUndici("undici")', 'return changedUndici("undici")'),
+        source.replace(
+          'return requireUndici("undici/index.js")',
+          'return changedUndici("undici/index.js")',
+        ),
         dispatcherPath,
       ),
     ).toThrow("undici dispatcher bootstrap changed");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw's HTTP dispatcher could lack the installed Undici lifecycle API when running under Bun. Bun substitutes a partial built-in adapter for a bare Undici import.

## Why This Change Was Made

Load the declared dependency through its explicit installed entry point. Update the existing worker build transform in the same change so the sealed worker bundles that implementation without requiring a runtime dependency directory. Existing test overrides and dispatcher policies remain unchanged.

## User Impact

Direct guarded HTTP callers receive the installed dispatcher's expected close and destroy behavior under Bun, including the exercised Matrix HTTP path.

## Evidence

- 26 focused tests pass on Node and 26 on true Bun, including four real local Matrix HTTP tests through OpenClaw's transport and two unmocked dispatcher lifecycle regressions.
- The new lifecycle tests fail on the original Bun loader and pass after repair.
- After rebasing and installing the locked dependencies, the complete four-file gate and all 26 cases on each runtime pass. The loader patch is unchanged from its clean P0–P2 review.
- The refreshed real unified worker build passes. Its standalone bundle prewarms under Node and Bun with network denied and isolated home/state; a negative control confirms Undici cannot be imported from outside the bundle.
- The focused worker build is the build proof; no full repository build is claimed for this patch.
- This does not repair the separate Proxyline dependency integration or establish complete Matrix/Bun support. Matrix's broader runtime-support PR remains held pending that work.
- No dependency version, override, or vendored source changes are introduced.
