### PR TITLE
refactor(plugins): unify public artifact factory loading

### DIFF
--- a/src/plugins/document-extractor-public-artifacts.ts
+++ b/src/plugins/document-extractor-public-artifacts.ts
@@ -4,12 +4,7 @@ import type {
   DocumentExtractorPlugin,
   PluginDocumentExtractorEntry,
 } from "./document-extractor-types.js";
-import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "./public-surface-loader.js";
-
-const DOCUMENT_EXTRACTOR_ARTIFACT_CANDIDATES = [
-  "document-extractor.js",
-  "document-extractor-api.js",
-] as const;
+import { loadBundledPublicArtifactEntries } from "./public-artifact-factories.js";
 
 function isDocumentExtractorPlugin(value: unknown): value is DocumentExtractorPlugin {
   return (
@@ -23,57 +18,16 @@ function isDocumentExtractorPlugin(value: unknown): value is DocumentExtractorPl
   );
 }
 
-function collectExtractorFactories(mod: Record<string, unknown>): {
-  extractors: DocumentExtractorPlugin[];
-  errors: unknown[];
-} {
-  const extractors: DocumentExtractorPlugin[] = [];
-  const errors: unknown[] = [];
-  for (const [name, exported] of Object.entries(mod).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    if (
-      typeof exported !== "function" ||
-      exported.length !== 0 ||
-      !name.startsWith("create") ||
-      !name.endsWith("DocumentExtractor")
-    ) {
-      continue;
-    }
-    let candidate: unknown;
-    try {
-      candidate = exported();
-    } catch (error) {
-      errors.push(error);
-      continue;
-    }
-    if (isDocumentExtractorPlugin(candidate)) {
-      extractors.push(candidate);
-    }
-  }
-  return { extractors, errors };
-}
-
 /** Loads document extractor entries from a bundled plugin public artifact module. */
 export function loadBundledDocumentExtractorEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginDocumentExtractorEntry[] | null {
-  const mod = loadBundledPluginPublicArtifactModuleFromCandidatesSync<Record<string, unknown>>({
-    dirName: params.dirName,
-    artifactCandidates: DOCUMENT_EXTRACTOR_ARTIFACT_CANDIDATES,
+  return loadBundledPublicArtifactEntries({
+    ...params,
+    artifactCandidates: ["document-extractor.js", "document-extractor-api.js"],
+    suffix: "DocumentExtractor",
+    isArtifact: isDocumentExtractorPlugin,
+    partialFailureLabel: "document extractors",
   });
-  if (!mod) {
-    return null;
-  }
-  const { extractors, errors } = collectExtractorFactories(mod);
-  if (extractors.length === 0) {
-    if (errors.length > 0) {
-      throw new Error(`Unable to initialize document extractors for plugin ${params.pluginId}`, {
-        cause: errors.length === 1 ? errors[0] : new AggregateError(errors),
-      });
-    }
-    return null;
-  }
-  return extractors.map((extractor) => Object.assign({}, extractor, { pluginId: params.pluginId }));
 }

--- a/src/plugins/provider-contract-public-artifacts.ts
+++ b/src/plugins/provider-contract-public-artifacts.ts
@@ -1,6 +1,7 @@
 // Extracts provider contract public artifacts from plugin manifests.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { collectPublicArtifactFactories } from "./public-artifact-factories.js";
 import { loadBundledPluginPublicArtifactModuleSync } from "./public-surface-loader.js";
 import type { ProviderPlugin } from "./types.js";
 
@@ -35,30 +36,6 @@ function tryLoadProviderContractApi(pluginId: string): Record<string, unknown> |
   }
 }
 
