### PR TITLE
refactor(config): derive metadata through one schema traversal

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2596,7 +2596,6 @@ src/config/redact-snapshot.ts	4
 src/config/runtime-overrides.ts	2
 src/config/runtime-snapshot.ts	1
 src/config/runtime-source-projection.ts	4
-src/config/schema.hints.ts	15
 src/config/schema.ts	1
 src/config/sessions/archive-compression.ts	1
 src/config/sessions/cleanup-service.ts	3

--- a/src/config/schema-base.ts
+++ b/src/config/schema-base.ts
@@ -1,13 +1,7 @@
 // Builds base config schema metadata shared across generated config surfaces.
-import { isSensitiveUrlConfigPath } from "@openclaw/net-policy/redact-sensitive-url";
 import { VERSION } from "../version.js";
 import { FIELD_HELP } from "./schema.help.js";
-import {
-  applySensitiveUrlHints,
-  buildBaseHints,
-  collectMatchingSchemaPaths,
-  mapSensitivePaths,
-} from "./schema.hints.js";
+import { buildBaseHints, mapSensitivePaths } from "./schema.hints.js";
 import { FIELD_LABELS } from "./schema.labels.js";
 import {
   asSchemaObject,
@@ -133,19 +127,11 @@ function computeBaseConfigSchemaStablePayload(): BaseConfigSchemaStablePayload {
     applyFieldDocumentation(schemaRoot);
   }
   const baseHints = mapSensitivePaths(OpenClawSchema, "", buildBaseHints());
-  const sensitiveUrlPaths = collectMatchingSchemaPaths(
-    OpenClawSchema,
-    "",
-    isSensitiveUrlConfigPath,
-  );
   const publicSchema = preparePublicSchema(schema);
   const stablePayload = {
     schema: publicSchema,
     uiHints: applyDerivedTags(
-      applyResolvedConfigTierHints(
-        publicSchema,
-        applyDerivedTags(applySensitiveUrlHints(baseHints, sensitiveUrlPaths)),
-      ),
+      applyResolvedConfigTierHints(publicSchema, applyDerivedTags(baseHints)),
     ),
     version: VERSION,
   } satisfies BaseConfigSchemaStablePayload;

--- a/src/config/schema.field-metadata.test.ts
+++ b/src/config/schema.field-metadata.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { projectConfigFieldMetadata } from "./schema.field-metadata.js";
+import { configUiMetadata } from "./zod-schema.sensitive.js";
+
+describe("schema-owned config field documentation", () => {
+  it("discovers nested fields and preserves outer documentation overrides", () => {
+    const field = z.string().register(configUiMetadata, { label: "Field", help: "Shared help" });
+    const schema = z.object({
+      undocumented: z.boolean(),
+      direct: field.optional().register(configUiMetadata, { help: "Direct field help" }),
+      list: z.array(field),
+      dictionary: z.record(z.string(), z.object({ value: field })),
+      catchall: z.object({}).catchall(field),
+      deferred: z.lazy(() => z.object({ value: field })),
+      variants: z.union([z.object({ first: field }), z.object({ second: field })]),
+      merged: z.object({ left: field }).and(z.object({ right: field })),
+      preprocessed: z.preprocess((value) => value, z.object({ value: field })),
+    });
+
+    expect(projectConfigFieldMetadata(schema, "example")).toEqual({
+      labels: {
+        "example.direct": "Field",
+        "example.list[]": "Field",
+        "example.dictionary.*.value": "Field",
+        "example.catchall.*": "Field",
+        "example.deferred.value": "Field",
+        "example.variants.first": "Field",
+        "example.variants.second": "Field",
+        "example.merged.left": "Field",
+        "example.merged.right": "Field",
+        "example.preprocessed.value": "Field",
+      },
+      help: {
+        "example.direct": "Direct field help",
+        "example.list[]": "Shared help",
+        "example.dictionary.*.value": "Shared help",
+        "example.catchall.*": "Shared help",
+        "example.deferred.value": "Shared help",
+        "example.variants.first": "Shared help",
+        "example.variants.second": "Shared help",
+        "example.merged.left": "Shared help",
+        "example.merged.right": "Shared help",
+        "example.preprocessed.value": "Shared help",
+      },
+    });
+  });
+});

--- a/src/config/schema.field-metadata.ts
+++ b/src/config/schema.field-metadata.ts
@@ -1,0 +1,24 @@
+import type { z } from "zod";
+import { walkConfigSchema } from "./schema.walk.js";
+import { configUiMetadata } from "./zod-schema.sensitive.js";
+
+export type ConfigSchemaShape<T extends object> = {
+  [Key in keyof T]-?: z.ZodType<T[Key]>;
+};
+
+/** Derive documented paths from the schema instead of maintaining a second field inventory. */
+export function projectConfigFieldMetadata(schema: z.ZodType, path: string) {
+  const labels: Record<string, string> = {};
+  const help: Record<string, string> = {};
+  walkConfigSchema(schema, path, (fieldSchema, fieldPath) => {
+    const metadata = configUiMetadata.get(fieldSchema);
+    // The outer wrapper owns overrides, e.g. a field-specific description of a shared object.
+    if (typeof metadata?.label === "string") {
+      labels[fieldPath] ??= metadata.label;
+    }
+    if (typeof metadata?.help === "string") {
+      help[fieldPath] ??= metadata.help;
+    }
+  });
+  return { labels, help };
+}

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -2,7 +2,7 @@
 import { describeTalkSilenceTimeoutDefaults } from "./talk-defaults.js";
 import { CLOUD_WORKER_FIELD_HELP } from "./zod-schema.cloud-workers.js";
 import { DESKTOP_FIELD_HELP } from "./zod-schema.desktop.js";
-import { projectTelemetryFieldMetadata } from "./zod-schema.telemetry.js";
+import { TELEMETRY_FIELD_HELP } from "./zod-schema.telemetry.js";
 
 export const CORE_FIELD_HELP: Record<string, string> = {
   worktreeRoot:
@@ -86,7 +86,7 @@ export const CORE_FIELD_HELP: Record<string, string> = {
     "Enable background auto-update for stable and beta package installs; extended-stable never auto-applies (default: false).",
   telemetry:
     "Explicit consent for anonymous feature statistics attached to the daily update check. Feature statistics are disabled by default and never include messages, credentials, or identifiers.",
-  ...projectTelemetryFieldMetadata("help"),
+  ...TELEMETRY_FIELD_HELP,
   cloudWorkers:
     "Opt-in cloud worker profiles for disposable remote environments. When this section is omitted or has no profiles, cloud worker creation remains unavailable and existing gateway/node status behavior is unchanged.",
   ...CLOUD_WORKER_FIELD_HELP,

--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -1,16 +1,11 @@
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 // Verifies schema hint metadata and sensitive path handling.
-import { isSensitiveUrlConfigPath } from "@openclaw/net-policy/redact-sensitive-url";
+import { SENSITIVE_URL_HINT_TAG } from "@openclaw/net-policy/redact-sensitive-url";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { buildSecretInputSchema } from "../plugin-sdk/secret-input-schema.js";
-import {
-  buildBaseHints,
-  collectMatchingSchemaPaths,
-  mapSensitivePaths,
-  testApi,
-} from "./schema.hints.js";
+import { buildBaseHints, mapSensitivePaths, testApi } from "./schema.hints.js";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import { OpenClawSchema } from "./zod-schema.js";
 import { OpenClawSchemaShape } from "./zod-schema.root-shape.js";
@@ -128,6 +123,17 @@ describe("mapSensitivePaths", () => {
       merged: z
         .object({ id: z.string() })
         .and(z.object({ nested: z.string().register(sensitive) })),
+      deferred: z.lazy(() => z.object({ value: z.string().register(sensitive) })),
+      defaulted: z.string().register(sensitive).default("synthetic"),
+      nullable: z.string().register(sensitive).nullable().readonly(),
+      preprocessed: z.preprocess(
+        (value) => value,
+        z.object({ value: z.string().register(sensitive) }),
+      ),
+      discriminated: z.discriminatedUnion("type", [
+        z.object({ type: z.literal("none") }),
+        z.object({ type: z.literal("token"), value: z.string().register(sensitive) }),
+      ]),
     });
 
     const result = mapSensitivePaths(GrandSchema, "", {});
@@ -141,6 +147,11 @@ describe("mapSensitivePaths", () => {
     expect(result["headersNested.*.nested"]?.sensitive).toBe(true);
     expect(result["auth.value"]?.sensitive).toBe(true);
     expect(result["merged.nested"]?.sensitive).toBe(true);
+    expect(result["deferred.value"]?.sensitive).toBe(true);
+    expect(result["defaulted"]?.sensitive).toBe(true);
+    expect(result["nullable"]?.sensitive).toBe(true);
+    expect(result["preprocessed.value"]?.sensitive).toBe(true);
+    expect(result["discriminated.value"]?.sensitive).toBe(true);
   });
 
   it("should not detect non-sensitive fields nested inside all structural Zod types", () => {
@@ -252,15 +263,15 @@ describe("mapSensitivePaths", () => {
     expect(hints["appSecret"]?.sensitive).toBe(true);
     expect(hints["nested.verificationToken"]?.sensitive).toBe(true);
   });
-});
-
-describe("collectMatchingSchemaPaths", () => {
-  it("finds base-config URL fields that may embed secrets", () => {
-    const paths = collectMatchingSchemaPaths(OpenClawSchema, "", isSensitiveUrlConfigPath);
-
-    expect(paths.has("mcp.servers.*.url")).toBe(true);
-    expect(paths.has("models.providers.*.baseUrl")).toBe(true);
-    expect(paths.has("models.providers.*.request.proxy.url")).toBe(true);
-    expect(paths.has("tools.media.audio.request.proxy.url")).toBe(true);
+  it("tags base-config URL fields that may embed secrets", () => {
+    const hints = mapSensitivePaths(OpenClawSchema, "", {});
+    for (const path of [
+      "mcp.servers.*.url",
+      "models.providers.*.baseUrl",
+      "models.providers.*.request.proxy.url",
+      "tools.media.audio.request.proxy.url",
+    ]) {
+      expect(hints[path]?.tags, path).toContain(SENSITIVE_URL_HINT_TAG);
+    }
   });
 });

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -3,13 +3,14 @@ import {
   isSensitiveUrlConfigPath,
   SENSITIVE_URL_HINT_TAG,
 } from "@openclaw/net-policy/redact-sensitive-url";
-import { z } from "zod";
+import type { z } from "zod";
 import type { ConfigUiHints } from "../shared/config-ui-hints-types.js";
 import { isKernelOwnedChannelConfigKey } from "./channel-config-keys.js";
 import { FIELD_HELP } from "./schema.help.js";
 import { FIELD_LABELS } from "./schema.labels.js";
 import { applyDerivedTags } from "./schema.tags.js";
 import { applyConfigTierHints } from "./schema.tiers.js";
+import { walkConfigSchema } from "./schema.walk.js";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import { sensitive } from "./zod-schema.sensitive.js";
 
@@ -205,82 +206,9 @@ export function applySensitiveUrlHints(
   return next;
 }
 
-/** Walk a Zod schema and collect concrete/wildcard paths accepted by `matchesPath`. */
-export function collectMatchingSchemaPaths(
-  schema: z.ZodType,
-  path: string,
-  matchesPath: (path: string) => boolean,
-  paths: Set<string> = new Set(),
-): Set<string> {
-  let currentSchema = schema;
-
-  while (isUnwrappable(currentSchema)) {
-    currentSchema = currentSchema.unwrap();
-  }
-
-  if (path && matchesPath(path)) {
-    paths.add(path);
-  }
-
-  if (currentSchema instanceof z.ZodPipe) {
-    collectMatchingSchemaPaths(currentSchema.out as unknown as z.ZodType, path, matchesPath, paths);
-  } else if (currentSchema instanceof z.ZodObject) {
-    const shape = currentSchema.shape;
-    for (const key in shape) {
-      const nextPath = path ? `${path}.${key}` : key;
-      collectMatchingSchemaPaths(shape[key], nextPath, matchesPath, paths);
-    }
-    const catchallSchema = currentSchema["_def"].catchall as z.ZodType | undefined;
-    if (catchallSchema && !(catchallSchema instanceof z.ZodNever)) {
-      const nextPath = path ? `${path}.*` : "*";
-      collectMatchingSchemaPaths(catchallSchema, nextPath, matchesPath, paths);
-    }
-  } else if (currentSchema instanceof z.ZodArray) {
-    const nextPath = path ? `${path}[]` : "[]";
-    collectMatchingSchemaPaths(currentSchema.element as z.ZodType, nextPath, matchesPath, paths);
-  } else if (currentSchema instanceof z.ZodRecord) {
-    const nextPath = path ? `${path}.*` : "*";
-    collectMatchingSchemaPaths(
-      currentSchema["_def"].valueType as z.ZodType,
-      nextPath,
-      matchesPath,
-      paths,
-    );
-  } else if (
-    currentSchema instanceof z.ZodUnion ||
-    currentSchema instanceof z.ZodDiscriminatedUnion
-  ) {
-    for (const option of currentSchema.options) {
-      collectMatchingSchemaPaths(option as z.ZodType, path, matchesPath, paths);
-    }
-  } else if (currentSchema instanceof z.ZodIntersection) {
-    collectMatchingSchemaPaths(currentSchema["_def"].left as z.ZodType, path, matchesPath, paths);
-    collectMatchingSchemaPaths(currentSchema["_def"].right as z.ZodType, path, matchesPath, paths);
-  }
-
-  return paths;
-}
-
-// Seems to be the only way tsgo accepts us to check if we have a ZodClass
-// with an unwrap() method. And it's overly complex because oxlint and
-// tsgo are each forbidding what the other allows.
-interface ZodDummy {
-  unwrap: () => z.ZodType;
-}
-function isUnwrappable(object: unknown): object is ZodDummy {
-  if (!object || typeof object !== "object") {
-    return false;
-  }
-  return (
-    "unwrap" in object &&
-    typeof (object as Record<string, unknown>).unwrap === "function" &&
-    !(object instanceof z.ZodArray)
-  );
-}
-
 /**
  * Traverses the Zod schema tree and returns a copy of `hints` with every
- * sensitive path marked.
+ * sensitive path marked and credential-bearing URL paths tagged.
  */
 export function mapSensitivePaths(
   schema: z.ZodType,
@@ -288,53 +216,16 @@ export function mapSensitivePaths(
   hints: ConfigUiHints,
 ): ConfigUiHints {
   const next = { ...hints };
-  mapSensitivePathsMut(schema, path, next);
-  return next;
-}
-
-function mapSensitivePathsMut(schema: z.ZodType, path: string, hints: ConfigUiHints): void {
-  let currentSchema = schema;
-  let isSensitive = sensitive.has(currentSchema);
-
-  while (isUnwrappable(currentSchema)) {
-    currentSchema = currentSchema.unwrap();
-    isSensitive ||= sensitive.has(currentSchema);
-  }
-
-  if (isSensitive) {
-    hints[path] = { ...hints[path], sensitive: true };
-  }
-
-  if (currentSchema instanceof z.ZodPipe) {
-    mapSensitivePathsMut(currentSchema.out as unknown as z.ZodType, path, hints);
-  } else if (currentSchema instanceof z.ZodObject) {
-    const shape = currentSchema.shape;
-    for (const key in shape) {
-      const nextPath = path ? `${path}.${key}` : key;
-      mapSensitivePathsMut(shape[key], nextPath, hints);
+  const urlPaths = new Set<string>();
+  walkConfigSchema(schema, path, (fieldSchema, fieldPath) => {
+    if (sensitive.has(fieldSchema)) {
+      next[fieldPath] = { ...next[fieldPath], sensitive: true };
     }
-    const catchallSchema = currentSchema["_def"].catchall as z.ZodType | undefined;
-    if (catchallSchema && !(catchallSchema instanceof z.ZodNever)) {
-      const nextPath = path ? `${path}.*` : "*";
-      mapSensitivePathsMut(catchallSchema, nextPath, hints);
+    if (fieldPath && isSensitiveUrlConfigPath(fieldPath)) {
+      urlPaths.add(fieldPath);
     }
-  } else if (currentSchema instanceof z.ZodArray) {
-    const nextPath = path ? `${path}[]` : "[]";
-    mapSensitivePathsMut(currentSchema.element as z.ZodType, nextPath, hints);
-  } else if (currentSchema instanceof z.ZodRecord) {
-    const nextPath = path ? `${path}.*` : "*";
-    mapSensitivePathsMut(currentSchema["_def"].valueType as z.ZodType, nextPath, hints);
-  } else if (
-    currentSchema instanceof z.ZodUnion ||
-    currentSchema instanceof z.ZodDiscriminatedUnion
-  ) {
-    for (const option of currentSchema.options) {
-      mapSensitivePathsMut(option as z.ZodType, path, hints);
-    }
-  } else if (currentSchema instanceof z.ZodIntersection) {
-    mapSensitivePathsMut(currentSchema["_def"].left as z.ZodType, path, hints);
-    mapSensitivePathsMut(currentSchema["_def"].right as z.ZodType, path, hints);
-  }
+  });
+  return applySensitiveUrlHints(next, urlPaths);
 }
 
 /** @internal */

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -3,7 +3,7 @@ import { MEDIA_AUDIO_FIELD_LABELS } from "./media-audio-field-metadata.js";
 import { NODE_CAPABILITY_FIELD_LABELS } from "./schema.node-capabilities.js";
 import { CLOUD_WORKER_FIELD_LABELS } from "./zod-schema.cloud-workers.js";
 import { DESKTOP_FIELD_LABELS } from "./zod-schema.desktop.js";
-import { projectTelemetryFieldMetadata } from "./zod-schema.telemetry.js";
+import { TELEMETRY_FIELD_LABELS } from "./zod-schema.telemetry.js";
 
 export const FIELD_LABELS: Record<string, string> = {
   worktreeRoot: "Worktree Root",
@@ -51,7 +51,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "update.checkOnStart": "Update Check on Start",
   "update.auto.enabled": "Auto Update Enabled",
   telemetry: "Telemetry",
-  ...projectTelemetryFieldMetadata("label"),
+  ...TELEMETRY_FIELD_LABELS,
   surfaces: "Surface Policies",
   "surfaces.*.silentReply": "Surface Silent Reply Policy",
   "diagnostics.enabled": "Diagnostics Enabled",

--- a/src/config/schema.walk.ts
+++ b/src/config/schema.walk.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+/** Visit schema wrappers and their fields in config path order, preserving array/wildcard paths. */
+export function walkConfigSchema(
+  schema: z.ZodType,
+  path: string,
+  visit: (schema: z.ZodType, path: string) => void,
+): void {
+  const walk = (node: z.core.$ZodType, fieldPath: string): void => {
+    let current = node;
+    while (true) {
+      // SAFETY: Config trees use classic Zod; its child generics expose only the core type.
+      visit(current as z.ZodType, fieldPath);
+      if (!isUnwrappable(current)) {
+        break;
+      }
+      current = current.unwrap();
+    }
+
+    if (current instanceof z.ZodPipe) {
+      // Config projections follow parsed output, including preprocess pipelines.
+      walk(current.out, fieldPath);
+    } else if (current instanceof z.ZodObject) {
+      for (const key in current.shape) {
+        walk(current.shape[key], fieldPath ? `${fieldPath}.${key}` : key);
+      }
+      const catchall = current.def.catchall;
+      if (catchall && !(catchall instanceof z.ZodNever)) {
+        walk(catchall, fieldPath ? `${fieldPath}.*` : "*");
+      }
+    } else if (current instanceof z.ZodArray) {
+      walk(current.element, fieldPath ? `${fieldPath}[]` : "[]");
+    } else if (current instanceof z.ZodRecord) {
+      walk(current.def.valueType, fieldPath ? `${fieldPath}.*` : "*");
+    } else if (current instanceof z.ZodUnion) {
+      for (const option of current.options) {
+        walk(option, fieldPath);
+      }
+    } else if (current instanceof z.ZodIntersection) {
+      walk(current.def.left, fieldPath);
+      walk(current.def.right, fieldPath);
+    }
+  };
+  walk(schema, path);
+}
+
+function isUnwrappable(
+  schema: z.core.$ZodType,
+): schema is z.core.$ZodType & { unwrap: () => z.core.$ZodType } {
+  // Arrays also expose unwrap(), but introduce a path segment before visiting their element.
+  return (
+    "unwrap" in schema && typeof schema.unwrap === "function" && !(schema instanceof z.ZodArray)
+  );
+}

--- a/src/config/zod-schema.cloud-workers.ts
+++ b/src/config/zod-schema.cloud-workers.ts
@@ -4,14 +4,11 @@ import { parseDurationMs } from "../cli/parse-duration.js";
 import { isPluginJsonValue } from "../plugins/host-hook-json.js";
 import { isValidSecretRef } from "../secrets/ref-contract.js";
 import { normalizeCloudRepo } from "./cloud-worker-project-profiles.js";
+import { type ConfigSchemaShape, projectConfigFieldMetadata } from "./schema.field-metadata.js";
 import { isSensitiveConfigPath } from "./sensitive-paths.js";
 import type { CloudWorkerProfileConfig, CloudWorkersConfig } from "./types.cloud-workers.js";
 import { isSecretRef } from "./types.secrets.js";
 import { configUiMetadata } from "./zod-schema.sensitive.js";
-
-type ConfigSchemaShape<T extends object> = {
-  [Key in keyof T]-?: z.ZodType<T[Key]>;
-};
 
 export function validateCloudWorkerProfileSettings(value: unknown): string | undefined {
   if (
@@ -136,26 +133,5 @@ const CloudWorkersConfigShape = {
 
 export const CloudWorkersConfigSchema = z.object(CloudWorkersConfigShape).strict().optional();
 
-const CLOUD_WORKER_FIELD_SCHEMAS = {
-  "cloudWorkers.desktop": CloudWorkersConfigShape.desktop,
-  "cloudWorkers.projectProfiles": CloudWorkersConfigShape.projectProfiles,
-  "cloudWorkers.projectProfiles.*": CloudWorkerProjectProfileSchema,
-  "cloudWorkers.profiles": CloudWorkersConfigShape.profiles,
-  "cloudWorkers.profiles.*": CloudWorkerProfileSchema,
-  "cloudWorkers.profiles.*.provider": CloudWorkerProfileShape.provider,
-  "cloudWorkers.profiles.*.install": CloudWorkerProfileShape.install,
-  "cloudWorkers.profiles.*.suspendAfter": CloudWorkerProfileShape.suspendAfter,
-  "cloudWorkers.profiles.*.settings": CloudWorkerProfileShape.settings,
-};
-
-function projectCloudWorkerFieldMetadata(field: "label" | "help"): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(CLOUD_WORKER_FIELD_SCHEMAS).flatMap(([path, schema]) => {
-      const value = configUiMetadata.get(schema)?.[field];
-      return typeof value === "string" ? [[path, value]] : [];
-    }),
-  );
-}
-
-export const CLOUD_WORKER_FIELD_LABELS = projectCloudWorkerFieldMetadata("label");
-export const CLOUD_WORKER_FIELD_HELP = projectCloudWorkerFieldMetadata("help");
+export const { labels: CLOUD_WORKER_FIELD_LABELS, help: CLOUD_WORKER_FIELD_HELP } =
+  projectConfigFieldMetadata(CloudWorkersConfigSchema, "cloudWorkers");

--- a/src/config/zod-schema.desktop.test.ts
+++ b/src/config/zod-schema.desktop.test.ts
@@ -34,7 +34,15 @@ describe("OpenClawSchema desktop config", () => {
 
   it("projects labels and help from each desktop field schema", () => {
     const response = computeBaseConfigSchemaResponse({ generatedAt: "desktop-metadata" });
-    for (const path of Object.keys(DESKTOP_FIELD_LABELS)) {
+    for (const path of [
+      "desktop.host",
+      "desktop.host.enabled",
+      "desktop.host.managed",
+      "desktop.host.port",
+      "desktop.host.passwordFile",
+    ]) {
+      expect(DESKTOP_FIELD_LABELS[path], path).toEqual(expect.any(String));
+      expect(DESKTOP_FIELD_HELP[path], path).toEqual(expect.any(String));
       expect(response.uiHints[path]?.label, path).toBe(DESKTOP_FIELD_LABELS[path]);
       expect(response.uiHints[path]?.help, path).toBe(DESKTOP_FIELD_HELP[path]);
     }

--- a/src/config/zod-schema.desktop.ts
+++ b/src/config/zod-schema.desktop.ts
@@ -1,12 +1,9 @@
 // Defines gateway-host desktop config parsing and generated field metadata.
 import path from "node:path";
 import { z } from "zod";
+import { type ConfigSchemaShape, projectConfigFieldMetadata } from "./schema.field-metadata.js";
 import type { DesktopConfig } from "./types.desktop.js";
 import { configUiMetadata } from "./zod-schema.sensitive.js";
-
-type ConfigSchemaShape<T extends object> = {
-  [Key in keyof T]-?: z.ZodType<T[Key]>;
-};
 
 type DesktopHostConfig = NonNullable<DesktopConfig["host"]>;
 
@@ -52,22 +49,5 @@ const DesktopConfigShape = {
 
 export const DesktopConfigSchema = z.object(DesktopConfigShape).strict().optional();
 
-const DESKTOP_FIELD_SCHEMAS = {
-  "desktop.host": DesktopConfigShape.host,
-  "desktop.host.enabled": DesktopHostConfigShape.enabled,
-  "desktop.host.managed": DesktopHostConfigShape.managed,
-  "desktop.host.port": DesktopHostConfigShape.port,
-  "desktop.host.passwordFile": DesktopHostConfigShape.passwordFile,
-};
-
-function projectDesktopFieldMetadata(field: "label" | "help"): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(DESKTOP_FIELD_SCHEMAS).flatMap(([fieldPath, schema]) => {
-      const value = configUiMetadata.get(schema)?.[field];
-      return typeof value === "string" ? [[fieldPath, value]] : [];
-    }),
-  );
-}
-
-export const DESKTOP_FIELD_LABELS = projectDesktopFieldMetadata("label");
-export const DESKTOP_FIELD_HELP = projectDesktopFieldMetadata("help");
+export const { labels: DESKTOP_FIELD_LABELS, help: DESKTOP_FIELD_HELP } =
+  projectConfigFieldMetadata(DesktopConfigSchema, "desktop");

--- a/src/config/zod-schema.root-support.ts
+++ b/src/config/zod-schema.root-support.ts
@@ -2,15 +2,12 @@ import { isHttpsUrl, isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
 import { findEdgeAuthIssue } from "../shared/gateway-edge-auth-headers.js";
+import type { ConfigSchemaShape } from "./schema.field-metadata.js";
 import type { GatewayRemoteConfig } from "./types.gateway.js";
 import { MemorySearchSchema } from "./zod-schema.agent-runtime.js";
 import { SecretInputSchema } from "./zod-schema.core.js";
 import { NodeHostAgentRunsSchema, NodeHostWorkerRunsSchema } from "./zod-schema.node-host.js";
 import { sensitive } from "./zod-schema.sensitive.js";
-
-type ConfigSchemaShape<T extends object> = {
-  [Key in keyof T]-?: z.ZodType<T[Key]>;
-};
 
 const EdgeAuthHeadersSchema = z
   .record(z.string(), SecretInputSchema.register(sensitive))

--- a/src/config/zod-schema.telemetry.test.ts
+++ b/src/config/zod-schema.telemetry.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { computeBaseConfigSchemaResponse } from "./schema-base.js";
 import { OpenClawSchema } from "./zod-schema.js";
-import { projectTelemetryFieldMetadata } from "./zod-schema.telemetry.js";
 
 describe("OpenClawSchema telemetry config", () => {
   it("keeps feature statistics absent by default and preserves explicit consent decisions", () => {
@@ -24,13 +23,14 @@ describe("OpenClawSchema telemetry config", () => {
 
   it("projects schema-owned labels, help, docs, and the existing configuration tier", () => {
     const response = computeBaseConfigSchemaResponse({ generatedAt: "telemetry-metadata" });
-    const labels = projectTelemetryFieldMetadata("label");
-    const help = projectTelemetryFieldMetadata("help");
-
-    for (const fieldPath of Object.keys(labels)) {
-      expect(response.uiHints[fieldPath]?.label, fieldPath).toBe(labels[fieldPath]);
-      expect(response.uiHints[fieldPath]?.help, fieldPath).toBe(help[fieldPath]);
-    }
+    expect(response.uiHints["telemetry.enabled"]).toMatchObject({
+      label: "Anonymous Feature Statistics",
+      help: expect.stringContaining("Disabled by default"),
+    });
+    expect(response.uiHints["telemetry.consentedAt"]).toMatchObject({
+      label: "Feature Statistics Consent Timestamp",
+      help: expect.stringContaining("ISO timestamp"),
+    });
 
     expect(response.uiHints.telemetry?.docsUrl).toBe("https://docs.openclaw.ai/gateway/telemetry");
     expect(response.uiHints["telemetry.enabled"]?.advanced).toBe(true);

--- a/src/config/zod-schema.telemetry.ts
+++ b/src/config/zod-schema.telemetry.ts
@@ -1,11 +1,8 @@
 // Defines anonymous feature-usage consent and its generated field metadata.
 import { z } from "zod";
+import { type ConfigSchemaShape, projectConfigFieldMetadata } from "./schema.field-metadata.js";
 import type { TelemetryConfig } from "./types.telemetry.js";
 import { configUiMetadata } from "./zod-schema.sensitive.js";
-
-type ConfigSchemaShape<T extends object> = {
-  [Key in keyof T]-?: z.ZodType<T[Key]>;
-};
 
 const TelemetryConfigShape = {
   enabled: z.boolean().optional().register(configUiMetadata, {
@@ -20,16 +17,5 @@ const TelemetryConfigShape = {
 
 export const TelemetryConfigSchema = z.object(TelemetryConfigShape).strict().optional();
 
-const TELEMETRY_FIELD_SCHEMAS = {
-  "telemetry.enabled": TelemetryConfigShape.enabled,
-  "telemetry.consentedAt": TelemetryConfigShape.consentedAt,
-};
-
-export function projectTelemetryFieldMetadata(field: "label" | "help"): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(TELEMETRY_FIELD_SCHEMAS).flatMap(([fieldPath, schema]) => {
-      const value = configUiMetadata.get(schema)?.[field];
-      return typeof value === "string" ? [[fieldPath, value]] : [];
-    }),
-  );
-}
+export const { labels: TELEMETRY_FIELD_LABELS, help: TELEMETRY_FIELD_HELP } =
+  projectConfigFieldMetadata(TelemetryConfigSchema, "telemetry");


### PR DESCRIPTION
## What Problem This Solves

Config metadata is maintained through separate schema walkers and manual field inventories. A field can be represented correctly in validation while its help, label, sensitive flag, or credential-bearing URL annotation drifts from the schema.

## Why This Change Was Made

Use one canonical Zod traversal for sensitive flags, URL annotations, and registered field metadata. Derive desktop, cloud-worker, and telemetry labels/help from their schemas, and remove the duplicate walkers and path inventories. Keep configuration types, validators, defaults, and lightweight type imports intact.

## User Impact

No intended behavior change: the complete public schema and UI hints remain byte-identical. Five independently maintained traversal/projection paths become one structural owner. The change removes 94 production code lines and adds 68 test code lines; it is a bounded ownership cleanup, not a large volume reduction.

Compatibility review confirms that validators, defaults, stored configuration formats, and plugin APIs are unchanged. The automated data-model flag is a metadata-traversal classification, not a persistent-store change; no migration or retention change is introduced. Exact schema/hint equality and the existing parsing tests cover this compatibility boundary.

## Evidence

- Exact comparison against the rebased main implementation: 856,552 identical serialized bytes and 2,561 UI-hint paths.
- Focused final-head config tests: 153 tests across seven files passed.
- Independent P2 review: no actionable findings.
- The assertion baseline shrinks only for the removed casts in `schema.hints.ts`.
- Full changed checks passed, and exact-head CI passed at `336938f614a45e767ee9ea15d50ad418dd2e88fa`.
