### PR TITLE
fix: restore critical session notices after reset

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -134,6 +134,8 @@ data class SessionObserverPlanProgress(
 data class SessionObserverDigest(
   val sessionKey: String,
   val agentId: String? = null,
+  val sessionId: String? = null,
+  val lifecycleRevision: String? = null,
   val runId: String? = null,
   val revision: Long,
   val updatedAt: Long,

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6505,6 +6505,8 @@ public struct SessionObserverPlanProgress: Codable, Sendable {
 public struct SessionObserverDigest: Codable, Sendable {
     public let sessionkey: String
     public let agentid: String?
+    public let sessionid: String?
+    public let lifecyclerevision: String?
     public let runid: String?
     public let revision: Int
     public let updatedat: Int
@@ -6516,6 +6518,8 @@ public struct SessionObserverDigest: Codable, Sendable {
     public init(
         sessionkey: String,
         agentid: String? = nil,
+        sessionid: String? = nil,
+        lifecyclerevision: String? = nil,
         runid: String? = nil,
         revision: Int,
         updatedat: Int,
@@ -6526,6 +6530,8 @@ public struct SessionObserverDigest: Codable, Sendable {
     {
         self.sessionkey = sessionkey
         self.agentid = agentid
+        self.sessionid = sessionid
+        self.lifecyclerevision = lifecyclerevision
         self.runid = runid
         self.revision = revision
         self.updatedat = updatedat
@@ -6538,6 +6544,8 @@ public struct SessionObserverDigest: Codable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case agentid = "agentId"
+        case sessionid = "sessionId"
+        case lifecyclerevision = "lifecycleRevision"
         case runid = "runId"
         case revision
         case updatedat = "updatedAt"

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -926,6 +926,11 @@ count.
 - `session.observer`: safe live session headline and status digest. A model-authored
   preamble can update the headline immediately; utility-model assessments replace
   it later when available. Web, iOS, and Android use the same run-scoped digest.
+  The optional `sessionId` and opaque `lifecycleRevision` identify the session
+  lifecycle; `lifecycleRevision` can be absent before the first reset. Revisions
+  increase across runs within that lifecycle but can restart after a reset.
+  Critical notice history starts fresh when the identity pair changes, including
+  when `/clear` preserves `sessionId` and changes `lifecycleRevision`.
   Clients show its headline or inspector link only while the digest's exact `runId`
   is present in `activeRunIds`.
 - `sessions.changed`: session index or metadata changed. Active-run fields use the

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -93,6 +93,8 @@ export const SessionObserverPlanProgressSchema = closedObject({
 export const SessionObserverDigestSchema = closedObject({
   sessionKey: NonEmptyString,
   agentId: Type.Optional(NonEmptyString),
+  sessionId: Type.Optional(NonEmptyString),
+  lifecycleRevision: Type.Optional(NonEmptyString),
   runId: Type.Optional(NonEmptyString),
   revision: Type.Integer({ minimum: 1 }),
   updatedAt: Type.Integer({ minimum: 0 }),

--- a/src/gateway/server-methods/sessions-list-cache.observer-digest.test.ts
+++ b/src/gateway/server-methods/sessions-list-cache.observer-digest.test.ts
@@ -171,7 +171,7 @@ it("invalidates the cache after terminal observer-digest synthesis", async () =>
       source: {
         state: observerState(sessionKey, sessionId, previousDigest),
       },
-      readSession: () => undefined,
+      readSession: () => loadSessionEntry({ sessionKey, agentId: "main" }),
       persistDigest: defaultPersistDigest,
       now: () => 2,
     });

--- a/src/gateway/session-observer-lifecycle.ts
+++ b/src/gateway/session-observer-lifecycle.ts
@@ -1,0 +1,189 @@
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { resolveSessionAgentId } from "../agents/agent-scope.js";
+import { createSessionActivityNoteState } from "../agents/session-activity-notes.js";
+import type { SessionObserverEvent } from "./session-observer-contract.js";
+import {
+  isSameSessionObserverLifecycle,
+  markSessionObserverRunSuperseded,
+  rememberSessionObserverRevisionFloor,
+  resolveSessionObserverDigestForLifecycle,
+} from "./session-observer-model.js";
+import type {
+  DormantSessionObserverRun,
+  SessionObserverDeps,
+  SessionObserverRevisionFloor,
+  SessionObserverState,
+} from "./session-observer-model.js";
+import { onGatewaySessionReset } from "./session-reset-notifications.js";
+import { resolveSessionSubscriptionKey } from "./session-subscription-keys.js";
+
+type ReadSession = NonNullable<SessionObserverDeps["readSession"]>;
+
+export function createSessionObserverLifecycle(params: {
+  getConfig: SessionObserverDeps["getConfig"];
+  readSession: ReadSession;
+  now: () => number;
+  isTerminal: (runId: string) => boolean;
+  clearPendingTerminalError: (runId: string) => void;
+  releaseState: (state: SessionObserverState) => void;
+}) {
+  const states = new Map<string, SessionObserverState>();
+  const dormantRuns = new Map<string, DormantSessionObserverRun>();
+  const revisionFloors = new Map<string, SessionObserverRevisionFloor>();
+  const supersededRuns = new Map<string, number>();
+  const disabledRuns = new Set<string>();
+
+  const isTracked = (state: SessionObserverState): boolean =>
+    states.get(resolveSessionSubscriptionKey(state.sessionKey, state.agentId)) === state;
+
+  const dropState = (state: SessionObserverState) => {
+    params.releaseState(state);
+    if (isTracked(state)) {
+      const scopeKey = resolveSessionSubscriptionKey(state.sessionKey, state.agentId);
+      if (
+        state.terminalHealth === "failed" &&
+        !params.isTerminal(state.runId) &&
+        !supersededRuns.has(state.runId) &&
+        state.previousDigest
+      ) {
+        rememberSessionObserverRevisionFloor(revisionFloors, scopeKey, {
+          sessionId: state.sessionId,
+          lifecycleRevision: state.lifecycleRevision,
+          revision: state.revision,
+          previousDigest: state.previousDigest,
+        });
+      }
+      states.delete(scopeKey);
+    }
+  };
+
+  const retireRun = (runId: string) => {
+    markSessionObserverRunSuperseded(supersededRuns, runId, params.now());
+    params.clearPendingTerminalError(runId);
+    dormantRuns.delete(runId);
+    disabledRuns.delete(runId);
+  };
+
+  const retireObsolete = (scopeKey: string, session: ReturnType<ReadSession>): void => {
+    const state = states.get(scopeKey);
+    if (state && !isSameSessionObserverLifecycle(state, session)) {
+      retireRun(state.runId);
+      dropState(state);
+    }
+    for (const run of dormantRuns.values()) {
+      if (
+        resolveSessionSubscriptionKey(run.sessionKey, run.agentId) === scopeKey &&
+        !isSameSessionObserverLifecycle(run, session)
+      ) {
+        retireRun(run.runId);
+      }
+    }
+    const floor = revisionFloors.get(scopeKey);
+    if (floor && !isSameSessionObserverLifecycle(floor, session)) {
+      if (floor.previousDigest?.runId) {
+        retireRun(floor.previousDigest.runId);
+      }
+      revisionFloors.delete(scopeKey);
+    }
+  };
+
+  const acceptPublication = (state: SessionObserverState): boolean => {
+    const session = params.readSession(state.sessionKey, state.agentId);
+    if (isSameSessionObserverLifecycle(state, session)) {
+      return true;
+    }
+    retireObsolete(resolveSessionSubscriptionKey(state.sessionKey, state.agentId), session);
+    return false;
+  };
+
+  const admit = (
+    event: SessionObserverEvent,
+    sessionKey: string,
+    agentId: string,
+    session: ReturnType<ReadSession>,
+    utilityModelRef: string | undefined,
+  ): SessionObserverState => {
+    const scopeKey = resolveSessionSubscriptionKey(sessionKey, agentId);
+    const dormant = dormantRuns.get(event.runId);
+    if (dormant && isSameSessionObserverLifecycle(dormant, session)) {
+      dormantRuns.delete(event.runId);
+      const { utilityModelRef: _dormantModelRef, ...dormantState } = dormant;
+      const state: SessionObserverState = {
+        ...createSessionActivityNoteState(),
+        ...dormantState,
+        ...(dormantState.lastPreambleHeadline
+          ? { lastPublishedPreambleHeadline: dormantState.lastPreambleHeadline }
+          : {}),
+        ...(utilityModelRef ? { utilityModelRef } : {}),
+        lastActivityAt: event.ts,
+        lastRunAt: params.now(),
+        lastDigestNoteSequence: 0,
+        inFlight: false,
+        finalPending: false,
+      };
+      states.set(scopeKey, state);
+      return state;
+    }
+    const previousDigest = resolveSessionObserverDigestForLifecycle(
+      session?.observerDigest,
+      session,
+    );
+    const startedAt =
+      asFiniteNumber(event.data.startedAt) ?? session?.startedAt ?? event.ts ?? params.now();
+    const state: SessionObserverState = {
+      ...createSessionActivityNoteState(),
+      sessionKey,
+      sessionId: session?.sessionId,
+      lifecycleRevision: session?.lifecycleRevision,
+      runId: event.runId,
+      agentId,
+      ...(utilityModelRef ? { utilityModelRef } : {}),
+      startedAt,
+      lastActivityAt: event.ts,
+      lastRunAt: startedAt,
+      lastPersistedAt: previousDigest?.updatedAt,
+      revision: previousDigest?.revision ?? 0,
+      digestCount: 0,
+      consecutiveFailures: 0,
+      lastDigestNoteSequence: 0,
+      previousDigest,
+      inFlight: false,
+      finalPending: false,
+    };
+    states.set(scopeKey, state);
+    return state;
+  };
+
+  const unsubscribeReset = onGatewaySessionReset((sessionKey, suppliedAgentId) => {
+    const agentId =
+      suppliedAgentId ?? resolveSessionAgentId({ sessionKey, config: params.getConfig() });
+    // Reset notification can follow awaited cleanup. Preserve a newer admitted owner.
+    retireObsolete(
+      resolveSessionSubscriptionKey(sessionKey, agentId),
+      params.readSession(sessionKey, agentId),
+    );
+  });
+
+  return {
+    states,
+    dormantRuns,
+    revisionFloors,
+    supersededRuns,
+    disabledRuns,
+    isTracked,
+    dropState,
+    retireObsolete,
+    acceptPublication,
+    admit,
+    dispose() {
+      unsubscribeReset();
+      for (const state of states.values()) {
+        dropState(state);
+      }
+      dormantRuns.clear();
+      revisionFloors.clear();
+      supersededRuns.clear();
+      disabledRuns.clear();
+    },
+  };
+}

--- a/src/gateway/session-observer-model.test.ts
+++ b/src/gateway/session-observer-model.test.ts
@@ -140,16 +140,29 @@ describe("defaultPersistDigest tri-state contract", () => {
     });
   });
 
-  it.each([undefined, "lifecycle-a"])(
-    "rejects lifecycle %s after reset keeps the session id",
-    async (lifecycleRevision) => {
-      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+  it.each([
+    ["default", undefined],
+    ["default", "lifecycle-a"],
+    ["configured", undefined],
+    ["configured", "lifecycle-a"],
+  ] as const)(
+    "%s store rejects lifecycle %s after reset keeps the session id",
+    async (store, lifecycleRevision) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (fixture) => {
         const sessionKey = "agent:main:persist-digest-reset";
         const sessionId = "sess-1";
-        await upsertSessionEntryCore(
-          { sessionKey, agentId, env: process.env },
-          { sessionId, lifecycleRevision: "lifecycle-b", updatedAt: 1 },
-        );
+        const scope = {
+          sessionKey,
+          agentId,
+          ...(store === "configured"
+            ? { storePath: fixture.path("observer-sessions", "sessions.json") }
+            : {}),
+        };
+        await upsertSessionEntryCore(scope, {
+          sessionId,
+          lifecycleRevision: "lifecycle-b",
+          updatedAt: 1,
+        });
         const before = readSessionObserverDigestVersion();
         const previousDigest = {
           ...makeDigest(sessionKey, 10),
@@ -157,24 +170,25 @@ describe("defaultPersistDigest tri-state contract", () => {
           lifecycleRevision,
         };
 
-        expect(
-          await defaultPersistDigest({ sessionKey, agentId, sessionId, digest: previousDigest }),
-        ).toBe(false);
+        expect(await defaultPersistDigest({ ...scope, sessionId, digest: previousDigest })).toBe(
+          false,
+        );
         expect(readSessionObserverDigestVersion()).toBe(before);
-        expect(loadSessionEntryReadOnly({ sessionKey, agentId })?.observerDigest).toBeUndefined();
+        expect(loadSessionEntryReadOnly(scope)?.observerDigest).toBeUndefined();
 
         const currentDigest = {
           ...makeDigest(sessionKey, 1),
           sessionId,
           lifecycleRevision: "lifecycle-b",
         };
-        expect(
-          await defaultPersistDigest({ sessionKey, agentId, sessionId, digest: currentDigest }),
-        ).toBe(true);
-        expect(readSessionObserverDigestVersion()).toBe(before + 1);
-        expect(loadSessionEntryReadOnly({ sessionKey, agentId })?.observerDigest).toEqual(
-          currentDigest,
+        expect(await defaultPersistDigest({ ...scope, sessionId, digest: currentDigest })).toBe(
+          true,
         );
+        expect(readSessionObserverDigestVersion()).toBe(before + 1);
+        expect(loadSessionEntryReadOnly(scope)?.observerDigest).toEqual(currentDigest);
+        if (store === "configured") {
+          expect(loadSessionEntryReadOnly({ sessionKey, agentId })).toBeUndefined();
+        }
       });
     },
   );

--- a/src/gateway/session-observer-model.test.ts
+++ b/src/gateway/session-observer-model.test.ts
@@ -139,6 +139,45 @@ describe("defaultPersistDigest tri-state contract", () => {
       expect(loadSessionEntryReadOnly({ sessionKey, agentId })?.observerDigest?.revision).toBe(0);
     });
   });
+
+  it.each([undefined, "lifecycle-a"])(
+    "rejects lifecycle %s after reset keeps the session id",
+    async (lifecycleRevision) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const sessionKey = "agent:main:persist-digest-reset";
+        const sessionId = "sess-1";
+        await upsertSessionEntryCore(
+          { sessionKey, agentId, env: process.env },
+          { sessionId, lifecycleRevision: "lifecycle-b", updatedAt: 1 },
+        );
+        const before = readSessionObserverDigestVersion();
+        const previousDigest = {
+          ...makeDigest(sessionKey, 10),
+          sessionId,
+          lifecycleRevision,
+        };
+
+        expect(
+          await defaultPersistDigest({ sessionKey, agentId, sessionId, digest: previousDigest }),
+        ).toBe(false);
+        expect(readSessionObserverDigestVersion()).toBe(before);
+        expect(loadSessionEntryReadOnly({ sessionKey, agentId })?.observerDigest).toBeUndefined();
+
+        const currentDigest = {
+          ...makeDigest(sessionKey, 1),
+          sessionId,
+          lifecycleRevision: "lifecycle-b",
+        };
+        expect(
+          await defaultPersistDigest({ sessionKey, agentId, sessionId, digest: currentDigest }),
+        ).toBe(true);
+        expect(readSessionObserverDigestVersion()).toBe(before + 1);
+        expect(loadSessionEntryReadOnly({ sessionKey, agentId })?.observerDigest).toEqual(
+          currentDigest,
+        );
+      });
+    },
+  );
 });
 
 describe("session observer digest fence", () => {
@@ -198,7 +237,7 @@ describe("session observer digest fence", () => {
             terminalHealth: "done",
           },
         },
-        readSession: () => undefined,
+        readSession: () => loadSessionEntryReadOnly({ sessionKey, agentId }),
         persistDigest: defaultPersistDigest,
         now: () => 1,
       });

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -295,10 +295,14 @@ function sanitizeSessionObserverModelText(value: string, maxChars: number): stri
   return truncateUtf16Safe(normalized, maxChars);
 }
 
-export function defaultReadSession(sessionKey: string, agentId: string): SessionEntry | undefined {
+export function defaultReadSession(
+  sessionKey: string,
+  agentId: string,
+  storePath?: string,
+): SessionEntry | undefined {
   // Read-only: observation must never materialize agent state (dirs, agent DB
   // registration) for agents that are not configured.
-  return loadSessionEntryReadOnly({ sessionKey, agentId });
+  return loadSessionEntryReadOnly({ sessionKey, agentId, ...(storePath ? { storePath } : {}) });
 }
 
 // sessions.list cache fence input. Both production writers (live/preamble
@@ -316,6 +320,7 @@ export async function defaultPersistDigest(params: {
   sessionKey: string;
   sessionId?: string;
   agentId: string;
+  storePath?: string;
   digest: SessionObserverDigest;
   stillCurrent?: () => boolean;
 }): Promise<boolean | null> {
@@ -324,7 +329,11 @@ export async function defaultPersistDigest(params: {
   // separately since the result alone can't distinguish the three states.
   let applied = false;
   const result = await patchSessionEntryCore(
-    { sessionKey: params.sessionKey, agentId: params.agentId },
+    {
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      ...(params.storePath ? { storePath: params.storePath } : {}),
+    },
     (entry) => {
       if (params.stillCurrent?.() === false) {
         return null;

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -459,8 +459,13 @@ export function buildSessionObserverPrompt(
   state: Pick<SessionObserverState, "previousDigest" | "planProgress">,
   notes: readonly string[],
 ): string {
+  const {
+    sessionId: _sessionId,
+    lifecycleRevision: _lifecycleRevision,
+    ...previousDigest
+  } = state.previousDigest ?? {};
   return JSON.stringify({
-    previousDigest: state.previousDigest ?? null,
+    previousDigest: state.previousDigest ? previousDigest : null,
     newNotes: notes,
     planProgress: state.planProgress ?? null,
   });

--- a/src/gateway/session-observer-model.ts
+++ b/src/gateway/session-observer-model.ts
@@ -48,9 +48,48 @@ type PrepareModel = typeof prepareUtilityCompletionForAgent;
 type CompleteModel = typeof runIsolatedCompletion;
 type PreparedModel = Awaited<ReturnType<PrepareModel>>;
 
+export type SessionObserverLifecycle = Pick<
+  SessionObserverDigest,
+  "sessionId" | "lifecycleRevision"
+>;
+
+export function isSameSessionObserverLifecycle(
+  left: SessionObserverLifecycle | undefined,
+  right: SessionObserverLifecycle | undefined,
+): boolean {
+  return (
+    left !== undefined &&
+    right !== undefined &&
+    left.sessionId === right.sessionId &&
+    left.lifecycleRevision === right.lifecycleRevision
+  );
+}
+
+export function resolveSessionObserverDigestForLifecycle(
+  digest: SessionObserverDigest | undefined,
+  lifecycle: SessionObserverLifecycle | undefined,
+): SessionObserverDigest | undefined {
+  if (
+    !digest ||
+    !lifecycle ||
+    (digest.sessionId !== undefined && digest.sessionId !== lifecycle.sessionId) ||
+    ((digest.sessionId !== undefined || digest.lifecycleRevision !== undefined) &&
+      digest.lifecycleRevision !== lifecycle.lifecycleRevision)
+  ) {
+    return undefined;
+  }
+  // Legacy stored digests inherit the captured owner before any asynchronous write.
+  return {
+    ...digest,
+    ...(lifecycle.sessionId ? { sessionId: lifecycle.sessionId } : {}),
+    ...(lifecycle.lifecycleRevision ? { lifecycleRevision: lifecycle.lifecycleRevision } : {}),
+  };
+}
+
 export type SessionObserverState = SessionActivityNoteState & {
   sessionKey: string;
   sessionId?: string;
+  lifecycleRevision?: string;
   runId: string;
   agentId: string;
   utilityModelRef?: string;
@@ -77,6 +116,7 @@ export type DormantSessionObserverRun = Pick<
   SessionObserverState,
   | "sessionKey"
   | "sessionId"
+  | "lifecycleRevision"
   | "runId"
   | "agentId"
   | "utilityModelRef"
@@ -92,7 +132,7 @@ export type DormantSessionObserverRun = Pick<
 
 export type SessionObserverRevisionFloor = Pick<
   DormantSessionObserverRun,
-  "revision" | "previousDigest"
+  "sessionId" | "lifecycleRevision" | "revision" | "previousDigest"
 >;
 
 export function rememberSessionObserverRevisionFloor(
@@ -101,7 +141,11 @@ export function rememberSessionObserverRevisionFloor(
   candidate: SessionObserverRevisionFloor,
 ): void {
   const current = floors.get(sessionKey);
-  if (!current || candidate.revision > current.revision) {
+  if (
+    !current ||
+    !isSameSessionObserverLifecycle(current, candidate) ||
+    candidate.revision > current.revision
+  ) {
     floors.delete(sessionKey);
     floors.set(sessionKey, candidate);
   }
@@ -129,6 +173,8 @@ export function rememberSessionObserverDormantRun(
         floors,
         resolveSessionSubscriptionKey(evicted.sessionKey, evicted.agentId),
         {
+          sessionId: evicted.sessionId,
+          lifecycleRevision: evicted.lifecycleRevision,
           revision: evicted.revision,
           previousDigest: evicted.previousDigest,
         },
@@ -165,6 +211,7 @@ export function createDormantSessionObserverRun(
   return {
     sessionKey: state.sessionKey,
     sessionId: state.sessionId,
+    lifecycleRevision: state.lifecycleRevision,
     runId: state.runId,
     agentId: state.agentId,
     ...(state.utilityModelRef ? { utilityModelRef: state.utilityModelRef } : {}),
@@ -282,10 +329,20 @@ export async function defaultPersistDigest(params: {
       if (params.stillCurrent?.() === false) {
         return null;
       }
-      if (params.sessionId && entry.sessionId !== params.sessionId) {
+      if (params.sessionId !== undefined && entry.sessionId !== params.sessionId) {
         return null;
       }
-      if ((entry.observerDigest?.revision ?? 0) >= params.digest.revision) {
+      const hasSessionIdentity =
+        params.sessionId !== undefined || params.digest.sessionId !== undefined;
+      if (
+        (params.digest.sessionId !== undefined && entry.sessionId !== params.digest.sessionId) ||
+        ((hasSessionIdentity || params.digest.lifecycleRevision !== undefined) &&
+          entry.lifecycleRevision !== params.digest.lifecycleRevision)
+      ) {
+        return null;
+      }
+      const previousDigest = resolveSessionObserverDigestForLifecycle(entry.observerDigest, entry);
+      if ((previousDigest?.revision ?? 0) >= params.digest.revision) {
         return null;
       }
       applied = true;
@@ -326,16 +383,25 @@ export async function synthesizeSessionObserverTerminalDigest(params: {
     return undefined;
   }
   const session = params.readSession(sessionKey, agentId);
+  const lifecycle = params.source.state ?? params.dormant ?? session;
+  if (
+    !isSameSessionObserverLifecycle(lifecycle, session) ||
+    (params.source.event?.sessionId !== undefined &&
+      params.source.event.sessionId !== lifecycle?.sessionId)
+  ) {
+    return undefined;
+  }
   const previous = [
     params.source.state?.previousDigest,
     params.dormant?.previousDigest,
     session?.observerDigest,
-  ].find((digest) => digest?.runId === runId);
+  ]
+    .map((digest) => resolveSessionObserverDigestForLifecycle(digest, lifecycle))
+    .find((digest) => digest?.runId === runId);
   if (!previous) {
     return undefined;
   }
-  const sessionId =
-    params.source.state?.sessionId ?? params.dormant?.sessionId ?? session?.sessionId;
+  const sessionId = lifecycle?.sessionId;
   const terminalReply = params.source.event
     ? normalizeAgentRunTerminalReplySnapshot(params.source.event.data.terminalReply)
     : params.source.state?.terminalReply;

--- a/src/gateway/session-observer-preamble.ts
+++ b/src/gateway/session-observer-preamble.ts
@@ -47,6 +47,8 @@ export function createSessionObserverPreamblePublisher(params: {
     const digest: SessionObserverDigest = {
       sessionKey: state.sessionKey,
       agentId: state.agentId,
+      ...(state.sessionId ? { sessionId: state.sessionId } : {}),
+      ...(state.lifecycleRevision ? { lifecycleRevision: state.lifecycleRevision } : {}),
       runId: state.runId,
       revision: state.revision,
       updatedAt: Math.max(entry.updatedAt, (previous?.updatedAt ?? -1) + 1),

--- a/src/gateway/session-observer.terminal.test.ts
+++ b/src/gateway/session-observer.terminal.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionObserverDigest } from "../../packages/gateway-protocol/src/schema/sessions.js";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { emitSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
 import type { SessionObserverDeps } from "./session-observer-model.js";
 import {
   createHarness as createBaseHarness,
@@ -12,6 +14,7 @@ import {
   resetSessionObserverEventSequence,
   startAndAddToolNotes,
 } from "./session-observer.test-utils.js";
+import { notifyGatewaySessionReset } from "./session-reset-notifications.js";
 
 afterEach(() => {
   for (const harness of activeHarnesses) {
@@ -100,6 +103,25 @@ function persistGuard(harness: Harness): (() => boolean) | undefined {
 
 function completionPrompt(harness: Harness, index = 0): string {
   return harness.completeModel.mock.calls[index]?.[0]?.prompt ?? "";
+}
+
+function commitObserverSessionReset(harness: Harness, notify = true): void {
+  const sessionKey = "agent:main:session-1";
+  const sessionId = "session-id";
+  harness.readSession.mockReturnValue({
+    sessionId,
+    lifecycleRevision: "lifecycle-b",
+    updatedAt: Date.now(),
+  });
+  if (!notify) {
+    return;
+  }
+  emitSessionIdentityMutation({
+    kind: "reset",
+    previous: { sessionId, sessionKeys: [sessionKey] },
+    current: { sessionId, sessionKeys: [sessionKey] },
+  });
+  notifyGatewaySessionReset(sessionKey, "main");
 }
 
 describe("session observer terminal, persistence, synthesis, and races", () => {
@@ -715,6 +737,148 @@ describe("session observer terminal, persistence, synthesis, and races", () => {
     harness.observer.handleEvent(lifecycleEvent({ phase: "start" }, { runId: "run-2" }));
     expect(vi.getTimerCount()).toBe(0);
     expect(guard?.()).toBe(false);
+  });
+
+  it.each([
+    { name: "notified reset", notify: true, lifecycleRevision: "lifecycle-a" },
+    { name: "missed notification", notify: false, lifecycleRevision: "lifecycle-a" },
+    { name: "first reset of a legacy lifecycle", notify: false, lifecycleRevision: undefined },
+  ])(
+    "discards a final result after same-id reset: $name",
+    async ({ notify, lifecycleRevision }) => {
+      useFakeTime();
+      const final = createDeferred<ReturnType<typeof modelMessage>>();
+      const completeModel = vi.fn(() => final.promise);
+      const readSession = vi.fn<NonNullable<SessionObserverDeps["readSession"]>>(() => ({
+        sessionId: "session-id",
+        lifecycleRevision,
+        updatedAt: 1_000,
+        observerDigest: persistedLiveDigest({ revision: 10, health: "stuck" }),
+      }));
+      const harness = createHarness({ completeModel, readSession });
+      await handleLifecycle(harness, { phase: "start", startedAt: 0 });
+      vi.setSystemTime(30_000);
+      await handleLifecycle(harness, { phase: "end", startedAt: 0, endedAt: 30_000 });
+      expect(completeModel).toHaveBeenCalledOnce();
+
+      commitObserverSessionReset(harness, notify);
+      final.resolve(modelMessage({ headline: "Previous run finished", health: "done" }));
+      await flushObserver();
+
+      expect(observerBroadcasts(harness)).toHaveLength(0);
+      expect(harness.persistDigest).not.toHaveBeenCalled();
+    },
+  );
+
+  it("discards a queued preamble from a reset lifecycle", async () => {
+    useFakeTime();
+    const readSession = vi.fn<NonNullable<SessionObserverDeps["readSession"]>>(() => ({
+      sessionId: "session-id",
+      lifecycleRevision: "lifecycle-a",
+      updatedAt: 0,
+    }));
+    const harness = createHarness({ readSession, utilityModelRef: null });
+    emitEvent(harness, "item", { kind: "preamble", progressText: "Initial work" });
+    await advanceAndFlush(100);
+    emitEvent(harness, "item", { kind: "preamble", progressText: "Obsolete queued work" });
+    commitObserverSessionReset(harness, false);
+    await advanceAndFlush(2_000);
+
+    expect(observerBroadcasts(harness)).toHaveLength(1);
+    emitEvent(
+      harness,
+      "item",
+      { kind: "preamble", progressText: "Fresh work" },
+      { runId: "run-2" },
+    );
+    expect(broadcastDigest(harness, -1)).toMatchObject({
+      runId: "run-2",
+      revision: 1,
+      headline: "Fresh work",
+      sessionId: "session-id",
+      lifecycleRevision: "lifecycle-b",
+    });
+  });
+
+  it.each([
+    {
+      name: "reset lifecycle before its notification",
+      reset: true,
+      legacy: false,
+      revision: 1,
+      notifyBackground: true,
+    },
+    { name: "same lifecycle", reset: false, legacy: false, revision: 11, notifyBackground: false },
+    {
+      name: "legacy persisted digest",
+      reset: false,
+      legacy: true,
+      revision: 11,
+      notifyBackground: false,
+    },
+  ])(
+    "keeps critical transitions and revision floors within the $name",
+    async ({ reset, legacy, revision, notifyBackground }) => {
+      useFakeTime();
+      const final = createDeferred<ReturnType<typeof modelMessage>>();
+      const completeModel = vi
+        .fn(async () => modelMessage({ headline: "Waiting for a repair", health: "stuck" }))
+        .mockImplementationOnce(() => final.promise);
+      const readSession = vi.fn<NonNullable<SessionObserverDeps["readSession"]>>(() => ({
+        sessionId: "session-id",
+        lifecycleRevision: "lifecycle-a",
+        updatedAt: 1_000,
+        observerDigest: persistedLiveDigest({
+          revision: 10,
+          health: "stuck",
+          ...(legacy ? {} : { sessionId: "session-id", lifecycleRevision: "lifecycle-a" }),
+        }),
+      }));
+      const harness = createHarness({ completeModel, readSession });
+      harness.sessionEventSubscribers.subscribe("background");
+      harness.observer.setConnectionVisibility("background", false);
+      await handleLifecycle(harness, { phase: "start", startedAt: 0 });
+      vi.setSystemTime(30_000);
+      await handleLifecycle(harness, { phase: "end", startedAt: 0, endedAt: 30_000 });
+      expect(completeModel).toHaveBeenCalledOnce();
+
+      if (reset) {
+        commitObserverSessionReset(harness, false);
+      }
+      startAndAddToolNotes(harness.observer, { runId: "run-2" });
+      if (reset) {
+        notifyGatewaySessionReset("agent:main:session-1", "main");
+      }
+      await advanceAndFlush(12_000);
+      final.resolve(modelMessage({ headline: "Previous run finished", health: "done" }));
+      await flushObserver();
+
+      const broadcasts = observerBroadcasts(harness);
+      expect(broadcasts).toHaveLength(1);
+      expect(broadcasts[0]?.[1]).toMatchObject({
+        runId: "run-2",
+        health: "stuck",
+        revision,
+        sessionId: "session-id",
+        lifecycleRevision: reset ? "lifecycle-b" : "lifecycle-a",
+      });
+      expect(broadcasts[0]?.[2]).toEqual(
+        new Set(notifyBackground ? ["conn-1", "background"] : ["conn-1"]),
+      );
+    },
+  );
+
+  it.each([
+    { name: "no audience", options: { subscribe: false } },
+    { name: "broad audience", options: { subscribe: false, broadSubscribe: true } },
+    { name: "disabled utility model", options: { utilityModelRef: null } },
+  ])("does not read lifecycle state for tool events with $name", ({ options }) => {
+    const harness = createHarness(options);
+    for (let index = 0; index < 5; index += 1) {
+      emitEvent(harness, "tool", { phase: "start", name: "read", args: { index } });
+    }
+    expect(harness.readSession).not.toHaveBeenCalled();
+    expect(harness.completeModel).not.toHaveBeenCalled();
   });
 
   it.each(["deleted", "reset"])("disables model work after the session is %s", async (change) => {

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -10,6 +10,7 @@ import {
   terminalHealthFor,
 } from "../agents/session-activity-notes.js";
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { getAgentRunContext } from "../infra/agent-run-registry.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -64,8 +65,14 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const resolveUtilityModelRef = deps.resolveUtilityModelRef ?? resolveUtilityModelRefForAgent;
   const prepareModel = deps.prepareModel ?? defaultPrepareModel;
   const completeModel = deps.completeModel ?? defaultCompleteModel;
-  const readSession = deps.readSession ?? defaultReadSession;
-  const persistDigest = deps.persistDigest ?? defaultPersistDigest;
+  const resolveStorePath = (agentId: string) =>
+    resolveSessionStorePathCore(deps.getConfig().session?.store, { agentId });
+  const readSession: NonNullable<SessionObserverDeps["readSession"]> =
+    deps.readSession ??
+    ((sessionKey, agentId) => defaultReadSession(sessionKey, agentId, resolveStorePath(agentId)));
+  const persistDigest: NonNullable<SessionObserverDeps["persistDigest"]> =
+    deps.persistDigest ??
+    ((params) => defaultPersistDigest({ ...params, storePath: resolveStorePath(params.agentId) }));
   const contextlessTerminalRuns = new Map<string, number>();
   const terminalRuns = new Map<string, number>();
   const pendingTerminalErrors = new Map<string, ReturnType<typeof setTimeout>>();

--- a/src/gateway/session-observer.ts
+++ b/src/gateway/session-observer.ts
@@ -5,7 +5,6 @@ import {
   isDefinitiveRunLifecycle,
 } from "../agents/agent-run-terminal-outcome.js";
 import {
-  createSessionActivityNoteState,
   flushSessionActivityAssistantNote,
   noteSessionActivityEvent,
   terminalHealthFor,
@@ -21,6 +20,7 @@ import {
 import { createSessionObserverCompanionSnapshotReader } from "./session-observer-companion.js";
 import { createSessionObserverCompletion } from "./session-observer-completion.js";
 import type { SessionObserverEvent, SessionObserverService } from "./session-observer-contract.js";
+import { createSessionObserverLifecycle } from "./session-observer-lifecycle.js";
 import { createSessionObserverModelSlots } from "./session-observer-model-slots.js";
 import {
   createDormantSessionObserverRun,
@@ -28,16 +28,17 @@ import {
   defaultPersistDigest,
   defaultPrepareModel,
   defaultReadSession,
+  isSameSessionObserverLifecycle,
   markSessionObserverRunSuperseded,
   rememberSessionObserverDisabledRun,
   rememberSessionObserverDormantRun,
   rememberSessionObserverRevisionFloor,
+  resolveSessionObserverDigestForLifecycle,
   synthesizeSessionObserverTerminalDigest,
 } from "./session-observer-model.js";
 import type {
   DormantSessionObserverRun,
   SessionObserverDeps,
-  SessionObserverRevisionFloor,
   SessionObserverState,
 } from "./session-observer-model.js";
 import { createSessionObserverDigestPersister } from "./session-observer-persistence.js";
@@ -65,20 +66,30 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
   const completeModel = deps.completeModel ?? defaultCompleteModel;
   const readSession = deps.readSession ?? defaultReadSession;
   const persistDigest = deps.persistDigest ?? defaultPersistDigest;
-  const states = new Map<string, SessionObserverState>();
-  const dormantRuns = new Map<string, DormantSessionObserverRun>();
-  const revisionFloors = new Map<string, SessionObserverRevisionFloor>();
-  const supersededRuns = new Map<string, number>();
   const contextlessTerminalRuns = new Map<string, number>();
   const terminalRuns = new Map<string, number>();
   const pendingTerminalErrors = new Map<string, ReturnType<typeof setTimeout>>();
-  const disabledRuns = new Set<string>();
   const visibleConnections = new Set<string>();
   let disposed = false;
   const clearPendingTerminalError = (runId: string) => {
     clearTimeoutFn(pendingTerminalErrors.get(runId));
     pendingTerminalErrors.delete(runId);
   };
+  const lifecycle = createSessionObserverLifecycle({
+    getConfig: deps.getConfig,
+    readSession,
+    now,
+    isTerminal: (runId) => terminalRuns.has(runId),
+    clearPendingTerminalError,
+    releaseState: (state) => {
+      preamblePublisher.clear(state);
+      if (state.timer) {
+        clearTimeoutFn(state.timer);
+      }
+      modelSlots.invalidateRequest(state);
+    },
+  });
+  const { states, dormantRuns, revisionFloors, supersededRuns, disabledRuns } = lifecycle;
   const getCompanionSnapshot = createSessionObserverCompanionSnapshotReader({
     getConfig: deps.getConfig,
     readSession,
@@ -129,7 +140,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     now,
     setTimeoutFn,
     clearTimeoutFn,
-    isCurrent: (state) => audienceLifecycle.stateIsCurrent(state),
+    isCurrent: (state) =>
+      audienceLifecycle.stateIsCurrent(state) && lifecycle.acceptPublication(state),
     publish: (state, digest) => {
       broadcastDigest(digest, audience.recipients(state.sessionKey, state.agentId), state.agentId);
       void persistAcceptedDigest(state, digest, false, "preamble");
@@ -165,7 +177,11 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         now,
         stillCurrent,
       });
-      if (digest && stillCurrent()) {
+      if (
+        digest &&
+        stillCurrent() &&
+        isSameSessionObserverLifecycle(digest, readSession(sessionKey, agentId))
+      ) {
         // Live subscribers already saw the in-progress digest over this event;
         // the synthesized terminal correction must reach them the same way.
         broadcastDigest(digest, audience.recipients(digest.sessionKey, agentId), agentId);
@@ -178,35 +194,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     }
   }
 
-  const stateIsTracked = (state: SessionObserverState): boolean =>
-    states.get(resolveSessionSubscriptionKey(state.sessionKey, state.agentId)) === state;
-
-  const dropState = (state: SessionObserverState) => {
-    preamblePublisher.clear(state);
-    if (state.timer) {
-      clearTimeoutFn(state.timer);
-    }
-    modelSlots.invalidateRequest(state);
-    if (stateIsTracked(state)) {
-      const scopeKey = resolveSessionSubscriptionKey(state.sessionKey, state.agentId);
-      if (
-        state.terminalHealth === "failed" &&
-        !terminalRuns.has(state.runId) &&
-        state.previousDigest
-      ) {
-        rememberSessionObserverRevisionFloor(revisionFloors, scopeKey, {
-          revision: state.revision,
-          previousDigest: state.previousDigest,
-        });
-      }
-      states.delete(scopeKey);
-    }
-  };
-
   const retireTerminalState = (state: SessionObserverState) => {
     void synthesizeTerminalDigest({ state });
     dormantRuns.delete(state.runId);
-    dropState(state);
+    lifecycle.dropState(state);
   };
 
   const suspendState = (state: SessionObserverState) => {
@@ -219,10 +210,10 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       revisionFloors,
       createDormantSessionObserverRun(state),
     );
-    dropState(state);
+    lifecycle.dropState(state);
   };
   const retireInactiveState = (state: SessionObserverState) =>
-    (disposed ? dropState : suspendState)(state);
+    (disposed || supersededRuns.has(state.runId) ? lifecycle.dropState : suspendState)(state);
 
   const demoteUtilityModel = (state: SessionObserverState): void => {
     if (state.timer) {
@@ -252,7 +243,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     subscribers: deps.subscribers,
     isCurrent: (state) =>
       !disposed &&
-      stateIsTracked(state) &&
+      lifecycle.isTracked(state) &&
       deps.getConfig().gateway?.controlUi?.sessionObserver !== false,
     resolveUtilityModelRef: (agentId) => resolveUtilityModelRef({ cfg: deps.getConfig(), agentId }),
     suspend: suspendState,
@@ -358,18 +349,13 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         );
         if (digestIsStale()) {
           retireSelectedNotes();
-          if (final && stateIsTracked(state)) {
+          if (final && lifecycle.isTracked(state)) {
             retireTerminalState(state);
           }
           return;
         }
-        // A deleted/reset session cannot accept this run's digest. Disable its
-        // model work so pending notes cannot keep scheduling unpersistable results.
-        if (
-          state.sessionId &&
-          readSession(state.sessionKey, state.agentId)?.sessionId !== state.sessionId
-        ) {
-          return disableModelForRun(state);
+        if (!lifecycle.acceptPublication(state)) {
+          return;
         }
         preamblePublisher.clear(state);
         state.consecutiveFailures = 0;
@@ -378,6 +364,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         const digest: SessionObserverDigest = {
           sessionKey: state.sessionKey,
           agentId: state.agentId,
+          ...(state.sessionId ? { sessionId: state.sessionId } : {}),
+          ...(state.lifecycleRevision ? { lifecycleRevision: state.lifecycleRevision } : {}),
           runId: state.runId,
           revision: state.revision,
           updatedAt: now(),
@@ -406,9 +394,12 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       } catch (error) {
         if (digestIsStale()) {
           retireSelectedNotes();
-          if (final && stateIsTracked(state)) {
+          if (final && lifecycle.isTracked(state)) {
             retireTerminalState(state);
           }
+          return;
+        }
+        if (!lifecycle.acceptPublication(state)) {
           return;
         }
         state.consecutiveFailures += 1;
@@ -427,88 +418,20 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
           state.finalPending = true;
         }
       } finally {
-        if (stateIsTracked(state)) {
+        if (lifecycle.isTracked(state)) {
           state.inFlight = false;
           const runFinal = state.finalPending;
           state.finalPending = false;
           if (runFinal) {
             runDigest(state, true);
           } else if (final) {
-            dropState(state);
+            lifecycle.dropState(state);
           } else {
             schedule(state, runDigest);
           }
         }
       }
     })();
-  };
-
-  const admitState = (
-    event: SessionObserverEvent,
-    allowPreambleOnly: boolean,
-    sessionKey: string,
-    agentId: string,
-    observedAudience: ObservedAudience,
-  ): SessionObserverState | undefined => {
-    if (observedAudience === "none") {
-      return undefined;
-    }
-    const scopeKey = resolveSessionSubscriptionKey(sessionKey, agentId);
-    const cfg = deps.getConfig();
-    if (cfg.gateway?.controlUi?.sessionObserver === false) {
-      return undefined;
-    }
-    const utilityModelRef =
-      disabledRuns.has(event.runId) || observedAudience !== "direct"
-        ? undefined
-        : modelSlots.claim(agentId);
-    if (!utilityModelRef && !allowPreambleOnly) {
-      return undefined;
-    }
-    const dormant = dormantRuns.get(event.runId);
-    if (dormant) {
-      dormantRuns.delete(event.runId);
-      const { utilityModelRef: _dormantModelRef, ...dormantState } = dormant;
-      const state: SessionObserverState = {
-        ...createSessionActivityNoteState(),
-        ...dormantState,
-        ...(dormantState.lastPreambleHeadline
-          ? { lastPublishedPreambleHeadline: dormantState.lastPreambleHeadline }
-          : {}),
-        ...(utilityModelRef ? { utilityModelRef } : {}),
-        lastActivityAt: event.ts,
-        lastRunAt: now(),
-        lastDigestNoteSequence: 0,
-        inFlight: false,
-        finalPending: false,
-      };
-      states.set(scopeKey, state);
-      return state;
-    }
-    const session = readSession(sessionKey, agentId);
-    const startedAt =
-      asFiniteNumber(event.data.startedAt) ?? session?.startedAt ?? event.ts ?? now();
-    const state: SessionObserverState = {
-      ...createSessionActivityNoteState(),
-      sessionKey,
-      sessionId: event.sessionId ?? session?.sessionId,
-      runId: event.runId,
-      agentId,
-      ...(utilityModelRef ? { utilityModelRef } : {}),
-      startedAt,
-      lastActivityAt: event.ts,
-      lastRunAt: startedAt,
-      lastPersistedAt: session?.observerDigest?.updatedAt,
-      revision: session?.observerDigest?.revision ?? 0,
-      digestCount: 0,
-      consecutiveFailures: 0,
-      lastDigestNoteSequence: 0,
-      previousDigest: session?.observerDigest,
-      inFlight: false,
-      finalPending: false,
-    };
-    states.set(scopeKey, state);
-    return state;
   };
 
   const handleEvent = (event: SessionObserverEvent, settledError = false) => {
@@ -591,10 +514,42 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       return;
     }
     const isRunStart = event.stream === "lifecycle" && event.data.phase === "start";
-    let revisionFloor = revisionFloors.get(scopeKey);
     let state = states.get(scopeKey);
+    let session: ReturnType<typeof readSession> = undefined;
+    let admittedModelRef: string | undefined;
+    let canAdmit = false;
+    if (!state || state.runId !== event.runId) {
+      const observesSession =
+        currentAudience !== "none" &&
+        deps.getConfig().gateway?.controlUi?.sessionObserver !== false;
+      admittedModelRef =
+        observesSession && currentAudience === "direct" && !disabledRuns.has(event.runId)
+          ? modelSlots.claim(agentId, state)
+          : undefined;
+      canAdmit = observesSession && (admittedModelRef !== undefined || isPreamble);
+      if (canAdmit || isRunStart) {
+        session = readSession(sessionKey, agentId);
+        // Select revision history only after removing obsolete lifecycle owners.
+        // Tool/text events do not read the store unless they admit an observer state.
+        lifecycle.retireObsolete(scopeKey, session);
+        if (
+          !session ||
+          (event.sessionId !== undefined && event.sessionId !== session.sessionId) ||
+          supersededRuns.has(event.runId)
+        ) {
+          return;
+        }
+        state = states.get(scopeKey);
+      }
+    }
+    let revisionFloor = revisionFloors.get(scopeKey);
     if (state && state.runId !== event.runId) {
-      const candidate = { revision: state.revision, previousDigest: state.previousDigest };
+      const candidate = {
+        sessionId: state.sessionId,
+        lifecycleRevision: state.lifecycleRevision,
+        revision: state.revision,
+        previousDigest: state.previousDigest,
+      };
       if (!revisionFloor || candidate.revision > revisionFloor.revision) {
         revisionFloor = candidate;
       }
@@ -614,6 +569,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         .filter(
           (run) =>
             resolveSessionSubscriptionKey(run.sessionKey, run.agentId) === scopeKey &&
+            isSameSessionObserverLifecycle(run, session) &&
             run.runId !== event.runId,
         )
         .toSorted(
@@ -621,7 +577,12 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
         );
       const latest = superseded[0];
       if (latest && (!revisionFloor || latest.revision > revisionFloor.revision)) {
-        revisionFloor = { revision: latest.revision, previousDigest: latest.previousDigest };
+        revisionFloor = {
+          sessionId: latest.sessionId,
+          lifecycleRevision: latest.lifecycleRevision,
+          revision: latest.revision,
+          previousDigest: latest.previousDigest,
+        };
       }
       if (isRunStart) {
         if (revisionFloor) {
@@ -645,8 +606,8 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       suspendState(state);
       state = undefined;
     }
-    if (!state) {
-      state = admitState(event, isPreamble, sessionKey, agentId, currentAudience);
+    if (!state && canAdmit) {
+      state = lifecycle.admit(event, sessionKey, agentId, session, admittedModelRef);
     }
     if (!state) {
       if (terminal) {
@@ -659,9 +620,16 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
     if (state.terminalHealth) {
       return;
     }
-    if (revisionFloor && revisionFloor.revision > state.revision) {
+    if (
+      revisionFloor &&
+      isSameSessionObserverLifecycle(revisionFloor, state) &&
+      revisionFloor.revision > state.revision
+    ) {
       state.revision = revisionFloor.revision;
-      state.previousDigest = revisionFloor.previousDigest;
+      state.previousDigest = resolveSessionObserverDigestForLifecycle(
+        revisionFloor.previousDigest,
+        state,
+      );
     }
     revisionFloors.delete(scopeKey);
     const utilityModelRef =
@@ -695,7 +663,7 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       const hasRunDigest = state.previousDigest?.runId === state.runId;
       if (!hasRunDigest && endedAt - state.startedAt < FINAL_DIGEST_MIN_RUN_MS) {
         dormantRuns.delete(state.runId);
-        dropState(state);
+        lifecycle.dropState(state);
         return;
       }
       runDigest(state, true);
@@ -725,15 +693,9 @@ export function createSessionObserver(deps: SessionObserverDeps): SessionObserve
       pendingTerminalErrors.forEach((_timer, runId) => clearPendingTerminalError(runId));
       preamblePublisher.dispose();
       audienceLifecycle.unsubscribe();
-      for (const state of states.values()) {
-        dropState(state);
-      }
-      dormantRuns.clear();
-      revisionFloors.clear();
-      supersededRuns.clear();
+      lifecycle.dispose();
       terminalRuns.clear();
       contextlessTerminalRuns.clear();
-      disabledRuns.clear();
       visibleConnections.clear();
     },
   };

--- a/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.e2e.test.ts
@@ -356,6 +356,151 @@ suite.define(() => {
     );
   });
 
+  it("announces after /clear, dedupes reconnects, and notices a missed reset", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      },
+      async ({ page }) => {
+        const sessionId = "observer-background-session";
+        const readyText = "The session is ready to clear.";
+        const roster = sessionsListResponse();
+        for (const row of roster.sessions) {
+          if (row.key === backgroundSessionKey) {
+            Object.assign(row, { sessionId });
+          }
+        }
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["sessions.reset"],
+          historyMessages: [
+            {
+              content: [{ type: "text", text: readyText }],
+              role: "assistant",
+              timestamp: baseTime,
+            },
+          ],
+          methodResponses: { "sessions.list": roster },
+          sessionKey: selectedSessionKey,
+        });
+        const pane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+        const waitForPane = async (sessionKey: string) => {
+          await expect
+            .poll(() => new URL(page.url()).pathname)
+            .toBe(controlUiSessionPath(sessionKey));
+          await expect
+            .poll(() =>
+              pane.evaluate((element, key) => {
+                const state = (
+                  element as HTMLElement & {
+                    state?: { sessionKey: string; connected: boolean; chatLoading: boolean };
+                  }
+                ).state;
+                return state?.sessionKey === key && state.connected && !state.chatLoading;
+              }, sessionKey),
+            )
+            .toBe(true);
+          await pane.evaluate(async (element) => {
+            await (element as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+          });
+        };
+
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, selectedSessionKey));
+        await waitForPane(selectedSessionKey);
+        await pane.getByText(readyText, { exact: true }).waitFor({ state: "visible" });
+
+        const beforeResetDigest = {
+          ...observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: "Background work needs attention before clear",
+            revision: 10,
+          }),
+          sessionId,
+          lifecycleRevision: "before-clear",
+        };
+        const beforeReset = await emitObserverAndReadToast(page, beforeResetDigest, "open");
+        expect(beforeReset.visible).toBe(true);
+        expect(beforeReset.actionable).toBe(true);
+        expect(beforeReset.message).toContain(beforeResetDigest.headline);
+        await waitForPane(backgroundSessionKey);
+        await pane.getByText(readyText, { exact: true }).waitFor({ state: "visible" });
+
+        const historyBefore = await gateway.getRequests("chat.history", {
+          sessionKey: backgroundSessionKey,
+        });
+        const textarea = pane.locator(".agent-chat__composer-combobox textarea");
+        await textarea.fill("/clear");
+        await expect
+          .poll(() =>
+            pane.evaluate(
+              (element) =>
+                (element as HTMLElement & { state: { chatMessage: string } }).state.chatMessage,
+            ),
+          )
+          .toBe("/clear");
+        await textarea.press("Escape");
+        await textarea.press("Enter");
+        const reset = await gateway.waitForRequest("sessions.reset");
+        expect(reset.params).toMatchObject({ key: backgroundSessionKey });
+        expect(await gateway.getRequests("sessions.reset")).toHaveLength(1);
+        await gateway.setHistoryMessages([]);
+        await gateway.resolveDeferred("sessions.reset", { ok: true });
+        await gateway.waitForRequest("chat.history", {
+          after: historyBefore.length,
+          match: { sessionKey: backgroundSessionKey },
+        });
+        await pane.getByText(readyText, { exact: true }).waitFor({ state: "hidden" });
+        await waitForPane(backgroundSessionKey);
+
+        await page.locator("a.nav-item--home").click();
+        await waitForPane(selectedSessionKey);
+        const afterResetDigest = {
+          ...observerDigest({
+            sessionKey: backgroundSessionKey,
+            health: "stuck",
+            headline: "Background work needs attention after clear",
+            revision: 1,
+          }),
+          sessionId,
+          lifecycleRevision: "after-clear",
+          runId: "observer-run-after-clear",
+        };
+        const afterReset = await emitObserverAndReadToast(page, afterResetDigest, "dismiss");
+        expect(afterReset.visible).toBe(true);
+        expect(afterReset.actionable).toBe(true);
+        expect(afterReset.message).toContain(afterResetDigest.headline);
+
+        const connectBefore = (await gateway.getRequests("connect")).length;
+        await gateway.closeLatest(1012, "observer notice reconnect");
+        await gateway.waitForRequest("connect", { after: connectBefore });
+        await waitForPane(selectedSessionKey);
+        const replay = await emitObserverAndReadToast(page, { ...afterResetDigest });
+        expect(replay.visible).toBe(false);
+        const continued = await emitObserverAndReadToast(page, {
+          ...afterResetDigest,
+          revision: 2,
+          updatedAt: baseTime + 12,
+        });
+        expect(continued.visible).toBe(false);
+
+        // The browser receives no reset notification before this new lifecycle digest.
+        const missedResetDigest = {
+          ...afterResetDigest,
+          lifecycleRevision: "after-missed-clear",
+          runId: "observer-run-after-missed-clear",
+          revision: 3,
+          updatedAt: baseTime + 13,
+        };
+        const missedReset = await emitObserverAndReadToast(page, missedResetDigest, "dismiss");
+        expect(missedReset.visible).toBe(true);
+        expect(missedReset.actionable).toBe(true);
+        expect(await gateway.getRequests("sessions.reset")).toHaveLength(1);
+      },
+    );
+  });
+
   it.each([
     {
       name: "suppresses the configured selected-agent foreground alias",

--- a/ui/src/pages/chat/critical-observer-notice.test.ts
+++ b/ui/src/pages/chat/critical-observer-notice.test.ts
@@ -50,6 +50,8 @@ describe("critical session observer notice", () => {
       payload: {
         sessionKey: testCase.sessionKey,
         agentId: testCase.agentId,
+        sessionId: "configured-session",
+        lifecycleRevision: "configured-lifecycle",
         headline: "Configured-global observer regression",
         health: "stuck",
         revision: 1,
@@ -131,5 +133,133 @@ describe("critical session observer notice", () => {
     show("agent:main:other", "stuck", 5);
     await toastHost.updateComplete;
     expect(toastHost.querySelector(".app-toast")).not.toBeNull();
+  });
+
+  describe.each([
+    {
+      name: "session replacement",
+      before: { sessionId: "before-reset", lifecycleRevision: undefined },
+      after: { sessionId: "after-reset", lifecycleRevision: undefined },
+    },
+    {
+      name: "first clear",
+      before: { sessionId: "cleared-session", lifecycleRevision: undefined },
+      after: { sessionId: "cleared-session", lifecycleRevision: "after-clear" },
+    },
+    {
+      name: "later clear",
+      before: { sessionId: "cleared-session", lifecycleRevision: "before-clear" },
+      after: { sessionId: "cleared-session", lifecycleRevision: "after-clear" },
+    },
+  ])("$name", ({ before, after }) => {
+    it.each([1, 11])("announces unchanged critical health at revision %i", async (revision) => {
+      const tracker = new CriticalObserverNoticeTracker();
+      const toastHost = document.createElement("openclaw-toast-host");
+      document.body.append(toastHost);
+      const show = (identity: typeof before, nextRevision: number, runId: string) =>
+        showCriticalSessionObserverNotice({
+          payload: {
+            ...identity,
+            sessionKey: "agent:main:background",
+            runId,
+            headline: "Background task needs help",
+            health: "stuck",
+            revision: nextRevision,
+          },
+          selectedSessionKey: "agent:main:selected",
+          sessionHost: {},
+          sessions: [],
+          tracker,
+          onOpen: vi.fn(),
+        });
+
+      show(before, 10, "run-before-reset");
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast")).not.toBeNull();
+      toastHost.querySelector<HTMLButtonElement>(".app-toast__dismiss")?.click();
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast")).toBeNull();
+
+      show(after, revision, "run-after-reset");
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast__message")?.textContent).toContain(
+        "Background task needs help",
+      );
+      toastHost.querySelector<HTMLButtonElement>(".app-toast__dismiss")?.click();
+      await toastHost.updateComplete;
+
+      show({ ...after }, revision, "run-after-reset");
+      show(after, revision + 1, "next-run-in-same-lifecycle");
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast")).toBeNull();
+    });
+  });
+
+  it.each(["sessionId", "lifecycleRevision"])(
+    "rejects malformed %s before tracking",
+    async (field) => {
+      const tracker = new CriticalObserverNoticeTracker();
+      const toastHost = document.createElement("openclaw-toast-host");
+      document.body.append(toastHost);
+      const show = (value: unknown) =>
+        showCriticalSessionObserverNotice({
+          payload: {
+            sessionKey: "agent:main:background",
+            [field]: value,
+            headline: "Background task needs help",
+            health: "stuck",
+            revision: 1,
+          },
+          selectedSessionKey: "agent:main:selected",
+          sessionHost: {},
+          sessions: [],
+          tracker,
+          onOpen: vi.fn(),
+        });
+
+      for (const value of [null, 1, "", "   "]) {
+        show(value);
+        await toastHost.updateComplete;
+        expect(toastHost.querySelector(".app-toast")).toBeNull();
+      }
+      show("valid-identity");
+      await toastHost.updateComplete;
+      expect(toastHost.querySelector(".app-toast")).not.toBeNull();
+    },
+  );
+
+  it("keeps reset history separate between agents sharing the global session key", () => {
+    const tracker = new CriticalObserverNoticeTracker();
+    const digest = { sessionKey: "global", sessionId: "same-id", health: "stuck", revision: 10 };
+    expect(tracker.record({ ...digest, agentId: "work" })).toBe(true);
+    expect(tracker.record({ ...digest, agentId: "other" })).toBe(true);
+    expect(
+      tracker.record({ ...digest, agentId: "work", lifecycleRevision: "after-clear", revision: 1 }),
+    ).toBe(true);
+    expect(tracker.record({ ...digest, agentId: "other", revision: 11 })).toBe(false);
+    expect(
+      tracker.record({ ...digest, agentId: "WORK", lifecycleRevision: "after-clear", revision: 2 }),
+    ).toBe(false);
+  });
+
+  it("bounds history by session even when an existing session resets", () => {
+    const tracker = new CriticalObserverNoticeTracker();
+    const record = (index: number, lifecycleRevision?: string) =>
+      tracker.record({
+        sessionKey: `agent:main:session-${index}`,
+        sessionId: `session-${index}`,
+        lifecycleRevision,
+        health: "stuck",
+        revision: 1,
+      });
+    for (let index = 0; index < 256; index += 1) {
+      expect(record(index)).toBe(true);
+    }
+
+    expect(record(255, "after-clear")).toBe(true);
+    expect(record(0)).toBe(false);
+    expect(record(256)).toBe(true);
+    expect(record(0)).toBe(true);
+    expect(record(255, "after-clear")).toBe(false);
   });
 });

--- a/ui/src/pages/chat/critical-observer-notice.ts
+++ b/ui/src/pages/chat/critical-observer-notice.ts
@@ -16,7 +16,10 @@ import { showToast } from "../../lib/toast.ts";
 const NOTICE_TRACKER_LIMIT = 256;
 
 export class CriticalObserverNoticeTracker {
-  private readonly seen = new Map<string, { health: string; revision: number }>();
+  private readonly seen = new Map<
+    string,
+    { sessionId?: string; lifecycleRevision?: string; health: string; revision: number }
+  >();
 
   clear(): void {
     this.seen.clear();
@@ -25,6 +28,8 @@ export class CriticalObserverNoticeTracker {
   record(params: {
     sessionKey: string;
     agentId?: string;
+    sessionId?: string;
+    lifecycleRevision?: string;
     health: string;
     revision: number;
   }): boolean {
@@ -33,23 +38,32 @@ export class CriticalObserverNoticeTracker {
       isUiGlobalSessionKey(sessionKey) && params.agentId
         ? `${sessionKey}:${normalizeAgentId(params.agentId)}`
         : sessionKey;
-    const previous = this.seen.get(key);
-    // Gateway revision floors keep revisions session-monotonic across run
-    // rollover, so a gap reliably means this connection missed digest state.
+    const recorded = this.seen.get(key);
+    const previous =
+      recorded?.sessionId === params.sessionId &&
+      recorded?.lifecycleRevision === params.lifecycleRevision
+        ? recorded
+        : undefined;
+    // Revision floors span runs within one lifecycle; a reset starts new notice history.
     if (previous && params.revision <= previous.revision) {
       return false;
     }
     const shouldAnnounce =
       isCriticalObserverHealth(params.health) &&
       (!previous || previous.health !== params.health || params.revision > previous.revision + 1);
-    if (!previous && this.seen.size >= NOTICE_TRACKER_LIMIT) {
+    if (!recorded && this.seen.size >= NOTICE_TRACKER_LIMIT) {
       const oldest = this.seen.keys().next().value;
       if (oldest !== undefined) {
         this.seen.delete(oldest);
       }
     }
     this.seen.delete(key);
-    this.seen.set(key, { health: params.health, revision: params.revision });
+    this.seen.set(key, {
+      sessionId: params.sessionId,
+      lifecycleRevision: params.lifecycleRevision,
+      health: params.health,
+      revision: params.revision,
+    });
     return shouldAnnounce;
   }
 }
@@ -72,6 +86,10 @@ export function showCriticalSessionObserverNotice(params: {
   if (
     !sessionKey ||
     !headline ||
+    (digest.sessionId !== undefined &&
+      (typeof digest.sessionId !== "string" || !digest.sessionId.trim())) ||
+    (digest.lifecycleRevision !== undefined &&
+      (typeof digest.lifecycleRevision !== "string" || !digest.lifecycleRevision.trim())) ||
     typeof digest.health !== "string" ||
     revision === undefined ||
     !Number.isInteger(revision) ||
@@ -82,6 +100,8 @@ export function showCriticalSessionObserverNotice(params: {
   const shouldAnnounce = params.tracker.record({
     sessionKey,
     agentId: digest.agentId,
+    sessionId: digest.sessionId,
+    lifecycleRevision: digest.lifecycleRevision,
     health: digest.health,
     revision,
   });


### PR DESCRIPTION
Fixes #137125

## What Problem This Solves

Clearing a session could suppress its later critical-attention notices. The browser retained the previous conversation's revision and health, and retained Gateway observer work could also prevent a fresh critical transition from reaching background subscribers.

## Why This Change Was Made

Observer state and digests now carry the existing session identity and lifecycle revision. Reset retires obsolete work; publication and persistence reject results from an earlier lifecycle; notice deduplication starts fresh when that identity changes. Reads and writes use the configured canonical session store. Existing saved digests retain revision continuity within their current lifecycle.

## User Impact

A cleared session that becomes stuck or needs input can show its attention notice and Open session action again. Ordinary run continuity, reconnect deduplication, foreground suppression, and agent-specific session boundaries are preserved.

## Evidence

Verified source: `d644e69a481e5759eedb467ef86bd70f64aa3f8c`.

- Blacksmith Testbox: 157 Gateway tests, 19 UI unit tests, the focused browser regression, `pnpm protocol:check`, and the full changed-path gate passed. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34019521549).
- Six Gateway and six UI regression cases fail against baseline `652611689023bb518e7f3bcec56cb1940abfcc4c` for the stale-publication, persistence, revision-floor, and missing-notice failures.
- Browser proof exercises Open session, literal `/clear`, the exact `sessions.reset` key, Home, the renewed notice, and reconnect replay. The committed browser regression also covers a missed reset notification.
- Saved-state compatibility passed in both store layouts with real isolated SQLite, production observer/default adapters, and the production notice tracker. Model completions and agent events are synthetic; the probe applies the existing same-ID reset entry mutation. [Compatibility run](https://github.com/openclaw/openclaw/actions/runs/34020494382).

| Store | Legacy persisted revision | After same-ID reset | Separate fresh session | Exact replay after reconnect |
| --- | --- | --- | --- | --- |
| Default | 10 -> 11, continuity preserved | Revision 1 persisted; background notice allowed | Revision 1 persisted; notice allowed | Suppressed |
| Configured | 10 -> 11, continuity preserved | Revision 1 persisted; background notice allowed | Revision 1 persisted; notice allowed | Suppressed |

[Raw reports and repeatable probe](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjE2NTM3NzYzNg/publish/public/20260906-080521-155018000/artifact-manifest.json?X-Amz-Expires=604800&X-Amz-Date=20260906T080521Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260906%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=df16d537ec047e0627c925e3ca60885b0928ec1924ca8e0c903be0cb72e89e93) (download links expire September 13). Both compatibility fixtures were removed after completion.

## Visual evidence

| Before | After |
| --- | --- |
| ![Before the fix, revision 1 after clearing Reset target has no attention notice](https://github.com/user-attachments/assets/327be908-d963-4ce5-af1b-347a79fee1f2) | ![After the fix, revision 1 after clearing Reset target shows the attention notice and Open session action](https://github.com/user-attachments/assets/1734eb97-aed8-4e8b-8a40-fada4ffd0c8d) |

### Final-head /clear, renewed notice, and reconnect replay

https://github.com/user-attachments/assets/88cb52a6-f84e-4c68-8e60-892c186b5ba0

Both browser captures use the same synthetic sessions, Chromium 144, and 1440x900 viewport. The baseline is `652611689023bb518e7f3bcec56cb1940abfcc4c`; the after capture is the verified head above. The video omits two seconds of startup. No uncaught page errors occurred.
