### PR TITLE
refactor(tests): share explicit browser context fixtures

### DIFF
--- a/ui/src/e2e/about.e2e.test.ts
+++ b/ui/src/e2e/about.e2e.test.ts
@@ -1,7 +1,10 @@
 // Control UI tests cover About artifact identity against a mocked Gateway.
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI About mocked Gateway E2E",
@@ -14,11 +17,7 @@ const BUILT_AT = "2026-07-10T12:34:56.000Z";
 
 suite.define(() => {
   it("shows and copies browser artifact identity, separately from the Gateway version", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     await context.addInitScript(() => {
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,

--- a/ui/src/e2e/agent-channel-runtime-status.e2e.test.ts
+++ b/ui/src/e2e/agent-channel-runtime-status.e2e.test.ts
@@ -4,7 +4,10 @@ import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI Agents channel status",
@@ -34,70 +37,61 @@ async function screenshot(page: Page) {
 
 suite.define(() => {
   it("keeps an explicit stopped runtime in warning state when its API probe succeeds", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, {
-          assistantName: "Main agent",
-          defaultAgentId: "main",
-          methodResponses: {
-            "agents.list": {
-              agents: [{ id: "main", name: "Main agent" }],
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-            },
-            "channels.status": {
-              ts: Date.now(),
-              channelOrder: ["discord"],
-              channelLabels: { discord: "Discord" },
-              channelMeta: [{ id: "discord", label: "Discord", detailLabel: "Discord Bot" }],
-              channels: {},
-              channelAccounts: {
-                discord: [
-                  {
-                    accountId: "default",
-                    configured: true,
-                    connected: false,
-                    enabled: true,
-                    probe: { ok: true },
-                    running: false,
-                  },
-                ],
-              },
-              channelDefaultAccountId: { discord: "default" },
-            },
-            "config.get": {
-              config: { agents: { entries: { main: { default: true } } } },
-              hash: "hash-1",
-              issues: [],
-              raw: '{"agents":{"list":[{"id":"main"}]}}',
-              valid: true,
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page, {
+        assistantName: "Main agent",
+        defaultAgentId: "main",
+        methodResponses: {
+          "agents.list": {
+            agents: [{ id: "main", name: "Main agent" }],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
           },
-        });
+          "channels.status": {
+            ts: Date.now(),
+            channelOrder: ["discord"],
+            channelLabels: { discord: "Discord" },
+            channelMeta: [{ id: "discord", label: "Discord", detailLabel: "Discord Bot" }],
+            channels: {},
+            channelAccounts: {
+              discord: [
+                {
+                  accountId: "default",
+                  configured: true,
+                  connected: false,
+                  enabled: true,
+                  probe: { ok: true },
+                  running: false,
+                },
+              ],
+            },
+            channelDefaultAccountId: { discord: "default" },
+          },
+          "config.get": {
+            config: { agents: { entries: { main: { default: true } } } },
+            hash: "hash-1",
+            issues: [],
+            raw: '{"agents":{"list":[{"id":"main"}]}}',
+            valid: true,
+          },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/channels`);
-        expect(response?.status()).toBe(200);
-        await expect
-          .poll(() => new URL(page.url()).pathname)
-          .toBe("/settings/agents/main/channels");
-        await page.getByRole("tab", { name: /^Channels/ }).click();
+      const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/channels`);
+      expect(response?.status()).toBe(200);
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/main/channels");
+      await page.getByRole("tab", { name: /^Channels/ }).click();
 
-        const discordRow = page.locator(".settings-row").filter({ hasText: "Discord" });
-        await expect.poll(() => discordRow.count()).toBe(1);
+      const discordRow = page.locator(".settings-row").filter({ hasText: "Discord" });
+      await expect.poll(() => discordRow.count()).toBe(1);
 
-        const status = discordRow.locator(".settings-status");
-        await expect.poll(async () => (await status.textContent())?.trim()).toBe("0/1 connected");
-        await expect
-          .poll(async () => await status.getAttribute("class"))
-          .toContain("settings-status--warn");
-        await screenshot(page);
-      },
-    );
+      const status = discordRow.locator(".settings-status");
+      await expect.poll(async () => (await status.textContent())?.trim()).toBe("0/1 connected");
+      await expect
+        .poll(async () => await status.getAttribute("class"))
+        .toContain("settings-status--warn");
+      await screenshot(page);
+    });
   });
 });

--- a/ui/src/e2e/agent-config-save.e2e.test.ts
+++ b/ui/src/e2e/agent-config-save.e2e.test.ts
@@ -4,7 +4,10 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI agent config save",
@@ -117,207 +120,193 @@ suite.define(() => {
       expectedTools: { profile: "minimal", alsoAllow: ["web_*"], deny: ["web_fetch"] },
     },
   ])("submits keyed entries and surfaces Gateway validation failures ($name)", async (scenario) => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const config = {
-          agents: {
-            entries: {
-              main: {
-                default: true,
-                tools: scenario.tools,
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const config = {
+        agents: {
+          entries: {
+            main: {
+              default: true,
+              tools: scenario.tools,
+            },
+          },
+        },
+      };
+      const gateway = await installMockGateway(page, {
+        assistantName: "Main agent",
+        defaultAgentId: "main",
+        methodResponses: {
+          "agents.list": {
+            agents: [{ id: "main", name: "Main agent" }],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+          "config.get": {
+            config,
+            sourceConfig: config,
+            runtimeConfig: config,
+            hash: "agent-config-hash-1",
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
+          },
+          "tools.catalog": {
+            agentId: "main",
+            profiles: [{ id: scenario.tools.profile, label: scenario.profileLabel }],
+            groups: [
+              {
+                id: scenario.groupId,
+                label: scenario.groupLabel,
+                source: "core",
+                tools: [
+                  {
+                    id: scenario.toolId,
+                    label: scenario.toolId,
+                    description: scenario.description,
+                    source: "core",
+                    defaultProfiles: ["full"],
+                  },
+                ],
               },
+            ],
+          },
+          "tools.effective": {
+            agentId: "main",
+            profile: scenario.tools.profile,
+            groups: [],
+            notices: [],
+          },
+        },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("agents.list");
+      await gateway.waitForRequest("config.get");
+      await gateway.waitForRequest("tools.catalog");
+
+      await page
+        .locator(".agent-tools-group")
+        .filter({ hasText: scenario.groupLabel })
+        .locator(".agent-tools-group__summary")
+        .click();
+      const toggle = page.locator(`#agent-tool-${scenario.toolId} wa-switch`);
+      await expect
+        .poll(() =>
+          toggle.evaluate((element) => (element as HTMLElement & { checked: boolean }).checked),
+        )
+        .toBe(true);
+      await gateway.deferNext("config.set");
+      await toggle.click();
+
+      const request = await gateway.waitForRequest("config.set");
+      const params = requireRecord(request.params);
+      const raw = requireRecord(JSON.parse(String(params.raw)));
+      expect(raw).toEqual({
+        agents: {
+          entries: {
+            main: {
+              default: true,
+              tools: scenario.expectedTools,
             },
           },
-        };
-        const gateway = await installMockGateway(page, {
-          assistantName: "Main agent",
-          defaultAgentId: "main",
-          methodResponses: {
-            "agents.list": {
-              agents: [{ id: "main", name: "Main agent" }],
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-            },
-            "config.get": {
-              config,
-              sourceConfig: config,
-              runtimeConfig: config,
-              hash: "agent-config-hash-1",
-              issues: [],
-              raw: JSON.stringify(config),
-              valid: true,
-            },
-            "tools.catalog": {
-              agentId: "main",
-              profiles: [{ id: scenario.tools.profile, label: scenario.profileLabel }],
-              groups: [
-                {
-                  id: scenario.groupId,
-                  label: scenario.groupLabel,
-                  source: "core",
-                  tools: [
-                    {
-                      id: scenario.toolId,
-                      label: scenario.toolId,
-                      description: scenario.description,
-                      source: "core",
-                      defaultProfiles: ["full"],
-                    },
-                  ],
-                },
-              ],
-            },
-            "tools.effective": {
-              agentId: "main",
-              profile: scenario.tools.profile,
-              groups: [],
-              notices: [],
-            },
-          },
+        },
+      });
+      expect(requireRecord(raw.agents)).not.toHaveProperty("list");
+      expect(params.baseHash).toBe("agent-config-hash-1");
+
+      await gateway.rejectDeferred("config.set", {
+        code: "INVALID_REQUEST",
+        message: "mock validation failure",
+      });
+      await page.getByRole("alert").filter({ hasText: "mock validation failure" }).waitFor();
+
+      if (captureUiProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(proofDir, "01-save-error.png"),
         });
-
-        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
-        expect(response?.status()).toBe(200);
-        await gateway.waitForRequest("agents.list");
-        await gateway.waitForRequest("config.get");
-        await gateway.waitForRequest("tools.catalog");
-
-        await page
-          .locator(".agent-tools-group")
-          .filter({ hasText: scenario.groupLabel })
-          .locator(".agent-tools-group__summary")
-          .click();
-        const toggle = page.locator(`#agent-tool-${scenario.toolId} wa-switch`);
-        await expect
-          .poll(() =>
-            toggle.evaluate((element) => (element as HTMLElement & { checked: boolean }).checked),
-          )
-          .toBe(true);
-        await gateway.deferNext("config.set");
-        await toggle.click();
-
-        const request = await gateway.waitForRequest("config.set");
-        const params = requireRecord(request.params);
-        const raw = requireRecord(JSON.parse(String(params.raw)));
-        expect(raw).toEqual({
-          agents: {
-            entries: {
-              main: {
-                default: true,
-                tools: scenario.expectedTools,
-              },
-            },
-          },
-        });
-        expect(requireRecord(raw.agents)).not.toHaveProperty("list");
-        expect(params.baseHash).toBe("agent-config-hash-1");
-
-        await gateway.rejectDeferred("config.set", {
-          code: "INVALID_REQUEST",
-          message: "mock validation failure",
-        });
-        await page.getByRole("alert").filter({ hasText: "mock validation failure" }).waitFor();
-
-        if (captureUiProof) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(proofDir, "01-save-error.png"),
-          });
-        }
-      },
-    );
+      }
+    });
   });
 
   it("stages skill changes from the inherited allowlist", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const config = {
-          agents: {
-            defaults: { skills: ["github"] },
-            entries: { main: { default: true } },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const config = {
+        agents: {
+          defaults: { skills: ["github"] },
+          entries: { main: { default: true } },
+        },
+      };
+      const skill = (name: string, blockedByAgentFilter: boolean) => ({
+        name,
+        description: `${name} skill`,
+        source: "openclaw-managed",
+        bundled: false,
+        filePath: `/tmp/skills/${name}/SKILL.md`,
+        baseDir: `/tmp/skills/${name}`,
+        skillKey: name,
+        always: false,
+        disabled: false,
+        blockedByAllowlist: false,
+        blockedByAgentFilter,
+        eligible: true,
+        requirements: { bins: [], anyBins: [], env: [], config: [], os: [] },
+        missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
+        configChecks: [],
+        install: [],
+      });
+      const gateway = await installMockGateway(page, {
+        assistantName: "Main agent",
+        defaultAgentId: "main",
+        methodResponses: {
+          "agents.list": {
+            agents: [{ id: "main", name: "Main agent" }],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
           },
-        };
-        const skill = (name: string, blockedByAgentFilter: boolean) => ({
-          name,
-          description: `${name} skill`,
-          source: "openclaw-managed",
-          bundled: false,
-          filePath: `/tmp/skills/${name}/SKILL.md`,
-          baseDir: `/tmp/skills/${name}`,
-          skillKey: name,
-          always: false,
-          disabled: false,
-          blockedByAllowlist: false,
-          blockedByAgentFilter,
-          eligible: true,
-          requirements: { bins: [], anyBins: [], env: [], config: [], os: [] },
-          missing: { bins: [], anyBins: [], env: [], config: [], os: [] },
-          configChecks: [],
-          install: [],
-        });
-        const gateway = await installMockGateway(page, {
-          assistantName: "Main agent",
-          defaultAgentId: "main",
-          methodResponses: {
-            "agents.list": {
-              agents: [{ id: "main", name: "Main agent" }],
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-            },
-            "config.get": {
-              config,
-              sourceConfig: config,
-              runtimeConfig: config,
-              hash: "agent-config-hash-1",
-              issues: [],
-              raw: JSON.stringify(config),
-              valid: true,
-            },
-            "skills.status": {
-              agentId: "main",
-              agentSkillFilter: ["github"],
-              workspaceDir: "/tmp/workspace",
-              managedSkillsDir: "/tmp/skills",
-              skills: [skill("github", false), skill("weather", true)],
-            },
+          "config.get": {
+            config,
+            sourceConfig: config,
+            runtimeConfig: config,
+            hash: "agent-config-hash-1",
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
           },
-        });
-
-        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/skills`);
-        expect(response?.status()).toBe(200);
-        await gateway.waitForRequest("config.get");
-        await gateway.waitForRequest("skills.status");
-
-        await gateway.deferNext("config.set");
-        await page
-          .locator(".agent-skill-row", { hasText: "github skill" })
-          .locator("wa-switch")
-          .click();
-
-        const request = await gateway.waitForRequest("config.set");
-        const params = requireRecord(request.params);
-        expect(JSON.parse(String(params.raw))).toEqual({
-          agents: {
-            defaults: { skills: ["github"] },
-            entries: { main: { default: true, skills: [] } },
+          "skills.status": {
+            agentId: "main",
+            agentSkillFilter: ["github"],
+            workspaceDir: "/tmp/workspace",
+            managedSkillsDir: "/tmp/skills",
+            skills: [skill("github", false), skill("weather", true)],
           },
-        });
-        expect(params.baseHash).toBe("agent-config-hash-1");
-        await gateway.resolveDeferred("config.set", { hash: "agent-config-hash-2" });
-      },
-    );
+        },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/skills`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("config.get");
+      await gateway.waitForRequest("skills.status");
+
+      await gateway.deferNext("config.set");
+      await page
+        .locator(".agent-skill-row", { hasText: "github skill" })
+        .locator("wa-switch")
+        .click();
+
+      const request = await gateway.waitForRequest("config.set");
+      const params = requireRecord(request.params);
+      expect(JSON.parse(String(params.raw))).toEqual({
+        agents: {
+          defaults: { skills: ["github"] },
+          entries: { main: { default: true, skills: [] } },
+        },
+      });
+      expect(params.baseHash).toBe("agent-config-hash-1");
+      await gateway.resolveDeferred("config.set", { hash: "agent-config-hash-2" });
+    });
   });
 });

--- a/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
+++ b/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI agent model fallback ownership",
@@ -55,109 +58,102 @@ suite.define(() => {
       expectedFallbacks: ["google/gemini-3-pro"],
     },
   ])("$name", async ({ model, expectedFallbacks }) => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const config = {
-          agents: {
-            defaults: {
-              workspace: "/tmp/agents",
-              model: { primary: primaryModel, fallbacks: [inheritedFallback] },
-            },
-            entries: {
-              main: { default: true },
-              writer: model === undefined ? {} : { model },
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const config = {
+        agents: {
+          defaults: {
+            workspace: "/tmp/agents",
+            model: { primary: primaryModel, fallbacks: [inheritedFallback] },
           },
-        };
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "agents.list": {
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-              agents: [
-                { id: "main", identity: { name: "Main" }, name: "Main" },
-                {
-                  id: "writer",
-                  identity: { name: "Writer" },
-                  name: "Writer",
-                  workspace: writerWorkspace,
-                  model: { primary: primaryModel, fallbacks: expectedFallbacks },
-                },
-              ],
-            },
-            "config.get": {
-              config,
-              sourceConfig: config,
-              hash: "agent-model-fallback-ownership",
-              issues: [],
-              raw: JSON.stringify(config),
-              valid: true,
-            },
+          entries: {
+            main: { default: true },
+            writer: model === undefined ? {} : { model },
           },
+        },
+      };
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "agents.list": {
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+            agents: [
+              { id: "main", identity: { name: "Main" }, name: "Main" },
+              {
+                id: "writer",
+                identity: { name: "Writer" },
+                name: "Writer",
+                workspace: writerWorkspace,
+                model: { primary: primaryModel, fallbacks: expectedFallbacks },
+              },
+            ],
+          },
+          "config.get": {
+            config,
+            sourceConfig: config,
+            hash: "agent-model-fallback-ownership",
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
+          },
+        },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("agents.list");
+      await gateway.waitForRequest("config.get");
+      const agentPicker = page.locator("openclaw-agents-page openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").click();
+      // Switching agents is the user action under test; the Tools panel must survive it.
+      await agentPicker
+        .locator("wa-dropdown-item[data-agent-option]")
+        .filter({ hasText: "Writer" })
+        .evaluate((item) => (item as HTMLElement).click());
+      await expect
+        .poll(() =>
+          agentPicker.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
+        )
+        .toBe("writer");
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/writer/tools");
+      await page.getByRole("tab", { name: "Overview", exact: true }).click();
+      await expect
+        .poll(() => new URL(page.url()).pathname)
+        .toBe("/settings/agents/writer/overview");
+
+      if (captureUiProof && model && !("primary" in Object(model))) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(
+            proofDir,
+            `${process.env.OPENCLAW_UI_PROOF_LABEL ?? "agent-context"}.png`,
+          ),
         });
+      }
 
-        const response = await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
-        expect(response?.status()).toBe(200);
-        await gateway.waitForRequest("agents.list");
-        await gateway.waitForRequest("config.get");
-        const agentPicker = page.locator("openclaw-agents-page openclaw-agent-select");
-        await agentPicker.locator(".agent-select__trigger").click();
-        // Switching agents is the user action under test; the Tools panel must survive it.
-        await agentPicker
-          .locator("wa-dropdown-item[data-agent-option]")
-          .filter({ hasText: "Writer" })
-          .evaluate((item) => (item as HTMLElement).click());
-        await expect
-          .poll(() =>
-            agentPicker.evaluate((picker) => (picker as HTMLElement & { value: string }).value),
-          )
-          .toBe("writer");
-        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/agents/writer/tools");
-        await page.getByRole("tab", { name: "Overview", exact: true }).click();
-        await expect
-          .poll(() => new URL(page.url()).pathname)
-          .toBe("/settings/agents/writer/overview");
+      await expect
+        .poll(() => page.locator(".workspace-link").textContent())
+        .toContain(writerWorkspace);
+      const modelDescription = page
+        .locator(".settings-kv dt")
+        .filter({ hasText: "Primary Model" })
+        .locator("xpath=following-sibling::dd[1]");
+      const displayedModel = expectedFallbacks.length
+        ? `${primaryModel} (+${expectedFallbacks.length} fallback)`
+        : primaryModel;
+      await expect.poll(() => modelDescription.textContent()).toContain(displayedModel);
 
-        if (captureUiProof && model && !("primary" in Object(model))) {
-          await page.screenshot({
-            animations: "disabled",
-            fullPage: true,
-            path: path.join(
-              proofDir,
-              `${process.env.OPENCLAW_UI_PROOF_LABEL ?? "agent-context"}.png`,
-            ),
-          });
-        }
-
-        await expect
-          .poll(() => page.locator(".workspace-link").textContent())
-          .toContain(writerWorkspace);
-        const modelDescription = page
-          .locator(".settings-kv dt")
-          .filter({ hasText: "Primary Model" })
-          .locator("xpath=following-sibling::dd[1]");
-        const displayedModel = expectedFallbacks.length
-          ? `${primaryModel} (+${expectedFallbacks.length} fallback)`
-          : primaryModel;
-        await expect.poll(() => modelDescription.textContent()).toContain(displayedModel);
-
-        const fallbackInput = page.locator(".agent-chip-input");
-        await fallbackInput.waitFor({ timeout: 10_000 });
-        await expect
-          .poll(async () =>
-            (await fallbackInput.locator(".chip").allTextContents()).map((value) =>
-              value.replace("×", "").trim(),
-            ),
-          )
-          .toEqual(expectedFallbacks);
-        expect(await gateway.getRequests("config.set")).toHaveLength(0);
-      },
-    );
+      const fallbackInput = page.locator(".agent-chip-input");
+      await fallbackInput.waitFor({ timeout: 10_000 });
+      await expect
+        .poll(async () =>
+          (await fallbackInput.locator(".chip").allTextContents()).map((value) =>
+            value.replace("×", "").trim(),
+          ),
+        )
+        .toEqual(expectedFallbacks);
+      expect(await gateway.getRequests("config.set")).toHaveLength(0);
+    });
   });
 });

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -4,7 +4,10 @@ import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI agent picker avatar timeout",
@@ -34,91 +37,84 @@ async function screenshot(page: Page, name: string) {
 
 suite.define(() => {
   it("aborts a stalled authenticated avatar request and keeps the text fallback", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await page.clock.install();
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await page.clock.install();
 
-        let avatarRequestCount = 0;
-        let avatarAuthorization: string | undefined;
-        const failedAvatarRequests: string[] = [];
-        page.on("requestfailed", (request) => {
-          if (new URL(request.url()).pathname === "/avatar/main") {
-            failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
-          }
-        });
-        await page.route(/\/avatar\/main$/, (route) => {
-          avatarRequestCount += 1;
-          avatarAuthorization = route.request().headers().authorization;
-          // Leave the route unanswered. The page-owned deadline must cancel it.
-        });
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "agent.identity.get": {
-              cases: [
-                {
-                  match: { agentId: "main" },
-                  response: {
-                    agentId: "main",
-                    avatar: "/avatar/main",
-                    avatarStatus: "local",
-                    name: "Main agent",
-                  },
+      let avatarRequestCount = 0;
+      let avatarAuthorization: string | undefined;
+      const failedAvatarRequests: string[] = [];
+      page.on("requestfailed", (request) => {
+        if (new URL(request.url()).pathname === "/avatar/main") {
+          failedAvatarRequests.push(request.failure()?.errorText ?? "unknown");
+        }
+      });
+      await page.route(/\/avatar\/main$/, (route) => {
+        avatarRequestCount += 1;
+        avatarAuthorization = route.request().headers().authorization;
+        // Leave the route unanswered. The page-owned deadline must cancel it.
+      });
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "agent.identity.get": {
+            cases: [
+              {
+                match: { agentId: "main" },
+                response: {
+                  agentId: "main",
+                  avatar: "/avatar/main",
+                  avatarStatus: "local",
+                  name: "Main agent",
                 },
-                {
-                  match: { agentId: "writer" },
-                  response: {
-                    agentId: "writer",
-                    avatar: "",
-                    avatarStatus: "none",
-                    name: "Writer",
-                  },
+              },
+              {
+                match: { agentId: "writer" },
+                response: {
+                  agentId: "writer",
+                  avatar: "",
+                  avatarStatus: "none",
+                  name: "Writer",
                 },
-              ],
-            },
-            "agents.list": {
-              agents: [
-                { id: "main", name: "OpenClaw" },
-                { id: "writer", name: "Writer" },
-              ],
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-            },
+              },
+            ],
           },
-        });
+          "agents.list": {
+            agents: [
+              { id: "main", name: "OpenClaw" },
+              { id: "writer", name: "Writer" },
+            ],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}agents`);
-        expect(response?.status()).toBe(200);
-        await gateway.waitForRequest("agent.identity.get");
-        await expect.poll(() => avatarRequestCount).toBe(1);
-        const picker = page.locator("openclaw-agent-select");
-        await expect
-          .poll(() =>
-            picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
-          )
-          .toBe("O");
-        expect(avatarAuthorization).toBe("Bearer e2e-device-token");
-        await screenshot(page, "01-request-stalled.png");
+      const response = await page.goto(`${suite.server.baseUrl}agents`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("agent.identity.get");
+      await expect.poll(() => avatarRequestCount).toBe(1);
+      const picker = page.locator("openclaw-agent-select");
+      await expect
+        .poll(() =>
+          picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
+        )
+        .toBe("O");
+      expect(avatarAuthorization).toBe("Bearer e2e-device-token");
+      await screenshot(page, "01-request-stalled.png");
 
-        await page.clock.runFor(30_000);
-        await expect.poll(() => failedAvatarRequests.length).toBe(1);
-        await expect.poll(() => picker.locator("img.agent-select__avatar").count()).toBe(0);
-        await expect
-          .poll(() =>
-            picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
-          )
-          .toBe("O");
+      await page.clock.runFor(30_000);
+      await expect.poll(() => failedAvatarRequests.length).toBe(1);
+      await expect.poll(() => picker.locator("img.agent-select__avatar").count()).toBe(0);
+      await expect
+        .poll(() =>
+          picker.locator(".agent-select__avatar--text").first().getAttribute("data-avatar"),
+        )
+        .toBe("O");
 
-        // A later render must use the cached miss instead of launching another fetch.
-        await picker.locator(".agent-select__trigger").click();
-        expect(avatarRequestCount).toBe(1);
-        await screenshot(page, "02-timeout-fallback.png");
-      },
-    );
+      // A later render must use the cached miss instead of launching another fetch.
+      await picker.locator(".agent-select__trigger").click();
+      expect(avatarRequestCount).toBe(1);
+      await screenshot(page, "02-timeout-fallback.png");
+    });
   });
 });

--- a/ui/src/e2e/agents-set-default-persistence.e2e.test.ts
+++ b/ui/src/e2e/agents-set-default-persistence.e2e.test.ts
@@ -2,7 +2,10 @@
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { expect, it } from "vitest";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI agents Set Default mocked Gateway E2E",
@@ -19,69 +22,62 @@ function requestParams(request: MockGatewayRequest): Record<string, unknown> {
 
 suite.define(() => {
   it("persists Set Default through config.set instead of only staging the form draft", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const initialConfig = {
-          agents: { entries: { main: { default: true }, kimi: {} } },
-        };
-        const savedConfig = {
-          agents: { entries: { main: {}, kimi: { default: true } } },
-        };
-        const gateway = await installMockGateway(page, {
-          assistantName: "Main agent",
-          defaultAgentId: "main",
-          methodResponses: {
-            "agents.list": {
-              agents: [
-                { id: "main", name: "Main agent" },
-                { id: "kimi", name: "Kimi agent" },
-              ],
-              defaultId: "main",
-              mainKey: "main",
-              scope: "agent",
-            },
-            "config.get": {
-              config: initialConfig,
-              sourceConfig: initialConfig,
-              hash: "hash-1",
-              issues: [],
-              raw: JSON.stringify(initialConfig),
-              valid: true,
-            },
-            "config.set": {
-              config: savedConfig,
-              sourceConfig: savedConfig,
-              hash: "hash-2",
-              issues: [],
-              raw: JSON.stringify(savedConfig),
-              valid: true,
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const initialConfig = {
+        agents: { entries: { main: { default: true }, kimi: {} } },
+      };
+      const savedConfig = {
+        agents: { entries: { main: {}, kimi: { default: true } } },
+      };
+      const gateway = await installMockGateway(page, {
+        assistantName: "Main agent",
+        defaultAgentId: "main",
+        methodResponses: {
+          "agents.list": {
+            agents: [
+              { id: "main", name: "Main agent" },
+              { id: "kimi", name: "Kimi agent" },
+            ],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
           },
-        });
+          "config.get": {
+            config: initialConfig,
+            sourceConfig: initialConfig,
+            hash: "hash-1",
+            issues: [],
+            raw: JSON.stringify(initialConfig),
+            valid: true,
+          },
+          "config.set": {
+            config: savedConfig,
+            sourceConfig: savedConfig,
+            hash: "hash-2",
+            issues: [],
+            raw: JSON.stringify(savedConfig),
+            valid: true,
+          },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}agents`);
-        expect(response?.status()).toBe(200);
+      const response = await page.goto(`${suite.server.baseUrl}agents`);
+      expect(response?.status()).toBe(200);
 
-        // Click auto-waits for the elements to be actionable (enabled), so
-        // these implicitly assert the dropdown loaded and Set Default is clickable for a
-        // non-default agent.
-        const agentSelect = page.locator("wa-dropdown.agent-select");
-        await agentSelect.locator(".agent-select__trigger").click();
-        await agentSelect.getByRole("menuitemradio", { name: "Kimi agent", exact: true }).click();
-        await page.getByRole("button", { name: "Set Default", exact: true }).click();
+      // Click auto-waits for the elements to be actionable (enabled), so
+      // these implicitly assert the dropdown loaded and Set Default is clickable for a
+      // non-default agent.
+      const agentSelect = page.locator("wa-dropdown.agent-select");
+      await agentSelect.locator(".agent-select__trigger").click();
+      await agentSelect.getByRole("menuitemradio", { name: "Kimi agent", exact: true }).click();
+      await page.getByRole("button", { name: "Set Default", exact: true }).click();
 
-        // The fix routes Set Default through the canonical save path; without it the click
-        // only stages a form draft and never emits config.set, so this request never arrives.
-        const setRequest = await gateway.waitForRequest("config.set");
-        const raw = requestParams(setRequest).raw;
-        expect(JSON.parse(String(raw))).toEqual(savedConfig);
-        expect(requireRecord(JSON.parse(String(raw))).agents).not.toHaveProperty("list");
-      },
-    );
+      // The fix routes Set Default through the canonical save path; without it the click
+      // only stages a form draft and never emits config.set, so this request never arrives.
+      const setRequest = await gateway.waitForRequest("config.set");
+      const raw = requestParams(setRequest).raw;
+      expect(JSON.parse(String(raw))).toEqual(savedConfig);
+      expect(requireRecord(JSON.parse(String(raw))).agents).not.toHaveProperty("list");
+    });
   });
 });

