### PR TITLE
fix(imessage): recover oldest missed messages when backlog exceeds perRunLimit

### DIFF
--- a/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
@@ -9,7 +9,7 @@ import {
 } from "../state-contract.js";
 import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
-import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
+import { resolveCatchupConfig } from "./catchup.js";
 import type { IMessagePayload } from "./types.js";
 
 type RpcCall = {
@@ -504,5 +504,4 @@ describe("runIMessageCatchup", () => {
     expect(second.cursorAfter.lastSeenRowid).toBe(100);
     expect(dispatched).toEqual(Array.from({ length: 100 }, (_, index) => index + 1));
   });
-
 });

--- a/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.test-support.ts
@@ -9,7 +9,7 @@ import {
 } from "../state-contract.js";
 import { installIMessageStateRuntimeForTest } from "../test-support/runtime.js";
 import { runIMessageCatchup } from "./catchup-bridge.js";
-import { resolveCatchupConfig } from "./catchup.js";
+import { advanceIMessageCatchupCursor, resolveCatchupConfig } from "./catchup.js";
 import type { IMessagePayload } from "./types.js";
 
 type RpcCall = {
@@ -447,4 +447,62 @@ describe("runIMessageCatchup", () => {
     expect(summary.replayed).toBe(1);
     expect(dispatched).toEqual(["g-600"]);
   });
+  it("recovers the oldest rows when one chat's backlog exceeds perRunLimit", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-08T12:00:00Z"));
+    seedCatchupCursor("default", {
+      lastSeenMs: Date.parse("2026-05-08T11:30:00Z"),
+      lastSeenRowid: 0,
+    });
+    const backlogStartMs = Date.parse("2026-05-08T11:31:00Z");
+    const backlog = Array.from({ length: 100 }, (_, index) =>
+      makeRow({
+        id: index + 1,
+        guid: `g-${index + 1}`,
+        chat_id: 1,
+        created_at: new Date(backlogStartMs + (index + 1) * 1_000).toISOString(),
+      }),
+    );
+    const { client } = makeFakeClient(({ method, params }) => {
+      if (method === "chats.list") {
+        return { chats: [{ id: 1, last_message_at: "2026-05-08T11:59:00.000Z" }] };
+      }
+      if (method === "messages.history") {
+        const p = params as { limit: number; start?: string };
+        const startMs = p.start ? Date.parse(p.start) : Number.NEGATIVE_INFINITY;
+        return {
+          messages: backlog
+            .filter((row) => Date.parse(String(row.created_at)) >= startMs)
+            .toSorted((a, b) => Date.parse(String(b.created_at)) - Date.parse(String(a.created_at)))
+            .slice(0, p.limit),
+        };
+      }
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const dispatched: number[] = [];
+    const runCatchup = async () =>
+      await runIMessageCatchup({
+        client: client as never,
+        accountId: "default",
+        config: resolveCatchupConfig({ enabled: true, perRunLimit: 50, maxAgeMinutes: 60 }),
+        includeAttachments: false,
+        dispatchPayload: async (msg) => {
+          if (typeof msg.id === "number") {
+            dispatched.push(msg.id);
+          }
+        },
+      });
+
+    const first = await runCatchup();
+    expect(first.fullyCaughtUp).toBe(false);
+    expect(first.cursorAfter.lastSeenRowid).toBe(50);
+    expect(dispatched).toEqual(Array.from({ length: 50 }, (_, index) => index + 1));
+
+    const second = await runCatchup();
+    expect(second.fullyCaughtUp).toBe(true);
+    expect(second.cursorAfter.lastSeenRowid).toBe(100);
+    expect(dispatched).toEqual(Array.from({ length: 100 }, (_, index) => index + 1));
+  });
+
 });

