### PR TITLE
refactor(tests): reuse zero-usage inputs in provider stream suites

### DIFF
--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -144,6 +144,10 @@ validates schema-parsed channel data through the host config boundary. Each
 plugin test still owns its schema parsing, account resolver, and assertions,
 including checks that omitted account policies remain absent.
 
+For complete zero-usage inputs, `createZeroUsageFixture()` from
+`openclaw/plugin-sdk/test-fixtures` returns fresh usage and nested cost objects
+without optional telemetry fields. Keep expected usage values explicit.
+
 ### Types
 
 Focused testing subpaths also re-export types useful in test files:

--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
 import { createProviderUsageFetch, makeResponse } from "openclaw/plugin-sdk/test-env";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import deepseekPlugin from "./index.js";
@@ -34,14 +35,7 @@ type ReplayToolCall = {
 
 type RegisteredProvider = Awaited<ReturnType<typeof registerSingleProviderPlugin>>;
 
-const emptyUsage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
+const emptyUsage = createZeroUsageFixture();
 
 function requireThinkingProfileResolver(
   provider: RegisteredProvider,

--- a/extensions/github-copilot/stream.test.ts
+++ b/extensions/github-copilot/stream.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from "node:net";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { streamSimple, type Context, type Model } from "openclaw/plugin-sdk/llm";
 import { buildCopilotIdeHeaders } from "openclaw/plugin-sdk/provider-auth";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { wrapCopilotProviderStream } from "./stream.js";
 
@@ -419,14 +420,7 @@ describe("wrapCopilotAnthropicStream", () => {
             name: "read",
             arguments: {},
           })),
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
+          usage: createZeroUsageFixture(),
           stopReason: "toolUse",
           timestamp: 2,
         },

--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -1,7 +1,7 @@
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream, type AssistantMessage } from "openclaw/plugin-sdk/llm";
 // Lmstudio tests cover stream plugin behavior.
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { createRequireRecord, createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let wrapLmstudioInferencePreload: typeof import("./stream.js").wrapLmstudioInferencePreload;
@@ -40,14 +40,7 @@ function lmstudioAssistantMessage(content: AssistantMessage["content"]): Assista
     api: "openai-completions" as const,
     provider: "lmstudio",
     model: "qwen3-8b-instruct",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop" as const,
     timestamp: 1,
   };

--- a/extensions/longcat/index.test.ts
+++ b/extensions/longcat/index.test.ts
@@ -9,6 +9,7 @@ import {
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 import { LONGCAT_DEFAULT_MODEL_REF } from "./models.js";
@@ -119,14 +120,7 @@ describe("LongCat provider plugin", () => {
             },
             { type: "toolCall", id: "call_1", name: "read", arguments: {} },
           ],
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
+          usage: createZeroUsageFixture(),
           stopReason: "toolUse",
           timestamp: 2,
         },

--- a/extensions/xai/server-compaction.test.ts
+++ b/extensions/xai/server-compaction.test.ts
@@ -5,6 +5,7 @@ import {
 } from "@openclaw/ai/transports";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import type { AssistantMessage, Context, Model } from "openclaw/plugin-sdk/llm";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { wrapXaiProviderStream } from "./stream.js";
 
@@ -37,14 +38,7 @@ const model = {
   maxTokens: 8_192,
 } satisfies Model<"openai-responses">;
 
