### PR TITLE
fix(discord): preserve system-control handoffs through message preflight

### DIFF
--- a/extensions/discord/src/monitor/message-handler.preflight-context.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight-context.ts
@@ -10,6 +10,7 @@ type SharedPreflightFields =
   | "accountId"
   | "token"
   | "runtime"
+  | "buildContext"
   | "botUserId"
   | "abortSignal"
   | "guildHistories"
@@ -40,6 +41,7 @@ export function buildDiscordMessagePreflightContext({
     accountId: preflightParams.accountId,
     token: preflightParams.token,
     runtime: preflightParams.runtime,
+    buildContext: preflightParams.buildContext,
     botUserId: preflightParams.botUserId,
     abortSignal: preflightParams.abortSignal,
     guildHistories: preflightParams.guildHistories,

--- a/extensions/discord/src/monitor/message-handler.preflight.test.ts
+++ b/extensions/discord/src/monitor/message-handler.preflight.test.ts
@@ -45,6 +45,7 @@ import {
   registerSessionBindingAdapter,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";
+import { buildDiscordMessageProcessContext } from "./message-handler.context.js";
 import {
   createDiscordMessage,
   createDiscordPreflightArgs,
@@ -381,6 +382,58 @@ describe("preflightDiscordMessage", () => {
     handleDiscordDmCommandDecisionMock.mockReset();
     handleDiscordDmCommandDecisionMock.mockResolvedValue(undefined);
   });
+
+  it.each(["guild", "direct"] as const)(
+    "uses the supplied host context builder after %s message preflight",
+    async (conversationKind) => {
+      const channelId = `host-context-${conversationKind}`;
+      const message = createDiscordMessage({
+        id: `host-context-message-${conversationKind}`,
+        channelId,
+        content: "hello <@openclaw-bot>",
+        mentionedUsers: [{ id: "openclaw-bot" }],
+        author: { id: "123456789012345678", bot: false, username: "alice" },
+      });
+      const hostBoundaryError = new Error("host context authority is no longer active");
+      const buildContext: NonNullable<
+        Parameters<typeof preflightDiscordMessage>[0]["buildContext"]
+      > = () => {
+        throw hostBoundaryError;
+      };
+      const ctx = expectPreflightResult(
+        await preflightDiscordMessage({
+          ...createPreflightArgs({
+            cfg: DEFAULT_PREFLIGHT_CFG,
+            discordConfig: { dmPolicy: "open" },
+            data:
+              conversationKind === "guild"
+                ? createGuildEvent({
+                    channelId,
+                    guildId: "host-context-guild",
+                    author: message.author,
+                    message,
+                  })
+                : ({
+                    channel_id: channelId,
+                    author: message.author,
+                    message,
+                  } as DiscordMessageEvent),
+            client:
+              conversationKind === "guild"
+                ? createGuildTextClient(channelId)
+                : createDmClient(channelId),
+          }),
+          buildContext,
+        }),
+      );
+
+      // Processing must enter the host's builder, including its authority checks.
+      await expect(
+        buildDiscordMessageProcessContext({ ctx, text: message.content ?? "", mediaList: [] }),
+      ).rejects.toBe(hostBoundaryError);
+      expect(ctx.buildContext).toBe(buildContext);
+    },
+  );
 
   it("admits embed-only messages when their text appears after a textless first embed", async () => {
     const channelId = "dm-channel-multiple-embeds";


### PR DESCRIPTION
Related: #138869 (same reported symptom; this PR covers Discord only).
Related: #139620 (preserves Gateway delegation through later reply-context copies).
Related: #139854 (registered channel ownership and resolver lifetime).

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users requesting a system-control handoff from Discord would encounter `delegated OpenClaw approval requires an active run authority` even when the Gateway and the session were running. Both guild messages and DMs can lose the handoff context before agent execution.

## Why This Change Was Made

Forward the existing host-injected `buildContext` through Discord message preflight so processing enters the registered builder and its authority checks. This follows the [channel ingress contract](https://docs.openclaw.ai/plugins/sdk-channel-plugins#inbound-ingress-experimental): the standalone public builder cannot substitute for the registered host builder.

This repair covers the Discord preflight boundary. The later context-copy repair in #139620 and the registry ownership repair in #139854 address other points in the same handoff path; this PR does not change plugin trust or approval policy.

## User Impact

Discord messages retain the host context needed for an authorized handoff, and the host's existing authority checks still run. Operators do not need to broaden permissions for this fix.

## Evidence

- On upstream base `6f32397ce3`, both new guild/DM regressions fail: actual processing bypasses the supplied host builder. With this patch, both enter that builder and propagate its exact rejection sentinel.
- `pnpm test:extension discord`: **3,395 tests passed across 247 files**.
- `node scripts/check-changed.mjs`: passed, including extension/source test type checks, lint, and import-cycle checks. Required autoreview: no actionable P0 findings.
- The operator confirmed that the original failing Discord handoff succeeded after deploying this change together with #139620 and the registry ownership repair in #139854 on a source-checkout Gateway. That live result validates the combined deployment; the automated regressions isolate this PR's builder-forwarding behavior.
