### PR TITLE
refactor(apns): share registration deletion transaction

### DIFF
--- a/src/infra/push-apns-store.ts
+++ b/src/infra/push-apns-store.ts
@@ -18,7 +18,10 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
-import { nextApnsRegistrationVersion } from "./push-apns-store-transaction.js";
+import {
+  clearApnsRegistrationFromDatabase,
+  nextApnsRegistrationVersion,
+} from "./push-apns-store-transaction.js";
 import {
   normalizeApnsRelayBaseUrl,
   normalizePersistedApnsRelayBaseUrl,
@@ -617,32 +620,6 @@ export async function clearApnsRegistrationIfCurrent(params: {
     ) {
       return false;
     }
-    const tombstone = executeSqliteQueryTakeFirstSync(
-      db,
-      stateDb
-        .selectFrom("apns_registration_tombstones")
-        .select("deleted_at_ms")
-        .where("node_id", "=", normalizedNodeId),
-    );
-    const previousVersions = [currentRow.updated_at_ms, tombstone?.deleted_at_ms].filter(
-      (version): version is number => version !== undefined,
-    );
-    const deletedAtMs = nextApnsRegistrationVersion(normalizedNodeId, previousVersions);
-    // Doctor may not have retired the old JSON yet. This durable tombstone
-    // prevents that stale source from restoring an invalidated registration.
-    executeSqliteQuerySync(
-      db,
-      stateDb
-        .insertInto("apns_registration_tombstones")
-        .values({ node_id: normalizedNodeId, deleted_at_ms: deletedAtMs })
-        .onConflict((conflict) =>
-          conflict.column("node_id").doUpdateSet({ deleted_at_ms: deletedAtMs }),
-        ),
-    );
-    executeSqliteQuerySync(
-      db,
-      stateDb.deleteFrom("apns_registrations").where("node_id", "=", normalizedNodeId),
-    );
-    return true;
+    return clearApnsRegistrationFromDatabase(db, normalizedNodeId);
   }, apnsStateDatabaseOptions(params.baseDir));
 }


### PR DESCRIPTION
## What Problem This Solves

APNs registration invalidation maintained a second copy of the tombstone, version, and row-deletion transaction already owned by the registration store. Keeping both implementations aligned made pairing and invalidation changes harder to maintain.

## Why This Change Was Made

After the existing full-registration compare-and-swap guard succeeds, conditional invalidation now calls the existing deletion primitive on the same connection inside the same synchronous transaction. This removes 21 production code lines (23 physical lines) and leaves one implementation of deletion and version advancement. Successful conditional deletion performs one additional indexed local SELECT.

## User Impact

No intended user-visible change. Stale registration rejection, monotonic versions, return values, empty-row tombstones, version-exhaustion rollback, and Doctor migration suppression retain their existing behavior. There are no schema, configuration, migration, retention, or public API changes.

## Evidence

- 34 baseline tests and 112 final store, Doctor, and device-pairing tests passed; no tests removed or changed.
- An isolated real SQLite probe verified direct/relay comparison, missing and normalized IDs, repeated deletion, monotonic replacements, empty-row tombstones, version-exhaustion atomicity, and close/reopen durability.
- The complete selected changed gate passed, including core/test typechecks, lint, dead-export and boundary guards.
- Independent P2 review found no actionable issue. Live APNs delivery was not run: transport and delivery code are unchanged.
