### PR TITLE
refactor(tests): consolidate chat history trace coverage

### DIFF
--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -1894,73 +1894,6 @@ describe("projectChatDisplayMessages", () => {
     ]);
   });
 
-  it("preserves structured trace alongside visible assistant progress text", () => {
-    const result = projectChatDisplayMessages(
-      [
-        userHistoryMessage("fix it", { timestamp: 1 }),
-        {
-          role: "assistant",
-          content: [
-            { type: "thinking", thinking: "private reasoning" },
-            {
-              type: "text",
-              text: "I will clean that up now.",
-              textSignature: JSON.stringify({
-                v: 1,
-                id: "msg-progress",
-                phase: "commentary",
-              }),
-            },
-            {
-              type: "toolCall",
-              id: "call-read",
-              name: "read",
-              arguments: { path: "AGENTS.md" },
-            },
-          ],
-          timestamp: 2,
-          __openclaw: { seq: 2 },
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call-read",
-          toolName: "read",
-          content: [{ type: "text", text: "file contents" }],
-          timestamp: 3,
-        },
-      ],
-      { includeCommentaryFallbacks: true },
-    );
-
-    expect(result.slice(1, 3)).toEqual([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "I will clean that up now." }],
-        timestamp: 2,
-        __openclaw: { seq: 2 },
-        openclawStreamFallback: {
-          replacementText: "I will clean that up now.",
-          source: "segment",
-          itemId: "msg-progress",
-        },
-      },
-      {
-        role: "assistant",
-        content: [
-          { type: "thinking", thinking: "private reasoning" },
-          {
-            type: "toolCall",
-            id: "call-read",
-            name: "read",
-            arguments: { path: "AGENTS.md" },
-          },
-        ],
-        timestamp: 2,
-        __openclaw: { seq: 2 },
-      },
-    ]);
-  });
-
   it("projects pure keyed commentary as a durable preamble", () => {
     const result = projectChatDisplayMessages(
       [
@@ -2173,15 +2106,6 @@ describe("projectChatDisplayMessages", () => {
     {
       name: "type-only",
       message: { __openclaw: { media: [{ contentType: "image/png" }] } },
-      expectedPath: undefined,
-    },
-    {
-      name: "media-only",
-      message: {
-        __openclaw: {
-          media: [{ path: "/tmp/openclaw/media-only.png", contentType: "image/png" }],
-        },
-      },
       expectedPath: undefined,
     },
   ])("keeps $name media-only users through canonical display projection", (testCase) => {

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -7034,13 +7034,17 @@ describe("gateway server chat", () => {
       expect(assistantMessage.role).toBe("assistant");
       expect(messages[1]).toMatchObject({
         role: "assistant",
-        content: [{ type: "text", text: "I will clean that up now." }],
-        openclawStreamFallback: {
-          replacementText: "I will clean that up now.",
-          source: "segment",
-          itemId: "msg-progress",
-        },
+        timestamp: 2,
       });
+      expect(messages[1]).toHaveProperty("content", [
+        { type: "text", text: "I will clean that up now." },
+      ]);
+      expect(messages[1]).toHaveProperty("openclawStreamFallback", {
+        replacementText: "I will clean that up now.",
+        source: "segment",
+        itemId: "msg-progress",
+      });
+      expect(messages.slice(1, 3).map(readOpenClawSeq)).toEqual([2, 2]);
       expect(assistantMessage.content).toEqual([
         { type: "thinking", thinking: "private reasoning" },
         {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Chat history tests repeat the same mixed commentary and tool-trace scenario at the projection and real Gateway boundaries. The projection table also repeats an identical unmanaged media-path case under a different filename.

## Why This Change Was Made

Keep the real WebSocket/SQLite history scenario and strengthen it with both projected sequence numbers, the commentary timestamp, and exact commentary content and fallback metadata. Remove the duplicated unit case and media row while retaining distinct recovery, provenance, cancellation and media-shape cases.

## User Impact

No production behavior changes. This removes 72 net test lines while retaining the independent assertions previously supplied by the removed case.

## Evidence

Both complete suites passed: 358 cases before and 356 after the two documented duplicate removals. Four targeted regression controls confirm that the retained RPC case rejects lost sequence numbers, a missing timestamp, extra thinking data on commentary text, and extra fallback metadata; the production source was restored byte-for-byte afterward.

The full changed-file gate, formatting, deslop and independent review pass. After a patch-identical refresh containing the upstream fixture repair #139794, the retained real Gateway case passed again to cover intervening startup/teardown changes. No aggregate runtime or coverage improvement is claimed from this batch alone.
