### PR TITLE
fix(test): preserve runner fixture lifecycles under Bun

### DIFF
--- a/test/fixtures/vitest-shutdown-cancellation.mjs
+++ b/test/fixtures/vitest-shutdown-cancellation.mjs
@@ -1,54 +1,56 @@
 import childProcess from "node:child_process";
 import fs from "node:fs";
-import { syncBuiltinESMExports } from "node:module";
 import path from "node:path";
+import { syncFixtureBuiltinExports } from "../scripts/fixtures/ci-fixture-runtime.cjs";
 
-const root = new URL(import.meta.url).searchParams.get("root");
-const file = (name) => path.join(root, name);
-const publish = (name, value) => {
-  fs.writeFileSync(file(`${name}.tmp`), String(value));
-  fs.renameSync(file(`${name}.tmp`), file(name));
-};
-
-if (process.argv[2] === root) {
-  const spawn = childProcess.spawn;
-  childProcess.spawn = (command, args, options) => {
-    const child = spawn(command, args, {
-      ...options,
-      env: {
-        ...options.env,
-        NODE_OPTIONS: `${options.env.NODE_OPTIONS} --import=${JSON.stringify(import.meta.url)}`,
-      },
-    });
-    publish("shim.pid", child.pid);
-    return child;
+/** @param {{ root: string, preload: string }} options */
+export function installVitestShutdownCancellation({ root, preload }) {
+  const file = (name) => path.join(root, name);
+  const publish = (name, value) => {
+    fs.writeFileSync(file(`${name}.tmp`), String(value));
+    fs.renameSync(file(`${name}.tmp`), file(name));
   };
-  // Release after every TERM listener and its microtasks run. An immediate KILL
-  // loses the paused forwarding shim; a graceful owner lets it forward first.
-  process.on("SIGTERM", () => {
-    publish("term-received", process.pid);
-    setImmediate(() => {
-      for (const name of ["shim.pid", "worker.pid"]) {
-        try {
-          process.kill(Number(fs.readFileSync(file(name), "utf8")), "SIGCONT");
-        } catch (error) {
-          if (error.code !== "ESRCH") {
-            throw error;
+
+  if (process.argv[2] === root) {
+    const spawn = childProcess.spawn;
+    childProcess.spawn = (command, args, options) => {
+      const child = spawn(command, args, {
+        ...options,
+        env: {
+          ...options.env,
+          NODE_OPTIONS: `${options.env.NODE_OPTIONS} --import=${JSON.stringify(preload)}`,
+        },
+      });
+      publish("shim.pid", child.pid);
+      return child;
+    };
+    // Release after every TERM listener and its microtasks run. An immediate KILL
+    // loses the paused forwarding shim; a graceful owner lets it forward first.
+    process.on("SIGTERM", () => {
+      publish("term-received", process.pid);
+      setImmediate(() => {
+        for (const name of ["shim.pid", "worker.pid"]) {
+          try {
+            process.kill(Number(fs.readFileSync(file(name), "utf8")), "SIGCONT");
+          } catch (error) {
+            if (error.code !== "ESRCH") {
+              throw error;
+            }
           }
         }
-      }
+      });
     });
-  });
-} else {
-  const write = fs.writeFileSync;
-  fs.writeFileSync = (target, ...args) => {
-    const result = write(target, ...args);
-    if (target === file("receipt.json")) {
-      // Stop at the actual worker receipt, before any test result or teardown.
-      publish("worker.pid", process.pid);
-      process.kill(process.pid, "SIGSTOP");
-    }
-    return result;
-  };
+  } else {
+    const write = fs.writeFileSync;
+    fs.writeFileSync = (target, ...args) => {
+      const result = write(target, ...args);
+      if (target === file("receipt.json")) {
+        // Stop at the actual worker receipt, before any test result or teardown.
+        publish("worker.pid", process.pid);
+        process.kill(process.pid, "SIGSTOP");
+      }
+      return result;
+    };
+  }
+  syncFixtureBuiltinExports();
 }
-syncBuiltinESMExports();

--- a/test/helpers/process-wait.test.ts
+++ b/test/helpers/process-wait.test.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { once } from "node:events";
 import fsSync from "node:fs";
 import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { killPidIfAlive } from "../../src/test-utils/process-tree.js";
 import {
@@ -9,9 +10,10 @@ import {
   waitForChildClose,
   waitForDead,
   waitForFile,
+  waitForFixtureFile,
   waitForPidFile,
 } from "./process-wait.js";
-import { withTestTimeout } from "./promise.js";
+import { createDeferred, withTestTimeout } from "./promise.js";
 import { useAutoCleanupTempDirTracker } from "./temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -167,3 +169,41 @@ child.once('close', (_code, signal) => {
     }
   }
 });
+
+it.each(["borrower completion", "persistent file"] as const)(
+  "observes readiness from %s without a file-watch event",
+  async (observation) => {
+    const filename = path.join(tempDirs.make("openclaw-process-receipt-"), "ready");
+    const { promise: completion, resolve: finish } = createDeferred();
+    const watchFile = fsSync.watchFile;
+    // A successful initial stat establishes a baseline without notifying Node's
+    // watchFile listener. A receipt created during that stat must still be seen.
+    const watcher = vi
+      .spyOn(fsSync, "watchFile")
+      .mockImplementation((target, ...args) =>
+        target === filename
+          ? watchFile(filename, { interval: 50 }, () => {})
+          : watchFile(target, ...args),
+      );
+    let ready = false;
+    const waiting = waitForFixtureFile(filename, completion).then(() => {
+      ready = true;
+    });
+    try {
+      fsSync.writeFileSync(filename, "ready");
+      if (observation === "borrower completion") {
+        finish();
+        await nextTurn();
+        expect(ready).toBe(true);
+      }
+      await withTestTimeout(waiting, 10_000, "Persistent readiness was not observed");
+      expect(ready).toBe(true);
+    } finally {
+      finish();
+      await waiting.finally(() => {
+        fsSync.unwatchFile(filename);
+        watcher.mockRestore();
+      });
+    }
+  },
+);

--- a/test/helpers/process-wait.ts
+++ b/test/helpers/process-wait.ts
@@ -1,5 +1,5 @@
 import type { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import fs, { existsSync, readFileSync } from "node:fs";
 import { isPidAlive } from "../../src/shared/pid-alive.js";
 
 export { isPidAlive as isProcessAlive };
@@ -70,5 +70,42 @@ export function waitForChildClose(
       clearTimeout(timeout);
       resolve({ code, signal });
     });
+  });
+}
+
+export function waitForFixtureFile(
+  filename: string,
+  completion: Promise<unknown>,
+  expected?: string,
+) {
+  return new Promise<void>((resolve, reject) => {
+    const matches = () =>
+      fs.existsSync(filename) &&
+      fs.statSync(filename).size > 0 &&
+      (expected === undefined || fs.readFileSync(filename, "utf8") === expected);
+    const check = () => {
+      if (matches()) {
+        clearInterval(poll);
+        resolve();
+      }
+    };
+    // watchFile can adopt a newly created receipt in its first stat without an event.
+    // Poll the persistent state itself so readiness never depends on that race.
+    const poll = setInterval(check, 50);
+    void completion.then(
+      () => {
+        clearInterval(poll);
+        if (matches()) {
+          resolve();
+        } else {
+          reject(new Error(`Child exited before writing ${filename}`));
+        }
+      },
+      (error: unknown) => {
+        clearInterval(poll);
+        reject(new Error(`Child failed before writing ${filename}`, { cause: error }));
+      },
+    );
+    check();
   });
 }

