### PR TITLE
fix(ui): refresh automation model suggestions on catalog changes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3869,7 +3869,7 @@ ui/src/lib/chat/tool-cards.ts	2
 ui/src/lib/chat/tool-display.ts	1
 ui/src/lib/config-form-utils.ts	7
 ui/src/lib/config/config-draft-model.ts	5
-ui/src/lib/cron/index.ts	13
+ui/src/lib/cron/index.ts	11
 ui/src/lib/gateway-diagnostics.ts	3
 ui/src/lib/gateway-errors.ts	1
 ui/src/lib/keyboard-shortcuts.ts	1

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -638,6 +638,7 @@ are Gateway settings and remain available in every browser.
     - Webhook mode uses `delivery.mode = "webhook"` with `delivery.to` set to a valid HTTP(S) webhook URL.
     - For main-session tasks, webhook and none delivery modes are available.
     - Advanced edit controls include delete-after-run, clear agent override, cron exact/stagger options, agent model/thinking overrides, and best-effort delivery toggles.
+    - Model suggestions update when the Gateway publishes catalog or configuration changes. A failed read shows an error and keeps the last suggestions for the same agent and connection; the next successful read replaces them without changing your draft.
     - Saved interval labels retain millisecond precision: a 90-second interval displays as `Every 1m 30s`. Repeat and stagger inputs accept decimal amounts that resolve to whole milliseconds; editing a cron expression preserves its stagger window.
     - Form validation is inline with field-level errors; invalid values disable the save button until fixed.
     - Set `cron.webhookToken` to send a dedicated bearer token; if omitted, the webhook is sent without an auth header.

--- a/ui/src/e2e/cron-agent-ownership.e2e.test.ts
+++ b/ui/src/e2e/cron-agent-ownership.e2e.test.ts
@@ -1,4 +1,5 @@
 // Control UI browser proof covers explicit automation ownership across widened page scope.
