### PR TITLE
fix(test): avoid environment dumps in registry failures

### DIFF
--- a/src/cli/plugin-registry.test.ts
+++ b/src/cli/plugin-registry.test.ts
@@ -36,7 +36,8 @@ function expectConfiguredChannelPluginIdsParams(expected: {
     | { config?: unknown; env?: NodeJS.ProcessEnv; workspaceDir?: string }
     | undefined;
   expect(params?.config).toBe(expected.config);
-  expect(params?.env).toBe(process.env);
+  // Compare identity without exposing ambient credentials in failure output.
+  expect(params?.env === process.env).toBe(true);
   expect(params?.workspaceDir).toBe(expected.workspaceDir);
 }
 

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -110,7 +110,7 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       mode: "validate",
       loadModules: false,
     });
-    expect(loadOptions.env).toBe(process.env);
+    expect(loadOptions.env === process.env).toBe(true);
     expect(loadOptions.logger).toBeDefined();
   });
 
@@ -127,12 +127,12 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       workspaceDir: "/workspace",
     });
 
-    expect(getOnlyLoadOpenClawPluginsOptions()).toMatchObject({
+    const { env, ...loadOptions } = getOnlyLoadOpenClawPluginsOptions();
+    expect(loadOptions).toMatchObject({
       config: { plugins: {} },
       activationSourceConfig: { plugins: {} },
       autoEnabledReasons: {},
       workspaceDir: "/workspace",
-      env: process.env,
       logger,
       throwOnLoadError: true,
       cache: false,
@@ -140,6 +140,10 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       mode: "validate",
       loadModules: undefined,
     });
+    // Preserve the env subset check without handing its values to the matcher.
+    expect(
+      env !== undefined && Object.entries(process.env).every(([key, value]) => env[key] === value),
+    ).toBe(true);
   });
 
   it("honors explicit load options when reusing a resolved runtime context", () => {
@@ -206,7 +210,7 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
       loadModules: undefined,
       onlyPluginIds: [],
     });
-    expect(loadOptions.env).toBe(process.env);
+    expect(loadOptions.env === process.env).toBe(true);
     expect(loadOptions.logger).toBeDefined();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where registry-test failures could print environment values to the console when an environment-forwarding check failed.

## Why This Change Was Made

The tests now pass boolean identity/subset results to the assertion formatter and keep the ambient environment out of the remaining options comparison. Existing identity checks still reject copied environments; the value-subset check still accepts equal copies and extra keys and rejects missing or changed values.

## User Impact

Developers retain useful failures without these assertions rendering their environment values. The change is confined to two test files; production behavior and test-runner environment setup are unchanged.

## Evidence

- All seven existing cases passed before and after the change through the normal repository runner.
- Eight synthetic controls per side verified matching success/failure semantics and worker-side marker presence. Value-loss failures printed the synthetic marker before the change; none of the candidate controls printed it. Equal-valued copies were a negative-exposure control, not evidence of a leak. No real credentials were used.
- Targeted formatting and diff checks passed. Independent Codex review found no actionable issues through P2.
- Required changed-file gate: all 20 checks passed through the configured Testbox command ([run](https://github.com/openclaw/openclaw/actions/runs/34017939893)); the one-shot lease and temporary source capsule are cleaned up.
- Production delta: 0. Test delta: +10/-5; all seven cases retained.

Follow-up: `src/plugins/runtime/load-context.test.ts` and `src/plugins/runtime/runtime-registry-loader.test.ts` still have ambient-environment call matchers. Their existential/ordered call matching needs separate treatment; this PR does not claim repository-wide diagnostic redaction.
