### PR TITLE
fix(ollama): preserve model catalogs during discovery failures

### DIFF
--- a/docs/providers/ollama-cloud.md
+++ b/docs/providers/ollama-cloud.md
@@ -71,9 +71,11 @@ openclaw models set ollama-cloud/kimi-k2.6
 ```
 
 Hosted ids in the live catalog include `deepseek-v4-flash`, `glm-5.2`,
-`gpt-oss:20b`, `kimi-k3`, and `minimax-m3`. When live discovery returns
-nothing, OpenClaw falls back to the bundled rows `minimax-m2.7`, `minimax-m3`,
-`kimi-k3`, `glm-5.1`, and `glm-5.2`. Retired `kimi-k2.5` remains marked
+`gpt-oss:20b`, `kimi-k3`, and `minimax-m3`. Failed discovery keeps the last
+successful inventory for the same credentials. Without a prior inventory,
+OpenClaw offers bundled suggestions and records the discovery failure. A
+successful empty response clears discovered models; later failures preserve
+that empty result. Retired `kimi-k2.5` remains marked
 deprecated for existing exact references, but is no longer a current hosted
 model.
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -192,6 +192,10 @@ self-hosted endpoint with `models: []` remains eligible for discovery;
 `models.providers.ollama.apiKey` alone does not select that provider for Gateway
 model browsing.
 
+Failed discovery records an unavailable or catalog-authentication failure and
+keeps the last successful inventory for the same endpoint and credentials. A
+successful empty response clears discovered models. Manual models stay separate.
+
 Hosted `https://ollama.com` entries skip discovery because Ollama Cloud models
 are provider-managed. Without an explicit Ollama endpoint, a custom provider
 with `api: "ollama"` and a non-loopback `baseUrl` suppresses ambient localhost

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -1185,11 +1185,10 @@ describe("ollama plugin", () => {
     });
     expect(buildOllamaProviderMock).toHaveBeenCalledWith("http://remote-ollama:11434", {
       discoveryMode: "strict",
-      quiet: false,
     });
   });
 