+import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { expect, it } from "vitest";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
@@ -30,6 +31,80 @@ function cronListResponse(jobs: unknown[]) {
 }
 
 suite.define(() => {
+  it("refreshes model suggestions after catalog changes without replacing the draft", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1_280 },
+        recordVideo: { dir: suite.artifactDir },
+      },
+      async ({ page }) => {
+        const models = (id: string) => ({ models: [{ id, name: id, provider: "fixture" }] });
+        const gateway = await installMockGateway(page, {
+          models: [],
+          methodResponses: {
+            "models.list": models("fixture/old"),
+            "cron.list": cronListResponse([]),
+            "cron.runs": { entries: [], total: 0, offset: 0, hasMore: false },
+            "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}cron`);
+        await page.locator('[data-test-id="cron-new-task"]').click();
+        await page.locator("#cron-name").fill("Keep this draft");
+        const picker = page.locator("#cron-payload-model-picker");
+        await picker.click();
+        await page.getByRole("option", { name: "fixture/old", exact: true }).waitFor();
+        await page.screenshot({ path: path.join(suite.artifactDir, "initial.png") });
+        await page.keyboard.press("Escape");
+
+        await gateway.setMethodResponse("models.list", models("fixture/new"));
+        await gateway.emitGatewayEvent("chat.metadata.changed", {});
+        await expect.poll(() => picker.locator('wa-option[value="fixture/new"]').count()).toBe(1);
+        expect(await picker.locator('wa-option[value="fixture/old"]').count()).toBe(0);
+        await picker.click();
+        await page.getByRole("option", { name: "fixture/new", exact: true }).waitFor();
+        await page.screenshot({ path: path.join(suite.artifactDir, "refreshed.png") });
+        await page.keyboard.press("Escape");
+
+        await gateway.setMethodResponse("models.list", {
+          __mockError: { code: "UNAVAILABLE", message: "Model suggestions unavailable" },
+        });
+        await gateway.emitGatewayEvent("config.changed", {});
+        await page.getByText("Model suggestions unavailable", { exact: true }).waitFor();
+        expect(await picker.locator('wa-option[value="fixture/new"]').count()).toBe(1);
+        await page.screenshot({ path: path.join(suite.artifactDir, "failed-refresh.png") });
+
+        await gateway.setMethodResponse("models.list", { models: [] });
+        await gateway.emitGatewayEvent("chat.metadata.changed", {});
+        await expect.poll(() => picker.locator('wa-option[value="fixture/new"]').count()).toBe(0);
+        await expect
+          .poll(() => page.getByText("Model suggestions unavailable", { exact: true }).count())
+          .toBe(0);
+        expect(await page.locator("#cron-name").inputValue()).toBe("Keep this draft");
+        const requests = await gateway.getRequests();
+        expect(
+          requests
+            .filter(({ method }) => method === "models.list")
+            .every(({ params }) => requireRecord(params).preparedOnly === true),
+        ).toBe(true);
+        expect(
+          requests.filter(({ method }) =>
+            [
+              "config.set",
+              "config.patch",
+              "cron.add",
+              "cron.update",
+              "cron.run",
+              "sessions.patch",
+            ].includes(method),
+          ),
+        ).toEqual([]);
+      },
+    );
+  });
+
   it("keeps the selected agent as owner while browsing all agents", async () => {
     const createdJob = {
       id: "weekday-report",

--- a/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/cron-duration-save.real-gateway.e2e.test.ts
@@ -54,6 +54,177 @@ const suite = createControlUiE2eSuite({
   },
 });
 const captureEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+
+let catalogInstance: OpenClawTestInstance | undefined;
+const catalogModels = (id: string) => [
+  { id: "anchor", name: "Anchor" },
+  { id, name: id },
+];
+const catalogSuite = createControlUiE2eSuite({
+  name: "Automation catalog publication with a real Gateway",
+  startServerBeforeBrowser: true,
+  async startServer() {
+    const owner = await createOpenClawTestInstance({
+      name: "automation-catalog-publication",
+      env: { OPENCLAW_TEST_MINIMAL_GATEWAY: undefined, VITEST: undefined },
+      config: {
+        gateway: { controlUi: { enabled: true } },
+        cron: { enabled: false },
+        agents: { defaults: { model: "fixture/anchor" } },
+        models: {
+          providers: {
+            fixture: {
+              api: "openai-completions",
+              apiKey: "synthetic-catalog-key",
+              baseUrl: "http://127.0.0.1:9/v1",
+              models: catalogModels("retiring"),
+            },
+          },
+        },
+      },
+    });
+    catalogInstance = owner;
+    try {
+      await owner.startGateway();
+      return { baseUrl: `http://127.0.0.1:${owner.port}/`, close: () => owner.cleanup() };
+    } catch (error) {
+      await owner.cleanup();
+      throw error;
+    }
+  },
+});
+
+catalogSuite.define(() => {
+  it("keeps an open automation draft current through real catalog publication and read recovery", async () => {
+    const owner = catalogInstance;
+    if (!owner) {
+      throw new Error("Catalog Gateway fixture was not started");
+    }
+    const handoff = await owner.cli(["dashboard", "--json"]);
+    expect(handoff.code).toBe(0);
+    const browserUrl = requireRecord(JSON.parse(handoff.stdout)).browserUrl;
+    if (typeof browserUrl !== "string") {
+      throw new Error("Dashboard did not return a browser handoff");
+    }
+    const url = new URL("cron", browserUrl);
+    url.hash = new URL(browserUrl).hash;
+    const frames: unknown[] = [];
+    const catalogRequests = new Set<string>();
+    const commands: unknown[] = [];
+    let rejectCatalogReplies = false;
+    const rejected = new Set<string>();
+    const publish = async (id: string) => {
+      const args = [
+        "config",
+        "set",
+        "models.providers.fixture.models",
+        JSON.stringify(catalogModels(id)),
+        "--strict-json",
+        "--replace",
+      ];
+      const result = await owner.cli(args);
+      commands.push({ args, ...result });
+      expect(result.code, result.stderr).toBe(0);
+    };
+    try {
+      await catalogSuite.withPage(
+        {
+          locale: "en-US",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1280 },
+          recordVideo: { dir: catalogSuite.artifactDir },
+        },
+        async ({ page }) => {
+          await page.routeWebSocket(`ws://127.0.0.1:${owner.port}/**`, (socket) => {
+            const server = socket.connectToServer();
+            socket.onMessage((message) => {
+              const frame = requireRecord(JSON.parse(message.toString()));
+              if (frame.type === "req" && frame.method !== "connect") {
+                frames.push({ direction: "sent", frame });
+                if (frame.method === "models.list" && typeof frame.id === "string") {
+                  catalogRequests.add(frame.id);
+                }
+              }
+              server.send(message);
+            });
+            server.onMessage((message) => {
+              const frame = requireRecord(JSON.parse(message.toString()));
+              const catalogReply = typeof frame.id === "string" && catalogRequests.has(frame.id);
+              if (
+                catalogReply ||
+                frame.event === "config.changed" ||
+                frame.event === "chat.metadata.changed"
+              ) {
+                frames.push({
+                  direction: "received",
+                  frame,
+                  transportFailure: catalogReply && rejectCatalogReplies,
+                });
+              }
+              // Inject failure after observing the real reply. Notifications and recovery
+              // still come from the Gateway; no synthetic catalog or event replaces them.
+              if (catalogReply && rejectCatalogReplies && typeof frame.id === "string") {
+                rejected.add(frame.id);
+                socket.send(
+                  JSON.stringify({
+                    type: "res",
+                    id: frame.id,
+                    ok: false,
+                    error: { code: "UNAVAILABLE", message: "Catalog transport unavailable" },
+                  }),
+                );
+              } else {
+                socket.send(message);
+              }
+            });
+          });
+          await page.goto(url.toString());
+          await waitForControlUiGatewayReady(page);
+          await page.locator('[data-test-id="cron-new-task"]').click();
+          await page.locator("#cron-name").fill("Retain this draft");
+          await page.locator("#cron-payload-text").fill("Do not submit this draft");
+          const picker = page.locator("#cron-payload-model-picker");
+          await expect.poll(() => picker.locator('wa-option[value="retiring"]').count()).toBe(1);
+          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "initial.png") });
+          await publish("published");
+          await expect.poll(() => picker.locator('wa-option[value="published"]').count()).toBe(1);
+          expect(await picker.locator('wa-option[value="retiring"]').count()).toBe(0);
+          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "published.png") });
+
+          rejectCatalogReplies = true;
+          await publish("held");
+          await expect.poll(() => rejected.size).toBeGreaterThan(0);
+          const error = page.locator(".cron-error-banner");
+          await error.waitFor({ state: "visible" });
+          expect(await error.textContent()).toContain("Catalog transport unavailable");
+          expect(await picker.locator('wa-option[value="published"]').count()).toBe(1);
+          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "read-failure.png") });
+
+          rejectCatalogReplies = false;
+          await publish("recovered");
+          await expect.poll(() => picker.locator('wa-option[value="recovered"]').count()).toBe(1);
+          await error.waitFor({ state: "hidden" });
+          expect(await page.locator("#cron-name").inputValue()).toBe("Retain this draft");
+          expect(await page.locator("#cron-payload-text").inputValue()).toBe(
+            "Do not submit this draft",
+          );
+          await page.screenshot({ path: path.join(catalogSuite.artifactDir, "recovered.png") });
+        },
+      );
+    } finally {
+      const redact = (text: string) =>
+        text
+          .replaceAll(owner.gatewayToken, "[synthetic token]")
+          .replaceAll(owner.hookToken, "[synthetic token]");
+      await fs.writeFile(
+        path.join(catalogSuite.artifactDir, "publication.json"),
+        redact(JSON.stringify({ frames, commands }, null, 2)),
+      );
+      await fs.writeFile(path.join(catalogSuite.artifactDir, "gateway.log"), redact(owner.logs()));
+    }
+  }, 120_000);
+});
+
 const requireRecord = createRequireRecord("record", "expected-object-value");
 type CliJson = (args: string[]) => Promise<Record<string, unknown>>;
 type ServedAsset = { path: string; status: number; sha256?: string; error?: string };

