### PR TITLE
fix(agents): preserve exact model matches in session SDK

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -593,8 +593,9 @@ naming, and cleanup. Use `api.runtime.tasks.managedFlows` inside the scheduled
 turn when the work itself needs durable multi-step Task Flow state.
 
 Within session extensions, `openclaw/plugin-sdk/agent-sessions` provides the host's
-model-selection helpers. Exact model IDs take precedence over case-insensitive
-matches; ambiguous references need an exact `provider/model` ID. Human-name
+model-selection helpers. Exact provider/model IDs take precedence over case-insensitive
+matches; ambiguous references need exact provider and model IDs. Pass the provider
+separately when distinct identities share a combined reference. Human-name
 matching, alias/date version selection, and case-insensitive glob scopes remain
 available.
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -592,6 +592,12 @@ turn runs; the Plugin SDK only constrains the target session, plugin-owned
 naming, and cleanup. Use `api.runtime.tasks.managedFlows` inside the scheduled
 turn when the work itself needs durable multi-step Task Flow state.
 
+Within session extensions, `openclaw/plugin-sdk/agent-sessions` provides the host's
+model-selection helpers. Exact model IDs take precedence over case-insensitive
+matches; ambiguous references need an exact `provider/model` ID. Human-name
+matching, alias/date version selection, and case-insensitive glob scopes remain
+available.
+
 Session extension SDK and supported TypeBox imports share the host's modules.
 
 The contracts intentionally split authority:

