### PR TITLE
fix(test): preserve error and tool planning coverage under Bun

### DIFF
--- a/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
+++ b/src/agents/embedded-agent-runner/tool-name-allowlist.test.ts
@@ -1,6 +1,6 @@
 // Tool-name allowlist tests cover session replay names, client tool conflict
 // checks, and Tool Search compaction visibility.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { findClientToolNameConflicts } from "../agent-tool-definition-adapter.js";
 import { createStubTool } from "../test-helpers/agent-tool-stubs.js";
 import {
@@ -9,6 +9,7 @@ import {
   createToolSearchCatalogRef,
   TOOL_SEARCH_CODE_MODE_TOOL_NAME,
 } from "../tool-search.js";
+import { testing } from "../tool-search.test-support.js";
 import type { ClientToolDefinition } from "./run/params.js";
 import {
   collectAllowedToolNames,
@@ -57,6 +58,8 @@ describe("tool name allowlists", () => {
   });
 
   it("keeps hidden core names available for client conflict admission", () => {
+    onTestFinished(() => testing.setToolSearchCodeModeSupportedForTest(undefined));
+    testing.setToolSearchCodeModeSupportedForTest(true);
     // Tool Search hides many built-ins from the visible tool list (core coding
     // tools like exec stay visible), but conflict checks still need the
     // original core names to reject duplicate client tools.
@@ -126,6 +129,8 @@ describe("tool name allowlists", () => {
   });
 
   it("excludes client tool names when Tool Search compacts them into the catalog", () => {
+    onTestFinished(() => testing.setToolSearchCodeModeSupportedForTest(undefined));
+    testing.setToolSearchCodeModeSupportedForTest(true);
     const config = { tools: { toolSearch: true } } as never;
     const catalogRef = createToolSearchCatalogRef();
     const compacted = applyToolSearchCatalog({
@@ -163,6 +168,8 @@ describe("tool name allowlists", () => {
   });
 
   it("keeps hidden catalog tools valid for replay guards after Tool Search compaction", () => {
+    onTestFinished(() => testing.setToolSearchCodeModeSupportedForTest(undefined));
+    testing.setToolSearchCodeModeSupportedForTest(true);
     // Replay validation uses the full registered tool set; the visible session
     // allowlist can be narrower after catalog compaction.
     const config = { tools: { toolSearch: true } } as never;

--- a/src/agents/harness/tool-surface-bridge.test.ts
+++ b/src/agents/harness/tool-surface-bridge.test.ts
@@ -1,5 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 import { migratePersistedImplicitMainRoster } from "../../config/legacy.roster.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { finalizeAgentToolAvailability } from "../agent-tool-availability.js";
@@ -323,6 +323,8 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
   });
 
   it("atomically filters and restores direct tools plus the hidden catalog", () => {
+    onTestFinished(() => testing.setToolSearchCodeModeSupportedForTest(undefined));
+    testing.setToolSearchCodeModeSupportedForTest(true);
     const runtime = createRuntime({ tools: { toolSearch: true } });
     const compacted = runtime.compactTools(
       tools([TOOL_SEARCH_CODE_MODE_TOOL_NAME, "read", "hidden_alpha", "hidden_beta"]),
@@ -351,6 +353,8 @@ describe("createAgentHarnessToolSurfaceRuntime", () => {
   });
 
   it("derives callable inventory after runtime schema projection", () => {
+    onTestFinished(() => testing.setToolSearchCodeModeSupportedForTest(undefined));
+    testing.setToolSearchCodeModeSupportedForTest(true);
     const runtime = createRuntime({ tools: { toolSearch: true } });
     const invalid = {
       ...createStubTool("invalid_hidden"),

--- a/src/agents/tool-result-error.test.ts
+++ b/src/agents/tool-result-error.test.ts
@@ -9,15 +9,11 @@ import {
 } from "./tool-result-error.js";
 import { ToolAuthorizationError, ToolInputError } from "./tools/common.js";
 
-const undiciErrors = (
-  createRequire(import.meta.url)("undici") as {
-    errors: {
-      ConnectTimeoutError: new (message: string) => Error;
-      HeadersTimeoutError: new (message: string) => Error;
-      BodyTimeoutError: new (message: string) => Error;
-    };
-  }
-).errors;
+// Bun's built-in Undici shim does not carry the installed package's error codes.
+const requireUndiciPackage = createRequire(
+  createRequire(import.meta.url).resolve("undici/package.json"),
+);
+const undiciErrors = (requireUndiciPackage("./index.js") as typeof import("undici")).errors;
 
 describe("isToolResultError", () => {
   it("keeps completed results with nonzero exit codes nonfatal", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes false failures in timeout-error and tool-planning tests under Bun. The native Undici substitute lacks the installed package's structured error codes, and planning tests implicitly depended on the host's code-mode capability.

## Why This Change Was Made

Construct timeout errors from the declared installed dependency. Use the existing test-only capability override for the five planning/projection cases and register its cleanup before changing it.

## User Impact

No production behavior changes. The tests exercise the same error classification and tool inventory contracts on both runtimes.

## Evidence

- All 53 affected-file tests pass on Node and true Bun.
- The existing unsupported-mode structured fallback case also passes on both runtimes.
- Complete changed-file gate and fresh P0–P2 review pass.
- Runtime capability guards and executable selection remain unchanged; no MCP guest execution was added or enabled.
- The broader Bun compatibility campaign remains in progress.
