### PR TITLE
refactor(workboard): share diagnostic construction

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -259,7 +259,6 @@ extensions/whatsapp/src/connection-controller.ts
 extensions/workboard/browser/lib/workboard/index.test.ts
 extensions/workboard/browser/pages/workboard/view.test.ts
 extensions/workboard/src/sqlite-store.ts
-extensions/workboard/src/store-card-helpers.ts
 extensions/workboard/src/store-core.ts
 extensions/workboard/src/store-normalizers.ts
 extensions/workboard/src/store.test.ts

--- a/extensions/workboard/src/store-card-helpers.ts
+++ b/extensions/workboard/src/store-card-helpers.ts
@@ -4,9 +4,6 @@ import {
   type WorkboardAttemptStatus,
   type WorkboardCard,
   type WorkboardDiagnostic,
-  type WorkboardDiagnosticAction,
-  type WorkboardDiagnosticKind,
-  type WorkboardDiagnosticSeverity,
   type WorkboardEvent,
   type WorkboardExecution,
   type WorkboardMetadata,
@@ -363,24 +360,6 @@ export function retryBudgetExhausted(card: WorkboardCard): boolean {
   return Boolean(maxRetries && (card.metadata?.failureCount ?? 0) > maxRetries);
 }
 
-function diagnostic(
-  params: {
-    kind: WorkboardDiagnosticKind;
-    severity: WorkboardDiagnosticSeverity;
-    title: string;
-    detail: string;
-    actions: WorkboardDiagnosticAction[];
-  },
-  now: number,
-): WorkboardDiagnostic {
-  return {
-    ...params,
-    firstSeenAt: now,
-    lastSeenAt: now,
-    count: 1,
-  };
-}
-
 export function mergeDiagnostics(
   previous: readonly WorkboardDiagnostic[] | undefined,
   next: WorkboardDiagnostic[],
@@ -399,26 +378,26 @@ export function mergeDiagnostics(
 }
 
 export function computeCardDiagnostics(card: WorkboardCard, now: number): WorkboardDiagnostic[] {
+  const diagnostics: WorkboardDiagnostic[] = [];
+  const addDiagnostic = (
+    params: Omit<WorkboardDiagnostic, "firstSeenAt" | "lastSeenAt" | "count">,
+  ): void => {
+    diagnostics.push({ ...params, firstSeenAt: now, lastSeenAt: now, count: 1 });
+  };
   if (card.metadata?.archivedAt) {
     // Archived cards intentionally skip automation. Keep nonterminal cards
     // visible as a transient diagnostic without rewriting archived metadata.
     if (card.status !== "done") {
-      return [
-        diagnostic(
-          {
-            kind: "archived_but_active",
-            severity: "warning",
-            title: "Archived card is still in an active status",
-            detail: `Card status is "${card.status}" but it is archived, so it is excluded from dispatch without any start failure or error. Unarchive it or move it to "done" to stop the silent skip.`,
-            actions: [],
-          },
-          now,
-        ),
-      ];
+      addDiagnostic({
+        kind: "archived_but_active",
+        severity: "warning",
+        title: "Archived card is still in an active status",
+        detail: `Card status is "${card.status}" but it is archived, so it is excluded from dispatch without any start failure or error. Unarchive it or move it to "done" to stop the silent skip.`,
+        actions: [],
+      });
     }
-    return [];
+    return diagnostics;
   }
-  const diagnostics: WorkboardDiagnostic[] = [];
   const claim = card.metadata?.claim;
   const lastHeartbeatAt = claim?.lastHeartbeatAt ?? card.execution?.updatedAt ?? card.updatedAt;
   if (
@@ -426,63 +405,43 @@ export function computeCardDiagnostics(card: WorkboardCard, now: number): Workbo
     card.agentId &&
     now - card.updatedAt > READY_STRANDED_MS
   ) {
-    diagnostics.push(
-      diagnostic(
-        {
-          kind: "stranded_ready",
-          severity: "warning",
-          title: "Assigned card is waiting",
-          detail: "The card has an assigned agent but has not been claimed recently.",
-          actions: [{ kind: "claim", label: "Claim card" }],
-        },
-        now,
-      ),
-    );
+    addDiagnostic({
+      kind: "stranded_ready",
+      severity: "warning",
+      title: "Assigned card is waiting",
+      detail: "The card has an assigned agent but has not been claimed recently.",
+      actions: [{ kind: "claim", label: "Claim card" }],
+    });
   }
   if (card.status === "running" && now - lastHeartbeatAt > RUNNING_HEARTBEAT_STALE_MS) {
-    diagnostics.push(
-      diagnostic(
-        {
-          kind: "running_without_heartbeat",
-          severity: "error",
-          title: "Running card has no recent heartbeat",
-          detail: "The linked run or claim has not reported recent activity.",
-          actions: [
-            { kind: "open_session", label: "Open session" },
-            { kind: "reassign", label: "Reassign card" },
-          ],
-        },
-        now,
-      ),
-    );
+    addDiagnostic({
+      kind: "running_without_heartbeat",
+      severity: "error",
+      title: "Running card has no recent heartbeat",
+      detail: "The linked run or claim has not reported recent activity.",
+      actions: [
+        { kind: "open_session", label: "Open session" },
+        { kind: "reassign", label: "Reassign card" },
+      ],
+    });
   }
   if (card.status === "blocked" && now - card.updatedAt > BLOCKED_TOO_LONG_MS) {
-    diagnostics.push(
-      diagnostic(
-        {
-          kind: "blocked_too_long",
-          severity: "warning",
-          title: "Blocked card needs attention",
-          detail: "The card has been blocked for more than a day.",
-          actions: [{ kind: "unblock", label: "Move to todo" }],
-        },
-        now,
-      ),
-    );
+    addDiagnostic({
+      kind: "blocked_too_long",
+      severity: "warning",
+      title: "Blocked card needs attention",
+      detail: "The card has been blocked for more than a day.",
+      actions: [{ kind: "unblock", label: "Move to todo" }],
+    });
   }
   if ((card.metadata?.failureCount ?? 0) >= 2) {
-    diagnostics.push(
-      diagnostic(
-        {
-          kind: "repeated_failures",
-          severity: "error",
-          title: "Repeated run failures",
-          detail: "Multiple attempts failed or blocked on this card.",
-          actions: [{ kind: "reassign", label: "Reassign card" }],
-        },
-        now,
-      ),
-    );
+    addDiagnostic({
+      kind: "repeated_failures",
+      severity: "error",
+      title: "Repeated run failures",
+      detail: "Multiple attempts failed or blocked on this card.",
+      actions: [{ kind: "reassign", label: "Reassign card" }],
+    });
   }
   if (
     card.status === "done" &&
@@ -492,32 +451,22 @@ export function computeCardDiagnostics(card: WorkboardCard, now: number): Workbo
       card.metadata?.attachments?.length
     )
   ) {
-    diagnostics.push(
-      diagnostic(
-        {
-          kind: "missing_proof",
-          severity: "warning",
-          title: "Done card has no proof",
-          detail: "The card is marked done without proof or an attached artifact.",
-          actions: [{ kind: "add_proof", label: "Add proof" }],
-        },
-        now,
-      ),
-    );
+    addDiagnostic({
+      kind: "missing_proof",
+      severity: "warning",
+      title: "Done card has no proof",
+      detail: "The card is marked done without proof or an attached artifact.",
+      actions: [{ kind: "add_proof", label: "Add proof" }],
+    });
   }
   if (card.sessionKey && !card.execution && card.status === "running") {
-    diagnostics.push(
-      diagnostic(
-        {
-          kind: "orphaned_session",
-          severity: "warning",
-          title: "Running card has only a loose session link",
-          detail: "The card is running but has no execution record for lifecycle handoff.",
-          actions: [{ kind: "open_session", label: "Open session" }],
-        },
-        now,
-      ),
-    );
+    addDiagnostic({
+      kind: "orphaned_session",
+      severity: "warning",
+      title: "Running card has only a loose session link",
+      detail: "The card is running but has no execution record for lifecycle handoff.",
+      actions: [{ kind: "open_session", label: "Open session" }],
+    });
   }
   return diagnostics;
 }
@@ -755,4 +704,3 @@ export function compareNotifications(a: WorkboardNotification, b: WorkboardNotif
   }
   return a.id.localeCompare(b.id);
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Workboard's diagnostic owner carried repeated construction and append logic and needed a standing file-size exception. The duplication made changes to diagnostic policy harder to review.

Cleanup companion to #135868; no recovery feature content is included.

## Why This Change Was Made

One local appender now supplies the shared timestamps and initial count for all diagnostic rules. The archived-card early return, conditions, messages, actions, and ordering remain unchanged. The old private factory and repeated call envelopes are removed, which brings the file below the configured max-lines budget without moving code.

The existing diagnostic behavior comes from #106306 and the archived-card repair in #117290; both contracts remain covered.

## User Impact

Users receive the same diagnostics. Production code shrinks by 52 lines (+59/−111, 758 → 706 raw lines); the file's max-lines suppression and its baseline entry are removed. Tests and docs are unchanged.

## Evidence

- All 145 unchanged Workboard store tests passed, including archive behavior, concurrent diagnostic refresh, and worker context.
- 244,944 comparisons against the pre-change diagnostic function produced identical outputs and did not mutate input cards.
- The max-lines ratchet passes with the exception removed.
- Independent local and branch Codex reviews are clean through P2.
- The complete changed-check plan passed in isolated Blacksmith Testbox ([run 34016545655](https://github.com/openclaw/openclaw/actions/runs/34016545655), command exit 0). This includes production/test typing, exports, extension/script lint, and architecture guards. The one-shot lease stopped after success; its backing Actions run may appear cancelled during cleanup.
- Isolation preserves the declaration-input guard that rejects ancestor dependencies in the nested local worktree. No dependencies or guards were changed.

The focused tests, differential comparisons, and full changed check were repeated after main updated the lockfile. The required frozen offline install succeeded; no dependency files are part of this PR. `pnpm plugins:assets:check` also passes without generated-file changes.

An unrelated sandbox-browser hash failure in the previous CI run was repaired separately in #139894. This branch is rebased onto that repair; the diagnostic implementation and dependency lock are unchanged, and the bundled asset check passes.

ClawSweeper reviewed final head `abdd264be2e57139400129c348718cddc1143102` with no findings, before-merge requests, or rank-up moves. No review changes were needed.

Exact-head CI passed for `abdd264be2e57139400129c348718cddc1143102` in [run 34019995827](https://github.com/openclaw/openclaw/actions/runs/34019995827).
