### PR TITLE
fix: restore filesystem mock typechecks after dependency refresh

### DIFF
--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -289,27 +289,25 @@ function mockLinuxManagedChromeOwnership(params: {
     ...(params.extraArgs ?? []),
   ];
   const readFileSync = fs.readFileSync.bind(fs);
-  vi.spyOn(fs, "readFileSync").mockImplementation(
-    (filePath, options?: BufferEncoding | fs.ReadFileSyncOptions | null) => {
-      const s = String(filePath);
-      if (s === `/proc/${params.pid}/cmdline`) {
-        return Buffer.from(`${argv.join("\0")}\0`);
-      }
-      if (s === `/proc/${params.pid}/stat`) {
-        return linuxProcStatLine(params.pid, "1234567");
-      }
-      if (s === "/proc/net/tcp") {
-        return ownsPort ? linuxTcpTableForPort(params.port, inode) : linuxTcpTableForPort(1, inode);
-      }
-      if (s === "/proc/net/tcp6") {
-        return "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
-      }
-      return readFileSync(
-        filePath,
-        typeof options === "string" ? { encoding: options } : (options ?? {}),
-      );
-    },
-  );
+  vi.spyOn(fs, "readFileSync").mockImplementation((filePath, options) => {
+    const s = String(filePath);
+    if (s === `/proc/${params.pid}/cmdline`) {
+      return Buffer.from(`${argv.join("\0")}\0`);
+    }
+    if (s === `/proc/${params.pid}/stat`) {
+      return linuxProcStatLine(params.pid, "1234567");
+    }
+    if (s === "/proc/net/tcp") {
+      return ownsPort ? linuxTcpTableForPort(params.port, inode) : linuxTcpTableForPort(1, inode);
+    }
+    if (s === "/proc/net/tcp6") {
+      return "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode";
+    }
+    return readFileSync(
+      filePath,
+      typeof options === "string" ? { encoding: options } : (options ?? {}),
+    );
+  });
 
   const readdirSync = fs.readdirSync.bind(fs);
   vi.spyOn(fs, "readdirSync").mockImplementation(((dirPath, options) => {

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -1,5 +1,4 @@
 // Codex tests cover conversation binding plugin behavior.
-import type { ReadFileSyncOptions } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -65,7 +64,7 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual,
     readFileSync(
       filePath: string | URL | number,
-      options?: BufferEncoding | ReadFileSyncOptions | null,
+      options?: Parameters<typeof actual.readFileSync>[1],
     ) {
       if (filePath === "/etc/codex/requirements.toml") {
         const content = codexRequirementsTomlMock();

--- a/src/config/io.write-reread.test.ts
+++ b/src/config/io.write-reread.test.ts
@@ -44,17 +44,15 @@ describe("writeConfigFile canonical reread", () => {
         }
       });
       const realReadFileSync = fsNode.readFileSync.bind(fsNode);
-      vi.spyOn(fsNode, "readFileSync").mockImplementation(
-        (target, options?: BufferEncoding | fsNode.ReadFileSyncOptions | null) => {
-          if (corrupted && target === configPath) {
-            return "{ definitely not json";
-          }
-          return realReadFileSync(
-            target,
-            typeof options === "string" ? { encoding: options } : (options ?? {}),
-          );
-        },
-      );
+      vi.spyOn(fsNode, "readFileSync").mockImplementation((target, options) => {
+        if (corrupted && target === configPath) {
+          return "{ definitely not json";
+        }
+        return realReadFileSync(
+          target,
+          typeof options === "string" ? { encoding: options } : (options ?? {}),
+        );
+      });
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       const preflight = vi.fn<NonNullable<RuntimeConfigSnapshotRefreshHandler["preflight"]>>(
         ({ sourceConfig }) => ({ sourceConfig }),

--- a/src/infra/shell-env.test.ts
+++ b/src/infra/shell-env.test.ts
@@ -111,7 +111,7 @@ describe("shell env fallback", () => {
     const etcShellsContent = `${shells.join("\n")}\n`;
     const readFileSyncSpy = vi
       .spyOn(fs, "readFileSync")
-      .mockImplementation((filePath, encoding?: BufferEncoding | fs.ReadFileSyncOptions | null) => {
+      .mockImplementation((filePath, encoding) => {
         if (filePath === "/etc/shells" && encoding === "utf8") {
           return etcShellsContent;
         }

--- a/test/scripts/tsdown-build.test.ts
+++ b/test/scripts/tsdown-build.test.ts
@@ -49,14 +49,10 @@ const TEST_PHYSICAL_MEMORY_BYTES = 16 * 1024 * 1024 * 1024;
 // fixtures prove only their declared hierarchy instead of inheriting the runner's RAM.
 vi.spyOn(os, "totalmem").mockReturnValue(TEST_PHYSICAL_MEMORY_BYTES);
 const readFileSync = fs.readFileSync.bind(fs);
-vi.spyOn(fs, "readFileSync").mockImplementation(
-  (filePath, options?: BufferEncoding | fs.ReadFileSyncOptions | null) =>
-    filePath === "/proc/meminfo" && options === "utf8"
-      ? "MemTotal:       16777216 kB\nMemAvailable:   16777216 kB\n"
-      : readFileSync(
-          filePath,
-          typeof options === "string" ? { encoding: options } : (options ?? {}),
-        ),
+vi.spyOn(fs, "readFileSync").mockImplementation((filePath, options) =>
+  filePath === "/proc/meminfo" && options === "utf8"
+    ? "MemTotal:       16777216 kB\nMemAvailable:   16777216 kB\n"
+    : readFileSync(filePath, typeof options === "string" ? { encoding: options } : (options ?? {})),
 );
 const NO_MEMORY_LIMIT = {
   availableMemoryBytes: TEST_PHYSICAL_MEMORY_BYTES,


### PR DESCRIPTION
Withdrawn: the reported missing-type errors came from a stale local dependency install, not current main.

The repository locks `@types/node` 26.4.0, which exports `ReadFileSyncOptions`. Our initial proof used an unreconciled 26.3.0 install. The corrected compiler matrix verifies the declaration file actually loaded in each run:

| Source | 26.3.0 | Locked 26.4.0 |
| --- | --- | --- |
| Original main mocks | Missing-alias errors | Pass |
| Proposed mocks | Pass | TS2367 in the shell and build-tooling comparisons |

CI correctly rejected this patch. Its inferred last overload is narrower than the full string-or-options call contract. The original dependency-refresh annotations are correct for the lockfile; no compatibility change is warranted for stale dependencies.

Local proof checkouts have been reconciled with `pnpm install --frozen-lockfile`. Closing without merge. Earlier performance PRs are separate and unaffected.
