### PR TITLE
refactor(ui): share settings gateway lifecycle

### DIFF
--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -1,8 +1,10 @@
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   installMockGateway,
   waitForControlUiSettingsTakeover,
 } from "../test-helpers/control-ui-e2e.ts";
+import { deviceSystemInfo } from "../test-helpers/devices-fixtures.ts";
 import { installNativeWebChrome } from "./native-nav.test-support.ts";
 import {
   captureSidebarUiProof,
@@ -368,7 +370,10 @@ suite.define(() => {
       viewport: { height: 900, width: 1440 },
     });
     const page = await context.newPage();
-    await installMockGateway(page);
+    const gateway = await installMockGateway(page, {
+      featureMethods: ["system.info"],
+      methodResponses: { "system.info": deviceSystemInfo },
+    });
 
     try {
       await page.goto(`${suite.server.baseUrl}settings/connection`);
@@ -397,6 +402,37 @@ suite.define(() => {
       expect(await password.getAttribute("type")).toBe("text");
       expect(await password.inputValue()).toBe("browser-proof-password");
       expect(await password.isEditable()).toBe(true);
+
+      await gateway.waitForRequest("system.info");
+      const reads = (await gateway.getRequests("system.info")).length;
+      const connections = (await gateway.getRequests("connect")).length;
+      await page.getByRole("button", { name: "Toggle token visibility", exact: true }).click();
+      await gateway.deferNext("connect");
+      await gateway.closeLatest(1012, "synthetic reconnect");
+      const notice = page.locator('.connection-action-block[role="status"]');
+      await notice.waitFor();
+      expect(await gatewayToken.getAttribute("type")).toBe("password");
+      expect(await password.getAttribute("type")).toBe("password");
+      await gateway.waitForRequest("connect", { after: connections });
+      await gateway.resolveDeferred("connect");
+      await notice.waitFor({ state: "hidden" });
+      await gateway.waitForRequest("system.info", { after: reads });
+
+      for (const [input, value] of [
+        [gatewayUrl, "ws://gateway.example.test:18789"],
+        [gatewayToken, "browser-proof-token"],
+        [password, "browser-proof-password"],
+        [sessionKey, "browser-proof-session"],
+      ] as const) {
+        expect(await input.inputValue()).toBe(value);
+        expect(await input.isEditable()).toBe(true);
+      }
+      if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+        await page.screenshot({
+          animations: "disabled",
+          path: path.join(suite.artifactDir, "gateway-draft-reconnected.png"),
+        });
+      }
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/pages/config/config-page.session-observer.test.ts
+++ b/ui/src/pages/config/config-page.session-observer.test.ts
@@ -1,27 +1,68 @@
 /* @vitest-environment jsdom */
 
+import { html } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry, ModelCatalogResult } from "../../api/types.ts";
-import type {
-  ApplicationContext,
-  ApplicationGateway,
-  ApplicationGatewaySnapshot,
-} from "../../app/context.ts";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import * as modelCatalogStore from "../../lib/model-catalog-store.ts";
+import {
+  createApplicationContextProvider,
+  createApplicationGateway,
+} from "../../test-helpers/application-context.ts";
+import { settleLitElement, settleLitElements } from "../../test-helpers/lit-settle.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import { ConfigPage } from "./config-page.ts";
 
 beforeEach(() => {
   vi.stubGlobal("localStorage", createStorageMock());
+  vi.useFakeTimers();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  const pages = document.querySelectorAll<ConfigPage>("openclaw-config-page");
   document.body.replaceChildren();
+  await settleLitElements(pages);
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
+
+async function mount(client: GatewayBrowserClient) {
+  const source = createApplicationGateway({
+    client,
+    phase: "connected",
+    hello: { features: { methods: ["system.info"] } },
+  } as ApplicationGatewaySnapshot);
+  const subscribe = () => () => undefined;
+  const context = {
+    gateway: source.gateway,
+    agentSelection: { state: { selectedId: "main" }, subscribe },
+    runtimeConfig: { state: { configSnapshot: {}, configSchema: {} }, subscribe },
+    theme: { serverSelection: null, subscribe },
+    overlays: { snapshot: {}, subscribe },
+    config: { subscribe },
+    webPush: { subscribe },
+  } as unknown as ApplicationContext;
+  const page = new ConfigPage();
+  page.pageId = "appearance";
+  // Exercise the actual host, subscriptions and Tasks; browser recovery tests own the picker UI.
+  vi.spyOn(page, "render").mockReturnValue(html``);
+  const provider = createApplicationContextProvider(context);
+  provider.append(page);
+  document.body.append(provider);
+  await settleLitElement(page);
+  const state = page as unknown as {
+    sessionObserverModels: ModelCatalogEntry[];
+    sessionObserverModelsUnavailable: boolean;
+    sessionObserverModelsTask: {
+      run: () => Promise<void>;
+      taskComplete: Promise<unknown>;
+    };
+  };
+  return { page, state, source, provider, context };
+}
 
 describe("ConfigPage session observer models", () => {
   it.each(["client", "source"] as const)(
@@ -32,47 +73,21 @@ describe("ConfigPage session observer models", () => {
       vi.spyOn(modelCatalogStore, "loadModelCatalog")
         .mockReturnValueOnce(first.promise)
         .mockReturnValueOnce(second.promise);
-      const firstClient = {} as GatewayBrowserClient;
-      const secondClient = replacement === "client" ? ({} as GatewayBrowserClient) : firstClient;
-      const gateway = {
-        snapshot: {
-          client: firstClient,
-          phase: "connected",
-          hello: { features: { methods: ["system.info"] } },
-        },
-      } as unknown as ApplicationGateway;
-      const page = new ConfigPage();
-      page.pageId = "appearance";
-      const state = page as unknown as {
-        context: ApplicationContext;
-        systemInfoGatewaySource: ApplicationGateway;
-        systemInfo: unknown;
-        sessionObserverModels: ModelCatalogEntry[];
-        sessionObserverModelsUnavailable: boolean;
-        sessionObserverModelsTask: {
-          run: () => Promise<void>;
-          hostUpdate: () => void;
-          taskComplete: Promise<unknown>;
-        };
-      };
-      Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-      state.context = {
-        gateway,
-        agentSelection: { state: { selectedId: "main" } },
-      } as ApplicationContext;
-      state.systemInfoGatewaySource = gateway;
-      state.systemInfo = {};
-
-      const firstLoad = state.sessionObserverModelsTask.run();
-      (gateway as { snapshot: ApplicationGatewaySnapshot }).snapshot = {
-        client: secondClient,
-        phase: "connected",
-        hello: { features: { methods: ["system.info"] } },
-      } as ApplicationGatewaySnapshot;
-      const nextGateway = replacement === "source" ? { ...gateway } : gateway;
-      state.context = { ...state.context, gateway: nextGateway };
-      state.systemInfoGatewaySource = nextGateway;
-      state.sessionObserverModelsTask.hostUpdate();
+      const firstClient = {
+        request: vi.fn().mockResolvedValue({}),
+      } as unknown as GatewayBrowserClient;
+      const secondClient =
+        replacement === "client"
+          ? ({ request: vi.fn().mockResolvedValue({}) } as unknown as GatewayBrowserClient)
+          : firstClient;
+      const { page, state, source, provider, context } = await mount(firstClient);
+      const snapshot = { ...source.gateway.snapshot, client: secondClient };
+      if (replacement === "source") {
+        provider.setContext({ ...context, gateway: createApplicationGateway(snapshot).gateway });
+      } else {
+        source.publish(snapshot);
+      }
+      await settleLitElement(page);
       const secondLoad = state.sessionObserverModelsTask.taskComplete;
       const currentModels = [{ id: "small", name: "Small", provider: "openai" }];
       second.resolve({ models: currentModels });
@@ -80,7 +95,8 @@ describe("ConfigPage session observer models", () => {
       expect(state.sessionObserverModels).toEqual(currentModels);
 
       first.resolve({ models: [{ id: "stale", name: "Stale", provider: "old" }] });
-      await firstLoad;
+      await first.promise;
+      await settleLitElement(page);
       expect(state.sessionObserverModels).toEqual(currentModels);
       expect(modelCatalogStore.loadModelCatalog).toHaveBeenCalledTimes(2);
       expect(modelCatalogStore.loadModelCatalog).toHaveBeenNthCalledWith(1, firstClient, {
@@ -101,7 +117,10 @@ describe("ConfigPage session observer models", () => {
     const writer = deferred<ModelCatalogResult>();
     const secondMain = deferred<ModelCatalogResult>();
     let mainRequests = 0;
-    const request = vi.fn((_method: string, params: unknown) => {
+    const request = vi.fn((method: string, params: unknown) => {
+      if (method === "system.info") {
+        return Promise.resolve({});
+      }
       const agentId = (params as { agentId?: string }).agentId;
       if (agentId === "writer") {
         return writer.promise;
@@ -110,35 +129,11 @@ describe("ConfigPage session observer models", () => {
       return mainRequests === 1 ? firstMain.promise : secondMain.promise;
     });
     const client = { request } as unknown as GatewayBrowserClient;
-    const gateway = {
-      snapshot: { client, phase: "connected", hello: { features: { methods: ["system.info"] } } },
-    } as unknown as ApplicationGateway;
-    const selectionState = { selectedId: "main" as string | null };
-    const page = new ConfigPage();
-    page.pageId = "appearance";
-    const state = page as unknown as {
-      context: ApplicationContext;
-      systemInfoGatewaySource: ApplicationGateway;
-      systemInfo: unknown;
-      sessionObserverModels: ModelCatalogEntry[];
-      sessionObserverModelsUnavailable: boolean;
-      sessionObserverModelsTask: {
-        run: () => Promise<void>;
-        hostUpdate: () => void;
-        taskComplete: Promise<unknown>;
-      };
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.context = {
-      gateway,
-      agentSelection: { state: selectionState },
-    } as ApplicationContext;
-    state.systemInfoGatewaySource = gateway;
-    state.systemInfo = {};
-
-    const mainLoad = state.sessionObserverModelsTask.run();
-    selectionState.selectedId = "writer";
-    state.sessionObserverModelsTask.hostUpdate();
+    const { page, state, context } = await mount(client);
+    const selection = context.agentSelection.state as { selectedId: string | null };
+    selection.selectedId = "writer";
+    page.requestUpdate();
+    await settleLitElement(page);
     const writerLoad = state.sessionObserverModelsTask.taskComplete;
     const writerModels = [{ id: "writer-model", name: "Writer Model", provider: "openai" }];
     writer.resolve({ models: writerModels });
@@ -146,32 +141,31 @@ describe("ConfigPage session observer models", () => {
     expect(state.sessionObserverModels).toEqual(writerModels);
 
     modelCatalogStore.invalidateModelCatalogCache(client);
-    selectionState.selectedId = "main";
-    state.sessionObserverModelsTask.hostUpdate();
+    selection.selectedId = "main";
+    page.requestUpdate();
+    await settleLitElement(page);
     const secondMainLoad = state.sessionObserverModelsTask.taskComplete;
     const currentMainModels = [{ id: "current-main", name: "Current Main", provider: "openai" }];
     secondMain.resolve({ models: currentMainModels });
     await secondMainLoad;
-    firstMain.resolve({
-      models: [{ id: "stale-main", name: "Stale Main", provider: "openai" }],
-    });
-    await mainLoad;
-
+    firstMain.resolve({ models: [{ id: "stale-main", name: "Stale Main", provider: "openai" }] });
+    await firstMain.promise;
+    await settleLitElement(page);
     expect(state.sessionObserverModels).toEqual(currentMainModels);
-    for (const [index, agentId] of ["main", "writer", "main"].entries()) {
-      expect(request).toHaveBeenNthCalledWith(
-        index + 1,
+    expect(request.mock.calls.filter(([method]) => method === "models.list")).toEqual(
+      ["main", "writer", "main"].map((agentId) => [
         "models.list",
         { agentId, preparedOnly: true, view: "configured" },
         { signal: expect.any(AbortSignal) },
-      );
-    }
+      ]),
+    );
 
-    selectionState.selectedId = null;
-    state.sessionObserverModelsTask.hostUpdate();
+    selection.selectedId = null;
+    page.requestUpdate();
+    await settleLitElement(page);
     expect(state.sessionObserverModels).toEqual([]);
     expect(state.sessionObserverModelsUnavailable).toBe(true);
-    expect(request).toHaveBeenCalledTimes(3);
+    expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(3);
   });
 
   it("keeps a slow refresh through status polls and retires it on disconnect", async () => {
@@ -189,49 +183,40 @@ describe("ConfigPage session observer models", () => {
         : Promise.resolve({ models: signals.length === 1 ? original : fresh });
     });
     const client = { request } as unknown as GatewayBrowserClient;
-    const gateway = {
-      snapshot: { client, phase: "connected", hello: { features: { methods: ["system.info"] } } },
-    } as unknown as ApplicationGateway;
-    const page = new ConfigPage();
-    page.pageId = "appearance";
-    const state = page as unknown as {
-      context: ApplicationContext;
-      systemInfoGatewaySource: ApplicationGateway;
-      sessionObserverModels: ModelCatalogEntry[];
-      sessionObserverModelsTask: {
-        run: (args: readonly [ApplicationGateway, GatewayBrowserClient, string]) => Promise<void>;
-      };
-      systemInfoTask: {
-        run: (args: readonly [ApplicationGateway, GatewayBrowserClient]) => Promise<void>;
-      };
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.context = {
-      gateway,
-      agentSelection: { state: { selectedId: "main" } },
-    } as ApplicationContext;
-    state.systemInfoGatewaySource = gateway;
-    const args = [gateway, client, "main"] as const;
-    await state.sessionObserverModelsTask.run(args);
+    const { page, state, provider } = await mount(client);
     modelCatalogStore.invalidateModelCatalogCache(client);
-    const pending = state.sessionObserverModelsTask.run(args);
+    const pending = state.sessionObserverModelsTask.run();
     expect(state.sessionObserverModels).toEqual(original);
-
-    for (let poll = 0; poll < 3; poll += 1) {
-      await state.systemInfoTask.run([gateway, client]);
-    }
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(4);
     expect(signals).toHaveLength(2);
     expect(signals[1]?.aborted).toBe(false);
-    page.disconnectedCallback();
+    page.remove();
     expect(signals[1]?.aborted).toBe(true);
     expect(state.sessionObserverModels).toEqual([]);
     await pending;
 
-    state.systemInfoGatewaySource = gateway;
-    await state.sessionObserverModelsTask.run(args);
+    provider.append(page);
+    await settleLitElement(page);
     stale.resolve({ models: original });
-    await stale.promise;
+    await settleLitElement(page);
     expect(state.sessionObserverModels).toEqual(fresh);
     expect(signals).toHaveLength(3);
+  });
+
+  it("stops status polling outside Appearance while the page remains mounted", async () => {
+    const request = vi.fn((method: string) =>
+      Promise.resolve(method === "models.list" ? { models: [] } : {}),
+    );
+    const { page } = await mount({ request } as unknown as GatewayBrowserClient);
+    expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(1);
+    page.pageId = "advanced";
+    await settleLitElement(page);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(page.isConnected).toBe(true);
+    expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(1);
+    page.pageId = "appearance";
+    await settleLitElement(page);
+    expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(2);
   });
 });

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -12,11 +12,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ModelCatalogEntry } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { pathForRoute, type RouteId } from "../../app-route-paths.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGatewaySnapshot,
-} from "../../app/context.ts";
+import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { isBrowserPanelAvailable } from "../../app/panel-availability.ts";
 import { isAppearancePref, type ResettableServerUiPrefKey } from "../../app/server-prefs-state.ts";
@@ -54,6 +50,10 @@ import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
 import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
 import { resolveScrollBehavior } from "../../lib/scroll-behavior.ts";
+import {
+  GatewayPageController,
+  type GatewayPageChange,
+} from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -330,8 +330,6 @@ export class ConfigPage extends OpenClawLightDomElement {
   });
   private configViewState: ConfigViewState = createConfigViewState();
   private runtimeConfigSource: ApplicationContext["runtimeConfig"] | null = null;
-  private systemInfoGatewaySource: ApplicationContext["gateway"] | null = null;
-  private systemInfoClient: GatewayBrowserClient | null = null;
   private updateStatusClient: GatewayBrowserClient | null = null;
   private readonly systemInfoPolling = new PollController(
     this,
@@ -352,7 +350,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   private readonly systemInfoTask = new Task(this, {
     autoRun: false,
     // Null is an explicit visibility/capability invalidation for the current source.
-    args: () => [this.systemInfoGatewaySource, this.systemInfoRequestClient()] as const,
+    args: () => [this.gateway.gateway, this.systemInfoRequestClient()] as const,
     task: ([gateway, client], { signal }) =>
       gateway && client
         ? client.request<SystemInfoResult>("system.info", {}, { signal })
@@ -379,7 +377,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   > = new Task(this, {
     args: () =>
       [
-        this.systemInfoGatewaySource,
+        this.gateway.gateway,
         this.systemInfo ? this.systemInfoRequestClient() : null,
         this.context?.agentSelection.state.selectedId ?? null,
       ] as const,
@@ -444,6 +442,11 @@ export class ConfigPage extends OpenClawLightDomElement {
     },
   });
   private pendingRouteTargetId: string | null = null;
+  private readonly gateway = new GatewayPageController(this, {
+    getGateway: () => this.context?.gateway,
+    invalidateRequests: () => this.invalidateSystemInfoRequest(),
+    onSnapshot: (change) => this.handleGatewaySnapshot(change),
+  });
   private readonly subscriptions = new SubscriptionsController(this)
     .watch(
       () => this.context?.runtimeConfig,
@@ -457,11 +460,6 @@ export class ConfigPage extends OpenClawLightDomElement {
     .watch(
       () => this.context?.config,
       (config, notify) => config.subscribe(notify),
-    )
-    .watch(
-      () => this.context?.gateway,
-      (gateway, notify) => gateway.subscribe(notify),
-      (gateway) => this.synchronizeSystemInfoGateway(gateway),
     )
     .watch(
       () => this.context?.agentSelection,
@@ -532,11 +530,8 @@ export class ConfigPage extends OpenClawLightDomElement {
     this.mediaDeviceWatch = null;
     this.systemInfoPolling.stop();
     this.updateCountdownPolling.stop();
-    this.invalidateSystemInfoRequest();
     this.runtimeConfigSource = null;
     this.resetConfigViewState();
-    this.systemInfoGatewaySource = null;
-    this.systemInfoClient = null;
     this.updateStatusClient = null;
     this.subscriptions.clear();
     super.disconnectedCallback();
@@ -723,52 +718,42 @@ export class ConfigPage extends OpenClawLightDomElement {
     }
   }
 
-  private synchronizeSystemInfoGateway(gateway: ApplicationContext["gateway"]) {
-    this.customThemeImportOwner.synchronizeScope(
-      gateway.connection.gatewayUrl,
-      this.context.theme.serverSelection,
-    );
-    if (gateway !== this.systemInfoGatewaySource) {
-      this.systemInfoPolling.stop();
-      this.invalidateSystemInfoRequest();
-      this.systemInfoGatewaySource = gateway;
-      this.resetConfigViewState();
-      this.systemInfoClient = null;
-      this.updateStatusClient = null;
-      this.systemInfo = null;
-      this.systemInfoUnavailable = false;
-      this.resetSessionObserverModels();
-    }
-    this.handleSystemInfoGatewaySnapshot(gateway.snapshot);
-    this.syncUpdateStatusRefresh();
-  }
-
   private resetConfigViewState() {
     // Revealed secrets and raw caches never cross a capability/source epoch.
     this.configViewState = createConfigViewState();
   }
 
-  private handleSystemInfoGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
-    const clientChanged = snapshot.client !== this.systemInfoClient;
-    const hasSystemInfo = supportsSystemInfo(snapshot.hello);
-    this.systemInfoClient = snapshot.client;
-    if (clientChanged) {
-      this.invalidateSystemInfoRequest();
+  private handleGatewaySnapshot({
+    snapshot,
+    initial,
+    sourceChanged,
+    clientChanged,
+  }: GatewayPageChange) {
+    this.customThemeImportOwner.synchronizeScope(
+      this.context.gateway.connection.gatewayUrl,
+      this.context.theme.serverSelection,
+    );
+    if (initial || sourceChanged) {
+      this.systemInfoPolling.stop();
+      this.resetConfigViewState();
+      this.updateStatusClient = null;
+    }
+    if (initial || sourceChanged || clientChanged) {
       this.systemInfo = null;
       this.systemInfoUnavailable = false;
       this.resetSessionObserverModels();
     } else if (snapshot.phase !== "connected") {
-      this.invalidateSystemInfoRequest();
       this.systemInfo = null;
     }
     if (snapshot.phase === "connected" && snapshot.hello) {
-      this.systemInfoUnavailable = !hasSystemInfo;
-      if (!hasSystemInfo) {
+      this.systemInfoUnavailable = !supportsSystemInfo(snapshot.hello);
+      if (this.systemInfoUnavailable) {
         this.invalidateSystemInfoRequest();
         this.systemInfo = null;
       }
     }
     this.syncSystemInfoPolling(clientChanged);
+    this.syncUpdateStatusRefresh();
   }
 
   private syncSystemInfoPolling(forceRefresh = false) {
@@ -796,7 +781,7 @@ export class ConfigPage extends OpenClawLightDomElement {
   }
 
   private systemInfoRequestClient(): GatewayBrowserClient | null {
-    const gatewaySource = this.systemInfoGatewaySource;
+    const gatewaySource = this.gateway.gateway;
     const gateway = gatewaySource?.snapshot;
     if (
       !gatewaySource ||

--- a/ui/src/pages/connection/connection-page.test.ts
+++ b/ui/src/pages/connection/connection-page.test.ts
@@ -3,26 +3,57 @@
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createDeferred as deferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   ApplicationContext,
   ApplicationGateway,
   ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { loadSettings } from "../../app/settings.ts";
+import {
+  createApplicationContextProvider,
+  createApplicationGateway,
+} from "../../test-helpers/application-context.ts";
+import { deviceSystemInfo } from "../../test-helpers/devices-fixtures.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
+import { settleLitElement } from "../../test-helpers/lit-settle.ts";
 import { ConnectionPage, supportsSystemInfo } from "./connection-page.ts";
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((next) => {
-    resolve = next;
-  });
-  return { promise, resolve };
+function source(client: GatewayBrowserClient) {
+  return createApplicationGateway({
+    client,
+    phase: "connected",
+    hello: gatewayHelloForMethods(["system.info"]),
+    sessionKey: "main",
+  } as ApplicationGatewaySnapshot);
+}
+
+async function mount(gateway: ApplicationGateway) {
+  const page = new ConnectionPage();
+  const context = {
+    gateway,
+    channels: { state: { channelsLastSuccess: null }, subscribe: () => () => undefined },
+  } as unknown as ApplicationContext;
+  const provider = createApplicationContextProvider(context);
+  provider.append(page);
+  document.body.append(provider);
+  await settleLitElement(page);
+  return { page, context, provider };
+}
+
+function control(page: ConnectionPage, selector: string) {
+  const element = page.querySelector<HTMLInputElement | HTMLButtonElement>(selector);
+  if (!element) {
+    throw new Error(`Missing Connection control: ${selector}`);
+  }
+  return element;
 }
 
 afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe("supportsSystemInfo", () => {
@@ -74,76 +105,153 @@ describe("ConnectionPage credentials", () => {
   });
 });
 
-describe("ConnectionPage system info", () => {
-  it("clears stale host info when the Gateway disconnects", () => {
-    const client = {} as GatewayBrowserClient;
-    const snapshot = {
-      client,
-      phase: "stopped",
-      hello: null,
-    } as ApplicationGatewaySnapshot;
-    const page = new ConnectionPage();
-    const state = page as unknown as {
-      context: { gateway: { snapshot: ApplicationGatewaySnapshot } };
-      systemInfo: SystemInfoResult | null;
-      systemInfoClient: GatewayBrowserClient | null;
-      handleSystemInfoGatewaySnapshot: (snapshot: ApplicationGatewaySnapshot) => void;
+describe("ConnectionPage Gateway lifecycle", () => {
+  it("keeps an edited draft through reconnect and resets it for a replacement source", async () => {
+    const request = vi.fn().mockResolvedValue(deviceSystemInfo);
+    const client = { request } as unknown as GatewayBrowserClient;
+    const first = source(client);
+    const { page, context, provider } = await mount(first.gateway);
+    const input = (label: string) => control(page, `input[aria-label="${label}"]`);
+    const edit = (label: string, value: string) => {
+      input(label).value = value;
+      input(label).dispatchEvent(new Event("input"));
     };
-    state.context = { gateway: { snapshot } };
-    state.systemInfoClient = client;
-    state.systemInfo = {} as SystemInfoResult;
+    edit("Gateway Token", "draft-token");
+    edit("Password (not stored)", "draft-password");
+    edit("Default Session Key", "draft-session");
+    control(page, 'button[aria-label="Toggle token visibility"]').click();
+    control(page, 'button[aria-label="Toggle password visibility"]').click();
+    await settleLitElement(page);
+    expect(input("Gateway Token").type).toBe("text");
+    expect(input("Password (not stored)").type).toBe("text");
 
-    state.handleSystemInfoGatewaySnapshot(snapshot);
+    first.publish({ ...first.gateway.snapshot, phase: "reconnecting" });
+    await settleLitElement(page);
+    expect(input("Gateway Token").type).toBe("password");
+    expect(input("Password (not stored)").type).toBe("password");
+    expect(page.querySelector(".config-host__name")?.textContent?.trim()).toBe("—");
+    first.publish({ ...first.gateway.snapshot, phase: "connected", sessionKey: "remote-session" });
+    await settleLitElement(page);
+    expect(input("Gateway Token").value).toBe("draft-token");
+    expect(input("Password (not stored)").value).toBe("draft-password");
+    expect(input("Default Session Key").value).toBe("draft-session");
+    expect(request).toHaveBeenCalledTimes(2);
 
-    expect(state.systemInfo).toBeNull();
+    const second = source(client);
+    Object.assign(second.gateway.connection, {
+      token: "replacement-token",
+      password: "replacement-password",
+    });
+    provider.setContext({ ...context, gateway: second.gateway });
+    await settleLitElement(page);
+    expect(input("Gateway Token").value).toBe("replacement-token");
+    expect(input("Password (not stored)").value).toBe("replacement-password");
+    expect(input("Default Session Key").value).toBe("main");
+    expect(input("Gateway Token").type).toBe("password");
+    expect(request).toHaveBeenCalledTimes(3);
   });
 
-  it("rejects an old Gateway source response when the replacement reuses its client", async () => {
-    const firstResponse = deferred<SystemInfoResult>();
-    const secondResponse = deferred<SystemInfoResult>();
-    const client = {
-      request: vi
+  it.each(["response", "error", "response before rebinding"] as const)(
+    "rejects an old Gateway source %s when the replacement reuses its client",
+    async (outcome) => {
+      vi.useFakeTimers();
+      const firstResponse = deferred<SystemInfoResult>();
+      const secondResponse = deferred<SystemInfoResult>();
+      const request = vi
         .fn()
-        .mockImplementationOnce(() => firstResponse.promise)
-        .mockImplementationOnce(() => secondResponse.promise),
-    } as unknown as GatewayBrowserClient;
-    const snapshot = {
-      client,
-      phase: "connected",
-      hello: { features: { methods: ["system.info"] } },
-    } as ApplicationGatewaySnapshot;
-    const firstGateway = { snapshot } as ApplicationGateway;
-    const secondGateway = { snapshot } as ApplicationGateway;
-    const page = new ConnectionPage();
-    const state = page as unknown as {
-      context: ApplicationContext;
-      syncSystemInfoPolling: () => void;
-      synchronizeSystemInfoGateway: (gateway: ApplicationGateway) => void;
-      loadSystemInfo: () => Promise<void>;
-      systemInfo: SystemInfoResult | null;
-      systemInfoUnavailable: boolean;
-    };
-    Object.defineProperty(page, "isConnected", { configurable: true, value: true });
-    state.syncSystemInfoPolling = () => undefined;
-    state.context = { gateway: firstGateway } as ApplicationContext;
-    state.synchronizeSystemInfoGateway(firstGateway);
+        .mockReturnValueOnce(firstResponse.promise)
+        .mockReturnValueOnce(secondResponse.promise);
+      const client = { request } as unknown as GatewayBrowserClient;
+      const first = source(client);
+      const second = source(client);
+      const { page, context, provider } = await mount(first.gateway);
+      if (outcome === "response before rebinding") {
+        // Queue completion before Lit's update, while context replacement itself is synchronous.
+        firstResponse.resolve({ ...deviceSystemInfo, machineName: "Stale" });
+      }
+      provider.setContext({ ...context, gateway: second.gateway });
+      await settleLitElement(page);
+      expect(request).toHaveBeenCalledTimes(2);
 
-    const firstLoad = state.loadSystemInfo();
-    state.systemInfo = {} as SystemInfoResult;
-    state.systemInfoUnavailable = true;
-    state.context = { gateway: secondGateway } as ApplicationContext;
-    state.synchronizeSystemInfoGateway(secondGateway);
-    const secondLoad = state.loadSystemInfo();
+      if (outcome === "response") {
+        firstResponse.resolve({ ...deviceSystemInfo, machineName: "Stale" });
+      } else if (outcome === "error") {
+        firstResponse.reject(
+          new GatewayRequestError({
+            code: "INVALID_REQUEST",
+            message: "unknown method: system.info",
+          }),
+        );
+      }
+      await settleLitElement(page);
+      expect(page.querySelector(".config-host__name")?.textContent?.trim()).toBe("—");
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(request).toHaveBeenCalledTimes(2);
 
-    const stale = { platform: "stale" } as unknown as SystemInfoResult;
-    firstResponse.resolve(stale);
-    await firstLoad;
-    expect(state.systemInfo).toBeNull();
-    expect(state.systemInfoUnavailable).toBe(false);
+      secondResponse.resolve({ ...deviceSystemInfo, machineName: "Current" });
+      await settleLitElement(page);
+      expect(page.querySelector(".config-host__name")?.textContent?.trim()).toBe("Current");
+    },
+  );
 
-    const current = { platform: "current" } as unknown as SystemInfoResult;
-    secondResponse.resolve(current);
-    await secondLoad;
-    expect(state.systemInfo).toBe(current);
+  it.each([
+    ["transient", new Error("temporarily unavailable"), true],
+    [
+      "unknown method",
+      new GatewayRequestError({ code: "INVALID_REQUEST", message: "unknown method: system.info" }),
+      false,
+    ],
+    [
+      "missing read scope",
+      new GatewayRequestError({
+        code: "FORBIDDEN",
+        message: "permission denied",
+        details: {
+          code: "MISSING_SCOPE",
+          missingScope: "operator.read",
+          requiredScopes: ["operator.read"],
+        },
+      }),
+      false,
+    ],
+  ] as const)("preserves the polling policy after a %s error", async (_kind, error, retry) => {
+    vi.useFakeTimers();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(deviceSystemInfo)
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(deviceSystemInfo);
+    const { page } = await mount(source({ request } as unknown as GatewayBrowserClient).gateway);
+    await vi.advanceTimersByTimeAsync(10_000);
+    await settleLitElement(page);
+    expect(page.querySelector(".config-host__name")?.textContent?.trim() ?? null).toBe(
+      retry ? "Gateway" : null,
+    );
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(request).toHaveBeenCalledTimes(retry ? 3 : 2);
+  });
+
+  it("retires a pending host read when its method advertisement disappears", async () => {
+    const response = deferred<SystemInfoResult>();
+    const request = vi
+      .fn()
+      .mockReturnValueOnce(response.promise)
+      .mockResolvedValue(deviceSystemInfo);
+    const current = source({ request } as unknown as GatewayBrowserClient);
+    const { page } = await mount(current.gateway);
+    current.publish({
+      ...current.gateway.snapshot,
+      hello: gatewayHelloForMethods([]),
+    });
+    response.resolve(deviceSystemInfo);
+    await settleLitElement(page);
+    expect(page.querySelector(".config-host__name")).toBeNull();
+    current.publish({
+      ...current.gateway.snapshot,
+      hello: gatewayHelloForMethods(["system.info"]),
+    });
+    await settleLitElement(page);
+    expect(page.querySelector(".config-host__name")?.textContent?.trim()).toBe("Gateway");
+    expect(request).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -5,13 +5,8 @@ import { consume } from "@lit/context";
 import { html } from "lit";
 import { state } from "lit/decorators.js";
 import type { SystemInfoResult } from "../../../../packages/gateway-protocol/src/index.js";
-import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
-import {
-  applicationContext,
-  type ApplicationContext,
-  type ApplicationGatewaySnapshot,
-} from "../../app/context.ts";
+import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import {
   loadGatewaySessionSelection,
   loadSettings,
@@ -21,6 +16,10 @@ import {
 import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
+import {
+  GatewayPageController,
+  type GatewayPageChange,
+} from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
@@ -46,11 +45,7 @@ export class ConnectionPage extends OpenClawLightDomElement {
   // Distinguishes an operator-edited session key from the stored selection so
   // Connect only overrides the per-gateway selection after an explicit edit.
   private sessionKeyDirty = false;
-  private gatewayClient: ApplicationContext["gateway"]["snapshot"]["client"] = null;
-  private systemInfoGatewaySource: ApplicationContext["gateway"] | null = null;
-  private systemInfoClient: GatewayBrowserClient | null = null;
   private systemInfoLoading = false;
-  private systemInfoRequestId = 0;
 
   private readonly systemInfoPolling = new PollController(
     this,
@@ -61,33 +56,20 @@ export class ConnectionPage extends OpenClawLightDomElement {
     false,
   );
 
-  private readonly subscriptions = new SubscriptionsController(this)
-    .effect(
-      () => this.context?.gateway,
-      (gateway) => {
-        this.resetDraft(gateway);
-        this.synchronizeSystemInfoGateway(gateway);
-        return gateway.subscribe((snapshot) => {
-          if (snapshot.client !== this.gatewayClient) {
-            this.resetDraft(gateway);
-          } else if (snapshot.phase !== "connected") {
-            this.resetSensitiveUi();
-          }
-          this.handleSystemInfoGatewaySnapshot(snapshot);
-          this.requestUpdate();
-        });
-      },
-    )
-    .watch(
-      () => this.context?.channels,
-      (channels, notify) => channels.subscribe(notify),
-    );
+  private readonly gateway = new GatewayPageController(this, {
+    getGateway: () => this.context?.gateway,
+    invalidateRequests: () => {
+      this.systemInfoLoading = false;
+    },
+    onSnapshot: (change) => this.handleGatewaySnapshot(change),
+  });
+  private readonly subscriptions = new SubscriptionsController(this).watch(
+    () => this.context?.channels,
+    (channels, notify) => channels.subscribe(notify),
+  );
 
   override disconnectedCallback() {
     this.systemInfoPolling.stop();
-    this.invalidateSystemInfoRequest();
-    this.systemInfoGatewaySource = null;
-    this.systemInfoClient = null;
     this.subscriptions.clear();
     this.resetSensitiveUi();
     super.disconnectedCallback();
@@ -98,34 +80,28 @@ export class ConnectionPage extends OpenClawLightDomElement {
     this.gatewayPasswordVisible = false;
   }
 
-  private synchronizeSystemInfoGateway(gateway: ApplicationContext["gateway"]) {
-    if (gateway !== this.systemInfoGatewaySource) {
-      this.systemInfoPolling.stop();
-      this.invalidateSystemInfoRequest();
-      this.systemInfoGatewaySource = gateway;
-      this.systemInfoClient = null;
-      this.systemInfo = null;
-      this.systemInfoUnavailable = false;
-    }
-    this.handleSystemInfoGatewaySnapshot(gateway.snapshot);
-  }
-
-  private handleSystemInfoGatewaySnapshot(snapshot: ApplicationGatewaySnapshot) {
-    const clientChanged = snapshot.client !== this.systemInfoClient;
-    const hasSystemInfo = supportsSystemInfo(snapshot.hello);
-    this.systemInfoClient = snapshot.client;
-    if (clientChanged) {
-      this.invalidateSystemInfoRequest();
+  private handleGatewaySnapshot({
+    snapshot,
+    initial,
+    sourceChanged,
+    clientChanged,
+  }: GatewayPageChange) {
+    if (initial || sourceChanged || clientChanged) {
+      this.resetDraft(this.context.gateway);
       this.systemInfo = null;
       this.systemInfoUnavailable = false;
     } else if (snapshot.phase !== "connected") {
-      this.invalidateSystemInfoRequest();
+      this.resetSensitiveUi();
       this.systemInfo = null;
     }
+    if (initial || sourceChanged) {
+      this.systemInfoPolling.stop();
+    }
     if (snapshot.phase === "connected" && snapshot.hello) {
-      this.systemInfoUnavailable = !hasSystemInfo;
-      if (!hasSystemInfo) {
-        this.invalidateSystemInfoRequest();
+      this.systemInfoUnavailable = !supportsSystemInfo(snapshot.hello);
+      if (this.systemInfoUnavailable) {
+        this.gateway.invalidate();
+        this.systemInfoLoading = false;
         this.systemInfo = null;
       }
     }
@@ -149,53 +125,27 @@ export class ConnectionPage extends OpenClawLightDomElement {
     }
   }
 
-  private invalidateSystemInfoRequest() {
-    this.systemInfoRequestId += 1;
-    this.systemInfoLoading = false;
-  }
-
-  private isCurrentSystemInfoRequest(
-    requestId: number,
-    client: GatewayBrowserClient,
-    gatewaySource: ApplicationContext["gateway"],
-  ): boolean {
-    const gateway = gatewaySource.snapshot;
-    return (
-      this.isConnected &&
-      requestId === this.systemInfoRequestId &&
-      this.systemInfoGatewaySource === gatewaySource &&
-      this.context.gateway === gatewaySource &&
-      gateway.phase === "connected" &&
-      gateway.client === client
-    );
-  }
-
   private async loadSystemInfo() {
-    const gatewaySource = this.systemInfoGatewaySource;
+    const gatewaySource = this.gateway.gateway;
     if (!gatewaySource || gatewaySource !== this.context.gateway) {
       return;
     }
-    const gateway = gatewaySource.snapshot;
-    const client = gateway.client;
-    if (
-      gateway.phase !== "connected" ||
-      !client ||
-      this.systemInfoUnavailable ||
-      this.systemInfoLoading
-    ) {
+    const scope = this.gateway.capture();
+    if (!scope || this.systemInfoUnavailable || this.systemInfoLoading) {
       return;
     }
-
-    const requestId = ++this.systemInfoRequestId;
+    // Context can change before Lit rebinds the controller's source.
+    const isCurrent = () =>
+      this.isConnected && this.context.gateway === gatewaySource && this.gateway.isCurrent(scope);
     this.systemInfoLoading = true;
     try {
-      const response = await client.request("system.info", {});
-      if (!this.isCurrentSystemInfoRequest(requestId, client, gatewaySource)) {
+      const response = await scope.client.request("system.info", {});
+      if (!isCurrent()) {
         return;
       }
       this.systemInfo = response as SystemInfoResult;
     } catch (error) {
-      if (!this.isCurrentSystemInfoRequest(requestId, client, gatewaySource)) {
+      if (!isCurrent()) {
         return;
       }
       if (isMissingOperatorReadScopeError(error) || isUnknownSystemInfoMethodError(error)) {
@@ -204,7 +154,7 @@ export class ConnectionPage extends OpenClawLightDomElement {
         this.systemInfoPolling.stop();
       }
     } finally {
-      if (this.isCurrentSystemInfoRequest(requestId, client, gatewaySource)) {
+      if (isCurrent()) {
         this.systemInfoLoading = false;
       }
     }
@@ -213,7 +163,6 @@ export class ConnectionPage extends OpenClawLightDomElement {
   private resetDraft(gateway: ApplicationContext["gateway"]) {
     const sessionKey = gateway.snapshot.sessionKey;
     const { gatewayUrl, token, password } = gateway.connection;
-    this.gatewayClient = gateway.snapshot.client;
     this.settings = {
       ...loadSettings(),
       gatewayUrl,

--- a/ui/src/test-helpers/application-context.ts
+++ b/ui/src/test-helpers/application-context.ts
@@ -1,6 +1,11 @@
 import { ContextProvider } from "@lit/context";
 import type { RouteId } from "../app-route-paths.ts";
-import { applicationContext, type ApplicationContext } from "../app/context.ts";
+import {
+  applicationContext,
+  type ApplicationContext,
+  type ApplicationGateway,
+  type ApplicationGatewaySnapshot,
+} from "../app/context.ts";
 import type { MentionsCapability } from "../app/mentions.ts";
 
 export const hiddenScopeUpgradeCapability = {
@@ -47,3 +52,28 @@ export function createApplicationContextProvider(context: ApplicationContext<Rou
 }
 
 export type ApplicationContextProvider = ReturnType<typeof createApplicationContextProvider>;
+
+export function createApplicationGateway(initial: ApplicationGatewaySnapshot) {
+  let snapshot = initial;
+  const listeners = new Set<(value: ApplicationGatewaySnapshot) => void>();
+  const gateway = {
+    connection: { gatewayUrl: "ws://gateway.example.test", token: "", password: "" },
+    get snapshot() {
+      return snapshot;
+    },
+    connect: () => undefined,
+    subscribe(listener: (value: ApplicationGatewaySnapshot) => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  } as unknown as ApplicationGateway;
+  return {
+    gateway,
+    publish(next: ApplicationGatewaySnapshot) {
+      snapshot = next;
+      for (const listener of listeners) {
+        listener(snapshot);
+      }
+    },
+  };
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Gateway connection settings and Appearance duplicated the logic that binds a page to its Gateway and prevents stale responses from updating a replacement connection.

## Why This Change Was Made

Both pages now use the existing `GatewayPageController`, removing 66 production lines. Each page keeps its own polling and presentation policy. Tests now drive mounted pages and real subscription delivery instead of assigning the removed private fields.

## User Impact

Preserves existing behavior: edited credentials survive a reconnect and become masked; replacing the connection resets the draft. Appearance polls only while visible, and ordinary status refreshes leave a slow Observer catalog request running.

## Evidence

- The same 71 preservation cases passed against the original owners and the refactor, covering stale responses/errors, draft resets, capability changes, page visibility, and Observer lifecycle behavior.
- Five synthetic browser cases passed before and after: the four Observer recovery scenarios and the extended Connection form/reconnect case.
- All 20 selected changed checks passed, including core/UI types, i18n, lint/style, and export checks.
- Independently captured Connection screenshots are byte-identical. The inspected before/after captures are attached below.
- Independent source review and all three managed review passes found no actionable issues.

![Before: Gateway settings after reconnect](https://github.com/user-attachments/assets/a7836948-5eb3-409b-ab80-89546b447123)

![After: Gateway settings after reconnect](https://github.com/user-attachments/assets/41028e4b-157c-4b8a-8088-117c544fd4dc)