### PR TITLE
fix(state): identify slow database open warning emitters

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -302,6 +302,13 @@ monotonic clock after lease acquisition. Live cache hits remain quiet. These
 are elapsed durations, including asynchronous waits, rather than CPU time or
 proof that the main event loop was blocked for the whole interval.
 
+The structured warning also includes `pid`, Node's `threadId`, and `isMainThread`
+for the opener emitting it. Inspect each `openclaw logs --json` event's original
+`raw` record; ordinary console text omits structured metadata.
+An opener on the main thread may have awaited an integrity Worker, so these
+fields do not identify the thread performing every phase. Correlate the process
+ID with the log timestamp and current process; PIDs can be reused after exit.
+
 ### Slow reply preparation
 
 When a reply spends a long time preparing, inspect the normal Gateway logs:

--- a/src/state/openclaw-agent-db-lifecycle.ts
+++ b/src/state/openclaw-agent-db-lifecycle.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import type { DatabaseSync } from "node:sqlite";
+import { isMainThread, threadId } from "node:worker_threads";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { setSqliteBusyTimeout } from "../infra/sqlite-busy-timeout.js";
@@ -83,6 +84,9 @@ export function startAgentDatabaseOpenTiming(agentId: string, pathname: string) 
         agentId,
         elapsedMs,
         path: pathname,
+        pid: process.pid,
+        threadId,
+        isMainThread,
         phaseDurationsMs,
         thresholdMs: OPENCLAW_AGENT_DB_SLOW_OPEN_MS,
       });

--- a/src/state/openclaw-agent-db.open-timing.test.ts
+++ b/src/state/openclaw-agent-db.open-timing.test.ts
@@ -1,4 +1,5 @@
 import { performance } from "node:perf_hooks";
+import { isMainThread, threadId } from "node:worker_threads";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import * as sqlite from "../infra/node-sqlite.js";
@@ -107,6 +108,9 @@ describe("agent database open timings", () => {
       agentId: options.agentId,
       elapsedMs: 1_000,
       path: pathname,
+      pid: process.pid,
+      threadId,
+      isMainThread,
       thresholdMs: 1_000,
       phaseDurationsMs: {
         open: 60,
@@ -138,6 +142,9 @@ describe("agent database open timings", () => {
       agentId: options.agentId,
       elapsedMs: 1_150,
       path: pathname,
+      pid: process.pid,
+      threadId,
+      isMainThread,
       thresholdMs: 1_000,
       phaseDurationsMs: {
         open: 60,
@@ -195,6 +202,9 @@ describe("agent database open timings", () => {
         agentId: options.agentId,
         elapsedMs: 1_310,
         path: pathname,
+        pid: process.pid,
+        threadId,
+        isMainThread,
         thresholdMs: 1_000,
         phaseDurationsMs: {
           open: 60,


### PR DESCRIPTION
Related: #138125

## What Problem This Solves

Fixes an issue where operators could not attribute slow agent database open warnings when a Gateway, CLI process, or Worker wrote to the same log file. The existing phase durations and hostname did not identify the process and thread emitting each warning.

## Why This Change Was Made

The existing completed-open warning now includes `pid`, `threadId`, and `isMainThread` directly from Node's runtime. This follows the existing SQLite warning convention for `pid` and adds the explicit main-thread flag rather than requiring consumers to infer it from a thread-number convention. The shared opener, timing checkpoints, threshold, lease ownership, and cleanup remain unchanged.

## User Impact

Operators can correlate a warning with the current process and distinguish a Worker emitter sharing that PID. The logging guide explains how to inspect the structured record through `openclaw logs --json`.

These fields identify the emitting opener. A main-thread opener may have awaited a separate integrity Worker; the fields do not identify the thread performing every phase or turn elapsed validation time into main-thread CPU/blocking time. PIDs should be interpreted with timestamps and current process state because they can be reused.

## Evidence

- On unchanged production, three existing timing cases fail only because the identity fields are absent; below-threshold silence passes. The candidate passes all 55 timing, admission, and cache-eviction tests, preserving coalescing, phase totals, thresholds, and cache-hit behavior.
- Native Node 26.7 proof performs real SQLite-contended opens first on a process's main thread, then in an actual Worker in that same process. Each open has two coalesced callers and one completed warning. Expected PID comes from the controller's child handle; expected Worker ID comes from its parent's Worker handle. Baseline records omit identity; candidate records distinguish main and Worker while retaining the same PID and correctly partitioned elapsed durations.
- Both native runs close all four child processes and the Worker normally, leave no process groups, use no forced cleanup, and remove their isolated fixtures. There are no clock, database, logging, or identity mocks in the native proof. This proves emitter provenance, not a performance improvement or production stall cause.
- Production adds four lines; reversing only that import and the three fields restores the existing owner byte-for-byte. No new helper, dependency, setting, schema, timer, or registry is introduced. Independent review is clean through P2, and focused MDX validation passes.
- The required Linux changed-file gate passed, including core/core-test types, lint, dead exports, database guards, and runtime import cycles. Its owned Testbox stopped after success. Exact-head hosted CI follows publication.