--- a/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
+++ b/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI browser screenshot failed-body E2E",
@@ -22,193 +25,183 @@ beforeEach(() => {
 
 suite.define(() => {
   it("keeps the status error visible and cancels the unread media body", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await page.addInitScript(() => {
-          localStorage.removeItem("openclaw.browser.panel.v1");
-          const originalFetch = window.fetch.bind(window);
-          window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
-            const response = await originalFetch(input, init);
-            const url =
-              typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-            if (!url.includes("/__openclaw__/assistant-media")) {
-              return response;
-            }
-            const source = response.body;
-            if (!source) {
-              return response;
-            }
-            type ScreenshotProof = {
-              cancelCount: number;
-              cancelResolvedCount: number;
-              fetchCount: number;
-              statuses: number[];
-            };
-            const proofWindow = window as Window & { openclawScreenshotProof?: ScreenshotProof };
-            const proof = (proofWindow.openclawScreenshotProof ??= {
-              cancelCount: 0,
-              cancelResolvedCount: 0,
-              fetchCount: 0,
-              statuses: [],
-            });
-            proof.fetchCount += 1;
-            proof.statuses.push(response.status);
-            const originalCancel = source.cancel.bind(source);
-            source.cancel = async (reason) => {
-              proof.cancelCount += 1;
-              await originalCancel(reason);
-              proof.cancelResolvedCount += 1;
-            };
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await page.addInitScript(() => {
+        localStorage.removeItem("openclaw.browser.panel.v1");
+        const originalFetch = window.fetch.bind(window);
+        window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+          const response = await originalFetch(input, init);
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+          if (!url.includes("/__openclaw__/assistant-media")) {
             return response;
+          }
+          const source = response.body;
+          if (!source) {
+            return response;
+          }
+          type ScreenshotProof = {
+            cancelCount: number;
+            cancelResolvedCount: number;
+            fetchCount: number;
+            statuses: number[];
           };
-        });
-        let mediaRequest: { authorization: string; source: string | null } | null = null;
-        await page.route("**/__openclaw__/assistant-media**", (route) => {
-          const request = route.request();
-          mediaRequest = {
-            authorization: request.headers().authorization ?? "",
-            source: new URL(request.url()).searchParams.get("source"),
+          const proofWindow = window as Window & { openclawScreenshotProof?: ScreenshotProof };
+          const proof = (proofWindow.openclawScreenshotProof ??= {
+            cancelCount: 0,
+            cancelResolvedCount: 0,
+            fetchCount: 0,
+            statuses: [],
+          });
+          proof.fetchCount += 1;
+          proof.statuses.push(response.status);
+          const originalCancel = source.cancel.bind(source);
+          source.cancel = async (reason) => {
+            proof.cancelCount += 1;
+            await originalCancel(reason);
+            proof.cancelResolvedCount += 1;
           };
-          return route.fulfill({
-            body: "screenshot unavailable",
-            contentType: "text/plain; charset=utf-8",
-            status: 404,
-          });
+          return response;
+        };
+      });
+      let mediaRequest: { authorization: string; source: string | null } | null = null;
+      await page.route("**/__openclaw__/assistant-media**", (route) => {
+        const request = route.request();
+        mediaRequest = {
+          authorization: request.headers().authorization ?? "",
+          source: new URL(request.url()).searchParams.get("source"),
+        };
+        return route.fulfill({
+          body: "screenshot unavailable",
+          contentType: "text/plain; charset=utf-8",
+          status: 404,
         });
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "browser.request"],
-          methodResponses: {
-            "browser.request": {
-              cases: [
-                {
-                  match: { method: "GET", path: "/tabs" },
-                  response: {
-                    running: true,
-                    tabs: [
-                      {
-                        targetId: "target-1",
-                        tabId: "t1",
-                        title: "Example",
-                        url: "https://example.test/",
-                      },
-                    ],
-                  },
-                },
-                {
-                  match: { method: "POST", path: "/screenshot" },
-                  response: {
-                    path: "/proof/missing.png",
-                    targetId: "target-1",
-                    url: "https://example.test/",
-                  },
-                },
-              ],
-            },
-          },
-        });
-
-        const response = await page.goto(`${suite.server.baseUrl}chat`);
-        expect(response?.status()).toBe(200);
-        await openChatSidePanelType(page, "Files");
-        await openChatSidePanelType(page, "Browser");
-
-        const panel = page.locator("section.bp");
-        await panel.waitFor();
-        await expect
-          .poll(async () =>
-            (await gateway.getRequests("browser.request")).map((request) => request.params),
-          )
-          .toContainEqual({
-            body: { targetId: "t1", type: "png" },
-            method: "POST",
-            path: "/screenshot",
-          });
-        const alert = panel.getByRole("alert");
-        await alert.waitFor();
-        expect(await alert.textContent()).toBe(
-          "Browser request failed: Screenshot fetch failed (404).",
-        );
-        await expect
-          .poll(() =>
-            page.evaluate(
-              () =>
-                (
-                  window as Window & {
-                    openclawScreenshotProof?: {
-                      cancelCount?: number;
-                      cancelResolvedCount?: number;
-                      fetchCount?: number;
-                      statuses?: number[];
-                    };
-                  }
-                ).openclawScreenshotProof,
-            ),
-          )
-          .toEqual({
-            cancelCount: 1,
-            cancelResolvedCount: 1,
-            fetchCount: 1,
-            statuses: [404],
-          });
-
-        const requests = await gateway.getRequests("browser.request");
-        const requestParams = requests.map(
-          (request) => request.params as { method?: string; path?: string; body?: unknown },
-        );
-        expect(requestParams).toContainEqual({ method: "GET", path: "/tabs" });
-        expect(
-          requestParams.filter(
-            (params) => params.method === "POST" && params.path === "/screenshot",
-          ),
-        ).toEqual([
-          {
-            body: { targetId: "t1", type: "png" },
-            method: "POST",
-            path: "/screenshot",
-          },
-        ]);
-        expect(mediaRequest).toEqual({
-          authorization: "Bearer e2e-device-token",
-          source: "/proof/missing.png",
-        });
-
-        if (captureUiProofEnabled) {
-          await page.screenshot({
-            animations: "disabled",
-            path: path.join(proofDir, "failed-screenshot.png"),
-          });
-          const stream = await page.evaluate(
-            () =>
-              (window as Window & { openclawScreenshotProof?: unknown }).openclawScreenshotProof,
-          );
-          await writeFile(
-            path.join(proofDir, "proof.json"),
-            `${JSON.stringify(
+      });
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "browser.request"],
+        methodResponses: {
+          "browser.request": {
+            cases: [
               {
-                error: (await alert.textContent())?.trim() ?? "",
-                mediaRequest,
-                requests,
-                stream,
+                match: { method: "GET", path: "/tabs" },
+                response: {
+                  running: true,
+                  tabs: [
+                    {
+                      targetId: "target-1",
+                      tabId: "t1",
+                      title: "Example",
+                      url: "https://example.test/",
+                    },
+                  ],
+                },
               },
-              null,
-              2,
-            )}\n`,
-          );
-          console.log(
-            `CONTROL_UI_BROWSER_SCREENSHOT_PROOF=${JSON.stringify({
+              {
+                match: { method: "POST", path: "/screenshot" },
+                response: {
+                  path: "/proof/missing.png",
+                  targetId: "target-1",
+                  url: "https://example.test/",
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      await openChatSidePanelType(page, "Files");
+      await openChatSidePanelType(page, "Browser");
+
+      const panel = page.locator("section.bp");
+      await panel.waitFor();
+      await expect
+        .poll(async () =>
+          (await gateway.getRequests("browser.request")).map((request) => request.params),
+        )
+        .toContainEqual({
+          body: { targetId: "t1", type: "png" },
+          method: "POST",
+          path: "/screenshot",
+        });
+      const alert = panel.getByRole("alert");
+      await alert.waitFor();
+      expect(await alert.textContent()).toBe(
+        "Browser request failed: Screenshot fetch failed (404).",
+      );
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (
+                window as Window & {
+                  openclawScreenshotProof?: {
+                    cancelCount?: number;
+                    cancelResolvedCount?: number;
+                    fetchCount?: number;
+                    statuses?: number[];
+                  };
+                }
+              ).openclawScreenshotProof,
+          ),
+        )
+        .toEqual({
+          cancelCount: 1,
+          cancelResolvedCount: 1,
+          fetchCount: 1,
+          statuses: [404],
+        });
+
+      const requests = await gateway.getRequests("browser.request");
+      const requestParams = requests.map(
+        (request) => request.params as { method?: string; path?: string; body?: unknown },
+      );
+      expect(requestParams).toContainEqual({ method: "GET", path: "/tabs" });
+      expect(
+        requestParams.filter((params) => params.method === "POST" && params.path === "/screenshot"),
+      ).toEqual([
+        {
+          body: { targetId: "t1", type: "png" },
+          method: "POST",
+          path: "/screenshot",
+        },
+      ]);
+      expect(mediaRequest).toEqual({
+        authorization: "Bearer e2e-device-token",
+        source: "/proof/missing.png",
+      });
+
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(proofDir, "failed-screenshot.png"),
+        });
+        const stream = await page.evaluate(
+          () => (window as Window & { openclawScreenshotProof?: unknown }).openclawScreenshotProof,
+        );
+        await writeFile(
+          path.join(proofDir, "proof.json"),
+          `${JSON.stringify(
+            {
               error: (await alert.textContent())?.trim() ?? "",
               mediaRequest,
-              requests: requests.map((request) => request.params),
+              requests,
               stream,
-            })}`,
-          );
-        }
-      },
-    );
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        console.log(
+          `CONTROL_UI_BROWSER_SCREENSHOT_PROOF=${JSON.stringify({
+            error: (await alert.textContent())?.trim() ?? "",
+            mediaRequest,
+            requests: requests.map((request) => request.params),
+            stream,
+          })}`,
+        );
+      }
+    });
   });
 });

--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -4,7 +4,10 @@ import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI Unicode build identity mocked Gateway E2E",
@@ -101,51 +104,44 @@ async function assertFullBranchLabel(page: Page) {
 
 suite.define(() => {
   it("keeps slow build-link navigation intact across Unicode boundaries and reload", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page);
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page);
 
-        const response = await page.goto(`${suite.server.baseUrl}chat`);
-        expect(response?.status()).toBe(200);
-        const identityCard = page.locator(".sidebar-identity-card");
-        await expect
-          .poll(async () => {
-            // The compact build identity lives in the identity button's
-            // aria-label; the visible subtitle span was removed as dead markup.
-            const ariaLabel = (await identityCard.getAttribute("aria-label")) ?? "";
-            const detail = ariaLabel.split(": ").slice(1).join(": ");
-            const [gitIdentity, relativeAge] = detail.trim().split(" · ", 2);
-            return { gitIdentity, hasRelativeAge: Boolean(relativeAge?.trim()) };
-          })
-          .toEqual({
-            gitIdentity: `${COMPACT_BRANCH}@0123456*`,
-            hasRelativeAge: true,
-          });
+      const response = await page.goto(`${suite.server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      const identityCard = page.locator(".sidebar-identity-card");
+      await expect
+        .poll(async () => {
+          // The compact build identity lives in the identity button's
+          // aria-label; the visible subtitle span was removed as dead markup.
+          const ariaLabel = (await identityCard.getAttribute("aria-label")) ?? "";
+          const detail = ariaLabel.split(": ").slice(1).join(": ");
+          const [gitIdentity, relativeAge] = detail.trim().split(" · ", 2);
+          return { gitIdentity, hasRelativeAge: Boolean(relativeAge?.trim()) };
+        })
+        .toEqual({
+          gitIdentity: `${COMPACT_BRANCH}@0123456*`,
+          hasRelativeAge: true,
+        });
 
-        if (captureUiProofEnabled) {
-          await identityCard.screenshot({
-            animations: "disabled",
-            path: path.join(uiProofArtifactDir, "00-footer-custom-build-identity.png"),
-          });
-        }
+      if (captureUiProofEnabled) {
+        await identityCard.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "00-footer-custom-build-identity.png"),
+        });
+      }
 
-        await openBuildDetails(page);
-        await assertFullBranchLabel(page);
-        await page.reload();
-        await assertFullBranchLabel(page);
+      await openBuildDetails(page);
+      await assertFullBranchLabel(page);
+      await page.reload();
+      await assertFullBranchLabel(page);
 
-        if (captureUiProofEnabled) {
-          await page.screenshot({
-            animations: "disabled",
-            path: path.join(uiProofArtifactDir, "01-about-build-identity.png"),
-          });
-        }
-      },
-    );
+      if (captureUiProofEnabled) {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(uiProofArtifactDir, "01-about-build-identity.png"),
+        });
+      }
+    });
   });
 });

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -8,7 +8,10 @@ import {
   type MockGatewayControls,
   waitForControlUiRoute,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "active turn recovery",
@@ -236,11 +239,7 @@ async function finishRecoveredTurn(
 }
 
 async function openActiveTurn(scenario: Parameters<typeof installMockGateway>[1] = {}) {
-  const context = await suite.newBrowserContext({
-    locale: "en-US",
-    serviceWorkers: "block",
-    viewport: { height: 900, width: 1280 },
-  });
+  const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
   const page = await context.newPage();
   const gateway = await installMockGateway(page, scenario);
   await page.goto(`${suite.server.baseUrl}chat`);

--- a/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-read-lifecycle.e2e.test.ts
@@ -12,7 +12,10 @@ import {
   installMockGateway,
   navigateToControlUiSession,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 import { waitForCommittedComposerDraft, waitForCommittedState } from "./settle.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -99,335 +102,316 @@ suite.define(() => {
   ])(
     "admits $expectedTurns turn(s) from $gesture during terminal history (attachment=$attachment)",
     async ({ attachment, gesture, expectedTurns }) => {
-      await suite.withPage(
-        {
-          locale: "en-US",
-          serviceWorkers: "block",
-          viewport: { height: 900, width: 1280 },
-        },
-        async ({ page }) => {
-          const held = gesture === "held Enter";
-          const capture = held && attachment;
-          const proofDir = path.resolve(
-            process.env.OPENCLAW_UI_E2E_DIAGNOSTIC_DIR?.trim() || ".artifacts/control-ui-e2e",
-            "held-enter",
+      await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+        const held = gesture === "held Enter";
+        const capture = held && attachment;
+        const proofDir = path.resolve(
+          process.env.OPENCLAW_UI_E2E_DIAGNOSTIC_DIR?.trim() || ".artifacts/control-ui-e2e",
+          "held-enter",
+        );
+        if (capture) {
+          await mkdir(proofDir, { recursive: true });
+          await Promise.all(
+            ["held-enter-before.png", "held-enter-after.png"].map((name) =>
+              rm(path.join(proofDir, name), { force: true }),
+            ),
           );
-          if (capture) {
-            await mkdir(proofDir, { recursive: true });
-            await Promise.all(
-              ["held-enter-before.png", "held-enter-after.png"].map((name) =>
-                rm(path.join(proofDir, name), { force: true }),
-              ),
-            );
-          }
-          const ready = {
-            content: [{ text: "Ready for the held Enter check.", type: "text" }],
-            role: "assistant",
-            __openclaw: { id: "held-enter-ready", seq: 1 },
-          };
-          const gateway = await installMockGateway(page, { historyMessages: [ready] });
-          const pageErrors: string[] = [];
-          page.on("pageerror", (error) => pageErrors.push(error.message));
-          await page.goto(controlUiSessionUrl(suite.server.baseUrl, "main"));
-          const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
-          const composer = pane.locator(".agent-chat__composer-combobox textarea");
-          await pane.getByText("Ready for the held Enter check.", { exact: true }).waitFor();
-          await gateway.waitForRequest("chat.startup");
-          const initialText = "Finish the initial synthetic turn.";
-          await composer.fill(initialText);
-          await composer.press("Enter");
-          const initial = await gateway.waitForRequest("chat.send");
-          expect(initial.params).toMatchObject({
-            idempotencyKey: expect.any(String),
-            message: initialText,
-            sessionKey: "agent:main:main",
-          });
-          const initialRunId = (initial.params as { idempotencyKey: string }).idempotencyKey;
-          expect(initialRunId).not.toBe("");
-          await pane.getByRole("button", { name: "Stop generating" }).waitFor();
+        }
+        const ready = {
+          content: [{ text: "Ready for the held Enter check.", type: "text" }],
+          role: "assistant",
+          __openclaw: { id: "held-enter-ready", seq: 1 },
+        };
+        const gateway = await installMockGateway(page, { historyMessages: [ready] });
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(error.message));
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, "main"));
+        const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+        const composer = pane.locator(".agent-chat__composer-combobox textarea");
+        await pane.getByText("Ready for the held Enter check.", { exact: true }).waitFor();
+        await gateway.waitForRequest("chat.startup");
+        const initialText = "Finish the initial synthetic turn.";
+        await composer.fill(initialText);
+        await composer.press("Enter");
+        const initial = await gateway.waitForRequest("chat.send");
+        expect(initial.params).toMatchObject({
+          idempotencyKey: expect.any(String),
+          message: initialText,
+          sessionKey: "agent:main:main",
+        });
+        const initialRunId = (initial.params as { idempotencyKey: string }).idempotencyKey;
+        expect(initialRunId).not.toBe("");
+        await pane.getByRole("button", { name: "Stop generating" }).waitFor();
 
-          const followUpText = attachment ? "" : "Submit this follow-up once per key press.";
-          const fileName = "held-enter.txt";
-          const fileContents = "Synthetic held Enter attachment contents.";
-          await composer.fill(followUpText);
-          if (attachment) {
-            await pane.locator(".agent-chat__file-input").setInputFiles({
-              name: fileName,
-              mimeType: "text/plain",
-              buffer: Buffer.from(fileContents),
-            });
-            await pane.locator(".chat-attachment-thumb", { hasText: fileName }).waitFor();
-          }
-          const terminalText = "The initial synthetic turn completed.";
-          const terminalMessage = {
-            content: [{ text: terminalText, type: "text" }],
-            role: "assistant",
-            __openclaw: { id: "held-enter-terminal", seq: 3 },
-          };
-          const historyMessages = [
-            ready,
-            {
-              content: [{ text: initialText, type: "text" }],
-              role: "user",
-              __openclaw: {
-                id: "held-enter-initial-user",
-                idempotencyKey: `${initialRunId}:user`,
-                seq: 2,
-              },
+        const followUpText = attachment ? "" : "Submit this follow-up once per key press.";
+        const fileName = "held-enter.txt";
+        const fileContents = "Synthetic held Enter attachment contents.";
+        await composer.fill(followUpText);
+        if (attachment) {
+          await pane.locator(".agent-chat__file-input").setInputFiles({
+            name: fileName,
+            mimeType: "text/plain",
+            buffer: Buffer.from(fileContents),
+          });
+          await pane.locator(".chat-attachment-thumb", { hasText: fileName }).waitFor();
+        }
+        const terminalText = "The initial synthetic turn completed.";
+        const terminalMessage = {
+          content: [{ text: terminalText, type: "text" }],
+          role: "assistant",
+          __openclaw: { id: "held-enter-terminal", seq: 3 },
+        };
+        const historyMessages = [
+          ready,
+          {
+            content: [{ text: initialText, type: "text" }],
+            role: "user",
+            __openclaw: {
+              id: "held-enter-initial-user",
+              idempotencyKey: `${initialRunId}:user`,
+              seq: 2,
             },
-            terminalMessage,
-          ];
-          await gateway.setHistoryMessages(historyMessages);
-          const historyBefore = (await gateway.getRequests("chat.history")).length;
-          await gateway.deferNext("chat.history");
-          await gateway.emitChatFinal({ runId: initialRunId, text: terminalText });
-          await pane
-            .locator(".chat-group.assistant .chat-bubble")
-            .getByText(terminalText, { exact: true })
-            .waitFor();
-          await gateway.emitGatewayEvent("session.message", {
+          },
+          terminalMessage,
+        ];
+        await gateway.setHistoryMessages(historyMessages);
+        const historyBefore = (await gateway.getRequests("chat.history")).length;
+        await gateway.deferNext("chat.history");
+        await gateway.emitChatFinal({ runId: initialRunId, text: terminalText });
+        await pane
+          .locator(".chat-group.assistant .chat-bubble")
+          .getByText(terminalText, { exact: true })
+          .waitFor();
+        await gateway.emitGatewayEvent("session.message", {
+          activeRunIds: [],
+          clientRunId: initialRunId,
+          hasActiveRun: false,
+          message: terminalMessage,
+          messageId: "held-enter-terminal",
+          messageSeq: 3,
+          session: {
             activeRunIds: [],
-            clientRunId: initialRunId,
             hasActiveRun: false,
-            message: terminalMessage,
-            messageId: "held-enter-terminal",
-            messageSeq: 3,
-            session: {
+            key: "agent:main:main",
+            status: "done",
+          },
+          sessionKey: "agent:main:main",
+        });
+        await gateway.waitForRequest("chat.history", { after: historyBefore });
+        await expect
+          .poll(() => pane.getByRole("button", { name: "Send message" }).isEnabled())
+          .toBe(true);
+        expect(await composer.inputValue()).toBe(followUpText);
+        expect(await pane.locator(".chat-attachment-thumb").count()).toBe(attachment ? 1 : 0);
+        expect(await pane.locator(".chat-queue__item").count()).toBe(0);
+        await composer.click();
+        expect(
+          await composer.evaluate((element) => ({
+            focused: document.hasFocus() && document.activeElement === element,
+            visibility: document.visibilityState,
+          })),
+        ).toEqual({ focused: true, visibility: "visible" });
+        if (capture) {
+          await pane.screenshot({ path: path.join(proofDir, "held-enter-before.png") });
+        }
+
+        const keyProof = await composer.evaluateHandle((element) => {
+          const textarea = element as HTMLTextAreaElement;
+          const events: Array<{ isTrusted: boolean; repeat: boolean }> = [];
+          const record = (event: KeyboardEvent) => {
+            if (event.key === "Enter" && events.length < 4) {
+              events.push({ isTrusted: event.isTrusted, repeat: event.repeat });
+            }
+          };
+          textarea.addEventListener("keydown", record, true);
+          return {
+            events,
+            dispose: () => textarea.removeEventListener("keydown", record, true),
+          };
+        });
+        try {
+          try {
+            await page.keyboard.down("Enter");
+            if (!held) {
+              await page.keyboard.up("Enter");
+            }
+            await page.keyboard.down("Enter");
+          } finally {
+            await page.keyboard.up("Enter");
+          }
+          const keys = await keyProof.evaluate((proof) => proof.events);
+          expect(keys).toEqual([
+            { isTrusted: true, repeat: false },
+            { isTrusted: true, repeat: held },
+          ]);
+          expect(await gateway.getRequests("chat.history")).toHaveLength(historyBefore + 1);
+          expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+          expect(await composer.inputValue()).toBe(followUpText);
+          expect(await pane.locator(".chat-attachment-thumb").count()).toBe(attachment ? 1 : 0);
+
+          const sendsBefore = (await gateway.getRequests("chat.send")).length;
+          await gateway.deferNext("chat.send");
+          await gateway.resolveDeferred("chat.history", {
+            messages: historyMessages,
+            sessionId: "session:agent:main:main",
+            sessionInfo: {
+              activeLeafEntryId: "held-enter-terminal",
               activeRunIds: [],
               hasActiveRun: false,
               key: "agent:main:main",
               status: "done",
             },
+            thinkingLevel: null,
+          });
+          const followUp = await gateway.waitForRequest("chat.send", { after: sendsBefore });
+          expect(followUp.params).toMatchObject({
+            expectedLeafEntryId: "held-enter-terminal",
+            idempotencyKey: expect.any(String),
+            message: followUpText,
             sessionKey: "agent:main:main",
+            ...(attachment
+              ? {
+                  attachments: [
+                    {
+                      content: Buffer.from(fileContents).toString("base64"),
+                      fileName,
+                      mimeType: "text/plain",
+                      type: "file",
+                    },
+                  ],
+                }
+              : {}),
           });
-          await gateway.waitForRequest("chat.history", { after: historyBefore });
-          await expect
-            .poll(() => pane.getByRole("button", { name: "Send message" }).isEnabled())
-            .toBe(true);
-          expect(await composer.inputValue()).toBe(followUpText);
-          expect(await pane.locator(".chat-attachment-thumb").count()).toBe(attachment ? 1 : 0);
-          expect(await pane.locator(".chat-queue__item").count()).toBe(0);
-          await composer.click();
-          expect(
-            await composer.evaluate((element) => ({
-              focused: document.hasFocus() && document.activeElement === element,
-              visibility: document.visibilityState,
-            })),
-          ).toEqual({ focused: true, visibility: "visible" });
-          if (capture) {
-            await pane.screenshot({ path: path.join(proofDir, "held-enter-before.png") });
+          const followUpRunId = (followUp.params as { idempotencyKey: string }).idempotencyKey;
+          expect(followUpRunId).not.toBe("");
+          expect(followUpRunId).not.toBe(initialRunId);
+          if (!attachment) {
+            expect(followUp.params).not.toHaveProperty("attachments");
           }
 
-          const keyProof = await composer.evaluateHandle((element) => {
-            const textarea = element as HTMLTextAreaElement;
-            const events: Array<{ isTrusted: boolean; repeat: boolean }> = [];
-            const record = (event: KeyboardEvent) => {
-              if (event.key === "Enter" && events.length < 4) {
-                events.push({ isTrusted: event.isTrusted, repeat: event.repeat });
-              }
-            };
-            textarea.addEventListener("keydown", record, true);
-            return {
-              events,
-              dispose: () => textarea.removeEventListener("keydown", record, true),
-            };
-          });
-          try {
-            try {
-              await page.keyboard.down("Enter");
-              if (!held) {
-                await page.keyboard.up("Enter");
-              }
-              await page.keyboard.down("Enter");
-            } finally {
-              await page.keyboard.up("Enter");
-            }
-            const keys = await keyProof.evaluate((proof) => proof.events);
-            expect(keys).toEqual([
-              { isTrusted: true, repeat: false },
-              { isTrusted: true, repeat: held },
-            ]);
-            expect(await gateway.getRequests("chat.history")).toHaveLength(historyBefore + 1);
-            expect(await gateway.getRequests("chat.send")).toHaveLength(1);
-            expect(await composer.inputValue()).toBe(followUpText);
-            expect(await pane.locator(".chat-attachment-thumb").count()).toBe(attachment ? 1 : 0);
-
-            const sendsBefore = (await gateway.getRequests("chat.send")).length;
-            await gateway.deferNext("chat.send");
-            await gateway.resolveDeferred("chat.history", {
-              messages: historyMessages,
-              sessionId: "session:agent:main:main",
-              sessionInfo: {
-                activeLeafEntryId: "held-enter-terminal",
-                activeRunIds: [],
-                hasActiveRun: false,
-                key: "agent:main:main",
-                status: "done",
-              },
-              thinkingLevel: null,
-            });
-            const followUp = await gateway.waitForRequest("chat.send", { after: sendsBefore });
-            expect(followUp.params).toMatchObject({
-              expectedLeafEntryId: "held-enter-terminal",
-              idempotencyKey: expect.any(String),
-              message: followUpText,
-              sessionKey: "agent:main:main",
-              ...(attachment
-                ? {
-                    attachments: [
-                      {
-                        content: Buffer.from(fileContents).toString("base64"),
-                        fileName,
-                        mimeType: "text/plain",
-                        type: "file",
-                      },
-                    ],
-                  }
-                : {}),
-            });
-            const followUpRunId = (followUp.params as { idempotencyKey: string }).idempotencyKey;
-            expect(followUpRunId).not.toBe("");
-            expect(followUpRunId).not.toBe(initialRunId);
-            if (!attachment) {
-              expect(followUp.params).not.toHaveProperty("attachments");
-            }
-
-            // Both held-history continuations enqueue synchronously before their
-            // next await. Cross a committed render boundary, not a transient count=1.
-            await waitForCommittedState(
-              page,
-              () => {
-                const active = document.querySelector('openclaw-chat-pane[aria-hidden="false"]');
-                const input = active?.querySelector(".agent-chat__composer-combobox textarea");
-                return (
-                  input instanceof HTMLTextAreaElement &&
-                  input.value === "" &&
-                  active?.querySelectorAll(".chat-attachment-thumb").length === 0
-                );
-              },
-              {},
-            );
-            // The held ACK keeps the first turn in the transcript; later
-            // waiting turns remain in the composer queue. Read both together.
-            const observed = await pane.evaluate(
-              (active, followUpContent) => {
-                const readRow = (row: Element, idAttribute: string) => {
-                  const rect = row.getBoundingClientRect();
-                  return {
-                    id: row.getAttribute(idAttribute),
-                    visible:
-                      rect.height > 0 &&
-                      rect.width > 0 &&
-                      rect.bottom > 0 &&
-                      rect.top < innerHeight,
-                  };
-                };
+          // Both held-history continuations enqueue synchronously before their
+          // next await. Cross a committed render boundary, not a transient count=1.
+          await waitForCommittedState(
+            page,
+            () => {
+              const active = document.querySelector('openclaw-chat-pane[aria-hidden="false"]');
+              const input = active?.querySelector(".agent-chat__composer-combobox textarea");
+              return (
+                input instanceof HTMLTextAreaElement &&
+                input.value === "" &&
+                active?.querySelectorAll(".chat-attachment-thumb").length === 0
+              );
+            },
+            {},
+          );
+          // The held ACK keeps the first turn in the transcript; later
+          // waiting turns remain in the composer queue. Read both together.
+          const observed = await pane.evaluate(
+            (active, followUpContent) => {
+              const readRow = (row: Element, idAttribute: string) => {
+                const rect = row.getBoundingClientRect();
                 return {
-                  bubbles: [...active.querySelectorAll(".chat-group.user .chat-bubble")]
-                    .filter((bubble) => bubble.textContent?.includes(followUpContent))
-                    .map((bubble) => readRow(bubble, "data-message-id")),
-                  queued: [
-                    ...active.querySelectorAll(".agent-chat__composer-shell .chat-queue__item"),
-                  ].map((row) => {
-                    const { id, visible } = readRow(row, "data-chat-queue-item");
-                    return {
-                      id,
-                      visible,
-                      text: row.querySelector(".chat-queue__text")?.textContent?.trim(),
-                    };
-                  }),
+                  id: row.getAttribute(idAttribute),
+                  visible:
+                    rect.height > 0 && rect.width > 0 && rect.bottom > 0 && rect.top < innerHeight,
                 };
-              },
-              attachment ? fileName : followUpText,
-            );
-            console.info("held-enter admission proof", {
-              attachment,
-              gesture,
-              keys,
-              followUpRequestId: followUp.id,
-              followUpRunId,
-              observed,
-            });
-            expect(pageErrors).toEqual([]);
-            if (capture) {
-              await pane.screenshot({ path: path.join(proofDir, "held-enter-after.png") });
-            }
-            expect(observed.bubbles.map((row) => row.id)).toEqual([`msg:send:${followUpRunId}:0`]);
-            for (const rows of [observed.bubbles, observed.queued]) {
-              expect(rows.every((row) => row.visible && row.id)).toBe(true);
-              expect(new Set(rows.map((row) => row.id)).size).toBe(rows.length);
-            }
-            expect(
-              observed.queued.every(
-                (row) => row.text === (attachment ? "Image (1)" : followUpText),
-              ),
-            ).toBe(true);
-            expect(observed.bubbles.length + observed.queued.length).toBe(expectedTurns);
-            expect(await gateway.getRequests("chat.send")).toHaveLength(sendsBefore + 1);
-          } finally {
-            try {
-              await keyProof.evaluate((proof) => proof.dispose());
-            } finally {
-              await keyProof.dispose();
-            }
+              };
+              return {
+                bubbles: [...active.querySelectorAll(".chat-group.user .chat-bubble")]
+                  .filter((bubble) => bubble.textContent?.includes(followUpContent))
+                  .map((bubble) => readRow(bubble, "data-message-id")),
+                queued: [
+                  ...active.querySelectorAll(".agent-chat__composer-shell .chat-queue__item"),
+                ].map((row) => {
+                  const { id, visible } = readRow(row, "data-chat-queue-item");
+                  return {
+                    id,
+                    visible,
+                    text: row.querySelector(".chat-queue__text")?.textContent?.trim(),
+                  };
+                }),
+              };
+            },
+            attachment ? fileName : followUpText,
+          );
+          console.info("held-enter admission proof", {
+            attachment,
+            gesture,
+            keys,
+            followUpRequestId: followUp.id,
+            followUpRunId,
+            observed,
+          });
+          expect(pageErrors).toEqual([]);
+          if (capture) {
+            await pane.screenshot({ path: path.join(proofDir, "held-enter-after.png") });
           }
-        },
-      );
+          expect(observed.bubbles.map((row) => row.id)).toEqual([`msg:send:${followUpRunId}:0`]);
+          for (const rows of [observed.bubbles, observed.queued]) {
+            expect(rows.every((row) => row.visible && row.id)).toBe(true);
+            expect(new Set(rows.map((row) => row.id)).size).toBe(rows.length);
+          }
+          expect(
+            observed.queued.every((row) => row.text === (attachment ? "Image (1)" : followUpText)),
+          ).toBe(true);
+          expect(observed.bubbles.length + observed.queued.length).toBe(expectedTurns);
+          expect(await gateway.getRequests("chat.send")).toHaveLength(sendsBefore + 1);
+        } finally {
+          try {
+            await keyProof.evaluate((proof) => proof.dispose());
+          } finally {
+            await keyProof.dispose();
+          }
+        }
+      });
     },
   );
 
   it("restores an attachment staged offline after reload and reconnect", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page);
-        const sessionKey = "agent:main:main";
-        const text = "offline attachment draft";
-        const contents = "offline attachment contents";
-        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        await composer.waitFor();
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page);
+      const sessionKey = "agent:main:main";
+      const text = "offline attachment draft";
+      const contents = "offline attachment contents";
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor();
 
-        await gateway.setOnline(false);
-        await page.locator('.agent-chat__composer-underlaps[data-tone="warn"]').waitFor();
-        await composer.fill(text);
-        await page.locator(".agent-chat__file-input").setInputFiles({
-          name: "offline.txt",
-          mimeType: "text/plain",
-          buffer: Buffer.from(contents),
-        });
-        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(1);
-        await waitForCommittedAttachmentDraft(page, sessionKey, text);
+      await gateway.setOnline(false);
+      await page.locator('.agent-chat__composer-underlaps[data-tone="warn"]').waitFor();
+      await composer.fill(text);
+      await page.locator(".agent-chat__file-input").setInputFiles({
+        name: "offline.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from(contents),
+      });
+      await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(1);
+      await waitForCommittedAttachmentDraft(page, sessionKey, text);
 
-        await page.reload();
-        await gateway.setOnline(true);
-        await expect.poll(() => composer.inputValue()).toBe(text);
-        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(1);
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-        if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
-          await page.screenshot({ path: path.join(artifactDir, "offline-draft-restored.png") });
-        }
-        await composer.press("Enter");
+      await page.reload();
+      await gateway.setOnline(true);
+      await expect.poll(() => composer.inputValue()).toBe(text);
+      await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(1);
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({ path: path.join(artifactDir, "offline-draft-restored.png") });
+      }
+      await composer.press("Enter");
 
-        const request = await gateway.waitForRequest("chat.send");
-        expect(request.params).toMatchObject({
-          attachments: [
-            {
-              content: Buffer.from(contents).toString("base64"),
-              fileName: "offline.txt",
-              mimeType: "text/plain",
-            },
-          ],
-          message: text,
-          sessionKey,
-        });
-      },
-    );
+      const request = await gateway.waitForRequest("chat.send");
+      expect(request.params).toMatchObject({
+        attachments: [
+          {
+            content: Buffer.from(contents).toString("base64"),
+            fileName: "offline.txt",
+            mimeType: "text/plain",
+          },
+        ],
+        message: text,
+        sessionKey,
+      });
+    });
   });
 
   it("restores isolated session drafts across fresh pages and retires sent or removed attachments", async () => {
@@ -554,180 +538,157 @@ suite.define(() => {
   });
 
   it("rejects a combined attachment frame before the Gateway connection is lost", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          attachmentMaxBytes: 256,
-          maxPayload: 700,
-        });
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        attachmentMaxBytes: 256,
+        maxPayload: 700,
+      });
 
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        await composer.fill("Send both files");
-        await page.locator(".agent-chat__file-input").setInputFiles([
-          { name: "first.txt", mimeType: "text/plain", buffer: Buffer.alloc(200, 0x61) },
-          { name: "second.txt", mimeType: "text/plain", buffer: Buffer.alloc(200, 0x62) },
-        ]);
-        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("Send both files");
+      await page.locator(".agent-chat__file-input").setInputFiles([
+        { name: "first.txt", mimeType: "text/plain", buffer: Buffer.alloc(200, 0x61) },
+        { name: "second.txt", mimeType: "text/plain", buffer: Buffer.alloc(200, 0x62) },
+      ]);
+      await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
 
