### PR TITLE
fix(agents): reuse host SDK modules for session plugins

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -592,6 +592,8 @@ turn runs; the Plugin SDK only constrains the target session, plugin-owned
 naming, and cleanup. Use `api.runtime.tasks.managedFlows` inside the scheduled
 turn when the work itself needs durable multi-step Task Flow state.
 
+Session extension SDK and supported TypeBox imports share the host's modules.
+
 The contracts intentionally split authority:
 
 - External plugins can own session extensions, UI descriptors, commands, tool

--- a/src/agents/embedded-agent-subscribe.native-reasoning.test-support.ts
+++ b/src/agents/embedded-agent-subscribe.native-reasoning.test-support.ts
@@ -6,9 +6,9 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { processCompletionsStream } from "../../packages/ai/src/transports/openai-completions-stream.js";
 import { onAgentEventForRun } from "../infra/agent-events.js";
+import { runAgentLoop, type AgentEvent } from "../plugin-sdk/agent-core.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
-import { runAgentLoop, type AgentEvent } from "./runtime/index.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
 export const NATIVE_REASONING_BENCH_PREFIX = "REASONING_BENCH:";

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import { createResponsesAssistantOutput } from "../../packages/ai/src/providers/openai-responses-shared.js";
 import { processResponsesStream } from "../../packages/ai/src/transports/openai-responses-stream-internal.js";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { runAgentLoop } from "../plugin-sdk/agent-core.js";
 import {
   createSubscribedSessionHarness,
   createTextEndBlockReplyHarness,
@@ -21,7 +22,6 @@ import {
   createOpenAiResponsesTextEvent,
   type OpenAiResponsesTextEventPhase,
 } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
-import { runAgentLoop } from "./runtime/index.js";
 
 describe("text_end snapshot reconciliation", () => {
   it.each([

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -17,6 +17,7 @@ import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import * as agentEvents from "../infra/agent-events.js";
 import { flushLogger, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { parseLogLine } from "../logging/parse-log-line.js";
+import { runAgentLoop, type AgentEvent } from "../plugin-sdk/agent-core.js";
 import {
   THINKING_TAG_CASES,
   createSubscribedSessionHarness,
@@ -31,7 +32,6 @@ import {
   createOpenAiResponsesTextBlock,
   createOpenAiResponsesTextEvent,
 } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
-import { runAgentLoop, type AgentEvent } from "./runtime/index.js";
 import { SessionManager } from "./sessions/session-manager.js";
 import { recordSessionModelUsage } from "./sessions/session-model-usage.js";
 import { markCoreTtsToolResult } from "./tools/tts-tool-result-provenance.js";

--- a/src/agents/runtime/index.ts
+++ b/src/agents/runtime/index.ts
@@ -16,7 +16,6 @@ export {
   openClawAgentCoreRuntime,
   prepareBranchEntries,
   prepareCompaction,
-  runAgentLoop,
   serializeConversation,
   shouldCompact,
   uuidv7,

--- a/src/agents/sessions/extensions/loader.test.ts
+++ b/src/agents/sessions/extensions/loader.test.ts
@@ -48,4 +48,48 @@ export default async function(api) {
     expect(result.extensions).toHaveLength(1);
     expect(result.extensions[0]?.commands.has("sdk-subpath-probe")).toBe(true);
   });
+
+  it.each([
+    { sdk: "openclaw/plugin-sdk/agent-sessions", typebox: "typebox" },
+    { sdk: "@openclaw/plugin-sdk/agent-sessions", typebox: "@sinclair/typebox" },
+  ])("loads the host session SDK and schema helpers through $sdk", async ({ sdk, typebox }) => {
+    const dir = await mkdtemp(join(tmpdir(), "openclaw-extension-session-sdk-"));
+    tempDirs.push(dir);
+    const extensionPath = join(dir, "extension.ts");
+    await writeFile(
+      extensionPath,
+      `
+import { AuthStorage, ModelRegistry } from "${sdk}";
+import { streamProxy, IMAGE_BLOCK_TOKENS } from "${sdk.replace("agent-sessions", "agent-core")}";
+import { Type } from "${typebox}";
+import { Compile } from "${typebox}/compile";
+import { IsEmail } from "${typebox}/format";
+import { Check } from "${typebox}/value";
+
+export default function(api) {
+  const registry = ModelRegistry.inMemory(AuthStorage.inMemory({}));
+  registry.registerProvider("sdk-probe", {
+    api: "openai-responses",
+    baseUrl: "https://example.test",
+    models: [{ id: "probe" }],
+  });
+  const schema = Type.Number();
+  if (!Compile(schema).Check(1) || Check(schema, "invalid") || !IsEmail("probe@example.test")) {
+    throw new Error("host schema helpers did not preserve their contracts");
+  }
+  if (typeof streamProxy !== "function" || !(IMAGE_BLOCK_TOKENS > 0)) {
+    throw new Error("public agent-core exports were lost");
+  }
+  api.registerCommand("session-sdk-probe", {
+    description: registry.find("sdk-probe", "probe").id,
+    handler() {},
+  });
+}
+`,
+    );
+
+    const loaded = await loadExtensionsCached([extensionPath], dir);
+    expect(loaded.errors).toEqual([]);
+    expect(loaded.extensions[0]?.commands.get("session-sdk-probe")?.description).toBe("probe");
+  });
 });

--- a/src/agents/sessions/extensions/loader.ts
+++ b/src/agents/sessions/extensions/loader.ts
@@ -16,6 +16,7 @@ import * as bundledTypebox from "typebox";
 import * as bundledTypeboxCompile from "typebox/compile";
 import * as bundledTypeboxFormat from "typebox/format";
 import * as bundledTypeboxValue from "typebox/value";
+import * as bundledAgentCore from "../../../plugin-sdk/agent-core.js";
 import * as bundledLlm from "../../../plugin-sdk/llm.js";
 import { installOpenClawInternalCorePackageNativeResolver } from "../../../plugins/plugin-sdk-native-resolver.js";
 import {
@@ -23,33 +24,6 @@ import {
   buildPluginLoaderJitiOptions,
 } from "../../../plugins/sdk-alias.js";
 import { isBunBinary } from "../../config.js";
-import {
-  Agent,
-  bashExecutionToText,
-  buildSessionContext,
-  calculateContextTokens,
-  collectEntriesForBranchSummaryFromBranches,
-  compact,
-  estimateContextTokens,
-  estimateTokens,
-  findCutPoint,
-  findTurnStartIndex,
-  generateBranchSummary,
-  generateSummary,
-  getLastAssistantUsage,
-  openClawAgentCoreRuntime,
-  prepareBranchEntries,
-  prepareCompaction,
-  runAgentLoop,
-  serializeConversation,
-  shouldCompact,
-  uuidv7,
-  BRANCH_SUMMARY_PREFIX,
-  BRANCH_SUMMARY_SUFFIX,
-  COMPACTION_SUMMARY_PREFIX,
-  COMPACTION_SUMMARY_SUFFIX,
-  DEFAULT_COMPACTION_SETTINGS,
-} from "../../runtime/index.js";
 import { createEventBus, type EventBus } from "../event-bus.js";
 import type { ExecOptions } from "../exec.js";
 import { execCommand } from "../exec.js";
@@ -68,35 +42,7 @@ import type {
   ToolDefinition,
 } from "./types.js";
 
-/** Modules available to extensions via virtualModules (for compiled Bun binary) */
-const bundledAgentCore = {
-  Agent,
-  bashExecutionToText,
-  buildSessionContext,
-  calculateContextTokens,
-  collectEntriesForBranchSummaryFromBranches,
-  compact,
-  estimateContextTokens,
-  estimateTokens,
-  findCutPoint,
-  findTurnStartIndex,
-  generateBranchSummary,
-  generateSummary,
-  getLastAssistantUsage,
-  openClawAgentCoreRuntime,
-  prepareBranchEntries,
-  prepareCompaction,
-  runAgentLoop,
-  serializeConversation,
-  shouldCompact,
-  uuidv7,
-  BRANCH_SUMMARY_PREFIX,
-  BRANCH_SUMMARY_SUFFIX,
-  COMPACTION_SUMMARY_PREFIX,
-  COMPACTION_SUMMARY_SUFFIX,
-  DEFAULT_COMPACTION_SETTINGS,
-};
-
+/** Canonical host modules shared by source extensions and compiled binaries. */
 const VIRTUAL_MODULES: Record<string, unknown> = {
   typebox: bundledTypebox,
   "typebox/compile": bundledTypeboxCompile,
@@ -116,7 +62,6 @@ const VIRTUAL_MODULES: Record<string, unknown> = {
 
 const require = createRequire(import.meta.url);
 
-let aliases: Record<string, string> | null = null;
 let createJitiLoaderFactory: typeof createJiti | undefined;
 let nativeExtensionLoadCounter = 0;
 // One cwd slot bounds the process cache. The generation keeps an in-flight
@@ -140,43 +85,6 @@ async function loadCreateJitiLoaderFactory(): Promise<typeof createJiti> {
   }
   createJitiLoaderFactory = loaded.createJiti;
   return createJitiLoaderFactory;
-}
-
-function resolveExtensionSafeAgentSessionsEntry(): string {
-  const currentDirname = path.dirname(fileURLToPath(import.meta.url));
-  const jsEntry = path.resolve(currentDirname, "..", "extension-sdk.js");
-  return fs.existsSync(jsEntry) ? jsEntry : path.resolve(currentDirname, "..", "extension-sdk.ts");
-}
-
-function getExtensionLoaderAliases(): Record<string, string> {
-  if (aliases) {
-    return aliases;
-  }
-
-  const agentSessionsEntry = resolveExtensionSafeAgentSessionsEntry();
-  const typeboxEntry = require.resolve("typebox");
-  const typeboxCompileEntry = require.resolve("typebox/compile");
-  const typeboxFormatEntry = require.resolve("typebox/format");
-  const typeboxValueEntry = require.resolve("typebox/value");
-  const loaderModulePath = fileURLToPath(import.meta.url);
-
-  aliases = {
-    ...buildPluginLoaderAliasMap(loaderModulePath, process.argv[1], import.meta.url),
-    // The public agent-sessions export includes the resource loader. Extensions
-    // load through the resource loader, so use the cycle-safe SDK barrel here.
-    "openclaw/plugin-sdk/agent-sessions": agentSessionsEntry,
-    "@openclaw/plugin-sdk/agent-sessions": agentSessionsEntry,
-    typebox: typeboxEntry,
-    "typebox/compile": typeboxCompileEntry,
-    "typebox/format": typeboxFormatEntry,
-    "typebox/value": typeboxValueEntry,
-    "@sinclair/typebox": typeboxEntry,
-    "@sinclair/typebox/compile": typeboxCompileEntry,
-    "@sinclair/typebox/format": typeboxFormatEntry,
-    "@sinclair/typebox/value": typeboxValueEntry,
-  };
-
-  return aliases;
 }
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
@@ -524,15 +432,14 @@ async function loadExtensionSourceTransformModule(
   if (!context.sourceTransformLoader) {
     installOpenClawInternalCorePackageNativeResolver({ moduleUrl: import.meta.url });
     const createJitiLoader = await loadCreateJitiLoaderFactory();
+    const aliases = isBunBinary
+      ? {}
+      : buildPluginLoaderAliasMap(fileURLToPath(import.meta.url), process.argv[1], import.meta.url);
     context.sourceTransformLoader = createJitiLoader(import.meta.url, {
-      ...(isBunBinary
-        ? {
-            ...buildPluginLoaderJitiOptions({}),
-            // Bun binaries need virtual modules because extension SDK files are
-            // bundled into the executable rather than present on disk.
-            virtualModules: VIRTUAL_MODULES,
-          }
-        : buildPluginLoaderJitiOptions(getExtensionLoaderAliases())),
+      ...buildPluginLoaderJitiOptions(aliases),
+      // Share the host SDK graph; entry-file aliases misresolve package subpaths
+      // and re-evaluate SDK dependencies instead of using their native owners.
+      virtualModules: VIRTUAL_MODULES,
       // Extension entry modules must bypass the native ESM cache so an explicit
       // reload observes edited source. Product modules stay native via nativeModules.
       tryNative: false,

--- a/src/agents/tool-search.mcp-error.test.ts
+++ b/src/agents/tool-search.mcp-error.test.ts
@@ -8,9 +8,9 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { runAgentLoop, type AgentEvent, type AgentMessage } from "../plugin-sdk/agent-core.js";
 import { materializeBundleMcpToolsForRun } from "./agent-bundle-mcp-materialize.js";
 import type { SessionMcpRuntime } from "./agent-bundle-mcp-types.js";
-import { runAgentLoop, type AgentEvent, type AgentMessage } from "./runtime/index.js";
 import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 import { isToolResultError } from "./tool-result-error.js";
 import {

--- a/test/plugins/native-reasoning-subscription.test.ts
+++ b/test/plugins/native-reasoning-subscription.test.ts
@@ -1,10 +1,10 @@
 import { createServer } from "node:http";
 import { crc32 } from "node:zlib";
+import { runAgentLoop } from "openclaw/plugin-sdk/agent-core";
 import type { Message, Model } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import bedrockPlugin from "../../extensions/amazon-bedrock/index.js";
 import { createSubscribedSessionHarness } from "../../src/agents/embedded-agent-subscribe.e2e-harness.js";
-import { runAgentLoop } from "../../src/agents/runtime/index.js";
 import { onAgentEventForRun } from "../../src/infra/agent-events.js";
 import { registerSingleProviderPlugin } from "../../src/test-utils/plugin-registration.js";
 import { createDeferred } from "../helpers/promise.js";
@@ -60,7 +60,7 @@ describe("native provider reasoning subscription", () => {
   it.for(["incremental", "buffered"] as const)(
     "keeps Bedrock's redacted snapshot with %s consumption",
     async (consumption, { signal }) => {
-      const firstDeltaConsumed = createDeferred<void>();
+      const firstDeltaConsumed = createDeferred();
       async function* responses() {
         yield { messageStart: { role: "assistant" } };
         yield {


### PR DESCRIPTION
## What Problem This Solves

Session plugins importing the host session SDK could fail before registration because the loader treated TypeBox package subpaths as paths beneath its entry file. A real extension failed trying to resolve `typebox/build/index.mjs/guard` while loading the SDK's schema dependency.

## Why This Change Was Made

Use the host's existing SDK and TypeBox module objects for source plugins, just as compiled binaries already do. Remove the duplicate entry-file aliases and use the canonical agent-core namespace so existing public exports stay available. Generic SDK subpath resolution and extension reload behavior remain intact.

Remove the now-unused internal `runAgentLoop` forwarding export and point its test callers at the unchanged public owner. Production code decreases by 94 lines. This is a bounded repair discovered while extracting #130706; no dependency, configuration, storage, or protocol surface is added.

## User Impact

Session plugins can import the host session SDK and supported TypeBox helpers without a module-resolution failure. Scoped SDK spellings and existing TypeBox compatibility imports continue working. Native JavaScript loading, explicit reload, and the existing agent-core exports remain available.

## Evidence

Two real loader regressions failed before the repair, covering scoped and unscoped SDK/TypeBox imports. The loader-only split passes 182 focused tests across loader, native JavaScript reload, Bun virtual-module contracts, MCP recovery, session event delivery, and migrated callers. CI found one additional tooling caller of the removed internal export; after migrating it, both native Bedrock reasoning cases pass with an actual loopback request each. A whole-repository search found no remaining callers of that retired export. Test-root type checking, typed lint, and independent P2 reviews pass.

The full build passed on `b2f21c3afeb3c8987fc8200c96b92068468362f6`. Its completed runtime passes real session-resource-loader first-load and reload checks, including SDK registry/schema helpers and the preserved public agent-core exports. All 8,536 runtime JavaScript files stayed identical during proof.

Current commit `504ab72c10fcbe52ad710ac37a28a5557538e4c5` changes only the missed test import and its redundant default type argument. Production source and all built runtime JavaScript files are identical to the completed-build proof. The final full changed gate passed on this exact head. Exact-head CI also passed: https://github.com/openclaw/openclaw/actions/runs/34017281596. The first CI run exposed the missed test caller; that defect is repaired, and its failing job was not bypassed.

The latest ClawSweeper review and its rank-up move requested the split build and built first-load/reload evidence above. Both are now complete. Production −94, tests/support +44, docs +2. No proof gap remains for this loader cut; model matching is a separate extraction.
