### PR TITLE
fix(gateway-client): preserve WebSocket options under Bun

### DIFF
--- a/packages/gateway-client/src/client.cloudflare-access.test.ts
+++ b/packages/gateway-client/src/client.cloudflare-access.test.ts
@@ -2,9 +2,9 @@ import { X509Certificate } from "node:crypto";
 import { createServer as createHttpsServer } from "node:https";
 import type { AddressInfo } from "node:net";
 import { afterEach, expect, test } from "vitest";
-import { WebSocketServer } from "ws";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../../test/helpers/tls-fixture.js";
 import { GatewayClient } from "./client.js";
+import { WebSocketServer } from "./websocket.test-support.js";
 
 const tlsFingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
 const websocketServers: WebSocketServer[] = [];

--- a/packages/gateway-client/src/client.handshake.test.ts
+++ b/packages/gateway-client/src/client.handshake.test.ts
@@ -3,10 +3,10 @@ import http from "node:http";
 import net from "node:net";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSocketServer, type WebSocket } from "ws";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { GatewayClient } from "./client.js";
 import { rawDataToString } from "./websocket-data.js";
+import { WebSocketServer, type WebSocket } from "./websocket.test-support.js";
 
 describe("GatewayClient websocket opening handshakeTimeout", () => {
   const servers: net.Server[] = [];

--- a/packages/gateway-client/src/client.tls.test.ts
+++ b/packages/gateway-client/src/client.tls.test.ts
@@ -10,10 +10,10 @@ import {
 } from "node:net";
 import { installGlobalProxy, type ProxylineHandle } from "@openclaw/proxyline";
 import { afterEach, describe, expect, it } from "vitest";
-import { WebSocketServer } from "ws";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../../test/helpers/tls-fixture.js";
 import { GatewayClient, type GatewayClientCloseInfo } from "./client.js";
+import { WebSocketServer } from "./websocket.test-support.js";
 
 const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256;
 const servers: Server[] = [];

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -20,7 +20,6 @@ import {
 } from "@openclaw/gateway-protocol/version";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { WebSocket } from "ws";
 import {
   isSensitiveUrlQueryParamName,
   normalizeTlsFingerprint,
@@ -59,6 +58,7 @@ import {
   isGatewayLoopbackHost,
   resolveGatewayWebSocketTransport,
 } from "./websocket-transport.js";
+import { WebSocket } from "./websocket.js";
 
 export type DeviceIdentity = {
   deviceId: string;

--- a/packages/gateway-client/src/client.watchdog.test.ts
+++ b/packages/gateway-client/src/client.watchdog.test.ts
@@ -3,7 +3,6 @@ import { createServer as createHttpsServer } from "node:https";
 import { createServer } from "node:net";
 import type { EventFrame } from "@openclaw/gateway-protocol";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { WebSocket, WebSocketServer } from "ws";
 import { GatewayClient } from "./client.js";
 import {
   GatewayProtocolClient,
@@ -12,6 +11,7 @@ import {
 } from "./protocol-client.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timeouts.js";
 import { rawDataToString } from "./websocket-data.js";
+import { WebSocket, WebSocketServer } from "./websocket.test-support.js";
 
 async function getFreePort(): Promise<number> {
   return await new Promise((resolve, reject) => {

--- a/packages/gateway-client/src/websocket.test-support.ts
+++ b/packages/gateway-client/src/websocket.test-support.ts
@@ -1,0 +1,11 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+export { WebSocket } from "./websocket.js";
+
+const require = createRequire(import.meta.url);
+export const { WebSocketServer }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
+
+export type WebSocketServer = import("ws").WebSocketServer;

--- a/packages/gateway-client/src/websocket.ts
+++ b/packages/gateway-client/src/websocket.ts
@@ -1,0 +1,10 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// Use the installed Node transport so Bun preserves ws options and lifecycle behavior.
+const require = createRequire(import.meta.url);
+export const { WebSocket }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
+
+export type WebSocket = import("ws").WebSocket;

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -173,7 +173,7 @@ class MockWebSocket {
   }
 }
 
-vi.mock("ws", () => ({
+vi.mock("../../packages/gateway-client/src/websocket.js", () => ({
   WebSocket: MockWebSocket,
 }));
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -54,7 +54,7 @@ const wsMockState = vi.hoisted(() => ({
   } | null,
 }));
 
-vi.mock("ws", () => ({
+vi.mock("../../packages/gateway-client/src/websocket.js", () => ({
   WebSocket: class MockWebSocket {
     static readonly OPEN = 1;
     on = vi.fn();

--- a/src/gateway/probe.device-auth-scope.test.ts
+++ b/src/gateway/probe.device-auth-scope.test.ts
@@ -72,7 +72,7 @@ class ProbeWebSocket {
   }
 }
 
-vi.mock("ws", () => ({ WebSocket: ProbeWebSocket }));
+vi.mock("../../packages/gateway-client/src/websocket.js", () => ({ WebSocket: ProbeWebSocket }));
 
 const { probeGateway } = await import("./probe.js");
 

--- a/src/gateway/test-helpers.acquisition.test.ts
+++ b/src/gateway/test-helpers.acquisition.test.ts
@@ -7,7 +7,8 @@ import os from "node:os";
 import path from "node:path";
 import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSocket, WebSocketServer } from "ws";
+import { WebSocket } from "ws";
+import { WebSocketServer } from "../../packages/gateway-client/src/websocket.test-support.js";
 import { createVitestResourceOwner } from "../../scripts/lib/vitest-resource-ownership.mts";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { runVitestShutdownCommand } from "../../test/helpers/vitest-shutdown-command.js";
@@ -21,6 +22,7 @@ import {
 
 afterEach(() => {
   vi.doUnmock("ws");
+  vi.doUnmock("../../packages/gateway-client/src/websocket.js");
   vi.doUnmock("./server.js");
   vi.doUnmock("../test-utils/ports.js");
   vi.doUnmock("../infra/device-pairing.js");
@@ -64,8 +66,10 @@ async function withAcquisitionPeer(
   const rejectAuth = behavior === "reject auth" || behavior === "reject auth without close";
   // Observe the real dependency; keep otherwise-unhandled errors local to this case.
   // Counting the remaining listeners makes a removed owner handler observable.
-  vi.doMock("ws", async (importOriginal) => {
-    const actual = await importOriginal<typeof import("ws")>();
+  const observeWebSocket = async () => {
+    const actual = await vi.importActual<
+      typeof import("../../packages/gateway-client/src/websocket.js")
+    >("../../packages/gateway-client/src/websocket.js");
     class ObservedWebSocket extends actual.WebSocket {
       constructor(...args: ConstructorParameters<typeof WebSocket>) {
         super(...args);
@@ -80,8 +84,15 @@ async function withAcquisitionPeer(
         });
       }
     }
-    return { ...actual, default: ObservedWebSocket, WebSocket: ObservedWebSocket };
-  });
+    return {
+      ...actual,
+      default: ObservedWebSocket,
+      WebSocket: ObservedWebSocket,
+      WebSocketServer,
+    };
+  };
+  vi.doMock("ws", observeWebSocket);
+  vi.doMock("../../packages/gateway-client/src/websocket.js", observeWebSocket);
   const sockets = new Set<Socket>();
   const requests: ReturnType<typeof parseMinimalGatewayRequestFrame>[] = [];
   let receivedUpgrade = false;

--- a/src/tui/gateway-chat.scopes.test.ts
+++ b/src/tui/gateway-chat.scopes.test.ts
@@ -88,8 +88,9 @@ describe("GatewayChatClient operator scopes", () => {
     }
 
     vi.resetModules();
-    vi.doMock("ws", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("ws")>();
+    vi.doMock("../../packages/gateway-client/src/websocket.js", async (importOriginal) => {
+      const actual =
+        await importOriginal<typeof import("../../packages/gateway-client/src/websocket.js")>();
       return { ...actual, WebSocket: ScopeUpgradeWebSocket };
     });
     vi.doMock("../gateway/client.js", async (importOriginal) => {
@@ -265,7 +266,7 @@ describe("GatewayChatClient operator scopes", () => {
       });
     } finally {
       await Promise.all(clients.map((client) => client.stop()));
-      vi.doUnmock("ws");
+      vi.doUnmock("../../packages/gateway-client/src/websocket.js");
       vi.doUnmock("../gateway/client.js");
       vi.resetModules();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Gateway client's configured Origin header was missing under Bun because its bare ws import selected a substituted adapter. The same substitution also bypassed the existing socket mocks.

## Why This Change Was Made

Resolve the package-owned installed WebSocket implementation through a private Node transport module. Update test mocks to that owner and keep the real test server in a test-only helper. The browser entry keeps its existing browser transport.

## User Impact

The covered Node/Bun Gateway connection path preserves its configured transport options and lifecycle. No authentication, TLS, scope, or protocol policy is changed.

## Evidence

- Eight focused benign existing cases pass on Node and true Bun. The unchanged Origin-header regression failed before the repair and passes afterward.
- Source and built-package loopback connections exchange one ordinary frame successfully on both runtimes.
- The browser-platform bundle contains no Node or ws imports.
- Complete final 12-path gate, final package build, and independent P0–P2 review pass. The full repository build passed before the final test-only export cleanup; final package/core checks cover that cleanup.
- Authentication, TLS, and other security cases were not run locally. Their mocks were updated without changing assertions; fresh hosted CI remains required.
- No live Gateway or configured proxy integration is claimed. The broader Bun compatibility campaign remains in progress.
