### PR TITLE
improve: avoid CLI setup discovery in learn policy tests

### DIFF
--- a/src/auto-reply/reply/commands-learn.test.ts
+++ b/src/auto-reply/reply/commands-learn.test.ts
@@ -1,5 +1,6 @@
 // Tests /learn prompt rewriting, defaults, standards, and availability gating.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import { migratePersistedImplicitMainRoster } from "../../config/legacy.roster.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { DEFAULT_LEARN_REQUEST } from "../../skills/workshop/learn-prompt.js";
@@ -72,6 +73,8 @@ function buildLearnParams(
     isGroup: false,
   } as unknown as HandleCommandsParams;
 }
+
+afterEach(() => cliBackendsTesting.resetDepsForTest());
 
 describe("learn command", () => {
   it.each([
@@ -152,6 +155,18 @@ describe("learn command", () => {
         },
       };
       if (surface === "paired-node") {
+        // Supply runtime backend metadata for the placement and authoring policy checks.
+        cliBackendsTesting.setDepsForTest({
+          resolveRuntimeCliBackends: () => [
+            {
+              id: "claude-cli",
+              modelProvider: "anthropic",
+              pluginId: "anthropic",
+              config: { command: "claude" },
+              bundleMcp: true,
+            },
+          ],
+        });
         params.provider = "anthropic";
         params.model = "claude-sonnet-5";
         params.sessionEntry = {


### PR DESCRIPTION
## What Problem This Solves

Resolves a slow `/learn` policy test that loads CLI setup metadata merely to establish its paired-node backend. The case took 23.282 seconds in a successful CI sample and 29.076 seconds in the local baseline.

## Why This Change Was Made

Supply one runtime CLI backend descriptor through the existing test dependency seam, only for the paired-node case, and restore it after each test. The handler still runs real provider/runtime alias resolution, backend normalization, node-placement detection, capability checks, and authoring policy.

All 16 original cases and assertions remain. This policy fixture no longer exercises setup discovery; backend registration and setup behavior retain their dedicated owner tests. No production behavior or new test seam changes.

## User Impact

Faster developer and CI policy tests. Runtime behavior is unchanged.

## Evidence

Same-host Node 24.19.0 pair with matching dependencies and separate fresh filesystem caches: paired-node case 29.076 seconds → 2 milliseconds, all 16 cases passing. Full command 65.48 → 38.87 seconds; first-run worker preparation and transform variation mean this is not a whole-CI prediction.

- A temporary control changed node placement to gateway. The original refusal assertion failed because the real handler continued. The diagnostic was reverted.
- Initial owner/registration siblings passed 29 tests; final contained proof with freshly frozen-installed dependencies passed 77 tests across `/learn`, command registration, and CLI backend owners.
- Full changed-file gate, formatting, and independent P2 review passed.
- Production delta zero; tests +16/-1. No timeout, shard, or assertion changes.

Validation used `node scripts/run-vitest.mjs src/auto-reply/reply/commands-learn.test.ts src/auto-reply/commands-registry.test.ts src/agents/cli-backends.test.ts --maxWorkers=1` and the changed-file gate for `commands-learn.test.ts`.
