### PR TITLE
fix: stop OAuth fallback after catalog discovery times out

### DIFF
--- a/src/agents/models-config.providers.catalog-context.ts
+++ b/src/agents/models-config.providers.catalog-context.ts
@@ -32,10 +32,11 @@ export async function prepareProviderCatalogRun(
   params: Parameters<typeof runProviderCatalog>[0] & {
     agentDir: string;
     authStore: AuthProfileStore;
+    isActive: () => boolean;
     timeoutMs?: number | null;
   },
 ): Promise<Parameters<typeof runProviderCatalog>[0] & { timeoutMs?: number | null }> {
-  const { authStore, ...catalogParams } = params;
+  const { authStore, isActive, ...catalogParams } = params;
   if (
     !params.provider.auth.some((method) => method.kind === "oauth") ||
     (params.providerIds !== undefined &&
@@ -57,6 +58,7 @@ export async function prepareProviderCatalogRun(
         authStore,
         provider: params.provider.id,
         resolveProviderAuth: params.resolveProviderAuth,
+        isActive,
       },
       params.config,
     ),

--- a/src/agents/models-config.providers.discovery-auth.runtime.ts
+++ b/src/agents/models-config.providers.discovery-auth.runtime.ts
@@ -102,17 +102,21 @@ export async function prepareProviderCatalogOAuthAuth(
     authStore,
     provider,
     resolveProviderAuth,
+    isActive,
   }: {
     agentDir: string;
     authStore: AuthProfileStore;
     provider: string;
     resolveProviderAuth: ProviderAuthResolver;
+    isActive: () => boolean;
   },
   config?: OpenClawConfig,
 ) {
   const failedProfileIds: string[] = [];
   let preparedProfile: { profileId: string; apiKey: string } | undefined;
-  while (true) {
+  // Let an admitted refresh finish persisting its rotation, but do not start
+  // another candidate after the catalog owner closes preparation admission.
+  while (isActive()) {
     let auth: ReturnType<ProviderAuthResolver>;
     try {
       auth = resolveProviderAuth(provider, { excludeProfileIds: failedProfileIds });

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -369,6 +369,7 @@ async function runProviderCatalogWithTimeout(
   let active = true;
   const catalogParams = {
     ...params,
+    isActive: () => active,
     reportCatalogOutcome: (outcome: ProviderCatalogOutcome) => {
       if (active) {
         params.reportCatalogOutcome?.(outcome);
@@ -390,6 +391,7 @@ async function runProviderCatalogWithTimeout(
       catalogRun,
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
+          active = false;
           reject(timeoutError);
         }, timeoutMs);
         timer.unref?.();

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -83,6 +83,10 @@ describe("Provider model discovery auth preparation", () => {
         },
       }),
     );
+    vi.spyOn(providerRuntime, "formatProviderAuthProfileApiKeyWithPlugin").mockImplementation(
+      async ({ provider, context }) =>
+        discovery.providers.find((candidate) => candidate.id === provider)?.formatApiKey?.(context),
+    );
     const profileId = "chutes:oauth";
     const config: OpenClawConfig = { auth: { order: { chutes: [profileId] } } };
     const store = createExpiredOauthStore({
@@ -350,50 +354,130 @@ describe("Provider model discovery auth preparation", () => {
     }
   });
 
-  it("does not start a live catalog after OAuth preparation times out", async () => {
-    const { config, store, refreshedCredential } = await createChutesCatalogFixture();
-    const refreshResult =
-      createDeferredCore<
-        Awaited<ReturnType<typeof providerRuntime.resolveProviderOAuthCredentialWithPlugin>>
-      >();
-    const refresh = vi
-      .spyOn(providerRuntime, "resolveProviderOAuthCredentialWithPlugin")
-      .mockImplementation(() => refreshResult.promise);
-    const preparation = vi.spyOn(catalogContext, "prepareProviderCatalogRun");
-    const catalog = vi.spyOn(providerDiscovery, "runProviderCatalog");
-    const fetch = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(Response.json({ data: [{ id: "late-account-model" }] }));
-    const outcomes: ProviderCatalogOutcome[] = [];
-
-    try {
-      const plan = await planCatalog(config, store, {
+  it.each([
+    { completion: "success", timedOut: true },
+    { completion: "failure", timedOut: true },
+    { completion: "failure", timedOut: false },
+  ] as const)(
+    "keeps OAuth preparation bounded after $completion (timeout: $timedOut)",
+    async ({ completion, timedOut }) => {
+      const { profileId, config, store, capturedCredential, refreshedCredential } =
+        await createChutesCatalogFixture();
+      const fallbackProfileId = "chutes:fallback";
+      const fallbackCredential: OAuthCredential = {
+        type: "oauth",
+        provider: "chutes",
+        access: "expired-fallback-access",
+        refresh: "fallback-refresh-token",
+        expires: Date.now() - 60_000,
+      };
+      const refreshedFallback: OAuthCredential = {
+        ...fallbackCredential,
+        access: "refreshed-fallback-access",
+        refresh: "rotated-fallback-refresh-token",
+        expires: Date.now() + 3_600_000,
+      };
+      config.auth = { order: { chutes: [profileId, fallbackProfileId] } };
+      store.profiles[fallbackProfileId] = fallbackCredential;
+      await state.writeAuthProfiles(store);
+      const persistedBefore = readAuthProfileStoreForTest(agentDir);
+      const refreshStarted = createDeferredCore();
+      const refreshResult =
+        createDeferredCore<
+          Awaited<ReturnType<typeof providerRuntime.resolveProviderOAuthCredentialWithPlugin>>
+        >();
+      vi.spyOn(providerRuntime, "buildProviderAuthDoctorHintWithPlugin").mockResolvedValue(
+        undefined,
+      );
+      const refresh = vi
+        .spyOn(providerRuntime, "resolveProviderOAuthCredentialWithPlugin")
+        .mockImplementation(async ({ credential }) => {
+          if (credential.access !== fallbackCredential.access) {
+            refreshStarted.resolve();
+            return refreshResult.promise;
+          }
+          return {
+            status: "available",
+            credential: refreshedFallback,
+            apiKey: refreshedFallback.access,
+          };
+        });
+      const preparation = vi.spyOn(catalogContext, "prepareProviderCatalogRun");
+      const catalog = vi.spyOn(providerDiscovery, "runProviderCatalog");
+      const fetch = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(Response.json({ data: [{ id: "late-account-model" }] }));
+      const outcomes: ProviderCatalogOutcome[] = [];
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const planning = planCatalog(config, store, {
         providerId: "chutes",
-        timeoutMs: 25,
+        timeoutMs: timedOut ? 25 : undefined,
         outcomes,
       });
 
-      expect(outcomes).toEqual([{ provider: "chutes", status: "unavailable" }]);
-      expect(readPlannedProvider(plan, "chutes")?.models.length).toBeGreaterThan(0);
-      expect(fetch).not.toHaveBeenCalled();
-    } finally {
-      refreshResult.resolve({
-        status: "available",
-        credential: refreshedCredential,
-        apiKey: refreshedCredential.access,
-      });
-      // Drain the real preparation and any erroneously started catalog before checking late I/O.
-      const completedPreparation = await Promise.allSettled(
-        preparation.mock.results.map((result) => result.value),
-      );
-      await Promise.allSettled(catalog.mock.results.map((result) => result.value));
-      expect(completedPreparation).toEqual([expect.objectContaining({ status: "fulfilled" })]);
-    }
+      try {
+        await refreshStarted.promise;
+        if (timedOut) {
+          await vi.advanceTimersByTimeAsync(25);
+          const plan = await planning;
+          expect(outcomes).toEqual([{ provider: "chutes", status: "unavailable" }]);
+          expect(readPlannedProvider(plan, "chutes")?.models.length).toBeGreaterThan(0);
+        }
+        expect(refresh).toHaveBeenCalledOnce();
+        expect(fetch).not.toHaveBeenCalled();
+      } finally {
+        try {
+          if (completion === "success") {
+            refreshResult.resolve({
+              status: "available",
+              credential: refreshedCredential,
+              apiKey: refreshedCredential.access,
+            });
+          } else {
+            refreshResult.reject(new Error("synthetic OAuth refresh failure"));
+          }
+          // Join the real refresh owner so late credential persistence and I/O are observable.
+          const completedPreparation = await Promise.allSettled(
+            preparation.mock.results.map((result) => result.value),
+          );
+          await Promise.allSettled(catalog.mock.results.map((result) => result.value));
+          expect(completedPreparation).toEqual([expect.objectContaining({ status: "fulfilled" })]);
+        } finally {
+          vi.useRealTimers();
+        }
+      }
 
-    expect(refresh).toHaveBeenCalledOnce();
-    expect(preparation).toHaveBeenCalledOnce();
-    expect(catalog).not.toHaveBeenCalled();
-    expect(fetch).not.toHaveBeenCalled();
-    expect(outcomes).toEqual([{ provider: "chutes", status: "unavailable" }]);
-  });
+      const plan = await planning;
+      expect(refresh.mock.calls.map(([params]) => params.credential)).toEqual(
+        timedOut ? [capturedCredential] : [capturedCredential, fallbackCredential],
+      );
+      const persisted = readAuthProfileStoreForTest(agentDir);
+      expect(persisted.profiles[profileId]).toMatchObject(
+        completion === "success" ? refreshedCredential : persistedBefore.profiles[profileId],
+      );
+      expect(persisted.profiles[fallbackProfileId]).toMatchObject(
+        timedOut ? fallbackCredential : refreshedFallback,
+      );
+      expect(store.profiles[profileId]).toEqual(capturedCredential);
+      expect(store.profiles[fallbackProfileId]).toEqual(fallbackCredential);
+      expect(preparation).toHaveBeenCalledOnce();
+      if (timedOut) {
+        expect(catalog).not.toHaveBeenCalled();
+        expect(fetch).not.toHaveBeenCalled();
+        expect(outcomes).toEqual([{ provider: "chutes", status: "unavailable" }]);
+      } else {
+        expect(catalog).toHaveBeenCalledOnce();
+        expect(fetch).toHaveBeenCalledOnce();
+        expect(new Headers(fetch.mock.calls[0]?.[1]?.headers).get("authorization")).toBe(
+          `Bearer ${refreshedFallback.access}`,
+        );
+        expect(outcomes).toEqual([
+          { provider: "chutes", profileId: fallbackProfileId, status: "ready" },
+        ]);
+        expect(readPlannedProvider(plan, "chutes")?.models.map((model) => model.id)).toContain(
+          "late-account-model",
+        );
+      }
+    },
+  );
 });

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -381,6 +381,10 @@ describe("Provider model discovery auth preparation", () => {
       store.profiles[fallbackProfileId] = fallbackCredential;
       await state.writeAuthProfiles(store);
       const persistedBefore = readAuthProfileStoreForTest(agentDir);
+      const persistedFirstProfile = persistedBefore.profiles[profileId];
+      if (!persistedFirstProfile) {
+        throw new Error("missing persisted first-profile fixture");
+      }
       const refreshStarted = createDeferredCore();
       const refreshResult =
         createDeferredCore<
@@ -453,7 +457,7 @@ describe("Provider model discovery auth preparation", () => {
       );
       const persisted = readAuthProfileStoreForTest(agentDir);
       expect(persisted.profiles[profileId]).toMatchObject(
-        completion === "success" ? refreshedCredential : persistedBefore.profiles[profileId],
+        completion === "success" ? refreshedCredential : persistedFirstProfile,
       );
       expect(persisted.profiles[fallbackProfileId]).toMatchObject(
         timedOut ? fallbackCredential : refreshedFallback,


### PR DESCRIPTION
Related: #137120

<details>
<summary>Additional instructions</summary>

This PR uses a branch in `openclaw/openclaw`.

</details>

## What Problem This Solves

Fixes an issue where users waiting for model discovery could have additional
accounts' OAuth credentials refreshed in the background after discovery had
already timed out. This happened when the first account's pending refresh later
failed and preparation advanced to the next candidate.

## Why This Change Was Made

The catalog timeout already suppressed late catalog results, but its preparation
loop could not observe that discovery had ended. Carry the existing owner's
liveness state into that loop and close admission when the timer fires.

An already-started refresh is allowed to finish and persist its rotated token.
Normal fallback before timeout, account ordering, failure-outcome semantics and
provider SDK contracts are unchanged.

## User Impact

Model discovery stops starting additional account refreshes after its timeout.
Late preparation still cannot start the catalog hook, while an in-progress token
rotation can finish safely. No configuration changes are required.

## Evidence

Validated head: `4af27929a0718f0077eeedf57884172139528333`.

- The real planner regression fails on base `9e5bb4a3ecd03772156fdbf3201ab54af5c6be98`
  because A's late failure starts B after timeout. Late-success and untimed
  fallback controls pass on that base.
- All 63 affected tests pass on the final head in
  [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34020542510),
  including persisted rotation, scoped outcomes, static fallback, and refresh-queue
  lifecycle. The tests join the actual preparation before checking late work.
- A separate runtime proof calls `ensureOpenClawModelsJson` with the real Chutes
  plugin and refresh owner, synthetic persisted accounts, and controlled HTTP
  grant/catalog responses. It verifies the following results and removes its
  isolated state and servers afterward:

| Scenario | Observed result |
|---|---|
| A fails after timeout | Only A's refresh starts; B is unchanged; no catalog request or late outcome. |
| A succeeds after timeout | A's rotated token persists; B is unchanged; no catalog request or late outcome. |
| A fails while discovery remains active | B refreshes, its current token authenticates catalog discovery, and its model is published. |

- The runtime build and applicable changed-path gates pass. Unchanged core type
  graphs were reused from the preceding tested head after verifying that the only
  intervening change is the root test's fixture-presence assertion; final root-test
  types and remaining gates were rerun successfully.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34021567848)
  is green. Independent full-patch and fixture-correction reviews are clean
  through P2. No production findings remain.