-const usage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
+const usage = createZeroUsageFixture();
 
 function wrapResponses(options: { fastMode?: boolean; clientVersion?: string }): StreamFn {
   const wrapped = wrapXaiProviderStream(

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -8,6 +8,7 @@ import {
   type Model,
   type ModelThinkingLevel,
 } from "openclaw/plugin-sdk/llm";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { XAI_BASE_URL } from "./model-definitions.js";
 import { XAI_GROK_OAUTH_BASE_URL } from "./provider-catalog.js";
@@ -28,14 +29,7 @@ function xaiAssistantMessage(content: AssistantMessage["content"]): AssistantMes
     api: "openai-responses" as const,
     provider: "xai",
     model: "grok-4.3",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop" as const,
     timestamp: 1,
   };

--- a/extensions/xiaomi/index.test.ts
+++ b/extensions/xiaomi/index.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
 import * as ssrfRuntime from "openclaw/plugin-sdk/ssrf-runtime";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import xiaomiPlugin from "./index.js";
@@ -34,14 +35,7 @@ type ReplayToolCall = {
 };
 
 type RegisteredProvider = RegisteredProviderCollections["providers"][number];
-const emptyUsage = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-  totalTokens: 0,
-  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-};
+const emptyUsage = createZeroUsageFixture();
 
 function requireThinkingProfileResolver(
   provider: RegisteredProvider,

--- a/extensions/zai/index.test.ts
+++ b/extensions/zai/index.test.ts
@@ -7,6 +7,7 @@ import type { Context, Model } from "openclaw/plugin-sdk/llm";
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
+import { createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
@@ -545,14 +546,7 @@ describe("zai provider plugin", () => {
             },
             { type: "text", text: "visible reply" },
           ],
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
+          usage: createZeroUsageFixture(),
           stopReason: "stop",
           timestamp: 2,
         },

--- a/src/llm/ai-transport-host.test.ts
+++ b/src/llm/ai-transport-host.test.ts
@@ -7,6 +7,7 @@ import { resolveOpenAICompletionsCompat } from "../../packages/ai/src/transports
 import type { Context, Model } from "../../packages/ai/src/types.js";
 import { projectProviderError } from "../../packages/ai/src/utils/provider-error.js";
 import { createOpenClawReadTool } from "../agents/agent-tools.read.js";
+import { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 import { registerSecretValueForRedaction } from "../logging/secret-redaction-registry.js";
 import { resetSecretRedactionRegistryForTest } from "../logging/secret-redaction-registry.test-support.js";
 import "./ai-transport-host.js";
@@ -87,14 +88,7 @@ describe("OpenClaw provider tool-result redaction", () => {
           provider: "anthropic",
           model: "claude-test",
           content: [{ type: "toolCall", id: "call-1", name: "read", arguments: {} }],
-          usage: {
-            input: 0,
-            output: 0,
-            cacheRead: 0,
-            cacheWrite: 0,
-            totalTokens: 0,
-            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-          },
+          usage: createZeroUsageFixture(),
           stopReason: "toolUse",
           timestamp: 1,
         },

--- a/src/llm/openai-compatible-auth.test.ts
+++ b/src/llm/openai-compatible-auth.test.ts
@@ -4,6 +4,7 @@ import { streamOpenAICompletions, streamOpenAIResponses } from "@openclaw/ai/int
 // Lives in core: it proves the facade-installed guarded fetch routes provider
 // requests through OpenClaw's SSRF guard.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 import { captureEnv } from "../test-utils/env.js";
 // Importing the facade installs the OpenClaw AI transport host ports.
 import "./stream.js";
@@ -113,14 +114,7 @@ describe("OpenAI-compatible provider credentials", () => {
             api: "openai-responses",
             provider: model.provider,
             model: model.id,
-            usage: {
-              input: 0,
-              output: 0,
-              cacheRead: 0,
-              cacheWrite: 0,
-              totalTokens: 0,
-              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-            },
+            usage: createZeroUsageFixture(),
             stopReason: "toolUse",
             timestamp: 1,
             content: [

--- a/src/llm/stream.complete-host.test.ts
+++ b/src/llm/stream.complete-host.test.ts
@@ -7,6 +7,7 @@ import type {
   SimpleStreamOptions,
 } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 import { bindModelLlmRuntime } from "./model-runtime-binding.js";
 import { completeSimple } from "./stream.js";
 import { createAssistantMessageEventStream } from "./utils/event-stream.js";
@@ -34,14 +35,7 @@ function createCompletionRuntime(
     api: model.api,
     provider: model.provider,
     model: model.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop",
     timestamp: Date.now(),
   } satisfies AssistantMessage;

--- a/src/llm/stream.sync-host.test.ts
+++ b/src/llm/stream.sync-host.test.ts
@@ -6,6 +6,7 @@ import type {
   Model,
 } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 import { bindModelLlmRuntime } from "./model-runtime-binding.js";
 import { stream, streamSimple } from "./stream.js";
 import { createAssistantMessageEventStream } from "./utils/event-stream.js";
@@ -33,14 +34,7 @@ describe("LLM synchronous stream transport host", () => {
       api: model.api,
       provider: model.provider,
       model: model.id,
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: Date.now(),
     } satisfies AssistantMessage;

--- a/src/llm/stream.test.ts
+++ b/src/llm/stream.test.ts
@@ -1,6 +1,7 @@
 import { createApiRegistry, createLlmRuntime } from "@openclaw/ai";
 import type { AssistantMessage, Model } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
+import { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 import { bindModelLlmRuntime } from "./model-runtime-binding.js";
 import { streamSimple } from "./stream.js";
 import { createAssistantMessageEventStream } from "./utils/event-stream.js";
@@ -16,14 +17,7 @@ describe("LLM stream facade", () => {
       api: "test-lifecycle-api",
       provider: "test-provider",
       model: "test-model",
-      usage: {
-        input: 0,
-        output: 0,
-        cacheRead: 0,
-        cacheWrite: 0,
-        totalTokens: 0,
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-      },
+      usage: createZeroUsageFixture(),
       stopReason: "stop",
       timestamp: Date.now(),
     } satisfies AssistantMessage;

--- a/src/llm/utils/retry.test.ts
+++ b/src/llm/utils/retry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { failoverClassificationCorpus } from "../../agents/failover/failover-classification.corpus.cases.test-support.js";
 import { failoverRetryExpectations } from "../../agents/failover/failover-retry.expected.test-support.js";
+import { createZeroUsageFixture } from "../../agents/test-helpers/usage-fixtures.js";
 import {
   PROVIDER_FAILURE_WITH_OUTPUT_ERROR_CODE,
   PROVIDER_POST_DISPATCH_AMBIGUITY_ERROR_CODE,
@@ -15,14 +16,7 @@ function errorMessage(message: string): AssistantMessage {
     api: "test-api",
     provider: "test-provider",
     model: "test-model",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "error",
     errorMessage: message,
     timestamp: 1,

--- a/src/plugin-sdk/provider-stream-shared.test.ts
+++ b/src/plugin-sdk/provider-stream-shared.test.ts
@@ -3,7 +3,7 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 /**
  * Tests provider stream shared helpers and stream hook capture.
  */
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { createRequireRecord, createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import {
@@ -45,14 +45,7 @@ function completeAssistantMessage(
     api: "openai-completions",
     provider: "test",
     model: "test-model",
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: typeof value.stopReason === "string" ? value.stopReason : fallbackStopReason,
     timestamp: 1,
   };

--- a/src/plugin-sdk/provider-stream.test.ts
+++ b/src/plugin-sdk/provider-stream.test.ts
@@ -1,7 +1,7 @@
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/core";
 import type { Model } from "openclaw/plugin-sdk/llm";
 // Provider stream tests cover shared stream-wrapper families and payload compatibility.
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { createRequireRecord, createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import { createAssistantMessageEventStream } from "../llm/utils/event-stream.js";
 import { VERSION } from "../version.js";
@@ -68,14 +68,7 @@ function streamTestMessage(text: string) {
     api: streamTestModel.api,
     provider: streamTestModel.provider,
     model: streamTestModel.id,
-    usage: {
-      input: 0,
-      output: 0,
-      cacheRead: 0,
-      cacheWrite: 0,
-      totalTokens: 0,
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-    },
+    usage: createZeroUsageFixture(),
     stopReason: "stop" as const,
     timestamp: 1,
   };

--- a/src/plugin-sdk/test-fixtures.ts
+++ b/src/plugin-sdk/test-fixtures.ts
@@ -20,6 +20,7 @@ export {
   makeAgentAssistantMessage,
   makeAgentUserMessage,
 } from "../agents/test-helpers/agent-message-fixtures.js";
+export { createZeroUsageFixture } from "../agents/test-helpers/usage-fixtures.js";
 export { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 export { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 export { countLines, hasBalancedFences } from "../test-utils/chunk-test-helpers.js";

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1,7 +1,7 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
 /** Exercises provider runtime loading, ordering, and manifest-backed discovery paths. */
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
+import { createRequireRecord, createZeroUsageFixture } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
@@ -128,14 +128,7 @@ const DEMO_SANITIZED_MESSAGE: AgentMessage = {
   api: MODEL.api,
   provider: MODEL.provider,
   model: MODEL.id,
-  usage: {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    totalTokens: 0,
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-  },
+  usage: createZeroUsageFixture(),
   stopReason: "stop",
   timestamp: 2,
 };


### PR DESCRIPTION
Related: #139745

## What Problem This Solves

Seventeen provider-stream test suites repeat the same complete zero-usage input object. This maintainer-requested test-audit batch removes that fixture duplication while retaining every provider-specific regression case and assertion.

## Why This Change Was Made

Reuse the existing fresh usage factory through the repo-local SDK test-fixtures entrypoint. Each replacement stays at its original allocation point, preserving shared constants, per-message objects, nested cost freshness, property order, and absent optional telemetry. Expected usage values remain explicit. The SDK testing reference documents the helper.

## User Impact

No runtime behavior changes. Tests lose 106 lines; the test-helper export adds one and documentation adds four, for 101 fewer lines overall. Test coverage and invocation counts are preserved; this batch makes no test-runtime reduction claim.

## Evidence

- Focused repository Vitest run: all 977 tests passed across the 17 affected suites, with identical full test names and outcomes before and after.
- Expanded-source comparison and runtime fixture-graph checks confirmed identical values, property order/descriptors, absent fields, allocation scope, and existing sharing.
- Full classified changed gate passed on repaired main, including SDK boundaries, core/plugin typechecks, unused exports, lint, and runtime guards.
- Documentation formatting/MDX checks and independent P2 review passed.
