### PR TITLE
fix(test): isolate skill and browser workspaces

### DIFF
--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -23,6 +23,7 @@ import { SANDBOX_MOUNT_FORMAT_VERSION } from "./workspace-mounts.js";
 let BROWSER_BRIDGES: Map<string, unknown>;
 let ensureSandboxBrowser: typeof import("./browser.js").ensureSandboxBrowser;
 let capturedDockerCreateEnvEntries: string[] | undefined;
+let testWorkspaceDir: string;
 
 const dockerMocks = vi.hoisted(() => ({
   dockerContainerState: vi.fn(),
@@ -166,7 +167,7 @@ function computeTestBrowserHash(params: {
   agentWorkspaceDir?: string;
   dockerEnvPolicyEpoch?: string;
 }): string {
-  const workspaceDir = params.workspaceDir ?? "/tmp/workspace";
+  const workspaceDir = params.workspaceDir ?? testWorkspaceDir;
   const agentWorkspaceDir = params.agentWorkspaceDir ?? workspaceDir;
   const browserDockerCfg = resolveSandboxBrowserDockerCreateConfig({
     docker: params.cfg.docker,
@@ -248,6 +249,7 @@ describe("ensureSandboxBrowser create args", () => {
   });
 
   beforeEach(() => {
+    testWorkspaceDir = tempDirs.make("openclaw-browser-workspace-");
     vi.restoreAllMocks();
     BROWSER_BRIDGES.clear();
     dockerMocks.dockerContainerState.mockClear();
@@ -310,8 +312,8 @@ describe("ensureSandboxBrowser create args", () => {
     await expect(
       ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg: buildConfig(false),
       }),
     ).rejects.toThrow(
@@ -341,8 +343,8 @@ describe("ensureSandboxBrowser create args", () => {
     cfg.docker.env = { ...cfg.docker.env, BROWSER_TRANSPORT_SENTINEL: configuredSentinel };
     const result = await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg,
     });
 
@@ -379,8 +381,8 @@ describe("ensureSandboxBrowser create args", () => {
   it("creates browser containers with Docker init and the shared args epoch", async () => {
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     });
 
@@ -426,8 +428,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     const params = {
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     };
     await expect(
@@ -471,8 +473,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg,
     });
 
@@ -512,8 +514,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg,
     });
 
@@ -530,8 +532,8 @@ describe("ensureSandboxBrowser create args", () => {
   it("does not inject noVNC password env when noVNC is disabled", async () => {
     const result = await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     });
 
@@ -585,8 +587,8 @@ describe("ensureSandboxBrowser create args", () => {
       GEMINI_API_KEY: "dummy-gemini",
     };
     const scopeKey = "session-1";
-    const workspaceDir = "/tmp/workspace";
-    const agentWorkspaceDir = "/tmp/workspace";
+    const workspaceDir = testWorkspaceDir;
+    const agentWorkspaceDir = testWorkspaceDir;
     const expectedHash = computeTestBrowserHash({
       cfg,
       dockerEnvPolicyEpoch: SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,
@@ -627,8 +629,8 @@ describe("ensureSandboxBrowser create args", () => {
     await expect(
       ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg: buildConfig(false),
       }),
     ).rejects.toThrow("Docker daemon is not available");
@@ -639,8 +641,8 @@ describe("ensureSandboxBrowser create args", () => {
   it("passes the browser SSRF policy to the sandbox bridge", async () => {
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
       ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
     });
@@ -702,8 +704,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
       ssrfPolicy: { allowedHostnames: ["example.com"] },
     });
@@ -765,8 +767,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
       evaluateEnabled: false,
     });
@@ -787,22 +789,22 @@ describe("ensureSandboxBrowser create args", () => {
 
       await ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg,
       });
 
       const createArgs = requireDockerCreateArgs();
-      expect(createArgs).toContain(`/tmp/workspace:/workspace:${flags}`);
-      expect(createArgs).not.toContain(`/tmp/workspace:/workspace:${rejectedFlags}`);
+      expect(createArgs).toContain(`${testWorkspaceDir}:/workspace:${flags}`);
+      expect(createArgs).not.toContain(`${testWorkspaceDir}:/workspace:${rejectedFlags}`);
     },
   );
 
   it("stamps the mount format version label on browser containers", async () => {
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     });
 
@@ -836,8 +838,8 @@ describe("ensureSandboxBrowser create args", () => {
     await expect(
       ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg,
       }),
     ).rejects.toThrow("hung container has been forcefully removed");
@@ -871,8 +873,8 @@ describe("ensureSandboxBrowser create args", () => {
       await expect(
         ensureTestSandboxBrowser({
           scopeKey: "session:test",
-          workspaceDir: "/tmp/workspace",
-          agentWorkspaceDir: "/tmp/workspace",
+          workspaceDir: testWorkspaceDir,
+          agentWorkspaceDir: testWorkspaceDir,
           cfg,
         }),
       ).rejects.toThrow(
@@ -930,8 +932,8 @@ describe("ensureSandboxBrowser create args", () => {
     try {
       const startup = ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg,
       });
       const startupResult = startup.then(
@@ -968,8 +970,8 @@ describe("ensureSandboxBrowser create args", () => {
   it("requires auth for the sandbox CDP relay without auto-derived source ranges", async () => {
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     });
 
@@ -997,8 +999,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg,
     });
 
@@ -1012,8 +1014,8 @@ describe("ensureSandboxBrowser create args", () => {
 
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     });
 
@@ -1038,8 +1040,8 @@ describe("ensureSandboxBrowser create args", () => {
     await expect(
       ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg: buildConfig(false),
       }),
     ).rejects.toThrow("bridge cleanup failed");
@@ -1051,8 +1053,8 @@ describe("ensureSandboxBrowser create args", () => {
     dockerMocks.execDocker.mockClear();
     await ensureTestSandboxBrowser({
       scopeKey: "session:test",
-      workspaceDir: "/tmp/workspace",
-      agentWorkspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
+      agentWorkspaceDir: testWorkspaceDir,
       cfg: buildConfig(false),
     });
 
@@ -1070,8 +1072,8 @@ describe("ensureSandboxBrowser create args", () => {
     await expect(
       ensureTestSandboxBrowser({
         scopeKey: "session:test",
-        workspaceDir: "/tmp/workspace",
-        agentWorkspaceDir: "/tmp/workspace",
+        workspaceDir: testWorkspaceDir,
+        agentWorkspaceDir: testWorkspaceDir,
         cfg,
       }),
     ).rejects.toThrow(

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -320,11 +320,14 @@ function writeTrackedSkill(
 }
 
 describe("skills-clawhub", () => {
+  let testWorkspaceDir: string;
+
   afterEach(async () => {
     await tempDirs.cleanup();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    testWorkspaceDir = await tempDirs.make("openclaw-clawhub-workspace-");
     fetchClawHubSkillDetailMock.mockReset();
     fetchClawHubSkillInstallResolutionMock.mockReset();
     fetchClawHubSkillVerificationMock.mockReset();
@@ -445,14 +448,14 @@ describe("skills-clawhub", () => {
         if (backup && !backup.ok) {
           return backup;
         }
-        return { ok: true, targetDir: "/tmp/workspace/skills/agentreceipt" };
+        return { ok: true, targetDir: path.join(testWorkspaceDir, "skills", "agentreceipt") };
       },
     );
     evaluateSkillInstallPolicyMock.mockResolvedValue(undefined);
   });
 
   it("installs ClawHub skills from flat-root archives", async () => {
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "agentreceipt",
@@ -470,7 +473,7 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "agentreceipt",
       version: "1.0.0",
-      targetDir: "/tmp/workspace/skills/agentreceipt",
+      targetDir: path.join(testWorkspaceDir, "skills", "agentreceipt"),
     });
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
     expect(reportClawHubSkillInstallTelemetryMock).toHaveBeenCalledWith({
@@ -517,7 +520,7 @@ describe("skills-clawhub", () => {
     }
 
     const result = await installTestSkill(
-      "/tmp/workspace",
+      testWorkspaceDir,
       "missing-skill",
       lookup === "detail" ? { version: "1.2.3" } : {},
     );
@@ -551,10 +554,10 @@ describe("skills-clawhub", () => {
     });
     installPackageDirMock.mockResolvedValueOnce({
       ok: true,
-      targetDir: "/tmp/workspace/skills/weather",
+      targetDir: path.join(testWorkspaceDir, "skills", "weather"),
     });
 
-    const result = await installTestSkill("/tmp/workspace", reference);
+    const result = await installTestSkill(testWorkspaceDir, reference);
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
@@ -584,7 +587,7 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "weather",
       version: commit,
-      targetDir: "/tmp/workspace/skills/weather",
+      targetDir: path.join(testWorkspaceDir, "skills", "weather"),
     });
     expect(result.warning).toBe("Not scanned by ClawHub");
     expect(reportClawHubSkillInstallTelemetryMock).toHaveBeenCalledWith({
@@ -611,7 +614,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
+    const result = await installTestSkill(testWorkspaceDir, "skills-sh:openclaw/skills/weather");
 
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
@@ -628,7 +631,7 @@ describe("skills-clawhub", () => {
     "skills-sh:-owner/repo/slug",
     "skills-sh:owner/../slug",
   ])("rejects invalid skills-sh reference %s before network access", async (reference) => {
-    const result = await installTestSkill("/tmp/workspace", reference);
+    const result = await installTestSkill(testWorkspaceDir, reference);
 
     expect(result).toMatchObject({
       ok: false,
@@ -639,7 +642,7 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects versions for skills-sh references before network access", async () => {
-    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather", {
+    const result = await installTestSkill(testWorkspaceDir, "skills-sh:openclaw/skills/weather", {
       version: "1.2.3",
     });
 
@@ -663,7 +666,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
+    const result = await installTestSkill(testWorkspaceDir, "skills-sh:openclaw/skills/weather");
 
     expect(result).toEqual({
       ok: false,
@@ -690,7 +693,7 @@ describe("skills-clawhub", () => {
         },
       });
 
-      const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
+      const result = await installTestSkill(testWorkspaceDir, "skills-sh:openclaw/skills/weather");
 
       expect(result).toEqual({
         ok: false,
@@ -711,7 +714,7 @@ describe("skills-clawhub", () => {
     });
 
     const result = await preflightSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: testWorkspaceDir,
       slug: "agentreceipt",
       version: "1.0.0",
     });
@@ -733,7 +736,7 @@ describe("skills-clawhub", () => {
       cleanup: archiveCleanupMock,
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt", {
       version: "1.0.0",
       expectedIntegrity: `sha256:${"a".repeat(64)}`,
     });
@@ -760,12 +763,12 @@ describe("skills-clawhub", () => {
     });
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
       version: "1.0.0",
-      targetDir: "/tmp/workspace/skills/agentreceipt",
+      targetDir: path.join(testWorkspaceDir, "skills", "agentreceipt"),
     });
     expect(fetchClawHubSkillSecurityVerdictsMock).not.toHaveBeenCalled();
     expect(installPolicyInput()).toMatchObject({
@@ -794,12 +797,12 @@ describe("skills-clawhub", () => {
     });
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
 
-    const result = await installTestSkill("/tmp/workspace", "tao-setup-nvidia-gpu-host");
+    const result = await installTestSkill(testWorkspaceDir, "tao-setup-nvidia-gpu-host");
 
     expectInstalledSkill(result, {
       slug: "tao-setup-nvidia-gpu-host",
       version: "1.0.0",
-      targetDir: "/tmp/workspace/skills/tao-setup-nvidia-gpu-host",
+      targetDir: path.join(testWorkspaceDir, "skills", "tao-setup-nvidia-gpu-host"),
     });
     expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
       slug: "tao-setup-nvidia-gpu-host",
@@ -831,7 +834,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "@acme/agentreceipt", {
+    const result = await installTestSkill(testWorkspaceDir, "@acme/agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -874,7 +877,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -923,7 +926,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -941,7 +944,7 @@ describe("skills-clawhub", () => {
       new Error("security verdicts unavailable"),
     );
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -960,7 +963,7 @@ describe("skills-clawhub", () => {
       items: [],
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -993,7 +996,7 @@ describe("skills-clawhub", () => {
       ...verdict,
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1021,7 +1024,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -1052,7 +1055,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, { slug: "agentreceipt", version: "1.0.0" });
     if (!result.ok) {
@@ -1078,7 +1081,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "@acme/agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "@acme/agentreceipt");
 
     expectInstalledSkill(result, { slug: "agentreceipt", version: "1.0.0" });
     if (!result.ok) {
@@ -1107,7 +1110,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -1300,7 +1303,7 @@ describe("skills-clawhub", () => {
       signature: { status: "unsigned" },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "@demo-owner/weather");
+    const result = await installTestSkill(testWorkspaceDir, "@demo-owner/weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1321,7 +1324,7 @@ describe("skills-clawhub", () => {
       status: 409,
     });
 
-    const result = await installTestSkill("/tmp/workspace", "weather");
+    const result = await installTestSkill(testWorkspaceDir, "weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1333,7 +1336,7 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects malformed owner-qualified ClawHub install refs", async () => {
-    const result = await installTestSkill("/tmp/workspace", "@@demo-owner/weather");
+    const result = await installTestSkill(testWorkspaceDir, "@@demo-owner/weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1745,10 +1748,10 @@ describe("skills-clawhub", () => {
     });
     installPackageDirMock.mockResolvedValueOnce({
       ok: true,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
+      targetDir: path.join(testWorkspaceDir, "skills", "aiq-deploy"),
     });
 
-    const result = await installTestSkill("/tmp/workspace", "aiq-deploy");
+    const result = await installTestSkill(testWorkspaceDir, "aiq-deploy");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "aiq-deploy",
@@ -1774,7 +1777,7 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "aiq-deploy",
       version: commit,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
+      targetDir: path.join(testWorkspaceDir, "skills", "aiq-deploy"),
     });
   });
 
@@ -1788,7 +1791,7 @@ describe("skills-clawhub", () => {
       sourceUrl: "https://github.com/NVIDIA/skills/tree/main/skills/aiq-deploy",
     });
 
-    const result = await installTestSkill("/tmp/workspace", "aiq-deploy");
+    const result = await installTestSkill(testWorkspaceDir, "aiq-deploy");
 
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
@@ -1812,10 +1815,10 @@ describe("skills-clawhub", () => {
     });
     installPackageDirMock.mockResolvedValueOnce({
       ok: true,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
+      targetDir: path.join(testWorkspaceDir, "skills", "aiq-deploy"),
     });
 
-    const result = await installTestSkill("/tmp/workspace", "aiq-deploy", {
+    const result = await installTestSkill(testWorkspaceDir, "aiq-deploy", {
       forceInstall: true,
     });
 
@@ -1829,14 +1832,14 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "aiq-deploy",
       version: commit,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
+      targetDir: path.join(testWorkspaceDir, "skills", "aiq-deploy"),
     });
   });
 
   it("keeps ClawHub install telemetry best-effort", async () => {
     reportClawHubSkillInstallTelemetryMock.mockRejectedValueOnce(new Error("telemetry down"));
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -1845,7 +1848,7 @@ describe("skills-clawhub", () => {
   });
 
   it("marks custom ClawHub skill registries as third-party install policy authority", async () => {
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(testWorkspaceDir, "agentreceipt", {
       baseUrl: "https://clawhub.internal.example",
     });
 
@@ -1864,7 +1867,7 @@ describe("skills-clawhub", () => {
     async (marker) => {
       pathExistsMock.mockImplementation(async (input: string) => input.endsWith(marker));
 
-      const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+      const result = await installTestSkill(testWorkspaceDir, "agentreceipt");
 
       expectInstalledSkill(result);
       expectInstallPackageSourceDir("/tmp/extracted-skill");
@@ -2575,53 +2578,53 @@ describe("skills-clawhub", () => {
 
   describe("normalizeSlug rejects non-ASCII homograph slugs", () => {
     it("rejects Cyrillic homograph 'а' (U+0430) in slug", async () => {
-      const result = await installTestSkill("/tmp/workspace", "re\u0430ct");
+      const result = await installTestSkill(testWorkspaceDir, "re\u0430ct");
       expectInvalidSlug(result);
     });
 
     it("rejects Cyrillic homograph 'е' (U+0435) in slug", async () => {
-      const result = await installTestSkill("/tmp/workspace", "r\u0435act");
+      const result = await installTestSkill(testWorkspaceDir, "r\u0435act");
       expectInvalidSlug(result);
     });
 
     it("rejects Cyrillic homograph 'о' (U+043E) in slug", async () => {
-      const result = await installTestSkill("/tmp/workspace", "t\u043Edo");
+      const result = await installTestSkill(testWorkspaceDir, "t\u043Edo");
       expectInvalidSlug(result);
     });
 
     it("rejects slug with mixed Unicode and ASCII", async () => {
-      const result = await installTestSkill("/tmp/workspace", "cаlеndаr");
+      const result = await installTestSkill(testWorkspaceDir, "cаlеndаr");
       expectInvalidSlug(result);
     });
 
     it("rejects slug with non-Latin scripts", async () => {
-      const result = await installTestSkill("/tmp/workspace", "技能");
+      const result = await installTestSkill(testWorkspaceDir, "技能");
       expectInvalidSlug(result);
     });
 
     it("rejects Unicode that case-folds to ASCII (Kelvin sign U+212A)", async () => {
       // "\u212A" (Kelvin sign) lowercases to "k" — must be caught before lowercasing
-      const result = await installTestSkill("/tmp/workspace", "\u212Aalendar");
+      const result = await installTestSkill(testWorkspaceDir, "\u212Aalendar");
       expectInvalidSlug(result);
     });
 
     it("rejects slug starting with a hyphen", async () => {
-      const result = await installTestSkill("/tmp/workspace", "-calendar");
+      const result = await installTestSkill(testWorkspaceDir, "-calendar");
       expectInvalidSlug(result);
     });
 
     it("rejects slug ending with a hyphen", async () => {
-      const result = await installTestSkill("/tmp/workspace", "calendar-");
+      const result = await installTestSkill(testWorkspaceDir, "calendar-");
       expectInvalidSlug(result);
     });
 
     it("accepts uppercase ASCII slugs (preserves original casing behavior)", async () => {
-      const result = await installTestSkill("/tmp/workspace", "React");
+      const result = await installTestSkill(testWorkspaceDir, "React");
       expectInstalledSkill(result);
     });
 
     it("accepts valid lowercase ASCII slugs", async () => {
-      const result = await installTestSkill("/tmp/workspace", "calendar-2");
+      const result = await installTestSkill(testWorkspaceDir, "calendar-2");
       expectInstalledSkill(result);
     });
   });
@@ -2691,7 +2694,7 @@ describe("skills-clawhub", () => {
       async ({ version, tag }) => {
         await expect(
           resolveClawHubSkillVerificationTarget({
-            workspaceDir: "/tmp/workspace",
+            workspaceDir: testWorkspaceDir,
             slug: "skills-sh:openclaw/skills/agentreceipt",
             version,
             tag,
@@ -3210,7 +3213,7 @@ describe("skills-clawhub", () => {
     it("fails clearly for invalid slugs and conflicting selectors", async () => {
       await expect(
         resolveClawHubSkillVerificationTarget({
-          workspaceDir: "/tmp/workspace",
+          workspaceDir: testWorkspaceDir,
           slug: "bad/slug",
         }),
       ).resolves.toMatchObject({
@@ -3220,7 +3223,7 @@ describe("skills-clawhub", () => {
 
       await expect(
         resolveClawHubSkillVerificationTarget({
-          workspaceDir: "/tmp/workspace",
+          workspaceDir: testWorkspaceDir,
           slug: "agentreceipt",
           version: "1.0.0",
           tag: "latest",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the sandbox browser's config-hash test fails after the ClawHub installation tests run in the same CI job. This blocked the otherwise unrelated Workboard cleanup #139866 in [run 34017941104](https://github.com/openclaw/openclaw/actions/runs/34017941104), job `checks-node-compact-large-6`.

## Why This Change Was Made

Both suites used `/tmp/workspace`. The ClawHub installation fixture writes real origin metadata beneath that directory, while the browser hash fixture assumes it has no skill mounts. Since #135702, private sandbox workspaces correctly include existing skill mounts in their config hash.

Each suite now allocates and cleans up a tracked workspace per test. ClawHub input paths, mock output paths, and matching expectations use that owned workspace; the browser's expected hash and runtime input do likewise. Existing explicitly allocated fixtures and all test assertions remain intact.

## User Impact

CI no longer depends on whether another test created skills beneath a shared temporary path. Runtime behavior is unchanged. This is a test-only CI repair discovered during the #135868 cleanup campaign: production, tooling, and docs are unchanged; tests add five lines (+109/−104).

## Evidence

- The original browser suite passed alone (27 tests), then reproduced the exact env-policy hash failure with a skill directory present in an owned temporary workspace (1 failed, 26 passed). The reproduction did not read or modify the shared `/tmp/workspace` directory.
- The failing CI log shows ClawHub's flat-root install completing before the browser hash test. The real origin writer creates the skill directory; the browser runtime hashes its mount while the expected fixture assumes an empty mount list.
- Both suites passed in the same invocation, ClawHub first: 117 ClawHub tests and 27 browser tests.
- Independent Codex review through P2 found no actionable defects.
- The full selected `node scripts/check-changed.mjs` plan passed (exit 0), including agents-other/services test types, all three unused-export scans, and lint.
- Exact-head CI passed for `cda54a9b9bebea7a5ac7307c47a5ba2eef33dc33` in [run 34019118162](https://github.com/openclaw/openclaw/actions/runs/34019118162).
- ClawSweeper reviewed the final head with no findings, before-merge requests, or rank-up moves; no review changes were needed.