-  it("keeps stored ollama-local marker auth on the quiet ambient path", async () => {
+  it("keeps stored ollama-local marker auth during discovery", async () => {
     const provider = registerProvider();
     mockDiscoveredOllamaProvider([], { once: true });
 
@@ -1206,7 +1205,6 @@ describe("ollama plugin", () => {
     expect(resultProvider.models).toEqual([]);
     expect(buildOllamaProviderMock).toHaveBeenCalledWith(undefined, {
       discoveryMode: "strict",
-      quiet: true,
     });
   });
 
@@ -2228,7 +2226,6 @@ describe("ollama plugin", () => {
       expect(resultProvider.api).toBe("ollama");
       expect(buildOllamaProviderMock).toHaveBeenCalledWith(undefined, {
         discoveryMode: "strict",
-        quiet: false,
       });
     },
   );
@@ -2414,7 +2411,6 @@ describe("ollama plugin", () => {
     expect(buildOllamaProviderMock).toHaveBeenCalledWith("https://ollama.com", {
       apiKey: "cloud-key",
       discoveryMode: "strict",
-      quiet: true,
     });
     expect(result?.provider.apiKey).toBe("OLLAMA_API_KEY");
     expect(result?.provider.models).toEqual(
@@ -2443,7 +2439,6 @@ describe("ollama plugin", () => {
     expect(buildOllamaProviderMock).toHaveBeenCalledWith("https://ollama.com", {
       apiKey: "cloud-key",
       discoveryMode: "strict",
-      quiet: true,
     });
     expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith("https://ollama.com", "glm-5.2", {
       apiKey: "cloud-key",

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -5,7 +5,7 @@ import {
   capturePluginRegistration,
   createPluginRuntimeMock,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { LiveModelCatalogHttpError } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 // Ollama tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -96,7 +96,6 @@ vi.mock("./src/stream-registration.js", () => ({
 }));
 
 beforeEach(() => {
-  clearLiveCatalogCacheForTests();
   promptAndConfigureOllamaMock.mockClear();
   ensureOllamaModelPulledMock.mockClear();
   fetchWithSsrFGuardMock.mockReset();
@@ -1110,6 +1109,7 @@ describe("ollama plugin", () => {
 
     expect(buildOllamaProviderMock).toHaveBeenCalledOnce();
     expect(result).toEqual({
+      outcomes: [{ provider: "ollama", status: "ready" }],
       provider: {
         baseUrl: "http://127.0.0.1:11434",
         api: "ollama",
@@ -1179,8 +1179,12 @@ describe("ollama plugin", () => {
       resolveProviderApiKey: () => ({ apiKey: "" }),
     } as never);
 
-    expect(result).toBeNull();
+    expect(result).toMatchObject({
+      provider: { models: [] },
+      outcomes: [{ provider: "ollama", status: "ready" }],
+    });
     expect(buildOllamaProviderMock).toHaveBeenCalledWith("http://remote-ollama:11434", {
+      discoveryMode: "strict",
       quiet: false,
     });
   });
@@ -1201,6 +1205,7 @@ describe("ollama plugin", () => {
     expect(resultProvider.apiKey).toBe("ollama-local");
     expect(resultProvider.models).toEqual([]);
     expect(buildOllamaProviderMock).toHaveBeenCalledWith(undefined, {
+      discoveryMode: "strict",
       quiet: true,
     });
   });
@@ -2222,6 +2227,7 @@ describe("ollama plugin", () => {
       expect(resultProvider.baseUrl).toBe("http://127.0.0.1:11434");
       expect(resultProvider.api).toBe("ollama");
       expect(buildOllamaProviderMock).toHaveBeenCalledWith(undefined, {
+        discoveryMode: "strict",
         quiet: false,
       });
     },
@@ -2337,6 +2343,58 @@ describe("ollama plugin", () => {
     expect(requireConfiguredStreamParams().providerBaseUrl).toBe("https://ollama.com");
   });
 
+  it.each(
+    ["ollama", "ollama-cloud"].flatMap((providerId) =>
+      [401, 403, 503, undefined].map((status) => ({ providerId, status })),
+    ),
+  )(
+    "reports $providerId discovery failure $status with its profile",
+    async ({ providerId, status }) => {
+      const provider = registerProvidersWithPluginConfig({}).find(
+        (entry) => entry.id === providerId,
+      );
+      buildOllamaProviderMock.mockRejectedValue(
+        status ? new LiveModelCatalogHttpError(providerId, status) : new Error("Endpoint offline"),
+      );
+      const result = await provider.catalog.run({
+        config: {},
+        env: {},
+        resolveProviderApiKey: () => ({
+          apiKey: "catalog-key",
+          discoveryApiKey: "catalog-key",
+          profileId: `${providerId}:default`,
+        }),
+      });
+      expect(result).toEqual({
+        providers: {},
+        outcomes: [
+          {
+            provider: providerId,
+            profileId: `${providerId}:default`,
+            ...(status === 401 || status === 403
+              ? { status: "auth-rejected", rejectionScope: "catalog" }
+              : { status: "unavailable" }),
+          },
+        ],
+      });
+    },
+  );
+
+  it.each(["ollama", "ollama-cloud"])("keeps %s live empties authoritative", async (providerId) => {
+    const provider = registerProvidersWithPluginConfig({}).find((entry) => entry.id === providerId);
+    mockDiscoveredOllamaProvider([], { once: true });
+    const result = await provider.catalog.run({
+      config: {},
+      env: {},
+      resolveProviderApiKey: () => ({ apiKey: "catalog-key", discoveryApiKey: "catalog-key" }),
+    });
+    expect(result).toMatchObject({
+      provider: { models: [] },
+      outcomes: [{ provider: providerId, status: "ready" }],
+    });
+    expect(queryOllamaModelShowInfoMock).not.toHaveBeenCalled();
+  });
+
   it("uses Ollama Cloud auth for live catalog discovery", async () => {
     const provider = registerOllamaCloudProvider();
     mockDiscoveredOllamaProvider([buildOllamaModelDefinitionMock("glm-5.2")], {
@@ -2355,6 +2413,7 @@ describe("ollama plugin", () => {
 
     expect(buildOllamaProviderMock).toHaveBeenCalledWith("https://ollama.com", {
       apiKey: "cloud-key",
+      discoveryMode: "strict",
       quiet: true,
     });
     expect(result?.provider.apiKey).toBe("OLLAMA_API_KEY");
@@ -2383,6 +2442,7 @@ describe("ollama plugin", () => {
 
     expect(buildOllamaProviderMock).toHaveBeenCalledWith("https://ollama.com", {
       apiKey: "cloud-key",
+      discoveryMode: "strict",
       quiet: true,
     });
     expect(queryOllamaModelShowInfoMock).toHaveBeenCalledWith("https://ollama.com", "glm-5.2", {

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -558,7 +558,6 @@ async function buildOllamaCloudProvider(apiKey?: string): Promise<ModelProviderC
   const discovered = await buildOllamaProvider(OLLAMA_CLOUD_BASE_URL, {
     ...(apiKey ? { apiKey } : {}),
     discoveryMode: "strict",
-    quiet: true,
   });
   if (
     !discovered.models.length ||

--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -25,6 +25,7 @@ import {
   isNonSecretApiKeyMarker,
 } from "openclaw/plugin-sdk/provider-auth";
 import { createProviderApiKeyAuthMethod } from "openclaw/plugin-sdk/provider-auth-api-key";
+import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
@@ -556,12 +557,14 @@ function buildStaticOllamaCloudProvider(): ModelProviderConfig {
 async function buildOllamaCloudProvider(apiKey?: string): Promise<ModelProviderConfig> {
   const discovered = await buildOllamaProvider(OLLAMA_CLOUD_BASE_URL, {
     ...(apiKey ? { apiKey } : {}),
+    discoveryMode: "strict",
     quiet: true,
   });
-  if (!discovered.models?.length) {
-    return buildStaticOllamaCloudProvider();
-  }
-  if (!apiKey || discovered.models.some((model) => model.id === OLLAMA_GLM52_CLOUD_MODEL_ID)) {
+  if (
+    !discovered.models.length ||
+    !apiKey ||
+    discovered.models.some((model) => model.id === OLLAMA_GLM52_CLOUD_MODEL_ID)
+  ) {
     return discovered;
   }
   const showInfo = await queryOllamaModelShowInfo(
@@ -791,22 +794,26 @@ export default definePluginEntry({
       catalog: {
         order: "simple",
         run: async (ctx: ProviderCatalogContext) => {
-          const resolvedAuth = ctx.resolveProviderApiKey(OLLAMA_CLOUD_PROVIDER_ID);
-          const apiKey = resolvedAuth.apiKey ?? resolvedAuth.discoveryApiKey;
-          if (!apiKey) {
+          if (ctx.providerIds && !ctx.providerIds.includes(OLLAMA_CLOUD_PROVIDER_ID)) {
             return null;
           }
-          const discoveryApiKey = readUsableOllamaShowApiKey({
-            env: ctx.env,
-            allowAmbientEnvFallback: true,
-            resolved: resolvedAuth,
+          const resolvedAuth = ctx.resolveProviderApiKey(OLLAMA_CLOUD_PROVIDER_ID);
+          const apiKey = resolvedAuth.apiKey ?? resolvedAuth.discoveryApiKey;
+          const discoveryApiKey =
+            resolvedAuth.discoveryApiKey ?? readConcreteOllamaApiKey(resolvedAuth.apiKey);
+          if (!apiKey || !discoveryApiKey) {
+            return null;
+          }
+          return await runLiveProviderCatalog({
+            providerId: OLLAMA_CLOUD_PROVIDER_ID,
+            profileId: resolvedAuth.profileId,
+            run: async () => ({
+              provider: {
+                ...(await buildOllamaCloudProvider(discoveryApiKey)),
+                apiKey,
+              },
+            }),
           });
-          return {
-            provider: {
-              ...(await buildOllamaCloudProvider(discoveryApiKey)),
-              apiKey,
-            },
-          };
         },
       },
       staticCatalog: {

--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -3,7 +3,6 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createModel } from "./model.test-support.js";
@@ -15,18 +14,12 @@ const createConfiguredModel = () =>
   createModel("gpt-oss:20b", "GPT-OSS 20B", { contextWindow: 8_192, maxTokens: 81_920 });
 
 afterEach(() => {
-  clearLiveCatalogCacheForTests();
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
 });
 
 describe("Ollama provider", () => {
   const createAgentDir = () => mkdtempSync(join(tmpdir(), "openclaw-test-"));
-
-  const enableDiscoveryEnv = () => {
-    vi.stubEnv("VITEST", "");
-    vi.stubEnv("NODE_ENV", "development");
-  };
 
   const fetchCallUrls = (fetchMock: ReturnType<typeof vi.fn>): string[] =>
     fetchMock.mock.calls.map(([input]) => String(input));
@@ -36,16 +29,6 @@ describe("Ollama provider", () => {
 
   const stubOllamaFetch = (fetchMock: ReturnType<typeof vi.fn>) => {
     vi.stubGlobal("fetch", withFetchPreconnect(fetchMock));
-  };
-
-  const countWarnCallsIncluding = (warnSpy: ReturnType<typeof vi.spyOn>, text: string): number => {
-    let count = 0;
-    for (const [message] of warnSpy.mock.calls) {
-      if (String(message).includes(text)) {
-        count++;
-      }
-    }
-    return count;
   };
 
   const expectDiscoveryCallCounts = (
@@ -222,7 +205,6 @@ describe("Ollama provider", () => {
   });
 
   it("discovers per-model context windows from /api/show", async () => {
-    enableDiscoveryEnv();
     const fetchMock = vi.fn(async (input: unknown, init?: RequestInit) => {
       const url = String(input);
       if (url.endsWith("/api/tags")) {
@@ -256,7 +238,6 @@ describe("Ollama provider", () => {
 
   it("auto-registers ollama provider when models are discovered locally", async () => {
     await withoutAmbientOllamaEnv(async () => {
-      enableDiscoveryEnv();
       const fetchMock = vi.fn(async (input: unknown) => {
         const url = String(input);
         if (url.endsWith("/api/tags")) {
@@ -286,7 +267,6 @@ describe("Ollama provider", () => {
 
   it("does not warn when Ollama is unreachable and not explicitly configured", async () => {
     await withoutAmbientOllamaEnv(async () => {
-      enableDiscoveryEnv();
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const fetchMock = vi
         .fn()
@@ -305,37 +285,7 @@ describe("Ollama provider", () => {
     });
   });
 
-  it("warns when Ollama is unreachable and explicitly configured", async () => {
-    await withoutAmbientOllamaEnv(async () => {
-      enableDiscoveryEnv();
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const fetchMock = vi
-        .fn()
-        .mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:11434"));
-      stubOllamaFetch(fetchMock);
-
-      await runOllamaCatalog({
-        config: {
-          models: {
-            providers: {
-              ollama: {
-                baseUrl: "http://127.0.0.1:11435/v1",
-                api: "openai-completions",
-                models: [],
-              },
-            },
-          },
-        },
-        env: { VITEST: "", NODE_ENV: "development" },
-      });
-
-      expect(countWarnCallsIncluding(warnSpy, "Ollama")).toBeGreaterThan(0);
-      warnSpy.mockRestore();
-    });
-  });
-
   it("falls back to default context window when /api/show fails", async () => {
-    enableDiscoveryEnv();
     const fetchMock = vi.fn(async (input: unknown) => {
       const url = String(input);
       if (url.endsWith("/api/tags")) {
@@ -359,7 +309,6 @@ describe("Ollama provider", () => {
   });
 
   it("caps /api/show requests when /api/tags returns a very large model list", async () => {
-    enableDiscoveryEnv();
     const manyModels = Array.from({ length: 250 }, (_, idx) => ({
       name: `model-${idx}`,
       modified_at: "",

--- a/extensions/ollama/provider-discovery.test.ts
+++ b/extensions/ollama/provider-discovery.test.ts
@@ -21,11 +21,8 @@ afterEach(() => {
 describe("Ollama provider", () => {
   const createAgentDir = () => mkdtempSync(join(tmpdir(), "openclaw-test-"));
 
-  const fetchCallUrls = (fetchMock: ReturnType<typeof vi.fn>): string[] =>
-    fetchMock.mock.calls.map(([input]) => String(input));
-
   const countFetchCallUrls = (fetchMock: ReturnType<typeof vi.fn>, suffix: string): number =>
-    fetchCallUrls(fetchMock).reduce((count, url) => count + (url.endsWith(suffix) ? 1 : 0), 0);
+    fetchMock.mock.calls.filter(([input]) => String(input).endsWith(suffix)).length;
 
   const stubOllamaFetch = (fetchMock: ReturnType<typeof vi.fn>) => {
     vi.stubGlobal("fetch", withFetchPreconnect(fetchMock));

--- a/extensions/ollama/provider-discovery.ts
+++ b/extensions/ollama/provider-discovery.ts
@@ -38,9 +38,6 @@ function resolveOllamaPluginConfig(ctx: ProviderCatalogContext): OllamaPluginCon
 }
 
 async function runOllamaDiscovery(ctx: ProviderCatalogContext) {
-  if (ctx.providerIds && !ctx.providerIds.includes(OLLAMA_PROVIDER_ID)) {
-    return null;
-  }
   return await resolveOllamaDiscoveryResult({
     ctx,
     pluginConfig: resolveOllamaPluginConfig(ctx),

--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -79,10 +79,7 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
     params: { num_ctx: 48_000 },
   } satisfies ModelProviderConfig["models"][number];
 
-  const buildMockProvider = async (
-    _configuredBaseUrl?: string,
-    _opts?: { quiet?: boolean },
-  ): Promise<ModelProviderConfig> => ({
+  const buildMockProvider = async (): Promise<ModelProviderConfig> => ({
     baseUrl: "https://ollama.com",
     api: "ollama",
     models: [discoveredModel],
@@ -480,7 +477,6 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
 
       expect(buildProvider).toHaveBeenCalledWith(baseUrl, {
         discoveryMode: "strict",
-        quiet: false,
         apiKey: "resolved-ollama-discovery-token",
       });
       expect(result).toMatchObject({
@@ -539,7 +535,6 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
 
       expect(buildProvider).toHaveBeenCalledWith(baseUrl, {
         discoveryMode: "strict",
-        quiet: false,
         apiKey: secretValue,
       });
       expect(result).toMatchObject({

--- a/extensions/ollama/src/discovery-shared.test.ts
+++ b/extensions/ollama/src/discovery-shared.test.ts
@@ -1,15 +1,11 @@
 // Ollama tests cover discovery shared plugin behavior.
-import { expectDefined } from "@openclaw/normalization-core";
-import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   isLocalOllamaBaseUrl,
   resolveOllamaDiscoveryResult,
   shouldUseSyntheticOllamaAuth,
 } from "./discovery-shared.js";
-
-afterEach(clearLiveCatalogCacheForTests);
 
 describe("isLocalOllamaBaseUrl", () => {
   it.each([
@@ -250,8 +246,7 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
         buildProvider: buildMockProvider,
       });
 
-      expect(result?.provider.apiKey).toEqual(apiKey);
-      expect(result?.provider.models).toEqual([cloudModel]);
+      expect(result).toMatchObject({ provider: { apiKey, models: [cloudModel] } });
     },
   );
 
@@ -262,6 +257,7 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
     "https://api.ollama.com/v1",
     "https://sub.ollama.com",
   ])("returns null for hosted base URL %s without explicit models", async (baseUrl) => {
+    const buildProvider = vi.fn(buildMockProvider);
     const result = await resolveOllamaDiscoveryResult({
       ctx: {
         config: {
@@ -279,9 +275,10 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
         resolveProviderApiKey: () => ({ apiKey: "test-key" }),
       },
       pluginConfig: {},
-      buildProvider: buildMockProvider,
+      buildProvider,
     });
     expect(result).toBeNull();
+    expect(buildProvider).not.toHaveBeenCalled();
   });
 
   it("returns explicit models for remote base URL when models are configured", async () => {
@@ -305,12 +302,7 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
       pluginConfig: {},
       buildProvider: buildMockProvider,
     });
-    expect(result).not.toBeNull();
-    const discoveryResult = expectDefined(result, "Ollama Cloud discovery result");
-    expect(discoveryResult.provider.models).toHaveLength(1);
-    expect(expectDefined(discoveryResult.provider.models[0], "Ollama Cloud model")).toEqual(
-      cloudModel,
-    );
+    expect(result).toMatchObject({ provider: { models: [cloudModel] } });
   });
 
   it("preserves explicit local model context overrides without discovery", async () => {
@@ -339,7 +331,7 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
     });
 
     expect(providerCalled).toBe(false);
-    expect(result?.provider.models).toEqual([cloudModel]);
+    expect(result).toMatchObject({ provider: { models: [cloudModel] } });
   });
 
   it.each([
@@ -367,41 +359,8 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
       buildProvider: buildMockProvider,
     });
 
-    expect(result?.provider.apiKey).toBe("ollama-local");
+    expect(result).toMatchObject({ provider: { apiKey: "ollama-local" } });
     expect(shouldUseSyntheticOllamaAuth(provider)).toBe(true);
-  });
-
-  it("does not call buildProvider for remote base URL without explicit models", async () => {
-    let providerCalled = false;
-    const trackingBuildProvider = async (
-      _configuredBaseUrl?: string,
-      _opts?: { quiet?: boolean },
-    ): Promise<ModelProviderConfig> => {
-      providerCalled = true;
-      return buildMockProvider();
-    };
-
-    const result = await resolveOllamaDiscoveryResult({
-      ctx: {
-        config: {
-          models: {
-            providers: {
-              ollama: {
-                baseUrl: "https://ollama.com",
-                apiKey: "test-key",
-                api: "ollama",
-              },
-            },
-          },
-        },
-        env: {},
-        resolveProviderApiKey: () => ({ apiKey: "test-key" }),
-      },
-      pluginConfig: {},
-      buildProvider: trackingBuildProvider,
-    });
-    expect(result).toBeNull();
-    expect(providerCalled).toBe(false);
   });
 
   it.each([
@@ -520,11 +479,13 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
       });
 
       expect(buildProvider).toHaveBeenCalledWith(baseUrl, {
+        discoveryMode: "strict",
         quiet: false,
         apiKey: "resolved-ollama-discovery-token",
       });
-      expect(result?.provider.apiKey).toEqual(owner === "config" ? apiKey : marker);
-      expect(result?.provider.models).toEqual([discoveredModel]);
+      expect(result).toMatchObject({
+        provider: { apiKey: owner === "config" ? apiKey : marker, models: [discoveredModel] },
+      });
     },
   );
 
@@ -577,11 +538,16 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
       });
 
       expect(buildProvider).toHaveBeenCalledWith(baseUrl, {
+        discoveryMode: "strict",
         quiet: false,
         apiKey: secretValue,
       });
-      expect(result?.provider.apiKey).toEqual(owner === "config" ? apiKey : "secretref-managed");
-      expect(result?.provider.models).toEqual([discoveredModel]);
+      expect(result).toMatchObject({
+        provider: {
+          apiKey: owner === "config" ? apiKey : "secretref-managed",
+          models: [discoveredModel],
+        },
+      });
     },
   );
 
@@ -626,12 +592,13 @@ describe("resolveOllamaDiscoveryResult — hosted Ollama Cloud guard", () => {
 
     const first = await discoverWithCredential("ollama-cache-token-a");
     const second = await discoverWithCredential("ollama-cache-token-b");
-    const cachedFirst = await discoverWithCredential("ollama-cache-token-a");
-
     expect(buildProvider).toHaveBeenCalledTimes(2);
-    expect(first?.provider.models[0]?.id).toBe("model-for-ollama-cache-token-a");
-    expect(second?.provider.models[0]?.id).toBe("model-for-ollama-cache-token-b");
-    expect(cachedFirst?.provider.models[0]?.id).toBe("model-for-ollama-cache-token-a");
+    expect(first).toMatchObject({
+      provider: { models: [{ id: "model-for-ollama-cache-token-a" }] },
+    });
+    expect(second).toMatchObject({
+      provider: { models: [{ id: "model-for-ollama-cache-token-b" }] },
+    });
   });
 });
 

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -1,5 +1,7 @@
 // Ollama plugin module implements discovery shared behavior.
-import { getCachedLiveCatalogValue } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { isRfc1918Ipv4Address } from "@openclaw/net-policy/ip";
+import type { ProviderCatalogResult } from "openclaw/plugin-sdk/plugin-entry";
+import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import type {
   ModelProviderConfig,
   ModelDefinitionConfig,
@@ -29,6 +31,7 @@ export type OllamaPluginConfig = {
 };
 
 type OllamaDiscoveryContext = {
+  providerIds?: readonly string[];
   config: {
     models?: {
       providers?: Record<string, OllamaProviderConfigInput | undefined>;
@@ -38,6 +41,7 @@ type OllamaDiscoveryContext = {
   resolveProviderApiKey: (providerId: string) => {
     apiKey?: unknown;
     discoveryApiKey?: unknown;
+    profileId?: string;
   };
 };
 
@@ -106,10 +110,6 @@ function resolveOllamaDiscoveryAuth(params: {
   return { apiKey: OLLAMA_DEFAULT_API_KEY };
 }
 
-function shouldSkipAmbientOllamaDiscovery(env: NodeJS.ProcessEnv): boolean {
-  return Boolean(env.VITEST) || env.NODE_ENV === "test";
-}
-
 const LOCAL_OLLAMA_HOSTNAMES = new Set([
   "localhost",
   "0.0.0.0",
@@ -120,21 +120,6 @@ const LOCAL_OLLAMA_HOSTNAMES = new Set([
   "host.orb.internal",
 ]);
 const LOOPBACK_OLLAMA_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);
-
-function isIpv4PrivateRange(host: string): boolean {
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
-    return false;
-  }
-  const octets = host.split(".").map((part) => Number.parseInt(part, 10));
-  if (octets.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-  const [a, b] = octets;
-  if (a === undefined || b === undefined) {
-    return false;
-  }
-  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
-}
 
 function isIpv6LocalRange(host: string): boolean {
   const lower = host.toLowerCase();
@@ -159,7 +144,7 @@ export function isLocalOllamaBaseUrl(baseUrl: string | undefined | null): boolea
     LOCAL_OLLAMA_HOSTNAMES.has(host) ||
     isLoopbackHost(host) ||
     host.endsWith(".local") ||
-    isIpv4PrivateRange(host) ||
+    isRfc1918Ipv4Address(host) ||
     isIpv6LocalRange(host) ||
     (!host.includes(".") && !host.includes(":"))
   );
@@ -278,9 +263,12 @@ export async function resolveOllamaDiscoveryResult(params: {
   pluginConfig: OllamaPluginConfig;
   buildProvider: (
     configuredBaseUrl?: string,
-    opts?: { apiKey?: string; quiet?: boolean },
+    opts?: { apiKey?: string; quiet?: boolean; discoveryMode?: "strict" },
   ) => Promise<ModelProviderConfig>;
-}): Promise<{ provider: ModelProviderConfig } | null> {
+}): Promise<ProviderCatalogResult> {
+  if (params.ctx.providerIds && !params.ctx.providerIds.includes(OLLAMA_PROVIDER_ID)) {
+    return null;
+  }
   const explicit = params.ctx.config.models?.providers?.ollama;
   const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
   const hasMeaningfulExplicitConfig = hasMeaningfulExplicitOllamaConfig(explicit);
@@ -335,43 +323,29 @@ export async function resolveOllamaDiscoveryResult(params: {
   if (!hasOllamaDiscoveryOptIn && !hasMeaningfulExplicitConfig) {
     return null;
   }
-  if (
-    !hasRealOllamaKey &&
-    !hasMeaningfulExplicitConfig &&
-    shouldSkipAmbientOllamaDiscovery(params.ctx.env)
-  ) {
-    return null;
-  }
-
   const quiet = !hasRealOllamaKey && !hasMeaningfulExplicitConfig;
-  const provider = await getCachedLiveCatalogValue({
-    keyParts: [
-      OLLAMA_PROVIDER_ID,
-      "models",
-      resolveOllamaApiBase(configuredBaseUrl),
-      discoveryApiKey,
-      quiet,
-    ],
-    load: async () =>
-      await params.buildProvider(configuredBaseUrl, {
+  return await runLiveProviderCatalog({
+    providerId: OLLAMA_PROVIDER_ID,
+    profileId: resolvedOllamaAuth.profileId,
+    run: async () => {
+      const provider = await params.buildProvider(configuredBaseUrl, {
+        discoveryMode: "strict",
         quiet,
         ...(discoveryApiKey ? { apiKey: discoveryApiKey } : {}),
-      }),
-  });
-  if (provider.models?.length === 0 && !ollamaKey && !explicit?.apiKey) {
-    return null;
-  }
-  const api = explicit?.api ?? provider.api;
-  return {
-    provider: {
-      ...provider,
-      baseUrl: resolveOllamaRuntimeBaseUrl({
-        api,
-        configuredBaseUrl,
-        discoveredBaseUrl: provider.baseUrl,
-      }),
-      api,
-      ...(apiKey ? { apiKey } : {}),
+      });
+      const api = explicit?.api ?? provider.api;
+      return {
+        provider: {
+          ...provider,
+          baseUrl: resolveOllamaRuntimeBaseUrl({
+            api,
+            configuredBaseUrl,
+            discoveredBaseUrl: provider.baseUrl,
+          }),
+          api,
+          ...(apiKey ? { apiKey } : {}),
+        },
+      };
     },
-  };
+  });
 }

--- a/extensions/ollama/src/discovery-shared.ts
+++ b/extensions/ollama/src/discovery-shared.ts
@@ -1,5 +1,5 @@
 // Ollama plugin module implements discovery shared behavior.
-import { isRfc1918Ipv4Address } from "@openclaw/net-policy/ip";
+import { isIPv4 } from "node:net";
 import type { ProviderCatalogResult } from "openclaw/plugin-sdk/plugin-entry";
 import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import type {
@@ -121,6 +121,16 @@ const LOCAL_OLLAMA_HOSTNAMES = new Set([
 ]);
 const LOOPBACK_OLLAMA_HOSTNAMES = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1", "::"]);
 
+function isIpv4PrivateRange(host: string): boolean {
+  const [firstOctet, secondOctet] = host.split(".");
+  return (
+    isIPv4(host) &&
+    (firstOctet === "10" ||
+      (firstOctet === "172" && Number(secondOctet) >= 16 && Number(secondOctet) <= 31) ||
+      (firstOctet === "192" && secondOctet === "168"))
+  );
+}
+
 function isIpv6LocalRange(host: string): boolean {
   const lower = host.toLowerCase();
   return /^fe[89ab][0-9a-f]:/.test(lower) || /^f[cd][0-9a-f]{2}:/.test(lower);
@@ -144,7 +154,7 @@ export function isLocalOllamaBaseUrl(baseUrl: string | undefined | null): boolea
     LOCAL_OLLAMA_HOSTNAMES.has(host) ||
     isLoopbackHost(host) ||
     host.endsWith(".local") ||
-    isRfc1918Ipv4Address(host) ||
+    isIpv4PrivateRange(host) ||
     isIpv6LocalRange(host) ||
     (!host.includes(".") && !host.includes(":"))
   );
@@ -263,7 +273,7 @@ export async function resolveOllamaDiscoveryResult(params: {
   pluginConfig: OllamaPluginConfig;
   buildProvider: (
     configuredBaseUrl?: string,
-    opts?: { apiKey?: string; quiet?: boolean; discoveryMode?: "strict" },
+    opts?: { apiKey?: string; discoveryMode?: "strict" },
   ) => Promise<ModelProviderConfig>;
 }): Promise<ProviderCatalogResult> {
   if (params.ctx.providerIds && !params.ctx.providerIds.includes(OLLAMA_PROVIDER_ID)) {
@@ -290,10 +300,6 @@ export async function resolveOllamaDiscoveryResult(params: {
   const resolvedOllamaAuth = params.ctx.resolveProviderApiKey(OLLAMA_PROVIDER_ID);
   const ollamaKey = resolvedOllamaAuth.apiKey;
   const hasOllamaDiscoveryOptIn = typeof ollamaKey === "string" && ollamaKey.trim().length > 0;
-  const hasRealOllamaKey =
-    typeof ollamaKey === "string" &&
-    ollamaKey.trim().length > 0 &&
-    ollamaKey.trim() !== OLLAMA_DEFAULT_API_KEY;
   const auth = resolveOllamaDiscoveryAuth({
     env: params.ctx.env,
     baseUrl: configuredBaseUrl,
@@ -323,14 +329,12 @@ export async function resolveOllamaDiscoveryResult(params: {
   if (!hasOllamaDiscoveryOptIn && !hasMeaningfulExplicitConfig) {
     return null;
   }
-  const quiet = !hasRealOllamaKey && !hasMeaningfulExplicitConfig;
   return await runLiveProviderCatalog({
     providerId: OLLAMA_PROVIDER_ID,
     profileId: resolvedOllamaAuth.profileId,
     run: async () => {
       const provider = await params.buildProvider(configuredBaseUrl, {
         discoveryMode: "strict",
-        quiet,
         ...(discoveryApiKey ? { apiKey: discoveryApiKey } : {}),
       });
       const api = explicit?.api ?? provider.api;

--- a/extensions/ollama/src/provider-models.failure.test.ts
+++ b/extensions/ollama/src/provider-models.failure.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildOllamaProvider } from "./provider-models.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("Ollama model discovery failures", () => {
+  it.each([401, 403, 503, "invalid-json", "missing-models", "offline"])(
+    "preserves advisory discovery while strict catalogs reject %s",
+    async (failure) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          if (failure === "offline") {
+            throw new Error("Ollama endpoint unavailable");
+          }
+          return new Response(failure === "invalid-json" ? "{" : "{}", {
+            status: typeof failure === "number" ? failure : 200,
+          });
+        }),
+      );
+
+      await expect(
+        buildOllamaProvider("http://127.0.0.1:11434", { quiet: true }),
+      ).resolves.toMatchObject({ models: [] });
+      await expect(
+        buildOllamaProvider("http://127.0.0.1:11434", { discoveryMode: "strict" }),
+      ).rejects.toThrow();
+    },
+  );
+});

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -45,6 +45,30 @@ function cancelTrackedResponse(
 }
 
 describe("ollama provider models", () => {
+  it.each([401, 403, 503, "invalid-json", "missing-models", "offline"])(
+    "preserves advisory discovery while strict catalogs reject %s",
+    async (failure) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => {
+          if (failure === "offline") {
+            throw new Error("Ollama endpoint unavailable");
+          }
+          return new Response(failure === "invalid-json" ? "{" : "{}", {
+            status: typeof failure === "number" ? failure : 200,
+          });
+        }),
+      );
+
+      await expect(
+        buildOllamaProvider("http://127.0.0.1:11434", { quiet: true }),
+      ).resolves.toMatchObject({ models: [] });
+      await expect(
+        buildOllamaProvider("http://127.0.0.1:11434", { discoveryMode: "strict" }),
+      ).rejects.toThrow();
+    },
+  );
+
   afterEach(() => {
     vi.unstubAllGlobals();
   });

--- a/extensions/ollama/src/provider-models.test.ts
+++ b/extensions/ollama/src/provider-models.test.ts
@@ -45,30 +45,6 @@ function cancelTrackedResponse(
 }
 
 describe("ollama provider models", () => {
-  it.each([401, 403, 503, "invalid-json", "missing-models", "offline"])(
-    "preserves advisory discovery while strict catalogs reject %s",
-    async (failure) => {
-      vi.stubGlobal(
-        "fetch",
-        vi.fn(async () => {
-          if (failure === "offline") {
-            throw new Error("Ollama endpoint unavailable");
-          }
-          return new Response(failure === "invalid-json" ? "{" : "{}", {
-            status: typeof failure === "number" ? failure : 200,
-          });
-        }),
-      );
-
-      await expect(
-        buildOllamaProvider("http://127.0.0.1:11434", { quiet: true }),
-      ).resolves.toMatchObject({ models: [] });
-      await expect(
-        buildOllamaProvider("http://127.0.0.1:11434", { discoveryMode: "strict" }),
-      ).rejects.toThrow();
-    },
-  );
-
   afterEach(() => {
     vi.unstubAllGlobals();
   });

--- a/extensions/ollama/src/provider-models.ts
+++ b/extensions/ollama/src/provider-models.ts
@@ -1,6 +1,7 @@
 // Ollama provider module implements model/runtime integration.
 import { createHash } from "node:crypto";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { LiveModelCatalogHttpError } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
   isCloudModelRef,
@@ -130,6 +131,7 @@ type OllamaModelRequestOptions = {
   apiKey?: string;
   timeoutMs?: number;
   signal?: AbortSignal;
+  discoveryMode?: "strict";
 };
 
 type OllamaModelShowRequestOptions = OllamaModelRequestOptions & {
@@ -507,19 +509,28 @@ async function fetchOllamaModelRows(params: {
         // Capture can retain a cloned tee branch, so cancellation must not delay
         // the guard's bounded dispatcher release.
         void response.body?.cancel().catch(() => undefined);
+        if (params.opts?.discoveryMode === "strict") {
+          throw new LiveModelCatalogHttpError("ollama", response.status);
+        }
         return { reachable: true, models: [] };
       }
       const data = await readProviderJsonResponse<{ models?: OllamaModelRow[] }>(
         response,
         auditContext,
       );
+      if (params.opts?.discoveryMode === "strict" && !Array.isArray(data.models)) {
+        throw new Error("Ollama model discovery response must contain models[]");
+      }
       const models = Array.isArray(data.models) ? data.models : [];
       return { reachable: true, models };
     } finally {
       await release();
     }
-  } catch {
+  } catch (error) {
     throwIfOllamaRequestAborted(params.opts?.signal);
+    if (params.opts?.discoveryMode === "strict") {
+      throw error;
+    }
     return { reachable: false, models: [] };
   }
 }
@@ -560,11 +571,11 @@ export async function fetchLoadedOllamaModelNames(
 
 export async function buildOllamaProvider(
   configuredBaseUrl?: string,
-  opts?: { apiKey?: string; quiet?: boolean },
+  opts?: { apiKey?: string; quiet?: boolean; discoveryMode?: "strict" },
 ): Promise<ModelProviderConfig> {
   const apiBase = resolveOllamaApiBase(configuredBaseUrl);
   const auth = opts?.apiKey ? { apiKey: opts.apiKey } : undefined;
-  const { reachable, models } = await fetchOllamaModels(apiBase, auth);
+  const { reachable, models } = await fetchOllamaModels(apiBase, opts);
   if (!reachable && !opts?.quiet) {
     console.warn(`Ollama could not be reached at ${apiBase}.`);
   }


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Local and cloud model discovery hid failures, lost learned inventory, or presented bundled models as successful discovery. A successful empty cloud response also restored bundled rows.

## Why This Change Was Made

The plugin's catalog hooks report ready, unavailable, or catalog-scoped authentication rejection through the shared catalog owner. It retains compatible last-good inventory, including authoritative empty results. The duplicate inventory cache and static substitution are removed. Public helper defaults remain advisory; registered catalog acquisition is strict.

## User Impact

Failed refreshes retain learned models only for matching endpoints and credentials. Empty discovery clears learned membership. Cold failures may show starter suggestions with an explicit failure outcome. Local discovery does not send ambient cloud credentials.

Consumers: local and cloud catalog publication now preserve truthful failure and empty outcomes.

## Evidence

Built baseline checks hid service failures and returned 24 declared rows after empty cloud discovery. Six acquisition regressions failed before the fix. Compiled checks covered recovery, empty results, credential and endpoint changes, manual/scoped discovery, public helper defaults, request context, socket cleanup, and cancellation. A later package correction separately verified address handling and strict outcomes. Endpoints were synthetic; live inference was not tested.
