### PR TITLE
feat(transcripts): browse and export saved meeting archives

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -923,6 +923,8 @@ enum class GatewayMethod(
   GatewaySuspendHandoff("gateway.suspend.handoff"),
   UpdateReport("update.report"),
   SkillsWorkshopRead("skills.workshop.read"),
+  TranscriptsExport("transcripts.export"),
+  TranscriptsStatus("transcripts.status"),
 }
 
 enum class GatewayEvent(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -921,10 +921,10 @@ enum class GatewayMethod(
   UpdateRunsGet("update.runs.get"),
   UpdateRunsList("update.runs.list"),
   GatewaySuspendHandoff("gateway.suspend.handoff"),
-  UpdateReport("update.report"),
-  SkillsWorkshopRead("skills.workshop.read"),
   TranscriptsExport("transcripts.export"),
   TranscriptsStatus("transcripts.status"),
+  UpdateReport("update.report"),
+  SkillsWorkshopRead("skills.workshop.read"),
 }
 
 enum class GatewayEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -15283,6 +15283,10 @@ public struct TranscriptSessionSummary: Codable, Sendable {
     public let hassummary: Bool
     public let summarysource: AnyCodable?
     public let overview: String?
+    public let agentid: AnyCodable
+    public let updatedat: String
+    public let lastutteranceat: AnyCodable
+    public let activesubscription: Bool
 
     public init(
         selector: String,
@@ -15298,7 +15302,11 @@ public struct TranscriptSessionSummary: Codable, Sendable {
         participants: [String],
         hassummary: Bool,
         summarysource: AnyCodable? = nil,
-        overview: String? = nil)
+        overview: String? = nil,
+        agentid: AnyCodable,
+        updatedat: String,
+        lastutteranceat: AnyCodable,
+        activesubscription: Bool)
     {
         self.selector = selector
         self.sessionid = sessionid
@@ -15314,6 +15322,10 @@ public struct TranscriptSessionSummary: Codable, Sendable {
         self.hassummary = hassummary
         self.summarysource = summarysource
         self.overview = overview
+        self.agentid = agentid
+        self.updatedat = updatedat
+        self.lastutteranceat = lastutteranceat
+        self.activesubscription = activesubscription
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -15331,52 +15343,100 @@ public struct TranscriptSessionSummary: Codable, Sendable {
         case hassummary = "hasSummary"
         case summarysource = "summarySource"
         case overview
+        case agentid = "agentId"
+        case updatedat = "updatedAt"
+        case lastutteranceat = "lastUtteranceAt"
+        case activesubscription = "activeSubscription"
     }
 }
 
 public struct TranscriptsListParams: Codable, Sendable {
     public let limit: Int?
+    public let cursor: String?
+    public let query: String?
     public let providerid: String?
+    public let accountid: String?
+    public let agentid: String?
+    public let startedafter: String?
+    public let startedbefore: String?
 
     public init(
         limit: Int? = nil,
-        providerid: String? = nil)
+        cursor: String? = nil,
+        query: String? = nil,
+        providerid: String? = nil,
+        accountid: String? = nil,
+        agentid: String? = nil,
+        startedafter: String? = nil,
+        startedbefore: String? = nil)
     {
         self.limit = limit
+        self.cursor = cursor
+        self.query = query
         self.providerid = providerid
+        self.accountid = accountid
+        self.agentid = agentid
+        self.startedafter = startedafter
+        self.startedbefore = startedbefore
     }
 
     private enum CodingKeys: String, CodingKey {
         case limit
+        case cursor
+        case query
         case providerid = "providerId"
+        case accountid = "accountId"
+        case agentid = "agentId"
+        case startedafter = "startedAfter"
+        case startedbefore = "startedBefore"
     }
 }
 
 public struct TranscriptsListResult: Codable, Sendable {
     public let sessions: [TranscriptSessionSummary]
+    public let nextcursor: AnyCodable
 
     public init(
-        sessions: [TranscriptSessionSummary])
+        sessions: [TranscriptSessionSummary],
+        nextcursor: AnyCodable)
     {
         self.sessions = sessions
+        self.nextcursor = nextcursor
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessions
+        case nextcursor = "nextCursor"
     }
 }
 
 public struct TranscriptsGetParams: Codable, Sendable {
     public let selector: String
     public let includeutterances: Bool?
+    public let limit: Int?
+    public let cursor: String?
+    public let query: String?
 
     public init(
         selector: String,
-        includeutterances: Bool? = nil)
+        includeutterances: Bool? = nil,
+        limit: Int? = nil,
+        cursor: String? = nil,
+        query: String? = nil)
     {
         self.selector = selector
         self.includeutterances = includeutterances
+        self.limit = limit
+        self.cursor = cursor
+        self.query = query
     }
 
     private enum CodingKeys: String, CodingKey {
         case selector
         case includeutterances = "includeUtterances"
+        case limit
+        case cursor
+        case query
     }
 }
 
@@ -15384,15 +15444,25 @@ public struct TranscriptsGetResult: Codable, Sendable {
     public let session: TranscriptSessionSummary
     public let summary: [String: AnyCodable]?
     public let utterances: [[String: AnyCodable]]?
+    public let nextcursor: AnyCodable
 
     public init(
         session: TranscriptSessionSummary,
         summary: [String: AnyCodable]? = nil,
-        utterances: [[String: AnyCodable]]? = nil)
+        utterances: [[String: AnyCodable]]? = nil,
+        nextcursor: AnyCodable)
     {
         self.session = session
         self.summary = summary
         self.utterances = utterances
+        self.nextcursor = nextcursor
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case session
+        case summary
+        case utterances
+        case nextcursor = "nextCursor"
     }
 }
 
@@ -18464,6 +18534,89 @@ public struct SkillsUploadCommitParams: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case uploadid = "uploadId"
         case sha256
+    }
+}
+
+public struct TranscriptsExportParams: Codable, Sendable {
+    public let selector: String
+    public let format: AnyCodable
+
+    public init(
+        selector: String,
+        format: AnyCodable)
+    {
+        self.selector = selector
+        self.format = format
+    }
+}
+
+public struct TranscriptsExportResult: Codable, Sendable {
+    public let selector: String
+    public let filename: String
+    public let mimetype: String
+    public let encoding: String
+    public let data: String
+    public let sizebytes: Int
+
+    public init(
+        selector: String,
+        filename: String,
+        mimetype: String,
+        encoding: String,
+        data: String,
+        sizebytes: Int)
+    {
+        self.selector = selector
+        self.filename = filename
+        self.mimetype = mimetype
+        self.encoding = encoding
+        self.data = data
+        self.sizebytes = sizebytes
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case selector
+        case filename
+        case mimetype = "mimeType"
+        case encoding
+        case data
+        case sizebytes = "sizeBytes"
+    }
+}
+
+public struct TranscriptsStatusParams: Codable, Sendable {}
+
+public struct TranscriptsStatusResult: Codable, Sendable {
+    public let enabled: Bool
+    public let providers: [[String: AnyCodable]]
+    public let configuredsources: [[String: AnyCodable]]
+    public let active: [TranscriptSessionSummary]
+    public let latesttranscript: AnyCodable
+    public let omitted: [String: AnyCodable]
+
+    public init(
+        enabled: Bool,
+        providers: [[String: AnyCodable]],
+        configuredsources: [[String: AnyCodable]],
+        active: [TranscriptSessionSummary],
+        latesttranscript: AnyCodable,
+        omitted: [String: AnyCodable])
+    {
+        self.enabled = enabled
+        self.providers = providers
+        self.configuredsources = configuredsources
+        self.active = active
+        self.latesttranscript = latesttranscript
+        self.omitted = omitted
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case enabled
+        case providers
+        case configuredsources = "configuredSources"
+        case active
+        case latesttranscript = "latestTranscript"
+        case omitted
     }
 }
 

--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -167,12 +167,12 @@ Open **Meetings** in the [Control UI](/web/control-ui#meetings-page) to browse
 captured meetings and notes without a terminal. The page and other Gateway
 clients use these read-only RPC methods:
 
-| Method               | Parameters                                                                                                                                             | Result                                                                                                                                         |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `transcripts.list`   | Optional `limit` (1–200, default 50), `cursor`, `query`, exact `providerId`/`accountId`/`agentId`, and `startedAfter`/`startedBefore` date-time bounds | Newest-first `sessions`, including participants, utterance counts, active state, summary availability, a bounded overview, and `nextCursor`.   |
-| `transcripts.get`    | Required `selector`; optional `includeUtterances`, `limit` (1–100, default 50), `cursor`, and utterance `query`                                        | One `session`, stored `summary`, optional full-text `utterances`, and `nextCursor`.                                                            |
-| `transcripts.export` | Required `selector` and `format` (`markdown` or `jsonl`)                                                                                               | A base64-encoded file with `filename`, `mimeType`, and `sizeBytes`.                                                                            |
-| `transcripts.status` | None                                                                                                                                                   | Capture enablement, provider availability and setup metadata, configured-source health, active subscriptions, and the latest saved transcript. |
+| Method               | Parameters                                                                                                                                             | Result                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transcripts.list`   | Optional `limit` (1–200, default 50), `cursor`, `query`, exact `providerId`/`accountId`/`agentId`, and `startedAfter`/`startedBefore` date-time bounds | Newest-first `sessions`, including participants, utterance counts, active state, summary availability, a bounded overview, and `nextCursor`.                               |
+| `transcripts.get`    | Required `selector`; optional `includeUtterances`, `limit` (1–100), `cursor`, and utterance `query`                                                    | One `session`, stored `summary`, optional `utterances`, and `nextCursor`. Explicit pagination returns full text; legacy requests retain the recent window described below. |
+| `transcripts.export` | Required `selector` and `format` (`markdown` or `jsonl`)                                                                                               | A base64-encoded file with `filename`, `mimeType`, and `sizeBytes`.                                                                                                        |
+| `transcripts.status` | None                                                                                                                                                   | Capture enablement, provider availability and setup metadata, configured-source health, active subscriptions, and the latest saved transcript.                             |
 
 These methods require `operator.read` or its write/admin implication and expose
 meetings across one trusted Gateway domain. Restricted operator profiles need
@@ -195,11 +195,24 @@ changing either requires a fresh first page. A null `nextCursor` ends pagination
 
 The stored summary Markdown is the canonical notes text, matching the CLI's
 `show` output. Reads do not generate summaries or materialize files. Utterances
-are omitted unless requested and paginated without truncating stored text;
-`query` searches the full stored transcript, including unloaded pages. Each read
-result is bounded to 1 MiB. Oversized rows or invalid cursors fail visibly.
+are omitted unless `includeUtterances` is true. Supplying `limit`, `cursor`, or
+`query` selects paginated reads: at most 100 utterances per page, default 50,
+without truncating stored text. `query` searches the full stored transcript,
+including unloaded pages. Paginated reads, lists, and status results are bounded
+to 1 MiB, with stored payload bounds enforced before transfer into JavaScript.
+Oversized rows or invalid cursors fail visibly.
 Summary participants and model/heuristic provenance are shown when available;
 older summaries need not contain them.
+
+For compatibility with clients released before archive pagination, `transcripts.get`
+without `limit`, `cursor`, or `query` retains the most recent 2,000 utterances in
+chronological order, with each sanitized text clipped to 4,000 UTF-16 units.
+These legacy requests return `nextCursor: null` and retain a 25 MiB public-result
+ceiling, matching the existing Gateway client transport limit. They preserve
+the original raw-row reading behavior before text clipping and public projection.
+Send an explicit `limit` to adopt bounded page reads and retrieve complete text;
+continue with `nextCursor` until it is null. All archive access checks apply to
+both request shapes.
 
 Exports are bounded to 4 MiB and fail without returning a partial file. Markdown
 preserves stored notes and appends the complete transcript under a separate

--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -165,24 +165,58 @@ when one capture is active.
 
 Open **Meetings** in the [Control UI](/web/control-ui#meetings-page) to browse
 captured meetings and notes without a terminal. The page and other Gateway
-clients use two read-only RPC methods:
+clients use these read-only RPC methods:
 
-| Method             | Parameters                                            | Result                                                                                                                                                    |
-| ------------------ | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `transcripts.list` | Optional `limit` (1–200, default 50) and `providerId` | Newest-first `sessions`, including participants, utterance counts, active state, summary availability, and an overview preview of at most 280 characters. |
-| `transcripts.get`  | Required `selector`; optional `includeUtterances`     | One `session`, stored `summary` and its Markdown when available, and optional bounded `utterances`.                                                       |
+| Method               | Parameters                                                                                                                                             | Result                                                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `transcripts.list`   | Optional `limit` (1–200, default 50), `cursor`, `query`, exact `providerId`/`accountId`/`agentId`, and `startedAfter`/`startedBefore` date-time bounds | Newest-first `sessions`, including participants, utterance counts, active state, summary availability, a bounded overview, and `nextCursor`.   |
+| `transcripts.get`    | Required `selector`; optional `includeUtterances`, `limit` (1–100, default 50), `cursor`, and utterance `query`                                        | One `session`, stored `summary`, optional full-text `utterances`, and `nextCursor`.                                                            |
+| `transcripts.export` | Required `selector` and `format` (`markdown` or `jsonl`)                                                                                               | A base64-encoded file with `filename`, `mimeType`, and `sizeBytes`.                                                                            |
+| `transcripts.status` | None                                                                                                                                                   | Capture enablement, provider availability and setup metadata, configured-source health, active subscriptions, and the latest saved transcript. |
 
-Both methods require `operator.read` and expose meetings across one trusted
-Gateway domain, not just the current agent or chat session. Use separate Gateway
-domains when readers need isolation. Source locators contain only `providerId`,
-`accountId`, `guildId`, `channelId`, and `meetingUrl` when present, never arbitrary
-capture metadata. See [Gateway protocol](/gateway/protocol).
+These methods require `operator.read` or its write/admin implication and expose
+meetings across one trusted Gateway domain. Restricted operator profiles need
+permission to read the shared archive; selecting an agent filter does not grant
+access. Use separate Gateway domains when readers need isolation. Source
+locators contain only `providerId`, `accountId`, `guildId`, `channelId`, `threadTs`,
+`fileId`, `kind`, and sanitized `meetingUrl` when present, never arbitrary capture
+metadata. See [Gateway protocol](/gateway/protocol).
+
+List search matches titles and session/source IDs, excluding meeting URLs.
+Date bounds use session start times: `startedAfter` is inclusive and
+`startedBefore` is exclusive. Dates are compared by instant using JavaScript
+date-string semantics, including stored UTC offsets. Original timestamps and
+selectors remain unchanged. Unparseable stored dates sort last and are excluded
+from date ranges. Equal instants sort by session ID, then original timestamp.
+Chronological page selection scans candidate captures before reading only the
+selected page's notes and participants, so read time grows with archive size.
+Cursors belong to their current query and filters;
+changing either requires a fresh first page. A null `nextCursor` ends pagination.
 
 The stored summary Markdown is the canonical notes text, matching the CLI's
-`show` output. RPC reads do not materialize files. Utterances are omitted unless
-requested and bounded by the capture limit of 2,000; each utterance text is also
-sanitized and bounded. Summary participants and model/heuristic provenance are
-shown when available; older summaries need not contain them.
+`show` output. Reads do not generate summaries or materialize files. Utterances
+are omitted unless requested and paginated without truncating stored text;
+`query` searches the full stored transcript, including unloaded pages. Each read
+result is bounded to 1 MiB. Oversized rows or invalid cursors fail visibly.
+Summary participants and model/heuristic provenance are shown when available;
+older summaries need not contain them.
+
+Exports are bounded to 4 MiB and fail without returning a partial file. Markdown
+preserves stored notes and appends the complete transcript under a separate
+heading. JSONL contains the public
+utterance projection: sequence, utterance ID, full text, speaker identity, source
+timestamps, and finality when available. It excludes private provider metadata
+and filesystem paths; the local CLI export retains its raw utterance format.
+Use `openclaw transcripts path <session> --transcript` on the Gateway host for
+larger exports.
+
+Status reports registered subscriptions, not confirmed recording. `armed`,
+`not-active`, and `unknown` remain distinct; a sanitized URL alone cannot prove
+which original invitation started a capture. Provider, configured-source, and
+active lists are limited to 100 entries with omitted counts. Saved utterance
+counts come from durable rows. The latest transcript is the most recently
+updated session containing utterances; source speech times are not ingestion
+timestamps.
 
 ## JSON output
 
@@ -293,6 +327,19 @@ to the legacy files. Keep the archive until you have verified the imported
 sessions and any exports you rely on.
 
 ## Configuration
+
+Changing only auto-start source titles applies to future captures without
+restarting or interrupting current captures. Current and historical notes keep
+their original title, source, agent attribution, and selector. Other source edits
+retain normal Gateway restart behavior.
+
+Startup retries preserve the same admitted ID, original title, start time,
+source, and saved notes only while the exact failed provider attempt retains
+retry authority. This applies to generated and configured IDs. Retries stop
+after twelve attempts, service shutdown, manual stop, or a failure that retains
+cleanup custody. Status reports a bounded diagnostic without provider error
+details. Recover pending cleanup with the tool's `stop` action before trying a
+new capture.
 
 Meeting transcript capture is enabled by default. To opt out globally:
 

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -174,6 +174,7 @@ See [Plugins](/tools/plugin) for the full plugin system guide, and [Capability m
 | `dashboard`                          | No       | `object`                     | Dashboard widget data bindings and action verbs. Each entry is validated against a Gateway method registered by this plugin with the required read or write scope. See [dashboard reference](#dashboard-reference).                                                                                                                                                                              |
 | `mcpServers`                         | No       | `Record<string, object>`     | Static MCP server definitions contributed while this plugin is enabled. Relative command arguments and working directories resolve from the plugin root. Operator `mcp.servers` entries override or disable definitions with the same name. See [MCP server reference](#mcp-server-reference).                                                                                                   |
 | `contracts`                          | No       | `object`                     | Static capability ownership snapshot for external auth hooks, embeddings, speech, realtime transcription, realtime voice, media-understanding, image/video/music generation, web fetch, web search, worker providers, document/web-content extraction, and tool ownership.                                                                                                                       |
+| `transcriptSources`                  | No       | `Record<string, object>`     | Static transcript source names and auto-start locator requirements for IDs declared in `contracts.transcriptSourceProviders`. See [Transcript sources reference](#transcript-sources-reference).                                                                                                                                                                                                 |
 | `configContracts`                    | No       | `object`                     | Manifest-owned config behavior consumed by generic core helpers: dangerous-flag detection, SecretRef migration targets, and legacy config-path narrowing. See [configContracts reference](#configcontracts-reference).                                                                                                                                                                           |
 | `mediaUnderstandingProviderMetadata` | No       | `Record<string, object>`     | Cheap media-understanding defaults for provider ids declared in `contracts.mediaUnderstandingProviders`.                                                                                                                                                                                                                                                                                         |
 | `imageGenerationProviderMetadata`    | No       | `Record<string, object>`     | Cheap image-generation auth metadata for provider ids declared in `contracts.imageGenerationProviders`, including provider-owned auth aliases and base-url guards.                                                                                                                                                                                                                               |
@@ -249,6 +250,40 @@ distributed separately. This lets `doctor --fix` migrate older configuration
 before plugin installation or capability consent. An installed plugin's doctor
 contract remains authoritative; retained entrypoints do not expose state
 migrations, install plugins, or grant capabilities.
+
+## Transcript sources reference
+
+`transcriptSources` maps provider IDs to static setup descriptors. Each key must
+also appear in this plugin's `contracts.transcriptSourceProviders`; descriptors
+for undeclared IDs are ignored. Names and setup controls are available from the
+prepared manifest snapshot without importing provider runtime.
+
+```json
+{
+  "contracts": { "transcriptSourceProviders": ["captions"] },
+  "transcriptSources": {
+    "captions": {
+      "name": "Captions",
+      "autoStart": { "accountId": "optional", "meetingUrl": "required" }
+    }
+  }
+}
+```
+
+`name` is an optional display name. `autoStart` advertises setup controls to
+Gateway clients through `transcripts.status`. Its only keys are `accountId`,
+`guildId`, `channelId`, and `meetingUrl`; each value must be `"required"` or
+`"optional"`. An explicit empty object supports setup without locator controls.
+Omit `autoStart` for sources that only attach to an already-active meeting bot.
+Malformed objects, unknown locator keys, or invalid modes do not advertise
+partial setup. Title and custom session ID remain existing configuration fields, not locator
+descriptor keys.
+
+Setup requires an enabled plugin. Runtime capabilities remain observed facts:
+an absent `canStart` does not hide the manifest descriptor, while an observed
+`canStart: false` prevents new setup. The descriptor does not change acceptance
+of existing `transcripts.autoStart` config or provider start semantics. Existing
+source edits preserve configured fields when metadata is unavailable.
 
 ## backupResources reference
 

--- a/extensions/discord/openclaw.plugin.json
+++ b/extensions/discord/openclaw.plugin.json
@@ -20,6 +20,16 @@
       "discord-voice"
     ]
   },
+  "transcriptSources": {
+    "discord-voice": {
+      "name": "Discord Voice",
+      "autoStart": {
+        "accountId": "optional",
+        "guildId": "required",
+        "channelId": "required"
+      }
+    }
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/extensions/discord/src/voice/voice-gateway-capture.test-support.ts
+++ b/extensions/discord/src/voice/voice-gateway-capture.test-support.ts
@@ -1,0 +1,348 @@
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import { PassThrough } from "node:stream";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createPluginRuntimeStore, type PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
+import { discordPlugin } from "../../channel-plugin-api.js";
+import { registerDiscordTranscriptSourceProvider } from "../../transcripts-source-api.js";
+import type { Client } from "../internal/discord.js";
+import * as audio from "./audio.js";
+import * as sdkRuntime from "./sdk-runtime.js";
+import type { VoiceSessionEntry } from "./session.js";
+import {
+  discordVoiceTranscriptsSourceProvider,
+  setDiscordTranscriptsVoiceManager,
+} from "./transcripts-source.js";
+import { DiscordVoiceManager } from "./voice-runtime.js";
+
+export const captureTarget = {
+  accountId: "gateway-capture-fixture",
+  guildId: "810000000000000001",
+  channelId: "810000000000000002",
+};
+const speakerId = "810000000000000003";
+const speakerLabel = "Synthetic speaker";
+export const capturedText = "Synthetic capture continues after the initiating turn settles.";
+export const lateText = "Synthetic late STT must not enter the stopped capture.";
+
+/** Owns only external Discord/codec/STT edges; no routing, authorization or dispatch mocks. */
+export function createDiscordGatewayCaptureFixture(params: {
+  cfg: OpenClawConfig;
+  test: { expect: typeof import("vitest").expect; vi: typeof import("vitest").vi };
+}) {
+  const { expect, vi } = params.test;
+  const runtimeStore = createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "discord",
+    errorMessage: "Discord runtime not initialized",
+  });
+  const previousRuntime = runtimeStore.tryGetRuntime();
+  const sdk = sdkRuntime.loadDiscordVoiceSdk();
+  const createTransport = () => {
+    const speaking = Object.assign(new EventEmitter(), {
+      // Speech predates readiness: there is deliberately no initial native start event.
+      users: new Map([[speakerId, Date.now()]]),
+    });
+    const streams: PassThrough[] = [];
+    const subscribe = vi.fn(() => {
+      const stream = new PassThrough();
+      streams.push(stream);
+      return stream;
+    });
+    const player = Object.assign(new EventEmitter(), {
+      state: { status: sdk.AudioPlayerStatus.Idle },
+      stop: vi.fn(() => true),
+      play: vi.fn(),
+    });
+    const connection = Object.assign(new EventEmitter(), {
+      state: { status: sdk.VoiceConnectionStatus.Ready },
+      receiver: { speaking, subscribe },
+      subscribe: vi.fn(),
+      destroy: vi.fn(() => {
+        connection.state.status = sdk.VoiceConnectionStatus.Destroyed;
+        connection.emit(sdk.VoiceConnectionStatus.Destroyed);
+      }),
+    });
+    return { speaking, streams, subscribe, player, connection };
+  };
+  let transport = createTransport();
+  const transports = [transport];
+  const firstTransport = transport;
+  // Canonical consumers retain initial spy bindings, so spies must outlive manager rotation.
+  const sdkSpy = vi.spyOn(sdkRuntime, "loadDiscordVoiceSdk").mockReturnValue({
+    ...sdk,
+    getVoiceConnection: () => undefined,
+    joinVoiceChannel: vi.fn(() => transport.connection),
+    createAudioPlayer: vi.fn(() => transport.player),
+    entersState: vi.fn(async (target) => target),
+  } as unknown as ReturnType<typeof sdkRuntime.loadDiscordVoiceSdk>);
+  const writeWav = audio.writeVoiceWavFile;
+  const wavCleanups: Promise<void>[] = [];
+  const wavSpy = vi.spyOn(audio, "writeVoiceWavFile").mockImplementation(async (pcm) => {
+    const wav = await writeWav(pcm);
+    const released = createDeferred<void>();
+    wavCleanups.push(released.promise);
+    return {
+      ...wav,
+      cleanup: async () => {
+        try {
+          await wav.cleanup();
+        } finally {
+          released.resolve();
+        }
+      },
+    };
+  });
+  const decoding = new Set<Promise<void>>();
+  const codecSpy = vi
+    .spyOn(audio, "decodeOpusStreamChunks")
+    .mockImplementation((input, options) => {
+      const work = (async () => {
+        for await (const packet of input) {
+          // One synthetic packet is 20 ms of stereo PCM. Preserve packet identity for receipts.
+          const pcm = Buffer.alloc(960 * 2 * 2);
+          pcm.fill(packet[0]);
+          await options.onChunk(pcm, packet);
+        }
+      })();
+      decoding.add(work);
+      void work.then(
+        () => decoding.delete(work),
+        () => decoding.delete(work),
+      );
+      return work;
+    });
+  const lateStt = createDeferred<void>();
+  const wavPaths: string[] = [];
+  let installedRuntime: PluginRuntime | undefined;
+  let sttSpy: { mockRestore(): void } | undefined;
+  const stt = vi.fn<PluginRuntime["mediaUnderstanding"]["transcribeAudioFile"]>(
+    async ({ filePath, mime }) => {
+      const wav = await fs.readFile(filePath);
+      expect(mime).toBe("audio/wav");
+      expect(wav.subarray(0, 4).toString()).toBe("RIFF");
+      expect(wav.subarray(8, 12).toString()).toBe("WAVE");
+      expect(wav.readUInt32LE(24)).toBe(48_000);
+      expect(wav.readUInt16LE(22)).toBe(2);
+      expect(wav.readUInt32LE(40)).toBe(wav.length - 44);
+      expect(wav.subarray(44).equals(Buffer.alloc(960 * 2 * 2, wav[44]))).toBe(true);
+      wavPaths.push(filePath);
+      if (wav[44] === 2) {
+        await lateStt.promise;
+        return { text: lateText };
+      }
+      expect(wav[44]).toBe(1);
+      return { text: capturedText };
+    },
+  );
+  const client = {
+    fetchChannel: async () => ({
+      id: captureTarget.channelId,
+      guildId: captureTarget.guildId,
+      type: 2,
+      name: "synthetic-capture",
+    }),
+    fetchGuild: async () => ({ id: captureTarget.guildId, name: "Synthetic guild" }),
+    fetchMember: async () => ({
+      nickname: speakerLabel,
+      user: { id: speakerId, username: "synthetic-speaker", bot: false },
+      roles: [],
+    }),
+    getPlugin: (id: string) =>
+      id === "voice"
+        ? { getGatewayAdapterCreator: () => () => ({ sendPayload: () => true, destroy() {} }) }
+        : id === "gateway"
+          ? {
+              listVoiceChannelStates: () => [
+                {
+                  user_id: speakerId,
+                  channel_id: captureTarget.channelId,
+                  member: { nick: speakerLabel, user: { id: speakerId, bot: false } },
+                },
+              ],
+            }
+          : undefined,
+  } as unknown as Client;
+  function restoreRuntime() {
+    // A different owner installed during teardown must never be overwritten or cleared.
+    const currentRuntime = runtimeStore.tryGetRuntime();
+    if (installedRuntime !== undefined && currentRuntime === installedRuntime) {
+      if (previousRuntime) {
+        runtimeStore.setRuntime(previousRuntime);
+      } else {
+        runtimeStore.clearRuntime();
+      }
+    }
+  }
+  function restore() {
+    sttSpy?.mockRestore();
+    codecSpy.mockRestore();
+    wavSpy.mockRestore();
+    sdkSpy.mockRestore();
+  }
+  const createManager = (cfg: OpenClawConfig) => {
+    const createdManager = new DiscordVoiceManager({
+      client,
+      cfg,
+      discordConfig: cfg.channels!.discord!.accounts![captureTarget.accountId]!,
+      accountId: captureTarget.accountId,
+      botUserId: "810000000000000004",
+      runtime: {
+        log() {},
+        error() {},
+        exit: () => {
+          throw new Error("unexpected Discord exit");
+        },
+      },
+    });
+    setDiscordTranscriptsVoiceManager({
+      accountId: captureTarget.accountId,
+      manager: createdManager,
+    });
+    return createdManager;
+  };
+  let manager: DiscordVoiceManager;
+  try {
+    manager = createManager(params.cfg);
+  } catch (error) {
+    restore();
+    throw error;
+  }
+  let entry: VoiceSessionEntry | undefined;
+  const entries = new Set<VoiceSessionEntry>();
+
+  async function drain() {
+    await Promise.all(decoding);
+    // The receiver removes packet listeners only after scheduling its final WAV/STT work.
+    await expect
+      .poll(() =>
+        transports.every((ownedTransport) =>
+          ownedTransport.streams.every((stream) => stream.listenerCount("data") === 0),
+        ),
+      )
+      .toBe(true);
+    await Promise.all(
+      [...entries].flatMap((ownedEntry) => [ownedEntry.processingQueue, ownedEntry.playbackQueue]),
+    );
+    // Retired capture queues can release before their WAV owner finishes disposal.
+    await Promise.all(wavCleanups);
+  }
+
+  async function closeCurrentManager() {
+    const closingManager = manager;
+    const currentEntry = closingManager["sessions"].get(captureTarget.guildId);
+    if (currentEntry) {
+      entries.add(currentEntry);
+    }
+    try {
+      const captures = await discordVoiceTranscriptsSourceProvider.status!({
+        providerId: "discord-voice",
+        ...captureTarget,
+      });
+      for (const capture of captures) {
+        if (capture.sessionId) {
+          await discordVoiceTranscriptsSourceProvider.stop!({
+            sessionId: capture.sessionId,
+            source: { providerId: "discord-voice", ...captureTarget },
+          });
+        }
+      }
+    } finally {
+      try {
+        await closingManager.destroy();
+      } finally {
+        for (const ownedTransport of transports) {
+          for (const stream of ownedTransport.streams) {
+            stream.destroy();
+          }
+        }
+        lateStt.resolve();
+        try {
+          await drain();
+        } finally {
+          setDiscordTranscriptsVoiceManager({
+            accountId: captureTarget.accountId,
+            manager: null,
+            expectedManager: closingManager,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    register(api: OpenClawPluginApi) {
+      // Same probe-type erasure used by defineBundledChannelEntry at registration.
+      api.registerChannel({ plugin: discordPlugin as ChannelPlugin });
+      registerDiscordTranscriptSourceProvider(api);
+    },
+    bindPublishedRuntime() {
+      expect(sttSpy).toBeUndefined();
+      // Registration owns the runtime slot. Intercept only its external STT edge.
+      installedRuntime = runtimeStore.getRuntime();
+      const media = installedRuntime.mediaUnderstanding;
+      sttSpy = vi.spyOn(media, "transcribeAudioFile").mockImplementation(stt);
+    },
+    async rotateManager(cfg: OpenClawConfig) {
+      await closeCurrentManager();
+      transport = createTransport();
+      transports.push(transport);
+      manager = createManager(cfg);
+    },
+    async expectReady() {
+      expect(sttSpy).toBeDefined();
+      expect(runtimeStore.getRuntime().mediaUnderstanding.transcribeAudioFile).toBe(sttSpy);
+      await expect.poll(() => firstTransport.streams.length).toBe(1);
+      // Observe the actual typed session; never construct or mutate a session substitute.
+      entry = manager["sessions"].get(captureTarget.guildId);
+      if (entry) {
+        entries.add(entry);
+      }
+      expect(entry).toMatchObject({
+        captureOnly: true,
+        sessionLifecycle: { status: "active" },
+        realtimeLifecycle: { status: "inactive", generation: 0 },
+        route: { agentId: "main", accountId: captureTarget.accountId },
+      });
+      expect(entry?.transcripts?.isCurrent()).toBe(true);
+      expect(firstTransport.subscribe).toHaveBeenCalledWith(speakerId, {
+        end: { behavior: sdk.EndBehaviorType.Manual },
+      });
+      return { speakerId, speakerLabel, voiceSessionKey: entry!.voiceSessionKey };
+    },
+    async recordAfterTurn() {
+      firstTransport.streams[0]!.end(Buffer.from([1]));
+      await drain();
+      expect(stt).toHaveBeenCalledTimes(1);
+      await expect(fs.stat(wavPaths[0]!)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+    async beginLateDelivery() {
+      expect(runtimeStore.getRuntime().mediaUnderstanding.transcribeAudioFile).toBe(sttSpy);
+      firstTransport.speaking.emit("start", speakerId);
+      await expect.poll(() => firstTransport.streams.length).toBe(2);
+      firstTransport.streams[1]!.end(Buffer.from([2]));
+      await expect.poll(() => wavPaths.length).toBe(2);
+    },
+    async finishLateDelivery() {
+      lateStt.resolve();
+      await drain();
+      expect(stt).toHaveBeenCalledTimes(2);
+      expect(manager.status()).toEqual([]);
+      expect(entry?.sessionLifecycle.status).toBe("stopped");
+      expect(entry?.transcripts).toBeUndefined();
+      expect(firstTransport.connection.state.status).toBe(sdk.VoiceConnectionStatus.Destroyed);
+      expect(firstTransport.speaking.listenerCount("start")).toBe(0);
+      expect(firstTransport.speaking.listenerCount("end")).toBe(0);
+      expect(firstTransport.player.play).not.toHaveBeenCalled();
+      expect(entry?.capture.size).toBe(0);
+      for (const filePath of wavPaths) {
+        await expect(fs.stat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+      }
+    },
+    close: closeCurrentManager,
+    restore,
+    restoreRuntime,
+  };
+}

--- a/extensions/discord/test-api.ts
+++ b/extensions/discord/test-api.ts
@@ -7,3 +7,7 @@ export {
 // Voice harness mocks must remain opt-in for provider-only integration tests.
 export const loadDiscordVoiceTestHarness = () =>
   import("./src/voice/voice-test-harness.test-support.js");
+
+// Gateway capture proof keeps routing/admission real; only transport edges are substituted.
+export const loadDiscordGatewayCaptureFixture = () =>
+  import("./src/voice/voice-gateway-capture.test-support.js");

--- a/packages/gateway-protocol/src/index.ts
+++ b/packages/gateway-protocol/src/index.ts
@@ -17,6 +17,7 @@ export * from "./schema/ui-command.js";
 export * from "./schema/board.js";
 export * from "./schema/canvas.js";
 export * from "./schema/progress-card.js";
+export * from "./schema/transcripts.js";
 export {
   SessionCreatedActorSchema,
   SessionEntryArchiveReasonSchema,

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-agents-skills.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-agents-skills.ts
@@ -143,4 +143,8 @@ export const AgentSkillProtocolSchemas = {
   SkillsUploadCommitParams: agentsModelsSkills.SkillsUploadCommitParamsSchema,
   SkillsInstallParams: agentsModelsSkills.SkillsInstallParamsSchema,
   SkillsUpdateParams: agentsModelsSkills.SkillsUpdateParamsSchema,
+  TranscriptsExportParams: transcripts.TranscriptsExportParamsSchema,
+  TranscriptsExportResult: transcripts.TranscriptsExportResultSchema,
+  TranscriptsStatusParams: transcripts.TranscriptsStatusParamsSchema,
+  TranscriptsStatusResult: transcripts.TranscriptsStatusResultSchema,
 } as const;

--- a/packages/gateway-protocol/src/schema/transcripts.test.ts
+++ b/packages/gateway-protocol/src/schema/transcripts.test.ts
@@ -24,18 +24,26 @@ describe("meeting transcript contracts", () => {
       source: { providerId: "voice" },
       startedAt: "2026-08-02T00:00:00Z",
       active: false,
+      activeSubscription: false,
+      agentId: null,
+      updatedAt: "2026-08-02T00:00:00Z",
+      lastUtteranceAt: null,
       utteranceCount: 0,
       participants: [],
       hasSummary: false,
     };
-    expect(Value.Check(TranscriptsListResultSchema, { sessions: [session] })).toBe(true);
+    expect(
+      Value.Check(TranscriptsListResultSchema, { sessions: [session], nextCursor: null }),
+    ).toBe(true);
     expect(
       Value.Check(TranscriptsListResultSchema, {
+        nextCursor: null,
         sessions: [{ ...session, source: { ...session.source, private: "hidden" } }],
       }),
     ).toBe(false);
     expect(
       Value.Check(TranscriptsListResultSchema, {
+        nextCursor: null,
         sessions: [{ ...session, overview: "x".repeat(281) }],
       }),
     ).toBe(false);

--- a/packages/gateway-protocol/src/schema/transcripts.ts
+++ b/packages/gateway-protocol/src/schema/transcripts.ts
@@ -3,21 +3,46 @@ import { Type } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { NonEmptyString } from "./primitives.js";
 
+export const TRANSCRIPTS_PAGE_DEFAULT = 50;
+export const TRANSCRIPTS_PAGE_MAX = 100;
+export const TRANSCRIPTS_LIST_MAX = 200;
+export const TRANSCRIPTS_RESULT_MAX_BYTES = 1024 * 1024;
+export const TRANSCRIPTS_EXPORT_MAX_BYTES = 4 * 1024 * 1024;
+
+const Selector = Type.String({ minLength: 1, maxLength: TRANSCRIPTS_RESULT_MAX_BYTES });
+const Filter = Type.String({ minLength: 1, maxLength: 256 });
+const NullableString = Type.Union([Type.String(), Type.Null()]);
+const Page = {
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: TRANSCRIPTS_PAGE_MAX })),
+  cursor: Type.Optional(Type.String({ minLength: 1, maxLength: TRANSCRIPTS_RESULT_MAX_BYTES })),
+  query: Type.Optional(Type.String({ maxLength: 256 })),
+};
 const SummarySourceSchema = Type.Union([Type.Literal("model"), Type.Literal("heuristic")]);
+const SourceKind = Type.Union([
+  Type.Literal("live-audio"),
+  Type.Literal("live-caption"),
+  Type.Literal("posthoc-transcript"),
+  Type.Literal("recording-stt"),
+]);
+const AutoStartField = Type.Union([Type.Literal("optional"), Type.Literal("required")]);
+const Source = closedObject({
+  providerId: NonEmptyString,
+  kind: Type.Optional(SourceKind),
+  accountId: Type.Optional(Type.String()),
+  guildId: Type.Optional(Type.String()),
+  channelId: Type.Optional(Type.String()),
+  meetingUrl: Type.Optional(Type.String()),
+  threadTs: Type.Optional(Type.String()),
+  fileId: Type.Optional(Type.String()),
+});
 
 export const TranscriptSessionSummarySchema = closedObject({
-  selector: NonEmptyString,
+  selector: Selector,
   sessionId: NonEmptyString,
   title: Type.Optional(Type.String()),
   providerId: NonEmptyString,
   providerName: Type.Optional(Type.String()),
-  source: closedObject({
-    providerId: NonEmptyString,
-    accountId: Type.Optional(Type.String()),
-    guildId: Type.Optional(Type.String()),
-    channelId: Type.Optional(Type.String()),
-    meetingUrl: Type.Optional(Type.String()),
-  }),
+  source: Source,
   startedAt: NonEmptyString,
   stoppedAt: Type.Optional(Type.String()),
   active: Type.Boolean(),
@@ -26,18 +51,38 @@ export const TranscriptSessionSummarySchema = closedObject({
   hasSummary: Type.Boolean(),
   summarySource: Type.Optional(SummarySourceSchema),
   overview: Type.Optional(Type.String({ maxLength: 280 })),
+  agentId: NullableString,
+  updatedAt: Type.String(),
+  lastUtteranceAt: NullableString,
+  activeSubscription: Type.Boolean(),
 });
-
+export const TranscriptUtteranceSchema = closedObject({
+  sequence: Type.Integer({ minimum: 0 }),
+  id: Type.Optional(Type.String()),
+  startedAt: Type.Optional(Type.String()),
+  endedAt: Type.Optional(Type.String()),
+  speakerId: Type.Optional(Type.String()),
+  speakerLabel: Type.Optional(Type.String()),
+  text: Type.String(),
+  final: Type.Optional(Type.Boolean()),
+});
 export const TranscriptsListParamsSchema = closedObject({
-  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200, default: 50 })),
+  ...Page,
+  limit: Type.Optional(Type.Integer({ minimum: 1, maximum: TRANSCRIPTS_LIST_MAX, default: 50 })),
   providerId: Type.Optional(NonEmptyString),
+  accountId: Type.Optional(Filter),
+  agentId: Type.Optional(Filter),
+  startedAfter: Type.Optional(Type.String({ format: "date-time", maxLength: 64 })),
+  startedBefore: Type.Optional(Type.String({ format: "date-time", maxLength: 64 })),
 });
 export const TranscriptsListResultSchema = closedObject({
-  sessions: Type.Array(TranscriptSessionSummarySchema, { maxItems: 200 }),
+  sessions: Type.Array(TranscriptSessionSummarySchema, { maxItems: TRANSCRIPTS_LIST_MAX }),
+  nextCursor: NullableString,
 });
 export const TranscriptsGetParamsSchema = closedObject({
-  selector: NonEmptyString,
+  selector: Selector,
   includeUtterances: Type.Optional(Type.Boolean()),
+  ...Page,
 });
 export const TranscriptsGetResultSchema = closedObject({
   session: TranscriptSessionSummarySchema,
@@ -52,25 +97,96 @@ export const TranscriptsGetResultSchema = closedObject({
       source: Type.Optional(SummarySourceSchema),
       model: Type.Optional(Type.String()),
       markdown: Type.String(),
+      utteranceCount: Type.Integer({ minimum: 0 }),
     }),
   ),
   utterances: Type.Optional(
-    Type.Array(
-      closedObject({
-        sequence: Type.Integer({ minimum: 0 }),
-        startedAt: Type.Optional(Type.String()),
-        endedAt: Type.Optional(Type.String()),
-        speakerId: Type.Optional(Type.String()),
-        speakerLabel: Type.Optional(Type.String()),
-        text: Type.String({ maxLength: 4000 }),
-        final: Type.Optional(Type.Boolean()),
-      }),
-    ),
+    Type.Array(TranscriptUtteranceSchema, { maxItems: TRANSCRIPTS_PAGE_MAX }),
   ),
+  nextCursor: NullableString,
+});
+export const TranscriptsExportParamsSchema = closedObject({
+  selector: Selector,
+  format: Type.Union([Type.Literal("markdown"), Type.Literal("jsonl")]),
+});
+export const TranscriptsExportResultSchema = closedObject({
+  selector: Selector,
+  filename: Type.String(),
+  mimeType: Type.String(),
+  encoding: Type.Literal("base64"),
+  data: Type.String(),
+  sizeBytes: Type.Integer({ minimum: 0, maximum: TRANSCRIPTS_EXPORT_MAX_BYTES }),
+});
+export const TranscriptsStatusParamsSchema = closedObject({});
+export const TranscriptsStatusResultSchema = closedObject({
+  enabled: Type.Boolean(),
+  providers: Type.Array(
+    closedObject({
+      providerId: Type.String(),
+      pluginId: Type.Optional(Type.String()),
+      name: Type.String(),
+      availability: Type.Union([
+        Type.Literal("enabled"),
+        Type.Literal("disabled"),
+        Type.Literal("unavailable"),
+        Type.Literal("unknown"),
+      ]),
+      sourceKinds: Type.Optional(Type.Array(SourceKind)),
+      canStart: Type.Optional(Type.Boolean()),
+      canStop: Type.Optional(Type.Boolean()),
+      canImport: Type.Optional(Type.Boolean()),
+      autoStart: Type.Optional(
+        closedObject({
+          accountId: Type.Optional(AutoStartField),
+          guildId: Type.Optional(AutoStartField),
+          channelId: Type.Optional(AutoStartField),
+          meetingUrl: Type.Optional(AutoStartField),
+        }),
+      ),
+    }),
+    { maxItems: TRANSCRIPTS_PAGE_MAX },
+  ),
+  configuredSources: Type.Array(
+    closedObject({
+      source: Source,
+      title: Type.Optional(Type.String()),
+      sessionId: Type.Optional(Type.String()),
+      state: Type.Union([
+        Type.Literal("disabled"),
+        Type.Literal("armed"),
+        Type.Literal("not-active"),
+        Type.Literal("unknown"),
+      ]),
+      activeSelectors: Type.Array(Selector, { maxItems: TRANSCRIPTS_PAGE_MAX }),
+      startDiagnostic: Type.Optional(
+        Type.Union([
+          Type.Literal("starting"),
+          Type.Literal("retrying"),
+          Type.Literal("id-conflict"),
+          Type.Literal("admitted-start-failed"),
+          Type.Literal("start-failed"),
+          Type.Literal("ended"),
+        ]),
+      ),
+    }),
+    { maxItems: TRANSCRIPTS_PAGE_MAX },
+  ),
+  active: Type.Array(TranscriptSessionSummarySchema, { maxItems: TRANSCRIPTS_PAGE_MAX }),
+  latestTranscript: Type.Union([TranscriptSessionSummarySchema, Type.Null()]),
+  omitted: closedObject({
+    providers: Type.Integer({ minimum: 0 }),
+    configuredSources: Type.Integer({ minimum: 0 }),
+    active: Type.Integer({ minimum: 0 }),
+  }),
 });
 
 export type TranscriptSessionSummary = Static<typeof TranscriptSessionSummarySchema>;
+export type TranscriptUtterance = Static<typeof TranscriptUtteranceSchema>;
 export type TranscriptsListParams = Static<typeof TranscriptsListParamsSchema>;
 export type TranscriptsListResult = Static<typeof TranscriptsListResultSchema>;
 export type TranscriptsGetParams = Static<typeof TranscriptsGetParamsSchema>;
 export type TranscriptsGetResult = Static<typeof TranscriptsGetResultSchema>;
+export type TranscriptsExportParams = Static<typeof TranscriptsExportParamsSchema>;
+export type TranscriptsExportResult = Static<typeof TranscriptsExportResultSchema>;
+export type TranscriptsStatusParams = Static<typeof TranscriptsStatusParamsSchema>;
+export type TranscriptsStatusResult = Static<typeof TranscriptsStatusResultSchema>;

--- a/packages/gateway-protocol/src/schema/transcripts.ts
+++ b/packages/gateway-protocol/src/schema/transcripts.ts
@@ -8,6 +8,10 @@ export const TRANSCRIPTS_PAGE_MAX = 100;
 export const TRANSCRIPTS_LIST_MAX = 200;
 export const TRANSCRIPTS_RESULT_MAX_BYTES = 1024 * 1024;
 export const TRANSCRIPTS_EXPORT_MAX_BYTES = 4 * 1024 * 1024;
+// Shipped unpaged get requests retain their recent-window and transport limits.
+export const TRANSCRIPTS_LEGACY_MAX_UTTERANCES = 2_000;
+export const TRANSCRIPTS_LEGACY_MAX_TEXT_LENGTH = 4_000;
+export const TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES = 25 * 1024 * 1024;
 
 const Selector = Type.String({ minLength: 1, maxLength: TRANSCRIPTS_RESULT_MAX_BYTES });
 const Filter = Type.String({ minLength: 1, maxLength: 256 });
@@ -101,7 +105,7 @@ export const TranscriptsGetResultSchema = closedObject({
     }),
   ),
   utterances: Type.Optional(
-    Type.Array(TranscriptUtteranceSchema, { maxItems: TRANSCRIPTS_PAGE_MAX }),
+    Type.Array(TranscriptUtteranceSchema, { maxItems: TRANSCRIPTS_LEGACY_MAX_UTTERANCES }),
   ),
   nextCursor: NullableString,
 });

--- a/packages/gateway-protocol/src/transcripts.test.ts
+++ b/packages/gateway-protocol/src/transcripts.test.ts
@@ -56,6 +56,18 @@ describe("transcript UI wire contracts", () => {
     expect(lazyCompile(TranscriptsListResultSchema)(transcriptListFixture)).toBe(true);
     expect(lazyCompile(TranscriptsGetResultSchema)(transcriptGetFixture)).toBe(true);
     expect(lazyCompile(TranscriptsStatusResultSchema)(transcriptStatusFixture)).toBe(true);
+    const validateGet = lazyCompile(TranscriptsGetResultSchema);
+    const utterances = Array.from({ length: 2000 }, (_, sequence) => ({
+      sequence,
+      text: "speech",
+    }));
+    expect(validateGet({ ...transcriptGetFixture, utterances })).toBe(true);
+    expect(
+      validateGet({
+        ...transcriptGetFixture,
+        utterances: [...utterances, { sequence: 2000, text: "outside the recent window" }],
+      }),
+    ).toBe(false);
   });
 
   it("keeps pagination and search bounded and rejects mutation arguments", () => {

--- a/packages/gateway-protocol/src/transcripts.test.ts
+++ b/packages/gateway-protocol/src/transcripts.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  transcriptGetFixture,
+  transcriptListFixture,
+  transcriptStatusFixture,
+} from "../../../src/transcripts/library.test-support.js";
+import { lazyCompile } from "./protocol-validator.js";
+import {
+  TranscriptsGetResultSchema,
+  TranscriptsListResultSchema,
+  TranscriptsStatusResultSchema,
+} from "./schema/transcripts.js";
+import {
+  validateTranscriptsExportParams,
+  validateTranscriptsGetParams,
+  validateTranscriptsListParams,
+  validateTranscriptsStatusParams,
+} from "./validator-registry.js";
+
+describe("transcript UI wire contracts", () => {
+  it("accepts closed startup diagnostics without raw errors or unbounded extra rows", () => {
+    const validate = lazyCompile(TranscriptsStatusResultSchema);
+    const row = { source: { providerId: "fixture" }, state: "not-active", activeSelectors: [] };
+    const response = (startDiagnostic: unknown) => ({
+      ...transcriptStatusFixture,
+      configuredSources: [{ ...row, startDiagnostic }],
+    });
+    for (const code of [
+      "starting",
+      "retrying",
+      "id-conflict",
+      "admitted-start-failed",
+      "start-failed",
+      "ended",
+    ]) {
+      expect(validate(response(code))).toBe(true);
+    }
+    expect(validate(response("raw provider error"))).toBe(false);
+    expect(
+      validate({
+        ...transcriptStatusFixture,
+        configuredSources: [{ ...row, startDiagnostic: "start-failed", error: "private" }],
+      }),
+    ).toBe(false);
+    expect(
+      validate({
+        ...transcriptStatusFixture,
+        configuredSources: Array.from({ length: 101 }, () => ({
+          ...row,
+          startDiagnostic: "starting",
+        })),
+      }),
+    ).toBe(false);
+  });
+  it("validates shared UI fixture responses against the canonical wire schemas", () => {
+    expect(lazyCompile(TranscriptsListResultSchema)(transcriptListFixture)).toBe(true);
+    expect(lazyCompile(TranscriptsGetResultSchema)(transcriptGetFixture)).toBe(true);
+    expect(lazyCompile(TranscriptsStatusResultSchema)(transcriptStatusFixture)).toBe(true);
+  });
+
+  it("keeps pagination and search bounded and rejects mutation arguments", () => {
+    expect(validateTranscriptsListParams({})).toBe(true);
+    expect(
+      validateTranscriptsListParams({
+        limit: 100,
+        query: "x".repeat(256),
+        startedAfter: "2026-08-20T00:00:00Z",
+      }),
+    ).toBe(true);
+    expect(validateTranscriptsListParams({ limit: 200 })).toBe(true);
+    for (const limit of [0, 201, -1, 1.5, "50"]) {
+      expect(validateTranscriptsListParams({ limit })).toBe(false);
+    }
+    expect(validateTranscriptsListParams({ query: "x".repeat(257) })).toBe(false);
+    expect(validateTranscriptsGetParams({ selector: "opaque/full-value", limit: 100 })).toBe(true);
+    expect(
+      validateTranscriptsGetParams({ selector: "opaque", includeUtterances: true, limit: 101 }),
+    ).toBe(false);
+    expect(validateTranscriptsGetParams({ selector: "opaque", agentId: "forged" })).toBe(false);
+    expect(validateTranscriptsExportParams({ selector: "opaque", format: "jsonl" })).toBe(true);
+    expect(validateTranscriptsExportParams({ selector: "opaque", format: "markdown" })).toBe(true);
+    expect(validateTranscriptsExportParams({ selector: "opaque", format: "audio" })).toBe(false);
+    expect(validateTranscriptsStatusParams({})).toBe(true);
+    expect(validateTranscriptsStatusParams({ enabled: true, autoStart: [] })).toBe(false);
+  });
+
+  it("keeps auto-start descriptors optional, closed, and limited to existing locator fields", () => {
+    const validate = lazyCompile(TranscriptsStatusResultSchema);
+    const response = (autoStart: unknown) => ({
+      ...transcriptStatusFixture,
+      providers: [{ ...transcriptStatusFixture.providers[0], autoStart }],
+    });
+    expect(
+      validate(
+        response({
+          accountId: "optional",
+          guildId: "required",
+          channelId: "required",
+          meetingUrl: "optional",
+        }),
+      ),
+    ).toBe(true);
+    expect(validate(response({}))).toBe(true);
+    for (const descriptor of [
+      { fileId: "required" },
+      { sessionId: "optional" },
+      { accountId: true },
+      { channelId: "unknown" },
+    ]) {
+      expect(validate(response(descriptor))).toBe(false);
+    }
+  });
+});

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -546,3 +546,5 @@ export const validateWebLoginWaitParams = compile(S.WebLoginWaitParamsSchema);
 
 export const validateTranscriptsListParams = compile(S.TranscriptsListParamsSchema);
 export const validateTranscriptsGetParams = compile(S.TranscriptsGetParamsSchema);
+export const validateTranscriptsExportParams = compile(S.TranscriptsExportParamsSchema);
+export const validateTranscriptsStatusParams = compile(S.TranscriptsStatusParamsSchema);

--- a/src/agents/tools/transcripts-tool-read.test.ts
+++ b/src/agents/tools/transcripts-tool-read.test.ts
@@ -1,11 +1,21 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { activeSessions } from "../../transcripts/capture.js";
 import type { TranscriptSourceProvider } from "../../transcripts/provider-types.js";
 import { TranscriptsStore, transcriptSessionSelector } from "../../transcripts/store.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
+import {
+  createToolSearchCatalogRef,
+  registerHeadlessToolSearchCatalog,
+} from "../tool-search-catalog.js";
+import { resolveToolSearchConfig } from "../tool-search-config.js";
+import { ToolSearchRuntime } from "../tool-search-runtime.js";
 import { createTranscriptsTool } from "./transcripts-tool.js";
 
 const { getProvider } = vi.hoisted(() => ({ getProvider: vi.fn() }));
@@ -35,6 +45,14 @@ function tool(channel = false) {
 function run(params: Record<string, unknown>, channel = false) {
   return tool(channel).execute("read", params);
 }
+function readThroughCatalog(params: Record<string, unknown>) {
+  const catalogRef = createToolSearchCatalogRef();
+  registerHeadlessToolSearchCatalog({ catalogRef, tools: [tool()] });
+  const runtime = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(), {
+    validateInput: true,
+  });
+  return runtime.callValue("transcripts", params);
+}
 
 beforeEach(async () => {
   stateDir = tempDirs.make("transcripts-read-");
@@ -50,6 +68,72 @@ afterEach(() => {
 });
 
 describe("transcripts read actions", () => {
+  it.each(["active", "stopped"] as const)(
+    "rejects notes rewritten while %s source authorization is pending",
+    async (state) => {
+      const descriptor = {
+        ...session,
+        ...(state === "stopped" ? { stoppedAt: "2026-08-02T15:00:00.000Z" } : {}),
+      };
+      await store.writeSession(descriptor);
+      await store.writeSummary(
+        summarizeTranscripts({ session: descriptor, utterances: [{ text: "Authorized notes" }] }),
+        descriptor,
+      );
+      if (state === "active") {
+        activeSessions.set(session.sessionId, {
+          session: descriptor,
+          providerId: "voice",
+          provider: {},
+          phase: "active",
+        });
+      }
+      const entered = createDeferred();
+      const release = createDeferred();
+      const authorize = vi.fn<NonNullable<TranscriptSourceProvider["accessControl"]>["authorize"]>(
+        async ({ source }) => {
+          if (source.guildId !== "team") {
+            return { ok: false, error: "denied" };
+          }
+          entered.resolve();
+          await release.promise;
+          return { ok: true, value: undefined };
+        },
+      );
+      getProvider.mockReturnValue({
+        id: "voice",
+        accessControl: { channelId: "discord", authorize },
+      });
+      const params = { action: "show", selector: transcriptSessionSelector(descriptor) };
+      const reading = run(params, true);
+      try {
+        await Promise.race([entered.promise, reading]);
+        expect(authorize).toHaveBeenCalledOnce();
+        const rewritten = { ...descriptor, source: { providerId: "voice", guildId: "other" } };
+        await store.writeSession(rewritten);
+        await store.writeSummary(
+          summarizeTranscripts({ session: rewritten, utterances: [{ text: "Other guild notes" }] }),
+          rewritten,
+        );
+        release.resolve();
+        const shown = await reading;
+        expect(shown.details).toMatchObject({
+          sessionId: descriptor.sessionId,
+          selector: params.selector,
+          skipped: true,
+          retryable: true,
+          text: expect.stringContaining("Retry show"),
+        });
+        expect(JSON.stringify(shown)).not.toContain("Other guild notes");
+        await expect(run(params, true)).rejects.toThrow("session not found");
+        expect(await store.readSession(params.selector)).toEqual(rewritten);
+      } finally {
+        release.resolve();
+        await reading.catch(() => undefined);
+      }
+    },
+  );
+
   it("reads across agent ownership without widening mutation authority", async () => {
     await store.appendUtteranceForSession(session, {
       text: "Ship the design",
@@ -85,11 +169,14 @@ describe("transcripts read actions", () => {
       name: "Voice",
       accessControl: { channelId: "discord", authorize },
     });
-    await store.writeSession({
-      ...session,
-      sessionId: "hidden",
-      source: { providerId: "voice", guildId: "other" },
-    });
+    for (const sessionId of ["hidden", "hidden-too"]) {
+      await store.writeSession({
+        ...session,
+        sessionId,
+        source: { providerId: "voice", guildId: "other" },
+        metadata: { providerPrivate: "x".repeat(600_000) },
+      });
+    }
     expect((await run({ action: "list", limit: 1 }, true)).details).toMatchObject({
       sessions: [{ sessionId: "meeting" }],
     });
@@ -146,6 +233,31 @@ describe("transcripts read actions", () => {
     );
   });
 
+  it("closes its read page before awaited source authorization writes and checkpoints state", async () => {
+    getProvider.mockReturnValue({
+      id: "voice",
+      name: "Voice",
+      accessControl: {
+        channelId: "discord",
+        authorize: async () => {
+          await store.appendUtteranceForSession(session, { text: "Written during authorization" });
+          const { db } = openOpenClawStateDatabase({
+            env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+          });
+          // A pending SELECT would prevent the provider's committed write from checkpointing.
+          db.exec("PRAGMA wal_checkpoint(TRUNCATE)");
+          return { ok: true, value: undefined };
+        },
+      },
+    });
+    expect((await run({ action: "list", limit: 1 }, true)).details).toMatchObject({
+      sessions: [{ sessionId: session.sessionId, utteranceCount: 0 }],
+    });
+    expect(await store.readUtterancesForSession(session)).toMatchObject([
+      { text: "Written during authorization" },
+    ]);
+  });
+
   it("bounds model-facing notes and reports active captures without summaries", async () => {
     activeSessions.set(session.sessionId, {
       session,
@@ -153,8 +265,11 @@ describe("transcripts read actions", () => {
       provider: {},
       phase: "active",
     });
-    expect((await run({ action: "show", sessionId: "meeting" })).details).toMatchObject({
+    await expect(
+      readThroughCatalog({ action: "show", sessionId: "meeting" }),
+    ).resolves.toMatchObject({
       active: true,
+      text: "No summary exists yet for this meeting. Capture is active.",
     });
     await store.writeSummary(
       { ...summarizeTranscripts({ session, utterances: [] }), overview: "x".repeat(20000) },
@@ -169,6 +284,11 @@ describe("transcripts read actions", () => {
     expect(text.text).toContain(
       `[truncated; run openclaw transcripts show ${transcriptSessionSelector(session)} for the full notes]`,
     );
+    await expect(
+      readThroughCatalog({ action: "show", sessionId: "meeting" }),
+    ).resolves.toMatchObject({
+      text: text.text,
+    });
     for (let index = 0; index < 50; index++) {
       await store.writeSession({
         ...session,

--- a/src/agents/tools/transcripts-tool-read.ts
+++ b/src/agents/tools/transcripts-tool-read.ts
@@ -1,6 +1,7 @@
 import type { TranscriptSessionSummary } from "../../../packages/gateway-protocol/src/schema/transcripts.js";
 import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import {
+  isTranscriptSelectionCurrent,
   isTranscriptSessionActive,
   resolveSourceProvider,
   type TranscriptsRuntimeContext,
@@ -78,6 +79,16 @@ export async function showPastTranscript(params: ReadParams) {
   }
   const notes = await readTranscriptNotes(store, selection.session);
   ctx.assertCallerActive?.();
+  if (!isTranscriptSelectionCurrent(selection, store)) {
+    const text = "Transcript changed while reading. Retry show to read the current notes.";
+    return toolText(text, {
+      text,
+      sessionId: selection.session.sessionId,
+      selector: selection.selector,
+      skipped: true,
+      retryable: true,
+    });
+  }
   const session = projectTranscriptSession(
     { ...entry, session: selection.session },
     isTranscriptSessionActive(selection.session),
@@ -104,6 +115,7 @@ export async function showPastTranscript(params: ReadParams) {
   return {
     content: [{ type: "text" as const, text }],
     details: {
+      text,
       selector,
       sessionId,
       title,

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -11,6 +11,7 @@ import {
   getActivePluginHttpRouteRegistryVersion,
 } from "../plugins/runtime.js";
 import { DEFAULT_ACCOUNT_ID } from "../routing/account-id.js";
+import { isTranscriptTitleOnlyConfigChange } from "../transcripts/config-reload.js";
 import { isPlainObject } from "../utils.js";
 import { canHotReloadGatewayAuthCredentials } from "./auth-resolve.js";
 
@@ -82,6 +83,9 @@ type GatewayReloadPlanOptions = {
   /** Candidate config used to reject removed, unknown, or unresolvable account targets. */
   candidateConfig?: OpenClawConfig;
   previousConfig?: OpenClawConfig;
+  /** Authored comparison snapshots retain intent that runtime overlays may hide. */
+  previousCompareConfig?: OpenClawConfig;
+  candidateCompareConfig?: OpenClawConfig;
 };
 
 const PLUGIN_INSTALL_TIMESTAMP_KEYS = ["installedAt", "resolvedAt"] as const;
@@ -504,6 +508,22 @@ export function buildGatewayReloadPlan(
   };
 
   for (const path of changedPaths) {
+    // Arrays diff at their parent path. Titles configure future admissions;
+    // retaining this exact live capture must not rename or finalize its archive.
+    if (
+      path === "transcripts.autoStart" &&
+      !forceChangedPaths.has(path) &&
+      options.previousConfig &&
+      options.candidateConfig &&
+      options.candidateConfig.gateway?.reload?.mode !== "off" &&
+      isTranscriptTitleOnlyConfigChange(
+        options.previousCompareConfig ?? options.previousConfig,
+        options.candidateCompareConfig ?? options.candidateConfig,
+      )
+    ) {
+      plan.noopPaths.push(path);
+      continue;
+    }
     const isTimestampNoop =
       !forceChangedPaths.has(path) &&
       (noopPaths.size > 0 ? noopPaths.has(path) : isPluginInstallTimestampPath(path));

--- a/src/gateway/config-reload.transcripts.test.ts
+++ b/src/gateway/config-reload.transcripts.test.ts
@@ -1,0 +1,410 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readConfigFileSnapshotForWrite, registerConfigWriteListener } from "../config/config.js";
+import { createConfigIO } from "../config/io.js";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { createTranscriptsAutoStartService } from "../transcripts/auto-start.js";
+import type {
+  TranscriptSourceProvider,
+  TranscriptStartRequest,
+} from "../transcripts/provider-types.js";
+import { readTranscriptLibraryStatus } from "../transcripts/status.js";
+import { TranscriptsStore, transcriptSessionSelector } from "../transcripts/store.js";
+import { diffGatewayReloadPaths } from "./config-diff.js";
+import {
+  buildGatewayReloadPlan,
+  listConfigReloadRefinementPrefixes,
+} from "./config-reload-plan.js";
+import {
+  type GatewayConfigReloadTransactionOwnership,
+  type GatewayReloadPlan,
+  startGatewayConfigReloader,
+} from "./config-reload.js";
+import { commitGatewayConfigWrite } from "./server-methods/config-write-flow.js";
+
+const tempDirs = createTempDirTracker();
+afterEach(() => {
+  resetConfigRuntimeState();
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+const source = {
+  providerId: "fixture",
+  accountId: "demo",
+  sessionId: "daily",
+  title: "Before",
+  meetingUrl: "https://example.test/room?invite=one#one",
+  providerOptions: { credential: "synthetic-one" },
+};
+const previous: OpenClawConfig = { transcripts: { enabled: true, autoStart: [source] } };
+it.each([
+  ["title", { ...source, title: "After" }, false],
+  ["removed title", { ...source, title: undefined }, false],
+  ["provider", { ...source, title: "After", providerId: "other" }, true],
+  ["account", { ...source, title: "After", accountId: "other" }, true],
+  ["omitted account", { ...source, title: "After", accountId: undefined }, true],
+  ["guild", { ...source, title: "After", guildId: "other" }, true],
+  ["channel", { ...source, title: "After", channelId: "other" }, true],
+  ["custom ID", { ...source, title: "After", sessionId: "other" }, true],
+  [
+    "invitation with same public locator",
+    { ...source, title: "After", meetingUrl: "https://example.test/room?invite=two#two" },
+    true,
+  ],
+  [
+    "unknown provider field",
+    { ...source, title: "After", providerOptions: { credential: "synthetic-two" } },
+    true,
+  ],
+] as const)(
+  "classifies authoritative %s changes without weakening source identity",
+  (_name, candidate, restart) => {
+    const next: OpenClawConfig = { transcripts: { enabled: true, autoStart: [candidate] } };
+    expect(
+      buildGatewayReloadPlan(
+        diffGatewayReloadPaths(previous, next, listConfigReloadRefinementPrefixes()),
+        {
+          previousConfig: previous,
+          candidateConfig: next,
+        },
+      ).restartGateway,
+    ).toBe(restart);
+  },
+);
+
+it.each([
+  ["disable", { enabled: false, autoStart: [{ ...source, title: "After" }] }],
+  ["add", { enabled: true, autoStart: [source, { ...source, sessionId: "second" }] }],
+  ["remove", { enabled: true, autoStart: [] }],
+  ["duplicate", { enabled: true, autoStart: [source, source] }],
+] as const)("retains restart on source %s", (_name, transcripts) => {
+  const next = { transcripts: { ...transcripts, autoStart: [...transcripts.autoStart] } };
+  expect(
+    buildGatewayReloadPlan(
+      diffGatewayReloadPaths(previous, next, listConfigReloadRefinementPrefixes()),
+      {
+        previousConfig: previous,
+        candidateConfig: next,
+      },
+    ).restartGateway,
+  ).toBe(true);
+});
+
+it("preserves reorder, forced work, unrelated restart and agent reload requirements", () => {
+  const before = { transcripts: { autoStart: [source, { ...source, sessionId: "second" }] } };
+  const reordered = { transcripts: { autoStart: before.transcripts.autoStart.toReversed() } };
+  expect(
+    buildGatewayReloadPlan(
+      diffGatewayReloadPaths(before, reordered, listConfigReloadRefinementPrefixes()),
+      {
+        previousConfig: before,
+        candidateConfig: reordered,
+      },
+    ).restartGateway,
+  ).toBe(true);
+  const next = {
+    ...previous,
+    transcripts: { ...previous.transcripts, autoStart: [{ ...source, title: "After" }] },
+  };
+  expect(
+    buildGatewayReloadPlan(["transcripts.autoStart"], {
+      previousConfig: previous,
+      candidateConfig: next,
+      forceChangedPaths: ["transcripts.autoStart"],
+    }).restartGateway,
+  ).toBe(true);
+  expect(
+    buildGatewayReloadPlan(["transcripts.autoStart", "gateway.port"], {
+      previousConfig: previous,
+      candidateConfig: next,
+    }).restartReasons,
+  ).toEqual(["gateway.port"]);
+  expect(
+    buildGatewayReloadPlan(["transcripts.autoStart", "agents.entries.notes.model"], {
+      previousConfig: previous,
+      candidateConfig: next,
+    }).restartHeartbeat,
+  ).toBe(true);
+  // Path text alone cannot claim metadata-only authority.
+  expect(buildGatewayReloadPlan(["transcripts.autoStart"]).restartGateway).toBe(true);
+  expect(
+    buildGatewayReloadPlan(["transcripts.autoStart"], {
+      previousConfig: previous,
+      candidateConfig: { ...next, gateway: { reload: { mode: "off" } } },
+    }).restartGateway,
+  ).toBe(true);
+});
+
+it.each([
+  ["agent", { agents: { entries: { notes: { workspace: "/tmp/notes" } } } }],
+  ["default", { agents: { defaults: { workspace: "/tmp/other" } } }],
+  ["routing", { bindings: [{ agentId: "notes", match: { channel: "discord" } }] }],
+  ["default account", { channels: { discord: { defaultAccount: "other" } } }],
+  ["credential", { channels: { discord: { token: "synthetic-changed-credential" } } }],
+] satisfies Array<[string, Partial<OpenClawConfig>]>)(
+  "does not classify a mixed title and %s edit as title-only",
+  (_name, other) => {
+    const next: OpenClawConfig = {
+      ...previous,
+      ...other,
+      transcripts: { enabled: true, autoStart: [{ ...source, title: "After" }] },
+    };
+    const plan = buildGatewayReloadPlan(
+      diffGatewayReloadPaths(previous, next, listConfigReloadRefinementPrefixes()),
+      {
+        previousConfig: previous,
+        candidateConfig: next,
+      },
+    );
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toContain("transcripts.autoStart");
+  },
+);
+
+it("allows normal writer bookkeeping beside titles but not other metadata", () => {
+  const next: OpenClawConfig = {
+    ...previous,
+    meta: { lastTouchedVersion: "2026.8.1" },
+    transcripts: { enabled: true, autoStart: [{ ...source, title: "After" }] },
+  };
+  expect(
+    buildGatewayReloadPlan(
+      diffGatewayReloadPaths(previous, next, listConfigReloadRefinementPrefixes()),
+      {
+        previousConfig: previous,
+        candidateConfig: next,
+      },
+    ).restartGateway,
+  ).toBe(false);
+  const migration: OpenClawConfig = {
+    ...next,
+    meta: { ...next.meta, migrations: { modelPolicyAllowlist: true } },
+  };
+  expect(
+    buildGatewayReloadPlan(
+      diffGatewayReloadPaths(previous, migration, listConfigReloadRefinementPrefixes()),
+      {
+        previousConfig: previous,
+        candidateConfig: migration,
+      },
+    ).restartGateway,
+  ).toBe(true);
+});
+
+it.each([false, true])(
+  "keeps an admitted capture through a real title config commit (pending=%s) and applies the future title",
+  async (pending) => {
+    const stateDir = await fs.realpath(tempDirs.make("transcripts-title-reload-"));
+    const configPath = path.join(stateDir, "openclaw.json");
+    const requests: TranscriptStartRequest[] = [];
+    const startupGate = createDeferred();
+    if (!pending) {
+      startupGate.resolve();
+    }
+    const stop = vi.fn(async ({ sessionId }: { sessionId: string }) => ({
+      ok: true as const,
+      sessionId,
+    }));
+    const provider: TranscriptSourceProvider = {
+      id: "title-reload-fixture",
+      name: "Title reload fixture",
+      sourceKinds: ["live-caption"],
+      async start(request) {
+        requests.push(request);
+        await startupGate.promise;
+        return { ok: true, session: request.session };
+      },
+      stop,
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.transcriptSourceProviders.push({
+      pluginId: provider.id,
+      provider,
+      source: import.meta.url,
+    });
+    const initial: OpenClawConfig = {
+      gateway: { mode: "local", reload: { mode: "hybrid" } },
+      transcripts: {
+        enabled: true,
+        autoStart: [
+          {
+            providerId: provider.id,
+            accountId: "demo",
+            sessionId: "daily-proof",
+            title: "Original title",
+          },
+        ],
+      },
+    };
+    const logger = { warn: vi.fn(), info: vi.fn(), error: vi.fn() };
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    await withEnvAsync(
+      { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+      async () => {
+        await withPluginRuntimeRegistryScope(registry, async () => {
+          await fs.writeFile(configPath, "{}");
+          const seed = await readConfigFileSnapshotForWrite();
+          const created = await commitGatewayConfigWrite({ ...seed, nextConfig: initial });
+          created.queueFollowUp();
+          const io = createConfigIO({ configPath });
+          const snapshot = await io.readConfigFileSnapshot();
+          expect(snapshot.valid).toBe(true);
+          let current = snapshot.config;
+          setRuntimeConfigSnapshot(current, current);
+          let service = createTranscriptsAutoStartService({
+            stateDir,
+            config: current,
+            agentId: "notes",
+            logger,
+          });
+          const restart = vi.fn(async (_plan: GatewayReloadPlan, next: OpenClawConfig) => {
+            current = next;
+            await service.stop();
+            service = createTranscriptsAutoStartService({
+              stateDir,
+              config: next,
+              agentId: "notes",
+              logger,
+            });
+            service.start();
+          });
+          const commit = vi.fn(
+            async (
+              plan: GatewayReloadPlan,
+              next: OpenClawConfig,
+              ownership: GatewayConfigReloadTransactionOwnership,
+            ) => {
+              ownership.markRuntimeCommitted(next, plan);
+              setRuntimeConfigSnapshot(next, next);
+              current = next;
+            },
+          );
+          const applied = vi.fn();
+          const hotReload = vi.fn(
+            async (
+              plan: GatewayReloadPlan,
+              next: OpenClawConfig,
+              ownership: GatewayConfigReloadTransactionOwnership,
+            ) => {
+              await commit(plan, next, ownership);
+              return "applied" as const;
+            },
+          );
+          const reloader = startGatewayConfigReloader({
+            initialConfig: current,
+            initialCompareConfig: snapshot.sourceConfig ?? current,
+            initialSnapshotRawHash: snapshot.hash ?? null,
+            initialAuthoredConfig: initial,
+            initialSnapshotValid: true,
+            initialSnapshotIssues: [],
+            testDebounceMs: 0,
+            watchPath: configPath,
+            readSnapshot: () => io.readConfigFileSnapshot(),
+            initialPluginInstallRecords: {},
+            readPluginInstallRecords: async () => ({}),
+            subscribeToWrites: (listener) =>
+              registerConfigWriteListener(listener, {
+                ownsRuntimeActivationFor: configPath,
+                preCommitRuntimePreflight: async (config) => ({
+                  runtimeConfig: config,
+                  compareConfig: config,
+                }),
+              }),
+            onNoopConfigCommit: commit,
+            onHotReload: hotReload,
+            onRestart: restart,
+            onConfigApplied: applied,
+            log: logger,
+          });
+          try {
+            service.start();
+            await vi.waitFor(async () =>
+              expect(
+                pending ? requests : (await readTranscriptLibraryStatus(store, current)).active,
+              ).toHaveLength(1),
+            );
+            const request = requests[0]!;
+            const admitted = structuredClone(request.session);
+            const selector = transcriptSessionSelector(admitted);
+            await request.onUtterance({ text: "Before title edit", final: true });
+            const prepared = await readConfigFileSnapshotForWrite();
+            const next = structuredClone(
+              prepared.snapshot.sourceConfig ?? prepared.snapshot.config,
+            );
+            next.transcripts!.autoStart![0]!.title = "Future title";
+            const write = await commitGatewayConfigWrite({ ...prepared, nextConfig: next });
+            write.queueFollowUp();
+            await vi.waitFor(() =>
+              expect(applied.mock.calls.length + restart.mock.calls.length).toBeGreaterThan(0),
+            );
+            expect(restart).not.toHaveBeenCalled();
+            expect(hotReload).not.toHaveBeenCalled();
+            expect(commit).toHaveBeenCalledTimes(1);
+            expect(stop).not.toHaveBeenCalled();
+            expect(requests).toHaveLength(1);
+            startupGate.resolve();
+            await vi.waitFor(async () =>
+              expect((await readTranscriptLibraryStatus(store, current)).active).toHaveLength(1),
+            );
+            expect(current.transcripts?.autoStart?.[0]?.title).toBe("Future title");
+            await expect(store.readSession(selector)).resolves.toEqual(admitted);
+            await expect(store.readSummary(admitted)).resolves.toEqual({});
+            await request.onUtterance({ text: "After title edit", final: true });
+            expect((await store.readUtterancesForSession(admitted)).map((u) => u.text)).toEqual([
+              "Before title edit",
+              "After title edit",
+            ]);
+            expect(
+              (await readTranscriptLibraryStatus(store, current)).configuredSources[0],
+            ).toMatchObject({ state: "armed", activeSelectors: [selector] });
+            await service.stop();
+            const historical = await store.readSession(selector);
+            const notes = await store.readUtterancesForSession(admitted);
+            const summary = await store.readSummary(admitted);
+            expect(historical?.stoppedAt).toEqual(expect.any(String));
+            const { sessionId: _fixedId, ...generatedSource } = current.transcripts!.autoStart![0]!;
+            const generated = {
+              ...current,
+              transcripts: { ...current.transcripts, autoStart: [generatedSource] },
+            };
+            for (let capture = 0; capture < 2; capture++) {
+              await service.stop();
+              service = createTranscriptsAutoStartService({
+                stateDir,
+                config: generated,
+                agentId: "notes",
+                logger,
+              });
+              service.start();
+              await vi.waitFor(async () =>
+                expect(
+                  (await readTranscriptLibraryStatus(store, generated)).configuredSources[0]?.state,
+                ).toBe("armed"),
+              );
+              expect(requests.at(-1)?.session.title).toBe("Future title");
+            }
+            expect(new Set(requests.map((capture) => capture.session.sessionId)).size).toBe(3);
+            await expect(store.readSession(selector)).resolves.toEqual(historical);
+            await expect(store.readUtterancesForSession(admitted)).resolves.toEqual(notes);
+            await expect(store.readSummary(admitted)).resolves.toEqual(summary);
+          } finally {
+            startupGate.resolve();
+            await reloader.stop();
+            await service.stop();
+          }
+        });
+      },
+    );
+  },
+);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -701,6 +701,8 @@ export function startGatewayConfigReloader(opts: {
       noopPaths: pluginInstallTimestampNoopPaths,
       forceChangedPaths: pluginInstallWholeRecordPaths,
       candidateConfig: nextConfig,
+      candidateCompareConfig: nextCompareConfig,
+      previousCompareConfig: currentCompareConfig,
       previousConfig: currentConfig,
     });
     if (forcePluginMetadataReload && !plan.restartGateway) {

--- a/src/gateway/gateway-transcripts-discord-capture.e2e.test.ts
+++ b/src/gateway/gateway-transcripts-discord-capture.e2e.test.ts
@@ -1,0 +1,855 @@
+import { randomUUID } from "node:crypto";
+import { writeSync } from "node:fs";
+import fs from "node:fs/promises";
+import { createServer, type ServerResponse } from "node:http";
+import { Socket } from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, inject, it, vi } from "vitest";
+import type {
+  TranscriptsGetResult,
+  TranscriptsListResult,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import { withIsolatedTestHome } from "../../test/test-env.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OpenClawPluginApi } from "../plugins/types.js";
+import { resolveRelativeBundledPluginPublicModuleId } from "../test-utils/bundled-plugin-public-surface.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
+
+type TranscriptCapturePorts = { gateway: number; provider: number };
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    transcriptCapturePorts?: TranscriptCapturePorts;
+  }
+}
+
+type CaptureArguments = { action: "start" | "stop" | "summarize" } & Record<string, unknown>;
+type ScriptedCall = {
+  callId: string;
+  agentId: "main" | "agent-b";
+  args: CaptureArguments;
+  output?: string;
+};
+type DiscordCaptureFixture = {
+  register(api: OpenClawPluginApi): void;
+  bindPublishedRuntime(): void;
+  rotateManager(cfg: OpenClawConfig): Promise<void>;
+  expectReady(): Promise<{ speakerId: string; speakerLabel: string; voiceSessionKey: string }>;
+  recordAfterTurn(): Promise<void>;
+  beginLateDelivery(): Promise<void>;
+  finishLateDelivery(): Promise<void>;
+  close(): Promise<void>;
+  restore(): void;
+  restoreRuntime(this: void): void;
+};
+type DiscordCaptureTestApi = {
+  loadDiscordGatewayCaptureFixture(this: void): Promise<{
+    captureTarget: { accountId: string; guildId: string; channelId: string };
+    capturedText: string;
+    lateText: string;
+    createDiscordGatewayCaptureFixture(
+      this: void,
+      params: {
+        cfg: OpenClawConfig;
+        test: { expect: typeof expect; vi: typeof vi };
+      },
+    ): DiscordCaptureFixture;
+  }>;
+};
+
+function sendResponse(response: ServerResponse, item: Record<string, unknown>) {
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  for (const event of [
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, status: "in_progress" },
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: `resp_${randomUUID()}`,
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      },
+    },
+  ]) {
+    response.write(`data: ${JSON.stringify(event)}\n\n`);
+  }
+  response.end();
+}
+
+describe("Gateway admitted Discord transcript capture", () => {
+  it("fences late STT and preserves the admitted owner's history after a room route changes", async () => {
+    const proofStartedAt = Date.now();
+    const phase = (name: string) => {
+      writeSync(
+        2,
+        `[capture-proof] ${JSON.stringify({ phase: name, elapsedMs: Date.now() - proofStartedAt })}\n`,
+      );
+    };
+    phase("setup:start");
+    const ports = inject("transcriptCapturePorts");
+    if (
+      ports !== undefined &&
+      (ports.gateway === ports.provider ||
+        [ports.gateway, ports.provider].some(
+          (port) => !Number.isInteger(port) || port <= 0 || port > 65535,
+        ))
+    ) {
+      throw new Error(
+        "transcriptCapturePorts requires distinct integer gateway and provider ports",
+      );
+    }
+    // Manual live validation adds a clean environment and an OS egress fence.
+    // Ordinary CI uses this scripted loopback provider and the Node socket guard below.
+    const env = captureEnv([
+      "NODE_ENV",
+      "OPENCLAW_TEST_MINIMAL_GATEWAY",
+      "OPENCLAW_SKIP_CHANNELS",
+      "OPENCLAW_SKIP_GMAIL_WATCHER",
+      "OPENCLAW_SKIP_CRON",
+      "OPENCLAW_SKIP_CANVAS_HOST",
+      "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+      "OPENCLAW_SKIP_PROVIDERS",
+      "OPENCLAW_BUILD_PRIVATE_QA",
+      "OPENCLAW_QA_FORCE_RUNTIME",
+      "OPENCLAW_GATEWAY_TOKEN",
+      "OPENCLAW_GATEWAY_PASSWORD",
+      "OPENCLAW_GATEWAY_PORT",
+    ]);
+    const isolated = withIsolatedTestHome({ mode: "hermetic" });
+    const stateDir = path.join(isolated.tempHome, ".openclaw");
+    const workspace = path.join(isolated.tempHome, "workspace");
+    const configPath = path.join(stateDir, "openclaw.json");
+    let gateway:
+      | Awaited<ReturnType<typeof import("./test-helpers.e2e.js").startGatewayWithClient>>
+      | undefined;
+    let fixture: DiscordCaptureFixture | undefined;
+    let restoreDiscordRuntime: (() => void) | undefined;
+    let routedService:
+      | ReturnType<typeof import("../transcripts/auto-start.js").createTranscriptsAutoStartService>
+      | undefined;
+    let cleanupRuntime: (() => Promise<void>) | undefined;
+    const requests: Record<string, unknown>[] = [];
+    const errors: unknown[] = [];
+    const calls: ScriptedCall[] = [];
+    const deniedConnections: string[] = [];
+    let providerPort: number | undefined;
+    deleteTestEnvValue("OPENCLAW_GATEWAY_PORT");
+    const selectedGatewayPort = () => ports?.gateway ?? Number(process.env.OPENCLAW_GATEWAY_PORT);
+    // The native method must retain each caller's socket, supplied by Reflect.apply below.
+    // oxlint-disable-next-line typescript/unbound-method
+    const originalConnect = Socket.prototype.connect;
+    // Reject unexpected Node HTTP(S), WS and fetch destinations. This guard does
+    // not isolate native transports or child processes; the manual OS fence does.
+    const socketFence = vi.spyOn(Socket.prototype, "connect").mockImplementation(function (
+      this: Socket,
+      ...args: unknown[]
+    ) {
+      const normalized = Array.isArray(args[0]) ? args[0] : args;
+      const options = asOptionalRecord(normalized[0]);
+      const host = options?.host ?? normalized[1];
+      const port = Number(options?.port ?? normalized[0]);
+      // startGatewayWithClient publishes its allocated port before opening its WS client.
+      const gatewayPort = selectedGatewayPort();
+      if (
+        host !== "127.0.0.1" ||
+        !Number.isInteger(port) ||
+        port <= 0 ||
+        (port !== providerPort && port !== gatewayPort)
+      ) {
+        const reason = `unexpected socket destination ${String(host)}:${port}`;
+        deniedConnections.push(reason);
+        throw new Error(reason);
+      }
+      return Reflect.apply(originalConnect, this, args);
+    });
+    let currentCall: ScriptedCall | undefined;
+    let awaitingOutput = false;
+    let summaryTranscript: string | undefined;
+    let summaryRequests = 0;
+    const providerServer = createServer((request, response) => {
+      void (async () => {
+        expect(request.method).toBe("POST");
+        expect(request.url).toBe("/v1/responses");
+        expect(request.headers.authorization).toBe("Bearer test");
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) {
+          chunks.push(Buffer.from(chunk));
+        }
+        const body = asOptionalRecord(JSON.parse(Buffer.concat(chunks).toString("utf8")));
+        expect(body?.model).toBe("capture-proof");
+        expect(body?.stream).toBe(true);
+        requests.push(body!);
+        // Unscripted conversation calls fail visibly, including recording-only scan regressions.
+        expect(currentCall, "unexpected model request outside an admitted tool turn").toBeDefined();
+        const call = currentCall!;
+        if (
+          awaitingOutput &&
+          (call.args.action === "stop" || call.args.action === "summarize") &&
+          !body?.tools
+        ) {
+          expect(call.agentId).toBe("main");
+          summaryRequests++;
+          expect(summaryTranscript).toBeDefined();
+          const summaryInput = JSON.stringify(body);
+          expect(summaryInput).toContain(
+            "Write concise meeting notes in the transcript's language.",
+          );
+          expect(summaryInput).toContain(summaryTranscript!);
+          sendResponse(response, {
+            type: "message",
+            id: "msg_capture_summary",
+            role: "assistant",
+            status: "completed",
+            content: [
+              {
+                type: "output_text",
+                text: JSON.stringify({
+                  overview: "The participant supplied a synthetic capture note.",
+                  decisions: [],
+                  actionItems: [],
+                  risks: [],
+                }),
+                annotations: [],
+              },
+            ],
+          });
+          return;
+        }
+        if (!awaitingOutput) {
+          expect(body?.tools).toEqual(
+            expect.arrayContaining([expect.objectContaining({ name: "transcripts" })]),
+          );
+          awaitingOutput = true;
+          sendResponse(response, {
+            type: "function_call",
+            id: `fc_${call.callId}`,
+            call_id: call.callId,
+            name: "transcripts",
+            arguments: JSON.stringify(call.args),
+            status: "completed",
+          });
+          return;
+        }
+        const input = body?.input;
+        expect(Array.isArray(input)).toBe(true);
+        const inputItems = (input as unknown[]).map(asOptionalRecord);
+        const result = inputItems.findLast(
+          (item) => item?.type === "function_call_output" && item.call_id === call.callId,
+        );
+        const replayDiagnostics = JSON.stringify({
+          expectedCallId: call.callId,
+          input: inputItems.slice(-8).map((item) => ({
+            type: item?.type,
+            call_id: item?.call_id,
+            outputType: typeof item?.output,
+          })),
+        }).slice(0, 2_048);
+        expect(
+          result,
+          `the actual tool result must return through the runtime: ${replayDiagnostics}`,
+        ).toBeDefined();
+        expect(typeof result?.output).toBe("string");
+        call.output = result!.output as string;
+        currentCall = undefined;
+        awaitingOutput = false;
+        sendResponse(response, {
+          type: "message",
+          id: `msg_${call.callId}`,
+          role: "assistant",
+          status: "completed",
+          content: [
+            { type: "output_text", text: `Completed ${call.args.action}.`, annotations: [] },
+          ],
+        });
+      })().catch((error: unknown) => {
+        errors.push(error);
+        response.writeHead(500).end("Unexpected scripted capture request");
+      });
+    });
+    try {
+      // Both the fixture and selected plugin loaders use the production SDK artifact order.
+      // VITEST and the explicit minimal flag retain test lifecycle isolation.
+      setTestEnvValue("NODE_ENV", "production");
+      for (const key of [
+        "OPENCLAW_BUILD_PRIVATE_QA",
+        "OPENCLAW_QA_FORCE_RUNTIME",
+        "OPENCLAW_GATEWAY_TOKEN",
+        "OPENCLAW_GATEWAY_PASSWORD",
+        // These flags remove channel config from the effective runtime as well as
+        // skipping startup. Minimal Gateway mode already skips channel login.
+        "OPENCLAW_SKIP_CHANNELS",
+        "OPENCLAW_SKIP_PROVIDERS",
+      ]) {
+        deleteTestEnvValue(key);
+      }
+      for (const key of [
+        "OPENCLAW_TEST_MINIMAL_GATEWAY",
+        "OPENCLAW_SKIP_GMAIL_WATCHER",
+        "OPENCLAW_SKIP_CRON",
+        "OPENCLAW_SKIP_CANVAS_HOST",
+        "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+      ]) {
+        setTestEnvValue(key, "1");
+      }
+      setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      await Promise.all([
+        fs.mkdir(workspace, { recursive: true }),
+        fs.mkdir(stateDir, { recursive: true }),
+      ]);
+      await new Promise<void>((resolve, reject) => {
+        providerServer.once("error", reject);
+        providerServer.listen(ports?.provider ?? 0, "127.0.0.1", resolve);
+      });
+      const address = providerServer.address();
+      if (
+        !address ||
+        typeof address === "string" ||
+        address.address !== "127.0.0.1" ||
+        (ports !== undefined && address.port !== ports.provider)
+      ) {
+        throw new Error("Unexpected transcript fixture provider address");
+      }
+      providerPort = address.port;
+      const provider = buildMockOpenAiResponsesProvider(
+        `http://127.0.0.1:${address.port}/v1`,
+        "capture-proof",
+      );
+      const testApiId = resolveRelativeBundledPluginPublicModuleId({
+        fromModuleUrl: import.meta.url,
+        pluginId: "discord",
+        artifactBasename: "test-api.js",
+      });
+      const testApiPath = fileURLToPath(new URL(testApiId, import.meta.url));
+      const discordPluginDir = path.dirname(testApiPath);
+      phase("plugin-loader:import");
+      const [
+        { createPluginModuleLoader },
+        { resolveOpenClawDevSourceRoot },
+        { preparePluginLoaderAliases, resolvePluginRuntimeModulePathWithDiagnostics },
+      ] = await Promise.all([
+        import("../plugins/loader-module-runtime.js"),
+        import("../plugins/dev-source-root.js"),
+        import("../plugins/sdk-alias.js"),
+      ]);
+      phase("plugin-loader:imported");
+      const devSourceRoot = resolveOpenClawDevSourceRoot();
+      const sdkAliases = preparePluginLoaderAliases({
+        modulePath: testApiPath,
+        devSourceRoot,
+      });
+      const isBuiltPath = (target: string) => /[/\\]dist(?:-runtime)?[/\\]/.test(target);
+      const sdkTargets = ["runtime-store", "extension-shared", "channel-entry-contract"].map(
+        (subpath) => {
+          const target = sdkAliases.resolveAlias(`openclaw/plugin-sdk/${subpath}`);
+          expect(target, `Missing SDK seam: ${subpath}`).toBeDefined();
+          expect(
+            isBuiltPath(target!),
+            `The capture proof requires the built ${subpath} SDK; run pnpm build before using skip-build.`,
+          ).toBe(true);
+          return target!;
+        },
+      );
+      const runtimeModule = resolvePluginRuntimeModulePathWithDiagnostics({ devSourceRoot });
+      expect(runtimeModule.resolvedPath, JSON.stringify(runtimeModule)).toBeDefined();
+      expect(isBuiltPath(runtimeModule.resolvedPath!)).toBe(true);
+      await Promise.all(
+        [...new Set([...sdkTargets, runtimeModule.resolvedPath!])].map((target) =>
+          fs.access(target),
+        ),
+      );
+      phase("plugin-sdk:built");
+      // Use the runtime entry's loader graph so the fixture manager and model-selected
+      // provider share Discord's lifecycle state. Vitest owns only the injected test utilities.
+      const loadDiscordModule = createPluginModuleLoader({
+        devSourceRoot,
+        loaderFilename: path.join(discordPluginDir, "index.ts"),
+      });
+      phase("test-api:load");
+      const { loadDiscordGatewayCaptureFixture } = loadDiscordModule(
+        testApiPath,
+      ) as DiscordCaptureTestApi;
+      phase("test-api:loaded");
+      phase("fixture-module:load");
+      const { createDiscordGatewayCaptureFixture, captureTarget, capturedText, lateText } =
+        await loadDiscordGatewayCaptureFixture();
+      phase("fixture-module:loaded");
+      phase("host-runtime:import");
+      summaryTranscript = capturedText;
+      const { startGatewayWithClient } = await import("./test-helpers.e2e.js");
+      const { createPluginRuntime } = await import("../plugins/runtime/index.js");
+      const { createPluginRegistry } = await import("../plugins/registry.js");
+      const { createPluginRecord } = await import("../plugins/loader-records.js");
+      const {
+        getActivePluginRegistry,
+        setActivePluginRegistry,
+        captureActivePluginRegistrySnapshot,
+        restoreActivePluginRegistrySnapshot,
+      } = await import("../plugins/runtime.js");
+      const { getPluginRuntimeLoadContext } = await import("../plugins/runtime/load-context.js");
+      const { withPluginRuntimeRegistryScope } =
+        await import("../plugins/runtime/gateway-request-scope.js");
+      const { refreshPreparedModelRuntimeSnapshots, loadPublishedGatewayReplyDispatchRuntime } =
+        await import("../agents/prepared-model-runtime.js");
+      const { resetPreparedModelRuntimeSnapshotsForTest } =
+        await import("../agents/prepared-model-runtime.test-support.js");
+      const { clearConfigCache, clearRuntimeConfigSnapshot, getRuntimeConfig } =
+        await import("../config/config.js");
+      const { resetConfigOverrides } = await import("../config/runtime-overrides.js");
+      const { drainSessionStoreWriterQueuesForTest, clearSessionStoreCacheForTest } =
+        await import("../config/sessions/store-writer-state.js");
+      const { closeOpenClawStateDatabaseByPath } = await import("../state/openclaw-state-db.js");
+      const { activeSessions, resolveSourceProvider } = await import("../transcripts/capture.js");
+      const { createTranscriptsAutoStartService } = await import("../transcripts/auto-start.js");
+      const { readConfiguredTranscriptStarts } =
+        await import("../transcripts/configured-start-status.js");
+      const { TranscriptsStore } = await import("../transcripts/store.js");
+      phase("host-runtime:imported");
+      const previousRegistry = captureActivePluginRegistrySnapshot();
+      cleanupRuntime = async () => {
+        const ownedCaptures = () =>
+          [...activeSessions.values()].filter(
+            (capture) => capture.session.source.accountId === captureTarget.accountId,
+          );
+        try {
+          for (const capture of ownedCaptures()) {
+            await capture.finalization;
+          }
+          expect(ownedCaptures()).toEqual([]);
+        } finally {
+          try {
+            await drainSessionStoreWriterQueuesForTest();
+          } finally {
+            clearSessionStoreCacheForTest();
+            resetPreparedModelRuntimeSnapshotsForTest();
+            closeOpenClawStateDatabaseByPath(path.join(stateDir, "state", "openclaw.sqlite"));
+            resetConfigOverrides();
+            clearRuntimeConfigSnapshot();
+            clearConfigCache();
+            restoreActivePluginRegistrySnapshot(previousRegistry);
+          }
+        }
+      };
+      resetConfigOverrides();
+      const token = "synthetic-gateway-capture-token";
+      const cfg: OpenClawConfig = {
+        agents: {
+          list: [
+            { id: "main", default: true, workspace },
+            { id: "agent-b", workspace },
+          ],
+          defaults: {
+            workspace,
+            skipBootstrap: true,
+            heartbeat: { every: "0m" },
+            model: { primary: provider.modelRef, fallbacks: [] },
+            models: {
+              [provider.modelRef]: {
+                agentRuntime: { id: "openclaw" },
+                params: { transport: "sse", openaiWsWarmup: false },
+              },
+            },
+          },
+        },
+        bindings: [
+          {
+            agentId: "main",
+            match: {
+              channel: "discord",
+              accountId: captureTarget.accountId,
+              peer: { kind: "channel", id: captureTarget.channelId },
+            },
+          },
+        ],
+        channels: {
+          discord: {
+            // Minimal startup skips login; the health monitor must not start it later.
+            healthMonitor: { enabled: false },
+            accounts: {
+              [captureTarget.accountId]: {
+                token: "synthetic-discord-token",
+                voice: { enabled: true, mode: "stt-tts" },
+              },
+            },
+          },
+        },
+        gateway: { auth: { mode: "token", token } },
+        models: { mode: "replace", providers: { [provider.providerId]: provider.config } },
+        plugins: {
+          allow: ["discord"],
+          entries: { discord: { enabled: true } },
+          // Keep source proof on the same explicit plugin entry even when dist exists.
+          load: { paths: [discordPluginDir] },
+          slots: { memory: "none" },
+        },
+        tools: { allow: ["transcripts"], codeMode: false, toolSearch: false },
+        transcripts: { enabled: true },
+      };
+      phase("host-runtime:create");
+      const runtime = createPluginRuntime();
+      phase("host-runtime:created");
+      phase("fixture:create");
+      fixture = createDiscordGatewayCaptureFixture({ cfg, test: { expect, vi } });
+      restoreDiscordRuntime = fixture.restoreRuntime;
+      phase("fixture:created");
+      const registration = createPluginRegistry({ runtime, logger: console });
+      const record = createPluginRecord({
+        id: "discord",
+        source: path.join(discordPluginDir, "index.ts"),
+        rootDir: discordPluginDir,
+        origin: "bundled",
+        enabled: true,
+        configSchema: true,
+      });
+      registration.registry.plugins.push(record);
+      fixture.register(registration.createApi(record, { config: cfg }));
+      expect(registration.registry.diagnostics).toEqual([]);
+      expect(record.transcriptSourceProviderIds).toEqual(["discord-voice"]);
+      // Minimal startup retains this real registration; it skips monitor login/sidecars only.
+      // This does not prove full plugin discovery or Discord monitor startup.
+      setActivePluginRegistry(registration.registry);
+      phase("gateway:start");
+      gateway = await startGatewayWithClient({
+        port: ports?.gateway,
+        cfg,
+        configPath,
+        token,
+        scopes: ["operator.admin"],
+      });
+      phase("gateway:started");
+      await gateway.server.startupSettled;
+      phase("gateway:settled");
+      expect(getRuntimeConfig().channels?.discord).toMatchObject(cfg.channels!.discord!);
+      const metadata = getPluginRuntimeLoadContext(registration.registry)?.metadataSnapshot;
+      expect(metadata).toBeDefined();
+      // Minimal startup skips the model-publication sidecar. Publish through its
+      // production owner, retaining the real fixture registration for both agents.
+      setActivePluginRegistry(
+        registration.registry,
+        undefined,
+        "gateway-bindable",
+        metadata!.workspaceDir,
+      );
+      phase("model-publication:start");
+      await withPluginRuntimeRegistryScope(registration.registry, () =>
+        refreshPreparedModelRuntimeSnapshots(getRuntimeConfig, {
+          gatewayLifecycle: true,
+          catalogMode: "static",
+          allowGatewaySubagentBinding: true,
+          defaultWorkspaceDir: workspace,
+          pluginMetadataSnapshot: metadata,
+        }),
+      );
+      phase("model-publication:published");
+      for (const agentId of ["main", "agent-b"]) {
+        const published = await loadPublishedGatewayReplyDispatchRuntime({ agentId });
+        expect(published?.inboundPluginRegistry).toBe(registration.registry);
+        const selectedRegistry = published?.pluginGeneration.pluginRegistry;
+        const selectedProvider = selectedRegistry?.transcriptSourceProviders.find(
+          (entry) => entry.provider.id === "discord-voice",
+        )?.provider;
+        expect(
+          selectedProvider,
+          JSON.stringify({
+            agentId,
+            selectedOwners: selectedRegistry?.plugins.map(({ id, status, source }) => ({
+              id,
+              status,
+              source,
+            })),
+          }),
+        ).toBe(registration.registry.transcriptSourceProviders[0]?.provider);
+      }
+      fixture.bindPublishedRuntime();
+      phase("model-publication:verified");
+      expect(gateway.port).not.toBe(providerPort);
+      expect(getActivePluginRegistry()).toBe(registration.registry);
+      const client = gateway.client;
+      const sessionKeys = {
+        main: `agent:main:capture-proof-${randomUUID()}`,
+        "agent-b": `agent:agent-b:capture-proof-${randomUUID()}`,
+      };
+      const sessionId = `capture-${randomUUID()}`;
+      const store = new TranscriptsStore(path.join(stateDir, "transcripts"));
+      const runTurn = async (args: CaptureArguments, agentId: "main" | "agent-b" = "main") => {
+        const call: ScriptedCall = { callId: `call_capture_${calls.length}`, agentId, args };
+        calls.push(call);
+        currentCall = call;
+        phase(`turn:${agentId}:${args.action}:request`);
+        const accepted = await client.request<{ runId: string; status: string }>("agent", {
+          sessionKey: sessionKeys[agentId],
+          message: `Perform the synthetic capture ${args.action} operation.`,
+          deliver: false,
+          idempotencyKey: randomUUID(),
+        });
+        expect(accepted.status).toBe("accepted");
+        expect(accepted.runId).toEqual(expect.any(String));
+        phase(`turn:${agentId}:${args.action}:accepted`);
+        const completed = await client.request<{ status: string }>("agent.wait", {
+          runId: accepted.runId,
+          timeoutMs: 30_000,
+        });
+        phase(`turn:${agentId}:${args.action}:completed`);
+        const diagnostics = JSON.stringify({
+          agentId,
+          action: args.action,
+          completed,
+          errors: errors.map((error) =>
+            error instanceof Error
+              ? { name: error.name, message: error.message, stack: error.stack }
+              : error,
+          ),
+          deniedConnections,
+          providerRequestCount: requests.length,
+        });
+        expect(completed.status, diagnostics).toBe("ok");
+        expect(errors, diagnostics).toEqual([]);
+        expect(call.output).toBeDefined();
+        expect(currentCall).toBeUndefined();
+        return call.output!;
+      };
+      const start = await runTurn({
+        action: "start",
+        providerId: "discord-voice",
+        ...captureTarget,
+        sessionId,
+      });
+      expect(start).toContain(`Transcripts started: ${sessionId}`);
+      const selector = /^Selector: (.+)$/m.exec(start)?.[1];
+      expect(selector).toBeDefined();
+      const speaker = await fixture.expectReady();
+      const admitted = await store.readSession(selector!);
+      expect(admitted).toMatchObject({ sessionId, metadata: { agentId: "main" } });
+      expect(admitted?.source).toEqual({
+        providerId: "discord-voice",
+        ...captureTarget,
+        agentId: "main",
+      });
+      const listed = await client.request<TranscriptsListResult>("transcripts.list", {});
+      expect(listed.sessions).toHaveLength(1);
+      expect(listed.sessions[0]).toMatchObject({
+        selector,
+        sessionId,
+        agentId: "main",
+        source: { providerId: "discord-voice", ...captureTarget },
+        activeSubscription: true,
+      });
+      expect(requests).toHaveLength(2);
+
+      await fixture.recordAfterTurn();
+      const captured = await client.request<TranscriptsGetResult>("transcripts.get", {
+        selector,
+        includeUtterances: true,
+      });
+      expect(captured.session).toMatchObject({
+        selector,
+        sessionId,
+        utteranceCount: 1,
+        activeSubscription: true,
+      });
+      expect(captured.utterances).toEqual([
+        expect.objectContaining({
+          sequence: 0,
+          text: capturedText,
+          final: true,
+          speakerId: speaker.speakerId,
+          speakerLabel: speaker.speakerLabel,
+        }),
+      ]);
+      expect(requests).toHaveLength(2);
+      expect(errors).toEqual([]);
+
+      await fixture.beginLateDelivery();
+      const stop = await runTurn({ action: "stop", selector });
+      expect(stop).toContain(`Transcripts stopped: ${sessionId}`);
+      expect(stop).toContain(`Selector: ${selector}`);
+      await fixture.finishLateDelivery();
+      const stopped = await client.request<TranscriptsGetResult>("transcripts.get", {
+        selector,
+        includeUtterances: true,
+      });
+      expect(stopped.session).toMatchObject({
+        selector,
+        sessionId,
+        agentId: "main",
+        utteranceCount: 1,
+        activeSubscription: false,
+        stoppedAt: expect.any(String),
+      });
+      expect(stopped.utterances).toEqual(captured.utterances);
+      expect(stopped.summary).toMatchObject({ utteranceCount: 1, source: "model" });
+      expect(JSON.stringify(stopped)).not.toContain(lateText);
+      const stoppedSession = await store.readSession(selector!);
+      expect(stoppedSession).toEqual({ ...admitted, stoppedAt: stopped.session.stoppedAt });
+      const utterances = await store.readUtterancesForSession(stoppedSession!);
+      expect(utterances).toEqual([
+        expect.objectContaining({
+          text: capturedText,
+          metadata: {
+            channel: "discord",
+            guildId: captureTarget.guildId,
+            channelId: captureTarget.channelId,
+            voiceSessionKey: speaker.voiceSessionKey,
+          },
+        }),
+      ]);
+      expect(requests).toHaveLength(5);
+      expect(summaryRequests).toBe(1);
+
+      // Rotate the real manager and transport while preserving the scenario's SDK spies.
+      const routedConfig: OpenClawConfig = {
+        ...cfg,
+        bindings: [{ ...cfg.bindings![0]!, agentId: "agent-b" }],
+        transcripts: {
+          enabled: true,
+          autoStart: [{ providerId: "discord-voice", ...captureTarget, whenOccupied: true }],
+        },
+      };
+      await fixture.rotateManager(routedConfig);
+      const routedWarnings: string[] = [];
+      const routedContext: Parameters<typeof createTranscriptsAutoStartService>[0] = {
+        stateDir,
+        config: routedConfig,
+        logger: {
+          warn: (message) => {
+            if (routedWarnings.length < 8) {
+              routedWarnings.push(message);
+            }
+            writeSync(
+              2,
+              `[capture-proof] ${JSON.stringify({ phase: "routed-warning", message })}\n`,
+            );
+          },
+        },
+        caller: { kind: "operator", source: "scheduled" },
+      };
+      phase("routed-provider:resolve");
+      const routedProvider = resolveSourceProvider("discord-voice", routedContext);
+      const activeRegistry = getActivePluginRegistry();
+      expect(
+        routedProvider,
+        JSON.stringify({
+          activeRegistryIsFixture: activeRegistry === registration.registry,
+          activeProviders: activeRegistry?.transcriptSourceProviders.map(
+            ({ pluginId, source, provider: entryProvider }) => ({
+              pluginId,
+              source,
+              providerId: entryProvider.id,
+            }),
+          ),
+          resolvedProviderId: routedProvider?.id,
+        }),
+      ).toBe(registration.registry.transcriptSourceProviders[0]?.provider);
+      phase("routed-provider:verified");
+      routedService = createTranscriptsAutoStartService(routedContext);
+      phase("routed-service:start");
+      routedService.start();
+      const readRoutedState = () => {
+        const capture = [...activeSessions.values()].find(
+          (candidate) => candidate.session.source.accountId === captureTarget.accountId,
+        );
+        return {
+          capture: capture && {
+            phase: capture.phase,
+            session: { sessionId: capture.session.sessionId, metadata: capture.session.metadata },
+          },
+          starts: [...(readConfiguredTranscriptStarts(routedConfig.transcripts) ?? [])].map(
+            ([index, fact]) => ({ index, diagnostic: fact.diagnostic }),
+          ),
+          warnings: routedWarnings,
+        };
+      };
+      try {
+        await expect.poll(readRoutedState).toMatchObject({
+          capture: { phase: "active", session: { metadata: { agentId: "agent-b" } } },
+        });
+      } catch (error) {
+        writeSync(
+          2,
+          `[capture-proof] ${JSON.stringify({ phase: "routed-service:failed", ...readRoutedState() })}\n`,
+        );
+        throw error;
+      }
+      phase("routed-service:active");
+      const replacement = [...activeSessions.values()].find(
+        (capture) => capture.session.source.accountId === captureTarget.accountId,
+      )!;
+      expect(replacement.session.sessionId).not.toBe(sessionId);
+      expect(await store.readSession(selector!)).toEqual(stoppedSession);
+      expect(await store.readUtterancesForSession(stoppedSession!)).toEqual(utterances);
+      const savedSummary = await store.readSummary(stoppedSession!);
+      const providerStop = vi.spyOn(replacement.provider, "stop");
+      const sessionWrite = vi.spyOn(TranscriptsStore.prototype, "writeSession");
+      const summaryWrite = vi.spyOn(TranscriptsStore.prototype, "writeSummary");
+      try {
+        for (const action of ["stop", "summarize"] as const) {
+          expect(await runTurn({ action, selector }, "agent-b")).toContain("session not found");
+        }
+        expect(providerStop).not.toHaveBeenCalled();
+        expect(sessionWrite).not.toHaveBeenCalled();
+        expect(summaryWrite).not.toHaveBeenCalled();
+        expect(await store.readSession(selector!)).toEqual(stoppedSession);
+        expect(await store.readSummary(stoppedSession!)).toEqual(savedSummary);
+        expect(await store.readUtterancesForSession(stoppedSession!)).toEqual(utterances);
+        expect(await runTurn({ action: "summarize", selector })).toContain(
+          `Transcripts summarized: ${sessionId}`,
+        );
+        expect(summaryWrite).toHaveBeenCalledTimes(1);
+        expect(providerStop).not.toHaveBeenCalled();
+        expect(activeSessions.get(replacement.session.sessionId)).toBe(replacement);
+      } finally {
+        providerStop.mockRestore();
+        sessionWrite.mockRestore();
+        summaryWrite.mockRestore();
+      }
+      await routedService.stop();
+      expect(requests).toHaveLength(12);
+      expect(summaryRequests).toBe(2);
+      expect(errors).toEqual([]);
+      expect(deniedConnections).toEqual([]);
+    } finally {
+      phase("cleanup:start");
+      // Keep the actual runtime and edge spies alive until sources, streams and Gateway settle.
+      try {
+        try {
+          await routedService?.stop();
+        } finally {
+          await fixture?.close();
+        }
+      } finally {
+        try {
+          if (gateway) {
+            try {
+              await gateway.client.stopAndWait();
+            } finally {
+              await gateway.server.close({ reason: "synthetic transcript capture cleanup" });
+            }
+          }
+        } finally {
+          providerServer.closeAllConnections();
+          await new Promise<void>((resolve) => {
+            providerServer.close(() => resolve());
+          });
+          try {
+            await cleanupRuntime?.();
+          } finally {
+            fixture?.restore();
+            restoreDiscordRuntime?.();
+            socketFence.mockRestore();
+            isolated.cleanup();
+            env.restore();
+            phase("cleanup:done");
+          }
+        }
+      }
+    }
+  });
+});

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -648,10 +648,10 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["update.runs.get", "update", "operator.admin", "2026.9"],
   ["update.runs.list", "update", "operator.admin", "2026.9"],
   ["gateway.suspend.handoff", "suspend", "operator.admin", "2026.9", CONTROL_PLANE_WRITE],
-  ["update.report", "update", "operator.admin", "2026.9", { controlPlaneWrite: true }],
-  ["skills.workshop.read", "skills", "operator.read", "2026.9"],
   ["transcripts.export", "transcripts", "operator.read", "2026.9"],
   ["transcripts.status", "transcripts", "operator.read", "2026.9"],
+  ["update.report", "update", "operator.admin", "2026.9", { controlPlaneWrite: true }],
+  ["skills.workshop.read", "skills", "operator.read", "2026.9"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -650,6 +650,8 @@ const CORE_GATEWAY_METHOD_SPECS = [
   ["gateway.suspend.handoff", "suspend", "operator.admin", "2026.9", CONTROL_PLANE_WRITE],
   ["update.report", "update", "operator.admin", "2026.9", { controlPlaneWrite: true }],
   ["skills.workshop.read", "skills", "operator.read", "2026.9"],
+  ["transcripts.export", "transcripts", "operator.read", "2026.9"],
+  ["transcripts.status", "transcripts", "operator.read", "2026.9"],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/methods/core-profile-access.ts
+++ b/src/gateway/methods/core-profile-access.ts
@@ -38,6 +38,7 @@ const PROFILE_DEPENDENT_CORE_PREFIXES = [
   "taskSuggestions.",
   "tasks.",
   "terminal.",
+  "transcripts.",
   "users.authConnect.",
   "users.prefs.",
   "users.github.",

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -76,7 +76,7 @@ describe("listGatewayMethods", () => {
     expect(listGatewayMethods()).toContain("approval.resolve");
   });
 
-  it("appends plugin UI, update history and report methods without changing the legacy prefix", () => {
+  it("appends plugin UI, update and transcript methods without changing the legacy prefix", () => {
     const methods = listGatewayMethods();
     const legacyCount = LEGACY_ADVERTISED_GATEWAY_METHODS.length;
 
@@ -93,6 +93,8 @@ describe("listGatewayMethods", () => {
       "gateway.suspend.handoff",
       "update.report",
       "skills.workshop.read",
+      "transcripts.export",
+      "transcripts.status",
     ]);
   });
 

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -91,10 +91,10 @@ describe("listGatewayMethods", () => {
       "update.runs.get",
       "update.runs.list",
       "gateway.suspend.handoff",
-      "update.report",
-      "skills.workshop.read",
       "transcripts.export",
       "transcripts.status",
+      "update.report",
+      "skills.workshop.read",
     ]);
   });
 

--- a/src/gateway/server-methods/config-write-flow.test.ts
+++ b/src/gateway/server-methods/config-write-flow.test.ts
@@ -30,7 +30,35 @@ vi.mock("../../secrets/runtime-state.js", async (importOriginal) => {
   };
 });
 
-import { commitGatewayConfigWrite, didActiveSharedGatewayAuthChange } from "./config-write-flow.js";
+import {
+  commitGatewayConfigWrite,
+  didActiveSharedGatewayAuthChange,
+  shouldAwaitGatewayConfigApplication,
+} from "./config-write-flow.js";
+
+it("awaits title application only with authoritative identity and an enabled reload owner", () => {
+  const previousConfig: OpenClawConfig = {
+    transcripts: { autoStart: [{ providerId: "fixture", sessionId: "daily", title: "Before" }] },
+  };
+  const nextConfig: OpenClawConfig = {
+    transcripts: { autoStart: [{ providerId: "fixture", sessionId: "daily", title: "After" }] },
+  };
+  const params = { previousConfig, nextConfig, changedPaths: ["transcripts.autoStart"] };
+  expect(shouldAwaitGatewayConfigApplication(params)).toBe(true);
+  expect(shouldAwaitGatewayConfigApplication({ ...params, previousConfig: {} })).toBe(false);
+  expect(
+    shouldAwaitGatewayConfigApplication({
+      ...params,
+      changedPaths: [...params.changedPaths, "gateway.port"],
+    }),
+  ).toBe(false);
+  expect(
+    shouldAwaitGatewayConfigApplication({
+      ...params,
+      nextConfig: { ...nextConfig, gateway: { reload: { mode: "off" } } },
+    }),
+  ).toBe(false);
+});
 
 describe("commitGatewayConfigWrite", () => {
   beforeEach(() => {

--- a/src/gateway/server-methods/transcripts.test.ts
+++ b/src/gateway/server-methods/transcripts.test.ts
@@ -1,75 +1,475 @@
+import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_RESULT_MAX_BYTES,
+} from "../../../packages/gateway-protocol/src/schema/transcripts.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
-import { activeSessions } from "../../transcripts/capture.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import {
+  createOpenClawTestState,
+  withOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { activeSessions, startTranscripts } from "../../transcripts/capture.js";
 import { resolveTranscriptsConfig } from "../../transcripts/config.js";
+import * as transcriptProviders from "../../transcripts/provider-registry.js";
 import { meetingTranscriptDb } from "../../transcripts/store-sqlite.js";
 import { TranscriptsStore, transcriptSessionSelector } from "../../transcripts/store.js";
 import { summarizeTranscripts, type TranscriptsSummary } from "../../transcripts/summary.js";
+import { handleGatewayRequest } from "../server-methods.js";
 import { transcriptsHandlers } from "./transcripts.js";
-import type { GatewayRequestContext } from "./types.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
-vi.mock("../../transcripts/provider-registry.js", () => ({
-  getTranscriptSourceProvider: () => undefined,
-}));
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-let store: TranscriptsStore;
+afterEach(() => closeOpenClawStateDatabaseForTest());
+const logGateway = { warn: vi.fn() };
 
-const session = {
-  sessionId: "weekly",
-  title: "Design review",
-  startedAt: "2026-08-02T14:00:00.000Z",
-  source: {
-    providerId: "manual-transcript",
-    guildId: "team",
-    meetingUrl: "https://example.com/meeting?token=secret#secret",
-    privateField: "hidden",
-  },
-  metadata: { privateMetadata: "hidden" },
-};
-
-async function invoke(method: string, params: Record<string, unknown>) {
-  const respond = vi.fn();
-  const handler = transcriptsHandlers[method];
-  if (!handler) {
-    throw new Error(`missing handler: ${method}`);
-  }
-  await handler({
-    req: { type: "req", id: "test", method },
-    params,
+function client(profileId?: string, scopes = ["operator.read"]): GatewayClient {
+  return {
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes,
+    },
+    ...(profileId
+      ? {
+          authenticatedUserProfile: {
+            profileId,
+            displayName: null,
+            hasAvatar: false,
+            updatedAt: 1,
+          },
+        }
+      : {}),
+  };
+}
+function roles(others: "none" | "view"): OpenClawConfig {
+  return {
+    gateway: {
+      roles: {
+        default: "limited",
+        definitions: {
+          limited: { sessions: { others }, agents: ["main"], scopes: ["operator.read"] },
+        },
+      },
+    },
+  };
+}
+async function request(
+  method: string,
+  params: Record<string, unknown> = {},
+  cfg: OpenClawConfig = {},
+  caller = client(),
+) {
+  const respond = vi.fn<RespondFn>();
+  await handleGatewayRequest({
+    req: { type: "req", id: "transcript-read", method, params },
     respond,
-    client: null,
+    client: caller,
     isWebchatConnect: () => false,
-    context: { getRuntimeConfig: () => ({}) } as GatewayRequestContext,
+    context: {
+      getRuntimeConfig: () => cfg,
+      logGateway,
+    } as unknown as GatewayRequestContext,
   });
-  expect(respond).toHaveBeenCalledOnce();
-  const response = respond.mock.calls[0];
-  if (!response) {
-    throw new Error(`missing response: ${method}`);
-  }
-  return response;
+  expect(respond).toHaveBeenCalledTimes(1);
+  return respond.mock.calls[0]!;
+}
+async function seed(stateDir: string) {
+  const store = new TranscriptsStore(path.join(stateDir, "transcripts"));
+  const session = {
+    sessionId: "meeting",
+    source: { providerId: "manual-transcript" },
+    startedAt: "2026-08-20T10:00:00.000Z",
+    metadata: { agentId: "ops" },
+  };
+  await store.writeSession(session);
+  await store.appendUtteranceForSession(session, { text: "Archive-only text", final: true });
+  return { store, session, selector: transcriptSessionSelector(session) };
 }
 
-beforeEach(async () => {
-  const stateDir = tempDirs.make("transcripts-rpc-");
-  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-  store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+describe("transcript Gateway read authorization and errors", () => {
+  beforeEach(() => {
+    logGateway.warn.mockClear();
+    vi.spyOn(transcriptProviders, "getTranscriptSourceProvider").mockReturnValue(undefined);
   });
-  await store.writeSession(session);
-});
-afterEach(() => {
-  activeSessions.clear();
-  closeOpenClawStateDatabaseForTest();
-  vi.unstubAllEnvs();
+  afterEach(() => vi.restoreAllMocks());
+
+  it("returns explicit byte-limit errors without a partial read or download", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const { store, session, selector } = await seed(state.stateDir);
+      await store.appendUtteranceForSession(session, {
+        text: "x".repeat(TRANSCRIPTS_EXPORT_MAX_BYTES + 1),
+      });
+      for (const [method, params, type, maxBytes] of [
+        [
+          "transcripts.get",
+          { selector, includeUtterances: true },
+          "transcript_result_too_large",
+          TRANSCRIPTS_RESULT_MAX_BYTES,
+        ],
+        [
+          "transcripts.export",
+          { selector, format: "jsonl" },
+          "transcript_export_too_large",
+          TRANSCRIPTS_EXPORT_MAX_BYTES,
+        ],
+      ] as const) {
+        const [ok, payload, error] = await request(method, params);
+        expect(ok).toBe(false);
+        expect(payload).toBeUndefined();
+        expect(error).toMatchObject({ code: "INVALID_REQUEST", details: { type, maxBytes } });
+      }
+      expect(fs.existsSync(path.join(state.stateDir, "transcripts"))).toBe(false);
+    });
+  });
+
+  it("keeps configured capture intent out of RPC results and durable session metadata", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const source = { providerId: "fixture-voice", channelId: "room" };
+      const cfg = { transcripts: { autoStart: [source] } };
+      const provider = vi
+        .spyOn(transcriptProviders, "getTranscriptSourceProvider")
+        .mockReturnValue({
+          id: source.providerId,
+          name: "Fixture voice",
+          sourceKinds: ["live-audio"],
+          accessControl: {
+            channelId: "discord",
+            resolveAccountId: () => ({ ok: true, value: "default" }),
+            authorize: async () => ({ ok: true, value: undefined }),
+          },
+          start: async ({ session }) => ({ ok: true, session }),
+        });
+      try {
+        const store = new TranscriptsStore(path.join(state.stateDir, "transcripts"));
+        await startTranscripts({
+          ctx: { config: cfg, stateDir: state.stateDir, logger: { warn: vi.fn() } },
+          store,
+          rawParams: { ...source, sessionId: "configured-capture" },
+          configuredLifecycle: true,
+        });
+        const [ok, payload] = await request("transcripts.status", {}, cfg);
+        expect(ok).toBe(true);
+        expect(payload).toMatchObject({
+          configuredSources: [{ state: "armed" }],
+          active: [{ source: { accountId: "default" }, activeSubscription: true }],
+        });
+        expect(JSON.stringify(payload)).not.toContain('configuredSource"');
+        expect(JSON.stringify(await store.readSession("configured-capture"))).not.toContain(
+          "configuredSource",
+        );
+      } finally {
+        provider.mockRestore();
+        activeSessions.clear();
+      }
+    });
+  });
+
+  it("denies every global archive read for sessions.others:none even with allowed or forged agent filters", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const { selector } = await seed(state.stateDir);
+      const profile = ensureProfileForEmail("transcript-guest@example.test");
+      const cfg = roles("none");
+      const queries: Array<[string, Record<string, unknown>]> = [
+        ["transcripts.list", {}],
+        ["transcripts.list", { agentId: "main" }],
+        ["transcripts.list", { agentId: "ops" }],
+        ["transcripts.get", { selector }],
+        ["transcripts.export", { selector, format: "jsonl" }],
+        ["transcripts.status", {}],
+      ];
+      for (const [method, params] of queries) {
+        const [ok, payload, error] = await request(method, params, cfg, client(profile.id));
+        expect(ok, method).toBe(false);
+        expect(payload).toBeUndefined();
+        expect(error).toMatchObject({ code: "FORBIDDEN" });
+      }
+      expect((await request("transcripts.list", {}, cfg, client()))[2]).toMatchObject({
+        code: "FORBIDDEN",
+      });
+      expect(fs.existsSync(path.join(state.stateDir, "transcripts"))).toBe(false);
+    });
+  });
+
+  it("preserves global reads for view roles and admins without treating the creation agent allowlist as read scope", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const { selector } = await seed(state.stateDir);
+      const profile = ensureProfileForEmail("transcript-reader@example.test");
+      const caller = client(profile.id);
+      const [ok, payload] = await request(
+        "transcripts.list",
+        { agentId: "ops" },
+        roles("view"),
+        caller,
+      );
+      expect(ok).toBe(true);
+      expect(payload).toMatchObject({
+        sessions: [{ selector, agentId: "ops", utteranceCount: 1 }],
+      });
+      expect((await request("transcripts.get", { selector }, roles("view"), caller))[0]).toBe(true);
+      expect(
+        (
+          await request("transcripts.export", { selector, format: "jsonl" }, roles("view"), caller)
+        )[1],
+      ).toMatchObject({ encoding: "base64", selector });
+      expect(
+        (
+          await request(
+            "transcripts.list",
+            {},
+            roles("none"),
+            client(profile.id, ["operator.admin"]),
+          )
+        )[0],
+      ).toBe(true);
+      expect(
+        (await request("transcripts.get", { selector, agentId: "main" }, roles("view"), caller))[2],
+      ).toMatchObject({ code: "INVALID_REQUEST" });
+      expect(fs.existsSync(path.join(state.stateDir, "transcripts"))).toBe(false);
+    });
+  });
+
+  it("does not expose hidden legacy URL content through authorized search, reads or exports", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const hidden = [
+        "fixture-user-amber",
+        "fixture-pass-cobalt",
+        "fixture-query-violet",
+        "fixture-fragment-ochre",
+      ];
+      const url = new URL(`https://example.test/public-room?invite=${hidden[2]}#${hidden[3]}`);
+      url.username = hidden[0]!;
+      url.password = hidden[1]!;
+      const store = new TranscriptsStore(path.join(state.stateDir, "transcripts"));
+      const session = {
+        sessionId: "public-session",
+        title: "Public planning",
+        source: {
+          providerId: "fixture-provider",
+          channelId: "public-channel",
+          meetingUrl: url.href,
+        },
+        startedAt: "2026-08-20T10:00:00.000Z",
+      };
+      await store.writeSession(session);
+      await store.appendUtteranceForSession(session, {
+        text: "Synthetic planning note",
+        final: true,
+      });
+      const profile = ensureProfileForEmail("url-reader@example.test");
+      const caller = client(profile.id);
+      closeOpenClawStateDatabaseForTest();
+      const selector = transcriptSessionSelector(session);
+      const publicOutputs: string[] = [];
+      for (const query of ["PLANNING", "public-session", "public-channel", "fixture-provider"]) {
+        const [ok, payload] = await request("transcripts.list", { query }, roles("view"), caller);
+        expect(ok).toBe(true);
+        expect(payload).toMatchObject({
+          sessions: [{ selector, source: { meetingUrl: "https://example.test/public-room" } }],
+        });
+        publicOutputs.push(JSON.stringify(payload));
+      }
+      for (const query of hidden.flatMap((part) => [part, part.slice(0, -3).toUpperCase()])) {
+        const [ok, payload] = await request("transcripts.list", { query }, roles("view"), caller);
+        expect(ok).toBe(true);
+        expect(payload, query).toMatchObject({ sessions: [], nextCursor: null });
+      }
+      for (const query of ["planning", hidden[0]]) {
+        const denied = await request("transcripts.list", { query }, roles("none"), caller);
+        expect(denied[0]).toBe(false);
+        expect(denied[1]).toBeUndefined();
+        expect(denied[2]).toMatchObject({ code: "FORBIDDEN" });
+        const missingScope = await request(
+          "transcripts.list",
+          { query },
+          roles("view"),
+          client(profile.id, []),
+        );
+        expect(missingScope[0]).toBe(false);
+        expect(missingScope[2]?.details).toMatchObject({ missingScope: "operator.read" });
+      }
+      const [ok, read] = await request(
+        "transcripts.get",
+        { selector, includeUtterances: true },
+        roles("view"),
+        caller,
+      );
+      expect(ok).toBe(true);
+      expect(read).toMatchObject({
+        session: { source: { meetingUrl: "https://example.test/public-room" } },
+        utterances: [{ text: "Synthetic planning note" }],
+      });
+      publicOutputs.push(JSON.stringify(read));
+      for (const format of ["markdown", "jsonl"] as const) {
+        const [exported, payload] = await request(
+          "transcripts.export",
+          { selector, format },
+          roles("view"),
+          caller,
+        );
+        expect(exported).toBe(true);
+        expect(payload).toMatchObject({ selector, encoding: "base64" });
+        const content = Buffer.from((payload as { data: string }).data, "base64").toString("utf8");
+        expect(content).toContain("Synthetic planning note");
+        publicOutputs.push(content);
+      }
+      for (const output of publicOutputs) {
+        for (const part of hidden) {
+          expect(output).not.toContain(part);
+        }
+      }
+      expect((await store.readSession(selector))?.source.meetingUrl).toBe(url.href);
+    });
+  });
+
+  it("uses the normal operator role and scope fence and never advertises a capture mutation method", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      for (const [method, params] of [
+        ["transcripts.list", {}],
+        ["transcripts.get", { selector: "missing" }],
+        ["transcripts.export", { selector: "missing", format: "markdown" }],
+        ["transcripts.status", {}],
+      ] as const) {
+        const denied = await request(method, params, {}, client(undefined, ["operator.questions"]));
+        expect(denied[0]).toBe(false);
+        expect(denied[2]?.details).toMatchObject({ missingScope: "operator.read" });
+        const node = client(undefined, ["operator.admin"]);
+        node.connect.role = "node";
+        expect((await request(method, params, {}, node))[2]).toMatchObject({
+          code: "INVALID_REQUEST",
+          message: "unauthorized role: node",
+        });
+      }
+      expect(
+        (await request("transcripts.start", {}, {}, client(undefined, ["operator.admin"])))[0],
+      ).toBe(false);
+      expect(
+        (await request("transcripts.list", {}, {}, client(undefined, ["operator.write"])))[0],
+      ).toBe(true);
+    });
+  });
+
+  it("waits for the authenticated profile before reading the library", async () => {
+    const caller = client();
+    caller.authenticatedUserId = "pending@example.test";
+    caller.authenticatedGitHubIdentitySync = vi
+      .fn()
+      .mockRejectedValue(new Error("private identity detail"));
+    const result = await request("transcripts.status", {}, roles("view"), caller);
+    expect(result[2]).toMatchObject({
+      code: "UNAVAILABLE",
+      retryable: true,
+      details: { code: "AUTHENTICATED_PROFILE_UNAVAILABLE" },
+    });
+    expect(JSON.stringify(result)).not.toContain("private identity detail");
+  });
+
+  it("rejects invalid requests and missing selectors, and redacts archive failures", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const { session, selector } = await seed(state.stateDir);
+      for (const [method, params] of [
+        ["transcripts.list", { limit: 201 }],
+        ["transcripts.list", { query: "x".repeat(257) }],
+        ["transcripts.list", { startedAfter: "not-a-date" }],
+        ["transcripts.get", { selector, limit: 0 }],
+        ["transcripts.export", { selector, format: "audio" }],
+        ["transcripts.status", { enabled: false }],
+      ] as const) {
+        expect((await request(method, params))[2]).toMatchObject({ code: "INVALID_REQUEST" });
+      }
+      for (const method of ["transcripts.get", "transcripts.export"]) {
+        const params = {
+          selector: "missing",
+          ...(method.endsWith("export") ? { format: "jsonl" } : {}),
+        };
+        expect((await request(method, params))[2]).toMatchObject({
+          code: "INVALID_REQUEST",
+          details: { type: "transcript_session_not_found" },
+        });
+      }
+      expect(logGateway.warn).not.toHaveBeenCalled();
+      const { db } = openOpenClawStateDatabase();
+      executeSqliteQuerySync(
+        db,
+        meetingTranscriptDb(db)
+          .updateTable("meeting_transcript_sessions")
+          .set({ source_json: "private corrupt source /host/private/path" })
+          .where("session_id", "=", session.sessionId),
+      );
+      const result = await request("transcripts.get", { selector });
+      expect(result[2]).toMatchObject({ code: "UNAVAILABLE" });
+      expect(JSON.stringify(result)).not.toContain("/host/private/path");
+      expect(logGateway.warn).toHaveBeenCalledWith(
+        expect.stringMatching(/transcripts\.get failed: SyntaxError/),
+      );
+    });
+  });
 });
 
 describe("meeting transcript RPC", () => {
+  let store: TranscriptsStore;
+
+  const session = {
+    sessionId: "weekly",
+    title: "Design review",
+    startedAt: "2026-08-02T14:00:00.000Z",
+    source: {
+      providerId: "manual-transcript",
+      guildId: "team",
+      meetingUrl: "https://example.com/meeting?token=secret#secret",
+      privateField: "hidden",
+    },
+    metadata: { privateMetadata: "hidden" },
+  };
+
+  async function invoke(method: string, params: Record<string, unknown>) {
+    const respond = vi.fn();
+    const handler = transcriptsHandlers[method];
+    if (!handler) {
+      throw new Error(`missing handler: ${method}`);
+    }
+    await handler({
+      req: { type: "req", id: "test", method },
+      params,
+      respond,
+      client: null,
+      isWebchatConnect: () => false,
+      context: { getRuntimeConfig: () => ({}) } as GatewayRequestContext,
+    });
+    expect(respond).toHaveBeenCalledOnce();
+    const response = respond.mock.calls[0];
+    if (!response) {
+      throw new Error(`missing response: ${method}`);
+    }
+    return response;
+  }
+
+  let state: OpenClawTestState;
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ scenario: "minimal" });
+    const stateDir = state.stateDir;
+    vi.spyOn(transcriptProviders, "getTranscriptSourceProvider").mockReturnValue(undefined);
+    store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    await store.writeSession(session);
+  });
+  afterEach(async () => {
+    activeSessions.clear();
+    vi.restoreAllMocks();
+    closeOpenClawStateDatabaseForTest();
+    await state.cleanup();
+  });
+
   it("lists exact capture counts, first-appearance speakers, and sanitized source fields", async () => {
     const older = { ...session, startedAt: "2026-08-01T14:00:00.000Z" };
     await store.writeSession(older);
@@ -122,7 +522,7 @@ describe("meeting transcript RPC", () => {
     expect((await invoke("transcripts.list", { providerId: "absent" }))[1].sessions).toEqual([]);
   });
 
-  it("reads canonical notes without exporting and lazily bounds the ordered utterance tail", async () => {
+  it("reads canonical notes without exporting and paginates full ordered utterances", async () => {
     const count = resolveTranscriptsConfig({}).maxUtterances + 1;
     for (let index = 0; index < count; index++) {
       await store.appendUtteranceForSession(session, {
@@ -145,16 +545,27 @@ describe("meeting transcript RPC", () => {
     );
     expect(payload.summary.participants).toEqual(["Ada"]);
     expect(payload.utterances).toBeUndefined();
-    const withUtterances = (
-      await invoke("transcripts.get", { selector, includeUtterances: true })
-    )[1];
-    expect(withUtterances.utterances).toHaveLength(count - 1);
-    expect(withUtterances.utterances[0]).toMatchObject({ sequence: 1, text: "line 1" });
-    expect(withUtterances.utterances.at(-1)).toEqual({
+    const utterances: Array<{ sequence: number; text: string }> = [];
+    let cursor: string | null = null;
+    do {
+      const [read, page] = await invoke("transcripts.get", {
+        selector,
+        includeUtterances: true,
+        limit: 100,
+        ...(cursor ? { cursor } : {}),
+      });
+      expect(read).toBe(true);
+      expect(page.utterances.length).toBeLessThanOrEqual(100);
+      utterances.push(...page.utterances);
+      cursor = page.nextCursor;
+    } while (cursor);
+    expect(utterances).toHaveLength(count);
+    expect(utterances[0]).toMatchObject({ sequence: 0, text: "line 0" });
+    expect(utterances.at(-1)).toEqual({
       sequence: count - 1,
       speakerId: "speaker",
       speakerLabel: "Ada",
-      text: "x".repeat(4000),
+      text: "x".repeat(5000),
       final: true,
     });
   });

--- a/src/gateway/server-methods/transcripts.test.ts
+++ b/src/gateway/server-methods/transcripts.test.ts
@@ -112,7 +112,7 @@ describe("transcript Gateway read authorization and errors", () => {
       for (const [method, params, type, maxBytes] of [
         [
           "transcripts.get",
-          { selector, includeUtterances: true },
+          { selector, includeUtterances: true, limit: 50 },
           "transcript_result_too_large",
           TRANSCRIPTS_RESULT_MAX_BYTES,
         ],
@@ -524,9 +524,14 @@ describe("meeting transcript RPC", () => {
 
   it("reads canonical notes without exporting and paginates full ordered utterances", async () => {
     const count = resolveTranscriptsConfig({}).maxUtterances + 1;
+    const finalSpeech = "x".repeat(3999) + "😀" + "x".repeat(1000);
     for (let index = 0; index < count; index++) {
       await store.appendUtteranceForSession(session, {
-        text: index === count - 1 ? "\u001b[31m" + "x".repeat(5000) : `line ${index}`,
+        id: `speech-${index}`,
+        text:
+          index === count - 1
+            ? "\u001b[31m" + finalSpeech
+            : `line ${index}` + (index < 2 ? "" : "x".repeat(600)),
         speaker: { id: "speaker", label: "Ada" },
         final: true,
         metadata: { private: true },
@@ -545,6 +550,41 @@ describe("meeting transcript RPC", () => {
     );
     expect(payload.summary.participants).toEqual(["Ada"]);
     expect(payload.utterances).toBeUndefined();
+    const [recentRead, recent] = await invoke("transcripts.get", {
+      selector,
+      includeUtterances: true,
+    });
+    expect(recentRead).toBe(true);
+    expect(recent.utterances).toHaveLength(count - 1);
+    expect(recent.utterances[0]).toMatchObject({ sequence: 1, text: "line 1" });
+    expect(recent.utterances.at(-1)).toEqual({
+      sequence: count - 1,
+      speakerId: "speaker",
+      speakerLabel: "Ada",
+      text: "x".repeat(3999),
+      final: true,
+    });
+    expect(recent.nextCursor).toBeNull();
+    expect(Buffer.byteLength(JSON.stringify(recent))).toBeGreaterThan(1024 * 1024);
+    const [, searched] = await invoke("transcripts.get", {
+      selector,
+      includeUtterances: true,
+      query: "line",
+    });
+    expect(searched.utterances).toHaveLength(50);
+    expect(searched.utterances[0]).toMatchObject({ sequence: 0 });
+    const [, first] = await invoke("transcripts.get", {
+      selector,
+      includeUtterances: true,
+      limit: 1,
+    });
+    const [, next] = await invoke("transcripts.get", {
+      selector,
+      includeUtterances: true,
+      cursor: first.nextCursor,
+    });
+    expect(next.utterances).toHaveLength(50);
+    expect(next.utterances[0]).toMatchObject({ sequence: 1 });
     const utterances: Array<{ sequence: number; text: string }> = [];
     let cursor: string | null = null;
     do {
@@ -563,9 +603,10 @@ describe("meeting transcript RPC", () => {
     expect(utterances[0]).toMatchObject({ sequence: 0, text: "line 0" });
     expect(utterances.at(-1)).toEqual({
       sequence: count - 1,
+      id: `speech-${count - 1}`,
       speakerId: "speaker",
       speakerLabel: "Ada",
-      text: "x".repeat(5000),
+      text: finalSpeech,
       final: true,
     });
   });

--- a/src/gateway/server-methods/transcripts.ts
+++ b/src/gateway/server-methods/transcripts.ts
@@ -1,92 +1,118 @@
-import path from "node:path";
 import {
   ErrorCodes,
   errorShape,
-  validateTranscriptsGetParams,
   validateTranscriptsListParams,
+  validateTranscriptsGetParams,
+  validateTranscriptsExportParams,
+  validateTranscriptsStatusParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isTranscriptSessionActive, resolveSourceProvider } from "../../transcripts/capture.js";
-import { resolveTranscriptsConfig } from "../../transcripts/config.js";
-import { projectTranscriptSession, readTranscriptNotes } from "../../transcripts/read.js";
-import type { TranscriptReadEntry } from "../../transcripts/store-read.js";
-import { TranscriptsStore } from "../../transcripts/store.js";
-import { truncateUtf16Safe } from "../../utils.js";
-import type { GatewayRequestHandlers } from "./types.js";
-import { assertValidParams } from "./validation.js";
+import { createTranscriptsStore } from "../../transcripts/capture-operations.js";
+import { resolveSourceProvider } from "../../transcripts/capture.js";
+import {
+  exportTranscriptLibrary,
+  getTranscriptLibrary,
+  listTranscriptLibrary,
+} from "../../transcripts/library.js";
+import { readTranscriptLibraryStatus } from "../../transcripts/status.js";
+import { TranscriptLibraryError } from "../../transcripts/store-read.js";
+import type { TranscriptsStore } from "../../transcripts/store.js";
+import { operatorSessionCap } from "../operator-role-policy.js";
+import { isGatewayAdmin } from "../session-sharing.js";
+import { formatForLog } from "../ws-log.js";
+import type { GatewayRequestHandler, GatewayRequestHandlers } from "./types.js";
+import { assertValidParams, type Validator } from "./validation.js";
 
-function createStore() {
-  const stateDir = resolveStateDir();
-  return new TranscriptsStore(path.join(stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-  });
-}
-
-function projectSessions(entries: TranscriptReadEntry[], config: OpenClawConfig) {
-  const names = new Map<string, string | undefined>();
-  return entries.map((entry) => {
-    const providerId = entry.session.source.providerId;
-    if (!names.has(providerId)) {
-      names.set(
-        providerId,
-        resolveSourceProvider(providerId, { config, stateDir: resolveStateDir(), logger: console })
-          ?.name,
-      );
-    }
-    return projectTranscriptSession(
-      entry,
-      isTranscriptSessionActive(entry.session),
-      names.get(providerId),
-    );
-  });
-}
-
-export const transcriptsHandlers: GatewayRequestHandlers = {
-  "transcripts.list": async ({ params, respond, context }) => {
-    if (!assertValidParams(params, validateTranscriptsListParams, "transcripts.list", respond)) {
+function transcriptReadMethod<T>(
+  method: string,
+  validate: Validator<T>,
+  read: (store: TranscriptsStore, params: T, cfg: OpenClawConfig) => unknown,
+): GatewayRequestHandler {
+  return async ({ params, context, client, respond }) => {
+    if (!assertValidParams(params, validate, method, respond)) {
       return;
     }
-    const entries = createStore().listReadEntries({
-      limit: params.limit ?? 50,
-      providerId: params.providerId,
-    });
-    respond(true, { sessions: projectSessions(entries, context.getRuntimeConfig()) });
-  },
-  "transcripts.get": async ({ params, respond, context }) => {
-    if (!assertValidParams(params, validateTranscriptsGetParams, "transcripts.get", respond)) {
-      return;
-    }
-    const store = createStore();
-    const session = await store.readSession(params.selector);
-    if (!session) {
+    const cfg = context.getRuntimeConfig();
+    // Meeting rows have agent attribution but no person owner. Mirror global
+    // aggregate visibility; an agent filter cannot make hidden archive data readable.
+    if (!isGatewayAdmin(client) && operatorSessionCap(client, cfg) === "none") {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "transcripts session not found", {
-          details: { type: "transcript_session_not_found", selector: params.selector },
-        }),
+        errorShape(
+          ErrorCodes.FORBIDDEN,
+          "The transcript archive includes sessions hidden by your operator role; ask a Gateway administrator for archive access.",
+        ),
       );
       return;
     }
-    const config = context.getRuntimeConfig();
-    const entries = store.listReadEntries({ limit: 1, session });
-    const summary = await readTranscriptNotes(store, session);
-    const utterances = params.includeUtterances
-      ? store
-          .readUtteranceEntries(session, resolveTranscriptsConfig(config.transcripts).maxUtterances)
-          .map((row) => ({
-            sequence: row.sequence,
-            startedAt: row.started_at ?? undefined,
-            endedAt: row.ended_at ?? undefined,
-            speakerId: row.speaker_id ?? undefined,
-            speakerLabel:
-              row.speaker_label === null ? undefined : sanitizeTerminalText(row.speaker_label),
-            text: truncateUtf16Safe(sanitizeTerminalText(row.text), 4000),
-            final: row.final === null ? undefined : row.final === 1,
-          }))
-      : undefined;
-    respond(true, { session: projectSessions(entries, config)[0], summary, utterances });
-  },
+    try {
+      const store = createTranscriptsStore({
+        stateDir: resolveStateDir(),
+        config: cfg,
+        logger: console,
+      });
+      respond(true, await read(store, params, cfg));
+    } catch (error) {
+      if (!(error instanceof TranscriptLibraryError)) {
+        context.logGateway.warn(`${method} failed: ${formatForLog(error)}`);
+      }
+      respond(
+        false,
+        undefined,
+        error instanceof TranscriptLibraryError
+          ? errorShape(ErrorCodes.INVALID_REQUEST, error.message, {
+              details: {
+                type: error.type,
+                ...(error.maxBytes !== undefined ? { maxBytes: error.maxBytes } : {}),
+              },
+            })
+          : errorShape(
+              ErrorCodes.UNAVAILABLE,
+              "The transcript archive could not be read. Check Gateway diagnostics and retry.",
+            ),
+      );
+    }
+  };
+}
+
+export const transcriptsHandlers: GatewayRequestHandlers = {
+  "transcripts.list": transcriptReadMethod(
+    "transcripts.list",
+    validateTranscriptsListParams,
+    (store, params, cfg) => listTranscriptLibrary(store, params, providerNames(cfg)),
+  ),
+  "transcripts.get": transcriptReadMethod(
+    "transcripts.get",
+    validateTranscriptsGetParams,
+    (store, params, cfg) => getTranscriptLibrary(store, params, providerNames(cfg)),
+  ),
+  "transcripts.export": transcriptReadMethod(
+    "transcripts.export",
+    validateTranscriptsExportParams,
+    exportTranscriptLibrary,
+  ),
+  "transcripts.status": transcriptReadMethod(
+    "transcripts.status",
+    validateTranscriptsStatusParams,
+    (store, _params, cfg) => readTranscriptLibraryStatus(store, cfg),
+  ),
 };
+
+function providerNames(config: OpenClawConfig) {
+  const names = new Map<string, string | undefined>();
+  return (providerId: string) => {
+    if (!names.has(providerId)) {
+      names.set(
+        providerId,
+        resolveSourceProvider(providerId, {
+          config,
+          stateDir: resolveStateDir(),
+          logger: console,
+        })?.name,
+      );
+    }
+    return names.get(providerId);
+  };
+}

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -2,11 +2,11 @@
  * Gateway post-attach startup task tests.
  */
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { AuthProfileFailureReason } from "../agents/auth-profiles/types.js";
+import * as configPaths from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import type { PluginHookGatewayContext, PluginHookHandlerMap } from "../plugins/hook-types.js";
@@ -26,6 +26,10 @@ import {
 import { AsyncWorkScope, getAsyncWorkSignal } from "../shared/async-work-scope.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { GatewayConnectionWork } from "./server-connection-work.js";
 import { createGatewayPluginRuntimeGeneration } from "./server-plugin-runtime-generation.js";
 import "./server-startup-outcomes.test-support.js";
@@ -163,12 +167,13 @@ vi.mock("../config/paths.js", async () => {
   const actual = await vi.importActual<typeof import("../config/paths.js")>("../config/paths.js");
   return {
     ...actual,
-    STATE_DIR: "/tmp/openclaw-state",
-    resolveConfigPath: vi.fn(() => "/tmp/openclaw-state/openclaw.json"),
+    get STATE_DIR() {
+      return actual.resolveStateDir();
+    },
+    get CONFIG_PATH() {
+      return actual.resolveConfigPath();
+    },
     resolveGatewayPort: vi.fn(() => 18789),
-    resolveStateDir: vi.fn((env: NodeJS.ProcessEnv = process.env) =>
-      env.OPENCLAW_STATE_DIR?.trim() ? actual.resolveStateDir(env) : "/tmp/openclaw-state",
-    ),
   };
 });
 
@@ -296,6 +301,7 @@ const publishedConnectionDependentSidecars = new Set<SidecarHandle>();
 const publishedGatewayLifetimeSidecars = new Set<SidecarHandle>();
 const publishedPostReadySidecars = new Set<SidecarHandle>();
 const transferredSidecars = new Set<SidecarHandle>();
+let testState: OpenClawTestState;
 
 function adoptSidecars(target: Set<SidecarHandle>, sidecars: ReadonlyArray<SidecarHandle>): void {
   for (const sidecar of sidecars) {
@@ -387,6 +393,7 @@ async function cleanupGatewayTestState(): Promise<void> {
   await cleanup(() => {
     vi.unstubAllEnvs();
   });
+  await cleanup(() => testState?.cleanup());
 
   if (firstError !== undefined) {
     throw firstError;
@@ -476,9 +483,10 @@ function firstGatewayStartCall(
 }
 
 describe("startGatewayPostAttachRuntime", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetGatewayWorkAdmission();
     closeOpenClawStateDatabaseForTest();
+    testState = await createOpenClawTestState({ label: "gateway-post-attach" });
     vi.stubEnv("OPENCLAW_SKIP_CHANNELS", "0");
     vi.stubEnv("OPENCLAW_SKIP_PROVIDERS", "0");
     hoisted.startPluginServices.mockClear();
@@ -544,22 +552,54 @@ describe("startGatewayPostAttachRuntime", () => {
     await cleanupGatewayTestState();
   });
 
+  it("keeps default and explicit startup paths inside the owned fixture root", () => {
+    expect(configPaths.STATE_DIR).toBe(testState.stateDir);
+    expect(configPaths.CONFIG_PATH).toBe(testState.configPath);
+    expect(configPaths.resolveStateDir()).toBe(testState.stateDir);
+    expect(configPaths.resolveConfigPath()).toBe(testState.configPath);
+    expect(createPostAttachParams().defaultWorkspaceDir).toBe(testState.workspaceDir);
+
+    const defaultEnv = {
+      ...testState.env,
+      OPENCLAW_STATE_DIR: undefined,
+      OPENCLAW_CONFIG_PATH: undefined,
+    };
+    expect(configPaths.resolveStateDir(defaultEnv)).toBe(testState.stateDir);
+    expect(configPaths.resolveConfigPath(defaultEnv)).toBe(testState.configPath);
+
+    const explicitStateDir = testState.path("explicit-state");
+    const explicitEnv = { ...defaultEnv, OPENCLAW_STATE_DIR: explicitStateDir };
+    expect(configPaths.resolveStateDir(explicitEnv)).toBe(explicitStateDir);
+    expect(configPaths.resolveConfigPath(explicitEnv)).toBe(
+      path.join(explicitStateDir, "openclaw.json"),
+    );
+    expect(
+      configPaths.resolveConfigPath({
+        ...explicitEnv,
+        OPENCLAW_CONFIG_PATH: testState.path("config", "custom.json"),
+      }),
+    ).toBe(testState.path("config", "custom.json"));
+  });
+
   it("drains tracked sidecars and resets fixture state after the first cleanup failure", async () => {
     const firstError = new Error("first cleanup failure");
     const stopOrder: string[] = [];
     const firstLifetimeSidecar = {
       stop: vi.fn(async () => {
+        expect(fs.existsSync(testState.root)).toBe(true);
         stopOrder.push("lifetime:first");
         throw firstError;
       }),
     };
     const secondLifetimeSidecar = {
       stop: vi.fn(async () => {
+        expect(fs.existsSync(testState.root)).toBe(true);
         stopOrder.push("lifetime:second");
       }),
     };
     const postReadySidecar = {
       stop: vi.fn(async () => {
+        expect(fs.existsSync(testState.root)).toBe(true);
         stopOrder.push("post-ready");
       }),
     };
@@ -580,6 +620,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(getActiveGatewayRootWorkCount()).toBe(0);
     expect(vi.isFakeTimers()).toBe(false);
     expect(process.env.OPENCLAW_CLEANUP_TEST).toBe(originalCleanupEnv);
+    expect(fs.existsSync(testState.root)).toBe(false);
   });
 
   it("re-enables startup-gated methods after post-attach sidecars start", async () => {
@@ -617,7 +658,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(hoisted.startPluginServices).toHaveBeenCalledTimes(1);
     expect(hoisted.prepareInternalHooks).toHaveBeenCalledWith(
       { hooks: { internal: { enabled: false } } },
-      "/tmp/openclaw-workspace",
+      testState.workspaceDir,
       { failureMode: "best-effort" },
     );
     expect(hoisted.commitInternalHooks).toHaveBeenCalledWith({ initial: true });
@@ -1419,7 +1460,7 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("skips heavy restart sentinel refresh when no sentinel file exists", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-no-sentinel-"));
+    const stateDir = fs.mkdtempSync(path.join(testState.root, "openclaw-no-sentinel-"));
     try {
       await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
         hoisted.refreshLatestUpdateRestartSentinel.mockClear();
@@ -1436,7 +1477,7 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("refreshes the restart sentinel when the sentinel row exists", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sentinel-"));
+    const stateDir = fs.mkdtempSync(path.join(testState.root, "openclaw-sentinel-"));
     try {
       await writeRestartSentinel(
         {
@@ -1463,7 +1504,7 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("detects restart sentinel rows in explicit state directories", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sentinel-state-"));
+    const stateDir = fs.mkdtempSync(path.join(testState.root, "openclaw-sentinel-state-"));
     try {
       await writeRestartSentinel(
         {
@@ -1486,7 +1527,7 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("avoids sync filesystem probes while checking restart sentinel presence", async () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-async-sentinel-"));
+    const stateDir = fs.mkdtempSync(path.join(testState.root, "openclaw-async-sentinel-"));
     try {
       await writeRestartSentinel(
         {
@@ -2258,7 +2299,7 @@ describe("startGatewayPostAttachRuntime", () => {
             agents: { defaults: { model: "openai/gpt-5.4" } },
           } as never,
           pluginRegistry: createPostAttachParams().pluginRegistry,
-          defaultWorkspaceDir: "/tmp/openclaw-workspace",
+          defaultWorkspaceDir: testState.workspaceDir,
           deps: {} as never,
           startChannels,
           log: { warn: vi.fn() },
@@ -2297,7 +2338,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const sidecars = startGatewaySidecars({
       cfg: { hooks: { internal: { enabled: false } } } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels,
       onChannelsStarted,
@@ -2674,7 +2715,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const sidecars = await startGatewaySidecars({
       cfg: { hooks: { internal: { enabled: false } } } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       shouldStartPluginServices: () => shouldStartPluginServices,
@@ -2715,7 +2756,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await startGatewaySidecars({
         cfg: { hooks: { internal: { enabled: false } } } as never,
         pluginRegistry: createPostAttachParams().pluginRegistry,
-        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        defaultWorkspaceDir: testState.workspaceDir,
         deps: {} as never,
         startChannels: vi.fn(async () => {}),
         onPluginServices: (handle) => {
@@ -2818,7 +2859,7 @@ describe("startGatewayPostAttachRuntime", () => {
       sidecars = startGatewaySidecars({
         cfg: { hooks: { internal: { enabled: false } } } as never,
         pluginRegistry: registry,
-        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        defaultWorkspaceDir: testState.workspaceDir,
         deps: {} as never,
         startChannels: vi.fn(async () => {}),
         broadcastPluginEvent,
@@ -2948,7 +2989,7 @@ describe("startGatewayPostAttachRuntime", () => {
             agents: { defaults: { model: "openai/gpt-5.6" } },
           } as never,
           pluginRegistry: createPostAttachParams().pluginRegistry,
-          defaultWorkspaceDir: "/tmp/openclaw-workspace",
+          defaultWorkspaceDir: testState.workspaceDir,
           deps: {} as never,
           startChannels: vi.fn(async () => {}),
           log: { warn: vi.fn() },
@@ -2985,7 +3026,7 @@ describe("startGatewayPostAttachRuntime", () => {
     await startGatewaySidecars({
       cfg: { hooks: { internal: { enabled: false } } } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -3184,7 +3225,7 @@ describe("startGatewayPostAttachRuntime", () => {
     await startGatewaySidecars({
       cfg: { hooks: { internal: { enabled: false } } } as never,
       pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -3220,7 +3261,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const sidecars = startGatewaySidecars({
       cfg: { hooks: { internal: { enabled: false } } } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels,
       prewarmPrimaryModel,
@@ -3271,7 +3312,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const sidecars = startGatewaySidecars({
       cfg: {},
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -3394,7 +3435,7 @@ describe("startGatewayPostAttachRuntime", () => {
       startGatewaySidecars({
         cfg: { hooks: { internal: { enabled: false } } } as never,
         pluginRegistry: createPostAttachParams().pluginRegistry,
-        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        defaultWorkspaceDir: testState.workspaceDir,
         deps: {} as never,
         startChannels,
         prewarmPrimaryModel,
@@ -3426,7 +3467,7 @@ describe("startGatewayPostAttachRuntime", () => {
     await startGatewaySidecars({
       cfg: { hooks: { internal: { enabled: false } } } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels,
       log,
@@ -3487,7 +3528,7 @@ describe("startGatewayPostAttachRuntime", () => {
         hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
       } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       onPostReadySidecars: (sidecars) => {
@@ -3543,7 +3584,7 @@ describe("startGatewayPostAttachRuntime", () => {
         hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
       } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels,
       shouldCreatePostReadySidecars: () => !closeStarted,
@@ -3752,7 +3793,7 @@ describe("startGatewayPostAttachRuntime", () => {
         hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
       } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log,
@@ -3781,7 +3822,7 @@ describe("startGatewayPostAttachRuntime", () => {
         hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
       } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -3900,7 +3941,7 @@ describe("startGatewayPostAttachRuntime", () => {
         hooks: { internal: { enabled: false }, gmail: { model: "openai/gpt-5.4" } },
       } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -4358,7 +4399,7 @@ describe("startGatewayPostAttachRuntime", () => {
       await startGatewaySidecars({
         cfg,
         pluginRegistry: createPostAttachParams().pluginRegistry,
-        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        defaultWorkspaceDir: testState.workspaceDir,
         deps,
         startChannels: vi.fn(async () => {}),
         log: { warn: vi.fn() },
@@ -4385,7 +4426,7 @@ describe("startGatewayPostAttachRuntime", () => {
         {
           cfg,
           deps,
-          workspaceDir: "/tmp/openclaw-workspace",
+          workspaceDir: testState.workspaceDir,
         },
       );
       expect(hoisted.triggerInternalHook).toHaveBeenCalledWith(hoisted.startupHookEvent);
@@ -4410,7 +4451,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const result = await startGatewaySidecars({
       cfg: {} as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -4455,7 +4496,7 @@ describe("startGatewayPostAttachRuntime", () => {
         acp: { enabled: true, backend: "acpx" },
       } as never,
       pluginRegistry: createPostAttachParams().pluginRegistry,
-      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      defaultWorkspaceDir: testState.workspaceDir,
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
@@ -4835,7 +4876,7 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(event).toEqual({ port: 18789 });
     expect(ctx.port).toBe(18789);
     expect(ctx.config).toBe(params.gatewayPluginConfigAtStart);
-    expect(ctx.workspaceDir).toBe("/tmp/openclaw-workspace");
+    expect(ctx.workspaceDir).toBe(testState.workspaceDir);
     const getCron = ctx.getCron;
     if (!getCron) {
       throw new Error("gateway_start context did not expose getCron");
@@ -4970,7 +5011,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       ],
       typedHooks: [],
     } as never,
-    defaultWorkspaceDir: "/tmp/openclaw-workspace",
+    defaultWorkspaceDir: testState.workspaceDir,
     deps: {} as never,
     startChannels: vi.fn(async () => {}),
     recoveryRuntime: {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -358,6 +358,7 @@ function scheduleRestartSentinelWakeAfterReady(params: {
 
 function scheduleTranscriptsAutoStartSidecar(params: {
   cfg: OpenClawConfig;
+  getConfig: () => OpenClawConfig;
   startupTrace?: GatewayStartupTrace;
   log: { warn: (msg: string) => void };
   waitForPostReadyWork?: () => Promise<void>;
@@ -375,11 +376,14 @@ function scheduleTranscriptsAutoStartSidecar(params: {
       if (isStopped()) {
         return;
       }
-      const service = createTranscriptsAutoStartService({
-        config: params.cfg,
-        stateDir: resolveStateDir(),
-        logger: params.log,
-      });
+      const service = createTranscriptsAutoStartService(
+        {
+          config: params.cfg,
+          stateDir: resolveStateDir(),
+          logger: params.log,
+        },
+        params.getConfig,
+      );
       stopTranscriptsAutoStart = () => service.stop();
       service.start();
     },
@@ -1608,6 +1612,7 @@ export async function startGatewayPostAttachRuntime(
             newGatewayLifetimeSidecars.push(
               scheduleTranscriptsAutoStartSidecar({
                 cfg: params.gatewayPluginConfigAtStart,
+                getConfig: params.getConfig,
                 startupTrace: params.startupTrace,
                 log: params.log,
                 waitForPostReadyWork: params.waitForPostReadyWork,

--- a/src/gateway/test-helpers.e2e.ts
+++ b/src/gateway/test-helpers.e2e.ts
@@ -270,6 +270,7 @@ export async function connectDeviceAuthReq(params: { url: string; token?: string
 }
 
 export async function startGatewayWithClient(params: {
+  port?: number;
   cfg: unknown;
   configPath: string;
   token: string;
@@ -289,7 +290,7 @@ export async function startGatewayWithClient(params: {
     clearConfigCache();
     clearSessionStoreCacheForTest();
 
-    const port = await getGatewayE2ePortBlock();
+    const port = params.port ?? (await getGatewayE2ePortBlock());
     const startedServer = await startGatewayServer(port, {
       bind: "loopback",
       auth: { mode: "token", token: params.token },

--- a/src/infra/state-migrations.meeting-transcripts-projections.test.ts
+++ b/src/infra/state-migrations.meeting-transcripts-projections.test.ts
@@ -6,6 +6,11 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import {
+  exportTranscriptLibrary,
+  getTranscriptLibrary,
+  listTranscriptLibrary,
+} from "../transcripts/library.js";
 import { safeTranscriptPathSegment } from "../transcripts/store-artifacts.js";
 import { TranscriptsStore } from "../transcripts/store.js";
 import { summarizeTranscripts } from "../transcripts/summary.js";
@@ -144,6 +149,44 @@ describe("meeting transcript Doctor oversized projections", () => {
       expect(harness.detect()).toMatchObject({ hasLegacy: true, pendingImportCount: 0 });
       expect(harness.snapshot()).toEqual(before);
 
+      const readListedCapture = async (expectedSelector: string) => {
+        closeOpenClawStateDatabaseForTest();
+        const reopened = new TranscriptsStore(harness.root, { env: harness.env });
+        const listed = listTranscriptLibrary(reopened, {}).sessions.find(
+          (entry) => entry.sessionId === sessionId,
+        );
+        expect(listed?.selector).toBe(expectedSelector);
+        const selector = listed!.selector;
+        const detail = await getTranscriptLibrary(reopened, { selector, includeUtterances: true });
+        expect(detail.session).toMatchObject({
+          sessionId,
+          selector,
+          utteranceCount: 1,
+          hasSummary: true,
+        });
+        expect(detail.utterances).toEqual([
+          { sequence: 0, text: "Preserve this note.", final: true },
+        ]);
+        for (const format of ["markdown", "jsonl"] as const) {
+          const exported = await exportTranscriptLibrary(reopened, { selector, format });
+          const body = Buffer.from(exported.data, "base64").toString("utf8");
+          expect(exported.selector).toBe(selector);
+          expect(Buffer.byteLength(exported.filename)).toBeLessThanOrEqual(255);
+          expect(body).toContain("Preserve this note.");
+          if (format === "jsonl") {
+            expect(
+              body
+                .trim()
+                .split("\n")
+                .map((line) => JSON.parse(line)),
+            ).toEqual(detail.utterances);
+          }
+        }
+        expect(await reopened.readSession(sessionId)).toEqual(seeded.session);
+      };
+      await readListedCapture(`2026-07-01/${historicalSlug}`);
+      expect(harness.snapshot()).toEqual(before);
+
       const result = await harness.migrate();
       expect(result.warnings).toEqual([]);
       expect(result.changes).toEqual([expect.stringMatching(/1.*oversized/i)]);
@@ -159,9 +202,13 @@ describe("meeting transcript Doctor oversized projections", () => {
         },
       );
       expect(harness.snapshot()).toEqual(expected);
+      await readListedCapture(`2026-07-01/${slug}`);
+      expect(harness.snapshot()).toEqual(expected);
       await expect(fs.stat(harness.root)).rejects.toMatchObject({ code: "ENOENT" });
       expect(harness.detect().hasLegacy).toBe(false);
       await expect(harness.migrate()).resolves.toEqual({ changes: [], warnings: [] });
+      await readListedCapture(`2026-07-01/${slug}`);
+      expect(harness.snapshot()).toEqual(expected);
       const entry = await harness.store.readSessionEntry(`2026-07-01/${slug}`);
       expect(entry?.session).toEqual(seeded.session);
       expect(await harness.store.readSummary(seeded.session)).toEqual({

--- a/src/plugins/manifest-capability-normalizers.ts
+++ b/src/plugins/manifest-capability-normalizers.ts
@@ -21,6 +21,7 @@ import type {
   PluginManifestSecretInputPath,
   PluginManifestToolMetadata,
   PluginManifestToolProfile,
+  PluginManifestTranscriptSource,
 } from "./manifest-types.js";
 
 function isPluginToolProfile(profile: string): profile is PluginManifestToolProfile {
@@ -83,7 +84,7 @@ export function normalizeManifestMcpServers(
 
 function normalizeNamedMetadataRecord<T>(
   value: unknown,
-  normalizeEntry: (entry: Record<string, unknown>) => T | undefined,
+  normalizeEntry: (entry: Record<string, unknown>, id: string) => T | undefined,
 ): Record<string, T> | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -92,12 +93,40 @@ function normalizeNamedMetadataRecord<T>(
   for (const [rawId, rawEntry] of Object.entries(value)) {
     const id = normalizeOptionalString(rawId) ?? "";
     const entry =
-      !id || isBlockedObjectKey(id) || !isRecord(rawEntry) ? undefined : normalizeEntry(rawEntry);
+      !id || isBlockedObjectKey(id) || !isRecord(rawEntry)
+        ? undefined
+        : normalizeEntry(rawEntry, id);
     if (entry) {
       normalized[id] = entry;
     }
   }
   return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export function normalizeManifestTranscriptSources(
+  value: unknown,
+  ownedProviders: readonly string[] = [],
+): Record<string, PluginManifestTranscriptSource> | undefined {
+  const locatorKeys = ["accountId", "guildId", "channelId", "meetingUrl"] as const;
+  return normalizeNamedMetadataRecord(value, (entry, id) => {
+    if (!ownedProviders.includes(id)) {
+      return undefined;
+    }
+    const name = normalizeOptionalString(entry.name);
+    const raw = entry.autoStart;
+    const autoStart: PluginManifestTranscriptSource["autoStart"] =
+      isRecord(raw) &&
+      Object.entries(raw).every(
+        ([key, mode]) =>
+          locatorKeys.some((locator) => locator === key) &&
+          (mode === "optional" || mode === "required"),
+      )
+        ? Object.fromEntries(Object.entries(raw))
+        : undefined;
+    return name || autoStart
+      ? { ...(name ? { name } : {}), ...(autoStart ? { autoStart } : {}) }
+      : undefined;
+  });
 }
 
 const MEDIA_UNDERSTANDING_CAPABILITIES = new Set(["image", "audio", "video"]);

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -315,6 +315,7 @@ function loadRegistryForMinHostVersionCase(params: {
   env?: NodeJS.ProcessEnv;
 }) {
   return loadPluginManifestRegistryCore({
+    installRecords: {},
     ...(params.env ? { env: params.env } : {}),
     candidates: [
       createPluginCandidate({
@@ -341,6 +342,7 @@ function loadRegistryForPluginApiCase(params: {
   idHint?: string;
 }) {
   return loadPluginManifestRegistryCore({
+    installRecords: {},
     ...(params.env ? { env: params.env } : {}),
     candidates: [
       createPluginCandidate({
@@ -3022,6 +3024,7 @@ describe("loadPluginManifestRegistry", () => {
     writeManifest(dir, { id: "codex", configSchema: { type: "object" } });
 
     const registry = loadPluginManifestRegistryCore({
+      installRecords: {},
       candidates: [
         createPluginCandidate({
           idHint: "codex",

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -522,6 +522,7 @@ function buildRecord(params: {
       params.manifest.contracts,
       officialCatalogManifest?.contracts,
     ),
+    transcriptSources: params.manifest.transcriptSources,
     mediaUnderstandingProviderMetadata: params.manifest.mediaUnderstandingProviderMetadata,
     imageGenerationProviderMetadata: params.manifest.imageGenerationProviderMetadata,
     videoGenerationProviderMetadata: params.manifest.videoGenerationProviderMetadata,

--- a/src/plugins/manifest-registry.types.ts
+++ b/src/plugins/manifest-registry.types.ts
@@ -130,6 +130,7 @@ export type PluginManifestRecord = {
   configSchema?: Record<string, unknown>;
   configUiHints?: Record<string, PluginConfigUiHint>;
   contracts?: PluginManifestContracts;
+  transcriptSources?: PluginManifest["transcriptSources"];
   mediaUnderstandingProviderMetadata?: Record<
     string,
     PluginManifestMediaUnderstandingProviderMetadata

--- a/src/plugins/manifest-transcript-sources.test.ts
+++ b/src/plugins/manifest-transcript-sources.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { loadPluginManifest } from "./manifest.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function loadDescriptor(descriptor: unknown, declared = ["captions"]) {
+  const root = tempDirs.make("manifest-transcript-sources-");
+  fs.writeFileSync(
+    path.join(root, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "fixture",
+      configSchema: { type: "object" },
+      contracts: { transcriptSourceProviders: declared },
+      transcriptSources: { captions: descriptor },
+    }),
+  );
+  const result = loadPluginManifest(root);
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  return result.manifest;
+}
+
+describe("manifest transcript source setup", () => {
+  it("normalizes a declared source's static name and closed locator requirements", () => {
+    expect(
+      loadDescriptor({
+        name: " Captions ",
+        autoStart: {
+          accountId: "optional",
+          guildId: "required",
+          channelId: "required",
+          meetingUrl: "optional",
+        },
+      }),
+    ).toHaveProperty("transcriptSources.captions", {
+      name: "Captions",
+      autoStart: {
+        accountId: "optional",
+        guildId: "required",
+        channelId: "required",
+        meetingUrl: "optional",
+      },
+    });
+  });
+  it("allows an explicit empty locator set and an attach-only source name", () => {
+    expect(loadDescriptor({ name: "Captions", autoStart: {} })).toHaveProperty(
+      "transcriptSources.captions.autoStart",
+      {},
+    );
+    expect(loadDescriptor({ name: "Captions" })).toHaveProperty("transcriptSources.captions", {
+      name: "Captions",
+    });
+  });
+  it("does not advertise a descriptor owned by another plugin", () => {
+    expect(
+      loadDescriptor({ name: "Captions", autoStart: {} }, ["other"]).transcriptSources,
+    ).toBeUndefined();
+  });
+  it.each([
+    null,
+    [],
+    "yes",
+    { channelId: "sometimes" },
+    { channelId: "required", token: "required" },
+  ])("does not turn malformed setup %j into offered partial setup", (autoStart) => {
+    expect(
+      loadDescriptor({ name: "Captions", autoStart }).transcriptSources?.captions?.autoStart,
+    ).toBeUndefined();
+  });
+});

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -349,6 +349,14 @@ export type PluginManifestCatalog = {
   order?: number;
 };
 
+/** Static transcript setup metadata; runtime registration does not gate configuration. */
+export type PluginManifestTranscriptSource = {
+  name?: string;
+  autoStart?: Partial<
+    Record<"accountId" | "guildId" | "channelId" | "meetingUrl", "optional" | "required">
+  >;
+};
+
 /** Declarative backup ownership rooted at host-managed state or each configured agent. */
 export type PluginManifestBackupResource = {
   disposition: "include" | "regenerable";
@@ -456,6 +464,8 @@ export type PluginManifest = {
    * compat wiring, and contract coverage without importing plugin runtime.
    */
   contracts?: PluginManifestContracts;
+  /** Setup descriptors keyed by ids owned in contracts.transcriptSourceProviders. */
+  transcriptSources?: Record<string, PluginManifestTranscriptSource>;
   /** Cheap media-understanding provider defaults without importing plugin runtime. */
   mediaUnderstandingProviderMetadata?: Record<
     string,

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -217,6 +217,7 @@ export function loadPluginManifest(
     raw.autoEnableWhenConfiguredProviders,
   );
   const providers = normalizeTrimmedStringList(raw.providers);
+  const contracts = capabilityNormalizers.normalizeManifestContracts(raw.contracts);
   const cliBackends = normalizeTrimmedStringList(raw.cliBackends);
   const rawDoctorContract = isRecord(raw.doctorContract) ? raw.doctorContract : undefined;
   const stateMigrations = parseDoctorStateMigrationDescriptors(rawDoctorContract?.stateMigrations);
@@ -324,7 +325,11 @@ export function loadPluginManifest(
       catalog: capabilityNormalizers.normalizeManifestCatalog(raw.catalog),
       version: normalizeOptionalString(raw.version),
       uiHints: setupNormalizers.normalizeConfigUiHints(raw.uiHints),
-      contracts: capabilityNormalizers.normalizeManifestContracts(raw.contracts),
+      contracts,
+      transcriptSources: capabilityNormalizers.normalizeManifestTranscriptSources(
+        raw.transcriptSources,
+        contracts?.transcriptSourceProviders,
+      ),
       mediaUnderstandingProviderMetadata:
         capabilityNormalizers.normalizeMediaUnderstandingProviderMetadata(
           raw.mediaUnderstandingProviderMetadata,

--- a/src/transcripts/auto-start.ts
+++ b/src/transcripts/auto-start.ts
@@ -1,4 +1,5 @@
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { createTranscriptsStore, stopTranscriptCapture } from "./capture-operations.js";
@@ -14,7 +15,9 @@ import {
   TranscriptStartError,
   type TranscriptsRuntimeContext,
 } from "./capture.js";
+import { hasSameTranscriptCaptureIntent } from "./config-reload.js";
 import { resolveTranscriptsConfig, type ResolvedTranscriptsAutoStartConfig } from "./config.js";
+import { beginConfiguredTranscriptStarts } from "./configured-start-status.js";
 import type { TranscriptOccupancyWatchHandle, TranscriptSourceLocator } from "./provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "./source-locator.js";
 import { transcriptSessionSelector, type TranscriptsStore } from "./store.js";
@@ -52,12 +55,16 @@ async function waitForPendingAutoStartsToSettle(pending: Set<Promise<void>>): Pr
 }
 
 /** Own configured captures independently of the room's provider connection. */
-export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext): {
+export function createTranscriptsAutoStartService(
+  ctx: TranscriptsRuntimeContext,
+  getConfig: () => OpenClawConfig | undefined = () => ctx.config,
+): {
   start: () => void;
   stop: () => Promise<void>;
 } {
   let stopped = false;
   let started = false;
+  let diagnostics: ReturnType<typeof beginConfiguredTranscriptStarts> | undefined;
   const timers = new Set<Timer>();
   const watchers = new Set<TranscriptOccupancyWatchHandle>();
   const startedSessions = new Map<string, symbol>();
@@ -69,6 +76,12 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
   const clearRetry = (index: number) => {
     retries.get(index)?.release();
     retries.delete(index);
+  };
+  const futureTitle = (entry: ResolvedTranscriptsAutoStartConfig, index: number) => {
+    const latest = getConfig();
+    return hasSameTranscriptCaptureIntent(ctx.config?.transcripts, latest?.transcripts)
+      ? resolveTranscriptsConfig(latest?.transcripts).autoStart[index]?.title
+      : entry.title;
   };
   const terminalDiagnostic = (error: unknown) =>
     error instanceof TranscriptStartError && !error.retry ? error.code : undefined;
@@ -160,6 +173,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       "store" | "rawParams" | "abortSignal" | "existingSession" | "onCaptureEnded"
     >,
   ) => {
+    diagnostics?.record(index, capture.lifecycleToken, "starting");
     try {
       const retry = retries.get(index);
       // Both modes validate the exact failed attempt immediately before the
@@ -175,6 +189,13 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
         rawParams: { ...params.rawParams, sessionId: capture.sessionId },
       });
       clearRetry(index);
+      if (!stopped) {
+        diagnostics?.record(
+          index,
+          capture.lifecycleToken,
+          result.status === "ended" ? "ended" : undefined,
+        );
+      }
       return result;
     } catch (error) {
       if (error instanceof TranscriptStartError) {
@@ -215,7 +236,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
         await startCapture(capture, index, {
           store,
           abortSignal: controller.signal,
-          rawParams: entry,
+          rawParams: { ...entry, title: futureTitle(entry, index) },
         });
       } catch (error) {
         if (stopped) {
@@ -225,10 +246,13 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
         const terminal = terminalDiagnostic(error);
         if (terminal || attempt >= AUTO_START_RETRY_ATTEMPTS) {
           clearRetry(index);
+          const diagnostic = terminal ?? "start-failed";
+          diagnostics?.record(index, capture.lifecycleToken, diagnostic);
           ctx.logger.warn(
-            `transcripts autoStart failed provider=${entry.providerId}: ${formatAutoStopDiagnostic(error)} (check the transcripts.autoStart entry in your config)`,
+            `transcripts autoStart source ${index + 1}: ${diagnostic}. Check Meeting capture health in Settings.`,
           );
         } else {
+          diagnostics?.record(index, capture.lifecycleToken, "retrying");
           schedule(() => startContinuous(entry, index, attempt + 1, store), AUTO_START_RETRY_MS);
         }
       }
@@ -249,6 +273,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
     let emptyTimer: Timer | undefined;
     let retryTimer: Timer | undefined;
     let source: TranscriptSourceLocator;
+    let diagnosticToken = Symbol(`transcripts occupancy ${index}`);
     const label = `transcripts autoStart[${index}] provider=${entry.providerId}`;
     const retry = (
       run: () => void,
@@ -262,11 +287,13 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       const terminal = terminalDiagnostic(error);
       if (terminal || attempt >= AUTO_START_RETRY_ATTEMPTS) {
         clearRetry(index);
+        diagnostics?.record(index, diagnosticToken, terminal ?? "start-failed");
         ctx.logger.warn(
           `${label} failed: ${formatAutoStopDiagnostic(error)}; check the entry and provider connection. ${phase === "watch" ? "Restart the gateway to retry occupancy watching." : "Waiting for the next occupancy transition."}`,
         );
         return;
       }
+      diagnostics?.record(index, diagnosticToken, "retrying");
       cancel(retryTimer);
       retryTimer = schedule(run, AUTO_START_RETRY_MS);
     };
@@ -316,6 +343,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             sessionId: candidate?.sessionId ?? createTranscriptSessionId(),
             lifecycleToken: Symbol(label),
           };
+          diagnosticToken = owned.lifecycleToken;
           capture = owned;
           const result = await startCapture(owned, index, {
             store,
@@ -324,7 +352,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
             rawParams: {
               ...entry,
               ...source,
-              title: entry.title,
+              title: futureTitle(entry, index),
             },
             onCaptureEnded: () => {
               if (capture !== owned || stopped || !occupied) {
@@ -471,6 +499,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
         return;
       }
       started = true;
+      diagnostics = beginConfiguredTranscriptStarts(ctx.config?.transcripts);
       const config = resolveTranscriptsConfig(ctx.config?.transcripts);
       if (!config.enabled || !config.autoStart.length) {
         return;
@@ -489,6 +518,7 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       for (const index of retries.keys()) {
         clearRetry(index);
       }
+      diagnostics?.clear();
       for (const watcher of watchers) {
         watcher.stop();
       }

--- a/src/transcripts/capture.ts
+++ b/src/transcripts/capture.ts
@@ -45,6 +45,12 @@ type ActiveTranscriptsSession = {
   providerId: string;
   // Cleanup belongs to the admitted provider, even after registry replacement.
   provider: Pick<TranscriptSourceProvider, "stop">;
+  // Diagnostic request identity, never authority. URLs retain presence only, not invitations.
+  configuredSource?: Readonly<
+    Pick<TranscriptSourceLocator, "providerId" | "accountId" | "guildId" | "channelId"> & {
+      meetingUrl: boolean;
+    }
+  >;
   // Durable timestamps can collide; lifecycle cleanup must match this exact process-owned capture.
   lifecycleToken?: symbol;
   // Keep the capture reserved until provider and durable stop work both finish.
@@ -76,6 +82,26 @@ export function isTranscriptSelectionCurrent(
       (selection.historicalRevision !== undefined &&
         store.readSummaryInputRevision(selection.session) === selection.historicalRevision))
   );
+}
+
+/** Read-only process facts; a retained stop/cleanup owner does not prove capture is armed. */
+export function readTranscriptCaptureSnapshot() {
+  return [...activeSessions.values()]
+    .filter((entry) => entry.phase !== "terminal" && entry.phase !== "failed")
+    .map((entry) => ({
+      session: {
+        sessionId: entry.session.sessionId,
+        startedAt: entry.session.startedAt,
+        source: { ...entry.session.source },
+      },
+      providerId: entry.providerId,
+      configuredSource: entry.configuredSource ? { ...entry.configuredSource } : undefined,
+      lifecycleToken: entry.lifecycleToken,
+      state:
+        entry.phase === "active" && !entry.stopping && !entry.cleanupPending
+          ? ("armed" as const)
+          : ("unknown" as const),
+    }));
 }
 
 export function isTranscriptSessionActive(
@@ -478,6 +504,16 @@ export async function startTranscripts(params: {
     ...sourceFromParams(params.rawParams),
     ...(params.ctx.agentId ? { agentId: params.ctx.agentId } : {}),
   };
+  // Capture omissions before account resolution or provider handoff can replace them.
+  const configuredSource = params.configuredLifecycle
+    ? {
+        providerId: requestedSource.providerId,
+        accountId: requestedSource.accountId,
+        guildId: requestedSource.guildId,
+        channelId: requestedSource.channelId,
+        meetingUrl: Boolean(requestedSource.meetingUrl),
+      }
+    : undefined;
   const provider = resolveSourceProvider(requestedSource.providerId, params.ctx);
   if (!provider?.start) {
     throw new Error(`transcripts provider ${requestedSource.providerId} cannot start live capture`);
@@ -537,6 +573,7 @@ export async function startTranscripts(params: {
     providerId: provider.id,
     provider,
     phase: "starting",
+    configuredSource,
     lifecycleToken: params.lifecycleToken,
   };
   let admitted = false;

--- a/src/transcripts/config-reload.ts
+++ b/src/transcripts/config-reload.ts
@@ -1,0 +1,45 @@
+import { isDeepStrictEqual } from "node:util";
+import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { TranscriptsConfig } from "./config.js";
+
+function withoutTitles(config: TranscriptsConfig | undefined) {
+  return (
+    config && {
+      ...config,
+      ...(config.autoStart && {
+        autoStart: config.autoStart.map(({ title: _title, ...source }) => source),
+      }),
+    }
+  );
+}
+
+/** Compare full source intent before reading titles, without borrowing new routing authority. */
+export function hasSameTranscriptCaptureIntent(
+  previous: TranscriptsConfig | undefined,
+  candidate: TranscriptsConfig | undefined,
+): boolean {
+  return isDeepStrictEqual(withoutTitles(previous), withoutTitles(candidate));
+}
+
+/** Bounded process diagnostic correlation only, never admission or resume authority. */
+export function transcriptCaptureConfigHash(config: TranscriptsConfig | undefined): string {
+  return hashRuntimeConfigValue({ transcripts: withoutTitles(config) });
+}
+
+/** Compare authoritative config, including routing, credentials and full invitation URLs. */
+export function isTranscriptTitleOnlyConfigChange(
+  previous: OpenClawConfig | undefined,
+  candidate: OpenClawConfig | undefined,
+): boolean {
+  if (!previous || !candidate || isDeepStrictEqual(previous.transcripts, candidate.transcripts)) {
+    return false;
+  }
+  const captureConfig = ({ transcripts, meta, ...config }: OpenClawConfig) => {
+    // Only writer bookkeeping is irrelevant to this reload decision. Other
+    // metadata and every non-title config value retain their normal handling.
+    const { lastTouchedVersion: _version, ...metadata } = meta ?? {};
+    return { ...config, meta: metadata, transcripts: withoutTitles(transcripts) };
+  };
+  return isDeepStrictEqual(captureConfig(previous), captureConfig(candidate));
+}

--- a/src/transcripts/config.ts
+++ b/src/transcripts/config.ts
@@ -1,4 +1,3 @@
-// Resolves transcript source configuration from OpenClaw config.
 import { normalizeOptionalString as readString } from "@openclaw/normalization-core/string-coerce";
 
 /**

--- a/src/transcripts/configured-start-status.ts
+++ b/src/transcripts/configured-start-status.ts
@@ -1,0 +1,45 @@
+import {
+  TRANSCRIPTS_PAGE_MAX,
+  type TranscriptsStatusResult,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import { transcriptCaptureConfigHash } from "./config-reload.js";
+import type { TranscriptsConfig } from "./config.js";
+
+type StartDiagnostic = NonNullable<
+  TranscriptsStatusResult["configuredSources"][number]["startDiagnostic"]
+>;
+type StartFact = { lifecycleToken: symbol; diagnostic?: StartDiagnostic };
+type ConfiguredStarts = {
+  configHash: string;
+  entries: Map<number, StartFact>;
+};
+
+// One Gateway service owns this bounded process snapshot. It is never persisted
+// or used to authorize capture, stop, or recovery of an archived session.
+let current: ConfiguredStarts | undefined;
+
+export function beginConfiguredTranscriptStarts(config: TranscriptsConfig | undefined) {
+  const owner: ConfiguredStarts = {
+    configHash: transcriptCaptureConfigHash(config),
+    entries: new Map(),
+  };
+  current = owner;
+  return {
+    record(index: number, lifecycleToken: symbol, diagnostic?: StartDiagnostic) {
+      if (current === owner && index < TRANSCRIPTS_PAGE_MAX) {
+        owner.entries.set(index, { lifecycleToken, diagnostic });
+      }
+    },
+    clear() {
+      if (current === owner) {
+        current = undefined;
+      }
+    },
+  };
+}
+
+export function readConfiguredTranscriptStarts(config: TranscriptsConfig | undefined) {
+  return current && current.configHash === transcriptCaptureConfigHash(config)
+    ? new Map(current.entries)
+    : undefined;
+}

--- a/src/transcripts/library.test-support.ts
+++ b/src/transcripts/library.test-support.ts
@@ -1,0 +1,77 @@
+import type {
+  TranscriptsGetResult,
+  TranscriptsListResult,
+  TranscriptsStatusResult,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+
+export const transcriptListFixture: TranscriptsListResult = {
+  sessions: [
+    {
+      selector: "2026-08-20/team-check-in",
+      sessionId: "team-check-in",
+      title: "Team check-in",
+      source: { providerId: "manual-transcript", kind: "posthoc-transcript" },
+      providerId: "manual-transcript",
+      agentId: "main",
+      startedAt: "2026-08-20T15:00:00.000Z",
+      stoppedAt: "2026-08-20T15:15:00.000Z",
+      updatedAt: "2026-08-20T15:15:01.000Z",
+      utteranceCount: 2,
+      lastUtteranceAt: "2026-08-20T15:14:00.000Z",
+      hasSummary: true,
+      active: false,
+      participants: ["Alex", "Sam"],
+      activeSubscription: false,
+    },
+  ],
+  nextCursor: null,
+};
+export const transcriptGetFixture: TranscriptsGetResult = {
+  session: transcriptListFixture.sessions[0]!,
+  utterances: [
+    {
+      sequence: 0,
+      speakerLabel: "Alex",
+      text: "We agreed to verify the reader before shipping.",
+      startedAt: "2026-08-20T15:00:00.000Z",
+      final: true,
+    },
+    {
+      sequence: 1,
+      speakerLabel: "Sam",
+      text: "Action: check pagination and permissions.",
+      startedAt: "2026-08-20T15:14:00.000Z",
+      final: true,
+    },
+  ],
+  nextCursor: null,
+  summary: {
+    source: "heuristic",
+    participants: ["Alex", "Sam"],
+    markdown: "## Overview\n\nWe agreed to verify the reader before shipping.",
+    generatedAt: "2026-08-20T15:15:01.000Z",
+    overview: "We agreed to verify the reader before shipping.",
+    decisions: ["Alex: We agreed to verify the reader before shipping."],
+    actionItems: ["Sam: Action: check pagination and permissions."],
+    risks: [],
+    utteranceCount: 2,
+  },
+};
+export const transcriptStatusFixture: TranscriptsStatusResult = {
+  enabled: true,
+  providers: [
+    {
+      providerId: "manual-transcript",
+      name: "Manual Transcript Import",
+      availability: "enabled",
+      sourceKinds: ["posthoc-transcript"],
+      canStart: false,
+      canStop: false,
+      canImport: true,
+    },
+  ],
+  configuredSources: [],
+  active: [],
+  latestTranscript: transcriptListFixture.sessions[0]!,
+  omitted: { providers: 0, configuredSources: 0, active: 0 },
+};

--- a/src/transcripts/library.test.ts
+++ b/src/transcripts/library.test.ts
@@ -1,0 +1,917 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_RESULT_MAX_BYTES,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  clearNodeSqliteKyselyCacheForDatabase,
+  executeSqliteQuerySync,
+} from "../infra/kysely-sync.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { activeSessions } from "./capture.js";
+import { exportTranscriptLibrary, getTranscriptLibrary, listTranscriptLibrary } from "./library.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { readTranscriptLibraryStatus } from "./status.js";
+import { meetingTranscriptDb } from "./store-sqlite.js";
+import { TranscriptsStore, transcriptSessionSelector } from "./store.js";
+import { summarizeTranscripts } from "./summary.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  vi.restoreAllMocks();
+  activeSessions.clear();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function fixture() {
+  const stateDir = tempDirs.make("transcript-library-");
+  const options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+  return {
+    stateDir,
+    store: new TranscriptsStore(path.join(stateDir, "transcripts"), options),
+    database: () => openOpenClawStateDatabase(options).db,
+  };
+}
+
+function observeArchiveReads(database: DatabaseSync) {
+  clearNodeSqliteKyselyCacheForDatabase(database);
+  const queries: Array<{
+    sql: string;
+    rows: number;
+    bytes: number;
+    maxRowBytes: number;
+    closed: boolean;
+  }> = [];
+  const prepare = database.prepare.bind(database);
+  vi.spyOn(database, "prepare").mockImplementation((sql) => {
+    const statement = prepare(sql);
+    if (!/^select\b/iu.test(sql) || !sql.includes("meeting_transcript_")) {
+      return statement;
+    }
+    const record = { sql, rows: 0, bytes: 0, maxRowBytes: 0, closed: false };
+    queries.push(record);
+    const iterate = statement.iterate.bind(statement);
+    vi.spyOn(statement, "iterate").mockImplementation((...parameters) => {
+      const iterator = iterate(...parameters);
+      const next = iterator.next.bind(iterator);
+      vi.spyOn(iterator, "next").mockImplementation(() => {
+        const result = next();
+        if (result.done) {
+          record.closed = true;
+        } else {
+          const bytes = Object.values(result.value).reduce<number>(
+            (total, value) => total + (typeof value === "string" ? Buffer.byteLength(value) : 0),
+            0,
+          );
+          record.rows++;
+          record.bytes += bytes;
+          record.maxRowBytes = Math.max(record.maxRowBytes, bytes);
+        }
+        return result;
+      });
+      if (iterator.return) {
+        const finish = iterator.return.bind(iterator);
+        vi.spyOn(iterator, "return").mockImplementation(() => {
+          record.closed = true;
+          return finish();
+        });
+      }
+      return iterator;
+    });
+    return statement;
+  });
+  return queries;
+}
+function session(
+  sessionId: string,
+  overrides: Partial<TranscriptSessionDescriptor> = {},
+): TranscriptSessionDescriptor {
+  return {
+    sessionId,
+    title: sessionId,
+    source: { providerId: "manual-transcript" },
+    startedAt: "2026-08-20T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("transcript library SQLite reads", () => {
+  it("orders and filters stored offset dates by instant without rewriting their identities", async () => {
+    const { store } = fixture();
+    const rows = [
+      session("offset-at-1000", { startedAt: "2026-08-20T03:00:00-07:00" }),
+      session("utc-at-0930", { startedAt: "2026-08-20T09:30:00.000Z" }),
+      session("utc-at-1030", { startedAt: "2026-08-20T10:30:00.000Z" }),
+    ];
+    for (const row of rows) {
+      await store.writeSession(row);
+    }
+    const result = listTranscriptLibrary(store, { startedAfter: "2026-08-20T09:00:00Z" });
+    expect(result.sessions.map(({ sessionId }) => sessionId)).toEqual([
+      "utc-at-1030",
+      "offset-at-1000",
+      "utc-at-0930",
+    ]);
+    for (const row of rows) {
+      expect(await store.readSession(transcriptSessionSelector(row))).toEqual(row);
+    }
+  });
+
+  it("paginates equal instants and unknown dates using original identity ties and date-string semantics", async () => {
+    const env = captureEnv(["TZ"]);
+    setTestEnvValue("TZ", "America/Los_Angeles");
+    try {
+      const { store } = fixture();
+      const ordered = [
+        session("local", { startedAt: "2026-08-20T06:00:00" }),
+        session("later", { startedAt: "2026-08-20T06:30:00Z" }),
+        session("fraction-tail", { startedAt: "2026-08-20T06:00:00.9999Z" }),
+        session("basic", { startedAt: "2026-08-20T06:00:00+0000" }),
+        session("fraction", { startedAt: "2026-08-20T06:00:00.0005Z" }),
+        session("same", { startedAt: "2026-08-19T23:00:00-07:00" }),
+        session("same", { startedAt: "2026-08-20T06:00:00.000Z" }),
+        session("earlier", { startedAt: "2026-08-20T05:30:00Z" }),
+        session("unknown", { startedAt: "2026-08-21Tbad" }),
+        session("unknown", { startedAt: "2026-08-22Tbad" }),
+        session("unknown-z", { startedAt: "2026-08-20Tbad" }),
+      ];
+      for (const row of ordered.toReversed()) {
+        await store.writeSession(row);
+      }
+      const seen: Array<{ sessionId: string; startedAt: string; selector: string }> = [];
+      let cursor: string | undefined;
+      for (let index = 0; index < ordered.length; index++) {
+        const page = listTranscriptLibrary(store, { limit: 1, cursor });
+        expect(page.sessions).toHaveLength(1);
+        const { sessionId, startedAt, selector } = page.sessions[0]!;
+        seen.push({ sessionId, startedAt, selector });
+        if (index === ordered.length - 1) {
+          expect(page.nextCursor).toBeNull();
+        } else {
+          expect(page.nextCursor).toEqual(expect.any(String));
+          cursor = page.nextCursor!;
+        }
+      }
+      expect(seen).toEqual(
+        ordered.map((row) => ({
+          sessionId: row.sessionId,
+          startedAt: row.startedAt,
+          selector: transcriptSessionSelector(row),
+        })),
+      );
+      expect(
+        listTranscriptLibrary(store, {
+          startedAfter: "2026-08-20T06:00:00.0005Z",
+          startedBefore: "2026-08-20T06:00:00.001Z",
+        }).sessions.map(({ sessionId }) => sessionId),
+      ).toEqual(["basic", "fraction", "same", "same"]);
+      expect(
+        listTranscriptLibrary(store, {
+          startedAfter: "2026-08-20T06:00:00",
+          startedBefore: "2026-08-20T13:00:00.001Z",
+        }).sessions.map(({ sessionId }) => sessionId),
+      ).toEqual(["local"]);
+    } finally {
+      env.restore();
+    }
+  });
+
+  it.each(["at-cap", "oversized-ascii", "oversized-utf8"] as const)(
+    "bounds %s stored date input before the JavaScript parser",
+    async (kind) => {
+      const { store } = fixture();
+      const prefix = "2026-08-20T";
+      const remaining = TRANSCRIPTS_RESULT_MAX_BYTES - prefix.length;
+      const startedAt =
+        prefix +
+        (kind === "oversized-utf8"
+          ? "é".repeat(Math.floor(remaining / 2) + 1)
+          : "x".repeat(remaining + Number(kind === "oversized-ascii")));
+      await store.writeSession(session(kind, { startedAt }));
+      const parse = vi.spyOn(Date, "parse");
+      expect(() => listTranscriptLibrary(store, {})).toThrow(
+        expect.objectContaining({ type: "transcript_result_too_large" }),
+      );
+      expect(parse.mock.calls.some(([value]) => value === startedAt)).toBe(kind === "at-cap");
+    },
+  );
+
+  it("keeps unread notes outside the chronological page and its lookahead", async () => {
+    const { store, database } = fixture();
+    const old = session("old", { startedAt: "2026-08-18T00:00:00Z" });
+    await store.writeSession(old);
+    await store.writeSummary(summarizeTranscripts({ session: old, utterances: [] }), old);
+    const db = database();
+    executeSqliteQuerySync(
+      db,
+      meetingTranscriptDb(db)
+        .updateTable("meeting_transcript_summaries")
+        .set({ summary_json: "unreadable old notes" })
+        .where("session_id", "=", old.sessionId),
+    );
+    for (const id of ["b", "a"]) {
+      await store.writeSession(session(id));
+    }
+    const result = listTranscriptLibrary(store, { limit: 1 });
+    expect(result.sessions.map(({ sessionId }) => sessionId)).toEqual(["a"]);
+    expect(result.nextCursor).toEqual(expect.any(String));
+  });
+
+  it("shares date registration across readers and registers a fresh canonical connection after close", async () => {
+    const { store, database } = fixture();
+    await store.writeSession(session("one"));
+    const db = database();
+    const schema = db.prepare("SELECT type, name, sql FROM sqlite_schema ORDER BY name").all();
+    expect(listTranscriptLibrary(store, {}).sessions).toHaveLength(1);
+    const held = db.prepare("SELECT 1 UNION ALL SELECT 2").iterate();
+    held.next();
+    try {
+      expect(listTranscriptLibrary(store, {}).sessions).toHaveLength(1);
+    } finally {
+      held.return?.();
+    }
+    expect(db.prepare("SELECT type, name, sql FROM sqlite_schema ORDER BY name").all()).toEqual(
+      schema,
+    );
+    closeOpenClawStateDatabaseForTest();
+    expect(database() === db).toBe(false);
+    expect(listTranscriptLibrary(store, {}).sessions).toHaveLength(1);
+  });
+
+  it("stops active status descriptor reads when the public result budget is consumed", async () => {
+    const { store, database } = fixture();
+    for (let index = 0; index < 6; index++) {
+      const target = session(`active-${index}`, {
+        title: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES / 2),
+      });
+      await store.writeSession(target);
+      activeSessions.set(target.sessionId, {
+        session: target,
+        providerId: target.source.providerId,
+        provider: {},
+        phase: "active",
+      });
+    }
+    const reads = observeArchiveReads(database());
+    await expect(readTranscriptLibraryStatus(store, {})).rejects.toThrow(
+      expect.objectContaining({ type: "transcript_result_too_large" }),
+    );
+    expect(
+      reads.filter((read) => read.sql.includes('from "meeting_transcript_sessions"')).length,
+    ).toBeLessThanOrEqual(3);
+  });
+
+  it.each(["text", "combined speaker and metadata"])(
+    "bounds %s before SQLite returns an oversized row",
+    async (kind) => {
+      const { store, database } = fixture();
+      const target = session("allocation");
+      await store.writeSession(target);
+      const payload = "é\0".repeat(TRANSCRIPTS_RESULT_MAX_BYTES / 2);
+      await store.appendUtteranceForSession(
+        target,
+        kind === "text"
+          ? { text: payload }
+          : {
+              text: "small",
+              speaker: { id: "x".repeat(400_000), label: "y".repeat(400_000) },
+              metadata: { private: "z".repeat(400_000) },
+            },
+      );
+      const reads = observeArchiveReads(database());
+      await expect(
+        getTranscriptLibrary(store, {
+          selector: transcriptSessionSelector(target),
+          includeUtterances: true,
+        }),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          type: "transcript_result_too_large",
+          maxBytes: TRANSCRIPTS_RESULT_MAX_BYTES,
+        }),
+      );
+      expect(reads.length).toBeGreaterThan(0);
+      expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+        TRANSCRIPTS_RESULT_MAX_BYTES,
+      );
+      expect(reads.every((read) => read.closed)).toBe(true);
+      expect(await store.readUtterancesForSession(target)).toHaveLength(1);
+    },
+  );
+
+  it("stops a cumulative page before consuming the remaining rows and releases its iterator", async () => {
+    const { store, database } = fixture();
+    const target = session("cumulative");
+    await store.writeSession(target);
+    for (let index = 0; index < 6; index++) {
+      await store.appendUtteranceForSession(target, {
+        text: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES / 2),
+      });
+    }
+    const reads = observeArchiveReads(database());
+    expect(() => store.readUtterancePage(target, { limit: 6 })).toThrow(
+      expect.objectContaining({ type: "transcript_result_too_large" }),
+    );
+    const page = reads.find((read) => read.sql.includes('"sequence"'))!;
+    expect(page.rows).toBeLessThanOrEqual(3);
+    expect(page.bytes).toBeLessThanOrEqual(2 * TRANSCRIPTS_RESULT_MAX_BYTES);
+    expect(page.closed).toBe(true);
+    await store.appendUtteranceForSession(target, { text: "after rejection" });
+    expect(store.readUtterancePage(target, { after: 5 }).utterances).toMatchObject([
+      { text: "after rejection", sequence: 6 },
+    ]);
+  });
+
+  it("uses oversized lookahead only for pagination, then rejects that requested row", async () => {
+    const { store, database } = fixture();
+    const target = session("lookahead");
+    await store.writeSession(target);
+    await store.appendUtteranceForSession(target, { text: "first" });
+    await store.appendUtteranceForSession(target, {
+      text: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES + 1),
+    });
+    const reads = observeArchiveReads(database());
+    const first = await getTranscriptLibrary(store, {
+      selector: transcriptSessionSelector(target),
+      includeUtterances: true,
+      limit: 1,
+    });
+    expect(first.utterances).toEqual([{ sequence: 0, text: "first" }]);
+    expect(first.nextCursor).not.toBeNull();
+    expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+      TRANSCRIPTS_RESULT_MAX_BYTES,
+    );
+    await expect(
+      getTranscriptLibrary(store, {
+        selector: first.session.selector,
+        includeUtterances: true,
+        limit: 1,
+        cursor: first.nextCursor!,
+      }),
+    ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
+  });
+
+  it.each(["title", "source and metadata", "last timestamp"])(
+    "bounds %s in list, selector and latest descriptors without limiting full-store reads",
+    async (field) => {
+      const { store, database } = fixture();
+      const target = session(
+        "descriptor",
+        field === "title"
+          ? { title: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES + 1) }
+          : field === "source and metadata"
+            ? {
+                source: { providerId: "manual-transcript", private: "x".repeat(600_000) },
+                metadata: { private: "y".repeat(600_000) },
+              }
+            : {},
+      );
+      await store.writeSession(target);
+      await store.appendUtteranceForSession(target, {
+        text: "note",
+        ...(field === "last timestamp"
+          ? { endedAt: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES + 1) }
+          : {}),
+      });
+      const reads = observeArchiveReads(database());
+      expect(() => listTranscriptLibrary(store, {})).toThrow(
+        expect.objectContaining({ type: "transcript_result_too_large" }),
+      );
+      expect(() => store.readLatestEntry()).toThrow(
+        expect.objectContaining({ type: "transcript_result_too_large" }),
+      );
+      expect(() => store.readEntry(transcriptSessionSelector(target))).toThrow(
+        expect.objectContaining({ type: "transcript_result_too_large" }),
+      );
+      expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+        TRANSCRIPTS_RESULT_MAX_BYTES,
+      );
+      expect(store.readEntry(target.sessionId)).toBeUndefined();
+      expect(await store.readSession(target.sessionId)).toEqual(target);
+    },
+  );
+
+  it("streams list projections, preserves oversized lookahead and does not retain private metadata across rows", async () => {
+    const { store, database } = fixture();
+    const first = session("a");
+    const second = session("b", { title: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES + 1) });
+    await store.writeSession(first);
+    await store.writeSession(second);
+    const reads = observeArchiveReads(database());
+    const page = listTranscriptLibrary(store, { limit: 1 });
+    expect(page.sessions.map((entry) => entry.sessionId)).toEqual(["a"]);
+    expect(page.nextCursor).not.toBeNull();
+    expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+      TRANSCRIPTS_RESULT_MAX_BYTES,
+    );
+    expect(() => listTranscriptLibrary(store, { cursor: page.nextCursor! })).toThrow(
+      expect.objectContaining({ type: "transcript_result_too_large" }),
+    );
+    for (const id of ["b", "c", "d"]) {
+      await store.writeSession(session(id, { title: "x".repeat(600_000) }));
+    }
+    reads.length = 0;
+    expect(() => listTranscriptLibrary(store, { query: "x" })).toThrow(
+      expect.objectContaining({ type: "transcript_result_too_large" }),
+    );
+    expect(reads[0]?.rows).toBe(2);
+    expect(reads.every((read) => read.closed)).toBe(true);
+    for (const id of ["b", "c", "d"]) {
+      await store.writeSession(session(id, { metadata: { private: "x".repeat(600_000) } }));
+    }
+    expect(listTranscriptLibrary(store, {}).sessions.map((entry) => entry.sessionId)).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+    ]);
+  });
+
+  it("bounds summary transfer after omitting duplicated history and keeps the larger export budget", async () => {
+    const { store, database } = fixture();
+    const target = session("summary-bound");
+    await store.writeSession(target);
+    await store.appendUtteranceForSession(target, { text: "saved note" });
+    const summary = {
+      ...summarizeTranscripts({ session: target, utterances: [] }),
+      transcript: ["x".repeat(TRANSCRIPTS_EXPORT_MAX_BYTES + 1)],
+    };
+    await store.writeSummary({ ...summary, transcript: [] }, target);
+    const db = database();
+    executeSqliteQuerySync(
+      db,
+      meetingTranscriptDb(db)
+        .updateTable("meeting_transcript_summaries")
+        .set({ summary_json: JSON.stringify(summary) })
+        .where("session_id", "=", target.sessionId)
+        .where("session_started_at", "=", target.startedAt),
+    );
+    const reads = observeArchiveReads(database());
+    expect(
+      (await getTranscriptLibrary(store, { selector: transcriptSessionSelector(target) })).summary
+        ?.overview,
+    ).toBe(summary.overview);
+    expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+      TRANSCRIPTS_RESULT_MAX_BYTES,
+    );
+    await store.writeSummary(
+      { ...summary, transcript: [], overview: "é".repeat(TRANSCRIPTS_RESULT_MAX_BYTES / 2 + 1) },
+      target,
+    );
+    reads.length = 0;
+    await expect(
+      getTranscriptLibrary(store, { selector: transcriptSessionSelector(target) }),
+    ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
+    expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+      TRANSCRIPTS_RESULT_MAX_BYTES,
+    );
+    const exported = await exportTranscriptLibrary(store, {
+      selector: transcriptSessionSelector(target),
+      format: "markdown",
+    });
+    expect(exported.sizeBytes).toBeGreaterThan(TRANSCRIPTS_RESULT_MAX_BYTES);
+    expect(exported.sizeBytes).toBeLessThan(TRANSCRIPTS_EXPORT_MAX_BYTES);
+    expect(Buffer.from(exported.data, "base64").toString("utf8")).toContain("saved note");
+  });
+
+  it("keeps exact JSON escaping checks and exports valid content above the reader limit", async () => {
+    const { store, database } = fixture();
+    const target = session("escaping");
+    await store.writeSession(target);
+    const text = '"'.repeat(600_000) + "é🦞";
+    await store.appendUtteranceForSession(target, { text });
+    const reads = observeArchiveReads(database());
+    await expect(
+      getTranscriptLibrary(store, {
+        selector: transcriptSessionSelector(target),
+        includeUtterances: true,
+      }),
+    ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
+    const exported = await exportTranscriptLibrary(store, {
+      selector: transcriptSessionSelector(target),
+      format: "jsonl",
+    });
+    expect(exported.sizeBytes).toBeGreaterThan(TRANSCRIPTS_RESULT_MAX_BYTES);
+    expect(exported.sizeBytes).toBeLessThan(TRANSCRIPTS_EXPORT_MAX_BYTES);
+    expect(JSON.parse(Buffer.from(exported.data, "base64").toString("utf8"))).toEqual({
+      sequence: 0,
+      text,
+    });
+    await store.appendUtteranceForSession(target, {
+      text: "x".repeat(TRANSCRIPTS_EXPORT_MAX_BYTES + 1),
+    });
+    reads.length = 0;
+    await expect(
+      exportTranscriptLibrary(store, {
+        selector: transcriptSessionSelector(target),
+        format: "jsonl",
+      }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        type: "transcript_export_too_large",
+        maxBytes: TRANSCRIPTS_EXPORT_MAX_BYTES,
+      }),
+    );
+    expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
+      TRANSCRIPTS_EXPORT_MAX_BYTES,
+    );
+    expect(reads.every((read) => read.closed)).toBe(true);
+  });
+
+  it("pages with a stable tie-break, a default of 50, and an explicit upper bound", async () => {
+    const { store } = fixture();
+    for (let index = 0; index < 103; index++) {
+      await store.writeSession(session(`session-${String(index).padStart(3, "0")}`));
+    }
+    const first = listTranscriptLibrary(store, {});
+    expect(first.sessions).toHaveLength(50);
+    const second = listTranscriptLibrary(store, { cursor: first.nextCursor! });
+    const third = listTranscriptLibrary(store, { cursor: second.nextCursor! });
+    expect(second.sessions).toHaveLength(50);
+    expect(third.sessions).toHaveLength(3);
+    expect(third.nextCursor).toBeNull();
+    expect(
+      [...first.sessions, ...second.sessions, ...third.sessions].map((entry) => entry.sessionId),
+    ).toEqual(
+      Array.from({ length: 103 }, (_, index) => `session-${String(index).padStart(3, "0")}`),
+    );
+    expect(listTranscriptLibrary(store, { limit: 100 }).sessions).toHaveLength(100);
+    expect(listTranscriptLibrary(store, { limit: 200 }).sessions).toHaveLength(103);
+    for (const limit of [0, 201, 1.5]) {
+      expect(() => listTranscriptLibrary(store, { limit })).toThrow("between 1 and 200");
+    }
+    await store.writeSession(session("newer", { startedAt: "2026-08-21T10:00:00.000Z" }));
+    expect(listTranscriptLibrary(store, { cursor: first.nextCursor! }).sessions[0]?.sessionId).toBe(
+      "session-050",
+    );
+  });
+
+  it("combines literal title/source search, exact owner/account/provider filters and inclusive/exclusive dates", async () => {
+    const { store } = fixture();
+    const source = {
+      providerId: "room-provider",
+      accountId: "work",
+      channelId: "room-a",
+      kind: "live-audio" as const,
+    };
+    await store.writeSession(
+      session("one", { title: "100% Launch_review", source, metadata: { agentId: "ops" } }),
+    );
+    await store.writeSession(
+      session("two", {
+        source,
+        metadata: { agentId: "main" },
+        startedAt: "2026-08-21T10:00:00.000Z",
+      }),
+    );
+    await store.writeSession(session("legacy", { source }));
+    const filters = {
+      providerId: "room-provider",
+      accountId: "work",
+      agentId: "ops",
+      startedAfter: "2026-08-20T03:00:00-07:00",
+      startedBefore: "2026-08-21T10:00:00Z",
+    };
+    expect(
+      listTranscriptLibrary(store, { ...filters, query: "% LAUNCH_" }).sessions.map(
+        (entry) => entry.sessionId,
+      ),
+    ).toEqual(["one"]);
+    expect(
+      listTranscriptLibrary(store, { ...filters, query: "ROOM-A" }).sessions.map(
+        (entry) => entry.sessionId,
+      ),
+    ).toEqual(["one"]);
+    expect(listTranscriptLibrary(store, { ...filters, accountId: "personal" }).sessions).toEqual(
+      [],
+    );
+    expect(listTranscriptLibrary(store, { ...filters, providerId: "different" }).sessions).toEqual(
+      [],
+    );
+    expect(
+      listTranscriptLibrary(store, { agentId: "main" }).sessions.map((entry) => entry.sessionId),
+    ).toEqual(["two"]);
+    expect(
+      listTranscriptLibrary(store, {}).sessions.find((entry) => entry.sessionId === "legacy")
+        ?.agentId,
+    ).toBeNull();
+    expect(() => listTranscriptLibrary(store, { startedAfter: "bad date" })).toThrow("date filter");
+    expect(() =>
+      listTranscriptLibrary(store, { startedAfter: "2026-08-22", startedBefore: "2026-08-21" }),
+    ).toThrow("range");
+  });
+
+  it("preserves full canonical handles and pages/searches durable utterances without reading exports", async () => {
+    const { store, stateDir } = fixture();
+    const hidden = [
+      "fixture-user-amber",
+      "fixture-pass-cobalt",
+      "fixture-query-violet",
+      "fixture-fragment-ochre",
+    ];
+    const meetingUrl = new URL(`https://example.test/room?invite=${hidden[2]}#${hidden[3]}`);
+    meetingUrl.username = hidden[0]!;
+    meetingUrl.password = hidden[1]!;
+    const target = session("standup:@room?opaque", {
+      title: "Public planning",
+      source: {
+        providerId: "meet",
+        accountId: "public-account",
+        guildId: "public-guild",
+        channelId: "public-channel",
+        threadTs: "public-thread",
+        fileId: "public-file",
+        meetingUrl: meetingUrl.href,
+        privateKey: "not-for-ui",
+      },
+      metadata: { private: "not-for-ui" },
+    });
+    await store.writeSession(target);
+    const utterances = [
+      {
+        text: "First decision: approved.",
+        speaker: { label: "Sam", id: "speaker-1" },
+        startedAt: "2026-08-20T10:01:00.000Z",
+        final: true,
+      },
+      { text: "Background." },
+      {
+        text: "Follow up: FIRST milestone.",
+        endedAt: "2026-08-20T10:03:00.000Z",
+        metadata: { private: "not-for-ui" },
+      },
+    ];
+    for (const utterance of utterances) {
+      await store.appendUtteranceForSession(target, utterance);
+    }
+    await store.writeSummary(summarizeTranscripts({ session: target, utterances }), target);
+    // Reopen a raw legacy-shaped URL row without Doctor or read-time normalization.
+    closeOpenClawStateDatabaseForTest();
+    const selector = listTranscriptLibrary(store, {}).sessions[0]!.selector;
+    for (const query of [
+      "PLANNING",
+      "opaque",
+      "meet",
+      "public-account",
+      "public-guild",
+      "public-channel",
+      "public-thread",
+      "public-file",
+    ]) {
+      expect(
+        listTranscriptLibrary(store, { query }).sessions.map((entry) => entry.selector),
+        query,
+      ).toEqual([selector]);
+    }
+    for (const query of [
+      ...hidden.flatMap((part) => [part, part.slice(0, -3).toUpperCase()]),
+      "invite",
+      "example.test",
+    ]) {
+      expect(
+        [...store.iterateReadEntries({ query })].map((entry) => entry.selector),
+        query,
+      ).toEqual([]);
+      expect(listTranscriptLibrary(store, { query }).sessions, query).toEqual([]);
+    }
+    const first = await getTranscriptLibrary(store, {
+      selector,
+      includeUtterances: true,
+      limit: 1,
+      query: "first",
+    });
+    expect(first.session).toMatchObject({
+      selector: transcriptSessionSelector(target),
+      sessionId: target.sessionId,
+      utteranceCount: 3,
+      lastUtteranceAt: "2026-08-20T10:03:00.000Z",
+      activeSubscription: false,
+      source: { providerId: "meet", meetingUrl: "https://example.test/room" },
+    });
+    expect(first.utterances).toEqual([
+      {
+        sequence: 0,
+        text: utterances[0]!.text,
+        speakerId: "speaker-1",
+        speakerLabel: "Sam",
+        startedAt: utterances[0]!.startedAt,
+        final: true,
+      },
+    ]);
+    expect(first.summary).toMatchObject({ utteranceCount: 3 });
+    expect(first.summary).not.toHaveProperty("transcript");
+    const last = await getTranscriptLibrary(store, {
+      selector,
+      includeUtterances: true,
+      limit: 1,
+      query: "first",
+      cursor: first.nextCursor!,
+    });
+    expect(last.utterances).toEqual([
+      { sequence: 2, text: utterances[2]!.text, endedAt: "2026-08-20T10:03:00.000Z" },
+    ]);
+    expect(last.nextCursor).toBeNull();
+    expect(JSON.stringify(first)).not.toContain("private");
+    const publicOutputs = [JSON.stringify(first), JSON.stringify(listTranscriptLibrary(store, {}))];
+    for (const format of ["markdown", "jsonl"] as const) {
+      const exported = await exportTranscriptLibrary(store, { selector, format });
+      const content = Buffer.from(exported.data, "base64").toString("utf8");
+      expect(content).toContain("First decision: approved.");
+      expect(content).toContain("Follow up: FIRST milestone.");
+      publicOutputs.push(content);
+    }
+    for (const output of publicOutputs) {
+      for (const part of hidden) {
+        expect(output).not.toContain(part);
+      }
+    }
+    expect((await store.readSession(selector))?.source.meetingUrl).toBe(meetingUrl.href);
+    expect(fs.existsSync(path.join(stateDir, "transcripts"))).toBe(false);
+    await expect(getTranscriptLibrary(store, { selector: target.sessionId })).rejects.toThrow(
+      "not found",
+    );
+  });
+
+  it("rejects malformed and cross-filter, cross-transcript or cross-method cursors", async () => {
+    const { store } = fixture();
+    for (const id of ["one", "two"]) {
+      const target = session(id);
+      await store.writeSession(target);
+      await store.appendUtteranceForSession(target, { text: "a" });
+      await store.appendUtteranceForSession(target, { text: "b" });
+    }
+    const listed = listTranscriptLibrary(store, { limit: 1 });
+    const selector = listed.sessions[0]!.selector;
+    const read = await getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 1 });
+    expect(() => listTranscriptLibrary(store, { cursor: "not-a-cursor" })).toThrow("cursor");
+    expect(() =>
+      listTranscriptLibrary(store, { cursor: listed.nextCursor!, agentId: "other" }),
+    ).toThrow("cursor");
+    await expect(
+      getTranscriptLibrary(store, { selector, cursor: listed.nextCursor! }),
+    ).rejects.toThrow("cursor");
+    await expect(
+      getTranscriptLibrary(store, { selector, cursor: read.nextCursor!, query: "a" }),
+    ).rejects.toThrow("cursor");
+    await expect(
+      getTranscriptLibrary(store, {
+        selector: transcriptSessionSelector(session("two")),
+        cursor: read.nextCursor!,
+      }),
+    ).rejects.toThrow("cursor");
+  });
+
+  it.each(["structured", "structured-only", "divergent-markdown", "markdown-only"] as const)(
+    "exports full canonical content with %s notes even when the stored summary covers only a tail",
+    async (notesKind) => {
+      const { store, stateDir, database } = fixture();
+      const target = session("download");
+      await store.writeSession(target);
+      await store.appendUtteranceForSession(target, {
+        text: "Opening context",
+        id: "utterance-1",
+        speaker: { label: "Alex", id: "speaker-1" },
+        startedAt: "2026-08-20T10:01:00.000Z",
+        metadata: { recordingPath: "/private/provider/audio.wav", private: "provider-only" },
+      });
+      await store.appendUtteranceForSession(target, { text: "Action: verify downloads" });
+      await store.writeSummary(
+        summarizeTranscripts({
+          session: target,
+          utterances: [{ text: "Action: verify downloads" }],
+        }),
+        target,
+      );
+      const canonicalMarkdown =
+        "# Historical notes\r\n\r\nKeep this exact historical decision.\r\n";
+      if (notesKind !== "structured") {
+        const db = database();
+        executeSqliteQuerySync(
+          db,
+          meetingTranscriptDb(db)
+            .updateTable("meeting_transcript_summaries")
+            .set({
+              markdown: notesKind === "structured-only" ? null : canonicalMarkdown,
+              ...(notesKind === "markdown-only" ? { summary_json: null } : {}),
+            })
+            .where("session_id", "=", target.sessionId)
+            .where("session_started_at", "=", target.startedAt),
+        );
+      }
+      const selector = transcriptSessionSelector(target);
+      const markdown = await exportTranscriptLibrary(store, { selector, format: "markdown" });
+      const text = Buffer.from(markdown.data, "base64").toString("utf8");
+      if (notesKind === "divergent-markdown" || notesKind === "markdown-only") {
+        const projectedMarkdown =
+          "# Historical notes\\r\n\\r\nKeep this exact historical decision.\\r\n";
+        expect((await getTranscriptLibrary(store, { selector })).summary?.markdown).toBe(
+          projectedMarkdown,
+        );
+        expect(text).toContain(projectedMarkdown);
+      }
+      expect(text).toContain("Alex: Opening context");
+      expect(text).toContain("Action: verify downloads");
+      expect(text).toContain("Transcript utterances: 2");
+      if (notesKind !== "markdown-only") {
+        expect(text).toContain("Summary covers 1 saved utterances.");
+      }
+      expect(markdown.filename).toMatch(/^transcript-2026-08-20-[a-f0-9]{12}\.md$/);
+      expect(markdown.sizeBytes).toBe(Buffer.byteLength(text));
+      const jsonl = await exportTranscriptLibrary(store, { selector, format: "jsonl" });
+      expect(
+        Buffer.from(jsonl.data, "base64")
+          .toString("utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line)),
+      ).toEqual(
+        (await getTranscriptLibrary(store, { selector, includeUtterances: true })).utterances,
+      );
+      expect(Buffer.from(jsonl.data, "base64").toString("utf8")).not.toContain("provider-only");
+      expect((await store.readUtterancesForSession(target))[0]?.metadata).toEqual({
+        recordingPath: "/private/provider/audio.wav",
+        private: "provider-only",
+      });
+      expect(fs.existsSync(path.join(stateDir, "transcripts"))).toBe(false);
+    },
+  );
+
+  it("leaves missing summaries missing and rejects oversized reads/downloads without partial output", async () => {
+    const { store, stateDir } = fixture();
+    const target = session("large");
+    await store.writeSession(target);
+    const selector = transcriptSessionSelector(target);
+    expect((await getTranscriptLibrary(store, { selector })).summary).toBeUndefined();
+    expect(
+      Buffer.from(
+        (await exportTranscriptLibrary(store, { selector, format: "markdown" })).data,
+        "base64",
+      ).toString("utf8"),
+    ).not.toContain("## Overview");
+    await store.appendUtteranceForSession(target, {
+      text: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES + 1),
+    });
+    await expect(
+      getTranscriptLibrary(store, { selector, includeUtterances: true }),
+    ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
+    for (const format of ["jsonl", "markdown"] as const) {
+      const exported = await exportTranscriptLibrary(store, { selector, format });
+      expect(exported.sizeBytes).toBeGreaterThan(TRANSCRIPTS_RESULT_MAX_BYTES);
+      expect(exported.sizeBytes).toBeLessThan(TRANSCRIPTS_EXPORT_MAX_BYTES);
+    }
+    await store.appendUtteranceForSession(target, {
+      text: "x".repeat(TRANSCRIPTS_EXPORT_MAX_BYTES),
+    });
+    for (const format of ["jsonl", "markdown"] as const) {
+      await expect(exportTranscriptLibrary(store, { selector, format })).rejects.toThrow(
+        expect.objectContaining({
+          type: "transcript_export_too_large",
+          maxBytes: TRANSCRIPTS_EXPORT_MAX_BYTES,
+        }),
+      );
+    }
+    expect(fs.existsSync(path.join(stateDir, "transcripts"))).toBe(false);
+    expect(store.readNotes(target)).toEqual({});
+  });
+
+  it("distinguishes historical unstopped rows from exact live subscriptions and stopping captures", async () => {
+    const { store } = fixture();
+    const old = session("reused");
+    const current = session("reused", { startedAt: "2026-08-21T10:00:00.000Z" });
+    await store.writeSession(old);
+    await store.writeSession(current);
+    activeSessions.set(current.sessionId, {
+      session: current,
+      phase: "active",
+      provider: {},
+      providerId: current.source.providerId,
+    });
+    const first = listTranscriptLibrary(store, {});
+    expect(first.sessions.map((entry) => entry.activeSubscription)).toEqual([true, false]);
+    activeSessions.get(current.sessionId)!.stopping = true;
+    expect(
+      (await getTranscriptLibrary(store, { selector: transcriptSessionSelector(current) })).session
+        .activeSubscription,
+    ).toBe(false);
+    const capture = activeSessions.get(current.sessionId)!;
+    delete capture.stopping;
+    capture.phase = "terminal";
+    expect(
+      listTranscriptLibrary(store, {}).sessions.every((entry) => !entry.activeSubscription),
+    ).toBe(true);
+    activeSessions.clear();
+    expect(
+      listTranscriptLibrary(store, {}).sessions.every(
+        (entry) => !entry.activeSubscription && entry.stoppedAt === undefined,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/transcripts/library.test.ts
+++ b/src/transcripts/library.test.ts
@@ -4,6 +4,7 @@ import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES,
   TRANSCRIPTS_RESULT_MAX_BYTES,
 } from "../../packages/gateway-protocol/src/schema/transcripts.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -269,7 +270,7 @@ describe("transcript library SQLite reads", () => {
     ).toBeLessThanOrEqual(3);
   });
 
-  it.each(["text", "combined speaker and metadata"])(
+  it.each(["text", "combined speaker fields"])(
     "bounds %s before SQLite returns an oversized row",
     async (kind) => {
       const { store, database } = fixture();
@@ -282,8 +283,7 @@ describe("transcript library SQLite reads", () => {
           ? { text: payload }
           : {
               text: "small",
-              speaker: { id: "x".repeat(400_000), label: "y".repeat(400_000) },
-              metadata: { private: "z".repeat(400_000) },
+              speaker: { id: "x".repeat(600_000), label: "y".repeat(600_000) },
             },
       );
       const reads = observeArchiveReads(database());
@@ -291,6 +291,7 @@ describe("transcript library SQLite reads", () => {
         getTranscriptLibrary(store, {
           selector: transcriptSessionSelector(target),
           includeUtterances: true,
+          limit: 1,
         }),
       ).rejects.toThrow(
         expect.objectContaining({
@@ -468,11 +469,16 @@ describe("transcript library SQLite reads", () => {
     );
     reads.length = 0;
     await expect(
-      getTranscriptLibrary(store, { selector: transcriptSessionSelector(target) }),
+      getTranscriptLibrary(store, { selector: transcriptSessionSelector(target), limit: 50 }),
     ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
     expect(Math.max(...reads.map((read) => read.maxRowBytes))).toBeLessThanOrEqual(
       TRANSCRIPTS_RESULT_MAX_BYTES,
     );
+    const legacy = await getTranscriptLibrary(store, {
+      selector: transcriptSessionSelector(target),
+    });
+    expect(Buffer.byteLength(JSON.stringify(legacy))).toBeGreaterThan(TRANSCRIPTS_RESULT_MAX_BYTES);
+    expect(legacy.summary?.overview).toBe("é".repeat(TRANSCRIPTS_RESULT_MAX_BYTES / 2 + 1));
     const exported = await exportTranscriptLibrary(store, {
       selector: transcriptSessionSelector(target),
       format: "markdown",
@@ -480,6 +486,73 @@ describe("transcript library SQLite reads", () => {
     expect(exported.sizeBytes).toBeGreaterThan(TRANSCRIPTS_RESULT_MAX_BYTES);
     expect(exported.sizeBytes).toBeLessThan(TRANSCRIPTS_EXPORT_MAX_BYTES);
     expect(Buffer.from(exported.data, "base64").toString("utf8")).toContain("saved note");
+  });
+
+  it("clips legacy speech before its transport envelope while retaining modern raw-row bounds", async () => {
+    const { store } = fixture();
+    const target = session("legacy-clipping");
+    const selector = transcriptSessionSelector(target);
+    await store.writeSession(target);
+    await store.appendUtteranceForSession(target, {
+      text: "\u001b[31m" + "x".repeat(TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES + 1),
+    });
+    const legacy = await getTranscriptLibrary(store, { selector, includeUtterances: true });
+    expect(legacy.utterances).toEqual([{ sequence: 0, text: "x".repeat(4000) }]);
+    await expect(
+      getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 1 }),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        type: "transcript_result_too_large",
+        maxBytes: TRANSCRIPTS_RESULT_MAX_BYTES,
+      }),
+    );
+    await store.writeSession({
+      ...target,
+      title: "x".repeat(TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES + 1),
+    });
+    await expect(getTranscriptLibrary(store, { selector })).rejects.toThrow(
+      expect.objectContaining({
+        type: "transcript_result_too_large",
+        maxBytes: TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES,
+      }),
+    );
+  });
+
+  it("preserves ID-only stored speakers across legacy reads, pages, and exports", async () => {
+    const { store, database } = fixture();
+    const target = session("speaker-id-only");
+    const selector = transcriptSessionSelector(target);
+    await store.writeSession(target);
+    await store.appendUtteranceForSession(target, {
+      id: "speech-id",
+      text: "Saved speech",
+      speaker: { id: "speaker-id", label: "Stored label" },
+    });
+    const db = database();
+    executeSqliteQuerySync(
+      db,
+      meetingTranscriptDb(db)
+        .updateTable("meeting_transcript_utterances")
+        .set({
+          speaker_label: null,
+          metadata_json: JSON.stringify({ private: "x".repeat(2 * TRANSCRIPTS_RESULT_MAX_BYTES) }),
+        })
+        .where("session_id", "=", target.sessionId)
+        .where("session_started_at", "=", target.startedAt),
+    );
+    for (const limit of [undefined, 1]) {
+      const read = await getTranscriptLibrary(store, { selector, includeUtterances: true, limit });
+      expect(read.utterances?.[0]).toMatchObject({ speakerId: "speaker-id", text: "Saved speech" });
+      expect(read.utterances?.[0]?.speakerLabel).toBeUndefined();
+      expect(read.utterances?.[0]?.id).toBe(limit === undefined ? undefined : "speech-id");
+    }
+    const exported = await exportTranscriptLibrary(store, { selector, format: "jsonl" });
+    expect(JSON.parse(Buffer.from(exported.data, "base64").toString("utf8"))).toEqual({
+      sequence: 0,
+      id: "speech-id",
+      speakerId: "speaker-id",
+      text: "Saved speech",
+    });
   });
 
   it("keeps exact JSON escaping checks and exports valid content above the reader limit", async () => {
@@ -493,6 +566,7 @@ describe("transcript library SQLite reads", () => {
       getTranscriptLibrary(store, {
         selector: transcriptSessionSelector(target),
         includeUtterances: true,
+        limit: 1,
       }),
     ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
     const exported = await exportTranscriptLibrary(store, {
@@ -833,7 +907,8 @@ describe("transcript library SQLite reads", () => {
           .split("\n")
           .map((line) => JSON.parse(line)),
       ).toEqual(
-        (await getTranscriptLibrary(store, { selector, includeUtterances: true })).utterances,
+        (await getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 50 }))
+          .utterances,
       );
       expect(Buffer.from(jsonl.data, "base64").toString("utf8")).not.toContain("provider-only");
       expect((await store.readUtterancesForSession(target))[0]?.metadata).toEqual({
@@ -860,7 +935,7 @@ describe("transcript library SQLite reads", () => {
       text: "x".repeat(TRANSCRIPTS_RESULT_MAX_BYTES + 1),
     });
     await expect(
-      getTranscriptLibrary(store, { selector, includeUtterances: true }),
+      getTranscriptLibrary(store, { selector, includeUtterances: true, limit: 50 }),
     ).rejects.toThrow(expect.objectContaining({ type: "transcript_result_too_large" }));
     for (const format of ["jsonl", "markdown"] as const) {
       const exported = await exportTranscriptLibrary(store, { selector, format });

--- a/src/transcripts/library.test.ts
+++ b/src/transcripts/library.test.ts
@@ -16,7 +16,7 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { spawnNodeEvalSync } from "../test-utils/node-process.js";
 import { activeSessions } from "./capture.js";
 import { exportTranscriptLibrary, getTranscriptLibrary, listTranscriptLibrary } from "./library.js";
 import type { TranscriptSessionDescriptor } from "./provider-types.js";
@@ -127,63 +127,98 @@ describe("transcript library SQLite reads", () => {
   });
 
   it("paginates equal instants and unknown dates using original identity ties and date-string semantics", async () => {
-    const env = captureEnv(["TZ"]);
-    setTestEnvValue("TZ", "America/Los_Angeles");
-    try {
-      const { store } = fixture();
-      const ordered = [
-        session("local", { startedAt: "2026-08-20T06:00:00" }),
-        session("later", { startedAt: "2026-08-20T06:30:00Z" }),
-        session("fraction-tail", { startedAt: "2026-08-20T06:00:00.9999Z" }),
-        session("basic", { startedAt: "2026-08-20T06:00:00+0000" }),
-        session("fraction", { startedAt: "2026-08-20T06:00:00.0005Z" }),
-        session("same", { startedAt: "2026-08-19T23:00:00-07:00" }),
-        session("same", { startedAt: "2026-08-20T06:00:00.000Z" }),
-        session("earlier", { startedAt: "2026-08-20T05:30:00Z" }),
-        session("unknown", { startedAt: "2026-08-21Tbad" }),
-        session("unknown", { startedAt: "2026-08-22Tbad" }),
-        session("unknown-z", { startedAt: "2026-08-20Tbad" }),
-      ];
-      for (const row of ordered.toReversed()) {
-        await store.writeSession(row);
-      }
-      const seen: Array<{ sessionId: string; startedAt: string; selector: string }> = [];
-      let cursor: string | undefined;
-      for (let index = 0; index < ordered.length; index++) {
-        const page = listTranscriptLibrary(store, { limit: 1, cursor });
-        expect(page.sessions).toHaveLength(1);
-        const { sessionId, startedAt, selector } = page.sessions[0]!;
-        seen.push({ sessionId, startedAt, selector });
-        if (index === ordered.length - 1) {
-          expect(page.nextCursor).toBeNull();
-        } else {
-          expect(page.nextCursor).toEqual(expect.any(String));
-          cursor = page.nextCursor!;
-        }
-      }
-      expect(seen).toEqual(
-        ordered.map((row) => ({
-          sessionId: row.sessionId,
-          startedAt: row.startedAt,
-          selector: transcriptSessionSelector(row),
-        })),
-      );
-      expect(
-        listTranscriptLibrary(store, {
-          startedAfter: "2026-08-20T06:00:00.0005Z",
-          startedBefore: "2026-08-20T06:00:00.001Z",
-        }).sessions.map(({ sessionId }) => sessionId),
-      ).toEqual(["basic", "fraction", "same", "same"]);
-      expect(
-        listTranscriptLibrary(store, {
-          startedAfter: "2026-08-20T06:00:00",
-          startedBefore: "2026-08-20T13:00:00.001Z",
-        }).sessions.map(({ sessionId }) => sessionId),
-      ).toEqual(["local"]);
-    } finally {
-      env.restore();
+    const { store } = fixture();
+    const ordered = [
+      session("later", { startedAt: "2026-08-20T06:30:00Z" }),
+      session("fraction-tail", { startedAt: "2026-08-20T06:00:00.9999Z" }),
+      session("basic", { startedAt: "2026-08-20T06:00:00+0000" }),
+      session("fraction", { startedAt: "2026-08-20T06:00:00.0005Z" }),
+      session("same", { startedAt: "2026-08-19T23:00:00-07:00" }),
+      session("same", { startedAt: "2026-08-20T06:00:00.000Z" }),
+      session("earlier", { startedAt: "2026-08-20T05:30:00Z" }),
+      session("unknown", { startedAt: "2026-08-21Tbad" }),
+      session("unknown", { startedAt: "2026-08-22Tbad" }),
+      session("unknown-z", { startedAt: "2026-08-20Tbad" }),
+    ];
+    for (const row of ordered.toReversed()) {
+      await store.writeSession(row);
     }
+    const seen: Array<{ sessionId: string; startedAt: string; selector: string }> = [];
+    let cursor: string | undefined;
+    for (let index = 0; index < ordered.length; index++) {
+      const page = listTranscriptLibrary(store, { limit: 1, cursor });
+      expect(page.sessions).toHaveLength(1);
+      const { sessionId, startedAt, selector } = page.sessions[0]!;
+      seen.push({ sessionId, startedAt, selector });
+      expect(page.nextCursor).toEqual(index === ordered.length - 1 ? null : expect.any(String));
+      cursor = page.nextCursor ?? undefined;
+    }
+    expect(seen).toEqual(
+      ordered.map((row) => ({
+        sessionId: row.sessionId,
+        startedAt: row.startedAt,
+        selector: transcriptSessionSelector(row),
+      })),
+    );
+    expect(
+      listTranscriptLibrary(store, {
+        startedAfter: "2026-08-20T06:00:00.0005Z",
+        startedBefore: "2026-08-20T06:00:00.001Z",
+      }).sessions.map(({ sessionId }) => sessionId),
+    ).toEqual(["basic", "fraction", "same", "same"]);
   });
+
+  it(
+    "uses the process timezone for unzoned stored dates and range bounds",
+    { timeout: 45_000 },
+    () => {
+      const stateDir = tempDirs.make("transcript-library-timezone-");
+      const local = session("local", { startedAt: "2026-08-20T06:00:00" });
+      const earlier = session("earlier", { startedAt: "2026-08-20T06:30:00Z" });
+      const child = spawnNodeEvalSync(
+        `
+        import assert from "node:assert/strict";
+        import { TranscriptsStore, transcriptSessionSelector } from ${JSON.stringify(new URL("./store.ts", import.meta.url).href)};
+        import { listTranscriptLibrary } from ${JSON.stringify(new URL("./library.ts", import.meta.url).href)};
+        import { closeOpenClawStateDatabaseForTest } from ${JSON.stringify(new URL("../state/openclaw-state-db.ts", import.meta.url).href)};
+        const store = new TranscriptsStore(${JSON.stringify(path.join(stateDir, "transcripts"))});
+        const local = ${JSON.stringify(local)};
+        try {
+          await store.writeSession(local);
+          await store.writeSession(${JSON.stringify(earlier)});
+          const first = listTranscriptLibrary(store, { limit: 1 });
+          assert.deepEqual(first.sessions.map(row => row.sessionId), ["local"]);
+          assert.equal(typeof first.nextCursor, "string");
+          const next = listTranscriptLibrary(store, { limit: 1, cursor: first.nextCursor });
+          assert.deepEqual(next.sessions.map(row => row.sessionId), ["earlier"]);
+          assert.equal(next.nextCursor, null);
+          assert.deepEqual(listTranscriptLibrary(store, {
+            startedAfter: "2026-08-20T06:00:00",
+            startedBefore: "2026-08-20T13:00:00.001Z",
+          }).sessions.map(row => row.sessionId), ["local"]);
+          assert.deepEqual(listTranscriptLibrary(store, {
+            startedAfter: "2026-08-20T13:00:00.000Z",
+            startedBefore: "2026-08-20T13:00:00.001Z",
+          }).sessions.map(row => row.sessionId), ["local"]);
+          assert.deepEqual(await store.readSession(transcriptSessionSelector(local)), local);
+        } finally {
+          closeOpenClawStateDatabaseForTest();
+        }
+      `,
+        {
+          imports: ["tsx"],
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            TZ: "America/Los_Angeles",
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+          },
+        },
+      );
+      expect(child.status, child.stderr).toBe(0);
+    },
+  );
 
   it.each(["at-cap", "oversized-ascii", "oversized-utf8"] as const)(
     "bounds %s stored date input before the JavaScript parser",

--- a/src/transcripts/library.ts
+++ b/src/transcripts/library.ts
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+import {
+  asSafeIntegerInRange,
+  parseDateStringTimestampMs,
+} from "@openclaw/normalization-core/number-coercion";
+import {
+  TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_RESULT_MAX_BYTES,
+  type TranscriptSessionSummary,
+  type TranscriptsExportParams,
+  type TranscriptsExportResult,
+  type TranscriptsGetParams,
+  type TranscriptsGetResult,
+  type TranscriptsListParams,
+  type TranscriptsListResult,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { readTranscriptCaptureSnapshot } from "./capture.js";
+import {
+  projectTranscriptMarkdown,
+  projectTranscriptSession,
+  projectTranscriptUtterance,
+  readTranscriptNotes,
+} from "./read.js";
+import {
+  assertTranscriptByteLimit,
+  assertTranscriptByteCount,
+  TranscriptLibraryError,
+  type TranscriptReadOptions,
+} from "./store-read.js";
+import { safeTranscriptPathSegment, type TranscriptsStore } from "./store.js";
+import { renderTranscriptsMarkdown } from "./summary.js";
+
+function cursorScope(values: unknown[]): string {
+  return createHash("sha256").update(JSON.stringify(values)).digest("hex");
+}
+
+function encodeCursor(scope: string, position: [string, string] | [number]): string {
+  return Buffer.from(JSON.stringify([1, scope, ...position])).toString("base64url");
+}
+
+function decodeCursor(cursor: string | undefined, scope: string): unknown[] | undefined {
+  if (cursor === undefined) {
+    return undefined;
+  }
+  try {
+    if (cursor.length > TRANSCRIPTS_RESULT_MAX_BYTES || !/^[A-Za-z0-9_-]+$/u.test(cursor)) {
+      throw new Error();
+    }
+    const value: unknown = JSON.parse(Buffer.from(cursor, "base64url").toString("utf8"));
+    if (Array.isArray(value) && value[0] === 1 && value[1] === scope) {
+      return value.slice(2);
+    }
+  } catch {
+    /* Invalid or cross-query cursors are never used as selectors. */
+  }
+  throw new TranscriptLibraryError(
+    "transcript_invalid_cursor",
+    "Invalid transcript cursor; restart pagination with the current filters.",
+  );
+}
+
+function normalizeDate(value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const time = parseDateStringTimestampMs(value);
+  if (time === undefined) {
+    throw new TranscriptLibraryError(
+      "transcript_invalid_filter",
+      "Invalid transcript date filter.",
+    );
+  }
+  return new Date(time).toISOString();
+}
+
+function requireEntry(store: TranscriptsStore, selector: string, exporting = false) {
+  const entry = store.readEntry(selector, exporting);
+  if (!entry) {
+    throw new TranscriptLibraryError(
+      "transcript_session_not_found",
+      "Transcript not found; refresh the library and use its full selector.",
+    );
+  }
+  return entry;
+}
+
+export function listTranscriptLibrary(
+  store: TranscriptsStore,
+  params: TranscriptsListParams,
+  providerName?: (providerId: string) => string | undefined,
+): TranscriptsListResult {
+  const { cursor, ...filters } = params;
+  const startedAfter = normalizeDate(filters.startedAfter);
+  const startedBefore = normalizeDate(filters.startedBefore);
+  if (startedAfter && startedBefore && startedAfter >= startedBefore) {
+    throw new TranscriptLibraryError(
+      "transcript_invalid_filter",
+      "Transcript date range must end after it starts.",
+    );
+  }
+  const scope = cursorScope([
+    "list",
+    filters.query,
+    filters.providerId,
+    filters.accountId,
+    filters.agentId,
+    startedAfter,
+    startedBefore,
+  ]);
+  const position = decodeCursor(cursor, scope);
+  let after: TranscriptReadOptions["after"];
+  if (position) {
+    const [startedAt, sessionId] = position;
+    if (position.length !== 2 || typeof startedAt !== "string" || typeof sessionId !== "string") {
+      throw new TranscriptLibraryError(
+        "transcript_invalid_cursor",
+        "Invalid transcript library cursor.",
+      );
+    }
+    after = { startedAt, sessionId };
+  }
+  const page = store.iterateReadEntries({ ...filters, startedAfter, startedBefore, after });
+  const captures = readTranscriptCaptureSnapshot();
+  const sessions: TranscriptSessionSummary[] = [];
+  let bytes = 0;
+  let hasMore = false;
+  try {
+    for (let step = page.next(); ; step = page.next()) {
+      if (step.done) {
+        hasMore = step.value;
+        break;
+      }
+      const entry = projectTranscriptSession(
+        step.value,
+        undefined,
+        providerName?.(step.value.session.source.providerId),
+        captures,
+      );
+      bytes += Buffer.byteLength(JSON.stringify(entry), "utf8");
+      assertTranscriptByteCount(bytes);
+      sessions.push(entry);
+    }
+  } finally {
+    page.return(false);
+  }
+  const last = sessions.at(-1);
+  const result = {
+    sessions,
+    nextCursor: hasMore && last ? encodeCursor(scope, [last.startedAt, last.sessionId]) : null,
+  };
+  assertTranscriptByteLimit(JSON.stringify(result));
+  return result;
+}
+
+export async function getTranscriptLibrary(
+  store: TranscriptsStore,
+  params: TranscriptsGetParams,
+  providerName?: (providerId: string) => string | undefined,
+): Promise<TranscriptsGetResult> {
+  const entry = requireEntry(store, params.selector);
+  const scope = cursorScope(["get", entry.selector, params.query]);
+  const position = decodeCursor(params.cursor, scope);
+  const after = asSafeIntegerInRange(position?.[0], { min: 0 });
+  if (position && (position.length !== 1 || after === undefined)) {
+    throw new TranscriptLibraryError(
+      "transcript_invalid_cursor",
+      "Invalid transcript reader cursor.",
+    );
+  }
+  const page = params.includeUtterances
+    ? store.readUtterancePage(entry.session, {
+        limit: params.limit,
+        query: params.query,
+        after,
+      })
+    : undefined;
+  const utterances = page?.utterances.map(projectTranscriptUtterance);
+  const last = utterances?.at(-1);
+  const result: TranscriptsGetResult = {
+    session: projectTranscriptSession(
+      entry,
+      undefined,
+      providerName?.(entry.session.source.providerId),
+    ),
+    ...(utterances ? { utterances } : {}),
+    nextCursor: page?.hasMore && last ? encodeCursor(scope, [last.sequence]) : null,
+    summary: await readTranscriptNotes(store, entry.session),
+  };
+  assertTranscriptByteLimit(JSON.stringify(result));
+  return result;
+}
+
+export async function exportTranscriptLibrary(
+  store: TranscriptsStore,
+  params: TranscriptsExportParams,
+): Promise<TranscriptsExportResult> {
+  const entry = requireEntry(store, params.selector, true);
+  const parts: string[] = [];
+  let sizeBytes = 0;
+  for (const utterance of store.iterateUtterances(entry.session)) {
+    const text =
+      params.format === "jsonl"
+        ? `${JSON.stringify(projectTranscriptUtterance(utterance))}\n`
+        : sanitizeTerminalText(utterance.text).trim();
+    const speaker = sanitizeTerminalText(utterance.speaker?.label ?? "").trim();
+    const line = params.format === "markdown" && speaker ? `${speaker}: ${text}` : text;
+    // Include Markdown list/newline overhead while accumulating, before rendering the body.
+    sizeBytes += Buffer.byteLength(line, "utf8") + (params.format === "markdown" ? 3 : 0);
+    assertTranscriptByteCount(sizeBytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
+    parts.push(line);
+  }
+  const notes = params.format === "markdown" ? store.readNotes(entry.session, true) : undefined;
+  const summary = notes?.summary;
+  const title = sanitizeTerminalText(entry.session.title ?? "").trim() || "Transcript";
+  const body =
+    params.format === "jsonl"
+      ? parts.join("")
+      : notes?.markdown !== undefined
+        ? [
+            projectTranscriptMarkdown(notes.markdown),
+            ...(summary ? [`Summary covers ${summary.utteranceCount} saved utterances.`] : []),
+            `## Full Transcript\n${parts.map((line) => `- ${line}`).join("\n")}`,
+            `Transcript utterances: ${entry.utteranceCount}\n`,
+          ].join("\n\n")
+        : summary
+          ? `${renderTranscriptsMarkdown({ ...summary, title, transcript: parts, utteranceCount: entry.utteranceCount })}\n\nSummary covers ${summary.utteranceCount} saved utterances.\n`
+          : `# ${title}\n\nSession: ${sanitizeTerminalText(entry.session.sessionId)}\nStarted: ${entry.session.startedAt}\n\n## Transcript\n${parts.map((line) => `- ${line}`).join("\n")}\n`;
+  assertTranscriptByteLimit(body, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
+  const digest = createHash("sha256").update(entry.selector).digest("hex").slice(0, 12);
+  const filename = `transcript-${safeTranscriptPathSegment(entry.session.startedAt.slice(0, 10))}-${digest}.${params.format === "markdown" ? "md" : "jsonl"}`;
+  return {
+    selector: entry.selector,
+    filename,
+    mimeType:
+      params.format === "markdown"
+        ? "text/markdown;charset=utf-8"
+        : "application/x-ndjson;charset=utf-8",
+    encoding: "base64",
+    data: Buffer.from(body, "utf8").toString("base64"),
+    sizeBytes: Buffer.byteLength(body, "utf8"),
+  };
+}

--- a/src/transcripts/library.ts
+++ b/src/transcripts/library.ts
@@ -3,8 +3,11 @@ import {
   asSafeIntegerInRange,
   parseDateStringTimestampMs,
 } from "@openclaw/normalization-core/number-coercion";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_LEGACY_MAX_TEXT_LENGTH,
+  TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES,
   TRANSCRIPTS_RESULT_MAX_BYTES,
   type TranscriptSessionSummary,
   type TranscriptsExportParams,
@@ -27,6 +30,7 @@ import {
   assertTranscriptByteCount,
   TranscriptLibraryError,
   type TranscriptReadOptions,
+  type TranscriptReadPurpose,
 } from "./store-read.js";
 import { safeTranscriptPathSegment, type TranscriptsStore } from "./store.js";
 import { renderTranscriptsMarkdown } from "./summary.js";
@@ -74,8 +78,12 @@ function normalizeDate(value: string | undefined): string | undefined {
   return new Date(time).toISOString();
 }
 
-function requireEntry(store: TranscriptsStore, selector: string, exporting = false) {
-  const entry = store.readEntry(selector, exporting);
+function requireEntry(
+  store: TranscriptsStore,
+  selector: string,
+  purpose: TranscriptReadPurpose = "page",
+) {
+  const entry = store.readEntry(selector, purpose);
   if (!entry) {
     throw new TranscriptLibraryError(
       "transcript_session_not_found",
@@ -158,7 +166,11 @@ export async function getTranscriptLibrary(
   params: TranscriptsGetParams,
   providerName?: (providerId: string) => string | undefined,
 ): Promise<TranscriptsGetResult> {
-  const entry = requireEntry(store, params.selector);
+  const purpose =
+    params.limit === undefined && params.cursor === undefined && params.query === undefined
+      ? "legacy"
+      : "page";
+  const entry = requireEntry(store, params.selector, purpose);
   const scope = cursorScope(["get", entry.selector, params.query]);
   const position = decodeCursor(params.cursor, scope);
   const after = asSafeIntegerInRange(position?.[0], { min: 0 });
@@ -169,13 +181,19 @@ export async function getTranscriptLibrary(
     );
   }
   const page = params.includeUtterances
-    ? store.readUtterancePage(entry.session, {
-        limit: params.limit,
-        query: params.query,
-        after,
-      })
+    ? store.readUtterancePage(
+        entry.session,
+        { limit: params.limit, query: params.query, after },
+        purpose,
+      )
     : undefined;
-  const utterances = page?.utterances.map(projectTranscriptUtterance);
+  const utterances = page?.utterances.map((utterance) => {
+    const projected = projectTranscriptUtterance(utterance);
+    if (purpose === "legacy") {
+      projected.text = truncateUtf16Safe(projected.text, TRANSCRIPTS_LEGACY_MAX_TEXT_LENGTH);
+    }
+    return projected;
+  });
   const last = utterances?.at(-1);
   const result: TranscriptsGetResult = {
     session: projectTranscriptSession(
@@ -185,9 +203,12 @@ export async function getTranscriptLibrary(
     ),
     ...(utterances ? { utterances } : {}),
     nextCursor: page?.hasMore && last ? encodeCursor(scope, [last.sequence]) : null,
-    summary: await readTranscriptNotes(store, entry.session),
+    summary: await readTranscriptNotes(store, entry.session, purpose),
   };
-  assertTranscriptByteLimit(JSON.stringify(result));
+  assertTranscriptByteLimit(
+    JSON.stringify(result),
+    purpose === "legacy" ? TRANSCRIPTS_LEGACY_RESULT_MAX_BYTES : TRANSCRIPTS_RESULT_MAX_BYTES,
+  );
   return result;
 }
 
@@ -195,7 +216,7 @@ export async function exportTranscriptLibrary(
   store: TranscriptsStore,
   params: TranscriptsExportParams,
 ): Promise<TranscriptsExportResult> {
-  const entry = requireEntry(store, params.selector, true);
+  const entry = requireEntry(store, params.selector, "export");
   const parts: string[] = [];
   let sizeBytes = 0;
   for (const utterance of store.iterateUtterances(entry.session)) {
@@ -203,14 +224,14 @@ export async function exportTranscriptLibrary(
       params.format === "jsonl"
         ? `${JSON.stringify(projectTranscriptUtterance(utterance))}\n`
         : sanitizeTerminalText(utterance.text).trim();
-    const speaker = sanitizeTerminalText(utterance.speaker?.label ?? "").trim();
+    const speaker = sanitizeTerminalText(utterance.speakerLabel ?? "").trim();
     const line = params.format === "markdown" && speaker ? `${speaker}: ${text}` : text;
     // Include Markdown list/newline overhead while accumulating, before rendering the body.
     sizeBytes += Buffer.byteLength(line, "utf8") + (params.format === "markdown" ? 3 : 0);
     assertTranscriptByteCount(sizeBytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
     parts.push(line);
   }
-  const notes = params.format === "markdown" ? store.readNotes(entry.session, true) : undefined;
+  const notes = params.format === "markdown" ? store.readNotes(entry.session, "export") : undefined;
   const summary = notes?.summary;
   const title = sanitizeTerminalText(entry.session.title ?? "").trim() || "Transcript";
   const body =

--- a/src/transcripts/read.ts
+++ b/src/transcripts/read.ts
@@ -6,14 +6,10 @@ import type {
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { truncateUtf16Safe } from "../utils.js";
 import { isTranscriptSessionActive, readTranscriptCaptureSnapshot } from "./capture.js";
-import type {
-  TranscriptSessionDescriptor,
-  TranscriptSourceLocator,
-  TranscriptUtterance,
-} from "./provider-types.js";
+import type { TranscriptSessionDescriptor, TranscriptSourceLocator } from "./provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "./source-locator.js";
 import { normalizeExportText } from "./store-artifacts.js";
-import type { TranscriptReadEntry } from "./store-read.js";
+import type { TranscriptReadEntry, TranscriptReadPurpose } from "./store-read.js";
 import type { TranscriptsStore } from "./store.js";
 
 /** Only public locator fields cross the Gateway; provider-private keys stay in the archive. */
@@ -84,8 +80,9 @@ export function projectTranscriptMarkdown(markdown: string): string {
 export async function readTranscriptNotes(
   store: TranscriptsStore,
   session: TranscriptSessionDescriptor,
+  purpose: TranscriptReadPurpose = "page",
 ): Promise<TranscriptsGetResult["summary"]> {
-  const stored = store.readNotes(session);
+  const stored = store.readNotes(session, purpose);
   if (stored.markdown === undefined) {
     return undefined;
   }
@@ -107,15 +104,18 @@ export async function readTranscriptNotes(
 
 /** Downloads and reader pages share an allowlist; raw provider metadata stays local. */
 export function projectTranscriptUtterance(
-  utterance: TranscriptUtterance & { sequence: number },
+  utterance: ProjectedTranscriptUtterance,
 ): ProjectedTranscriptUtterance {
   return {
     sequence: utterance.sequence,
     id: utterance.id,
     startedAt: utterance.startedAt,
     endedAt: utterance.endedAt,
-    speakerId: utterance.speaker?.id,
-    speakerLabel: utterance.speaker ? sanitizeTerminalText(utterance.speaker.label) : undefined,
+    speakerId: utterance.speakerId,
+    speakerLabel:
+      utterance.speakerLabel === undefined
+        ? undefined
+        : sanitizeTerminalText(utterance.speakerLabel),
     text: sanitizeTerminalText(utterance.text),
     final: utterance.final,
   };

--- a/src/transcripts/read.ts
+++ b/src/transcripts/read.ts
@@ -1,39 +1,71 @@
 import type {
   TranscriptSessionSummary,
   TranscriptsGetResult,
+  TranscriptUtterance as ProjectedTranscriptUtterance,
 } from "../../packages/gateway-protocol/src/schema/transcripts.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { truncateUtf16Safe } from "../utils.js";
-import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { isTranscriptSessionActive, readTranscriptCaptureSnapshot } from "./capture.js";
+import type {
+  TranscriptSessionDescriptor,
+  TranscriptSourceLocator,
+  TranscriptUtterance,
+} from "./provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "./source-locator.js";
 import { normalizeExportText } from "./store-artifacts.js";
 import type { TranscriptReadEntry } from "./store-read.js";
 import type { TranscriptsStore } from "./store.js";
 
+/** Only public locator fields cross the Gateway; provider-private keys stay in the archive. */
+export function projectTranscriptSource(
+  source: TranscriptSourceLocator,
+): TranscriptSessionSummary["source"] {
+  const safe = sanitizeTranscriptSourceLocator(source);
+  const kind = safe.kind;
+  return {
+    providerId: safe.providerId,
+    ...(["live-audio", "live-caption", "posthoc-transcript", "recording-stt"].includes(kind ?? "")
+      ? { kind }
+      : {}),
+    ...(safe.accountId !== undefined ? { accountId: safe.accountId } : {}),
+    ...(safe.guildId !== undefined ? { guildId: safe.guildId } : {}),
+    ...(safe.channelId !== undefined ? { channelId: safe.channelId } : {}),
+    ...(safe.meetingUrl && /^https?:\/\//u.test(safe.meetingUrl)
+      ? { meetingUrl: safe.meetingUrl }
+      : {}),
+    ...(safe.threadTs !== undefined ? { threadTs: safe.threadTs } : {}),
+    ...(safe.fileId !== undefined ? { fileId: safe.fileId } : {}),
+  };
+}
+
 export function projectTranscriptSession(
   entry: TranscriptReadEntry,
-  active: boolean,
+  active = isTranscriptSessionActive(entry.session),
   providerName?: string,
+  captures = readTranscriptCaptureSnapshot(),
 ): TranscriptSessionSummary {
   const { session } = entry;
-  const source = sanitizeTranscriptSourceLocator(session.source);
+  const source = projectTranscriptSource(session.source);
+  const owner = session.metadata?.agentId;
   return {
     selector: entry.selector,
     sessionId: session.sessionId,
     title: session.title === undefined ? undefined : sanitizeTerminalText(session.title),
     providerId: source.providerId,
     providerName,
-    // Locator fields are an allowlist, not arbitrary provider metadata.
-    source: {
-      providerId: source.providerId,
-      accountId: source.accountId,
-      guildId: source.guildId,
-      channelId: source.channelId,
-      meetingUrl: source.meetingUrl,
-    },
+    source,
     startedAt: session.startedAt,
     stoppedAt: session.stoppedAt,
     active,
+    activeSubscription: captures.some(
+      (capture) =>
+        capture.state === "armed" &&
+        capture.session.sessionId === session.sessionId &&
+        capture.session.startedAt === session.startedAt,
+    ),
+    agentId: typeof owner === "string" ? owner : null,
+    updatedAt: entry.updatedAt,
+    lastUtteranceAt: entry.lastUtteranceAt,
     utteranceCount: entry.utteranceCount,
     participants: entry.participants.map(sanitizeTerminalText),
     hasSummary: entry.hasSummary,
@@ -45,11 +77,15 @@ export function projectTranscriptSession(
   };
 }
 
+export function projectTranscriptMarkdown(markdown: string): string {
+  return normalizeExportText(markdown).split("\n").map(sanitizeTerminalText).join("\n");
+}
+
 export async function readTranscriptNotes(
   store: TranscriptsStore,
   session: TranscriptSessionDescriptor,
 ): Promise<TranscriptsGetResult["summary"]> {
-  const stored = await store.readSummary(session);
+  const stored = store.readNotes(session);
   if (stored.markdown === undefined) {
     return undefined;
   }
@@ -63,7 +99,24 @@ export async function readTranscriptNotes(
     participants: (summary?.participants ?? []).map(sanitizeTerminalText),
     source: summary?.source,
     model: summary?.model,
+    utteranceCount: summary?.utteranceCount ?? 0,
     // Stored Markdown is the canonical CLI rendering; reading never exports files.
-    markdown: normalizeExportText(stored.markdown).split("\n").map(sanitizeTerminalText).join("\n"),
+    markdown: projectTranscriptMarkdown(stored.markdown),
+  };
+}
+
+/** Downloads and reader pages share an allowlist; raw provider metadata stays local. */
+export function projectTranscriptUtterance(
+  utterance: TranscriptUtterance & { sequence: number },
+): ProjectedTranscriptUtterance {
+  return {
+    sequence: utterance.sequence,
+    id: utterance.id,
+    startedAt: utterance.startedAt,
+    endedAt: utterance.endedAt,
+    speakerId: utterance.speaker?.id,
+    speakerLabel: utterance.speaker ? sanitizeTerminalText(utterance.speaker.label) : undefined,
+    text: sanitizeTerminalText(utterance.text),
+    final: utterance.final,
   };
 }

--- a/src/transcripts/status.metadata.test.ts
+++ b/src/transcripts/status.metadata.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { installTemporaryCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import * as discovery from "../plugins/discovery.js";
+import * as loader from "../plugins/loader.js";
+import { loadPluginManifestRegistryForInstalledIndex } from "../plugins/manifest-registry-installed.js";
+import { restorePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  getActivePluginRegistry,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { readTranscriptLibraryStatus } from "./status.js";
+import { TranscriptsStore } from "./store.js";
+
+describe("transcript setup metadata boundary", () => {
+  it("offers a cold manifest source before and after a provider-only scoped registration without discovering runtime in status", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const pluginId = "fixture-captions";
+      const providerId = "fixture-caption-source";
+      const rootDir = state.statePath("fixture-plugin");
+      const source = await state.writeText(
+        "fixture-plugin/index.cjs",
+        `module.exports = {
+        id: "fixture-captions", register(api) {
+          api.registerTranscriptSourceProvider({ id: "fixture-caption-source", name: "Runtime captions", sourceKinds: ["live-caption"],
+            async start() { throw new Error("status must not start capture"); }
+          });
+        }
+      };`,
+      );
+      const descriptor = {
+        name: "Fixture captions",
+        autoStart: { accountId: "optional", meetingUrl: "required" },
+      };
+      const manifestPath = await state.writeJson("fixture-plugin/openclaw.plugin.json", {
+        id: pluginId,
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+        contracts: { transcriptSourceProviders: [providerId] },
+        transcriptSources: { [providerId]: descriptor },
+      });
+      const cfg: OpenClawConfig = {
+        plugins: {
+          allow: [pluginId],
+          entries: { [pluginId]: { enabled: true } },
+          load: { paths: [rootDir] },
+          slots: { memory: "none" },
+        },
+      };
+      const initial = createPluginMetadataSnapshot({
+        config: cfg,
+        manifestRegistry: { plugins: [], diagnostics: [] },
+      });
+      initial.index.plugins = [
+        {
+          pluginId,
+          source,
+          manifestPath,
+          rootDir,
+          manifestHash: "fixture",
+          origin: "config",
+          enabled: true,
+          startup: { sidecar: false, memory: false, agentHarnesses: [] },
+          compat: [],
+        },
+      ];
+      const manifestRegistry = loadPluginManifestRegistryForInstalledIndex({
+        index: initial.index,
+        config: cfg,
+        env: state.env,
+      });
+      const metadata = restorePluginMetadataSnapshot({
+        ...initial,
+        manifestRegistry,
+        plugins: manifestRegistry.plugins,
+        byPluginId: new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
+      });
+      const previous = captureActivePluginRegistrySnapshot();
+      const active = createEmptyPluginRegistry();
+      setActivePluginRegistry(active);
+      const lease = installTemporaryCurrentPluginMetadataSnapshot(metadata, { config: cfg });
+      const store = new TranscriptsStore(state.statePath("transcripts"));
+      const readStatus = async () => {
+        const discover = vi.spyOn(discovery, "discoverOpenClawPlugins").mockImplementation(() => {
+          throw new Error("status must not discover plugins");
+        });
+        const resolve = vi.spyOn(loader, "resolveRuntimePluginRegistry").mockImplementation(() => {
+          throw new Error("status must not resolve runtime");
+        });
+        const read = vi.spyOn(fs, "readFileSync");
+        try {
+          const result = await readTranscriptLibraryStatus(store, cfg);
+          expect(discover).not.toHaveBeenCalled();
+          expect(resolve).not.toHaveBeenCalled();
+          expect(
+            read.mock.calls.some(
+              ([file]) => String(file) === manifestPath || String(file) === source,
+            ),
+          ).toBe(false);
+          return result;
+        } finally {
+          read.mockRestore();
+          resolve.mockRestore();
+          discover.mockRestore();
+        }
+      };
+      try {
+        const before = await readStatus();
+        const scoped = loader.loadPluginRegistryHandle({
+          config: cfg,
+          env: state.env,
+          onlyPluginIds: [pluginId],
+          manifestRegistry,
+          discovery: {
+            candidates: [{ idHint: pluginId, source, rootDir, origin: "config" }],
+            diagnostics: [],
+          },
+          cache: false,
+        });
+        expect(scoped.transcriptSourceProviders.map((entry) => entry.provider.id)).toEqual([
+          providerId,
+        ]);
+        expect(getActivePluginRegistry()).toBe(active);
+        expect(active.transcriptSourceProviders).toEqual([]);
+        const after = await readStatus();
+        for (const result of [before, after]) {
+          expect(result.providers.find((provider) => provider.providerId === providerId)).toEqual({
+            providerId,
+            pluginId,
+            name: descriptor.name,
+            availability: "enabled",
+            autoStart: descriptor.autoStart,
+          });
+        }
+      } finally {
+        lease.release();
+        restoreActivePluginRegistrySnapshot(previous);
+      }
+    });
+  });
+});

--- a/src/transcripts/status.producer.test.ts
+++ b/src/transcripts/status.producer.test.ts
@@ -1,0 +1,935 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createTranscriptsTool } from "../agents/tools/transcripts-tool.js";
+import {
+  getRuntimeConfigSnapshot,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { diffGatewayReloadPaths } from "../gateway/config-diff.js";
+import {
+  buildGatewayReloadPlan,
+  isNoopGatewayReloadPlan,
+  listConfigReloadRefinementPrefixes,
+} from "../gateway/config-reload-plan.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createTranscriptsAutoStartService } from "./auto-start.js";
+import { activeSessions, readTranscriptCaptureSnapshot, startTranscripts } from "./capture.js";
+import * as providerRegistry from "./provider-registry.js";
+import type {
+  TranscriptOccupancyWatchRequest,
+  TranscriptSourceProvider,
+  TranscriptStartRequest,
+} from "./provider-types.js";
+import { readTranscriptLibraryStatus } from "./status.js";
+import { transcriptSessionSelector, TranscriptsStore } from "./store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+let previousRegistry: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+beforeEach(() => {
+  previousRegistry = captureActivePluginRegistrySnapshot();
+});
+afterEach(() => {
+  activeSessions.clear();
+  resetConfigRuntimeState();
+  closeOpenClawStateDatabaseForTest();
+  restoreActivePluginRegistrySnapshot(previousRegistry);
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const room = {
+  providerId: "fixture-voice",
+  accountId: "work",
+  guildId: "guild",
+  channelId: "room",
+};
+
+function fixture(config: OpenClawConfig = { transcripts: { autoStart: [room] } }) {
+  const stateDir = tempDirs.make("transcript-status-producer-");
+  const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  });
+  const provider: TranscriptSourceProvider = {
+    id: room.providerId,
+    aliases: ["voice-alias"],
+    name: "Fixture voice",
+    sourceKinds: ["live-audio"],
+    accessControl: {
+      channelId: "discord",
+      resolveAccountId: ({ source }) => ({ ok: true, value: source.accountId ?? "default" }),
+      authorize: async ({ caller }) =>
+        caller.kind === "operator"
+          ? { ok: true, value: undefined }
+          : { ok: false, error: "operator required" },
+    },
+    start: async ({ session }) => ({ ok: true, session }),
+    stop: async ({ sessionId }) => ({ ok: true, sessionId }),
+  };
+  vi.spyOn(providerRegistry, "getTranscriptSourceProvider").mockReturnValue(provider);
+  vi.spyOn(providerRegistry, "listTranscriptSourceProviders").mockReturnValue([provider]);
+  const registry = createEmptyPluginRegistry();
+  registry.transcriptSourceProviders.push({ pluginId: "fixture", source: "fixture", provider });
+  setActivePluginRegistry(registry);
+  const ctx = { config, stateDir, agentId: "main", logger: { warn: vi.fn() } };
+  const tool = createTranscriptsTool({ ...ctx, caller: { kind: "operator", source: "local" } });
+  return {
+    ctx,
+    store,
+    provider,
+    tool,
+    read: () => readTranscriptLibraryStatus(store, config),
+    start: (rawParams: Record<string, unknown>, configuredLifecycle?: true) =>
+      startTranscripts({
+        ctx: { ...ctx, caller: { kind: "operator", source: "local" } },
+        store,
+        rawParams,
+        configuredLifecycle,
+      }),
+  };
+}
+
+describe("configured transcript source provenance", () => {
+  it.each([
+    { name: "direct title edit", titles: ["Future title"], unrelated: false },
+    { name: "logging then title", titles: ["Future title"], unrelated: true },
+    { name: "successive reloads", titles: ["First title", "Latest title"], unrelated: true },
+    { name: "title removal", titles: ["First title", undefined], unrelated: true },
+  ])(
+    "uses the published future title after $name with original routing authority",
+    async ({ titles, unrelated }) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const source = { ...room, title: "Before", sessionId: "future-title" };
+      const f = fixture({
+        logging: { level: "info" },
+        agents: { entries: { main: {}, notes: {}, other: {} } },
+        bindings: [{ agentId: "notes", match: { channel: "discord", accountId: room.accountId } }],
+        transcripts: { autoStart: [source] },
+      });
+      let current = f.ctx.config;
+      setRuntimeConfigSnapshot(current, current);
+      const publish = (candidate: OpenClawConfig) => {
+        const plan = buildGatewayReloadPlan(
+          diffGatewayReloadPaths(current, candidate, listConfigReloadRefinementPrefixes()),
+          {
+            previousConfig: current,
+            candidateConfig: candidate,
+          },
+        );
+        expect(isNoopGatewayReloadPlan(plan)).toBe(true);
+        setRuntimeConfigSnapshot(candidate, candidate);
+        current = candidate;
+      };
+      vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(undefined);
+      const start = vi.fn(f.provider.start!);
+      f.provider.start = start;
+      const service = createTranscriptsAutoStartService(
+        { ...f.ctx, agentId: undefined },
+        () => getRuntimeConfigSnapshot() ?? undefined,
+      );
+      try {
+        service.start();
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]?.startDiagnostic).toBe("retrying"),
+        );
+        expect(await f.store.listSessionEntries()).toHaveLength(0);
+        for (const [index, title] of titles.entries()) {
+          if (unrelated) {
+            publish({ ...current, logging: { level: index === 0 ? "debug" : "warn" } });
+            publish({
+              ...current,
+              bindings: [
+                { agentId: "other", match: { channel: "discord", accountId: room.accountId } },
+              ],
+            });
+          }
+          const { title: _title, ...intent } = source;
+          publish({
+            ...current,
+            transcripts: { autoStart: [{ ...intent, ...(title === undefined ? {} : { title }) }] },
+          });
+          await vi.advanceTimersByTimeAsync(5_000);
+          expect(start).not.toHaveBeenCalled();
+          expect(await f.store.listSessionEntries()).toHaveLength(0);
+        }
+        vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(f.provider);
+        await vi.advanceTimersByTimeAsync(5_000);
+        await vi.waitFor(async () => expect((await f.read()).active).toHaveLength(1));
+        expect(start).toHaveBeenCalledTimes(1);
+        const request = start.mock.calls[0]![0];
+        expect(request.cfg).toBe(f.ctx.config);
+        expect(request.session).toMatchObject({
+          sessionId: source.sessionId,
+          title: titles.at(-1),
+          source: { ...room, agentId: "notes" },
+          metadata: { agentId: "notes" },
+        });
+        await expect(f.store.readSession(source.sessionId)).resolves.toEqual(request.session);
+      } finally {
+        await service.stop();
+      }
+    },
+  );
+  it.each([
+    ["full invitation", { meetingUrl: "https://example.test/room?invitation=other-private" }],
+    ["unknown provider field", { providerOptions: { mode: "other" } }],
+    ["explicit omitted field", { channelId: undefined }],
+  ])("does not borrow a retry title from changed %s intent", async (_name, changed) => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const source = {
+      ...room,
+      sessionId: "original-intent",
+      title: "Before",
+      meetingUrl: "https://example.test/room?invitation=synthetic-private",
+      providerOptions: { mode: "original" },
+    };
+    const f = fixture({ transcripts: { autoStart: [source] } });
+    let current = f.ctx.config;
+    vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(undefined);
+    const start = vi.fn(f.provider.start!);
+    f.provider.start = start;
+    const service = createTranscriptsAutoStartService(f.ctx, () => current);
+    try {
+      service.start();
+      await vi.waitFor(async () =>
+        expect((await f.read()).configuredSources[0]?.startDiagnostic).toBe("retrying"),
+      );
+      current = { transcripts: { autoStart: [{ ...source, ...changed, title: "Ineligible" }] } };
+      vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(f.provider);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+      const request = start.mock.calls[0]![0];
+      expect(request.cfg).toBe(f.ctx.config);
+      expect(request.session).toMatchObject({
+        title: "Before",
+        source: { ...room, meetingUrl: source.meetingUrl, agentId: "main" },
+      });
+      await expect(f.store.readSession(source.sessionId)).resolves.toMatchObject({
+        title: "Before",
+        source: { ...room, meetingUrl: "https://example.test/room", agentId: "main" },
+      });
+    } finally {
+      await service.stop();
+    }
+  });
+  it("reports only its exact configured URL attempt and keeps changed invitations uncertain", async () => {
+    const source = {
+      ...room,
+      meetingUrl: "https://example.test/room?invitation=synthetic-private",
+    };
+    const f = fixture({ transcripts: { autoStart: [source] } });
+    const service = createTranscriptsAutoStartService(f.ctx);
+    try {
+      service.start();
+      await vi.waitFor(async () =>
+        expect((await f.read()).configuredSources[0]?.state).toBe("armed"),
+      );
+      const changed = await readTranscriptLibraryStatus(f.store, {
+        transcripts: {
+          autoStart: [
+            { ...source, meetingUrl: "https://example.test/room?invitation=other-private" },
+          ],
+        },
+      });
+      expect(changed.configuredSources[0]).toMatchObject({ state: "unknown", activeSelectors: [] });
+      expect(changed.configuredSources[0]).not.toHaveProperty("startDiagnostic");
+      expect(JSON.stringify([await f.read(), changed])).not.toMatch(
+        /synthetic-private|other-private/,
+      );
+    } finally {
+      await service.stop();
+    }
+  });
+
+  it("bounds unavailable-start diagnostics and clears them with their service", async () => {
+    const f = fixture({
+      transcripts: {
+        autoStart: Array.from({ length: 101 }, (_, index) => ({
+          ...room,
+          sessionId: `source-${index}`,
+        })),
+      },
+    });
+    vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(undefined);
+    const service = createTranscriptsAutoStartService(f.ctx);
+    try {
+      service.start();
+      await vi.waitFor(async () =>
+        expect(
+          (await f.read()).configuredSources.every(
+            (source) => source.startDiagnostic === "retrying",
+          ),
+        ).toBe(true),
+      );
+      const result = await f.read();
+      expect(result.configuredSources).toHaveLength(100);
+      expect(result.omitted.configuredSources).toBe(1);
+      await service.stop();
+      expect(
+        (await f.read()).configuredSources.every((source) => source.startDiagnostic === undefined),
+      ).toBe(true);
+    } finally {
+      await service.stop();
+    }
+  });
+  it.each([
+    ...(["throw", "reject"] as const).flatMap((outcome) => [
+      { outcome, fixed: true, title: "Original", failures: 12 },
+      { outcome, fixed: false, title: "Original", failures: 2 },
+      { outcome, fixed: false, title: undefined, failures: 1 },
+    ]),
+    { outcome: "reject", fixed: false, title: undefined, failures: 12 },
+  ])(
+    "retains admission and notes after $outcome (fixed=$fixed, title=$title, failures=$failures)",
+    async ({ outcome, fixed, title, failures }) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const source = { ...room, sessionId: fixed ? "failed-admission" : undefined, title };
+      const f = fixture({
+        transcripts: { autoStart: [source] },
+      });
+      let current = f.ctx.config;
+      const start = vi.fn(async (candidate: TranscriptStartRequest) => {
+        await candidate.onUtterance({ text: `Valid note ${start.mock.calls.length}`, final: true });
+        if (start.mock.calls.length > failures) {
+          return {
+            ok: true as const,
+            session: { ...candidate.session, title: "Provider title after retry" },
+          };
+        }
+        if (outcome === "throw") {
+          throw new Error("synthetic-secret https://example.test/?invite=private /private/stack");
+        }
+        return {
+          ok: false as const,
+          error: "synthetic-secret https://example.test/?invite=private",
+        };
+      });
+      f.provider.start = start;
+      const service = createTranscriptsAutoStartService(f.ctx, () => current);
+      try {
+        service.start();
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]).toMatchObject({
+            startDiagnostic: "retrying",
+            state: "unknown",
+          }),
+        );
+        const request = start.mock.calls[0]![0];
+        const admitted = structuredClone(request.session);
+        const before = await f.store.readSession(admitted.sessionId);
+        current = { transcripts: { autoStart: [{ ...source, title: "Future title" }] } };
+        await vi.advanceTimersByTimeAsync(65_000);
+        const attempts = Math.min(failures + 1, 12);
+        expect(start).toHaveBeenCalledTimes(attempts);
+        for (const [candidate] of start.mock.calls) {
+          expect(candidate.session).toEqual(admitted);
+        }
+        await request.onUtterance({ text: "Stale callback", final: true });
+        await expect(f.store.readUtterancesForSession(admitted)).resolves.toMatchObject(
+          Array.from({ length: attempts }, (_, index) => ({ text: `Valid note ${index + 1}` })),
+        );
+        const { stoppedAt: _stoppedAt, ...running } = before!;
+        await expect(f.store.readSession(admitted.sessionId)).resolves.toEqual(
+          failures < 12 ? running : before,
+        );
+        expect(await f.store.listSessionEntries()).toHaveLength(1);
+        const configured = (await f.read()).configuredSources[0];
+        expect(configured?.state).toBe(failures < 12 ? "armed" : "not-active");
+        if (failures < 12) {
+          expect(configured).not.toHaveProperty("startDiagnostic");
+        } else {
+          expect(configured?.startDiagnostic).toBe("start-failed");
+        }
+        await vi.advanceTimersByTimeAsync(65_000);
+        expect(start).toHaveBeenCalledTimes(attempts);
+        expect(JSON.stringify([await f.read(), f.ctx.logger.warn.mock.calls])).not.toMatch(
+          /synthetic-secret|invite=private|\/private\/stack|UNIQUE/,
+        );
+      } finally {
+        await service.stop();
+      }
+    },
+  );
+
+  it.each(
+    (["returned-stop", "thrown-stop", "session-write", "summary-write"] as const).flatMap((fault) =>
+      ["fixed", "generated"].map((identity) => ({ fault, identity })),
+    ),
+  )(
+    "retains failed startup cleanup custody after $fault ($identity identity)",
+    async ({ fault, identity }) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const f = fixture({
+        transcripts: {
+          autoStart: [{ ...room, sessionId: identity === "fixed" ? "retained" : undefined }],
+        },
+      });
+      const start = vi.fn(async (request: TranscriptStartRequest) => {
+        await request.onUtterance({ text: "Admitted note", final: true });
+        return { ok: true as const, session: { ...request.session, title: "Room title" } };
+      });
+      f.provider.start = start;
+      const stop = vi.spyOn(f.provider, "stop");
+      const originalWrite = f.store.writeSession.bind(f.store);
+      let titleFailed = false;
+      let cleanupFails = true;
+      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(async (session) => {
+        if (session.title === "Room title" && !titleFailed) {
+          titleFailed = true;
+          throw new Error("title write unavailable");
+        }
+        if (session.stoppedAt && fault === "session-write" && cleanupFails) {
+          throw new Error("final session write unavailable");
+        }
+        await originalWrite(session);
+      });
+      const originalSummary = f.store.writeSummary.bind(f.store);
+      vi.spyOn(TranscriptsStore.prototype, "writeSummary").mockImplementation(async (...args) => {
+        if (fault === "summary-write" && cleanupFails) {
+          throw new Error("summary write unavailable");
+        }
+        return originalSummary(...args);
+      });
+      stop.mockImplementation(async ({ sessionId }) => {
+        if (cleanupFails && fault === "returned-stop") {
+          return { ok: false, error: "cleanup unavailable" };
+        }
+        if (cleanupFails && fault === "thrown-stop") {
+          throw new Error("cleanup unavailable");
+        }
+        return { ok: true, sessionId };
+      });
+      const service = createTranscriptsAutoStartService(f.ctx);
+      try {
+        service.start();
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]?.startDiagnostic).not.toBe("starting"),
+        );
+        await vi.advanceTimersByTimeAsync(65_000);
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]?.startDiagnostic).not.toBe("starting"),
+        );
+        expect.soft(start).toHaveBeenCalledOnce();
+        expect.soft(await f.store.listSessionEntries()).toHaveLength(1);
+        expect
+          .soft((await f.read()).configuredSources[0]?.startDiagnostic)
+          .toBe("admitted-start-failed");
+        const request = start.mock.calls.at(-1)![0];
+        const session = request.session;
+        await request.onUtterance({ text: "Late failed-start note", final: true });
+        const terminal = fault === "session-write" || fault === "summary-write";
+        await expect(f.tool.execute("status", { action: "status" })).resolves.toMatchObject({
+          details: {
+            [terminal ? "pendingFinalization" : "active"]: [
+              expect.objectContaining({ sessionId: session.sessionId }),
+            ],
+          },
+        });
+        const otherConfig = {
+          transcripts: { autoStart: [{ ...room, sessionId: session.sessionId }] },
+        };
+        const other = createTranscriptsAutoStartService({ ...f.ctx, config: otherConfig });
+        try {
+          other.start();
+          await vi.waitFor(async () =>
+            expect(
+              (await readTranscriptLibraryStatus(f.store, otherConfig)).configuredSources[0]
+                ?.startDiagnostic,
+            ).toBe("id-conflict"),
+          );
+        } finally {
+          await other.stop();
+        }
+        expect.soft(stop).toHaveBeenCalledOnce();
+        await service.stop();
+        cleanupFails = false;
+        // A failed shutdown still owns cleanup; another stop drains that same owner.
+        await service.stop();
+        expect.soft(stop).toHaveBeenCalledTimes(terminal ? 1 : 3);
+        expect.soft(activeSessions.has(session.sessionId)).toBe(false);
+        const stored = (await f.store.readSession(session.sessionId))!;
+        expect.soft(stored).toMatchObject({
+          sessionId: session.sessionId,
+          startedAt: session.startedAt,
+          title: "Room title",
+          stoppedAt: expect.any(String),
+        });
+        expect.soft(stored.source).toEqual(session.source);
+        expect.soft(await f.store.readSummary(stored)).toMatchObject({
+          summary: { transcript: ["Admitted note"] },
+        });
+      } finally {
+        cleanupFails = false;
+        await service.stop();
+        for (const [request] of start.mock.calls) {
+          await f.tool.execute("cleanup", { action: "stop", sessionId: request.session.sessionId });
+        }
+      }
+    },
+  );
+
+  it.each(
+    [false, true].flatMap((whenOccupied) =>
+      ["returned-stop", "thrown-stop", "session-write", "summary-write"].map((fault) => ({
+        whenOccupied,
+        fault,
+      })),
+    ),
+  )(
+    "retains and drains late $fault after shutdown (occupied=$whenOccupied)",
+    async ({ whenOccupied, fault }) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const f = fixture({ transcripts: { autoStart: [{ ...room, whenOccupied }] } });
+      const watches: TranscriptOccupancyWatchRequest[] = [];
+      const unwatch = vi.fn();
+      f.provider.watchOccupancy = async (request) => {
+        watches.push(request);
+        request.onOccupied();
+        return { ok: true, value: { stop: unwatch } };
+      };
+      const gate = createDeferred();
+      const start = vi.fn(async (request: TranscriptStartRequest) => {
+        await request.onUtterance({ text: "Before shutdown" });
+        await gate.promise;
+        await request.onUtterance({ text: "After shutdown" });
+        return { ok: true as const, session: { ...request.session, title: "Late title" } };
+      });
+      f.provider.start = start;
+      let cleanupFails = true;
+      const stop = vi.spyOn(f.provider, "stop").mockImplementation(async ({ sessionId }) => {
+        if (cleanupFails && fault === "returned-stop") {
+          return { ok: false, error: "cleanup unavailable" };
+        }
+        if (cleanupFails && fault === "thrown-stop") {
+          throw new Error("cleanup unavailable");
+        }
+        return { ok: true, sessionId };
+      });
+      const writeSession = f.store.writeSession.bind(f.store);
+      vi.spyOn(TranscriptsStore.prototype, "writeSession").mockImplementation(async (session) => {
+        if (cleanupFails && fault === "session-write" && session.stoppedAt) {
+          throw new Error("final session unavailable");
+        }
+        await writeSession(session);
+      });
+      const writeSummary = f.store.writeSummary.bind(f.store);
+      vi.spyOn(TranscriptsStore.prototype, "writeSummary").mockImplementation(async (...args) => {
+        if (cleanupFails && fault === "summary-write") {
+          throw new Error("summary unavailable");
+        }
+        return writeSummary(...args);
+      });
+      const service = createTranscriptsAutoStartService(f.ctx);
+      try {
+        service.start();
+        await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+        const request = start.mock.calls[0]![0];
+        const session = request.session;
+        const stopping = service.stop();
+        await vi.advanceTimersByTimeAsync(5_000);
+        await stopping;
+        expect(f.ctx.logger.warn).toHaveBeenCalledWith(expect.stringContaining("stop timed out"));
+        expect(unwatch).toHaveBeenCalledTimes(whenOccupied ? 1 : 0);
+        expect(request.abortSignal?.aborted).toBe(true);
+        gate.resolve();
+        // A failed late drain must be visible and still owned after startup settles.
+        await vi.waitFor(() =>
+          expect(f.ctx.logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining("transcripts autoStart session="),
+          ),
+        );
+        const terminal = fault === "session-write" || fault === "summary-write";
+        await expect(f.tool.execute("status", { action: "status" })).resolves.toMatchObject({
+          details: {
+            [terminal ? "pendingFinalization" : "active"]: [
+              expect.objectContaining({ sessionId: session.sessionId }),
+            ],
+          },
+        });
+        const otherConfig = {
+          transcripts: { autoStart: [{ ...room, sessionId: session.sessionId }] },
+        };
+        const other = createTranscriptsAutoStartService({ ...f.ctx, config: otherConfig });
+        try {
+          other.start();
+          await vi.waitFor(async () =>
+            expect(
+              (await readTranscriptLibraryStatus(f.store, otherConfig)).configuredSources[0]
+                ?.startDiagnostic,
+            ).toBe("id-conflict"),
+          );
+        } finally {
+          await other.stop();
+        }
+        expect(stop).toHaveBeenCalledTimes(terminal ? 1 : 2);
+        cleanupFails = false;
+        await service.stop();
+        expect(stop).toHaveBeenCalledTimes(terminal ? 1 : 3);
+        expect(activeSessions.has(session.sessionId)).toBe(false);
+        expect((await f.store.readSession(session.sessionId))?.stoppedAt).toEqual(
+          expect.any(String),
+        );
+        expect(await f.store.readSummary(session)).toMatchObject({
+          summary: { transcript: ["Before shutdown"] },
+        });
+        watches[0]?.onEmpty();
+        watches[0]?.onOccupied();
+        await request.onUtterance({ text: "Retired callback" });
+        await request.onStatus?.({ active: false });
+        await vi.advanceTimersByTimeAsync(65_000);
+        expect(start).toHaveBeenCalledOnce();
+        expect(await f.store.listSessionEntries()).toHaveLength(1);
+        expect(await f.store.readUtterancesForSession(session)).toMatchObject([
+          { text: "Before shutdown" },
+        ]);
+        // Even the same raw ID on a later day belongs to a distinct lifecycle.
+        vi.setSystemTime(new Date(Date.parse(session.startedAt) + 86_400_000));
+        await f.start({ ...room, sessionId: session.sessionId });
+        await service.stop();
+        expect(stop).toHaveBeenCalledTimes(terminal ? 1 : 3);
+        expect((await f.read()).active).toMatchObject([
+          { sessionId: session.sessionId, activeSubscription: true },
+        ]);
+      } finally {
+        cleanupFails = false;
+        gate.resolve();
+        await service.stop();
+        for (const [request] of start.mock.calls) {
+          await f.tool.execute("cleanup", {
+            action: "stop",
+            selector: transcriptSessionSelector(request.session),
+          });
+        }
+      }
+    },
+  );
+
+  it.each(["queued", "pending", "manual"] as const)(
+    "cancels generated retries after %s stop",
+    async (mode) => {
+      const pending = mode === "pending";
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const f = fixture();
+      const gate = createDeferred();
+      const start = vi.fn(async (request: TranscriptStartRequest) => {
+        if (start.mock.calls.length === 1) {
+          return { ok: false as const, error: "temporary provider failure" };
+        }
+        await gate.promise;
+        return { ok: true as const, session: request.session };
+      });
+      f.provider.start = start;
+      const stop = vi.spyOn(f.provider, "stop");
+      const service = createTranscriptsAutoStartService(f.ctx);
+      try {
+        service.start();
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]?.startDiagnostic).toBe("retrying"),
+        );
+        if (pending) {
+          await vi.advanceTimersByTimeAsync(5_000);
+          expect(start).toHaveBeenCalledTimes(2);
+        }
+        const session = start.mock.calls[0]![0].session;
+        if (mode === "manual") {
+          await f.tool.execute("stop", { action: "stop", sessionId: session.sessionId });
+        } else {
+          const stopping = service.stop();
+          if (pending) {
+            expect(start.mock.calls[1]![0].abortSignal?.aborted).toBe(true);
+          }
+          gate.resolve();
+          await stopping;
+        }
+        const stoppedSession = await f.store.readSession(session.sessionId);
+        gate.resolve();
+        await vi.advanceTimersByTimeAsync(65_000);
+        expect(start).toHaveBeenCalledTimes(pending ? 2 : 1);
+        expect(stop).toHaveBeenCalledTimes(pending ? 1 : 0);
+        for (const [request] of start.mock.calls) {
+          await request.onUtterance({ text: "late cancelled note", final: true });
+          await expect(f.store.readUtterancesForSession(request.session)).resolves.toEqual([]);
+        }
+        expect((await f.read()).active).toEqual([]);
+        if (mode === "manual") {
+          expect((await f.read()).configuredSources[0]?.startDiagnostic).toBe("id-conflict");
+        } else {
+          expect((await f.read()).configuredSources[0]).not.toHaveProperty("startDiagnostic");
+        }
+        expect(await f.store.readSession(session.sessionId)).toEqual(stoppedSession);
+        expect(await f.store.listSessionEntries()).toHaveLength(1);
+      } finally {
+        gate.resolve();
+        await service.stop();
+      }
+    },
+  );
+
+  it("retries unavailable providers only before admission and distinguishes duplicate configured entries", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const entry = { ...room, sessionId: "daily" };
+    const f = fixture({ transcripts: { autoStart: [entry, entry] } });
+    vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(undefined);
+    const start = vi.fn(f.provider.start!);
+    f.provider.start = start;
+    const service = createTranscriptsAutoStartService(f.ctx);
+    try {
+      service.start();
+      await vi.waitFor(async () =>
+        expect((await f.read()).configuredSources.map((s) => s.startDiagnostic)).toEqual([
+          "retrying",
+          "retrying",
+        ]),
+      );
+      expect(await f.store.listSessionEntries()).toHaveLength(0);
+      vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(f.provider);
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(async () =>
+        expect((await f.read()).configuredSources.map((s) => s.state)).toEqual([
+          "armed",
+          "not-active",
+        ]),
+      );
+      const result = await f.read();
+      expect(result.configuredSources[1]?.startDiagnostic).toBe("id-conflict");
+      expect(start).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(65_000);
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(await f.store.listSessionEntries()).toHaveLength(1);
+    } finally {
+      await service.stop();
+    }
+  });
+
+  it("fences late diagnostics and teardown against a replacement service and a manual capture", async () => {
+    const f = fixture({ transcripts: { autoStart: [{ ...room, sessionId: "pending" }] } });
+    const gate = createDeferred();
+    let pending: TranscriptStartRequest | undefined;
+    f.provider.start = async (request) => {
+      if (request.session.sessionId === "pending") {
+        pending = request;
+        await gate.promise;
+      }
+      return { ok: true, session: request.session };
+    };
+    const old = createTranscriptsAutoStartService(f.ctx);
+    old.start();
+    await vi.waitFor(() => expect(pending).toBeDefined());
+    const stopping = old.stop();
+    await f.start({ ...room, sessionId: "manual" });
+    const config = { transcripts: { autoStart: [{ ...room, sessionId: "manual" }] } };
+    const replacement = createTranscriptsAutoStartService({ ...f.ctx, config });
+    try {
+      replacement.start();
+      await vi.waitFor(async () =>
+        expect(
+          (await readTranscriptLibraryStatus(f.store, config)).configuredSources[0]
+            ?.startDiagnostic,
+        ).toBe("id-conflict"),
+      );
+      gate.resolve();
+      await stopping;
+      await old.stop();
+      expect(
+        (await readTranscriptLibraryStatus(f.store, config)).configuredSources[0]?.startDiagnostic,
+      ).toBe("id-conflict");
+      await pending!.onUtterance({ text: "stale pending note" });
+      await expect(f.store.readUtterancesForSession(pending!.session)).resolves.toEqual([]);
+      expect((await f.read()).active.map((s) => s.sessionId)).toEqual(["manual"]);
+      await replacement.stop();
+      expect((await f.read()).active.map((s) => s.sessionId)).toEqual(["manual"]);
+    } finally {
+      gate.resolve();
+      await stopping;
+      await replacement.stop();
+      await f.tool.execute("stop", { action: "stop", sessionId: "manual" });
+    }
+  });
+  it.each(
+    (["accountId", "guildId", "channelId", "meetingUrl"] as const).flatMap((key) =>
+      ([undefined, true] as const).map((configuredLifecycle) => ({ key, configuredLifecycle })),
+    ),
+  )(
+    "does not let an explicit $key capture arm an omitted locator (configured=$configuredLifecycle)",
+    async ({ key, configuredLifecycle }) => {
+      const source = {
+        ...room,
+        ...(key === "meetingUrl" ? { meetingUrl: "https://example.test/room" } : {}),
+      };
+      const configured = { ...source, [key]: undefined };
+      const f = fixture({ transcripts: { autoStart: [configured] } });
+      const sessionId = configuredLifecycle ? "configured" : "manual";
+      await f.start({ ...source, sessionId }, configuredLifecycle);
+      const result = await f.read();
+      expect(result.configuredSources[0]).toMatchObject({
+        state: configuredLifecycle ? "not-active" : "unknown",
+        activeSelectors: [],
+      });
+      expect(result.active).toMatchObject([{ sessionId, activeSubscription: true }]);
+      await f.tool.execute("stop", { action: "stop", sessionId });
+    },
+  );
+
+  it("associates a successful configured default start with its requested source, not its resolved account", async () => {
+    const configured = { ...room, providerId: " voice-alias ", accountId: undefined };
+    const config = {
+      transcripts: {
+        autoStart: [configured],
+      },
+    };
+    const f = fixture(config);
+    const service = createTranscriptsAutoStartService(f.ctx);
+    service.start();
+    try {
+      await vi.waitFor(async () => expect((await f.read()).active).toHaveLength(1));
+      const result = await f.read();
+      const capture = result.active[0]!;
+      expect(capture.source).toMatchObject({ accountId: "default", providerId: "voice-alias" });
+      expect(result.configuredSources[0]).toMatchObject({
+        state: "armed",
+        activeSelectors: [capture.selector],
+      });
+      const explicit = await readTranscriptLibraryStatus(f.store, {
+        transcripts: { autoStart: [{ ...room, accountId: "default" }] },
+      });
+      expect(explicit.configuredSources[0]).toMatchObject({
+        state: "not-active",
+        activeSelectors: [],
+      });
+      // Provider-only registrations need not remain in the active registry for alias evidence.
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      expect((await f.read()).configuredSources[0]?.state).toBe("armed");
+      expect(JSON.stringify(await f.store.readSession(capture.sessionId))).not.toContain(
+        "configuredSource",
+      );
+      expect(JSON.stringify(result)).not.toContain('"configuredSource":');
+      expect(JSON.stringify(await f.tool.execute("status", { action: "status" }))).not.toContain(
+        "configuredSource",
+      );
+    } finally {
+      await service.stop();
+    }
+    expect((await f.read()).active).toEqual([]);
+  });
+
+  it("requires complete manual identity and preserves exact explicit matching", async () => {
+    const f = fixture();
+    for (const configuredLifecycle of [undefined, true] as const) {
+      const sessionId = configuredLifecycle ? "configured-exact" : "manual-exact";
+      await f.start({ ...room, sessionId }, configuredLifecycle);
+      const exact = await f.read();
+      expect(exact.configuredSources[0]).toMatchObject({
+        state: "armed",
+        activeSelectors: [exact.active[0]!.selector],
+      });
+      for (const key of ["accountId", "guildId", "channelId"] as const) {
+        const other = await readTranscriptLibraryStatus(f.store, {
+          transcripts: { autoStart: [{ ...room, [key]: "other" }] },
+        });
+        expect(other.configuredSources[0]).toMatchObject({
+          state: "not-active",
+          activeSelectors: [],
+        });
+      }
+      await f.tool.execute("stop", { action: "stop", sessionId });
+    }
+    await f.start({
+      ...room,
+      accountId: undefined,
+      guildId: undefined,
+      sessionId: "manual-default",
+    });
+    const result = await readTranscriptLibraryStatus(f.store, {
+      transcripts: { autoStart: [{ ...room, accountId: undefined }] },
+    });
+    expect(result.configuredSources[0]).toMatchObject({ state: "unknown", activeSelectors: [] });
+  });
+
+  it("retains only configured URL presence and never claims exact invitation identity", async () => {
+    const url = new URL("https://example.test/room?invitation=synthetic-invite#synthetic-fragment");
+    url.username = "synthetic-user";
+    url.password = "synthetic-password";
+    const source = { ...room, meetingUrl: url.href };
+    const f = fixture({
+      transcripts: { autoStart: [source, { ...source, meetingUrl: "https://example.test/room" }] },
+    });
+    await f.start({ ...source, sessionId: "url", privateMarker: "not-source-intent" }, true);
+    const result = await f.read();
+    expect(
+      result.configuredSources.map(({ state, activeSelectors }) => ({ state, activeSelectors })),
+    ).toEqual([
+      { state: "unknown", activeSelectors: [] },
+      { state: "unknown", activeSelectors: [] },
+    ]);
+    expect(result.active[0]?.activeSubscription).toBe(true);
+    const snapshot = readTranscriptCaptureSnapshot();
+    expect(snapshot[0]).toHaveProperty("configuredSource.meetingUrl", true);
+    const retained = JSON.stringify([snapshot, await f.store.readSession("url"), result]);
+    for (const privateText of ["synthetic-", "privateMarker", "not-source-intent"]) {
+      expect(retained).not.toContain(privateText);
+    }
+  });
+
+  it("keeps configured cleanup and in-flight stop owners unknown without transferring their evidence", async () => {
+    const source = { ...room, accountId: undefined };
+    const f = fixture({ transcripts: { autoStart: [source] } });
+    const controller = new AbortController();
+    f.provider.start = async ({ session }) => {
+      controller.abort();
+      return { ok: true, session };
+    };
+    f.provider.stop = async () => ({ ok: false, error: "cleanup pending" });
+    await expect(
+      startTranscripts({
+        ctx: f.ctx,
+        store: f.store,
+        rawParams: { ...source, sessionId: "retained" },
+        configuredLifecycle: true,
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toThrow("provider cleanup failed");
+    const retainedSession = await f.store.readSession("retained");
+    expect(readTranscriptCaptureSnapshot()[0]).toHaveProperty(
+      "configuredSource.accountId",
+      undefined,
+    );
+    expect((await f.read()).configuredSources[0]).toMatchObject({
+      state: "unknown",
+      activeSelectors: [],
+    });
+    const stopGate = createDeferred();
+    const stopping = createDeferred();
+    f.provider.stop = async ({ sessionId }) => {
+      stopping.resolve();
+      await stopGate.promise;
+      return { ok: true, sessionId };
+    };
+    const stopped = f.tool.execute("stop", { action: "stop", sessionId: "retained" });
+    await stopping.promise;
+    try {
+      const result = await f.read();
+      expect(result.configuredSources[0]).toMatchObject({ state: "unknown", activeSelectors: [] });
+      expect(result.active[0]?.activeSubscription).toBe(false);
+    } finally {
+      stopGate.resolve();
+      await stopped;
+    }
+    f.provider.start = async ({ session }) => ({ ok: true, session });
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date(Date.parse(retainedSession!.startedAt) + 86_400_000));
+    await f.start({ ...room, sessionId: "retained" });
+    expect((await f.read()).configuredSources[0]).toMatchObject({
+      state: "unknown",
+      activeSelectors: [],
+    });
+  });
+});

--- a/src/transcripts/status.test.ts
+++ b/src/transcripts/status.test.ts
@@ -1,0 +1,279 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../config/plugin-auto-enable.test-helpers.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  installTemporaryCurrentPluginMetadataSnapshot,
+  withPluginMetadataSnapshotScope,
+} from "../plugins/current-plugin-metadata-snapshot.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  listImportedRuntimePluginIds,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { createPluginRecord } from "../plugins/status.test-helpers.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { activeSessions } from "./capture.js";
+import { sanitizeTranscriptSourceLocator } from "./source-locator.js";
+import { readTranscriptLibraryStatus } from "./status.js";
+import { TranscriptsStore, transcriptSessionSelector } from "./store.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  activeSessions.clear();
+  closeOpenClawStateDatabaseForTest();
+});
+
+describe("transcript library capture health", () => {
+  it("does not claim an exact configured URL identity from a sanitized capture locator", async () => {
+    const stateDir = tempDirs.make("transcript-status-url-");
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const url = new URL("https://example.test/room?invitation=first#caption");
+    url.username = "synthetic-user";
+    url.password = "synthetic-password";
+    const source = { providerId: "fixture-captions", meetingUrl: url.href };
+    const session = {
+      sessionId: "url-capture",
+      startedAt: "2026-08-20T10:00:00.000Z",
+      source: sanitizeTranscriptSourceLocator(source),
+    };
+    await store.writeSession(session);
+    activeSessions.set(session.sessionId, {
+      session,
+      providerId: source.providerId,
+      provider: {},
+      phase: "active",
+    });
+    const configured = [
+      url.href,
+      "https://example.test/room?invitation=second",
+      "https://example.test/room",
+    ];
+    const result = await readTranscriptLibraryStatus(store, {
+      transcripts: { autoStart: configured.map((meetingUrl) => ({ ...source, meetingUrl })) },
+    });
+    expect(
+      result.configuredSources.map((entry) => ({
+        state: entry.state,
+        selectors: entry.activeSelectors,
+      })),
+    ).toEqual(configured.map(() => ({ state: "unknown", selectors: [] })));
+    expect(result.active[0]?.activeSubscription).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("invitation");
+    expect(JSON.stringify(result)).not.toContain("synthetic-password");
+  });
+
+  it("uses the successful capture's requested alias even when its provider is absent from the active registry", async () => {
+    const stateDir = tempDirs.make("transcript-status-alias-");
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const source = { providerId: "caption-alias", channelId: "room" };
+    const session = { sessionId: "alias-capture", startedAt: "2026-08-20T10:00:00.000Z", source };
+    await store.writeSession(session);
+    activeSessions.set(session.sessionId, {
+      session,
+      providerId: "canonical-captions",
+      provider: {},
+      phase: "active",
+    });
+    const result = await readTranscriptLibraryStatus(store, {
+      transcripts: { autoStart: [source] },
+    });
+    expect(result.configuredSources[0]).toMatchObject({
+      state: "armed",
+      activeSelectors: [transcriptSessionSelector(session)],
+    });
+  });
+
+  it("reports a durable source timestamp without inventing persistence time or recording from unstopped rows", async () => {
+    const stateDir = tempDirs.make("transcript-status-");
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const source = {
+      providerId: "fixture-voice",
+      guildId: "guild",
+      channelId: "room",
+      accountId: "work",
+    };
+    const cfg: OpenClawConfig = { transcripts: { autoStart: [source] } };
+    const session = { sessionId: "persistent-room", startedAt: "2026-08-20T10:00:00.000Z", source };
+    await store.writeSession(session);
+    await store.appendUtteranceForSession(session, {
+      text: "Saved before restart",
+      endedAt: "2026-08-20T10:10:00.000Z",
+    });
+    let result = await readTranscriptLibraryStatus(store, cfg);
+    expect(result.active).toEqual([]);
+    expect(result.configuredSources[0]?.state).not.toBe("armed");
+    expect(result.latestTranscript).toMatchObject({
+      lastUtteranceAt: "2026-08-20T10:10:00.000Z",
+      activeSubscription: false,
+    });
+    activeSessions.set(session.sessionId, {
+      session,
+      providerId: source.providerId,
+      phase: "active",
+      provider: {},
+    });
+    result = await readTranscriptLibraryStatus(store, cfg);
+    expect(result.configuredSources[0]).toMatchObject({
+      state: "armed",
+      activeSelectors: [transcriptSessionSelector(session)],
+    });
+    expect(result.active[0]?.activeSubscription).toBe(true);
+    activeSessions.get(session.sessionId)!.cleanupPending = true;
+    result = await readTranscriptLibraryStatus(store, cfg);
+    expect(result.configuredSources[0]).toMatchObject({ state: "unknown", activeSelectors: [] });
+    expect(result.active[0]?.activeSubscription).toBe(false);
+    expect(
+      (
+        await readTranscriptLibraryStatus(store, {
+          transcripts: { enabled: false, autoStart: [source] },
+        })
+      ).configuredSources[0]?.state,
+    ).toBe("disabled");
+  });
+
+  it("reads declared, disabled and unavailable providers from prepared metadata without calling provider runtime", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const cfg: OpenClawConfig = {
+        transcripts: { autoStart: [{ providerId: "absent" }, { providerId: "disabled-source" }] },
+      };
+      const manifests = makeRegistry([
+        { id: "fixture-plugin", channels: [] },
+        { id: "disabled-plugin", channels: [] },
+      ]);
+      manifests.plugins[0]!.contracts = { transcriptSourceProviders: ["declared-source"] };
+      manifests.plugins[1]!.contracts = { transcriptSourceProviders: ["disabled-source"] };
+      const metadata = createPluginMetadataSnapshot({ config: cfg, manifestRegistry: manifests });
+      metadata.index = {
+        ...metadata.index,
+        plugins: manifests.plugins.map((plugin) => ({
+          pluginId: plugin.id,
+          manifestPath: plugin.manifestPath,
+          manifestHash: "fixture",
+          rootDir: plugin.rootDir,
+          origin: plugin.origin,
+          enabled: plugin.id !== "disabled-plugin",
+          startup: { sidecar: false, memory: false, agentHarnesses: [] },
+          compat: [],
+        })),
+      };
+      const previous = captureActivePluginRegistrySnapshot();
+      const registry = createEmptyPluginRegistry();
+      const start = vi.fn();
+      const stop = vi.fn();
+      const status = vi.fn();
+      registry.plugins.push(createPluginRecord({ id: "live-plugin" }));
+      registry.transcriptSourceProviders.push({
+        pluginId: "live-plugin",
+        source: "fixture",
+        provider: {
+          id: "live-source",
+          name: "Fixture source",
+          sourceKinds: ["live-caption"],
+          start,
+          stop,
+          status,
+        },
+      });
+      setActivePluginRegistry(registry);
+      const lease = installTemporaryCurrentPluginMetadataSnapshot(metadata, { config: cfg });
+      try {
+        const store = new TranscriptsStore(path.join(state.stateDir, "transcripts"));
+        const importedBefore = listImportedRuntimePluginIds();
+        const result = await readTranscriptLibraryStatus(store, cfg);
+        expect(result.providers).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ providerId: "declared-source", availability: "enabled" }),
+            expect.objectContaining({ providerId: "disabled-source", availability: "disabled" }),
+            expect.objectContaining({ providerId: "absent", availability: "unavailable" }),
+            expect.objectContaining({
+              providerId: "live-source",
+              sourceKinds: ["live-caption"],
+              canStart: true,
+              canStop: true,
+              canImport: false,
+            }),
+          ]),
+        );
+        expect(
+          result.providers.find((provider) => provider.providerId === "declared-source"),
+        ).not.toHaveProperty("canStart");
+        expect(
+          result.providers.find((provider) => provider.providerId === "declared-source"),
+        ).not.toHaveProperty("autoStart");
+        expect(
+          result.providers.find((provider) => provider.providerId === "manual-transcript"),
+        ).not.toHaveProperty("autoStart");
+        expect(result.configuredSources.map((source) => source.state)).toEqual([
+          "not-active",
+          "not-active",
+        ]);
+        expect(start).not.toHaveBeenCalled();
+        expect(stop).not.toHaveBeenCalled();
+        expect(status).not.toHaveBeenCalled();
+        expect(listImportedRuntimePluginIds()).toEqual(importedBefore);
+      } finally {
+        lease.release();
+        restoreActivePluginRegistrySnapshot(previous);
+      }
+    });
+  });
+
+  it.each([false, true])(
+    "bounds settings rows and treats scoped omissions as unknown (immutable=%s)",
+    async (immutable) => {
+      const stateDir = tempDirs.make("transcript-status-bound-");
+      const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      const cfg: OpenClawConfig = {
+        transcripts: {
+          autoStart: Array.from({ length: 102 }, (_, index) => ({
+            providerId: `missing-${index}`,
+          })),
+        },
+      };
+      const metadata = createPluginMetadataSnapshot({
+        config: cfg,
+        manifestRegistry: { plugins: [], diagnostics: [] },
+      });
+      const scoped = { ...metadata, pluginIds: ["limited-scope"] };
+      // An agent-scoped metadata generation cannot establish Gateway-wide absence.
+      const lease = installTemporaryCurrentPluginMetadataSnapshot(scoped, { config: cfg });
+      try {
+        const result = await withPluginMetadataSnapshotScope(
+          scoped,
+          () => readTranscriptLibraryStatus(store, cfg),
+          { config: cfg, trustConfigIdentity: immutable },
+        );
+        expect(result.configuredSources).toHaveLength(100);
+        expect(result.providers).toHaveLength(100);
+        expect(result.omitted).toMatchObject({
+          configuredSources: 2,
+          providers: expect.any(Number),
+        });
+        expect(
+          result.providers
+            .filter((provider) => provider.providerId.startsWith("missing-"))
+            .every((provider) => provider.availability === "unknown"),
+        ).toBe(true);
+        expect(result.latestTranscript).toBeNull();
+      } finally {
+        lease.release();
+      }
+    },
+  );
+});

--- a/src/transcripts/status.ts
+++ b/src/transcripts/status.ts
@@ -1,0 +1,211 @@
+import {
+  TRANSCRIPTS_PAGE_MAX,
+  type TranscriptsStatusResult,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { readTranscriptCaptureSnapshot } from "./capture.js";
+import { resolveTranscriptsConfig } from "./config.js";
+import { readConfiguredTranscriptStarts } from "./configured-start-status.js";
+import { manualTranscriptSourceProvider } from "./manual-source.js";
+import { projectTranscriptSession, projectTranscriptSource } from "./read.js";
+import { assertTranscriptByteCount, assertTranscriptByteLimit } from "./store-read.js";
+import { transcriptSessionSelector, type TranscriptsStore } from "./store.js";
+
+type ProviderStatus = TranscriptsStatusResult["providers"][number];
+
+/** Reads lifecycle snapshots only; status must not discover/import providers or probe audio. */
+export async function readTranscriptLibraryStatus(
+  store: TranscriptsStore,
+  cfg: OpenClawConfig,
+): Promise<TranscriptsStatusResult> {
+  const config = resolveTranscriptsConfig(cfg.transcripts);
+  const metadata = getCurrentPluginMetadataSnapshot({
+    config: cfg,
+    allowWorkspaceScopedSnapshot: true,
+  });
+  const registry = getActivePluginRegistry();
+  const providers = new Map<string, ProviderStatus>();
+  const installed = new Map(metadata?.index.plugins.map((plugin) => [plugin.pluginId, plugin]));
+  const runtime = new Map(registry?.plugins.map((plugin) => [plugin.id, plugin]));
+  for (const plugin of metadata?.plugins ?? []) {
+    for (const providerId of plugin.contracts?.transcriptSourceProviders ?? []) {
+      const record = runtime.get(plugin.id);
+      const enabled = installed.get(plugin.id)?.enabled;
+      const descriptor = plugin.transcriptSources?.[providerId];
+      providers.set(providerId, {
+        providerId,
+        pluginId: plugin.id,
+        name: descriptor?.name ?? plugin.name ?? providerId,
+        ...(descriptor?.autoStart ? { autoStart: descriptor.autoStart } : {}),
+        availability:
+          record?.status === "error"
+            ? "unavailable"
+            : record?.enabled === false || enabled === false
+              ? "disabled"
+              : enabled === true
+                ? "enabled"
+                : "unknown",
+      });
+    }
+  }
+  const registrations = [
+    { provider: manualTranscriptSourceProvider, pluginId: undefined },
+    ...(registry?.transcriptSourceProviders ?? []),
+  ];
+  const aliases = new Map<string, string>();
+  for (const { provider, pluginId } of registrations) {
+    aliases.set(provider.id.toLowerCase(), provider.id);
+    for (const alias of provider.aliases ?? []) {
+      aliases.set(alias.toLowerCase(), provider.id);
+    }
+    const record = pluginId ? runtime.get(pluginId) : undefined;
+    const existing = providers.get(provider.id);
+    providers.set(provider.id, {
+      providerId: provider.id,
+      ...(pluginId ? { pluginId } : {}),
+      name: existing?.name ?? provider.name,
+      availability:
+        record?.status === "error"
+          ? "unavailable"
+          : record?.enabled === false || existing?.availability === "disabled"
+            ? "disabled"
+            : "enabled",
+      sourceKinds: [...provider.sourceKinds],
+      canStart: Boolean(provider.start),
+      canStop: Boolean(provider.stop),
+      canImport: Boolean(provider.importTranscript),
+      ...(existing?.pluginId === pluginId && existing?.autoStart
+        ? { autoStart: existing.autoStart }
+        : {}),
+    });
+  }
+  const captures = readTranscriptCaptureSnapshot();
+  for (const source of [
+    ...config.autoStart,
+    ...captures.map((capture) => capture.session.source),
+  ]) {
+    const providerId = aliases.get(source.providerId.toLowerCase()) ?? source.providerId;
+    if (!providers.has(providerId)) {
+      providers.set(providerId, {
+        providerId,
+        name: providerId,
+        // A projected runtime inventory cannot establish Gateway-wide absence.
+        availability: metadata && metadata.pluginIds === undefined ? "unavailable" : "unknown",
+      });
+    }
+  }
+  const allProviders = [...providers.values()].toSorted((a, b) =>
+    a.providerId.localeCompare(b.providerId),
+  );
+  const selectedCaptures = captures
+    .toSorted(
+      (a, b) =>
+        a.session.startedAt.localeCompare(b.session.startedAt) ||
+        a.session.sessionId.localeCompare(b.session.sessionId),
+    )
+    .slice(0, TRANSCRIPTS_PAGE_MAX);
+  const active: TranscriptsStatusResult["active"] = [];
+  let activeBytes = 0;
+  // Project each bounded row before reading the next to avoid retaining private descriptors.
+  for (const capture of selectedCaptures) {
+    const entry = store.readEntry(transcriptSessionSelector(capture.session));
+    if (entry) {
+      const projected = projectTranscriptSession(entry, undefined, undefined, captures);
+      activeBytes += Buffer.byteLength(JSON.stringify(projected), "utf8");
+      assertTranscriptByteCount(activeBytes);
+      active.push(projected);
+    }
+  }
+  const configuredStarts = readConfiguredTranscriptStarts(cfg.transcripts);
+  const configuredSources: TranscriptsStatusResult["configuredSources"] = config.autoStart
+    .slice(0, TRANSCRIPTS_PAGE_MAX)
+    .map((configured, index) => {
+      const start = configuredStarts?.get(index);
+      const requestedId = configured.providerId;
+      const providerId = aliases.get(requestedId.toLowerCase()) ?? requestedId;
+      const matches = captures.flatMap((capture) => {
+        // An exact service attempt distinguishes duplicate entries and full URL
+        // requests. Display matching below remains uncertain, never authority.
+        if (start) {
+          return capture.lifecycleToken === start.lifecycleToken ? [{ capture, exact: true }] : [];
+        }
+        const source = capture.configuredSource ?? capture.session.source;
+        if (
+          (capture.providerId.toLowerCase() !== providerId.toLowerCase() &&
+            source.providerId.toLowerCase() !== requestedId.toLowerCase()) ||
+          (configured.sessionId && configured.sessionId !== capture.session.sessionId)
+        ) {
+          return [];
+        }
+        if (
+          capture.configuredSource &&
+          Boolean(configured.meetingUrl) !== capture.configuredSource.meetingUrl
+        ) {
+          return [];
+        }
+        // Configured intent proves omissions. Manual captures cannot establish
+        // whether a missing locator was resolved to an unrelated source.
+        let exact = !configured.meetingUrl && !source.meetingUrl;
+        for (const key of ["accountId", "guildId", "channelId"] as const) {
+          if (configured[key] === source[key]) {
+            continue;
+          }
+          if (
+            capture.configuredSource ||
+            (configured[key] !== undefined && source[key] !== undefined)
+          ) {
+            return [];
+          }
+          exact = false;
+        }
+        return [{ capture, exact }];
+      });
+      // Capture ownership retains sanitized URLs, not the invitation identity.
+      // Even an equal origin/path cannot prove which configured URL started it.
+      const activeSelectors = matches
+        .filter(({ capture, exact }) => exact && capture.state === "armed")
+        .slice(0, TRANSCRIPTS_PAGE_MAX)
+        .map(({ capture }) => transcriptSessionSelector(capture.session));
+      const provider = providers.get(providerId);
+      const { whenOccupied: _whenOccupied, title, sessionId, ...source } = configured;
+      const result: TranscriptsStatusResult["configuredSources"][number] = {
+        source: projectTranscriptSource(source),
+        title,
+        sessionId,
+        state: !config.enabled
+          ? "disabled"
+          : activeSelectors.length > 0
+            ? "armed"
+            : matches.length > 0 ||
+                start?.diagnostic === "starting" ||
+                start?.diagnostic === "retrying" ||
+                (!start && provider?.availability === "unknown")
+              ? "unknown"
+              : "not-active",
+        activeSelectors,
+      };
+      if (start?.diagnostic) {
+        result.startDiagnostic = start.diagnostic;
+      }
+      return result;
+    });
+  const latest = store.readLatestEntry();
+  const result: TranscriptsStatusResult = {
+    enabled: config.enabled,
+    providers: allProviders.slice(0, TRANSCRIPTS_PAGE_MAX),
+    configuredSources,
+    active,
+    latestTranscript: latest
+      ? projectTranscriptSession(latest, undefined, undefined, captures)
+      : null,
+    omitted: {
+      providers: Math.max(0, allProviders.length - TRANSCRIPTS_PAGE_MAX),
+      configuredSources: Math.max(0, config.autoStart.length - TRANSCRIPTS_PAGE_MAX),
+      active: Math.max(0, captures.length - TRANSCRIPTS_PAGE_MAX),
+    },
+  };
+  assertTranscriptByteLimit(JSON.stringify(result));
+  return result;
+}

--- a/src/transcripts/store-export-jsonl.ts
+++ b/src/transcripts/store-export-jsonl.ts
@@ -1,7 +1,12 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import type { DatabaseSync } from "node:sqlite";
 import { writeExternalFileWithinRoot } from "../infra/fs-safe.js";
-import { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync } from "../infra/kysely-sync.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
+} from "../infra/kysely-sync.js";
 import {
   openOpenClawStateDatabase,
   type OpenClawStateDatabaseOptions,
@@ -15,6 +20,20 @@ import {
 } from "./store-sqlite.js";
 
 const TRANSCRIPT_EXPORT_ROW_BATCH_SIZE = 64;
+
+export function transcriptJsonlDigest(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+): string {
+  const query = meetingTranscriptUtteranceQuery(database, session)
+    .selectAll()
+    .orderBy("sequence", "asc");
+  const digest = createHash("sha256");
+  for (const row of iterateSqliteQuerySync(database, query)) {
+    digest.update(`${JSON.stringify(utteranceFromRow(row))}\n`);
+  }
+  return digest.digest("hex");
+}
 
 export async function writeTranscriptJsonlArtifact(params: {
   sessionDir: string;

--- a/src/transcripts/store-read.ts
+++ b/src/transcripts/store-read.ts
@@ -490,7 +490,7 @@ export function readTranscriptUtterancePage(
 }
 
 /** Omit the duplicated transcript inside SQLite before materializing the stored summary. */
-export function readTranscriptNotes(
+export function readStoredTranscriptNotes(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
   exporting = false,

--- a/src/transcripts/store-read.ts
+++ b/src/transcripts/store-read.ts
@@ -1,112 +1,544 @@
 import type { DatabaseSync } from "node:sqlite";
-import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
-import type { TranscriptSessionDescriptor } from "./provider-types.js";
-import { meetingTranscriptDb, sessionFromRow } from "./store-sqlite.js";
+import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-coercion";
+import { expressionBuilder, type Expression, type SqlBool } from "kysely";
+import {
+  TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_PAGE_DEFAULT,
+  TRANSCRIPTS_PAGE_MAX,
+  TRANSCRIPTS_LIST_MAX,
+  TRANSCRIPTS_RESULT_MAX_BYTES,
+  type TranscriptsListParams,
+} from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import { executeSqliteQueryTakeFirstSync, iterateSqliteQuerySync } from "../infra/kysely-sync.js";
+import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provider-types.js";
+import {
+  meetingTranscriptDb,
+  type meetingTranscriptSessionQuery,
+  meetingTranscriptUtteranceQuery,
+  sessionFromRow,
+  utteranceFromRow,
+} from "./store-sqlite.js";
+import type { TranscriptsSummary } from "./summary.js";
 
-export type TranscriptReadEntry = {
-  session: TranscriptSessionDescriptor;
-  selector: string;
-  utteranceCount: number;
-  participants: string[];
-  hasSummary: boolean;
-  overview?: string;
-  summarySource?: "model" | "heuristic";
-};
+export class TranscriptLibraryError extends Error {
+  constructor(
+    readonly type:
+      | "transcript_invalid_cursor"
+      | "transcript_invalid_filter"
+      | "transcript_session_not_found"
+      | "transcript_result_too_large"
+      | "transcript_export_too_large",
+    message: string,
+    readonly maxBytes?: number,
+  ) {
+    super(message);
+  }
+}
 
-export type TranscriptReadOptions = {
-  limit: number;
+function transcriptPageLimit(limit = TRANSCRIPTS_PAGE_DEFAULT, max = TRANSCRIPTS_PAGE_MAX): number {
+  if (!Number.isInteger(limit) || limit < 1 || limit > max) {
+    throw new TranscriptLibraryError(
+      "transcript_invalid_filter",
+      `Transcript page limit must be between 1 and ${max}.`,
+    );
+  }
+  return limit;
+}
+
+export function assertTranscriptByteLimit(
+  text: string,
+  maxBytes = TRANSCRIPTS_RESULT_MAX_BYTES,
+  exporting = false,
+): void {
+  assertTranscriptByteCount(Buffer.byteLength(text, "utf8"), maxBytes, exporting);
+}
+
+export function assertTranscriptByteCount(
+  bytes: number,
+  maxBytes = TRANSCRIPTS_RESULT_MAX_BYTES,
+  exporting = false,
+): void {
+  if (bytes > maxBytes) {
+    throw new TranscriptLibraryError(
+      exporting ? "transcript_export_too_large" : "transcript_result_too_large",
+      exporting
+        ? "Transcript exceeds the download limit; use a local transcript export."
+        : "Transcript response exceeds the read limit; request a smaller page or use a local transcript export.",
+      maxBytes,
+    );
+  }
+}
+
+function byteLimit(exporting: boolean) {
+  return exporting ? TRANSCRIPTS_EXPORT_MAX_BYTES : TRANSCRIPTS_RESULT_MAX_BYTES;
+}
+
+function textBytes(...values: Expression<unknown>[]) {
+  const eb = expressionBuilder();
+  const bytes = values.reduce<Expression<number>>(
+    (sum, value) => eb(sum, "+", eb.fn.coalesce(eb.fn<number>("octet_length", [value]), eb.val(0))),
+    eb.val(0),
+  );
+  return eb.parens(bytes);
+}
+
+function boundedText<T extends string | null>(
+  value: Expression<T>,
+  bytes: Expression<number>,
+  maxBytes: number,
+) {
+  // CASE pairs the size decision with its payload in one statement. The empty
+  // branch preserves the row; callers reject its byte count before decoding.
+  return expressionBuilder().case().when(bytes, "<=", maxBytes).then(value).else("").end();
+}
+
+function readQuery(query: ReturnType<typeof meetingTranscriptSessionQuery>, exporting = false) {
+  return query.select((eb) => {
+    const notes = eb
+      .selectFrom("meeting_transcript_summaries as notes")
+      .whereRef("notes.session_id", "=", "meeting_transcript_sessions.session_id")
+      .whereRef("notes.session_started_at", "=", "meeting_transcript_sessions.started_at");
+    const overview = notes
+      .select((n) =>
+        n
+          .fn<string | null>("json_extract", [n.ref("notes.summary_json"), n.val("$.overview")])
+          .as("overview"),
+      )
+      .$asScalar();
+    const summarySource = notes
+      .select((n) =>
+        n
+          .fn<string | null>("json_extract", [n.ref("notes.summary_json"), n.val("$.source")])
+          .as("source"),
+      )
+      .$asScalar();
+    const utterances = eb
+      .selectFrom("meeting_transcript_utterances as u")
+      .whereRef("u.session_id", "=", "meeting_transcript_sessions.session_id")
+      .whereRef("u.session_started_at", "=", "meeting_transcript_sessions.started_at");
+    // Group and order in SQLite. The aggregate is byte-checked in this statement
+    // before any participant strings cross into JavaScript.
+    const speakers = utterances
+      .select("u.speaker_label")
+      .where("u.speaker_label", "is not", null)
+      .where("u.speaker_label", "!=", "")
+      .groupBy("u.speaker_label")
+      .orderBy((u) => u.fn.min("u.sequence"), "asc");
+    const participants = eb
+      .selectFrom(speakers.as("speakers"))
+      .select((s) =>
+        s.fn<string>("json_group_array", [s.ref("speakers.speaker_label")]).as("participants"),
+      )
+      .$asScalar();
+    const lastAt = eb
+      .selectFrom("meeting_transcript_utterances as u")
+      .select((u) => u.fn.coalesce("u.ended_at", "u.started_at").as("at"))
+      .whereRef("u.session_id", "=", "meeting_transcript_sessions.session_id")
+      .whereRef("u.session_started_at", "=", "meeting_transcript_sessions.started_at")
+      .orderBy("u.sequence", "desc")
+      .limit(1)
+      .$asScalar();
+    const identityBytes = textBytes(eb.ref("session_id"), eb.ref("started_at"), eb.ref("selector"));
+    const bytes = textBytes(
+      eb.ref("session_id"),
+      eb.ref("started_at"),
+      eb.ref("selector"),
+      eb.ref("source_json"),
+      eb.ref("metadata_json"),
+      eb.ref("title"),
+      eb.ref("stopped_at"),
+      lastAt,
+      overview,
+      summarySource,
+      participants,
+    );
+    const maxBytes = byteLimit(exporting);
+    return [
+      boundedText(eb.ref("session_id"), identityBytes, maxBytes).as("session_id"),
+      boundedText(eb.ref("started_at"), identityBytes, maxBytes).as("started_at"),
+      boundedText(eb.ref("selector"), identityBytes, maxBytes).as("selector"),
+      boundedText(eb.ref("source_json"), bytes, maxBytes).as("source_json"),
+      boundedText(eb.ref("metadata_json"), bytes, maxBytes).as("metadata_json"),
+      boundedText(eb.ref("title"), bytes, maxBytes).as("title"),
+      boundedText(eb.ref("stopped_at"), bytes, maxBytes).as("stopped_at"),
+      boundedText(lastAt, bytes, maxBytes).as("last_utterance_at"),
+      boundedText(overview, bytes, maxBytes).as("overview"),
+      boundedText(summarySource, bytes, maxBytes).as("summary_source"),
+      boundedText(participants, bytes, maxBytes).as("participants_json"),
+      bytes.as("payload_bytes"),
+      identityBytes.as("identity_bytes"),
+      utterances
+        .select((u) => u.fn.countAll<number>().as("count"))
+        .$asScalar()
+        .as("utterance_count"),
+      "updated_at_ms",
+      eb
+        .exists(
+          eb
+            .selectFrom("meeting_transcript_summaries as summary")
+            .select("summary.session_id")
+            .whereRef("summary.session_id", "=", "meeting_transcript_sessions.session_id")
+            .whereRef("summary.session_started_at", "=", "meeting_transcript_sessions.started_at"),
+        )
+        .as("has_summary"),
+    ];
+  });
+}
+
+type TranscriptReadRow = Awaited<
+  ReturnType<ReturnType<typeof readQuery>["executeTakeFirstOrThrow"]>
+>;
+
+function transcriptReadEntryFromRow(row: TranscriptReadRow, exporting = false) {
+  assertTranscriptByteCount(row.payload_bytes, byteLimit(exporting), exporting);
+  const session = sessionFromRow(row);
+  const summarySource: TranscriptsSummary["source"] | undefined =
+    row.summary_source === "model" || row.summary_source === "heuristic"
+      ? row.summary_source
+      : undefined;
+  return {
+    session,
+    // Doctor owns historical selector repair; reads return the handle that actually resolves.
+    selector: row.selector,
+    hasSummary: Boolean(row.has_summary),
+    utteranceCount: row.utterance_count,
+    // SAFETY: readQuery aggregates only non-null STRICT TEXT speaker labels into a JSON array.
+    participants: JSON.parse(row.participants_json ?? "[]") as string[],
+    overview: typeof row.overview === "string" ? row.overview : undefined,
+    summarySource,
+    updatedAt: new Date(row.updated_at_ms).toISOString(),
+    lastUtteranceAt: row.last_utterance_at ?? null,
+  };
+}
+
+export type TranscriptReadEntry = ReturnType<typeof transcriptReadEntryFromRow>;
+export type TranscriptReadOptions = Omit<TranscriptsListParams, "cursor"> & {
+  after?: { startedAt: string; sessionId: string };
   offset?: number;
-  providerId?: string;
   session?: Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">;
 };
 
-/** Two bounded queries, independent of the number of meetings in the page. */
-export function queryTranscriptReadEntries(
+const dateReaders = new WeakSet<DatabaseSync>();
+
+function registerTranscriptDateReader(database: DatabaseSync): void {
+  if (dateReaders.has(database)) {
+    return;
+  }
+  // Canonical database reopen creates a new handle. Date parsing is not
+  // deterministic because timezone-free strings depend on the process timezone.
+  database.function(
+    "openclaw_transcript_date_ms",
+    (value) => parseDateStringTimestampMs(value) ?? null,
+  );
+  dateReaders.add(database);
+}
+
+function transcriptStartTime(startedAt: Expression<string>) {
+  const eb = expressionBuilder();
+  // Bound the native-to-JavaScript argument before invoking the parser.
+  return eb
+    .case()
+    .when(eb.fn<number>("octet_length", [startedAt]), "<=", TRANSCRIPTS_RESULT_MAX_BYTES)
+    .then(eb.fn<number | null>("openclaw_transcript_date_ms", [startedAt]))
+    .end();
+}
+
+/** Chronological key selection scans candidates; filters never turn into ownership. */
+export function* iterateTranscriptReadEntries(
   database: DatabaseSync,
   options: TranscriptReadOptions,
-): TranscriptReadEntry[] {
-  const db = meetingTranscriptDb(database);
-  let query = db
-    .selectFrom("meeting_transcript_sessions as sessions")
-    .leftJoin("meeting_transcript_summaries as notes", (join) =>
-      join
-        .onRef("notes.session_id", "=", "sessions.session_id")
-        .onRef("notes.session_started_at", "=", "sessions.started_at"),
-    )
-    .selectAll("sessions")
-    .select((eb) => [
-      "notes.session_id as summary_id",
-      eb
-        .fn<string | null>("json_extract", ["notes.summary_json", eb.val("$.overview")])
-        .as("overview"),
-      eb
-        .fn<string | null>("json_extract", ["notes.summary_json", eb.val("$.source")])
-        .as("summary_source"),
-    ])
-    .orderBy("sessions.started_at", "desc")
-    .orderBy("sessions.session_id", "asc")
-    .limit(options.limit)
-    .offset(options.offset ?? 0);
-  if (options.providerId !== undefined) {
-    query = query.where("sessions.provider_id", "=", options.providerId);
-  }
+): Generator<TranscriptReadEntry, boolean> {
+  const limit = transcriptPageLimit(options.limit, TRANSCRIPTS_LIST_MAX);
+  registerTranscriptDateReader(database);
+  let query = meetingTranscriptDb(database).selectFrom("meeting_transcript_sessions");
   if (options.session) {
     query = query
-      .where("sessions.session_id", "=", options.session.sessionId)
-      .where("sessions.started_at", "=", options.session.startedAt);
+      .where("session_id", "=", options.session.sessionId)
+      .where("started_at", "=", options.session.startedAt);
   }
-  const rows = executeSqliteQuerySync(database, query).rows;
-  if (!rows.length) {
-    return [];
+  if (options.offset !== undefined) {
+    query = query.offset(options.offset);
   }
-  // Group on the full capture identity: providers can reuse a session ID tomorrow.
-  // NULL-speaker groups still count toward utterance totals.
-  const speakers = executeSqliteQuerySync(
-    database,
-    db
-      .selectFrom("meeting_transcript_utterances")
-      .select(["session_id", "session_started_at", "speaker_label"])
-      .select((eb) => [
-        eb.fn.countAll<number>().as("count"),
-        eb.fn.min<number>("sequence").as("first"),
-      ])
-      .where((eb) =>
-        eb.or(
-          rows.map((row) =>
-            eb.and([
-              eb("session_id", "=", row.session_id),
-              eb("session_started_at", "=", row.started_at),
-            ]),
+  if (options.providerId) {
+    query = query.where("provider_id", "=", options.providerId);
+  }
+  if (options.accountId) {
+    const accountId = options.accountId;
+    query = query.where((eb) =>
+      eb(
+        eb.fn<string>("json_extract", [eb.ref("source_json"), eb.val("$.accountId")]),
+        "=",
+        accountId,
+      ),
+    );
+  }
+  if (options.agentId) {
+    const agentId = options.agentId;
+    query = query.where((eb) =>
+      eb(
+        eb.fn<string>("json_extract", [eb.ref("metadata_json"), eb.val("$.agentId")]),
+        "=",
+        agentId,
+      ),
+    );
+  }
+  if (options.startedAfter) {
+    const startedAfter = parseDateStringTimestampMs(options.startedAfter) ?? null;
+    query = query.where((eb) => eb(transcriptStartTime(eb.ref("started_at")), ">=", startedAfter));
+  }
+  if (options.startedBefore) {
+    const startedBefore = parseDateStringTimestampMs(options.startedBefore) ?? null;
+    query = query.where((eb) => eb(transcriptStartTime(eb.ref("started_at")), "<", startedBefore));
+  }
+  if (options.after) {
+    const after = options.after;
+    const afterTime = parseDateStringTimestampMs(after.startedAt);
+    query = query.where((eb) => {
+      const time = transcriptStartTime(eb.ref("started_at"));
+      const afterIdentity = eb(
+        eb.refTuple("session_id", "started_at"),
+        ">",
+        eb.tuple(after.sessionId, after.startedAt),
+      );
+      return afterTime === undefined
+        ? eb.and([eb(time, "is", null), afterIdentity])
+        : eb.or([
+            eb(time, "<", afterTime),
+            eb(time, "is", null),
+            eb.and([eb(time, "=", afterTime), afterIdentity]),
+          ]);
+    });
+  }
+  if (options.query) {
+    const search = options.query;
+    query = query.where((eb) => {
+      const fields = [
+        eb.ref("title"),
+        eb.ref("session_id"),
+        eb.ref("provider_id"),
+        // Raw meeting URLs can contain credentials or tokens hidden by the public
+        // projection. Search must not expose those values through result membership.
+        ...["accountId", "guildId", "channelId", "threadTs", "fileId"].map((key) =>
+          eb.fn<string>("json_extract", [eb.ref("source_json"), eb.val(`$.${key}`)]),
+        ),
+      ];
+      return eb.or(
+        fields.map((field): Expression<SqlBool> =>
+          eb(
+            eb.fn<number>("instr", [eb.fn("lower", [field]), eb.fn("lower", [eb.val(search)])]),
+            ">",
+            0,
           ),
         ),
+      );
+    });
+  }
+  const keys = query
+    .select(["session_id", "started_at"])
+    .orderBy((eb) => transcriptStartTime(eb.ref("started_at")), "desc")
+    .orderBy("session_id", "asc")
+    .orderBy("started_at", "asc")
+    .limit(limit + 1);
+  // Select identities before projecting notes and participants, so the scan
+  // evaluates expensive payloads only for this page and its lookahead.
+  const rows = iterateSqliteQuerySync(
+    database,
+    readQuery(
+      meetingTranscriptDb(database)
+        .selectFrom("meeting_transcript_sessions")
+        .where((eb) =>
+          eb(
+            eb.refTuple("session_id", "started_at"),
+            "in",
+            keys.$asTuple("session_id", "started_at"),
+          ),
+        ),
+    )
+      .orderBy(
+        (eb) => transcriptStartTime(eb.ref("meeting_transcript_sessions.started_at")),
+        "desc",
       )
-      .groupBy(["session_id", "session_started_at", "speaker_label"])
-      .orderBy("first", "asc"),
-  ).rows;
-  const entries = rows.map((row): TranscriptReadEntry => ({
-    session: sessionFromRow(row),
-    selector: row.selector,
-    utteranceCount: 0,
-    participants: [],
-    hasSummary: row.summary_id !== null,
-    overview: typeof row.overview === "string" ? row.overview : undefined,
-    summarySource:
-      row.summary_source === "model" || row.summary_source === "heuristic"
-        ? row.summary_source
-        : undefined,
-  }));
-  const byIdentity = new Map(
-    entries.map((entry) => [
-      JSON.stringify([entry.session.sessionId, entry.session.startedAt]),
-      entry,
-    ]),
+      .orderBy("meeting_transcript_sessions.session_id", "asc")
+      .orderBy("meeting_transcript_sessions.started_at", "asc"),
   );
-  for (const speaker of speakers) {
-    const entry = byIdentity.get(JSON.stringify([speaker.session_id, speaker.session_started_at]))!;
-    entry.utteranceCount += speaker.count;
-    if (speaker.speaker_label) {
-      entry.participants.push(speaker.speaker_label);
+  let count = 0;
+  for (const row of rows) {
+    // Lookahead establishes presence only, even when its payload exceeds the cap.
+    if (count++ === limit) {
+      return true;
     }
+    yield transcriptReadEntryFromRow(row);
+  }
+  return false;
+}
+
+/** Selectors are unique; identity and payload bounds remain in the same SQLite statement. */
+export function readTranscriptEntry(database: DatabaseSync, selector: string, exporting = false) {
+  const row = executeSqliteQueryTakeFirstSync(
+    database,
+    readQuery(
+      meetingTranscriptDb(database)
+        .selectFrom("meeting_transcript_sessions")
+        .where("selector", "=", selector),
+      exporting,
+    ),
+  );
+  if (!row) {
+    return undefined;
+  }
+  assertTranscriptByteCount(row.identity_bytes, byteLimit(exporting), exporting);
+  return row.selector === selector ? transcriptReadEntryFromRow(row, exporting) : undefined;
+}
+
+export function readLatestTranscriptEntry(database: DatabaseSync) {
+  const row = executeSqliteQueryTakeFirstSync(
+    database,
+    readQuery(meetingTranscriptDb(database).selectFrom("meeting_transcript_sessions"))
+      .where("next_utterance_seq", ">", 0)
+      .orderBy("updated_at_ms", "desc")
+      .orderBy("meeting_transcript_sessions.started_at", "desc")
+      .orderBy("meeting_transcript_sessions.session_id", "asc")
+      .limit(1),
+  );
+  return row ? transcriptReadEntryFromRow(row) : undefined;
+}
+
+export function queryTranscriptReadEntries(database: DatabaseSync, options: TranscriptReadOptions) {
+  const entries: TranscriptReadEntry[] = [];
+  let bytes = 0;
+  for (const entry of iterateTranscriptReadEntries(database, options)) {
+    // Reads need attribution, while provider authorization uses the unchanged source.
+    const agentId = entry.session.metadata?.agentId;
+    entry.session.metadata = typeof agentId === "string" ? { agentId } : undefined;
+    bytes += Buffer.byteLength(JSON.stringify(entry), "utf8");
+    assertTranscriptByteCount(bytes);
+    entries.push(entry);
   }
   return entries;
+}
+
+function utteranceQuery(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+  maxBytes: number,
+) {
+  return meetingTranscriptUtteranceQuery(database, session).select((eb) => {
+    const identityBytes = textBytes(eb.ref("session_id"), eb.ref("session_started_at"));
+    const bytes = textBytes(
+      eb.ref("session_id"),
+      eb.ref("session_started_at"),
+      eb.ref("utterance_id"),
+      eb.ref("started_at"),
+      eb.ref("ended_at"),
+      eb.ref("speaker_id"),
+      eb.ref("speaker_label"),
+      eb.ref("text"),
+      eb.ref("metadata_json"),
+    );
+    return [
+      boundedText(eb.ref("session_id"), identityBytes, maxBytes).as("session_id"),
+      boundedText(eb.ref("session_started_at"), identityBytes, maxBytes).as("session_started_at"),
+      boundedText(eb.ref("utterance_id"), bytes, maxBytes).as("utterance_id"),
+      boundedText(eb.ref("started_at"), bytes, maxBytes).as("started_at"),
+      boundedText(eb.ref("ended_at"), bytes, maxBytes).as("ended_at"),
+      boundedText(eb.ref("speaker_id"), bytes, maxBytes).as("speaker_id"),
+      boundedText(eb.ref("speaker_label"), bytes, maxBytes).as("speaker_label"),
+      boundedText(eb.ref("text"), bytes, maxBytes).as("text"),
+      boundedText(eb.ref("metadata_json"), bytes, maxBytes).as("metadata_json"),
+      bytes.as("payload_bytes"),
+      "sequence",
+      "final",
+    ];
+  });
+}
+
+export function readTranscriptUtterancePage(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+  options: { limit?: number; after?: number; query?: string },
+) {
+  const limit = transcriptPageLimit(options.limit);
+  let query = utteranceQuery(database, session, TRANSCRIPTS_RESULT_MAX_BYTES);
+  if (options.after !== undefined) {
+    query = query.where("sequence", ">", options.after);
+  }
+  if (options.query) {
+    const search = options.query;
+    query = query.where((eb) =>
+      eb(
+        eb.fn<number>("instr", [
+          eb.fn("lower", [eb.ref("text")]),
+          eb.fn("lower", [eb.val(search)]),
+        ]),
+        ">",
+        0,
+      ),
+    );
+  }
+  const rows = iterateSqliteQuerySync(database, query.orderBy("sequence", "asc").limit(limit + 1));
+  const utterances: Array<TranscriptUtterance & { sequence: number }> = [];
+  let bytes = 0;
+  for (const row of rows) {
+    if (utterances.length === limit) {
+      return { utterances, hasMore: true };
+    }
+    bytes += row.payload_bytes;
+    assertTranscriptByteCount(bytes);
+    utterances.push({ ...utteranceFromRow(row), sequence: row.sequence });
+  }
+  return { utterances, hasMore: false };
+}
+
+/** Omit the duplicated transcript inside SQLite before materializing the stored summary. */
+export function readTranscriptNotes(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+  exporting = false,
+): { summary?: Omit<TranscriptsSummary, "transcript">; markdown?: string } {
+  const row = executeSqliteQueryTakeFirstSync(
+    database,
+    meetingTranscriptDb(database)
+      .selectFrom("meeting_transcript_summaries")
+      .select((eb) => {
+        const summary = eb.fn<string | null>("json_remove", [
+          eb.ref("summary_json"),
+          eb.val("$.transcript"),
+        ]);
+        const bytes = textBytes(summary, eb.ref("markdown"));
+        return [
+          boundedText(summary, bytes, byteLimit(exporting)).as("summary"),
+          boundedText(eb.ref("markdown"), bytes, byteLimit(exporting)).as("markdown"),
+          bytes.as("payload_bytes"),
+        ];
+      })
+      .where("session_id", "=", session.sessionId)
+      .where("session_started_at", "=", session.startedAt),
+  );
+  if (!row) {
+    return {};
+  }
+  assertTranscriptByteCount(row.payload_bytes, byteLimit(exporting), exporting);
+  let summary: Omit<TranscriptsSummary, "transcript"> | undefined;
+  if (row.summary) {
+    // SAFETY: writeSummary/legacy import own the summary shape; this query removes only transcript.
+    summary = JSON.parse(row.summary) as Omit<TranscriptsSummary, "transcript">;
+  }
+  return {
+    summary,
+    markdown: row.markdown ?? undefined,
+  };
+}
+
+/** Iterate canonical rows for downloads without materializing export files or an unbounded array. */
+export function* iterateTranscriptUtterances(
+  database: DatabaseSync,
+  session: TranscriptSessionDescriptor,
+): Generator<TranscriptUtterance & { sequence: number }> {
+  for (const row of iterateSqliteQuerySync(
+    database,
+    utteranceQuery(database, session, TRANSCRIPTS_EXPORT_MAX_BYTES).orderBy("sequence", "asc"),
+  )) {
+    assertTranscriptByteCount(row.payload_bytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
+    yield { ...utteranceFromRow(row), sequence: row.sequence };
+  }
 }

--- a/src/transcripts/store-read.ts
+++ b/src/transcripts/store-read.ts
@@ -3,20 +3,21 @@ import { parseDateStringTimestampMs } from "@openclaw/normalization-core/number-
 import { expressionBuilder, type Expression, type SqlBool } from "kysely";
 import {
   TRANSCRIPTS_EXPORT_MAX_BYTES,
+  TRANSCRIPTS_LEGACY_MAX_UTTERANCES,
   TRANSCRIPTS_PAGE_DEFAULT,
   TRANSCRIPTS_PAGE_MAX,
   TRANSCRIPTS_LIST_MAX,
   TRANSCRIPTS_RESULT_MAX_BYTES,
+  type TranscriptUtterance,
   type TranscriptsListParams,
 } from "../../packages/gateway-protocol/src/schema/transcripts.js";
 import { executeSqliteQueryTakeFirstSync, iterateSqliteQuerySync } from "../infra/kysely-sync.js";
-import type { TranscriptSessionDescriptor, TranscriptUtterance } from "./provider-types.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
 import {
   meetingTranscriptDb,
   type meetingTranscriptSessionQuery,
   meetingTranscriptUtteranceQuery,
   sessionFromRow,
-  utteranceFromRow,
 } from "./store-sqlite.js";
 import type { TranscriptsSummary } from "./summary.js";
 
@@ -69,8 +70,23 @@ export function assertTranscriptByteCount(
   }
 }
 
-function byteLimit(exporting: boolean) {
-  return exporting ? TRANSCRIPTS_EXPORT_MAX_BYTES : TRANSCRIPTS_RESULT_MAX_BYTES;
+export type TranscriptReadPurpose = "page" | "export" | "legacy";
+
+function byteLimit(purpose: TranscriptReadPurpose) {
+  // The shipped unpaged reader bounded rows and projected text, not raw stored
+  // inputs. Its public result budget is enforced after projection in library.ts.
+  return purpose === "legacy"
+    ? undefined
+    : purpose === "export"
+      ? TRANSCRIPTS_EXPORT_MAX_BYTES
+      : TRANSCRIPTS_RESULT_MAX_BYTES;
+}
+
+function assertReadBytes(bytes: number, purpose: TranscriptReadPurpose) {
+  const maxBytes = byteLimit(purpose);
+  if (maxBytes !== undefined) {
+    assertTranscriptByteCount(bytes, maxBytes, purpose === "export");
+  }
 }
 
 function textBytes(...values: Expression<unknown>[]) {
@@ -85,14 +101,20 @@ function textBytes(...values: Expression<unknown>[]) {
 function boundedText<T extends string | null>(
   value: Expression<T>,
   bytes: Expression<number>,
-  maxBytes: number,
+  maxBytes: number | undefined,
 ) {
+  if (maxBytes === undefined) {
+    return expressionBuilder().parens(value);
+  }
   // CASE pairs the size decision with its payload in one statement. The empty
   // branch preserves the row; callers reject its byte count before decoding.
   return expressionBuilder().case().when(bytes, "<=", maxBytes).then(value).else("").end();
 }
 
-function readQuery(query: ReturnType<typeof meetingTranscriptSessionQuery>, exporting = false) {
+function readQuery(
+  query: ReturnType<typeof meetingTranscriptSessionQuery>,
+  purpose: TranscriptReadPurpose = "page",
+) {
   return query.select((eb) => {
     const notes = eb
       .selectFrom("meeting_transcript_summaries as notes")
@@ -152,7 +174,7 @@ function readQuery(query: ReturnType<typeof meetingTranscriptSessionQuery>, expo
       summarySource,
       participants,
     );
-    const maxBytes = byteLimit(exporting);
+    const maxBytes = byteLimit(purpose);
     return [
       boundedText(eb.ref("session_id"), identityBytes, maxBytes).as("session_id"),
       boundedText(eb.ref("started_at"), identityBytes, maxBytes).as("started_at"),
@@ -189,8 +211,11 @@ type TranscriptReadRow = Awaited<
   ReturnType<ReturnType<typeof readQuery>["executeTakeFirstOrThrow"]>
 >;
 
-function transcriptReadEntryFromRow(row: TranscriptReadRow, exporting = false) {
-  assertTranscriptByteCount(row.payload_bytes, byteLimit(exporting), exporting);
+function transcriptReadEntryFromRow(
+  row: TranscriptReadRow,
+  purpose: TranscriptReadPurpose = "page",
+) {
+  assertReadBytes(row.payload_bytes, purpose);
   const session = sessionFromRow(row);
   const summarySource: TranscriptsSummary["source"] | undefined =
     row.summary_source === "model" || row.summary_source === "heuristic"
@@ -373,21 +398,25 @@ export function* iterateTranscriptReadEntries(
 }
 
 /** Selectors are unique; identity and payload bounds remain in the same SQLite statement. */
-export function readTranscriptEntry(database: DatabaseSync, selector: string, exporting = false) {
+export function readTranscriptEntry(
+  database: DatabaseSync,
+  selector: string,
+  purpose: TranscriptReadPurpose = "page",
+) {
   const row = executeSqliteQueryTakeFirstSync(
     database,
     readQuery(
       meetingTranscriptDb(database)
         .selectFrom("meeting_transcript_sessions")
         .where("selector", "=", selector),
-      exporting,
+      purpose,
     ),
   );
   if (!row) {
     return undefined;
   }
-  assertTranscriptByteCount(row.identity_bytes, byteLimit(exporting), exporting);
-  return row.selector === selector ? transcriptReadEntryFromRow(row, exporting) : undefined;
+  assertReadBytes(row.identity_bytes, purpose);
+  return row.selector === selector ? transcriptReadEntryFromRow(row, purpose) : undefined;
 }
 
 export function readLatestTranscriptEntry(database: DatabaseSync) {
@@ -420,31 +449,26 @@ export function queryTranscriptReadEntries(database: DatabaseSync, options: Tran
 function utteranceQuery(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
-  maxBytes: number,
+  purpose: TranscriptReadPurpose,
 ) {
   return meetingTranscriptUtteranceQuery(database, session).select((eb) => {
-    const identityBytes = textBytes(eb.ref("session_id"), eb.ref("session_started_at"));
+    const maxBytes = byteLimit(purpose);
+    const utteranceId = purpose === "legacy" ? eb.val(null) : eb.ref("utterance_id");
     const bytes = textBytes(
-      eb.ref("session_id"),
-      eb.ref("session_started_at"),
-      eb.ref("utterance_id"),
+      utteranceId,
       eb.ref("started_at"),
       eb.ref("ended_at"),
       eb.ref("speaker_id"),
       eb.ref("speaker_label"),
       eb.ref("text"),
-      eb.ref("metadata_json"),
     );
     return [
-      boundedText(eb.ref("session_id"), identityBytes, maxBytes).as("session_id"),
-      boundedText(eb.ref("session_started_at"), identityBytes, maxBytes).as("session_started_at"),
-      boundedText(eb.ref("utterance_id"), bytes, maxBytes).as("utterance_id"),
+      boundedText(utteranceId, bytes, maxBytes).as("utterance_id"),
       boundedText(eb.ref("started_at"), bytes, maxBytes).as("started_at"),
       boundedText(eb.ref("ended_at"), bytes, maxBytes).as("ended_at"),
       boundedText(eb.ref("speaker_id"), bytes, maxBytes).as("speaker_id"),
       boundedText(eb.ref("speaker_label"), bytes, maxBytes).as("speaker_label"),
       boundedText(eb.ref("text"), bytes, maxBytes).as("text"),
-      boundedText(eb.ref("metadata_json"), bytes, maxBytes).as("metadata_json"),
       bytes.as("payload_bytes"),
       "sequence",
       "final",
@@ -452,13 +476,30 @@ function utteranceQuery(
   });
 }
 
+function transcriptReadUtteranceFromRow(
+  row: Awaited<ReturnType<ReturnType<typeof utteranceQuery>["executeTakeFirstOrThrow"]>>,
+): TranscriptUtterance {
+  return {
+    sequence: row.sequence,
+    id: row.utterance_id ?? undefined,
+    startedAt: row.started_at ?? undefined,
+    endedAt: row.ended_at ?? undefined,
+    speakerId: row.speaker_id ?? undefined,
+    speakerLabel: row.speaker_label ?? undefined,
+    text: row.text,
+    final: row.final === null ? undefined : row.final === 1,
+  };
+}
+
 export function readTranscriptUtterancePage(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
   options: { limit?: number; after?: number; query?: string },
+  purpose: "page" | "legacy" = "page",
 ) {
-  const limit = transcriptPageLimit(options.limit);
-  let query = utteranceQuery(database, session, TRANSCRIPTS_RESULT_MAX_BYTES);
+  const recent = purpose === "legacy";
+  const limit = recent ? TRANSCRIPTS_LEGACY_MAX_UTTERANCES : transcriptPageLimit(options.limit);
+  let query = utteranceQuery(database, session, purpose);
   if (options.after !== undefined) {
     query = query.where("sequence", ">", options.after);
   }
@@ -475,25 +516,28 @@ export function readTranscriptUtterancePage(
       ),
     );
   }
-  const rows = iterateSqliteQuerySync(database, query.orderBy("sequence", "asc").limit(limit + 1));
-  const utterances: Array<TranscriptUtterance & { sequence: number }> = [];
+  const rows = iterateSqliteQuerySync(
+    database,
+    query.orderBy("sequence", recent ? "desc" : "asc").limit(recent ? limit : limit + 1),
+  );
+  const utterances: TranscriptUtterance[] = [];
   let bytes = 0;
   for (const row of rows) {
     if (utterances.length === limit) {
       return { utterances, hasMore: true };
     }
     bytes += row.payload_bytes;
-    assertTranscriptByteCount(bytes);
-    utterances.push({ ...utteranceFromRow(row), sequence: row.sequence });
+    assertReadBytes(bytes, purpose);
+    utterances.push(transcriptReadUtteranceFromRow(row));
   }
-  return { utterances, hasMore: false };
+  return { utterances: recent ? utterances.toReversed() : utterances, hasMore: false };
 }
 
 /** Omit the duplicated transcript inside SQLite before materializing the stored summary. */
 export function readStoredTranscriptNotes(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
-  exporting = false,
+  purpose: TranscriptReadPurpose = "page",
 ): { summary?: Omit<TranscriptsSummary, "transcript">; markdown?: string } {
   const row = executeSqliteQueryTakeFirstSync(
     database,
@@ -506,8 +550,8 @@ export function readStoredTranscriptNotes(
         ]);
         const bytes = textBytes(summary, eb.ref("markdown"));
         return [
-          boundedText(summary, bytes, byteLimit(exporting)).as("summary"),
-          boundedText(eb.ref("markdown"), bytes, byteLimit(exporting)).as("markdown"),
+          boundedText(summary, bytes, byteLimit(purpose)).as("summary"),
+          boundedText(eb.ref("markdown"), bytes, byteLimit(purpose)).as("markdown"),
           bytes.as("payload_bytes"),
         ];
       })
@@ -517,7 +561,7 @@ export function readStoredTranscriptNotes(
   if (!row) {
     return {};
   }
-  assertTranscriptByteCount(row.payload_bytes, byteLimit(exporting), exporting);
+  assertReadBytes(row.payload_bytes, purpose);
   let summary: Omit<TranscriptsSummary, "transcript"> | undefined;
   if (row.summary) {
     // SAFETY: writeSummary/legacy import own the summary shape; this query removes only transcript.
@@ -533,12 +577,12 @@ export function readStoredTranscriptNotes(
 export function* iterateTranscriptUtterances(
   database: DatabaseSync,
   session: TranscriptSessionDescriptor,
-): Generator<TranscriptUtterance & { sequence: number }> {
+): Generator<TranscriptUtterance> {
   for (const row of iterateSqliteQuerySync(
     database,
-    utteranceQuery(database, session, TRANSCRIPTS_EXPORT_MAX_BYTES).orderBy("sequence", "asc"),
+    utteranceQuery(database, session, "export").orderBy("sequence", "asc"),
   )) {
     assertTranscriptByteCount(row.payload_bytes, TRANSCRIPTS_EXPORT_MAX_BYTES, true);
-    yield { ...utteranceFromRow(row), sequence: row.sequence };
+    yield transcriptReadUtteranceFromRow(row);
   }
 }

--- a/src/transcripts/store-sqlite.ts
+++ b/src/transcripts/store-sqlite.ts
@@ -61,6 +61,16 @@ export function readTranscriptSummaryInputRevision(
   return row ? JSON.stringify(row) : undefined;
 }
 
+export function readTranscriptSummaryKeys(database: DatabaseSync): Set<string> {
+  const rows = executeSqliteQuerySync(
+    database,
+    meetingTranscriptDb(database)
+      .selectFrom("meeting_transcript_summaries")
+      .select(["session_id", "session_started_at"]),
+  ).rows;
+  return new Set(rows.map((row) => `${row.session_id}\0${row.session_started_at}`));
+}
+
 export function readRecentStoppedTranscriptSession(
   database: DatabaseSync,
   source: TranscriptSourceLocator,
@@ -191,7 +201,12 @@ function parseOptionalJsonRecord(value: string | null): Record<string, unknown> 
   return asOptionalRecord(JSON.parse(value));
 }
 
-export function sessionFromRow(row: MeetingTranscriptSessionRow): TranscriptSessionDescriptor {
+export function sessionFromRow(
+  row: Pick<
+    MeetingTranscriptSessionRow,
+    "session_id" | "source_json" | "metadata_json" | "started_at" | "title" | "stopped_at"
+  >,
+): TranscriptSessionDescriptor {
   const source = parseOptionalJsonRecord(row.source_json);
   const metadata = parseOptionalJsonRecord(row.metadata_json);
   if (!source || typeof source.providerId !== "string") {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -1,15 +1,10 @@
 // Stores meeting-capture transcripts in the shared SQLite state database.
-import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveOptionalIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { sha256File, sha256Hex } from "../infra/crypto-digest.js";
 import { ensureAbsoluteDirectory } from "../infra/fs-safe.js";
-import {
-  executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
-  iterateSqliteQuerySync,
-} from "../infra/kysely-sync.js";
+import { executeSqliteQuerySync, executeSqliteQueryTakeFirstSync } from "../infra/kysely-sync.js";
 import {
   openOpenClawStateDatabase,
   runOpenClawStateWriteTransaction,
@@ -34,12 +29,12 @@ import {
   transcriptSessionSelector,
   writeTranscriptArtifact,
 } from "./store-artifacts.js";
-import { writeTranscriptJsonlArtifact } from "./store-export-jsonl.js";
+import { transcriptJsonlDigest, writeTranscriptJsonlArtifact } from "./store-export-jsonl.js";
 import {
   assertTranscriptExportPathAvailable,
   hasAliasedCanonicalTranscriptExportPathOwner,
 } from "./store-export-ownership.js";
-import { queryTranscriptReadEntries, type TranscriptReadOptions } from "./store-read.js";
+import * as read from "./store-read.js";
 import {
   appendMeetingTranscriptUtterance,
   meetingTranscriptDb,
@@ -47,6 +42,7 @@ import {
   meetingTranscriptUtteranceQuery,
   type MeetingTranscriptSessionRow,
   readRecentStoppedTranscriptSession,
+  readTranscriptSummaryKeys,
   readTranscriptSummaryInputRevision,
   sessionFromRow,
   summaryFromRow,
@@ -103,16 +99,6 @@ export class TranscriptsStore {
     };
   }
 
-  private readSummaryKeys(database: OpenClawStateDatabase): Set<string> {
-    const rows = executeSqliteQuerySync(
-      database.db,
-      meetingTranscriptDb(database.db)
-        .selectFrom("meeting_transcript_summaries")
-        .select(["session_id", "session_started_at"]),
-    ).rows;
-    return new Set(rows.map((row) => `${row.session_id}\0${row.session_started_at}`));
-  }
-
   private hasSummary(database: OpenClawStateDatabase, row: MeetingTranscriptSessionRow): boolean {
     return Boolean(
       executeSqliteQueryTakeFirstSync(
@@ -158,25 +144,6 @@ export class TranscriptsStore {
     return row ? sessionFromRow(row) : undefined;
   }
 
-  private transcriptRows(session: TranscriptSessionDescriptor) {
-    const database = this.database();
-    return {
-      database,
-      query: meetingTranscriptUtteranceQuery(database.db, session)
-        .selectAll()
-        .orderBy("sequence", "asc"),
-    };
-  }
-
-  private transcriptJsonlDigest(session: TranscriptSessionDescriptor): string {
-    const { database, query } = this.transcriptRows(session);
-    const digest = createHash("sha256");
-    for (const row of iterateSqliteQuerySync(database.db, query)) {
-      digest.update(`${JSON.stringify(utteranceFromRow(row))}\n`);
-    }
-    return digest.digest("hex");
-  }
-
   private async expectedExportHashes(
     session: TranscriptSessionDescriptor,
   ): Promise<Record<string, string>> {
@@ -186,7 +153,7 @@ export class TranscriptsStore {
     }
     const hashes: Record<string, string> = {
       "metadata.json": sha256Hex(`${JSON.stringify(storedSession, null, 2)}\n`),
-      "transcript.jsonl": this.transcriptJsonlDigest(storedSession),
+      "transcript.jsonl": transcriptJsonlDigest(this.database().db, storedSession),
     };
     const summary = await this.readSummary(storedSession);
     if (summary.summary) {
@@ -321,10 +288,37 @@ export class TranscriptsStore {
         .orderBy("started_at", "desc")
         .orderBy("session_id", "asc"),
     ).rows;
-    const summaryKeys = this.readSummaryKeys(database);
+    const summaryKeys = readTranscriptSummaryKeys(database.db);
     return rows.map((row) =>
       this.entryFromRow(row, summaryKeys.has(`${row.session_id}\0${row.started_at}`)),
     );
+  }
+
+  iterateReadEntries(options: read.TranscriptReadOptions = {}) {
+    return read.iterateTranscriptReadEntries(this.database().db, options);
+  }
+
+  readEntry(selector: string, exporting = false) {
+    return read.readTranscriptEntry(this.database().db, selector, exporting);
+  }
+
+  readLatestEntry() {
+    return read.readLatestTranscriptEntry(this.database().db);
+  }
+
+  readNotes(session: TranscriptSessionDescriptor, exporting = false) {
+    return read.readTranscriptNotes(this.database().db, session, exporting);
+  }
+
+  readUtterancePage(
+    session: TranscriptSessionDescriptor,
+    options: { limit?: number; after?: number; query?: string } = {},
+  ) {
+    return read.readTranscriptUtterancePage(this.database().db, session, options);
+  }
+
+  iterateUtterances(session: TranscriptSessionDescriptor) {
+    return read.iterateTranscriptUtterances(this.database().db, session);
   }
 
   readRecentStoppedSession(
@@ -344,27 +338,8 @@ export class TranscriptsStore {
     return readTranscriptSummaryInputRevision(this.database().db, session);
   }
 
-  listReadEntries(options: TranscriptReadOptions) {
-    return queryTranscriptReadEntries(this.database().db, options);
-  }
-
-  readUtteranceEntries(session: TranscriptSessionDescriptor, maxUtterances: number) {
-    const database = this.database();
-    return executeSqliteQuerySync(
-      database.db,
-      meetingTranscriptUtteranceQuery(database.db, session)
-        .select([
-          "sequence",
-          "started_at",
-          "ended_at",
-          "speaker_id",
-          "speaker_label",
-          "text",
-          "final",
-        ])
-        .orderBy("sequence", "desc")
-        .limit(maxUtterances),
-    ).rows.toReversed();
+  listReadEntries(options: read.TranscriptReadOptions) {
+    return read.queryTranscriptReadEntries(this.database().db, options);
   }
 
   async writeSession(session: TranscriptSessionDescriptor): Promise<void> {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -298,23 +298,24 @@ export class TranscriptsStore {
     return read.iterateTranscriptReadEntries(this.database().db, options);
   }
 
-  readEntry(selector: string, exporting = false) {
-    return read.readTranscriptEntry(this.database().db, selector, exporting);
+  readEntry(selector: string, purpose: read.TranscriptReadPurpose = "page") {
+    return read.readTranscriptEntry(this.database().db, selector, purpose);
   }
 
   readLatestEntry() {
     return read.readLatestTranscriptEntry(this.database().db);
   }
 
-  readNotes(session: TranscriptSessionDescriptor, exporting = false) {
-    return read.readStoredTranscriptNotes(this.database().db, session, exporting);
+  readNotes(session: TranscriptSessionDescriptor, purpose: read.TranscriptReadPurpose = "page") {
+    return read.readStoredTranscriptNotes(this.database().db, session, purpose);
   }
 
   readUtterancePage(
     session: TranscriptSessionDescriptor,
     options: { limit?: number; after?: number; query?: string } = {},
+    purpose: "page" | "legacy" = "page",
   ) {
-    return read.readTranscriptUtterancePage(this.database().db, session, options);
+    return read.readTranscriptUtterancePage(this.database().db, session, options, purpose);
   }
 
   iterateUtterances(session: TranscriptSessionDescriptor) {

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -307,7 +307,7 @@ export class TranscriptsStore {
   }
 
   readNotes(session: TranscriptSessionDescriptor, exporting = false) {
-    return read.readTranscriptNotes(this.database().db, session, exporting);
+    return read.readStoredTranscriptNotes(this.database().db, session, exporting);
   }
 
   readUtterancePage(

--- a/test/e2e/gateway-transcripts-discord-capture.e2e.test.ts
+++ b/test/e2e/gateway-transcripts-discord-capture.e2e.test.ts
@@ -11,12 +11,12 @@ import type {
   TranscriptsGetResult,
   TranscriptsListResult,
 } from "../../packages/gateway-protocol/src/schema/transcripts.js";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import { buildMockOpenAiResponsesProvider } from "../../src/gateway/test-openai-responses-model.js";
+import type { OpenClawPluginApi } from "../../src/plugins/types.js";
+import { resolveRelativeBundledPluginPublicModuleId } from "../../src/test-utils/bundled-plugin-public-surface.js";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../src/test-utils/env.js";
 import { withIsolatedTestHome } from "../../test/test-env.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { OpenClawPluginApi } from "../plugins/types.js";
-import { resolveRelativeBundledPluginPublicModuleId } from "../test-utils/bundled-plugin-public-surface.js";
-import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
-import { buildMockOpenAiResponsesProvider } from "./test-openai-responses-model.js";
 
 type TranscriptCapturePorts = { gateway: number; provider: number };
 
@@ -128,12 +128,16 @@ describe("Gateway admitted Discord transcript capture", () => {
     const workspace = path.join(isolated.tempHome, "workspace");
     const configPath = path.join(stateDir, "openclaw.json");
     let gateway:
-      | Awaited<ReturnType<typeof import("./test-helpers.e2e.js").startGatewayWithClient>>
+      | Awaited<
+          ReturnType<typeof import("../../src/gateway/test-helpers.e2e.js").startGatewayWithClient>
+        >
       | undefined;
     let fixture: DiscordCaptureFixture | undefined;
     let restoreDiscordRuntime: (() => void) | undefined;
     let routedService:
-      | ReturnType<typeof import("../transcripts/auto-start.js").createTranscriptsAutoStartService>
+      | ReturnType<
+          typeof import("../../src/transcripts/auto-start.js").createTranscriptsAutoStartService
+        >
       | undefined;
     let cleanupRuntime: (() => Promise<void>) | undefined;
     const requests: Record<string, unknown>[] = [];
@@ -336,9 +340,9 @@ describe("Gateway admitted Discord transcript capture", () => {
         { resolveOpenClawDevSourceRoot },
         { preparePluginLoaderAliases, resolvePluginRuntimeModulePathWithDiagnostics },
       ] = await Promise.all([
-        import("../plugins/loader-module-runtime.js"),
-        import("../plugins/dev-source-root.js"),
-        import("../plugins/sdk-alias.js"),
+        import("../../src/plugins/loader-module-runtime.js"),
+        import("../../src/plugins/dev-source-root.js"),
+        import("../../src/plugins/sdk-alias.js"),
       ]);
       phase("plugin-loader:imported");
       const devSourceRoot = resolveOpenClawDevSourceRoot();
@@ -384,34 +388,38 @@ describe("Gateway admitted Discord transcript capture", () => {
       phase("fixture-module:loaded");
       phase("host-runtime:import");
       summaryTranscript = capturedText;
-      const { startGatewayWithClient } = await import("./test-helpers.e2e.js");
-      const { createPluginRuntime } = await import("../plugins/runtime/index.js");
-      const { createPluginRegistry } = await import("../plugins/registry.js");
-      const { createPluginRecord } = await import("../plugins/loader-records.js");
+      const { startGatewayWithClient } = await import("../../src/gateway/test-helpers.e2e.js");
+      const { createPluginRuntime } = await import("../../src/plugins/runtime/index.js");
+      const { createPluginRegistry } = await import("../../src/plugins/registry.js");
+      const { createPluginRecord } = await import("../../src/plugins/loader-records.js");
       const {
         getActivePluginRegistry,
         setActivePluginRegistry,
         captureActivePluginRegistrySnapshot,
         restoreActivePluginRegistrySnapshot,
-      } = await import("../plugins/runtime.js");
-      const { getPluginRuntimeLoadContext } = await import("../plugins/runtime/load-context.js");
+      } = await import("../../src/plugins/runtime.js");
+      const { getPluginRuntimeLoadContext } =
+        await import("../../src/plugins/runtime/load-context.js");
       const { withPluginRuntimeRegistryScope } =
-        await import("../plugins/runtime/gateway-request-scope.js");
+        await import("../../src/plugins/runtime/gateway-request-scope.js");
       const { refreshPreparedModelRuntimeSnapshots, loadPublishedGatewayReplyDispatchRuntime } =
-        await import("../agents/prepared-model-runtime.js");
+        await import("../../src/agents/prepared-model-runtime.js");
       const { resetPreparedModelRuntimeSnapshotsForTest } =
-        await import("../agents/prepared-model-runtime.test-support.js");
+        await import("../../src/agents/prepared-model-runtime.test-support.js");
       const { clearConfigCache, clearRuntimeConfigSnapshot, getRuntimeConfig } =
-        await import("../config/config.js");
-      const { resetConfigOverrides } = await import("../config/runtime-overrides.js");
+        await import("../../src/config/config.js");
+      const { resetConfigOverrides } = await import("../../src/config/runtime-overrides.js");
       const { drainSessionStoreWriterQueuesForTest, clearSessionStoreCacheForTest } =
-        await import("../config/sessions/store-writer-state.js");
-      const { closeOpenClawStateDatabaseByPath } = await import("../state/openclaw-state-db.js");
-      const { activeSessions, resolveSourceProvider } = await import("../transcripts/capture.js");
-      const { createTranscriptsAutoStartService } = await import("../transcripts/auto-start.js");
+        await import("../../src/config/sessions/store-writer-state.js");
+      const { closeOpenClawStateDatabaseByPath } =
+        await import("../../src/state/openclaw-state-db.js");
+      const { activeSessions, resolveSourceProvider } =
+        await import("../../src/transcripts/capture.js");
+      const { createTranscriptsAutoStartService } =
+        await import("../../src/transcripts/auto-start.js");
       const { readConfiguredTranscriptStarts } =
-        await import("../transcripts/configured-start-status.js");
-      const { TranscriptsStore } = await import("../transcripts/store.js");
+        await import("../../src/transcripts/configured-start-status.js");
+      const { TranscriptsStore } = await import("../../src/transcripts/store.js");
       phase("host-runtime:imported");
       const previousRegistry = captureActivePluginRegistrySnapshot();
       cleanupRuntime = async () => {

--- a/ui/src/e2e/meetings.e2e.test.ts
+++ b/ui/src/e2e/meetings.e2e.test.ts
@@ -15,6 +15,10 @@ const meeting: TranscriptSessionSummary = {
   startedAt: "2026-08-12T17:00:00Z",
   stoppedAt: "2026-08-12T17:45:00Z",
   active: false,
+  activeSubscription: false,
+  agentId: "main",
+  updatedAt: "2026-08-12T17:45:00Z",
+  lastUtteranceAt: "2026-08-12T17:44:00Z",
   utteranceCount: 42,
   participants: ["Ada", "Sam", "Jo", "Alex"],
   hasSummary: true,
@@ -23,6 +27,7 @@ const meeting: TranscriptSessionSummary = {
 };
 const detail: TranscriptsGetResult = {
   session: meeting,
+  nextCursor: null,
   summary: {
     generatedAt: "2026-08-12T17:45:00Z",
     overview: meeting.overview!,
@@ -30,6 +35,7 @@ const detail: TranscriptsGetResult = {
     actionItems: [],
     risks: [],
     participants: meeting.participants,
+    utteranceCount: meeting.utteranceCount,
     source: "model",
     markdown:
       "# Design review\n\n## Overview\nAgreed on a simpler onboarding flow and a focused launch checklist.\n\n## Participants\n- Ada\n- Sam\n- Jo\n- Alex\n\n## Decisions\n- Keep the first-run setup to three steps.\n- Ship the accessible navigation before launch.\n\n## Action Items\n- Ada: prepare the revised prototype.\n- Sam: review keyboard navigation.\n\n## Risks\n- Leave time for mobile testing.\n\n## Transcript\n- Ada: Let's keep the setup simple.",
@@ -44,6 +50,7 @@ suite.define(() => {
         const gateway = await installMockGateway(page, {
           methodResponses: {
             "transcripts.list": {
+              nextCursor: null,
               sessions: [
                 meeting,
                 {
@@ -135,7 +142,7 @@ suite.define(() => {
   it("shows an actionable empty state and refreshes without hiding errors", async () => {
     await suite.withPage({ viewport: { width: 1200, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
-        methodResponses: { "transcripts.list": { sessions: [] } },
+        methodResponses: { "transcripts.list": { sessions: [], nextCursor: null } },
       });
       await page.goto(`${suite.server.baseUrl}meetings`);
       const view = page.locator("openclaw-meetings-page");


### PR DESCRIPTION
Related: #130860
Builds on #139572 and #139658.

## What Problem This Solves

Gateway clients can read recent meeting notes, but cannot page through a large archive, search saved utterances, download a public transcript projection, or reliably distinguish configured capture from a registered subscription. Large stored payloads also need bounds before entering the new archive reader.

## Why This Change Was Made

Add one archive read layer over the existing SQLite records, with authorization before access, filter-bound cursors, complete paginated utterance text, and bounded Markdown/JSONL exports. Public projections omit provider-private metadata, URL credentials, and filesystem paths. Stored speaker IDs and labels are mapped independently, including rows with an ID and no display name. Agent reads release SQLite cursors before awaited source authorization and retain exact tuple selection across that boundary.

Sort stored dates by instant while preserving original identities and selectors. This fixes offset timestamps being misplaced or excluded from date ranges. Unknown dates sort last; equal instants use session ID and original timestamp as stable ties. Selection scans candidate keys, then projects only the requested page plus one lookahead row. Storage admission, schema, indexes, writes, and current occupied-source ID behavior remain unchanged.

Preserve the published `v2026.9.2` `transcripts.get` contract: without `limit`, `cursor`, or `query`, callers still receive the latest 2,000 utterances in chronological order, with sanitized text clipped to 4,000 UTF-16 units and the existing 25 MiB client transport ceiling. This named compatibility path retains historical raw-row reading behavior before projection; it does not impose the new 1 MiB page cap on formerly valid legacy responses. An explicit paging/search argument selects modern pages. Generic store page calls retain their modern defaults, and both request shapes use the same access checks and public allowlist.

Capture status reads lifecycle and prepared plugin metadata snapshots without loading providers or probing audio. Only a complete metadata inventory can establish that a provider is absent. Manifest descriptors advertise supported auto-start locator fields. Title-only configuration changes update future titles without interrupting an admitted capture or changing its routing authority. Lightweight config types are separate from runtime reload helpers to avoid import cycles.

The fixed-ID origin/day policy remains deferred on #130860; the separate UI slice exposes browsing and setup controls.

## User Impact

Authorized clients can search and page through meeting history, search a saved transcript, and download up to 4 MiB without receiving a partial file. Modern page, list, and status results are bounded to 1 MiB and report actionable errors. Markdown preserves canonical saved notes and appends complete durable speech; legacy JSON-only notes retain their existing rendering. Existing unpaged clients keep their recent-window behavior; clients can adopt full-text pages by sending an explicit `limit` and following `nextCursor`.

Restricted operator profiles cannot obtain shared archive data by selecting an agent filter. Status distinguishes registered subscriptions from inactive or uncertain configuration matches, with bounded startup diagnostics, durable counts, and source timestamps. Existing notes retain their title, source, agent, and selector through title-only configuration edits.

## Evidence

- Final focused proof passed 61 tests across library, Gateway, agent-read, and wire-schema owners. Native SQLite regressions cover stored-offset chronology, stable cursor ties and unknown dates, pre-JavaScript page bounds, iterator cleanup, public projections, and nullable speaker labels. The ID-only speaker regression failed before the flat-row projection repair.
- The existing 2,001-utterance Gateway fixture proves the legacy latest-2,000 window, clipping across a surrogate pair, omitted legacy utterance IDs, a response above 1 MiB, explicit-limit full traversal, query-only paging, and cursor-only continuation. The response schema accepts 2,000 legacy rows while explicit request limits remain capped at 100.
- Old-head/new-source probes demonstrate failure-before/fix-after for legacy raw speech above 25 MiB clipping to a small public response, legacy notes above 1 MiB, and the projected 25 MiB ceiling. Modern reads still reject oversized raw public fields before JavaScript. The released handler, tail reader, response schema, and GatewayClient WebSocket limit were inspected in the published stable tag.
- Actual Kysely-compiled queries over 100,000 synthetic captures, each with notes and an utterance, project exactly 51 captures for 50-item first-page, range, cursor, combined range/cursor, and offset reads. Instrumented replay returns identical rows and touches only those notes. Chronology SQL and bound parameters remain byte-identical after the compatibility repair; scan cost remains proportional to candidate count.
- Metadata/manifest/wire checks passed 133 cases; config-write/reload/startup checks passed 148 cases. After the config helper split, 79 config/status tests and a full build passed. Protocol generation, Swift checks, Kotlin generation, and the protocol-since guard pass; compatibility changes leave generated native models unchanged.
- [Final combined real Gateway/SQLite/Chromium proof](https://github.com/openclaw/openclaw/actions/runs/34021555293) passed on production commit `147b19375d2e8eecd8644ff467f289b65d83c120`, with all 46 dependency hashes verified. It covered native agent/tool/capture ownership, a 2,000-row legacy response of 8,293,490 bytes, full-text modern pages and search beyond the legacy clip, ID-only speakers, chronological cursor traversal with unchanged identities, and a title update verified as applied and persisted without a Gateway restart or capture interruption. The owned lease was stopped after evidence retrieval. Follow-up archive changes only adjust test fixtures and move the cross-plugin E2E to its root test owner, preserving every assertion and resolved import target. After rebasing onto main, 43 runtime-proof sources remain byte-identical; the other runtime changes are upstream assistant-error transcript plumbing and an opt-in update-canary branch, neither exercised by this successful-turn, ordinary-startup proof. The archive production delta remains unchanged. Discord transport, model, and STT edges were synthetic; this does not claim an external Discord/provider round trip.
- Earlier [real Gateway/browser download proof](https://github.com/openclaw/openclaw/actions/runs/34004773590) exercised complete Markdown/JSONL downloads with 55 synthetic sessions and 310 utterances. That earlier revision is supplemental evidence; final export projection and byte bounds have focused regression coverage.
- The final full compatibility/projection delta has a fresh scoped-clean P0–P2 review. The full changed gate passed, including core/test types, lint, dead-export scans, schema/storage checks, import cycles, and access guards. The final real Gateway proof above covers the frozen archive production source, with the explicitly reviewed upstream rebase differences described above.
- CI exposed an exported-name collision between public notes projection and the raw reader; the raw reader and its sole caller were renamed, with a reproduced guard and focused proof. A subsequent run found two failures in unchanged browser owners (sandbox config hash and Chromium selected-tab creation); those are being investigated separately from archive code.
- CI fixture repairs passed 93 focused tests under parent `TZ=UTC`, including a fresh-process timezone check, plus all 10 extension-boundary checks. The moved E2E is discovered by the existing E2E config; its 27 import rewrites resolve to the same targets. Test types, lint, and the final scoped P0–P2 review pass without raising baselines or adding exclusions.

- [Focused relocated capture E2E](https://github.com/openclaw/openclaw/actions/runs/34025278982) executed `test/e2e/gateway-transcripts-discord-capture.e2e.test.ts` on the fully tested pre-rebase `8b9efd8b8085d19b30dd9943f7abc03ec531bd30` source, with all 83 frozen source hashes verified. The named late-STT/route-change case passed, actual Vitest exit was 0, and cleanup completed; the owned lease was stopped. The outer proof wrapper exited 1 solely because its duration-summary regex did not strip ANSI formatting. The original report and log remain unchanged; independent ANSI-normalized log inspection verified the test pass. Normal PR CI does not execute this general E2E case; this focused run closes the relocation execution gap. External Discord/model/STT edges remain synthetic.

- The generic hello-fixture cleanup is separately landed in #140044 and is no longer part of this archive diff. The new archive methods sit immediately after the complete 434-entry published `v2026.9.2` catalog, before main's unshipped `update.report` and `skills.workshop.read` rows. Every shipped prefix/index and every method's complete descriptor remain unchanged. A three-way merge check reproduces future-append conflicts before this placement and merges cleanly afterward in the descriptor catalog, generated Android enum, and exact inventory test. The placement passed 31 method tests, canonical generation/Swift checks, lint/format checks, and a fresh scoped-clean P0–P2 review.
- Final composition `1db5b20b7c7d07828254b009cd9ed2c00a490397` cleanly inherits #140044. The reviewed placement files are byte-identical after rebase, and 77 of the 83 source files frozen for the relocated capture proof remain byte-identical. The remaining six contain protocol/catalog additions, the approved method placement, and its inventory assertion; no archive, capture, startup, dispatch, or store owner changed. Later main also added unrelated optional session/repository fields to generated Swift models. Fresh CI validates the composed head; earlier runtime proof remains explicitly bound to its tested source.

- [Final exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34028848349/attempts/2) passed on `1db5b20b7c7d07828254b009cd9ed2c00a490397`. The first attempt hit an unchanged Android caption-test readiness race: existing approval text can remain visible during refresh, while the test immediately expects the refresh flag to be false. Android owners, themes, test and build inputs match the earlier green revision; only the generated method enum differs. One targeted job retry passed the unchanged third-party suite. The original failure and successful retry logs are retained; no assertions, timeouts or source changed for the retry.
