### PR TITLE
fix(git): reject truncated output instead of returning partial data

### DIFF
--- a/docs/cli/backup.md
+++ b/docs/cli/backup.md
@@ -214,6 +214,11 @@ openclaw backup git verify --repository ~/Backups/openclaw-git --ref <commit> --
 openclaw backup git verify --repository ~/Backups/openclaw-git --ref <commit> --agent main
 ```
 
+Git history output must fit within a 16 MiB read. If a log request reports an
+output-limit error, retry with a smaller `--limit`. An oversized commit subject
+can exceed the limit even with `--limit 1`; inspect that history directly with
+Git. OpenClaw reports the failure without returning partial history entries.
+
 Verification restores the selected snapshot into private scratch space, checks each table's row count and SHA-256, runs `PRAGMA integrity_check` and `PRAGMA foreign_key_check`, and removes the scratch copy. Restore writes only to a fresh target and refuses existing `-wal`, `-shm`, and `-journal` sidecars:
 
 ```bash

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -123,6 +123,12 @@ describe.each([
 
   it.each([
     {
+      termination: "exit",
+      code: 128,
+      stdoutTruncatedBytes: 1,
+      expected: "exit code 128",
+    },
+    {
       termination: "timeout",
       signal: "SIGKILL",
       code: 124,
@@ -166,26 +172,69 @@ describe.each([
   );
 });
 
-describe("successful Git output", () => {
+describe("required Git output", () => {
+  async function withGitBlob(
+    input: string | Buffer,
+    run: (root: string, args: string[]) => Promise<void>,
+  ) {
+    await withTestDir({ prefix: "openclaw-git-output-" }, async (root) => {
+      await requireGitCommand(root, ["init"]);
+      const oid = await requireGitCommand(root, ["hash-object", "-w", "--stdin"], { input });
+      await run(root, ["cat-file", "blob", oid]);
+    });
+  }
+
   it("keeps raw text byte-for-byte and preserves the trimmed text contract", async () => {
     const stdout = " \u001b[31mname\u001b[0m\rredraw\0\r\n ";
-    vi.spyOn(processExec, "runCommandWithTimeout").mockResolvedValue({
-      ...failure,
-      code: 0,
-      stdout,
+    await withGitBlob(stdout, async (root, args) => {
+      await expect(requireGitCommandRaw(root, args)).resolves.toBe(stdout);
+      await expect(requireGitCommand(root, args)).resolves.toBe(stdout.trim());
     });
-    await expect(requireGitCommandRaw("/repo", ["status"])).resolves.toBe(stdout);
-    await expect(requireGitCommand("/repo", ["status"])).resolves.toBe(stdout.trim());
   });
 
   it("keeps binary output including invalid UTF-8 and terminal control bytes", async () => {
     const stdout = Buffer.from([0, 255, 13, 10, 27, 91, 51, 49, 109, 32]);
-    vi.spyOn(processExec, "runCommandBuffered").mockResolvedValue({
+    await withGitBlob(stdout, async (root, args) => {
+      await expect(requireGitCommandBuffer(root, args)).resolves.toEqual(stdout);
+    });
+  });
+
+  it.each([
+    ["text", requireGitCommand],
+    ["raw", requireGitCommandRaw],
+    ["buffered", requireGitCommandBuffer],
+  ] as const)("rejects incomplete %s output from a real Git blob", async (_kind, requireGit) => {
+    const sentinel = "complete-git-output-leading-sentinel\0";
+    const blob = Buffer.alloc(17 * 1024 * 1024, "x");
+    blob.write(sentinel);
+    await withGitBlob(blob, async (root, args) => {
+      const outcome = await requireGit(root, args).then(
+        (stdout) => ({
+          kind: "returned",
+          bytes: Buffer.byteLength(stdout),
+          hasSentinel: stdout.includes(sentinel),
+        }),
+        (error: unknown) => ({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        }),
+      );
+      expect(outcome).toEqual({
+        kind: "error",
+        message: expect.stringContaining("output limit exceeded"),
+      });
+    });
+  });
+
+  it("accepts complete text when only diagnostic stderr was truncated", async () => {
+    vi.spyOn(processExec, "runCommandWithTimeout").mockResolvedValue({
       ...failure,
       code: 0,
-      stdout,
-      stderr: Buffer.alloc(0),
+      stdout: "complete\n",
+      stderr: "progress tail",
+      stderrTruncatedBytes: 1,
     });
-    await expect(requireGitCommandBuffer("/repo", ["show"])).resolves.toEqual(stdout);
+    await expect(requireGitCommandRaw("/repo", ["status"])).resolves.toBe("complete\n");
+    await expect(requireGitCommand("/repo", ["status"])).resolves.toBe("complete");
   });
 });

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -4,6 +4,8 @@ import { runCommandBuffered, runCommandWithTimeout, type CommandOptions } from "
 
 export const GIT_TIMEOUT_MS = 120_000;
 
+type GitCommandResult = SpawnResult & { timeoutMs: number };
+
 export function withForegroundGitMaintenance(argv: string[]): string[] {
   // Maintenance and legacy auto-GC must stay in their cancellable process tree.
   return argv[0] === "git"
@@ -18,7 +20,7 @@ export async function executeGitCommand(
     CommandOptions,
     "env" | "input" | "timeoutMs" | "signal" | "killProcessTree" | "maxOutputBytes"
   > = {},
-): Promise<SpawnResult & { timeoutMs: number }> {
+): Promise<GitCommandResult> {
   const timeoutMs = options.timeoutMs ?? GIT_TIMEOUT_MS;
   const argv = ["git", "-C", cwd, ...args];
   const result = await runCommandWithTimeout(
@@ -47,21 +49,31 @@ export async function requireGitCommand(
   args: string[],
   options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
 ): Promise<string> {
-  const result = await executeGitCommand(cwd, args, options);
-  if (result.code !== 0) {
-    throw createGitCommandError(`git ${args.join(" ")}`, result);
-  }
-  return result.stdout.trim();
+  return (await requireGitCommandRaw(cwd, args, options)).trim();
 }
 
 export async function requireGitCommandRaw(
   cwd: string,
   args: string[],
-  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
+  options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array; timeoutMs?: number } = {},
 ): Promise<string> {
-  const result = await executeGitCommand(cwd, args, options);
+  return requireGitCommandOutput(
+    `git ${args.join(" ")}`,
+    await executeGitCommand(cwd, args, options),
+  );
+}
+
+export function requireGitCommandOutput(
+  command: string,
+  result: GitCommandResult,
+  createError: (command: string, result: GitCommandResult) => Error = createGitCommandError,
+): string {
+  // Required stdout is data, not a diagnostic tail; a clean exit cannot make it complete.
+  if (result.code === 0 && result.stdoutTruncatedBytes) {
+    throw createError(command, { ...result, code: null, outputLimitExceeded: true });
+  }
   if (result.code !== 0) {
-    throw createGitCommandError(`git ${args.join(" ")}`, result);
+    throw createError(command, result);
   }
   return result.stdout;
 }

--- a/src/snapshot/git-backup.test.ts
+++ b/src/snapshot/git-backup.test.ts
@@ -656,6 +656,50 @@ describe("Git-backed SQLite snapshots", () => {
     expect(output).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u);
   });
 
+  it("rejects a truncated Git history record with bounded redacted diagnostics", async () => {
+    const repositoryPath = await tempRoot();
+    await requireGit(repositoryPath, ["init"]);
+    const tree = await requireGit(repositoryPath, ["hash-object", "-w", "-t", "tree", "--stdin"], {
+      input: "",
+    });
+    const secret = ["synthetic", "history", "password"].join("-");
+    const remote = `https://synthetic:${secret}@example.invalid/history`;
+    const commit = await requireGit(
+      repositoryPath,
+      [
+        "-c",
+        "user.name=OpenClaw Backup Test",
+        "-c",
+        "user.email=backup@example.invalid",
+        "commit-tree",
+        tree,
+      ],
+      { input: `openclaw backup ${"x".repeat(17 * 1024 * 1024)} ${remote}\n` },
+    );
+    await fs.writeFile(path.join(repositoryPath, ".git", "HEAD"), `${commit}\n`);
+
+    const outcome = await readGitBackupLog({ repositoryPath, limit: 1 }).then(
+      (entries) => ({
+        kind: "returned",
+        entries: entries.map((entry) => ({
+          commitBytes: Buffer.byteLength(entry.commit),
+          date: entry.date,
+          messageBytes: Buffer.byteLength(entry.message),
+        })),
+      }),
+      (error: unknown) => ({
+        kind: "error",
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    expect(outcome).toEqual({ kind: "error", message: expect.stringContaining("output-limit") });
+    if ("message" in outcome) {
+      expect(outcome.message.length).toBeLessThanOrEqual(1_200);
+      expect(outcome.message).toContain("https://***:***@example.invalid/history");
+      expect(outcome.message).not.toContain(secret);
+    }
+  });
+
   it("does not treat a symbolic HEAD with a missing object as an empty log", async () => {
     const root = await tempRoot();
     const repositoryPath = path.join(root, "broken-repository");

--- a/src/snapshot/git-backup.ts
+++ b/src/snapshot/git-backup.ts
@@ -8,6 +8,7 @@ import {
   GIT_TIMEOUT_MS,
   executeGitCommand as runGit,
   requireGitCommand as requireGit,
+  requireGitCommandOutput,
 } from "../infra/git-exec.js";
 import { formatCommandOutput, formatCommandResult } from "../process/command-error.js";
 import { spawnCommand } from "../process/exec-spawn.js";
@@ -514,10 +515,11 @@ export async function readGitBackupLog(params: {
     `--max-count=${params.limit}`,
     "--pretty=format:%H%x09%cI%x09%s",
   ]);
-  if (result.code !== 0) {
-    throw new Error(formatGitBackupCommandResult("git log", result));
-  }
-  return result.stdout
+  return requireGitCommandOutput(
+    "git log",
+    result,
+    (command, failure) => new Error(formatGitBackupCommandResult(command, failure)),
+  )
     .split("\n")
     .filter(Boolean)
     .map((line) => {


### PR DESCRIPTION
Closes #139857. Related: #135455.

## What Problem This Solves

Fixes an issue where users reading sufficiently large Git output receive only its retained stdout tail as successful data. In `openclaw backup git log`, an oversized history entry can then appear as a malformed commit/date/message record even with `--limit 1`.

## Why This Change Was Made

The required Git-output adapter now checks completeness before returning data. Raw and trimmed reads share that adapter, and backup history uses it with its existing bounded, redacted error formatter. Ordinary nonzero failures retain precedence; the low-level diagnostic-tail executor, binary reads, stderr-only truncation behavior, and mutation completion keep their existing contracts.

Production is **+27/−13 (net +14)**, tests **+104/−11 (net +93)**, and docs **+5**. The production growth provides one complete-data result adapter shared by current callers while preserving the backup-specific error boundary; duplicated trimmed execution and manual backup exit validation are removed. No new configuration, dependency, SQLite schema, persistence format, or public SDK surface.

## User Impact

Required Git reads return complete data or a visible error. Backup history never returns partial records when stdout exceeds the retained limit. The backup CLI docs explain reducing `--limit` and inspecting an individually oversized commit directly with Git.

## Evidence

Exact candidate `9153ef1ec9f382c48a47341270c63f4213be603e`, based on main `e19a7694cef6d38140033f798215103dd638fafb`.

- Before: real Git reads of a 17 MiB blob exited 0 but supplied only the retained 16 MiB tail; a real oversized backup-history entry produced malformed parsed history. These reproductions use actual Git processes and data.
- Current integration: **72 tests passed**: 46 Git-owner cases, 25 full backup-owner cases, and a 256 MiB streaming create/restore/verify plus missing-blob cleanup control. Main's newer streaming materialization remains intact.
- The actual built `pnpm openclaw backup git log` flow passed both cases in disposable home/state/repositories: normal history produced complete JSON with exit 0; a real oversized entry at `--limit 1` returned exit 1 and an output-limit error with no partial stdout record. The credential-like fixture URL was redacted, and combined wrapper/diagnostic output was **1,066 characters**. Fixtures were removed.
- All required changed-check stages passed across the recorded full run and narrow recovery. The initial full run caught parameter reassignment; the same-LOC direct-throw correction passed 52 owner/backup tests, lint, and every remaining guard without repeating the already-passing broad stages. Rebased format, diff, core types, and targeted lint passed again.
- Runtime/UI build passed in **86.44 seconds** using the repository-supported runtime mode of `pnpm build`. `dist/build-info.json` records this exact candidate. Declaration regeneration is not claimed; no SDK export surface changed.
- Fresh managed complete-source branch Codex review at **P0–P2** was **scoped-clean with zero findings**. Full changed production owners and complete caller, process, backup, worktree, streaming, and dependency context were supplied with the managed safeguards enabled.

Execa's success/rejection and file-stream contracts were inspected directly: exit code 0 cannot report bytes discarded by OpenClaw's independent diagnostic capture. No provider, channel, or operator state was used for this proof.

Hosted CI [34017637291](https://github.com/openclaw/openclaw/actions/runs/34017637291) is green on this exact head after one failed-jobs-only rerun. The first attempt's pnpm-store warmup crashed in Node 24.20.0 Undici while downloading the pinned pnpm native binary, before cache restore/dependency installation; build-artifacts and 106 other jobs passed. The saved failure was inspected, and no source, lockfile, package pin, or workflow changed for the successful rerun.

A final dependency audit found that the earlier local post-rebase runs retained the old installed dependency graph. Those artifacts are preserved as source-current/old-dependency evidence. After a normal frozen install, the installed workspace lock exactly matches the committed workspace document (175 importers, 1,643 packages, 1,650 snapshots; zero differences). The 72 tests, targeted checks, cache-disabled clean runtime/UI build and actual built CLI probes were repeated successfully with current locked packages on the unchanged candidate.
