### PR TITLE
fix(gateway): stop repeated PR lookups for watched sessions

### DIFF
--- a/src/gateway/control-ui-session-pr-cache.test.ts
+++ b/src/gateway/control-ui-session-pr-cache.test.ts
@@ -1,0 +1,61 @@
+import { getEventListeners } from "node:events";
+import { describe, expect, it } from "vitest";
+import { createSessionPullRequestCache } from "./control-ui-session-pr-cache.js";
+
+describe("session PR cache retention", () => {
+  it("retains watched entries beyond the unobserved bound and releases them on retirement", () => {
+    const cache = createSessionPullRequestCache<number>();
+    const watchers = Array.from({ length: 300 }, () => new AbortController());
+    for (const [index, watcher] of watchers.entries()) {
+      cache.set(String(index), index, watcher.signal);
+    }
+    for (const [index, watcher] of watchers.entries()) {
+      expect(cache.get(String(index))).toBe(index);
+      expect(getEventListeners(watcher.signal, "abort")).toHaveLength(1);
+      watcher.abort();
+      expect(getEventListeners(watcher.signal, "abort")).toHaveLength(0);
+    }
+    expect(
+      Array.from({ length: 300 }, (_, index) => cache.get(String(index))).filter(
+        (entry) => entry !== undefined,
+      ),
+    ).toHaveLength(100);
+  });
+
+  it("shares refreshed entries while releasing only the departing watcher's pin", () => {
+    const cache = createSessionPullRequestCache<number>();
+    const first = new AbortController();
+    const second = new AbortController();
+    cache.set("shared", 1, first.signal);
+    expect(cache.get("shared", second.signal)).toBe(1);
+    cache.set("shared", 2, first.signal);
+    first.abort();
+    for (let index = 0; index < 101; index++) {
+      cache.set(String(index), index);
+    }
+    expect(cache.get("shared", second.signal)).toBe(2);
+    expect(getEventListeners(second.signal, "abort")).toHaveLength(1);
+    second.abort();
+    expect(cache.get("shared")).toBeUndefined();
+  });
+
+  it("releases replaced keys and cannot repin after abort or accumulate listeners", () => {
+    const cache = createSessionPullRequestCache<number>();
+    const watcher = new AbortController();
+    for (let index = 0; index < 300; index++) {
+      cache.get(String(index), watcher.signal);
+      cache.set(String(index), index, watcher.signal);
+      expect(getEventListeners(watcher.signal, "abort")).toHaveLength(1);
+    }
+    expect(cache.get("0")).toBeUndefined();
+    cache.release(watcher.signal);
+    expect(getEventListeners(watcher.signal, "abort")).toHaveLength(0);
+    watcher.abort();
+    cache.set("late", 1, watcher.signal);
+    for (let index = 0; index < 101; index++) {
+      cache.set(String(index), index, watcher.signal);
+    }
+    expect(cache.get("late", watcher.signal)).toBeUndefined();
+    expect(getEventListeners(watcher.signal, "abort")).toHaveLength(0);
+  });
+});

--- a/src/gateway/control-ui-session-pr-cache.ts
+++ b/src/gateway/control-ui-session-pr-cache.ts
@@ -1,0 +1,61 @@
+import { pruneMapToMaxSize } from "../infra/map-size.js";
+
+const UNWATCHED_CACHE_LIMIT = 100;
+
+/** Watched keys retain one canonical entry per cache until their lifetime ends. */
+export function createSessionPullRequestCache<T>() {
+  const entries = new Map<string, T>();
+  const retained = new Map<string, { entry: T; watchers: Set<AbortSignal> }>();
+  const pins = new WeakMap<AbortSignal, { key: string; release: () => void }>();
+
+  const release = (signal?: AbortSignal) => {
+    if (signal) {
+      pins.get(signal)?.release();
+    }
+  };
+
+  const retain = (key: string, entry: T, signal?: AbortSignal) => {
+    if (!signal || signal.aborted || pins.get(signal)?.key === key) {
+      return;
+    }
+    release(signal);
+    const current = retained.get(key) ?? { entry, watchers: new Set<AbortSignal>() };
+    retained.set(key, current);
+    current.watchers.add(signal);
+    const unpin = () => {
+      signal.removeEventListener("abort", unpin);
+      pins.delete(signal);
+      current.watchers.delete(signal);
+      if (current.watchers.size === 0) {
+        retained.delete(key);
+      }
+    };
+    pins.set(signal, { key, release: unpin });
+    signal.addEventListener("abort", unpin, { once: true });
+  };
+
+  return {
+    get(key: string, signal?: AbortSignal): T | undefined {
+      if (signal && pins.get(signal)?.key !== key) {
+        release(signal);
+      }
+      const entry = retained.get(key)?.entry ?? entries.get(key);
+      if (entry !== undefined) {
+        retain(key, entry, signal);
+      }
+      return entry;
+    },
+    set(key: string, entry: T, signal?: AbortSignal): void {
+      // Refreshes replace the shared value, never a private copy held by one watcher.
+      const current = retained.get(key);
+      if (current) {
+        current.entry = entry;
+      }
+      entries.delete(key);
+      entries.set(key, entry);
+      pruneMapToMaxSize(entries, UNWATCHED_CACHE_LIMIT);
+      retain(key, entry, signal);
+    },
+    release,
+  };
+}

