### PR TITLE
fix: keep startup responsive during agent maintenance checks

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -574,6 +574,8 @@ Background verification errors retain the original name and message and append b
 
 Agent database maintenance fences other writers with a 60-second lease in the shared state database. A dedicated worker renews that lease during synchronous integrity scans and migration phases. Maintenance still checks the exact persisted owner before mutations and commit, and stops if the heartbeat fails or ownership expires or changes. Finishing or cancelling maintenance stops renewal before releasing the lease; process death leaves at most the remaining lease duration.
 
+Maintenance schema admission runs its initial full-file integrity check in a read-only Worker when that check is outside a write transaction. The connection and maintenance lease remain held until the Worker exits. Schema changes, index repairs, and compaction retain their synchronous phases.
+
 The heartbeat proves ownership, not migration progress. A live but stuck maintenance process can keep its lease; stop that process before retrying Doctor.
 
 ## Troubleshooting

--- a/src/commands/doctor-agent-memory-schema.test.ts
+++ b/src/commands/doctor-agent-memory-schema.test.ts
@@ -1,13 +1,18 @@
 // Doctor memory schema tests exercise registered agent databases through the repair path.
 import fs from "node:fs";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { AGENT_DATABASE_MAINTENANCE_LEASE } from "../state/openclaw-agent-db-lease.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { noteDoctorAgentMemorySchemaHealth } from "./doctor-agent-memory-schema.js";
 
 const tempDirs: string[] = [];
@@ -176,6 +181,86 @@ describe("doctor agent memory schema repair", () => {
       }
     },
   );