--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -39,6 +39,19 @@ function registry(models: Model[], authenticatedModels: Model[] = models): Model
 }
 
 describe("exact model reference selection", () => {
+  it.each([
+    { provider: "custom", id: " alpha", reference: "custom/ alpha" },
+    { provider: "custom ", id: "alpha", reference: "custom /alpha" },
+  ])("preserves literal canonical components in $reference", ({ provider, id, reference }) => {
+    const exact = model(provider, id);
+    const models = [model("custom", "alpha"), exact];
+    expect(findExactModelReferenceMatch(reference, models)).toBe(exact);
+    expect(parseModelPattern(reference, models).model).toBe(exact);
+    expect(resolveCliModel({ cliModel: reference, modelRegistry: registry(models) }).model).toBe(
+      exact,
+    );
+  });
+
   it.each(["alpha", "custom/alpha", " CUSTOM / alpha "])(
     "prefers the exact model id in %s before case-insensitive matching",
     (reference) => {
@@ -106,6 +119,20 @@ describe("exact model reference selection", () => {
     );
   });
 
+  it.each(["Alpha", "custom/Alpha", "ALPHA", "custom/ALPHA"])(
+    "preserves the first row when %s matches repeated model identities",
+    async (reference) => {
+      const first = model("custom", "Alpha");
+      const models = [first, first, { ...first, name: "Duplicate catalog row" }];
+      expect(findExactModelReferenceMatch(reference, models)).toBe(first);
+      expect(parseModelPattern(reference, models).model).toBe(first);
+      const selected = resolveCliModel({ cliModel: reference, modelRegistry: registry(models) });
+      expect(selected.model).toBe(first);
+      expect(selected.error).toBeUndefined();
+      expect(await resolveModelScope([reference], registry(models))).toEqual([{ model: first }]);
+    },
+  );
+
   it("keeps an explicit provider ahead of a slash-containing bare id", () => {
     const scoped = model("custom", "Alpha");
     const models = [model("gateway", "custom/alpha"), scoped];
@@ -114,6 +141,184 @@ describe("exact model reference selection", () => {
       resolveCliModel({ cliModel: "custom/alpha", modelRegistry: registry(models) }).model,
     ).toBe(scoped);
   });
+
+  it.each(["custom", "CUSTOM"])("preserves the exact provider identity %s", (provider) => {
+    const exact = model(provider, "alpha");
+    const other = model(provider === "custom" ? "CUSTOM" : "custom", "alpha");
+    for (const models of [
+      [exact, other],
+      [other, exact],
+    ]) {
+      expect(findExactModelReferenceMatch(`${provider}/alpha`, models)).toBe(exact);
+      expect(parseModelPattern(`${provider}/alpha`, models).model).toBe(exact);
+      for (const selection of [
+        { cliModel: `${provider}/alpha` },
+        { cliProvider: provider, cliModel: "alpha" },
+      ]) {
+        expect(resolveCliModel({ ...selection, modelRegistry: registry(models) }).model).toBe(
+          exact,
+        );
+      }
+    }
+  });
+
+  it.each([
+    { cliModel: "Custom/alpha" },
+    { cliProvider: "Custom", cliModel: "alpha" },
+    { cliProvider: "Custom", cliModel: "unknown" },
+  ])("rejects ambiguous provider identities: %j", (selection) => {
+    const models = [model("custom", "alpha"), model("CUSTOM", "alpha")];
+    const result = resolveCliModel({ ...selection, modelRegistry: registry(models) });
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it.each([{ cliModel: "Custom/alpha" }, { cliProvider: "Custom", cliModel: "alpha" }])(
+    "does not disambiguate provider identities through fuzzy matching: %j",
+    (selection) => {
+      const models = [model("custom", "alpha-one"), model("CUSTOM", "alpha-two")];
+      const result = resolveCliModel({ ...selection, modelRegistry: registry(models) });
+      expect(result.model).toBeUndefined();
+      expect(result.error).toContain("ambiguous");
+    },
+  );
+
+  it("keeps duplicate names as aliases for registry-first metadata", () => {
+    const first = { ...model("custom", "shared"), name: "Canonical title" };
+    const later = { ...first, name: "Hidden title", baseUrl: "https://later.example.test" };
+    const models = [first, later];
+    expect(parseModelPattern("Canonical title", models).model).toBe(first);
+    expect(parseModelPattern("Hidden title", models).model).toBe(first);
+    const result = resolveCliModel({ cliModel: "Hidden title", modelRegistry: registry(models) });
+    expect(result.model).toBe(first);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("uses the full tuple to disambiguate folded provider names", () => {
+    const exact = model("custom", "alpha");
+    const models = [exact, model("CUSTOM", "other")];
+    expect(findExactModelReferenceMatch("Custom/alpha", models)).toBe(exact);
+    expect(parseModelPattern("Custom/alpha", models).model).toBe(exact);
+    for (const selection of [
+      { cliModel: "Custom/alpha" },
+      { cliProvider: "Custom", cliModel: "alpha" },
+    ]) {
+      expect(resolveCliModel({ ...selection, modelRegistry: registry(models) }).model).toBe(exact);
+    }
+  });
+
+  it("keeps exact raw-id fallback when folded providers are ambiguous", () => {
+    const exact = model("gateway", "Custom/raw-id");
+    const models = [model("custom", "other"), model("CUSTOM", "different"), exact];
+    const result = resolveCliModel({ cliModel: exact.id, modelRegistry: registry(models) });
+    expect(result.model).toBe(exact);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("strips the entire explicit provider prefix when its identity contains slashes", () => {
+    const exact = model("team/custom", "alpha");
+    const result = resolveCliModel({
+      cliProvider: "team/custom",
+      cliModel: "team/custom/alpha",
+      modelRegistry: registry([exact]),
+    });
+    expect(result.model).toBe(exact);
+    expect(result.warning).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  it.each([false, true])(
+    "resolves a slash-provider tuple before raw ids (short provider: %s)",
+    (shortProvider) => {
+      const exact = model("team/custom", "Alpha");
+      const models = [model("gateway", "team/custom/Alpha"), exact];
+      if (shortProvider) {
+        models.push(model("team", "other"));
+      }
+      expect(findExactModelReferenceMatch("team/custom/Alpha", models)).toBe(exact);
+      expect(parseModelPattern("team/custom/Alpha", models).model).toBe(exact);
+      expect(
+        resolveCliModel({ cliModel: "team/custom/Alpha", modelRegistry: registry(models) }).model,
+      ).toBe(exact);
+    },
+  );
+
+  it("requires an explicit provider when distinct tuples share a canonical reference", () => {
+    const models = [model("team/custom", "Alpha"), model("team", "custom/Alpha")];
+    const reference = "team/custom/Alpha";
+    expect(findExactModelReferenceMatch(reference, models)).toBeUndefined();
+    expect(parseModelPattern(reference, models).warning).toContain("ambiguous");
+    const result = resolveCliModel({ cliModel: reference, modelRegistry: registry(models) });
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ambiguous");
+    for (const exact of models) {
+      expect(
+        resolveCliModel({
+          cliProvider: exact.provider,
+          cliModel: reference,
+          modelRegistry: registry(models),
+        }).model,
+      ).toBe(exact);
+    }
+  });
+
+  it("keeps mixed-case full tuples ambiguous across different slash boundaries", () => {
+    const models = [model("team", "custom/Alpha"), model("TEAM/CUSTOM", "alpha")];
+    const reference = "team/custom/alpha";
+    expect(findExactModelReferenceMatch(reference, models)).toBeUndefined();
+    expect(parseModelPattern(reference, models).warning).toContain("ambiguous");
+    const result = resolveCliModel({ cliModel: reference, modelRegistry: registry(models) });
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ambiguous");
+    for (const exact of models) {
+      expect(findExactModelReferenceMatch(`${exact.provider}/${exact.id}`, models)).toBe(exact);
+    }
+  });
+
+  it.each([false, true])(
+    "infers slash-containing providers for fuzzy patterns (short provider: %s)",
+    (shortProvider) => {
+      const exact = model("team/custom", "alpha");
+      const models = shortProvider ? [model("team", "other"), exact] : [exact];
+      const result = resolveCliModel({
+        cliModel: "team/custom/alph",
+        modelRegistry: registry(models),
+      });
+      expect(result.model).toBe(exact);
+      expect(result.error).toBeUndefined();
+      expect(result.warning).toBeUndefined();
+    },
+  );
+
+  it("does not choose an owner when different slash-provider scopes both match fuzzily", () => {
+    const models = [model("team/custom", "alpha"), model("team", "custom/alpha")];
+    const result = resolveCliModel({
+      cliModel: "team/custom/alph",
+      modelRegistry: registry(models),
+    });
+    expect(result.model).toBeUndefined();
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it.each([false, true])(
+    "preserves slash-provider resolution through thinking suffixes (ambiguous: %s)",
+    (ambiguous) => {
+      const exact = model("team/custom", "Alpha");
+      const models = [exact, model("team", ambiguous ? "custom/Alpha" : "other")];
+      const result = resolveCliModel({
+        cliModel: "team/custom/Alpha:high",
+        modelRegistry: registry(models),
+      });
+      if (ambiguous) {
+        expect(result.model).toBeUndefined();
+        expect(result.error).toContain("ambiguous");
+      } else {
+        expect(result.model).toBe(exact);
+        expect(result.thinkingLevel).toBe("high");
+        expect(result.error).toBeUndefined();
+      }
+    },
+  );
 
   it("uses exact raw ids when an inferred provider has no matching model", () => {
     const exact = model("gateway", "custom/alpha");
@@ -129,6 +334,22 @@ describe("exact model reference selection", () => {
       model: exact,
       thinkingLevel: undefined,
     });
+  });
+
+  it("keeps a literal raw colon id before inferring a qualified thinking suffix", () => {
+    const qualified = model("custom", "alpha");
+    const literal = model("gateway", "custom/alpha:high");
+    const modelRegistry = registry([qualified, literal]);
+    const result = resolveCliModel({ cliModel: literal.id, modelRegistry });
+    expect(result.model).toBe(literal);
+    expect(result.thinkingLevel).toBeUndefined();
+    const explicit = resolveCliModel({
+      cliProvider: "custom",
+      cliModel: literal.id,
+      modelRegistry,
+    });
+    expect(explicit.model).toBe(qualified);
+    expect(explicit.thinkingLevel).toBe("high");
   });
 
   it("keeps glob matching case-insensitive without collapsing exact identities", async () => {

--- a/src/agents/sessions/model-resolver.test.ts
+++ b/src/agents/sessions/model-resolver.test.ts
@@ -5,9 +5,11 @@ import type { Model } from "../../llm/types.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import type { ModelRegistry } from "./model-registry.js";
 import {
+  findExactModelReferenceMatch,
   findInitialModel,
   parseModelPattern,
   resolveCliModel,
+  resolveModelScope,
   restoreModelFromSession,
 } from "./model-resolver.js";
 
@@ -35,6 +37,107 @@ function registry(models: Model[], authenticatedModels: Model[] = models): Model
     hasConfiguredAuth: (entry: Model) => authenticatedModels.includes(entry),
   } as ModelRegistry;
 }
+
+describe("exact model reference selection", () => {
+  it.each(["alpha", "custom/alpha", " CUSTOM / alpha "])(
+    "prefers the exact model id in %s before case-insensitive matching",
+    (reference) => {
+      const exact = model("custom", "alpha");
+      const folded = model("custom", "Alpha");
+      for (const models of [
+        [folded, exact],
+        [exact, folded],
+      ]) {
+        expect(findExactModelReferenceMatch(reference, models)).toBe(exact);
+      }
+    },
+  );
+
+  it.each([
+    { cliModel: "alpha" },
+    { cliModel: "custom/alpha" },
+    { cliProvider: "CUSTOM", cliModel: "alpha" },
+    { cliProvider: "custom", cliModel: "CUSTOM/alpha" },
+  ])("preserves the exact model through CLI selection: %j", (selection) => {
+    const exact = model("custom", "alpha");
+    const result = resolveCliModel({
+      ...selection,
+      modelRegistry: registry([model("custom", "Alpha"), exact]),
+    });
+    expect(result.model).toBe(exact);
+    expect(result.error).toBeUndefined();
+  });
+
+  it.each(["alpha", "alpha:high"])("preserves an exact scope selection: %s", (pattern) => {
+    const exact = model("custom", "alpha");
+    const result = parseModelPattern(pattern, [model("custom", "Alpha"), exact]);
+    expect(result.model).toBe(exact);
+    expect(result.thinkingLevel).toBe(pattern.includes(":") ? "high" : undefined);
+  });
+
+  it.each([
+    { models: [model("first", "shared"), model("second", "shared")], reference: "shared" },
+    { models: [model("custom", "Alpha"), model("custom", "alpha")], reference: "ALPHA" },
+    { models: [model("custom", "Alpha"), model("custom", "alpha")], reference: "custom/ALPHA" },
+  ])("does not turn ambiguous $reference into a fuzzy or custom model", ({ models, reference }) => {
+    expect(findExactModelReferenceMatch(reference, models)).toBeUndefined();
+    const parsed = parseModelPattern(reference, models);
+    expect(parsed.model).toBeUndefined();
+    expect(parsed.warning).toContain("ambiguous");
+    const selected = resolveCliModel({ cliModel: reference, modelRegistry: registry(models) });
+    expect(selected.model).toBeUndefined();
+    expect(selected.error).toContain("ambiguous");
+  });
+
+  it("selects an exact bare id across providers before folded candidates", () => {
+    const exact = model("second", "alpha");
+    const models = [model("first", "Alpha"), exact];
+    expect(findExactModelReferenceMatch("alpha", models)).toBe(exact);
+    expect(resolveCliModel({ cliModel: "alpha", modelRegistry: registry(models) }).model).toBe(
+      exact,
+    );
+  });
+
+  it("keeps a unique case-insensitive match", () => {
+    const available = model("custom", "Alpha");
+    expect(findExactModelReferenceMatch("CUSTOM/ALPHA", [available])).toBe(available);
+    expect(resolveCliModel({ cliModel: "ALPHA", modelRegistry: registry([available]) }).model).toBe(
+      available,
+    );
+  });
+
+  it("keeps an explicit provider ahead of a slash-containing bare id", () => {
+    const scoped = model("custom", "Alpha");
+    const models = [model("gateway", "custom/alpha"), scoped];
+    expect(findExactModelReferenceMatch("custom/alpha", models)).toBe(scoped);
+    expect(
+      resolveCliModel({ cliModel: "custom/alpha", modelRegistry: registry(models) }).model,
+    ).toBe(scoped);
+  });
+
+  it("uses exact raw ids when an inferred provider has no matching model", () => {
+    const exact = model("gateway", "custom/alpha");
+    const models = [model("custom", "other"), model("gateway", "custom/Alpha"), exact];
+    expect(
+      resolveCliModel({ cliModel: "custom/alpha", modelRegistry: registry(models) }).model,
+    ).toBe(exact);
+  });
+
+  it("keeps exact colon ids ahead of thinking suffix parsing", () => {
+    const exact = model("custom", "alpha:high");
+    expect(parseModelPattern("alpha:high", [model("custom", "alpha"), exact])).toMatchObject({
+      model: exact,
+      thinkingLevel: undefined,
+    });
+  });
+
+  it("keeps glob matching case-insensitive without collapsing exact identities", async () => {
+    const models = [model("custom", "Alpha"), model("custom", "alpha")];
+    expect(await resolveModelScope(["CUSTOM/ALP*:high"], registry(models))).toEqual(
+      models.map((entry) => ({ model: entry, thinkingLevel: "high" })),
+    );
+  });
+});
 
 describe("model resolver fallback selection", () => {
   it("prefers the product default when no configured or scoped model is selected", async () => {
@@ -137,6 +240,15 @@ describe("custom model fallback", () => {
 });
 
 describe("parseModelPattern version sorting", () => {
+  it("keeps human-name matching and prefers an alias over dated versions", () => {
+    const alias = { ...model("custom", "family"), name: "Friendly Model" };
+    const dated = { ...model("custom", "family-20260901"), name: "Friendly Model Snapshot" };
+    expect(parseModelPattern("friendly", [dated, alias]).model).toBe(alias);
+    expect(parseModelPattern("family", [model("custom", "family-20260801"), dated]).model).toBe(
+      dated,
+    );
+  });
+
   it("selects the numerically highest version when aliases span double-digit minors", () => {
     const models = [
       model("anthropic", "claude-opus-4-9"),

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -38,68 +38,54 @@ function isAlias(id: string): boolean {
   return !datePattern.test(id);
 }
 
+function collectModelReferenceMatches(modelReference: string, availableModels: Model[]): Model[] {
+  const trimmedReference = modelReference.trim();
+  if (!trimmedReference) {
+    return [];
+  }
+
+  const scopes: Array<[string, Model[]]> = [[trimmedReference, availableModels]];
+  const slashIndex = trimmedReference.indexOf("/");
+  if (slashIndex !== -1) {
+    const provider = trimmedReference.slice(0, slashIndex).trim().toLowerCase();
+    const modelId = trimmedReference.slice(slashIndex + 1).trim();
+    // A provider-qualified reference wins over another provider's slash-containing id.
+    scopes.unshift([
+      modelId,
+      availableModels.filter((model) => model.provider.toLowerCase() === provider),
+    ]);
+  }
+
+  for (const [modelId, candidates] of scopes) {
+    const exact = candidates.filter((model) => model.id === modelId);
+    if (exact.length > 0) {
+      return exact;
+    }
+    const foldedId = modelId.toLowerCase();
+    const folded = candidates.filter((model) => model.id.toLowerCase() === foldedId);
+    if (folded.length > 0) {
+      return folded;
+    }
+  }
+  return [];
+}
+
 /**
- * Find an exact model reference match.
- * Supports either a bare model id or a canonical provider/modelId reference.
- * When matching by bare id, ambiguous matches across providers are rejected.
+ * Match a bare id or provider/model reference, preferring exact model-id casing.
+ * Case-insensitive matches remain available only when unambiguous.
  */
 export function findExactModelReferenceMatch(
   modelReference: string,
   availableModels: Model[],
 ): Model | undefined {
-  const trimmedReference = modelReference.trim();
-  if (!trimmedReference) {
-    return undefined;
-  }
-
-  const normalizedReference = trimmedReference.toLowerCase();
-
-  const canonicalMatches = availableModels.filter(
-    (model) => `${model.provider}/${model.id}`.toLowerCase() === normalizedReference,
-  );
-  if (canonicalMatches.length === 1) {
-    return canonicalMatches[0];
-  }
-  if (canonicalMatches.length > 1) {
-    return undefined;
-  }
-
-  const slashIndex = trimmedReference.indexOf("/");
-  if (slashIndex !== -1) {
-    const provider = trimmedReference.slice(0, slashIndex).trim();
-    const modelId = trimmedReference.slice(slashIndex + 1).trim();
-    if (provider && modelId) {
-      const providerMatches = availableModels.filter(
-        (model) =>
-          model.provider.toLowerCase() === provider.toLowerCase() &&
-          model.id.toLowerCase() === modelId.toLowerCase(),
-      );
-      if (providerMatches.length === 1) {
-        return providerMatches[0];
-      }
-      if (providerMatches.length > 1) {
-        return undefined;
-      }
-    }
-  }
-
-  const idMatches = availableModels.filter(
-    (model) => model.id.toLowerCase() === normalizedReference,
-  );
-  return idMatches.length === 1 ? idMatches[0] : undefined;
+  const matches = collectModelReferenceMatches(modelReference, availableModels);
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
-/**
- * Try to match a pattern to a model from the available models list.
- * Returns the matched model or undefined if no match found.
- */
-function tryMatchModel(modelPattern: string, availableModels: Model[]): Model | undefined {
-  const exactMatch = findExactModelReferenceMatch(modelPattern, availableModels);
-  if (exactMatch) {
-    return exactMatch;
-  }
-
-  // No exact match - fall back to partial matching
+function matchPartialModelPattern(
+  modelPattern: string,
+  availableModels: Model[],
+): Model | undefined {
   const matches = availableModels.filter(
     (m) =>
       m.id.toLowerCase().includes(modelPattern.toLowerCase()) ||
@@ -167,22 +153,30 @@ function selectAvailableFallbackModel(availableModels: readonly Model[]): Model 
  *
  * Algorithm:
  * 1. Try to match full pattern as a model
- * 2. If found, return it with "off" thinking level
+ * 2. If found, leave the thinking level unspecified
  * 3. If not found and has colons, split on last colon:
  *    - If suffix is valid thinking level, use it and recurse on prefix
- *    - If suffix is invalid, warn and recurse on prefix with "off"
+ *    - If suffix is invalid, warn and leave the thinking level unspecified
  *
- * @internal Exported for testing
+ * @internal Shared with the session extension SDK
  */
 export function parseModelPattern(
   pattern: string,
   availableModels: Model[],
   options?: { allowInvalidThinkingLevelFallback?: boolean },
 ): ParsedModelResult {
-  // Try exact match first
-  const exactMatch = tryMatchModel(pattern, availableModels);
-  if (exactMatch) {
-    return { model: exactMatch, thinkingLevel: undefined, warning: undefined };
+  const exactMatches = collectModelReferenceMatches(pattern, availableModels);
+  // Ambiguity must not fall through to fuzzy selection or custom-model construction.
+  if (exactMatches.length > 1) {
+    return {
+      model: undefined,
+      thinkingLevel: undefined,
+      warning: `Model "${pattern}" is ambiguous. Use an exact provider/model ID.`,
+    };
+  }
+  const model = exactMatches[0] ?? matchPartialModelPattern(pattern, availableModels);
+  if (model) {
+    return { model, thinkingLevel: undefined, warning: undefined };
   }
 
   // No match - try splitting on last colon if present
@@ -386,18 +380,6 @@ export function resolveCliModel(options: {
     }
   }
 
-  // If no provider was inferred from the slash, try exact matches without provider inference.
-  // This handles models whose IDs naturally contain slashes (e.g. OpenRouter-style IDs).
-  if (!provider) {
-    const lower = cliModel.toLowerCase();
-    const exact = availableModels.find(
-      (m) => m.id.toLowerCase() === lower || `${m.provider}/${m.id}`.toLowerCase() === lower,
-    );
-    if (exact) {
-      return { model: exact, warning: undefined, thinkingLevel: undefined, error: undefined };
-    }
-  }
-
   if (cliProvider && provider) {
     // If both were provided, tolerate --model <provider>/<pattern> by stripping the provider prefix
     const prefix = `${provider}/`;
@@ -409,38 +391,28 @@ export function resolveCliModel(options: {
   const candidates = provider
     ? availableModels.filter((m) => m.provider === provider)
     : availableModels;
-  const { model, thinkingLevel, warning } = parseModelPattern(pattern, candidates, {
+  let parsed = parseModelPattern(pattern, candidates, {
     allowInvalidThinkingLevelFallback: false,
   });
-
-  if (model) {
-    return { model, thinkingLevel, warning, error: undefined };
-  }
 
   // If we inferred a provider from the slash but found no match within that provider,
   // fall back to matching the full input as a raw model id across all models.
   // This handles OpenRouter-style IDs like "openai/gpt-4o:extended" where "openai"
   // looks like a provider but the full string is actually a model id on openrouter.
-  if (inferredProvider) {
-    const lower = cliModel.toLowerCase();
-    const exact = availableModels.find(
-      (m) => m.id.toLowerCase() === lower || `${m.provider}/${m.id}`.toLowerCase() === lower,
-    );
-    if (exact) {
-      return { model: exact, warning: undefined, thinkingLevel: undefined, error: undefined };
-    }
-    // Also try parseModelPattern on the full input against all models
-    const fallback = parseModelPattern(cliModel, availableModels, {
+  if (!parsed.model && !parsed.warning && inferredProvider) {
+    parsed = parseModelPattern(cliModel, availableModels, {
       allowInvalidThinkingLevelFallback: false,
     });
-    if (fallback.model) {
-      return {
-        model: fallback.model,
-        thinkingLevel: fallback.thinkingLevel,
-        warning: fallback.warning,
-        error: undefined,
-      };
-    }
+  }
+
+  const { model, thinkingLevel, warning } = parsed;
+  if (model || warning) {
+    return {
+      model,
+      thinkingLevel,
+      warning: model ? warning : undefined,
+      error: model ? undefined : warning,
+    };
   }
 
   if (provider) {

--- a/src/agents/sessions/model-resolver.ts
+++ b/src/agents/sessions/model-resolver.ts
@@ -17,6 +17,11 @@ function isValidThinkingLevel(level: string): level is ThinkingLevel {
   return VALID_THINKING_LEVELS.includes(level as ThinkingLevel);
 }
 
+function splitModelPatternSuffix(pattern: string): [string, string] | undefined {
+  const index = pattern.lastIndexOf(":");
+  return index === -1 ? undefined : [pattern.slice(0, index), pattern.slice(index + 1)];
+}
+
 export interface ScopedModel {
   model: Model;
   /** Thinking level if explicitly specified in pattern (e.g., "model:high"), undefined otherwise */
@@ -28,46 +33,109 @@ export interface ScopedModel {
  * Dates are typically in format: -20241022 or -20250929
  */
 function isAlias(id: string): boolean {
-  // Check if ID ends with -latest
-  if (id.endsWith("-latest")) {
-    return true;
-  }
-
-  // Check if ID ends with a date pattern (-YYYYMMDD)
-  const datePattern = /-\d{8}$/;
-  return !datePattern.test(id);
+  return !/-\d{8}$/.test(id);
 }
 
-function collectModelReferenceMatches(modelReference: string, availableModels: Model[]): Model[] {
+function scopeModelsToProvider(provider: string, availableModels: Model[]): Model[] {
+  const exact = availableModels.filter((model) => model.provider === provider);
+  return exact.length
+    ? exact
+    : availableModels.filter((model) => model.provider.toLowerCase() === provider.toLowerCase());
+}
+
+type ModelReferenceScope = [pattern: string, models: Model[]];
+
+function collectQualifiedModelScopes(
+  modelReference: string,
+  availableModels: Model[],
+): ModelReferenceScope[][] {
+  const canonicalScopes: ModelReferenceScope[] = [];
+  const qualifiedScopes: ModelReferenceScope[] = [];
+  for (
+    let slashIndex = modelReference.indexOf("/");
+    slashIndex !== -1;
+    slashIndex = modelReference.indexOf("/", slashIndex + 1)
+  ) {
+    const provider = modelReference.slice(0, slashIndex);
+    const modelId = modelReference.slice(slashIndex + 1);
+    const models = scopeModelsToProvider(provider, availableModels);
+    if (models.length) {
+      canonicalScopes.push([modelId, models]);
+    }
+    const trimmedModels =
+      provider === provider.trim()
+        ? models
+        : scopeModelsToProvider(provider.trim(), availableModels);
+    if (trimmedModels.length) {
+      qualifiedScopes.push([modelId.trim(), trimmedModels]);
+    }
+  }
+  return [canonicalScopes, qualifiedScopes];
+}
+
+function collectModelReferenceMatches(
+  modelReference: string,
+  availableModels: Model[],
+  qualifiedOnly = false,
+): Model[] {
   const trimmedReference = modelReference.trim();
   if (!trimmedReference) {
     return [];
   }
 
-  const scopes: Array<[string, Model[]]> = [[trimmedReference, availableModels]];
-  const slashIndex = trimmedReference.indexOf("/");
-  if (slashIndex !== -1) {
-    const provider = trimmedReference.slice(0, slashIndex).trim().toLowerCase();
-    const modelId = trimmedReference.slice(slashIndex + 1).trim();
-    // A provider-qualified reference wins over another provider's slash-containing id.
-    scopes.unshift([
-      modelId,
-      availableModels.filter((model) => model.provider.toLowerCase() === provider),
-    ]);
+  // Compare every provider/model split before raw ids: both identities may contain slashes.
+  // Literal tuple components win before the whitespace-tolerant reference form.
+  const groups = collectQualifiedModelScopes(trimmedReference, availableModels);
+  if (!qualifiedOnly) {
+    groups.push([[trimmedReference, availableModels]]);
   }
-
-  for (const [modelId, candidates] of scopes) {
-    const exact = candidates.filter((model) => model.id === modelId);
-    if (exact.length > 0) {
-      return exact;
-    }
-    const foldedId = modelId.toLowerCase();
-    const folded = candidates.filter((model) => model.id.toLowerCase() === foldedId);
-    if (folded.length > 0) {
-      return folded;
+  for (const scopes of groups) {
+    const matchedScopes = scopes
+      .map<ModelReferenceScope>(([id, models]) => [
+        id,
+        models.filter((model) => model.id.toLowerCase() === id.toLowerCase()),
+      ])
+      .filter(([, models]) => models.length);
+    const folded = matchedScopes.flatMap(([, models]) => models);
+    const canonical = folded.filter(
+      (model) => `${model.provider}/${model.id}` === trimmedReference,
+    );
+    // Across different split positions only a complete exact tuple can break a case-folded tie.
+    const matches = canonical.length
+      ? canonical
+      : matchedScopes.length > 1
+        ? folded
+        : matchedScopes.flatMap(([id, models]) => {
+            const exact = models.filter((model) => model.id === id);
+            return exact.length ? exact : models;
+          });
+    if (matches.length > 0) {
+      // Catalogs may repeat an identity; preserve the registry's first-row precedence.
+      return matches.filter(
+        (model, index) =>
+          matches.findIndex((candidate) => modelsAreEqual(candidate, model)) === index,
+      );
     }
   }
   return [];
+}
+
+function ambiguousModelReference(pattern: string): string {
+  return `Model "${pattern}" is ambiguous. Use exact provider and model IDs, specifying the provider separately if needed.`;
+}
+
+function collectModelPatternMatches(
+  pattern: string,
+  availableModels: Model[],
+  deferRawIds = false,
+): Model[] {
+  const parts = splitModelPatternSuffix(pattern);
+  const suffix = parts && isValidThinkingLevel(parts[1]) ? parts : undefined;
+  // A complete literal id must win before a thinking suffix changes its interpretation.
+  const matches = collectModelReferenceMatches(pattern, availableModels, deferRawIds && !suffix);
+  return matches.length || !suffix
+    ? matches
+    : collectModelPatternMatches(suffix[0], availableModels, deferRawIds);
 }
 
 /**
@@ -86,28 +154,20 @@ function matchPartialModelPattern(
   modelPattern: string,
   availableModels: Model[],
 ): Model | undefined {
+  const normalizedPattern = modelPattern.toLowerCase();
   const matches = availableModels.filter(
-    (m) =>
-      m.id.toLowerCase().includes(modelPattern.toLowerCase()) ||
-      m.name?.toLowerCase().includes(modelPattern.toLowerCase()),
+    (model) =>
+      model.id.toLowerCase().includes(normalizedPattern) ||
+      model.name?.toLowerCase().includes(normalizedPattern),
   );
-
-  if (matches.length === 0) {
-    return undefined;
-  }
-
-  // Separate into aliases and dated versions
-  const aliases = matches.filter((m) => isAlias(m.id));
-  const datedVersions = matches.filter((m) => !isAlias(m.id));
-
-  if (aliases.length > 0) {
-    // Prefer alias - if multiple aliases, pick the one that sorts highest
-    aliases.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
-    return aliases[0];
-  }
-  // No alias found, pick latest dated version
-  datedVersions.sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true }));
-  return datedVersions[0];
+  // Aliases precede snapshots; each group keeps its highest numeric version.
+  const matched = matches.toSorted(
+    (a, b) =>
+      Number(isAlias(b.id)) - Number(isAlias(a.id)) ||
+      b.id.localeCompare(a.id, undefined, { numeric: true }),
+  )[0];
+  // Duplicate names remain searchable aliases; the first registry row owns runtime metadata.
+  return matched && availableModels.find((model) => modelsAreEqual(model, matched));
 }
 
 export interface ParsedModelResult {
@@ -122,21 +182,8 @@ function buildFallbackModel(
   modelId: string,
   availableModels: Model[],
 ): Model | undefined {
-  const providerModels = availableModels.filter((m) => m.provider === provider);
-  if (providerModels.length === 0) {
-    return undefined;
-  }
-
-  const baseModel = providerModels.at(0);
-  if (!baseModel) {
-    return undefined;
-  }
-
-  return {
-    ...baseModel,
-    id: modelId,
-    name: modelId,
-  };
+  const baseModel = availableModels.find((model) => model.provider === provider);
+  return baseModel ? { ...baseModel, id: modelId, name: modelId } : undefined;
 }
 
 function selectAvailableFallbackModel(availableModels: readonly Model[]): Model | undefined {
@@ -171,7 +218,7 @@ export function parseModelPattern(
     return {
       model: undefined,
       thinkingLevel: undefined,
-      warning: `Model "${pattern}" is ambiguous. Use an exact provider/model ID.`,
+      warning: ambiguousModelReference(pattern),
     };
   }
   const model = exactMatches[0] ?? matchPartialModelPattern(pattern, availableModels);
@@ -180,14 +227,13 @@ export function parseModelPattern(
   }
 
   // No match - try splitting on last colon if present
-  const lastColonIndex = pattern.lastIndexOf(":");
-  if (lastColonIndex === -1) {
+  const parts = splitModelPatternSuffix(pattern);
+  if (!parts) {
     // No colons, pattern simply doesn't match unknown model
     return { model: undefined, thinkingLevel: undefined, warning: undefined };
   }
 
-  const prefix = pattern.slice(0, lastColonIndex);
-  const suffix = pattern.slice(lastColonIndex + 1);
+  const [prefix, suffix] = parts;
 
   if (isValidThinkingLevel(suffix)) {
     // Valid thinking level - recurse on prefix and use this level
@@ -244,16 +290,13 @@ export async function resolveModelScope(
     // Check if pattern contains glob characters
     if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
       // Extract optional thinking level suffix (e.g., "provider/*:high")
-      const colonIdx = pattern.lastIndexOf(":");
+      const suffix = splitModelPatternSuffix(pattern);
       let globPattern = pattern;
       let thinkingLevel: ThinkingLevel | undefined;
 
-      if (colonIdx !== -1) {
-        const suffix = pattern.slice(colonIdx + 1);
-        if (isValidThinkingLevel(suffix)) {
-          thinkingLevel = suffix;
-          globPattern = pattern.slice(0, colonIdx);
-        }
+      if (suffix && isValidThinkingLevel(suffix[1])) {
+        thinkingLevel = suffix[1];
+        globPattern = suffix[0];
       }
 
       // Match against "provider/modelId" format OR just model ID
@@ -344,89 +387,84 @@ export function resolveCliModel(options: {
     };
   }
 
-  // Build canonical provider lookup (case-insensitive)
-  const providerMap = new Map<string, string>();
-  for (const m of availableModels) {
-    providerMap.set(m.provider.toLowerCase(), m.provider);
-  }
-
-  let provider = cliProvider ? providerMap.get(cliProvider.toLowerCase()) : undefined;
-  if (cliProvider && !provider) {
-    return {
-      model: undefined,
-      warning: undefined,
-      error: `Unknown provider "${cliProvider}". Use --list-models to see available providers/models.`,
-    };
-  }
-
-  // If no explicit --provider, try to interpret "provider/model" format first.
-  // When the prefix before the first slash matches a known provider, prefer that
-  // interpretation over matching models whose IDs literally contain slashes
-  // (e.g. "zai/glm-5" should resolve to provider=zai, model=glm-5, not to a
-  // vercel-ai-gateway model with id "zai/glm-5").
-  let pattern = cliModel;
-  let inferredProvider = false;
-
-  if (!provider) {
-    const slashIndex = cliModel.indexOf("/");
-    if (slashIndex !== -1) {
-      const maybeProvider = cliModel.slice(0, slashIndex);
-      const canonical = providerMap.get(maybeProvider.toLowerCase());
-      if (canonical) {
-        provider = canonical;
-        pattern = cliModel.slice(slashIndex + 1);
-        inferredProvider = true;
-      }
+  let scopeGroups: ModelReferenceScope[][];
+  if (cliProvider) {
+    const models = scopeModelsToProvider(cliProvider, availableModels);
+    if (!models.length) {
+      return {
+        model: undefined,
+        warning: undefined,
+        error: `Unknown provider "${cliProvider}". Use --list-models to see available providers/models.`,
+      };
     }
+    const prefix = `${cliProvider}/`;
+    scopeGroups = [
+      [
+        [
+          cliModel.toLowerCase().startsWith(prefix.toLowerCase())
+            ? cliModel.slice(prefix.length)
+            : cliModel,
+          models,
+        ],
+      ],
+    ];
+  } else {
+    scopeGroups = collectQualifiedModelScopes(cliModel.trim(), availableModels);
   }
-
-  if (cliProvider && provider) {
-    // If both were provided, tolerate --model <provider>/<pattern> by stripping the provider prefix
-    const prefix = `${provider}/`;
-    if (cliModel.toLowerCase().startsWith(prefix.toLowerCase())) {
-      pattern = cliModel.slice(prefix.length);
-    }
-  }
-
-  const candidates = provider
-    ? availableModels.filter((m) => m.provider === provider)
-    : availableModels;
-  let parsed = parseModelPattern(pattern, candidates, {
-    allowInvalidThinkingLevelFallback: false,
-  });
-
-  // If we inferred a provider from the slash but found no match within that provider,
-  // fall back to matching the full input as a raw model id across all models.
-  // This handles OpenRouter-style IDs like "openai/gpt-4o:extended" where "openai"
-  // looks like a provider but the full string is actually a model id on openrouter.
-  if (!parsed.model && !parsed.warning && inferredProvider) {
-    parsed = parseModelPattern(cliModel, availableModels, {
+  const parse = (pattern: string, models: Model[]) =>
+    parseModelPattern(pattern, models, {
       allowInvalidThinkingLevelFallback: false,
     });
+  const canonicalMatches = cliProvider
+    ? []
+    : collectModelPatternMatches(cliModel, availableModels, true);
+  let parsed = canonicalMatches.length ? parse(cliModel, canonicalMatches) : undefined;
+  for (const scopes of scopeGroups) {
+    if (parsed) {
+      break;
+    }
+    const matches = scopes
+      .map(([scopePattern, models]) => {
+        // Fuzzy ordering cannot choose between provider identities, including case-only variants.
+        const candidates = models.some((entry) => entry.provider !== models[0]?.provider)
+          ? collectModelPatternMatches(scopePattern, models)
+          : models;
+        return parse(scopePattern, candidates);
+      })
+      .filter((result) => result.model || result.warning);
+    parsed =
+      matches.find((result) => result.warning) ??
+      (matches.length > 1
+        ? { model: undefined, warning: ambiguousModelReference(cliModel) }
+        : matches[0]);
   }
-
-  const { model, thinkingLevel, warning } = parsed;
-  if (model || warning) {
+  // Preserve raw slash-id fallback after known provider patterns fail.
+  parsed ??= cliProvider ? undefined : parse(cliModel, availableModels);
+  if (parsed?.model || parsed?.warning) {
     return {
-      model,
-      thinkingLevel,
-      warning: model ? warning : undefined,
-      error: model ? undefined : warning,
+      model: parsed.model,
+      thinkingLevel: parsed.thinkingLevel,
+      warning: parsed.model ? parsed.warning : undefined,
+      error: parsed.model ? undefined : parsed.warning,
     };
   }
 
+  const fallbackScopes = scopeGroups.find((scopes) => scopes.length) ?? [];
+  const providers = new Set(
+    fallbackScopes.flatMap(([, models]) => models.map((entry) => entry.provider)),
+  );
+  if (providers.size > 1) {
+    return { model: undefined, warning: undefined, error: ambiguousModelReference(cliModel) };
+  }
+  const [provider] = providers;
+  const pattern = fallbackScopes[0]?.[0] ?? cliModel;
   if (provider) {
     let fallbackPattern = pattern;
     let fallbackThinking: ThinkingLevel | undefined;
-    if (!cliThinking) {
-      const lastColon = pattern.lastIndexOf(":");
-      if (lastColon !== -1) {
-        const suffix = pattern.slice(lastColon + 1);
-        if (isValidThinkingLevel(suffix)) {
-          fallbackPattern = pattern.slice(0, lastColon);
-          fallbackThinking = suffix;
-        }
-      }
+    const suffix = splitModelPatternSuffix(pattern);
+    if (!cliThinking && suffix && isValidThinkingLevel(suffix[1])) {
+      fallbackPattern = suffix[0];
+      fallbackThinking = suffix[1];
     }
 
     const fallbackModel = buildFallbackModel(provider, fallbackPattern, availableModels);
@@ -436,13 +474,10 @@ export function resolveCliModel(options: {
         requestedThinking && requestedThinking !== "off"
           ? { ...fallbackModel, reasoning: true }
           : fallbackModel;
-      const fallbackWarning = warning
-        ? `${warning} Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`
-        : `Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`;
       return {
         model: resolvedModel,
         thinkingLevel: requestedThinking,
-        warning: fallbackWarning,
+        warning: `Model "${fallbackPattern}" not found for provider "${provider}". Using custom model id.`,
         error: undefined,
       };
     }
@@ -452,7 +487,7 @@ export function resolveCliModel(options: {
   return {
     model: undefined,
     thinkingLevel: undefined,
-    warning,
+    warning: undefined,
     error: `Model "${display}" not found. Use --list-models to see available models.`,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Session SDK selection could choose `Alpha` when the caller requested the distinct model `alpha`, or silently choose a provider for an ambiguous reference. Duplicate catalog rows could also change the selected metadata.

## Why This Change Was Made

Share exact-first provider and model matching across SDK and CLI selection. Compare complete provider/model identities, including slash-containing components, before tolerant or fuzzy lookup. Preserve registry-first metadata when duplicate rows or alternate names identify the same model. Ambiguity produces an actionable error.

The same flow preserves explicit providers, raw IDs, human names, alias/date and numeric ordering, literal colons, thinking suffixes, custom IDs, and case-insensitive glob scopes. It removes the overwritten provider map and duplicate suffix, ordering, and fallback branches.

## User Impact

Selections retain the requested model identity and metadata. References that identify several models require an exact provider/model choice. This focused repair was found while extracting #130706; it adds no public argument or configuration option.

## Evidence

- All 55 owner tests and typed lint pass; regressions were reproduced before repair.
- Real resource loader → jiti extension SDK → model registry first-load and explicit-reload proof passes on tree `b461b36233f81a0b86c9320cd2d6aee839c05ca4`, committed as `c49515c69621af70e744100c2f4331b119b8a666`. The matrix includes exact/folded identities, duplicate metadata and names, every registered provider split, ambiguity, raw IDs, fuzzy/version ordering, literal colon IDs, thinking suffixes, custom models and globs. Proof uses isolated HOME/state/config and an allowlisted environment.
- Independent P2 review is scoped-clean on that exact source.
- Production: +7 lines (217 added / 210 removed); tests: +333; docs: +7. Remaining growth preserves distinct identity and parsing contracts within one shared matcher.

The exact committed head passed the complete build (455 seconds), full changed gate, and compiled SDK first-load/reload replay. All 8,547 runtime files remained unchanged during replay (manifest SHA256 `57430d4cc6bc3b387d65db7c5577088ff7cade2adc80bfef0d7a9d936f699d4b`). [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34024203124) passed.

Maintainer disposition: accept the documented ambiguity diagnostic as the repair for arbitrary wrong-model selection. Callers can use exact identities or specify the provider separately; public function signatures and unambiguous fuzzy/custom selection remain supported.
