### PR TITLE
fix(test): preserve Node tool contracts with a Bun runner

### DIFF
--- a/src/security/install-policy.test.ts
+++ b/src/security/install-policy.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { requireNodeTool } from "../../test/helpers/node-toolchain.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -195,7 +196,7 @@ describe("runInstallPolicy", () => {
         },
       },
       env: {
-        PATH: path.dirname(process.execPath),
+        PATH: path.dirname(requireNodeTool("node")),
       },
       request: baseRequest(sourceDir),
     });

--- a/test/helpers/node-toolchain.ts
+++ b/test/helpers/node-toolchain.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import { resolveExecutablePath } from "../../src/infra/executable-path.js";
+
+/** Resolve explicit Node tools instead of substituting the test runner's runtime. */
+export function requireNodeTool(command: "node" | "npm"): string {
+  const executable = resolveExecutablePath(command);
+  if (!executable) {
+    throw new Error(`Node tool fixture requires ${command} on PATH.`);
+  }
+  return path.resolve(executable);
+}
+
+/** Keep Node's strip-only parser while callers execute the JavaScript in their own runtime. */
+export function stripNodeTypeScriptTypes(source: string): string {
+  return execFileSync(
+    requireNodeTool("node"),
+    [
+      "--disable-warning=ExperimentalWarning",
+      "--input-type=module",
+      "--eval",
+      'import { readFileSync } from "node:fs"; import { stripTypeScriptTypes } from "node:module"; process.stdout.write(stripTypeScriptTypes(readFileSync(0, "utf8")));',
+    ],
+    { encoding: "utf8", input: source },
+  );
+}

--- a/test/scripts/check-script-erasability.test.ts
+++ b/test/scripts/check-script-erasability.test.ts
@@ -1,11 +1,31 @@
 // Script erasability tests cover Node's transformation-free TypeScript boundary.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { checkScriptErasability } from "../../scripts/check-script-erasability.mjs";
