### PR TITLE
improve(test): read fresh Doctor canonical install records

### DIFF
--- a/src/commands/doctor-plugin-install-config.process.test.ts
+++ b/src/commands/doctor-plugin-install-config.process.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  clearLoadInstalledPluginIndexInstallRecordsCache,
   readPersistedInstalledPluginIndexInstallRecords,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
@@ -91,6 +92,8 @@ describe("Doctor retired plugin install config", () => {
             kind === "empty-included" ? {} : { enabled: false },
           );
         }
+        // Child Doctor writes cannot invalidate the parent process cache.
+        clearLoadInstalledPluginIndexInstallRecordsCache();
         expect(await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env })).toEqual(
           empty ? { existing: durable } : { existing: durable, imported: legacy },
         );
@@ -139,6 +142,7 @@ describe("Doctor retired plugin install config", () => {
     const repaired = JSON.parse(fs.readFileSync(configPath, "utf8"));
     expect(repaired.plugins, result.stderr).not.toHaveProperty("installs");
     expect(repaired).not.toHaveProperty("unknownKey");
+    clearLoadInstalledPluginIndexInstallRecordsCache();
     expect(await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env })).toEqual({
       imported: legacy,
     });
@@ -205,6 +209,7 @@ describe("Doctor retired plugin install config", () => {
       JSON.parse(fs.readFileSync(path.join(root, "first-write.json"), "utf8")).plugins,
       result.stderr,
     ).not.toHaveProperty("installs");
+    clearLoadInstalledPluginIndexInstallRecordsCache();
     expect(await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env })).toEqual({});
     expect(JSON.parse(fs.readFileSync(configPath, "utf8")).plugins).not.toHaveProperty("installs");
   }, 90_000);
@@ -256,6 +261,7 @@ describe("Doctor retired plugin install config", () => {
     const repaired = JSON.parse(fs.readFileSync(configPath, "utf8")) as OpenClawConfig;
     expect(repaired.plugins, output).not.toHaveProperty("installs");
     expect(repaired.plugins?.entries?.["migration-proof-plugin"], output).toEqual(entry);
+    clearLoadInstalledPluginIndexInstallRecordsCache();
     expect(
       (await readPersistedInstalledPluginIndexInstallRecords({ stateDir, env }))?.[
         "migration-proof-plugin"


### PR DESCRIPTION
## What Problem This Solves

The Doctor plugin-install process tests read canonical install records in the parent process after child Doctor executions. That reader caches records by store path, and a child commit cannot invalidate the parent's cache. In particular, repeat-pass assertions could reuse the first pass's records instead of observing the persisted result.

## Why This Change Was Made

Clear the existing reader cache immediately before each of the four parent persistence assertion sites. This six-line test-only change retains the upstream async direct-seed fixtures, independent roots, all eight scenarios, and every existing expected result. No runtime cache semantics, process lifecycle, or deadlines change.

## User Impact

More reliable migration and idempotency coverage: the assertions now observe fresh canonical records after child-process writes. There is no production behavior change.

## Evidence

- A task-owned synthetic child commit reproduced the stale parent read through the real reader; explicit invalidation exposed the child's updated canonical records.
- All eight Doctor process cases passed through the normal test wrapper on the refreshed base.
- Full changed-file gate, diff checks, deslop, and independent review through P2 passed.
- Removing the new import, explanatory comment, and four cache-clear calls yields the upstream test file byte-for-byte, preserving fixture setup and assertions.