-        await composer.press("Enter");
+      await composer.press("Enter");
 
-        const alert = page
-          .getByRole("alert")
-          .filter({ hasText: "Remove one or more attachments and retry" });
-        const outcome = await Promise.race([
-          alert.waitFor().then(() => "rejected" as const),
-          gateway.waitForRequest("chat.send").then(() => "sent" as const),
-        ]);
-        expect(outcome).toBe("rejected");
-        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
-        await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
-        await expect.poll(() => composer.inputValue()).toBe("Send both files");
+      const alert = page
+        .getByRole("alert")
+        .filter({ hasText: "Remove one or more attachments and retry" });
+      const outcome = await Promise.race([
+        alert.waitFor().then(() => "rejected" as const),
+        gateway.waitForRequest("chat.send").then(() => "sent" as const),
+      ]);
+      expect(outcome).toBe("rejected");
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await expect.poll(() => page.locator(".chat-attachment-thumb").count()).toBe(2);
+      await expect.poll(() => composer.inputValue()).toBe("Send both files");
 
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-        if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
-          await page.screenshot({ path: path.join(artifactDir, "attachment-frame-rejected.png") });
-        }
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      if (artifactDir) {
+        await mkdir(artifactDir, { recursive: true });
+        await page.screenshot({ path: path.join(artifactDir, "attachment-frame-rejected.png") });
+      }
 
-        await page.locator(".chat-attachment-remove").first().click();
-        await composer.press("Enter");
-        const request = await gateway.waitForRequest("chat.send");
-        expect(request.params).toMatchObject({
-          attachments: [{ fileName: "second.txt", mimeType: "text/plain" }],
-          message: "Send both files",
-        });
-      },
-    );
+      await page.locator(".chat-attachment-remove").first().click();
+      await composer.press("Enter");
+      const request = await gateway.waitForRequest("chat.send");
+      expect(request.params).toMatchObject({
+        attachments: [{ fileName: "second.txt", mimeType: "text/plain" }],
+        message: "Send both files",
+      });
+    });
   });
 
   it("waits for a pasted image before sending its complete gateway payload", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installDeferredAttachmentReader(page);
-        const gateway = await installMockGateway(page);
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installDeferredAttachmentReader(page);
+      const gateway = await installMockGateway(page);
 
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        const send = page.getByRole("button", { name: "Send message" });
-        await composer.fill("Include the image that is still loading");
-        await pastePng(composer);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      const send = page.getByRole("button", { name: "Send message" });
+      await composer.fill("Include the image that is still loading");
+      await pastePng(composer);
 
-        await expect.poll(() => send.isDisabled()).toBe(true);
-        await composer.press("Enter");
-        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      await expect.poll(() => send.isDisabled()).toBe(true);
+      await composer.press("Enter");
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
-        await page.evaluate(() => {
-          const proof = (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
-            .attachmentReadProof;
-          if (!proof.finish) {
-            throw new Error("Pasted image read was not started");
-          }
-          proof.finish();
-        });
-        await page.getByRole("img", { name: "pixel.png" }).waitFor();
-        await expect.poll(() => send.isEnabled()).toBe(true);
-        await send.click();
+      await page.evaluate(() => {
+        const proof = (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
+          .attachmentReadProof;
+        if (!proof.finish) {
+          throw new Error("Pasted image read was not started");
+        }
+        proof.finish();
+      });
+      await page.getByRole("img", { name: "pixel.png" }).waitFor();
+      await expect.poll(() => send.isEnabled()).toBe(true);
+      await send.click();
 
-        const request = await gateway.waitForRequest("chat.send");
-        expect(request.params).toMatchObject({
-          attachments: [
-            { content: ONE_PIXEL_PNG_B64, fileName: "pixel.png", mimeType: "image/png" },
-          ],
-          message: "Include the image that is still loading",
-        });
-      },
-    );
+      const request = await gateway.waitForRequest("chat.send");
+      expect(request.params).toMatchObject({
+        attachments: [{ content: ONE_PIXEL_PNG_B64, fileName: "pixel.png", mimeType: "image/png" }],
+        message: "Include the image that is still loading",
+      });
+    });
   });
 
   it("keeps a session's pending image isolated while another session is active", async () => {
     const firstSession = "agent:main:attachment-session-a";
     const secondSession = "agent:main:attachment-session-b";
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installDeferredAttachmentReader(page);
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "sessions.list": {
-              count: 2,
-              defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
-              path: "",
-              sessions: [
-                { key: firstSession, kind: "direct", updatedAt: 2 },
-                { key: secondSession, kind: "direct", updatedAt: 1 },
-              ],
-              ts: Date.now(),
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installDeferredAttachmentReader(page);
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "sessions.list": {
+            count: 2,
+            defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
+            path: "",
+            sessions: [
+              { key: firstSession, kind: "direct", updatedAt: 2 },
+              { key: secondSession, kind: "direct", updatedAt: 1 },
+            ],
+            ts: Date.now(),
           },
-          sessionKey: firstSession,
-        });
+        },
+        sessionKey: firstSession,
+      });
 
-        await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstSession));
-        const activeComposer = () =>
-          page.locator(
-            'openclaw-chat-pane[aria-hidden="false"] .agent-chat__composer-combobox textarea',
-          );
-        await activeComposer().fill("Private session A attachment");
-        await pastePng(activeComposer());
-        await expect
-          .poll(() => page.getByRole("button", { name: "Send message" }).isDisabled())
-          .toBe(true);
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, firstSession));
+      const activeComposer = () =>
+        page.locator(
+          'openclaw-chat-pane[aria-hidden="false"] .agent-chat__composer-combobox textarea',
+        );
+      await activeComposer().fill("Private session A attachment");
+      await pastePng(activeComposer());
+      await expect
+        .poll(() => page.getByRole("button", { name: "Send message" }).isDisabled())
+        .toBe(true);
 
-        await navigateToControlUiSession(page, secondSession);
+      await navigateToControlUiSession(page, secondSession);
 
-        await expect
-          .poll(() =>
-            page.evaluate(
-              () =>
-                (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
-                  .attachmentReadProof.aborts,
-            ),
-          )
-          .toBe(0);
-        await expect
-          .poll(() =>
-            page.locator('openclaw-chat-pane[aria-hidden="false"] .chat-attachment-thumb').count(),
-          )
-          .toBe(0);
+      await expect
+        .poll(() =>
+          page.evaluate(
+            () =>
+              (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
+                .attachmentReadProof.aborts,
+          ),
+        )
+        .toBe(0);
+      await expect
+        .poll(() =>
+          page.locator('openclaw-chat-pane[aria-hidden="false"] .chat-attachment-thumb').count(),
+        )
+        .toBe(0);
 
-        await activeComposer().fill("Safe session B message");
-        await activeComposer().press("Enter");
-        const request = await gateway.waitForRequest("chat.send");
-        expect(request.params).toMatchObject({
-          message: "Safe session B message",
-          sessionKey: secondSession,
-        });
-        expect((request.params as { attachments?: unknown }).attachments).toBeUndefined();
+      await activeComposer().fill("Safe session B message");
+      await activeComposer().press("Enter");
+      const request = await gateway.waitForRequest("chat.send");
+      expect(request.params).toMatchObject({
+        message: "Safe session B message",
+        sessionKey: secondSession,
+      });
+      expect((request.params as { attachments?: unknown }).attachments).toBeUndefined();
 
-        await navigateToControlUiSession(page, firstSession);
-        await page.evaluate(() => {
-          const proof = (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
-            .attachmentReadProof;
-          if (!proof.finish) {
-            throw new Error("Pasted image read was not retained");
-          }
-          proof.finish();
-        });
-        await page
-          .locator('openclaw-chat-pane[aria-hidden="false"]')
-          .getByRole("img", { name: "pixel.png" })
-          .waitFor();
-      },
-    );
+      await navigateToControlUiSession(page, firstSession);
+      await page.evaluate(() => {
+        const proof = (globalThis as unknown as { attachmentReadProof: DeferredAttachmentProof })
+          .attachmentReadProof;
+        if (!proof.finish) {
+          throw new Error("Pasted image read was not retained");
+        }
+        proof.finish();
+      });
+      await page
+        .locator('openclaw-chat-pane[aria-hidden="false"]')
+        .getByRole("img", { name: "pixel.png" })
+        .waitFor();
+    });
   });
 });

