### PR TITLE
fix(llama-cpp): report external server model discovery failures

### DIFF
--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -197,6 +197,12 @@ OpenClaw reads `/health`, `/models` (falling back to `/v1/models`), and
 wakes, unloads, downloads, or reloads models. Explicit configured model rows
 remain authoritative over discovered rows with the same ID.
 
+Refreshing a configured external server reports authentication rejection or
+unavailability when discovery fails. Previously discovered models remain visible
+only while their endpoint and credentials are unchanged. A successful empty list
+removes discovered rows; explicit configured models remain. Restore the server or
+correct its credentials, then refresh again to recover the live inventory.
+
 ### Authentication and endpoint replacement
 
 Existing endpoints support no auth, API keys, SecretRefs, auth profiles, and

--- a/extensions/llama-cpp/src/external-server/provider.test.ts
+++ b/extensions/llama-cpp/src/external-server/provider.test.ts
@@ -40,8 +40,8 @@ function success() {
   return {
     kind: "success" as const,
     endpoint: {
-      origin: "http://localhost:8080",
-      inferenceBaseUrl: "http://localhost:8080/v1",
+      origin: "http://127.0.0.1:8080",
+      inferenceBaseUrl: "http://127.0.0.1:8080/v1",
     },
     models: [model()],
   };
@@ -83,16 +83,26 @@ describe("llama-server provider discovery", () => {
     runtimeApiKeyMock.mockResolvedValue(undefined);
   });
 
-  it("builds the legacy runtime provider from live discovery", async () => {
+  it("publishes live discovery with the profile that supplied its credential", async () => {
     discoverMock.mockResolvedValue(success());
+    const ctx = catalogContext();
+    ctx.resolveProviderApiKey = () => ({
+      apiKey: "LLAMA_SERVER_API_KEY",
+      discoveryApiKey: "profile-key",
+      profileId: "llama-cpp:default",
+    });
 
-    await expect(discoverLlamaServerProvider(catalogContext())).resolves.toMatchObject({
+    await expect(discoverLlamaServerProvider(ctx)).resolves.toMatchObject({
       provider: {
-        baseUrl: "http://localhost:8080/v1",
+        baseUrl: "http://127.0.0.1:8080/v1",
         api: "openai-completions",
         models: [expect.objectContaining({ id: "org/model:Q4" })],
       },
+      outcomes: [{ provider: "llama-cpp", profileId: "llama-cpp:default", status: "ready" }],
     });
+    expect(discoverMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: "profile-key", cacheTtlMs: 0 }),
+    );
   });
 
   it("prefers configured Authorization over ambient API-key discovery auth", async () => {
@@ -110,9 +120,11 @@ describe("llama-server provider discovery", () => {
     ctx.resolveProviderApiKey = vi.fn(() => ({
       apiKey: "LLAMA_SERVER_API_KEY",
       discoveryApiKey: "ambient-key",
+      profileId: "llama-cpp:ambient",
     }));
 
-    await discoverLlamaServerProvider(ctx);
+    const result = await discoverLlamaServerProvider(ctx);
+    expect(result?.outcomes).toEqual([{ provider: "llama-cpp", status: "ready" }]);
 
     expect(discoverMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -122,26 +134,51 @@ describe("llama-server provider discovery", () => {
     );
   });
 
-  it("preserves explicit models when the server is unavailable", async () => {
-    discoverMock.mockResolvedValue({
-      kind: "unreachable",
-      endpoint: { origin: "http://localhost:8080", inferenceBaseUrl: "http://localhost:8080/v1" },
-      error: new Error("offline"),
-    });
-    const ctx = catalogContext();
-    ctx.config.models = {
-      providers: {
-        "llama-cpp": {
-          baseUrl: "http://localhost:8080/v1",
-          models: [model().config],
+  it.each([
+    { failure: { kind: "http-error", status: 401 }, status: "auth-rejected" },
+    { failure: { kind: "http-error", status: 403 }, status: "auth-rejected" },
+    { failure: { kind: "http-error", status: 503 }, status: "unavailable" },
+    { failure: { kind: "unreachable", error: new Error("offline") }, status: "unavailable" },
+    { failure: { kind: "invalid-response", error: new Error("malformed") }, status: "unavailable" },
+  ])(
+    "reports $failure as $status instead of publishing empty discovery",
+    async ({ failure, status }) => {
+      discoverMock.mockResolvedValue({
+        ...failure,
+        endpoint: { origin: "http://localhost:8080", inferenceBaseUrl: "http://localhost:8080/v1" },
+      });
+      const ctx = catalogContext();
+      ctx.config.models = {
+        providers: {
+          "llama-cpp": {
+            baseUrl: "http://localhost:8080/v1",
+            models: [model().config],
+          },
         },
-      },
-    };
+      };
 
-    await expect(discoverLlamaServerProvider(ctx)).resolves.toMatchObject({
-      provider: { models: [expect.objectContaining({ id: "org/model:Q4" })] },
-    });
-  });
+      await expect(discoverLlamaServerProvider(ctx)).resolves.toEqual({
+        providers: {},
+        outcomes: [
+          {
+            provider: "llama-cpp",
+            status,
+            ...(status === "auth-rejected" ? { rejectionScope: "catalog" } : {}),
+          },
+        ],
+      });
+    },
+  );
+
+  it.each([undefined, "custom-local"])(
+    "keeps unconfigured probes quiet with marker %s",
+    async (apiKey) => {
+      discoverMock.mockResolvedValue({ kind: "unreachable", error: new Error("offline") });
+      const ctx = catalogContext();
+      ctx.resolveProviderApiKey = () => ({ apiKey });
+      await expect(discoverLlamaServerProvider(ctx)).resolves.toBeNull();
+    },
+  );
 
   it("returns only the requested discovered model directly to its preparation owner", async () => {
     discoverMock.mockResolvedValue({

--- a/extensions/llama-cpp/src/external-server/provider.ts
+++ b/extensions/llama-cpp/src/external-server/provider.ts
@@ -1,9 +1,14 @@
 import type {
   ProviderCatalogContext,
+  ProviderCatalogResult,
   ProviderPrepareDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { isNonSecretApiKeyMarker } from "openclaw/plugin-sdk/provider-auth";
+import {
+  LiveModelCatalogHttpError,
+  runLiveProviderCatalog,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { LLAMA_CPP_PROVIDER_ID } from "../defaults.js";
 import {
   hasLlamaServerAuthorizationHeader,
@@ -17,7 +22,7 @@ import { buildLlamaServerProviderConfig } from "./models.js";
 /** Discovers external llama-server models for provider runtime resolution. */
 export async function discoverLlamaServerProvider(
   ctx: ProviderCatalogContext,
-): Promise<{ provider: ModelProviderConfig } | null> {
+): Promise<ProviderCatalogResult> {
   const configured = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   const auth = ctx.resolveProviderApiKey(LLAMA_CPP_PROVIDER_ID);
   const headers = await resolveLlamaServerProviderHeaders({
@@ -25,33 +30,38 @@ export async function discoverLlamaServerProvider(
     env: ctx.env,
     headers: configured?.headers,
   });
-  const discovery = await discoverLlamaServer({
-    baseUrl: configured?.baseUrl,
-    apiKey: hasLlamaServerAuthorizationHeader(headers)
+  const authApiKey = auth.discoveryApiKey ?? auth.apiKey;
+  const apiKey =
+    hasLlamaServerAuthorizationHeader(headers) ||
+    (authApiKey && isNonSecretApiKeyMarker(authApiKey))
       ? undefined
-      : (auth.discoveryApiKey ?? auth.apiKey),
-    headers,
-  });
-  if (discovery.kind !== "success") {
-    return configured
-      ? {
-          provider: buildLlamaServerProviderConfig({
-            configured,
-            discoveredModels: [],
-          }),
+      : authApiKey;
+  return await runLiveProviderCatalog({
+    providerId: LLAMA_CPP_PROVIDER_ID,
+    profileId: apiKey ? auth.profileId : undefined,
+    run: async () => {
+      const discovery = await discoverLlamaServer({
+        baseUrl: configured?.baseUrl,
+        apiKey,
+        headers,
+        cacheTtlMs: 0,
+      });
+      if (discovery.kind !== "success") {
+        if (!configured && !apiKey && !headers) {
+          return null;
         }
-      : null;
-  }
-  return {
-    provider: buildLlamaServerProviderConfig({
-      configured: {
-        ...configured,
-        baseUrl: discovery.endpoint.inferenceBaseUrl,
-        models: configured?.models ?? [],
-      },
-      discoveredModels: discovery.models,
-    }),
-  };
+        throw discovery.kind === "http-error"
+          ? new LiveModelCatalogHttpError(LLAMA_CPP_PROVIDER_ID, discovery.status)
+          : discovery.error;
+      }
+      return {
+        provider: buildLlamaServerProviderConfig({
+          configured,
+          discoveredModels: discovery.models,
+        }),
+      };
+    },
+  });
 }
 
 export async function prepareLlamaServerDynamicModel(


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Refreshing an external model server could silently return empty or cached inventory after authentication rejection or discovery failure.

## Why This Change Was Made

The external producer uses the shared catalog-outcome handler and bypasses the advisory discovery cache on explicit refresh. It preserves explicit authorization-header precedence and attributes outcomes only to the credential profile actually used. Redundant provider reconstruction and success-shaped failures are removed.

## User Impact

Authentication rejection and unavailability remain visible while compatible inventory survives temporary failure. Endpoint or credential replacement retires old learned rows. Successful empty results remove discovery rows but preserve explicit models. Managed-server behavior and public advisory defaults remain unchanged.

Consumers: external-server refresh now publishes actual acquisition outcomes.

## Evidence

The built baseline hid failures; the candidate reported them. Seven regressions failed before repair. Candidate tests passed 15 producer, 87 sibling, and five Doctor cases. Built Gateway/CLI checks covered failures, recovery, empty results, credential changes, headers, attribution, and helper compatibility against synthetic endpoints. Shared discovery retains a separate stored-profile/no-provider-key selection limitation. No live inference was tested. The bundled helper requires normal host/plugin release synchronization.
