### PR TITLE
fix(plugins): restore handoffs for official channel installs

### DIFF
--- a/src/plugins/registry-runtime.channel-ingress.test.ts
+++ b/src/plugins/registry-runtime.channel-ingress.test.ts
@@ -5,10 +5,16 @@ import {
   configureChannelAdmissionEvidenceCollection,
   consumeChannelAdmissionEvidence,
   readChannelContextAdmissionEvidence,
+  readChannelContextGatewayContextResolver,
 } from "../channels/message-access/admission-evidence.js";
 import type { ResolvedChannelMessageIngress } from "../channels/message-access/runtime-types.js";
 import { resolveStableChannelMessageIngress } from "../channels/message-access/runtime.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type {
+  GatewayContextResolver,
+  GatewayRequestContext,
+} from "../gateway/server-methods/types.js";
+import { createGatewaySubagentRuntime } from "../gateway/server-plugin-subagent-runtime.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
 import { markPluginRegistryActive, markPluginRegistryRetired } from "./registry-lifecycle.js";
 import { createPluginRegistry } from "./registry.js";
@@ -16,17 +22,27 @@ import { createPluginRuntime } from "./runtime/index.js";
 import type { PluginRuntime } from "./runtime/types.js";
 import { createPluginRecord } from "./status.test-fixtures.js";
 