--- a/ui/src/e2e/chat-cli-history-redaction.e2e.test.ts
+++ b/ui/src/e2e/chat-cli-history-redaction.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   visibleChatBubbleTexts,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -21,11 +22,7 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 suite.define(() => {
   it("renders a real imported Claude transcript once without exposing its unredacted secret", async () => {
     const homeDir = tempDirs.make("openclaw-cli-history-redaction-");
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
 
     try {
       const page = await context.newPage();

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -11,16 +11,13 @@ import {
   requireString,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("preserves a non-steer server default for active-run follow-ups", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const runtimeConfig = {
       messages: { queue: { byChannel: { webchat: "followup" }, mode: "steer" } },
@@ -102,11 +99,7 @@ suite.define(() => {
   });
 
   it("keeps the active run across a live steer operation", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const runId = "run-a";
     const gateway = await installMockGateway(page, {
@@ -390,11 +383,7 @@ suite.define(() => {
   it.each(["before", "after"] as const)(
     "keeps cumulative stream text ordered when history resolves %s the live steer event",
     async (historyOrder) => {
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const runId = "run-steer-order";
       const steerRunId = "steer-order";
@@ -500,11 +489,7 @@ suite.define(() => {
   );
 
   it("replaces a retained cumulative steer prefix with split history around keyed commentary", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const runId = "run-steer-split";
     const steerRunId = "steer-split";
@@ -635,11 +620,7 @@ suite.define(() => {
   });
 
   it("keeps modified Enter queued in modifier-enter shortcut mode", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -668,11 +649,7 @@ suite.define(() => {
   });
 
   it("projects one disconnected state for an offline steer follow-up", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -729,11 +706,7 @@ suite.define(() => {
   });
 
   it("sends a queued follow-up after an exact terminal session publication", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionInfo: { hasActiveRun: false, status: "done" },
@@ -811,11 +784,7 @@ suite.define(() => {
   });
 
   it("honors a session interrupt override ahead of the webchat config default", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:main:main";
     const runtimeConfig = {
@@ -876,11 +845,7 @@ suite.define(() => {
   });
 
   it("routes /redirect through one interrupt-mode chat.send", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -906,11 +871,7 @@ suite.define(() => {
   });
 
   it("steers a restored queued message when only the session row reports the active run", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 

--- a/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
@@ -3,6 +3,7 @@ import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -369,11 +370,7 @@ suite.define(() => {
   ] as const)(
     "shows a visible error when the workspace header $action clipboard action fails",
     async ({ action, label, value }) => {
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       await installDeniedClipboard(page);
       const gateway = await installMockGateway(page, {
@@ -416,11 +413,7 @@ suite.define(() => {
   );
 
   it("shows and resets a visible accessible failure when assistant code cannot be copied", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.clock.install();
     await installDeniedClipboard(page);

--- a/ui/src/e2e/chat-flow.composer-shortcuts.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.composer-shortcuts.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   requireString,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -14,11 +15,7 @@ suite.define(() => {
   it.each(["queue", "steer", "collect", "followup"] as const)(
     "explains and submits the opposite of %s with modified Enter",
     async (followUpMode) => {
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const inheritsQueueMode = followUpMode === "collect" || followUpMode === "followup";
       const runtimeConfig = {

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -23,11 +24,7 @@ suite.define(() => {
   it.each(["named", "short"] as const)(
     "retains deferred history across %s chat canonicalization",
     async (reference) => {
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
       const marker = "The selected conversation survived canonical navigation.";
@@ -110,11 +107,7 @@ suite.define(() => {
   );
 
   it("renders a failed history load in the transcript and retries it", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["chat.startup"],
@@ -165,11 +158,7 @@ suite.define(() => {
   });
 
   it("automatically resumes retryable history failures once after reconnect", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["chat.startup"],
@@ -215,11 +204,7 @@ suite.define(() => {
     }
   });
   it("keeps cached history visible and actionable when a refresh fails", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       historyMessages: [

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -20,17 +20,14 @@ import {
   waitForChatScrollIdle,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 type ChatFlowTestApp = HTMLElement & { runtime?: { context: ApplicationContext } };
 
 suite.define(() => {
   it("keeps an unrelated retained transcript after another tab deletes a session", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionA = "agent:main:session-a";
     const sessionB = "agent:main:session-b";
@@ -272,11 +269,7 @@ suite.define(() => {
   });
 
   it("keeps valid assistant history visible after a malformed transcript block", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const visibleAnswer = "The valid assistant answer remains visible.";
     const gateway = await installMockGateway(page, {
@@ -301,11 +294,7 @@ suite.define(() => {
   });
 
   it("shows persisted user messages after opening History and scrolling mixed history", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const baseTs = Date.now() - 100_000;
     const currentSessionMessages = [

--- a/ui/src/e2e/chat-flow.local-media-dollar-home.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.local-media-dollar-home.e2e.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import { createPlaybackMediaFixture } from "../../../test/fixtures/media-playback.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -25,11 +26,7 @@ suite.define(() => {
     const artifactDir = artifactDirParent
       ? createControlUiE2eArtifactDir("chat-flow.local-media-dollar-home", artifactDirParent)
       : undefined;
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const requestedMediaUrls: URL[] = [];
 

--- a/ui/src/e2e/chat-flow.local-media-policy.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.local-media-policy.e2e.test.ts
@@ -8,6 +8,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const mediaTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -53,11 +54,7 @@ suite.define(() => {
         "structured" in options
           ? `FILE:${path.join(mediaTempDirs.make("control-ui-audio-"), fixtureSource)}`
           : fixtureSource;
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const requestedMediaUrls: URL[] = [];
       const expectedSource = "structured" in options ? new URL(source).pathname : source;
@@ -231,11 +228,7 @@ suite.define(() => {
       source: "/home/node/.openclaw/media/outbound/bootstrap-missing.mp3",
     },
   ] as const)("keeps server-rejected $code media blocked", async ({ code, reason, source }) => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const requestedMediaUrls: URL[] = [];
 

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -11,16 +11,13 @@ import {
   waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("exposes an assistant document download with its Unicode filename and ticketed URL", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const source = "/tmp/openclaw/测试 report.pdf";
     const mediaUrl = `/__openclaw__/assistant-media?source=${encodeURIComponent(source)}&mediaTicket=ticket-download`;
@@ -64,11 +61,7 @@ suite.define(() => {
   });
 
   it("renders a direct tool-result image from Gateway history", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const imageData =
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M/wHwAF/gL+X3q8AAAAAElFTkSuQmCC";
@@ -100,11 +93,7 @@ suite.define(() => {
   });
 
   it("renders a managed image through an artifact-scoped ticket", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const attachmentId = crypto.randomUUID();
     const artifactId = `artifact_managed_image_${attachmentId}`;
@@ -177,11 +166,7 @@ suite.define(() => {
   });
 
   it("moves a managed document batch from skeletons directly to final cards", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
       ? suite.artifactDir
@@ -357,11 +342,7 @@ suite.define(() => {
       const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
         ? suite.artifactDir
         : undefined;
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const requestedMediaUrls: URL[] = [];
       await page.route("**/__openclaw__/assistant-media?**", async (route) => {
@@ -436,11 +417,7 @@ suite.define(() => {
   );
 
   it("evicts and refetches managed image Blob URLs after the cache reaches capacity", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.addInitScript(() => {
       const originalCreateObjectURL = URL.createObjectURL.bind(URL);
@@ -672,11 +649,7 @@ suite.define(() => {
   });
 
   it("copies a code block over a non-secure context via the execCommand fallback", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     // Simulate a plain-HTTP deployment where navigator.clipboard is unavailable.
     await installPlainHttpClipboardCapture(page);
@@ -747,11 +720,7 @@ suite.define(() => {
   });
 
   it("copies a workspace file path over a non-secure context via the execCommand fallback", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installPlainHttpClipboardCapture(page);
     const gateway = await installMockGateway(page, {

--- a/ui/src/e2e/chat-flow.messaging.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.messaging.e2e.test.ts
@@ -12,15 +12,12 @@ import {
   requireString,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 async function withChatPage(run: (page: Page) => Promise<void>): Promise<void> {
-  const context = await suite.newBrowserContext({
-    locale: "en-US",
-    serviceWorkers: "block",
-    viewport: { height: 900, width: 1280 },
-  });
+  const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
   try {
     await run(await context.newPage());
   } finally {

--- a/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   installMockGateway,
   requireRecord,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -242,11 +243,7 @@ suite.define(() => {
   });
 
   it("keeps the warm model list interactive while a picker-open refresh is in flight", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       models: [

--- a/ui/src/e2e/chat-flow.model-switch-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-switch-reasoning.e2e.test.ts
@@ -9,16 +9,13 @@ import {
   requireRecord,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("applies provider-specific reasoning after the selected model is saved", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:main:session-a";
     const fableSession = {

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   requireRecord,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
@@ -41,11 +42,7 @@ async function createReasoningProofPage(scope: string) {
 
 suite.define(() => {
   it("patches a selectable Claude CLI context window", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:main:session-a";
     const contextWindows = [
@@ -113,11 +110,7 @@ suite.define(() => {
   });
 
   it("settles permission patches before reflecting changes and observes remote updates", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const session = {
       key: "agent:main:session-a",
@@ -249,11 +242,7 @@ suite.define(() => {
   });
 
   it("keeps picker menus in the viewport while preferring the space above", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       models: Array.from({ length: 12 }, (_, index) => ({
@@ -335,11 +324,7 @@ suite.define(() => {
   });
 
   it("routes runtime-aware model commands through the server directive path", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       sessionKey: "agent:main:main",
@@ -364,11 +349,7 @@ suite.define(() => {
   });
 
   it("keeps high-velocity model scrolling inside the picker", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const models = [
       { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
@@ -524,11 +505,7 @@ suite.define(() => {
   });
 
   it("keeps a session model override selected after switching away and back", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -603,11 +580,7 @@ suite.define(() => {
   });
 
   it("restores the selected agent model after clearing a session override", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const agentsList = {
       agents: [
@@ -895,11 +868,7 @@ suite.define(() => {
       patch: { permissionMode: "full" },
     },
   ])("shows a pending send while a $label update is still pending", async (setting) => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.patch"],
@@ -958,11 +927,7 @@ suite.define(() => {
   });
 
   it("previews reasoning and provider choices before committing them", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:main:session-a";
     const session = {

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -14,6 +14,7 @@ import {
   waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
 import { dockChatSidePanel, openChatSidePanelType } from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
@@ -481,11 +482,7 @@ suite.define(() => {
   });
 
   it("opens current context and latest-run usage from the composer ring", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       historyMessages: [
@@ -576,11 +573,7 @@ suite.define(() => {
   });
 
   it("routes page typing to the active composer without stealing text input focus", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       historyMessages: [
@@ -623,11 +616,7 @@ suite.define(() => {
   });
 
   it("keeps stale context visible as approximate without warning", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -672,11 +661,7 @@ suite.define(() => {
   });
 
   it("keeps chat usable while sessions are still loading", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.list"],
@@ -718,11 +703,7 @@ suite.define(() => {
   });
 
   it("keeps every sidebar session stable while selecting sessions and supports sort modes", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const createdSessionKeys = Array.from(
       { length: 11 },
@@ -811,11 +792,7 @@ suite.define(() => {
   });
 
   it("releases a retained queued send after the canonical session list records idle", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const firstKey = "agent:main:thread:aaaaaaaa-1111-4111-8111-111111111111";
     const secondKey = "agent:main:thread:bbbbbbbb-2222-4222-8222-222222222222";
@@ -948,11 +925,7 @@ suite.define(() => {
   });
 
   it("keeps derived sidebar titles and accessible state after session patch refreshes", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const initialKey = "agent:main:session-a";
     const key = "agent:main:session-b";

--- a/ui/src/e2e/chat-flow.pending-settings.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.pending-settings.e2e.test.ts
@@ -10,17 +10,14 @@ import {
   requireRecord,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
 
 suite.define(() => {
   it("keeps send pending until reasoning and speed patches finish", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   requireString,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -18,11 +19,7 @@ const QUEUED = ["review the migration", "then update the docs", "finally run the
 
 suite.define(() => {
   it("edits a queued message in its row and returns it to its place", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -77,11 +74,7 @@ suite.define(() => {
   });
 
   it("puts the row back untouched when the edit is cancelled", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -118,11 +111,7 @@ suite.define(() => {
   });
 
   it("keeps a normal composer send separate from an open row edit", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 

--- a/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -13,11 +14,7 @@ const QUEUED = ["review the migration", "then update the docs", "finally run the
 
 suite.define(() => {
   it("reorders offline queued messages from the keyboard-focused handle", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -63,11 +60,7 @@ suite.define(() => {
         recursive: true,
       });
     }
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       // A real active turn holds the restored queue while we inspect its order.

--- a/ui/src/e2e/chat-flow.session-start.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.session-start.e2e.test.ts
@@ -5,16 +5,13 @@ import {
   requireRecord,
   requireString,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("opens a git-backed agent draft from the sidebar new-session action", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, { workspaceGit: true });
 
@@ -33,11 +30,7 @@ suite.define(() => {
   });
 
   it("waits for configured inference before sending the first chat turn", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "openai/startup-model",
@@ -158,11 +151,7 @@ suite.define(() => {
   });
 
   it("paints startup history while canonical roster and metadata requests remain pending", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "openai/hydrated-model",

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -16,6 +16,7 @@ import {
   pauseVirtualClock,
   requireRecord,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
@@ -254,11 +255,7 @@ suite.define(() => {
   });
 
   it("keeps long sidebar labels clipped after a session switch", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.clock.install();
     const sessions = chatSessionListResponse();
@@ -682,11 +679,7 @@ suite.define(() => {
   });
 
   it("keeps the authenticated assistant avatar stable across same-agent switches", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const avatarBody = Buffer.from(
       "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nPcAAAAASUVORK5CYII=",

--- a/ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   requireRecord,
   requireString,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -166,76 +167,69 @@ suite.define(() => {
   );
 
   it("reconciles distinct commentary items once across reconnect", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const runId = "commentary-reconciliation-run";
-        const items = [
-          { itemId: "commentary-item-one", text: "Inspecting the workspace." },
-          { itemId: "commentary-item-two", text: "Checking the result." },
-        ];
-        const events = items.map(({ itemId, text }, index) => ({
-          data: { kind: "preamble", itemId, phase: "update", progressText: text },
-          runId,
-          seq: index + 1,
-          sessionKey: "agent:main:main",
-          stream: "item",
-          ts: 2_000 + index,
-        }));
-        const historyMessages = items.map(({ itemId, text }, index) => ({
-          role: "assistant",
-          content: [{ type: "text", text }],
-          timestamp: 1_000 + index,
-          __openclaw: { id: `commentary-message-${index}`, runId, seq: index + 1 },
-          openclawStreamFallback: { itemId, replacementText: text, source: "segment" },
-        }));
-        const sessionInfo = {
-          activeRunIds: [runId],
-          hasActiveRun: true,
-          key: "agent:main:main",
-        };
-        const gateway = await installMockGateway(page, {
-          historyMessages: [],
-          inFlightRun: { runId, startedAt: 1_000, text: "" },
-          sessionInfo,
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const runId = "commentary-reconciliation-run";
+      const items = [
+        { itemId: "commentary-item-one", text: "Inspecting the workspace." },
+        { itemId: "commentary-item-two", text: "Checking the result." },
+      ];
+      const events = items.map(({ itemId, text }, index) => ({
+        data: { kind: "preamble", itemId, phase: "update", progressText: text },
+        runId,
+        seq: index + 1,
+        sessionKey: "agent:main:main",
+        stream: "item",
+        ts: 2_000 + index,
+      }));
+      const historyMessages = items.map(({ itemId, text }, index) => ({
+        role: "assistant",
+        content: [{ type: "text", text }],
+        timestamp: 1_000 + index,
+        __openclaw: { id: `commentary-message-${index}`, runId, seq: index + 1 },
+        openclawStreamFallback: { itemId, replacementText: text, source: "segment" },
+      }));
+      const sessionInfo = {
+        activeRunIds: [runId],
+        hasActiveRun: true,
+        key: "agent:main:main",
+      };
+      const gateway = await installMockGateway(page, {
+        historyMessages: [],
+        inFlightRun: { runId, startedAt: 1_000, text: "" },
+        sessionInfo,
+      });
+      const transcript = page.locator(".chat-thread-inner");
+      const itemOccurrences = async () => {
+        const bubbles = await transcript.locator(".chat-bubble").allTextContents();
+        return items.map(({ text }) => bubbles.filter((bubble) => bubble.trim() === text).length);
+      };
+
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await page.getByRole("button", { name: "Stop generating" }).waitFor();
+      for (const event of events) {
+        await gateway.emitGatewayEvent("agent", event);
+      }
+      await expect.poll(itemOccurrences).toEqual([1, 1]);
+
+      const startupCount = (await gateway.getRequests("chat.startup")).length;
+      await gateway.setMethodResponse("chat.startup", {
+        messages: historyMessages,
+        inFlightRun: { runId, startedAt: 1_000, text: "", events },
+        sessionInfo,
+        thinkingLevel: null,
+      });
+      await gateway.setOnline(false);
+      await gateway.setOnline(true);
+      await gateway.waitForRequest("chat.startup", { after: startupCount });
+      await expect.poll(itemOccurrences).toEqual([1, 1]);
+
+      if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+        await page.screenshot({
+          fullPage: true,
+          path: path.join(suite.artifactDir, "commentary-reconciliation.png"),
         });
-        const transcript = page.locator(".chat-thread-inner");
-        const itemOccurrences = async () => {
-          const bubbles = await transcript.locator(".chat-bubble").allTextContents();
-          return items.map(({ text }) => bubbles.filter((bubble) => bubble.trim() === text).length);
-        };
-
-        await page.goto(`${suite.server.baseUrl}chat`);
-        await page.getByRole("button", { name: "Stop generating" }).waitFor();
-        for (const event of events) {
-          await gateway.emitGatewayEvent("agent", event);
-        }
-        await expect.poll(itemOccurrences).toEqual([1, 1]);
-
-        const startupCount = (await gateway.getRequests("chat.startup")).length;
-        await gateway.setMethodResponse("chat.startup", {
-          messages: historyMessages,
-          inFlightRun: { runId, startedAt: 1_000, text: "", events },
-          sessionInfo,
-          thinkingLevel: null,
-        });
-        await gateway.setOnline(false);
-        await gateway.setOnline(true);
-        await gateway.waitForRequest("chat.startup", { after: startupCount });
-        await expect.poll(itemOccurrences).toEqual([1, 1]);
-
-        if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
-          await page.screenshot({
-            fullPage: true,
-            path: path.join(suite.artifactDir, "commentary-reconciliation.png"),
-          });
-        }
-      },
-    );
+      }
+    });
   });
 
   it.each([
@@ -244,119 +238,110 @@ suite.define(() => {
   ])(
     "keeps one answer during workspace reconciliation with persistence $persistence and $terminal",
     async ({ persistence, terminal }) => {
-      await suite.withPage(
-        {
-          locale: "en-US",
-          serviceWorkers: "block",
-          viewport: { height: 900, width: 1280 },
-        },
-        async ({ page }) => {
-          const gateway = await installMockGateway(page, { historyMessages: [] });
-          await page.goto(`${suite.server.baseUrl}chat`);
-          await page.locator(".agent-chat__composer-combobox textarea").fill("Check the workspace");
-          await page.getByRole("button", { name: "Send message" }).click();
-          const send = await gateway.waitForRequest("chat.send");
-          const runId = requireString(requireRecord(send.params).idempotencyKey, "chat run id");
-          const text = "Workspace changes are ready.";
-          const partial = "Workspace";
-          const emitDelta = (snapshot: string, deltaText: string) =>
-            gateway.emitGatewayEvent("chat", {
-              sessionKey: "main",
-              runId,
-              state: "delta",
-              deltaText,
-              message: { role: "assistant", content: [{ type: "text", text: snapshot }] },
-            });
-          if (persistence === "between deltas") {
-            await emitDelta(partial, partial);
-            await page.locator(".chat-bubble.streaming", { hasText: partial }).waitFor();
-          }
-          // Hold background refreshes so only the live message/delta boundary can repair the view.
-          await gateway.deferNext("chat.history");
-          await gateway.emitGatewayEvent("session.message", {
+      await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+        const gateway = await installMockGateway(page, { historyMessages: [] });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await page.locator(".agent-chat__composer-combobox textarea").fill("Check the workspace");
+        await page.getByRole("button", { name: "Send message" }).click();
+        const send = await gateway.waitForRequest("chat.send");
+        const runId = requireString(requireRecord(send.params).idempotencyKey, "chat run id");
+        const text = "Workspace changes are ready.";
+        const partial = "Workspace";
+        const emitDelta = (snapshot: string, deltaText: string) =>
+          gateway.emitGatewayEvent("chat", {
             sessionKey: "main",
             runId,
-            clientRunId: runId,
+            state: "delta",
+            deltaText,
+            message: { role: "assistant", content: [{ type: "text", text: snapshot }] },
+          });
+        if (persistence === "between deltas") {
+          await emitDelta(partial, partial);
+          await page.locator(".chat-bubble.streaming", { hasText: partial }).waitFor();
+        }
+        // Hold background refreshes so only the live message/delta boundary can repair the view.
+        await gateway.deferNext("chat.history");
+        await gateway.emitGatewayEvent("session.message", {
+          sessionKey: "main",
+          runId,
+          clientRunId: runId,
+          hasActiveRun: true,
+          activeRunIds: [runId],
+          messageId: "workspace-answer",
+          messageSeq: 2,
+          session: {
+            key: "main",
+            kind: "direct",
+            status: "running",
+            updatedAt: Date.now(),
             hasActiveRun: true,
             activeRunIds: [runId],
-            messageId: "workspace-answer",
-            messageSeq: 2,
-            session: {
-              key: "main",
-              kind: "direct",
-              status: "running",
-              updatedAt: Date.now(),
-              hasActiveRun: true,
-              activeRunIds: [runId],
-            },
-            message: {
-              role: "assistant",
-              content: [{ type: "text", text }],
-              __openclaw: { id: "workspace-answer", seq: 2, runId },
-            },
-          });
-          await page.locator(".chat-group.assistant .chat-text", { hasText: text }).waitFor();
-          if (persistence === "before streaming") {
-            await emitDelta(partial, partial);
-          }
-          await emitDelta(text, text.slice(partial.length));
-          await gateway.emitGatewayEvent("agent", {
-            sessionKey: "main",
-            runId,
-            seq: 3,
-            ts: Date.now(),
-            stream: "lifecycle",
-            data: { phase: "finishing" },
-          });
-          // Positive telemetry proves a render after the deltas; absence alone can pass on the old frame.
-          await gateway.emitGatewayEvent("agent", {
-            sessionKey: "main",
-            runId,
-            seq: 4,
-            ts: Date.now(),
-            stream: "usage",
-            data: { outputTokens: 2400 },
-          });
-          await expect
-            .poll(async () =>
-              (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
-            )
-            .toBe("2.4k output tokens");
-          await expect.poll(() => page.locator(".chat-bubble.streaming").count()).toBe(0);
-          expect(
-            (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map(
-              (value) => value.trim(),
-            ),
-          ).toEqual([text]);
-          expect(await page.locator(".chat-duplicate-count").count()).toBe(0);
-          expect(await page.getByRole("button", { name: "Stop generating" }).isEnabled()).toBe(
-            true,
-          );
-          await page.locator(".chat-working-indicator").waitFor();
+          },
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text }],
+            __openclaw: { id: "workspace-answer", seq: 2, runId },
+          },
+        });
+        await page.locator(".chat-group.assistant .chat-text", { hasText: text }).waitFor();
+        if (persistence === "before streaming") {
+          await emitDelta(partial, partial);
+        }
+        await emitDelta(text, text.slice(partial.length));
+        await gateway.emitGatewayEvent("agent", {
+          sessionKey: "main",
+          runId,
+          seq: 3,
+          ts: Date.now(),
+          stream: "lifecycle",
+          data: { phase: "finishing" },
+        });
+        // Positive telemetry proves a render after the deltas; absence alone can pass on the old frame.
+        await gateway.emitGatewayEvent("agent", {
+          sessionKey: "main",
+          runId,
+          seq: 4,
+          ts: Date.now(),
+          stream: "usage",
+          data: { outputTokens: 2400 },
+        });
+        await expect
+          .poll(async () =>
+            (await page.locator(".chat-working-indicator__tokens").textContent())?.trim(),
+          )
+          .toBe("2.4k output tokens");
+        await expect.poll(() => page.locator(".chat-bubble.streaming").count()).toBe(0);
+        expect(
+          (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map((value) =>
+            value.trim(),
+          ),
+        ).toEqual([text]);
+        expect(await page.locator(".chat-duplicate-count").count()).toBe(0);
+        expect(await page.getByRole("button", { name: "Stop generating" }).isEnabled()).toBe(true);
+        await page.locator(".chat-working-indicator").waitFor();
 
-          const errorMessage = "Workspace reconciliation failed: the destination is read-only.";
-          await gateway.emitGatewayEvent("chat", {
-            sessionKey: "main",
-            runId,
-            state: terminal,
-            ...(terminal === "error" ? { errorMessage } : {}),
-            message: { role: "assistant", content: [{ type: "text", text }] },
-          });
-          await page.getByRole("button", { name: "Stop generating" }).waitFor({ state: "hidden" });
-          await page.locator(".chat-working-indicator").waitFor({ state: "hidden" });
-          if (terminal === "error") {
-            await page.locator(".chat-error strong", { hasText: errorMessage }).waitFor();
-          }
-          await emitDelta(text, text.slice(partial.length));
-          await expect.poll(() => page.locator(".chat-bubble.streaming").count()).toBe(0);
-          expect(
-            (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map(
-              (value) => value.trim(),
-            ),
-          ).toEqual([text]);
-          expect(await page.locator(".chat-duplicate-count").count()).toBe(0);
-        },
-      );
+        const errorMessage = "Workspace reconciliation failed: the destination is read-only.";
+        await gateway.emitGatewayEvent("chat", {
+          sessionKey: "main",
+          runId,
+          state: terminal,
+          ...(terminal === "error" ? { errorMessage } : {}),
+          message: { role: "assistant", content: [{ type: "text", text }] },
+        });
+        await page.getByRole("button", { name: "Stop generating" }).waitFor({ state: "hidden" });
+        await page.locator(".chat-working-indicator").waitFor({ state: "hidden" });
+        if (terminal === "error") {
+          await page.locator(".chat-error strong", { hasText: errorMessage }).waitFor();
+        }
+        await emitDelta(text, text.slice(partial.length));
+        await expect.poll(() => page.locator(".chat-bubble.streaming").count()).toBe(0);
+        expect(
+          (await page.locator(".chat-group.assistant .chat-text").allTextContents()).map((value) =>
+            value.trim(),
+          ),
+        ).toEqual([text]);
+        expect(await page.locator(".chat-duplicate-count").count()).toBe(0);
+      });
     },
   );
 });

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   requireString,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import { waitForCommittedState } from "./settle.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -180,11 +181,7 @@ suite.define(() => {
   });
 
   it("renders stable markdown during a streaming chat turn and finalizes the tail", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -238,11 +235,7 @@ suite.define(() => {
   });
 
   it("normalizes Unicode line separators in streaming and final chat DOM", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -473,11 +466,7 @@ suite.define(() => {
   );
 
   it("keeps the pending telemetry row stable through acknowledgement and streaming", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -641,11 +630,7 @@ suite.define(() => {
   });
 
   it("refreshes history after a tool-call window disconnects and reconnects", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 
@@ -747,11 +732,7 @@ suite.define(() => {
   });
 
   it("keeps live assistant stream text before the matching tool card", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
 

--- a/ui/src/e2e/chat-flow.task-suggestions.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.task-suggestions.e2e.test.ts
@@ -9,16 +9,13 @@ import {
   installMockGateway,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("starts a model-suggested follow-up in a new session before workspace decisions", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const suggestion = {
       id: "task_123",
@@ -88,11 +85,7 @@ suite.define(() => {
   });
 
   it("clears model-suggested follow-ups while switching sessions", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: [
@@ -142,11 +135,7 @@ suite.define(() => {
   });
 
   it("keeps copy available when only listing is advertised", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "taskSuggestions.list"],

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   requireRecord,
   requireString,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -61,11 +62,7 @@ suite.define(() => {
     const artifactDir = artifactRoot
       ? createControlUiE2eArtifactDir("chat-canvas-history-stability", artifactRoot)
       : undefined;
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const documentIds = ["cv_first", "cv_second"];
     const finalText = "Both previews are ready.";
@@ -262,11 +259,7 @@ suite.define(() => {
   });
 
   it("keeps durable turns ordered when a live final arrives before transcript events", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const currentRunId = "current-run";
     const previousPrompt = "What happened before this run?";

--- a/ui/src/e2e/chat-only-model.e2e.test.ts
+++ b/ui/src/e2e/chat-only-model.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const sessionKey = "agent:main:main";
@@ -62,11 +63,7 @@ function sessionsList(model: string, modelProvider: string) {
 
 suite.define(() => {
   it("explains chat-only models and keeps model switching as the recovery path", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "lmstudio/qwen3-8b",

--- a/ui/src/e2e/chat-panel-reflow.e2e.test.ts
+++ b/ui/src/e2e/chat-panel-reflow.e2e.test.ts
@@ -6,7 +6,10 @@ import {
   activateChatHeaderPanelAction,
   openChatSidePanelType,
 } from "./chat-side-panel.test-support.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "chat transcript panel reflow",
@@ -65,102 +68,95 @@ async function expectMessagesNotToOverlap(page: import("playwright").Page): Prom
 suite.define(() => {
   it("keeps transcript rows separate across background-task, file, and diff panel toggles", async () => {
     const artifactDir = createControlUiE2eArtifactDir("chat-panel-reflow");
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
-          historyMessages,
-          methodResponses: {
-            "artifacts.list": { artifacts: [] },
-            "sessions.diff": {
-              additions: 1,
-              baseRef: "main",
-              branch: "feature/reflow",
-              deletions: 0,
-              files: [
-                {
-                  additions: 1,
-                  deletions: 0,
-                  patch: [
-                    "diff --git a/src/app.ts b/src/app.ts",
-                    "--- a/src/app.ts",
-                    "+++ b/src/app.ts",
-                    "@@ -1 +1,2 @@",
-                    " current line",
-                    "+new line",
-                    "",
-                  ].join("\n"),
-                  path: "src/app.ts",
-                  status: "modified",
-                },
-              ],
-              root: "/workspace",
-              sessionKey: "main",
-            },
-            "sessions.files.list": {
-              browser: { entries: [], path: "" },
-              files: [
-                {
-                  kind: "modified",
-                  missing: false,
-                  name: "AGENTS.md",
-                  path: "/workspace/AGENTS.md",
-                  size: 2048,
-                },
-              ],
-              root: "/workspace",
-              sessionKey: "main",
-            },
-            "tasks.list": {
-              tasks: [
-                {
-                  agentId: "main",
-                  createdAt: Date.now() - 5_000,
-                  id: "task-reflow",
-                  kind: "subagent",
-                  ownerKey: chatSessionKey,
-                  progressSummary: "Checking transcript layout",
-                  runtime: "subagent",
-                  startedAt: Date.now() - 4_000,
-                  status: "running",
-                  taskId: "task-reflow",
-                  title: "Reflow proof",
-                  updatedAt: Date.now(),
-                },
-              ],
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],
+        historyMessages,
+        methodResponses: {
+          "artifacts.list": { artifacts: [] },
+          "sessions.diff": {
+            additions: 1,
+            baseRef: "main",
+            branch: "feature/reflow",
+            deletions: 0,
+            files: [
+              {
+                additions: 1,
+                deletions: 0,
+                patch: [
+                  "diff --git a/src/app.ts b/src/app.ts",
+                  "--- a/src/app.ts",
+                  "+++ b/src/app.ts",
+                  "@@ -1 +1,2 @@",
+                  " current line",
+                  "+new line",
+                  "",
+                ].join("\n"),
+                path: "src/app.ts",
+                status: "modified",
+              },
+            ],
+            root: "/workspace",
+            sessionKey: "main",
           },
-        });
+          "sessions.files.list": {
+            browser: { entries: [], path: "" },
+            files: [
+              {
+                kind: "modified",
+                missing: false,
+                name: "AGENTS.md",
+                path: "/workspace/AGENTS.md",
+                size: 2048,
+              },
+            ],
+            root: "/workspace",
+            sessionKey: "main",
+          },
+          "tasks.list": {
+            tasks: [
+              {
+                agentId: "main",
+                createdAt: Date.now() - 5_000,
+                id: "task-reflow",
+                kind: "subagent",
+                ownerKey: chatSessionKey,
+                progressSummary: "Checking transcript layout",
+                runtime: "subagent",
+                startedAt: Date.now() - 4_000,
+                status: "running",
+                taskId: "task-reflow",
+                title: "Reflow proof",
+                updatedAt: Date.now(),
+              },
+            ],
+          },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}chat`);
-        expect(response?.status()).toBe(200);
-        await expect.poll(() => page.locator(".chat-group").count()).toBe(historyMessageCount);
-        await page.locator(".chat-thread").evaluate((element) => {
-          element.scrollTop = Math.max(0, element.scrollHeight / 2);
-        });
-        await expectMessagesNotToOverlap(page);
-        await page.screenshot({ path: path.join(artifactDir, "00-closed.png") });
+      const response = await page.goto(`${suite.server.baseUrl}chat`);
+      expect(response?.status()).toBe(200);
+      await expect.poll(() => page.locator(".chat-group").count()).toBe(historyMessageCount);
+      await page.locator(".chat-thread").evaluate((element) => {
+        element.scrollTop = Math.max(0, element.scrollHeight / 2);
+      });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "00-closed.png") });
 
-        await openChatSidePanelType(page, "Tasks");
-        await page.locator(".chat-tasks-rail").waitFor({ state: "visible" });
-        await expectMessagesNotToOverlap(page);
-        await page.screenshot({ path: path.join(artifactDir, "01-background-tasks.png") });
+      await openChatSidePanelType(page, "Tasks");
+      await page.locator(".chat-tasks-rail").waitFor({ state: "visible" });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "01-background-tasks.png") });
 
-        await openChatSidePanelType(page, "Files");
-        await page.locator(".chat-workspace-rail").waitFor({ state: "visible" });
-        await expectMessagesNotToOverlap(page);
-        await page.screenshot({ path: path.join(artifactDir, "02-thread-files.png") });
+      await openChatSidePanelType(page, "Files");
+      await page.locator(".chat-workspace-rail").waitFor({ state: "visible" });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "02-thread-files.png") });
 
-        await activateChatHeaderPanelAction(page, "Show session changes");
-        await page.locator(".session-diff").waitFor({ state: "visible" });
-        await expectMessagesNotToOverlap(page);
-        await page.screenshot({ path: path.join(artifactDir, "03-thread-changes.png") });
-      },
-    );
+      await activateChatHeaderPanelAction(page, "Show session changes");
+      await page.locator(".session-diff").waitFor({ state: "visible" });
+      await expectMessagesNotToOverlap(page);
+      await page.screenshot({ path: path.join(artifactDir, "03-thread-changes.png") });
+    });
   });
 });

--- a/ui/src/e2e/chat-permission-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-permission-refresh.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const rosterMatch = { includeGlobal: true };
@@ -13,11 +14,7 @@ type PermissionTestApp = HTMLElement & { runtime?: { context: ApplicationContext
 
 suite.define(() => {
   it("keeps a saved permission mode when its list refresh fails", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const session = {
       key: "agent:main:permission-refresh",
@@ -65,11 +62,7 @@ suite.define(() => {
   });
 
   it("keeps a newer permission event after an older patch response arrives", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const session = {
       key: "agent:main:permission-ordering",

--- a/ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts
@@ -5,6 +5,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -60,11 +61,7 @@ suite.define(() => {
   });
 
   it("animates inline pickers from their placed edge and honors reduced motion", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       models: Array.from({ length: 12 }, (_, index) => ({

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -12,7 +12,10 @@ import {
   installMockGateway,
   type MockGatewayControls,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI #93041 desktop chat quota popover (mocked Gateway E2E)",
@@ -202,11 +205,7 @@ async function openChat(
   let context: BrowserContext | undefined;
   let page: Page | undefined;
   try {
-    context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    context = await suite.browser.newContext(createControlUiE2eContextOptions());
     page = await context.newPage();
     page.setDefaultTimeout(controlUiE2eWaitTimeoutMs);
     const gateway = await installMockGateway(page, {

--- a/ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   installMockGateway,
   waitForRequests,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -108,11 +109,7 @@ suite.define(() => {
   it.each(["temporary failure", "previous success", "not found"] as const)(
     "refreshes a reply preview after reconnect from $0 and keeps source navigation working",
     async (initial) => {
-      const context = await suite.newBrowserContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const source = {
         role: "assistant",

--- a/ui/src/e2e/chat-scroll.e2e.test.ts
+++ b/ui/src/e2e/chat-scroll.e2e.test.ts
@@ -13,6 +13,7 @@ import {
   scrollChatThreadToTop,
   waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -22,11 +23,7 @@ suite.define(() => {
     const artifactDir = artifactDirParent
       ? createControlUiE2eArtifactDir("chat-flow.streaming", artifactDirParent)
       : undefined;
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const baseTs = Date.now() - 100_000;
     const historyMessages = Array.from({ length: 50 }, (_, index) => ({
@@ -210,11 +207,7 @@ suite.define(() => {
   });
 
   it("overlays the scroll-to-bottom affordance without shrinking the transcript", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const baseTs = Date.now() - 100_000;
     const historyMessages = Array.from({ length: 50 }, (_, index) => ({

--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   requireString,
   waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import { waitForCommittedComposerDraft } from "./settle.test-support.ts";
 
 // Durable runtime budgets for the chat streaming surface. Byte budgets
@@ -469,257 +470,220 @@ function buildLongTranscriptFixture(messageCount: number): Array<Record<string, 
 
 suite.define(() => {
   it("commits a streamed delta burst in frame-bound transcript batches", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page);
-        await page.goto(`${suite.server.baseUrl}chat`);
-        await gateway.waitForRequest("chat.startup");
-        const runId = await openStreamingTurn(page, gateway, "burst coalescing probe");
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const runId = await openStreamingTurn(page, gateway, "burst coalescing probe");
 
-        await installRenderProbe(page);
-        await resetRenderProbe(page);
+      await installRenderProbe(page);
+      await resetRenderProbe(page);
 
-        await emitDeltaBurstInPage(page, runId, BURST_DELTA_COUNT);
-        await expect
-          .poll(() =>
-            page.evaluate(
-              (finalChunk) =>
-                (document.querySelector(".chat-thread-inner")?.textContent ?? "").includes(
-                  finalChunk,
-                ),
-              renderedChunkText(BURST_DELTA_COUNT),
-            ),
-          )
-          .toBe(true);
-        // Sample after the trailing animation frame drained so the batch count
-        // reflects the whole burst, not a mid-render snapshot.
-        await expect
-          .poll(async () => {
-            const before = await readRenderProbe(page);
-            await new Promise((resolve) => {
-              setTimeout(resolve, 200);
-            });
-            const after = await readRenderProbe(page);
-            return before.mutationBatches === after.mutationBatches ? after : null;
-          })
-          .not.toBeNull();
+      await emitDeltaBurstInPage(page, runId, BURST_DELTA_COUNT);
+      await expect
+        .poll(() =>
+          page.evaluate(
+            (finalChunk) =>
+              (document.querySelector(".chat-thread-inner")?.textContent ?? "").includes(
+                finalChunk,
+              ),
+            renderedChunkText(BURST_DELTA_COUNT),
+          ),
+        )
+        .toBe(true);
+      // Sample after the trailing animation frame drained so the batch count
+      // reflects the whole burst, not a mid-render snapshot.
+      await expect
+        .poll(async () => {
+          const before = await readRenderProbe(page);
+          await new Promise((resolve) => {
+            setTimeout(resolve, 200);
+          });
+          const after = await readRenderProbe(page);
+          return before.mutationBatches === after.mutationBatches ? after : null;
+        })
+        .not.toBeNull();
 
-        const probe = await readRenderProbe(page);
-        await recordBudgetMetrics("delta-burst-commits", {
-          mutationBatches: probe.mutationBatches,
-          rafCount: probe.rafCount,
-          hostUpdates: probe.hostUpdates,
-          hostUpdatesInsideFrame: probe.hostUpdatesInsideFrame,
-        });
+      const probe = await readRenderProbe(page);
+      await recordBudgetMetrics("delta-burst-commits", {
+        mutationBatches: probe.mutationBatches,
+        rafCount: probe.rafCount,
+        hostUpdates: probe.hostUpdates,
+        hostUpdatesInsideFrame: probe.hostUpdatesInsideFrame,
+      });
 
-        expect(probe.hostUpdates).toBeGreaterThanOrEqual(MIN_BURST_HOST_UPDATES);
-        expect(probe.hostUpdates).toBeLessThanOrEqual(MAX_BURST_HOST_UPDATES);
-        expect(probe.hostUpdatesInsideFrame / probe.hostUpdates).toBeGreaterThanOrEqual(
-          FRAME_SCHEDULED_MIN_RATIO,
-        );
-      },
-    );
+      expect(probe.hostUpdates).toBeGreaterThanOrEqual(MIN_BURST_HOST_UPDATES);
+      expect(probe.hostUpdates).toBeLessThanOrEqual(MAX_BURST_HOST_UPDATES);
+      expect(probe.hostUpdatesInsideFrame / probe.hostUpdates).toBeGreaterThanOrEqual(
+        FRAME_SCHEDULED_MIN_RATIO,
+      );
+    });
   });
 
   it("keeps the live tool stream bounded under complete tool lifecycles", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page);
-        await page.goto(`${suite.server.baseUrl}chat`);
-        await gateway.waitForRequest("chat.startup");
-        const runId = await openStreamingTurn(page, gateway, "tool flood probe");
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const runId = await openStreamingTurn(page, gateway, "tool flood probe");
 
-        await probeDeferredToolProjection(page, runId);
-        const projection = await page.evaluate(
-          () => (window as ScopedWindow).ocToolProjectionProbe!,
-        );
-        expect(projection.beforeThrottleCardCount).toBe(0);
-        expect(projection.afterThrottleCardCount).toBe(1);
-        expect(projection.afterThrottleText).toContain("Editing");
-        expect(projection.afterThrottleText).toContain("+1");
-        expect(projection.afterThrottleText).toContain("-1");
+      await probeDeferredToolProjection(page, runId);
+      const projection = await page.evaluate(() => (window as ScopedWindow).ocToolProjectionProbe!);
+      expect(projection.beforeThrottleCardCount).toBe(0);
+      expect(projection.afterThrottleCardCount).toBe(1);
+      expect(projection.afterThrottleText).toContain("Editing");
+      expect(projection.afterThrottleText).toContain("+1");
+      expect(projection.afterThrottleText).toContain("-1");
 
-        await completeFirstToolLifecycle(page, runId);
-        const firstCard = page.locator('[data-message-id^="tool:assistant:call-1:"]');
-        expect(await firstCard.count()).toBe(1);
-        expect(await firstCard.textContent()).toContain("Edited");
+      await completeFirstToolLifecycle(page, runId);
+      const firstCard = page.locator('[data-message-id^="tool:assistant:call-1:"]');
+      expect(await firstCard.count()).toBe(1);
+      expect(await firstCard.textContent()).toContain("Edited");
 
-        await emitRemainingToolLifecycleFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
-        const floodCards = page.locator('[data-message-id^="tool:assistant:call-"]');
-        // Eviction drops the oldest entries and keeps the freshest ones.
-        await expect
-          .poll(() => floodCards.count(), { timeout: 15_000 })
-          .toBe(TOOL_STREAM_LIMIT_CONTRACT);
-        const firstRetainedCall = TOOL_FLOOD_PAIR_COUNT - TOOL_STREAM_LIMIT_CONTRACT + 1;
-        expect(await page.locator('[data-message-id^="tool:assistant:call-1:"]').count()).toBe(0);
-        expect(
-          await page
-            .locator(`[data-message-id^="tool:assistant:call-${firstRetainedCall}:"]`)
-            .count(),
-        ).toBe(1);
-        expect(
-          await page
-            .locator(`[data-message-id^="tool:assistant:call-${TOOL_FLOOD_PAIR_COUNT}:"]`)
-            .count(),
-        ).toBe(1);
-      },
-    );
+      await emitRemainingToolLifecycleFlood(page, runId, TOOL_FLOOD_PAIR_COUNT);
+      const floodCards = page.locator('[data-message-id^="tool:assistant:call-"]');
+      // Eviction drops the oldest entries and keeps the freshest ones.
+      await expect
+        .poll(() => floodCards.count(), { timeout: 15_000 })
+        .toBe(TOOL_STREAM_LIMIT_CONTRACT);
+      const firstRetainedCall = TOOL_FLOOD_PAIR_COUNT - TOOL_STREAM_LIMIT_CONTRACT + 1;
+      expect(await page.locator('[data-message-id^="tool:assistant:call-1:"]').count()).toBe(0);
+      expect(
+        await page
+          .locator(`[data-message-id^="tool:assistant:call-${firstRetainedCall}:"]`)
+          .count(),
+      ).toBe(1);
+      expect(
+        await page
+          .locator(`[data-message-id^="tool:assistant:call-${TOOL_FLOOD_PAIR_COUNT}:"]`)
+          .count(),
+      ).toBe(1);
+    });
   });
 
   it("loads a long transcript and streams a rich turn inside budget ceilings", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page, context }) => {
-        const gateway = await installMockGateway(page, {
-          historyMessages: buildLongTranscriptFixture(LONG_TRANSCRIPT_MESSAGE_COUNT),
-        });
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page, context }) => {
+      const gateway = await installMockGateway(page, {
+        historyMessages: buildLongTranscriptFixture(LONG_TRANSCRIPT_MESSAGE_COUNT),
+      });
 
-        const loadStartedAt = Date.now();
-        await page.goto(`${suite.server.baseUrl}chat`);
-        await gateway.waitForRequest("chat.startup");
-        await page
-          .locator(".chat-thread-inner")
-          .getByText("LONG-TAIL-SENTINEL")
-          .waitFor({ timeout: LONG_TRANSCRIPT_LOAD_CEILING_MS });
-        const loadMs = Date.now() - loadStartedAt;
-        expect(loadMs).toBeLessThanOrEqual(LONG_TRANSCRIPT_LOAD_CEILING_MS);
+      const loadStartedAt = Date.now();
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await page
+        .locator(".chat-thread-inner")
+        .getByText("LONG-TAIL-SENTINEL")
+        .waitFor({ timeout: LONG_TRANSCRIPT_LOAD_CEILING_MS });
+      const loadMs = Date.now() - loadStartedAt;
+      expect(loadMs).toBeLessThanOrEqual(LONG_TRANSCRIPT_LOAD_CEILING_MS);
 
-        const runId = await openStreamingTurn(page, gateway, "rich streaming turn");
-        await emitDeltaBurstInPage(page, runId, RICH_TURN_CHUNK_COUNT);
-        await gateway.emitChatFinal({ runId, text: "rich turn finalized" });
-        await page.locator(".chat-thread-inner").getByText("rich turn finalized").waitFor();
+      const runId = await openStreamingTurn(page, gateway, "rich streaming turn");
+      await emitDeltaBurstInPage(page, runId, RICH_TURN_CHUNK_COUNT);
+      await gateway.emitChatFinal({ runId, text: "rich turn finalized" });
+      await page.locator(".chat-thread-inner").getByText("rich turn finalized").waitFor();
 
-        const cdpSession = await context.newCDPSession(page);
-        // Metric collection requires the domain to be enabled first.
-        await cdpSession.send("Performance.enable");
-        await cdpSession.send("HeapProfiler.collectGarbage");
-        await cdpSession.send("HeapProfiler.collectGarbage");
-        const { metrics } = await cdpSession.send("Performance.getMetrics");
-        const heapUsedBytes = metrics.find((metric) => metric.name === "JSHeapUsedSize")!.value;
-        expect(heapUsedBytes).toBeLessThanOrEqual(STREAM_SESSION_HEAP_CEILING_BYTES);
+      const cdpSession = await context.newCDPSession(page);
+      // Metric collection requires the domain to be enabled first.
+      await cdpSession.send("Performance.enable");
+      await cdpSession.send("HeapProfiler.collectGarbage");
+      await cdpSession.send("HeapProfiler.collectGarbage");
+      const { metrics } = await cdpSession.send("Performance.getMetrics");
+      const heapUsedBytes = metrics.find((metric) => metric.name === "JSHeapUsedSize")!.value;
+      expect(heapUsedBytes).toBeLessThanOrEqual(STREAM_SESSION_HEAP_CEILING_BYTES);
 
-        await recordBudgetMetrics("long-transcript-rich-turn", {
-          loadMs,
-          heapUsedBytes: Math.round(heapUsedBytes),
-        });
-      },
-    );
+      await recordBudgetMetrics("long-transcript-rich-turn", {
+        loadMs,
+        heapUsedBytes: Math.round(heapUsedBytes),
+      });
+    });
   });
 
   it("keeps steady-state composer edits local to a long transcript", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          historyMessages: buildLongTranscriptFixture(LONG_TRANSCRIPT_MESSAGE_COUNT),
-        });
-        await page.goto(`${suite.server.baseUrl}chat`);
-        await gateway.waitForRequest("chat.startup");
-        await page.locator(".chat-thread-inner").getByText("LONG-TAIL-SENTINEL").waitFor();
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        historyMessages: buildLongTranscriptFixture(LONG_TRANSCRIPT_MESSAGE_COUNT),
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      await page.locator(".chat-thread-inner").getByText("LONG-TAIL-SENTINEL").waitFor();
 
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        const scopeKey = "chat:v3:agent:main:main\u0000agent:main";
-        await composer.fill("seed");
-        await page.getByRole("button", { name: "Send message" }).waitFor();
-        // The first saved draft notifies presence subscribers. Drain that transition
-        // before measuring edits to an already-present draft.
-        await waitForCommittedComposerDraft(page, scopeKey, "seed", 0);
-        // Finish startup scrolling before measuring steady-state composer invalidations.
-        await waitForChatScrollIdle(page);
-        await installRenderProbe(page);
-        await resetRenderProbe(page);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      const scopeKey = "chat:v3:agent:main:main\u0000agent:main";
+      await composer.fill("seed");
+      await page.getByRole("button", { name: "Send message" }).waitFor();
+      // The first saved draft notifies presence subscribers. Drain that transition
+      // before measuring edits to an already-present draft.
+      await waitForCommittedComposerDraft(page, scopeKey, "seed", 0);
+      // Finish startup scrolling before measuring steady-state composer invalidations.
+      await waitForChatScrollIdle(page);
+      await installRenderProbe(page);
+      await resetRenderProbe(page);
 
-        const suffix = " ordinary typing without commands";
-        await composer.pressSequentially(suffix);
-        await waitForCommittedComposerDraft(page, scopeKey, `seed${suffix}`, 0);
-        expect(await composer.inputValue()).toBe(`seed${suffix}`);
-        const probe = await readRenderProbe(page);
+      const suffix = " ordinary typing without commands";
+      await composer.pressSequentially(suffix);
+      await waitForCommittedComposerDraft(page, scopeKey, `seed${suffix}`, 0);
+      expect(await composer.inputValue()).toBe(`seed${suffix}`);
+      const probe = await readRenderProbe(page);
 
-        expect(probe.hostUpdates).toBeLessThanOrEqual(MAX_STEADY_COMPOSER_HOST_UPDATES);
+      expect(probe.hostUpdates).toBeLessThanOrEqual(MAX_STEADY_COMPOSER_HOST_UPDATES);
 
-        const send = page.locator(".chat-send-btn--send");
-        await composer.fill("");
-        await expect.poll(() => send.isDisabled()).toBe(true);
+      const send = page.locator(".chat-send-btn--send");
+      await composer.fill("");
+      await expect.poll(() => send.isDisabled()).toBe(true);
 
-        await composer.fill("new draft");
-        await expect.poll(() => send.isDisabled()).toBe(false);
+      await composer.fill("new draft");
+      await expect.poll(() => send.isDisabled()).toBe(false);
 
-        await composer.fill("مرحبا");
-        await expect.poll(() => composer.getAttribute("dir")).toBe("rtl");
-      },
-    );
+      await composer.fill("مرحبا");
+      await expect.poll(() => composer.getAttribute("dir")).toBe("rtl");
+    });
   });
 
   it("stays quiet while idle after a settled stream", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page, context }) => {
-        const gateway = await installMockGateway(page);
-        await page.goto(`${suite.server.baseUrl}chat`);
-        await gateway.waitForRequest("chat.startup");
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page, context }) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
 
-        const runId = await openStreamingTurn(page, gateway, "idle quiescence probe");
-        await gateway.emitChatFinal({ runId, text: "short finalized turn" });
-        await page.locator(".chat-thread-inner").getByText("short finalized turn").waitFor();
+      const runId = await openStreamingTurn(page, gateway, "idle quiescence probe");
+      await gateway.emitChatFinal({ runId, text: "short finalized turn" });
+      await page.locator(".chat-thread-inner").getByText("short finalized turn").waitFor();
 
-        const cdpSession = await context.newCDPSession(page);
-        await cdpSession.send("Performance.enable");
-        const beforeMetrics = await cdpSession.send("Performance.getMetrics");
-        const taskDurationBefore = beforeMetrics.metrics.find(
-          (metric) => metric.name === "TaskDuration",
-        )!.value;
-        await page.evaluate(() => {
-          const scope = window as ScopedWindow;
-          scope.ocIdleProbe = { longTasks: 0, longTaskMs: 0 };
-          new PerformanceObserver((list) => {
-            for (const entry of list.getEntries()) {
-              scope.ocIdleProbe!.longTasks += 1;
-              scope.ocIdleProbe!.longTaskMs += entry.duration;
-            }
-          }).observe({ entryTypes: ["longtask"] });
-        });
+      const cdpSession = await context.newCDPSession(page);
+      await cdpSession.send("Performance.enable");
+      const beforeMetrics = await cdpSession.send("Performance.getMetrics");
+      const taskDurationBefore = beforeMetrics.metrics.find(
+        (metric) => metric.name === "TaskDuration",
+      )!.value;
+      await page.evaluate(() => {
+        const scope = window as ScopedWindow;
+        scope.ocIdleProbe = { longTasks: 0, longTaskMs: 0 };
+        new PerformanceObserver((list) => {
+          for (const entry of list.getEntries()) {
+            scope.ocIdleProbe!.longTasks += 1;
+            scope.ocIdleProbe!.longTaskMs += entry.duration;
+          }
+        }).observe({ entryTypes: ["longtask"] });
+      });
 
-        await new Promise((resolve) => {
-          setTimeout(resolve, IDLE_WINDOW_MS);
-        });
+      await new Promise((resolve) => {
+        setTimeout(resolve, IDLE_WINDOW_MS);
+      });
 
-        const afterMetrics = await cdpSession.send("Performance.getMetrics");
-        const taskDurationAfter = afterMetrics.metrics.find(
-          (metric) => metric.name === "TaskDuration",
-        )!.value;
-        const taskDurationMs = (taskDurationAfter - taskDurationBefore) * 1_000;
-        const idle = await page.evaluate(() => (window as ScopedWindow).ocIdleProbe!);
-        await recordBudgetMetrics("idle-quiescence", {
-          longTasks: idle.longTasks,
-          longTaskMs: Math.round(idle.longTaskMs),
-          taskDurationMs: Math.round(taskDurationMs),
-        });
+      const afterMetrics = await cdpSession.send("Performance.getMetrics");
+      const taskDurationAfter = afterMetrics.metrics.find(
+        (metric) => metric.name === "TaskDuration",
+      )!.value;
+      const taskDurationMs = (taskDurationAfter - taskDurationBefore) * 1_000;
+      const idle = await page.evaluate(() => (window as ScopedWindow).ocIdleProbe!);
+      await recordBudgetMetrics("idle-quiescence", {
+        longTasks: idle.longTasks,
+        longTaskMs: Math.round(idle.longTaskMs),
+        taskDurationMs: Math.round(taskDurationMs),
+      });
 
-        expect(idle.longTaskMs).toBeLessThanOrEqual(IDLE_LONGTASK_TOTAL_CEILING_MS);
-        expect(taskDurationMs).toBeLessThanOrEqual(IDLE_TASK_DURATION_CEILING_MS);
-      },
-    );
+      expect(idle.longTaskMs).toBeLessThanOrEqual(IDLE_LONGTASK_TOTAL_CEILING_MS);
+      expect(taskDurationMs).toBeLessThanOrEqual(IDLE_TASK_DURATION_CEILING_MS);
+    });
   });
 });

--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
@@ -20,11 +21,7 @@ suite.define(() => {
       "",
       "rerun the same session we had for these",
     ].join("\n");
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       historyMessages: [{ role: "user", content: [{ type: "text", text }], timestamp: 1 }],

--- a/ui/src/e2e/chat-workspace-files.e2e.test.ts
+++ b/ui/src/e2e/chat-workspace-files.e2e.test.ts
@@ -1,16 +1,13 @@
 import { expect, it } from "vitest";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("starts the workspace files panel collapsed and toggles it open", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.diff"],

--- a/ui/src/e2e/child-session-load-errors.e2e.test.ts
+++ b/ui/src/e2e/child-session-load-errors.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
@@ -32,11 +33,7 @@ suite.define(() => {
     const childResponse = sessionsListResponse([
       sessionRow(childKey, "Recovered child", 40, { spawnedBy: parentKey }),
     ]);
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {

--- a/ui/src/e2e/community-invite-showing.e2e.test.ts
+++ b/ui/src/e2e/community-invite-showing.e2e.test.ts
@@ -11,7 +11,10 @@ import {
   waitForControlUiSettingsTakeover,
 } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiSessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 import { sessionsListResponse } from "./session-management.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -483,11 +486,7 @@ suite.define(() => {
   });
 
   it("shows immediately, survives Join, and stays dismissed across gateway connections on one origin", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page);
 
@@ -544,11 +543,7 @@ suite.define(() => {
   });
 
   it("does not mount the workspace invite in Settings", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page);
 
@@ -612,11 +607,7 @@ suite.define(() => {
   });
 
   it("hides after a malformed cross-tab state update", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page);
 

--- a/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
+++ b/ui/src/e2e/config-quick-thinking-persistence.e2e.test.ts
@@ -1,7 +1,10 @@
 // Control UI tests cover shared model-behavior persistence through the mocked Gateway.
 import { expect, it } from "vitest";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI Models settings behavior persistence mocked Gateway E2E",
@@ -43,36 +46,77 @@ function requestRaw(request: MockGatewayRequest): Record<string, unknown> {
 
 suite.define(() => {
   it("redirects the legacy General model deep link to Models", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page);
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page);
 
-        const response = await page.goto(
-          `${suite.server.baseUrl}settings/general#settings-general-model`,
-        );
-        expect(response?.status()).toBe(200);
+      const response = await page.goto(
+        `${suite.server.baseUrl}settings/general#settings-general-model`,
+      );
+      expect(response?.status()).toBe(200);
 
-        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-providers");
-        expect(await gateway.getRequests("config.set")).toHaveLength(0);
-      },
-    );
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/model-providers");
+      expect(await gateway.getRequests("config.set")).toHaveLength(0);
+    });
   });
 
   it("persists agents.defaults.thinkingDefault through autosave", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ context, page }) => {
-        const initialConfig = configResponse("low", "hash-1");
-        const savedConfig = configResponse("high", "hash-2");
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ context, page }) => {
+      const initialConfig = configResponse("low", "hash-1");
+      const savedConfig = configResponse("high", "hash-2");
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "config.get": { sequence: [initialConfig, savedConfig] },
+          "config.patch": savedConfig,
+        },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}settings/model-providers`);
+      expect(response?.status()).toBe(200);
+
+      const modelCard = page.locator("#settings-model-behavior");
+      const lowButton = modelCard.getByRole("radio", { name: "Low", exact: true });
+      await lowButton.waitFor();
+      expect(await lowButton.getAttribute("aria-checked")).toBe("true");
+
+      await modelCard.getByRole("radio", { name: "High", exact: true }).click();
+
+      const raw = requestRaw(await gateway.waitForRequest("config.patch"));
+      expect(raw).toEqual({
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5",
+            utilityModel: null,
+            thinkingDefault: "high",
+            fastModeDefault: null,
+          },
+        },
+      });
+      expect(JSON.stringify(raw)).not.toContain("thinkingLevel");
+      expect(raw.agents).not.toHaveProperty("defaults.fastMode");
+
+      const freshPage = await context.newPage();
+      await installMockGateway(freshPage, {
+        methodResponses: { "config.get": savedConfig },
+      });
+      await freshPage.goto(`${suite.server.baseUrl}settings/model-providers`);
+      const highButton = freshPage
+        .locator("#settings-model-behavior")
+        .getByRole("radio", { name: "High", exact: true });
+      await highButton.waitFor();
+      expect(await highButton.getAttribute("aria-checked")).toBe("true");
+    });
+  });
+
+  it.each([
+    { initial: false, initialLabel: "Off", next: true, nextLabel: "On" },
+    { initial: true, initialLabel: "On", next: "auto" as const, nextLabel: "Auto" },
+    { initial: "auto" as const, initialLabel: "Auto", next: false, nextLabel: "Off" },
+  ])(
+    "persists agents.defaults.fastModeDefault from $initialLabel to $nextLabel",
+    async ({ initial, initialLabel, next, nextLabel }) => {
+      await suite.withPage(createControlUiE2eContextOptions(), async ({ context, page }) => {
+        const initialConfig = configResponse("low", "hash-1", initial);
+        const savedConfig = configResponse("low", "hash-2", next);
         const gateway = await installMockGateway(page, {
           methodResponses: {
             "config.get": { sequence: [initialConfig, savedConfig] },
@@ -84,11 +128,15 @@ suite.define(() => {
         expect(response?.status()).toBe(200);
 
         const modelCard = page.locator("#settings-model-behavior");
-        const lowButton = modelCard.getByRole("radio", { name: "Low", exact: true });
-        await lowButton.waitFor();
-        expect(await lowButton.getAttribute("aria-checked")).toBe("true");
+        const fastModeGroup = modelCard.locator("wa-radio-group").nth(1);
+        const initialButton = fastModeGroup.getByRole("radio", {
+          name: initialLabel,
+          exact: true,
+        });
+        await initialButton.waitFor();
+        expect(await initialButton.getAttribute("aria-checked")).toBe("true");
 
-        await modelCard.getByRole("radio", { name: "High", exact: true }).click();
+        await fastModeGroup.getByRole("radio", { name: nextLabel, exact: true }).click();
 
         const raw = requestRaw(await gateway.waitForRequest("config.patch"));
         expect(raw).toEqual({
@@ -96,97 +144,31 @@ suite.define(() => {
             defaults: {
               model: "openai/gpt-5.5",
               utilityModel: null,
-              thinkingDefault: "high",
-              fastModeDefault: null,
+              thinkingDefault: "low",
+              fastModeDefault: next,
             },
           },
         });
-        expect(JSON.stringify(raw)).not.toContain("thinkingLevel");
         expect(raw.agents).not.toHaveProperty("defaults.fastMode");
 
         const freshPage = await context.newPage();
         await installMockGateway(freshPage, {
           methodResponses: { "config.get": savedConfig },
         });
-        await freshPage.goto(`${suite.server.baseUrl}settings/model-providers`);
-        const highButton = freshPage
-          .locator("#settings-model-behavior")
-          .getByRole("radio", { name: "High", exact: true });
-        await highButton.waitFor();
-        expect(await highButton.getAttribute("aria-checked")).toBe("true");
-      },
-    );
-  });
-
-  it.each([
-    { initial: false, initialLabel: "Off", next: true, nextLabel: "On" },
-    { initial: true, initialLabel: "On", next: "auto" as const, nextLabel: "Auto" },
-    { initial: "auto" as const, initialLabel: "Auto", next: false, nextLabel: "Off" },
-  ])(
-    "persists agents.defaults.fastModeDefault from $initialLabel to $nextLabel",
-    async ({ initial, initialLabel, next, nextLabel }) => {
-      await suite.withPage(
-        {
-          locale: "en-US",
-          serviceWorkers: "block",
-          viewport: { height: 900, width: 1280 },
-        },
-        async ({ context, page }) => {
-          const initialConfig = configResponse("low", "hash-1", initial);
-          const savedConfig = configResponse("low", "hash-2", next);
-          const gateway = await installMockGateway(page, {
-            methodResponses: {
-              "config.get": { sequence: [initialConfig, savedConfig] },
-              "config.patch": savedConfig,
-            },
-          });
-
-          const response = await page.goto(`${suite.server.baseUrl}settings/model-providers`);
-          expect(response?.status()).toBe(200);
-
-          const modelCard = page.locator("#settings-model-behavior");
-          const fastModeGroup = modelCard.locator("wa-radio-group").nth(1);
-          const initialButton = fastModeGroup.getByRole("radio", {
-            name: initialLabel,
+        const reloadResponse = await freshPage.goto(
+          `${suite.server.baseUrl}settings/model-providers`,
+        );
+        expect(reloadResponse?.status()).toBe(200);
+        const persistedButton = freshPage
+          .locator("#settings-model-behavior wa-radio-group")
+          .nth(1)
+          .getByRole("radio", {
+            name: nextLabel,
             exact: true,
           });
-          await initialButton.waitFor();
-          expect(await initialButton.getAttribute("aria-checked")).toBe("true");
-
-          await fastModeGroup.getByRole("radio", { name: nextLabel, exact: true }).click();
-
-          const raw = requestRaw(await gateway.waitForRequest("config.patch"));
-          expect(raw).toEqual({
-            agents: {
-              defaults: {
-                model: "openai/gpt-5.5",
-                utilityModel: null,
-                thinkingDefault: "low",
-                fastModeDefault: next,
-              },
-            },
-          });
-          expect(raw.agents).not.toHaveProperty("defaults.fastMode");
-
-          const freshPage = await context.newPage();
-          await installMockGateway(freshPage, {
-            methodResponses: { "config.get": savedConfig },
-          });
-          const reloadResponse = await freshPage.goto(
-            `${suite.server.baseUrl}settings/model-providers`,
-          );
-          expect(reloadResponse?.status()).toBe(200);
-          const persistedButton = freshPage
-            .locator("#settings-model-behavior wa-radio-group")
-            .nth(1)
-            .getByRole("radio", {
-              name: nextLabel,
-              exact: true,
-            });
-          await persistedButton.waitFor();
-          expect(await persistedButton.getAttribute("aria-checked")).toBe("true");
-        },
-      );
+        await persistedButton.waitFor();
+        expect(await persistedButton.getAttribute("aria-checked")).toBe("true");
+      });
     },
   );
 });

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,6 +1,13 @@
 import { writeSync } from "node:fs";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
-import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
+import {
+  chromium,
+  type Browser,
+  type BrowserContext,
+  type BrowserContextOptions,
+  type Locator,
+  type Page,
+} from "playwright";
 import {
   afterAll,
   afterEach,
@@ -134,6 +141,14 @@ async function settleControlUiCleanup(promises: Promise<unknown>[]): Promise<voi
   throwControlUiCleanupErrors(
     results.flatMap((result) => (result.status === "rejected" ? [result.reason] : [])),
   );
+}
+
+export function createControlUiE2eContextOptions(): BrowserContextOptions {
+  return {
+    locale: "en-US",
+    serviceWorkers: "block",
+    viewport: { height: 900, width: 1280 },
+  };
 }
 
 export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): ControlUiE2eSuite {

--- a/ui/src/e2e/cron-filters.e2e.test.ts
+++ b/ui/src/e2e/cron-filters.e2e.test.ts
@@ -7,7 +7,10 @@ import {
   type MockGatewayControls,
   type MockGatewayRequest,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI cron mocked Gateway E2E",
@@ -189,105 +192,83 @@ suite.define(() => {
       {},
     );
 
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const pageErrors: string[] = [];
-        const consoleMessages: string[] = [];
-        page.on("pageerror", (err) => pageErrors.push(String(err)));
-        page.on("console", (msg) => consoleMessages.push(`${msg.type()}: ${msg.text()}`));
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "cron.list": {
-              cases: [
-                {
-                  match: { scheduleKind: "cron", lastRunStatus: "unknown" },
-                  response: cronListResponse([cronUnknown]),
-                },
-                {
-                  match: {},
-                  response: cronListResponse([everyOk, cronUnknown], 2),
-                },
-              ],
-            },
-            "cron.runs": {
-              entries: [],
-              total: 0,
-              offset: 0,
-              limit: 50,
-              hasMore: false,
-              nextOffset: null,
-            },
-            "cron.status": {
-              enabled: true,
-              jobs: 2,
-              nextWakeAtMs: Date.parse("2026-05-29T09:00:00.000Z"),
-              storePath: "/tmp/openclaw-e2e/cron/jobs.json",
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const pageErrors: string[] = [];
+      const consoleMessages: string[] = [];
+      page.on("pageerror", (err) => pageErrors.push(String(err)));
+      page.on("console", (msg) => consoleMessages.push(`${msg.type()}: ${msg.text()}`));
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "cron.list": {
+            cases: [
+              {
+                match: { scheduleKind: "cron", lastRunStatus: "unknown" },
+                response: cronListResponse([cronUnknown]),
+              },
+              {
+                match: {},
+                response: cronListResponse([everyOk, cronUnknown], 2),
+              },
+            ],
           },
-        });
+          "cron.runs": {
+            entries: [],
+            total: 0,
+            offset: 0,
+            limit: 50,
+            hasMore: false,
+            nextOffset: null,
+          },
+          "cron.status": {
+            enabled: true,
+            jobs: 2,
+            nextWakeAtMs: Date.parse("2026-05-29T09:00:00.000Z"),
+            storePath: "/tmp/openclaw-e2e/cron/jobs.json",
+          },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}cron`);
-        expect(response?.status()).toBe(200);
-        await waitForJobTitle(
-          page,
-          gateway,
-          { consoleMessages, pageErrors },
-          "Digest every minute",
-        );
-        await waitForJobTitle(
-          page,
-          gateway,
-          { consoleMessages, pageErrors },
-          "Nightly cron pending",
-        );
+      const response = await page.goto(`${suite.server.baseUrl}cron`);
+      expect(response?.status()).toBe(200);
+      await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Digest every minute");
+      await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Nightly cron pending");
 
-        const initialRequest = await waitForCronListRequest(
-          gateway,
-          (params) => params.limit === 50 && params.scheduleKind === "all",
-        );
-        expect(requestParams(initialRequest)).toMatchObject({
-          enabled: "all",
-          includeDisabled: true,
-          lastRunStatus: "all",
-          limit: 50,
-          offset: 0,
-          scheduleKind: "all",
-          sortBy: "nextRunAtMs",
-          sortDir: "asc",
-        });
+      const initialRequest = await waitForCronListRequest(
+        gateway,
+        (params) => params.limit === 50 && params.scheduleKind === "all",
+      );
+      expect(requestParams(initialRequest)).toMatchObject({
+        enabled: "all",
+        includeDisabled: true,
+        lastRunStatus: "all",
+        limit: 50,
+        offset: 0,
+        scheduleKind: "all",
+        sortBy: "nextRunAtMs",
+        sortDir: "asc",
+      });
 
-        await page.locator(".cron-filter-popover__trigger").click();
-        await page.locator('[data-test-id="cron-jobs-schedule-filter"]').selectOption("cron");
-        await page.locator('[data-test-id="cron-jobs-last-status-filter"]').selectOption("unknown");
+      await page.locator(".cron-filter-popover__trigger").click();
+      await page.locator('[data-test-id="cron-jobs-schedule-filter"]').selectOption("cron");
+      await page.locator('[data-test-id="cron-jobs-last-status-filter"]').selectOption("unknown");
 
-        const filteredRequest = await waitForCronListRequest(
-          gateway,
-          (params) => params.scheduleKind === "cron" && params.lastRunStatus === "unknown",
-        );
-        expect(requestParams(filteredRequest)).toMatchObject({
-          enabled: "all",
-          includeDisabled: true,
-          lastRunStatus: "unknown",
-          limit: 50,
-          offset: 0,
-          scheduleKind: "cron",
-          sortBy: "nextRunAtMs",
-          sortDir: "asc",
-        });
-        await waitForJobTitle(
-          page,
-          gateway,
-          { consoleMessages, pageErrors },
-          "Nightly cron pending",
-        );
-        await expect.poll(async () => jobTitle(page, "Digest every minute").count()).toBe(0);
-      },
-    );
+      const filteredRequest = await waitForCronListRequest(
+        gateway,
+        (params) => params.scheduleKind === "cron" && params.lastRunStatus === "unknown",
+      );
+      expect(requestParams(filteredRequest)).toMatchObject({
+        enabled: "all",
+        includeDisabled: true,
+        lastRunStatus: "unknown",
+        limit: 50,
+        offset: 0,
+        scheduleKind: "cron",
+        sortBy: "nextRunAtMs",
+        sortDir: "asc",
+      });
+      await waitForJobTitle(page, gateway, { consoleMessages, pageErrors }, "Nightly cron pending");
+      await expect.poll(async () => jobTitle(page, "Digest every minute").count()).toBe(0);
+    });
   });
 
   it("creates a cron-scheduled task and renders the refreshed row", async () => {
@@ -790,67 +771,60 @@ suite.define(() => {
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "Use the configured model", model: configuredModel },
     };
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "cron.add": { id: "quick-created-model-job" },
-            "cron.list": cronListResponse([existingJob]),
-            "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
-            "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
-          },
-        });
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "cron.add": { id: "quick-created-model-job" },
+          "cron.list": cronListResponse([existingJob]),
+          "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+          "cron.status": { enabled: true, jobs: 1, nextWakeAtMs: null },
+        },
+      });
 
-        await page.goto(`${suite.server.baseUrl}cron`);
-        await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
+      await page.goto(`${suite.server.baseUrl}cron`);
+      await jobTitle(page, existingJob.name).waitFor({ timeout: 10_000 });
 
-        // Selecting the task opens the detail view with its stored model override.
-        await jobTitle(page, existingJob.name).click();
-        await expect
-          .poll(async () => page.locator("#cron-payload-model").inputValue())
-          .toBe(configuredModel);
+      // Selecting the task opens the detail view with its stored model override.
+      await jobTitle(page, existingJob.name).click();
+      await expect
+        .poll(async () => page.locator("#cron-payload-model").inputValue())
+        .toBe(configuredModel);
 
-        // The create button lives on the list view; navigate back first.
-        await page.locator('[data-test-id="cron-back"]').click();
-        await page.locator('[data-test-id="cron-new-task"]').click();
-        await page.locator("#cron-payload-text").fill("Run with a selected model");
-        await page.locator("#cron-name").fill("Model override task");
+      // The create button lives on the list view; navigate back first.
+      await page.locator('[data-test-id="cron-back"]').click();
+      await page.locator('[data-test-id="cron-new-task"]').click();
+      await page.locator("#cron-payload-text").fill("Run with a selected model");
+      await page.locator("#cron-name").fill("Model override task");
 
-        const modelInput = page.locator("#cron-payload-model");
-        const modelPicker = page.locator("#cron-payload-model-picker");
-        const customValue = await modelPicker
-          .locator("wa-option", { hasText: "Custom model…" })
-          .getAttribute("value");
-        expect(customValue).not.toBeNull();
-        await modelPicker.evaluate((select, value) => {
-          (select as HTMLElement & { value: string }).value = String(value);
-          select.dispatchEvent(new Event("change", { bubbles: true }));
-        }, customValue);
-        await modelInput.fill("openai/gpt-5.5");
-        expect(
-          await modelPicker
-            .locator("wa-option")
-            .evaluateAll((options) => options.map((option) => option.getAttribute("value"))),
-        ).toContain(configuredModel);
+      const modelInput = page.locator("#cron-payload-model");
+      const modelPicker = page.locator("#cron-payload-model-picker");
+      const customValue = await modelPicker
+        .locator("wa-option", { hasText: "Custom model…" })
+        .getAttribute("value");
+      expect(customValue).not.toBeNull();
+      await modelPicker.evaluate((select, value) => {
+        (select as HTMLElement & { value: string }).value = String(value);
+        select.dispatchEvent(new Event("change", { bubbles: true }));
+      }, customValue);
+      await modelInput.fill("openai/gpt-5.5");
+      expect(
+        await modelPicker
+          .locator("wa-option")
+          .evaluateAll((options) => options.map((option) => option.getAttribute("value"))),
+      ).toContain(configuredModel);
 
-        await page.locator('[data-test-id="cron-submit"]').click();
-        const addRequest = await gateway.waitForRequest("cron.add");
-        expect(requestParams(addRequest)).toMatchObject({
-          name: "Model override task",
-          payload: {
-            kind: "agentTurn",
-            message: "Run with a selected model",
-            model: "openai/gpt-5.5",
-          },
-        });
-        expect(requireRecord(requestParams(addRequest).delivery).accountId).toBeUndefined();
-      },
-    );
+      await page.locator('[data-test-id="cron-submit"]').click();
+      const addRequest = await gateway.waitForRequest("cron.add");
+      expect(requestParams(addRequest)).toMatchObject({
+        name: "Model override task",
+        payload: {
+          kind: "agentTurn",
+          message: "Run with a selected model",
+          model: "openai/gpt-5.5",
+        },
+      });
+      expect(requireRecord(requestParams(addRequest).delivery).accountId).toBeUndefined();
+    });
   });
 
   it("creates and edits agent-turn jobs with an explicit zero timeout", async () => {

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -5,7 +5,10 @@ import { beforeEach, expect, it } from "vitest";
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI custodian event nudge mocked Gateway E2E",
@@ -32,39 +35,32 @@ async function settleUi(page: Page): Promise<void> {
 
 suite.define(() => {
   it("does not reopen agent chat when a deferred setup reply arrives after exit", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-          deferredMethods: ["openclaw.chat"],
-          methodResponses: {},
-        });
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+        deferredMethods: ["openclaw.chat"],
+        methodResponses: {},
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
-        expect(response?.status()).toBe(200);
-        await gateway.waitForRequest("openclaw.chat");
-        await page.getByRole("button", { name: "Exit setup" }).click();
-        await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/main");
-        const destination = page.url();
-        const agentListRequests = (await gateway.getRequests("agents.list")).length;
+      const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
+      expect(response?.status()).toBe(200);
+      await gateway.waitForRequest("openclaw.chat");
+      await page.getByRole("button", { name: "Exit setup" }).click();
+      await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/main");
+      const destination = page.url();
+      const agentListRequests = (await gateway.getRequests("agents.list")).length;
 
-        await gateway.resolveDeferred("openclaw.chat", {
-          sessionId: "late-e2e-custodian",
-          reply: "Your agent is hatching — handing you over now.",
-          action: "open-agent",
-          agentId: "main",
-          agentDraft: "hatch",
-        });
-        await expect.poll(() => page.url()).toBe(destination);
-        expect(new URL(page.url()).searchParams.has("draft")).toBe(false);
-        expect((await gateway.getRequests("agents.list")).length).toBe(agentListRequests);
-      },
-    );
+      await gateway.resolveDeferred("openclaw.chat", {
+        sessionId: "late-e2e-custodian",
+        reply: "Your agent is hatching — handing you over now.",
+        action: "open-agent",
+        agentId: "main",
+        agentDraft: "hatch",
+      });
+      await expect.poll(() => page.url()).toBe(destination);
+      expect(new URL(page.url()).searchParams.has("draft")).toBe(false);
+      expect((await gateway.getRequests("agents.list")).length).toBe(agentListRequests);
+    });
   });
 
   it("shows one consequential nudge and sends its canonical message", async () => {
@@ -211,106 +207,92 @@ suite.define(() => {
   });
 
   it("keeps event nudges out of sensitive wizard input", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-          methodResponses: {
-            "openclaw.chat": {
-              sessionId: "e2e-sensitive-custodian",
-              reply: "Paste your API key.",
-              action: "none",
-              sensitive: true,
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+        methodResponses: {
+          "openclaw.chat": {
+            sessionId: "e2e-sensitive-custodian",
+            reply: "Paste your API key.",
+            action: "none",
+            sensitive: true,
           },
-        });
+        },
+      });
 
-        await page.goto(`${suite.server.baseUrl}custodian`);
-        await page.getByPlaceholder("Enter sensitive value").waitFor();
-        await gateway.emitGatewayEvent("health", {
-          channelLabels: { discord: "Discord" },
-          channels: { discord: { configured: true, connected: false, running: true } },
-        });
+      await page.goto(`${suite.server.baseUrl}custodian`);
+      await page.getByPlaceholder("Enter sensitive value").waitFor();
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, connected: false, running: true } },
+      });
 
-        const nudge = page.getByRole("button", {
-          name: "Discord just disconnected — ask me what happened",
-        });
-        await nudge.waitFor();
-        await expect.poll(() => nudge.isDisabled()).toBe(true);
-        await nudge.evaluate((element) => (element as HTMLButtonElement).click());
-        await settleUi(page);
+      const nudge = page.getByRole("button", {
+        name: "Discord just disconnected — ask me what happened",
+      });
+      await nudge.waitFor();
+      await expect.poll(() => nudge.isDisabled()).toBe(true);
+      await nudge.evaluate((element) => (element as HTMLButtonElement).click());
+      await settleUi(page);
 
-        expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
-        expect(await page.getByText("what happened with discord?").count()).toBe(0);
-      },
-    );
+      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+      expect(await page.getByText("what happened with discord?").count()).toBe(0);
+    });
   });
 
   it("keeps nudges out of a closed question and sends a parseable skip answer", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-          methodResponses: {
-            "openclaw.chat": {
-              sessionId: "e2e-wizard-custodian",
-              reply: "Choose one.",
-              action: "none",
-              question: {
-                id: "access",
-                header: "Access",
-                question: "How should OpenClaw work?",
-                options: [{ label: "Full access" }, { label: "Ask first" }],
-                isOther: false,
-              },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+        methodResponses: {
+          "openclaw.chat": {
+            sessionId: "e2e-wizard-custodian",
+            reply: "Choose one.",
+            action: "none",
+            question: {
+              id: "access",
+              header: "Access",
+              question: "How should OpenClaw work?",
+              options: [{ label: "Full access" }, { label: "Ask first" }],
+              isOther: false,
             },
           },
-        });
+        },
+      });
 
-        await page.goto(`${suite.server.baseUrl}custodian`);
-        const skip = page.getByRole("button", { name: "Skip for now" });
-        await skip.waitFor();
-        await gateway.emitGatewayEvent("health", {
-          channelLabels: { discord: "Discord" },
-          channels: { discord: { configured: true, connected: false, running: true } },
-        });
-        const nudge = page.getByRole("button", {
-          name: "Discord just disconnected — ask me what happened",
-        });
-        await nudge.waitFor();
-        await expect.poll(() => nudge.isDisabled()).toBe(true);
-        await nudge.evaluate((element) => (element as HTMLButtonElement).click());
-        await settleUi(page);
-        expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
+      await page.goto(`${suite.server.baseUrl}custodian`);
+      const skip = page.getByRole("button", { name: "Skip for now" });
+      await skip.waitFor();
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { discord: "Discord" },
+        channels: { discord: { configured: true, connected: false, running: true } },
+      });
+      const nudge = page.getByRole("button", {
+        name: "Discord just disconnected — ask me what happened",
+      });
+      await nudge.waitFor();
+      await expect.poll(() => nudge.isDisabled()).toBe(true);
+      await nudge.evaluate((element) => (element as HTMLButtonElement).click());
+      await settleUi(page);
+      expect(await gateway.getRequests("openclaw.chat")).toHaveLength(1);
 
-        await gateway.setMethodResponse("openclaw.chat", {
-          sessionId: "e2e-wizard-custodian",
-          reply: "Moving on.",
-          action: "none",
-        });
-        await skip.click();
+      await gateway.setMethodResponse("openclaw.chat", {
+        sessionId: "e2e-wizard-custodian",
+        reply: "Moving on.",
+        action: "none",
+      });
+      await skip.click();
 
-        await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
-        const requests = await gateway.getRequests("openclaw.chat");
-        expect(requests[1]?.params).toMatchObject({
-          message: "cancel",
-          sessionId: "e2e-wizard-custodian",
-        });
-        await page.locator(".chat-group.user", { hasText: "Skip for now" }).waitFor();
-        await page.getByText("Moving on.").waitFor();
-        expect(await page.locator("openclaw-option-card").count()).toBe(0);
-      },
-    );
+      await expect.poll(async () => (await gateway.getRequests("openclaw.chat")).length).toBe(2);
+      const requests = await gateway.getRequests("openclaw.chat");
+      expect(requests[1]?.params).toMatchObject({
+        message: "cancel",
+        sessionId: "e2e-wizard-custodian",
+      });
+      await page.locator(".chat-group.user", { hasText: "Skip for now" }).waitFor();
+      await page.getByText("Moving on.").waitFor();
+      expect(await page.locator("openclaw-option-card").count()).toBe(0);
+    });
   });
 
   it("renders rich wizard controls and sends typed answers", async () => {
@@ -580,37 +562,30 @@ suite.define(() => {
   });
 
   it("stays silent during onboarding", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
-          methodResponses: {
-            "openclaw.chat": {
-              sessionId: "e2e-onboarding-custodian",
-              reply: "Let's finish setup.",
-              action: "none",
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "openclaw.chat"],
+        methodResponses: {
+          "openclaw.chat": {
+            sessionId: "e2e-onboarding-custodian",
+            reply: "Let's finish setup.",
+            action: "none",
           },
-        });
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
-        expect(response?.status()).toBe(200);
-        // Onboarding chrome keeps only the header actions; no identity heading.
-        await page.locator(".custodian__header--minimal").waitFor();
-        await gateway.emitGatewayEvent("health", {
-          channelLabels: { telegram: "Telegram" },
-          channels: {
-            telegram: { configured: true, connected: false, running: true },
-          },
-        });
-        await settleUi(page);
-        expect(await page.locator(".custodian__nudge").count()).toBe(0);
-      },
-    );
+      const response = await page.goto(`${suite.server.baseUrl}custodian?onboarding=1`);
+      expect(response?.status()).toBe(200);
+      // Onboarding chrome keeps only the header actions; no identity heading.
+      await page.locator(".custodian__header--minimal").waitFor();
+      await gateway.emitGatewayEvent("health", {
+        channelLabels: { telegram: "Telegram" },
+        channels: {
+          telegram: { configured: true, connected: false, running: true },
+        },
+      });
+      await settleUi(page);
+      expect(await page.locator(".custodian__nudge").count()).toBe(0);
+    });
   });
 });

--- a/ui/src/e2e/device-alias-rename.e2e.test.ts
+++ b/ui/src/e2e/device-alias-rename.e2e.test.ts
@@ -5,7 +5,10 @@ import type { Page } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI device alias rename mocked Gateway E2E",
@@ -49,100 +52,93 @@ function pairedDevice(operatorLabel?: string) {
 
 suite.define(() => {
   it("retries a rejected alias rename and dismisses unsaved edits on reconnect", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          methodResponses: {
-            "device.pair.list": { pending: [], paired: [pairedDevice()] },
-            "device.pair.rename": { deviceId: DEVICE_ID, label: "Office node" },
-            "environments.list": { environments: [] },
-            "exec.approvals.get": {
-              exists: false,
-              file: { agents: {}, defaults: {}, version: 1 },
-              hash: "e2e",
-              path: "/tmp/exec-approvals.json",
-            },
-            "node.list": { nodes: [] },
-            "system-presence": [],
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "device.pair.list": { pending: [], paired: [pairedDevice()] },
+          "device.pair.rename": { deviceId: DEVICE_ID, label: "Office node" },
+          "environments.list": { environments: [] },
+          "exec.approvals.get": {
+            exists: false,
+            file: { agents: {}, defaults: {}, version: 1 },
+            hash: "e2e",
+            path: "/tmp/exec-approvals.json",
           },
-        });
+          "node.list": { nodes: [] },
+          "system-presence": [],
+        },
+      });
 
-        await page.goto(`${suite.server.baseUrl}settings/devices`);
-        await waitForControlUiRoute(page, { pathname: "/settings/devices", routeId: "devices" });
+      await page.goto(`${suite.server.baseUrl}settings/devices`);
+      await waitForControlUiRoute(page, { pathname: "/settings/devices", routeId: "devices" });
 
-        const row = page.locator(".device-entry", { hasText: "office-workstation.example.test" });
-        await row.waitFor();
-        await captureUiProof(page, "01-devices-inventory.png");
+      const row = page.locator(".device-entry", { hasText: "office-workstation.example.test" });
+      await row.waitFor();
+      await captureUiProof(page, "01-devices-inventory.png");
 
-        await row.locator(".device-entry__menu-trigger").click();
-        await page.locator('wa-dropdown-item[value="editAlias"]').click();
-        const dialog = page.locator("openclaw-modal-dialog").last();
-        await dialog.locator('input[name="value"]').waitFor();
-        await captureUiProof(page, "02-alias-dialog-open.png");
+      await row.locator(".device-entry__menu-trigger").click();
+      await page.locator('wa-dropdown-item[value="editAlias"]').click();
+      const dialog = page.locator("openclaw-modal-dialog").last();
+      await dialog.locator('input[name="value"]').waitFor();
+      await captureUiProof(page, "02-alias-dialog-open.png");
 
-        await dialog.locator('input[name="value"]').fill("Office node");
-        await captureUiProof(page, "03-alias-dialog-filled.png");
+      await dialog.locator('input[name="value"]').fill("Office node");
+      await captureUiProof(page, "03-alias-dialog-filled.png");
 
-        // Reject the first request at the transport boundary; the same dialog
-        // must preserve the value and remain usable for a second attempt.
-        await gateway.deferNext("device.pair.rename");
-        const renamesBefore = (await gateway.getRequests("device.pair.rename")).length;
-        await dialog.getByRole("button", { name: "Save" }).click();
+      // Reject the first request at the transport boundary; the same dialog
+      // must preserve the value and remain usable for a second attempt.
+      await gateway.deferNext("device.pair.rename");
+      const renamesBefore = (await gateway.getRequests("device.pair.rename")).length;
+      await dialog.getByRole("button", { name: "Save" }).click();
 
-        const renameRequest = await gateway.waitForRequest("device.pair.rename", {
-          after: renamesBefore,
-        });
-        expect(renameRequest.params).toEqual({ deviceId: DEVICE_ID, label: "Office node" });
+      const renameRequest = await gateway.waitForRequest("device.pair.rename", {
+        after: renamesBefore,
+      });
+      expect(renameRequest.params).toEqual({ deviceId: DEVICE_ID, label: "Office node" });
 
-        await gateway.rejectDeferred("device.pair.rename", { message: "Alias change rejected" });
-        const failure = dialog.getByRole("alert");
-        await failure.waitFor();
-        expect(await failure.textContent()).toContain("Alias change rejected");
-        expect(await dialog.locator('input[name="value"]').inputValue()).toBe("Office node");
-        expect(await dialog.getByRole("button", { name: "Save" }).isEnabled()).toBe(true);
-        await captureUiProof(page, "03b-alias-rejected-retryable.png");
+      await gateway.rejectDeferred("device.pair.rename", { message: "Alias change rejected" });
+      const failure = dialog.getByRole("alert");
+      await failure.waitFor();
+      expect(await failure.textContent()).toContain("Alias change rejected");
+      expect(await dialog.locator('input[name="value"]').inputValue()).toBe("Office node");
+      expect(await dialog.getByRole("button", { name: "Save" }).isEnabled()).toBe(true);
+      await captureUiProof(page, "03b-alias-rejected-retryable.png");
 
-        const retryAfter = (await gateway.getRequests("device.pair.rename")).length;
-        await gateway.deferNext("device.pair.rename");
-        await dialog.getByRole("button", { name: "Save" }).click();
-        const retryRequest = await gateway.waitForRequest("device.pair.rename", {
-          after: retryAfter,
-        });
-        expect(retryRequest.params).toEqual({ deviceId: DEVICE_ID, label: "Office node" });
+      const retryAfter = (await gateway.getRequests("device.pair.rename")).length;
+      await gateway.deferNext("device.pair.rename");
+      await dialog.getByRole("button", { name: "Save" }).click();
+      const retryRequest = await gateway.waitForRequest("device.pair.rename", {
+        after: retryAfter,
+      });
+      expect(retryRequest.params).toEqual({ deviceId: DEVICE_ID, label: "Office node" });
 
-        // Publish the new list before releasing success so the refresh has no race.
-        await gateway.setMethodResponse("device.pair.list", {
-          pending: [],
-          paired: [pairedDevice("Office node")],
-        });
-        await gateway.resolveDeferred("device.pair.rename", {
-          deviceId: DEVICE_ID,
-          label: "Office node",
-        });
+      // Publish the new list before releasing success so the refresh has no race.
+      await gateway.setMethodResponse("device.pair.list", {
+        pending: [],
+        paired: [pairedDevice("Office node")],
+      });
+      await gateway.resolveDeferred("device.pair.rename", {
+        deviceId: DEVICE_ID,
+        label: "Office node",
+      });
 
-        await page
-          .locator(".device-entry .settings-row__title", { hasText: "Office node" })
-          .waitFor();
-        await captureUiProof(page, "04-alias-applied.png");
+      await page
+        .locator(".device-entry .settings-row__title", { hasText: "Office node" })
+        .waitFor();
+      await captureUiProof(page, "04-alias-applied.png");
 
-        await dialog.waitFor({ state: "hidden" });
-        const renamedRow = page.locator(".device-entry", { hasText: "Office node" });
-        await renamedRow.locator(".device-entry__menu-trigger").click();
-        await page.locator('wa-dropdown-item[value="editAlias"]').click();
-        await dialog.locator('input[name="value"]').fill("Unsaved alias");
-        const socketsBefore = await gateway.getSocketCount();
-        await gateway.closeLatest();
-        await dialog.waitFor({ state: "hidden" });
-        await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketsBefore);
-        await renamedRow.waitFor();
-        expect(await gateway.getRequests("device.pair.rename")).toHaveLength(renamesBefore + 2);
-        await captureUiProof(page, "05-alias-after-reconnect.png");
-      },
-    );
+      await dialog.waitFor({ state: "hidden" });
+      const renamedRow = page.locator(".device-entry", { hasText: "Office node" });
+      await renamedRow.locator(".device-entry__menu-trigger").click();
+      await page.locator('wa-dropdown-item[value="editAlias"]').click();
+      await dialog.locator('input[name="value"]').fill("Unsaved alias");
+      const socketsBefore = await gateway.getSocketCount();
+      await gateway.closeLatest();
+      await dialog.waitFor({ state: "hidden" });
+      await expect.poll(() => gateway.getSocketCount()).toBeGreaterThan(socketsBefore);
+      await renamedRow.waitFor();
+      expect(await gateway.getRequests("device.pair.rename")).toHaveLength(renamesBefore + 2);
+      await captureUiProof(page, "05-alias-after-reconnect.png");
+    });
   });
 });

--- a/ui/src/e2e/file-drop-guard.e2e.test.ts
+++ b/ui/src/e2e/file-drop-guard.e2e.test.ts
@@ -1,7 +1,10 @@
 // Control UI tests cover browser-level file-drop routing against a mocked Gateway.
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI file-drop guard",
@@ -11,116 +14,109 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("rejects a stray file drop while preserving attachment inputs", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page);
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page);
 
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        await composer.waitFor({ state: "visible", timeout: 10_000 });
-        await composer.fill("draft survives stray drop");
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.waitFor({ state: "visible", timeout: 10_000 });
+      await composer.fill("draft survives stray drop");
 
-        const stray = await page.locator("openclaw-app-shell").evaluate((element) => {
-          const transfer = new DataTransfer();
-          transfer.items.add(new File(["stray"], "stray-proof.txt", { type: "text/plain" }));
-          const beforeUrl = location.href;
-          const beforeDraft = document.querySelector<HTMLTextAreaElement>(
-            ".agent-chat__composer-combobox textarea",
-          )?.value;
-          const dragOver = new DragEvent("dragover", {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer: transfer,
-          });
-          const drop = new DragEvent("drop", {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer: transfer,
-          });
-          element.dispatchEvent(dragOver);
-          element.dispatchEvent(drop);
-          return {
-            draftUnchanged:
-              document.querySelector<HTMLTextAreaElement>(".agent-chat__composer-combobox textarea")
-                ?.value === beforeDraft,
-            dragOverPrevented: dragOver.defaultPrevented,
-            dropEffect: transfer.dropEffect,
-            dropPrevented: drop.defaultPrevented,
-            urlUnchanged: location.href === beforeUrl,
-          };
+      const stray = await page.locator("openclaw-app-shell").evaluate((element) => {
+        const transfer = new DataTransfer();
+        transfer.items.add(new File(["stray"], "stray-proof.txt", { type: "text/plain" }));
+        const beforeUrl = location.href;
+        const beforeDraft = document.querySelector<HTMLTextAreaElement>(
+          ".agent-chat__composer-combobox textarea",
+        )?.value;
+        const dragOver = new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
         });
-
-        expect(stray).toEqual({
-          draftUnchanged: true,
-          dragOverPrevented: true,
-          dropEffect: "none",
-          dropPrevented: true,
-          urlUnchanged: true,
+        const drop = new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
         });
+        element.dispatchEvent(dragOver);
+        element.dispatchEvent(drop);
+        return {
+          draftUnchanged:
+            document.querySelector<HTMLTextAreaElement>(".agent-chat__composer-combobox textarea")
+              ?.value === beforeDraft,
+          dragOverPrevented: dragOver.defaultPrevented,
+          dropEffect: transfer.dropEffect,
+          dropPrevented: drop.defaultPrevented,
+          urlUnchanged: location.href === beforeUrl,
+        };
+      });
 
-        const accepted = await page.locator("section.card.chat").evaluate((element) => {
-          const transfer = new DataTransfer();
-          transfer.items.add(
-            new File(["accepted drop"], "accepted-drop.txt", { type: "text/plain" }),
-          );
-          const dragOver = new DragEvent("dragover", {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer: transfer,
-          });
-          const drop = new DragEvent("drop", {
-            bubbles: true,
-            cancelable: true,
-            dataTransfer: transfer,
-          });
-          element.dispatchEvent(dragOver);
-          element.dispatchEvent(drop);
-          return {
-            dragOverPrevented: dragOver.defaultPrevented,
-            dropPrevented: drop.defaultPrevented,
-          };
-        });
+      expect(stray).toEqual({
+        draftUnchanged: true,
+        dragOverPrevented: true,
+        dropEffect: "none",
+        dropPrevented: true,
+        urlUnchanged: true,
+      });
 
-        expect(accepted).toEqual({
-          dragOverPrevented: true,
-          dropPrevented: true,
-        });
-        await page
-          .locator(".chat-attachment-file__name", { hasText: "accepted-drop.txt" })
-          .first()
-          .waitFor({ timeout: 10_000 });
-        await expect
-          .poll(() =>
-            page.locator(".chat-attachment-file__name", { hasText: "stray-proof.txt" }).count(),
-          )
-          .toBe(0);
-
-        const nativeInput = page.locator(".agent-chat__file-input");
-        expect(await nativeInput.isEnabled()).toBe(true);
-        await nativeInput.setInputFiles({
-          name: "native-input.txt",
-          mimeType: "text/plain",
-          buffer: Buffer.from("native input"),
-        });
-        await page
-          .locator(".chat-attachment-file__name", { hasText: "native-input.txt" })
-          .first()
-          .waitFor({ timeout: 10_000 });
-
-        console.info(
-          `[file-drop-proof] ${JSON.stringify({
-            accepted,
-            nativeInputAccepted: true,
-            path: new URL(page.url()).pathname,
-            stray,
-          })}`,
+      const accepted = await page.locator("section.card.chat").evaluate((element) => {
+        const transfer = new DataTransfer();
+        transfer.items.add(
+          new File(["accepted drop"], "accepted-drop.txt", { type: "text/plain" }),
         );
-      },
-    );
+        const dragOver = new DragEvent("dragover", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+        });
+        const drop = new DragEvent("drop", {
+          bubbles: true,
+          cancelable: true,
+          dataTransfer: transfer,
+        });
+        element.dispatchEvent(dragOver);
+        element.dispatchEvent(drop);
+        return {
+          dragOverPrevented: dragOver.defaultPrevented,
+          dropPrevented: drop.defaultPrevented,
+        };
+      });
+
+      expect(accepted).toEqual({
+        dragOverPrevented: true,
+        dropPrevented: true,
+      });
+      await page
+        .locator(".chat-attachment-file__name", { hasText: "accepted-drop.txt" })
+        .first()
+        .waitFor({ timeout: 10_000 });
+      await expect
+        .poll(() =>
+          page.locator(".chat-attachment-file__name", { hasText: "stray-proof.txt" }).count(),
+        )
+        .toBe(0);
+
+      const nativeInput = page.locator(".agent-chat__file-input");
+      expect(await nativeInput.isEnabled()).toBe(true);
+      await nativeInput.setInputFiles({
+        name: "native-input.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from("native input"),
+      });
+      await page
+        .locator(".chat-attachment-file__name", { hasText: "native-input.txt" })
+        .first()
+        .waitFor({ timeout: 10_000 });
+
+      console.info(
+        `[file-drop-proof] ${JSON.stringify({
+          accepted,
+          nativeInputAccepted: true,
+          path: new URL(page.url()).pathname,
+          stray,
+        })}`,
+      );
+    });
   });
 });

--- a/ui/src/e2e/locale-offline-retry.e2e.test.ts
+++ b/ui/src/e2e/locale-offline-retry.e2e.test.ts
@@ -8,7 +8,10 @@ import {
   startControlUiE2eServer,
   type MockGatewayControls,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI offline locale retry",
@@ -21,11 +24,7 @@ const suite = createControlUiE2eSuite({
 const frenchLocaleModule = /\/src\/i18n\/locales\/fr\.ts(?:\?.*)?$/;
 
 async function createContext(): Promise<BrowserContext> {
-  return suite.browser.newContext({
-    locale: "en-US",
-    serviceWorkers: "block",
-    viewport: { height: 900, width: 1280 },
-  });
+  return suite.browser.newContext(createControlUiE2eContextOptions());
 }
 
 async function gatewayPhase(page: Page): Promise<string | undefined> {

--- a/ui/src/e2e/managed-image-actions.e2e.test.ts
+++ b/ui/src/e2e/managed-image-actions.e2e.test.ts
@@ -7,6 +7,7 @@ import {
   createChatFlowE2eSuite,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const controlUiBasePath = "/rosita";
@@ -19,11 +20,7 @@ beforeEach(() => {
 
 suite.define(() => {
   it("previews, downloads, and opens a ticketed generated image", async () => {
-    const context = await suite.newBrowserContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const attachmentId = crypto.randomUUID();
     const artifactId = `artifact_managed_image_${attachmentId}`;

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -7,7 +7,10 @@ import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { requireRecord, requireString } from "./chat-flow.test-support.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI mobile pairing mocked Gateway E2E",
@@ -35,112 +38,105 @@ async function captureUiProof(page: Page, fileName: string) {
 
 suite.define(() => {
   it("opens pairing from a catalog command without creating a transcript turn", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const baselineText = "Pairing command baseline transcript.";
-        const gateway = await installMockGateway(page, {
-          historyMessages: [
-            {
-              content: [{ text: baselineText, type: "text" }],
-              role: "assistant",
-              timestamp: Date.now(),
-            },
-          ],
-          methodResponses: {
-            "commands.list": {
-              commands: [
-                {
-                  name: "pair",
-                  textAliases: ["/pair"],
-                  description: "Generate setup codes and approve device pairing requests.",
-                  source: "plugin",
-                  scope: "both",
-                  acceptsArgs: true,
-                  clientPresentation: {
-                    when: "no-arguments",
-                    action: { kind: "device-pairing" },
-                  },
-                },
-              ],
-            },
-            "device.pair.list": { paired: [], pending: [] },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const baselineText = "Pairing command baseline transcript.";
+      const gateway = await installMockGateway(page, {
+        historyMessages: [
+          {
+            content: [{ text: baselineText, type: "text" }],
+            role: "assistant",
+            timestamp: Date.now(),
           },
-          operatorScopes: ["operator.admin"],
-        });
+        ],
+        methodResponses: {
+          "commands.list": {
+            commands: [
+              {
+                name: "pair",
+                textAliases: ["/pair"],
+                description: "Generate setup codes and approve device pairing requests.",
+                source: "plugin",
+                scope: "both",
+                acceptsArgs: true,
+                clientPresentation: {
+                  when: "no-arguments",
+                  action: { kind: "device-pairing" },
+                },
+              },
+            ],
+          },
+          "device.pair.list": { paired: [], pending: [] },
+        },
+        operatorScopes: ["operator.admin"],
+      });
 
-        await page.goto(`${suite.server.baseUrl}chat`);
-        const baseline = page
-          .locator(".chat-group.assistant .chat-text")
-          .getByText(baselineText, { exact: true });
-        await baseline.waitFor();
-        const composer = page.locator(".agent-chat__composer-combobox textarea");
-        await composer.fill("/pa");
-        await gateway.waitForRequest("commands.list");
-        const pairOption = page.getByRole("option").filter({ hasText: "/pair" });
-        await pairOption.waitFor();
-        await pairOption.click();
-        await expect.poll(() => composer.inputValue()).toBe("/pair ");
-        await page.getByRole("button", { name: "Send message" }).click();
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const baseline = page
+        .locator(".chat-group.assistant .chat-text")
+        .getByText(baselineText, { exact: true });
+      await baseline.waitFor();
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/pa");
+      await gateway.waitForRequest("commands.list");
+      const pairOption = page.getByRole("option").filter({ hasText: "/pair" });
+      await pairOption.waitFor();
+      await pairOption.click();
+      await expect.poll(() => composer.inputValue()).toBe("/pair ");
+      await page.getByRole("button", { name: "Send message" }).click();
 
-        const dialog = page.getByRole("dialog", { name: "Pair a device" });
-        await dialog.waitFor();
-        expect(await gateway.getRequests("chat.send")).toEqual([]);
-        expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
-        expect(await baseline.count()).toBe(1);
-        expect(await page.locator(".chat-group.user", { hasText: "/pair" }).count()).toBe(0);
+      const dialog = page.getByRole("dialog", { name: "Pair a device" });
+      await dialog.waitFor();
+      expect(await gateway.getRequests("chat.send")).toEqual([]);
+      expect(await gateway.getRequests("device.pair.setupCode")).toEqual([]);
+      expect(await baseline.count()).toBe(1);
+      expect(await page.locator(".chat-group.user", { hasText: "/pair" }).count()).toBe(0);
 
-        await page.locator(".device-pair-setup__close").click();
-        await dialog.waitFor({ state: "hidden" });
-        await page.reload();
-        await baseline.waitFor();
-        expect(await page.locator(".chat-group.user", { hasText: "/pair" }).count()).toBe(0);
-        expect(await gateway.getRequests("chat.send")).toEqual([]);
+      await page.locator(".device-pair-setup__close").click();
+      await dialog.waitFor({ state: "hidden" });
+      await page.reload();
+      await baseline.waitFor();
+      expect(await page.locator(".chat-group.user", { hasText: "/pair" }).count()).toBe(0);
+      expect(await gateway.getRequests("chat.send")).toEqual([]);
 
-        await composer.fill("/pair status");
-        await page.getByRole("button", { name: "Send message" }).click();
-        const remote = await gateway.waitForRequest("chat.send");
-        const remoteParams = requireRecord(remote.params);
-        expect(remoteParams).toEqual(expect.objectContaining({ message: "/pair status" }));
-        const remoteReply = "Pair status completed remotely.";
-        await gateway.emitChatFinal({
-          runId: requireString(remoteParams.idempotencyKey, "pair status run id"),
-          text: remoteReply,
-        });
-        await page
-          .locator(".chat-group.assistant .chat-text")
-          .getByText(remoteReply, { exact: true })
-          .waitFor();
-        await expect.poll(() => page.locator(".chat-queue").count()).toBe(0);
+      await composer.fill("/pair status");
+      await page.getByRole("button", { name: "Send message" }).click();
+      const remote = await gateway.waitForRequest("chat.send");
+      const remoteParams = requireRecord(remote.params);
+      expect(remoteParams).toEqual(expect.objectContaining({ message: "/pair status" }));
+      const remoteReply = "Pair status completed remotely.";
+      await gateway.emitChatFinal({
+        runId: requireString(remoteParams.idempotencyKey, "pair status run id"),
+        text: remoteReply,
+      });
+      await page
+        .locator(".chat-group.assistant .chat-text")
+        .getByText(remoteReply, { exact: true })
+        .waitFor();
+      await expect.poll(() => page.locator(".chat-queue").count()).toBe(0);
 
-        await gateway.setMethodResponse("commands.list", {
-          commands: [
-            {
-              name: "pair",
-              textAliases: ["/pair"],
-              description: "Generate setup codes and approve device pairing requests.",
-              source: "plugin",
-              scope: "both",
-              acceptsArgs: true,
-            },
-          ],
-        });
-        await page.reload();
-        await baseline.waitFor();
-        await composer.fill("/pa");
-        await expect.poll(async () => (await gateway.getRequests("commands.list")).length).toBe(1);
-        await page.getByRole("option").filter({ hasText: "/pair" }).click();
-        await page.getByRole("button", { name: "Send message" }).click();
-        await expect.poll(async () => (await gateway.getRequests("chat.send")).length).toBe(1);
-        expect((await gateway.getRequests("chat.send")).at(-1)?.params).toEqual(
-          expect.objectContaining({ message: "/pair" }),
-        );
-      },
-    );
+      await gateway.setMethodResponse("commands.list", {
+        commands: [
+          {
+            name: "pair",
+            textAliases: ["/pair"],
+            description: "Generate setup codes and approve device pairing requests.",
+            source: "plugin",
+            scope: "both",
+            acceptsArgs: true,
+          },
+        ],
+      });
+      await page.reload();
+      await baseline.waitFor();
+      await composer.fill("/pa");
+      await expect.poll(async () => (await gateway.getRequests("commands.list")).length).toBe(1);
+      await page.getByRole("option").filter({ hasText: "/pair" }).click();
+      await page.getByRole("button", { name: "Send message" }).click();
+      await expect.poll(async () => (await gateway.getRequests("chat.send")).length).toBe(1);
+      expect((await gateway.getRequests("chat.send")).at(-1)?.params).toEqual(
+        expect.objectContaining({ message: "/pair" }),
+      );
+    });
   });
 
   it("retires exact setup credentials across success, expiry, regeneration, and errors", async () => {

--- a/ui/src/e2e/model-setup-reconnect.e2e.test.ts
+++ b/ui/src/e2e/model-setup-reconnect.e2e.test.ts
@@ -5,7 +5,10 @@ import { beforeEach, expect, it } from "vitest";
 import { ConnectParamsSchema } from "../../../packages/gateway-protocol/src/schema.js";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI model setup same-client reconnect",
@@ -49,153 +52,146 @@ suite.define(() => {
   it.each(["reconnect", "reopen"])(
     "retains manual first-run activation through restart during config refresh (%s)",
     async (restart) => {
-      await suite.withPage(
-        {
-          locale: "en-US",
-          serviceWorkers: "block",
-          viewport: { height: 900, width: 1280 },
-        },
-        async ({ page, context }) => {
-          const modelRef = "openai/gpt-5.6-luna";
-          const pendingVerification = {
-            ok: false,
-            status: "unavailable",
-            error: "Gateway settings are saved but not active yet. Retry after the restart.",
-          };
-          const gateway = await installMockGateway(page, {
-            featureMethods: [
-              "chat.metadata",
-              "chat.startup",
-              "openclaw.setup.detect",
-              "openclaw.setup.activate.start",
-              "wizard.next",
-              "openclaw.setup.verify",
-              "openclaw.chat",
-            ],
+      await suite.withPage(createControlUiE2eContextOptions(), async ({ page, context }) => {
+        const modelRef = "openai/gpt-5.6-luna";
+        const pendingVerification = {
+          ok: false,
+          status: "unavailable",
+          error: "Gateway settings are saved but not active yet. Retry after the restart.",
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "openclaw.setup.detect",
+            "openclaw.setup.activate.start",
+            "wizard.next",
+            "openclaw.setup.verify",
+            "openclaw.chat",
+          ],
+          methodResponses: {
+            "openclaw.chat": onboardingWelcome,
+            "openclaw.setup.detect": {
+              ...detection(modelRef),
+              configuredModel: undefined,
+              setupComplete: false,
+              manualProviders: [{ id: "openai", label: "OpenAI" }],
+            },
+            "openclaw.setup.activate.start": {
+              sessionId: "activation-session",
+              done: false,
+              status: "running",
+            },
+            "wizard.next": {
+              done: true,
+              status: "error",
+              error: "401: invalid test API key",
+              activationRejection: { disposition: "rejected-before-promotion", status: "auth" },
+            },
+            "openclaw.setup.verify": pendingVerification,
+          },
+        });
+
+        await page.goto(
+          `${suite.server.baseUrl}settings/model-setup?firstRun=1#bootstrapToken=e2e-first-grant&bootstrapProfile=owner`,
+        );
+        const firstConnect = connectParams((await gateway.waitForRequest("connect")).params);
+        expect(firstConnect.auth).toMatchObject({ bootstrapToken: "e2e-first-grant" });
+        const apiKey = page.locator('.model-setup__manual input[type="password"]');
+        await apiKey.fill("invalid-test-key");
+        await page.getByRole("button", { name: "Connect & verify" }).click();
+        await page.getByText("401: invalid test API key").waitFor();
+        expect(new URL(page.url()).pathname).toBe("/settings/model-setup");
+        expect(await gateway.getRequests("openclaw.setup.verify")).toHaveLength(0);
+
+        await page
+          .locator("openclaw-modal-dialog")
+          .getByRole("button", { name: "Close", exact: true })
+          .click();
+        await gateway.setMethodResponse("wizard.next", {
+          done: true,
+          status: "done",
+          modelActivation: { modelRef, gatewayRestartRequired: true },
+        });
+        const initialRefreshes = (await gateway.getRequests("config.get")).length;
+        await gateway.deferNext("config.get");
+        await apiKey.fill("accepted-test-key");
+        await page.getByRole("button", { name: "Connect & verify" }).click();
+        // The activation response has arrived, but its refresh has not. A
+        // restart here must retain the confirmed model without reactivating it.
+        await expect
+          .poll(async () => (await gateway.getRequests("config.get")).length)
+          .toBeGreaterThan(initialRefreshes);
+        await gateway.setMethodResponse("openclaw.setup.detect", detection(modelRef));
+        let destination = page;
+        let reconnectedGateway = gateway;
+        if (restart === "reopen") {
+          await page.close();
+          destination = await context.newPage();
+          reconnectedGateway = await installMockGateway(destination, {
+            featureMethods: ["openclaw.setup.detect", "openclaw.setup.verify", "openclaw.chat"],
             methodResponses: {
               "openclaw.chat": onboardingWelcome,
-              "openclaw.setup.detect": {
-                ...detection(modelRef),
-                configuredModel: undefined,
-                setupComplete: false,
-                manualProviders: [{ id: "openai", label: "OpenAI" }],
-              },
-              "openclaw.setup.activate.start": {
-                sessionId: "activation-session",
-                done: false,
-                status: "running",
-              },
-              "wizard.next": {
-                done: true,
-                status: "error",
-                error: "401: invalid test API key",
-                activationRejection: { disposition: "rejected-before-promotion", status: "auth" },
-              },
+              "openclaw.setup.detect": detection(modelRef),
               "openclaw.setup.verify": pendingVerification,
             },
           });
-
-          await page.goto(
-            `${suite.server.baseUrl}settings/model-setup?firstRun=1#bootstrapToken=e2e-first-grant&bootstrapProfile=owner`,
+          await destination.goto(
+            `${suite.server.baseUrl}#bootstrapToken=e2e-next-grant&bootstrapProfile=owner`,
           );
-          const firstConnect = connectParams((await gateway.waitForRequest("connect")).params);
-          expect(firstConnect.auth).toMatchObject({ bootstrapToken: "e2e-first-grant" });
-          const apiKey = page.locator('.model-setup__manual input[type="password"]');
-          await apiKey.fill("invalid-test-key");
-          await page.getByRole("button", { name: "Connect & verify" }).click();
-          await page.getByText("401: invalid test API key").waitFor();
-          expect(new URL(page.url()).pathname).toBe("/settings/model-setup");
-          expect(await gateway.getRequests("openclaw.setup.verify")).toHaveLength(0);
-
-          await page
-            .locator("openclaw-modal-dialog")
-            .getByRole("button", { name: "Close", exact: true })
-            .click();
-          await gateway.setMethodResponse("wizard.next", {
-            done: true,
-            status: "done",
-            modelActivation: { modelRef, gatewayRestartRequired: true },
+          const reopened = connectParams(
+            (await reconnectedGateway.waitForRequest("connect")).params,
+          );
+          expect(reopened.auth).toMatchObject({ bootstrapToken: "e2e-next-grant" });
+          expect(reopened.device).toMatchObject({
+            id: firstConnect.device?.id,
           });
-          const initialRefreshes = (await gateway.getRequests("config.get")).length;
-          await gateway.deferNext("config.get");
-          await apiKey.fill("accepted-test-key");
-          await page.getByRole("button", { name: "Connect & verify" }).click();
-          // The activation response has arrived, but its refresh has not. A
-          // restart here must retain the confirmed model without reactivating it.
-          await expect
-            .poll(async () => (await gateway.getRequests("config.get")).length)
-            .toBeGreaterThan(initialRefreshes);
-          await gateway.setMethodResponse("openclaw.setup.detect", detection(modelRef));
-          let destination = page;
-          let reconnectedGateway = gateway;
-          if (restart === "reopen") {
-            await page.close();
-            destination = await context.newPage();
-            reconnectedGateway = await installMockGateway(destination, {
-              featureMethods: ["openclaw.setup.detect", "openclaw.setup.verify", "openclaw.chat"],
-              methodResponses: {
-                "openclaw.chat": onboardingWelcome,
-                "openclaw.setup.detect": detection(modelRef),
-                "openclaw.setup.verify": pendingVerification,
-              },
-            });
-            await destination.goto(
-              `${suite.server.baseUrl}#bootstrapToken=e2e-next-grant&bootstrapProfile=owner`,
-            );
-            const reopened = connectParams(
-              (await reconnectedGateway.waitForRequest("connect")).params,
-            );
-            expect(reopened.auth).toMatchObject({ bootstrapToken: "e2e-next-grant" });
-            expect(reopened.device).toMatchObject({
-              id: firstConnect.device?.id,
-            });
-          } else {
-            await gateway.closeLatest(1012, "first-run activation restart");
-          }
-          await reconnectedGateway.waitForRequest("openclaw.setup.verify");
-          await destination.getByText(pendingVerification.error, { exact: false }).waitFor();
-          expect(new URL(destination.url()).pathname).toBe("/settings/model-setup");
-          expect(await reconnectedGateway.getRequests("openclaw.chat")).toHaveLength(0);
-          if (captureUiProofEnabled) {
-            await destination.screenshot({
-              animations: "disabled",
-              path: path.join(artifactDir, `manual-first-run-${restart}-pending.png`),
-            });
-          }
-          await reconnectedGateway.setMethodResponse("openclaw.setup.verify", {
-            ok: true,
-            modelRef,
-            latencyMs: 31,
+        } else {
+          await gateway.closeLatest(1012, "first-run activation restart");
+        }
+        await reconnectedGateway.waitForRequest("openclaw.setup.verify");
+        await destination.getByText(pendingVerification.error, { exact: false }).waitFor();
+        expect(new URL(destination.url()).pathname).toBe("/settings/model-setup");
+        expect(await reconnectedGateway.getRequests("openclaw.chat")).toHaveLength(0);
+        if (captureUiProofEnabled) {
+          await destination.screenshot({
+            animations: "disabled",
+            path: path.join(artifactDir, `manual-first-run-${restart}-pending.png`),
           });
-          await destination.getByRole("button", { name: "Verify & use selected model" }).click();
-          await expect.poll(() => new URL(destination.url()).pathname).toBe("/custodian");
-          if (restart === "reconnect") {
-            expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(2);
-            const connections = await gateway.getRequests("connect");
-            expect(connectParams(connections.at(-1)?.params).auth).toMatchObject({
-              deviceToken: "e2e-device-token",
-            });
-            expect(connectParams(connections.at(-1)?.params).auth).not.toHaveProperty(
-              "bootstrapToken",
-            );
-          } else {
-            expect(
-              await reconnectedGateway.getRequests("openclaw.setup.activate.start"),
-            ).toHaveLength(0);
-          }
-          await destination.getByText(onboardingWelcome.reply, { exact: true }).waitFor();
-          const welcomeRequest = await reconnectedGateway.waitForRequest("openclaw.chat");
-          expect(welcomeRequest.params).toMatchObject({ welcomeVariant: "onboarding" });
-          if (captureUiProofEnabled) {
-            await destination.locator(".custodian__header--minimal").waitFor();
-            await destination.screenshot({
-              animations: "disabled",
-              path: path.join(artifactDir, `manual-first-run-${restart}-fixed.png`),
-            });
-          }
-          expect(new URL(destination.url()).searchParams.get("onboarding")).toBe("1");
-        },
-      );
+        }
+        await reconnectedGateway.setMethodResponse("openclaw.setup.verify", {
+          ok: true,
+          modelRef,
+          latencyMs: 31,
+        });
+        await destination.getByRole("button", { name: "Verify & use selected model" }).click();
+        await expect.poll(() => new URL(destination.url()).pathname).toBe("/custodian");
+        if (restart === "reconnect") {
+          expect(await gateway.getRequests("openclaw.setup.activate.start")).toHaveLength(2);
+          const connections = await gateway.getRequests("connect");
+          expect(connectParams(connections.at(-1)?.params).auth).toMatchObject({
+            deviceToken: "e2e-device-token",
+          });
+          expect(connectParams(connections.at(-1)?.params).auth).not.toHaveProperty(
+            "bootstrapToken",
+          );
+        } else {
+          expect(
+            await reconnectedGateway.getRequests("openclaw.setup.activate.start"),
+          ).toHaveLength(0);
+        }
+        await destination.getByText(onboardingWelcome.reply, { exact: true }).waitFor();
+        const welcomeRequest = await reconnectedGateway.waitForRequest("openclaw.chat");
+        expect(welcomeRequest.params).toMatchObject({ welcomeVariant: "onboarding" });
+        if (captureUiProofEnabled) {
+          await destination.locator(".custodian__header--minimal").waitFor();
+          await destination.screenshot({
+            animations: "disabled",
+            path: path.join(artifactDir, `manual-first-run-${restart}-fixed.png`),
+          });
+        }
+        expect(new URL(destination.url()).searchParams.get("onboarding")).toBe("1");
+      });
     },
   );
 
@@ -311,51 +307,44 @@ suite.define(() => {
   );
 
   it("re-detects once and replaces stale visible model state after reconnect", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const pageErrors: string[] = [];
-        page.on("pageerror", (error) => pageErrors.push(String(error)));
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["openclaw.setup.detect"],
-          methodResponses: { "openclaw.setup.detect": detection("provider/original-model") },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const pageErrors: string[] = [];
+      page.on("pageerror", (error) => pageErrors.push(String(error)));
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["openclaw.setup.detect"],
+        methodResponses: { "openclaw.setup.detect": detection("provider/original-model") },
+      });
+
+      const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
+      expect(response?.status()).toBe(200);
+      await page.getByText("original-model", { exact: true }).waitFor();
+      const initialDetections = (await gateway.getRequests("openclaw.setup.detect")).length;
+      const initialConnections = (await gateway.getRequests("connect")).length;
+      await gateway.setMethodResponse(
+        "openclaw.setup.detect",
+        detection("provider/reconnected-model"),
+      );
+      await gateway.deferNext("connect");
+      await gateway.closeLatest(1012, "model setup reconnect proof");
+      await expect
+        .poll(async () => page.getByText("original-model", { exact: true }).count())
+        .toBe(0);
+      await expect
+        .poll(async () => (await gateway.getRequests("connect")).length)
+        .toBeGreaterThan(initialConnections);
+      await gateway.resolveDeferred("connect");
+      await expect
+        .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
+        .toBe(initialDetections + 1);
+      await page.getByText("reconnected-model", { exact: true }).waitFor();
+      expect(pageErrors).toEqual([]);
+
+      if (captureUiProofEnabled) {
+        await page.locator("openclaw-model-setup-page").screenshot({
+          animations: "disabled",
+          path: path.join(artifactDir, "00-reconnected-model-visible.png"),
         });
-
-        const response = await page.goto(`${suite.server.baseUrl}settings/model-setup`);
-        expect(response?.status()).toBe(200);
-        await page.getByText("original-model", { exact: true }).waitFor();
-        const initialDetections = (await gateway.getRequests("openclaw.setup.detect")).length;
-        const initialConnections = (await gateway.getRequests("connect")).length;
-        await gateway.setMethodResponse(
-          "openclaw.setup.detect",
-          detection("provider/reconnected-model"),
-        );
-        await gateway.deferNext("connect");
-        await gateway.closeLatest(1012, "model setup reconnect proof");
-        await expect
-          .poll(async () => page.getByText("original-model", { exact: true }).count())
-          .toBe(0);
-        await expect
-          .poll(async () => (await gateway.getRequests("connect")).length)
-          .toBeGreaterThan(initialConnections);
-        await gateway.resolveDeferred("connect");
-        await expect
-          .poll(async () => (await gateway.getRequests("openclaw.setup.detect")).length)
-          .toBe(initialDetections + 1);
-        await page.getByText("reconnected-model", { exact: true }).waitFor();
-        expect(pageErrors).toEqual([]);
-
-        if (captureUiProofEnabled) {
-          await page.locator("openclaw-model-setup-page").screenshot({
-            animations: "disabled",
-            path: path.join(artifactDir, "00-reconnected-model-visible.png"),
-          });
-        }
-      },
-    );
+      }
+    });
   });
 });

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   REFRESHED_RESEARCH_WORKSPACE,
   SESSION_LIST_DEFAULTS,
@@ -250,11 +251,7 @@ suite.define(() => {
       startTerminal: false,
     },
   ])("blocks native submission visibly when $label", async (testCase) => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       cliAgentsEnabled: testCase.cliAgentsEnabled,
@@ -477,11 +474,7 @@ suite.define(() => {
   });
 
   it("shows the terminal-start server error without rewriting it", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const serverMessage = "cwd is no longer available; choose another folder and retry";
     await installMockGateway(page, {
@@ -593,11 +586,7 @@ suite.define(() => {
   );
 
   it("navigates to a created session while canonical session refresh is pending", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:main:refresh-overlap-e2e";
     const listResponse = {
@@ -668,11 +657,7 @@ suite.define(() => {
   });
 
   it("resolves a pending catalog target after reconnect without clearing the draft", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       cliAgentsEnabled: true,
@@ -797,11 +782,7 @@ suite.define(() => {
   });
 
   it("clears the draft after a genuine new-session route navigation settles", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -845,11 +826,7 @@ suite.define(() => {
   });
 
   it("preserves a manually selected agent across a same-client reconnect", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -2,6 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
@@ -523,11 +524,7 @@ suite.define(() => {
   );
 
   it("checks an unconfirmed cloud turn without replay when composer storage is unavailable", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:cloud:storage-recovery";
     const message = "keep this cloud recovery task";

--- a/ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureUiProof,
   controlUiSessionPath,
@@ -13,11 +14,7 @@ const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
   it("lets a newer durable prompt and file beat a stale navigation handoff", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     try {
       const sessionKey = "agent:main:existing-session";
       const staleText = "stale draft from the first page";

--- a/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.durable-write-teardown.e2e.test.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   controlUiSessionPath,
   createNewSessionPageE2eSuite,
@@ -75,11 +76,7 @@ async function rawDraftMatches(
 
 suite.define(() => {
   it("coalesces a burst of near-limit attachment draft mutations into one write", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     try {
       const page = await context.newPage();
       await page.addInitScript(() => {
@@ -132,11 +129,7 @@ suite.define(() => {
   });
 
   it("starts an attachment write while an earlier text write is still pending", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     try {
       const text = "keep the attachment added during the pending text write";
       const fileName = "favicon-32.png";
@@ -249,11 +242,7 @@ suite.define(() => {
   });
 
   it("isolates route drafts and retires incognito and submitted drafts", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     try {
       const page = await context.newPage();
       await installMockGateway(page, {

--- a/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
@@ -1,5 +1,8 @@
 import { expect, it } from "vitest";
-import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  tooltipTitleText,
+} from "./control-ui-e2e-suite.test-support.ts";
 import {
   WORKSPACE,
   captureDeviceRuntimeUiProof,
@@ -18,11 +21,7 @@ const updateIssue = {
 
 suite.define(() => {
   it("offers paired devices to every model whose runtime explicitly supports them", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "anthropic/claude-sonnet-4-6",
@@ -173,11 +172,7 @@ suite.define(() => {
   });
 
   it("renders authoritative device eligibility and exact live capacity", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       workspace: WORKSPACE,

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { takeControlUiViewportScreenshot } from "../test-helpers/control-ui-e2e-screenshot.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   createNewSessionPageE2eSuite,
   installMockGateway,
@@ -168,11 +169,7 @@ suite.define(() => {
     if (captureUiProof) {
       await mkdir(path.join(suite.artifactDir, "new-session-skeleton-gap"), { recursive: true });
     }
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "openai/gpt-5.6-luna",
@@ -226,11 +223,7 @@ suite.define(() => {
   });
 
   it("selects a context window before creating a session", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "openai/gpt-5.6-luna",
@@ -288,11 +281,7 @@ suite.define(() => {
   });
 
   it("shows metadata failure truthfully and recovers when the picker opens", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const models = [
       {
@@ -354,11 +343,7 @@ suite.define(() => {
   });
 
   it("restores the model picker after startup-sidecars metadata becomes available", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const recoveredModel = {
       available: true,

--- a/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.operator-scopes.e2e.test.ts
@@ -1,5 +1,8 @@
 import { expect, it } from "vitest";
-import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  tooltipTitleText,
+} from "./control-ui-e2e-suite.test-support.ts";
 import {
   SESSION_LIST_DEFAULTS,
   createNewSessionPageE2eSuite,
@@ -19,11 +22,7 @@ async function openDraft(
     "sessions.dispatch",
   ],
 ) {
-  const context = await suite.browser.newContext({
-    locale: "en-US",
-    serviceWorkers: "block",
-    viewport: { height: 900, width: 1280 },
-  });
+  const context = await suite.browser.newContext(createControlUiE2eContextOptions());
   const page = await context.newPage();
   const gateway = await installMockGateway(page, {
     featureMethods,

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
 } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   ONE_PIXEL_PNG_B64,
   SESSION_LIST_DEFAULTS,
@@ -150,11 +151,7 @@ suite.define(() => {
   });
 
   it("uses shifted Enter for background start in modifier mode", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const gatewayUrl = controlUiBundledGatewayUrl(suite.server.baseUrl);
     await context.addInitScript(
       ({ key, url }) => {
@@ -189,11 +186,7 @@ suite.define(() => {
   });
 
   it("creates and lists a session with the default mock Gateway", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page);
     try {
@@ -251,11 +244,7 @@ suite.define(() => {
   });
 
   it("commits the confirmed session URL before Chat loads and animates only the ready composer", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const thinkingLevels = ["off", "low", "medium", "high", "xhigh"].map((id) => ({
       id,

--- a/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
+++ b/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
@@ -4,7 +4,10 @@ import type { Route } from "playwright";
 import { beforeEach, expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 let artifactDir: string;
 beforeEach(() => {
@@ -20,114 +23,105 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("stops automatic reloads after one failed recovery and keeps manual Reload", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          controlUiTabs: [
-            { group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" },
-          ],
-          methodResponses: {
-            "logbook.days": { days: [] },
-            "logbook.status": {
-              analysisIntervalMinutes: 15,
-              analysisRunning: false,
-              captureEnabled: true,
-              captureIntervalSeconds: 30,
-              capturePaused: false,
-              pendingFrames: 0,
-              retentionDays: 30,
-              timeZone: "UTC",
-              today: "2026-08-12",
-              todayCards: 0,
-              visionModelSource: "missing",
-            },
-            "logbook.timeline": {
-              cards: [],
-              day: "2026-08-12",
-              stats: { apps: [], categories: [], distractionMs: 0, trackedMs: 0 },
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        controlUiTabs: [{ group: "control", id: "logbook", label: "Logbook", pluginId: "logbook" }],
+        methodResponses: {
+          "logbook.days": { days: [] },
+          "logbook.status": {
+            analysisIntervalMinutes: 15,
+            analysisRunning: false,
+            captureEnabled: true,
+            captureIntervalSeconds: 30,
+            capturePaused: false,
+            pendingFrames: 0,
+            retentionDays: 30,
+            timeZone: "UTC",
+            today: "2026-08-12",
+            todayCards: 0,
+            visionModelSource: "missing",
           },
-        });
+          "logbook.timeline": {
+            cards: [],
+            day: "2026-08-12",
+            stats: { apps: [], categories: [], distractionMs: 0, trackedMs: 0 },
+          },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}plugin?plugin=missing&id=missing`);
-        expect(response?.status()).toBe(200);
-        await page.getByText("Plugin panel unavailable").waitFor();
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "before.png"),
-        });
+      const response = await page.goto(`${suite.server.baseUrl}plugin?plugin=missing&id=missing`);
+      expect(response?.status()).toBe(200);
+      await page.getByText("Plugin panel unavailable").waitFor();
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "before.png"),
+      });
 
-        let failedRequests = 0;
-        let assetRequests = 0;
-        let failingChunkPath: string | null = null;
-        const failBundledChunkTwice = async (route: Route) => {
-          assetRequests += 1;
-          const requestPath = new URL(route.request().url()).pathname;
-          failingChunkPath ??= requestPath;
-          if (requestPath === failingChunkPath && failedRequests < 2) {
-            failedRequests += 1;
-            await route.abort("internetdisconnected");
-            return;
-          }
+      let failedRequests = 0;
+      let assetRequests = 0;
+      let failingChunkPath: string | null = null;
+      const failBundledChunkTwice = async (route: Route) => {
+        assetRequests += 1;
+        const requestPath = new URL(route.request().url()).pathname;
+        failingChunkPath ??= requestPath;
+        if (requestPath === failingChunkPath && failedRequests < 2) {
+          failedRequests += 1;
+          await route.abort("internetdisconnected");
+          return;
+        }
+        await route.continue();
+      };
+      let markDocumentReachable!: () => void;
+      const documentReachable = new Promise<void>((resolve) => {
+        markDocumentReachable = resolve;
+      });
+      await page.route(/\/plugin(?:\?.*)?$/u, async (route) => {
+        if (route.request().method() !== "HEAD") {
           await route.continue();
-        };
-        let markDocumentReachable!: () => void;
-        const documentReachable = new Promise<void>((resolve) => {
-          markDocumentReachable = resolve;
-        });
-        await page.route(/\/plugin(?:\?.*)?$/u, async (route) => {
-          if (route.request().method() !== "HEAD") {
-            await route.continue();
-            return;
-          }
-          await documentReachable;
-          await route.fulfill({ status: 200 });
-        });
-        await page.route(bundledChunk, failBundledChunkTwice);
-        await page.getByRole("link", { name: "Logbook", exact: true }).click();
-        await expect.poll(() => failedRequests).toBe(1);
+          return;
+        }
+        await documentReachable;
+        await route.fulfill({ status: 200 });
+      });
+      await page.route(bundledChunk, failBundledChunkTwice);
+      await page.getByRole("link", { name: "Logbook", exact: true }).click();
+      await expect.poll(() => failedRequests).toBe(1);
 
-        const alert = page.getByRole("alert");
-        await alert.waitFor();
-        expect(await alert.textContent()).toContain("A new version is available");
-        expect(await alert.textContent()).toContain("Failed to fetch dynamically imported module");
-        await alert.getByRole("button", { name: "Reload" }).waitFor();
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "failure.png"),
-        });
+      const alert = page.getByRole("alert");
+      await alert.waitFor();
+      expect(await alert.textContent()).toContain("A new version is available");
+      expect(await alert.textContent()).toContain("Failed to fetch dynamically imported module");
+      await alert.getByRole("button", { name: "Reload" }).waitFor();
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "failure.png"),
+      });
 
-        let documentRequestCount = 0;
-        page.on("request", (request) => {
-          if (request.resourceType() === "document") {
-            documentRequestCount += 1;
-          }
-        });
-        markDocumentReachable();
+      let documentRequestCount = 0;
+      page.on("request", (request) => {
+        if (request.resourceType() === "document") {
+          documentRequestCount += 1;
+        }
+      });
+      markDocumentReachable();
 
-        await expect.poll(() => failedRequests).toBe(2);
-        await alert.waitFor();
-        await page.waitForTimeout(500);
-        expect(await alert.count()).toBe(1);
-        expect(documentRequestCount).toBe(1);
+      await expect.poll(() => failedRequests).toBe(2);
+      await alert.waitFor();
+      await page.waitForTimeout(500);
+      expect(await alert.count()).toBe(1);
+      expect(documentRequestCount).toBe(1);
 
-        await alert.getByRole("button", { name: "Reload" }).click();
-        await page.locator(".logbook").waitFor();
-        expect(await alert.count()).toBe(0);
-        expect(assetRequests).toBeGreaterThan(2);
-        expect(documentRequestCount).toBe(2);
-        await gateway.waitForRequest("logbook.status");
-        await page.screenshot({
-          fullPage: true,
-          path: path.join(artifactDir, "recovered.png"),
-        });
-        expect(new URL(page.url()).pathname).toBe("/plugin");
-      },
-    );
+      await alert.getByRole("button", { name: "Reload" }).click();
+      await page.locator(".logbook").waitFor();
+      expect(await alert.count()).toBe(0);
+      expect(assetRequests).toBeGreaterThan(2);
+      expect(documentRequestCount).toBe(2);
+      await gateway.waitForRequest("logbook.status");
+      await page.screenshot({
+        fullPage: true,
+        path: path.join(artifactDir, "recovered.png"),
+      });
+      expect(new URL(page.url()).pathname).toBe("/plugin");
+    });
   });
 });

--- a/ui/src/e2e/route-css.e2e.test.ts
+++ b/ui/src/e2e/route-css.e2e.test.ts
@@ -1,7 +1,10 @@
 // Control UI tests prove route-scoped CSS on fresh direct navigation.
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI route CSS mocked Gateway E2E",
@@ -11,127 +14,121 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("loads shared Markdown and session-link styles on direct Cron, Skills, and Chat routes", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, {
-          methodResponses: {
-            "cron.list": {
-              jobs: [],
-              total: 0,
-              offset: 0,
-              limit: 50,
-              hasMore: false,
-              nextOffset: null,
-            },
-            "cron.runs": {
-              entries: [],
-              total: 0,
-              offset: 0,
-              limit: 50,
-              hasMore: false,
-              nextOffset: null,
-            },
-            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
-            "skills.status": {
-              workspaceDir: "/tmp/openclaw-e2e/workspace",
-              managedSkillsDir: "/tmp/openclaw-e2e/skills",
-              skills: [],
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page, {
+        methodResponses: {
+          "cron.list": {
+            jobs: [],
+            total: 0,
+            offset: 0,
+            limit: 50,
+            hasMore: false,
+            nextOffset: null,
           },
-        });
+          "cron.runs": {
+            entries: [],
+            total: 0,
+            offset: 0,
+            limit: 50,
+            hasMore: false,
+            nextOffset: null,
+          },
+          "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [],
+          },
+        },
+      });
 
-        const cronResponse = await page.goto(`${suite.server.baseUrl}cron`);
-        expect(cronResponse?.status()).toBe(200);
-        await page.locator(".cron-page").waitFor();
+      const cronResponse = await page.goto(`${suite.server.baseUrl}cron`);
+      expect(cronResponse?.status()).toBe(200);
+      await page.locator(".cron-page").waitFor();
 
-        const cronStyles = await page.evaluate(() => {
-          const probe = document.createElement("div");
-          probe.innerHTML = `
+      const cronStyles = await page.evaluate(() => {
+        const probe = document.createElement("div");
+        probe.innerHTML = `
           <div class="chat-text"><ul><li>First</li><li>Second</li></ul><pre><code>code</code></pre></div>
           <a class="session-link">session</a>
         `;
-          document.body.append(probe);
-          const list = probe.querySelector("ul");
-          const secondListItem = probe.querySelector("li + li");
-          const pre = probe.querySelector("pre");
-          const link = probe.querySelector(".session-link");
-          if (
-            !(list instanceof HTMLElement) ||
-            !(secondListItem instanceof HTMLElement) ||
-            !(pre instanceof HTMLElement) ||
-            !link
-          ) {
-            throw new Error("Cron style probe did not render");
-          }
-          const listItemStyle = getComputedStyle(secondListItem);
-          const result = {
-            listPadding: Number.parseFloat(getComputedStyle(list).paddingLeft),
-            listItemGap: Number.parseFloat(listItemStyle.marginTop),
-            listItemFontSize: Number.parseFloat(listItemStyle.fontSize),
-            preBorderStyle: getComputedStyle(pre).borderTopStyle,
-            preOverflow: getComputedStyle(pre).overflowX,
-            sessionFontWeight: getComputedStyle(link).fontWeight,
-            sessionTextDecoration: getComputedStyle(link).textDecorationLine,
-          };
-          probe.remove();
-          return result;
-        });
-        expect(cronStyles.listPadding).toBeGreaterThan(0);
-        expect(cronStyles.listItemGap / cronStyles.listItemFontSize).toBeCloseTo(0.4, 2);
-        expect(cronStyles.preBorderStyle).toBe("solid");
-        expect(cronStyles.preOverflow).toBe("auto");
-        expect(cronStyles.sessionFontWeight).toBe("500");
-        expect(cronStyles.sessionTextDecoration).toBe("none");
+        document.body.append(probe);
+        const list = probe.querySelector("ul");
+        const secondListItem = probe.querySelector("li + li");
+        const pre = probe.querySelector("pre");
+        const link = probe.querySelector(".session-link");
+        if (
+          !(list instanceof HTMLElement) ||
+          !(secondListItem instanceof HTMLElement) ||
+          !(pre instanceof HTMLElement) ||
+          !link
+        ) {
+          throw new Error("Cron style probe did not render");
+        }
+        const listItemStyle = getComputedStyle(secondListItem);
+        const result = {
+          listPadding: Number.parseFloat(getComputedStyle(list).paddingLeft),
+          listItemGap: Number.parseFloat(listItemStyle.marginTop),
+          listItemFontSize: Number.parseFloat(listItemStyle.fontSize),
+          preBorderStyle: getComputedStyle(pre).borderTopStyle,
+          preOverflow: getComputedStyle(pre).overflowX,
+          sessionFontWeight: getComputedStyle(link).fontWeight,
+          sessionTextDecoration: getComputedStyle(link).textDecorationLine,
+        };
+        probe.remove();
+        return result;
+      });
+      expect(cronStyles.listPadding).toBeGreaterThan(0);
+      expect(cronStyles.listItemGap / cronStyles.listItemFontSize).toBeCloseTo(0.4, 2);
+      expect(cronStyles.preBorderStyle).toBe("solid");
+      expect(cronStyles.preOverflow).toBe("auto");
+      expect(cronStyles.sessionFontWeight).toBe("500");
+      expect(cronStyles.sessionTextDecoration).toBe("none");
 
-        const skillsResponse = await page.goto(`${suite.server.baseUrl}skills`);
-        expect(skillsResponse?.status()).toBe(200);
-        await page.locator(".settings-section__heading", { hasText: "ClawHub" }).waitFor();
+      const skillsResponse = await page.goto(`${suite.server.baseUrl}skills`);
+      expect(skillsResponse?.status()).toBe(200);
+      await page.locator(".settings-section__heading", { hasText: "ClawHub" }).waitFor();
 
-        const skillsStyles = await page.evaluate(() => {
-          const probe = document.createElement("article");
-          probe.className = "sidebar-markdown";
-          probe.innerHTML = `
+      const skillsStyles = await page.evaluate(() => {
+        const probe = document.createElement("article");
+        probe.className = "sidebar-markdown";
+        probe.innerHTML = `
           <h2>Heading</h2>
           <ul><li class="task-list-item">Task</li></ul>
           <pre><code>code</code></pre>
           <table><tbody><tr><td>Cell</td></tr></tbody></table>
         `;
-          document.body.append(probe);
-          const heading = probe.querySelector("h2");
-          const task = probe.querySelector(".task-list-item");
-          const pre = probe.querySelector("pre");
-          const table = probe.querySelector("table");
-          if (!heading || !task || !pre || !table) {
-            throw new Error("Skills style probe did not render");
-          }
-          const result = {
-            headingBorderStyle: getComputedStyle(heading).borderBottomStyle,
-            preOverflow: getComputedStyle(pre).overflowX,
-            tableDisplay: getComputedStyle(table).display,
-            taskListStyle: getComputedStyle(task).listStyleType,
-          };
-          probe.remove();
-          return result;
-        });
-        expect(skillsStyles.headingBorderStyle).toBe("solid");
-        expect(skillsStyles.preOverflow).toBe("auto");
-        expect(skillsStyles.tableDisplay).toBe("block");
-        expect(skillsStyles.taskListStyle).toBe("none");
+        document.body.append(probe);
+        const heading = probe.querySelector("h2");
+        const task = probe.querySelector(".task-list-item");
+        const pre = probe.querySelector("pre");
+        const table = probe.querySelector("table");
+        if (!heading || !task || !pre || !table) {
+          throw new Error("Skills style probe did not render");
+        }
+        const result = {
+          headingBorderStyle: getComputedStyle(heading).borderBottomStyle,
+          preOverflow: getComputedStyle(pre).overflowX,
+          tableDisplay: getComputedStyle(table).display,
+          taskListStyle: getComputedStyle(task).listStyleType,
+        };
+        probe.remove();
+        return result;
+      });
+      expect(skillsStyles.headingBorderStyle).toBe("solid");
+      expect(skillsStyles.preOverflow).toBe("auto");
+      expect(skillsStyles.tableDisplay).toBe("block");
+      expect(skillsStyles.taskListStyle).toBe("none");
 
-        const chatResponse = await page.goto(`${suite.server.baseUrl}chat?session=main`);
-        expect(chatResponse?.status()).toBe(200);
-        await page.locator("openclaw-chat-page").waitFor();
+      const chatResponse = await page.goto(`${suite.server.baseUrl}chat?session=main`);
+      expect(chatResponse?.status()).toBe(200);
+      await page.locator("openclaw-chat-page").waitFor();
 
-        const chatMarkdownStyles = await page.evaluate(() => {
-          const probe = document.createElement("div");
-          probe.className = "chat-text";
-          probe.style.width = "900px";
-          probe.innerHTML = `
+      const chatMarkdownStyles = await page.evaluate(() => {
+        const probe = document.createElement("div");
+        probe.className = "chat-text";
+        probe.style.width = "900px";
+        probe.innerHTML = `
           <ol class="probe-list"><li>First</li></ol>
           <blockquote class="probe-quote"><p>Quoted block</p></blockquote>
           <table>
@@ -144,77 +141,70 @@ suite.define(() => {
           <ul class="probe-unordered"><li>Unordered</li></ul>
           <ol class="probe-ordered"><li>Ordered</li></ol>
         `;
-          document.body.append(probe);
-          const list = probe.querySelector(".probe-list");
-          const quote = probe.querySelector(".probe-quote");
-          const dimension = probe.querySelector("th:first-child");
-          const demographics = probe.querySelector("td:first-child");
-          const table = probe.querySelector("table");
-          const tableCopy = probe.querySelector(".probe-table-copy");
-          const taskList = probe.querySelector(".probe-task-list");
-          const details = probe.querySelector(".probe-details");
-          const unordered = probe.querySelector(".probe-unordered");
-          const ordered = probe.querySelector(".probe-ordered");
-          if (
-            !dimension ||
-            !demographics ||
-            !list ||
-            !quote ||
-            !table ||
-            !tableCopy ||
-            !taskList ||
-            !details ||
-            !unordered ||
-            !ordered
-          ) {
-            throw new Error("Chat Markdown style probe did not render");
-          }
-          const lineCount = (element: Element) => {
-            const range = document.createRange();
-            range.selectNodeContents(element);
-            return new Set(Array.from(range.getClientRects(), (rect) => Math.round(rect.top))).size;
-          };
-          const result = {
-            demographicsLineCount: lineCount(demographics),
-            dimensionLineCount: lineCount(dimension),
-            firstColumnWidth: dimension.getBoundingClientRect().width,
-            listToQuoteGap: quote.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
-            quoteMargin: Number.parseFloat(getComputedStyle(quote).marginTop),
-            tableToCopyGap:
-              tableCopy.getBoundingClientRect().top - table.getBoundingClientRect().bottom,
-            tableCopyMargin: Number.parseFloat(getComputedStyle(tableCopy).marginTop),
-            taskListToDetailsGap:
-              details.getBoundingClientRect().top - taskList.getBoundingClientRect().bottom,
-            detailsMargin: Number.parseFloat(getComputedStyle(details).marginTop),
-            unorderedToOrderedGap:
-              ordered.getBoundingClientRect().top - unordered.getBoundingClientRect().bottom,
-            orderedMargin: Number.parseFloat(getComputedStyle(ordered).marginTop),
-            blockFontSize: Number.parseFloat(getComputedStyle(tableCopy).fontSize),
-          };
-          probe.remove();
-          return result;
-        });
-        expect(chatMarkdownStyles.dimensionLineCount).toBe(1);
-        expect(chatMarkdownStyles.demographicsLineCount).toBe(1);
-        expect(chatMarkdownStyles.firstColumnWidth).toBeGreaterThanOrEqual(128);
-        expect(chatMarkdownStyles.listToQuoteGap).toBeGreaterThan(0);
-        expect(chatMarkdownStyles.tableToCopyGap).toBeGreaterThan(0);
-        expect(chatMarkdownStyles.taskListToDetailsGap).toBeGreaterThan(0);
-        expect(chatMarkdownStyles.unorderedToOrderedGap).toBeGreaterThan(0);
-        expect(chatMarkdownStyles.quoteMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(1, 2);
-        expect(chatMarkdownStyles.tableCopyMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
-          1,
-          2,
-        );
-        expect(chatMarkdownStyles.detailsMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
-          1,
-          2,
-        );
-        expect(chatMarkdownStyles.orderedMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
-          1,
-          2,
-        );
-      },
-    );
+        document.body.append(probe);
+        const list = probe.querySelector(".probe-list");
+        const quote = probe.querySelector(".probe-quote");
+        const dimension = probe.querySelector("th:first-child");
+        const demographics = probe.querySelector("td:first-child");
+        const table = probe.querySelector("table");
+        const tableCopy = probe.querySelector(".probe-table-copy");
+        const taskList = probe.querySelector(".probe-task-list");
+        const details = probe.querySelector(".probe-details");
+        const unordered = probe.querySelector(".probe-unordered");
+        const ordered = probe.querySelector(".probe-ordered");
+        if (
+          !dimension ||
+          !demographics ||
+          !list ||
+          !quote ||
+          !table ||
+          !tableCopy ||
+          !taskList ||
+          !details ||
+          !unordered ||
+          !ordered
+        ) {
+          throw new Error("Chat Markdown style probe did not render");
+        }
+        const lineCount = (element: Element) => {
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          return new Set(Array.from(range.getClientRects(), (rect) => Math.round(rect.top))).size;
+        };
+        const result = {
+          demographicsLineCount: lineCount(demographics),
+          dimensionLineCount: lineCount(dimension),
+          firstColumnWidth: dimension.getBoundingClientRect().width,
+          listToQuoteGap: quote.getBoundingClientRect().top - list.getBoundingClientRect().bottom,
+          quoteMargin: Number.parseFloat(getComputedStyle(quote).marginTop),
+          tableToCopyGap:
+            tableCopy.getBoundingClientRect().top - table.getBoundingClientRect().bottom,
+          tableCopyMargin: Number.parseFloat(getComputedStyle(tableCopy).marginTop),
+          taskListToDetailsGap:
+            details.getBoundingClientRect().top - taskList.getBoundingClientRect().bottom,
+          detailsMargin: Number.parseFloat(getComputedStyle(details).marginTop),
+          unorderedToOrderedGap:
+            ordered.getBoundingClientRect().top - unordered.getBoundingClientRect().bottom,
+          orderedMargin: Number.parseFloat(getComputedStyle(ordered).marginTop),
+          blockFontSize: Number.parseFloat(getComputedStyle(tableCopy).fontSize),
+        };
+        probe.remove();
+        return result;
+      });
+      expect(chatMarkdownStyles.dimensionLineCount).toBe(1);
+      expect(chatMarkdownStyles.demographicsLineCount).toBe(1);
+      expect(chatMarkdownStyles.firstColumnWidth).toBeGreaterThanOrEqual(128);
+      expect(chatMarkdownStyles.listToQuoteGap).toBeGreaterThan(0);
+      expect(chatMarkdownStyles.tableToCopyGap).toBeGreaterThan(0);
+      expect(chatMarkdownStyles.taskListToDetailsGap).toBeGreaterThan(0);
+      expect(chatMarkdownStyles.unorderedToOrderedGap).toBeGreaterThan(0);
+      expect(chatMarkdownStyles.quoteMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(1, 2);
+      expect(chatMarkdownStyles.tableCopyMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(
+        1,
+        2,
+      );
+      expect(chatMarkdownStyles.detailsMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(1, 2);
+      expect(chatMarkdownStyles.orderedMargin / chatMarkdownStyles.blockFontSize).toBeCloseTo(1, 2);
+    });
   });
 });

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureUiProof,
   controlUiSessionUrl,
@@ -62,11 +63,7 @@ suite.define(() => {
 
   it("opens rename on the stored label, not the account-decorated name", async () => {
     const cardsKey = "agent:main:telegram:cards:direct:42";
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -102,11 +99,7 @@ suite.define(() => {
 
   it("opens chat pane rename on the stored label, not the account-decorated title", async () => {
     const cardsKey = "agent:main:telegram:cards:direct:42";
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -128,6 +121,7 @@ suite.define(() => {
     }
   });
 
+<<<<<<< HEAD
   it.each(["sidebar", "sessions", "header"] as const)(
     "edits a generated dashboard title through the %s",
     async (surface) => {
@@ -137,6 +131,38 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { height: 900, width: 1280 },
+=======
+  it("opens a generated dashboard title as editable text", async () => {
+    const key = "agent:main:dashboard:generated-title";
+    const generatedTitle = "Hide OS tooltips for custom hovers";
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          { ...sessionRow(key, generatedTitle, Date.now()), label: undefined },
+        ]),
+      },
+      sessionKey: key,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, key));
+      const title = page.locator(".chat-pane__session-title-button");
+      await expect.poll(() => title.textContent()).toContain(generatedTitle);
+
+      await title.click();
+      const field = page.locator(".chat-pane__session-title-input");
+      await field.waitFor({ state: "visible" });
+      expect(await field.inputValue()).toBe(generatedTitle);
+
+      await field.fill("Editable generated title");
+      await field.press("Enter");
+      const patchRequest = await gateway.waitForRequest("sessions.patch");
+      expect(patchRequest.params).toMatchObject({
+        key,
+        label: "Editable generated title",
+>>>>>>> 1b3cdbc5191 (refactor(tests): share explicit browser context fixtures)
       });
       const page = await context.newPage();
       const original = {

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -121,49 +121,12 @@ suite.define(() => {
     }
   });
 
-<<<<<<< HEAD
   it.each(["sidebar", "sessions", "header"] as const)(
     "edits a generated dashboard title through the %s",
     async (surface) => {
       const key = "agent:main:dashboard:generated-title";
       const generatedTitle = "Repository activity dashboard";
-      const context = await suite.browser.newContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-=======
-  it("opens a generated dashboard title as editable text", async () => {
-    const key = "agent:main:dashboard:generated-title";
-    const generatedTitle = "Hide OS tooltips for custom hovers";
-    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "sessions.list": sessionsListResponse([
-          { ...sessionRow(key, generatedTitle, Date.now()), label: undefined },
-        ]),
-      },
-      sessionKey: key,
-    });
-
-    try {
-      await page.goto(controlUiSessionUrl(suite.server.baseUrl, key));
-      const title = page.locator(".chat-pane__session-title-button");
-      await expect.poll(() => title.textContent()).toContain(generatedTitle);
-
-      await title.click();
-      const field = page.locator(".chat-pane__session-title-input");
-      await field.waitFor({ state: "visible" });
-      expect(await field.inputValue()).toBe(generatedTitle);
-
-      await field.fill("Editable generated title");
-      await field.press("Enter");
-      const patchRequest = await gateway.waitForRequest("sessions.patch");
-      expect(patchRequest.params).toMatchObject({
-        key,
-        label: "Editable generated title",
->>>>>>> 1b3cdbc5191 (refactor(tests): share explicit browser context fixtures)
-      });
+      const context = await suite.browser.newContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const original = {
         ...sessionRow(key, generatedTitle, Date.now()),

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -105,11 +106,7 @@ suite.define(() => {
   });
 
   it("refreshes the archived sidebar after restoring a session during a stale roster load", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const updatedAt = Date.parse("2026-07-01T16:00:00.000Z");
     const main = sessionRow("agent:main:main", "Main", updatedAt);
@@ -170,11 +167,7 @@ suite.define(() => {
   });
 
   it("deletes every archived thread exactly once when the paged roster reorders", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const keys = ["agent:main:first", "agent:main:repeated", "agent:main:moved"];
     const archived = keys.map((key, index) =>
@@ -228,11 +221,7 @@ suite.define(() => {
   });
 
   it("never deletes a hidden thread selected before changing the roster search", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const alpha = "agent:main:alpha";
     const bravo = "agent:main:bravo";
@@ -286,11 +275,7 @@ suite.define(() => {
   });
 
   it("archives a session from the Sessions page context menu and kebab", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -403,11 +388,7 @@ suite.define(() => {
   // The whole selection now crosses the Gateway once and settles from one list.
 
   it("archives a mixed active and idle sidebar multi-select in one RPC", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const batchKeys = ["agent:main:batch-a", "agent:main:batch-b", "agent:main:batch-c"] as const;
@@ -491,11 +472,7 @@ suite.define(() => {
   });
 
   it("keeps the selected session through archive refreshes and restores the composer", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const sessionRows = Array.from({ length: 15 }, (_, index) => {
@@ -811,11 +788,7 @@ suite.define(() => {
   });
 
   it("keeps archive state after navigating away and back", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
     const main = sessionRow("agent:main:main", "Main", baseTime);
@@ -916,11 +889,7 @@ suite.define(() => {
   });
 
   it("recovers a deleted active chat without repeatedly resolving its missing session", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const routeErrors: string[] = [];
     page.on("console", (message) => {
@@ -1004,11 +973,7 @@ suite.define(() => {
   });
 
   it("archive-gates a row-menu delete and keeps the row when the Gateway reports no deletion", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const key = "agent:main:research";
     const gateway = await installMockGateway(page, {

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -238,11 +239,7 @@ suite.define(() => {
   }
 
   it("shows the archived notice when an archived session is cold-loaded outside the active list", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const archived = sessionRow(
       "agent:main:dashboard:cold-archive",

--- a/ui/src/e2e/session-management.copy-session-id.e2e.test.ts
+++ b/ui/src/e2e/session-management.copy-session-id.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -17,11 +18,7 @@ const sessionId = "93be7617-9d1e-4091-aa0f-33332aff3321";
 
 suite.define(() => {
   it("copies the session ID from the session menu", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     await context.grantPermissions(["clipboard-read", "clipboard-write"], {
       origin: new URL(suite.server.baseUrl).origin,
     });

--- a/ui/src/e2e/session-management.filtered-errors.e2e.test.ts
+++ b/ui/src/e2e/session-management.filtered-errors.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureUiProof,
   createSessionManagementE2eSuite,
@@ -12,11 +13,7 @@ const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
   it("searches Sessions through the Gateway, appends matches, and retires failed or replaced queries", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const rows = Array.from({ length: 51 }, (_, index) =>
       sessionRow(`agent:main:match-${index}`, `Match ${index}`, 1000 - index),
@@ -119,11 +116,7 @@ suite.define(() => {
   it.each(["Archived", "All"] as const)(
     "clears the visible %s sidebar error after its failed roster recovers or retires",
     async (statusFilter) => {
-      const context = await suite.browser.newContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.browser.newContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const updatedAt = Date.parse("2026-07-01T16:00:00.000Z");
       const main = sessionRow("agent:main:main", "Main", updatedAt);

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureUiProof,
   createSessionManagementE2eSuite,
@@ -18,11 +19,7 @@ suite.define(() => {
       defaultBranch: "main",
       repositoryStatus: "git",
     };
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -185,11 +182,7 @@ suite.define(() => {
   it.each(["/home/peter/client-work", ""])(
     "blocks saving a worktree default until repository inspection succeeds (%s)",
     async (groupCwd) => {
-      const context = await suite.browser.newContext({
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      });
+      const context = await suite.browser.newContext(createControlUiE2eContextOptions());
       const page = await context.newPage();
       const gateway = await installMockGateway(page, {
         methodResponses: {
@@ -253,11 +246,7 @@ suite.define(() => {
   );
 
   it("omits the group category for a legacy Gateway", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       featureMethods: ["sessions.create", "sessions.groups.list"],
@@ -288,11 +277,7 @@ suite.define(() => {
   it("revalidates an open group route when its defaults or identity change", async () => {
     const initialCwd = "/home/peter/client-work";
     const refreshedCwd = "/home/peter/refreshed-client-work";
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -368,11 +353,7 @@ suite.define(() => {
   });
 
   it("fails an open group route closed while remote catalog invalidation is unresolved", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -435,11 +416,7 @@ suite.define(() => {
 
   it("keeps rejected group defaults editable and allows retry", async () => {
     const groupCwd = "/home/peter/client-work";
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.groups.update"],
@@ -506,11 +483,7 @@ suite.define(() => {
 
   it("offers retry when authoritative group defaults are unavailable", async () => {
     const groupCwd = "/home/peter/client-work";
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.groups.defaults"],
@@ -595,11 +568,7 @@ suite.define(() => {
   });
 
   it("blocks a missing group until a fresh catalog retry resolves it", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: { "sessions.list": sessionsListResponse([]) },

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   actionOpacity,
   activateSelfRemovingControl,
@@ -86,11 +87,7 @@ suite.define(() => {
   });
 
   it("recovers an empty group catalog after a transient load failure", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.groups.list"],
@@ -124,11 +121,7 @@ suite.define(() => {
   });
 
   it("keeps a rejected sidebar mutation visible until the user dismisses it", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.patch"],
@@ -438,11 +431,7 @@ suite.define(() => {
   });
 
   it("sorts threads from the keyboard and identifies destructive selection targets", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -496,11 +485,7 @@ suite.define(() => {
   });
 
   it("shows a rejected Sessions-page custom group instead of leaking a page error", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       deferredMethods: ["sessions.groups.put"],
@@ -546,11 +531,7 @@ suite.define(() => {
 
   it("renames, deletes, and toggles sidebar session groups", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -730,11 +711,7 @@ suite.define(() => {
 
   it("preserves a collapsed sidebar group when its rename is rejected", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.addInitScript(
       ({ key, value }) => {
@@ -814,11 +791,7 @@ suite.define(() => {
 
   it("pages sidebar sessions and supports complete drag-managed groups", async () => {
     const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessions = Array.from({ length: 13 }, (_, index) =>
       sessionRow(`agent:main:session-${index}`, `Session ${index}`, baseTime - index * 60_000, {
@@ -962,11 +935,7 @@ suite.define(() => {
   });
 
   it("keeps a new empty group visible before the first saved session", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -1006,11 +975,7 @@ suite.define(() => {
   });
 
   it("keeps empty gateway groups compact for the selected agent", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       assistantName: "Ivan",

--- a/ui/src/e2e/session-management.operator-scopes.e2e.test.ts
+++ b/ui/src/e2e/session-management.operator-scopes.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   createSessionManagementE2eSuite,
   installMockGateway,
@@ -23,11 +24,7 @@ async function confirmDelete(page: import("playwright").Page) {
 }
 
 async function openArchivedPage(operatorScopes: string[]) {
-  const context = await suite.browser.newContext({
-    locale: "en-US",
-    serviceWorkers: "block",
-    viewport: { height: 900, width: 1280 },
-  });
+  const context = await suite.browser.newContext(createControlUiE2eContextOptions());
   const page = await context.newPage();
   const gateway = await installMockGateway(page, {
     featureMethods: ["chat.metadata", "chat.startup", "sessions.delete"],

--- a/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
+++ b/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   activateSelfRemovingControl,
   captureUiProof,
@@ -89,11 +90,7 @@ suite.define(() => {
   });
 
   it("rolls a menu unpin back and surfaces the error when the Gateway rejects it", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: { "sessions.list": pinnedList(), "sessions.patch": {} },
@@ -133,11 +130,7 @@ suite.define(() => {
   });
 
   it("keeps the newest pin intent when the older completion refreshes the list first", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: { "sessions.list": unpinnedList(), "sessions.patch": {} },

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   actionOpacity,
   actionPointerEvents,
@@ -188,11 +189,7 @@ suite.define(() => {
   });
 
   it("dismisses fixed session menus before the sidebar or drawer hides", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       methodResponses: {
@@ -346,11 +343,7 @@ suite.define(() => {
   });
 
   it("names session-row actions and tabs from their menu into the next visible session", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -435,11 +428,7 @@ suite.define(() => {
   });
 
   it("keeps sidebar sessions visible through transport and client replacement reconnects", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const sessionKey = "agent:main:disconnect-proof";
     const otherSessionKeys = ["agent:main:other-a", "agent:main:other-b"] as const;
@@ -530,11 +519,7 @@ suite.define(() => {
   });
 
   it("retains the selected session and one observer while reconnecting across route changes", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const firstKey = "agent:main:reconnect-first";
     const selectedKey = "agent:main:reconnect-selected";
@@ -834,11 +819,7 @@ suite.define(() => {
         sessionRow("agent:main:node-mcp-debug-4de003fbff138fcb9239c9378b2e", "", ts - 180_000),
       ];
     };
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -2,6 +2,7 @@ import { expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 import {
   actionOpacity,
   captureUiProof,
@@ -86,11 +87,7 @@ suite.define(() => {
   });
 
   it("keeps action-only text stable and active state visible with actions", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await installMockGateway(page, {
       methodResponses: {
@@ -274,11 +271,7 @@ suite.define(() => {
   it("aligns trailing unread dots and trades unread/PR icons for hover actions", async () => {
     const plainKey = "agent:main:unread-plain";
     const pullRequestKey = "agent:main:unread-pr";
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem("openclaw:sidebar:sessions:show-preview", "false");
@@ -430,11 +423,7 @@ suite.define(() => {
   });
 
   it("does not widen desktop session text when hover actions appear beside trailing state", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
+    const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     await page.addInitScript(() => {
       localStorage.setItem("openclaw:sidebar:sessions:show-preview", "true");

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -9,7 +9,10 @@ import {
   controlUiSessionUrl,
   installMockGateway,
 } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 import { readThemedPopupPaint } from "./popup-theme.test-support.ts";
 import { openSessionMenuSubmenu } from "./session-management.test-support.ts";
 import { routeAvatarFixtures } from "./session-ownership-visuals.test-support.ts";
@@ -143,127 +146,113 @@ async function chooseMe(page: Page): Promise<void> {
 
 suite.define(() => {
   it("marks exactly one target when the session is assigned to self", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installOwnerGateway(page);
-        const row = page.locator('[data-session-key="agent:main:ada-research"]');
-        await row.hover();
-        await row
-          .getByRole("button", { name: "Open session menu: Ada research", exact: true })
-          .click();
-        const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
-        await assignTo.hover();
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installOwnerGateway(page);
+      const row = page.locator('[data-session-key="agent:main:ada-research"]');
+      await row.hover();
+      await row
+        .getByRole("button", { name: "Open session menu: Ada research", exact: true })
+        .click();
+      const assignTo = page.getByRole("menuitem", { name: "Assign to…", exact: true });
+      await assignTo.hover();
 
-        const checked = assignTo.locator(
-          ':scope > wa-dropdown-item[slot="submenu"][aria-checked="true"]',
-        );
-        await expectBrowser(checked).toHaveCount(1);
-        await expectBrowser(checked.locator(":scope > .session-menu__text")).toHaveText("Me");
-        await expectBrowser(
-          assignTo.locator(':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text'),
-        ).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
-      },
-    );
+      const checked = assignTo.locator(
+        ':scope > wa-dropdown-item[slot="submenu"][aria-checked="true"]',
+      );
+      await expectBrowser(checked).toHaveCount(1);
+      await expectBrowser(checked.locator(":scope > .session-menu__text")).toHaveText("Me");
+      await expectBrowser(
+        assignTo.locator(':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text'),
+      ).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
+    });
   });
 
   it("assigns named and self owners through one keyboard-accessible submenu", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installOwnerGateway(page);
-        const row = page.locator(`[data-session-key="${sessionKey}"]`);
-        await row.hover();
-        const trigger = row.getByRole("button", {
-          name: "Open session menu: Owner outcome",
-          exact: true,
-        });
-        await trigger.click();
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installOwnerGateway(page);
+      const row = page.locator(`[data-session-key="${sessionKey}"]`);
+      await row.hover();
+      const trigger = row.getByRole("button", {
+        name: "Open session menu: Owner outcome",
+        exact: true,
+      });
+      await trigger.click();
 
-        const menu = page.locator("openclaw-session-menu");
-        const rootAssignmentLabels = await menu
-          .locator(":scope > wa-dropdown > wa-dropdown-item > .session-menu__text")
-          .allTextContents();
-        expect(rootAssignmentLabels.filter((label) => label.startsWith("Assign to"))).toEqual([
-          "Assign to…",
-        ]);
-        const assignTo = menu.getByRole("menuitem", {
-          name: "Assign to…",
-          exact: true,
-        });
-        await assignTo.hover();
-        const ownerItems = assignTo.locator(
-          ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
+      const menu = page.locator("openclaw-session-menu");
+      const rootAssignmentLabels = await menu
+        .locator(":scope > wa-dropdown > wa-dropdown-item > .session-menu__text")
+        .allTextContents();
+      expect(rootAssignmentLabels.filter((label) => label.startsWith("Assign to"))).toEqual([
+        "Assign to…",
+      ]);
+      const assignTo = menu.getByRole("menuitem", {
+        name: "Assign to…",
+        exact: true,
+      });
+      await assignTo.hover();
+      const ownerItems = assignTo.locator(
+        ':scope > wa-dropdown-item[slot="submenu"] > .session-menu__text',
+      );
+      await captureProof(page, "assignment-submenu");
+      await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
+      const selfAvatar = assignTo
+        .getByRole("menuitemradio", { name: "Me", exact: true })
+        .locator("openclaw-viewer-avatar img");
+      await expectBrowser(selfAvatar).toHaveCount(1);
+      await expect
+        .poll(() => selfAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
+        .toBeGreaterThan(0);
+      const avatarSizes = await assignTo
+        .locator(':scope > wa-dropdown-item[slot="submenu"] .viewer-avatar')
+        .evaluateAll((avatars) =>
+          avatars.map((avatar) => {
+            const bounds = avatar.getBoundingClientRect();
+            const style = getComputedStyle(avatar);
+            return {
+              height: bounds.height,
+              width: bounds.width,
+              cssHeight: style.height,
+              cssWidth: style.width,
+            };
+          }),
         );
-        await captureProof(page, "assignment-submenu");
-        await expectBrowser(ownerItems).toHaveText(["Me", "OpenClaw", "Bob", "Carol"]);
-        const selfAvatar = assignTo
-          .getByRole("menuitemradio", { name: "Me", exact: true })
-          .locator("openclaw-viewer-avatar img");
-        await expectBrowser(selfAvatar).toHaveCount(1);
-        await expect
-          .poll(() => selfAvatar.evaluate((image) => (image as HTMLImageElement).naturalWidth))
-          .toBeGreaterThan(0);
-        const avatarSizes = await assignTo
-          .locator(':scope > wa-dropdown-item[slot="submenu"] .viewer-avatar')
-          .evaluateAll((avatars) =>
-            avatars.map((avatar) => {
-              const bounds = avatar.getBoundingClientRect();
-              const style = getComputedStyle(avatar);
-              return {
-                height: bounds.height,
-                width: bounds.width,
-                cssHeight: style.height,
-                cssWidth: style.width,
-              };
-            }),
-          );
-        expect(avatarSizes.length).toBeGreaterThan(0);
-        expect(
-          avatarSizes.every(
-            ({ width, height, cssWidth, cssHeight }) =>
-              Math.abs(width - height) < 0.01 && cssWidth === "14px" && cssHeight === "14px",
-          ),
-        ).toBe(true);
-        await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();
-        await expectAssignmentRequest(gateway, "profile-carol");
-        await gateway.resolveDeferred("sessions.assignOwner", {
-          ok: true,
-          key: sessionKey,
-          owner: { actor: { type: "human", id: "profile-carol", label: "Carol" } },
-        });
+      expect(avatarSizes.length).toBeGreaterThan(0);
+      expect(
+        avatarSizes.every(
+          ({ width, height, cssWidth, cssHeight }) =>
+            Math.abs(width - height) < 0.01 && cssWidth === "14px" && cssHeight === "14px",
+        ),
+      ).toBe(true);
+      await assignTo.getByRole("menuitemradio", { name: "Carol", exact: true }).click();
+      await expectAssignmentRequest(gateway, "profile-carol");
+      await gateway.resolveDeferred("sessions.assignOwner", {
+        ok: true,
+        key: sessionKey,
+        owner: { actor: { type: "human", id: "profile-carol", label: "Carol" } },
+      });
 
-        await gateway.deferNext("sessions.assignOwner");
-        await row.hover();
-        await trigger.press("Enter");
-        await openSessionMenuSubmenu(page, "Assign to…");
-        const keyboardAssignTo = page.getByRole("menuitem", {
-          name: "Assign to…",
-          exact: true,
-        });
-        await expectBrowser(
-          page.getByRole("menuitemradio", { name: "Me", exact: true }),
-        ).toBeFocused();
-        await page.keyboard.press("Escape");
-        await expectBrowser(trigger).toHaveAttribute("aria-expanded", "false");
-        await trigger.press("Enter");
-        await openSessionMenuSubmenu(page, "Assign to…");
-        await expectBrowser(keyboardAssignTo).toHaveAttribute("aria-expanded", "true");
-        await expectBrowser(
-          page.getByRole("menuitemradio", { name: "Me", exact: true }),
-        ).toBeFocused();
-        await page.keyboard.press("Enter");
-        await expectAssignmentRequest(gateway, "profile-ada", 1);
-      },
-    );
+      await gateway.deferNext("sessions.assignOwner");
+      await row.hover();
+      await trigger.press("Enter");
+      await openSessionMenuSubmenu(page, "Assign to…");
+      const keyboardAssignTo = page.getByRole("menuitem", {
+        name: "Assign to…",
+        exact: true,
+      });
+      await expectBrowser(
+        page.getByRole("menuitemradio", { name: "Me", exact: true }),
+      ).toBeFocused();
+      await page.keyboard.press("Escape");
+      await expectBrowser(trigger).toHaveAttribute("aria-expanded", "false");
+      await trigger.press("Enter");
+      await openSessionMenuSubmenu(page, "Assign to…");
+      await expectBrowser(keyboardAssignTo).toHaveAttribute("aria-expanded", "true");
+      await expectBrowser(
+        page.getByRole("menuitemradio", { name: "Me", exact: true }),
+      ).toBeFocused();
+      await page.keyboard.press("Enter");
+      await expectAssignmentRequest(gateway, "profile-ada", 1);
+    });
   });
 
   it.each([
@@ -434,33 +423,26 @@ suite.define(() => {
   });
 
   it("keeps a rejected sidebar owner assignment visible", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installOwnerGateway(page);
-        const row = page.locator(`[data-session-key="${sessionKey}"]`);
-        await row.hover();
-        await row
-          .getByRole("button", { name: "Open session menu: Owner outcome", exact: true })
-          .click();
-        await chooseMe(page);
-        await expectAssignmentRequest(gateway);
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installOwnerGateway(page);
+      const row = page.locator(`[data-session-key="${sessionKey}"]`);
+      await row.hover();
+      await row
+        .getByRole("button", { name: "Open session menu: Owner outcome", exact: true })
+        .click();
+      await chooseMe(page);
+      await expectAssignmentRequest(gateway);
 
-        const message = "Sidebar owner assignment rejected for visible outcome proof.";
-        await gateway.rejectDeferred("sessions.assignOwner", {
-          code: "INVALID_REQUEST",
-          message,
-        });
+      const message = "Sidebar owner assignment rejected for visible outcome proof.";
+      await gateway.rejectDeferred("sessions.assignOwner", {
+        code: "INVALID_REQUEST",
+        message,
+      });
 
-        await expectBrowser(page.getByRole("alert").filter({ hasText: message })).toBeVisible();
-        await expectBrowser(
-          row.getByRole("img", { name: "Created by Bob", exact: true }),
-        ).toHaveCount(1);
-      },
-    );
+      await expectBrowser(page.getByRole("alert").filter({ hasText: message })).toBeVisible();
+      await expectBrowser(
+        row.getByRole("img", { name: "Created by Bob", exact: true }),
+      ).toHaveCount(1);
+    });
   });
 });

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -3,7 +3,10 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { pathForRoute, type RouteId } from "../app-route-paths.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI settings layout mocked Gateway E2E",
@@ -187,11 +190,7 @@ suite.define(() => {
   it("loads provider-settings copy after New Session and Chat without startup errors", async () => {
     const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
+      createControlUiE2eContextOptions(),
       async ({ context, page: firstPage }) => {
         const errors: string[] = [];
         const failedScripts: string[] = [];

--- a/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
+++ b/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI sidebar dev branch badge E2E",
@@ -17,70 +20,56 @@ const DEV_BRANCH = "feat/dev-branch-badge";
 
 suite.define(() => {
   it("renders the dev checkout branch in the footer in the danger color", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, { devGitBranch: DEV_BRANCH });
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page, { devGitBranch: DEV_BRANCH });
 
-        const response = await page.goto(suite.server.baseUrl);
-        expect(response?.status()).toBe(200);
+      const response = await page.goto(suite.server.baseUrl);
+      expect(response?.status()).toBe(200);
 
-        const badge = page.locator(".sidebar-footer-branch");
-        await badge.waitFor();
-        await expect
-          .poll(() => badge.locator(".sidebar-footer-branch__name").textContent())
-          .toBe(DEV_BRANCH);
-        // The branch name surfaces via the shared tooltip's accessible
-        // description instead of a native title attribute.
-        await expect
-          .poll(() =>
-            badge.evaluate((element) => {
-              const id = element.getAttribute("aria-describedby");
-              return id ? (document.getElementById(id)?.textContent ?? null) : null;
-            }),
-          )
-          .toBe(DEV_BRANCH);
+      const badge = page.locator(".sidebar-footer-branch");
+      await badge.waitFor();
+      await expect
+        .poll(() => badge.locator(".sidebar-footer-branch__name").textContent())
+        .toBe(DEV_BRANCH);
+      // The branch name surfaces via the shared tooltip's accessible
+      // description instead of a native title attribute.
+      await expect
+        .poll(() =>
+          badge.evaluate((element) => {
+            const id = element.getAttribute("aria-describedby");
+            return id ? (document.getElementById(id)?.textContent ?? null) : null;
+          }),
+        )
+        .toBe(DEV_BRANCH);
 
-        const colors = await badge.evaluate((element) => {
-          // Compare resolved colors: getComputedStyle().color returns rgb() while
-          // the raw --danger token may be hex/oklch, so resolve it via a probe.
-          const probe = document.createElement("span");
-          probe.style.color = "var(--danger)";
-          element.append(probe);
-          const danger = getComputedStyle(probe).color;
-          probe.remove();
-          return { badge: getComputedStyle(element).color, danger };
-        });
-        expect(colors.danger).not.toBe("");
-        expect(colors.badge).toBe(colors.danger);
+      const colors = await badge.evaluate((element) => {
+        // Compare resolved colors: getComputedStyle().color returns rgb() while
+        // the raw --danger token may be hex/oklch, so resolve it via a probe.
+        const probe = document.createElement("span");
+        probe.style.color = "var(--danger)";
+        element.append(probe);
+        const danger = getComputedStyle(probe).color;
+        probe.remove();
+        return { badge: getComputedStyle(element).color, danger };
+      });
+      expect(colors.danger).not.toBe("");
+      expect(colors.badge).toBe(colors.danger);
 
-        const artifactDir = createControlUiE2eArtifactDir("dev-branch");
-        await page
-          .locator(".sidebar-shell__footer")
-          .screenshot({ path: path.join(artifactDir, "footer-dev-branch.png") });
-      },
-    );
+      const artifactDir = createControlUiE2eArtifactDir("dev-branch");
+      await page
+        .locator(".sidebar-shell__footer")
+        .screenshot({ path: path.join(artifactDir, "footer-dev-branch.png") });
+    });
   });
 
   it("omits the badge when the gateway reports no dev branch", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page);
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page);
 
-        const response = await page.goto(suite.server.baseUrl);
-        expect(response?.status()).toBe(200);
-        await page.locator(".sidebar-agent-card").waitFor();
-        expect(await page.locator(".sidebar-footer-branch").count()).toBe(0);
-      },
-    );
+      const response = await page.goto(suite.server.baseUrl);
+      expect(response?.status()).toBe(200);
+      await page.locator(".sidebar-agent-card").waitFor();
+      expect(await page.locator(".sidebar-footer-branch").count()).toBe(0);
+    });
   });
 });

--- a/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
+++ b/ui/src/e2e/skills-any-bin-requirements.e2e.test.ts
@@ -1,7 +1,10 @@
 // Control UI coverage proves alternative skill binaries remain diagnosable and installable.
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eContextOptions,
+  createControlUiE2eSuite,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI alternative skill binary requirements",
@@ -55,73 +58,57 @@ function codingAgentSkill(missingAnyBins: string[]) {
 
 suite.define(() => {
   it("explains alternative missing binaries and installs one through the Gateway", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        const gateway = await installMockGateway(page, {
-          featureMethods: ["chat.metadata", "chat.startup", "skills.install"],
-          methodResponses: {
-            "skills.status": {
-              workspaceDir: "/tmp/openclaw-e2e/workspace",
-              managedSkillsDir: "/tmp/openclaw-e2e/skills",
-              skills: [codingAgentSkill(["claude", "codex", "opencode"])],
-            },
-            "skills.install": { message: "Installed Codex CLI" },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["chat.metadata", "chat.startup", "skills.install"],
+        methodResponses: {
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [codingAgentSkill(["claude", "codex", "opencode"])],
           },
-        });
+          "skills.install": { message: "Installed Codex CLI" },
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}skills`);
-        expect(response?.status()).toBe(200);
-        await page.getByRole("button", { name: "Open Coding Agent details" }).click();
+      const response = await page.goto(`${suite.server.baseUrl}skills`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("button", { name: "Open Coding Agent details" }).click();
 
-        const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
-        await expect.poll(async () => await dialog.count()).toBe(1);
-        expect(await dialog.textContent()).toContain("bin:any of (claude, codex, opencode)");
-        await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).click();
+      const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
+      await expect.poll(async () => await dialog.count()).toBe(1);
+      expect(await dialog.textContent()).toContain("bin:any of (claude, codex, opencode)");
+      await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).click();
 
-        const request = await gateway.waitForRequest("skills.install");
-        expect(request.params).toMatchObject({
-          name: "Coding Agent",
-          installId: "node-codex",
-          dangerouslyForceUnsafeInstall: false,
-        });
-      },
-    );
+      const request = await gateway.waitForRequest("skills.install");
+      expect(request.params).toMatchObject({
+        name: "Coding Agent",
+        installId: "node-codex",
+        dangerouslyForceUnsafeInstall: false,
+      });
+    });
   });
 
   it("does not show missing alternatives or an installer for an eligible skill", async () => {
-    await suite.withPage(
-      {
-        locale: "en-US",
-        serviceWorkers: "block",
-        viewport: { height: 900, width: 1280 },
-      },
-      async ({ page }) => {
-        await installMockGateway(page, {
-          methodResponses: {
-            "skills.status": {
-              workspaceDir: "/tmp/openclaw-e2e/workspace",
-              managedSkillsDir: "/tmp/openclaw-e2e/skills",
-              skills: [codingAgentSkill([])],
-            },
+    await suite.withPage(createControlUiE2eContextOptions(), async ({ page }) => {
+      await installMockGateway(page, {
+        methodResponses: {
+          "skills.status": {
+            workspaceDir: "/tmp/openclaw-e2e/workspace",
+            managedSkillsDir: "/tmp/openclaw-e2e/skills",
+            skills: [codingAgentSkill([])],
           },
-        });
+        },
+      });
 
-        const response = await page.goto(`${suite.server.baseUrl}skills`);
-        expect(response?.status()).toBe(200);
-        await page.getByRole("button", { name: "Open Coding Agent details" }).click();
+      const response = await page.goto(`${suite.server.baseUrl}skills`);
+      expect(response?.status()).toBe(200);
+      await page.getByRole("button", { name: "Open Coding Agent details" }).click();
 
-        const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
-        await expect.poll(async () => await dialog.count()).toBe(1);
-        expect(await dialog.getByText("bin:any of", { exact: false }).count()).toBe(0);
-        expect(await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).count()).toBe(
-          0,
-        );
-      },
-    );
+      const dialog = page.locator("openclaw-modal-dialog", { hasText: "Coding Agent" });
+      await expect.poll(async () => await dialog.count()).toBe(1);
+      expect(await dialog.getByText("bin:any of", { exact: false }).count()).toBe(0);
+      expect(await dialog.getByRole("button", { name: "Install Codex CLI (npm)" }).count()).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
Related: #139428

<details>
<summary>Additional instructions</summary>

Maintainer branch access is available for this same-repository PR.

</details>

## What Problem This Solves

Control UI browser tests repeat the same explicit desktop context options at 200 sites, making shared fixture maintenance unnecessarily repetitive.

## Why This Change Was Made

A pure factory in the existing suite support returns the same ordered locale, service-worker policy, and viewport values with a fresh options object and fresh nested viewport on every call. The 79 consumers retain their existing raw browser, tracked context, or `withPage` calls and cleanup. Nondefault variants and two standalone browser owners remain unchanged.

## User Impact

No user-visible or UI appearance change. Test cases, assertions, and context isolation are preserved. The diff removes 821 physical test/support lines; only 648 count toward the audit campaign, excluding 173 formatter-only reflow lines. No aggregate runtime improvement is claimed.

## Evidence

- Expanded-source comparison passed for all 200 replacements: case names, bodies, calls, cleanup, and assertions match after expanding the factory, allowing only formatting and the intended imports. Ordered values match, and 200 evaluations produce distinct root objects and nested viewports.
- Earlier representative Chromium proof passed 6 cases across `about`, `chat-flow.composer-shortcuts`, and `agent-channel-runtime-status`, covering all three construction routes. The native-fork `control-ui-e2e-suite.test.ts` lifecycle sibling passed 14 cases. Other browser files were not rerun during the conflict repair.
- The complete `node scripts/check-changed.mjs` gate passed against the new base after conflict repair, including core test types, i18n, guards, dead exports, and targeted lint. P2 review and deslop are clean.

Rebase validation preserves main’s new task-suggestion UX and case removal, plus the community focused-popover regression. The two changed browser files pass 14 cases on the new base; fresh expanded-source equivalence and P2 review are clean.

The second conflict resolution preserves main’s complete three-surface account-title test, including editing, focus, save, and reset assertions. On the final corrective commit, all 6 account-label browser cases, the full changed gate, and conflict-marker checks pass. New-base equivalence still covers all 200 sites; fresh P2 review passed before the normal corrective commit. The intermediate commit is retained in history rather than amended or squashed.
