### PR TITLE
refactor(models): centralize runtime-aware availability

### DIFF
--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -122,11 +122,11 @@ export type ModelAuthAvailabilityEvaluation = {
   evidence?: ModelAuthAvailabilityEvidence;
 };
 export type ModelAuthAvailabilityResolver = {
-  providerDiscoveryProviderIds: readonly string[];
-  preparedSyntheticAuthComplete: boolean;
-  resolvePreparedRuntimeAuthMode(
+  evaluateRuntimeModelAuth(
     provider: string,
-  ): PreparedAgentCredentialModes[string] | undefined;
+    ref?: ModelAuthAvailabilityRef,
+  ): ModelAuthAvailabilityEvaluation;
+  providerDiscoveryProviderIds: readonly string[];
   evaluateModelAuth(
     provider: string,
     ref?: ModelAuthAvailabilityRef,
@@ -138,34 +138,27 @@ export type ModelAuthAvailabilityResolver = {
   hasSyntheticAuth(provider: string): boolean;
 };
 
-export function applyCliRuntimeModelAuthAvailability(params: {
-  authResolver: ModelAuthAvailabilityResolver;
-  evaluation: ModelAuthAvailabilityEvaluation;
-  cfg: OpenClawConfig;
-  agentId?: string;
-  metadataSnapshot?: PluginMetadataSnapshot;
-  provider: string;
-  modelId?: string;
-  preferredProfileId?: string;
-  pinnedProfileId?: string;
-}): ModelAuthAvailabilityEvaluation {
-  if (
-    params.evaluation.routeResolution !== null ||
-    normalizeProviderId(params.provider) === "openai"
-  ) {
-    return params.evaluation;
+function applyCliRuntimeModelAuthAvailability(
+  params: CreateModelAuthAvailabilityResolverParams,
+  provider: string,
+  ref: ModelAuthAvailabilityRef,
+  evaluation: ModelAuthAvailabilityEvaluation,
+  evaluateProviderAuth: ModelAuthAvailabilityResolver["evaluateModelAuth"],
+): ModelAuthAvailabilityEvaluation {
+  if (evaluation.routeResolution !== null || normalizeProviderId(provider) === "openai") {
+    return evaluation;
   }
-  const selectedProfileId = params.pinnedProfileId?.trim() || params.preferredProfileId?.trim();
+  const selectedProfileId = ref.pinnedProfileId?.trim() || ref.preferredProfileId?.trim();
   // Direct CLI refs have no alias, but still own plugin and selected-account checks.
   const runtimeProvider =
     resolveCliRuntimeExecutionProvider({
-      provider: params.provider,
+      provider,
       cfg: params.cfg,
       agentId: params.agentId,
-      modelId: params.modelId,
+      modelId: ref.modelId,
       authProfileId: selectedProfileId,
       metadataSnapshot: params.metadataSnapshot,
-    }) ?? normalizeProviderId(params.provider);
+    }) ?? normalizeProviderId(provider);
   const runtimeOwners = params.metadataSnapshot?.owners?.cliBackends.get(
     normalizeProviderId(runtimeProvider),
   );
@@ -180,7 +173,7 @@ export function applyCliRuntimeModelAuthAvailability(params: {
       )
     ) {
       return {
-        ...params.evaluation,
+        ...evaluation,
         availability: false,
         unavailableReason: "missing-auth",
         unavailableUntil: undefined,
@@ -195,17 +188,18 @@ export function applyCliRuntimeModelAuthAvailability(params: {
   ) {
     // This CLI forbids account substitution while materializing selected auth.
     // Neither shared profiles nor its native login can rescue that selection.
-    return params.pinnedProfileId
-      ? params.authResolver.evaluateModelAuth(params.provider, {
-          modelId: params.modelId,
+    return ref.pinnedProfileId
+      ? evaluateProviderAuth(provider, {
+          modelId: ref.modelId,
           requiredProfileId: selectedProfileId,
         })
-      : params.evaluation;
+      : evaluation;
   }
-  if (normalizeProviderId(runtimeProvider) === normalizeProviderId(params.provider)) {
-    return params.evaluation;
+  if (normalizeProviderId(runtimeProvider) === normalizeProviderId(provider)) {
+    return evaluation;
   }
-  const runtimeAuthMode = params.authResolver.resolvePreparedRuntimeAuthMode(runtimeProvider);
+  const runtimeAuthMode =
+    params.preparedRuntimeAuthModes?.[normalizeProviderIdForAuth(runtimeProvider)];
   // The prepared native-runtime result is authoritative for this route. Provider
   // credentials cannot prove that the separately authenticated CLI is usable.
   return runtimeAuthMode
@@ -215,12 +209,13 @@ export function applyCliRuntimeModelAuthAvailability(params: {
         selectedAuthMode: runtimeAuthMode,
         evidence: "runtime",
       }
-    : params.authResolver.preparedSyntheticAuthComplete
+    : params.preparedSyntheticAuthComplete
       ? { availability: false, routeResolution: null, unavailableReason: "missing-auth" }
       : { availability: undefined, routeResolution: null };
 }
 type CreateModelAuthAvailabilityResolverParams = {
   cfg: OpenClawConfig;
+  agentId?: string;
   authStore: AuthProfileStore;
   agentDir?: string;
   workspaceDir?: string;
@@ -1400,10 +1395,20 @@ export function createModelAuthAvailabilityResolver(
     providerDiscoveryProviderIds: [...providerDiscoveryProviderIds].toSorted((left, right) =>
       left.localeCompare(right),
     ),
-    preparedSyntheticAuthComplete: params.preparedSyntheticAuthComplete === true,
     evaluateModelAuth,
-    resolvePreparedRuntimeAuthMode: (provider) =>
-      params.preparedRuntimeAuthModes?.[normalizeProviderIdForAuth(provider)],
+    evaluateRuntimeModelAuth: (provider, ref = {}) => {
+      const evaluation = evaluateModelAuth(provider, ref);
+      if (ref.requiredProfileId?.trim()) {
+        return evaluation;
+      }
+      return applyCliRuntimeModelAuthAvailability(
+        params,
+        provider,
+        ref,
+        evaluation,
+        evaluateModelAuth,
+      );
+    },
     resolveProviderAuthAvailability,
     hasSyntheticAuth: (provider) =>
       synthetic.has(normalizeProviderIdForAuth(provider)) ||

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -123,6 +123,7 @@ export type ModelAuthAvailabilityEvaluation = {
 };
 export type ModelAuthAvailabilityResolver = {
   evaluateRuntimeModelAuth(
+    this: void,
     provider: string,
     ref?: ModelAuthAvailabilityRef,
   ): ModelAuthAvailabilityEvaluation;

--- a/src/agents/model-provider-auth.test.ts
+++ b/src/agents/model-provider-auth.test.ts
@@ -63,6 +63,7 @@ const modelAuthAvailabilityMocks = vi.hoisted(() => {
     evaluateModelAuth,
     createModelAuthAvailabilityResolver: vi.fn((_params: unknown) => ({
       evaluateModelAuth,
+      evaluateRuntimeModelAuth: evaluateModelAuth,
       resolveProviderAuthAvailability: vi.fn(() => false),
       hasSyntheticAuth: vi.fn(() => false),
     })),
@@ -110,11 +111,6 @@ vi.mock("./model-auth.js", () => ({
 }));
 
 vi.mock("./model-auth-availability.js", () => ({
-  applyCliRuntimeModelAuthAvailability: ({
-    evaluation,
-  }: {
-    evaluation: ModelAuthAvailabilityEvaluation;
-  }) => evaluation,
   createModelAuthAvailabilityResolver:
     modelAuthAvailabilityMocks.createModelAuthAvailabilityResolver,
 }));

--- a/src/agents/model-provider-auth.ts
+++ b/src/agents/model-provider-auth.ts
@@ -24,7 +24,6 @@ import {
   type AuthProfileStore,
 } from "./auth-profiles.js";
 import {
-  applyCliRuntimeModelAuthAvailability,
   createModelAuthAvailabilityResolver,
   type ModelAuthAvailabilityEvaluation,
   type ModelAuthAvailabilityRef,
@@ -248,6 +247,7 @@ export function createProviderAuthChecker(params: {
     });
     modelAuthResolver = createModelAuthAvailabilityResolver({
       cfg: params.cfg ?? {},
+      agentId: params.agentId,
       authStore,
       preparedRuntimeAuthStore: params.preparedAuth?.authStore,
       preparedRuntimeAuthModes: params.preparedAuth?.authModes,
@@ -306,23 +306,10 @@ export function createProviderAuthChecker(params: {
       async (): Promise<ModelAuthAvailabilityEvaluation> => {
         if (hasRouteFacts) {
           const authResolver = resolveModelAuthResolver();
-          const modelEvaluation = authResolver.evaluateModelAuth(key, ref);
           // Native readiness belongs to prepared owners; setup hints stay provider-only.
-          // Explicit runtime account bindings retain their own auth decision.
-          if (!params.preparedAuth || ref.requiredProfileId?.trim()) {
-            return modelEvaluation;
-          }
-          return applyCliRuntimeModelAuthAvailability({
-            authResolver,
-            evaluation: modelEvaluation,
-            cfg: params.cfg ?? {},
-            agentId: params.agentId,
-            metadataSnapshot: params.metadataSnapshot,
-            provider: key,
-            modelId: ref.modelId,
-            preferredProfileId: ref.preferredProfileId,
-            pinnedProfileId: ref.pinnedProfileId,
-          });
+          return params.preparedAuth
+            ? authResolver.evaluateRuntimeModelAuth(key, ref)
+            : authResolver.evaluateModelAuth(key, ref);
         }
         return {
           availability: await resolveLegacyProviderAuth(),

--- a/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
+++ b/src/auto-reply/reply/commands-models.catalog-recovery.test.ts
@@ -149,6 +149,36 @@ describe("/models browse catalog recovery", () => {
     },
   );
 
+  it("keeps unprepared setup hints on provider auth", async () => {
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+        },
+      ],
+    });
+    const checker = providerAuth.createProviderAuthChecker({
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+            },
+          },
+        },
+      },
+      env: { ANTHROPIC_API_KEY: "synthetic-provider-key" },
+      discoverExternalCliAuth: false,
+      allowPluginSyntheticAuth: false,
+      allowPreparedRuntimeAuth: false,
+    });
+
+    await expect(checker("anthropic", { modelId: "claude-sonnet-4-6" })).resolves.toBe(true);
+  });
+
   it.each(["pinnedProfileId", "requiredProfileId"] as const)(
     "does not replace an expired %s with a prepared native login",
     async (selection) => {

--- a/src/commands/models/list.auth-index.ts
+++ b/src/commands/models/list.auth-index.ts
@@ -3,7 +3,6 @@ import type { PreparedAgentCredentialModes } from "../../agents/agent-auth-crede
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import {
   createModelAuthAvailabilityResolver,
-  applyCliRuntimeModelAuthAvailability,
   type ModelAuthAvailabilityEvaluation,
   type ModelAuthAvailabilityRef,
 } from "../../agents/model-auth-availability.js";
@@ -55,6 +54,7 @@ export function createModelListAuthIndex(
   const env = params.env ?? process.env;
   const resolver = createModelAuthAvailabilityResolver({
     cfg: params.cfg,
+    agentId: params.agentId,
     authStore: params.authStore,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
@@ -71,19 +71,6 @@ export function createModelListAuthIndex(
   });
   return {
     providerDiscoveryProviderIds: resolver.providerDiscoveryProviderIds,
-    evaluateModelAuth: (provider, ref) => {
-      const evaluation = resolver.evaluateModelAuth(provider, ref);
-      return applyCliRuntimeModelAuthAvailability({
-        authResolver: resolver,
-        evaluation,
-        cfg: params.cfg,
-        agentId: params.agentId,
-        metadataSnapshot: params.metadataSnapshot,
-        provider,
-        modelId: ref?.modelId,
-        preferredProfileId: ref?.preferredProfileId,
-        pinnedProfileId: ref?.pinnedProfileId,
-      });
-    },
+    evaluateModelAuth: resolver.evaluateRuntimeModelAuth,
   };
 }

--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -7,7 +7,6 @@ import type { RuntimeAuthMaterialization } from "../../agents/auth-profiles/runt
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { createAgentHarnessCatalogEvaluator } from "../../agents/harness/model-catalog-readiness.js";
 import {
-  applyCliRuntimeModelAuthAvailability,
   createModelAuthAvailabilityResolver,
   type ModelAuthAvailabilityResolver,
   type ModelAuthAvailabilityEvaluation,
@@ -55,6 +54,7 @@ function createModelsListAuthResolver(params: {
   const agentDir = resolveAgentDir(params.cfg, params.agentId);
   return createModelAuthAvailabilityResolver({
     cfg: params.cfg,
+    agentId: params.agentId,
     authStore: params.preparedAuthStore,
     agentDir,
     workspaceDir: params.workspaceDir,
@@ -75,10 +75,7 @@ function createModelsListAuthResolver(params: {
 }
 
 function createModelsListEntryEvaluator(params: {
-  cfg: OpenClawConfig;
-  agentId: string;
   authResolver: ModelAuthAvailabilityResolver;
-  metadataSnapshot: PluginMetadataSnapshot;
   providerOutcomes?: readonly ProviderCatalogOutcome[];
   preferredProfileId?: string;
   preferredProfilesByProvider?: ReadonlyMap<string, string>;
@@ -102,7 +99,7 @@ function createModelsListEntryEvaluator(params: {
       const preferredProfileId = params.preferredProfileId ?? defaultProfileId;
       // New sessions capture personal defaults with the same strength as explicit account pins.
       const pinnedProfileId = params.pinnedProfileId ?? defaultProfileId;
-      const evaluation = params.authResolver.evaluateModelAuth(entry.provider, {
+      const resolved = params.authResolver.evaluateRuntimeModelAuth(entry.provider, {
         modelId: identity?.id ?? entry.id,
         ...(normalizeProviderId(entry.provider) === "openai"
           ? {}
@@ -113,17 +110,6 @@ function createModelsListEntryEvaluator(params: {
           api: variant.api,
           baseUrl: variant.baseUrl,
         })),
-      });
-      const resolved = applyCliRuntimeModelAuthAvailability({
-        authResolver: params.authResolver,
-        evaluation,
-        cfg: params.cfg,
-        agentId: params.agentId,
-        metadataSnapshot: params.metadataSnapshot,
-        provider: entry.provider,
-        modelId: entry.id,
-        preferredProfileId,
-        pinnedProfileId,
       });
       const provider = normalizeProviderId(entry.provider);
       // Stored credentials prove presence, not acceptance. Apply the live rejection only to the
@@ -254,10 +240,7 @@ export function createModelsListAuthProjection(params: ModelsListAuthProjectionP
     routeResolverFactory: params.routeResolverFactory,
   });
   const evaluateStoredEntry = createModelsListEntryEvaluator({
-    cfg: params.cfg,
-    agentId: params.agentId,
     authResolver,
-    metadataSnapshot,
     providerOutcomes: params.snapshot.providerOutcomes,
     preferredProfilesByProvider,
     ...(params.preferredProfileId ? { preferredProfileId: params.preferredProfileId } : {}),


### PR DESCRIPTION
Related: #139848, #139498, #139499

## What Problem This Solves

The picker repair in #139848 left Gateway, CLI listing, and prepared channel browsing each responsible for attaching the same native-runtime authentication adjustment. This maintainer-requested follow-up keeps that policy in its shared owner so another picker cannot omit part of it. The original regressions were reported by @goslingmanagment.

## Why This Change Was Made

The shared resolver now exposes runtime-aware evaluation alongside raw provider evaluation. It owns the configured agent/runtime context, plugin eligibility, native readiness, and required-account guard. The three consumers use that operation directly, removing their adjustment wrappers and the snapshot accessors those wrappers required. Unprepared setup hints retain raw provider evaluation.

This is an internal refactor with no configuration, database, protocol, dependency, or authentication-boundary change. @steipete explicitly requested the follow-up and is a verified active maintainer of the listed owner team, @openclaw/openclaw-secops.

## User Impact

The model availability behavior restored by #139848 remains the same across Gateway clients, CLI listing, and channel pickers. Native login still cannot replace a required account, and a disabled runtime plugin remains unavailable.

## Evidence

- 252 focused tests passed across seven files. After centralizing the required-account guard, the final 96-case auth, Gateway, and channel suite passed again. The final receiver declaration is type-only. A new behavior check protects unprepared setup hints.
- `node scripts/check-changed.mjs` passed, including both typecheck lanes, all three unused-export scans, targeted lint, and remaining guards. Independent P0–P2 review passed for the final committed head.
- Separate Blacksmith Testbox leases built the baseline and candidate and ran the same real-Gateway Telegram polling/callback scenarios. Both passed (two selected tests; one unrelated scenario filtered). Ordinary inventory membership also matched at startup and after restarting the same isolated Gateway state, before explicit refresh.

| Build | Exact source | Lease | Run |
| --- | --- | --- | --- |
| Baseline | `f2ba79354177e844ce69e19a56a7e55367c8cc66` | `tbx_01m1trja63rfbx9rq39vrx67mw` | [Blacksmith baseline](https://github.com/openclaw/openclaw/actions/runs/34018201182) |
| Candidate | `3f78f471b791f9ca057964e5162970997e54fb83` | `tbx_01m1tsfe1694zzy4494n9wms82` | [Blacksmith candidate](https://github.com/openclaw/openclaw/actions/runs/34018914590) |

Both runs observed the same results:

```json
{
  "nativeProviderButton": "anthropic (2)",
  "nativeAvailableModels": ["claude-haiku-4-5", "claude-sonnet-4-6"],
  "nativeAuthStatusCalls": 2,
  "modelRequests": 0,
  "initialDiscoveryRequests": 3,
  "discoveryRequestsAfterExplicitRefresh": 5,
  "discoveryAttemptsDuringReuse": 0,
  "ordinaryInventoryAvailableAfterSameStateRestart": true
}
```

The remote E2E command was:

```sh
OPENCLAW_E2E_VERBOSE=1 node scripts/run-vitest.mjs \
  test/e2e/qa-lab/runtime/telegram-model-picker-prepared-gateway.e2e.test.ts \
  -t 'initializes unrestricted|lists native CLI-bound'
```

The Gateway processes, plugin code, polling, and callback handling are real. External Telegram/Ollama endpoints and the Claude CLI auth-status process are synthetic. The supplemental restart fixture proves inventory membership; native readiness is established by the Telegram E2E. Live Telegram Test Server credentials were unavailable, and no real provider login or model inference is claimed. Both leases are stopped; isolated Gateway lifetimes shut down cleanly.

Production: **+50 / -87 = -37 lines**. Tests: **+31 / -5 = +26 lines**, from `git diff --numstat`. This offsets the preceding repair's +33 production lines while retaining its recovery paths.