--- a/src/gateway/control-ui-session-pr-subscriptions.test.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { ControlUiSessionPullRequests } from "./control-ui-contract.js";
+import { createSessionPullRequestCache } from "./control-ui-session-pr-cache.js";
 import {
   createControlUiSessionPullRequestSubscriptions,
   parseControlUiSessionPullRequestsSubscribeParams,
@@ -23,6 +24,81 @@ afterEach(async () => {
 });
 
 describe("control UI session PR subscriptions", () => {
+  it.each([
+    { cleanup: "stop", failing: false },
+    { cleanup: "stop", failing: true },
+    { cleanup: "disconnect", failing: false },
+    { cleanup: "disconnect", failing: true },
+    { cleanup: "empty replace", failing: false },
+    { cleanup: "empty replace", failing: true },
+  ])(
+    "retires cache retention before late completion on $cleanup with failing=$failing",
+    async ({ cleanup, failing }) => {
+      const cache = createSessionPullRequestCache<number>();
+      const entered = createDeferred();
+      const held = createDeferred();
+      const signals: AbortSignal[] = [];
+      active = createControlUiSessionPullRequestSubscriptions({
+        broadcastToConnIds: vi.fn(),
+        load: async ({ sessionKey }, signal) => {
+          if (!signal) {
+            throw new Error("missing watched-key lifetime");
+          }
+          signals.push(signal);
+          cache.set(sessionKey, 1, signal);
+          if (signals.length === 1) {
+            entered.resolve();
+            await held.promise;
+          }
+          cache.set(sessionKey, 2, signal);
+          if (failing) {
+            throw new Error("synthetic load failure");
+          }
+          return READY;
+        },
+      });
+      const initial = active.replace("first", ["shared"]);
+      await entered.promise;
+      const retired = signals[0]!;
+      expect(getEventListeners(retired, "abort")).toHaveLength(1);
+      const operations: Promise<unknown>[] = [initial];
+      try {
+        if (cleanup === "stop") {
+          operations.push(active.stop());
+        } else if (cleanup === "disconnect") {
+          active.unsubscribe("first");
+        } else {
+          await active.replace("first", []);
+        }
+        expect(retired.aborted).toBe(true);
+        expect(getEventListeners(retired, "abort")).toHaveLength(0);
+        if (cleanup !== "stop") {
+          operations.push(active.replace("second", ["shared"]));
+        }
+        held.resolve();
+        await Promise.all(operations);
+        expect(getEventListeners(retired, "abort")).toHaveLength(0);
+        if (cleanup !== "stop") {
+          expect(signals).toHaveLength(2);
+          expect(signals[1]).not.toBe(retired);
+          expect(signals[1]?.aborted).toBe(false);
+          await active.replace("third", ["shared"]);
+          active.unsubscribe("second");
+          expect(signals[1]?.aborted).toBe(false);
+          active.unsubscribe("third");
+          expect(signals[1]?.aborted).toBe(true);
+        }
+        for (let index = 0; index < 101; index++) {
+          cache.set(String(index), index);
+        }
+        expect(cache.get("shared")).toBeUndefined();
+      } finally {
+        held.resolve();
+        await Promise.allSettled(operations);
+      }
+    },
+  );
+
   it("bounds retained subscription keys", () => {
     expect(
       parseControlUiSessionPullRequestsSubscribeParams({
@@ -174,7 +250,7 @@ describe("control UI session PR subscriptions", () => {
 
     await active.replace("conn-a", ["first", "second", "added"]);
 
-    expect(load).toHaveBeenCalledExactlyOnceWith({ sessionKey: "added" });
+    expect(load).toHaveBeenCalledExactlyOnceWith({ sessionKey: "added" }, expect.any(AbortSignal));
     expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
       CHANGED_EVENT,
       { sessions: { added: { ...READY, status: "ready" } } },
@@ -213,9 +289,11 @@ describe("control UI session PR subscriptions", () => {
       blocked.resolve(READY);
       await Promise.all([blockers, retired, current]);
 
-      expect(load.mock.calls.filter(([params]) => params.sessionKey === "session")).toEqual([
-        [refresh ? { sessionKey: "session", refresh: true } : { sessionKey: "session" }],
-      ]);
+      expect(
+        load.mock.calls
+          .map(([params]) => params)
+          .filter((params) => params.sessionKey === "session"),
+      ).toEqual([refresh ? { sessionKey: "session", refresh: true } : { sessionKey: "session" }]);
       expect(broadcastToConnIds.mock.calls.filter((call) => "session" in call[1].sessions)).toEqual(
         [
           [
@@ -242,7 +320,10 @@ describe("control UI session PR subscriptions", () => {
     normal.resolve(READY);
     await Promise.all([initial, forced, current]);
 
-    expect(load).toHaveBeenCalledExactlyOnceWith({ sessionKey: "session" });
+    expect(load).toHaveBeenCalledExactlyOnceWith(
+      { sessionKey: "session" },
+      expect.any(AbortSignal),
+    );
     expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
       CHANGED_EVENT,
       { sessions: { session: { ...READY, status: "ready" } } },
@@ -269,7 +350,10 @@ describe("control UI session PR subscriptions", () => {
     await vi.waitFor(() => expect(load).toHaveBeenCalledTimes(2));
 
     expect(broadcastToConnIds).not.toHaveBeenCalled();
-    expect(load.mock.calls).toEqual([[{ sessionKey: "session" }], [{ sessionKey: "session" }]]);
+    expect(load.mock.calls.map(([params]) => params)).toEqual([
+      { sessionKey: "session" },
+      { sessionKey: "session" },
+    ]);
     fresh.resolve(READY);
     await Promise.all([initial, forced, current]);
 
@@ -290,7 +374,10 @@ describe("control UI session PR subscriptions", () => {
 
     await active.replace("conn-a", ["agent:work:global"]);
 
-    expect(load).toHaveBeenCalledWith({ sessionKey: "global", agentId: "work" });
+    expect(load).toHaveBeenCalledWith(
+      { sessionKey: "global", agentId: "work" },
+      expect.any(AbortSignal),
+    );
   });
 
   it("forces only requested watched keys through the shared loader", async () => {
@@ -309,7 +396,10 @@ describe("control UI session PR subscriptions", () => {
     await active.replace("conn-a", ["refresh-me", "leave-cached"], new Set(["refresh-me"]));
 
     expect(load).toHaveBeenCalledTimes(1);
-    expect(load).toHaveBeenCalledWith({ sessionKey: "refresh-me", refresh: true });
+    expect(load).toHaveBeenCalledWith(
+      { sessionKey: "refresh-me", refresh: true },
+      expect.any(AbortSignal),
+    );
     expect(broadcastToConnIds).toHaveBeenCalledExactlyOnceWith(
       CHANGED_EVENT,
       { sessions: { "refresh-me": { ...READY, rateLimited: true, status: "rate-limited" } } },
@@ -592,7 +682,9 @@ describe("control UI session PR subscriptions", () => {
     active = createControlUiSessionPullRequestSubscriptions({ broadcastToConnIds, load });
 
     const oldReplace = active.replace("conn-a", ["old", "current"]);
-    await vi.waitFor(() => expect(load).toHaveBeenCalledWith({ sessionKey: "old" }));
+    await vi.waitFor(() =>
+      expect(load).toHaveBeenCalledWith({ sessionKey: "old" }, expect.any(AbortSignal)),
+    );
     await active.replace("conn-a", ["current"]);
     resolveFirst(READY);
     await oldReplace;
@@ -662,3 +754,4 @@ describe("control UI session PR subscriptions", () => {
     });
   });
 });
+import { getEventListeners } from "node:events";

--- a/src/gateway/control-ui-session-pr-subscriptions.ts
+++ b/src/gateway/control-ui-session-pr-subscriptions.ts
@@ -19,9 +19,12 @@ const CONTROL_UI_SESSION_PR_LOAD_CONCURRENCY = 4;
 
 type LoadSessionPullRequests = (
   params: ControlUiSessionPullRequestsParams,
+  cacheSignal?: AbortSignal,
 ) => Promise<ControlUiSessionPullRequests>;
 
 type WatchedKeyState = {
+  // Retire cache pins with the shared key, without cancelling another watcher's load.
+  cacheLifetime: AbortController;
   hash?: string;
   snapshot?: ControlUiSessionPullRequestSnapshot;
 };
@@ -47,9 +50,10 @@ type ControlUiSessionPullRequestSubscriptions = {
 
 async function loadSessionPullRequests(
   params: ControlUiSessionPullRequestsParams,
+  cacheSignal?: AbortSignal,
 ): Promise<ControlUiSessionPullRequests> {
   const { loadControlUiSessionPullRequests } = await import("./control-ui-session-prs.js");
-  return await loadControlUiSessionPullRequests(params);
+  return await loadControlUiSessionPullRequests(params, { cacheSignal });
 }
 
 function pushedSnapshot(result: ControlUiSessionPullRequests): ControlUiSessionPullRequestSnapshot {
@@ -192,7 +196,7 @@ export function createControlUiSessionPullRequestSubscriptions(
           return UNAVAILABLE_SNAPSHOT;
         }
         // Fresh result identity acknowledges forced loads even when the failure is unchanged.
-        const snapshot = await load(loaderParams(sessionKey, refresh))
+        const snapshot = await load(loaderParams(sessionKey, refresh), state.cacheLifetime.signal)
           .then(pushedSnapshot)
           .catch(() => ({ ...UNAVAILABLE_SNAPSHOT }));
         if (keyStates.get(sessionKey) === state) {
@@ -236,8 +240,9 @@ export function createControlUiSessionPullRequestSubscriptions(
 
   const pruneOrphans = () => {
     const watched = watchedKeys();
-    for (const key of keyStates.keys()) {
+    for (const [key, state] of keyStates) {
       if (!watched.has(key)) {
+        state.cacheLifetime.abort(null);
         keyStates.delete(key);
       }
     }
@@ -298,7 +303,7 @@ export function createControlUiSessionPullRequestSubscriptions(
         Array.from(subscription, async ([sessionKey, watched]) => {
           let state = keyStates.get(sessionKey);
           if (!state) {
-            keyStates.set(sessionKey, (state = {}));
+            keyStates.set(sessionKey, (state = { cacheLifetime: new AbortController() }));
           }
           const isCurrent = () => subscriptions.get(normalizedConnId)?.get(sessionKey) === watched;
           const refresh = refreshSessionKeys.has(sessionKey);
@@ -343,6 +348,9 @@ export function createControlUiSessionPullRequestSubscriptions(
       timer = null;
     }
     subscriptions.clear();
+    for (const state of keyStates.values()) {
+      state.cacheLifetime.abort(null);
+    }
     keyStates.clear();
     stopPromise = scope.drain().then(() => {
       inflight.clear();

--- a/src/gateway/control-ui-session-prs-local-git.ts
+++ b/src/gateway/control-ui-session-prs-local-git.ts
@@ -1,5 +1,5 @@
 import { runGit } from "../agents/worktrees/git.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
+import { createSessionPullRequestCache } from "./control-ui-session-pr-cache.js";
 import {
   gitOutput,
   resolveBranchLanding,
@@ -8,7 +8,6 @@ import {
 import { parseGitHubRemoteUrl } from "./github-remote.js";
 
 const LOCAL_GIT_CACHE_MS = 75_000;
-const LOCAL_GIT_CACHE_LIMIT = 100;
 
 /** GitHub repo + branch resolved from a session's git checkout. */
 export type SessionPullRequestGitContext = {
@@ -22,6 +21,7 @@ export type SessionPullRequestGitContext = {
 };
 
 export type SessionPullRequestLocalGitDeps = {
+  cacheSignal?: AbortSignal;
   gitOutput?: typeof gitOutput;
   runGit?: typeof runGit;
   resolveBranchLanding?: typeof resolveBranchLanding;
@@ -35,19 +35,18 @@ type SessionPullRequestBranchFacts = {
 type LocalGitCacheEntry<T> = { expiresAt: number; promise: Promise<T> };
 
 function createLocalGitCache<T>() {
-  const entries = new Map<string, LocalGitCacheEntry<T>>();
-  return (key: string, refresh: boolean, load: () => Promise<T>): Promise<T> => {
-    const cached = entries.get(key);
-    if (!refresh && cached && cached.expiresAt > Date.now()) {
-      entries.delete(key);
-      entries.set(key, cached);
-      return cached.promise;
-    }
-    const entry = { expiresAt: Date.now() + LOCAL_GIT_CACHE_MS, promise: load() };
-    entries.delete(key);
-    entries.set(key, entry);
-    pruneMapToMaxSize(entries, LOCAL_GIT_CACHE_LIMIT);
-    return entry.promise;
+  const entries = createSessionPullRequestCache<LocalGitCacheEntry<T>>();
+  return {
+    load(key: string, refresh: boolean, load: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+      const cached = entries.get(key, signal);
+      const entry =
+        !refresh && cached && cached.expiresAt > Date.now()
+          ? cached
+          : { expiresAt: Date.now() + LOCAL_GIT_CACHE_MS, promise: load() };
+      entries.set(key, entry, signal);
+      return entry.promise;
+    },
+    release: entries.release,
   };
 }
 
@@ -56,29 +55,47 @@ function createLocalGitCache<T>() {
 const cachedGitContext = createLocalGitCache<SessionPullRequestGitContext | null>();
 const cachedBranchFacts = createLocalGitCache<SessionPullRequestBranchFacts | undefined>();
 
+export function releaseSessionPullRequestLocalGitCache(signal?: AbortSignal): void {
+  cachedGitContext.release(signal);
+  cachedBranchFacts.release(signal);
+}
+
+export function releaseSessionPullRequestBranchFacts(signal?: AbortSignal): void {
+  cachedBranchFacts.release(signal);
+}
+
 export function resolveCachedGitContext(
   root: string,
   deps: SessionPullRequestLocalGitDeps,
   refresh = false,
 ): Promise<SessionPullRequestGitContext | null> {
-  return cachedGitContext(root, refresh, async () => {
-    const output = deps.gitOutput ?? gitOutput;
-    const branch = await output(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
-    if (!branch || branch === "HEAD") {
-      return null;
-    }
-    const remoteUrl = await output(root, ["remote", "get-url", "origin"]);
-    const remote = remoteUrl ? parseGitHubRemoteUrl(remoteUrl) : null;
-    if (!remote) {
-      return null;
-    }
-    const defaultRef = await output(root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"]);
-    const defaultBranch = defaultRef?.replace(/^origin\//, "");
-    if (defaultBranch === branch) {
-      return null;
-    }
-    return { ...remote, branch, root, ...(defaultBranch ? { defaultBranch } : {}) };
-  });
+  return cachedGitContext.load(
+    root,
+    refresh,
+    async () => {
+      const output = deps.gitOutput ?? gitOutput;
+      const branch = await output(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
+      if (!branch || branch === "HEAD") {
+        return null;
+      }
+      const remoteUrl = await output(root, ["remote", "get-url", "origin"]);
+      const remote = remoteUrl ? parseGitHubRemoteUrl(remoteUrl) : null;
+      if (!remote) {
+        return null;
+      }
+      const defaultRef = await output(root, [
+        "symbolic-ref",
+        "--short",
+        "refs/remotes/origin/HEAD",
+      ]);
+      const defaultBranch = defaultRef?.replace(/^origin\//, "");
+      if (defaultBranch === branch) {
+        return null;
+      }
+      return { ...remote, branch, root, ...(defaultBranch ? { defaultBranch } : {}) };
+    },
+    deps.cacheSignal,
+  );
 }
 
 export function resolveCachedSessionBranchFacts(
@@ -86,7 +103,13 @@ export function resolveCachedSessionBranchFacts(
   mergedHeads: readonly MergedPullHead[],
   load: () => Promise<SessionPullRequestBranchFacts | undefined>,
   refresh = false,
+  signal?: AbortSignal,
 ): Promise<SessionPullRequestBranchFacts | undefined> {
   const landingKey = JSON.stringify([context.defaultBranch ?? null, mergedHeads]);
-  return cachedBranchFacts(`${context.root}\0${context.branch}\0${landingKey}`, refresh, load);
+  return cachedBranchFacts.load(
+    `${context.root}\0${context.branch}\0${landingKey}`,
+    refresh,
+    load,
+    signal,
+  );
 }

--- a/src/gateway/control-ui-session-prs-retention.test.ts
+++ b/src/gateway/control-ui-session-prs-retention.test.ts
@@ -1,0 +1,258 @@
+import { getEventListeners } from "node:events";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createControlUiSessionPullRequestSubscriptions } from "./control-ui-session-pr-subscriptions.js";
+import { loadControlUiSessionPullRequests } from "./control-ui-session-prs.js";
+import {
+  evictPullRequestCache,
+  githubJson,
+  pullListItem,
+  routedFetch,
+} from "./control-ui-session-prs.test-support.js";
+
+let cacheEpochMs = Date.now();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubEnv("GH_TOKEN", "");
+  vi.stubEnv("GITHUB_TOKEN", "");
+  cacheEpochMs += 10 * 60_000;
+  vi.setSystemTime(cacheEpochMs);
+});
+
+afterEach(async () => {
+  await evictPullRequestCache();
+  vi.unstubAllEnvs();
+  vi.useRealTimers();
+});
+
+describe("watched session PR retention", () => {
+  it("keeps every watched branch's last-good chips through quota backoff", async () => {
+    let limited = false;
+    const fetchImpl = routedFetch([
+      {
+        match: "/pulls?head=",
+        response: () =>
+          limited
+            ? githubJson({}, 429)
+            : githubJson([pullListItem({ merged_at: "2026-07-09T10:00:00Z" })]),
+      },
+    ]);
+    const snapshots = new Map<string, { rateLimited: boolean; pullRequests: unknown[] }>();
+    const subscriptions = createControlUiSessionPullRequestSubscriptions({
+      broadcastToConnIds: (_event, payload) => {
+        if (!isRecord(payload) || !isRecord(payload.sessions)) {
+          throw new Error("invalid subscription event");
+        }
+        for (const [key, snapshot] of Object.entries(payload.sessions)) {
+          if (
+            !isRecord(snapshot) ||
+            typeof snapshot.rateLimited !== "boolean" ||
+            !Array.isArray(snapshot.pullRequests)
+          ) {
+            throw new Error("invalid subscription snapshot");
+          }
+          snapshots.set(key, {
+            rateLimited: snapshot.rateLimited,
+            pullRequests: snapshot.pullRequests,
+          });
+        }
+      },
+      load: (params, cacheSignal) =>
+        loadControlUiSessionPullRequests(params, {
+          cacheSignal,
+          fetchImpl,
+          resolveGitContext: async () => ({
+            owner: "openclaw",
+            repo: "openclaw",
+            branch: params.sessionKey,
+          }),
+        }),
+    });
+    const keys = Array.from({ length: 101 }, (_, index) => `quota-${index}`);
+    try {
+      await subscriptions.replace("watcher", keys);
+      expect(fetchImpl.mock.calls).toHaveLength(101);
+      limited = true;
+      vi.setSystemTime(Date.now() + 90_001);
+      await subscriptions.pollNow();
+      const callsAtBackoff = fetchImpl.mock.calls.length;
+      expect(callsAtBackoff).toBeGreaterThan(101);
+      expect(
+        [...snapshots.values()].every(
+          (snapshot) => snapshot.rateLimited && snapshot.pullRequests.length === 1,
+        ),
+      ).toBe(true);
+      vi.setSystemTime(Date.now() + 61_000);
+      await subscriptions.replace("watcher", keys, new Set(keys));
+      expect(fetchImpl.mock.calls).toHaveLength(callsAtBackoff);
+      expect(
+        [...snapshots.values()].every(
+          (snapshot) => snapshot.rateLimited && snapshot.pullRequests.length === 1,
+        ),
+      ).toBe(true);
+      limited = false;
+      vi.setSystemTime(Date.now() + 240_001);
+      await subscriptions.pollNow();
+      expect(fetchImpl.mock.calls).toHaveLength(callsAtBackoff + 101);
+      expect(
+        [...snapshots.values()].every(
+          (snapshot) => !snapshot.rateLimited && snapshot.pullRequests.length === 1,
+        ),
+      ).toBe(true);
+    } finally {
+      await subscriptions.stop();
+    }
+  });
+
+  it("retains GitHub snapshots for the watched union across a poll", async () => {
+    const fetchImpl = routedFetch([
+      {
+        match: "/pulls?head=",
+        response: () => githubJson([pullListItem({ merged_at: "2026-07-09T10:00:00Z" })]),
+      },
+    ]);
+    const signals = new Set<AbortSignal>();
+    const gitOutput = vi.fn(async (root: string, args: string[]) => {
+      if (args.includes("--abbrev-ref")) {
+        return root.slice("/watched/".length);
+      }
+      if (args[0] === "remote") {
+        return "https://github.com/openclaw/openclaw.git";
+      }
+      if (args[0] === "symbolic-ref") {
+        return "origin/main";
+      }
+      return null;
+    });
+    const resolveBranchLanding = vi.fn(async () => ({
+      pushedSha: null,
+      statsBase: null,
+      hasLandedPullRequest: true,
+      provenNewPushedWork: false,
+    }));
+    const subscriptions = createControlUiSessionPullRequestSubscriptions({
+      broadcastToConnIds: vi.fn(),
+      load: (params, cacheSignal) => {
+        if (cacheSignal) {
+          signals.add(cacheSignal);
+        }
+        return loadControlUiSessionPullRequests(params, {
+          cacheSignal,
+          fetchImpl,
+          gitOutput,
+          resolveBranchLanding,
+          resolveGitRoot: async () => `/watched/${params.sessionKey}`,
+        });
+      },
+    });
+    try {
+      await subscriptions.replace(
+        "first",
+        Array.from({ length: 200 }, (_, index) => `watched-${index}`),
+      );
+      await subscriptions.replace(
+        "second",
+        Array.from({ length: 100 }, (_, index) => `watched-${index + 200}`),
+      );
+      expect(fetchImpl.mock.calls).toHaveLength(300);
+      expect(gitOutput).toHaveBeenCalledTimes(900);
+      expect(resolveBranchLanding).toHaveBeenCalledTimes(300);
+
+      vi.setSystemTime(Date.now() + 60_000);
+      await subscriptions.pollNow();
+
+      expect(fetchImpl.mock.calls).toHaveLength(300);
+      expect(gitOutput).toHaveBeenCalledTimes(900);
+      expect(resolveBranchLanding).toHaveBeenCalledTimes(300);
+
+      vi.setSystemTime(Date.now() + 15_001);
+      await subscriptions.pollNow();
+      expect(fetchImpl.mock.calls).toHaveLength(300);
+      expect(gitOutput).toHaveBeenCalledTimes(1_800);
+      expect(resolveBranchLanding).toHaveBeenCalledTimes(600);
+      expect(signals.size).toBe(300);
+      expect([...signals].every((signal) => getEventListeners(signal, "abort").length === 3)).toBe(
+        true,
+      );
+    } finally {
+      await subscriptions.stop();
+    }
+    expect(
+      [...signals].every(
+        (signal) => signal.aborted && getEventListeners(signal, "abort").length === 0,
+      ),
+    ).toBe(true);
+  });
+
+  it("releases obsolete retained facts when a watched checkout changes or disappears", async () => {
+    const cacheLifetime = new AbortController();
+    let root: string | null = "/retained/first";
+    let branch: string | null = "feature-a";
+    let rootFailure = false;
+    let fetchFailure = false;
+    const fetchImpl = routedFetch([
+      {
+        match: "/pulls?head=",
+        response: () => githubJson(fetchFailure ? {} : [], fetchFailure ? 503 : 200),
+      },
+      { match: "/repos/openclaw/openclaw", response: () => githubJson({ fork: false }) },
+    ]);
+    const load = () =>
+      loadControlUiSessionPullRequests(
+        { sessionKey: "retained", refresh: true },
+        {
+          cacheSignal: cacheLifetime.signal,
+          fetchImpl,
+          resolveGitRoot: async () => {
+            if (rootFailure) {
+              throw new Error("session unavailable");
+            }
+            return root;
+          },
+          gitOutput: async (_root, args) =>
+            args[0] === "rev-parse"
+              ? branch
+              : args[0] === "remote"
+                ? "https://github.com/openclaw/openclaw.git"
+                : "origin/main",
+          resolveBranchLanding: async () => ({
+            pushedSha: null,
+            statsBase: null,
+            hasLandedPullRequest: false,
+            provenNewPushedWork: false,
+          }),
+        },
+      );
+    const pins = () => getEventListeners(cacheLifetime.signal, "abort").length;
+    try {
+      await load();
+      expect(pins()).toBe(3);
+      root = "/retained/second";
+      branch = "feature-b";
+      await load();
+      expect(pins()).toBe(3);
+      root = null;
+      await load();
+      expect(pins()).toBe(0);
+      root = "/retained/third";
+      branch = "feature-c";
+      fetchFailure = true;
+      await expect(load()).rejects.toMatchObject({ statusCode: 502 });
+      // Preserve context and the GitHub failure's expiry, but drop obsolete branch facts.
+      expect(pins()).toBe(2);
+      fetchFailure = false;
+      vi.setSystemTime(Date.now() + 30_001);
+      await load();
+      expect(pins()).toBe(3);
+      branch = null;
+      await load();
+      expect(pins()).toBe(1);
+      rootFailure = true;
+      await expect(load()).rejects.toThrow("session unavailable");
+      expect(pins()).toBe(0);
+    } finally {
+      cacheLifetime.abort();
+    }
+  });
+});

--- a/src/gateway/control-ui-session-prs.test-support.ts
+++ b/src/gateway/control-ui-session-prs.test-support.ts
@@ -57,7 +57,7 @@ export const testGitContext: GitContext = {
 let cacheEvictionEpoch = 0;
 
 // The module-level branch cache would leak entries across tests; flooding it
-// past CACHE_LIMIT evicts everything a test created.
+// past the unobserved-entry limit evicts everything a test created.
 export async function evictPullRequestCache(): Promise<void> {
   const epoch = (cacheEvictionEpoch += 1);
   await Promise.all(

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -190,6 +190,7 @@ describe("loadControlUiSessionPullRequests", () => {
   });
 
   it("does not reuse cached private PRs after the GitHub token is removed", async () => {
+    const cacheLifetime = new AbortController();
     vi.stubEnv("GH_TOKEN", "github-token-a");
     const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async (_input, init) => {
       const authorization = new Headers(init?.headers).get("Authorization");
@@ -203,26 +204,31 @@ describe("loadControlUiSessionPullRequests", () => {
         : githubJson({ message: "Not Found" }, 404);
     });
 
-    const first = await loadControlUiSessionPullRequests(
-      { sessionKey: "agent:main:main" },
-      { fetchImpl, resolveGitContext },
-    );
-
-    vi.stubEnv("GH_TOKEN", "");
-    await expect(
-      loadControlUiSessionPullRequests(
+    try {
+      const first = await loadControlUiSessionPullRequests(
         { sessionKey: "agent:main:main" },
-        { fetchImpl, resolveGitContext },
-      ),
-    ).rejects.toMatchObject({ statusCode: 404 });
+        { fetchImpl, resolveGitContext, cacheSignal: cacheLifetime.signal },
+      );
 
-    expect(first.pullRequests[0]?.title).toBe("private PR from token A");
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(fetchImpl.mock.calls[0]?.[1]?.headers).toHaveProperty(
-      "Authorization",
-      "Bearer github-token-a",
-    );
-    expect(fetchImpl.mock.calls[1]?.[1]?.headers).not.toHaveProperty("Authorization");
+      vi.stubEnv("GH_TOKEN", "");
+      await expect(
+        loadControlUiSessionPullRequests(
+          { sessionKey: "agent:main:main" },
+          { fetchImpl, resolveGitContext, cacheSignal: cacheLifetime.signal },
+        ),
+      ).rejects.toMatchObject({ statusCode: 404 });
+
+      expect(first.pullRequests[0]?.title).toBe("private PR from token A");
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(fetchImpl.mock.calls[0]?.[1]?.headers).toHaveProperty(
+        "Authorization",
+        "Bearer github-token-a",
+      );
+      expect(fetchImpl.mock.calls[1]?.[1]?.headers).not.toHaveProperty("Authorization");
+      expect(getEventListeners(cacheLifetime.signal, "abort")).toHaveLength(1);
+    } finally {
+      cacheLifetime.abort();
+    }
   });
 
   it("skips diff and check fetches for merged PRs", async () => {
@@ -902,3 +908,4 @@ describe("loadControlUiSessionPullRequests", () => {
     );
   });
 });
+import { getEventListeners } from "node:events";

--- a/src/gateway/control-ui-session-prs.ts
+++ b/src/gateway/control-ui-session-prs.ts
@@ -10,7 +10,6 @@ import {
 } from "@openclaw/normalization-core/string-coerce";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { runGit } from "../agents/worktrees/git.js";
-import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 import type {
   ControlUiSessionBranch,
@@ -23,12 +22,15 @@ import {
   GITHUB_API_ORIGIN,
   resolveGitHubApiCredentialScope,
 } from "./control-ui-github-api.js";
+import { createSessionPullRequestCache } from "./control-ui-session-pr-cache.js";
 import {
   gitOutput,
   resolveBranchLanding,
   type MergedPullHead,
 } from "./control-ui-session-prs-landing.js";
 import {
+  releaseSessionPullRequestBranchFacts,
+  releaseSessionPullRequestLocalGitCache,
   resolveCachedGitContext,
   resolveCachedSessionBranchFacts,
   type SessionPullRequestGitContext,
@@ -42,7 +44,6 @@ const SUCCESS_CACHE_MS = 90_000;
 // showing the last-known chips with the stale warning during this window.
 const RATE_LIMIT_CACHE_MS = 5 * 60_000;
 const FAILURE_CACHE_MS = 30_000;
-const CACHE_LIMIT = 100;
 const MAX_PULL_REQUESTS = 3;
 
 export type ControlUiSessionPullRequestsParams = {
@@ -84,7 +85,7 @@ type CacheEntry = {
   lastGood?: { pullRequests: ControlUiSessionPullRequest[]; mergedHeads: MergedPullHead[] };
 };
 
-const branchCache = new Map<string, CacheEntry>();
+const branchCache = createSessionPullRequestCache<CacheEntry>();
 
 type LoadSessionPullRequestDeps = SessionPullRequestLocalGitDeps & {
   fetchImpl?: typeof fetch;
@@ -138,6 +139,7 @@ async function resolveSessionPullRequestGitContext(
     ? await deps.resolveGitRoot(params)
     : resolveSessionPullRequestGitRoot(params);
   if (!root) {
+    releaseSessionPullRequestLocalGitCache(deps.cacheSignal);
     return null;
   }
   return resolveCachedGitContext(root, deps, params.refresh === true);
@@ -309,6 +311,7 @@ async function resolveSessionBranch(
       return !creatable && !(stats && stats.changedFiles > 0) ? undefined : { creatable, stats };
     },
     refresh,
+    deps.cacheSignal,
   );
   if (!facts) {
     return undefined;
@@ -601,10 +604,19 @@ export async function loadControlUiSessionPullRequests(
   params: ControlUiSessionPullRequestsParams,
   deps: LoadSessionPullRequestDeps = {},
 ): Promise<ControlUiSessionPullRequests> {
-  const context = deps.resolveGitContext
-    ? await deps.resolveGitContext(params)
-    : await resolveSessionPullRequestGitContext(params, deps);
+  let context: SessionPullRequestGitContext | null;
+  try {
+    context = deps.resolveGitContext
+      ? await deps.resolveGitContext(params)
+      : await resolveSessionPullRequestGitContext(params, deps);
+  } catch (error) {
+    releaseSessionPullRequestLocalGitCache(deps.cacheSignal);
+    branchCache.release(deps.cacheSignal);
+    throw error;
+  }
   if (!context) {
+    releaseSessionPullRequestBranchFacts(deps.cacheSignal);
+    branchCache.release(deps.cacheSignal);
     return { pullRequests: [], rateLimited: false };
   }
   // Normal polling reuses local Git facts across a poll cycle; forced
@@ -613,7 +625,10 @@ export async function loadControlUiSessionPullRequests(
     context,
     deps,
     params.refresh === true,
-  );
+  ).catch((error: unknown) => {
+    releaseSessionPullRequestBranchFacts(deps.cacheSignal);
+    throw error;
+  });
   const branch = await resolveSessionBranch(context, mergedHeads, deps, params.refresh === true);
   return branch ? { ...snapshot, branch } : snapshot;
 }
@@ -642,12 +657,18 @@ async function cachedBranchPullRequests(
   deps: LoadSessionPullRequestDeps,
   refresh: boolean,
 ): Promise<BranchPullRequestsSnapshot> {
-  const { token, cacheScope } = resolveGitHubApiCredentialScope();
+  let identity: ReturnType<typeof resolveGitHubApiCredentialScope>;
+  try {
+    identity = resolveGitHubApiCredentialScope();
+  } catch (error) {
+    branchCache.release(deps.cacheSignal);
+    throw error;
+  }
+  const { token, cacheScope } = identity;
   const key = `${context.owner.toLowerCase()}/${context.repo.toLowerCase()}#${context.branch}\0${cacheScope}`;
-  const cached = branchCache.get(key);
+  const cached = branchCache.get(key, deps.cacheSignal);
   if (cached && cached.expiresAt > Date.now()) {
-    branchCache.delete(key);
-    branchCache.set(key, cached);
+    branchCache.set(key, cached, deps.cacheSignal);
     if (!refresh || cached.refreshMode === "forced") {
       return cached.promise;
     }
@@ -675,8 +696,6 @@ async function cachedBranchPullRequests(
   const promise = trackBranchRefresh(entry, refresh ? "forced" : "normal", () =>
     refreshBranchPullRequests(context, deps.fetchImpl ?? fetch, entry, token),
   );
-  branchCache.delete(key);
-  branchCache.set(key, entry);
-  pruneMapToMaxSize(branchCache, CACHE_LIMIT);
+  branchCache.set(key, entry, deps.cacheSignal);
   return promise;
 }

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -395,8 +395,8 @@ describe("SessionHistorySseState", () => {
       projection: {
         messages,
         turnBoundaryPending: false,
-        streamErrorFallbackPending: false,
-        streamErrorFallbackRepaired: false,
+        assistantErrorPending: false,
+        assistantErrorRecoveryObserved: false,
       },
       limit: 1,
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where large watched session lists repeat Git and GitHub PR lookups on every poll, even before their normal refresh windows expire. A connection can watch 200 sessions, but the caches retain only 100 entries; scanning a larger stable set evicts the entries the next poll is about to reuse.

## Why This Change Was Made

Retain the three canonical cache entries with each shared watched-key lifetime: checkout context, local branch facts, and the GitHub snapshot. Multiple watchers share refreshes and release their references on key replacement, unsubscribe, disconnect, or shutdown. Recently unwatched lookups retain the existing 100-entry LRU bound. Expiry, distinct forced Git reads, credential separation, GitHub quota backoff, and last-known chips retain their existing behavior.

The production growth is the lifecycle ownership needed to keep active entries out of eviction pressure while bounding retained entries to at most three per watched key. The change removes duplicated LRU mutation and pruning.

## User Impact

Large visible session lists reuse fresh PR facts across polls and release those references when views stop watching. No settings or migrations are needed.

## Evidence

- Original real-Git owner reproduction: the second poll across 100, 101, and 200 synthetic checkouts made 0, 477, and 1,000 Git launches. The candidate makes 0 in all three cases, with identical returned facts and per-checkout query order. Both runs used Node 26.5.0 and Git 2.55.0 on macOS; cold elapsed is not a controlled timing comparison.
- Actual subscription and GitHub-loader regression: 300 watched branches repeated all 300 synthetic HTTP fetches before cache expiry on the original code; the candidate reuses them.
- 94 focused tests pass, covering retained expiry, quota recovery, credential changes, shared refreshes, key changes, retirement, and late failures. A real Git branch-switch race verifies that separate forced reads still observe the switch.
- Independent P2 review and the full local changed gate pass. The same 94 tests also pass on Blacksmith Testbox (Linux, Node 24.19.0, Git 2.52.0, Execa 10.0.1), followed by a successful packaged build and CLI version check. All 38,314 source entries were verified around both phases; the complete Git tree matches the candidate. The initial attempt stopped before tests on a harness identity assumption; the corrected run binds the actual receiver carrier and source tree, with the original failure retained. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34017150453).

The network fixtures use an injected synthetic transport. These proofs establish cache behavior and process counts; they do not establish a production latency improvement or resolve every source of event-loop delay. The separately reviewed baseline fixture correction is tracked in #139773 and will not be part of the final merged cache delta.
