### PR TITLE
refactor(agents): keep embedded prompts on the canonical contract

### DIFF
--- a/src/agents/embedded-agent-runner/system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.test.ts
@@ -6,6 +6,7 @@ import {
   registerTestMemoryPromptBuilder,
 } from "../../plugins/memory-state.test-fixtures.js";
 import type { AgentSession } from "../sessions/index.js";
+import { createStubTool } from "../test-helpers/agent-tool-stubs.js";
 import { applySystemPromptToSession, buildEmbeddedSystemPrompt } from "./system-prompt.js";
 
 vi.mock("../../tts/tts-settings.js", () => ({
@@ -13,6 +14,38 @@ vi.mock("../../tts/tts-settings.js", () => ({
   resolveModelOverridePolicy: vi.fn(),
   setTtsMachinePrefsPathResolver: vi.fn(),
 }));
+
+function fixedEmbeddedPromptInputs(): Parameters<typeof buildEmbeddedSystemPrompt>[0] {
+  return {
+    workspaceDir: "/tmp/openclaw-prompt-agent",
+    runtimeCwd: "/tmp/openclaw-prompt-project",
+    reasoningTagHint: true,
+    runtimeInfo: {
+      host: "fixture-host",
+      os: "linux",
+      arch: "arm64",
+      node: "v24.14.0",
+      model: "fixture-model",
+      provider: "fixture-provider",
+      channel: "discord",
+      chatType: "direct",
+    },
+    tools: ["read", "exec", "process", "message", "sessions_spawn"].map(createStubTool),
+    capabilityToolNames: ["tool_search", "web_search"],
+    userTimezone: "UTC",
+    userDate: "2026-01-05",
+    ownerNumbers: ["fixture-owner"],
+    modelAliasLines: ["- direct-alias: fixture/direct"],
+    ttsHint: "Fixture direct TTS hint.",
+    skillsPrompt: "<available_skills>Fixture skill guidance.</available_skills>",
+    contextFiles: [{ path: "AGENTS.md", content: "Fixture project guidance." }],
+    extraSystemPrompt: "Fixture turn context.",
+    promptContribution: {
+      stablePrefix: "Fixture stable provider guidance.",
+      dynamicSuffix: "Fixture dynamic provider guidance.",
+    },
+  };
+}
 
 describe("applySystemPromptToSession", () => {
   it("applies the trimmed prompt through the session base prompt setter", () => {
@@ -350,5 +383,117 @@ describe("buildEmbeddedSystemPrompt", () => {
     expect(restrictedPrompt).not.toContain("Active exec sessions:");
     expect(restrictedPrompt).not.toContain("process log");
     expect(restrictedPrompt).not.toContain("process list");
+  });
+
+  it.each([
+    {
+      name: "runtime agent fallback",
+      selector: {},
+      runtime: { agentId: "strict" },
+      restricted: true,
+    },
+    {
+      name: "undefined agent fallback",
+      selector: { agentId: undefined },
+      runtime: { agentId: "strict" },
+      restricted: true,
+    },
+    {
+      name: "explicit loose agent",
+      selector: { agentId: "loose" },
+      runtime: { agentId: "strict" },
+      restricted: false,
+    },
+    {
+      name: "explicit strict agent",
+      selector: { agentId: "strict" },
+      runtime: { agentId: "loose" },
+      restricted: true,
+    },
+    {
+      name: "loose runtime agent",
+      selector: {},
+      runtime: { agentId: "loose" },
+      restricted: false,
+    },
+    { name: "no agent identity", selector: {}, runtime: {}, restricted: false },
+  ])("resolves embedded prompt policy for $name", ({ name, selector, runtime, restricted }) => {
+    const inputs = fixedEmbeddedPromptInputs();
+    const prompt = buildEmbeddedSystemPrompt({
+      ...inputs,
+      ...selector,
+      runtimeInfo: { ...inputs.runtimeInfo, ...runtime },
+      config: {
+        tools: { fs: { workspaceOnly: false } },
+        agents: {
+          entries: {
+            strict: { tools: { fs: { workspaceOnly: true } } },
+            loose: { tools: { fs: { workspaceOnly: false } } },
+          },
+        },
+      },
+    });
+    expect(prompt.includes("tools.fs.workspaceOnly ON"), name).toBe(restricted);
+    expect(prompt).toContain("Fixture stable provider guidance.");
+    expect(prompt).toContain("Fixture dynamic provider guidance.");
+  });
+
+  it.each(["full", "minimal", "none"] as const)(
+    "preserves the fixed embedded prompt in %s mode",
+    (promptMode) => {
+      const prompt = buildEmbeddedSystemPrompt({ ...fixedEmbeddedPromptInputs(), promptMode });
+      expect(prompt).toContain("You are a personal assistant running inside OpenClaw.");
+      if (promptMode === "none") {
+        expect(prompt).not.toContain("Fixture");
+        expect(prompt).not.toContain("## Tooling");
+      } else {
+        expect(prompt).toContain("Fixture stable provider guidance.");
+        expect(prompt).toContain("Fixture project guidance.");
+        expect(prompt).toContain("Working directory: /tmp/openclaw-prompt-project");
+      }
+      expect(prompt.includes("- direct-alias: fixture/direct")).toBe(promptMode === "full");
+    },
+  );
+
+  it.each([
+    { name: "absent config", configInput: {}, directHint: true },
+    { name: "empty config", configInput: { config: {} }, directHint: false },
+    {
+      name: "populated config",
+      configInput: {
+        config: {
+          agents: { defaults: { models: { "fixture/configured": { alias: "configured-alias" } } } },
+        },
+      },
+      directHint: false,
+    },
+  ])("preserves absent optional fields with $name", ({ name, configInput, directHint }) => {
+    const inputs = { ...fixedEmbeddedPromptInputs(), ...configInput };
+    const prompt = buildEmbeddedSystemPrompt(inputs);
+    const explicitUndefined = buildEmbeddedSystemPrompt({
+      ...inputs,
+      reactionGuidance: undefined,
+      workspaceNotes: undefined,
+      silentReplyPromptMode: undefined,
+      sourceReplyDeliveryMode: undefined,
+      nativeCommandNames: undefined,
+      nativeCommandGuidanceLines: undefined,
+      messageToolHints: undefined,
+      toolSchemaDirectoryPrompt: undefined,
+      sandboxInfo: undefined,
+      bootstrapMode: undefined,
+      bootstrapTruncationNotice: undefined,
+      includeMemorySection: undefined,
+      preparedMemoryPrompt: undefined,
+      preparedWatchedSessions: undefined,
+      projectMemoryBootstrap: undefined,
+      activeProjectKeys: undefined,
+    });
+    expect(explicitUndefined).toBe(prompt);
+    expect(prompt.includes("- direct-alias: fixture/direct")).toBe(directHint);
+    expect(prompt.includes("Fixture direct TTS hint.")).toBe(directHint);
+    expect(prompt.includes("- configured-alias: fixture/configured")).toBe(
+      name === "populated config",
+    );
   });
 });

--- a/src/agents/embedded-agent-runner/system-prompt.ts
+++ b/src/agents/embedded-agent-runner/system-prompt.ts
@@ -1,63 +1,17 @@
 /**
  * Builds and installs embedded-agent system prompts.
  */
-import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ChatType } from "../../channels/chat-type.js";
-import type { SubagentDelegationMode } from "../../config/types.agent-defaults.js";
-import type { MemoryCitationsMode } from "../../config/types.memory.js";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { PreparedMemoryPromptSection } from "../../plugins/memory-state.js";
-import type { AgentPromptSurfaceKind } from "../../plugins/types.js";
-import type { BootstrapMode } from "../bootstrap-mode.js";
-import type { EmbeddedContextFile } from "../embedded-agent-helpers.js";
 import type { AgentTool } from "../runtime/index.js";
 import type { AgentSession } from "../sessions/index.js";
 import { buildConfiguredAgentSystemPrompt } from "../system-prompt-config.js";
-import type { ProviderSystemPromptContribution } from "../system-prompt-contribution.js";
 import type { SystemPromptRuntimeInfo } from "../system-prompt.js";
-import type { PromptMode, SilentReplyPromptMode } from "../system-prompt.types.js";
-import type { PreparedWatchedSessionsPrompt } from "../watched-sessions-prompt.js";
-import type { EmbeddedSandboxInfo } from "./types.js";
-import type { ReasoningLevel } from "./utils.js";
 
-export function buildEmbeddedSystemPrompt(params: {
-  config?: OpenClawConfig;
-  agentId?: string;
-  workspaceDir: string;
-  runtimeCwd?: string;
-  reasoningLevel?: ReasoningLevel;
-  extraSystemPrompt?: string;
-  ownerNumbers?: string[];
-  ownerDisplay?: "raw" | "hash";
-  ownerDisplaySecret?: string;
+type EmbeddedSystemPromptParams = Omit<
+  Parameters<typeof buildConfiguredAgentSystemPrompt>[0],
+  "toolNames" | "toolSummaries" | "requireExplicitMessageTarget" | "fsWorkspaceOnly"
+> & {
   reasoningTagHint: boolean;
-  skillsPrompt?: string;
-  codeModeActive?: boolean;
-  docsPath?: string;
-  sourcePath?: string;
-  ttsHint?: string;
-  reactionGuidance?: {
-    level: "minimal" | "extensive";
-    channel: string;
-  };
-  workspaceNotes?: string[];
-  /** Controls which hardcoded sections to include. Defaults to "full". */
-  promptMode?: PromptMode;
-  /** Controls the generic silent-reply section. Channel-aware prompts can set "none". */
-  silentReplyPromptMode?: SilentReplyPromptMode;
-  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
-  /** Prompt-only strength for delegating non-trivial work through sub-agents. */
-  subagentDelegationMode?: SubagentDelegationMode;
-  /** Run-scoped Ultra behavior; independent from configured delegation preference. */
-  proactiveSubagentOrchestration?: boolean;
-  /** Whether ACP-specific routing guidance should be included. Defaults to true. */
-  acpEnabled?: boolean;
-  /** Prompt surface controls runtime-specific fallback fragments. Defaults to OpenClaw main. */
-  promptSurface?: AgentPromptSurfaceKind;
-  /** Registered runtime slash/native command names such as `codex`. */
-  nativeCommandNames?: string[];
-  /** Plugin-owned prompt guidance for registered native slash commands. */
-  nativeCommandGuidanceLines?: string[];
   runtimeInfo: SystemPromptRuntimeInfo & {
     host: string;
     os: string;
@@ -69,72 +23,17 @@ export function buildEmbeddedSystemPrompt(params: {
     /** Supported message actions for the current channel (e.g., react, edit, unsend) */
     channelActions?: string[];
   };
-  messageToolHints?: string[];
-  toolSchemaDirectoryPrompt?: string;
-  sandboxInfo?: EmbeddedSandboxInfo;
-  /** Callable tool names used for capability guidance without adding them to the visible tool list. */
-  capabilityToolNames?: string[];
   tools: AgentTool[];
-  modelAliasLines?: string[];
   userTimezone: string;
   userDate: string;
-  contextFiles?: EmbeddedContextFile[];
-  bootstrapMode?: BootstrapMode;
-  bootstrapTruncationNotice?: string;
-  includeMemorySection?: boolean;
-  memoryCitationsMode?: MemoryCitationsMode;
-  preparedMemoryPrompt?: PreparedMemoryPromptSection;
-  preparedWatchedSessions?: PreparedWatchedSessionsPrompt;
-  projectMemoryBootstrap?: string[];
-  activeProjectKeys?: readonly string[];
-  promptContribution?: ProviderSystemPromptContribution;
-}): string {
+};
+
+export function buildEmbeddedSystemPrompt(params: EmbeddedSystemPromptParams): string {
+  const { tools, ...promptParams } = params;
   return buildConfiguredAgentSystemPrompt({
-    config: params.config,
+    ...promptParams,
     agentId: params.agentId ?? params.runtimeInfo.agentId,
-    workspaceDir: params.workspaceDir,
-    runtimeCwd: params.runtimeCwd,
-    reasoningLevel: params.reasoningLevel,
-    extraSystemPrompt: params.extraSystemPrompt,
-    ownerNumbers: params.ownerNumbers,
-    ownerDisplay: params.ownerDisplay,
-    ownerDisplaySecret: params.ownerDisplaySecret,
-    reasoningTagHint: params.reasoningTagHint,
-    skillsPrompt: params.skillsPrompt,
-    codeModeActive: params.codeModeActive,
-    docsPath: params.docsPath,
-    sourcePath: params.sourcePath,
-    ttsHint: params.ttsHint,
-    workspaceNotes: params.workspaceNotes,
-    reactionGuidance: params.reactionGuidance,
-    promptMode: params.promptMode,
-    silentReplyPromptMode: params.silentReplyPromptMode,
-    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-    subagentDelegationMode: params.subagentDelegationMode,
-    proactiveSubagentOrchestration: params.proactiveSubagentOrchestration,
-    acpEnabled: params.acpEnabled,
-    promptSurface: params.promptSurface,
-    nativeCommandNames: params.nativeCommandNames,
-    nativeCommandGuidanceLines: params.nativeCommandGuidanceLines,
-    runtimeInfo: params.runtimeInfo,
-    messageToolHints: params.messageToolHints,
-    toolSchemaDirectoryPrompt: params.toolSchemaDirectoryPrompt,
-    sandboxInfo: params.sandboxInfo,
-    toolNames: params.tools.map((tool) => tool.name),
-    capabilityToolNames: params.capabilityToolNames,
-    modelAliasLines: params.modelAliasLines,
-    userTimezone: params.userTimezone,
-    userDate: params.userDate,
-    contextFiles: params.contextFiles,
-    bootstrapMode: params.bootstrapMode,
-    bootstrapTruncationNotice: params.bootstrapTruncationNotice,
-    includeMemorySection: params.includeMemorySection,
-    memoryCitationsMode: params.memoryCitationsMode,
-    preparedMemoryPrompt: params.preparedMemoryPrompt,
-    preparedWatchedSessions: params.preparedWatchedSessions,
-    projectMemoryBootstrap: params.projectMemoryBootstrap,
-    activeProjectKeys: params.activeProjectKeys,
-    promptContribution: params.promptContribution,
+    toolNames: tools.map((tool) => tool.name),
   });
 }
 

--- a/src/agents/embedded-agent-runner/utils.ts
+++ b/src/agents/embedded-agent-runner/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Small shared normalization helpers for embedded-agent runner settings.
  */
-import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { ThinkingLevel } from "../runtime/index.js";
 
 export type ProviderThinkLevel = Exclude<ThinkLevel, "ultra">;
@@ -31,4 +31,4 @@ export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
   return providerLevel;
 }
 
-export type { ReasoningLevel, ThinkLevel };
+export type { ThinkLevel };


### PR DESCRIPTION
## What Problem This Solves

Embedded prompt maintenance currently requires keeping a second input contract and forwarding list aligned with the canonical prompt builder. This maintainer-requested cleanup removes that duplication without changing the prompts operators or models receive.

## Why This Change Was Made

Derive the private embedded adapter's input type from the configured prompt builder and forward its owned input record. Keep embedded runtime/tool/date requirements, explicit agent fallback, and tool-name projection at the adapter boundary; keep configuration policy in its existing canonical owner. Remove the now-unused private `ReasoningLevel` type import/re-export.

Production changes are net **−101 lines**, with **145 test lines added**. No public SDK, configuration, dependency, protocol, or persistent-state contract changes; no changelog edit.

## User Impact

No user-visible behavior change is intended. Agent-specific filesystem policy, prompt modes, provider contributions, tool guidance, runtime working directory, and session prompt installation retain their existing behavior. Future prompt maintenance has one canonical input contract to follow.

## Evidence

- Original-base before/after proof passed 52 tests across four existing files; all 15 complete prompt strings across 12 records matched byte-for-byte. A control removing only the runtime-agent fallback failed exactly the two relevant policy rows; restoring it returned all six rows to green.
- On the current base, the six policy cases passed under Vitest 5 and the normal full build completed all 16 phases.
- One isolated built `agent --local` turn against the existing loopback Responses fixture produced exactly one successful request/response. The full request contained one 33,338-byte system message, the expected bootstrap and workspace guidance, and 59 tool definitions. The owned mock, synthetic state, and workspace were closed and cleaned up.
- The first changed gate caught the unused private type re-export. Removing it produced byte-identical emitted JavaScript. The final normal three-file gate then passed all 29 stages, including core/test typechecks, all dead-export scans, and lint: [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34018545829). Native exit was zero and the lease completed; the backing Actions step may show cancellation from delegated lease cleanup.
- Independent precommit and exact-commit P2 reviews returned scoped-clean, with both complete pass reports retained. The signed commit preserves the exact reviewed and gated tree.

The build and local operator run precede only the type-only cleanup; their preservation is explicitly qualified by identical JavaScript output. This is synthetic local request-boundary proof, not a live-provider, channel, tool-execution, or native Codex integration claim.

Separate follow-up: review acquisition-before-cleanup ordering in the existing prompt-composition scenario factory. The new pure-data fixture does not use that factory.
