### PR TITLE
fix: directory and search results disappear in Code Mode

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -825,6 +825,11 @@ Calling a global or catalog handle returns the normal tool's JSON `details`
 value directly. Exact catalog ids and raw `{ tool, result }` envelopes are not
 guest-visible.
 
+The `ls`, `find`, and `grep` tools include their bounded listing or search text
+in `content`, including empty-result messages and truncation notices. Directory
+pages retain `nextAfter`; search results retain their existing limit and
+truncation metadata.
+
 ## Declared output contracts
 
 OpenClaw tools can declare `outputSchema` for the structured value placed in

--- a/src/agents/filesystem-tools-output-contract.test.ts
+++ b/src/agents/filesystem-tools-output-contract.test.ts
@@ -6,7 +6,16 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createOpenClawReadTool } from "./agent-tools.read.js";
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { createApplyPatchTool } from "./apply-patch.js";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import {
+  createCodeModeHarness,
+  resetCodeModeTestState,
+  runUntilCompleted,
+} from "./code-mode.test-support.js";
 import { createEditTool, createReadTool, createWriteTool } from "./sessions/index.js";
+import { createFindTool } from "./sessions/tools/find.js";
+import { createGrepTool } from "./sessions/tools/grep.js";
+import { createLsTool } from "./sessions/tools/ls.js";
 import { DEFAULT_MAX_BYTES } from "./sessions/tools/truncate.js";
 import { compactToolOutputHint } from "./tool-schema-hints.js";
 
@@ -18,6 +27,16 @@ function expectContract(tool: AnyAgentTool, details: unknown): void {
   expect(Value.Check(tool.outputSchema!, details)).toBe(true);
 }
 
