### PR TITLE
fix(gateway): keep CLI session model identities consistent

### DIFF
--- a/src/gateway/session-utils-model.identity.test.ts
+++ b/src/gateway/session-utils-model.identity.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, expect, test } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { listSessionFixture } from "./session-list.test-support.js";
+import { getSessionDefaults, projectSessionPatchResult } from "./session-utils-model.js";
+import { buildGatewaySessionRow } from "./session-utils-row.js";
+
+afterEach(() => {
+  resetConfigRuntimeState();
+  resetPluginRuntimeStateForTest();
+});
+
+test.each([
+  { provider: "demo-cli", model: "shared-model", expectedProvider: "demo-provider" },
+  { provider: "standalone-cli", model: "shared-model", expectedProvider: "standalone-cli" },
+  { provider: "demo-cli", model: "demo-provider/shared-model", expectedProvider: "demo-provider" },
+  { provider: "demo-provider", model: "shared-model", expectedProvider: "demo-provider" },
+])("keeps $provider/$model identity across session reads", async (fixture) => {
+  await withStateDirEnv("session-model-identity-", async ({ stateDir }) => {
+    const registry = createEmptyPluginRegistry();
+    registry.cliBackends = [
+      {
+        pluginId: "fixture",
+        source: "fixture",
+        backend: {
+          id: "demo-cli",
+          modelProvider: "demo-provider",
+          config: { command: "false", output: "text", input: "arg" },
+        },
+      },
+      {
+        pluginId: "fixture",
+        source: "fixture",
+        backend: {
+          id: "standalone-cli",
+          config: { command: "false", output: "text", input: "arg" },
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+    const selected = `${fixture.provider}/${fixture.model}`;
+    const cfg: OpenClawConfig = {
+      agents: {
+        entries: { main: {} },
+        defaults: {
+          model: "unrelated/shared-model",
+          models: { [selected]: { agentRuntime: { id: "openclaw" } } },
+        },
+      },
+    };
+    setRuntimeConfigSnapshot(cfg);
+    const key = "agent:main:identity";
+    const entry: SessionEntry = {
+      sessionId: "identity",
+      updatedAt: 1,
+      providerOverride: fixture.provider,
+      modelOverride: fixture.model,
+      modelOverrideRouteResolution: "resolved",
+    };
+    const store = { [key]: entry };
+    const expected = { modelProvider: fixture.expectedProvider, model: "shared-model" };
+    for (const lightweightListRow of [false, true]) {
+      const row = buildGatewaySessionRow({
+        cfg,
+        agentId: "main",
+        storePath: stateDir,
+        store,
+        key,
+        entry,
+        lightweightListRow,
+        skipTranscriptUsageFallback: true,
+      });
+      expect(row).toMatchObject(expected);
+      expect(row.agentRuntime?.id).toBe("openclaw");
+    }
+    expect(
+      projectSessionPatchResult({
+        cfg,
+        canonicalKey: key,
+        entry,
+        targetAgentId: "main",
+        storePath: stateDir,
+      }).resolved,
+    ).toMatchObject({ ...expected, agentRuntime: { id: "openclaw" } });
+    const listed = await listSessionFixture({
+      cfg,
+      storePath: stateDir,
+      store,
+      opts: { agentId: "main", search: `${fixture.expectedProvider}/shared-model` },
+    });
+    expect(listed.sessions).toMatchObject([{ key, ...expected }]);
+    const defaultConfig: OpenClawConfig = {
+      ...cfg,
+      agents: { ...cfg.agents, defaults: { ...cfg.agents?.defaults, model: selected } },
+    };
+    expect(getSessionDefaults(defaultConfig, [], { agentId: "main" })).toMatchObject(expected);
+  });
+});

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -9,6 +9,7 @@ import {
   resolveModelAgentRuntimeMetadata,
 } from "../agents/agent-runtime-metadata.js";
 import { resolveAgentConfig, resolveSessionAgentId } from "../agents/agent-scope.js";
+import { resolveCliRuntimeCanonicalProvider } from "../agents/cli-backends.js";
 import { resolveContextTokensForModel } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
@@ -19,7 +20,6 @@ import {
 import { resolveModelContextWindowProfile } from "../agents/model-context-window.js";
 import {
   findNormalizedProviderValue,
-  inferUniqueProviderFromConfiguredModels,
   isCliProvider,
   parseModelRef,
   resolveConfiguredModelRef,
@@ -339,6 +339,11 @@ export function getSessionDefaults(
         defaultModel: DEFAULT_MODEL,
         allowPluginNormalization: options?.allowPluginNormalization,
       });
+  const displayModel = resolveSessionDisplayModelIdentityRef({
+    cfg,
+    provider: resolved.provider,
+    model: resolved.model,
+  });
   const catalogEntry = modelCatalog
     ? findModelCatalogEntry(modelCatalog, {
         provider: resolved.provider,
@@ -384,8 +389,8 @@ export function getSessionDefaults(
     providerPolicySource: options?.providerPolicySource,
   });
   return {
-    modelProvider: resolved.provider ?? null,
-    model: resolved.model ?? null,
+    modelProvider: displayModel.provider ?? resolved.provider,
+    model: displayModel.model ?? resolved.model,
     contextTokens: contextTokens ?? null,
     contextWindow: contextWindowProfile.contextWindow,
     contextWindows: contextWindowProfile.contextWindows,
@@ -608,7 +613,6 @@ export async function resolveGatewayModelSupportsImages(params: {
 
 export function resolveSessionDisplayModelIdentityRefCached(params: {
   cfg: OpenClawConfig;
-  agentId: string;
   provider?: string;
   model?: string;
   rowContext?: SessionListRowContext;
@@ -617,10 +621,7 @@ export function resolveSessionDisplayModelIdentityRefCached(params: {
   if (!ctx) {
     return resolveSessionDisplayModelIdentityRef(params);
   }
-  const key = `${params.agentId}\u0000${createSessionRowModelCacheKey(
-    params.provider,
-    params.model,
-  )}`;
+  const key = createSessionRowModelCacheKey(params.provider, params.model);
   const cached = ctx.displayModelIdentityByKey.get(key);
   if (cached) {
     return cached;
@@ -632,7 +633,6 @@ export function resolveSessionDisplayModelIdentityRefCached(params: {
 
 function resolveSessionDisplayModelIdentityRef(params: {
   cfg: OpenClawConfig;
-  agentId: string;
   provider?: string;
   model?: string;
 }): { provider?: string; model?: string } {
@@ -642,31 +642,20 @@ function resolveSessionDisplayModelIdentityRef(params: {
     return { provider, model };
   }
 
-  const defaultRef = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
-  if (model.includes("/")) {
-    const parsedModel = parseModelRef(model, defaultRef.provider);
-    if (parsedModel && !isCliProvider(parsedModel.provider, params.cfg)) {
-      return parsedModel;
-    }
-  }
-
-  const inferredProvider = inferUniqueProviderFromConfiguredModels({
-    cfg: params.cfg,
-    model,
-    agentId: params.agentId,
-  });
-  if (inferredProvider && !isCliProvider(inferredProvider, params.cfg)) {
-    return { provider: inferredProvider, model };
-  }
-
-  const parsedModel = parseModelRef(model, defaultRef.provider);
-  if (parsedModel && !isCliProvider(parsedModel.provider, params.cfg)) {
-    return parsedModel;
-  }
-
+  const identity = (model.includes("/")
+    ? parseModelRef(model, provider, {
+        allowPluginNormalization: false,
+        allowManifestNormalization: false,
+      })
+    : null) ?? { provider, model };
   return {
-    provider: defaultRef.provider || provider,
-    model,
+    provider:
+      resolveCliRuntimeCanonicalProvider({
+        runtime: identity.provider,
+        config: params.cfg,
+        includeSetupRegistry: true,
+      }) ?? identity.provider,
+    model: identity.model,
   };
 }
 
@@ -686,7 +675,6 @@ export function projectSessionPatchResult(params: {
   const resolved = resolveSessionModelRef(params.cfg, params.entry, agentId);
   const displayModel = resolveSessionDisplayModelIdentityRef({
     cfg: params.cfg,
-    agentId,
     provider: resolved.provider,
     model: resolved.model,
   });
@@ -694,16 +682,16 @@ export function projectSessionPatchResult(params: {
   const thinking = resolveGatewaySessionThinkingProjectionInternal({
     cfg: params.cfg,
     agentId,
-    provider: displayModel.provider ?? resolved.provider,
-    model: displayModel.model ?? resolved.model,
+    provider: resolved.provider,
+    model: resolved.model,
     sessionKey: params.canonicalKey,
     entry: params.entry,
     modelCatalog,
   });
   const catalogEntry = modelCatalog
     ? findModelCatalogEntry(modelCatalog, {
-        provider: displayModel.provider ?? resolved.provider,
-        modelId: displayModel.model ?? resolved.model,
+        provider: resolved.provider,
+        modelId: resolved.model,
       })
     : undefined;
   const contextWindow = resolveModelContextWindowProfile({

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -197,22 +197,18 @@ export function buildGatewaySessionRow(params: {
   const latestCompactionCheckpoint = buildCompactionCheckpointPreview(
     resolveLatestCompactionCheckpoint(compactionCheckpoints),
   );
-  const selectedModelProvider = selectedModel.provider;
-  const selectedModelId = selectedModel.model;
-  const rowModelIdentity = lightweight
-    ? { provider: selectedModelProvider, model: selectedModelId }
-    : resolveSessionDisplayModelIdentityRefCached({
-        cfg,
-        agentId: sessionAgentId,
-        provider: selectedModelProvider,
-        model: selectedModelId,
-        rowContext: params.rowContext,
-      });
-  const rowModelProvider = rowModelIdentity.provider;
-  const rowModel = rowModelIdentity.model;
+  const rowModelProvider = selectedModel.provider;
+  const rowModel = selectedModel.model;
+  const rowModelIdentity = resolveSessionDisplayModelIdentityRefCached({
+    cfg,
+    provider: rowModelProvider,
+    model: rowModel,
+    rowContext: params.rowContext,
+  });
+  // Display aliases do not change the selected route's catalog or runtime policy.
   const runtimeModels = resolveSelectedAndActiveModel({
-    selectedProvider: selectedModelProvider,
-    selectedModel: selectedModelId,
+    selectedProvider: rowModelProvider,
+    selectedModel: rowModel,
     sessionEntry: entry,
   });
   const activeFallback = resolveActiveFallbackState({
@@ -320,8 +316,8 @@ export function buildGatewaySessionRow(params: {
   });
   const fastModeState = resolveFastModeState({
     cfg,
-    provider: selectedModelProvider,
-    model: selectedModelId,
+    provider: rowModelProvider,
+    model: rowModel,
     agentId: sessionAgentId,
     sessionEntry:
       entry?.fastMode !== undefined
@@ -471,8 +467,8 @@ export function buildGatewaySessionRow(params: {
       channel: INTERNAL_MESSAGE_CHANNEL,
       sessionEntry: entry,
     }).mode,
-    modelProvider: rowModelProvider,
-    model: rowModel,
+    modelProvider: rowModelIdentity.provider,
+    model: rowModelIdentity.model,
     activeModelProvider: activeFallback.active ? runtimeModels.active.provider : undefined,
     activeModel: activeFallback.active ? runtimeModels.active.model : undefined,
     modelOverrideSource: resolveSessionModelOverrideSource(entry),

--- a/src/gateway/session-utils-search.ts
+++ b/src/gateway/session-utils-search.ts
@@ -132,7 +132,6 @@ function resolveSessionListSearchModelFields(params: {
   );
   const displayModelIdentity = resolveSessionDisplayModelIdentityRefCached({
     cfg: params.cfg,
-    agentId,
     provider: selectedModel.provider,
     model: selectedModel.model,
     rowContext: params.rowContext,


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

CLI-backed sessions could show inconsistent model providers in lists, details, and patch responses. Searching by the actual provider could miss the session.

## Why This Change Was Made

One Gateway projection uses the backend's declared model provider for display identity. Lists, defaults, details, search, and patch responses share it. Runtime policy retains the original selected route.

## User Impact

Session identity agrees across read surfaces, and provider/model search finds the session. Qualified and standalone backend identities remain intact. Stored selections do not change.

## Evidence

Built Gateway requests reproduced mismatched identities and missing search results before the fix. Three regressions failed before the repair; all 246 focused tests passed afterward. API acceptance checked identity, search, label-only edits, changed defaults, and preserved selections across 117 request/response pairs. Inference was not tested.

Consumers: session lists, details, defaults, search, and patch responses share declared display identity.

AI-assisted.