+import type { checkScriptErasability } from "../../scripts/check-script-erasability.mjs";
+import { requireNodeTool } from "../helpers/node-toolchain.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
+
+function checkNodeScriptErasability(root: string): ReturnType<typeof checkScriptErasability> {
+  // Only Node's strip-only parser can prove this contract, even with a Bun test runner.
+  const checkerUrl = new URL("../../scripts/check-script-erasability.mjs", import.meta.url).href;
+  const output = execFileSync(
+    requireNodeTool("node"),
+    [
+      "--disable-warning=ExperimentalWarning",
+      "--input-type=module",
+      "--eval",
+      `import { checkScriptErasability } from ${JSON.stringify(checkerUrl)};
+       console.log(JSON.stringify(checkScriptErasability(process.argv[1])));`,
+      root,
+    ],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(output);
+}
 
 function writeScriptsTree(files: Record<string, string>): string {
   const scriptsRoot = path.join(createTempDir("openclaw-script-erasability-"), "scripts");
@@ -36,7 +56,7 @@ describe("check-script-erasability", () => {
       "node_modules/example/index.ts": "enum DependencyOutput { Ready }",
     });
 
-    expect(checkScriptErasability(scriptsRoot)).toEqual({ checkedFiles: 2, errors: [] });
+    expect(checkNodeScriptErasability(scriptsRoot)).toEqual({ checkedFiles: 2, errors: [] });
   });
 
   it("rejects transform-required syntax in deterministic file order", () => {
@@ -45,7 +65,7 @@ describe("check-script-erasability", () => {
       "a-runtime-enum.cts": "enum State { Ready }",
     });
 
-    const result = checkScriptErasability(scriptsRoot);
+    const result = checkNodeScriptErasability(scriptsRoot);
 
     expect(result.checkedFiles).toBe(2);
     expect(result.errors.map(({ file, line }) => ({ file, line }))).toEqual([
@@ -58,7 +78,7 @@ describe("check-script-erasability", () => {
 
   it("accepts the repository scripts tree", () => {
     const scriptsRoot = path.resolve(import.meta.dirname, "../../scripts");
-    const result = checkScriptErasability(scriptsRoot);
+    const result = checkNodeScriptErasability(scriptsRoot);
 
     expect(result.checkedFiles).toBeGreaterThan(0);
     expect(result.errors).toEqual([]);

--- a/test/scripts/codex-install-assertions.test.ts
+++ b/test/scripts/codex-install-assertions.test.ts
@@ -997,7 +997,7 @@ describe("Codex install helpers", () => {
     const result = runCodexOnDemandAssertions(root);
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("Unexpected non-whitespace character after JSON");
+    expect(result.stderr).toMatch(/SyntaxError:.*JSON/u);
   });
 
   it("accepts SQLite-backed session and Codex binding state in the npm live assertion", () => {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { isSupportedOpenClawNodeVersion } from "../../node-version.mjs";
+import { requireNodeTool } from "../helpers/node-toolchain.js";
 import { NODE_RELEASE_VERSION_CASES } from "../helpers/node-version-cases.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { createInstallGitCommitFixtureScript } from "./install-git-fixtures.js";
@@ -29,6 +30,7 @@ import {
 import { linkPnpmBootstrapShellTools } from "./test-helpers.js";
 
 const SCRIPT_PATH = "scripts/install-cli.sh";
+const nodeExecutable = requireNodeTool("node");
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runInstallCliShell(script: string, env: NodeJS.ProcessEnv = {}) {
@@ -51,7 +53,7 @@ function linkRequiredShellTools(bin: string) {
 function linkNodeExecutable(nodeDir: string) {
   const bin = join(nodeDir, "bin");
   mkdirSync(bin, { recursive: true });
-  symlinkSync(process.execPath, join(bin, "node"));
+  symlinkSync(nodeExecutable, join(bin, "node"));
 }
 
 function writeInstalledOpenClawEntry(nodeDir: string) {
@@ -905,7 +907,7 @@ describe("install-cli.sh", () => {
       mkdirSync(join(repo, ".git"), { recursive: true });
       mkdirSync(join(repo, "dist"), { recursive: true });
       mkdirSync(otherRoot, { recursive: true });
-      symlinkSync(process.execPath, join(nodeDir, "bin", "node"));
+      symlinkSync(nodeExecutable, join(nodeDir, "bin", "node"));
       symlinkSync("node-v24.19.0", join(prefix, "tools", "node"));
       writeFileSync(
         join(nodeDir, "bin", "npm"),
@@ -1334,7 +1336,7 @@ HOOK
       writeFileSync(join(repo, "pnpm-lock.yaml"), "unchanged lock\n");
       writeFileSync(join(outer, "package.json"), '{"packageManager":"yarn@4.5.0"}');
       linkPnpmBootstrapShellTools(bin);
-      symlinkSync(process.execPath, join(bin, "node"));
+      symlinkSync(nodeExecutable, join(bin, "node"));
       const executable = (name: string, body: string) => {
         writeFileSync(join(bin, name), `#!/bin/bash\nset -eu\n${body}\n`);
         chmodSync(join(bin, name), 0o755);
@@ -1716,13 +1718,13 @@ HOOK
 
     mkdirSync(badBin, { recursive: true });
     mkdirSync(goodBin, { recursive: true });
-    symlinkSync(process.execPath, badNode);
+    symlinkSync(nodeExecutable, badNode);
     writeFileSync(
       goodNode,
       [
         "#!/bin/bash",
         'printf "%s\\n" "$*" >> "$GOOD_NODE_LOG"',
-        `exec ${JSON.stringify(process.execPath)} "$@"`,
+        `exec ${JSON.stringify(nodeExecutable)} "$@"`,
         "",
       ].join("\n"),
     );
@@ -2081,7 +2083,7 @@ HOOK
       const result = runInstallCliShell(
         [
           `source ${JSON.stringify(SCRIPT_PATH)}`,
-          `node_bin() { printf '%s\n' ${JSON.stringify(process.execPath)}; }`,
+          `node_bin() { printf '%s\n' ${JSON.stringify(nodeExecutable)}; }`,
           `result="$(npm_lifecycle_allow_arg ${JSON.stringify(npm)} openclaw@latest)"`,
           `printf '%s' "$result"`,
         ].join("\n"),
@@ -2092,7 +2094,7 @@ HOOK
       const tool = runInstallCliShell(
         [
           `source ${JSON.stringify(SCRIPT_PATH)}`,
-          `node_bin() { printf '%s\\n' ${JSON.stringify(process.execPath)}; }`,
+          `node_bin() { printf '%s\\n' ${JSON.stringify(nodeExecutable)}; }`,
           `npm_lifecycle_allow_arg ${JSON.stringify(npm)} pnpm@12.0.0 "$PWD" pnpm@12.0.0`,
         ].join("\n"),
         { NPM_FAKE_VERSION: version },
@@ -2115,7 +2117,7 @@ HOOK
         const result = runInstallCliShell(
           [
             `source ${JSON.stringify(SCRIPT_PATH)}`,
-            `node_bin() { printf '%s\n' ${JSON.stringify(process.execPath)}; }`,
+            `node_bin() { printf '%s\n' ${JSON.stringify(nodeExecutable)}; }`,
             `npm_lifecycle_allow_arg ${JSON.stringify(npm)} openclaw@latest`,
           ].join("\n"),
           { NPM_FAKE_ARGS: args, NPM_FAKE_VERSION: version },
@@ -2146,7 +2148,7 @@ HOOK
       const result = runInstallCliShell(
         [
           `source ${JSON.stringify(SCRIPT_PATH)}`,
-          `node_bin() { printf '%s\n' ${JSON.stringify(process.execPath)}; }`,
+          `node_bin() { printf '%s\n' ${JSON.stringify(nodeExecutable)}; }`,
           `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(spec)}`,
         ].join("\n"),
         { NPM_FAKE_VERSION: "12.0.0" },
@@ -2173,7 +2175,7 @@ HOOK
         const result = runInstallCliShell(
           [
             `source ${JSON.stringify(SCRIPT_PATH)}`,
-            `node_bin() { printf '%s\\n' ${JSON.stringify(process.execPath)}; }`,
+            `node_bin() { printf '%s\\n' ${JSON.stringify(nodeExecutable)}; }`,
             `cd ${JSON.stringify(commandCwd)}`,
             `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(spec)} "$PWD"`,
           ].join("\n"),
@@ -2201,7 +2203,7 @@ HOOK
         const result = runInstallCliShell(
           [
             `source ${JSON.stringify(SCRIPT_PATH)}`,
-            `node_bin() { printf '%s\\n' ${JSON.stringify(process.execPath)}; }`,
+            `node_bin() { printf '%s\\n' ${JSON.stringify(nodeExecutable)}; }`,
             `cd ${JSON.stringify(tmp)}`,
             `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(join(tmp, "candidate.tgz"))} "$PWD"`,
           ].join("\n"),
@@ -2231,7 +2233,7 @@ HOOK
       const result = runInstallCliShell(
         [
           `source ${JSON.stringify(SCRIPT_PATH)}`,
-          `node_bin() { printf '%s\\n' ${JSON.stringify(process.execPath)}; }`,
+          `node_bin() { printf '%s\\n' ${JSON.stringify(nodeExecutable)}; }`,
           `cd ${JSON.stringify(commandCwd)}`,
           `npm_lifecycle_allow_arg ${JSON.stringify(npm)} ${JSON.stringify(candidate)} "$PWD"`,
         ].join("\n"),

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { isSupportedOpenClawNodeVersion } from "../../node-version.mjs";
+import { requireNodeTool } from "../helpers/node-toolchain.js";
 import { NODE_RELEASE_VERSION_CASES } from "../helpers/node-version-cases.js";
 import { createInstallGitCommitFixtureScript } from "./install-git-fixtures.js";
 import {
@@ -29,6 +30,7 @@ import {
 import { linkPnpmBootstrapShellTools } from "./test-helpers.js";
 
 const SCRIPT_PATH = "scripts/install.sh";
+const nodeExecutable = requireNodeTool("node");
 
 function runInstallShell(script: string, env: NodeJS.ProcessEnv = {}) {
   const home = mkdtempSync(join(tmpdir(), "openclaw-install-home-"));
@@ -50,7 +52,7 @@ function runInstallShell(script: string, env: NodeJS.ProcessEnv = {}) {
 }
 
 function linkNodeExecutable(bin: string) {
-  symlinkSync(process.execPath, join(bin, "node"));
+  symlinkSync(nodeExecutable, join(bin, "node"));
 }
 
 describe("install.sh", () => {
@@ -1240,7 +1242,7 @@ NODE
         cat > "$bin/openclaw" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-exec ${process.execPath} $repo/dist/entry.js "\\$@"
+exec ${nodeExecutable} $repo/dist/entry.js "\\$@"
 EOF
         chmod +x "$bin/openclaw"
         fake_npm="$root/npm"
@@ -1305,7 +1307,7 @@ EOF
       cat > "$bin/openclaw" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
-exec ${process.execPath} $repo/dist/entry.js "\\$@"
+exec ${nodeExecutable} $repo/dist/entry.js "\\$@"
 EOF
       chmod +x "$bin/openclaw"
       cat > "$launcher" <<'EOF'
@@ -4376,7 +4378,7 @@ HOOK
       writeFileSync(join(repo, "pnpm-lock.yaml"), "unchanged lock\n");
       writeFileSync(join(outer, "package.json"), '{"packageManager":"yarn@4.5.0"}');
       linkPnpmBootstrapShellTools(bin);
-      symlinkSync(process.execPath, join(bin, "node"));
+      symlinkSync(nodeExecutable, join(bin, "node"));
       const executable = (name: string, body: string) => {
         writeFileSync(join(bin, name), `#!/bin/bash\nset -eu\n${body}\n`);
         chmodSync(join(bin, name), 0o755);
@@ -4631,15 +4633,18 @@ describe("install.sh macOS Homebrew Node behavior", () => {
     }
   });
 
-  it("gum spin preserves terminal stdin for direct interactive installs", () => {
-    // When needs_stdin_isolation returns false (direct interactive run),
-    // gum spin should NOT redirect stdin from /dev/null so that wrapped
-    // commands like Homebrew can still prompt the user via stdin.
+  it("gum spin preserves supplied stdin when isolation is disabled", () => {
+    // Force the non-isolating branch with known input, independently of the
+    // subprocess runtime's default stdin. This is inheritance proof, not a TTY probe.
     const dir = mkdtempSync(join(tmpdir(), "openclaw-install-sh-gum-stdin-"));
     try {
       const gumPath = join(dir, "gum");
       const commandPath = join(dir, "command");
       const stdinLog = join(dir, "stdin-source");
+      const stdinPath = join(dir, "stdin");
+      const inputLog = join(dir, "stdin-content");
+      const input = "spinner fixture input\n";
+      writeFileSync(stdinPath, input);
       // Gum stub: skip args up to and including "--", then run the rest
       writeFileSync(
         gumPath,
@@ -4654,26 +4659,32 @@ describe("install.sh macOS Homebrew Node behavior", () => {
 stdin_dev=$(stat -f '%d:%i' /dev/fd/0 2>/dev/null || stat -c '%d:%i' /dev/fd/0 2>/dev/null)
 null_dev=$(stat -f '%d:%i' /dev/null 2>/dev/null || stat -c '%d:%i' /dev/null 2>/dev/null)
 if [ "$stdin_dev" = "$null_dev" ]; then echo "devnull" > "${stdinLog}"; else echo "other" > "${stdinLog}"; fi
+cat > "${inputLog}"
 exit 0
 `,
         { mode: 0o755 },
       );
 
-      const result = runInstallShell(`
+      const result = runInstallShell(
+        `
         set -euo pipefail
+        exec < "$STDIN_FIXTURE_PATH"
         source "${SCRIPT_PATH}"
         # Override needs_stdin_isolation to return false (direct interactive)
         needs_stdin_isolation() { return 1; }
         gum_is_tty() { return 0; }
         GUM="${gumPath}"
         run_with_spinner "Installing node" "${commandPath}"
-      `);
+      `,
+        { STDIN_FIXTURE_PATH: stdinPath },
+      );
 
       // The gum spin command should NOT have redirected stdin from /dev/null
       expect(result.status).toBe(0);
       // Assert the child command's stdin was NOT /dev/null
       const observed = readFileSync(stdinLog, "utf8").trim();
       expect(observed).toBe("other");
+      expect(readFileSync(inputLog, "utf8")).toBe(input);
       expect(script).toContain("needs_stdin_isolation; then");
       expect(script).toContain(
         '"$GUM" spin --spinner dot --title "$title" -- "$@" >"$gum_out" 2>"$gum_err" || gum_status=$?',

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -9,10 +9,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { PLUGIN_NPM_RELEASE_AUTHORITY_PATHS } from "../../scripts/lib/plugin-publication-candidates.ts";
+import { requireNodeTool } from "../helpers/node-toolchain.js";
 
 const workflowPath = ".github/workflows/plugin-npm-release.yml";
 const metaPackagePath = "extensions/meta/package.json";
@@ -166,6 +167,8 @@ describe("plugin npm extended-stable workflow", () => {
   ])(
     "publishes the sealed artifact without a source install: $publishTag / identity $identityExit",
     ({ publishTag, identityExit }) => {
+      const nodeExecutable = requireNodeTool("node");
+      const npmCli = realpathSync(requireNodeTool("npm"));
       const root = mkdtempSync(join(tmpdir(), "plugin-oidc-artifact-"));
       try {
         const bin = join(root, "bin");
@@ -181,7 +184,7 @@ describe("plugin npm extended-stable workflow", () => {
         for (const command of ["node", "npm"]) {
           writeFileSync(
             join(bin, command),
-            `#!${process.execPath}
+            `#!${nodeExecutable}
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 if (${JSON.stringify(command)} === "npm") {
@@ -218,7 +221,7 @@ process.exit(${JSON.stringify(command)} === "node" ? Number(process.env.IDENTITY
               PATH: `${bin}:/usr/bin:/bin`,
               ...publish.env,
               EVENTS: events,
-              NPM_CLI: realpathSync(join(dirname(process.execPath), "npm")),
+              NPM_CLI: npmCli,
               RUNNER_TEMP: root,
               IDENTITY_EXIT: String(identityExit),
               TARBALL_PATH: tarball,

--- a/test/scripts/release-candidate-checklist.test.ts
+++ b/test/scripts/release-candidate-checklist.test.ts
@@ -11,7 +11,7 @@ import {
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { createRequire, stripTypeScriptTypes } from "node:module";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -51,6 +51,7 @@ import {
   validateTrustedToolingPin,
   validateWindowsSourceRelease,
 } from "../../scripts/release-candidate-checklist.mts";
+import { stripNodeTypeScriptTypes } from "../helpers/node-toolchain.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -154,7 +155,7 @@ describe("release candidate checklist", () => {
         pluginSdkApi: {},
       };
       // Run the real coordinator and evidence writers; unrelated remote release gates are fixtures.
-      const completion = runInNewContext(stripTypeScriptTypes(`${android}\n${main}\nmain();`), {
+      const completion = runInNewContext(stripNodeTypeScriptTypes(`${android}\n${main}\nmain();`), {
         process: { argv: [], cwd: () => targetRoot, env: {} },
         console: { log, warn: log },
         TOOLING_ROOT: "/trusted/tooling",
@@ -356,7 +357,7 @@ describe("release candidate checklist", () => {
       let childOutput = "";
       const execute = () =>
         runInNewContext(
-          stripTypeScriptTypes(
+          stripNodeTypeScriptTypes(
             `${jsonReader}\n${owner}\nrunFromTrustedTooling(argv, { targetRoot, workflowRef: "main" });`,
           ),
           {
@@ -438,7 +439,7 @@ describe("release candidate checklist", () => {
       JSON.stringify({ args, options, all: [{ packageName: "@openclaw/example" }], warnings }),
     );
     const result = runInNewContext(
-      stripTypeScriptTypes(
+      stripNodeTypeScriptTypes(
         `${summary}\n${owner}\ncollectPluginPlan("scripts/plugin-npm-release-plan.ts", {})`,
       ),
       {
@@ -1719,7 +1720,7 @@ describe("release candidate checklist", () => {
       }));
       // Execute the private owner and its real caller without exporting a test-only API.
       const result = (await runInNewContext(
-        stripTypeScriptTypes(
+        stripNodeTypeScriptTypes(
           `async function fixture() {\n${telegramOwner}\n${telegramCall}\nreturn npmTelegram;\n}\nfixture();`,
         ),
         {

--- a/test/scripts/test-report-utils.test.ts
+++ b/test/scripts/test-report-utils.test.ts
@@ -11,6 +11,7 @@ import {
   normalizeTrackedRepoPath,
 } from "../../scripts/test-report-utils.mts";
 import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
+import { requireNodeTool } from "../helpers/node-toolchain.js";
 import { runNodeScript } from "../helpers/run-node-script.js";
 
 const { spawnSyncMock } = vi.hoisted(() => ({
@@ -109,6 +110,13 @@ describe("scripts/test-report-utils runVitestJsonReport", () => {
     onTestFinished(() => lifetime.cleanup());
     await lifetime.run(async () => {
       const root = lifetime.createTempDir("oc-report-cli-");
+      const bin = path.join(root, "bin");
+      fs.mkdirSync(bin);
+      fs.symlinkSync(
+        requireNodeTool("node"),
+        path.join(bin, process.platform === "win32" ? "node.exe" : "node"),
+        "file",
+      );
       const repoRoot = process.cwd();
       const config = path.join(root, "vitest.config.mjs");
       const reportPath = path.join(root, "report.json");
@@ -134,7 +142,7 @@ assert.equal(runVitestJsonReport(${JSON.stringify({ config: path.join(root, "mis
           ["--import", path.join(repoRoot, "scripts/tsx.mjs"), entry],
           {
             ...process.env,
-            PATH: "",
+            PATH: bin,
             OPENCLAW_LIVE_USE_REAL_HOME: "0",
             TSX_TSCONFIG_PATH: path.join(repoRoot, "tsconfig.json"),
           },


### PR DESCRIPTION
## What Problem This Solves

Fixes script and installer test failures caused by treating the test runner executable as Node when the runner is Bun. Node-only parser contracts and fixtures that intentionally provide node or npm need those actual tools.

## Why This Change Was Made

Resolve explicit Node tools through the existing executable resolver. Run Node's strip-only parser in a Node child, then keep JavaScript execution in the caller's runtime. Preserve controlled PATH isolation and supply known stdin bytes to the existing inheritance fixture.

## User Impact

No production behavior changes. Developers can run the same tooling and installer coverage with a Bun test runner while still checking contracts that specifically belong to Node.

## Evidence

- 492 scoped checks pass with Node and with a true Bun outer runner: 187 script contracts, 292 installer cases, one benign policy PATH case, and 12 report/completion cases.
- After resolving the mainline completion-promise conflict and reconciling the locked dependencies, all 119 coordinator cases pass again on Node and true Bun. Main's new success/rejection handling is preserved.
- The complete nine-file changed gate and fresh full-candidate P0–P2 review pass. Initial local type errors came from stale installed Node types and disappeared after the normal frozen install; no baseline source change was needed.
- Node is used only for explicit Node parser and node/npm fixture contracts. General runtime and VM execution remain with the selected runner.
- Failure assertions, controlled PATH behavior, stdin inheritance, and installer checks are preserved. Engine-specific JSON wording was replaced with the retained nonzero and SyntaxError/JSON contract.
- The repository-wide Bun compatibility campaign remains in progress.
