### PR TITLE
fix(tui): keep model catalogs scoped to the selected agent

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -40,7 +40,6 @@ const getSessionGoalMock = vi.fn();
 const updateSessionGoalObjectiveMock = vi.fn();
 const updateSessionGoalStatusMock = vi.fn();
 const loadAgentRuntimePluginRegistryHandleMock = vi.fn();
-const withPluginRuntimeRegistryScopeMock = vi.fn((_registry: unknown, run: () => unknown) => run());
 const ensureContextWindowCacheLoadedMock = vi.fn(async () => undefined);
 const runSessionStartupMigrationMock = vi.fn<(...args: unknown[]) => Promise<void>>(
   async () => undefined,
@@ -73,8 +72,11 @@ const loadCombinedSessionStoreForGatewayMock = vi.fn((_options?: unknown) => ({
   store: {},
 }));
 const getRuntimeConfigMock = vi.fn(() => ({}));
+type CatalogLoadParams = Parameters<
+  typeof import("../gateway/server-model-catalog.js").loadGatewayModelCatalog
+>[0];
 const loadGatewayModelCatalogMock = vi.fn(
-  (_params?: unknown): Array<{ id: string; name: string; provider: string }> => [],
+  (_params?: CatalogLoadParams): Array<{ id: string; name: string; provider: string }> => [],
 );
 const buildAllowedModelSetMock = vi.fn(({ catalog }: { catalog: unknown[] }) => ({
   allowedCatalog: catalog,
@@ -179,11 +181,6 @@ vi.mock("../agents/runtime-plugins.js", () => ({
     loadAgentRuntimePluginRegistryHandleMock(...args),
 }));
 
-vi.mock("../plugins/runtime/gateway-request-scope.js", () => ({
-  withPluginRuntimeRegistryScope: (...args: [unknown, () => unknown]) =>
-    withPluginRuntimeRegistryScopeMock(...args),
-}));
-
 vi.mock("../agents/context.js", () => ({
   ensureContextWindowCacheLoaded: () => ensureContextWindowCacheLoadedMock(),
 }));
@@ -281,7 +278,7 @@ vi.mock("../gateway/session-utils.js", () => ({
 }));
 
 vi.mock("../gateway/server-model-catalog.js", () => ({
-  loadGatewayModelCatalog: (params?: unknown) => loadGatewayModelCatalogMock(params),
+  loadGatewayModelCatalog: (params?: CatalogLoadParams) => loadGatewayModelCatalogMock(params),
 }));
 
 vi.mock("../gateway/session-create-service.js", () => ({
@@ -391,7 +388,6 @@ describe("EmbeddedTuiBackend", () => {
       tokensUsed: 0,
     }));
     loadAgentRuntimePluginRegistryHandleMock.mockReset();
-    withPluginRuntimeRegistryScopeMock.mockClear();
     ensureContextWindowCacheLoadedMock.mockReset();
     ensureContextWindowCacheLoadedMock.mockResolvedValue(undefined);
     runSessionStartupMigrationMock.mockReset();
@@ -744,10 +740,12 @@ describe("EmbeddedTuiBackend", () => {
         reasoning: undefined,
       },
     ]);
-    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: false }),
+    );
   });
 
