### PR TITLE
improve: shorten the Gateway held-upgrade test wait

### DIFF
--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -46,6 +46,7 @@ type AcquisitionPeer = {
   errors: Error[];
   unownedErrors: Error[];
   requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[];
+  receivedUpgrade: () => boolean;
   isListening: () => boolean;
   failTransport: () => Promise<Error>;
   close: () => Promise<void>;
@@ -83,6 +84,7 @@ async function withAcquisitionPeer(
   });
   const sockets = new Set<Socket>();
   const requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[] = [];
+  let receivedUpgrade = false;
   const server = createServer();
   const wss = new WebSocketServer({ noServer: true, maxPayload: 64 * 1024 });
   server.on("connection", (socket) => {
@@ -90,6 +92,7 @@ async function withAcquisitionPeer(
     socket.once("close", () => sockets.delete(socket));
   });
   server.on("upgrade", (request, socket, head) => {
+    receivedUpgrade = true;
     if (behavior === "hold upgrade") {
       return;
     }
@@ -178,6 +181,7 @@ async function withAcquisitionPeer(
       errors,
       unownedErrors,
       requests,
+      receivedUpgrade: () => receivedUpgrade,
       isListening: () => server.listening,
       failTransport: () => {
         for (const socket of sockets) {
@@ -486,7 +490,12 @@ describe("raw Gateway helper acquisition ownership", () => {
             : helper === "webchat"
               ? connectWebchatClient({ port: peer.port })
               : helper === "shared auth"
-                ? openAuthenticatedGatewayWs(peer.port, "synthetic-token")
+                ? openAuthenticatedGatewayWs(
+                    peer.port,
+                    "synthetic-token",
+                    // Webchat retains the default opening deadline; this helper also accepts a budget.
+                    behavior === "hold upgrade" ? 1_000 : undefined,
+                  )
                 : connectDeviceAuthReq({
                     url: `ws://127.0.0.1:${peer.port}`,
                     token: "synthetic-token",
@@ -508,6 +517,9 @@ describe("raw Gateway helper acquisition ownership", () => {
         expect(peer.unownedErrors).toEqual([]);
         expect(failure).toBeInstanceOf(Error);
         expect(failure).toMatchObject({ message: expect.stringContaining(error) });
+        if (behavior === "hold upgrade") {
+          expect(peer.receivedUpgrade(), "the peer must receive the withheld upgrade").toBe(true);
+        }
         if (behavior === "no response") {
           expect(failure).toMatchObject({ message: "timeout" });
         }


### PR DESCRIPTION
## What Problem This Solves

Resolves an unnecessary ten-second wait in the shared-auth Gateway acquisition test when its local peer intentionally withholds the HTTP upgrade.

## Why This Change Was Made

Use the helper's existing caller-supplied opening budget of one second for this negative case. Record that the peer actually received the upgrade, so the shorter budget cannot silently turn connection setup delay into the test stimulus.

All 31 cases remain, including real socket errors and close events, borrowed-server ownership, environment restoration, and three isolated retained-owner forks. The webchat case retains the default ten-second opening deadline. Production and helper defaults are unchanged.

## User Impact

Less deliberate waiting in developer and CI tests; no runtime behavior change.

## Evidence

Four same-host runs passed all 31 cases. The warm original-budget control included the new upgrade witness. Its shared-auth case took 10.181 seconds; the final candidate took 1.232 seconds. The webchat default case remained about 10.15 seconds.

Whole-suite savings were within noise: warm control 89.92 seconds versus candidate 89.57 seconds, with varying cold-fork costs. The first cold baseline was 161.74 seconds; that cold/warm difference is not attributed to this change.

These comparisons used Node 26.8.1 with the same dependency tree. Additional validation on Node 24.19.0 in a contained checkout passed all 31 cases and the complete changed-file gate. Independent P2 review found no actionable issues. Formatting and diff checks passed. Test-only delta +13/-1; production zero.

Commands: `node scripts/run-vitest.mjs src/gateway/test-helpers.acquisition.test.ts --maxWorkers=1 --reporter=verbose` and `node scripts/check-changed.mjs -- src/gateway/test-helpers.acquisition.test.ts`. No increased timeouts, mocked transport, extra shards, or removed cases.
