### PR TITLE
fix(ui): restore configured agent avatars in chat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2766,6 +2766,7 @@ jobs:
             ui/src/e2e/profile-page.real-gateway.e2e.test.ts \
             ui/src/e2e/logs-lifecycle.e2e.test.ts \
             ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts \
+            ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts \
             ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts \
             ui/src/e2e/chat-project-media.real-gateway.e2e.test.ts \
             ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts \

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -212,7 +212,7 @@ GitHub-backed sign-in through Cloudflare Access or Tailscale Serve fills the rea
 
 **Settings → Profile → GitHub connections** separately shows **My GitHub** and **System GitHub**. Identified people, including read-scoped operators, can connect and disconnect only their own account; administrators can also change the shared System account. Connecting defaults to **For me** for identified users and never changes their sign-in identity, co-author preference, or shared execution defaults. Personal credentials support explicit Gateway-brokered **Publish PR** actions, not ordinary agent shell commands. See [GitHub connections](/concepts/user-model#github-connections).
 
-Set an agent's display name, emoji, and avatar under **Agent settings → Overview → Identity**. The identity is stored with that agent and is shared by Control UI clients.
+Set an agent's display name, emoji, and avatar under **Agent settings → Overview → Identity**. The identity is stored with that agent and is shared by Control UI clients. Where the transcript shows avatars, saved and streaming assistant replies use the configured agent image or text avatar. Agents without a configured avatar omit the repeated fallback icon.
 
 ## Runtime config endpoint
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -12535,6 +12535,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
 
     expect(privateServerFiles).toEqual(uiE2ePrivateServerTestFiles);
     expect(helperPrivateServerFiles.toSorted()).toEqual([
+      "ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts",
       "ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts",
       "ui/src/e2e/chat-project-media.real-gateway.e2e.test.ts",
       "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",

--- a/test/vitest-ui-e2e-config.test.ts
+++ b/test/vitest-ui-e2e-config.test.ts
@@ -109,6 +109,7 @@ const qaLabFiles = [
 ] as const;
 const realGatewayFiles = [
   "agent-file-lifecycle.real-gateway",
+  "chat-agent-avatar.real-gateway",
   "chat-loading-performance.real-gateway",
   "chat-project-media.real-gateway",
   "chat-widget-sandbox.real-gateway",
@@ -516,6 +517,13 @@ describe("Control UI E2E resource ownership", () => {
         expect(result.rootWorkers).toBe(workers);
       }
       expect(result.files.filter((entry) => entry.phase === 1)).toEqual([
+        {
+          file: "ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts",
+          project: "ui-e2e-serial-standalone",
+          phase: 1,
+          workers: 1,
+          fileParallelism: false,
+        },
         {
           file: "ui/src/e2e/device-alias-rename.real-gateway.e2e.test.ts",
           project: "ui-e2e-serial",

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -26,6 +26,7 @@ const uiE2eIncludePatterns = [
 ];
 export const uiE2eRealGatewayTestFiles = [
   "ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts",
+  "ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-project-media.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-widget-sandbox.real-gateway.e2e.test.ts",
@@ -48,6 +49,7 @@ export const uiE2eRealGatewayTestFiles = [
 export const uiE2ePrivateServerTestFiles = [
   "ui/src/e2e/approval-bootstrap.e2e.test.ts",
   "ui/src/e2e/build-info-unicode.e2e.test.ts",
+  "ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts",
   "ui/src/e2e/chat-code-block-fences.e2e.test.ts",
   "ui/src/e2e/chat-export-attribution.e2e.test.ts",
   "ui/src/e2e/chat-loading-performance.real-gateway.e2e.test.ts",

--- a/ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts
@@ -1,0 +1,141 @@
+import { copyFile, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { appendTranscriptMessage } from "../../../src/config/sessions/session-accessor.js";
+import { ensureGatewayOwnerProfile, setAvatar } from "../../../src/state/user-profiles.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "../../../test/helpers/openclaw-test-instance.ts";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
+import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { controlUiSessionUrl } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const captureEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+let instance: OpenClawTestInstance | undefined;
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent avatar with a real Gateway",
+  startServerBeforeBrowser: true,
+  async startServer() {
+    const owner = await createOpenClawTestInstance({
+      name: "control-ui-agent-avatar",
+      config: { gateway: { controlUi: { enabled: true } } },
+    });
+    instance = owner;
+    try {
+      const config = JSON.parse(await readFile(owner.configPath, "utf8"));
+      await owner.state.writeConfig({
+        ...config,
+        agents: {
+          defaults: {
+            workspace: owner.state.workspaceDir,
+            model: { primary: "openai/gpt-5.6-luna" },
+          },
+          entries: {
+            main: { identity: { name: "Avatar Proof", avatar: "agent-avatar.png" } },
+          },
+        },
+      });
+      const imagePath = path.join(process.cwd(), "ui/public/apple-touch-icon.png");
+      await copyFile(imagePath, path.join(owner.state.workspaceDir, "agent-avatar.png"));
+      // Seed the browser owner so no host account name or photo enters the capture.
+      const profile = ensureGatewayOwnerProfile("Chat Proof", { env: owner.env });
+      expect(
+        setAvatar(profile.id, await readFile(imagePath), "image/png", { env: owner.env }).ok,
+      ).toBe(true);
+      await owner.startGateway();
+      return { baseUrl: `http://127.0.0.1:${owner.port}/`, close: () => owner.cleanup() };
+    } catch (error) {
+      await runQaGatewayFixture(
+        async () => {
+          throw error;
+        },
+        () => owner.cleanup(),
+      );
+      throw error;
+    }
+  },
+});
+
+suite.define(() => {
+  it("renders the configured workspace avatar beside a persisted assistant reply", async () => {
+    if (!instance) {
+      throw new Error("Gateway fixture is not running");
+    }
+    const owner = instance;
+    const sessionKey = "agent:main:avatar-proof";
+    const created = await owner.cli([
+      "gateway",
+      "call",
+      "sessions.create",
+      "--params",
+      JSON.stringify({ key: sessionKey, agentId: "main", label: "Agent avatar proof" }),
+      "--json",
+    ]);
+    expect(created.code, created.stderr).toBe(0);
+    const session = JSON.parse(created.stdout) as { ok: boolean; sessionId: string };
+    expect(session.ok).toBe(true);
+    const reply = "My configured avatar appears beside this assistant reply.";
+    for (const [role, text] of [
+      ["user", "Show the configured agent identity in this conversation."],
+      ["assistant", reply],
+    ]) {
+      await appendTranscriptMessage(
+        { agentId: "main", sessionKey, sessionId: session.sessionId, env: owner.env },
+        { message: { role, content: [{ type: "text", text }], timestamp: Date.now() } },
+      );
+    }
+    const dashboard = await owner.cli(["dashboard", "--json"]);
+    expect(dashboard.code, dashboard.stderr).toBe(0);
+    const issued = new URL((JSON.parse(dashboard.stdout) as { browserUrl: string }).browserUrl);
+    const url = new URL(controlUiSessionUrl(suite.server.baseUrl, sessionKey, "chat"));
+    url.hash = issued.hash;
+    await suite.withPage(
+      { locale: "en-US", viewport: { width: 1440, height: 1000 }, serviceWorkers: "block" },
+      async ({ page }) => {
+        expect((await page.goto(url.toString()))?.status()).toBe(200);
+        await waitForControlUiGatewayReady(page);
+        await page.getByText(reply, { exact: true }).waitFor();
+        const avatar = page.locator("img.chat-avatar.assistant");
+        const decodedWidth = async () =>
+          (await avatar.count()) === 1
+            ? avatar.evaluate((element) => (element as HTMLImageElement).naturalWidth)
+            : 0;
+        // Preserve the missing avatar on the broken revision before the regression assertion.
+        if (captureEnabled) {
+          await page.screenshot({ path: path.join(suite.artifactDir, "01-loaded-transcript.png") });
+        }
+        await expect.poll(decodedWidth).toBeGreaterThan(0);
+        expect(await avatar.getAttribute("src")).toMatch(/^blob:/);
+        expect(await avatar.getAttribute("alt")).toBe("Avatar Proof");
+        expect(await avatar.isVisible()).toBe(true);
+        expect(
+          await avatar.evaluate((element) => element.closest(".chat-group")?.textContent),
+        ).toContain(reply);
+        if (captureEnabled) {
+          await page.screenshot({ path: path.join(suite.artifactDir, "02-avatar-decoded.png") });
+          await writeFile(
+            path.join(suite.artifactDir, "evidence.json"),
+            JSON.stringify(
+              {
+                sessionKey,
+                configuredWorkspaceAvatar: "agent-avatar.png",
+                assistantAvatarCount: await avatar.count(),
+                decodedWidth: await decodedWidth(),
+                visibleBesidePersistedReply: true,
+                servedScripts: await page
+                  .locator("script[src]")
+                  .evaluateAll((scripts) =>
+                    scripts.map((script) => new URL((script as HTMLScriptElement).src).pathname),
+                  ),
+              },
+              null,
+              2,
+            ),
+          );
+        }
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -299,7 +299,7 @@ export function projectChatTranscript(
     embedSandboxMode: props.embedSandboxMode ?? "scripts",
     allowExternalEmbedUrls: props.allowExternalEmbedUrls ?? false,
     fetchLinkFavicon: props.fetchLinkFavicon,
-    showAssistantAvatar: false,
+    showAssistantAvatar: avatarPlacement === "gutter" && Boolean(assistantIdentity.avatar),
   } satisfies StreamGroupOptions;
   const streamGroupOptions = {
     ...sharedMessageRenderOptions,
@@ -372,9 +372,6 @@ export function projectChatTranscript(
       latestAssistant: item.key === latestAssistantItemKey,
     } satisfies Parameters<typeof renderMessageGroup>[1];
   };
-  const renderGroupItem = (item: MessageGroup) => {
-    return renderMessageGroup(item, renderGroupOptions(item));
-  };
   // Only the working indicator shows live usage, so rows without one keep
   // memoizing across usage patches.
   const workingUsageKey = `usage:${runOutputTokens ?? ""}`;
@@ -436,7 +433,7 @@ export function projectChatTranscript(
         return nothing;
       }
       if (item.groups.length === 1) {
-        return renderGroupItem(firstGroup);
+        return renderMessageGroup(firstGroup, renderGroupOptions(firstGroup));
       }
       return renderActivityGroup(item.groups, renderGroupOptions(firstGroup));
     }
@@ -450,7 +447,7 @@ export function projectChatTranscript(
       });
     }
     if (item.kind === "group") {
-      return renderGroupItem(item);
+      return renderMessageGroup(item, renderGroupOptions(item));
     }
     if (item.kind === "question") {
       return renderStreamGroup([item], {

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -53,10 +53,10 @@ describe("chat transcript rendering", () => {
     "keeps configured avatar %s consistent across saved and streaming replies with %s placement",
     async (avatar, avatarPlacement) => {
       const props = threadProps("pane-agent-avatar");
-      props.userId = "synthetic-owner";
+      props.userId = avatarPlacement === "footer" ? null : "synthetic-owner";
       props.assistantAvatar = avatar;
       props.assistantAvatarUrl = avatar?.startsWith("blob:") ? avatar : null;
-      props.avatarPlacement = avatarPlacement;
+      props.avatarPlacement = avatarPlacement === "none" ? "none" : undefined;
       props.stream = "Reply in progress";
       props.streamStartedAt = 5_000;
       props.runActive = true;

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -43,6 +43,49 @@ describe("chat transcript rendering", () => {
   beforeEach(installTranscriptDomMocks);
   afterEach(resetTranscriptTestDom);
 
+  it.each([
+    ["blob:configured-agent", "gutter"],
+    ["🤖", "gutter"],
+    [null, "gutter"],
+    ["blob:configured-agent", "none"],
+    ["blob:configured-agent", "footer"],
+  ] as const)(
+    "keeps configured avatar %s consistent across saved and streaming replies with %s placement",
+    async (avatar, avatarPlacement) => {
+      const props = threadProps("pane-agent-avatar");
+      props.userId = "synthetic-owner";
+      props.assistantAvatar = avatar;
+      props.assistantAvatarUrl = avatar?.startsWith("blob:") ? avatar : null;
+      props.avatarPlacement = avatarPlacement;
+      props.stream = "Reply in progress";
+      props.streamStartedAt = 5_000;
+      props.runActive = true;
+      const container = document.body.appendChild(document.createElement("div"));
+      const transcript = createTestTranscript();
+      try {
+        render(renderChatThread(props, transcript), container);
+        transcript.hostConnected();
+        transcript.hostUpdated();
+        await flushDeferredRowPrune();
+        const replies = container.querySelectorAll(".chat-group.assistant");
+        expect(replies).toHaveLength(3);
+        for (const reply of replies) {
+          const image = reply.querySelector(".chat-avatar.assistant");
+          if (avatar === null || avatarPlacement !== "gutter") {
+            expect(image).toBeNull();
+          } else if (avatar.startsWith("blob:")) {
+            expect(image?.getAttribute("src")).toBe(avatar);
+          } else {
+            expect(image?.textContent?.trim()).toBe(avatar);
+          }
+        }
+      } finally {
+        transcript.hostDisconnected();
+        container.remove();
+      }
+    },
+  );
+
   it("keeps one inline compaction row through completion and history refresh", async () => {
     const props: ReturnType<typeof threadProps> = {
       ...threadProps("pane-compaction"),


### PR DESCRIPTION
Closes #139594. Thanks @RobertOnline69 for the report.

## What Problem This Solves

Fixes an issue where users with a configured agent avatar saw the agent's name but no avatar beside assistant replies in the Control UI transcript, even though the image appeared elsewhere in the UI.

## Why This Change Was Made

The transcript suppressed every assistant avatar, including configured images and text avatars. Its shared rendering options now show a resolved configured avatar when the transcript uses an avatar gutter. Saved and streaming replies follow the same decision, preserving compact/subagent layouts and the omission of generic fallback icons. A redundant message-rendering wrapper was removed.

History inspection traced the suppression to `2873fbbc5606` (#121405), already included in both v2026.9.1 and v2026.9.2. No avatar-suppression change was introduced between those tags. This repair restores configured identity while preserving the earlier fallback-icon reduction.

## User Impact

Configured agent images and text avatars appear beside assistant replies wherever transcript avatars are enabled. User avatars, compact layouts, and CSS remain unchanged.

## Evidence

- Pre-fix regression: configured image and text cases fail because the avatar is missing; the unconfigured case passes. Additional placement cases rejected an intermediate patch that exposed streaming avatars in compact layouts.
- Local validation: 276 avatar/message tests and 38 transcript rendering/invalidation tests passed; the corrected final five-case matrix and UI test typecheck passed. Both changed-file gates, workflow checks, and 40 focused CI ownership/command-selection cases passed. Final branch autoreview has no actionable P0–P2 findings.
- Production: +3 / -6 = **-3 lines**. CI workflow: +1 / -0. Tests/support: +195 / -0. Docs: +1 / -1. CSS: **0 lines**. No new configuration options, environment variables, schema/protocol changes, dependencies, or versions.

### Remote before/after

Provider: **Blacksmith Testbox**, through the repository Crabbox wrapper. The scenario builds the candidate, starts a real Gateway on an isolated state directory and free loopback port, configures a workspace-relative PNG, seeds a synthetic owner, creates a session through Gateway RPC, and loads a persisted assistant reply in Chromium.

| Proof | Lease | Run | Result |
| --- | --- | --- | --- |
| Original renderer on `c54319089356fd06bc58f3d749c30ad98e0912ad` | `tbx_01m1tprbqdhhhp5dvz6at9ws3s` | [34016805905](https://github.com/openclaw/openclaw/actions/runs/34016805905) | Reply displayed; configured avatar missing; intended `decodedWidth=0` failure |
| Final head `1d73309e4bd3efe81868f1817743b11dd83aa2b1` | `tbx_01m1tsv4absrzvbhqk06v7vtjz` | [34019203741](https://github.com/openclaw/openclaw/actions/runs/34019203741) | 40 CI guard cases, full build, five avatar/layout cases, and real-Gateway Chromium E2E passed |

The final wrapper attested source tree `2d25d240f2a165f061e998b3ab414c3bc5312b58`; the run verified source/test hashes before execution. Chromium decoded one configured assistant image at 128px through an authenticated blob URL. The served bundle changed from `/assets/index-DefhjbqO.js` to `/assets/index-BejWP9fn.js` (final SHA-256 `269279c5866030916695f777b0bf704a064cfd2e208ebffa38ac2e0138483c2a`). Captures were inspected in full and contain synthetic identities only. All task Testbox leases were stopped after retrieving artifacts.

```sh
node scripts/run-vitest.mjs test/vitest-ui-e2e-config.test.ts test/scripts/ci-workflow-guards.test.ts -t 'Control UI E2E resource ownership|private Control UI servers|complete real-Gateway command'
pnpm build
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-transcript-render.test.ts -t 'keeps configured avatar'
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-agent-avatar.real-gateway.e2e.test.ts
```

The browser proof loads a synthetic persisted transcript; streaming and compact/subagent placement use deterministic rendering tests. No external model turn is claimed.

Initial CI correctly caught omitted registrations in the real-Gateway workflow command and independent inventory assertions; those are fixed and now proved above. The unrelated sandbox hash failure on both this PR and main was traced to shared `/tmp/workspace` test pollution and is tracked separately in #139902. No assertions or gates were weakened.

### Before

![Before: configured agent avatar is missing beside the assistant reply](https://github.com/user-attachments/assets/67f11f8b-bc4d-499a-9b5d-b2f978a50577)

### After

![After: final head renders the configured agent avatar beside the assistant reply](https://github.com/user-attachments/assets/a53f4c57-56b1-4cf2-a9ec-bea181cbd283)