### PR TITLE
fix(test): close core HTTP fixtures reliably under Bun

### DIFF
--- a/scripts/lib/cross-os-release-checks/process.ts
+++ b/scripts/lib/cross-os-release-checks/process.ts
@@ -6,7 +6,7 @@ import {
   statSync,
   type WriteStream,
 } from "node:fs";
-import { createServer, type Server } from "node:http";
+import { createServer } from "node:http";
 import {
   createConnection as createNetConnection,
   createServer as createNetServer,
@@ -554,7 +554,6 @@ export async function startStaticFileServer(params: {
     url: `http://127.0.0.1:${port}/${fileName}`,
     close: () => {
       closePromise ??= new Promise<void>((resolvePromise, rejectPromise) => {
-        closeStaticFileServerConnections(server, sockets);
         server.close((error) => {
           void (async () => {
             const closeLogError = await finishStaticFileServerLog(logStream, logStreamError).catch(
@@ -575,20 +574,13 @@ export async function startStaticFileServer(params: {
             resolvePromise();
           })();
         });
-        closeStaticFileServerConnections(server, sockets);
+        for (const socket of sockets) {
+          socket.destroy();
+        }
       });
       return closePromise;
     },
   };
-}
-
-function closeStaticFileServerConnections(server: Server, sockets: Set<Socket>) {
-  for (const socket of sockets) {
-    socket.destroy();
-  }
-  if (typeof server.closeAllConnections === "function") {
-    server.closeAllConnections();
-  }
 }
 
 function finishStaticFileServerLog(logStream: WriteStream, pendingError: Error | null) {

--- a/src/agents/openai-thinking-contract.test.ts
+++ b/src/agents/openai-thinking-contract.test.ts
@@ -1,5 +1,4 @@
 // Verifies session thinking levels reach OpenAI and Codex Responses transports.
-import { createServer } from "node:http";
 import { createLlmRuntime } from "@openclaw/ai";
 import { Agent, type StreamFn } from "openclaw/plugin-sdk/agent-core";
 import {
@@ -10,6 +9,7 @@ import {
   type SimpleStreamOptions,
   streamSimple,
 } from "openclaw/plugin-sdk/llm";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { resolveEmbeddedAgentStream } from "./embedded-agent-runner/stream-resolution.js";
 import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
@@ -203,93 +203,83 @@ async function captureHttpProviderPayload(params: {
   mode: "agent" | "standalone";
 }): Promise<Record<string, unknown>> {
   let payload: Record<string, unknown> | undefined;
-  const server = createServer((request, response) => {
-    let body = "";
-    request.setEncoding("utf8");
-    request.on("data", (chunk: string) => {
-      body += chunk;
-    });
-    request.on("end", () => {
-      payload = JSON.parse(body) as Record<string, unknown>;
-      const event =
-        params.api === "openai-completions"
-          ? {
-              id: "chatcmpl_thinking",
-              choices: [
-                { index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: "stop" },
-              ],
-            }
-          : {
-              type: "response.completed",
-              response: { id: "resp_thinking", status: "completed", output: [] },
-            };
-      response.writeHead(200, { "content-type": "text/event-stream" });
-      response.end(`data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`);
-    });
-  });
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  try {
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("Missing loopback server address");
-    }
-    const model: Model = {
-      id: params.api === "openai-completions" ? "qwen3.6-27b" : "gpt-5.5",
-      name: "Thinking contract model",
-      api: params.api,
-      provider: "local-thinking",
-      baseUrl: `http://127.0.0.1:${address.port}/v1`,
-      reasoning: true,
-      thinkingLevelMap: params.thinkingLevelMap,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128_000,
-      maxTokens: 4_096,
-      ...(params.thinkingFormat
-        ? { compat: { thinkingFormat: params.thinkingFormat, supportsReasoningEffort: false } }
-        : {}),
-    };
-    const providerStream =
-      params.transport === "direct"
-        ? streamSimple
-        : resolveEmbeddedAgentStream({
-            llmRuntime: createLlmRuntime(),
-            currentStreamFn: undefined,
-            model,
-            sessionId: "thinking-contract",
-            resolvedApiKey: "synthetic-test-key",
-          }).streamFn;
-    const streamFn: StreamFn = (requestModel, context, options) =>
-      providerStream(requestModel, context, {
-        ...options,
-        apiKey: "synthetic-test-key",
-        ...(params.reasoningSummary ? { reasoningSummary: params.reasoningSummary } : {}),
+  await withServer(
+    (request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => {
+        body += chunk;
       });
-    if (params.mode === "agent") {
-      const agent = new Agent({
-        initialState: { model, thinkingLevel: params.thinkingLevel },
-        streamFn,
+      request.on("end", () => {
+        payload = JSON.parse(body) as Record<string, unknown>;
+        const event =
+          params.api === "openai-completions"
+            ? {
+                id: "chatcmpl_thinking",
+                choices: [
+                  { index: 0, delta: { role: "assistant", content: "ok" }, finish_reason: "stop" },
+                ],
+              }
+            : {
+                type: "response.completed",
+                response: { id: "resp_thinking", status: "completed", output: [] },
+              };
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.end(`data: ${JSON.stringify(event)}\n\ndata: [DONE]\n\n`);
       });
-      await agent.prompt("hello");
-      expect(agent.state.errorMessage).toBeUndefined();
-    } else {
-      const stream = await streamFn(model, {
-        messages: [{ role: "user", content: "hello", timestamp: 0 }],
-      });
-      expect((await stream.result()).stopReason).toBe("stop");
-    }
-    if (!payload) {
-      throw new Error("Provider did not receive a request");
-    }
-    return payload;
-  } finally {
-    server.closeAllConnections();
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
+    },
+    async (baseUrl) => {
+      const model: Model = {
+        id: params.api === "openai-completions" ? "qwen3.6-27b" : "gpt-5.5",
+        name: "Thinking contract model",
+        api: params.api,
+        provider: "local-thinking",
+        baseUrl: `${baseUrl}/v1`,
+        reasoning: true,
+        thinkingLevelMap: params.thinkingLevelMap,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+        ...(params.thinkingFormat
+          ? { compat: { thinkingFormat: params.thinkingFormat, supportsReasoningEffort: false } }
+          : {}),
+      };
+      const providerStream =
+        params.transport === "direct"
+          ? streamSimple
+          : resolveEmbeddedAgentStream({
+              llmRuntime: createLlmRuntime(),
+              currentStreamFn: undefined,
+              model,
+              sessionId: "thinking-contract",
+              resolvedApiKey: "synthetic-test-key",
+            }).streamFn;
+      const streamFn: StreamFn = (requestModel, context, options) =>
+        providerStream(requestModel, context, {
+          ...options,
+          apiKey: "synthetic-test-key",
+          ...(params.reasoningSummary ? { reasoningSummary: params.reasoningSummary } : {}),
+        });
+      if (params.mode === "agent") {
+        const agent = new Agent({
+          initialState: { model, thinkingLevel: params.thinkingLevel },
+          streamFn,
+        });
+        await agent.prompt("hello");
+        expect(agent.state.errorMessage).toBeUndefined();
+      } else {
+        const stream = await streamFn(model, {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        });
+        expect((await stream.result()).stopReason).toBe("stop");
+      }
+    },
+  );
+  if (!payload) {
+    throw new Error("Provider did not receive a request");
   }
+  return payload;
 }
 
 function createCapturingStreamFn(

--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -4,6 +4,7 @@ import { execFile, spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import fs from "node:fs/promises";
 import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
@@ -115,6 +116,7 @@ async function createGatewayControl(): Promise<FakeGatewayControl> {
   const released = createDeferred();
   const launches: number[] = [];
   const observers = { beforeRelease: () => {}, onLaunch: () => {} };
+  const sockets = new Set<Socket>();
   const server = createServer((request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
     if (url.pathname === "/wait") {
@@ -130,6 +132,10 @@ async function createGatewayControl(): Promise<FakeGatewayControl> {
       observers.onLaunch();
     }
     response.end("ok");
+  });
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -152,9 +158,11 @@ async function createGatewayControl(): Promise<FakeGatewayControl> {
     },
     close: async () => {
       released.resolve();
-      server.closeAllConnections();
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
+        for (const socket of sockets) {
+          socket.destroy();
+        }
       });
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes teardown failures in the Gateway-control, static-file, and provider-payload test fixtures under Bun. Force-closing connections before registering server shutdown could produce ERR_SERVER_NOT_RUNNING and cascade through otherwise passing tests.

## Why This Change Was Made

Register close completion before destroying each owned socket. Reuse the shared HTTP fixture owner landed in #139640 for provider payload capture, while preserving the specialized Gateway-control and static-log lifecycles.

## User Impact

Developers can run these existing HTTP fixture tests on both runtimes. Static-server log flushing, error precedence, retained-close failures, and provider payload assertions remain unchanged.

## Evidence

- Original Bun failures were reproduced at each of the three fixture owners.
- Existing four-file suites pass 238 tests on Node and 238 on true Bun, with one unchanged Windows-only skip on each runtime.
- The already-landed exporter cleanup from #139595 passes its 47 tests in that suite; this PR does not duplicate that edit or the shared helper.
- Complete three-file changed gate and independent P0–P2 review pass.
- Rebased onto the landed shared helper, retaining only these three owner changes. A mainline usage-fixture import changes diff context only.
- Existing runtime assertions and timeout bounds are preserved. The full Bun campaign remains in progress.