--- a/ui/src/lib/cron/index.test.ts
+++ b/ui/src/lib/cron/index.test.ts
@@ -13,7 +13,6 @@ import {
   addCronJob,
   cancelCronEdit,
   createInitialCronState,
-  loadCronModelSuggestions,
   toggleCronJob,
   loadCronJobsPage,
   loadCronRuns,
@@ -284,31 +283,6 @@ describe("cron controller", () => {
     expect(
       resolveConfiguredCronModelSuggestions({ agents: { defaults: { model: "" } } }),
     ).toStrictEqual([]);
-  });
-
-  it("loads model suggestions from the configured model view", async () => {
-    const request = vi.fn(async () => ({
-      models: [
-        { id: "z-model", provider: "zai" },
-        { id: "a-model", provider: "anthropic" },
-        { id: "z-model", provider: "other" },
-        { provider: "missing-id" },
-      ],
-    }));
-    const state = {
-      client: { request } as unknown as CronState["client"],
-      connected: true,
-      cronModelSuggestions: [],
-    };
-
-    await loadCronModelSuggestions(state, "writer");
-
-    expect(request).toHaveBeenCalledWith("models.list", {
-      agentId: "writer",
-      view: "configured",
-      preparedOnly: true,
-    });
-    expect(state.cronModelSuggestions).toEqual(["a-model", "z-model"]);
   });
 
   it("normalizes stale announce mode when session/payload no longer support announce", () => {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -250,12 +250,6 @@ export type CronState = {
   cronBusy: boolean;
 };
 
-export type CronModelSuggestionsState = {
-  client: GatewayBrowserClient | null;
-  connected: boolean;
-  cronModelSuggestions: string[];
-};
-
 export function createInitialCronState(
   snapshot: Partial<Pick<CronState, "client" | "connected">> = {},
 ): CronState {
@@ -465,39 +459,6 @@ export async function loadCronStatus(
       activeCronStatusRequests.delete(state);
     }
     request.queued?.resolve(reload ? loadCronStatus(state, opts) : undefined);
-  }
-}
-
-export async function loadCronModelSuggestions(
-  state: CronModelSuggestionsState,
-  agentId: string | null,
-) {
-  if (!state.client || !state.connected || !agentId) {
-    return;
-  }
-  try {
-    const res = await state.client.request("models.list", {
-      agentId,
-      view: "configured",
-      preparedOnly: true,
-    });
-    const models = (res as { models?: unknown[] } | null)?.models;
-    if (!Array.isArray(models)) {
-      state.cronModelSuggestions = [];
-      return;
-    }
-    const ids = models
-      .map((entry) => {
-        if (!entry || typeof entry !== "object") {
-          return "";
-        }
-        const id = (entry as { id?: unknown }).id;
-        return typeof id === "string" ? id.trim() : "";
-      })
-      .filter(Boolean);
-    state.cronModelSuggestions = sortUniqueStrings(ids);
-  } catch {
-    state.cronModelSuggestions = [];
   }
 }
 

--- a/ui/src/pages/cron/cron-page.lifecycle.test.ts
+++ b/ui/src/pages/cron/cron-page.lifecycle.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createChannelCapability } from "../../lib/channels/index.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import {
   createContext,
   createGateway,
@@ -19,6 +20,57 @@ afterEach(() => {
 });
 
 describe("CronPage lifecycle", () => {
+  it.each(["publication", "agent", "connection", "gateway", "detach"])(
+    "rejects a retired catalog result and error after %s changes",
+    async (change) => {
+      const oldResult = createDeferred<{ models: { id: string }[] }>();
+      const oldError = createDeferred();
+      const fallback = createRequest();
+      let reads = 0;
+      const client = createTestGatewayClient((method) => {
+        if (method !== "models.list") {
+          return fallback(method);
+        }
+        reads += 1;
+        if (reads === 1) {
+          return oldResult.promise;
+        }
+        if (reads === 2) {
+          return oldError.promise;
+        }
+        return { models: [{ id: "current-model" }] };
+      });
+      const gateway = createGateway(client, true);
+      const context = createContext(gateway);
+      const page = createPage(context, { render: true });
+      await waitForCronPage(() => expect(reads).toBe(1));
+      gateway.emitRetiredEvent({ type: "event", event: "config.changed", payload: {} });
+      await waitForCronPage(() => expect(reads).toBe(2));
+
+      if (change === "agent") {
+        context.agentSelection.set("writer");
+      } else if (change === "connection") {
+        gateway.emitSnapshot({ phase: "reconnecting" });
+        gateway.emitSnapshot({ phase: "connected" });
+      } else if (change === "gateway") {
+        page.context = createContext(createGateway(client, true));
+        page.requestUpdate();
+      } else if (change === "detach") {
+        page.remove();
+      } else {
+        gateway.emitRetiredEvent({ type: "event", event: "chat.metadata.changed", payload: {} });
+      }
+      const expected = change === "detach" ? [] : ["current-model"];
+      await waitForCronPage(() => expect(page.cronModelSuggestions).toEqual(expected));
+      oldResult.resolve({ models: [{ id: "retired-model" }] });
+      oldError.reject(new Error("Retired catalog error"));
+      await Promise.allSettled([oldResult.promise, oldError.promise]);
+      await page.updateComplete;
+      expect(page.cronModelSuggestions).toEqual(expected);
+      expect(page.textContent).not.toContain("Retired catalog error");
+    },
+  );
+
   it("coalesces a cron event burst into one trailing refresh of the current page", async () => {
     const held = createDeferred();
     let released = false;

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -1,7 +1,12 @@
 import { consume } from "@lit/context";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import type { AgentsListResult, CronJob, CronScratchGetResult } from "../../api/types.ts";
+import type {
+  AgentsListResult,
+  CronJob,
+  CronScratchGetResult,
+  ModelCatalogResult,
+} from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
@@ -18,7 +23,6 @@ import {
   hasCronFormErrors,
   invalidateCronRefresh,
   loadCronJobsPage,
-  loadCronModelSuggestions,
   loadCronRuns,
   loadCronStatus,
   loadMoreCronRuns,
@@ -32,7 +36,6 @@ import {
   updateCronRunsFilter,
   validateCronForm,
   type CronFormState,
-  type CronModelSuggestionsState,
   type CronState,
 } from "../../lib/cron/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
@@ -55,6 +58,7 @@ class CronPage extends OpenClawLightDomElement {
   @state() private cron = createInitialCronState();
   @state() private agentsList: AgentsListResult | null = null;
   @state() private cronModelSuggestions: string[] = [];
+  @state() private modelSuggestionsError: string | null = null;
   @state() private listTab: CronListTab = "tasks";
   @state() private detailTab: CronDetailTab = "settings";
   @state() private heartbeatScratch = "";
@@ -63,7 +67,7 @@ class CronPage extends OpenClawLightDomElement {
   private routeJobState: CronState | null = null;
   private highlightedRunId: string | null = null;
   private pendingRunScroll = false;
-  private modelSuggestionsState: CronState | null = null;
+  private modelSuggestionsRequest: { state: CronState; agentId: string } | null = null;
   private heartbeatScratchRequest = 0;
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
@@ -118,10 +122,16 @@ class CronPage extends OpenClawLightDomElement {
             this.gateway.gateway === gateway &&
             this.context.gateway === gateway &&
             this.gateway.connected &&
-            this.gateway.client &&
-            event.event === "cron"
+            this.gateway.client
           ) {
-            void this.refreshCron({ tableFilters: true, coalesce: true });
+            if (event.event === "cron") {
+              void this.refreshCron({ tableFilters: true, coalesce: true });
+            } else if (
+              event.event === "config.changed" ||
+              event.event === "chat.metadata.changed"
+            ) {
+              void this.loadModelSuggestions(this.cron);
+            }
           }
         }),
     );
@@ -142,7 +152,8 @@ class CronPage extends OpenClawLightDomElement {
     this.cron.cronAgentId = this.context.agentSelection.state.scopeId;
     this.agentsList = connected ? this.context.agents.state.agentsList : null;
     this.cronModelSuggestions = [];
-    this.modelSuggestionsState = null;
+    this.modelSuggestionsError = null;
+    this.modelSuggestionsRequest = null;
   }
 
   private syncAgentsState() {
@@ -161,10 +172,8 @@ class CronPage extends OpenClawLightDomElement {
     } else if (!this.cron.cronRuns.length && !this.cron.cronRunsLoadingMore) {
       void this.loadRuns(this.cron.cronRunsScope === "all" ? null : this.cron.cronRunsJobId);
     }
-    if (this.modelSuggestionsState !== this.cron) {
-      const cronState = this.cron;
-      this.modelSuggestionsState = cronState;
-      void this.loadModelSuggestions(cronState);
+    if (this.modelSuggestionsRequest?.state !== this.cron) {
+      void this.loadModelSuggestions(this.cron);
     }
   }
 
@@ -252,20 +261,33 @@ class CronPage extends OpenClawLightDomElement {
   }
 
   private async loadModelSuggestions(cronState: CronState) {
-    const suggestionState: CronModelSuggestionsState = {
-      client: cronState.client,
-      connected: cronState.connected,
-      cronModelSuggestions: this.cronModelSuggestions,
-    };
-    await loadCronModelSuggestions(suggestionState, this.context.agentSelection.state.selectedId);
-    if (
-      this.isConnected &&
+    const client = cronState.client;
+    const agentId = this.context.agentSelection.state.selectedId;
+    if (!client || !cronState.connected || !agentId) {
+      return;
+    }
+    const request = { state: cronState, agentId };
+    this.modelSuggestionsRequest = request;
+    // A publication can replace a pending read without changing the page or agent.
+    // Only that latest request may publish suggestions or a failure.
+    const isCurrent = () =>
       this.cron === cronState &&
-      this.modelSuggestionsState === cronState &&
-      cronState.connected &&
-      suggestionState.client === cronState.client
-    ) {
-      this.cronModelSuggestions = suggestionState.cronModelSuggestions;
+      this.modelSuggestionsRequest === request &&
+      this.context.agentSelection.state.selectedId === agentId;
+    try {
+      const result = await client.request<ModelCatalogResult>("models.list", {
+        agentId,
+        view: "configured",
+        preparedOnly: true,
+      });
+      if (isCurrent()) {
+        this.cronModelSuggestions = result.models.map((entry) => entry.id);
+        this.modelSuggestionsError = null;
+      }
+    } catch (error) {
+      if (isCurrent()) {
+        this.modelSuggestionsError = formatUiError(error);
+      }
     }
   }
 
@@ -518,7 +540,7 @@ class CronPage extends OpenClawLightDomElement {
           createOpen: this.cron.cronCreateOpen,
           listTab: this.listTab,
           detailTab: this.detailTab,
-          error: this.cron.cronError,
+          error: this.cron.cronError ?? this.modelSuggestionsError,
           busy: this.cron.cronBusy,
           form: this.cron.cronForm,
           heartbeatScratch: canManage ? this.heartbeatScratch : "",


### PR DESCRIPTION
Related: #136257, #135702.

## What Problem This Solves

Automations kept old model suggestions after catalog publication. Failed reads silently removed suggestions.

## Why This Change Was Made

The page owns its typed catalog read and follows existing publication events. Only the latest request for the current page and agent may update results or errors. Shared form normalization and sorting remain unchanged.

## User Impact

Suggestions update without reloading. Failed reads show an error and retain same-agent choices; successful empty results clear them. Draft fields remain intact, and automatic reads do not trigger discovery.

## Evidence

Built-browser checks reproduced stale suggestions and verified publication, recovery, empty results, and draft preservation. All 253 focused tests passed. Real Gateway/browser tests used CLI configuration changes to publish new choices and controlled read failures to verify recovery. All five real-Gateway automation scenarios passed. A separate sandbox fixture failure reproduced on the baseline.

Consumers: Automations suggestions now follow catalog publication and current-request ownership.
