### PR TITLE
refactor(talk): use the canonical integer conversion

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift
@@ -79,14 +79,6 @@ public enum TalkConfigParsing {
         if let timeout = value?.intValue, timeout > 0 {
             return timeout
         }
-        if
-            let timeout = value?.doubleValue,
-            timeout > 0,
-            timeout.rounded(.towardZero) == timeout,
-            timeout <= Double(Int.max)
-        {
-            return Int(timeout)
-        }
         return fallback
     }
 


### PR DESCRIPTION
## What Problem This Solves

Shared Talk configuration parsing repeats integer conversion after the canonical `AnyCodable.intValue` accessor has already accepted or rejected the number. Maintaining a second conversion path lets the Talk consumer drift from the numeric owner's contract.

## Why This Change Was Made

Remove the redundant Double conversion and use the existing exact-positive-integer result or caller-supplied fallback. Both Apple Talk configuration parsers retain their existing defaults and public interfaces. This removes eight production lines without adding a helper, configuration option, or test.

## User Impact

Ordinary valid silence timeouts keep the same value. Missing, nonpositive, fractional, Boolean and string values retain the existing fallback behavior; values rejected by the canonical integer owner remain rejected.

## Evidence

The existing shared `timeout fixtures` and `resolvesPositiveIntegerTimeout()` methods passed in [CI 34017213760](https://github.com/openclaw/openclaw/actions/runs/34017213760). The former checks six decoded fixture rows. All six relevant source/test/fixture files in that tested merge match this branch's baseline. The overall Mac job failed later unrelated tests; these are individual baseline results, not a green whole-job claim.

All 14 selected check phases passed: 13 static phases plus the macOS Node tooling phase (1,125 tests across 21 files). Independent managed source review found no actionable issue. Fresh candidate Swift CI results remain required before landing. No native app or Swift test was run against operator state.

### Candidate native proof

Exact-head [CI 34019107333](https://github.com/openclaw/openclaw/actions/runs/34019107333) passed 20 jobs, with 21 skipped and no failures. Its actual tested merge is `2c4265779120d9cab2f01ff95a9ec17865966892`, containing candidate `d103e686bc8c687b08f37f554a3100a5ac785688`; all six relevant source/test/fixture blobs match the candidate.

Both `resolvesPositiveIntegerTimeout()` and `timeout fixtures` passed on the candidate. The latter contains six decoded fixture rows, not six separately reported methods. The Mac shared and app runs, iOS simulator/release/screenshot jobs and selected Android consumers passed. The default Mac run explicitly skipped health rendering, caller-response-loss execution and the embedded socket handshake. Health rendering passed separately; the two other cases remained skipped. A separate two-test AppState isolation run passed and does not cover those skipped cases. Run totals are not combined as unique tests. This native proof ran on disposable CI, not operator state.
