### PR TITLE
refactor(process): remove unused anchor exit notifications

### DIFF
--- a/src/process/supervisor/service-child-protocol.ts
+++ b/src/process/supervisor/service-child-protocol.ts
@@ -57,7 +57,6 @@ export type ServiceChildAnchorMessage = ServiceChildAnchorPayload & {
 
 export type ServiceChildRelayMessage =
   | ServiceChildStart
-  | { type: "anchor-exit"; generation: string; code: number | null; signal: NodeJS.Signals | null }
   | { type: "relay-error"; generation: string; error: string };
 
 export function encodeServiceChildMessage(

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -19,7 +19,7 @@ function reserveIpcFd(stdio: StdioEntry[]): void {
   stdio[fd] = "ipc";
 }
 
-export function runServiceChildRelay(): void {
+function runServiceChildRelay(): void {
   let generation: string | undefined;
   let anchor: ChildProcess | undefined;
   let parentLost = false;
@@ -109,7 +109,6 @@ export function runServiceChildRelay(): void {
       report({ type: "relay-error", generation: generation!, error: error.message });
     });
     anchor.once("exit", (code, signal) => {
-      report({ type: "anchor-exit", generation: generation!, code, signal });
       process.exit(code === 0 || signal === "SIGKILL" ? 0 : 1);
     });
   });


### PR DESCRIPTION
Related: #135868
Cleanup consumers: #139657 (merged)

## What Problem This Solves

The POSIX service-child relay still sends an anchor-exit notification that its host no longer consumes. Cleanup now belongs to the direct anchor channel and kernel-confirmed process-group disappearance.

## Why This Change Was Made

Remove the unused emission and protocol variant, and make the relay entry function private to its module. Relay exit behavior and the authoritative cleanup path stay unchanged.

## User Impact

No user-visible behavior change. This is the Stage 3 follow-up deletion pass, removing a stale IPC path after the cleanup-owner migration.

## Evidence

Reverified current main: the host consumes relay errors and the direct anchor control protocol; it has no anchor-exit consumer. All 70 focused process tests passed, including real macOS anchored-shell/group-extinction tests. Independent review is clean through P2. [Isolated full changed check/build](https://github.com/openclaw/openclaw/actions/runs/34015179800) passed; the task-owned lease completed and stopped. After a mainline lockfile update, frozen dependency refresh and all 70 process tests passed again. The complete local changed-file gate also passed with the refreshed dependencies. Exact-head CI is required before merge.

Production +1/−3 (net −2); tests, tooling, and docs unchanged. No tests were added for this behavior-preserving removal.

The initial remote gate stopped on an unrelated stale history-projection fixture in main. Rebased onto the repair merged in #139794; this PR includes no change to that fixture.

The pre-landing rebase had unchanged relay/process code and patch identity. Its first CI attempt failed an unrelated `sandbox/browser.create.test.ts` environment-policy hash assertion; that exact case passed unchanged in isolation, and one diagnostic rerun of the failed job and its dependents passed on the same head (run 34018222586, attempt 2). No source/assertion/baseline was changed for the rerun. The intermittent mismatch remains an out-of-scope follow-up with an unconfirmed cause.
