### PR TITLE
chore(test): verify timeout completion invariants

### DIFF
--- a/src/node-host/with-timeout.test.ts
+++ b/src/node-host/with-timeout.test.ts
@@ -12,8 +12,14 @@ describe("runAbortableTimeout", () => {
   it("names the operation pending when the deadline fires", async () => {
     vi.useFakeTimers();
     let stage = "queued";
+    let signal: AbortSignal | undefined;
+    let reportProgress!: () => void;
     const pending = runAbortableTimeout(
-      () => new Promise<never>(() => {}),
+      (timeoutSignal, resetTimeout) => {
+        signal = timeoutSignal;
+        reportProgress = resetTimeout;
+        return new Promise<never>(() => {});
+      },
       30,
       () => `publication: ${stage}`,
     );
@@ -23,6 +29,9 @@ describe("runAbortableTimeout", () => {
     expect(await result).toEqual([
       { status: "rejected", reason: new Error("publication: credentials timed out") },
     ]);
+    expect(signal?.aborted).toBe(true);
+    await expect(pending).rejects.toBe(signal?.reason);
+    reportProgress();
     expect(vi.getTimerCount()).toBe(0);
   });
 


### PR DESCRIPTION
## What Problem This Solves

The node operation timeout test checks the error message but does not verify that callers receive the same error object carried by the aborted signal, or that a retained progress callback cannot restart the timer after completion.

## Why This Change Was Made

Extend the existing dynamic-label test to observe the work signal, compare rejection identity, and call the retained progress callback before the existing zero-timer assertion. The timeout implementation and dynamic stage labels already on main remain unchanged.

## User Impact

No runtime behavior changes. This protects timeout cancellation and cleanup contracts with nine net test lines and no additional test case.

## Evidence

The same three existing timeout cases passed before and after the change on current main. All 20 selected changed checks passed, including the relevant type graph and type-aware lint. Independent managed review found no actionable issue. Fresh exact-head CI supplies the final landing gate.

Related: #139757.
