### PR TITLE
refactor(test): isolate plugin runtime fixture environments

### DIFF
--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -216,6 +216,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
   });
 
   it("uses the source runtime snapshot for plugin activation source config", () => {
+    const env = { HOME: "/tmp/openclaw-home" };
     const runtimeConfig = { plugins: {} };
     const sourceConfig = {
       plugins: {
@@ -226,18 +227,19 @@ describe("resolvePluginRuntimeLoadContext", () => {
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     loadConfigMock.mockReturnValue(runtimeConfig);
 
-    const context = resolvePluginRuntimeLoadContext();
+    const context = resolvePluginRuntimeLoadContext({ env });
 
     expect(context.rawConfig).toBe(runtimeConfig);
     expect(context.activationSourceConfig).toBe(sourceConfig);
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
       config: runtimeConfig,
-      env: process.env,
+      env,
       manifestRegistry,
     });
   });
 
   it("applies auto-enable against each operation's exact prepared metadata", () => {
+    const env = { HOME: "/tmp/openclaw-home" };
     const config = { plugins: {} };
     const firstRegistry = { diagnostics: [], plugins: [] };
     const secondRegistry = { diagnostics: [], plugins: [] };
@@ -250,17 +252,17 @@ describe("resolvePluginRuntimeLoadContext", () => {
       .mockReturnValueOnce({ config: secondConfig, changes: [], autoEnabledReasons: {} });
 
     const first = withPluginCache(createPluginCache(), () =>
-      resolvePluginRuntimeLoadContext({ config, metadataSnapshot: firstSnapshot }),
+      resolvePluginRuntimeLoadContext({ config, env, metadataSnapshot: firstSnapshot }),
     );
     const second = withPluginCache(createPluginCache(), () =>
-      resolvePluginRuntimeLoadContext({ config, metadataSnapshot: secondSnapshot }),
+      resolvePluginRuntimeLoadContext({ config, env, metadataSnapshot: secondSnapshot }),
     );
     expect(first.config).toBe(firstConfig);
     expect(second.config).toBe(secondConfig);
     expect(second.manifestRegistry).toBe(secondRegistry);
     expect(applyPluginAutoEnableMock).toHaveBeenNthCalledWith(2, {
       config,
-      env: process.env,
+      env,
       manifestRegistry: secondRegistry,
       discovery: undefined,
     });

--- a/src/plugins/runtime/runtime-registry-loader.test.ts
+++ b/src/plugins/runtime/runtime-registry-loader.test.ts
@@ -151,10 +151,11 @@ describe("ensurePluginRegistryLoaded", () => {
   });
 
   it("loads configured channel owners through the canonical root loader", () => {
+    const env = { HOME: "/tmp/openclaw-home" };
     const config = { channels: { demo: { enabled: true } } };
     mocks.resolveConfiguredChannelPluginIds.mockReturnValue(["demo-channel"]);
 
-    ensurePluginRegistryLoaded({ scope: "configured-channels", config: config as never });
+    ensurePluginRegistryLoaded({ scope: "configured-channels", config: config as never, env });
 
     expect(mocks.resolveConfiguredChannelPluginIds).toHaveBeenCalledWith(
       expect.objectContaining({ config, workspaceDir: "/resolved-workspace" }),
@@ -177,14 +178,15 @@ describe("ensurePluginRegistryLoaded", () => {
   });
 
   it("loads effective plugin ids for the all scope", () => {
+    const env = { HOME: "/tmp/openclaw-home" };
     const config = { plugins: { enabled: true } };
     mocks.resolveEffectivePluginIds.mockReturnValue(["demo", "memory-core"]);
 
-    ensurePluginRegistryLoaded({ scope: "all", config });
+    ensurePluginRegistryLoaded({ scope: "all", config, env });
 
     expect(mocks.resolveEffectivePluginIds).toHaveBeenCalledWith({
       config,
-      env: process.env,
+      env,
       workspaceDir: "/resolved-workspace",
     });
     expect(requireLoadOptions()).toEqual(
@@ -311,6 +313,7 @@ describe("ensurePluginRegistryLoaded", () => {
   });
 
   it("loads only the selected memory backend and embedding provider owners", () => {
+    const env = { HOME: "/tmp/openclaw-home" };
     const config = {
       memory: { search: { provider: "openai" } },
       plugins: {
@@ -321,7 +324,7 @@ describe("ensurePluginRegistryLoaded", () => {
     };
     mocks.collectConfiguredMemoryEmbeddingProviderIds.mockReturnValue(new Set(["openai"]));
 
-    ensurePluginRegistryLoaded({ scope: "memory", config });
+    ensurePluginRegistryLoaded({ scope: "memory", config, env });
 
     expect(mocks.collectConfiguredMemoryEmbeddingProviderIds).toHaveBeenCalledWith(config);
     expect(requireLoadOptions()).toEqual(


### PR DESCRIPTION
Related: #139886

## What Problem This Solves

Five plugin metadata and scope tests inherited the machine environment even though their subject was configuration, registry ownership, or prepared metadata. Their recorded mock arguments consequently included unrelated ambient values.

## Why This Change Was Made

Each case now supplies the existing small HOME fixture through the normal environment parameter. All existing call matchers, ordering checks, argument comparisons and case definitions remain. The metadata snapshot tests still exercise the real resolver with env omitted, preserving default-environment coverage.

## User Impact

The affected fixtures have explicit, deterministic environment inputs. This is fixture isolation, not a guarantee that diagnostics stay redacted if a future production bug substitutes the ambient environment. Production behavior is unchanged.

## Evidence

- The same 32 cases passed before and after across the two changed files and the metadata/CLI sibling suites, with identical ordered case inventories within each file.
- Separate 25-case observation runs confirmed all six affected invocations across five cases changed from ambient input to exactly the supplied HOME fixture. Only synthetic markers, booleans and counts were observed; temporary observers are absent from the patch.
- All 51 assertion sites and existing matcher forms remain. Five unnecessary proposed casts were removed before proof and review.
- Formatting and diff checks passed; independent Codex review found no actionable findings through P2.
- Required changed-file gate: all 20 checks passed through the configured Testbox command ([run](https://github.com/openclaw/openclaw/actions/runs/34020853523)); lease and temporary capsule cleanup verified. A post-success portal-sync timeout is retained in the logs.
- Production delta: 0. Test delta: +14/-9.
