### PR TITLE
fix(skills): discover Workshop entries named skills

### DIFF
--- a/src/skills/loading/skill-root-discovery.ts
+++ b/src/skills/loading/skill-root-discovery.ts
@@ -335,20 +335,17 @@ function resolveContainedSkillPath(params: {
   return null;
 }
 
-function resolveNestedSkillsRoot(
-  dir: string,
-  opts?: { maxEntriesToScan?: number },
-): { baseDir: string; note?: string } {
+function resolveNestedSkillsRoot(dir: string, maxEntriesToScan: number): string {
   const nested = path.join(dir, "skills");
   try {
     if (!fs.existsSync(nested) || !fs.statSync(nested).isDirectory()) {
-      return { baseDir: dir };
+      return dir;
     }
   } catch {
-    return { baseDir: dir };
+    return dir;
   }
 
-  const scanLimit = Math.max(0, opts?.maxEntriesToScan ?? 100);
+  const scanLimit = Math.max(0, maxEntriesToScan);
   if (
     !hasSkillFileCandidate(dir) &&
     containsDiscoverableSkill(dir, {
@@ -356,14 +353,14 @@ function resolveNestedSkillsRoot(
       skipTopLevelDirName: "skills",
     })
   ) {
-    return { baseDir: dir };
+    return dir;
   }
 
   const discoveryBudget = createSkillDiscoveryBudget(scanLimit);
   const queue: Array<{ dir: string; depth: number }> = [{ dir: nested, depth: 0 }];
   for (const candidate of queue) {
     if (hasSkillFileCandidate(candidate.dir)) {
-      return { baseDir: nested, note: `Detected nested skills root at ${nested}` };
+      return nested;
     }
     if (candidate.depth >= MAX_GROUPED_SKILL_SCAN_DEPTH) {
       continue;
@@ -377,7 +374,7 @@ function resolveNestedSkillsRoot(
       queue.push({ dir: path.join(candidate.dir, childDir), depth: candidate.depth + 1 });
     }
   }
-  return { baseDir: dir };
+  return dir;
 }
 
 function shouldEnforceConfiguredSkillRootContainment(source: string): boolean {
@@ -460,10 +457,11 @@ export function discoverSkillCandidates(params: {
     }
     return { candidates: [], rootIsSkill: false };
   }
-  const resolved = resolveNestedSkillsRoot(params.dir, {
-    maxEntriesToScan: params.limits.maxCandidatesPerRoot,
-  });
-  const baseDir = resolved.baseDir;
+  // Workshop roots are containers; promotion would hide a child skill named "skills".
+  const rootIsContainer = params.source === "openclaw-workshop";
+  const baseDir = rootIsContainer
+    ? rootDir
+    : resolveNestedSkillsRoot(params.dir, params.limits.maxCandidatesPerRoot);
   const baseDirRealPath = resolveSkillRootCandidatePath({
     source: params.source,
     rootDir,
@@ -476,7 +474,6 @@ export function discoverSkillCandidates(params: {
     return { candidates: [], rootIsSkill: false };
   }
 
-  const rootIsContainer = params.source === "openclaw-workshop";
   if (!rootIsContainer && hasSkillFileCandidate(baseDir)) {
     const rootSkillRealPath = resolveSkillFilePath({
       source: params.source,

--- a/src/skills/workshop/workspace-skill-read.test.ts
+++ b/src/skills/workshop/workspace-skill-read.test.ts
@@ -39,23 +39,38 @@ async function writeSkill(dir: string, name: string, body = ""): Promise<void> {
 }
 
 describe("listWritableWorkshopSkillSummaries", () => {
-  it("ignores a SKILL.md placed directly in the Workshop root", async () => {
-    const workshopDir = resolveWorkshopSkillsDir({}, "main", testState.env);
-    await fs.mkdir(workshopDir, { recursive: true });
-    await fs.writeFile(path.join(workshopDir, "SKILL.md"), "# Root skill\n");
-    await writeSkill(path.join(workshopDir, "real"), "real");
+  it.each(
+    [false, true].flatMap((rootManifest) =>
+      [["real"], ["skills"], ["real", "skills"]].map((names) => ({ rootManifest, names })),
+    ),
+  )(
+    "discovers Workshop children $names with root manifest=$rootManifest",
+    async ({ rootManifest, names }) => {
+      const workshopDir = resolveWorkshopSkillsDir({}, "main", testState.env);
+      for (const name of names) {
+        await writeSkill(path.join(workshopDir, name), name);
+      }
+      if (rootManifest) {
+        await fs.writeFile(path.join(workshopDir, "SKILL.md"), "# Root skill\n");
+      }
 
-    expect(
-      listWritableWorkshopSkillSummaries({ config: {}, agentId: "main", env: testState.env }).map(
-        (skill) => skill.name,
-      ),
-    ).toEqual(["real"]);
-    expect(
-      loadSkillRootRecords({ dir: workshopDir, source: "openclaw-workshop" }).map(
-        ({ skill }) => skill.name,
-      ),
-    ).toEqual(["real"]);
-  });
+      expect(
+        listWritableWorkshopSkillSummaries({ config: {}, agentId: "main", env: testState.env }).map(
+          (skill) => skill.name,
+        ),
+      ).toEqual(names);
+      expect(
+        loadSkillRootRecords({ dir: workshopDir, source: "openclaw-workshop" }).map(
+          ({ skill }) => skill.name,
+        ),
+      ).toEqual(names);
+      for (const name of names) {
+        await expect(
+          readWritableWorkshopSkill(name, { config: {}, agentId: "main", env: testState.env }),
+        ).resolves.toMatchObject({ skillName: name, baseDir: path.join(workshopDir, name) });
+      }
+    },
+  );
 
   it("uses the declared name for grouped skills when reading and updating", async () => {
     const baseDir = path.join(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a valid Workshop skill named `skills` could disappear from discovery and become unreadable. The failure depended on neighboring entries and whether the Workshop container also contained a root manifest.

## Why This Change Was Made

Classify the existing Workshop container before the generic nested-skills-root promotion. Promoting its `skills` child incorrectly treats the skill itself as a container and skips its manifest. Ordinary workspace/grouped discovery, scan limits and containment checks remain unchanged. Remove the private unused discovery-note wrapper rather than adding a second discovery path.

## User Impact

Workshop entries named `skills` remain discoverable and readable, alone or alongside other skills. A manifest placed directly on the Workshop container stays ignored as before. No configuration, schema, SDK or migration changes.

Production −3 lines; tests +15.

## Evidence

- Real isolated filesystem regression: three affected cases failed before the fix, while three controls passed.
- All 45 tests across four discovery/loader/precedence/containment suites passed after the repair.
- The existing root-manifest test now covers ordinary and `skills` entries, alone and mixed, and checks both discovery projections plus actual skill reads.
- All 29 changed-file checks passed, including declarations, lint, dead exports and boundary guards. Fresh independent managed review completed without findings.
- Final current-base patch and source hashes exactly match the reviewed candidate. No provider calls or operator state were used; this is actual temporary-filesystem owner proof, not a live model/provider claim.

This is separate from the loopback tool-materialization repair in #139752.
