### PR TITLE
fix(lmstudio): report model discovery failures

### DIFF
--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -197,6 +197,14 @@ the default trust.
 
 ## Troubleshooting
 
+### Model discovery failures
+
+When a configured server cannot list models, OpenClaw reports an unavailable catalog or a
+catalog authentication rejection. A refresh can keep the last successful inventory when the
+connection and credentials still match. A successful empty response clears discovered models;
+explicitly configured models remain available without discovery. Restore the server connection
+or correct its credentials, then refresh the model list.
+
 ### LM Studio not detected
 
 Make sure LM Studio is running:

--- a/extensions/lmstudio/index.ts
+++ b/extensions/lmstudio/index.ts
@@ -114,7 +114,7 @@ export default definePluginEntry({
         order: "late",
         run: async (ctx) => {
           const providerSetup = await loadProviderSetup();
-          return await providerSetup.discoverLmstudioProvider(ctx);
+          return await providerSetup.discoverLmstudioProvider(ctx, { discoveryMode: "strict" });
         },
       },
       resolveSyntheticAuth: ({ providerConfig }) => {

--- a/extensions/lmstudio/src/models.fetch.test.ts
+++ b/extensions/lmstudio/src/models.fetch.test.ts
@@ -1,5 +1,9 @@
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/plugin-entry";
+import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterAll, afterEach, assert, describe, expect, it, vi } from "vitest";
+import plugin from "../index.js";
 import { fetchLmstudioModels } from "./models.fetch.js";
+import { discoverLmstudioProvider } from "./setup.js";
 
 const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
 
@@ -18,6 +22,111 @@ afterAll(() => {
 
 afterEach(() => {
   fetchWithSsrFGuardMock.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("LM Studio catalog acquisition", () => {
+  function context(headers?: Record<string, string>): ProviderCatalogContext {
+    return {
+      config: {
+        models: {
+          providers: {
+            lmstudio: {
+              baseUrl: "http://localhost:1234/api/v1/",
+              apiKey: "configured-key",
+              headers,
+              models: [],
+            },
+          },
+        },
+      },
+      env: {},
+      resolveProviderApiKey: () => ({
+        apiKey: "LM_API_TOKEN",
+        discoveryApiKey: "profile-key",
+        profileId: "lmstudio:profile",
+      }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    };
+  }
+
+  function catalog() {
+    const provider = capturePluginRegistration(plugin).providers[0];
+    assert(provider?.catalog);
+    return provider.catalog.run;
+  }
+
+  it.each([401, 403, 503, "disconnect", "invalid-json", "missing-models"])(
+    "reports %s as failed acquisition while preserving the public advisory helper",
+    async (failure) => {
+      const fetchMock = vi.fn(async () => {
+        if (failure === "disconnect") {
+          throw new Error("connection reset");
+        }
+        return new Response(failure === "invalid-json" ? "{" : "{}", {
+          status: typeof failure === "number" ? failure : 200,
+        });
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      const ctx = context();
+      const rejected = failure === 401 || failure === 403;
+      await expect(catalog()(ctx)).resolves.toEqual({
+        providers: {},
+        outcomes: [
+          {
+            provider: "lmstudio",
+            profileId: "lmstudio:profile",
+            status: rejected ? "auth-rejected" : "unavailable",
+            ...(rejected ? { rejectionScope: "catalog" } : {}),
+          },
+        ],
+      });
+      expect(fetchMock).toHaveBeenCalledWith("http://localhost:1234/api/v1/models", {
+        headers: { Authorization: "Bearer profile-key" },
+        signal: expect.any(AbortSignal),
+      });
+      await expect(discoverLmstudioProvider(ctx)).resolves.toMatchObject({
+        provider: { models: [] },
+      });
+    },
+  );
+
+  it("attributes header authentication to the request rather than an unused profile", async () => {
+    const fetchMock = vi.fn(async () => new Response("denied", { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(catalog()(context({ Authorization: "Bearer header-key" }))).resolves.toEqual({
+      providers: {},
+      outcomes: [{ provider: "lmstudio", status: "auth-rejected", rejectionScope: "catalog" }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:1234/api/v1/models", {
+      headers: { Authorization: "Bearer header-key" },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("distinguishes configured keyless empty inventory from quiet optional discovery", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ models: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+    const ctx = context();
+    ctx.resolveProviderApiKey = () => ({ apiKey: undefined });
+    const provider = ctx.config.models?.providers?.lmstudio;
+    assert(provider);
+    delete provider.apiKey;
+    await expect(catalog()(ctx)).resolves.toMatchObject({
+      provider: { models: [] },
+      outcomes: [{ provider: "lmstudio", status: "ready" }],
+    });
+    await expect(discoverLmstudioProvider(ctx)).resolves.toBeNull();
+    ctx.config = {};
+    await expect(catalog()(ctx)).resolves.toBeNull();
+    fetchMock.mockRejectedValueOnce(new Error("optional server offline"));
+    await expect(catalog()(ctx)).resolves.toBeNull();
+    fetchMock.mockClear();
+    await expect(
+      catalog()({ ...context(), providerIds: ["another-provider"] }),
+    ).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("LM Studio model response release", () => {

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -1,6 +1,7 @@
 // Lmstudio plugin module implements models.fetch behavior.
 import { createSubsystemLogger, redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveTimerTimeoutMs } from "openclaw/plugin-sdk/number-runtime";
+import { LiveModelCatalogHttpError } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {
   readProviderJsonArrayFieldResponse,
   readProviderJsonResponse,
@@ -62,6 +63,7 @@ type DiscoverLmstudioModelsParams = {
   apiKey: string;
   headers?: Record<string, string>;
   quiet: boolean;
+  discoveryMode?: "strict";
   /** Injectable fetch implementation; defaults to the global fetch. */
   fetchImpl?: typeof fetch;
 };
@@ -195,27 +197,21 @@ export async function discoverLmstudioModels(
     fetchImpl: params.fetchImpl,
   });
   const quiet = params.quiet;
-  if (!fetched.reachable) {
-    if (!quiet) {
-      log.debug(`Failed to discover LM Studio models: ${String(fetched.error)}`);
+  if (!fetched.reachable || (fetched.status !== undefined && fetched.status >= 400)) {
+    const error =
+      fetched.status === undefined
+        ? fetched.error
+        : new LiveModelCatalogHttpError("lmstudio", fetched.status);
+    if (params.discoveryMode === "strict") {
+      throw error;
     }
-    return [];
-  }
-  if (fetched.status !== undefined && fetched.status >= 400) {
     if (!quiet) {
-      log.debug(`Failed to discover LM Studio models: ${fetched.status}`);
-    }
-    return [];
-  }
-  const models = fetched.models;
-  if (models.length === 0) {
-    if (!quiet) {
-      log.debug("No LM Studio models found on local instance");
+      log.debug(`Failed to discover LM Studio models: ${String(error)}`);
     }
     return [];
   }
 
-  return models
+  return fetched.models
     .map((entry): ModelDefinitionConfig | null => {
       const base = mapLmstudioWireEntry(entry);
       if (!base) {

--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -1,16 +1,21 @@
 // Lmstudio setup module handles plugin onboarding behavior.
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
-import type { ProviderAppGuidedSetupContext } from "openclaw/plugin-sdk/plugin-entry";
+import type {
+  ProviderAppGuidedSetupContext,
+  ProviderCatalogResult,
+} from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildApiKeyCredential,
   ensureApiKeyFromEnvOrPrompt,
   hasConfiguredSecretInput,
+  isNonSecretApiKeyMarker,
   normalizeOptionalSecretInput,
   type OpenClawConfig,
   type SecretInput,
   type SecretInputMode,
 } from "openclaw/plugin-sdk/provider-auth";
 import { removeProviderAuthProfilesWithLock } from "openclaw/plugin-sdk/provider-auth-runtime";
+import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {
   selectPreferredLocalModelId,
   type ModelDefinitionConfig,
@@ -290,26 +295,6 @@ function resolvePersistedLmstudioApiKey(params: {
   })
     ? LMSTUDIO_LOCAL_API_KEY_PLACEHOLDER
     : undefined;
-}
-
-async function discoverLmstudioProviderCatalog(params: {
-  baseUrl?: string;
-  apiKey?: string;
-  headers?: Record<string, string>;
-  quiet: boolean;
-}): Promise<ModelProviderConfig> {
-  const baseUrl = resolveLmstudioInferenceBase(params.baseUrl);
-  const models = await discoverLmstudioModels({
-    baseUrl,
-    apiKey: params.apiKey ?? "",
-    headers: params.headers,
-    quiet: params.quiet,
-  });
-  return {
-    baseUrl,
-    api: "openai-completions",
-    models,
-  };
 }
 
 function isLmstudioDiscoveryConfigResolutionError(error: unknown): boolean {
@@ -950,18 +935,30 @@ export async function configureLmstudioNonInteractive(
 }
 
 /** Discovers provider settings, merging explicit config with live model discovery. */
-export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Promise<{
+// The published helper stays advisory; the registered catalog opts into strict acquisition.
+export function discoverLmstudioProvider(ctx: ProviderCatalogContext): Promise<{
   provider: ModelProviderConfig;
-} | null> {
-  const explicit = ctx.config.models?.providers?.[PROVIDER_ID];
-  const explicitAuth = explicit?.auth;
-  let explicitWithoutHeaders: Omit<ModelProviderConfig, "headers" | "auth" | "apiKey"> | undefined;
-  if (explicit) {
-    const { headers: _headers, auth: _auth, apiKey: _apiKey, ...rest } = explicit;
-    explicitWithoutHeaders = rest;
+} | null>;
+export function discoverLmstudioProvider(
+  ctx: ProviderCatalogContext,
+  options: { discoveryMode: "strict" },
+): Promise<ProviderCatalogResult>;
+export async function discoverLmstudioProvider(
+  ctx: ProviderCatalogContext,
+  options?: { discoveryMode: "strict" },
+): Promise<ProviderCatalogResult> {
+  if (ctx.providerIds && !ctx.providerIds.includes(PROVIDER_ID)) {
+    return null;
   }
+  const explicit = ctx.config.models?.providers?.[PROVIDER_ID];
+  const {
+    headers: _headers,
+    auth: explicitAuth,
+    apiKey: _apiKey,
+    ...explicitWithoutHeaders
+  } = explicit ?? {};
   const hasExplicitModels = Array.isArray(explicit?.models) && explicit.models.length > 0;
-  const { apiKey, discoveryApiKey } = ctx.resolveProviderApiKey(PROVIDER_ID);
+  const { apiKey, discoveryApiKey, profileId } = ctx.resolveProviderApiKey(PROVIDER_ID);
   let resolvedHeaders: Record<string, string> | undefined;
   let hasAuthorizationHeader: boolean;
   let configuredDiscoveryApiKey: string | undefined;
@@ -988,40 +985,51 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
     : (discoveryApiKey ?? configuredDiscoveryApiKey);
   // CLI/runtime-resolved key takes precedence over static provider config key.
   const resolvedApiKey = apiKey ?? explicit?.apiKey;
-  const explicitProvider = hasExplicitModels ? explicitWithoutHeaders : undefined;
-  const provider =
-    explicitProvider ??
-    (await discoverLmstudioProviderCatalog({
-      baseUrl: explicit?.baseUrl,
-      // Prefer resolved discovery auth, then configured provider auth.
-      apiKey: resolvedDiscoveryApiKey,
-      headers: resolvedHeaders,
-      quiet: !apiKey && !explicit && !resolvedDiscoveryApiKey,
-    }));
-  const models = provider.models;
-  if (models.length === 0 && !apiKey && !explicit?.apiKey) {
-    return null;
-  }
-  const persistedApiKey = resolvePersistedLmstudioApiKey({
-    currentApiKey: resolvedApiKey,
-    explicitAuth,
-    fallbackApiKey: LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
-    hasModels: models.length > 0,
-    hasAuthorizationHeader,
-  });
-  const persistedAuth = resolveLmstudioProviderAuthMode(persistedApiKey);
-  return {
-    provider: {
-      ...provider,
-      ...explicitWithoutHeaders,
-      ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
-      baseUrl: resolveLmstudioInferenceBase(explicit?.baseUrl ?? provider.baseUrl),
-      ...(explicitProvider ? { api: explicitProvider.api ?? "openai-completions" } : {}),
-      ...(persistedApiKey ? { apiKey: persistedApiKey } : {}),
-      ...(persistedAuth ? { auth: persistedAuth } : {}),
-      models,
-    },
+  const baseUrl = resolveLmstudioInferenceBase(explicit?.baseUrl);
+  const quiet = !apiKey && !explicit && !resolvedDiscoveryApiKey;
+  const run = async () => {
+    const models = hasExplicitModels
+      ? explicit.models
+      : await discoverLmstudioModels({
+          baseUrl,
+          apiKey: resolvedDiscoveryApiKey ?? "",
+          headers: resolvedHeaders,
+          quiet,
+          ...(!quiet && options ? options : {}),
+        });
+    if (models.length === 0 && (options ? quiet : !apiKey && !explicit?.apiKey)) {
+      return null;
+    }
+    const persistedApiKey = resolvePersistedLmstudioApiKey({
+      currentApiKey: resolvedApiKey,
+      explicitAuth,
+      fallbackApiKey: LMSTUDIO_DEFAULT_API_KEY_ENV_VAR,
+      hasModels: models.length > 0,
+      hasAuthorizationHeader,
+    });
+    const persistedAuth = resolveLmstudioProviderAuthMode(persistedApiKey);
+    return {
+      provider: {
+        ...explicitWithoutHeaders,
+        baseUrl,
+        api: explicit?.api ?? "openai-completions",
+        ...(resolvedHeaders ? { headers: resolvedHeaders } : {}),
+        ...(persistedApiKey ? { apiKey: persistedApiKey } : {}),
+        ...(persistedAuth ? { auth: persistedAuth } : {}),
+        models,
+      },
+    };
   };
+  return options && !hasExplicitModels
+    ? await runLiveProviderCatalog({
+        providerId: PROVIDER_ID,
+        profileId:
+          !hasAuthorizationHeader && discoveryApiKey && !isNonSecretApiKeyMarker(discoveryApiKey)
+            ? profileId
+            : undefined,
+        run,
+      })
+    : await run();
 }
 
 export async function prepareLmstudioDynamicModel(


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Refreshing a configured local model server returned empty inventory without a failure outcome when the server was unavailable, rejected authentication, or sent malformed data.

## Why This Change Was Made

The registered catalog reports typed acquisition outcomes to the existing publication owner. Request attribution names only the profile whose credential was used. The public discovery helper retains its advisory default and provider-or-null return contract; setup and dynamic preparation remain unchanged.

## User Impact

Failures retain compatible last-good rows with an unavailable or authentication-rejected outcome. Endpoint or credential changes retire incompatible inventory. Successful empty results clear learned rows, while explicit models remain available. Unconfigured probes stay quiet.

Consumers: registered catalog discovery and failure display now distinguish unavailable service from successful empty inventory.

## Evidence

The built baseline hid a service failure, and eight producer regressions failed before repair. Candidate checks covered failures, recovery, empty results, endpoint/key/header changes, manual rows, helper compatibility, and setup. Public command-line checks verified profile replacement without restart; provider-context tests verified exclusions. All 221 provider tests and focused checks passed. A Gateway used a synthetic endpoint; inference and deployment were not tested.
