### PR TITLE
fix: preserve Markdown literals in replies containing tables

### DIFF
--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -191,8 +191,8 @@ type MarkdownTableSource = {
 type MarkdownTableWithSource = MarkdownTableMeta & { source?: MarkdownTableSource };
 
 /** Private source coordinates do not change the serialized native-table payload. */
-export function getMarkdownTableSource(table: MarkdownTableMeta) {
-  return (table as MarkdownTableWithSource).source;
+export function getMarkdownTableSource(table: MarkdownTableWithSource) {
+  return table.source;
 }
 
 type OpenStyle = {
@@ -383,6 +383,7 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
   if (options.tableMode && options.tableMode !== "off") {
     md.enable("table");
     md.block.ruler.before("table", "markdown_core_table_source", (state, line, _end, silent) => {
+      // SAFETY: markdownToIRWithMeta creates and passes this parser's RenderEnv.
       const env = state.env as RenderEnv;
       if (!silent && env.tableSourceColumns) {
         const start = (state.bMarks[line] ?? 0) + (state.tShift[line] ?? 0);
@@ -933,7 +934,7 @@ function collectTableBlock(state: RenderState) {
   }
   const headerCells = state.table.headers.map(trimCell);
   const rowCells = state.table.rows.map((row) => row.map(trimCell));
-  const table = {
+  const table: MarkdownTableWithSource = {
     headers: headerCells.map((cell) => cell.text),
     rows: rowCells.map((row) => row.map((cell) => cell.text)),
     headerCells,
@@ -946,7 +947,7 @@ function collectTableBlock(state: RenderState) {
     const [first, after] = state.table.sourceLines;
     const { lines, starts } = (state.sourceIndex ??= indexSourceLines(state.source));
     const column = state.env.tableSourceColumns?.get(first) ?? 0;
-    defineMetadata(table as MarkdownTableWithSource, "source", {
+    defineMetadata(table, "source", {
       start: (starts[first] ?? 0) + column,
       end: (starts[after - 1] ?? 0) + (lines[after - 1]?.length ?? 0),
       // Continue list markers as indentation while retaining enclosing quote markers.

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -6,7 +6,6 @@ import MarkdownIt, {
   type StateInline,
 } from "markdown-it";
 import markdownItCjkFriendly from "markdown-it-cjk-friendly";
-import { visibleWidth } from "../../terminal-core/src/ansi.js";
 import {
   ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE,
   markdownItAssistantTranscriptRoles,
@@ -37,6 +36,7 @@ import {
   type MarkdownStyle,
   type MarkdownStyleSpan,
 } from "./ir-spans.js";
+import { renderMarkdownCodeTable, renderMarkdownTableBullets } from "./table-layout.js";
 import type { MarkdownTableMode } from "./types.js";
 
 export type { MarkdownLinkSpan, MarkdownStyle, MarkdownStyleSpan } from "./ir-spans.js";
@@ -83,6 +83,7 @@ type RenderEnv = {
   assistantTranscriptRoleHeaders?: boolean;
   assistantTranscriptRolePreserveLinks?: boolean;
   listStack: ListState[];
+  tableSourceColumns?: Map<number, number>;
 };
 
 type MarkdownToken = {
@@ -180,6 +181,20 @@ export type MarkdownTableMeta = MarkdownTableData & {
   rowCells: MarkdownTableCell[][];
 };
 
+type MarkdownTableSource = {
+  start: number;
+  end: number;
+  prefix: string;
+  headers: string[];
+  rows: string[][];
+};
+type MarkdownTableWithSource = MarkdownTableMeta & { source?: MarkdownTableSource };
+
+/** Private source coordinates do not change the serialized native-table payload. */
+export function getMarkdownTableSource(table: MarkdownTableMeta) {
+  return (table as MarkdownTableWithSource).source;
+}
+
 type OpenStyle = {
   style: MarkdownStyle;
   start: number;
@@ -197,6 +212,10 @@ type RenderTarget = {
 type TableCell = MarkdownTableCell;
 
 type TableState = {
+  sourceLines?: [number, number];
+  sourceHeaders: string[];
+  sourceRows: string[][];
+  currentSourceRow: string[];
   headers: TableCell[];
   rows: TableCell[][];
   aligns: (MarkdownTableAlignment | undefined)[];
@@ -363,6 +382,14 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
   md.enable("strikethrough");
   if (options.tableMode && options.tableMode !== "off") {
     md.enable("table");
+    md.block.ruler.before("table", "markdown_core_table_source", (state, line, _end, silent) => {
+      const env = state.env as RenderEnv;
+      if (!silent && env.tableSourceColumns) {
+        const start = (state.bMarks[line] ?? 0) + (state.tShift[line] ?? 0);
+        env.tableSourceColumns.set(line, start - state.src.lastIndexOf("\n", start - 1) - 1);
+      }
+      return false;
+    });
   } else {
     md.disable("table");
   }
@@ -834,6 +861,9 @@ function isInsideMarkdownHtmlTag(text: string): boolean {
 
 function initTableState(): TableState {
   return {
+    sourceHeaders: [],
+    sourceRows: [],
+    currentSourceRow: [],
     headers: [],
     rows: [],
     aligns: [],
@@ -897,14 +927,6 @@ function appendCell(state: RenderState, cell: TableCell) {
   }
 }
 
-function appendCellTextOnly(state: RenderState, cell: TableCell) {
-  if (!cell.text) {
-    return;
-  }
-  state.text += cell.text;
-  // Do not append styles - this is used for code blocks where inner styles would overlap
-}
-
 function collectTableBlock(state: RenderState) {
   if (!state.table) {
     return;
@@ -920,30 +942,19 @@ function collectTableBlock(state: RenderState) {
     ...(state.table.aligns.some(Boolean) ? { aligns: [...state.table.aligns] } : {}),
   };
   state.collectedTables.push(table);
-}
-
-function appendTableBulletValue(
-  state: RenderState,
-  params: {
-    header?: TableCell;
-    value?: TableCell;
-    columnIndex: number;
-    includeColumnFallback: boolean;
-  },
-) {
-  const { header, value, columnIndex, includeColumnFallback } = params;
-  if (!value?.text) {
-    return;
+  if (state.table.sourceLines) {
+    const [first, after] = state.table.sourceLines;
+    const { lines, starts } = (state.sourceIndex ??= indexSourceLines(state.source));
+    const column = state.env.tableSourceColumns?.get(first) ?? 0;
+    defineMetadata(table as MarkdownTableWithSource, "source", {
+      start: (starts[first] ?? 0) + column,
+      end: (starts[after - 1] ?? 0) + (lines[after - 1]?.length ?? 0),
+      // Continue list markers as indentation while retaining enclosing quote markers.
+      prefix: (lines[first] ?? "").slice(0, column).replace(/[^\t >]/gu, " "),
+      headers: state.table.sourceHeaders,
+      rows: state.table.sourceRows,
+    });
   }
-  state.text += "• ";
-  if (header?.text) {
-    appendCell(state, header);
-    state.text += ": ";
-  } else if (includeColumnFallback) {
-    state.text += `Column ${columnIndex}: `;
-  }
-  appendCell(state, value);
-  state.text += "\n";
 }
 
 function renderTableAsBullets(state: RenderState) {
@@ -952,127 +963,35 @@ function renderTableAsBullets(state: RenderState) {
   }
   const headers = state.table.headers.map(trimCell);
   const rows = state.table.rows.map((row) => row.map(trimCell));
-
-  // If no headers or rows, skip
-  if (headers.length === 0 && rows.length === 0) {
-    return;
-  }
-
-  // Determine if first column should be used as row labels
-  // (common pattern: first column is category/feature name)
-  const useFirstColAsLabel = headers.length > 1 && rows.length > 0;
-
-  if (useFirstColAsLabel) {
-    // Format: each row becomes a section with header as row[0], then key:value pairs
-    for (const row of rows) {
-      if (row.length === 0) {
-        continue;
+  renderMarkdownTableBullets(
+    headers,
+    rows,
+    (text) => {
+      state.text += text;
+    },
+    (cell, rowLabel) => {
+      const start = state.text.length;
+      appendCell(state, cell);
+      if (rowLabel) {
+        state.styles.push({ start, end: state.text.length, style: "bold" });
       }
-
-      const rowLabel = row[0];
-      if (rowLabel?.text) {
-        const labelStart = state.text.length;
-        appendCell(state, rowLabel);
-        const labelEnd = state.text.length;
-        if (labelEnd > labelStart) {
-          state.styles.push({ start: labelStart, end: labelEnd, style: "bold" });
-        }
-        state.text += "\n";
-      }
-
-      // Add each column as a bullet point
-      for (let i = 1; i < row.length; i++) {
-        appendTableBulletValue(state, {
-          header: headers[i],
-          value: row[i],
-          columnIndex: i,
-          includeColumnFallback: true,
-        });
-      }
-      state.text += "\n";
-    }
-  } else {
-    // Simple table: just list headers and values
-    for (const row of rows) {
-      for (let i = 0; i < row.length; i++) {
-        appendTableBulletValue(state, {
-          header: headers[i],
-          value: row[i],
-          columnIndex: i,
-          includeColumnFallback: false,
-        });
-      }
-      state.text += "\n";
-    }
-  }
+    },
+  );
 }
 
 function renderTableAsCode(state: RenderState) {
   if (!state.table) {
     return;
   }
-  const measureCell = (cell: TableCell) => {
-    const trimmed = trimCell(cell);
-    return { cell: trimmed, width: visibleWidth(trimmed.text) };
-  };
-  const headers = state.table.headers.map(measureCell);
-  const rows = state.table.rows.map((row) => row.map(measureCell));
-
-  const columnCount = Math.max(headers.length, ...rows.map((row) => row.length));
-  if (columnCount === 0) {
+  const headers = state.table.headers.map((cell) => trimCell(cell).text);
+  const rows = state.table.rows.map((row) => row.map((cell) => trimCell(cell).text));
+  const code = renderMarkdownCodeTable(headers, rows);
+  if (!code) {
     return;
   }
-
-  const widths = Array.from({ length: columnCount }, () => 0);
-  const updateWidths = (cells: typeof headers) => {
-    for (const [i, cell] of cells.entries()) {
-      widths[i] = Math.max(widths[i] ?? 0, cell.width);
-    }
-  };
-  updateWidths(headers);
-  for (const row of rows) {
-    updateWidths(row);
-  }
-
-  const codeStart = state.text.length;
-
-  const appendRow = (cells: typeof headers) => {
-    state.text += "|";
-    for (const [i, width] of widths.entries()) {
-      state.text += " ";
-      const cell = cells[i];
-      if (cell) {
-        // Use text-only append to avoid overlapping styles with code_block
-        appendCellTextOnly(state, cell.cell);
-      }
-      const pad = width - (cell?.width ?? 0);
-      if (pad > 0) {
-        state.text += " ".repeat(pad);
-      }
-      state.text += " |";
-    }
-    state.text += "\n";
-  };
-
-  const appendDivider = () => {
-    state.text += "|";
-    for (const width of widths) {
-      const dashCount = Math.max(3, width);
-      state.text += ` ${"-".repeat(dashCount)} |`;
-    }
-    state.text += "\n";
-  };
-
-  appendRow(headers);
-  appendDivider();
-  for (const row of rows) {
-    appendRow(row);
-  }
-
-  const codeEnd = state.text.length;
-  if (codeEnd > codeStart) {
-    state.styles.push({ start: codeStart, end: codeEnd, style: "code_block" });
-  }
+  const start = state.text.length;
+  state.text += code;
+  state.styles.push({ start, end: state.text.length, style: "code_block" });
   if (state.env.listStack.length === 0) {
     state.text += "\n";
   }
@@ -1096,6 +1015,9 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
     }
     switch (token.type) {
       case "inline":
+        if (state.table?.currentCell) {
+          state.table.currentSourceRow.push(token.content ?? "");
+        }
         if (token.children) {
           renderTokens(token.children, state);
         }
@@ -1316,6 +1238,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "table_open":
         if (state.tableMode !== "off") {
           state.table = initTableState();
+          state.table.sourceLines = token.map ?? undefined;
           state.hasTables = true;
         }
         break;
@@ -1347,14 +1270,17 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "tr_open":
         if (state.table) {
           state.table.currentRow = [];
+          state.table.currentSourceRow = [];
         }
         break;
       case "tr_close":
         if (state.table) {
           if (state.table.inHeader) {
             state.table.headers = state.table.currentRow;
+            state.table.sourceHeaders = state.table.currentSourceRow;
           } else {
             state.table.rows.push(state.table.currentRow);
+            state.table.sourceRows.push(state.table.currentSourceRow);
           }
           state.table.currentRow = [];
         }
@@ -1599,6 +1525,7 @@ export function markdownToIRWithMeta(
   const source = markdown ?? "";
   const env: RenderEnv = {
     listStack: [],
+    ...(options.tableMode === "block" ? { tableSourceColumns: new Map<number, number>() } : {}),
     assistantTranscriptRoleHeaders: options.assistantTranscriptRoleHeaders === true,
     assistantTranscriptRolePreserveLinks: options.assistantTranscriptRoleHeaders === true,
   };
@@ -1723,7 +1650,7 @@ export function markdownToIRWithMeta(
     ir,
     hasTables: state.hasTables,
     tables: state.collectedTables.map((table) =>
-      Object.assign({}, table, {
+      Object.assign(table, {
         placeholderOffset: Math.min(table.placeholderOffset, finalLength),
       }),
     ),

--- a/packages/markdown-core/src/table-layout.ts
+++ b/packages/markdown-core/src/table-layout.ts
@@ -1,0 +1,56 @@
+import { visibleWidth } from "../../terminal-core/src/ansi.js";
+
+/** Shared bullet layout, including the newline contributed by empty rows. */
+export function renderMarkdownTableBullets<T extends { text: string }>(
+  headers: readonly T[],
+  rows: readonly (readonly T[])[],
+  writeText: (text: string) => void,
+  writeCell: (cell: T, rowLabel: boolean) => void,
+) {
+  const labeled = headers.length > 1;
+  for (const row of rows) {
+    if (labeled && row[0]?.text) {
+      writeCell(row[0], true);
+      writeText("\n");
+    }
+    for (let index = labeled ? 1 : 0; index < row.length; index += 1) {
+      const value = row[index];
+      if (!value?.text) {
+        continue;
+      }
+      writeText("• ");
+      const header = headers[index];
+      if (header?.text) {
+        writeCell(header, false);
+        writeText(": ");
+      } else if (labeled) {
+        writeText(`Column ${index}: `);
+      }
+      writeCell(value, false);
+      writeText("\n");
+    }
+    writeText("\n");
+  }
+}
+
+/** Render the existing aligned, plain-text representation without a Markdown fence. */
+export function renderMarkdownCodeTable(headers: readonly string[], rows: readonly string[][]) {
+  const measured = [headers, ...rows].map((row) =>
+    row.map((text) => ({ text, width: visibleWidth(text) })),
+  );
+  const widths: number[] = [];
+  for (const row of measured) {
+    for (const [index, cell] of row.entries()) {
+      widths[index] = Math.max(widths[index] ?? 0, cell.width);
+    }
+  }
+  if (widths.length === 0) {
+    return "";
+  }
+  const renderRow = (row: (typeof measured)[number]) =>
+    `|${widths.map((width, index) => ` ${row[index]?.text ?? ""}${" ".repeat(width - (row[index]?.width ?? 0))} |`).join("")}`;
+  const divider = `|${widths.map((width) => ` ${"-".repeat(Math.max(3, width))} |`).join("")}`;
+  return [renderRow(measured[0] ?? []), divider, ...measured.slice(1).map(renderRow), ""].join(
+    "\n",
+  );
+}

--- a/packages/markdown-core/src/tables.test.ts
+++ b/packages/markdown-core/src/tables.test.ts
@@ -1,5 +1,7 @@
 // Markdown Core tests cover tables behavior.
+import MarkdownIt from "markdown-it";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { markdownToIR } from "./ir.js";
 import { convertMarkdownTables } from "./tables.js";
 
 const markdownToIRWithMetaMock = vi.hoisted(() => vi.fn());
@@ -13,6 +15,136 @@ vi.mock("./ir.js", async (importOriginal) => {
 describe("convertMarkdownTables", () => {
   beforeEach(() => {
     markdownToIRWithMetaMock.mockClear();
+  });
+
+  it.each(["code", "bullets", "block"] as const)(
+    "preserves non-table Markdown source in %s mode",
+    (mode) => {
+      const before = "# Heading\n\nKeep \\*stars\\* and ``a`b`` literal.\n\n";
+      const after = "\n\n> Keep this quote.\n";
+      const rendered = convertMarkdownTables(
+        `${before}| A | B |\n| --- | --- |\n| 1 | 2 |${after}`,
+        mode,
+      );
+
+      expect(rendered.startsWith(before)).toBe(true);
+      expect(rendered.endsWith(after)).toBe(true);
+    },
+  );
+
+  it("preserves escaped literals, code delimiters and reference links in bullet cells", () => {
+    const references = '\n\n[docs]: https://example.com/guide "Guide"\n';
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | \\*stars\\*, ``a`b`` and [manual][docs] |" +
+        references,
+      "bullets",
+    );
+    const html = new MarkdownIt().render(rendered);
+
+    expect(html).toContain("*stars*");
+    expect(html).not.toContain("<em>stars</em>");
+    expect(html).toContain("<code>a`b</code>");
+    expect(html).toContain('<a href="https://example.com/guide" title="Guide">manual</a>');
+    expect(rendered.endsWith(references)).toBe(true);
+  });
+
+  it.each([
+    ["single-column rows", "| A |\n| --- |\n| x |\n| y |", "• A: x\n\n• A: y"],
+    ["empty middle row", "| A |\n| --- |\n| x |\n| |\n| y |", "• A: x\n\n\n• A: y"],
+    ["empty edge rows", "| A |\n| --- |\n| |\n| x |\n| |", "\n• A: x"],
+    ["only empty rows", "| A |\n| --- |\n| |\n| |", ""],
+    [
+      "empty labeled row",
+      "| A | B |\n| --- | --- |\n| x | 1 |\n| | |\n| y | 2 |",
+      "**x**\n• B: 1\n\n\n**y**\n• B: 2",
+    ],
+  ])("preserves existing bullet spacing for %s", (_name, input, expected) => {
+    expect(convertMarkdownTables(input, "bullets")).toBe(expected);
+    expect(markdownToIR(input, { tableMode: "bullets" }).text).toBe(expected.replaceAll("**", ""));
+  });
+
+  it("keeps the existing table recognition for list-like headers", () => {
+    const rendered = convertMarkdownTables("- A | B\n---|---\nx|y", "code");
+
+    expect(rendered).toContain("| - A | B |");
+    expect(new MarkdownIt().render(rendered)).toContain("<pre><code>");
+  });
+
+  it.each(["code", "bullets"] as const)("preserves escaped table pipes in %s cells", (mode) => {
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | a\\|b and ``x`y`` |",
+      mode,
+    );
+    const html = new MarkdownIt().render(rendered);
+
+    expect(html).toContain("a|b");
+    expect(html).toContain(mode === "bullets" ? "<code>x`y</code>" : "x`y");
+  });
+
+  it("chooses a code fence that contains literal backtick runs", () => {
+    const rendered = convertMarkdownTables(
+      "| A | B |\n| --- | --- |\n| 1 | ````a```b```` |",
+      "code",
+    );
+
+    expect(new MarkdownIt().render(rendered)).toContain("a```b");
+    expect(rendered.startsWith("````\n")).toBe(true);
+  });
+
+  it("converts separate tables without changing the Markdown between them", () => {
+    const between = "\n\n## Middle\n\nKeep ``a`b`` and \\*literal\\*.\n\n";
+    const table = "| A | B |\n| --- | --- |\n| 1 | 2 |";
+    const rendered = convertMarkdownTables(table + between + table, "code");
+
+    expect(rendered.split(between)).toHaveLength(2);
+    expect(new MarkdownIt().render(rendered).match(/<pre><code>/g)).toHaveLength(2);
+  });
+
+  it.each([
+    ["blockquote", "> ", "> ", "<blockquote>"],
+    ["list", "- ", "  ", "<ul>"],
+    ["quoted list", "> - ", ">   ", "<blockquote>\n<ul>"],
+  ])("keeps a converted table in its %s container", (_label, first, continuation, container) => {
+    const input = [
+      `${first}| A | B |`,
+      `${continuation}| --- | --- |`,
+      `${continuation}| 1 | 2 |`,
+    ].join("\n");
+    const rendered = convertMarkdownTables(input, "code");
+    const html = new MarkdownIt().render(rendered);
+
+    expect(rendered.startsWith(`${first}\`\`\``)).toBe(true);
+    expect(html).toContain(container);
+    expect(html).toContain("<pre><code>| A | B |");
+  });
+
+  it("keeps reference labels in code tables and leaves document definitions untouched", () => {
+    const references = "\n\n[docs]: https://example.com/guide\n";
+    const rendered = convertMarkdownTables(
+      "| Name | Value |\n| --- | --- |\n| Entry | [manual][docs] |" + references,
+      "code",
+    );
+
+    expect(rendered).toContain("| Entry | manual |");
+    expect(rendered.endsWith(references)).toBe(true);
+  });
+
+  it("preserves CRLF source around a table", () => {
+    const before = "Keep \\*literal\\*.\r\n\r\n";
+    const after = "\r\n\r\nAfter.\r\n";
+    const rendered = convertMarkdownTables(
+      `${before}| A | B |\r\n| --- | --- |\r\n| 1 | 2 |${after}`,
+      "code",
+    );
+
+    expect(rendered.startsWith(before)).toBe(true);
+    expect(rendered.endsWith(after)).toBe(true);
+  });
+
+  it("leaves table-shaped text inside fences untouched", () => {
+    const input = "```markdown\n| A | B |\n| --- | --- |\n| 1 | 2 |\n```\n";
+
+    expect(convertMarkdownTables(input, "bullets")).toBe(input);
   });
 
   it("falls back to code rendering for block mode", () => {

--- a/packages/markdown-core/src/tables.ts
+++ b/packages/markdown-core/src/tables.ts
@@ -1,45 +1,57 @@
-// Markdown Core module implements tables behavior.
-import { markdownToIRWithMeta } from "./ir.js";
-import { renderMarkdownWithMarkers } from "./render.js";
+import { expectDefined } from "@openclaw/normalization-core/expect";
+import { getMarkdownTableSource, markdownToIRWithMeta, type MarkdownTableMeta } from "./ir.js";
+import { renderMarkdownCodeTable, renderMarkdownTableBullets } from "./table-layout.js";
 import type { MarkdownTableMode } from "./types.js";
 
-const MARKDOWN_STYLE_MARKERS = {
-  bold: { open: "**", close: "**" },
-  italic: { open: "_", close: "_" },
-  strikethrough: { open: "~~", close: "~~" },
-  code: { open: "`", close: "`" },
-  code_block: { open: "```\n", close: "```" },
-} as const;
+function renderTableSource(
+  table: MarkdownTableMeta,
+  mode: Exclude<MarkdownTableMode, "off">,
+): string {
+  if (mode !== "bullets") {
+    const text = renderMarkdownCodeTable(table.headers, table.rows);
+    let fenceLength = 3;
+    for (const run of text.matchAll(/`+/g)) {
+      fenceLength = Math.max(fenceLength, run[0].length + 1);
+    }
+    const fence = "`".repeat(fenceLength);
+    return `${fence}\n${text}${fence}`;
+  }
+  const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
+  const headers = table.headers.map((text, column) => ({ text, markdown: source.headers[column] }));
+  const rows = table.rows.map((row, index) =>
+    row.map((text, column) => ({ text, markdown: source.rows[index]?.[column] })),
+  );
+  let rendered = "";
+  renderMarkdownTableBullets(
+    headers,
+    rows,
+    (text) => {
+      rendered += text;
+    },
+    (cell, rowLabel) => {
+      rendered += rowLabel ? `**${cell.markdown}**` : cell.markdown;
+    },
+  );
+  return rendered.replace(/\n+$/u, "");
+}
 
-/** Converts markdown tables into the configured plaintext/code rendering mode. */
+/** Convert only parsed table ranges; unrelated Markdown retains its original source bytes. */
 export function convertMarkdownTables(markdown: string, mode: MarkdownTableMode): string {
   if (!markdown || mode === "off" || !markdown.includes("|")) {
     return markdown;
   }
-  const effectiveMode = mode === "block" ? "code" : mode;
-  const { ir, hasTables } = markdownToIRWithMeta(markdown, {
+  const { tables } = markdownToIRWithMeta(markdown, {
     linkify: false,
     autolink: false,
-    headingStyle: "none",
-    blockquotePrefix: "",
-    tableMode: effectiveMode,
+    tableMode: "block",
   });
-  if (!hasTables) {
-    return markdown;
+  let cursor = 0;
+  let result = "";
+  for (const table of tables) {
+    const source = expectDefined(getMarkdownTableSource(table), "Markdown table source");
+    const rendered = renderTableSource(table, mode).replaceAll("\n", "\n" + source.prefix);
+    result += markdown.slice(cursor, source.start) + rendered;
+    cursor = source.end;
   }
-  return renderMarkdownWithMarkers(ir, {
-    styleMarkers: MARKDOWN_STYLE_MARKERS,
-    escapeText: (text) => text,
-    buildLink: (link, text) => {
-      const href = link.href.trim();
-      if (!href) {
-        return null;
-      }
-      const label = text.slice(link.start, link.end);
-      if (!label) {
-        return null;
-      }
-      return { start: link.start, end: link.end, open: "[", close: `](${href})` };
-    },
-  });
+  return result + markdown.slice(cursor);
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users reading replies with Markdown tables would see escaped literals or inline code change meaning when the table was converted to a text fallback. For example, adding a table after ````Keep \*stars\* and ``a`b`` literal.```` could turn the stars into emphasis and break the embedded-backtick code span. Headings and blockquotes elsewhere in the same reply could also lose their formatting.

## Why This Change Was Made

The converter now replaces only the table ranges recognized by the existing MarkdownIt parser, preserving the original source everywhere else and retaining cell Markdown for bullet output. Native IR and Markdown fallbacks share table layout and newline emission, including the existing behavior for empty rows; the whole-message Markdown roundtrip and duplicate layout paths are removed.

## User Impact

Replies containing tables retain their surrounding formatting, escaped literals and inline code. Bullet tables preserve authored cell markup and document reference links, and tables remain inside their original quote or list containers. Code-table alignment and the block-mode code fallback keep their existing behavior.

A separate pre-existing issue remains: unescaped standalone emphasis/backtick delimiters in cells can bind to generated bullet-formatting markers. That requires its own inline delimiter-ownership repair; authored escapes are preserved by this change.

## Evidence

- Captured the original failure before editing: 9 failing converter regressions and 3 passing controls.
- Final focused verification: **138 tests passed** across the converter, native bullet/code/block table renderers, and Discord formatter/chunker. Five row-spacing cases cover ordinary, empty-middle, empty-edge, all-empty and labeled rows; six standalone comparisons confirm that the complete native IR and converted Markdown match the original spacing behavior.
- Scoped typed lint passed for all four changed files. Production code is **175 lines added / 179 removed (net −4)**; regression coverage adds 132 test lines.
- Exercised the actual `renderDiscordMarkdown` caller locally with synthetic Markdown in `code`, `bullets` and `block` modes, then parsed the result with MarkdownIt. Escaped literals, multi-backtick code and reference links remained intact. Additional source-range checks covered nested quotes/lists, tabs, CRLF/bare CR, header-only tables and MarkdownIt's existing list-like-header recognition.
- Independent Codex reviews of the row-spacing repair and the subsequent type-only correction are **scoped-clean through P2**, with no actionable findings.
- The canonical assertion-safety ratchet passes with the existing per-file allowance of nine; no baseline was raised. Actual caller/declaration checks pass, and the type-only correction emits byte-identical JavaScript while keeping private table metadata out of serialized payloads.
- Published head `1027f40156ef651e04cf733742e667ca2e974c49` contains only the four reviewed files relative to `f4bde51ed1c0519631efec33e8aa2bc78b1e0d38`. The complete tree and owned blobs were verified; the assertion correction preserves emitted JavaScript and native payloads.

Focused test command:

```sh
node scripts/run-vitest.mjs \
  packages/markdown-core/src/tables.test.ts \
  packages/markdown-core/src/ir.table-bullets.test.ts \
  packages/markdown-core/src/ir.table-code.test.ts \
  packages/markdown-core/src/ir.table-block.test.ts \
  extensions/discord/src/markdown.test.ts \
  extensions/discord/src/chunk.test.ts
```

The formatter proof was local; no external Discord message was sent. Broad local release gates were not rerun. Hosted exact-head CI remains required before native landing.
