### PR TITLE
fix(test): assert filesystem access consistently under Bun

### DIFF
--- a/extensions/codex/src/app-server/computer-use-cache.test.ts
+++ b/extensions/codex/src/app-server/computer-use-cache.test.ts
@@ -133,10 +133,8 @@ describe("Codex Computer Use shared plugin cache", () => {
     expect(activeCacheEntry?.isSymbolicLink()).toBe(false);
     expect((await fs.lstat(activeCachePath)).isDirectory()).toBe(true);
     expect((await fs.lstat(activeCachePath)).isSymbolicLink()).toBe(false);
-    await expect(
-      fs.access(path.join(activeCachePath, ".codex-plugin", "plugin.json")),
-    ).resolves.toBe(undefined);
-    await expect(fs.access(priorCachePath)).resolves.toBe(undefined);
+    await fs.access(path.join(activeCachePath, ".codex-plugin", "plugin.json"));
+    await fs.access(priorCachePath);
   });
 
   it("leaves an up-to-date copied cache entry unchanged", async () => {
@@ -174,9 +172,7 @@ describe("Codex Computer Use shared plugin cache", () => {
     });
     expect((await fs.lstat(activeCachePath)).isDirectory()).toBe(true);
     expect((await fs.lstat(activeCachePath)).isSymbolicLink()).toBe(false);
-    await expect(
-      fs.access(path.join(activeCachePath, ".codex-plugin", "plugin.json")),
-    ).resolves.toBe(undefined);
+    await fs.access(path.join(activeCachePath, ".codex-plugin", "plugin.json"));
   });
 
   it("refreshes same-version cache bytes for a new desktop generation", async () => {
@@ -364,8 +360,8 @@ describe("Codex Computer Use shared plugin cache", () => {
       changed: false,
       removedStaleVersions: [],
     });
-    await expect(fs.access(path.join(cacheRoot, "1.0.101"))).resolves.toBe(undefined);
-    await expect(fs.access(path.join(cacheRoot, "1.0.102"))).resolves.toBe(undefined);
+    await fs.access(path.join(cacheRoot, "1.0.101"));
+    await fs.access(path.join(cacheRoot, "1.0.102"));
   });
 
   it("preserves the default namespace when marketplacePath is explicit", async () => {
@@ -394,8 +390,8 @@ describe("Codex Computer Use shared plugin cache", () => {
       changed: false,
       removedStaleVersions: [],
     });
-    await expect(fs.access(path.join(cacheRoot, "1.0.101"))).resolves.toBe(undefined);
-    await expect(fs.access(path.join(cacheRoot, "1.0.102"))).resolves.toBe(undefined);
+    await fs.access(path.join(cacheRoot, "1.0.101"));
+    await fs.access(path.join(cacheRoot, "1.0.102"));
   });
 
   it("preserves the active cache when replacement copying fails", async () => {

--- a/extensions/codex/src/app-server/computer-use-service.test.ts
+++ b/extensions/codex/src/app-server/computer-use-service.test.ts
@@ -64,7 +64,7 @@ describe("Codex Computer Use native service", () => {
       sourceBuild: "1000761",
     });
     const targetPath = path.join(codexHome, "computer-use", "Codex Computer Use.app");
-    await expect(fs.access(path.join(targetPath, CLIENT_RELATIVE_PATH))).resolves.toBeUndefined();
+    await fs.access(path.join(targetPath, CLIENT_RELATIVE_PATH));
     await expect(inspectServiceFixture(targetPath)).resolves.toEqual(CURRENT_IDENTITY);
   });
 

--- a/src/acp/runtime/session-meta-doctor.test.ts
+++ b/src/acp/runtime/session-meta-doctor.test.ts
@@ -207,11 +207,9 @@ it.each(["global", "shared-project"])(
           (claim) => claim.agentId === "free-harness",
         ),
       ).toEqual(before.claims.find((claim) => claim.agentId === "free-harness"));
