### PR TITLE
fix(plugins): honor provider runtime cache invalidation

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3419,7 +3419,7 @@ src/plugins/official-external-plugin-catalog-snapshot-store.ts	4
 src/plugins/official-external-plugin-targets.ts	1
 src/plugins/official-external-provider-endpoints.ts	1
 src/plugins/openai-compatible-embedding-provider.ts	2
-src/plugins/plugin-cache-primitives.ts	2
+src/plugins/plugin-cache-primitives.ts	1
 src/plugins/plugin-command-dispatch-contract.ts	1
 src/plugins/plugin-command-execution.ts	2
 src/plugins/plugin-command-runtime.ts	3
@@ -3435,7 +3435,7 @@ src/plugins/provider-auth-choice-helpers.ts	12
 src/plugins/provider-catalog-result.ts	8
 src/plugins/provider-discovery.runtime.ts	2
 src/plugins/provider-discovery.ts	2
-src/plugins/provider-hook-runtime.ts	4
+src/plugins/provider-hook-runtime.ts	3
 src/plugins/provider-model-compat.ts	7
 src/plugins/provider-model-helpers.ts	4
 src/plugins/provider-model-primary.ts	1

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -249,6 +249,12 @@ OpenClaw still owns the generic agent loop, failover, transcript handling, and
 tool policy. These hooks are the extension surface for provider-specific
 behavior without needing a whole custom inference transport.
 
+Hook lookup uses the prepared generation or a matching loaded registry first.
+On a miss, provider/model-scoped discovery reuses the loader's registry cache;
+explicit runtime-discovery invalidation clears that lookup rather than leaving
+another provider cache holding old hooks. Attempt-prepared provider handles
+retain their selected plugin, while each hook receives the current call context.
+
 Use manifest `setup.providers[].envVars` when the provider has env-based
 credentials that generic auth/status/model-picker paths should see without
 loading plugin runtime. Use manifest `providerAuthAliases`

