### PR TITLE
fix(test): restore custodian UUID mocks under Bun

### DIFF
--- a/ui/src/pages/custodian/custodian-page-agent-create.test.ts
+++ b/ui/src/pages/custodian/custodian-page-agent-create.test.ts
@@ -7,6 +7,7 @@ import type {
   ApplicationGateway,
   ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
+import * as uuid from "../../lib/uuid.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { CustodianSessionStore } from "./custodian-session-store.ts";
@@ -96,7 +97,7 @@ async function mountPage(context: ApplicationContext): Promise<TestCustodianPage
 
 describe("custodian new-agent flow", () => {
   beforeEach(() => {
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+    vi.spyOn(uuid, "generateUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
   });
 
   afterEach(() => {

--- a/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
+++ b/ui/src/pages/custodian/custodian-page.channel-onboarding.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { ChannelsStatusSnapshot } from "../../api/types.ts";
 import { channelSnapshotEntryIsActive, createChannelCapability } from "../../lib/channels/index.ts";
+import * as uuid from "../../lib/uuid.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
@@ -21,7 +22,7 @@ function channelSnapshot(patch: Partial<ChannelsStatusSnapshot> = {}): ChannelsS
 
 describe("custodian channel onboarding", () => {
   beforeEach(() => {
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+    vi.spyOn(uuid, "generateUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
   });
 
   afterEach(() => {

--- a/ui/src/pages/custodian/custodian-page.history.test.ts
+++ b/ui/src/pages/custodian/custodian-page.history.test.ts
@@ -2,12 +2,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import * as uuid from "../../lib/uuid.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
 describe("custodian page history", () => {
   beforeEach(() => {
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+    vi.spyOn(uuid, "generateUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
   });
 
   afterEach(() => {

--- a/ui/src/pages/custodian/custodian-page.nudges.test.ts
+++ b/ui/src/pages/custodian/custodian-page.nudges.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayRequestError, type GatewayBrowserClient } from "../../api/gateway.ts";
+import * as uuid from "../../lib/uuid.ts";
 import { QUICK_ACTIONS_QUESTION } from "../../test-helpers/custodian-quick-actions.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
@@ -17,7 +18,7 @@ function rejectAfterSend(
 
 describe("custodian page nudges", () => {
   beforeEach(() => {
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+    vi.spyOn(uuid, "generateUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
   });
 
   afterEach(() => {

--- a/ui/src/pages/custodian/custodian-page.test.ts
+++ b/ui/src/pages/custodian/custodian-page.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import * as uuid from "../../lib/uuid.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
 
@@ -10,7 +11,7 @@ describe("custodian page", () => {
     // A persisted companion id would turn every mount into a rejoin candidate;
     // tests exercising the rejoin path seed the key explicitly instead.
     localStorage.clear();
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+    vi.spyOn(uuid, "generateUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
     window.history.replaceState({}, "", "/");
   });
 

--- a/ui/src/pages/custodian/custodian-transcript-status.test.ts
+++ b/ui/src/pages/custodian/custodian-transcript-status.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as uuid from "../../lib/uuid.ts";
 import { QUICK_ACTIONS_QUESTION } from "../../test-helpers/custodian-quick-actions.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { createContext, mountPage } from "./custodian-page.test-harness.ts";
@@ -16,7 +17,7 @@ function deferred<T>() {
 describe("custodian transcript status", () => {
   beforeEach(() => {
     localStorage.clear();
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
+    vi.spyOn(uuid, "generateUUID").mockReturnValue("00000000-0000-4000-8000-000000000001");
   });
 
   afterEach(() => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where custodian UI tests leaked a deterministic UUID mock into later tests under Bun, causing session identity regeneration checks to fail.

## Why This Change Was Made

Mock the existing project-owned UUID function in six test producers. Bun's inherited native crypto method cannot be restored reliably by the previous spy; the existing module boundary supports normal per-test restoration.

## User Impact

No production behavior changes. The UI tests retain their deterministic IDs without affecting later session identity tests.

## Evidence

- In the original campaign file order, Bun changed from 58 passes and two failures to all 60 passing. Node passed all 60 before and after repair.
- All 80 sibling tests in the six producer files pass on both runtimes.
- Complete changed-file gate and independent P0–P2 review pass.
- Production code, assertions, cleanup scope, and timeout limits are unchanged. The wider Bun campaign remains in progress.
