### PR TITLE
test(gateway): wait for session delivery completion

### DIFF
--- a/src/gateway/session-delivery-clock-jump.integration.test.ts
+++ b/src/gateway/session-delivery-clock-jump.integration.test.ts
@@ -184,14 +184,15 @@ describe("session delivery clock-jump integration", () => {
         await scheduleSessionDelivery(id);
 
         await vi.waitFor(
-          async () => expect(await loadPendingSessionDeliveries()).toStrictEqual([]),
+          async () => {
+            expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
+            expect(chatEvents.join("\n")).toContain("CLOCK_JUMP DELIVERED");
+            expect(getDeliveryQueueEntryStatus(SESSION_DELIVERY_QUEUE_NAME, id)).toBe("completed");
+          },
           { timeout: 15_000, interval: 50 },
         );
         expect(providerRequests).toHaveLength(1);
         expect(providerRequests[0]).toContain("clock-jump proof marker");
-        expect(chatEvents.join("\n")).toContain("CLOCK_JUMP DELIVERED");
-        expect(await loadPendingSessionDeliveries()).toStrictEqual([]);
-        expect(getDeliveryQueueEntryStatus(SESSION_DELIVERY_QUEUE_NAME, id)).toBe("completed");
       } finally {
         wallClock.mockRestore();
         try {


### PR DESCRIPTION
## What Problem This Solves

The session-delivery clock-jump integration test could observe an empty durable queue and immediately check the Gateway client before its chat event arrived. CI hit that boundary with one successful provider request but an empty client event buffer.

## Why This Change Was Made

Wait for queue removal, the client-visible reply, and durable completion together under the existing 15-second wait. Queue settlement does not acknowledge client receipt.

## User Impact

Test-only repair: exactly-one-provider-request and prompt checks, the real scheduler/Gateway/client, clock-jump sequence, 90-second case timeout, and cleanup remain unchanged. No production changes, new mocks, or longer deadlines.

## Evidence

The original failure is [CI job 101433311322](https://github.com/openclaw/openclaw/actions/runs/34013498703/job/101433311322), at the immediate client marker assertion. The original local baseline and repaired real Gateway test both passed; no local failing reproduction is claimed. The canonical changed gate and independent P2 review passed on the original repair.

Rebased as one commit onto main `e19a7694cef6d38140033f798215103dd638fafb`; the full-index patch and test bytes are identical to the reviewed repair. The direct queue/client-delivery owners are unchanged, but main updated dependencies. Frozen dependencies were refreshed in the task-owned worktree; the fresh real Gateway test passed on `c502c952f9e05cb5e949300a763ca90f49e02447` (one test, 68.66s).

Production LOC: 0. Tests: +5/−4.
