### PR TITLE
fix(models): restore missing picker choices after startup

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -86,6 +86,14 @@ Other selection rules:
 - The Control UI starts from the Gateway's prepared configured model view, so opening chat does not start provider discovery. Opening or refreshing a model picker may discover models required by a trailing `provider/*` policy entry. Default and configured picker views hide catalog rows marked `deprecated` or `disabled` unless that exact model is configured as a primary, fallback, utility/tool model, alias/settings key, or exact policy entry. Hidden rows remain selectable by exact `provider/model` ref. The full built-in catalog, including hidden rows, is reserved for explicit browse views (`models.list` with `view: "all"`, or `openclaw models list --all`).
 - Provider inventory UIs use `models.list` with `view: "provider-config"` to show source-authored `models.providers.*.models` rows without applying picker allowlists.
 
+After a Gateway restart, the first ordinary `models.list` or `/models` browse
+initializes provider inventory. A bounded request may show configured models while
+discovery finishes; later reads reuse the completed inventory. Startup, turn-path
+reads, and `models.list` with `preparedOnly: true` do not start discovery.
+For models configured to use a CLI runtime, channel picker availability follows that
+runtime's prepared authentication; a provider API key does not substitute for its
+native login.
+
 Once the Gateway has discovered a provider inventory, model-selection hot reloads
 retain it without running discovery again. Aliases, policy, and runtime capabilities
 use the new configuration. A successful catalog refresh replaces that inventory,

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -110,6 +110,11 @@ vi.mock("./model-auth.js", () => ({
 }));
 
 vi.mock("./model-auth-availability.js", () => ({
+  applyCliRuntimeModelAuthAvailability: ({
+    evaluation,
+  }: {
+    evaluation: ModelAuthAvailabilityEvaluation;
+  }) => evaluation,
   createModelAuthAvailabilityResolver:
     modelAuthAvailabilityMocks.createModelAuthAvailabilityResolver,
 }));

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -24,6 +24,7 @@ import {
   type AuthProfileStore,
 } from "./auth-profiles.js";
 import {
+  applyCliRuntimeModelAuthAvailability,
   createModelAuthAvailabilityResolver,
   type ModelAuthAvailabilityEvaluation,
   type ModelAuthAvailabilityRef,
@@ -304,7 +305,24 @@ export function createProviderAuthChecker(params: {
     const evaluation = Promise.resolve().then(
       async (): Promise<ModelAuthAvailabilityEvaluation> => {
         if (hasRouteFacts) {
-          return resolveModelAuthResolver().evaluateModelAuth(key, ref);
+          const authResolver = resolveModelAuthResolver();
+          const modelEvaluation = authResolver.evaluateModelAuth(key, ref);
+          // Native readiness belongs to prepared owners; setup hints stay provider-only.
+          // Explicit runtime account bindings retain their own auth decision.
+          if (!params.preparedAuth || ref.requiredProfileId?.trim()) {
+            return modelEvaluation;
+          }
+          return applyCliRuntimeModelAuthAvailability({
+            authResolver,
+            evaluation: modelEvaluation,
+            cfg: params.cfg ?? {},
+            agentId: params.agentId,
+            metadataSnapshot: params.metadataSnapshot,
+            provider: key,
+            modelId: ref.modelId,
+            preferredProfileId: ref.preferredProfileId,
+            pinnedProfileId: ref.pinnedProfileId,
+          });
         }
         return {
           availability: await resolveLegacyProviderAuth(),

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -54,8 +54,7 @@ vi.mock("./prepared-model-runtime.js", () => {
     preparedModelRuntimeConfigsMatch: (left: object, right: object) =>
       JSON.stringify(left) === JSON.stringify(right),
     prepareModelRuntimeSnapshot: (...args: unknown[]) => mocks.prepareSnapshot(...args),
-    refreshStalePreparedModelRuntimeCatalog: (...args: unknown[]) =>
-      mocks.refreshStaleCatalog(...args),
+    refreshPreparedModelRuntimeCatalog: (...args: unknown[]) => mocks.refreshStaleCatalog(...args),
   };
 });
 
@@ -253,7 +252,9 @@ describe("prepared model catalog access", () => {
       await expect(
         loadPreparedModelCatalogOwnerSnapshot({ readOnly, refreshFullCatalog }),
       ).resolves.toMatchObject({ modelCatalog: staleCatalog });
-      expect(mocks.refreshStaleCatalog).toHaveBeenCalledWith(snapshot);
+      expect(mocks.refreshStaleCatalog).toHaveBeenCalledWith(snapshot, {
+        refresh: refreshFullCatalog === true && !readOnly,
+      });
       expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
       expect(snapshot.loadFullModelCatalog).not.toHaveBeenCalled();
     },

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -31,7 +31,7 @@ import {
   prepareModelRuntimeSnapshot,
   PreparedModelRuntimeOwnerNotPublishedError,
   preparedModelRuntimeConfigsMatch,
-  refreshStalePreparedModelRuntimeCatalog,
+  refreshPreparedModelRuntimeCatalog,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.js";
@@ -53,7 +53,7 @@ export type LoadPreparedModelCatalogParams = {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   providerDiscoveryProviderIds?: readonly string[];
-  /** Refreshes auth-stale inventory; true also rebuilds a fresh full catalog on writable reads. */
+  /** Initializes cold or auth-stale inventory; true also refreshes a full catalog on writable reads. */
   refreshFullCatalog?: boolean | "stale";
   /** Scoped read-only loads may run live discovery for the scoped providers only. */
   scopedLiveProviderDiscovery?: boolean;
@@ -75,13 +75,15 @@ async function materializeRequestedModelCatalog(
   if (!snapshot.loadFullModelCatalog) {
     return snapshot;
   }
-  // Inventory reads repair auth-stale content without making turn-path reads start discovery.
-  const staleCatalog =
+  // Inventory demand initializes discovery; prepared-only and turn-path reads stay passive.
+  const inventoryCatalog =
     refreshFullCatalog === "stale" || refreshFullCatalog === true
-      ? await refreshStalePreparedModelRuntimeCatalog(snapshot)
+      ? await refreshPreparedModelRuntimeCatalog(snapshot, {
+          refresh: refreshFullCatalog === true && readOnly !== true,
+        })
       : undefined;
   const modelCatalog =
-    staleCatalog ??
+    inventoryCatalog ??
     (readOnly === true
       ? snapshot.readFullModelCatalog?.()
       : await snapshot.loadFullModelCatalog({ refresh: refreshFullCatalog === true }));

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -17,7 +17,7 @@ import {
   advancePreparedModelRuntimeConfig,
   loadPublishedGatewayReplyDispatchRuntime,
   prepareModelRuntimeSnapshot,
-  refreshStalePreparedModelRuntimeCatalog,
+  refreshPreparedModelRuntimeCatalog,
   registerPreparedModelRuntimePublicationListener,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
@@ -111,11 +111,11 @@ describe("prepared model runtime reload auth adoption", () => {
       entries: [model],
       routeVariants: [model],
     });
-    await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toMatchObject({
+    await expect(refreshPreparedModelRuntimeCatalog(published)).resolves.toMatchObject({
       entries: [model],
     });
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
-    await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toBeUndefined();
+    await expect(refreshPreparedModelRuntimeCatalog(published)).resolves.toBeUndefined();
   });
 
   it("does not refresh a catalog snapshot that is not owned by the runtime", async () => {
@@ -133,7 +133,7 @@ describe("prepared model runtime reload auth adoption", () => {
     const published = await prepareModelRuntimeSnapshot(input);
     const unowned = { ...published };
 
-    await expect(refreshStalePreparedModelRuntimeCatalog(unowned)).resolves.toBeUndefined();
+    await expect(refreshPreparedModelRuntimeCatalog(unowned)).resolves.toBeUndefined();
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
   });
 
@@ -197,8 +197,8 @@ describe("prepared model runtime reload auth adoption", () => {
     const published = await prepareModelRuntimeSnapshot(input);
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
 
-    const first = refreshStalePreparedModelRuntimeCatalog(published);
-    const second = refreshStalePreparedModelRuntimeCatalog(published);
+    const first = refreshPreparedModelRuntimeCatalog(published);
+    const second = refreshPreparedModelRuntimeCatalog(published);
     await vi.waitFor(() => expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce());
     liveBuild.resolve({ entries: [model], routeVariants: [model] });
 

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
+import { loadPreparedModelCatalogSnapshot } from "./prepared-model-catalog.js";
 import {
   getPreparedModelRuntimeAuthStore,
   setPreparedModelFullCatalogAuth,
@@ -768,8 +769,15 @@ describe("prepared model runtime scoped refresh", () => {
       entries: [learned, newlyDiscovered],
       routeVariants: [learned, newlyDiscovered],
     });
-    const explicitRefresh = nextOwner.loadFullModelCatalog!({ refresh: true });
-    const concurrentRefresh = nextOwner.loadFullModelCatalog!({ refresh: true });
+    const refreshParams = {
+      config: nextConfig,
+      agentId: "pro",
+      agentDir: state.agentDir("pro"),
+      readOnly: false,
+      refreshFullCatalog: true,
+    };
+    const explicitRefresh = loadPreparedModelCatalogSnapshot(refreshParams);
+    const concurrentRefresh = loadPreparedModelCatalogSnapshot(refreshParams);
     releaseNative.resolve();
     await ordinaryRead;
     const refreshed = await explicitRefresh;

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { setPreparedModelFullCatalogAuth } from "./prepared-model-runtime-auth.js";
@@ -229,7 +230,8 @@ const {
   refreshPreparedModelRuntimeSnapshots,
   registerPreparedModelRuntimePublicationListener,
 } = await import("./prepared-model-runtime.js");
-const { getAvailablePreparedModelCatalogSnapshot } = await import("./prepared-model-catalog.js");
+const { getAvailablePreparedModelCatalogSnapshot, loadPreparedModelCatalogSnapshot } =
+  await import("./prepared-model-catalog.js");
 const {
   prepareScopedReadOnlyLiveModelCatalog,
   prepareScopedReadOnlyModelAuthModes,
@@ -311,6 +313,78 @@ describe("prepareScopedReadOnlyModelAuthModes", () => {
 });
 
 describe("prepared model runtime Gateway catalog mode", () => {
+  it("initializes cold inventory once on ordinary demand while prepared reads stay static", async () => {
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    const params = { agentId: "default", config, readOnly: true };
+    const discovery = createDeferred<ModelCatalogSnapshot>();
+    const discovered = { provider: "openai", id: "discovered-model", name: "Discovered model" };
+    mocks.runPreparedModelCatalogWorker.mockImplementationOnce(() => discovery.promise);
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+
+    const prepared = await loadPreparedModelCatalogSnapshot(params);
+    expect(prepared.entries.map(({ id }) => id)).toEqual(["gpt-5.5"]);
+    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+
+    const first = loadPreparedModelCatalogSnapshot({ ...params, refreshFullCatalog: "stale" });
+    const second = loadPreparedModelCatalogSnapshot({ ...params, refreshFullCatalog: "stale" });
+    try {
+      await vi.waitFor(() => expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce());
+      await expect(loadPreparedModelCatalogSnapshot(params)).resolves.toBe(prepared);
+      discovery.resolve({ entries: [discovered], routeVariants: [discovered] });
+      const [firstCatalog, secondCatalog] = await Promise.all([first, second]);
+      expect(firstCatalog.entries.map(({ id }) => id)).toEqual(["discovered-model", "gpt-5.5"]);
+      expect(secondCatalog).toBe(firstCatalog);
+      await expect(
+        loadPreparedModelCatalogSnapshot({ ...params, refreshFullCatalog: "stale" }),
+      ).resolves.toBe(firstCatalog);
+      expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+    } finally {
+      discovery.resolve({ entries: [discovered], routeVariants: [discovered] });
+      await Promise.allSettled([first, second]);
+    }
+  });
+
+  it("rejects cold inventory publication after its runtime generation is retired", async () => {
+    const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    const params = { agentId: "default", config, readOnly: true };
+    const discovery = createDeferred<ModelCatalogSnapshot>();
+    mocks.runPreparedModelCatalogWorker.mockImplementationOnce(() => discovery.promise);
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const first = loadPreparedModelCatalogSnapshot({ ...params, refreshFullCatalog: "stale" });
+    let replacement: Promise<void> | undefined;
+    const publications: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) =>
+      publications.push(event.phase),
+    );
+    try {
+      await vi.waitFor(() => expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce());
+      replacement = refreshPreparedModelRuntimeSnapshots(config, {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+      });
+      const rejected = expect(first).rejects.toThrow("superseded");
+      discovery.resolve({
+        entries: [{ provider: "openai", id: "retired-model", name: "Retired model" }],
+        routeVariants: [],
+      });
+      await rejected;
+      await replacement;
+      expect(publications).not.toContain("catalog-published");
+      const current = await loadPreparedModelCatalogSnapshot(params);
+      expect(current.entries.map(({ id }) => id)).toEqual(["gpt-5.5"]);
+    } finally {
+      discovery.resolve({ entries: [], routeVariants: [] });
+      await Promise.allSettled([first, replacement]);
+      unregister();
+    }
+  });
+
   it.each([
     {
       name: "native orchestration",

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -14,6 +14,7 @@ import {
   registerPreparedRuntimeAuthMaterializationPublisher,
 } from "./prepared-model-runtime-materializations.js";
 import { preparedModelInventoryKey } from "./prepared-model-runtime.facts.js";
+import { isPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimeOwnerRetention,
@@ -370,21 +371,22 @@ export async function prepareModelRuntimeSnapshot(
   );
 }
 
-/** Refreshes stale inventory only for an explicit catalog read; turn admission remains static. */
-export async function refreshStalePreparedModelRuntimeCatalog(
+/** Initializes or refreshes inventory on catalog demand; turn admission remains static. */
+export async function refreshPreparedModelRuntimeCatalog(
   snapshot: PreparedModelRuntimeSnapshot,
+  options: { refresh?: boolean } = {},
 ): Promise<ModelCatalogSnapshot | undefined> {
   const owner = resolvePreparedModelRuntimeOwnerBySnapshot(snapshot);
-  if (
-    !owner ||
-    owners.get(ownerKey(owner.input)) !== owner ||
-    !owner.catalogStale ||
-    !snapshot.loadFullModelCatalog
-  ) {
+  if (!owner || owners.get(ownerKey(owner.input)) !== owner || !snapshot.loadFullModelCatalog) {
+    return undefined;
+  }
+  const currentCatalog = snapshot.readFullModelCatalog?.() ?? snapshot.modelCatalog;
+  const refresh = options.refresh === true || owner.catalogStale;
+  if (!refresh && isPreparedModelCatalogFull(currentCatalog)) {
     return undefined;
   }
   const generation = owner.generation;
-  const catalog = await snapshot.loadFullModelCatalog({ refresh: true });
+  const catalog = await snapshot.loadFullModelCatalog({ refresh });
   if (
     owner.catalogStale &&
     owner.generation === generation &&

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -1,16 +1,21 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import type { PreparedAgentCredentialModes } from "../../agents/agent-auth-credential-modes.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import * as providerAuth from "../../agents/model-provider-auth.js";
 import { PreparedModelCatalogConfigReplacedError } from "../../agents/prepared-model-catalog.errors.js";
 import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
 import { PreparedModelRuntimePublicationSupersededError } from "../../agents/prepared-model-runtime.errors.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 
 const catalogMocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
   loadPublishedOwner: vi.fn(),
+  getPreparedOwner: vi.fn(),
   authStore: { version: 1, profiles: {} } as AuthProfileStore,
+  authModes: {} as PreparedAgentCredentialModes,
   isCurrent: (): boolean => true,
 }));
 
@@ -18,7 +23,10 @@ vi.mock("../../agents/prepared-model-catalog.js", () => {
   const loadOwner = async (...args: unknown[]) => {
     const owner = {
       modelCatalog: await catalogMocks.loadSnapshot(...args),
-      authModes: {},
+      authModes: catalogMocks.authModes,
+      metadataSnapshot: createPluginMetadataSnapshotFixture({
+        plugins: [{ id: "anthropic", cliBackends: ["claude-cli"] }],
+      }),
       isCurrent: catalogMocks.isCurrent,
     };
     setPreparedModelRuntimeAuthStore(owner, catalogMocks.authStore);
@@ -32,6 +40,7 @@ vi.mock("../../agents/prepared-model-catalog.js", () => {
       read: (owner: Awaited<ReturnType<typeof loadOwner>>) => unknown,
     ) => read(await loadOwner(params)),
     loadPublishedPreparedModelCatalogOwnerSnapshot: catalogMocks.loadPublishedOwner,
+    getPreparedModelCatalogOwnerSnapshot: catalogMocks.getPreparedOwner,
   };
 });
 
@@ -46,16 +55,149 @@ const replacementCfg = {
   agents: { defaults: { model: { primary: "openai/gpt-5.6-luna" } } },
 } as OpenClawConfig;
 
+beforeEach(() => {
+  // Semantic projections must not exhaust their deadline through host CPU load.
+  vi.useFakeTimers({ toFake: ["Date"] });
+});
+
 afterEach(() => {
   catalogMocks.loadSnapshot.mockReset();
   catalogMocks.loadPublishedOwner.mockReset();
+  catalogMocks.getPreparedOwner.mockReset();
   vi.useRealTimers();
   catalogMocks.authStore = { version: 1, profiles: {} };
+  catalogMocks.authModes = {};
   catalogMocks.isCurrent = () => true;
+  cliBackendsTesting.resetDepsForTest();
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
 describe("/models browse catalog recovery", () => {
+  it.each([
+    { nativeAuth: true, providerKey: false, disabled: false, visible: true, slowCatalog: false },
+    { nativeAuth: false, providerKey: false, disabled: false, visible: false, slowCatalog: false },
+    { nativeAuth: false, providerKey: true, disabled: false, visible: false, slowCatalog: false },
+    { nativeAuth: true, providerKey: true, disabled: true, visible: false, slowCatalog: false },
+    { nativeAuth: true, providerKey: false, disabled: false, visible: true, slowCatalog: true },
+  ])(
+    "lists bound models using native auth=$nativeAuth, provider key=$providerKey, disabled=$disabled, slow catalog=$slowCatalog",
+    async ({ nativeAuth, providerKey, disabled, visible, slowCatalog }) => {
+      if (slowCatalog) {
+        vi.useRealTimers();
+        vi.useFakeTimers();
+      }
+      vi.stubEnv("ANTHROPIC_API_KEY", providerKey ? "synthetic-provider-key" : "");
+      cliBackendsTesting.setDepsForTest({
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            modelProvider: "anthropic",
+            pluginId: "anthropic",
+            config: { command: "claude" },
+          },
+        ],
+      });
+      catalogMocks.authModes = nativeAuth ? { "claude-cli": "api_key" } : {};
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            model: { primary: "anthropic/claude-opus-4-5" },
+            modelPolicy: { allow: [] },
+            models: {
+              "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+        ...(disabled ? { plugins: { entries: { anthropic: { enabled: false } } } } : {}),
+      };
+      const snapshot = {
+        entries: [
+          { provider: "anthropic", id: "claude-opus-4-5", name: "Default" },
+          { provider: "anthropic", id: "claude-sonnet-4-6", name: "Bound" },
+          { provider: "anthropic", id: "claude-haiku-4-5", name: "Unbound" },
+        ],
+        routeVariants: [],
+      };
+      const preparedOwner = {
+        modelCatalog: snapshot,
+        authModes: catalogMocks.authModes,
+        metadataSnapshot: createPluginMetadataSnapshotFixture({
+          plugins: [{ id: "anthropic", cliBackends: ["claude-cli"] }],
+        }),
+        isCurrent: () => true,
+      };
+      setPreparedModelRuntimeAuthStore(preparedOwner, catalogMocks.authStore);
+      catalogMocks.getPreparedOwner.mockReturnValue(preparedOwner);
+      catalogMocks.loadSnapshot.mockReturnValue(
+        slowCatalog ? new Promise(() => {}) : Promise.resolve(snapshot),
+      );
+
+      const replyPromise = resolveModelsCommandReply({
+        cfg,
+        commandBodyNormalized: "/models anthropic",
+        agentId: "main",
+      });
+      if (slowCatalog) {
+        await vi.advanceTimersByTimeAsync(750);
+      }
+      const reply = await replyPromise;
+
+      expect(reply?.text?.includes("- anthropic/claude-sonnet-4-6")).toBe(visible);
+      expect(reply?.text?.includes("- anthropic/claude-haiku-4-5")).toBe(providerKey);
+      expect(reply?.text).toContain("- anthropic/claude-opus-4-5");
+    },
+  );
+
+  it.each(["pinnedProfileId", "requiredProfileId"] as const)(
+    "does not replace an expired %s with a prepared native login",
+    async (selection) => {
+      cliBackendsTesting.setDepsForTest({
+        resolveRuntimeCliBackends: () => [
+          {
+            id: "claude-cli",
+            modelProvider: "anthropic",
+            pluginId: "anthropic",
+            config: { command: "claude" },
+          },
+        ],
+      });
+      const checker = providerAuth.createProviderAuthChecker({
+        cfg: {
+          agents: {
+            defaults: {
+              models: {
+                "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+              },
+            },
+          },
+        },
+        env: {},
+        discoverExternalCliAuth: false,
+        allowPluginSyntheticAuth: false,
+        allowPreparedRuntimeAuth: true,
+        preparedAuth: {
+          authModes: { "claude-cli": "api_key" },
+          authStore: {
+            version: 1,
+            profiles: {
+              selected: {
+                provider: "anthropic",
+                type: "token",
+                token: "synthetic-expired-token",
+                expires: 1,
+              },
+            },
+          },
+        },
+      });
+
+      await expect(
+        checker("anthropic", { modelId: "claude-sonnet-4-6", [selection]: "selected" }),
+      ).resolves.toBe(false);
+    },
+  );
+
   it.each([
     { view: "default", delayMs: 0 },
     { view: "all", delayMs: 1_000 },
@@ -63,6 +205,7 @@ describe("/models browse catalog recovery", () => {
   ] as const)(
     "recovers supersession during $view auth projection within its deadline (delay=$delayMs)",
     async ({ view, delayMs }) => {
+      vi.useRealTimers();
       vi.useFakeTimers();
       let current = true;
       catalogMocks.isCurrent = () => current;
@@ -321,6 +464,7 @@ describe("/models browse catalog recovery", () => {
   });
 
   it("uses one browse deadline across repeated owner replacements", async () => {
+    vi.useRealTimers();
     vi.useFakeTimers();
     const intermediateCfg = {
       agents: { defaults: { model: { primary: "google/gemini-3.1-pro" } } },
@@ -356,6 +500,7 @@ describe("/models browse catalog recovery", () => {
   });
 
   it("keeps explicit full-catalog recovery unbounded across late supersession", async () => {
+    vi.useRealTimers();
     vi.useFakeTimers();
     catalogMocks.loadSnapshot
       .mockImplementationOnce(
@@ -386,6 +531,7 @@ describe("/models browse catalog recovery", () => {
   });
 
   it("bounds current-owner reacquisition by the original browse deadline", async () => {
+    vi.useRealTimers();
     vi.useFakeTimers();
     const fallbackCfg = {
       agents: {

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -1,6 +1,6 @@
 // Tests model command output, catalog loading, and provider auth status rendering.
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -104,6 +104,7 @@ function setFastModelsCliBackendDeps(): void {
 }
 
 vi.mock("../../agents/prepared-model-catalog.js", () => ({
+  getPreparedModelCatalogOwnerSnapshot: () => undefined,
   loadProviderScopedThinkingCatalog: vi.fn(async () => []),
   withPreparedModelCatalogOwner: async (params: unknown, read: (owner: object) => unknown) => {
     const entries = await modelCatalogMocks.loadModelCatalog(params);
@@ -188,17 +189,9 @@ const textSurfaceModelsTestPlugins = (["discord", "whatsapp"] as const).map((id)
   source: "test",
 }));
 
-beforeAll(async () => {
-  setFastModelsCliBackendDeps();
-  modelCatalogMocks.loadModelCatalog.mockResolvedValue([
-    { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
-  ]);
-  await buildPreparedModelsProviderData({
-    agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
-  } as OpenClawConfig);
-});
-
 beforeEach(() => {
+  // Output assertions must not race the browse deadline on a busy test host.
+  vi.useFakeTimers();
   setFastModelsCliBackendDeps();
   modelCatalogMocks.loadModelCatalog.mockReset();
   modelCatalogMocks.loadModelCatalog.mockResolvedValue([
@@ -252,6 +245,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   cliBackendsTesting.resetDepsForTest();
 });
 
@@ -339,22 +333,17 @@ describe("handleModelsCommand", () => {
   });
 
   it("does not block default browse when read-only catalog loading is slow", async () => {
-    vi.useFakeTimers();
-    try {
-      modelCatalogMocks.loadModelCatalog.mockReturnValue(new Promise(() => {}));
+    modelCatalogMocks.loadModelCatalog.mockReturnValue(new Promise(() => {}));
 
-      const resultPromise = handleModelsCommand(buildParams("/models"), true);
-      await vi.advanceTimersByTimeAsync(750);
-      const result = await resultPromise;
+    const resultPromise = handleModelsCommand(buildParams("/models"), true);
+    await vi.advanceTimersByTimeAsync(750);
+    const result = await resultPromise;
 
-      expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledTimes(1);
-      expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(true);
-      expect(result?.shouldContinue).toBe(false);
-      expect(result?.reply?.text).toContain("Providers:");
-      expect(result?.reply?.text).toContain("- anthropic (1)");
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(modelCatalogMocks.loadModelCatalog).toHaveBeenCalledTimes(1);
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Providers:");
+    expect(result?.reply?.text).toContain("- anthropic (1)");
   });
 
   it("keeps explicit all browse on the full catalog path", async () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -261,22 +261,33 @@ async function buildPreparedDataForConfig(
   options: ModelsBrowseContext,
   control: { catalogFallback?: boolean; deadlineMs?: number },
 ): Promise<PreparedModelsProviderData> {
-  const project = (owner?: PreparedModelRuntimeSnapshot) =>
-    projectPreparedModelsProviderData(cfg, agentId, options, owner);
+  const agentDir = options.agentDir ?? (agentId ? resolveAgentDir(cfg, agentId) : undefined);
+  const catalogContext = {
+    config: cfg,
+    ...(agentId ? { agentId } : {}),
+    ...(agentDir ? { agentDir } : {}),
+    ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+  };
+  const project = (owner?: PreparedModelRuntimeSnapshot) => {
+    // Discovery can outlive the browse deadline; retain current configured rows and native auth.
+    const preparedOwner =
+      owner ??
+      preparedModelCatalog.getPreparedModelCatalogOwnerSnapshot({
+        ...catalogContext,
+        readOnly: true,
+      });
+    return projectPreparedModelsProviderData(cfg, agentId, options, preparedOwner);
+  };
   if (control.catalogFallback) {
     return project();
   }
-  const agentDir = options.agentDir ?? (agentId ? resolveAgentDir(cfg, agentId) : undefined);
   const result = await awaitWithinDeadline(
     () =>
       preparedModelCatalog.withPreparedModelCatalogOwner(
         {
-          config: cfg,
+          ...catalogContext,
           readOnly: !modelCatalogBrowseRequiresFullDiscovery({ cfg, agentId, view: options.view }),
           refreshFullCatalog: "stale",
-          ...(agentId ? { agentId } : {}),
-          ...(agentDir ? { agentDir } : {}),
-          ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
         },
         project,
       ),

--- a/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts
@@ -5,7 +5,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import net from "node:net";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { createWindowsCmdShimFixture, withServer, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { expect, test } from "vitest";
 import { createQaGatewayChild, writeJson } from "../../../../extensions/qa-lab/api.js";
 import {
@@ -418,7 +418,7 @@ async function settleCleanup(...cleanups: Array<() => Promise<void>>) {
   }
 }
 
-test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", async () => {
+test("initializes unrestricted Telegram model browsing and reuses its prepared catalog", async () => {
   const telegramCalls: TelegramCall[] = [];
   const pendingUpdates: unknown[] = [];
   let nextUpdateId = 2;
@@ -559,7 +559,7 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
           const repoRoot = path.resolve(import.meta.dirname, "../../../..");
           const gateway = await gatewayOwner.start({
             repoRoot,
-            useRepoCli: true,
+            mockAuthAgentIds: [],
             transportBaseUrl: apiRoot,
             transport: {
               requiredPluginIds: ["telegram"],
@@ -587,6 +587,7 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
             primaryModel: `ollama/${PREPARED_MODEL}`,
             alternateModel: `ollama/${PREPARED_MODEL}`,
             runtimeEnvPatch: {
+              OPENCLAW_SKIP_STARTUP_MODEL_PREWARM: undefined,
               OPENCLAW_SKIP_CHANNELS: undefined,
               OPENCLAW_SKIP_PROVIDERS: undefined,
               OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
@@ -599,7 +600,7 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
                 defaults: {
                   ...cfg.agents?.defaults,
                   model: `ollama/${PREPARED_MODEL}`,
-                  modelPolicy: { allow: ["ollama/*"] },
+                  modelPolicy: { allow: [] },
                   models: {
                     ...cfg.agents?.defaults?.models,
                     [`ollama/${PREPARED_MODEL}`]: {},
@@ -636,12 +637,16 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
               timeout: 30_000,
             })
             .toBe("providers");
-          const warmedModels = await gateway.call("models.list", { view: "all" });
-          expect(warmedModels).toMatchObject({
-            models: expect.arrayContaining([
-              expect.objectContaining({ provider: "ollama", id: DISCOVERED_MODEL }),
-            ]),
-          });
+          await expect
+            .poll(() => gateway.call("models.list", { view: "default" }), {
+              interval: 50,
+              timeout: 30_000,
+            })
+            .toMatchObject({
+              models: expect.arrayContaining([
+                expect.objectContaining({ provider: "ollama", id: DISCOVERED_MODEL }),
+              ]),
+            });
           expect(discoveryRequests).toBeGreaterThan(0);
           const warmDiscoveryRequests = discoveryRequests;
           discoveryFrozen = true;
@@ -697,11 +702,227 @@ test("keeps Telegram model-picker callbacks on the prepared Gateway catalog", as
             ]),
           });
           expect(discoveryRequests).toBeGreaterThan(warmDiscoveryRequests);
+          console.info(
+            "MODEL_INVENTORY_PROOF",
+            JSON.stringify({
+              scenario: "unrestricted-inventory",
+              callbacks: keyboardCallbackData(pickerEdits[1]!),
+              warmDiscoveryRequests,
+              postWarmDiscoveryAttempts,
+              refreshedDiscoveryRequests: discoveryRequests,
+            }),
+          );
         } finally {
           await settleCleanup(async () => await stopQaGatewayFixture(gatewayOwner));
         }
       }),
   );
+}, 120_000);
+
+test("lists native CLI-bound models through Telegram polling and provider callbacks", async () => {
+  const telegramCalls: TelegramCall[] = [];
+  const pendingUpdates: unknown[] = [];
+  const primaryRef = "anthropic/claude-haiku-4-5";
+  const boundRef = "anthropic/claude-sonnet-4-6";
+  let providerRequests = 0;
+  const handleRequest = async (req: IncomingMessage, res: ServerResponse) => {
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    const telegramMatch = pathname.match(/^\/bot([^/]+)\/([^/]+)$/);
+    if (!telegramMatch) {
+      providerRequests += 1;
+      writeJson(res, 404, { ok: false, error: "native command must not call a model" });
+      return;
+    }
+    const [, token = "", method = ""] = telegramMatch;
+    if (token !== BOT_TOKEN) {
+      writeJson(res, 401, { ok: false, error: "unexpected bot token" });
+      return;
+    }
+    const body = await readJson(req);
+    if (method === "getMe") {
+      succeed(res, {
+        id: 424242,
+        is_bot: true,
+        first_name: "QA Picker",
+        username: "qa_picker_bot",
+      });
+      return;
+    }
+    if (method === "getUpdates") {
+      const update = pendingUpdates.shift();
+      succeed(res, update ? [update] : []);
+      return;
+    }
+    telegramCalls.push({ method, body });
+    if (method === "sendMessage") {
+      pendingUpdates.push(callbackUpdate(2, "native-provider-list", "mdl_list_anthropic_1"));
+    }
+    succeed(res);
+  };
+
+  await withTempDir("openclaw-telegram-native-model-picker-", async (fixtureRoot) => {
+    const cliPath = path.join(fixtureRoot, process.platform === "win32" ? "claude.cjs" : "claude");
+    const authCallsPath = path.join(fixtureRoot, "native-auth-calls.jsonl");
+    if (process.platform === "win32") {
+      await createWindowsCmdShimFixture({
+        shimPath: path.join(fixtureRoot, "claude.cmd"),
+        scriptPath: cliPath,
+        shimLine: `@"${process.execPath}" "%~dp0\\claude.cjs" %*`,
+      });
+    }
+    await fs.writeFile(
+      cliPath,
+      `#!${process.execPath}
+const fs = require("node:fs");
+const argv = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(authCallsPath)}, JSON.stringify(argv) + "\\n");
+if (JSON.stringify(argv) !== JSON.stringify(["auth", "status", "--json"])) process.exit(1);
+process.stdout.write(JSON.stringify({ loggedIn: true, authMethod: "claude.ai" }));
+`,
+      { mode: 0o755 },
+    );
+    await withServer(
+      (req, res) => {
+        void handleRequest(req, res);
+      },
+      async (apiRoot) => {
+        const gatewayOwner = createQaGatewayChild();
+        try {
+          const gateway = await gatewayOwner.start({
+            repoRoot: path.resolve(import.meta.dirname, "../../../.."),
+            transportBaseUrl: apiRoot,
+            transport: {
+              requiredPluginIds: ["telegram"],
+              createGatewayConfig: () => ({
+                channels: {
+                  telegram: {
+                    enabled: true,
+                    botToken: BOT_TOKEN,
+                    apiRoot,
+                    dmPolicy: "open",
+                    allowFrom: ["*"],
+                    commands: { native: true },
+                  },
+                },
+              }),
+            },
+            enabledPluginIds: ["anthropic"],
+            mockAuthAgentIds: [],
+            controlUiEnabled: false,
+            primaryModel: primaryRef,
+            alternateModel: boundRef,
+            runtimeEnvPatch: {
+              PATH: `${fixtureRoot}${path.delimiter}${process.env.PATH ?? ""}`,
+              ANTHROPIC_API_KEY: undefined,
+              ANTHROPIC_AUTH_TOKEN: undefined,
+              CLAUDE_CODE_OAUTH_TOKEN: undefined,
+              CLAUDE_CONFIG_DIR: path.join(fixtureRoot, "claude-state"),
+              TELEGRAM_BOT_TOKEN: undefined,
+              OPENCLAW_SKIP_STARTUP_MODEL_PREWARM: undefined,
+              OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+            },
+            mutateConfig: (cfg) => ({
+              ...cfg,
+              auth: { profiles: {} },
+              agents: {
+                ...cfg.agents,
+                defaults: {
+                  ...cfg.agents?.defaults,
+                  model: primaryRef,
+                  modelPolicy: { allow: [] },
+                  models: {
+                    [primaryRef]: { agentRuntime: { id: "claude-cli" } },
+                    [boundRef]: { agentRuntime: { id: "claude-cli" } },
+                  },
+                },
+                entries: {
+                  ...cfg.agents?.entries,
+                  qa: { ...cfg.agents?.entries?.qa, model: primaryRef },
+                },
+              },
+              models: { providers: {} },
+            }),
+          });
+
+          // Observe startup auth without warming provider discovery before the channel command.
+          await expect
+            .poll(() => gateway.call("models.list", { preparedOnly: true }), {
+              interval: 50,
+              timeout: 30_000,
+            })
+            .toMatchObject({
+              models: expect.arrayContaining([
+                expect.objectContaining({
+                  provider: "anthropic",
+                  id: "claude-sonnet-4-6",
+                  available: true,
+                }),
+              ]),
+            });
+          pendingUpdates.push(initialModelsUpdate());
+          await expect
+            .poll(() => telegramCalls.find((call) => call.method === "editMessageText"), {
+              interval: 50,
+              timeout: 30_000,
+            })
+            .toBeDefined();
+          const modelList = telegramCalls.find((call) => call.method === "editMessageText");
+          const providerMenu = telegramCalls.find((call) => call.method === "sendMessage");
+          expect(providerMenu).toBeDefined();
+          const providerButton = inlineKeyboard(providerMenu!)
+            .flat()
+            .find((button) => button.callback_data === "mdl_list_anthropic_1");
+          const gatewayModels = (await gateway.call("models.list", { view: "default" })) as {
+            models: Array<{
+              provider: string;
+              id: string;
+              available?: boolean;
+              unavailableReason?: string;
+            }>;
+          };
+          console.info(
+            "MODEL_INVENTORY_PROOF",
+            JSON.stringify({
+              scenario: "native-cli-models",
+              providerButtonText: providerButton?.text,
+              callbacks: keyboardCallbackData(modelList!),
+              models: gatewayModels.models.filter(
+                (entry) =>
+                  `${entry.provider}/${entry.id}` === primaryRef ||
+                  `${entry.provider}/${entry.id}` === boundRef,
+              ),
+              fixtureProviderRequests: providerRequests,
+            }),
+          );
+          const cliCalls = (await fs.readFile(authCallsPath, "utf8"))
+            .trim()
+            .split("\n")
+            .map((line) => JSON.parse(line));
+          console.info("MODEL_INVENTORY_AUTH_PROOF", JSON.stringify(cliCalls));
+          expect(cliCalls.length).toBeGreaterThan(0);
+          expect(providerButton?.text).toBe("anthropic (2)");
+          expect(modelList?.body.text).toContain("Models (anthropic");
+          expect(keyboardCallbackData(modelList!)).toContain(`mdl_sel_${boundRef}`);
+          expect(keyboardCallbackData(modelList!)).toContain(`mdl_sel_${primaryRef}`);
+          expect(gatewayModels).toMatchObject({
+            models: expect.arrayContaining([
+              expect.objectContaining({
+                provider: "anthropic",
+                id: "claude-sonnet-4-6",
+                available: true,
+              }),
+            ]),
+          });
+          expect(
+            cliCalls.every((args) => JSON.stringify(args) === '["auth","status","--json"]'),
+          ).toBe(true);
+          expect(providerRequests).toBe(0);
+        } finally {
+          await stopQaGatewayFixture(gatewayOwner);
+        }
+      },
+    );
+  });
 }, 120_000);
 
 test("recovers a replaced model catalog and drains the following Telegram callback", async () => {


### PR DESCRIPTION
Closes #139498
Closes #139499

## What Problem This Solves

Fixes an issue where model pickers stayed on configured-only choices after a Gateway restart until another client explicitly refreshed the inventory. Channel pickers also omitted configured models routed through an authenticated CLI, even when Gateway model listing recognized their availability.

Reported by @goslingmanagment.

## Why This Change Was Made

Ordinary inventory demand now initializes an undiscovered catalog through its existing lifecycle owner. The same queue, generation checks, and paired catalog/auth publication remain responsible for discovery. Explicit refresh still queries providers after compatible reloads, even when retained inventory first needs native-harness projection. Startup, prepared-only reads, and turn preparation remain passive.

Prepared channel auth evaluation now uses the existing CLI-runtime projection, preserving disabled-plugin and selected-account restrictions. Unprepared setup hints retain their existing provider-only behavior. When discovery exceeds the existing browse deadline, channel rendering retains the current prepared owner instead of dropping its configured rows and auth facts.

This is a bounded repair to current behavior, separate from the broader model-surface work in draft #136257. There are no new configuration options, dependencies, database changes, or protocol changes.

## User Impact

After restart, ordinary browsing converges to the discovered inventory without opening another client or requesting an explicit refresh. Configured CLI-bound choices remain visible when the prepared native runtime is ready, including while discovery continues. A provider API key does not substitute for that runtime's native login.

## Evidence

Observed results from the final real-Gateway harness:

```json
{
  "scenariosPassed": 2,
  "initialNativeProviderButton": "anthropic (2)",
  "nativeSelectableModels": [
    "claude-haiku-4-5",
    "claude-sonnet-4-6"
  ],
  "gatewayNativeModelsAvailable": true,
  "nativeAuthStatusCalls": 2,
  "initialDiscoveryRequests": 3,
  "discoveryAttemptsDuringReuse": 0,
  "requestsAfterExplicitRefresh": 4
}
```


- Captured failing regressions before each repair: cold inventory never started discovery; channel auth omitted native-ready choices and incorrectly accepted a provider key/disabled runtime; bounded fallback dropped already prepared native facts.
- All 290 focused tests passed together across ten files, covering catalog ownership, concurrent discovery, retired generations, passive reads, channel menus, CLI setup pickers, and Gateway account restrictions. Assertions were retained; command-output fixtures now control clocks instead of racing host load against the 750 ms deadline.
- Real behavior is exercised with the existing isolated Gateway and Telegram polling/callback harness. Only the external Bot API, Ollama endpoint, and native CLI auth-status process are simulated. The cold inventory and native picker flows passed, including the first `anthropic (2)` menu and Haiku/Sonnet selection buttons. The final exact-source rerun after the explicit-refresh correction also passed both scenarios. The native case observes startup readiness with `preparedOnly: true`, then exercises the first cold `/models` menu and callback without warming full discovery.
- Fresh independent review found no remaining P0–P2 findings after the timeout-owner and explicit-refresh corrections. Changed-surface checks, core/E2E typechecks, and targeted lint passed.
- Production delta: +33 net lines to preserve inventory intent and prepared-auth ownership; no parallel catalog implementation.
- Live Telegram Test Server verification is unavailable on this host: no authenticated Convex CLI or broker credentials are present. No live Anthropic account, model turn, or Windows execution is claimed.

The separate existing channel session-account-context propagation gap is not addressed here: this PR does not claim end-to-end channel account-selection parity. Model execution retains its own account and authorization checks.

Runtime proof used Node 26.8.1/pnpm 12.3.4 on macOS arm64, base `b3bdf3e11da5671dac9b6033edd49673c129f511` plus the four-file candidate. Production/test postimages match this commit. The initial package-bootstrap timeout is excluded from behavior proof; final fixtures run the existing built-Gateway path with synthetic external boundaries.

[CI passed on the reviewed head](https://github.com/openclaw/openclaw/actions/runs/34016661831), including the required `openclaw/ci-gate`.

## Owner involvement

This repair was explicitly directed by @steipete, the PR author and an active maintainer of the listed authentication owner team, `openclaw/openclaw-secops`. Live GitHub verification on 2026-09-06 via `GET /orgs/openclaw/teams/openclaw-secops/memberships/steipete` returned `{"state":"active","role":"maintainer"}`. This establishes the listed-owner involvement requested in the ClawSweeper review; no ownership policy or enforced GitHub approval requirement is changed.


## Additional remote validation

<!-- model-picker-remote-validation -->

The prepared head `0171ed498cb764d189712a3b2ba3c70dea0dacec` was independently validated on Blacksmith Testbox. Its changed runtime and E2E fixture postimages match landed commit `48f76a5c11193086b1ec2b7abe408aac34214812`, whose ancestry on main was verified. These runs completed after the independent landing.

| Source | Lease | Run | Result |
| --- | --- | --- | --- |
| Baseline `b3bdf3e11da5671dac9b6033edd49673c129f511`, with only the candidate E2E fixture | `tbx_01m1tq88j2m393641cg1ev21zh` | [before](https://github.com/openclaw/openclaw/actions/runs/34017190953) | Both original defects reproduced |
| Exact prepared head `0171ed498cb764d189712a3b2ba3c70dea0dacec` | `tbx_01m1tq6a1rzdv6903fnwqjzyyx` | [after](https://github.com/openclaw/openclaw/actions/runs/34017144306) | Both scenarios passed |

Both sources passed `pnpm build` and harness-owned QA runtime preparation, followed by:

```sh
node scripts/run-vitest.mjs \
  test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts \
  -t 'initializes unrestricted|lists native CLI-bound'
```

Sanitized behavior transcript:

```text
Before: 2 failed; 1 unrelated scenario unselected
  Ordinary models.list omitted ollama/discovered-model
  Telegram: expected "anthropic (2)", received "anthropic (1)"
After: 2 passed; 1 unrelated scenario unselected
  Ordinary discovery, cached reuse and explicit-refresh assertions passed
  Telegram "anthropic (2)" and Haiku/Sonnet selection callbacks passed
  Gateway native availability and zero native-command model requests passed
```

A separate built-CLI check stopped and restarted each Gateway with the same isolated state. At both startup and restart, baseline ordinary `models.list` omitted the two synthetic Ollama rows until `refresh: true`; the candidate returned both before refresh. This supplemental check proves membership only: its rows were deliberately unavailable, and native readiness is established by the Telegram E2E above.

The Gateway/plugin/channel paths were real; the external Telegram Bot API, Ollama endpoint, and Claude CLI auth-status executable were synthetic. All state, homes, workspaces, and free loopback ports were isolated. No live inference or Telegram Test Server execution is claimed: the remote hosts had no authenticated Convex CLI or broker pair. Both leases were stopped and independently reported `completed`; Gateway logs showed clean shutdowns.

Fresh independent branch review found no actionable P0–P2 findings. `git diff --numstat` totals: production +56/-23 (**+33**), tests +495/-51 (**+444**), docs +8/-0. Production growth restores missing cold-inventory initialization and deadline recovery while applying the existing runtime-auth decision to channel browsing; no second catalog or auth policy is introduced.