-function collectProviderContractEntries(params: {
-  pluginId: string;
-  mod: Record<string, unknown>;
-}): ProviderContractEntry[] {
-  const providers: ProviderContractEntry[] = [];
-  for (const [name, exported] of Object.entries(params.mod).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    if (
-      typeof exported !== "function" ||
-      exported.length !== 0 ||
-      !name.startsWith("create") ||
-      !name.endsWith("Provider")
-    ) {
-      continue;
-    }
-    const candidate = exported();
-    if (isProviderPlugin(candidate)) {
-      providers.push({ pluginId: params.pluginId, provider: candidate });
-    }
-  }
-  return providers;
-}
-
 export function resolveBundledExplicitProviderContractsFromPublicArtifacts(params: {
   onlyPluginIds: readonly string[];
 }): ProviderContractEntry[] | null {
@@ -68,11 +45,15 @@ export function resolveBundledExplicitProviderContractsFromPublicArtifacts(param
     if (!mod) {
       return null;
     }
-    const entries = collectProviderContractEntries({ pluginId, mod });
+    const entries = collectPublicArtifactFactories({
+      mod,
+      suffix: "Provider",
+      isArtifact: isProviderPlugin,
+    });
     if (entries.length === 0) {
       return null;
     }
-    providers.push(...entries);
+    providers.push(...entries.map((provider) => ({ pluginId, provider })));
   }
   return providers;
 }

--- a/src/plugins/public-artifact-factories.ts
+++ b/src/plugins/public-artifact-factories.ts
@@ -1,0 +1,73 @@
+import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "./public-surface-loader.js";
+
+/** Factory order is observable when plugins initialize and when their entries are consumed. */
+export function collectPublicArtifactFactories<T>(params: {
+  mod: Record<string, unknown>;
+  suffix: string;
+  isArtifact: (value: unknown) => value is T;
+  onFactoryError?: (error: unknown) => void;
+}): T[] {
+  const artifacts: T[] = [];
+  for (const [name, exported] of Object.entries(params.mod).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (
+      typeof exported !== "function" ||
+      exported.length !== 0 ||
+      !name.startsWith("create") ||
+      !name.endsWith(params.suffix)
+    ) {
+      continue;
+    }
+    let candidate: unknown;
+    try {
+      candidate = exported();
+    } catch (error) {
+      if (!params.onFactoryError) {
+        throw error;
+      }
+      params.onFactoryError(error);
+      continue;
+    }
+    if (params.isArtifact(candidate)) {
+      artifacts.push(candidate);
+    }
+  }
+  return artifacts;
+}
+
+/** Loads a typed artifact surface without activating the plugin's runtime entry. */
+export function loadBundledPublicArtifactEntries<T extends object>(params: {
+  dirName: string;
+  pluginId: string;
+  artifactCandidates: readonly string[];
+  suffix: string;
+  isArtifact: (value: unknown) => value is T;
+  partialFailureLabel?: string;
+}): Array<T & { pluginId: string }> | null {
+  const mod = loadBundledPluginPublicArtifactModuleFromCandidatesSync<Record<string, unknown>>({
+    dirName: params.dirName,
+    artifactCandidates: params.artifactCandidates,
+  });
+  if (!mod) {
+    return null;
+  }
+  const errors: unknown[] = [];
+  const artifacts = collectPublicArtifactFactories({
+    mod,
+    suffix: params.suffix,
+    isArtifact: params.isArtifact,
+    // Only document and web providers tolerate failed siblings. Other surfaces fail immediately.
+    onFactoryError: params.partialFailureLabel ? (error) => errors.push(error) : undefined,
+  });
+  if (artifacts.length === 0) {
+    if (errors.length > 0) {
+      throw new Error(
+        `Unable to initialize ${params.partialFailureLabel} for plugin ${params.pluginId}`,
+        { cause: errors.length === 1 ? errors[0] : new AggregateError(errors) },
+      );
+    }
+    return null;
+  }
+  return artifacts.map((artifact) => Object.assign({}, artifact, { pluginId: params.pluginId }));
+}

--- a/src/plugins/web-content-extractor-public-artifacts.ts
+++ b/src/plugins/web-content-extractor-public-artifacts.ts
@@ -1,15 +1,10 @@
 // Extracts web content public artifacts from plugin manifests.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "./public-surface-loader.js";
+import { loadBundledPublicArtifactEntries } from "./public-artifact-factories.js";
 import type {
   PluginWebContentExtractorEntry,
   WebContentExtractorPlugin,
 } from "./web-content-extractor-types.js";