--- a/src/plugins/plugin-cache-primitives.test.ts
+++ b/src/plugins/plugin-cache-primitives.test.ts
@@ -2,12 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  PluginLruCache,
-  createConfigScopedPromiseLoader,
-  resolveConfigScopedRuntimeCacheValue,
-  type ConfigScopedRuntimeCache,
-} from "./plugin-cache-primitives.js";
+import { PluginLruCache, createConfigScopedPromiseLoader } from "./plugin-cache-primitives.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 
 describe("PluginLruCache", () => {
@@ -33,45 +28,6 @@ describe("PluginLruCache", () => {
 
     expect(cache.get("missing")).toBeNull();
     expect(cache.get("unknown")).toBeUndefined();
-  });
-});
-
-describe("resolveConfigScopedRuntimeCacheValue", () => {
-  it("caches values by config object and key", () => {
-    const cache: ConfigScopedRuntimeCache<string[]> = new WeakMap();
-    const config = {} as OpenClawConfig;
-    const load = vi.fn(() => ["loaded"]);
-
-    expect(resolveConfigScopedRuntimeCacheValue({ cache, config, key: "demo", load })).toEqual([
-      "loaded",
-    ]);
-    expect(resolveConfigScopedRuntimeCacheValue({ cache, config, key: "demo", load })).toEqual([
-      "loaded",
-    ]);
-    expect(load).toHaveBeenCalledOnce();
-  });
-
-  it("does not cache values without a config owner", () => {
-    const cache: ConfigScopedRuntimeCache<string> = new WeakMap();
-    const load = vi.fn(() => "loaded");
-
-    expect(resolveConfigScopedRuntimeCacheValue({ cache, key: "demo", load })).toBe("loaded");
-    expect(resolveConfigScopedRuntimeCacheValue({ cache, key: "demo", load })).toBe("loaded");
-    expect(load).toHaveBeenCalledTimes(2);
-  });
-
-  it("caches undefined values by key", () => {
-    const cache: ConfigScopedRuntimeCache<string | undefined> = new WeakMap();
-    const config = {} as OpenClawConfig;
-    const load = vi.fn(() => undefined);
-
-    expect(resolveConfigScopedRuntimeCacheValue({ cache, config, key: "missing", load })).toBe(
-      undefined,
-    );
-    expect(resolveConfigScopedRuntimeCacheValue({ cache, config, key: "missing", load })).toBe(
-      undefined,
-    );
-    expect(load).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/plugins/plugin-cache-primitives.ts
+++ b/src/plugins/plugin-cache-primitives.ts
@@ -49,37 +49,11 @@ export class PluginLruCache<T> {
   }
 }
 
-/** Runtime cache partitioned by config object identity so request-scoped configs do not collide. */
-export type ConfigScopedRuntimeCache<T> = WeakMap<OpenClawConfig, Map<string, T>>;
-
 /** Promise loader that coalesces concurrent loads per config object and for the default scope. */
 type ConfigScopedPromiseLoader<T> = {
   load(config?: OpenClawConfig): Promise<T>;
   clear(): void;
 };
-
-/** Resolves a config-scoped cached value; calls without config intentionally bypass caching. */
-export function resolveConfigScopedRuntimeCacheValue<T>(params: {
-  cache: ConfigScopedRuntimeCache<T>;
-  config?: OpenClawConfig;
-  key: string;
-  load: () => T;
-}): T {
-  if (!params.config) {
-    return params.load();
-  }
-  let configCache = params.cache.get(params.config);
-  if (!configCache) {
-    configCache = new Map();
-    params.cache.set(params.config, configCache);
-  }
-  if (configCache.has(params.key)) {
-    return configCache.get(params.key) as T;
-  }
-  const loaded = params.load();
-  configCache.set(params.key, loaded);
-  return loaded;
-}
 
 /** Encodes structured cache dimensions without separator ambiguity. */
 export function createPluginCacheKey(parts: readonly unknown[]): string {

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -1,4 +1,3 @@
-// Runtime bridge for invoking provider hooks supplied by plugins.
 import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -10,12 +9,6 @@ import {
   getLoadedRuntimePluginRegistry,
   registryContainsRuntimePluginIds,
 } from "./active-runtime-registry.js";
-import {
-  PluginLruCache,
-  resolveConfigScopedRuntimeCacheValue,
-  type ConfigScopedRuntimeCache,
-} from "./plugin-cache-primitives.js";
-import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import {
   resolveModelCatalogScope,
@@ -24,10 +17,7 @@ import {
 import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import { isPluginProvidersLoadInFlight, resolvePluginProvidersCore } from "./providers.runtime.js";
 import type { PluginRegistry } from "./registry-types.js";
-import {
-  getActivePluginRegistryWorkspaceDirFromState,
-  getPluginRegistryState,
-} from "./runtime-state.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
 import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
 import type {
@@ -37,9 +27,6 @@ import type {
   ProviderFollowupFallbackRouteResult,
   ProviderWrapStreamFnContext,
 } from "./types.js";
-
-const providerRuntimePluginCache: ConfigScopedRuntimeCache<ProviderPlugin | null> = new WeakMap();
-const defaultProviderRuntimePluginCache = new PluginLruCache<ProviderPlugin | null>(128);
 
 type ProviderRuntimePluginLookupParams = {
   provider: string;
@@ -68,17 +55,24 @@ type ProviderRuntimePluginHandleParams = ProviderRuntimePluginLookupParams & {
   runtimeHandle?: ProviderRuntimePluginHandle;
 };
 
+type ProviderHookParams<TContext> = {
+  provider: string;
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env?: NodeJS.ProcessEnv;
+  runtimeHandle?: ProviderRuntimePluginHandle;
+  context: TContext;
+};
+
 /** Carries one attempt's prepared provider plugin through the model transport boundary. */
 export function attachModelProviderRuntimePluginHandle<TModel extends object>(
   model: TModel,
   runtimeHandle: ProviderRuntimePluginHandle,
 ): TModel {
-  const next = attachModelProviderLocalServiceReconciler(
-    model,
-    runtimeHandle.plugin?.reconcileLocalService,
-  ) as TModel & ModelWithProviderRuntimePluginHandle;
-  next[MODEL_PROVIDER_RUNTIME_PLUGIN_HANDLE_SYMBOL] = runtimeHandle;
-  return next;
+  return Object.assign(
+    attachModelProviderLocalServiceReconciler(model, runtimeHandle.plugin?.reconcileLocalService),
+    { [MODEL_PROVIDER_RUNTIME_PLUGIN_HANDLE_SYMBOL]: runtimeHandle },
+  );
 }
 
 /** Reads the provider plugin handle attached to a prepared attempt model. */
@@ -88,31 +82,6 @@ export function getModelProviderRuntimePluginHandle(
   return model
     ? (model as ModelWithProviderRuntimePluginHandle)[MODEL_PROVIDER_RUNTIME_PLUGIN_HANDLE_SYMBOL]
     : undefined;
-}
-
-function resolveProviderRuntimePluginCacheKey(
-  params: ProviderRuntimePluginLookupParams,
-  registryState = getPluginRegistryState(),
-): string {
-  return JSON.stringify({
-    providerScope: [params.provider, params.providerOwner].map(normalizeLowercaseStringOrEmpty),
-    modelId: resolveProviderRuntimeLookupModelId(params) ?? null,
-    pluginControlPlane: resolvePluginControlPlaneFingerprint({
-      config: params.config,
-      env: params.env,
-      workspaceDir: params.workspaceDir,
-    }),
-    plugins: params.config?.plugins,
-    models: params.config?.models?.providers,
-    workspaceDir: params.workspaceDir ?? "",
-    applyAutoEnable: params.applyAutoEnable ?? null,
-    pluginMetadata:
-      params.pluginMetadataSnapshot?.manifestRegistry.plugins
-        .map((plugin) => plugin.id)
-        .join(",") ?? null,
-    pluginRegistryKey: registryState?.key ?? null,
-    pluginRegistryVersion: registryState?.activeVersion ?? null,
-  });
 }
 
 function matchesProviderLiteralId(provider: ProviderPlugin, providerId: string): boolean {
@@ -129,83 +98,32 @@ function resolveProviderRuntimeLookupModelId(
   );
 }
 
-function resolveProviderRuntimeLookupScope(
-  params: ProviderRuntimePluginLookupParams,
-  ownerRefs: readonly string[],
-): {
-  providerRefs: string[];
-  modelRefs?: string[];
-} {
-  const providerRefs = [params.provider, ...ownerRefs];
-  const modelId = resolveProviderRuntimeLookupModelId(params);
-  if (!modelId) {
-    return { providerRefs };
-  }
-  return {
-    providerRefs,
-    modelRefs: resolveModelCatalogScope({
-      cfg: params.config,
-      provider: params.provider,
-      model: modelId,
-    }).modelRefs,
-  };
-}
-
 function findProviderRuntimePluginInLoadedRegistries(params: {
   lookup: ProviderRuntimePluginLookupParams;
   ownerRefs: readonly string[];
 }): ProviderPlugin | undefined {
+  const find = (registry: PluginRegistry | undefined): ProviderPlugin | undefined => {
+    const entry = registry?.providers.find(({ provider: plugin }) =>
+      params.ownerRefs.length > 0
+        ? matchesProviderLiteralId(plugin, params.lookup.provider) ||
+          params.ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
+        : matchesProviderPluginRef(plugin, params.lookup.provider),
+    );
+    return entry ? Object.assign({}, entry.provider, { pluginId: entry.pluginId }) : undefined;
+  };
   const generationRegistry = getPluginRuntimeGenerationRegistry();
   if (generationRegistry) {
-    return findProviderRuntimePluginInRegistry({
-      registry: generationRegistry,
-      provider: params.lookup.provider,
-      ownerRefs: params.ownerRefs,
-    });
+    return find(generationRegistry);
   }
-  const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
-  const scopedPlugin = scopedRegistry
-    ? findProviderRuntimePluginInRegistry({
-        registry: scopedRegistry,
-        provider: params.lookup.provider,
-        ownerRefs: params.ownerRefs,
-      })
-    : undefined;
-  if (scopedPlugin) {
-    return scopedPlugin;
-  }
-  const activeRegistry = getLoadedRuntimePluginRegistry({
-    env: params.lookup.env,
-    workspaceDir: params.lookup.workspaceDir,
-  });
-  const activePlugin = activeRegistry
-    ? findProviderRuntimePluginInRegistry({
-        registry: activeRegistry,
-        provider: params.lookup.provider,
-        ownerRefs: params.ownerRefs,
-      })
-    : undefined;
-  if (activePlugin) {
-    return activePlugin;
-  }
-  return undefined;
-}
-
-function findProviderRuntimePluginInRegistry(params: {
-  registry: PluginRegistry;
-  provider: string;
-  ownerRefs: readonly string[];
-}): ProviderPlugin | undefined {
-  const entry = params.registry.providers.find(({ provider: plugin }) => {
-    if (params.ownerRefs.length > 0) {
-      return (
-        matchesProviderLiteralId(plugin, params.provider) ||
-        params.ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
-      );
-    }
-    return matchesProviderPluginRef(plugin, params.provider);
-  });
-  return entry ? Object.assign({}, entry.provider, { pluginId: entry.pluginId }) : undefined;
+  return (
+    find(getPluginRuntimeGatewayRequestScope()?.pluginRegistry) ??
+    find(
+      getLoadedRuntimePluginRegistry({
+        env: params.lookup.env,
+        workspaceDir: params.lookup.workspaceDir,
+      }),
+    )
+  );
 }
 
 function hasConfiguredModelProvider(params: {
@@ -314,50 +232,30 @@ export function resolveProviderRuntimePlugin(
   ) {
     return undefined;
   }
-  const cacheConfig = params.env && params.env !== process.env ? undefined : params.config;
-  const registryState = getPluginRegistryState();
-  const cacheKey = resolveProviderRuntimePluginCacheKey(lookup, registryState);
-  const load = () => {
-    const lookupScope = resolveProviderRuntimeLookupScope(params, ownerRefs);
-    return (
-      resolveProviderPluginsForHooks({
-        config: params.config,
-        workspaceDir,
-        env,
-        providerRefs: lookupScope.providerRefs,
-        modelRefs: lookupScope.modelRefs,
-        applyAutoEnable: params.applyAutoEnable,
-        pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-      }).find((plugin) => {
-        if (ownerRefs.length > 0) {
-          return (
-            matchesProviderLiteralId(plugin, params.provider) ||
-            ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
-          );
-        }
-        return matchesProviderPluginRef(plugin, params.provider);
-      }) ?? null
-    );
-  };
-  const plugin = cacheConfig
-    ? resolveConfigScopedRuntimeCacheValue({
-        cache: providerRuntimePluginCache,
-        config: cacheConfig,
-        key: cacheKey,
-        load,
-      })
-    : !registryState?.key
-      ? load()
-      : (() => {
-          const cached = defaultProviderRuntimePluginCache.get(cacheKey);
-          if (cached !== undefined) {
-            return cached;
-          }
-          const loaded = load();
-          defaultProviderRuntimePluginCache.set(cacheKey, loaded);
-          return loaded;
-        })();
-  return plugin ?? undefined;
+  const modelId = resolveProviderRuntimeLookupModelId(params);
+  return resolveProviderPluginsForHooks({
+    config: params.config,
+    workspaceDir,
+    env,
+    providerRefs,
+    modelRefs: modelId
+      ? resolveModelCatalogScope({
+          cfg: params.config,
+          provider: params.provider,
+          model: modelId,
+        }).modelRefs
+      : undefined,
+    applyAutoEnable: params.applyAutoEnable,
+    pluginMetadataSnapshot: params.pluginMetadataSnapshot,
+  }).find((plugin) => {
+    if (ownerRefs.length > 0) {
+      return (
+        matchesProviderLiteralId(plugin, params.provider) ||
+        ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
+      );
+    }
+    return matchesProviderPluginRef(plugin, params.provider);
+  });
 }
 
 export function resolveLoadedProviderRuntimePlugin(
@@ -398,20 +296,12 @@ export function resolveProviderHookPlugin(params: {
 export function resolveProviderRuntimePluginHandle(
   params: ProviderRuntimePluginLookupParams,
 ): ProviderRuntimePluginHandle {
-  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
-  const env = params.env;
-  const runtimePlugin = resolveProviderRuntimePlugin({
+  const lookup = {
     ...params,
-    workspaceDir,
-    env,
-  });
-
-  return {
-    ...params,
-    workspaceDir,
-    env,
-    plugin: runtimePlugin,
+    workspaceDir: params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState(),
+    env: params.env,
   };
+  return { ...lookup, plugin: resolveProviderRuntimePlugin(lookup) };
 }
 
 export function ensureProviderRuntimePluginHandle(
@@ -436,42 +326,27 @@ export function ensureProviderRuntimePluginHandle(
   return params.runtimeHandle;
 }
 
-export function resolveProviderAuthProfileId(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  runtimeHandle?: ProviderRuntimePluginHandle;
-  context: ProviderResolveAuthProfileIdContext;
-}): string | undefined {
+export function resolveProviderAuthProfileId(
+  params: ProviderHookParams<ProviderResolveAuthProfileIdContext>,
+): string | undefined {
   const resolved = ensureProviderRuntimePluginHandle(params).plugin?.resolveAuthProfileId?.(
     params.context,
   );
   return typeof resolved === "string" && resolved.trim() ? resolved.trim() : undefined;
 }
 
-export function resolveProviderFollowupFallbackRoute(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  runtimeHandle?: ProviderRuntimePluginHandle;
-  context: ProviderFollowupFallbackRouteContext;
-}): ProviderFollowupFallbackRouteResult | undefined {
+export function resolveProviderFollowupFallbackRoute(
+  params: ProviderHookParams<ProviderFollowupFallbackRouteContext>,
+): ProviderFollowupFallbackRouteResult | undefined {
   return (
     ensureProviderRuntimePluginHandle(params).plugin?.followupFallbackRoute?.(params.context) ??
     undefined
   );
 }
 
-export function wrapProviderSimpleCompletionStreamFn(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  runtimeHandle?: ProviderRuntimePluginHandle;
-  context: ProviderWrapStreamFnContext;
-}) {
+export function wrapProviderSimpleCompletionStreamFn(
+  params: ProviderHookParams<ProviderWrapStreamFnContext>,
+) {
   return (
     ensureProviderRuntimePluginHandle(params).plugin?.wrapSimpleCompletionStreamFn?.(
       params.context,

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1041,6 +1041,89 @@ describe("provider-runtime", () => {
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(2);
   });
 
+  it.each(["config", "default"] as const)(
+    "uses refreshed same-id metadata after %s runtime invalidation",
+    async (cacheOwner) => {
+      const config: OpenClawConfig | undefined = cacheOwner === "config" ? {} : undefined;
+      setActivePluginRegistry(
+        createEmptyPluginRegistry(),
+        "metadata-owner",
+        "default",
+        "/tmp/work",
+      );
+      const metadata = (source: string) =>
+        createPluginMetadataSnapshot({
+          config,
+          manifestRegistry: {
+            plugins: [
+              {
+                id: "same-provider-owner",
+                providers: [DEMO_PROVIDER_ID],
+                channels: [],
+                cliBackends: [],
+                skills: [],
+                hooks: [],
+                origin: "config",
+                rootDir: `/plugins/${source}`,
+                source: `/plugins/${source}/index.js`,
+                manifestPath: `/plugins/${source}/openclaw.plugin.json`,
+              },
+            ],
+            diagnostics: [],
+          },
+        });
+      const firstMetadata = metadata("first");
+      const currentMetadata = metadata("current");
+      const provider = (owner: string): ProviderPlugin => ({
+        id: DEMO_PROVIDER_ID,
+        label: owner,
+        auth: [],
+        resolveAuthProfileId: (context) => `${owner}/${context.preferredProfileId}`,
+      });
+      const firstProvider = provider("first");
+      const currentProvider = provider("current");
+      resolvePluginProvidersMock.mockImplementation((params) =>
+        params.pluginMetadataSnapshot === firstMetadata ? [firstProvider] : [currentProvider],
+      );
+      const context = {
+        provider: DEMO_PROVIDER_ID,
+        modelId: MODEL.id,
+        preferredProfileId: "first-profile",
+        profileOrder: [],
+        authStore: { version: 1 as const, profiles: {} },
+      };
+      const first = resolveProviderRuntimePlugin({
+        provider: DEMO_PROVIDER_ID,
+        config,
+        pluginMetadataSnapshot: firstMetadata,
+      });
+      expect(first?.resolveAuthProfileId?.(context)).toBe("first/first-profile");
+      const { invalidatePluginRuntimeDiscoveryAfterConfigMutation } =
+        await import("./registry-refresh.js");
+      const warnings: string[] = [];
+      await invalidatePluginRuntimeDiscoveryAfterConfigMutation({
+        logger: { warn: (message) => warnings.push(message) },
+      });
+      expect(warnings).toEqual([]);
+      const current = resolveProviderRuntimePlugin({
+        provider: DEMO_PROVIDER_ID,
+        config,
+        pluginMetadataSnapshot: currentMetadata,
+      });
+      expect(
+        current?.resolveAuthProfileId?.({ ...context, preferredProfileId: "current-profile" }),
+      ).toBe("current/current-profile");
+      // The already-prepared handle owns its selected plugin, while credential inputs stay per-call.
+      expect(
+        resolveProviderAuthProfileId({
+          provider: DEMO_PROVIDER_ID,
+          runtimeHandle: { provider: DEMO_PROVIDER_ID, plugin: first },
+          context: { ...context, preferredProfileId: "current-profile" },
+        }),
+      ).toBe("first/current-profile");
+    },
+  );
+
   it("does not reuse runtime provider cache entries across env-resolved plugin roots", () => {
     const firstProvider: ProviderPlugin = {
       id: DEMO_PROVIDER_ID,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where provider preparation could keep selecting old plugin hooks after runtime discovery was explicitly refreshed, when the plugin kept the same ID and configuration. Updating the package entry could leave auth or model behavior attached to the previous owner.

## Why This Change Was Made

The registry loader now owns provider lookup reuse, so its existing invalidation also governs subsequent hook selection. This removes duplicate config/default caches and their unused helper while preserving prepared-generation, loaded-registry, alias and model-owner selection. Production code decreases by 151 lines.

## User Impact

Unprepared provider lookups follow refreshed metadata after runtime-discovery invalidation. Existing prepared handles and generations retain their selected provider, with current context supplied to each hook call.

## Evidence

- Both config/default regression cases failed on the original code after the actual runtime invalidation boundary; 107 tests across four owner/sibling suites pass after the change.
- A real generated-provider filesystem probe reproduced stale selection on the original code. The candidate refreshes a same-ID package entry through the existing metadata/registry owners without changing the root generation. Repeated lookups produce exactly two registrations across two entries; five hook effects prove refreshed selection, prepared owner retention and current profile-selection input. Empty generation remains authoritative.
- Full changed-file checks and independent P2 review passed, including production/test typechecks, typed lint, dead exports and import-cycle guards.

The filesystem probe uses synthetic local state and profile identifiers. It does not claim Gateway reload, external authentication/inference, or new callback-revocation behavior.

Related: #135599. This is an independently landable provider-owner cleanup from that lifecycle work.
