### PR TITLE
fix: stop clock-jump delivery proof racing client events

### DIFF
--- a/src/gateway/session-delivery-clock-jump.integration.test.ts
+++ b/src/gateway/session-delivery-clock-jump.integration.test.ts
@@ -184,12 +184,15 @@ describe("session delivery clock-jump integration", () => {
         await scheduleSessionDelivery(id);
 
         await vi.waitFor(
-          async () => expect(await loadPendingSessionDeliveries()).toStrictEqual([]),
+          async () => {
+            expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
+            // Queue settlement can precede the client's WebSocket event callback.
+            expect(chatEvents.join("\n")).toContain("CLOCK_JUMP DELIVERED");
+          },
           { timeout: 15_000, interval: 50 },
         );
         expect(providerRequests).toHaveLength(1);
         expect(providerRequests[0]).toContain("clock-jump proof marker");
-        expect(chatEvents.join("\n")).toContain("CLOCK_JUMP DELIVERED");
         expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
         expect(getDeliveryQueueEntryStatus(SESSION_DELIVERY_QUEUE_NAME, id)).toBe("completed");
       } finally {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release CI intermittently fails the session-delivery clock-jump proof even though the provider replied and the delivery queue settled. The test reads the client event array before the WebSocket callback has necessarily run.

## Why This Change Was Made

Wait for both the empty queue and the exact client reply marker within the existing 15-second deadline. Queue settlement belongs to the server; it does not acknowledge that the receiving client's callback has run. Keep the provider request, durable completion, and cleanup assertions unchanged.

## User Impact

No runtime behavior changes. Release CI keeps its real Gateway/client delivery proof without failing on callback scheduling order. Production delta is zero; the existing test changes by +5/-2 lines.

## Evidence

- The original CI run failed with an empty client event array: https://github.com/openclaw/openclaw/actions/runs/34014959420/job/101437104195.
- A temporary 500 ms delay of the fixture's client event observation reproduces that exact assertion failure on the original test and passes with this repair. The diagnostic delay is removed from the final patch.
- The final loopback integration test passes with the real Gateway, scheduler, WebSocket client, and local Responses fixture: `node scripts/run-vitest.mjs src/gateway/session-delivery-clock-jump.integration.test.ts`.
- The full `check:changed` gate, changed-path Gateway test typecheck, targeted lint, formatting, and `git diff --check` pass. Independent Codex review found no actionable P0–P2 findings.

This is local loopback integration proof, not an authenticated provider or production Gateway run. No timeout increases, assertion weakening, new mocks, or production seams are introduced.
