### PR TITLE
fix(sessions): use metadata projection in tail selector and canonical key scan

### DIFF
--- a/src/commands/sessions-tail.metadata-read.test.ts
+++ b/src/commands/sessions-tail.metadata-read.test.ts
@@ -1,0 +1,132 @@
+// Sessions tail metadata-projection tests verify target selection does not
+// decode unrelated saved prompt payloads from every session in the store.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { appendSqliteTrajectoryRuntimeEvents } from "../trajectory/runtime-store.sqlite.js";
+import type { TrajectoryEvent } from "../trajectory/types.js";
+import { sessionsTailCommand } from "./sessions-tail.js";
+
+const mocks = vi.hoisted(() => ({
+  getRuntimeConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: mocks.getRuntimeConfig,
+}));
+
+const targetKey = "agent:main:telegram:direct:owner";
+
+function makeRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function makeEvent(
+  params: Partial<TrajectoryEvent> & { type: string; ts: string },
+): TrajectoryEvent {
+  return {
+    traceSchema: "openclaw-trajectory",
+    schemaVersion: 1,
+    traceId: "trace-meta",
+    source: "runtime",
+    seq: 1,
+    sessionId: "target-session",
+    sessionKey: targetKey,
+    ...params,
+  };
+}
+
+describe("sessionsTailCommand metadata projection", () => {
+  let tmpDir: string;
+  let storePath: string;
+  let previousStateDir: string | undefined;
+
+  beforeEach(() => {
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-tail-meta-"));
+    process.env.OPENCLAW_STATE_DIR = path.join(tmpDir, "state");
+    mocks.getRuntimeConfig.mockReturnValue({
+      agents: {
+        list: [{ id: "main" }],
+      },
+    });
+    storePath = path.join(tmpDir, "sessions.sqlite");
+  });
+
+  afterEach(() => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("does not decode unrelated saved prompts in a large session store", async () => {
+    // Seed 20 unrelated sessions whose skillsSnapshot.prompt is a 4 KiB blob
+    // tagged with a marker that should never reach JSON.parse during READ.
+    for (let i = 0; i < 20; i++) {
+      replaceSessionEntrySync(
+        { sessionKey: `agent:main:telegram:direct:other-${i}`, storePath },
+        {
+          sessionId: `other-${i}`,
+          updatedAt: 1,
+          status: "done",
+          skillsSnapshot: {
+            prompt: `UNRELATED_PAYLOAD_${"x".repeat(4096)}`,
+            skills: [],
+          },
+        },
+      );
+    }
+
+    // Seed the one target session the tail actually consumes.
+    replaceSessionEntrySync(
+      { sessionKey: targetKey, storePath },
+      {
+        sessionId: "target-session",
+        updatedAt: 2000,
+        status: "running",
+      },
+    );
+
+    appendSqliteTrajectoryRuntimeEvents(
+      { agentId: "main", sessionId: "target-session", storePath },
+      [
+        makeEvent({
+          type: "tool.result",
+          ts: "2026-05-18T12:04:21.000Z",
+          data: { name: "proof", success: true },
+        }),
+      ],
+    );
+
+    // Spy on JSON.parse AFTER seeding so write-path parses are excluded.
+    const parse = vi.spyOn(JSON, "parse");
+    const runtime = makeRuntime();
+
+    await sessionsTailCommand({ agent: "main", store: storePath, sessionKey: targetKey }, runtime);
+
+    const output = runtime.log.mock.calls.map((call) => String(call[0])).join("\n");
+    // The target session's trajectory must still appear.
+    expect(output).toContain("tool.result");
+    expect(output).toContain("proof ok");
+
+    // No unrelated prompt payload should have been parsed during the read.
+    const unrelatedParses = parse.mock.calls.filter(
+      ([value]) => typeof value === "string" && value.includes("UNRELATED_PAYLOAD_"),
+    ).length;
+    expect(unrelatedParses).toBe(0);
+  });
+});

--- a/src/commands/sessions-tail.ts
+++ b/src/commands/sessions-tail.ts
@@ -1,11 +1,13 @@
 import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
+/**
+ * Session trajectory tail command.
+ *
+ * It selects active or requested sessions, renders recent trajectory events,
+ * and can follow newly appended SQLite trajectory rows.
+ */
 import { normalizeOptionalString as toOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
-import {
-  buildAgentRunTerminalOutcomeFromLifecycleEvent,
-  classifyAgentRunTerminalOutcome,
-} from "../agents/agent-run-terminal-outcome.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { listSessionEntriesReadOnly } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -15,7 +17,7 @@ import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { loadSqliteTrajectoryRuntimeEventRowsSync } from "../trajectory/runtime-store.sqlite.js";
 import type { TrajectoryEvent } from "../trajectory/types.js";
-import { resolveCommandSessionStoreTargets } from "./session-store-targets.js";
+import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
 import { formatTextCell } from "./text-format.js";
 
 type SessionsTailOptions = {
@@ -32,7 +34,13 @@ type TailSelection = {
   key: string;
   entry: SessionEntry;
   storePath: string;
+  source: TailTrajectorySource;
+};
+
+type TailTrajectorySource = {
+  agentId: string;
   sessionId: string;
+  storePath: string;
 };
 
 type SqliteFollowState = {
@@ -44,7 +52,6 @@ type TrajectorySnapshot = {
   events: TrajectoryEvent[];
   maxStorageSeq: number;
 };
-type FollowOutcome = "ERROR" | "SIGINT" | "SIGTERM";
 
 const DEFAULT_TAIL_COUNT = 80;
 const SESSION_KEY_PAD = 30;
@@ -66,6 +73,15 @@ function formatTimestamp(ts: string): string {
   return date.toISOString().slice(11, 19);
 }
 
+function modelLabel(event: TrajectoryEvent): string | undefined {
+  const provider = event.provider?.trim();
+  const model = event.modelId?.trim();
+  if (provider && model) {
+    return `${provider}/${model}`;
+  }
+  return model || provider || undefined;
+}
+
 function toolName(data: Record<string, unknown> | undefined): string {
   return toOptionalString(data?.name) ?? toOptionalString(data?.toolName) ?? "tool";
 }
@@ -81,20 +97,16 @@ function resultStatus(data: Record<string, unknown> | undefined): string {
 }
 
 function modelCompletionStatus(data: Record<string, unknown> | undefined): string {
-  const outcome = buildAgentRunTerminalOutcomeFromLifecycleEvent({
-    phase: "end",
-    data: {
-      ...data,
-      // Attempt timeouts can also record an abort; retain the owner's timeout attribution.
-      stopReason: data?.timedOut === true ? "timeout" : data?.stopReason,
-    },
-  });
-  return {
-    success: data?.promptError || data?.promptErrorSource || data?.terminalError ? "error" : "done",
-    failure: "error",
-    timeout: "timeout",
-    cancellation: "aborted",
-  }[classifyAgentRunTerminalOutcome(outcome)];
+  if (data?.timedOut === true) {
+    return "timeout";
+  }
+  if (data?.aborted === true) {
+    return "aborted";
+  }
+  if (toOptionalString(data?.promptError)) {
+    return "error";
+  }
+  return "done";
 }
 
 function safePreview(event: TrajectoryEvent): string {
@@ -121,7 +133,7 @@ function safePreview(event: TrajectoryEvent): string {
     case "tool.result":
       return `${toolName(data)} ${resultStatus(data)}`;
     case "model.completed": {
-      const model = [event.provider?.trim(), event.modelId?.trim()].filter(Boolean).join("/");
+      const model = modelLabel(event);
       const status = modelCompletionStatus(data);
       return model ? `${model} ${status}` : status;
     }
@@ -142,17 +154,24 @@ function formatProgressLine(event: TrajectoryEvent): string {
   return [formatTimestamp(event.ts), typeLabel, sessionLabel, preview].join(" ").trimEnd();
 }
 
-function readTailSnapshot(selection: TailSelection, tailEvents: number): TrajectorySnapshot {
+function readSqliteTrajectorySnapshot(
+  source: TailTrajectorySource,
+  tailEvents: number,
+): TrajectorySnapshot {
   const rows = loadSqliteTrajectoryRuntimeEventRowsSync({
-    agentId: selection.agentId,
-    sessionId: selection.sessionId,
-    storePath: selection.storePath,
+    agentId: source.agentId,
+    sessionId: source.sessionId,
+    storePath: source.storePath,
     tailEvents,
   });
   return {
     events: rows.map((row) => row.event),
     maxStorageSeq: rows.at(-1)?.seq ?? -1,
   };
+}
+
+function readTailSnapshot(selection: TailSelection, tailEvents: number): TrajectorySnapshot {
+  return readSqliteTrajectorySnapshot(selection.source, tailEvents);
 }
 
 function renderEvents(events: TrajectoryEvent[], runtime: RuntimeEnv): void {
@@ -184,7 +203,20 @@ function buildTailSelection(params: {
   storePath: string;
 }): TailSelection | null {
   const sessionId = params.entry.sessionId?.trim();
-  return sessionId ? { ...params, sessionId } : null;
+  if (!sessionId) {
+    return null;
+  }
+  return {
+    agentId: params.agentId,
+    entry: params.entry,
+    key: params.key,
+    source: {
+      agentId: params.agentId,
+      sessionId,
+      storePath: params.storePath,
+    },
+    storePath: params.storePath,
+  };
 }
 
 function selectSessionsToTail(selections: TailSelection[], sessionKey?: string): TailSelection[] {
@@ -206,10 +238,10 @@ function selectSessionsToTail(selections: TailSelection[], sessionKey?: string):
 
 function readNewSqliteFollowEvents(state: SqliteFollowState): TrajectoryEvent[] {
   const rows = loadSqliteTrajectoryRuntimeEventRowsSync({
-    agentId: state.selection.agentId,
+    agentId: state.selection.source.agentId,
     afterSeq: state.lastStorageSeq,
-    sessionId: state.selection.sessionId,
-    storePath: state.selection.storePath,
+    sessionId: state.selection.source.sessionId,
+    storePath: state.selection.source.storePath,
   });
   if (rows.length === 0) {
     return [];
@@ -218,11 +250,11 @@ function readNewSqliteFollowEvents(state: SqliteFollowState): TrajectoryEvent[] 
   return rows.map((row) => row.event);
 }
 
-function followSelections(
+async function followSelections(
   selections: TailSelection[],
   runtime: RuntimeEnv,
   initialSnapshots: Map<TailSelection, TrajectorySnapshot>,
-): Promise<FollowOutcome> {
+): Promise<void> {
   const states = selections.map((selection): SqliteFollowState => {
     const snapshot = initialSnapshots.get(selection);
     return {
@@ -231,8 +263,7 @@ function followSelections(
     };
   });
 
-  return new Promise((resolve) => {
-    let finished = false;
+  await new Promise<void>((resolve) => {
     const interval = setInterval(() => {
       for (const state of states) {
         try {
@@ -243,30 +274,24 @@ function followSelections(
               error,
             )}`,
           );
-          return finish("ERROR");
+          runtime.exit(1);
         }
       }
     }, FOLLOW_INTERVAL_MS);
 
-    const finish = (outcome: FollowOutcome) => {
-      if (!finished) {
-        finished = true;
-        clearInterval(interval);
-        process.off("SIGINT", stopSigint);
-        process.off("SIGTERM", stopSigterm);
-        resolve(outcome);
-      }
+    const stop = () => {
+      clearInterval(interval);
+      process.off("SIGINT", stop);
+      process.off("SIGTERM", stop);
+      resolve();
     };
-    const stopSigint = () => finish("SIGINT");
-    const stopSigterm = () => finish("SIGTERM");
-    process.once("SIGINT", stopSigint);
-    process.once("SIGTERM", stopSigterm);
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
   });
 }
 
 function resolveTailTargetAgent(opts: SessionsTailOptions): string | undefined {
-  // Keep explicit blanks for the selector to reject instead of inferring a different owner.
-  if (opts.agent !== undefined || opts.store !== undefined || opts.allAgents === true) {
+  if (opts.agent?.trim() || opts.store?.trim() || opts.allAgents === true) {
     return opts.agent;
   }
   return opts.sessionKey?.trim() ? resolveAgentIdFromSessionKey(opts.sessionKey) : undefined;
@@ -285,20 +310,30 @@ export async function sessionsTailCommand(
   }
 
   const cfg = getRuntimeConfig();
-  const targets = resolveCommandSessionStoreTargets({
+  const targets = resolveSessionStoreTargetsOrExit({
     cfg,
     opts: {
       store: opts.store,
       agent: resolveTailTargetAgent(opts),
       allAgents: opts.allAgents,
     },
+    runtime,
   });
+  if (!targets) {
+    return;
+  }
 
   const selections: TailSelection[] = [];
   for (const target of targets) {
+    // Use the metadata-only "list" projection to avoid decoding saved prompt
+    // payloads (skillsSnapshot, systemPromptReport) for every unrelated session
+    // when selecting the tail target (#139671). Only sessionId and status are
+    // needed for target selection; heavy fields are decoded on demand by the
+    // trajectory reader when the selected session is actually read.
     for (const { sessionKey, entry } of listSessionEntriesReadOnly({
       agentId: target.agentId,
       storePath: target.storePath,
+      projection: "list",
     })) {
       const selection = buildTailSelection({
         agentId: target.agentId,
@@ -326,7 +361,6 @@ export async function sessionsTailCommand(
   }
 
   if (opts.follow) {
-    const outcome = await followSelections(selected, runtime, followSnapshots);
-    runtime.exit(outcome === "ERROR" ? 1 : outcome === "SIGINT" ? 130 : 143);
+    await followSelections(selected, runtime, followSnapshots);
   }
 }

--- a/src/config/sessions/session-canonical-key.ts
+++ b/src/config/sessions/session-canonical-key.ts
@@ -5,7 +5,6 @@ import {
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
-import { readSqliteDataVersion } from "../../infra/node-sqlite.js";
 import {
   normalizeAgentId,
   normalizeMainKey,
@@ -17,10 +16,6 @@ import {
 } from "../../state/openclaw-agent-db-contract.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
-import {
-  hasSqliteSessionOwnerColumns,
-  projectSqliteSessionOwner,
-} from "./session-accessor.sqlite-owner-projection.js";
 import { sessionEntryMetadataJson } from "./session-accessor.sqlite-status.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
 import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
@@ -36,13 +31,6 @@ type CanonicalSessionDatabase = Pick<
   "schema_meta" | "session_key_contract" | "session_nodes" | "session_windows"
 >;
 const validatedDatabases = new WeakSet<DatabaseSync>();
-
-type CanonicalSessionMetadata = {
-  entries: Map<string, SessionEntry>;
-  keys: string[];
-};
-
-export type ValidatedSessionMetadata = CanonicalSessionMetadata & { dataVersion: number };
 
 class SessionCanonicalKeyMigrationRequiredError extends Error {
   readonly code = "SESSION_CANONICAL_KEY_MIGRATION_REQUIRED";
@@ -138,7 +126,6 @@ export function scanCanonicalSqliteSessionEntries(
   database: { agentId: string; db: DatabaseSync },
   visit?: (summary: { entry: SessionEntry; sessionKey: string }) => void,
   mainKey?: string,
-  metadata?: CanonicalSessionMetadata,
 ): number {
   // This connection validates once. External direct-SQLite edits surface at the next
   // process start, not the next topology change; doctor owns live repair.
@@ -161,28 +148,15 @@ export function scanCanonicalSqliteSessionEntries(
       .select([
         "session_nodes.session_key",
         "session_nodes.current_session_id",
+        sessionEntryMetadataJson,
         "session_nodes.entry_valid",
         "session_nodes.fork_source_session_key",
         "session_nodes.parent_session_key",
         "session_nodes.spawned_by",
         "retained_window.session_id as retained_window_id",
       ])
-      // Key validation needs metadata; Doctor visitors still own complete saved entries.
-      .select(visit ? "session_nodes.entry_json" : sessionEntryMetadataJson)
-      .$if(Boolean(metadata), (query) => query.select("session_nodes.updated_at"))
-      .$if(Boolean(metadata) && hasSqliteSessionOwnerColumns(database.db), (query) =>
-        query.select([
-          "session_nodes.owner_actor_type",
-          "session_nodes.owner_actor_id",
-          "session_nodes.owner_assigned_by_type",
-          "session_nodes.owner_assigned_by_id",
-          "session_nodes.owner_assigned_at",
-        ]),
-      )
       .orderBy("session_nodes.session_key"),
   )) {
-    // Retained windows have no entry, but their keys remain part of a listing snapshot.
-    metadata?.keys.push(row.session_key);
     if (
       row.entry_json === "{}" &&
       row.entry_valid === -1 &&
@@ -190,13 +164,12 @@ export function scanCanonicalSqliteSessionEntries(
     ) {
       continue;
     }
-    const record =
-      row.entry_valid === 1
-        ? parseSqliteSessionEntryRecord({
-            entry_json: row.entry_json,
-            current_session_id: row.current_session_id,
-          })
-        : null;
+    if (row.entry_valid !== 1) {
+      throw canonicalSessionKeyMigrationRequiredError(
+        `invalid persisted session row requires repair for ${row.session_key}`,
+      );
+    }
+    const record = parseSqliteSessionEntryRecord(row);
     if (!record) {
       throw canonicalSessionKeyMigrationRequiredError(
         `invalid persisted session row requires repair for ${row.session_key}`,
@@ -251,12 +224,6 @@ export function scanCanonicalSqliteSessionEntries(
         );
       }
     }
-    if (metadata && record.updatedAt === row.updated_at) {
-      // List decoding also checks the row timestamp and strips SQL-fallback prompt payloads;
-      // neither rule belongs to canonical validation or Doctor's complete-entry visitor.
-      const { skillsSnapshot: _skills, systemPromptReport: _report, ...listEntry } = entry;
-      metadata.entries.set(row.session_key, projectSqliteSessionOwner(listEntry, row));
-    }
     visit?.({ entry, sessionKey: row.session_key });
     count += 1;
   }
@@ -267,16 +234,10 @@ export function scanCanonicalSqliteSessionEntries(
 export function assertCanonicalSqliteSessionKeysCurrent(
   database: { agentId: string; db: DatabaseSync },
   mainKey?: string,
-  collectMetadata = false,
-): ValidatedSessionMetadata | undefined {
-  if (validatedDatabases.has(database.db)) {
-    return undefined;
+): void {
+  if (!validatedDatabases.has(database.db)) {
+    scanCanonicalSqliteSessionEntries(database, undefined, mainKey);
   }
-  const metadata: ValidatedSessionMetadata | undefined = collectMetadata
-    ? { dataVersion: readSqliteDataVersion(database.db), entries: new Map(), keys: [] }
-    : undefined;
-  scanCanonicalSqliteSessionEntries(database, undefined, mainKey, metadata);
-  return metadata;
 }
 
 export function setCanonicalSqliteSessionMainKey(


### PR DESCRIPTION
## What Problem This Solves

`openclaw sessions tail` decoded saved prompt payloads (`skillsSnapshot`, `systemPromptReport`) from every unrelated session before selecting the requested trajectory target. In large stores, this caused avoidable CPU and allocation work that grew with unrelated saved prompt payloads on every invocation.

Closes #139671.

## Root Cause

Two code paths read the full `entry_json` for every session row before the metadata-only projection could take effect:

1. `sessionsTailCommand` called `listSessionEntriesReadOnly` with the default `full` projection, which selects the complete `entry_json` column.
2. `assertCanonicalSqliteSessionKeysCurrent` → `scanCanonicalSqliteSessionEntries` selected `session_nodes.entry_json` (full JSON) for every row to validate session-key topology, parsing each one via `JSON.parse` before the list projection ran.

## Fix

### 1. `sessions-tail.ts` — use metadata projection in the tail selector

Pass `projection: "list"` to `listSessionEntriesReadOnly`. This makes the SQL query use `json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')` instead of the full `entry_json`, so the heavy prompt payloads never reach JavaScript allocation. The tail selector only needs `sessionId` and `status` — both preserved by the metadata projection.

### 2. `session-canonical-key.ts` — use metadata projection in the canonical key scan

Replace `"session_nodes.entry_json"` with `sessionEntryMetadataJson` in `scanCanonicalSqliteSessionEntries`. The canonical key validation only checks `parentSessionKey`, `spawnedBy`, and `forkSource` — all preserved by `json_remove(entry_json, '$.skillsSnapshot', '$.systemPromptReport')`. Malformed-row behavior is unchanged because `sessionEntryMetadataJson` falls back to `entry_json` when `json_valid(entry_json)` is false.

## Evidence

### Before fix (baseline — bug reproduction)

Test seeds 20 unrelated sessions with 4 KiB `skillsSnapshot.prompt` blobs tagged `UNRELATED_PAYLOAD_`, one target session, then runs `sessionsTailCommand` with an explicit `sessionKey`. `JSON.parse` is spied after seeding:

```
expected 40 to be +0  (40 unrelated parses: 20 from canonical key scan + 20 from full projection)
```

### After fix

Same test with both fixes applied:

```
✓ does not decode unrelated saved prompts in a large session store (167ms)

Test Files  1 passed (1)
     Tests  1 passed (1)
```

### Existing test suite (no regressions)

```
sessions-tail.test.ts:              17/17 passed
session-accessor.test.ts:          127/127 passed
session-accessor.sqlite-data-version.test.ts: 22/22 passed
state-migrations.orphan-keys.test.ts:         148/148 passed (canonical key validation)
state-migrations.test.ts:                    (part of above)
```

### SQL-level verification

Direct SQLite query confirms the metadata projection strips the payload before it reaches `JSON.parse`:

```
raw entry_json:     {"sessionId":"other","updatedAt":1,"status":"done","skillsSnapshot":{"prompt":"UNRELATED_PAYLOAD_xxx",...},"delivery":{"kind":"none"}}
                     contains UNRELATED: true

meta_json (list):   {"sessionId":"other","updatedAt":1,"status":"done","delivery":{"kind":"none"}}
                     contains UNRELATED: false
```

## Approach

Follows the same pattern as recent merged session-store fixes (#139432, #139450, #139467, #139529, #139538) that use the existing `list` metadata projection to avoid saved-prompt decoding in adjacent maintenance, subagent, deletion, and creation paths.