-  it("passes the selected agent into model filtering", async () => {
+  it("loads the selected agent catalog before applying its model policy", async () => {
     getRuntimeConfigMock.mockReturnValue({
       agents: {
         ownership: "explicit",
@@ -756,19 +754,23 @@ describe("EmbeddedTuiBackend", () => {
           work: { modelPolicy: { allow: ["fixture/work-model"] } },
         },
       },
-      models: {
-        mode: "replace",
-        providers: {
-          fixture: {
-            models: [{ id: "main-model" }, { id: "work-model" }],
-          },
-        },
-      },
+    });
+    loadGatewayModelCatalogMock.mockImplementation((params) => {
+      const id = `${params?.agentId ?? "main"}-model`;
+      return [{ id, name: id, provider: "fixture" }];
     });
 
     const backend = new EmbeddedTuiBackend();
 
-    await backend.listModels({ agentId: "work" });
+    await expect(backend.listModels({ agentId: "work" })).resolves.toEqual([
+      {
+        id: "work-model",
+        name: "work-model",
+        provider: "fixture",
+        contextWindow: undefined,
+        reasoning: undefined,
+      },
+    ]);
 
     expect(buildAllowedModelSetMock).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "work" }),
@@ -846,7 +848,9 @@ describe("EmbeddedTuiBackend", () => {
     expect(applySessionPatchProjectionMock).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKeys: ["agent:main:main"] }),
     );
-    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith({ readOnly: false });
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", readOnly: false }),
+    );
   });
 
   it("rejects a missing harness-owned session before a local patch can create it", async () => {
@@ -1473,54 +1477,43 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
-  it("clears a prior runtime registry after plugins are disabled", async () => {
-    const registry = {};
-    loadAgentRuntimePluginRegistryHandleMock
-      .mockReturnValueOnce(registry)
-      .mockReturnValueOnce(undefined);
-    loadSessionEntryMock.mockReturnValue({
-      cfg: {},
-      agentId: "main",
-      canonicalKey: "agent:main:main",
-      entry: {},
-    });
+  it("waits for the newest publication before returning model choices", async () => {
+    const initial = deferred<void>();
+    const replacement = deferred<void>();
+    refreshPreparedModelRuntimeSnapshotsMock
+      .mockReturnValueOnce(initial.promise)
+      .mockReturnValueOnce(replacement.promise);
     const backend = new EmbeddedTuiBackend();
+    backend.start();
+    const choices = backend.listModels({ agentId: "work" });
+    await flushMicrotasks();
+    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
 
-    await backend.loadHistory({ sessionKey: "agent:main:main" });
-    await backend.loadHistory({ sessionKey: "agent:main:main" });
-    withPluginRuntimeRegistryScopeMock.mockClear();
-    await backend.listModels();
+    configWriteListener?.({ runtimeConfig: {} });
+    initial.resolve();
+    await flushMicrotasks();
+    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
 
-    expect(withPluginRuntimeRegistryScopeMock).toHaveBeenCalledWith(
-      undefined,
-      expect.any(Function),
-    );
+    loadGatewayModelCatalogMock.mockReturnValue([
+      { provider: "fixture", id: "updated", name: "Updated" },
+    ]);
+    replacement.resolve();
+    await expect(choices).resolves.toMatchObject([{ id: "updated" }]);
+    await backend.stop();
   });
 
-  it("clears a prior runtime registry after a later preload fails", async () => {
-    const registry = {};
-    loadAgentRuntimePluginRegistryHandleMock
-      .mockReturnValueOnce(registry)
-      .mockImplementationOnce(() => {
-        throw new Error("runtime unavailable");
-      });
-    loadSessionEntryMock.mockReturnValue({
-      cfg: {},
-      agentId: "main",
-      canonicalKey: "agent:main:main",
-      entry: {},
-    });
+  it("reports publication failure instead of returning stale model choices", async () => {
+    const publication = deferred<void>();
+    refreshPreparedModelRuntimeSnapshotsMock.mockReturnValueOnce(publication.promise);
     const backend = new EmbeddedTuiBackend();
+    backend.start();
+    const choices = backend.listModels({ agentId: "work" });
+    const failure = expect(choices).rejects.toThrow("catalog publication failed");
 
-    await backend.loadHistory({ sessionKey: "agent:main:main" });
-    await backend.loadHistory({ sessionKey: "agent:main:main" });
-    withPluginRuntimeRegistryScopeMock.mockClear();
-    await backend.listModels();
-
-    expect(withPluginRuntimeRegistryScopeMock).toHaveBeenCalledWith(
-      undefined,
-      expect.any(Function),
-    );
+    publication.reject(new Error("catalog publication failed"));
+    await failure;
+    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+    await backend.stop();
   });
 
   it.each(selectedGlobalSessionCases)(

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -93,8 +93,6 @@ import {
   setEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
 import { logInfo, logWarn } from "../logger.js";
-import type { PluginRegistry } from "../plugins/registry-types.js";
-import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
 import { agentSessionKeysMatchByRequestKey, normalizeAgentId } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
@@ -192,44 +190,33 @@ function hasProviderWildcardModelAllowlist(cfg: OpenClawConfig) {
   );
 }
 
-function resolveConfiguredReplaceModeCatalog(cfg: OpenClawConfig) {
-  if (cfg.models?.mode !== "replace") {
-    return undefined;
-  }
-  if (hasProviderWildcardModelAllowlist(cfg)) {
-    return undefined;
-  }
-  return buildConfiguredModelCatalog({ cfg });
-}
-
-function shouldLoadFullGatewayCatalogForReplaceMode(cfg: OpenClawConfig) {
-  return cfg.models?.mode === "replace" && hasProviderWildcardModelAllowlist(cfg);
-}
-
 function ensureEmbeddedHistoryRuntimePluginsLoaded(params: {
   cfg: OpenClawConfig;
   sessionAgentId: string;
-}): { status: "warmed"; registry?: PluginRegistry } | { status: "failed"; error: string } {
+}): { status: "warmed" } | { status: "failed"; error: string } {
   try {
     const workspaceDir = resolveAgentWorkspaceDir(params.cfg, params.sessionAgentId);
-    const registry = loadAgentRuntimePluginRegistryHandle({
+    loadAgentRuntimePluginRegistryHandle({
       config: params.cfg,
       workspaceDir,
     });
-    return { status: "warmed", ...(registry ? { registry } : {}) };
+    return { status: "warmed" };
   } catch (err) {
     return { status: "failed", error: formatTuiErrorMessage(err) };
   }
 }
 
-async function loadEmbeddedTuiModelCatalog(cfg: OpenClawConfig) {
-  const configuredCatalog = resolveConfiguredReplaceModeCatalog(cfg);
-  if (configuredCatalog !== undefined) {
-    return configuredCatalog;
+async function loadEmbeddedTuiModelCatalog(cfg: OpenClawConfig, agentId?: string) {
+  const replaceMode = cfg.models?.mode === "replace";
+  const fullDiscovery = replaceMode && hasProviderWildcardModelAllowlist(cfg);
+  if (replaceMode && !fullDiscovery) {
+    return buildConfiguredModelCatalog({ cfg });
   }
-  return await loadGatewayModelCatalog(
-    shouldLoadFullGatewayCatalogForReplaceMode(cfg) ? { readOnly: false } : undefined,
-  );
+  return await loadGatewayModelCatalog({
+    agentId,
+    getConfig: () => cfg,
+    ...(fullDiscovery ? { readOnly: false } : {}),
+  });
 }
 
 function resolveBtwQuestion(message: string): string | undefined {
@@ -364,11 +351,6 @@ async function waitForQueuedLocalRun(previousRun: QueuedSessionRun, runId: strin
 }
 
 export class EmbeddedTuiBackend implements TuiBackend {
-  private runtimePluginRegistry?: PluginRegistry;
-
-  private withRuntimePluginRegistry<T>(run: () => T): T {
-    return withPluginRuntimeRegistryScope(this.runtimePluginRegistry, run);
-  }
   readonly connection = { url: "local embedded" };
 
   onEvent?: (evt: TuiEvent) => void;
@@ -637,6 +619,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async loadHistory(opts: { sessionKey: string; agentId?: string; limit?: number }) {
     await this.ready;
+    await this.preparedModelRuntime.waitUntilReady();
     const loadOptions = opts.agentId ? { agentId: opts.agentId } : undefined;
     const {
       cfg,
@@ -654,8 +637,6 @@ export class EmbeddedTuiBackend implements TuiBackend {
       cfg,
       sessionAgentId,
     });
-    this.runtimePluginRegistry =
-      runtimePluginsPrewarm.status === "warmed" ? runtimePluginsPrewarm.registry : undefined;
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const max = Math.min(
       CHAT_HISTORY_MAX_ENTRIES,
@@ -705,7 +686,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const catalog = await this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg));
+      const catalog = await loadEmbeddedTuiModelCatalog(cfg, sessionAgentId);
       thinkingLevel = resolveThinkingDefault({
         cfg,
         provider: resolvedSessionModel.provider,
@@ -735,10 +716,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel: sessionInfo.verboseLevel,
-      runtimePluginsPrewarm:
-        runtimePluginsPrewarm.status === "warmed"
-          ? { status: "warmed" as const }
-          : runtimePluginsPrewarm,
+      runtimePluginsPrewarm,
       ...(inFlightRun ? { inFlightRun } : {}),
     };
   }
@@ -767,6 +745,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
     opts: Parameters<TuiBackend["patchSession"]>[0],
   ): Promise<SessionsPatchResult> {
     await this.ready;
+    await this.preparedModelRuntime.waitUntilReady();
     const cfg = getRuntimeConfig();
     const target = resolveGatewaySessionStoreTargetWithStore({
       cfg,
@@ -794,8 +773,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
           storeKey: primaryKey,
           agentId: target.agentId,
           patch: opts,
-          loadGatewayModelCatalog: () =>
-            this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg)),
+          loadGatewayModelCatalog: () => loadEmbeddedTuiModelCatalog(cfg, target.agentId),
         }),
     });
     if (!applied.ok) {
@@ -839,6 +817,7 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
   async createSession(opts: TuiSessionCreateOptions) {
     await this.ready;
+    await this.preparedModelRuntime.waitUntilReady();
     const cfg = getRuntimeConfig();
     const result = await createGatewaySession({
       cfg,
@@ -849,7 +828,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
       emitCommandHooks: Boolean(opts.parentSessionKey),
       commandSource: "tui:embedded",
       loadGatewayModelCatalog: () =>
-        this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg)),
+        loadEmbeddedTuiModelCatalog(
+          cfg,
+          resolveSessionAgentId({ sessionKey: opts.key, config: cfg, agentId: opts.agentId }),
+        ),
     });
     if (!result.ok) {
       throw new Error(result.error.message);
@@ -932,8 +914,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   async listModels(opts?: { agentId?: string }): Promise<TuiModelChoice[]> {
+    await this.ready;
+    await this.preparedModelRuntime.waitUntilReady();
     const cfg = getRuntimeConfig();
-    const catalog = await this.withRuntimePluginRegistry(() => loadEmbeddedTuiModelCatalog(cfg));
+    const catalog = await loadEmbeddedTuiModelCatalog(cfg, opts?.agentId);
     const { allowedCatalog } = buildAllowedModelSet({
       cfg,
       catalog,


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

The local terminal could show a selected agent but fail to load history, open its model picker, or change models when no ambient owner existed.

## Why This Change Was Made

Local operations pass the resolved session or selected agent into the prepared catalog loader and wait for the current catalog publication. The obsolete history registry cache is removed. Existing model restrictions and Gateway-backed behavior remain intact.

## User Impact

Users can select models, switch between agents with different restrictions, and continue or create sessions with the correct model. No configuration or storage change.

## Evidence

Real CLI and terminal checks reproduced missing-owner errors before the fix. Afterward, history, model selection, agent switching, and new-session boundaries worked. Six recorded requests confirmed selected models and history boundaries. Three regressions failed before repair; all 191 focused tests passed afterward. Endpoints were synthetic; native sign-in and live external inference were not tested.

Consumers: local terminal history, picker, and model changes use the selected agent's catalog.
