### PR TITLE
fix(test): keep invalid fixture JSON diagnostics bounded

### DIFF
--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -35,14 +35,18 @@ function assertAgentsDeleteResult([outputPath, agentsPath]) {
       )}`,
     );
   }
+  const outputText = fs.readFileSync(resolvedOutputPath, "utf8");
   let parsed;
   try {
-    parsed = readJson(resolvedOutputPath);
-  } catch (error) {
-    console.error("agents delete --json did not emit valid JSON:");
-    console.error(readTextFileTail(resolvedOutputPath, ERROR_DETAIL_TAIL_BYTES).trim());
-    const message = error instanceof Error ? error.message.split("\n").at(0) : String(error);
-    throw new Error(`agents delete --json parse failed: ${message}`, { cause: error });
+    parsed = JSON.parse(outputText);
+  } catch {
+    // Parser messages and causes can echo input outside the approved diagnostic tail.
+    throw new Error(
+      `agents delete --json did not emit valid JSON: ${resolvedOutputPath}\nstdout tail=${readTextFileTail(
+        resolvedOutputPath,
+        ERROR_DETAIL_TAIL_BYTES,
+      ).trim()}`,
+    );
   }
   /** @type {Array<[unknown, unknown, string]>} */
   const comparisons = [

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -113,7 +113,9 @@ describe("workspace fixture assertions", () => {
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("agents delete --json did not emit valid JSON");
     expect(result.stderr).toContain("recent invalid json tail");
-    expect(result.stderr).not.toContain("DO_NOT_DUMP_OLD_INVALID_JSON");
+    // Node can quote only a short input prefix, while Bun includes more of the same marker.
+    expect(result.stderr).not.toContain("DO_NOT_");
+    expect(result.stderr).toContain(outputPath);
   });
 
   it("rejects an agents delete result that explicitly reports local transport", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where invalid JSON from a fixture command could be repeated outside its bounded diagnostic tail through an engine-generated parser message or error cause.

## Why This Change Was Made

Report the output path and existing bounded tail without forwarding raw parser details. Keep filesystem read errors separate from JSON syntax errors.

## User Impact

Failed fixture assertions retain useful output context while respecting the existing diagnostic bound on Node and Bun.

## Evidence

- The strengthened existing invalid-JSON regression failed on both runtimes before repair.
- All nine workspace and neighboring dispatcher tests pass on Node and true Bun afterward.
- Complete changed-file gate and independent P0–P2 review pass.
- The wider Bun campaign remains in progress.