-function createRuntimeBuilder(params: { origin: PluginOrigin; id?: string }) {
-  const registryBuilder = createPluginRegistry({
-    logger: { info() {}, warn() {}, error() {}, debug() {} },
-    runtime: {
-      channel: { inbound: { buildContext: buildChannelInboundEventContext } },
-    } as PluginRuntime,
-    activateGlobalSideEffects: false,
-  });
+function createRuntimeBuilder(params: {
+  origin: PluginOrigin;
+  id?: string;
+  trustedOfficialInstall?: boolean;
+  resolveGatewayContext?: GatewayContextResolver;
+  registryBuilder?: ReturnType<typeof createPluginRegistry>;
+}) {
+  const registryBuilder =
+    params.registryBuilder ??
+    createPluginRegistry({
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+      runtime: {
+        channel: { inbound: { buildContext: buildChannelInboundEventContext } },
+        subagent: createGatewaySubagentRuntime(params.resolveGatewayContext),
+      } as PluginRuntime,
+      activateGlobalSideEffects: false,
+    });
   const record = createPluginRecord({
     id: params.id ?? "channel-owner",
     origin: params.origin,
+    trustedOfficialInstall: params.trustedOfficialInstall,
   });
   const api = registryBuilder.createApi(record, {
     config: {} as OpenClawConfig,
@@ -42,7 +58,7 @@ function createRuntimeBuilder(params: { origin: PluginOrigin; id?: string }) {
         docsPath: `/channels/${record.id}`,
         blurb: "test channel",
       },
-      capabilities: { chatTypes: ["direct"] },
+      capabilities: { chatTypes: ["direct", "channel"] },
       config: {
         listAccountIds: () => [],
         resolveAccount: () => ({ accountId: "default" }),
@@ -51,7 +67,9 @@ function createRuntimeBuilder(params: { origin: PluginOrigin; id?: string }) {
     },
   });
   registryBuilder.registry.plugins.push(record);
-  markPluginRegistryActive(registryBuilder.registry);
+  if (!params.registryBuilder) {
+    markPluginRegistryActive(registryBuilder.registry);
+  }
   const resolveBuildContext = () => {
     const registration = registryBuilder.registry.channels.find(
       (candidate) => candidate.plugin.id === record.id,
@@ -62,7 +80,7 @@ function createRuntimeBuilder(params: { origin: PluginOrigin; id?: string }) {
     }
     return runtime.inbound.buildContext;
   };
-  return { buildContext: resolveBuildContext(), record, registryBuilder, resolveBuildContext };
+  return { api, buildContext: resolveBuildContext(), record, registryBuilder, resolveBuildContext };
 }
 
 async function resolveIngress(
@@ -90,6 +108,7 @@ async function resolveIngress(
     subject: { stableId: participantId },
     conversation: params.conversation ?? { kind: "direct", id: "dm-1" },
     dmPolicy: "allowlist",
+    groupPolicy: "open",
     allowFrom: [participantId],
     contextBinding: params.contextBinding ?? {
       agentId: "main",
@@ -135,6 +154,94 @@ function inspect(context: object) {
 }
 
 describe("bundled channel ingress runtime ownership", () => {
+  describe.each([
+    { name: "bundled", origin: "bundled", trustedOfficialInstall: false, trusted: true },
+    { name: "official global", origin: "global", trustedOfficialInstall: true, trusted: true },
+    { name: "untrusted global", origin: "global", trustedOfficialInstall: false, trusted: false },
+  ] as const)("$name channel Gateway binding", (plugin) => {
+    it.each([
+      { kind: "direct", id: "dm-1" },
+      { kind: "channel", id: "guild-channel-1" },
+    ] as const)(
+      "binds $kind ingress only through a trusted registered runtime",
+      async (conversation) => {
+        const cleanup = configureChannelAdmissionEvidenceCollection(false);
+        const gatewayContext = { getRuntimeConfig: () => ({}) } as GatewayRequestContext;
+        const owner = createRuntimeBuilder({
+          ...plugin,
+          resolveGatewayContext: () => gatewayContext,
+        });
+        try {
+          const ingress = await resolveIngress("person-a", { conversation });
+          expect(ingress.ingress.admission).toBe("dispatch");
+          const context = owner.buildContext(contextParams({ ingress, conversation }));
+          expect(readChannelContextGatewayContextResolver(context)?.()).toBe(
+            plugin.trusted ? gatewayContext : undefined,
+          );
+          expect(readChannelContextAdmissionEvidence(context)).toBeUndefined();
+
+          const publicIngress = await resolveIngress("person-a", { conversation });
+          const publicContext = owner.api.runtime.channel.inbound.buildContext(
+            contextParams({ ingress: publicIngress, conversation }),
+          );
+          expect(readChannelContextGatewayContextResolver(publicContext)).toBeUndefined();
+        } finally {
+          markPluginRegistryRetired(owner.registryBuilder.registry);
+          cleanup();
+        }
+      },
+    );
+  });
+
+  describe.each([
+    { name: "bundled", origin: "bundled", trustedOfficialInstall: false },
+    { name: "official global", origin: "global", trustedOfficialInstall: true },
+  ] as const)("$name retained Gateway resolver", (plugin) => {
+    it.each(["retirement", "replacement"] as const)(
+      "revokes the exact owner on %s",
+      async (change) => {
+        const cleanup = configureChannelAdmissionEvidenceCollection(false);
+        const gatewayContext = { getRuntimeConfig: () => ({}) } as GatewayRequestContext;
+        const owner = createRuntimeBuilder({
+          ...plugin,
+          resolveGatewayContext: () => gatewayContext,
+        });
+        const { registryBuilder } = owner;
+        try {
+          const ingress = await resolveIngress("person-a");
+          const context = owner.buildContext(contextParams({ ingress }));
+          const retainedResolver = readChannelContextGatewayContextResolver(context);
+          expect(retainedResolver?.()).toBe(gatewayContext);
+
+          let nextBuildContext: typeof owner.buildContext;
+          if (change === "retirement") {
+            markPluginRegistryRetired(registryBuilder.registry);
+            expect(retainedResolver?.()).toBeUndefined();
+            markPluginRegistryActive(registryBuilder.registry);
+            nextBuildContext = owner.resolveBuildContext();
+          } else {
+            registryBuilder.rollbackPluginGlobalSideEffects(owner.record.id, owner.record);
+            registryBuilder.registry.plugins.splice(
+              registryBuilder.registry.plugins.indexOf(owner.record),
+              1,
+            );
+            nextBuildContext = createRuntimeBuilder({ ...plugin, registryBuilder }).buildContext;
+          }
+
+          expect(retainedResolver?.()).toBeUndefined();
+          expect(readChannelContextGatewayContextResolver(context)?.()).toBeUndefined();
+          const nextIngress = await resolveIngress("person-a");
+          const nextContext = nextBuildContext(contextParams({ ingress: nextIngress }));
+          expect(readChannelContextGatewayContextResolver(nextContext)?.()).toBe(gatewayContext);
+          expect(retainedResolver?.()).toBeUndefined();
+        } finally {
+          markPluginRegistryRetired(registryBuilder.registry);
+          cleanup();
+        }
+      },
+    );
+  });
+
   it("binds authenticated owner turns to the exact live trusted channel plugin", async () => {
     const runtime = createPluginRuntime();
     const command = vi.fn(async () => ({ payloads: [] }));

--- a/src/plugins/registry-runtime.ts
+++ b/src/plugins/registry-runtime.ts
@@ -102,7 +102,10 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
         });
       }
     })();
-    if (record.origin !== "bundled" || requireCurrentRuntimeRecord) {
+    if (
+      (record.origin !== "bundled" && record.trustedOfficialInstall !== true) ||
+      requireCurrentRuntimeRecord
+    ) {
       cache.set(record, channel);
       return channel;
     }
@@ -124,13 +127,18 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       cache.set(record, channel);
       return channel;
     }
+    const resolveGatewayContext = getGatewayContextResolver(registryParams.runtime.subagent);
+    const isLive = () =>
+      ownsLiveRegistrySlot() && isPluginRecordLifecycleEpochActive(registry, record, epoch);
     const owner = Object.freeze({
       channelId: record.id,
       record,
       epoch,
-      resolveGatewayContext: getGatewayContextResolver(registryParams.runtime.subagent),
-      isLive: () =>
-        ownsLiveRegistrySlot() && isPluginRecordLifecycleEpochActive(registry, record, epoch),
+      // Retained contexts belong to this channel generation, even while its Gateway stays live.
+      resolveGatewayContext: resolveGatewayContext
+        ? () => (isLive() ? resolveGatewayContext() : undefined)
+        : undefined,
+      isLive,
     });
     const disposeOwner = registerChannelIngressHostOwner(owner);
     registeredAdmissionOwnerByRecord.set(record, {
@@ -145,7 +153,7 @@ export function createPluginRuntimeResolver(state: PluginRegistryState) {
       params: Parameters<PluginRuntime["channel"]["inbound"]["buildContext"]>[0],
     ) => {
       // Audit provenance is passive: stale closures still build the message context,
-      // but only the exact live bundled owner may attach participant evidence.
+      // but only the exact live trusted owner may attach participant evidence.
       return buildHostContext(params as never);
     }) as unknown as PluginRuntime["channel"]["inbound"]["buildContext"];
     const scoped = {


### PR DESCRIPTION
Related: #138869 (same reported authority error; this PR covers verified official channel installs).
Related: #139620 (reply-context propagation) and #139839 (Discord preflight propagation).

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users requesting a system-control handoff through an officially installed channel plugin would encounter `delegated OpenClaw approval requires an active run authority` even though the channel admitted the message and the Gateway was active. Existing handoff contexts could also retain a Gateway binding after their channel plugin was retired or replaced.

## Why This Change Was Made

Apply the existing bundled-or-verified-official trust rule when creating a registered channel's host context builder. Resolve its captured Gateway binding only while the exact plugin record and registry lifecycle epoch remain active. This keeps admission and subsequent handoff resolution under the same live owner.

Trust derivation and approval policy stay with their existing owners. Untrusted plugins and the public runtime builder remain unable to obtain this private binding. The separate context-copy and Discord preflight fixes are linked above.

## User Impact

Verified official channel installs receive the same host handoff binding as bundled channels. Retired or replaced plugin contexts lose that binding, while a newly active owner can admit fresh messages.

## Evidence

- On upstream base `6f32397ce3`, the real registry/ingress/builder regression produces **6 intended failures and 31 passes**: official installs lack a resolver, and bundled contexts retain one after retirement or replacement.
- After the fix: **73 focused tests across 5 files passed**, covering registry ownership, lifecycle, hook trust, loader trust diagnostics, and admission evidence.
- Channel registry contracts: **196 tests across 12 files passed** (`node scripts/run-vitest.mjs run --config test/vitest/vitest.contracts-channel-registry.config.ts --maxWorkers=1`).
- The complete changed-file gate passed, including core and test type checks, lint, and import-cycle checks. Required autoreview found no actionable P0 defects.
- New cases cover DM and guild-channel contexts with audit collection disabled, untrusted installs, the public runtime surface, retirement/reactivation, and record replacement. These tests are independent of #139620 and stop at actual registry binding and resolver liveness; they do not claim a complete delegated model/tool call. The combined live Discord acceptance is documented in #139839.