+async function callThroughCodeMode(tool: AnyAgentTool, args: Record<string, unknown>) {
+  const harness = createCodeModeHarness();
+  applyCodeModeCatalog({ ...harness.ctx, tools: [...harness.tools, tool] });
+  return await runUntilCompleted({
+    execTool: harness.tools[0]!,
+    waitTool: harness.tools[1]!,
+    code: `return await ${tool.name}(${JSON.stringify(args)});`,
+  });
+}
+
 describe("filesystem tool output contracts", () => {
   let tmpDir = "";
 
@@ -26,8 +45,115 @@ describe("filesystem tool output contracts", () => {
   });
 
   afterEach(async () => {
+    resetCodeModeTestState();
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
+
+  it.each([
+    { mode: "empty", files: [], args: {}, output: "(empty directory)" },
+    {
+      mode: "complete",
+      files: ["alpha.txt", "beta.txt"],
+      args: {},
+      output: '"alpha.txt"\n"beta.txt"',
+    },
+    {
+      mode: "paged",
+      files: ["alpha.txt", "beta.txt"],
+      args: { limit: 1 },
+      output: '"alpha.txt"\n\n[More entries. Continue with the same path and after="alpha.txt".]',
+      nextAfter: "alpha.txt",
+    },
+  ])(
+    "preserves $mode directory output through Code Mode",
+    async ({ files, args, output, nextAfter }) => {
+      await Promise.all(files.map((file) => fs.writeFile(path.join(tmpDir, file), "fixture\n")));
+      const tool = createLsTool(tmpDir) as unknown as AnyAgentTool;
+      const direct = await tool.execute("direct-ls", args);
+      const result = await callThroughCodeMode(tool, args);
+
+      expect(direct.content).toEqual([{ type: "text", text: output }]);
+      expect(result).toMatchObject({
+        status: "completed",
+        value: { content: output, ...(nextAfter === undefined ? {} : { nextAfter }) },
+      });
+    },
+  );
+
+  it.each([
+    { mode: "matching", files: ["alpha.txt"], limit: 10, content: "alpha.txt" },
+    { mode: "empty", files: [], limit: 10, content: "No files found matching pattern" },
+    {
+      mode: "limited",
+      files: ["alpha.txt", "beta.txt"],
+      limit: 1,
+      content: "alpha.txt\n\n[1 results limit reached]",
+      resultLimitReached: 1,
+    },
+  ])(
+    "preserves $mode file search output through Code Mode",
+    async ({ files, limit, content, resultLimitReached }) => {
+      await Promise.all(files.map((file) => fs.writeFile(path.join(tmpDir, file), "fixture\n")));
+      const tool = createFindTool(tmpDir, {
+        operations: {
+          exists: (absolutePath) =>
+            fs.access(absolutePath).then(
+              () => true,
+              () => false,
+            ),
+          glob: async (pattern, cwd, options) => {
+            const matches: string[] = [];
+            for await (const match of fs.glob(pattern, { cwd })) {
+              matches.push(match);
+            }
+            return matches.toSorted().slice(0, options.limit);
+          },
+        },
+      }) as unknown as AnyAgentTool;
+      const args = { pattern: "*.txt", limit };
+      const direct = await tool.execute("direct-find", args);
+      const result = await callThroughCodeMode(tool, args);
+
+      expect(direct.content).toEqual([{ type: "text", text: content }]);
+      expect(result).toMatchObject({
+        status: "completed",
+        value: { content, ...(resultLimitReached === undefined ? {} : { resultLimitReached }) },
+      });
+    },
+  );
+
+  it.each([
+    {
+      mode: "matching",
+      pattern: "needle",
+      limit: 10,
+      content: "sample.txt:1: needle alpha\nsample.txt:2: needle beta",
+    },
+    { mode: "empty", pattern: "absent", limit: 10, content: "No matches found" },
+    {
+      mode: "limited",
+      pattern: "needle",
+      limit: 1,
+      content:
+        "sample.txt:1: needle alpha\n\n[1 matches limit reached. Use limit=2 for more, or refine pattern]",
+      matchLimitReached: 1,
+    },
+  ])(
+    "preserves $mode text search output through Code Mode",
+    async ({ pattern, limit, content, matchLimitReached }) => {
+      await fs.writeFile(path.join(tmpDir, "sample.txt"), "needle alpha\nneedle beta\n");
+      const tool = createGrepTool(tmpDir) as unknown as AnyAgentTool;
+      const args = { pattern, limit };
+      const direct = await tool.execute("direct-grep", args);
+      const result = await callThroughCodeMode(tool, args);
+
+      expect(direct.content).toEqual([{ type: "text", text: content }]);
+      expect(result).toMatchObject({
+        status: "completed",
+        value: { content, ...(matchLimitReached === undefined ? {} : { matchLimitReached }) },
+      });
+    },
+  );
 
   it("validates read text, image, truncation, and optional-not-found results", async () => {
     await fs.writeFile(path.join(tmpDir, "notes.txt"), "ordinary text\n", "utf8");

--- a/src/agents/sessions/tools/find.fd.test.ts
+++ b/src/agents/sessions/tools/find.fd.test.ts
@@ -99,7 +99,7 @@ it.each([false, true])("preserves fd paths with trailing search separator=%s", a
       process.platform === "win32" ? "literal/" : "literal\\",
     ].join("\n"),
   );
-  expect(result.details).toBeUndefined();
+  expect(result.details).toEqual({ content: textContent(result) });
 });
 
 it("keeps multibyte stderr intact when pipe chunks split a character", async () => {

--- a/src/agents/sessions/tools/find.test.ts
+++ b/src/agents/sessions/tools/find.test.ts
@@ -87,7 +87,7 @@ describe("find tool", () => {
       {} as never,
     );
     expect(textContent(result)).toBe(expected);
-    expect(result.details).toBeUndefined();
+    expect(result.details).toEqual({ content: expected });
   });
 
   it("rejects fractional limits", async () => {
@@ -118,7 +118,7 @@ describe("find tool", () => {
     const result = await execute(tool, Number.POSITIVE_INFINITY);
 
     expect(textContent(result)).toBe("a.ts\nb.ts");
-    expect(result.details).toBeUndefined();
+    expect(result.details).toEqual({ content: "a.ts\nb.ts" });
   });
 
   it.each([

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -122,7 +122,7 @@ function buildFindResult(params: {
   limitNotice: string;
 }): {
   content: Array<{ type: "text"; text: string }>;
-  details: FindToolDetails | undefined;
+  details: FindToolDetails;
 } {
   const resultLimitReached = params.paths.length > params.effectiveLimit;
   const rawOutput = params.paths
@@ -141,7 +141,7 @@ function buildFindResult(params: {
     .join("\n");
   const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
   let resultOutput = truncation.content;
-  const details: FindToolDetails = {};
+  const details: Omit<FindToolDetails, "content"> = {};
   const notices: string[] = [];
   if (resultLimitReached) {
     notices.push(params.limitNotice);
@@ -156,14 +156,14 @@ function buildFindResult(params: {
   }
   return {
     content: [{ type: "text", text: resultOutput }],
-    details: Object.keys(details).length > 0 ? details : undefined,
+    details: { ...details, content: resultOutput },
   };
 }
 
 export function createFindToolDefinition(
   cwd: string,
   options?: FindToolOptions,
-): ToolDefinition<typeof findSchema, FindToolDetails | undefined> {
+): ToolDefinition<typeof findSchema, FindToolDetails> {
   const customOps = options?.operations;
   const resolvePath = customOps ? resolveToCwd : resolveLocalPathToCwd;
   return {
@@ -239,7 +239,7 @@ export function createFindToolDefinition(
                 settle(() =>
                   resolve({
                     content: [{ type: "text", text: "No files found matching pattern" }],
-                    details: undefined,
+                    details: { content: "No files found matching pattern" },
                   }),
                 );
                 return;
@@ -358,7 +358,7 @@ export function createFindToolDefinition(
                 settle(() =>
                   resolve({
                     content: [{ type: "text", text: "No files found matching pattern" }],
-                    details: undefined,
+                    details: { content: "No files found matching pattern" },
                   }),
                 );
                 return;
@@ -399,6 +399,6 @@ export function createFindToolDefinition(
 export function createFindTool(
   cwd: string,
   options?: FindToolOptions,
-): AgentTool<typeof findSchema> {
+): AgentTool<typeof findSchema, FindToolDetails> {
   return wrapToolDefinition(createFindToolDefinition(cwd, options));
 }

--- a/src/agents/sessions/tools/grep.byte-path.test.ts
+++ b/src/agents/sessions/tools/grep.byte-path.test.ts
@@ -38,7 +38,7 @@ it.skipIf(process.platform !== "linux")(
           `report-�.txt-1- before ${index}\nreport-�.txt:2: needle ${index}\nreport-�.txt-3- after ${index}`,
         );
       }
-      expect(result.details).toBeUndefined();
+      expect(result.details).toEqual({ content: text });
     } finally {
       // Cleanup uses the same lossless paths that created the synthetic files.
       await Promise.all(paths.map((filePath) => fs.rm(filePath, { force: true })));

--- a/src/agents/sessions/tools/grep.stream-errors.test.ts
+++ b/src/agents/sessions/tools/grep.stream-errors.test.ts
@@ -192,7 +192,10 @@ describe("grep tool streaming", () => {
           ? "\n\n[1 matches limit reached. Use limit=2 for more, or refine pattern]"
           : ""),
     );
-    expect(result.details).toEqual(limit === 1 ? { matchLimitReached: 1 } : undefined);
+    expect(result.details).toEqual({
+      content: textContent(result),
+      ...(limit === 1 ? { matchLimitReached: 1 } : {}),
+    });
     expect(child.killed).toBe(limit === 1);
   });
 
@@ -275,7 +278,7 @@ describe("grep tool streaming", () => {
           text: `sample.txt-1- ${encoding === "byte-form" ? "before�" : "before"}\nsample.txt:2: ${encoding === "byte-form" ? "needle�" : "needle中"}\nsample.txt-3- after`,
         },
       ]);
-      expect(result.details).toBeUndefined();
+      expect(result.details).toEqual({ content: textContent(result) });
       expect(vi.mocked(spawnCommand).mock.calls[0]?.[0]).toEqual(
         expect.arrayContaining(["--context", "1"]),
       );
@@ -322,7 +325,7 @@ describe("grep tool streaming", () => {
     expect(textContent(result)).toBe(
       `sample.txt-1- before\nsample.txt:2: foo retained\nsample.txt-3- ${lines[2]}\nsample.txt-4- ${lines[3]}\n\n[1 matches limit reached. Use limit=2 for more, or refine pattern]`,
     );
-    expect(result.details).toEqual({ matchLimitReached: 1 });
+    expect(result.details).toEqual({ content: textContent(result), matchLimitReached: 1 });
   });
 
   it("keeps exact-limit overlapping windows in match order", async () => {
@@ -353,7 +356,7 @@ describe("grep tool streaming", () => {
     expect(textContent(result)).toBe(
       "match.txt-1- before\nmatch.txt:2: foo first\nmatch.txt-3- foo second\nmatch.txt-2- foo first\nmatch.txt:3: foo second\nmatch.txt-4- after",
     );
-    expect(result.details).toBeUndefined();
+    expect(result.details).toEqual({ content: textContent(result) });
     expect(child.killed).toBe(false);
   });
 
@@ -527,7 +530,7 @@ describe("grep tool streaming", () => {
 
       const result = await resultPromise;
       expect(result.content).toEqual([{ type: "text", text: expected.join("\n") }]);
-      expect(result.details).toBeUndefined();
+      expect(result.details).toEqual({ content: expected.join("\n") });
     },
   );
 

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -130,7 +130,7 @@ function formatGrepResult(
 export function createGrepToolDefinition(
   cwd: string,
   options?: GrepToolOptions,
-): ToolDefinition<typeof grepSchema, GrepToolDetails | undefined> {
+): ToolDefinition<typeof grepSchema, GrepToolDetails> {
   const customOps = options?.operations;
   const resolvePath = customOps ? resolveToCwd : resolveLocalPathToCwd;
   return {
@@ -455,7 +455,7 @@ export function createGrepToolDefinition(
                   settle(() =>
                     resolve({
                       content: [{ type: "text", text: "No matches found" }],
-                      details: undefined,
+                      details: { content: "No matches found" },
                     }),
                   );
                   return;
@@ -512,7 +512,7 @@ export function createGrepToolDefinition(
                 // Apply byte truncation. There is no line limit here because the match limit already capped rows.
                 const truncation = truncateHead(rawOutput, { maxLines: Number.MAX_SAFE_INTEGER });
                 let output = truncation.content;
-                const details: GrepToolDetails = {};
+                const details: Omit<GrepToolDetails, "content"> = {};
                 // Build actionable notices for truncation and match limits.
                 const notices: string[] = [];
                 if (matchLimitReached) {
@@ -535,7 +535,7 @@ export function createGrepToolDefinition(
                 settle(() =>
                   resolve({
                     content: [{ type: "text", text: output }],
-                    details: Object.keys(details).length > 0 ? details : undefined,
+                    details: { ...details, content: output },
                   }),
                 );
               })().catch((err: unknown) => {
@@ -563,6 +563,6 @@ export function createGrepToolDefinition(
 export function createGrepTool(
   cwd: string,
   options?: GrepToolOptions,
-): AgentTool<typeof grepSchema> {
+): AgentTool<typeof grepSchema, GrepToolDetails> {
   return wrapToolDefinition(createGrepToolDefinition(cwd, options));
 }

--- a/src/agents/sessions/tools/ls.test.ts
+++ b/src/agents/sessions/tools/ls.test.ts
@@ -129,7 +129,7 @@ describe("ls tool", () => {
 
     const dangling = await list();
     expect(dangling.content).toEqual([{ type: "text", text: '"a-broken"' }]);
-    expect(dangling.details).toBeUndefined();
+    expect(dangling.details).toEqual({ content: '"a-broken"' });
 
     await fs.mkdir(path.join(cwd, "target-dir"));
     await fs.symlink(path.join(cwd, "target-dir"), path.join(cwd, "link-to-dir"), symlinkType);
@@ -140,7 +140,7 @@ describe("ls tool", () => {
 
     const limited = await list(1);
     expect(textContent(limited).split("\n")[0]).toBe('"a-broken"');
-    expect(limited.details).toEqual({ nextAfter: "a-broken" });
+    expect(limited.details).toEqual({ content: textContent(limited), nextAfter: "a-broken" });
   });
 
   it("clamps non-positive limits instead of reporting a non-empty directory as empty", async () => {
@@ -163,7 +163,7 @@ describe("ls tool", () => {
     const result = await tool.execute("call-1", { limit: Number.NaN });
 
     expect(textContent(result)).toBe('"alpha.txt"\n"beta.txt"');
-    expect(result.details).toBeUndefined();
+    expect(result.details).toEqual({ content: '"alpha.txt"\n"beta.txt"' });
   });
 
   it("preserves a directory read failure and releases the abort listener", async () => {

--- a/src/agents/sessions/tools/ls.ts
+++ b/src/agents/sessions/tools/ls.ts
@@ -82,7 +82,7 @@ function formatLsContinuation(after: string): string {
 export function createLsToolDefinition(
   cwd: string,
   options?: LsToolOptions,
-): ToolDefinition<typeof lsSchema, LsToolDetails | undefined> {
+): ToolDefinition<typeof lsSchema, LsToolDetails> {
   const ops = options?.operations ?? defaultLsOperations;
   const resolvePath = options?.operations ? resolveToCwd : resolveLocalPathToCwd;
   return {
@@ -120,7 +120,7 @@ export function createLsToolDefinition(
           if (entries.length === 0) {
             return {
               content: [{ type: "text" as const, text: "(empty directory)" }],
-              details: undefined,
+              details: { content: "(empty directory)" },
             };
           }
           const fitsPage = (text: string) =>
@@ -150,7 +150,7 @@ export function createLsToolDefinition(
             if (fitsPage(output)) {
               return {
                 content: [{ type: "text" as const, text: output }],
-                details: nextAfter === undefined ? undefined : { nextAfter },
+                details: { content: output, ...(nextAfter === undefined ? {} : { nextAfter }) },
               };
             }
             lines.pop();
@@ -196,6 +196,6 @@ export function createLsToolDefinition(
 export function createLsTool(
   cwd: string,
   options?: LsToolOptions,
-): AgentTool<typeof lsSchema, LsToolDetails | undefined> {
+): AgentTool<typeof lsSchema, LsToolDetails> {
   return wrapToolDefinition(createLsToolDefinition(cwd, options));
 }

--- a/src/agents/sessions/tools/tool-contracts.ts
+++ b/src/agents/sessions/tools/tool-contracts.ts
@@ -47,6 +47,7 @@ export interface FindToolInput {
 }
 
 export interface FindToolDetails {
+  content: string;
   truncation?: TruncationResult;
   resultLimitReached?: number;
 }
@@ -62,6 +63,7 @@ export interface GrepToolInput {
 }
 
 export interface GrepToolDetails {
+  content: string;
   truncation?: TruncationResult;
   matchLimitReached?: number;
   linesTruncated?: boolean;
@@ -74,6 +76,7 @@ export interface LsToolInput {
 }
 
 export interface LsToolDetails {
+  content: string;
   nextAfter?: string;
 }
 


### PR DESCRIPTION
Related: #110395, #139725

## What Problem This Solves

Fixes an issue where agents listing directories or searching files in Code Mode received `null` or metadata without the actual results. This could trigger repeated searches and prevent otherwise successful tools from advancing the task.

## Why This Change Was Made

The `ls`, `find`, and `grep` producers now include their final bounded text in `details.content`, following the filesystem read contract. Directory cursors, search limits, truncation metadata, empty-result messages, and normal visible output are preserved. The shared bridge continues projecting the producer's structured result.

## User Impact

Code Mode can observe directory listings and file/content search results, including continuation and limit notices. Release note: preserve filesystem discovery results through Code Mode.

## Evidence

Nine synthetic Code Mode regressions demonstrated the loss before the repair: empty, complete, and paginated directory listings; matching, empty, and limited file and text searches. The file-search integration uses real filesystem globbing through the existing custom-operations interface; text search runs real ripgrep.

After repair, 105 focused tests passed across the filesystem contract and discovery-tool suites. One existing Linux-only byte-filename case is skipped on macOS. Fresh independent Codex review is scoped-clean for P0–P2.

The full changed-file gate passed, including core and core-test typechecks, lint, dead-export scans, import-cycle checks, formatting, and repository guards. The final contract test file also passed all 13 cases after two test-only lint corrections. Controlled candidate benchmark results will be recorded separately; these regression results do not claim a benchmark score improvement.
