### PR TITLE
improve: skip bind retries in occupied-port startup fixtures

### DIFF
--- a/src/gateway/server.fixture-lifetime.test-support.ts
+++ b/src/gateway/server.fixture-lifetime.test-support.ts
@@ -252,8 +252,9 @@ test("observes startup cleanup ownership through fixture teardown", async () => 
     });
     restorers.push(() => kernelSpy.mockRestore());
     const listen = listenModule.listenGatewayHttpServer;
-    const listenSpy = vi.spyOn(listenModule, "listenGatewayHttpServer").mockImplementation((...args) => {
-      const listening = own(listen(...args));
+    const listenSpy = vi.spyOn(listenModule, "listenGatewayHttpServer").mockImplementation((params) => {
+      // The owned blocker cannot leave; retry policy has its own listener tests.
+      const listening = own(listen({ ...params, retryEaddrinuse: false }));
       nativeListens.push(listening);
       return listening;
     });


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary bind retries in native Gateway startup-cleanup tests. Two fixtures intentionally occupy a port for the entire scenario, but the listener still waits through its default twenty 500-millisecond retries before testing cleanup.

## Why This Change Was Made

The existing recording spy delegates to the real listener with its supported `retryEaddrinuse: false` option. It still attempts a native bind and observes the actual EADDRINUSE error. All three isolated fixture scenarios, error identity, journal, retained-owner, cleanup, and successor-admission assertions remain unchanged.

Default retry policy is independently covered by listener tests, including transient contention, exhaustion, explicit disablement, and other failures. No production defaults, retry behavior, test timeout, or shard count change.

## User Impact

Less deliberate waiting in developer and CI startup-cleanup tests. Runtime behavior is unchanged.

## Evidence

All three scenarios passed in the original baseline, candidate, and original-code control. Candidate command time was 80.96 seconds, versus 104.30 seconds initially and 95.90 seconds in the control. The two changed cases totaled 53.387 seconds versus 64.141 seconds in the control.

Cold-process costs varied, including a 3.321-second difference in the unchanged TLS case. The source removes two configured ten-second retry sequences, but these measurements do not establish a precise twenty-second whole-suite saving.

- Initial paired comparisons used Node 26.8.1 and matching dependencies; all native child-exit and journal checks passed.
- Final contained proof on Node 24.19.0 with freshly frozen-installed dependencies passed 21 tests across startup fixtures, HTTP listener policy, and runtime-state integration.
- Full changed-file gate, formatting, and independent P2 review passed.
- Production delta zero; test support +3/-2. No new mocks or removed assertions.

Validation: `node scripts/run-vitest.mjs src/gateway/server.startup-fixture-lifetime.test.ts src/gateway/server/http-listen.test.ts src/gateway/server-runtime-state.test.ts --maxWorkers=1` and the changed-file gate for `server.fixture-lifetime.test-support.ts`.

Exact-head [CI 34019293357](https://github.com/openclaw/openclaw/actions/runs/34019293357) is green. Its startup cases took 11.994, 11.662, and 11.035 seconds (34.691 seconds summed), with all three cases and eight fixture-lifecycle siblings passing. The earlier main sample totaled 57.987 seconds for the same three names; this is a cross-head observation, separate from the controlled local pair.