+
+  it("leaves a later runtime admission untouched after the first repair loses maintenance", async () => {
+    const { databasePath, env } = createRegisteredAgentDatabase();
+    const laterOptions = { agentId: "worker-2", env };
+    const laterPath = openOpenClawAgentDatabase(laterOptions).path;
+    closeOpenClawAgentDatabasesForTest();
+    recreateUnreleasedInlineMemoryMetadata(databasePath);
+    recreateUnreleasedInlineMemoryMetadata(laterPath);
+    const agentDatabase = await import("../state/openclaw-agent-db.js");
+    const integrityWorker = await import("../infra/sqlite-integrity-worker.js");
+    const sqlite = await import("../infra/node-sqlite.js");
+    const startAdmission = createDeferred();
+    const admissionChecked = createDeferred();
+    const releaseAdmission = createDeferred();
+    // Register outside the old maintenance ALS scope: this is a new runtime owner.
+    const newerAdmission = startAdmission.promise.then(() =>
+      agentDatabase.withOpenClawAgentDatabaseAsync(laterOptions, (database) =>
+        database.db.prepare("SELECT id, text FROM memory_index_chunks").all(),
+      ),
+    );
+    void newerAdmission.catch(() => {});
+    const check = integrityWorker.assertSqliteIntegrityInWorker;
+    const scan = vi
+      .spyOn(integrityWorker, "assertSqliteIntegrityInWorker")
+      .mockImplementation(async (...args) => {
+        await check(...args);
+        if (args[0] === laterPath) {
+          // Keep the real pending admission alive before it converges the legacy shape.
+          admissionChecked.resolve();
+          await releaseAdmission.promise;
+        }
+      });
+    const open = sqlite.openNodeSqliteDatabase;
+    const inspectedPaths: string[] = [];
+    const inspection = vi
+      .spyOn(sqlite, "openNodeSqliteDatabase")
+      .mockImplementation((pathname, options) => {
+        if (options?.readOnly) {
+          inspectedPaths.push(pathname);
+        }
+        return open(pathname, options);
+      });
+    const close = vi.spyOn(agentDatabase, "closeOpenClawAgentDatabaseByPath");
+    const migrate = agentDatabase.migrateOpenClawAgentDatabaseForMaintenance;
+    const repair = vi
+      .spyOn(agentDatabase, "migrateOpenClawAgentDatabaseForMaintenance")
+      .mockImplementationOnce(async (options, maintenance) => {
+        await migrate(options, maintenance);
+        const removed = openOpenClawStateDatabase({ env })
+          .db.prepare("DELETE FROM state_leases WHERE scope = ? AND lease_key = ?")
+          .run(AGENT_DATABASE_MAINTENANCE_LEASE.scope, AGENT_DATABASE_MAINTENANCE_LEASE.key);
+        expect(removed.changes).toBe(1);
+        // Earlier registry discovery may inspect targets while the lease is still valid.
+        inspectedPaths.length = 0;
+        close.mockClear();
+        startAdmission.resolve();
+        await Promise.race([admissionChecked.promise, newerAdmission]);
+      });
+    try {
+      await expect(
+        noteDoctorAgentMemorySchemaHealth({ env, shouldRepair: true }, { note: vi.fn() }),
+      ).rejects.toThrow(/maintenance lease.*was lost/iu);
+      expect(repair.mock.calls.map(([options]) => options.pathname)).toEqual([databasePath]);
+      expect(inspectedPaths).not.toContain(laterPath);
+      expect(close.mock.calls.some(([pathname]) => pathname === laterPath)).toBe(false);
+      expect(scan.mock.calls.filter(([pathname]) => pathname === laterPath)).toHaveLength(1);
+      releaseAdmission.resolve();
+      await expect(newerAdmission).resolves.toEqual([
+        { id: "pre-provenance-sentinel", text: "sentinel text" },
+      ]);
+    } finally {
+      startAdmission.resolve();
+      releaseAdmission.resolve();
+      await newerAdmission.catch(() => {});
+      repair.mockRestore();
+      close.mockRestore();
+      inspection.mockRestore();
+      scan.mockRestore();
+    }
+  });
 
   it("is idempotent on a second doctor fix run", async () => {
     const { databasePath, env } = createRegisteredAgentDatabase();

--- a/src/commands/doctor-agent-memory-schema.ts
+++ b/src/commands/doctor-agent-memory-schema.ts
@@ -9,6 +9,7 @@ import {
   migrateOpenClawAgentDatabaseForMaintenance,
   withAgentDatabaseMaintenanceLease,
 } from "../state/openclaw-agent-db.js";
+import type { OpenClawStateLeaseContext } from "../state/openclaw-state-lease.js";
 import { shortenHomePath } from "../utils.js";
 import {
   DoctorSqliteMaintenanceLockUnavailableError,
@@ -81,9 +82,10 @@ function inspectAgentMemoryRecallMetadataMigration(
 }
 
 /** Move the unreleased inline metadata shape into rollback-safe additive tables. */
-function repairDoctorAgentMemorySchemas(
-  options: { env?: NodeJS.ProcessEnv } = {},
-): DoctorAgentMemorySchemaReport {
+async function repairDoctorAgentMemorySchemas(
+  options: { env?: NodeJS.ProcessEnv },
+  maintenance: OpenClawStateLeaseContext,
+): Promise<DoctorAgentMemorySchemaReport> {
   const env = options.env ?? process.env;
   const repaired: DoctorAgentMemorySchemaRepair[] = [];
   const warnings: string[] = [];
@@ -101,6 +103,8 @@ function repairDoctorAgentMemorySchemas(
   }
 
   for (const entry of registered) {
+    // A lost lease must stop the pass before a later target can close a new owner's handle.
+    maintenance.assertOwned();
     try {
       const before = inspectAgentMemoryRecallMetadataMigration(entry.path);
       if (!before || (before.columns.length === 0 && !before.hasProvenanceTrigger)) {
@@ -109,10 +113,11 @@ function repairDoctorAgentMemorySchemas(
       // Doctor owns offline maintenance. Close any handle opened by an earlier
       // doctor contribution before the feature owner migrates the shared table.
       closeOpenClawAgentDatabaseByPath(entry.path);
-      migrateOpenClawAgentDatabaseForMaintenance({
-        agentId: entry.agentId,
-        pathname: entry.path,
-      });
+      await migrateOpenClawAgentDatabaseForMaintenance(
+        { agentId: entry.agentId, pathname: entry.path },
+        maintenance,
+      );
+      maintenance.assertOwned();
       const after = inspectAgentMemoryRecallMetadataMigration(entry.path);
       if (
         after === null ||
@@ -154,8 +159,8 @@ export async function noteDoctorAgentMemorySchemaHealth(
       env: params.env,
       operation: "agent memory schema repair",
       run: () =>
-        withAgentDatabaseMaintenanceLease({ env: params.env }, async () =>
-          repairDoctorAgentMemorySchemas({ env: params.env }),
+        withAgentDatabaseMaintenanceLease({ env: params.env }, (maintenance) =>
+          repairDoctorAgentMemorySchemas({ env: params.env }, maintenance),
         ),
     });
   } catch (error) {

--- a/src/commands/doctor-session-sqlite-compact.ts
+++ b/src/commands/doctor-session-sqlite-compact.ts
@@ -52,14 +52,6 @@ export async function compactDoctorSessionSqliteTarget(
     }
   };
   const compactTarget = () => {
-    if (options.operation === "import-finalize") {
-      migrateOpenClawAgentDatabaseForMaintenance({
-        agentId: databaseOptions.agentId,
-        pathname: sqlitePath,
-      });
-      requireQuarantineCleared();
-    }
-
     const compact = compactDoctorSqliteFile({
       operation: options.operation,
       afterSuccess: () => {
@@ -87,7 +79,15 @@ export async function compactDoctorSessionSqliteTarget(
   };
   // The maintenance lease lives in shared state; never forward the agent database path.
   return options.operation === "import-finalize"
-    ? withAgentDatabaseMaintenanceLease({ env: databaseOptions.env }, async () => compactTarget())
+    ? withAgentDatabaseMaintenanceLease({ env: databaseOptions.env }, async (maintenance) => {
+        await migrateOpenClawAgentDatabaseForMaintenance(
+          { agentId: databaseOptions.agentId, pathname: sqlitePath },
+          maintenance,
+        );
+        maintenance.assertOwned();
+        requireQuarantineCleared();
+        return compactTarget();
+      })
     : compactTarget();
 }
 

--- a/src/commands/doctor-session-sqlite-recover-report.ts
+++ b/src/commands/doctor-session-sqlite-recover-report.ts
@@ -17,6 +17,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
+import type { OpenClawStateLeaseContext } from "../state/openclaw-state-lease.js";
 import {
   createSessionSqliteMigrationFailureIssue,
   writeSessionSqliteMigrationFailureReports,
@@ -60,7 +61,7 @@ export async function recoverDoctorSessionSqliteTargets(params: {
   if (!failedRun) {
     const recoveredCorruptTargets = await withAgentDatabaseMaintenanceLease(
       { env: params.env },
-      async () => recoverCorruptSqliteTargets(params.targets, params.env),
+      (maintenance) => recoverCorruptSqliteTargets(params.targets, params.env, maintenance),
     );
     if (recoveredCorruptTargets.length > 0) {
       return summarizeRecoverReport(recoveredCorruptTargets);
@@ -114,59 +115,76 @@ export async function recoverDoctorSessionSqliteTargets(params: {
   return report;
 }
 
-function recoverCorruptSqliteTargets(
+async function recoverCorruptSqliteTargets(
   targets: readonly SessionStoreTarget[],
   env: NodeJS.ProcessEnv,
-): DoctorSessionSqliteTargetReport[] {
-  return targets.flatMap((target) => {
+  maintenance: OpenClawStateLeaseContext,
+): Promise<DoctorSessionSqliteTargetReport[]> {
+  const reports: DoctorSessionSqliteTargetReport[] = [];
+  for (const target of targets) {
+    // A prior repair may have yielded or lost its lease; later targets can rename files.
+    maintenance.assertOwned();
     const databaseOptions = resolveTargetSqliteOptions(target, env);
     const sqlitePath = resolveOpenClawAgentSqlitePath(databaseOptions);
     let recoveryFiles: ReturnType<typeof inspectSqliteRecoveryFiles>;
     try {
       recoveryFiles = inspectSqliteRecoveryFiles(sqlitePath);
     } catch (error) {
-      return [createRecoverInspectionFailureTargetReport(target, sqlitePath, error)];
+      reports.push(createRecoverInspectionFailureTargetReport(target, sqlitePath, error));
+      continue;
     }
     if (recoveryFiles.existing.length === 0) {
-      return [];
+      continue;
     }
     if (!recoveryFiles.existing.includes(sqlitePath)) {
-      return [
+      reports.push(
         recoverCorruptSqliteTarget(
           target,
           sqlitePath,
           new Error(`SQLite sidecars exist without their main database: ${sqlitePath}`),
         ),
-      ];
+      );
+      continue;
     }
     const inspection = inspectSqliteForRecovery(sqlitePath, recoveryFiles.existing);
     if (inspection.ok) {
-      return [];
+      continue;
     }
     if (!isSqliteCorruptionError(inspection.error)) {
-      return [createRecoverInspectionFailureTargetReport(target, sqlitePath, inspection.error)];
+      reports.push(
+        createRecoverInspectionFailureTargetReport(target, sqlitePath, inspection.error),
+      );
+      continue;
     }
     if (!isCanonicalAgentIndexCorruptionError(inspection.error)) {
-      return [recoverCorruptSqliteTarget(target, sqlitePath, inspection.error)];
+      reports.push(recoverCorruptSqliteTarget(target, sqlitePath, inspection.error));
+      continue;
     }
-    const repair = repairCanonicalIndexesForRecovery(databaseOptions, sqlitePath);
-    return [
+    const repair = await repairCanonicalIndexesForRecovery(
+      databaseOptions,
+      sqlitePath,
+      maintenance,
+    );
+    reports.push(
       repair.ok
         ? createEmptyRecoverTargetReport(target, sqlitePath)
         : createRecoverInspectionFailureTargetReport(target, sqlitePath, repair.error),
-    ];
-  });
+    );
+  }
+  return reports;
 }
 
-function repairCanonicalIndexesForRecovery(
+async function repairCanonicalIndexesForRecovery(
   databaseOptions: OpenClawAgentDatabaseOptions,
   sqlitePath: string,
-): { ok: true } | { error: unknown; ok: false } {
+  maintenance: OpenClawStateLeaseContext,
+): Promise<{ ok: true } | { error: unknown; ok: false }> {
   try {
-    migrateOpenClawAgentDatabaseForMaintenance({
-      agentId: databaseOptions.agentId,
-      pathname: sqlitePath,
-    });
+    await migrateOpenClawAgentDatabaseForMaintenance(
+      { agentId: databaseOptions.agentId, pathname: sqlitePath },
+      maintenance,
+    );
+    maintenance.assertOwned();
     const sourcePaths = inspectSqliteRecoveryFiles(sqlitePath).existing;
     const inspection = inspectSqliteForRecovery(sqlitePath, sourcePaths);
     if (!inspection.ok) {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -31,6 +31,11 @@ import * as replaceFile from "../infra/replace-file.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
 import { ExitError } from "../runtime.js";
 import {
+  AGENT_DATABASE_MAINTENANCE_LEASE,
+  claimOpenClawAgentDatabaseLease,
+  releaseOpenClawAgentDatabaseLease,
+} from "../state/openclaw-agent-db-lease.js";
+import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -40,7 +45,10 @@ import {
   readOpenClawDatabaseQuarantine,
   recordOpenClawDatabaseQuarantine,
 } from "../state/openclaw-quarantine-store.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { sessionDeliveryRoute } from "../utils/delivery-context.shared.js";
 import * as migrationArtifact from "./doctor-session-sqlite-artifact.js";
@@ -3146,6 +3154,76 @@ describe("runDoctorSessionSqlite", () => {
       ).toBe(true);
     },
   );
+
+  it("fences quarantine clearing and later recovery targets after an awaited repair loses maintenance", async () => {
+    const { sqlitePath, store } = await createImportedStoreForCompaction();
+    createCanonicalCacheIndexDrift(sqlitePath);
+    const laterPath = resolveOpenClawAgentSqlitePath({ agentId: "later", env: store.env });
+    fs.mkdirSync(path.dirname(laterPath), { recursive: true });
+    const laterBytes = Buffer.from("synthetic corrupt database\n");
+    fs.writeFileSync(laterPath, laterBytes, { mode: 0o600 });
+    for (const databasePath of [sqlitePath, laterPath]) {
+      expect(
+        recordOpenClawDatabaseQuarantine({
+          env: store.env,
+          kind: "agent",
+          path: databasePath,
+          reason: "synthetic recovery quarantine",
+        }),
+      ).toBe(true);
+    }
+    const quarantineBefore = [sqlitePath, laterPath].map((databasePath) =>
+      readOpenClawDatabaseQuarantine(databasePath, { env: store.env }),
+    );
+    const agentDatabase = await import("../state/openclaw-agent-db.js");
+    const migrate = agentDatabase.migrateOpenClawAgentDatabaseForMaintenance;
+    let competingLeaseId: string | undefined;
+    const repair = vi
+      .spyOn(agentDatabase, "migrateOpenClawAgentDatabaseForMaintenance")
+      .mockImplementationOnce(async (options, maintenance) => {
+        await migrate(options, maintenance);
+        // Lose the real owner at the caller's new await boundary, after native repair succeeds.
+        const removed = openOpenClawStateDatabase({ env: store.env })
+          .db.prepare("DELETE FROM state_leases WHERE scope = ? AND lease_key = ?")
+          .run(AGENT_DATABASE_MAINTENANCE_LEASE.scope, AGENT_DATABASE_MAINTENANCE_LEASE.key);
+        expect(removed.changes).toBe(1);
+        competingLeaseId = claimOpenClawAgentDatabaseLease({
+          agentId: "later",
+          path: laterPath,
+          env: store.env,
+        });
+      });
+    try {
+      await expect(
+        recoverDoctorSessionSqliteTargets({
+          env: store.env,
+          options: { mode: "recover" },
+          targets: [
+            { agentId: "main", storePath: sqlitePath },
+            { agentId: "later", storePath: laterPath },
+          ],
+          validateTarget: async () => {
+            throw new Error("Expected direct recovery without a failed migration manifest");
+          },
+        }),
+      ).rejects.toThrow(/maintenance lease.*was lost/iu);
+      expect(competingLeaseId).toBeDefined();
+      expect(
+        [sqlitePath, laterPath].map((databasePath) =>
+          readOpenClawDatabaseQuarantine(databasePath, { env: store.env }),
+        ),
+      ).toEqual(quarantineBefore);
+      expect(fs.readFileSync(laterPath)).toEqual(laterBytes);
+      expect(
+        fs.readdirSync(path.dirname(laterPath)).some((name) => name.includes(".corrupt-")),
+      ).toBe(false);
+    } finally {
+      repair.mockRestore();
+      if (competingLeaseId) {
+        releaseOpenClawAgentDatabaseLease(competingLeaseId, { env: store.env });
+      }
+    }
+  });
 
   it.each(["newer schema", "mismatched older schema", "I/O error"] as const)(
     "keeps canonical-index repair failures in place after %s",

--- a/src/infra/sqlite-integrity-worker.ts
+++ b/src/infra/sqlite-integrity-worker.ts
@@ -34,14 +34,14 @@ export function readSqliteIntegrityFileIdentity(
   return { dev: current.dev, ino: current.ino };
 }
 
-/** The caller retains its canonical runtime lease until the read-only Worker exits. */
+/** The caller retains its owning lease until the read-only Worker exits. */
 export function assertSqliteIntegrityInWorker(
   pathname: string,
   busyTimeoutMs: number,
   signal: AbortSignal,
 ): Promise<void> {
   signal.throwIfAborted();
-  // The caller retains its runtime lease through native exit. This witness
+  // The caller retains its owning lease through native exit. This witness
   // detects observed path swaps; it is not native descriptor authority.
   const identity = readSqliteIntegrityFileIdentity(pathname);
   const entry = resolveRuntimeProcessEntrypointUrl("sqliteIntegrity");

--- a/src/infra/state-migrations.transcript-directives.ts
+++ b/src/infra/state-migrations.transcript-directives.ts
@@ -18,6 +18,7 @@ import {
   withAgentDatabaseMaintenanceLease,
 } from "../state/openclaw-agent-db.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "../state/openclaw-state-db.js";
+import type { OpenClawStateLeaseContext } from "../state/openclaw-state-lease.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
   executeSqliteQuerySync,
@@ -323,11 +324,12 @@ async function migrateTranscriptSessions(params: {
   }
 }
 
-async function migrateAgentDatabase(params: {
-  agentId: string;
-  pathname: string;
-}): Promise<DatabaseMigrationResult> {
-  migrateOpenClawAgentDatabaseForMaintenance(params);
+async function migrateAgentDatabase(
+  params: { agentId: string; pathname: string },
+  maintenance: OpenClawStateLeaseContext,
+): Promise<DatabaseMigrationResult> {
+  await migrateOpenClawAgentDatabaseForMaintenance(params, maintenance);
+  maintenance.assertOwned();
   const database = openNodeSqliteDatabase(params.pathname);
   try {
     database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
@@ -451,13 +453,13 @@ export async function migrateHistoricalTranscriptDirectives(
       }
     }
     if (targets.length > 0) {
-      await withAgentDatabaseMaintenanceLease({ env }, async () => {
+      await withAgentDatabaseMaintenanceLease({ env }, async (maintenance) => {
         for (const target of targets) {
           try {
-            const result = await migrateAgentDatabase({
-              agentId: target.agentId,
-              pathname: target.path,
-            });
+            const result = await migrateAgentDatabase(
+              { agentId: target.agentId, pathname: target.path },
+              maintenance,
+            );
             if (result.transcriptSessions > 0 || result.archivedTranscripts > 0) {
               changes.push(
                 `Migrated historical transcript directives in ${target.path}: ${result.transcriptSessions} active session(s), ${result.archivedTranscripts} archived transcript(s).`,

--- a/src/state/openclaw-agent-db-lease.ts
+++ b/src/state/openclaw-agent-db-lease.ts
@@ -47,9 +47,11 @@ export function runWithAgentDatabaseMaintenanceAuthority<T>(
 }
 
 /** Revalidate the held lease, including immediately before committing a versioned rebuild. */
-export function assertAgentDatabaseMaintenanceAuthority(): void {
+export function assertAgentDatabaseMaintenanceAuthority(
+  expected?: OpenClawStateLeaseContext,
+): void {
   const authority = maintenanceAuthority.getStore();
-  if (!authority) {
+  if (!authority || (expected && authority !== expected)) {
     throw new Error(
       "Agent identity migration requires stopped-writer maintenance; stop active agents and run openclaw doctor --fix.",
     );

--- a/src/state/openclaw-agent-db-maintenance.test.ts
+++ b/src/state/openclaw-agent-db-maintenance.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import * as sqlite from "../infra/node-sqlite.js";
+import * as integrityWorker from "../infra/sqlite-integrity-worker.js";
+import { readSqliteNumberPragma } from "../infra/sqlite-pragma.test-support.js";
+import {
+  AGENT_DATABASE_MAINTENANCE_LEASE,
+  assertNoOpenClawAgentDatabaseLeases,
+  runWithAgentDatabaseMaintenanceAuthority,
+} from "./openclaw-agent-db-lease.js";
+import {
+  closeOpenClawAgentDatabasesAsync,
+  closeOpenClawAgentDatabasesForTest,
+  migrateOpenClawAgentDatabaseForMaintenance,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+  openOpenClawAgentDatabase,
+  withAgentDatabaseMaintenanceLease,
+} from "./openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "./openclaw-state-db.js";
+import { withOpenClawStateLease, type OpenClawStateLeaseContext } from "./openclaw-state-lease.js";
+
+const roots: string[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await closeOpenClawAgentDatabasesAsync();
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(roots);
+});
+
+function fixture() {
+  const root = makeTempDir(roots, "agent-maintenance-");
+  const env = { OPENCLAW_STATE_DIR: root };
+  const database = openOpenClawAgentDatabase({ agentId: "worker", env });
+  const options = { agentId: "worker", pathname: database.path };
+  database.db.exec(`
+    INSERT INTO cache_entries (scope,key,value_json,expires_at,updated_at)
+      VALUES ('maintenance','retained','{"retained":true}',100,1);
+  `);
+  closeOpenClawAgentDatabasesForTest();
+  const state = openOpenClawStateDatabase({ env });
+  return { env, options, state };
+}
+
+function readIndexState(pathname: string) {
+  const database = sqlite.openNodeSqliteDatabase(pathname, { readOnly: true });
+  try {
+    return {
+      index: database
+        .prepare("SELECT sql FROM sqlite_schema WHERE name='idx_agent_cache_expiry'")
+        .get(),
+      integrity: database.prepare("PRAGMA integrity_check;").all(),
+      retained: database.prepare("SELECT value_json FROM cache_entries").all(),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+function installIndexDrift(pathname: string, corrupt: boolean) {
+  const database = sqlite.openNodeSqliteDatabase(pathname);
+  try {
+    database.exec(`
+      DROP INDEX idx_agent_cache_expiry;
+      CREATE INDEX idx_agent_cache_expiry ON cache_entries(key);
+    `);
+    if (corrupt) {
+      // The claimed definition disagrees with the real b-tree, exercising the
+      // Worker's genuine integrity-error path before maintenance resumes.
+      database.enableDefensive?.(false);
+      database.exec("PRAGMA writable_schema=ON;");
+      database
+        .prepare("UPDATE sqlite_schema SET sql=? WHERE name='idx_agent_cache_expiry'")
+        .run(
+          "CREATE INDEX idx_agent_cache_expiry ON cache_entries(scope, expires_at, key) WHERE expires_at IS NOT NULL",
+        );
+      database.exec("PRAGMA writable_schema=OFF;");
+      database.exec(
+        `PRAGMA schema_version=${readSqliteNumberPragma(database, "schema_version") + 1};`,
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function withAbortableMaintenance<T>(
+  f: ReturnType<typeof fixture>,
+  signal: AbortSignal,
+  run: (maintenance: OpenClawStateLeaseContext) => Promise<T>,
+): Promise<T> {
+  // Exercise the existing lease owner's abort signal without adding a production
+  // cancellation option or replacing the closure-bound maintenance context.
+  return withOpenClawStateLease(
+    {
+      ...AGENT_DATABASE_MAINTENANCE_LEASE,
+      database: { scope: "shared", options: { env: f.env } },
+      leaseMs: 60_000,
+      waitMs: 5_000,
+      heartbeat: "worker",
+      signal,
+    },
+    (maintenance) => {
+      assertNoOpenClawAgentDatabaseLeases(maintenance, { env: f.env });
+      return runWithAgentDatabaseMaintenanceAuthority(maintenance, () => run(maintenance));
+    },
+  );
+}
+
+describe("asynchronous agent database maintenance admission", () => {
+  it("yields during real integrity admission while retaining the maintenance fence", async () => {
+    const f = fixture();
+    const before = readIndexState(f.options.pathname);
+    await withAgentDatabaseMaintenanceLease({ env: f.env }, async (maintenance) => {
+      let progressed = false;
+      const tick = setImmediate(() => {
+        progressed = true;
+      });
+      try {
+        await migrateOpenClawAgentDatabaseForMaintenance(f.options, maintenance);
+        expect(progressed).toBe(true);
+        maintenance.assertOwned();
+        expect(() => openOpenClawAgentDatabase({ agentId: "worker", env: f.env })).toThrow(
+          /maintenance is in progress/,
+        );
+      } finally {
+        clearImmediate(tick);
+      }
+    });
+    expect(readIndexState(f.options.pathname)).toEqual(before);
+  });
+
+  it.each(
+    [false, true].flatMap((corrupt) =>
+      (["expiry", "replacement", "abort"] as const).map((loss) => ({ corrupt, loss })),
+    ),
+  )("fences Worker resume after $loss (integrity failure=$corrupt)", async ({ corrupt, loss }) => {
+    const f = fixture();
+    installIndexDrift(f.options.pathname, corrupt);
+    const before = readIndexState(f.options.pathname);
+    const abort = new AbortController();
+    const check = integrityWorker.assertSqliteIntegrityInWorker;
+    const spy = vi
+      .spyOn(integrityWorker, "assertSqliteIntegrityInWorker")
+      .mockImplementation(async (...args) => {
+        let failed = false;
+        let failure: unknown;
+        try {
+          await check(...args);
+        } catch (error) {
+          failed = true;
+          failure = error;
+        }
+        expect(failed).toBe(corrupt);
+        if (loss === "abort") {
+          abort.abort(new Error("synthetic maintenance abort"));
+        } else {
+          f.state.db
+            .prepare(
+              `UPDATE state_leases SET ${loss === "expiry" ? "expires_at=0" : "owner='successor'"}
+                WHERE scope=? AND lease_key=?`,
+            )
+            .run(AGENT_DATABASE_MAINTENANCE_LEASE.scope, AGENT_DATABASE_MAINTENANCE_LEASE.key);
+        }
+        if (failed) {
+          throw failure;
+        }
+      });
+    try {
+      await expect(
+        withAbortableMaintenance(f, abort.signal, (maintenance) =>
+          migrateOpenClawAgentDatabaseForMaintenance(f.options, maintenance),
+        ),
+      ).rejects.toThrow(/lost|abort/i);
+      expect(spy).toHaveBeenCalledOnce();
+      expect(readIndexState(f.options.pathname)).toEqual(before);
+      if (loss === "replacement") {
+        expect(f.state.db.prepare("SELECT owner FROM state_leases").all()).toEqual([
+          { owner: "successor" },
+        ]);
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it.each(
+    [false, true].flatMap((corrupt) =>
+      (["owner", "version"] as const).map((changed) => ({ corrupt, changed })),
+    ),
+  )(
+    "refuses changed database $changed before Worker resume repairs indexes (integrity failure=$corrupt)",
+    async ({ corrupt, changed }) => {
+      const f = fixture();
+      installIndexDrift(f.options.pathname, corrupt);
+      const before = readIndexState(f.options.pathname);
+      const check = integrityWorker.assertSqliteIntegrityInWorker;
+      const spy = vi
+        .spyOn(integrityWorker, "assertSqliteIntegrityInWorker")
+        .mockImplementationOnce(async (...args) => {
+          let failed = false;
+          let failure: unknown;
+          try {
+            await check(...args);
+          } catch (error) {
+            failed = true;
+            failure = error;
+          }
+          expect(failed).toBe(corrupt);
+          // Change the same file after the real scan, before its result is consumed.
+          const database = sqlite.openNodeSqliteDatabase(f.options.pathname);
+          try {
+            if (changed === "owner") {
+              database
+                .prepare("UPDATE schema_meta SET agent_id=? WHERE meta_key='primary'")
+                .run("other-agent");
+            } else {
+              database.exec(`PRAGMA user_version=${OPENCLAW_AGENT_SCHEMA_VERSION + 1};`);
+            }
+          } finally {
+            database.close();
+          }
+          if (failed) {
+            throw failure;
+          }
+        });
+      try {
+        await expect(
+          withAgentDatabaseMaintenanceLease({ env: f.env }, (maintenance) =>
+            migrateOpenClawAgentDatabaseForMaintenance(f.options, maintenance),
+          ),
+        ).rejects.toThrow(changed === "owner" ? /belongs to agent other-agent/ : /newer schema/);
+        expect(spy).toHaveBeenCalledOnce();
+        expect(readIndexState(f.options.pathname)).toEqual(before);
+      } finally {
+        spy.mockRestore();
+      }
+    },
+  );
+
+  it("joins a cancelled real Worker before closing its database or releasing the fence", async () => {
+    const f = fixture();
+    const abort = new AbortController();
+    const check = integrityWorker.assertSqliteIntegrityInWorker;
+    const open = sqlite.openNodeSqliteDatabase;
+    let completed = false;
+    let native: Promise<void> | undefined;
+    vi.spyOn(sqlite, "openNodeSqliteDatabase").mockImplementation((pathname, options) => {
+      const database = open(pathname, options);
+      if (pathname === f.options.pathname && options?.readOnly !== true) {
+        const close = database.close.bind(database);
+        database.close = () => {
+          try {
+            expect(completed).toBe(true);
+          } finally {
+            close();
+          }
+        };
+      }
+      return database;
+    });
+    vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker").mockImplementation((...args) => {
+      native = check(...args).finally(() => {
+        completed = true;
+      });
+      abort.abort(new Error("synthetic maintenance abort"));
+      expect(completed).toBe(false);
+      expect(f.state.db.prepare("SELECT owner FROM state_leases").all()).toHaveLength(1);
+      return native;
+    });
+    try {
+      await expect(
+        withAbortableMaintenance(f, abort.signal, (maintenance) =>
+          migrateOpenClawAgentDatabaseForMaintenance(f.options, maintenance),
+        ),
+      ).rejects.toThrow(/abort/i);
+      expect(completed).toBe(true);
+      expect(f.state.db.prepare("SELECT owner FROM state_leases").all()).toEqual([]);
+    } finally {
+      await native?.catch(() => {});
+    }
+  });
+
+  it("rejects a retained closed maintenance context before opening or scanning", async () => {
+    const f = fixture();
+    let retained: OpenClawStateLeaseContext | undefined;
+    await withAgentDatabaseMaintenanceLease({ env: f.env }, async (maintenance) => {
+      retained = maintenance;
+    });
+    expect(retained).toBeDefined();
+    const open = vi.spyOn(sqlite, "openNodeSqliteDatabase");
+    const scan = vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker");
+    await expect(migrateOpenClawAgentDatabaseForMaintenance(f.options, retained!)).rejects.toThrow(
+      /stopped-writer maintenance/,
+    );
+    expect(open).not.toHaveBeenCalled();
+    expect(scan).not.toHaveBeenCalled();
+  });
+
+  it.each(["outside", "copied"] as const)(
+    "requires the exact active maintenance scope when its context is %s",
+    async (scope) => {
+      const f = fixture();
+      const ready = createDeferred<OpenClawStateLeaseContext>();
+      const release = createDeferred();
+      const scan = vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker");
+      const running = withAgentDatabaseMaintenanceLease({ env: f.env }, async (maintenance) => {
+        if (scope === "copied") {
+          await expect(
+            migrateOpenClawAgentDatabaseForMaintenance(f.options, { ...maintenance }),
+          ).rejects.toThrow(/stopped-writer maintenance/);
+          return;
+        }
+        ready.resolve(maintenance);
+        await release.promise;
+      });
+      try {
+        if (scope === "outside") {
+          const maintenance = await ready.promise;
+          maintenance.assertOwned();
+          await expect(
+            migrateOpenClawAgentDatabaseForMaintenance(f.options, maintenance),
+          ).rejects.toThrow(/stopped-writer maintenance/);
+        }
+      } finally {
+        release.resolve();
+        await running;
+      }
+      expect(scan).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/src/state/openclaw-agent-db-maintenance.ts
+++ b/src/state/openclaw-agent-db-maintenance.ts
@@ -1,21 +1,24 @@
 import type { DatabaseSync } from "node:sqlite";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import { assertSqliteIntegrityInWorker } from "../infra/sqlite-integrity-worker.js";
 import {
   createNewerSqliteSchemaVersionError,
   readSqliteUserVersion,
 } from "../infra/sqlite-user-version.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
+import { assertAgentDatabaseMaintenanceAuthority } from "./openclaw-agent-db-lease.js";
 import {
   assertExistingAgentSchemaOwner,
   assertOpenClawAgentSchemaContains,
   assertSupportedAgentSchemaVersion,
   readExistingAgentSchemaMeta,
 } from "./openclaw-agent-db-schema-helpers.js";
-import { ensureOpenClawAgentDatabaseSchema } from "./openclaw-agent-db-schema.js";
+import { ensureOpenClawAgentDatabaseSchemaSteps } from "./openclaw-agent-db-schema.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "./openclaw-agent-schema.js";
 import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db.js";
+import type { OpenClawStateLeaseContext } from "./openclaw-state-lease.js";
 
 /** Require exact agent ownership without requiring the latest schema. */
 export function assertOpenClawAgentDatabaseOwner(
@@ -68,20 +71,27 @@ export function assertOpenClawAgentDatabaseForMaintenance(
 }
 
 /** Upgrade or repair a supported owned schema before strict offline maintenance. */
-export function migrateOpenClawAgentDatabaseForMaintenance(options: {
-  agentId: string;
-  pathname: string;
-}): void {
+export async function migrateOpenClawAgentDatabaseForMaintenance(
+  options: { agentId: string; pathname: string },
+  maintenance: OpenClawStateLeaseContext,
+): Promise<void> {
   const agentId = normalizeAgentId(options.agentId);
-  const database = openNodeSqliteDatabase(options.pathname);
+  const pathname = options.pathname;
+  const env = { ...process.env };
+  const assertOwned = () => {
+    maintenance.signal.throwIfAborted();
+    assertAgentDatabaseMaintenanceAuthority(maintenance);
+  };
+  assertOwned();
+  const database = openNodeSqliteDatabase(pathname);
   try {
     database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     const metadata = readExistingAgentSchemaMeta(database);
     if (!metadata) {
       return;
     }
-    assertExistingAgentSchemaOwner(metadata, agentId, options.pathname);
-    assertSupportedAgentSchemaVersion(database, options.pathname);
+    assertExistingAgentSchemaOwner(metadata, agentId, pathname);
+    assertSupportedAgentSchemaVersion(database, pathname);
     const userVersion = readSqliteUserVersion(database);
     const metadataVersion = metadata.schemaVersion;
     const hasCurrentVersion =
@@ -97,13 +107,42 @@ export function migrateOpenClawAgentDatabaseForMaintenance(options: {
     if (!hasCurrentVersion && !hasSupportedOlderVersion) {
       return;
     }
-    ensureOpenClawAgentDatabaseSchema(database, {
+    const operation = ensureOpenClawAgentDatabaseSchemaSteps(database, {
       agentId,
-      path: options.pathname,
+      path: pathname,
+      env,
     });
+    try {
+      let step = operation.next();
+      while (!step.done) {
+        assertOwned();
+        try {
+          // The maintenance fence and connection survive until native Worker exit.
+          // Revalidate before either resume path can repair indexes or mutate schema.
+          await assertSqliteIntegrityInWorker(
+            step.value.databaseLabel,
+            OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+            maintenance.signal,
+          );
+        } catch (error) {
+          assertOwned();
+          assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(database), agentId, pathname);
+          assertSupportedAgentSchemaVersion(database, pathname);
+          step = operation.throw(error);
+          continue;
+        }
+        assertOwned();
+        assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(database), agentId, pathname);
+        assertSupportedAgentSchemaVersion(database, pathname);
+        step = operation.next();
+      }
+    } finally {
+      operation.return();
+    }
+    assertOwned();
     assertOpenClawAgentDatabaseForMaintenance(database, {
       agentId,
-      pathname: options.pathname,
+      pathname,
     });
   } finally {
     clearNodeSqliteKyselyCacheForDatabase(database);

--- a/src/state/openclaw-agent-db-retired-lease-repair.test.ts
+++ b/src/state/openclaw-agent-db-retired-lease-repair.test.ts
@@ -8,6 +8,7 @@ import {
   migrateOpenClawAgentDatabaseForMaintenance,
   OPENCLAW_AGENT_SCHEMA_VERSION,
   openOpenClawAgentDatabase,
+  withAgentDatabaseMaintenanceLease,
 } from "./openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
 
@@ -131,17 +132,19 @@ describe("retired agent state lease repair", () => {
     }
   });
 
-  it("leaves a clean v17 database unchanged", () => {
-    const { databasePath } = createCurrentAgentDatabase();
+  it("leaves a clean v17 database unchanged", async () => {
+    const { databasePath, env } = createCurrentAgentDatabase();
     const beforeMetadata = readPrimarySchemaMetadata(databasePath);
     const before = openNodeSqliteDatabase(databasePath, { readOnly: true });
     const beforeSchemaVersion = before.prepare("PRAGMA schema_version").get();
     before.close();
 
-    migrateOpenClawAgentDatabaseForMaintenance({
-      agentId: "worker-1",
-      pathname: databasePath,
-    });
+    await withAgentDatabaseMaintenanceLease({ env }, (maintenance) =>
+      migrateOpenClawAgentDatabaseForMaintenance(
+        { agentId: "worker-1", pathname: databasePath },
+        maintenance,
+      ),
+    );
 
     const after = openNodeSqliteDatabase(databasePath, { readOnly: true });
     try {
@@ -160,8 +163,8 @@ describe("retired agent state lease repair", () => {
     }
   });
 
-  it("rejects a foreign state_leases structure without changing it", () => {
-    const { databasePath } = createCurrentAgentDatabase();
+  it("rejects a foreign state_leases structure without changing it", async () => {
+    const { databasePath, env } = createCurrentAgentDatabase();
     const beforeMetadata = readPrimarySchemaMetadata(databasePath);
     const database = openNodeSqliteDatabase(databasePath);
     try {
@@ -176,12 +179,14 @@ describe("retired agent state lease repair", () => {
       database.close();
     }
 
-    expect(() =>
-      migrateOpenClawAgentDatabaseForMaintenance({
-        agentId: "worker-1",
-        pathname: databasePath,
-      }),
-    ).toThrow(/state_leases.*noncanonical|column definitions differ for state_leases/iu);
+    await expect(
+      withAgentDatabaseMaintenanceLease({ env }, (maintenance) =>
+        migrateOpenClawAgentDatabaseForMaintenance(
+          { agentId: "worker-1", pathname: databasePath },
+          maintenance,
+        ),
+      ),
+    ).rejects.toThrow(/state_leases.*noncanonical|column definitions differ for state_leases/iu);
 
     const after = openNodeSqliteDatabase(databasePath, { readOnly: true });
     try {
@@ -199,8 +204,8 @@ describe("retired agent state lease repair", () => {
     }
   });
 
-  it("rolls back the lease drop when canonical validation fails", () => {
-    const { databasePath } = createCurrentAgentDatabase();
+  it("rolls back the lease drop when canonical validation fails", async () => {
+    const { databasePath, env } = createCurrentAgentDatabase();
     installRetiredLeaseSchema(databasePath);
     const beforeMetadata = readPrimarySchemaMetadata(databasePath);
     const database = openNodeSqliteDatabase(databasePath);
@@ -213,12 +218,14 @@ describe("retired agent state lease repair", () => {
       database.close();
     }
 
-    expect(() =>
-      migrateOpenClawAgentDatabaseForMaintenance({
-        agentId: "worker-1",
-        pathname: databasePath,
-      }),
-    ).toThrow(/session_key_contract/iu);
+    await expect(
+      withAgentDatabaseMaintenanceLease({ env }, (maintenance) =>
+        migrateOpenClawAgentDatabaseForMaintenance(
+          { agentId: "worker-1", pathname: databasePath },
+          maintenance,
+        ),
+      ),
+    ).rejects.toThrow(/session_key_contract/iu);
 
     const after = openNodeSqliteDatabase(databasePath, { readOnly: true });
     try {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -707,6 +707,14 @@ export function ensureOpenClawAgentDatabaseSchema(
   db: DatabaseSync,
   options: OpenClawAgentDatabaseOptions & { register?: boolean },
 ): void {
+  runSqliteIntegrityOperationSync(ensureOpenClawAgentDatabaseSchemaSteps(db, options));
+}
+
+/** Share one schema sequence between synchronous callers and leased maintenance. */
+export function* ensureOpenClawAgentDatabaseSchemaSteps(
+  db: DatabaseSync,
+  options: OpenClawAgentDatabaseOptions & { register?: boolean },
+): SqliteIntegrityOperation<void> {
   const agentId = normalizeAgentId(options.agentId);
   const databaseOptions = { ...options, agentId };
   const pathname = resolveOpenClawAgentSqlitePath(databaseOptions);
@@ -715,17 +723,15 @@ export function ensureOpenClawAgentDatabaseSchema(
   assertSupportedAgentSchemaVersion(db, pathname);
   assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
   if (readSqliteUserVersion(db) !== AGENT_MEDIA_SCHEMA_VERSION) {
-    runSqliteIntegrityOperationSync(
-      agentDatabaseIntegrityBeforeMutationSteps(db, agentId, pathname),
-    );
+    yield* agentDatabaseIntegrityBeforeMutationSteps(db, agentId, pathname);
   }
   configureSqlitePreSchemaPragmas(db, {
     busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   });
   ensureAgentSchema(db, agentId, pathname);
   ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
-  if (options.register === true) {
-    registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
+  if (databaseOptions.register === true) {
+    registerOpenClawAgentDatabase({ agentId, path: pathname, env: databaseOptions.env });
   }
 }
 

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3823,8 +3823,9 @@ describe("openclaw agent database", () => {
     ).toEqual({ name: "route_context_json" });
   });
 
-  it("installs same-version session additions before maintenance index repair", () => {
+  it("installs same-version session additions before maintenance index repair", async () => {
     const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
 
     const { DatabaseSync } = requireNodeSqlite();
@@ -3853,10 +3854,13 @@ describe("openclaw agent database", () => {
       drifted.close();
     }
 
-    migrateOpenClawAgentDatabaseForMaintenance({
-      agentId: "worker-1",
-      pathname: databasePath,
-    });
+    materializeSharedStateDatabase(env);
+    await withAgentDatabaseMaintenanceLease({ env }, (maintenance) =>
+      migrateOpenClawAgentDatabaseForMaintenance(
+        { agentId: "worker-1", pathname: databasePath },
+        maintenance,
+      ),
+    );
 
     const repaired = new DatabaseSync(databasePath, { readOnly: true });
     try {
@@ -4013,12 +4017,14 @@ describe("openclaw agent database", () => {
     await expect(
       migrateAndOpenLegacyAgentDatabaseForTest({ agentId: "worker-1", env }),
     ).rejects.toThrow(/missing table auth_profile_store/iu);
-    expect(() =>
-      migrateOpenClawAgentDatabaseForMaintenance({
-        agentId: "worker-1",
-        pathname: databasePath,
-      }),
-    ).toThrow(/missing table auth_profile_store/iu);
+    await expect(
+      withAgentDatabaseMaintenanceLease({ env }, (maintenance) =>
+        migrateOpenClawAgentDatabaseForMaintenance(
+          { agentId: "worker-1", pathname: databasePath },
+          maintenance,
+        ),
+      ),
+    ).rejects.toThrow(/missing table auth_profile_store/iu);
 
     const after = new DatabaseSync(databasePath, { readOnly: true });
     try {
@@ -4092,7 +4098,7 @@ describe("openclaw agent database", () => {
     ).toEqual({ name: "session_suggestions" });
   });
 
-  it("rejects an inline unique constraint hidden behind a SQLite autoindex", () => {
+  it("rejects an inline unique constraint hidden behind a SQLite autoindex", async () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
@@ -4120,12 +4126,14 @@ describe("openclaw agent database", () => {
     expect(() => openOpenClawAgentDatabase({ agentId: "worker-1", env })).toThrow(
       /unexpected unique index on cache_entries/iu,
     );
-    expect(() =>
-      migrateOpenClawAgentDatabaseForMaintenance({
-        agentId: "worker-1",
-        pathname: databasePath,
-      }),
-    ).toThrow(/unexpected unique index on cache_entries/iu);
+    await expect(
+      withAgentDatabaseMaintenanceLease({ env }, (maintenance) =>
+        migrateOpenClawAgentDatabaseForMaintenance(
+          { agentId: "worker-1", pathname: databasePath },
+          maintenance,
+        ),
+      ),
+    ).rejects.toThrow(/unexpected unique index on cache_entries/iu);
     const after = new DatabaseSync(databasePath, { readOnly: true });
     try {
       expect(


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where startup and Doctor maintenance stop responding while verifying a large existing agent database. The initial whole-file SQLite integrity check ran synchronously, even though the maintenance owner already held an asynchronous lease.

## Why This Change Was Made

Run that initial check in the existing read-only integrity Worker while retaining the same database connection and global maintenance lease until the Worker exits. Synchronous callers and asynchronous maintenance now drive one schema sequence; migrations, index repair, transactions and durable cursors retain their existing order.

Every continuation revalidates the exact maintenance context, database owner and schema version. Doctor also stops before a later target can close a new runtime owner's database or move its files after maintenance ownership is lost. No schema, configuration, retention or lease policy changes.

## User Impact

Startup and Doctor can keep their event loop responsive during agent maintenance integrity admission. The same full-file checks still complete before the database is used. Schema repairs and compaction remain synchronous.

## Evidence

- Native baseline on Node 26.7: a synthetic 764 MB agent database with 500,000 cache rows spent 531 ms in its first maintenance integrity scan with no main-thread timer progress. Its completion cursor skipped the scan on the second call.
- Current candidate `258bc39ddcc9`: full changed checks and 523 Linux owner/integration tests passed, with eight existing platform-specific skips. Independent Codex integration review found no actionable P0–P2 findings. [Exact-head CI is green](https://github.com/openclaw/openclaw/actions/runs/34024124818).
- Full build and ordinary `openclaw gateway run` on Node 26.7: the maintenance scan ran in a Worker for 558 ms with 55 main-thread ticks and a 10.08 ms maximum gap. The runtime-admission sibling ran in a Worker for 533 ms with 54 ticks and a 10.17 ms maximum gap. Actual constructor stacks and in-scan lease/cursor/main-key reads qualified both paths.
- Readiness, authenticated `chat.history` and `health` calls succeeded. History retained the root and active branch; all four raw transcript events and complete node/window/cache row digests remained unchanged through normal SIGTERM exit 0. All helpers joined and both runtime and maintenance lease counts returned to zero.

The test/native run and full-build/compiled run used separate retained execution commits, each verified against the identical complete public `258bc39ddcc9` tree and dependency fingerprint. Original failed harness attempts remain retained: a missing public Git object and a pre-build mode assumption invalidated by the test runner's normal prerequisite build. The canonical receiver and actual full build were then qualified without changing file modes by hand or weakening runtime assertions. Independent trace review corrected a private native counter that mixed adapter and application ticks; the compiled proof already matched the actual Gateway PID.

Six earlier exact guard-removal variants produced the expected failures; restoring the candidate passed all 17 selected boundary cases. The initial unrelated stale-test-field failure was resolved through its already-landed main fix. Integration with #139683 preserves its target-discovery and recoverable-warning behavior.

## Scope and remaining work

This is a responsiveness improvement for the selected integrity scans, not a claim that total startup is stall-free. The final health sample still reported event-loop degradation with an 847.2 ms maximum/P99 delay outside those qualified intervals; that residual needs separate attribution. The measured legacy-worktree query also remains a follow-up; tested query-only alternatives were slower and were withheld.

The automated SQLite-table-change warning does not describe this diff: table definitions, indexes, schema versions, migration contents, stored formats and lease policy are unchanged. The existing schema sequence is shared by synchronous callers and the awaited maintenance driver. Production changes are +141/-69 (net +72), supplying that shared asynchronous owner boundary and the required continuation/later-target fences; tests are +556/-42.
