### PR TITLE
fix(daemon): restore Doctor maintenance with legacy launchctl output

### DIFF
--- a/src/daemon/launchd-runtime.ts
+++ b/src/daemon/launchd-runtime.ts
@@ -221,10 +221,14 @@ export function parseLaunchAgentEnabled(output: string, label: string): boolean 
       continue;
     }
     const state = entry.slice(labelPrefix.length).trim();
-    if (state === "=> enabled") {
+    if (state === "=> enabled" || state === "=> false") {
+      // macOS 13+ prints "=> enabled"; macOS 12 prints the boolean
+      // "=> false" (disabled=false, i.e. enabled).
       return true;
     }
-    if (state === "=> disabled") {
+    if (state === "=> disabled" || state === "=> true") {
+      // macOS 13+ prints "=> disabled"; macOS 12 prints "=> true"
+      // (disabled=true, i.e. disabled).
       return false;
     }
     throw new Error(`launchctl print-disabled returned an unrecognized state for ${label}`);

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -760,6 +760,8 @@ describe("launchd runtime parsing", () => {
   it.each([
     ['disabled services = {\n\t"ai.openclaw.gateway" => enabled\n}', true],
     ['disabled services = {\n\t"ai.openclaw.gateway" => disabled\n}', false],
+    ['disabled services = {\n\t"ai.openclaw.gateway" => false\n}', true],
+    ['disabled services = {\n\t"ai.openclaw.gateway" => true\n}', false],
     ['disabled services = {\n\t"other.service" => disabled\n}', true],
   ])("parses the LaunchAgent enabled override", (output, expected) => {
     expect(parseLaunchAgentEnabled(output, "ai.openclaw.gateway")).toBe(expected);


### PR DESCRIPTION
Closes #139109. Supersedes #139213 with its original contributor ancestry and credit preserved. Thanks @NovaUnboundAi for the report and @gaoanze888 for the original fix.

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` on macOS 12 would fail before maintenance because launchctl reports a boolean disabled state. The same parser also owns update maintenance and Doctor's disabled-service diagnosis.

## Why This Change Was Made

Normalize both observed representations in the existing launchd parser: `false` means enabled and `true` means disabled. Keyword states, absent overrides, command failures, and unknown-state errors retain their existing behavior. Reuse the owner's existing sleep helper for its stopped-state poll.

This is the identical reviewed candidate from #139213. Its fork PR retained an old GitHub base projection after the maintainer update, exposing 3,137 upstream files to review and dependency CI despite a two-file Git diff against current main. The native wrapper correctly refused the incomplete 3,000-file API response. This maintainer PR gives that same fix a current base without bypassing the scope check or rewriting contributor ancestry.

## User Impact

Doctor and update maintenance can inspect older macOS launchd states. Enabled services resume after repair; deliberately disabled services remain offline. No configuration, schema, protocol, or dependency changes.

## Evidence

`git diff --numstat` against the source base:

| Area | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 3 | 5 | -2 |
| Tests | 2 | 0 | +2 |

Both new boolean regression fixtures failed before the repair with `launchctl print-disabled returned an unrecognized state`; existing keyword/absent-override cases passed. Afterward, 176 tests passed across the daemon, Doctor disabled-service, and update-maintenance suites (25 existing platform skips). `node scripts/check-changed.mjs -- src/daemon/launchd-runtime.ts src/daemon/launchd.test.ts` passed, including core/test types, lint, and guards. Local and branch autoreview passes had no accepted findings through P2.

Remote regression/check proof: Blacksmith Testbox lease `tbx_01m1tmd047tcf1d1ebp1xecmf1`, [Actions run](https://github.com/openclaw/openclaw/actions/runs/34015061949). The run returned exit 0; the lease was stopped after proof. The local wrapper initially found an incompatible shared Vitest installation, so the focused proof used the hydrated Testbox runtime.

### Platform contract

Apple's [launchctl(1) CAVEATS](https://keith.github.io/xcode-man-pages/launchctl.1.html#CAVEATS) explicitly say newer subcommands have no stable output format/API. Both observed representations are normalized in the existing launchd parser; unknown states still fail.

| Version | Published evidence |
| --- | --- |
| macOS 12 Monterey | [NIST report with native true/false output](https://github.com/usnistgov/macos_security/issues/167), [Monterey check](https://github.com/usnistgov/macos_security/blob/monterey/rules/os/os_httpd_disable.yaml#L8), and #139109's macOS 12.7.6/21H1320 `=> false` output. |
| macOS 13 Ventura | The same NIST report documents the change to enabled/disabled on 13 beta 22A5331f; [stable 13.1 output](https://github.com/docker/for-mac/issues/6661) corroborates both keywords. |
| macOS 14 Sonoma | [Maintained NIST check](https://github.com/usnistgov/macos_security/blob/sonoma/rules/os/os_httpd_disable.yaml#L8) matches `=> disabled`. |
| macOS 15 Sequoia | [Maintained NIST check](https://github.com/usnistgov/macos_security/blob/sequoia/rules/os/os_httpd_disable.yaml#L9) matches `=> enabled`. |

### Remote real-flow proof

Crabbox SSH provider, task lease `static_[host-redacted]`, native macOS 27.0/26A5421a arm64, Node 26.8.1. Static SSH has no hosted run URL (`portal=- logs=-`); opaque run IDs below identify the retained local transcripts. Published package installation: `run_deefadcf8195`; before-fix real-flow proof: `run_9d753c2c5d3f`.

Installed npm `openclaw@2026.9.2` (`3928bad`). Each attempt used a fresh canonical named profile/state directory created with `mktemp`, an explicit matching `OPENCLAW_STATE_DIR`, a unique derived launchd label, a free loopback port, and synthetic config. No default Gateway/state was used. The harness verified native launchd PID and `/healthz` and removed its task service/plist/state afterward.

Legacy-format proof executes real `launchctl print-disabled` and converts only printed state words (`enabled`→`false`, `disabled`→`true`). A task-only Node preload routes only that subprocess to the formatter, and a marker verifies its use. All other service/Gateway operations are native. This proves the Doctor boundary with simulated legacy output on macOS 27; no native macOS 12 machine was available.

Before-fix transcript:

```text
OpenClaw 2026.9.2 (3928bad)
gateway install: exit 0
native keyword doctor --fix --non-interactive: exit 0
Stopped the managed Gateway for Doctor repair.
Doctor complete.
PID changed: 45127 -> 51377
legacy output: "ai.openclaw.<task-profile>" => false
legacy doctor --fix --non-interactive: exit 1
Doctor could not enter maintenance. ... launchctl print-disabled returned an unrecognized state for ai.openclaw.<task-profile>
legacy formatter calls: 1
PID unchanged: 51377; /healthz: 200
cleanup: task service absent
```

After-fix build and transcript:

`pnpm install --frozen-lockfile` and full `pnpm build` passed remotely. Source tree matches candidate `88eb8d3f385beddfa78c4a21e83c7cc54a6d28ca` exactly; the build's embedded baseline stamp remains `5579546` because that baseline plus the reviewed patch was synced before the commit existed. Both changed-file SHA256 hashes were verified after sync and again before the final run.

Final combined run: `run_7ce6de2899e0` — exit 0, 77.049s.

```text
gateway install: exit 0
native keyword doctor --fix --non-interactive: exit 0
Stopped the managed Gateway for Doctor repair.
Doctor complete.
PID changed: 22238 -> 26278
legacy false doctor --fix --non-interactive: exit 0
Stopped the managed Gateway for Doctor repair.
Doctor complete.
PID changed: 26278 -> 29220; /healthz: 200
loaded/offline fixture: KeepAlive=false; native=>disabled; legacy=>true
legacy true doctor --fix --non-interactive: exit 0
native disabled doctor --fix --non-interactive: exit 0
offline state preserved: no PID, unchanged plist bytes
legacy formatter calls: 5
PROOF_PASS candidate-final
cleanup: task service absent
```

The offline fixture keeps the real task service registered after native disable+SIGTERM by setting only its own plist's KeepAlive=false. An earlier fixture setup attempted bootstrap before asynchronous bootout completed; the harness now waits for exact-label removal. The subsequent offline-only run `run_6ccca67b3a17` and the complete final run above passed. No product retry or timeout changed.

Follow-up: No additional owner refactor is justified; the parser stays centralized and the duplicate polling timer already uses its existing shared helper.