--- a/test/scripts/anthropic-preparation-probe.ts
+++ b/test/scripts/anthropic-preparation-probe.ts
@@ -23,8 +23,25 @@ assert.ok(
   JSON.stringify({ plugins: registry.plugins, diagnostics: registry.diagnostics }),
 );
 const loader = getPluginModuleLoaderStats();
-assert.equal(loader.nativeHits, 1, "the real provider must load its prepared JavaScript");
-assert.equal(loader.sourceTransformForced + loader.sourceTransformFallbacks, 0);
+// The loader deliberately selects Jiti on Bun and native require on Node.
+const isBun = Boolean(process.versions.bun);
+assert.deepEqual(
+  {
+    calls: loader.calls,
+    nativeHits: loader.nativeHits,
+    nativeMisses: loader.nativeMisses,
+    sourceTransformForced: loader.sourceTransformForced,
+    sourceTransformFallbacks: loader.sourceTransformFallbacks,
+  },
+  {
+    calls: 1,
+    nativeHits: isBun ? 0 : 1,
+    nativeMisses: 0,
+    sourceTransformForced: isBun ? 1 : 0,
+    sourceTransformFallbacks: 0,
+  },
+  "prepared provider loading must follow the runtime policy",
+);
 const result = withPluginRuntimeRegistryScope(registry, classify);
 assert.equal(result?.reason, "server_error");
 assert.equal(result?.provider, "anthropic");