-
-const WEB_CONTENT_EXTRACTOR_ARTIFACT_CANDIDATES = [
-  "web-content-extractor.js",
-  "web-content-extractor-api.js",
-] as const;
 
 /** Checks public artifact exports before adding them to runtime extractor registration. */
 function isWebContentExtractorPlugin(value: unknown): value is WebContentExtractorPlugin {
@@ -22,43 +17,15 @@ function isWebContentExtractorPlugin(value: unknown): value is WebContentExtract
   );
 }
 
-/** Collects zero-arg factory exports in deterministic order for prompt-cache stability. */
-function collectExtractorFactories(mod: Record<string, unknown>): WebContentExtractorPlugin[] {
-  const extractors: WebContentExtractorPlugin[] = [];
-  for (const [name, exported] of Object.entries(mod).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    if (
-      typeof exported !== "function" ||
-      exported.length !== 0 ||
-      !name.startsWith("create") ||
-      !name.endsWith("WebContentExtractor")
-    ) {
-      continue;
-    }
-    const candidate = exported();
-    if (isWebContentExtractorPlugin(candidate)) {
-      extractors.push(candidate);
-    }
-  }
-  return extractors;
-}
-
 /** Loads bundled web content extractor entries from public plugin artifacts. */
 export function loadBundledWebContentExtractorEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebContentExtractorEntry[] | null {
-  const mod = loadBundledPluginPublicArtifactModuleFromCandidatesSync<Record<string, unknown>>({
-    dirName: params.dirName,
-    artifactCandidates: WEB_CONTENT_EXTRACTOR_ARTIFACT_CANDIDATES,
+  return loadBundledPublicArtifactEntries({
+    ...params,
+    artifactCandidates: ["web-content-extractor.js", "web-content-extractor-api.js"],
+    suffix: "WebContentExtractor",
+    isArtifact: isWebContentExtractorPlugin,
   });
-  if (!mod) {
-    return null;
-  }
-  const extractors = collectExtractorFactories(mod);
-  if (extractors.length === 0) {
-    return null;
-  }
-  return extractors.map((extractor) => Object.assign({}, extractor, { pluginId: params.pluginId }));
 }

--- a/src/plugins/web-provider-public-artifacts.explicit.ts
+++ b/src/plugins/web-provider-public-artifacts.explicit.ts
@@ -1,7 +1,7 @@
 // Extracts explicit public artifacts from web provider plugin manifests.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { loadBundledPluginPublicArtifactModuleFromCandidatesSync } from "./public-surface-loader.js";
+import { loadBundledPublicArtifactEntries } from "./public-artifact-factories.js";
 import type {
   PluginWebFetchProviderEntry,
   PluginWebSearchProviderEntry,
@@ -43,78 +43,6 @@ function isWebProviderPlugin(
   );
 }
 
-function collectProviderFactories<TProvider>(params: {
-  mod: Record<string, unknown>;
-  suffix: string;
-  isProvider: (value: unknown) => value is TProvider;
-}): { providers: TProvider[]; errors: unknown[] } {
-  const providers: TProvider[] = [];
-  const errors: unknown[] = [];
-  for (const [name, exported] of Object.entries(params.mod).toSorted(([left], [right]) =>
-    left.localeCompare(right),
-  )) {
-    if (
-      typeof exported !== "function" ||
-      exported.length !== 0 ||
-      !name.startsWith("create") ||
-      !name.endsWith(params.suffix)
-    ) {
-      continue;
-    }
-    let candidate: unknown;
-    try {
-      candidate = exported();
-    } catch (error) {
-      errors.push(error);
-      continue;
-    }
-    if (params.isProvider(candidate)) {
-      providers.push(candidate);
-    }
-  }
-  return { providers, errors };
-}
-
-function unableToInitializeProviderError(params: {
-  pluginId: string;
-  errors: readonly unknown[];
-}): Error {
-  return new Error(`Unable to initialize web providers for plugin ${params.pluginId}`, {
-    cause: params.errors.length === 1 ? params.errors[0] : new AggregateError(params.errors),
-  });
-}
-
-function loadBundledProviderEntriesFromDir<TProvider extends object>(params: {
-  dirName: string;
-  pluginId: string;
-  artifactCandidates: readonly string[];
-  suffix: string;
-  isProvider: (value: unknown) => value is TProvider;
-}): Array<TProvider & { pluginId: string }> | null {
-  const mod = loadBundledPluginPublicArtifactModuleFromCandidatesSync<Record<string, unknown>>({
-    dirName: params.dirName,
-    artifactCandidates: params.artifactCandidates,
-  });
-  if (!mod) {
-    return null;
-  }
-  const { providers, errors } = collectProviderFactories({
-    mod,
-    suffix: params.suffix,
-    isProvider: params.isProvider,
-  });
-  if (providers.length === 0) {
-    if (errors.length > 0) {
-      throw unableToInitializeProviderError({
-        pluginId: params.pluginId,
-        errors,
-      });
-    }
-    return null;
-  }
-  return providers.map((provider) => Object.assign({}, provider, { pluginId: params.pluginId }));
-}
-
 function resolveBundledExplicitProviders<TProvider>(params: {
   onlyPluginIds: readonly string[];
   loadProviders: (pluginId: string) => TProvider[] | null;
@@ -136,11 +64,12 @@ export function loadBundledWebSearchProviderEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebSearchProviderEntry[] | null {
-  return loadBundledProviderEntriesFromDir<WebSearchProviderPlugin>({
+  return loadBundledPublicArtifactEntries({
     ...params,
     artifactCandidates: WEB_SEARCH_ARTIFACT_CANDIDATES,
     suffix: "WebSearchProvider",
-    isProvider: (value): value is WebSearchProviderPlugin => isWebProviderPlugin(value),
+    isArtifact: (value): value is WebSearchProviderPlugin => isWebProviderPlugin(value),
+    partialFailureLabel: "web providers",
   });
 }
 
@@ -148,11 +77,12 @@ export function loadBundledWebFetchProviderEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebFetchProviderEntry[] | null {
-  return loadBundledProviderEntriesFromDir<WebFetchProviderPlugin>({
+  return loadBundledPublicArtifactEntries({
     ...params,
     artifactCandidates: WEB_FETCH_ARTIFACT_CANDIDATES,
     suffix: "WebFetchProvider",
-    isProvider: (value): value is WebFetchProviderPlugin => isWebProviderPlugin(value),
+    isArtifact: (value): value is WebFetchProviderPlugin => isWebProviderPlugin(value),
+    partialFailureLabel: "web providers",
   });
 }
 
@@ -160,11 +90,12 @@ function loadBundledRuntimeWebFetchProviderEntriesFromDir(params: {
   dirName: string;
   pluginId: string;
 }): PluginWebFetchProviderEntry[] | null {
-  return loadBundledProviderEntriesFromDir<WebFetchProviderPlugin>({
+  return loadBundledPublicArtifactEntries({
     ...params,
     artifactCandidates: WEB_FETCH_RUNTIME_ARTIFACT_CANDIDATES,
     suffix: "WebFetchProvider",
-    isProvider: (value): value is WebFetchProviderPlugin => isWebProviderPlugin(value),
+    isArtifact: (value): value is WebFetchProviderPlugin => isWebProviderPlugin(value),
+    partialFailureLabel: "web providers",
   });
 }
 


### PR DESCRIPTION
## What Problem This Solves

Provider and document/web-extractor public artifacts repeat factory discovery and entry-loading logic. Separate implementations make deterministic initialization order and failure handling harder to maintain across those surfaces.

## Why This Change Was Made

Use one ordered zero-argument factory scanner and one typed entry loader. Preserve each surface's artifact candidates and validation predicate, document/web providers' partial-failure recovery, and provider-contract/web-content fail-fast behavior. Keep loading on the public artifact path without activating plugin runtime.

## User Impact

No intended behavior change. Four scanner implementations become one and three entry loaders become one, removing 90 production code lines without deleting tests or compatibility surfaces.

## Evidence

- 1,740 differential comparisons of outputs, initialization order, and nested error causes passed again against the rebased main implementation.
- All 40 existing boundary tests passed again on the final head.
- Fresh independent P2 review: no actionable findings.
- Normal `pnpm build` passed all 16 phases, including 90 external plugins, 53 native control-plane loads, and 152 SDK subpaths. Owned source files, loader/type dependencies, and package/lock inputs remained unchanged across the mechanical rebase.
- All 28 final-head changed-check stages and exact-head CI passed.
