### PR TITLE
improve: avoid cold plugin discovery in cache-TTL tests

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts
@@ -8,10 +8,12 @@ import {
   resolveProviderContext,
   type ProviderStreamOptions,
 } from "../../../../packages/ai/src/provider-types.js";
+import { createPluginMetadataSnapshot } from "../../../config/plugin-auto-enable.test-helpers.js";
 import { bindStreamLlmRuntime } from "../../../llm/model-runtime-binding.js";
 import { createCodexNativeWebSearchWrapper } from "../../../llm/providers/stream-wrappers/openai.js";
 import { createAssistantMessageEventStream } from "../../../llm/utils/event-stream.js";
 import { attachRuntimePromptMediaFacts } from "../../../media/media-facts.js";
+import { withPluginRuntimeGenerationScope } from "../../../plugins/runtime/generation-scope.js";
 import type { StreamFn } from "../../runtime/index.js";
 import { SessionManager } from "../../sessions/index.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
@@ -162,7 +164,14 @@ describe("settleEmbeddedAttemptStream liveness", () => {
       }
       expect(getEmbeddedSessionPromptState(sessionId).toolResults).not.toBe(state);
 
-      await settleEmbeddedAttemptStream(input);
+      // Production supplies this generation before entering the attempt runner.
+      const metadataSnapshot = createPluginMetadataSnapshot({
+        config: input.attempt.config,
+        manifestRegistry: { plugins: [], diagnostics: [] },
+      });
+      await withPluginRuntimeGenerationScope({ metadataSnapshot }, () =>
+        settleEmbeddedAttemptStream(input),
+      );
 
       expect(input.sessionManager.getEntries()).toContainEqual(
         expect.objectContaining({


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary cold plugin discovery in the cache-TTL settlement regression test. The eviction case took 24–29 seconds in two successful CI samples and 56.978 seconds in a contained local baseline.

## Why This Change Was Made

Supply the existing prepared plugin-generation context that production establishes around embedded runs. Its authoritative empty registry avoids discovery and exercises the real Anthropic eligibility fallback. The test still proves LRU eviction, hands the active projection object through real settlement, and checks the serialized cache-TTL marker.

All 18 cases and their assertions remain. No production behavior, mocks, timeouts, shard counts, or new test-only production seams change.

## User Impact

Faster developer and CI tests; no runtime behavior change.

## Evidence

Same contained checkout and dependencies, Node 24.19.0, pnpm 12.3.4, Vitest 5, one worker, and separate fresh filesystem caches:

| Measurement | Before | After |
| --- | ---: | ---: |
| Eviction case | 56.978 s | 0.0052 s |
| Entire test command | 135.64 s | 62.22 s |
| Passing cases | 18 | 18 |

This is one local pair. Transform time also varied, so the entire command reduction is not attributed to the fixture change or extrapolated to whole-CI duration.

- All 36 tests passed across the settlement, cache-TTL append, and projection/replay sibling files.
- A temporary counterfactual supplied the fresh post-eviction object instead of the active projection; the retained persisted-marker assertion failed as intended. That diagnostic was removed before final checks.
- Full changed-file gate and formatting passed. Independent P2 review found no actionable issues.
- Test-only delta: +10/-1; production delta: zero.

Commands: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts --maxWorkers=1`; sibling invocation additionally included `attempt.spawn-workspace.cache-ttl.test.ts` and `tool-result-truncation.cache-ttl.test.ts`; `node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/attempt-stream-settle.test.ts`.
