### PR TITLE
fix(browser): preserve code fences in page evaluation results

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp-result.ts
+++ b/extensions/browser/src/browser/chrome-mcp-result.ts
@@ -129,12 +129,6 @@ export function extractSnapshot(result: ChromeMcpToolResult): ChromeMcpSnapshotN
   return snapshot;
 }
 
-function extractJsonBlock(text: string): unknown {
-  const match = text.match(/```json\s*([\s\S]*?)\s*```/i);
-  const raw = match?.[1]?.trim() || text.trim();
-  return raw ? JSON.parse(raw) : null;
-}
-
 function extractMessageText(result: ChromeMcpToolResult): string {
   const message = extractStructuredContent(result).message;
   if (typeof message === "string" && message.trim()) {
@@ -195,7 +189,11 @@ export function extractJsonMessage(result: ChromeMcpToolResult): unknown {
   let lastError: unknown;
   for (const candidate of candidates) {
     try {
-      return extractJsonBlock(candidate);
+      // MCP fence delimiters occupy lines; backticks inside JSON strings are data.
+      const match = candidate.match(
+        /^[\t ]*```json[\t ]*\r?\n([\s\S]*?)\r?\n[\t ]*```[\t ]*\r?$/im,
+      );
+      return JSON.parse(match?.[1]?.trim() || candidate.trim());
     } catch (err) {
       lastError = err;
     }

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -1936,17 +1936,55 @@ describe("chrome MCP page parsing", () => {
     expect(calls).toEqual(["list_pages", "take_snapshot", "list_pages", "new_page", "click"]);
   });
 
-  it("parses evaluate_script text responses when structuredContent is missing", async () => {
-    const factory: ChromeMcpSessionFactory = async () => createFakeSession();
-    setChromeMcpSessionFactoryForTest(factory);
+  it.each([
+    ["script", "text", "fenced", 123],
+    ["script", "text", "fenced", "literal ``` inside text"],
+    ["script", "structured", "fenced", { text: '```json\n{"ok":true}\n```' }],
+    ["script", "text", "crlf", ["first", "```", "last"]],
+    ["script", "structured", "fenced", ""],
+    ["script", "text", "raw", "```json\nnot a wrapper\n```"],
+    ["script", "text", "trailing-fence", "preserved ``` text"],
+    ["document", "structured", "fenced", "Example:\n```js\nconst value = 1;\n```"],
+  ] as const)("preserves %s %s %s JSON result %j", async (caller, surface, format, value) => {
+    const json = JSON.stringify(value);
+    const message =
+      format === "raw"
+        ? json
+        : [
+            "Script ran on page and returned:",
+            "```json",
+            json,
+            "```",
+            ...(format === "trailing-fence" ? ["Diagnostic:", "```txt", "extra", "```"] : []),
+          ].join(format === "crlf" ? "\r\n" : "\n");
+    setChromeMcpSessionFactoryForTest(async () =>
+      createPageSession({
+        pid: 141,
+        pages: [{ id: 1, url: "https://example.com" }],
+        onTool: (call) => {
+          if (call.name === "take_snapshot") {
+            return {
+              structuredContent: { snapshot: { id: "root", role: "RootWebArea" } },
+            };
+          }
+          if (call.name === "evaluate_script") {
+            return {
+              ...(surface === "structured" ? { structuredContent: { message } } : {}),
+              content: [{ type: "text", text: message }],
+            };
+          }
+          return undefined;
+        },
+      }),
+    );
+    const targetId = (await listChromeMcpTabs("chrome-live"))[0]?.targetId ?? "";
+    const params = { profileName: "chrome-live", targetId };
+    const result =
+      caller === "document"
+        ? await withChromeMcpDocument(params, (document) => document.evaluate("() => 123"))
+        : await evaluateChromeMcpScript({ ...params, fn: "() => 123" });
 
-    const result = await evaluateChromeMcpScript({
-      profileName: "chrome-live",
-      targetId: FAKE_TARGET_1,
-      fn: "() => 123",
-    });
-
-    expect(result).toBe(123);
+    expect(result).toEqual(value);
   });
 
   it("defaults non-finite coordinate click delays before injecting the browser script", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users extracting page text containing Markdown code fences through an existing-session browser profile would receive JSON parsing errors even though browser evaluation succeeded. Strings nested in objects or arrays were affected too.

## Why This Change Was Made

The shared result decoder now recognizes standalone JSON-fence delimiter lines, keeping embedded backticks as data. Parsing stays in the existing candidate loop, removing a redundant helper while preserving raw JSON, structured/text fallback, and normal tool errors.

## User Impact

Page evaluation returns complete Markdown and code examples, including structured and document-bound results, instead of failing with an unterminated-string error.

## Evidence

- Before the repair, six regression cases failed. Afterward, all 111 adapter tests passed, covering structured and text output, raw JSON, CRLF framing, trailing fenced diagnostics, and the document-bound caller.
- Actual OpenClaw adapter → Chrome MCP 1.8.0 → isolated Chromium 151.0.7922.34 proof used only synthetic page content. Five affected cases failed before; all seven cases returned exact values afterward, including the two existing controls.
- Scoped lint, formatting, docs indexing, and diff checks passed. Independent review found no actionable P0–P2 issues.

Broad validation is pending exact-head hosted CI.

The captures show the synthetic fixture and decoder outcome summary, paired with the actual MCP/Chromium JSON assertions above.

**Before**

![Browser evaluation diagnostic before](https://github.com/user-attachments/assets/c018998f-fad5-4a71-8017-5ec5ccd7bcf9)

**After**

![Browser evaluation diagnostic after](https://github.com/user-attachments/assets/e6eb8fcd-47de-4c71-b794-08055d9dd40e)