--- a/test/scripts/fixtures/ci-fixture-runtime.cjs
+++ b/test/scripts/fixtures/ci-fixture-runtime.cjs
@@ -2,25 +2,44 @@ const { syncBuiltinESMExports } = require("node:module");
 const { pathToFileURL } = require("node:url");
 
 // Synthetic child fixtures replace builtin methods before loading their owners.
-exports.syncFixtureBuiltinExports = function syncFixtureBuiltinExports() {
+/** @param {string[]} [names] */
+exports.syncFixtureBuiltinExports = function syncFixtureBuiltinExports(
+  names = ["node:child_process", "node:fs"],
+) {
   if (!process.versions.bun) {
     syncBuiltinESMExports();
     return;
   }
   const { mock } = require("bun:test");
-  for (const name of ["node:child_process", "node:fs"]) {
+  for (const name of names) {
     const builtin = require(name);
     mock.module(name, () => ({ ...builtin, default: builtin }));
   }
 };
 
-/** @param {string} preload */
-exports.fixturePreloadEnv = function fixturePreloadEnv(preload) {
+/** @param {string} preload @param {"node" | "bun"} runtime */
+function preloadSpecifier(preload, runtime) {
   const url = pathToFileURL(preload).href;
-  if (!process.versions.bun) {
-    return { NODE_OPTIONS: `--import=${url}` };
+  if (runtime === "node") {
+    return url;
   }
   // BUN_OPTIONS cannot quote paths with spaces; import the original file by URL.
   const loader = Buffer.from(`import ${JSON.stringify(url)};`).toString("base64");
-  return { BUN_OPTIONS: `--preload=data:text/javascript;base64,${loader}` };
+  return `data:text/javascript;base64,${loader}`;
+}
+
+/** @param {string} preload */
+exports.fixturePreloadArgs = function fixturePreloadArgs(preload) {
+  return ["--import", preloadSpecifier(preload, process.versions.bun ? "bun" : "node")];
+};
+
+/** @param {string} preload @param {"node" | "bun"} [runtime] */
+exports.fixturePreloadEnv = function fixturePreloadEnv(
+  preload,
+  runtime = process.versions.bun ? "bun" : "node",
+) {
+  const specifier = preloadSpecifier(preload, runtime);
+  return runtime === "bun"
+    ? { BUN_OPTIONS: `--preload=${specifier}` }
+    : { NODE_OPTIONS: `--import=${specifier}` };
 };

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -55,7 +55,7 @@ beforeEach(() => {
   }));
   originalArgv = process.argv;
   originalExitCode = process.exitCode;
-  process.exitCode = undefined;
+  process.exitCode = 0;
   vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "");
   vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "");
   vi.stubEnv("OPENCLAW_E2E_SKIP_BUILD", "");
@@ -73,7 +73,7 @@ beforeEach(() => {
 afterEach(() => {
   patternFiles.cleanup();
   process.argv = originalArgv;
-  process.exitCode = originalExitCode;
+  process.exitCode = originalExitCode ?? 0;
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
@@ -143,11 +143,11 @@ describe("CLI runtime admission", () => {
     fs.writeFileSync(
       preload,
       `import cp from 'node:child_process';
-import { syncBuiltinESMExports } from 'node:module';
+import { syncFixtureBuiltinExports } from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 const spawn = cp.spawn;
 cp.spawn = (bin, args, options) => spawn(process.execPath, ['-e',
   args.includes('scripts/run-node.mjs') ? 'process.exit(91)' : ''], options);
-syncBuiltinESMExports();\n`,
+syncFixtureBuiltinExports();\n`,
     );
     const configArgs = args.includes("--config")
       ? []
@@ -315,7 +315,7 @@ process.stdin.resume();\n`,
               preload,
               `import cp from 'node:child_process';
 import fs from 'node:fs';
-import { syncBuiltinESMExports } from 'node:module';
+import { syncFixtureBuiltinExports } from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 const spawn = cp.spawn;
 cp.spawn = (bin, args, options) => {
   if (args.includes('scripts/run-node.mjs')) return spawn(process.execPath, [${JSON.stringify(builder)}], options);
@@ -325,7 +325,7 @@ cp.spawn = (bin, args, options) => {
   }
   return spawn(bin, args, options);
 };
-syncBuiltinESMExports();\n`,
+syncFixtureBuiltinExports();\n`,
             );
             const child = spawn(
               process.execPath,
@@ -546,7 +546,7 @@ describe("parallel cache lease completion", () => {
       expect(uiPaths).toHaveLength(4);
       expect(new Set(uiPaths).size).toBe(1);
       expect(attempts).toBe(2);
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     },
   );
 
@@ -784,7 +784,7 @@ describe("test-projects build admission", () => {
       }
       expect(await terminal.promise).toMatch(/^\[test\] passed 2 Vitest shards/u);
       expect(commands.reader).toHaveBeenCalledTimes(2);
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     },
   );
 

--- a/test/scripts/vitest-fork-shutdown.test.ts
+++ b/test/scripts/vitest-fork-shutdown.test.ts
@@ -4,9 +4,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, it, type TestContext } from "vitest";
 import { inspectManagedProcessGroup } from "../../scripts/lib/managed-child-process.mts";
-import { isProcessAlive, waitForDead, waitForFile } from "../helpers/process-wait.js";
+import {
+  isProcessAlive,
+  waitForDead,
+  waitForFile,
+  waitForFixtureFile,
+} from "../helpers/process-wait.js";
 import { createTempDirTracker } from "../helpers/temp-dir.js";
 import { runVitestShutdownCommand } from "../helpers/vitest-shutdown-command.js";
+import { fixturePreloadArgs } from "./fixtures/ci-fixture-runtime.cjs";
 
 const fixture = fileURLToPath(new URL("../fixtures/vitest-fork-shutdown.mjs", import.meta.url));
 // Outside the enclosing Vitest TMPDIR: its owner must not erase retained writers.
@@ -185,14 +191,18 @@ it.runIf(process.platform !== "win32").for(["signal", "timeout"])(
       const ownedDirs = createTempDirTracker();
       const root = ownedDirs.make("vitest-fork-cancellation-", fixtureRoots);
       const control = new URL("../fixtures/vitest-shutdown-cancellation.mjs", import.meta.url);
-      control.searchParams.set("root", root);
-      // Subscribe before launch; the producer publishes worker.pid atomically.
-      const watcher = fs.watch(root);
+      const preload = path.join(root, "cancellation-preload.mjs");
+      fs.writeFileSync(
+        preload,
+        `import {installVitestShutdownCancellation} from ${JSON.stringify(control.href)};
+installVitestShutdownCancellation({root:${JSON.stringify(root)},preload:import.meta.url});
+`,
+      );
       let child!: ChildProcess;
       const invocation = runFixture(
         root,
         { scenario: "slow-exit", setup: "shared", fail: false },
-        ["--import", control.href],
+        fixturePreloadArgs(preload),
         {
           onReady(owned) {
             child = owned;
@@ -204,36 +214,11 @@ it.runIf(process.platform !== "win32").for(["signal", "timeout"])(
         (result) => ({ result, error: undefined }),
         (error: unknown) => ({ result: undefined, error }),
       );
-      let cancelReady!: () => void;
-      const ready = new Promise<{ shim: number; worker: number }>((resolve, reject) => {
-        const readReady = () => {
-          try {
-            if (fs.existsSync(path.join(root, "worker.pid"))) {
-              resolve({
-                shim: Number(fs.readFileSync(path.join(root, "shim.pid"), "utf8")),
-                worker: Number(fs.readFileSync(path.join(root, "worker.pid"), "utf8")),
-              });
-            }
-          } catch (error) {
-            reject(error);
-          }
-        };
-        cancelReady = () => reject(context.signal.reason);
-        watcher.on("change", readReady).once("error", reject);
-        context.signal.addEventListener("abort", cancelReady, { once: true });
-        if (context.signal.aborted) cancelReady();
-        else readReady();
-        void outcome.then((result) => {
-          reject(
-            new Error(`Fixture exited before worker receipt: ${JSON.stringify(result)}`, {
-              cause: result.error,
-            }),
-          );
-        });
-      });
       const pids: number[] = [];
       try {
-        const { worker, shim } = await ready;
+        await waitForFixtureFile(path.join(root, "worker.pid"), invocation);
+        const shim = Number(fs.readFileSync(path.join(root, "shim.pid"), "utf8"));
+        const worker = Number(fs.readFileSync(path.join(root, "worker.pid"), "utf8"));
         context.signal.throwIfAborted();
         pids.push(shim, worker);
         process.kill(shim, "SIGSTOP");
@@ -297,9 +282,6 @@ it.runIf(process.platform !== "win32").for(["signal", "timeout"])(
         expectReleasedNamespace(root);
         ownedDirs.cleanup();
       } finally {
-        context.signal.removeEventListener("abort", cancelReady);
-        watcher.close();
-        watcher.removeAllListeners();
         for (const pid of pids) {
           if (isProcessAlive(pid)) {
             process.kill(pid, "SIGCONT");
@@ -336,8 +318,6 @@ fs.writeFileSync(process.argv[1] + ".tmp", String(process.pid));
 fs.renameSync(process.argv[1] + ".tmp", process.argv[1]);
 `;
       const controller = new AbortController();
-      // Watch before launch; the existing command deadline also bounds readiness.
-      const watcher = fs.watch(root);
       let child!: ChildProcess;
       const invocation = runVitestShutdownCommand({
         args: [
@@ -365,29 +345,12 @@ spawn(process.execPath, ["-e", ${JSON.stringify(descendantSource)}, process.argv
         (result) => ({ result, error: undefined }),
         (error: unknown) => ({ result: undefined, error }),
       );
-      let cancelReady!: () => void;
-      const ready = new Promise<number>((resolve, reject) => {
-        const readReady = () => {
-          try {
-            if (fs.existsSync(descendantPidPath)) {
-              const pid = Number(fs.readFileSync(descendantPidPath, "utf8"));
-              if (Number.isSafeInteger(pid) && pid > 0) resolve(pid);
-            }
-          } catch (error) {
-            reject(error);
-          }
-        };
-        cancelReady = () => reject(context.signal.reason);
-        watcher.on("change", readReady).once("error", reject);
-        context.signal.addEventListener("abort", cancelReady, { once: true });
-        if (context.signal.aborted) cancelReady();
-        else readReady();
-        void outcome.then((result) => {
-          reject(result.error ?? new Error("Fixture exited before descendant PID receipt"));
-        });
-      });
       try {
-        const descendantPid = await ready;
+        await waitForFixtureFile(descendantPidPath, invocation);
+        const descendantPid = Number(fs.readFileSync(descendantPidPath, "utf8"));
+        if (!Number.isSafeInteger(descendantPid) || descendantPid <= 0) {
+          throw new Error("Invalid descendant PID receipt");
+        }
         context.signal.throwIfAborted();
         const childPid = child.pid!;
         const processes = execFileSync(
@@ -436,9 +399,6 @@ spawn(process.execPath, ["-e", ${JSON.stringify(descendantSource)}, process.argv
           }),
         );
       } finally {
-        context.signal.removeEventListener("abort", cancelReady);
-        watcher.close();
-        watcher.removeAllListeners();
         controller.abort();
         expect((await outcome).error).toMatchObject({ code: "ABORT_ERR" });
       }

--- a/test/scripts/vitest-worker-artifacts.test-support.ts
+++ b/test/scripts/vitest-worker-artifacts.test-support.ts
@@ -167,43 +167,6 @@ export function writeFixture(directory: string, name: string, source: string) {
   return filename;
 }
 
-export function waitForFixtureFile(
-  filename: string,
-  completion: Promise<unknown>,
-  expected?: string,
-) {
-  return new Promise<void>((resolve, reject) => {
-    const matches = () =>
-      fs.existsSync(filename) &&
-      fs.statSync(filename).size > 0 &&
-      (expected === undefined || fs.readFileSync(filename, "utf8") === expected);
-    const check = () => {
-      if (matches()) {
-        clearInterval(poll);
-        resolve();
-      }
-    };
-    // watchFile can adopt a newly created receipt in its first stat without an event.
-    // Poll the persistent state itself so readiness never depends on that race.
-    const poll = setInterval(check, 50);
-    void completion.then(
-      () => {
-        clearInterval(poll);
-        if (matches()) {
-          resolve();
-        } else {
-          reject(new Error(`Child exited before writing ${filename}`));
-        }
-      },
-      (error: unknown) => {
-        clearInterval(poll);
-        reject(new Error(`Child failed before writing ${filename}`, { cause: error }));
-      },
-    );
-    check();
-  });
-}
-
 export function workerProbe(
   directory: string,
   holdSecond = false,
@@ -292,8 +255,9 @@ export function workerProbe(
             expect(url.endsWith(sourceMode ? '.ts' : '.js')).toBe(true);
             if (!sourceMode) expect(fileURLToPath(url).startsWith(fileURLToPath(new URL('../', generation)))).toBe(true);
           }
-          expect(args.includes('tsx')).toBe(sourceMode);
-          expect(args[sourceMode ? 2 : 0]).toMatch(sourceMode ? /\\.ts$/ : /\\.js$/);
+          const sourceLoader = sourceMode && !process.versions.bun;
+          expect(args.includes('tsx')).toBe(sourceLoader);
+          expect(args[sourceLoader ? 2 : 0]).toMatch(sourceMode ? /\\.ts$/ : /\\.js$/);
           fs.appendFileSync(${JSON.stringify(path.join(directory, "observations.jsonl"))}, JSON.stringify({args, tuiUrls, setupUrls, value, configValue:inject('configValue'), knn:resolveRuntimeWorkerUrl(vectorKnnProcessEntrypoint).href})+'\\n');
           fs.appendFileSync(${JSON.stringify(path.join(directory, "generations.jsonl"))}, JSON.stringify(generation)+'\\n');
           const release = inject('releaseFile');

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { setImmediate as nextTurn } from "node:timers/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { convertPathToPattern } from "tinyglobby";
 import { describe, expect, vi } from "vitest";
@@ -19,12 +18,12 @@ import { createVitestWorkerRun } from "../../scripts/lib/vitest-worker-run.mts";
 import { resolveVitestSpawnParams, spawnWatchedVitestProcess } from "../../scripts/run-vitest.mts";
 import { createVitestProcessCompletion } from "../../scripts/vitest-process-group.mts";
 import { resolveRuntimeWorkerArgv } from "../../src/infra/runtime-worker-url.js";
-import { createDeferred, withTestTimeout } from "../helpers/promise.js";
+import { waitForFixtureFile } from "../helpers/process-wait.js";
+import { fixturePreloadArgs } from "./fixtures/ci-fixture-runtime.cjs";
 import { copyFsSafePackageFixture } from "./fs-safe-package.test-support.js";
 import {
   createWorkerArtifactTest,
   preparationClient,
-  waitForFixtureFile,
   workerProbe,
   writeFixture,
 } from "./vitest-worker-artifacts.test-support.js";
@@ -38,8 +37,15 @@ function interceptCompilerBuild(directory: string, source: string): string {
   const wrapper = writeFixture(
     directory,
     "tsdown-wrapper.mjs",
-    `import {build as compile} from ${JSON.stringify(compilerModuleUrl)};\n${source}`,
+    `import * as compiler from ${JSON.stringify(compilerModuleUrl)};\nconst compile = compiler.build;\n${source}`,
   );
+  if (process.versions.bun) {
+    // Capture the real compiler before replacing live exports in the fixture process.
+    return `const actual = await import(${JSON.stringify(compilerModuleUrl)});
+const wrapper = await import(${JSON.stringify(pathToFileURL(wrapper).href)});
+const {mock} = await import('bun:test');
+mock.module('tsdown', () => ({...actual, ...wrapper}));`;
+  }
   return `import {registerHooks} from 'node:module';
 registerHooks({resolve(specifier,context,nextResolve) {
   return specifier==='tsdown'
@@ -177,8 +183,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         // Inject only into the actual native compiler entry, never the parent's
         // module cache or a production build flag. node() joins this direct child.
         const result = await node([
-          "--import",
-          pathToFileURL(preload).href,
+          ...fixturePreloadArgs(preload),
           path.join(root, compilerEntry),
           owner.descriptor.directory,
         ]);
@@ -209,7 +214,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       import fs from 'node:fs';
       import path from 'node:path';
       import {spawn} from 'node:child_process';
-      import {syncBuiltinESMExports} from 'node:module';
+      import {syncFixtureBuiltinExports} from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
       const directory=${JSON.stringify(directory)}, mode=${JSON.stringify(mode)};
       const record=(name,value)=>fs.writeFileSync(path.join(directory,name),value);
       const write=fs.writeFileSync;
@@ -254,7 +259,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         }
         return result;
       };
-      syncBuiltinESMExports();
+      syncFixtureBuiltinExports();
     `,
           ),
         );
@@ -266,7 +271,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       import fs from 'node:fs';
       import path from 'node:path';
       import cp from 'node:child_process';
-      import {syncBuiltinESMExports} from 'node:module';
+      import {syncFixtureBuiltinExports} from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
       import {setTimeout as tick} from 'node:timers/promises';
       import {inspectManagedProcessGroup} from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/lib/managed-child-process.mts")).href)};
       import {createVitestResourceOwner} from ${JSON.stringify(pathToFileURL(path.join(root, "scripts/lib/vitest-resource-ownership.mts")).href)};
@@ -281,11 +286,11 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       let compiler, closed=false, ready=false, finished=false, readyClosed, leafPid;
       cp.spawn=(bin,args,options)=>{
         if(args[0]!==${JSON.stringify(path.join(root, compilerEntry))}) return spawn(bin,args,options);
-        compiler=spawn(bin,['--import',${JSON.stringify(pathToFileURL(preload).href)},...args],options);
+        compiler=spawn(bin,[...${JSON.stringify(fixturePreloadArgs(preload))},...args],options);
         compiler.once('close',()=>{closed=true;});
         return compiler;
       };
-      syncBuiltinESMExports();
+      syncFixtureBuiltinExports();
       const {createVitestWorkerRun}=await import(${JSON.stringify(pathToFileURL(path.join(root, compilerModule)).href)});
       const {createVitestProcessCompletion}=await import(${JSON.stringify(pathToFileURL(path.join(root, "scripts/vitest-process-group.mts")).href)});
       const owner=createVitestWorkerRun(), generation=owner.descriptor.directory;
@@ -485,46 +490,6 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
         const observed = JSON.parse(fs.readFileSync(receipt, "utf8"));
         expect(observed).toMatchObject({ fault, closed: true, inputRemoved: true });
         console.log("whole-body lifetime", observed);
-      }),
-  );
-
-  it.for(["borrower completion", "persistent file"] as const)(
-    "observes readiness from %s without a file-watch event",
-    { concurrent: false },
-    (observation, { workerArtifacts }) =>
-      workerArtifacts.fixtureLifetime.run(async () => {
-        const filename = path.join(workerArtifacts.fixtureDirectory(), "ready");
-        const { promise: completion, resolve: finish } = createDeferred();
-        const watchFile = fs.watchFile;
-        // A successful initial stat establishes a baseline without notifying Node's
-        // watchFile listener. A receipt created during that stat must still be seen.
-        const watcher = vi
-          .spyOn(fs, "watchFile")
-          .mockImplementation((target, ...args) =>
-            target === filename
-              ? watchFile(filename, { interval: 50 }, () => {})
-              : watchFile(target, ...args),
-          );
-        let ready = false;
-        const waiting = waitForFixtureFile(filename, completion).then(() => {
-          ready = true;
-        });
-        try {
-          fs.writeFileSync(filename, "ready");
-          if (observation === "borrower completion") {
-            finish();
-            await nextTurn();
-            expect(ready).toBe(true);
-          }
-          await withTestTimeout(waiting, 10_000, "Persistent readiness was not observed");
-          expect(ready).toBe(true);
-        } finally {
-          finish();
-          await waiting.finally(() => {
-            fs.unwatchFile(filename);
-            watcher.mockRestore();
-          });
-        }
       }),
   );
 
@@ -976,7 +941,7 @@ if (process.argv[1]?.endsWith("vitest-worker-compiler.mts")) {
         const handle = startBorrower(
           owner,
           ["run", "--config", config, "--project", "second"],
-          action === "owner disconnect" ? ["--import", pathToFileURL(disconnect).href] : [],
+          action === "owner disconnect" ? fixturePreloadArgs(disconnect) : [],
         );
         try {
           const observed = path.join(directory, "generations.jsonl");
@@ -1180,6 +1145,7 @@ if (process.argv[1]?.endsWith("vitest-worker-compiler.mts")) {
     workerArtifacts.fixtureLifetime.run(async () => {
       const directory = workerArtifacts.fixtureDirectory();
       const observed = path.join(directory, "watch-result.txt");
+      const watchReady = path.join(directory, "watch-ready");
       const dependency = writeFixture(
         directory,
         "value.ts",
@@ -1205,12 +1171,21 @@ if (process.argv[1]?.endsWith("vitest-worker-compiler.mts")) {
       });
     `,
       );
+      const reporter = writeFixture(
+        directory,
+        "watch-reporter.mjs",
+        `import fs from 'node:fs';
+export default class {
+  onWatcherStart() { fs.writeFileSync(${JSON.stringify(watchReady)}, 'ready'); }
+}`,
+      );
       const config = writeFixture(
         directory,
         "vitest.config.mts",
         `
       import {sharedVitestConfig as shared} from ${JSON.stringify(pathToFileURL(path.join(root, "test/vitest/vitest.shared.config.ts")).href)};
-      export default {root:${JSON.stringify(directory)},plugins:shared.plugins,test:{include:[${JSON.stringify(convertPathToPattern(test))}],pool:'forks',maxWorkers:1}};
+      // This fixture tests live-source reruns independently of native filesystem notifications.
+      export default {root:${JSON.stringify(directory)},plugins:shared.plugins,server:{watch:{usePolling:true}},test:{include:[${JSON.stringify(convertPathToPattern(test))}],pool:'forks',maxWorkers:1,reporters:['default',${JSON.stringify(reporter)}]}};
     `,
       );
       const handle = spawnWatchedVitestProcess({
@@ -1230,11 +1205,17 @@ if (process.argv[1]?.endsWith("vitest-worker-compiler.mts")) {
         await handle.completion;
       });
       try {
-        await waitForFixtureFile(observed, handle.completion, "first");
+        await Promise.all([
+          waitForFixtureFile(observed, handle.completion, "first"),
+          waitForFixtureFile(watchReady, handle.completion),
+        ]);
         const rerun = waitForFixtureFile(observed, handle.completion, "second");
         fs.writeFileSync(dependency, 'export const value: string = "second"; console.log(value);');
         await rerun;
         expect(output).not.toContain("[vitest-workers] prepared");
+      } catch (error) {
+        console.error(output);
+        throw error;
       } finally {
         handle.child.kill("SIGTERM");
         await handle.completion;

--- a/test/scripts/vitest-worker-shutdown.test.ts
+++ b/test/scripts/vitest-worker-shutdown.test.ts
@@ -8,13 +8,13 @@ import { inspectManagedProcessGroup } from "../../scripts/lib/managed-child-proc
 import type { VitestWorkerManifest } from "../../scripts/lib/vitest-worker-artifacts.mts";
 import { createVitestWorkerRun } from "../../scripts/lib/vitest-worker-run.mts";
 import { createVitestProcessCompletion } from "../../scripts/vitest-process-group.mts";
-import { isProcessAlive, waitForDead } from "../helpers/process-wait.js";
+import { isProcessAlive, waitForDead, waitForFixtureFile } from "../helpers/process-wait.js";
 import { createDeferred, withTestTimeout } from "../helpers/promise.js";
 import { runNodeScript } from "../helpers/run-node-script.js";
+import { fixturePreloadEnv } from "./fixtures/ci-fixture-runtime.cjs";
 import {
   createWorkerArtifactTest,
   preparationClient,
-  waitForFixtureFile,
   writeFixture,
 } from "./vitest-worker-artifacts.test-support.js";
 
@@ -117,7 +117,7 @@ import cp from 'node:child_process';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
-import {syncBuiltinESMExports} from 'node:module';
+import {syncFixtureBuiltinExports} from ${JSON.stringify(new URL("./fixtures/ci-fixture-runtime.cjs", import.meta.url).href)};
 const root=${JSON.stringify(root)}, input=${JSON.stringify(input)};
 // CI workspaces need not provide native directory notifications. Control-file
 // readiness must remain observable without that optional filesystem facility.
@@ -193,7 +193,7 @@ fs.rmSync=(filename,...args)=>{
   }
   return rmSync(filename,...args);
 };
-syncBuiltinESMExports();
+syncFixtureBuiltinExports(["node:child_process", "node:fs", "node:fs/promises"]);
 `,
       );
       const config = writeFixture(root, "vitest.config.mjs", "export default {};\n");
@@ -218,7 +218,8 @@ syncBuiltinESMExports();
             TMPDIR: root,
             TMP: root,
             TEMP: root,
-            NODE_OPTIONS: `--import=${pathToFileURL(preload).href}`,
+            // The direct JavaScript shim owns a Node implementation; the serial entry uses this runtime.
+            ...fixturePreloadEnv(preload, route === "direct" ? "node" : undefined),
           },
           20_000,
           {


### PR DESCRIPTION
## What Problem This Solves

Fixes runtime-specific runner fixture failures under Bun involving builtin export interception, preload paths, receipt readiness, and assumptions about Node-only loader behavior.

## Why This Change Was Made

Reuse the census fixture runtime helper, preserve original preload files through a runtime-appropriate import, and move existing receipt-state observation into the shared test helper. Keep managed cancellation tied to command completion. The watch fixture observes watcher readiness and uses its existing supported polling mode.

The Anthropic preparation probe checks the exact existing runtime policy: one Node native load or one Bun forced-Jiti load, with zero native misses and zero fallback attempts. Provider classification and global-state assertions remain intact.

## User Impact

No production behavior changes. The same runner and worker fixtures exercise their intended lifecycle and loader contracts with either runtime. The prerequisite #139808 is merged, and this PR targets main.

## Evidence

- After the patch-identical two-commit rebase and locked install, all 271 selected tests pass on Node and all 271 on true Bun: 134 admission/fork, 49 worker, 14 shared-helper, and 74 census cases per runtime. Main added one case beyond the original 270-case selection.
- The complete ten-path changed gate passes; the unchanged patch retains its clean P0–P2 review.
- Existing cancellation proof preserves prompt rejection, closed pipes, and absent child PID. Every verification process joined without triggering its resource cap.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34028116528) passes.
- Production runtime policy, timeout bounds, and failure assertions are unchanged. No full repository Bun-green claim is made.