-      await expect(
-        fs.access(
-          path.join(state.workspaceDir, "state", "sessions", `${sessionKey}.json.migrated`),
-        ),
-      ).resolves.toBeUndefined();
+      await fs.access(
+        path.join(state.workspaceDir, "state", "sessions", `${sessionKey}.json.migrated`),
+      );
     });
   },
 );

--- a/src/config/sessions/disk-budget.artifacts.test.ts
+++ b/src/config/sessions/disk-budget.artifacts.test.ts
@@ -9,7 +9,7 @@ import { pruneUnreferencedSessionArtifacts } from "./disk-budget.js";
 import type { SessionEntry } from "./types.js";
 
 async function expectPathExists(targetPath: string): Promise<void> {
-  await expect(fs.access(targetPath)).resolves.toBeUndefined();
+  await fs.access(targetPath);
 }
 
 async function expectPathMissing(targetPath: string): Promise<void> {

--- a/src/config/sessions/disk-budget.test.ts
+++ b/src/config/sessions/disk-budget.test.ts
@@ -23,7 +23,7 @@ import { resolveMaintenanceConfigFromInput } from "./store-maintenance.js";
 import type { SessionEntry } from "./types.js";
 
 async function expectPathExists(targetPath: string): Promise<void> {
-  await expect(fs.access(targetPath)).resolves.toBeUndefined();
+  await fs.access(targetPath);
 }
 
 async function expectPathMissing(targetPath: string): Promise<void> {

--- a/src/config/sessions/store.pruning.test.ts
+++ b/src/config/sessions/store.pruning.test.ts
@@ -989,7 +989,7 @@ describe("resolveMaintenanceConfigFromInput", () => {
       expect(maintenance.maxDiskBytes).toBeNull();
       expect(maintenance.highWaterBytes).toBeNull();
       expect(result).toBeNull();
-      await expect(fs.access(transcriptPath)).resolves.toBeUndefined();
+      await fs.access(transcriptPath);
     });
   });
 

--- a/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
+++ b/test/e2e/qa-lab/tui/tui-pty-evidence-producer.test.ts
@@ -478,7 +478,7 @@ describe("TUI PTY evidence producer", () => {
     const reportText = await fs.readFile(path.join(artifactBase, "vitest-report.json"), "utf8");
     expect(reportText).toContain(`"name": "${HARNESS_FILE}"`);
     expect(reportText).not.toContain(repoRoot);
-    await expect(fs.access(path.join(artifactBase, "latest-run.json"))).resolves.toBeUndefined();
-    await expect(fs.access(path.join(artifactBase, "qa-evidence.json"))).resolves.toBeUndefined();
+    await fs.access(path.join(artifactBase, "latest-run.json"));
+    await fs.access(path.join(artifactBase, "qa-evidence.json"));
   });
 });

--- a/test/scripts/postinstall-bundled-plugins.test.ts
+++ b/test/scripts/postinstall-bundled-plugins.test.ts
@@ -21,7 +21,7 @@ import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDirAsync } = createScriptTestHarness();
 async function expectPathExists(filePath: string) {
-  await expect(fs.access(filePath)).resolves.toBeUndefined();
+  await fs.access(filePath);
 }
 
 async function expectPathMissing(filePath: string) {


### PR DESCRIPTION
## What Problem This Solves

Fixes false failures in filesystem existence checks under Bun. Successful fs.access calls can fulfill with a different value from Node, even though the file is accessible.

## Why This Change Was Made

Await successful access directly at 15 sites across eight test files. Failed access still rejects the test; all file type, content, migration, pruning, and cache-state assertions remain unchanged.

## User Impact

No production or persistence behavior changes. Existing file-access coverage accepts the native success contract on both runtimes.

## Evidence

- Node passes all 164 tests across the eight files.
- Bun passes 163 of 164 tests with the canonical SQLite preload. All access-sentinel failures are resolved.
- One pre-existing disk-budget accounting case still fails under Bun: sessionFilesBytes is 32768 rather than 0. The same failure appears in the original campaign run; this PR leaves that assertion and storage behavior unchanged.
- Complete combined changed-file gate and fresh P0–P2 review pass.
- No rejection checks, timeout limits, or production assertions were weakened. The full Bun campaign remains in progress.
