### PR TITLE
refactor(memory-wiki): share CLI and tool result presentation

### DIFF
--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -1,4 +1,3 @@
-// Memory Wiki plugin module implements cli behavior.
 import fs from "node:fs/promises";
 import type { Command } from "commander";
 import { callGatewayFromCli } from "openclaw/plugin-sdk/gateway-runtime";
@@ -36,6 +35,7 @@ import {
   runObsidianSearch,
 } from "./obsidian.js";
 import { formatOkfImportSummary, importMemoryWikiOkfBundle } from "./okf.js";
+import { renderWikiMutationSummary, renderWikiSearchResults } from "./presentation.js";
 import {
   getMemoryWikiPage,
   searchMemoryWiki,
@@ -386,15 +386,6 @@ async function resolveWikiApplyBody(params: { body?: string; bodyFile?: string }
   throw new Error("wiki apply synthesis requires --body or --body-file.");
 }
 
-type MemoryWikiMutationResult = Awaited<ReturnType<typeof applyMemoryWikiMutation>>;
-
-function formatMemoryWikiMutationSummary(result: MemoryWikiMutationResult, json?: boolean): string {
-  if (json) {
-    return JSON.stringify(result, null, 2);
-  }
-  return `${result.changed ? "Updated" : "No changes for"} ${result.pagePath} via ${result.operation}. ${result.compile.updatedFiles.length > 0 ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.` : "Indexes unchanged."}`;
-}
-
 function formatJsonOrText<T>(
   result: T,
   json: boolean | undefined,
@@ -653,17 +644,7 @@ async function runWikiSearch(params: {
     searchCorpus: params.searchCorpus,
     mode: params.mode,
   });
-  const summary = params.json
-    ? JSON.stringify(results, null, 2)
-    : results.length === 0
-      ? "No wiki or memory results."
-      : results
-          .map(
-            (result, index) =>
-              `${index + 1}. ${result.title} (${result.corpus}/${result.kind})\nPath: ${result.path}${typeof result.startLine === "number" && typeof result.endLine === "number" ? `\nLines: ${result.startLine}-${result.endLine}` : ""}${result.provenanceLabel ? `\nProvenance: ${result.provenanceLabel}` : ""}${result.matchedClaimId ? `\nClaim: ${result.matchedClaimId}` : ""}${result.evidenceKinds && result.evidenceKinds.length > 0 ? `\nEvidence: ${result.evidenceKinds.join(", ")}` : ""}\nSnippet: ${result.snippet}`,
-          )
-          .join("\n\n");
-  writeOutput(summary, params.stdout);
+  writeOutput(formatJsonOrText(results, params.json, renderWikiSearchResults), params.stdout);
   return results;
 }
 
@@ -734,7 +715,7 @@ async function runWikiApplySynthesis(params: {
       ...(params.status?.trim() ? { status: params.status.trim() } : {}),
     },
   });
-  writeOutput(formatMemoryWikiMutationSummary(result, params.json), params.stdout);
+  writeOutput(formatJsonOrText(result, params.json, renderWikiMutationSummary), params.stdout);
   return result;
 }
 
@@ -774,7 +755,7 @@ async function runWikiApplyMetadata(params: {
       ...(params.status?.trim() ? { status: params.status.trim() } : {}),
     },
   });
-  writeOutput(formatMemoryWikiMutationSummary(result, params.json), params.stdout);
+  writeOutput(formatJsonOrText(result, params.json, renderWikiMutationSummary), params.stdout);
   return result;
 }
 

--- a/extensions/memory-wiki/src/presentation.ts
+++ b/extensions/memory-wiki/src/presentation.ts
@@ -1,0 +1,20 @@
+import type { applyMemoryWikiMutation } from "./apply.js";
+import type { searchMemoryWiki } from "./query.js";
+
+type WikiSearchResults = Awaited<ReturnType<typeof searchMemoryWiki>>;
+type WikiMutationResult = Awaited<ReturnType<typeof applyMemoryWikiMutation>>;
+
+export function renderWikiSearchResults(results: WikiSearchResults): string {
+  return results.length === 0
+    ? "No wiki or memory results."
+    : results
+        .map(
+          (result, index) =>
+            `${index + 1}. ${result.title} (${result.corpus}/${result.kind})\nPath: ${result.path}${typeof result.startLine === "number" && typeof result.endLine === "number" ? `\nLines: ${result.startLine}-${result.endLine}` : ""}${result.provenanceLabel ? `\nProvenance: ${result.provenanceLabel}` : ""}${result.matchedClaimId ? `\nClaim: ${result.matchedClaimId}` : ""}${result.evidenceKinds && result.evidenceKinds.length > 0 ? `\nEvidence: ${result.evidenceKinds.join(", ")}` : ""}\nSnippet: ${result.snippet}`,
+        )
+        .join("\n\n");
+}
+
+export function renderWikiMutationSummary(result: WikiMutationResult): string {
+  return `${result.changed ? "Updated" : "No changes for"} ${result.pagePath} via ${result.operation}. ${result.compile.updatedFiles.length > 0 ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.` : "Indexes unchanged."}`;
+}

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -1,4 +1,3 @@
-// Memory Wiki plugin module implements tool behavior.
 import path from "node:path";
 import { optionalFiniteNumberSchema } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
@@ -13,6 +12,7 @@ import {
   type ResolvedMemoryWikiConfig,
 } from "./config.js";
 import { lintMemoryWikiVault } from "./lint.js";
+import { renderWikiMutationSummary, renderWikiSearchResults } from "./presentation.js";
 import { getMemoryWikiPage, searchMemoryWiki, WIKI_SEARCH_MODES } from "./query.js";
 import { syncMemoryWikiImportedSources } from "./source-sync.js";
 import { renderMemoryWikiStatus, resolveMemoryWikiStatus } from "./status.js";
@@ -179,16 +179,7 @@ export function createWikiSearchTool(
         ...(params.corpus ? { searchCorpus: params.corpus } : {}),
         ...(params.mode ? { mode: params.mode } : {}),
       });
