### PR TITLE
fix(ui): show agent-list failures on memory pages

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -671,6 +671,9 @@ into an OpenClaw agent. The Gateway discovers supported local memory on its own
 host, so a remote Control UI imports from the Gateway computer rather than the
 browser computer.
 
+If the agent list fails to load, the page shows the Gateway error. Select
+**Refresh** to try again; **Settings → Memory** provides **Retry** for the same failure.
+
 1. Choose the destination agent.
 2. Review the detected source collections and Markdown filenames. File contents
    are not sent in the plan response or displayed in the page.

--- a/ui/src/pages/config/memory-page.ts
+++ b/ui/src/pages/config/memory-page.ts
@@ -132,12 +132,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
     .watch(
       () => this.context?.agents,
       (agents, notify) => agents.subscribe(notify),
-      (agents) => {
-        if (!agents.state.agentsList && !agents.state.agentsLoading) {
-          void agents.ensureList().catch(() => undefined);
-        }
-        void this.loadOverviewStatus();
-      },
+      () => void this.loadOverviewStatus(),
     );
 
   override disconnectedCallback() {
@@ -637,6 +632,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
       this.mutationDisabled || (this.catalog.kind === "ready" && !this.catalog.mutationAllowed);
     const activeTab = this.activeTab();
     const agentId = this.resolveAgentId();
+    const agentError = agentId ? null : this.context.agents.state.agentsError;
     return renderMemory({
       activeTab,
       onTabChange: (tab) => this.navigateTab(tab),
@@ -668,9 +664,12 @@ class MemorySettingsPage extends OpenClawLightDomElement {
         agentId,
         engineSelection,
         engineDisabled: this.engineState(engineSelection) === "disabled",
-        status: this.overviewStatus,
+        status: agentError ? { kind: "error", message: agentError } : this.overviewStatus,
         probingEmbeddings: this.probingEmbeddings,
-        onRefresh: () => void this.loadOverviewStatus({ force: true }),
+        onRefresh: () =>
+          agentId
+            ? void this.loadOverviewStatus({ force: true })
+            : void this.context.agents.ensureList(),
         onProbeEmbeddings: () =>
           void this.loadOverviewStatus({ force: true, probeEmbeddings: true }),
         onNavigate: (tab) => this.navigateTab(tab),

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../../../../src/shared/deferred.ts";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { createAgentCapability } from "../../lib/agents/index.ts";
@@ -111,16 +112,15 @@ afterEach(() => {
 
 describe("MemoryImportPage", () => {
   it("settles a failed roster load until Refresh retries it", async () => {
-    const roster = Promise.withResolvers<unknown>();
+    const roster = createDeferredCore<unknown>();
     const request = vi.fn((method: string) =>
       method === "agents.list" ? roster.promise : Promise.resolve(createPlan()),
     );
     const context = createContext(request);
     const agents = createAgentCapability(context.gateway);
-    context.agents = agents;
     // The application shell owns the initial shared roster request.
     const initial = agents.ensureList();
-    const page = await mountPage(context);
+    const page = await mountPage({ ...context, agents });
     try {
       roster.reject(new Error("Agent roster unavailable"));
       request.mockImplementation((method: string) =>

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -124,7 +124,7 @@ describe("MemoryImportPage", () => {
     try {
       roster.reject(new Error("Agent roster unavailable"));
       request.mockImplementation((method: string) =>
-        method === "agents.list" ? new Promise(() => undefined) : Promise.resolve(createPlan()),
+        method === "agents.list" ? createDeferredCore().promise : Promise.resolve(createPlan()),
       );
       await initial;
       await page.updateComplete;

--- a/ui/src/pages/memory-import/memory-import-page.test.ts
+++ b/ui/src/pages/memory-import/memory-import-page.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { createAgentCapability } from "../../lib/agents/index.ts";
 import { createApplicationContextProvider } from "../../test-helpers/application-context.ts";
 import "./memory-import-page.ts";
 
@@ -109,6 +110,58 @@ afterEach(() => {
 });
 
 describe("MemoryImportPage", () => {
+  it("settles a failed roster load until Refresh retries it", async () => {
+    const roster = Promise.withResolvers<unknown>();
+    const request = vi.fn((method: string) =>
+      method === "agents.list" ? roster.promise : Promise.resolve(createPlan()),
+    );
+    const context = createContext(request);
+    const agents = createAgentCapability(context.gateway);
+    context.agents = agents;
+    // The application shell owns the initial shared roster request.
+    const initial = agents.ensureList();
+    const page = await mountPage(context);
+    try {
+      roster.reject(new Error("Agent roster unavailable"));
+      request.mockImplementation((method: string) =>
+        method === "agents.list" ? new Promise(() => undefined) : Promise.resolve(createPlan()),
+      );
+      await initial;
+      await page.updateComplete;
+      await page.updateComplete;
+      expect(request).toHaveBeenCalledTimes(1);
+      expect(page.textContent).toContain("Agent roster unavailable");
+
+      request.mockImplementation((method: string) =>
+        Promise.resolve(
+          method === "agents.list"
+            ? { defaultId: "research", agents: [{ id: "research", name: "Research" }] }
+            : createPlan(),
+        ),
+      );
+      [...page.querySelectorAll<HTMLButtonElement>("button")]
+        .find((button) => button.textContent?.trim() === "Refresh")
+        ?.click();
+      await waitForMemoryImport(() =>
+        expect(page.querySelector("[data-test-id='memory-import-provider-button']")).not.toBeNull(),
+      );
+      expect(request.mock.calls.filter(([method]) => method === "agents.list")).toHaveLength(2);
+      expect(page.textContent).not.toContain("Agent roster unavailable");
+      request.mockImplementation((method: string) =>
+        method === "agents.list"
+          ? Promise.reject(new Error("Agent roster unavailable"))
+          : Promise.resolve(createPlan()),
+      );
+      await agents.refreshList();
+      await page.updateComplete;
+      expect(page.textContent).not.toContain("Agent roster unavailable");
+      expect(page.querySelector("[data-test-id='memory-import-provider-button']")).not.toBeNull();
+    } finally {
+      page.parentElement?.remove();
+      agents.dispose();
+    }
+  });
+
   it("does not plan memory import without admin access", async () => {
     const request = vi.fn();
     const context = createContext(request);

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -137,9 +137,6 @@ export class MemoryImportPage extends OpenClawLightDomElement {
 
   override updated() {
     const snapshot = this.context.gateway.snapshot;
-    if (!this.context.agents.state.agentsList) {
-      void this.context.agents.ensureList();
-    }
     if (
       this.pendingImport &&
       (snapshot.phase !== "connected" ||
@@ -210,7 +207,9 @@ export class MemoryImportPage extends OpenClawLightDomElement {
   }
 
   private refresh(): Promise<void> {
-    return this.planTask.run();
+    return this.currentAgentId()
+      ? this.planTask.run()
+      : this.context.agents.ensureList().then(() => undefined);
   }
 
   private selectAgent(agentId: string) {
@@ -517,8 +516,8 @@ export class MemoryImportPage extends OpenClawLightDomElement {
       agents: listSelectableAgents(agentsList?.agents ?? []),
       selectedAgentId: agentId,
       plan: this.plan,
-      loading: this.loading,
-      error: this.error,
+      loading: this.loading || this.context.agents.state.agentsLoading,
+      error: (agentId ? null : this.context.agents.state.agentsError) ?? this.error,
       applyError: this.applyError,
       replaceExisting: this.replaceExisting,
       selectedByProvider: this.selectedByProvider,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening Memory or Import Memory would see a loading message or missing content when the Gateway could not load its agent list. Each failed request triggered another request automatically, while the actual error stayed hidden.

## Why This Change Was Made

Both pages now use the shared shell's existing initial agent-list loading. They display a failed prerequisite and retry it through their existing controls, removing the render and subscription callbacks that kept restarting failed requests. Production code changes by +12/−14 lines, **net −2**.

## User Impact

Users see the Gateway error and can select **Refresh** in Import Memory or **Retry** in Memory. A successful retry loads the normal page data. A previously loaded agent list remains usable if a later background refresh fails.

## Evidence

Real Chromium against the running Control UI with a synthetic Gateway WebSocket reproduced the failure on both pages. On the baseline, request counts advanced **1 → 2 → 3** after two failed responses without user interaction, and neither page showed the error. With the fix, each failure settled at **1 request** with the error visible. Refresh/Retry made exactly one additional request and loaded the import plan or memory status.

<details>
<summary>Import Memory: before and after</summary>

**Before**

![Memory Import before: missing agent-list failure and repeated requests](https://github.com/user-attachments/assets/f4816beb-8412-422e-af0f-5da77abefa0e)

**After**

![Memory Import after: agent-list failure is visible with Refresh](https://github.com/user-attachments/assets/451cfec9-15b6-4e77-b6ba-cb262888424d)

</details>

<details>
<summary>Memory: before and after</summary>

**Before**

![Memory before: Waking memory after repeated agent-list failures](https://github.com/user-attachments/assets/516b29de-6574-4047-8d44-aed99f261127)

**After**

![Memory after: visible agent-list error and Retry](https://github.com/user-attachments/assets/ba9d09f8-c65a-4610-906c-73e15742425e)

</details>

The new DOM regression uses the real shared agent capability. It failed before the production change because a second request appeared without user input, then passed after the fix. The focused Memory Import and Memory Settings suites passed **53 tests**; the final regression also verifies recovery and continued use of an already loaded roster. Formatting and diff checks pass. Managed Codex review through P2 returned **no actionable findings**.

The proof baseline is `b6a2e5b4eff71070a02e755d55aea0dd53904a20`. The candidate also applies cleanly to the locally available main snapshot `ba3a6cb5f690789e0824c7c92618579743b9cade`; the affected runtime owners have not changed between those commits. This is browser proof with a synthetic Gateway transport, not a packaged or authenticated provider test. Required exact-head hosted CI completed successfully on `0717949cd7f90d2d3c5f95a1c00eb178725ffec2` ([CI run](https://github.com/openclaw/openclaw/actions/runs/34021251130)), including the required `openclaw/ci-gate`. Full local gates were not repeated; the completed hosted run supplies the broad validation.

CI caught fixture type errors and then a promise-executor lint error ([type job](https://github.com/openclaw/openclaw/actions/runs/34019440396/job/101449257540), [lint job](https://github.com/openclaw/openclaw/actions/runs/34020290947/job/101451589406)). The fixture now reuses the shared deferred helper and constructs its readonly context correctly. Complete-file type-aware lint, all 12 tests, and the owning UI-pages type graph pass on the final fixture; both core type-check stripes also passed after the preceding typing correction. Production code and all four images are unchanged. Fresh focused P2 review is clean; required hosted CI remains the landing gate.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/memory-import/memory-import-page.test.ts
node scripts/run-tsgo-core-test-shards.mjs --stripe 3/5 --concurrency 1
node scripts/run-tsgo-core-test-shards.mjs --stripe 4/5 --concurrency 1
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/pages/memory-import/memory-import-page.test.ts
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.ui-pages.json --builders 1
```


ClawSweeper checklist disposition: data-model upgrade proof is not applicable to this diff. Only page request initiation, displayed loading/error state, and explicit retry dispatch change; stored formats, schema, migration/import writes, vector metadata, configuration, authorization, and protocol are untouched. The [latest current-head technical review](https://github.com/openclaw/openclaw/pull/139899#issuecomment-5557818413) also confirms that the generic upgrade-proof item does not apply.