--- a/extensions/imessage/src/monitor/catchup-bridge.ts
+++ b/extensions/imessage/src/monitor/catchup-bridge.ts
@@ -13,11 +13,11 @@ import {
 import { parseIMessageNotification } from "./parse-notification.js";
 import type { IMessagePayload } from "./types.js";
 
-// Per-chat history fetch budget. messages.history is per-chat; we cap each
-// chat's fetch to the global perRunLimit so a single noisy group cannot
-// dominate the cursor advance — the cross-chat sort + final slice still
-// caps the global pass at perRunLimit.
-const PER_CHAT_HISTORY_LIMIT_CAP = 500;
+// Per-chat history fetch budget. Upstream `messages.history` orders
+// `date DESC LIMIT ?`, so a smaller limit drops the OLDEST rows. Always ask
+// for the full budget: the cross-chat sort + perRunLimit slice below can only
+// pick the true oldest rows if the per-chat page reached them.
+const PER_CHAT_HISTORY_LIMIT = 500;
 
 // chats.list page size used during catchup. 200 covers far more than any
 // realistic offline window worth of distinct chats while staying well under
@@ -113,7 +113,6 @@ export async function runIMessageCatchup(
     }
     const chats = chatsResult?.chats ?? [];
     const collected: IMessageCatchupRow[] = [];
-    const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
     let historyFetchFailed = false;
     // Track the highest rowid / date the imsg bridge actually returned across
     // all chats, regardless of whether each row passed the parser. The catchup
@@ -143,7 +142,7 @@ export async function runIMessageCatchup(
           "messages.history",
           {
             chat_id: chatId,
-            limit: perChatLimit,
+            limit: PER_CHAT_HISTORY_LIMIT,
             start: sinceISO,
             attachments: includeAttachments,
           },


### PR DESCRIPTION
## What Problem This Solves

Closes #139669

With `catchup.enabled: true`, when a chat's backlog exceeds `perRunLimit` (default 50), the oldest missed messages are never fetched. The per-chat `messages.history` call was clamped to `Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP)`, but `imsg` serves history as `ORDER BY date DESC LIMIT ?`. Shrinking a descending limited query trims the **oldest** rows server-side before OpenClaw sees them. The cursor then advances past the un-fetched older rows, permanently dropping them and reporting `fullyCaughtUp: true`.

## Root Cause

`extensions/imessage/src/monitor/catchup-bridge.ts` computed the per-chat fetch budget from the global replay cap:

```ts
const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
```

With `perRunLimit: 50` and a 100-message backlog in one chat, the fetch returned rowids 51–100. Rowids 1–50 were never read, and the cursor advanced to 100, so no later startup could reach them either.

## Fix

Fetch the full `PER_CHAT_HISTORY_LIMIT` budget per chat (independent of `perRunLimit`) so the oldest-first slice always starts from the true oldest unseen row. `perRunLimit` still caps the total dispatched across all chats in the cross-chat sort + slice downstream.

```diff
-const PER_CHAT_HISTORY_LIMIT_CAP = 500;
+const PER_CHAT_HISTORY_LIMIT = 500;
```

```diff
-const perChatLimit = Math.min(limit, PER_CHAT_HISTORY_LIMIT_CAP);
 ...
-            limit: perChatLimit,
+            limit: PER_CHAT_HISTORY_LIMIT,
```

The comment above the constant explains why the full budget is needed: the cross-chat sort + `perRunLimit` slice can only pick the true oldest rows if the per-chat page reached them.

This is the same fix pattern as the original PR #116961 by @yetval, which was closed. Credit to @yetval for the regression test.

## Evidence

### Test passes WITH fix (43/43)
```
npx vitest run --project extension-imessage extensions/imessage/src/monitor/cache-lifecycle.test.ts
 Test Files  1 passed (1)
      Tests  43 passed (43)
```

### Test FAILS WITHOUT fix (regression confirmed)
```
 × |extension-imessage| cache-lifecycle.test.ts > runIMessageCatchup > recovers the oldest rows when one chat's backlog exceeds perRunLimit
   → expected true to be false // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 42 passed (43)
```

The regression test seeds 100 messages in one chat (rowids 1–100), sets `perRunLimit: 50`, runs catchup twice:
- **With fix:** First run dispatches rowids 1–50, cursor=50, `fullyCaughtUp=false`; second run dispatches 51–100, cursor=100, `fullyCaughtUp=true`. No messages lost.
- **Without fix:** First run fetches only rowids 51–100 (DESC LIMIT 50), cursor jumps to 100, `fullyCaughtUp=true` — rowids 1–50 permanently lost.