-      const text =
-        results.length === 0
-          ? "No wiki or memory results."
-          : results
-              .map(
-                (result, index) =>
-                  `${index + 1}. ${result.title} (${result.corpus}/${result.kind})\nPath: ${result.path}${typeof result.startLine === "number" && typeof result.endLine === "number" ? `\nLines: ${result.startLine}-${result.endLine}` : ""}${result.provenanceLabel ? `\nProvenance: ${result.provenanceLabel}` : ""}${result.matchedClaimId ? `\nClaim: ${result.matchedClaimId}` : ""}${result.evidenceKinds && result.evidenceKinds.length > 0 ? `\nEvidence: ${result.evidenceKinds.join(", ")}` : ""}\nSnippet: ${result.snippet}`,
-              )
-              .join("\n\n");
-      return textResult(text, { results });
+      return textResult(renderWikiSearchResults(results), { results });
     },
   };
 }
@@ -252,15 +243,7 @@ export function createWikiApplyTool(
         mutation,
         ...(signal ? { signal } : {}),
       });
-      const action = result.changed ? "Updated" : "No changes for";
-      const compileSummary =
-        result.compile.updatedFiles.length > 0
-          ? `Refreshed ${result.compile.updatedFiles.length} index file${result.compile.updatedFiles.length === 1 ? "" : "s"}.`
-          : "Indexes unchanged.";
-      return textResult(
-        `${action} ${result.pagePath} via ${result.operation}. ${compileSummary}`,
-        result,
-      );
+      return textResult(renderWikiMutationSummary(result), result);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Wiki CLI and tool responses independently format the same search metadata and mutation summaries. Keeping separate copies of provenance, claim, evidence and index-update wording makes those user-facing outputs prone to drift.

## Why This Change Was Made

Put both text renderers in one pure plugin-local presentation module, with types derived from their existing producers. The CLI retains its existing JSON selection and final-newline writer; tools retain their existing text/result envelopes. Remove the old duplicate formatters and two generic file-header comments. No query, mutation, synchronization, storage or visibility behavior changes.

## User Impact

Search text, result ordering, optional metadata, mutation summaries, CLI JSON and tool details remain unchanged. The three-file diff removes 16 production lines without adding tests, dependencies or public SDK exports.

## Evidence

The same 90 existing CLI, tool and query tests passed before and after. Separately, 400 exact presentation comparisons over ordinary prepared results checked text, JSON, newlines and envelopes using the frozen original and extracted presentation blocks; these are pure comparisons, not 400 full product runs.

All 24 selected changed-check phases passed, including type checks, formatting, lint, package boundaries, dead exports and runtime import-cycle checks. Independent managed review covered all three files and found no actionable issue. Fresh exact-head CI remains required before landing. No live operator vault or full product build was used.

## Data-model compatibility proof

- [x] **Add data-model compatibility proof:** No persisted data model, schema, migration, embedding metadata or write-path changes are introduced. The full diff is limited to `cli.ts`, `tool.ts` and the new pure `presentation.ts`; the query, mutation, configuration, source-sync, compile and mutation-coordinator modules are byte-identical to the base.

The new module imports its producer functions only as types. Its inputs are their unchanged return types, and its functions only return text. Existing CLI `formatJsonOrText` and `writeOutput` implementations are byte-identical; JSON still serializes the original result with two-space indentation, and tools retain the original details objects. The same 90 fixture CLI/tool/query tests passed before and after, with 400 additional exact presentation/JSON/newline/envelope comparisons. No data rewrite or migration is required for this presentation extraction.

This addresses the review's compatibility item with source and serialized-output preservation proof. Its file-level stored-data classification does not identify an introduced stored-data change. Exact-head [CI 34020430912](https://github.com/openclaw/openclaw/actions/runs/34020430912) passed all 29 selected jobs (17 skipped). No live operator vault or simulated upgrade is claimed.
