### PR TITLE
fix(test): prevent ClawHub fixtures from polluting sandbox hashes

### DIFF
--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -585,8 +585,8 @@ describe("ensureSandboxBrowser create args", () => {
       GEMINI_API_KEY: "dummy-gemini",
     };
     const scopeKey = "session-1";
-    const workspaceDir = "/tmp/workspace";
-    const agentWorkspaceDir = "/tmp/workspace";
+    const workspaceDir = tempDirs.make("openclaw-browser-env-policy-");
+    const agentWorkspaceDir = workspaceDir;
     const expectedHash = computeTestBrowserHash({
       cfg,
       dockerEnvPolicyEpoch: SANDBOX_DOCKER_EXPLICIT_ENV_POLICY_EPOCH,

--- a/src/skills/lifecycle/clawhub.test.ts
+++ b/src/skills/lifecycle/clawhub.test.ts
@@ -320,11 +320,14 @@ function writeTrackedSkill(
 }
 
 describe("skills-clawhub", () => {
+  let defaultWorkspaceDir: string;
+
   afterEach(async () => {
     await tempDirs.cleanup();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    defaultWorkspaceDir = await tempDirs.make("openclaw-clawhub-workspace-");
     fetchClawHubSkillDetailMock.mockReset();
     fetchClawHubSkillInstallResolutionMock.mockReset();
     fetchClawHubSkillVerificationMock.mockReset();
@@ -445,14 +448,14 @@ describe("skills-clawhub", () => {
         if (backup && !backup.ok) {
           return backup;
         }
-        return { ok: true, targetDir: "/tmp/workspace/skills/agentreceipt" };
+        return { ok: true, targetDir: params.targetDir };
       },
     );
     evaluateSkillInstallPolicyMock.mockResolvedValue(undefined);
   });
 
   it("installs ClawHub skills from flat-root archives", async () => {
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "agentreceipt",
@@ -470,7 +473,7 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "agentreceipt",
       version: "1.0.0",
-      targetDir: "/tmp/workspace/skills/agentreceipt",
+      targetDir: path.join(defaultWorkspaceDir, "skills", "agentreceipt"),
     });
     expect(archiveCleanupMock).toHaveBeenCalledTimes(1);
     expect(reportClawHubSkillInstallTelemetryMock).toHaveBeenCalledWith({
@@ -517,7 +520,7 @@ describe("skills-clawhub", () => {
     }
 
     const result = await installTestSkill(
-      "/tmp/workspace",
+      defaultWorkspaceDir,
       "missing-skill",
       lookup === "detail" ? { version: "1.2.3" } : {},
     );
@@ -549,12 +552,8 @@ describe("skills-clawhub", () => {
       expect(params.rootMarkers).toBeUndefined();
       return await params.onExtracted("/tmp/extracted-github-repo");
     });
-    installPackageDirMock.mockResolvedValueOnce({
-      ok: true,
-      targetDir: "/tmp/workspace/skills/weather",
-    });
 
-    const result = await installTestSkill("/tmp/workspace", reference);
+    const result = await installTestSkill(defaultWorkspaceDir, reference);
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "weather",
@@ -584,7 +583,7 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "weather",
       version: commit,
-      targetDir: "/tmp/workspace/skills/weather",
+      targetDir: path.join(defaultWorkspaceDir, "skills", "weather"),
     });
     expect(result.warning).toBe("Not scanned by ClawHub");
     expect(reportClawHubSkillInstallTelemetryMock).toHaveBeenCalledWith({
@@ -611,7 +610,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
+    const result = await installTestSkill(defaultWorkspaceDir, "skills-sh:openclaw/skills/weather");
 
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
@@ -628,7 +627,7 @@ describe("skills-clawhub", () => {
     "skills-sh:-owner/repo/slug",
     "skills-sh:owner/../slug",
   ])("rejects invalid skills-sh reference %s before network access", async (reference) => {
-    const result = await installTestSkill("/tmp/workspace", reference);
+    const result = await installTestSkill(defaultWorkspaceDir, reference);
 
     expect(result).toMatchObject({
       ok: false,
@@ -639,9 +638,13 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects versions for skills-sh references before network access", async () => {
-    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather", {
-      version: "1.2.3",
-    });
+    const result = await installTestSkill(
+      defaultWorkspaceDir,
+      "skills-sh:openclaw/skills/weather",
+      {
+        version: "1.2.3",
+      },
+    );
 
     expect(result).toEqual({
       ok: false,
@@ -663,7 +666,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
+    const result = await installTestSkill(defaultWorkspaceDir, "skills-sh:openclaw/skills/weather");
 
     expect(result).toEqual({
       ok: false,
@@ -690,7 +693,10 @@ describe("skills-clawhub", () => {
         },
       });
 
-      const result = await installTestSkill("/tmp/workspace", "skills-sh:openclaw/skills/weather");
+      const result = await installTestSkill(
+        defaultWorkspaceDir,
+        "skills-sh:openclaw/skills/weather",
+      );
 
       expect(result).toEqual({
         ok: false,
@@ -711,7 +717,7 @@ describe("skills-clawhub", () => {
     });
 
     const result = await preflightSkillFromClawHub({
-      workspaceDir: "/tmp/workspace",
+      workspaceDir: defaultWorkspaceDir,
       slug: "agentreceipt",
       version: "1.0.0",
     });
@@ -733,7 +739,7 @@ describe("skills-clawhub", () => {
       cleanup: archiveCleanupMock,
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt", {
       version: "1.0.0",
       expectedIntegrity: `sha256:${"a".repeat(64)}`,
     });
@@ -760,12 +766,12 @@ describe("skills-clawhub", () => {
     });
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
       version: "1.0.0",
-      targetDir: "/tmp/workspace/skills/agentreceipt",
+      targetDir: path.join(defaultWorkspaceDir, "skills", "agentreceipt"),
     });
     expect(fetchClawHubSkillSecurityVerdictsMock).not.toHaveBeenCalled();
     expect(installPolicyInput()).toMatchObject({
@@ -794,12 +800,12 @@ describe("skills-clawhub", () => {
     });
     fetchClawHubSkillSecurityVerdictsMock.mockRejectedValueOnce(new Error("should not be called"));
 
-    const result = await installTestSkill("/tmp/workspace", "tao-setup-nvidia-gpu-host");
+    const result = await installTestSkill(defaultWorkspaceDir, "tao-setup-nvidia-gpu-host");
 
     expectInstalledSkill(result, {
       slug: "tao-setup-nvidia-gpu-host",
       version: "1.0.0",
-      targetDir: "/tmp/workspace/skills/tao-setup-nvidia-gpu-host",
+      targetDir: path.join(defaultWorkspaceDir, "skills", "tao-setup-nvidia-gpu-host"),
     });
     expect(fetchClawHubSkillDetailMock).toHaveBeenCalledWith({
       slug: "tao-setup-nvidia-gpu-host",
@@ -831,7 +837,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "@acme/agentreceipt", {
+    const result = await installTestSkill(defaultWorkspaceDir, "@acme/agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -874,7 +880,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -923,7 +929,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -941,7 +947,7 @@ describe("skills-clawhub", () => {
       new Error("security verdicts unavailable"),
     );
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -960,7 +966,7 @@ describe("skills-clawhub", () => {
       items: [],
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -993,7 +999,7 @@ describe("skills-clawhub", () => {
       ...verdict,
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1021,7 +1027,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt", {
       logger: {
         warn: (message) => warnings.push(message),
       },
@@ -1052,7 +1058,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, { slug: "agentreceipt", version: "1.0.0" });
     if (!result.ok) {
@@ -1078,7 +1084,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "@acme/agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "@acme/agentreceipt");
 
     expectInstalledSkill(result, { slug: "agentreceipt", version: "1.0.0" });
     if (!result.ok) {
@@ -1107,7 +1113,7 @@ describe("skills-clawhub", () => {
       },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -1300,7 +1306,7 @@ describe("skills-clawhub", () => {
       signature: { status: "unsigned" },
     });
 
-    const result = await installTestSkill("/tmp/workspace", "@demo-owner/weather");
+    const result = await installTestSkill(defaultWorkspaceDir, "@demo-owner/weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1321,7 +1327,7 @@ describe("skills-clawhub", () => {
       status: 409,
     });
 
-    const result = await installTestSkill("/tmp/workspace", "weather");
+    const result = await installTestSkill(defaultWorkspaceDir, "weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1333,7 +1339,7 @@ describe("skills-clawhub", () => {
   });
 
   it("rejects malformed owner-qualified ClawHub install refs", async () => {
-    const result = await installTestSkill("/tmp/workspace", "@@demo-owner/weather");
+    const result = await installTestSkill(defaultWorkspaceDir, "@@demo-owner/weather");
 
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -1743,12 +1749,8 @@ describe("skills-clawhub", () => {
       expect(params.rootMarkers).toBeUndefined();
       return await params.onExtracted("/tmp/extracted-github-repo");
     });
-    installPackageDirMock.mockResolvedValueOnce({
-      ok: true,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
-    });
 
-    const result = await installTestSkill("/tmp/workspace", "aiq-deploy");
+    const result = await installTestSkill(defaultWorkspaceDir, "aiq-deploy");
 
     expect(fetchClawHubSkillInstallResolutionMock).toHaveBeenCalledWith({
       slug: "aiq-deploy",
@@ -1774,7 +1776,7 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "aiq-deploy",
       version: commit,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
+      targetDir: path.join(defaultWorkspaceDir, "skills", "aiq-deploy"),
     });
   });
 
@@ -1788,7 +1790,7 @@ describe("skills-clawhub", () => {
       sourceUrl: "https://github.com/NVIDIA/skills/tree/main/skills/aiq-deploy",
     });
 
-    const result = await installTestSkill("/tmp/workspace", "aiq-deploy");
+    const result = await installTestSkill(defaultWorkspaceDir, "aiq-deploy");
 
     expect(result.ok).toBe(false);
     expect(result.ok ? "" : result.error).toContain("expected a full 40-character commit SHA");
@@ -1810,12 +1812,8 @@ describe("skills-clawhub", () => {
     withExtractedArchiveRootMock.mockImplementationOnce(async (params) => {
       return await params.onExtracted("/tmp/extracted-github-repo");
     });
-    installPackageDirMock.mockResolvedValueOnce({
-      ok: true,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
-    });
 
-    const result = await installTestSkill("/tmp/workspace", "aiq-deploy", {
+    const result = await installTestSkill(defaultWorkspaceDir, "aiq-deploy", {
       forceInstall: true,
     });
 
@@ -1829,14 +1827,14 @@ describe("skills-clawhub", () => {
     expectInstalledSkill(result, {
       slug: "aiq-deploy",
       version: commit,
-      targetDir: "/tmp/workspace/skills/aiq-deploy",
+      targetDir: path.join(defaultWorkspaceDir, "skills", "aiq-deploy"),
     });
   });
 
   it("keeps ClawHub install telemetry best-effort", async () => {
     reportClawHubSkillInstallTelemetryMock.mockRejectedValueOnce(new Error("telemetry down"));
 
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
     expectInstalledSkill(result, {
       slug: "agentreceipt",
@@ -1845,7 +1843,7 @@ describe("skills-clawhub", () => {
   });
 
   it("marks custom ClawHub skill registries as third-party install policy authority", async () => {
-    const result = await installTestSkill("/tmp/workspace", "agentreceipt", {
+    const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt", {
       baseUrl: "https://clawhub.internal.example",
     });
 
@@ -1864,7 +1862,7 @@ describe("skills-clawhub", () => {
     async (marker) => {
       pathExistsMock.mockImplementation(async (input: string) => input.endsWith(marker));
 
-      const result = await installTestSkill("/tmp/workspace", "agentreceipt");
+      const result = await installTestSkill(defaultWorkspaceDir, "agentreceipt");
 
       expectInstalledSkill(result);
       expectInstallPackageSourceDir("/tmp/extracted-skill");
@@ -2575,53 +2573,53 @@ describe("skills-clawhub", () => {
 
   describe("normalizeSlug rejects non-ASCII homograph slugs", () => {
     it("rejects Cyrillic homograph 'а' (U+0430) in slug", async () => {
-      const result = await installTestSkill("/tmp/workspace", "re\u0430ct");
+      const result = await installTestSkill(defaultWorkspaceDir, "re\u0430ct");
       expectInvalidSlug(result);
     });
 
     it("rejects Cyrillic homograph 'е' (U+0435) in slug", async () => {
-      const result = await installTestSkill("/tmp/workspace", "r\u0435act");
+      const result = await installTestSkill(defaultWorkspaceDir, "r\u0435act");
       expectInvalidSlug(result);
     });
 
     it("rejects Cyrillic homograph 'о' (U+043E) in slug", async () => {
-      const result = await installTestSkill("/tmp/workspace", "t\u043Edo");
+      const result = await installTestSkill(defaultWorkspaceDir, "t\u043Edo");
       expectInvalidSlug(result);
     });
 
     it("rejects slug with mixed Unicode and ASCII", async () => {
-      const result = await installTestSkill("/tmp/workspace", "cаlеndаr");
+      const result = await installTestSkill(defaultWorkspaceDir, "cаlеndаr");
       expectInvalidSlug(result);
     });
 
     it("rejects slug with non-Latin scripts", async () => {
-      const result = await installTestSkill("/tmp/workspace", "技能");
+      const result = await installTestSkill(defaultWorkspaceDir, "技能");
       expectInvalidSlug(result);
     });
 
     it("rejects Unicode that case-folds to ASCII (Kelvin sign U+212A)", async () => {
       // "\u212A" (Kelvin sign) lowercases to "k" — must be caught before lowercasing
-      const result = await installTestSkill("/tmp/workspace", "\u212Aalendar");
+      const result = await installTestSkill(defaultWorkspaceDir, "\u212Aalendar");
       expectInvalidSlug(result);
     });
 
     it("rejects slug starting with a hyphen", async () => {
-      const result = await installTestSkill("/tmp/workspace", "-calendar");
+      const result = await installTestSkill(defaultWorkspaceDir, "-calendar");
       expectInvalidSlug(result);
     });
 
     it("rejects slug ending with a hyphen", async () => {
-      const result = await installTestSkill("/tmp/workspace", "calendar-");
+      const result = await installTestSkill(defaultWorkspaceDir, "calendar-");
       expectInvalidSlug(result);
     });
 
     it("accepts uppercase ASCII slugs (preserves original casing behavior)", async () => {
-      const result = await installTestSkill("/tmp/workspace", "React");
+      const result = await installTestSkill(defaultWorkspaceDir, "React");
       expectInstalledSkill(result);
     });
 
     it("accepts valid lowercase ASCII slugs", async () => {
-      const result = await installTestSkill("/tmp/workspace", "calendar-2");
+      const result = await installTestSkill(defaultWorkspaceDir, "calendar-2");
       expectInstalledSkill(result);
     });
   });
@@ -2691,7 +2689,7 @@ describe("skills-clawhub", () => {
       async ({ version, tag }) => {
         await expect(
           resolveClawHubSkillVerificationTarget({
-            workspaceDir: "/tmp/workspace",
+            workspaceDir: defaultWorkspaceDir,
             slug: "skills-sh:openclaw/skills/agentreceipt",
             version,
             tag,
@@ -3210,7 +3208,7 @@ describe("skills-clawhub", () => {
     it("fails clearly for invalid slugs and conflicting selectors", async () => {
       await expect(
         resolveClawHubSkillVerificationTarget({
-          workspaceDir: "/tmp/workspace",
+          workspaceDir: defaultWorkspaceDir,
           slug: "bad/slug",
         }),
       ).resolves.toMatchObject({
@@ -3220,7 +3218,7 @@ describe("skills-clawhub", () => {
 
       await expect(
         resolveClawHubSkillVerificationTarget({
-          workspaceDir: "/tmp/workspace",
+          workspaceDir: defaultWorkspaceDir,
           slug: "agentreceipt",
           version: "1.0.0",
           tag: "latest",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where unrelated pull requests and main CI fail the sandbox browser config-hash test when the ClawHub test shard runs first. The failure appeared in [main CI](https://github.com/openclaw/openclaw/actions/runs/34018552866/job/101447095671) and [the avatar repair CI](https://github.com/openclaw/openclaw/actions/runs/34018367288/job/101446355702).

## Why This Change Was Made

ClawHub's install mock returned a shared `/tmp/workspace/skills/agentreceipt` destination while the real provenance writer created files there. The browser fixture then discovered that directory as a protected skill mount, although its expected hash assumed no mounts.

ClawHub tests now allocate and clean an owned workspace for each case, and the install mock returns its actual requested destination. The browser epoch case also uses its existing tracked temporary-directory helper. Three redundant mock overrides are removed.

## User Impact

Developers get deterministic CI across concurrently scheduled shards. Runtime behavior and sandbox security policy are unchanged.

## Evidence

**Superseded by #139894**, merged as `9532052c47d87c2d2ea3eb7161bf49b7b8d18d52`. The landed repair isolates both owners, including every browser fixture. On captured main `83d1f53c51a262cf8cec0fce14548514daee4d35`, both repaired files match the canonical merge and all 144 relevant tests passed. The checkout is clean. The canonical PR's [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34019118162) passed. This candidate is retained for its diagnostic evidence and will not be merged.

The retained remote proof below applies to original candidate `64bcdb99e4f3dc9a7f5075fbb35ea64f0e78adb4`. It must not be mistaken for a remote run of the separately landed implementation. The later unchanged-patch rebase to `e0feeaf8dcc17d655acdb427a10e92f7105720ee` became redundant; its second Testbox acquisition was stopped before tests ran.

Local focused suites passed: 117 ClawHub tests and 27 sandbox browser tests. The original 63-file agents envelope also passed when run without the ClawHub writer, confirming the missing cross-shard interference in a narrow retry.

Remote proof ran on **Blacksmith Testbox** lease `tbx_01m1tt706weysfrjgwx9wf97qy`, [run 34019498275](https://github.com/openclaw/openclaw/actions/runs/34019498275), comparing baseline `ba3a6cb5f690789e0824c7c92618579743b9cade` with candidate `64bcdb99e4f3dc9a7f5075fbb35ea64f0e78adb4` in separate detached worktrees. The exact source trees were verified before execution.

The ordered replay used the original `installs ClawHub skills from flat-root archives` and `includes the explicit env policy epoch in the browser config hash when needed` cases via `node scripts/run-vitest.mjs`:

```text
baseline browser, clean workspace: PASS
baseline ClawHub writer: PASS; shared origin.json exists
baseline browser, after writer: EXPECTED FAIL at browser.create.test.ts:606
candidate browser, with old residue: PASS
candidate ClawHub writer: PASS; shared workspace absent
original browser, after candidate writer: PASS
candidate complete focused suites: 117 + 27 tests PASS
candidate full changed gate: PASS
lease cleanup: completed/stopped (independently verified)
```

The original browser passing after the repaired writer independently proves the producer repair. The full remote changed gate passed, including the agents-other and services test type graphs, formatting, lint, declaration, dependency, and repository guards. [Original-head CI](https://github.com/openclaw/openclaw/actions/runs/34019529909) is green. The lease is independently confirmed completed/stopped. A portal metadata-sync timeout occurred after successful proof and cleanup.

The local changed gate had rejected declaration inputs from its read-only linked dependency checkout before typechecking; the complete remote gate used owned prepared dependencies. This is test-harness proof with real filesystem effects; existing Docker and network mocks remain in place.

Independent local and committed-branch reviews found no actionable P0–P2 findings.

`git diff --numstat`:

| Scope | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production | 0 | 0 | 0 |
| Tests | 66 | 68 | -2 |

No changelog change: this is a test-fixture CI repair.
