### PR TITLE
fix(auto-reply): queued follow-up messages fail with "no active tool authority snapshot"

### DIFF
--- a/extensions/qa-lab/src/gateway-queued-followup-send.claude-cli.live.test.ts
+++ b/extensions/qa-lab/src/gateway-queued-followup-send.claude-cli.live.test.ts
@@ -1,20 +1,38 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { isLiveTestEnabled, isTruthyEnvValue } from "openclaw/plugin-sdk/test-live";
 import { afterEach, describe, expect, it } from "vitest";
 import { startQaBusServer } from "./bus-server.js";
 import { createQaBusState } from "./bus-state.js";
 import { createQaGatewayChild } from "./gateway-child.js";
-import { QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER } from "./providers/mock-openai/mock-openai-contracts.js";
-import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
 import { createQaChannelTransport } from "./qa-channel-transport.js";
 import { readRawQaSessionStore } from "./suite-runtime-agent-session.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../../..");
-const FIRST_REPLY_MARKER = "QA-QUEUED-FOLLOWUP-FIRST-OK";
+const FIRST_REPLY_MARKER = "QA-CLI-QUEUED-FOLLOWUP-FIRST-OK";
+const QUEUED_REPLY_MARKER = "QA-CLI-QUEUED-FOLLOWUP-SECOND-OK";
 const TOOL_AUTHORITY_SNAPSHOT_ERROR = "Reply operation has no active tool authority snapshot";
+const CLI_EXEC_LOG = "cli exec: provider=claude-cli";
+const CLI_TURN_LOG = "cli turn: provider=claude-cli";
+// The bundled Anthropic plugin's default Claude CLI model; override for a
+// cheaper or faster local login.
+const CLI_MODEL = process.env.OPENCLAW_LIVE_CLI_BACKEND_MODEL?.trim() || "claude-cli/claude-opus-5";
 
-describe.skipIf(process.platform === "win32")("queued follow-up after an active reply run", () => {
+// Live: needs an installed, logged-in Claude Code executable on PATH.
+//   OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CLI_BACKEND=1 pnpm test <this file>
+const describeLive =
+  isLiveTestEnabled() &&
+  isTruthyEnvValue(process.env.OPENCLAW_LIVE_CLI_BACKEND) &&
+  process.platform !== "win32"
+    ? describe
+    : describe.skip;
+
+function countOccurrences(haystack: string, needle: string) {
+  return haystack.split(needle).length - 1;
+}
+
+describeLive("queued follow-up after an active reply run (Claude CLI backend)", () => {
   const cleanups: Array<() => Promise<void>> = [];
   afterEach(async () => {
     const errors: unknown[] = [];
@@ -26,31 +44,31 @@ describe.skipIf(process.platform === "win32")("queued follow-up after an active 
       }
     }
     if (errors.length) {
-      throw new AggregateError(errors, "queued follow-up test cleanup failed");
+      throw new AggregateError(errors, "queued follow-up CLI test cleanup failed");
     }
   });
 
-  it("runs a message sent mid-turn as its own turn and delivers its reply", async () => {
+  it("runs a message sent mid-turn through the CLI backend and delivers its reply", async () => {
     const state = createQaBusState();
     const transport = createQaChannelTransport(state);
     const bus = await startQaBusServer({ state });
     cleanups.push(() => bus.stop());
-    const mock = await startQaMockOpenAiServer();
-    cleanups.push(() => mock.stop());
     const owner = createQaGatewayChild();
     cleanups.push(async () => {
       expect((await owner.stop()).errors).toEqual([]);
     });
     const gateway = await owner.start({
       repoRoot,
-      providerBaseUrl: `${mock.baseUrl}/v1`,
-      providerMode: "mock-openai",
-      forcedRuntime: "openclaw",
+      providerMode: "live-frontier",
+      primaryModel: CLI_MODEL,
+      alternateModel: CLI_MODEL,
+      // Claude Code owns its local login; forward the host home so the CLI
+      // backend can reuse it (subscription mode, no API key).
+      forwardHostHome: true,
+      claudeCliAuthMode: "subscription",
       transport,
       transportBaseUrl: bus.baseUrl,
       controlUiEnabled: false,
-      // Debug logging makes the queued-admission overlap ("sessionState=processing")
-      // observable in the child gateway log for this regression.
       runtimeEnvPatch: { OPENCLAW_LOG_LEVEL: "debug" },
       mutateConfig: (cfg) => ({
         ...cfg,
@@ -67,7 +85,7 @@ describe.skipIf(process.platform === "win32")("queued follow-up after an active 
         messages: { ...cfg.messages, queue: { ...cfg.messages?.queue, mode: "followup" } },
       }),
     });
-    const conversation = { id: "queued-followup-send", kind: "direct" as const };
+    const conversation = { id: "queued-followup-cli-send", kind: "direct" as const };
     const sessionKey = buildAgentSessionKey({
       agentId: "qa",
       channel: "qa-channel",
@@ -98,67 +116,54 @@ describe.skipIf(process.platform === "win32")("queued follow-up after an active 
     try {
       await transport.waitReady({ gateway });
       const sinceIndex = state.getSnapshot().messages.length;
-      // The mock holds the first turn's response so the second message is
-      // admitted as a queued follow-up while this reply run is still active.
       const first = await send(
-        `queued followup stall gateway qa check. Reply exactly: ${FIRST_REPLY_MARKER}`,
+        `Reply with exactly this text and nothing else: ${FIRST_REPLY_MARKER}`,
       );
       expect(first.runId).toBeTruthy();
-      // Wait until the first turn's reply run has actually started (INFO log),
-      // not merely enqueued, so the second message is a genuine mid-run arrival.
+      // Wait until the first turn has actually launched the CLI process, so
+      // the second message is a genuine mid-run arrival on the CLI backend.
       await transport.waitForCondition(
-        () => (gateway.logs().includes("embedded run start: runId=") ? true : undefined),
-        60_000,
+        () => (gateway.logs().includes(CLI_EXEC_LOG) ? true : undefined),
+        120_000,
         25,
       );
-      // The first turn's response is held by the mock, so its reply is not
-      // delivered yet when the second message arrives. (The inbound message
-      // text itself carries the marker, so scan outbound messages only.)
-      expect(
-        state
-          .getSnapshot()
-          .messages.some(
-            (message) =>
-              message.direction === "outbound" && message.text.includes(FIRST_REPLY_MARKER),
-          ),
-      ).toBe(false);
-      const second = await send("repeated request queued reply gateway qa check");
+      expect(countOccurrences(gateway.logs(), CLI_TURN_LOG)).toBe(0);
+      const second = await send(
+        `Reply with exactly this text and nothing else: ${QUEUED_REPLY_MARKER}`,
+      );
       expect(second.runId).toBeTruthy();
-      // Accepted while the first run was still active (its reply is still held).
-      expect(
-        state
-          .getSnapshot()
-          .messages.some(
-            (message) =>
-              message.direction === "outbound" && message.text.includes(FIRST_REPLY_MARKER),
-          ),
-      ).toBe(false);
+      // The second send was accepted while the first CLI turn was still running.
+      expect(countOccurrences(gateway.logs(), CLI_TURN_LOG)).toBe(0);
 
       const firstReply = await transport.waitForOutbound({
         conversation,
         sinceIndex,
         textIncludes: FIRST_REPLY_MARKER,
-        timeoutMs: 120_000,
+        timeoutMs: 300_000,
       });
+      // Pre-fix, the queued turn threw at route binding on CLI backends and the
+      // message was dropped; the reply below never arrived.
       const queuedReply = await transport.waitForOutbound({
         conversation,
         sinceIndex,
-        textIncludes: QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
-        timeoutMs: 120_000,
+        textIncludes: QUEUED_REPLY_MARKER,
+        timeoutMs: 300_000,
       });
-      // The queued message runs as its own turn after the first finishes and its
-      // reply is delivered. (On CLI backends the pre-fix queued run threw at route
-      // binding and dropped the message; that boundary is covered RED/GREEN by
-      // followup-turn-admission.queued-handoff.test.ts.)
       expect(queuedReply.accountId).toBe(transport.accountId);
 
-      // Ordering: the queued turn ran and replied after the first turn finished.
       const outbound = state
         .getSnapshot()
         .messages.slice(sinceIndex)
         .filter((message) => message.direction === "outbound");
+      // Ordering: the queued turn ran and replied after the first turn finished.
       expect(outbound.findIndex((message) => message.id === firstReply.id)).toBeLessThan(
         outbound.findIndex((message) => message.id === queuedReply.id),
+      );
+      // Both turns completed as separate CLI executions, with no route-binding failure.
+      await transport.waitForCondition(
+        () => (countOccurrences(gateway.logs(), CLI_TURN_LOG) >= 2 ? true : undefined),
+        30_000,
+        25,
       );
       expect(gateway.logs()).not.toContain(TOOL_AUTHORITY_SNAPSHOT_ERROR);
       await transport.waitForCondition(
@@ -176,5 +181,5 @@ describe.skipIf(process.platform === "win32")("queued follow-up after an active 
         { cause: error },
       );
     }
-  }, 600_000);
+  }, 900_000);
 });

--- a/extensions/qa-lab/src/gateway-queued-followup-send.e2e.test.ts
+++ b/extensions/qa-lab/src/gateway-queued-followup-send.e2e.test.ts
@@ -1,0 +1,164 @@
+import path from "node:path";
+import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
+import { afterEach, describe, expect, it } from "vitest";
+import { startQaBusServer } from "./bus-server.js";
+import { createQaBusState } from "./bus-state.js";
+import { createQaGatewayChild } from "./gateway-child.js";
+import { QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER } from "./providers/mock-openai/mock-openai-contracts.js";
+import { startQaMockOpenAiServer } from "./providers/mock-openai/server.js";
+import { createQaChannelTransport } from "./qa-channel-transport.js";
+import { readRawQaSessionStore } from "./suite-runtime-agent-session.js";
+
+const repoRoot = path.resolve(import.meta.dirname, "../../..");
+const FIRST_REPLY_MARKER = "QA-QUEUED-FOLLOWUP-FIRST-OK";
+const TOOL_AUTHORITY_SNAPSHOT_ERROR = "Reply operation has no active tool authority snapshot";
+
+describe.skipIf(process.platform === "win32")("queued follow-up after an active reply run", () => {
+  const cleanups: Array<() => Promise<void>> = [];
+  afterEach(async () => {
+    const errors: unknown[] = [];
+    for (const cleanup of cleanups.splice(0).toReversed()) {
+      try {
+        await cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length) {
+      throw new AggregateError(errors, "queued follow-up test cleanup failed");
+    }
+  });
+
+  it("runs a message sent mid-turn as its own turn and delivers its reply", async () => {
+    const state = createQaBusState();
+    const transport = createQaChannelTransport(state);
+    const bus = await startQaBusServer({ state });
+    cleanups.push(() => bus.stop());
+    const mock = await startQaMockOpenAiServer();
+    cleanups.push(() => mock.stop());
+    const owner = createQaGatewayChild();
+    cleanups.push(async () => {
+      expect((await owner.stop()).errors).toEqual([]);
+    });
+    const gateway = await owner.start({
+      repoRoot,
+      providerBaseUrl: `${mock.baseUrl}/v1`,
+      providerMode: "mock-openai",
+      forcedRuntime: "openclaw",
+      transport,
+      transportBaseUrl: bus.baseUrl,
+      controlUiEnabled: false,
+      // Debug logging makes the queued-admission overlap ("sessionState=processing")
+      // observable in the child gateway log for this regression.
+      runtimeEnvPatch: { OPENCLAW_LOG_LEVEL: "debug" },
+      mutateConfig: (cfg) => ({
+        ...cfg,
+        plugins: {
+          ...cfg.plugins,
+          slots: { ...cfg.plugins?.slots, memory: "none" },
+          entries: {
+            ...cfg.plugins?.entries,
+            acpx: { enabled: false },
+            "memory-core": { enabled: false },
+          },
+        },
+        // The reported loss is on the queued-followup path, so do not steer.
+        messages: { ...cfg.messages, queue: { ...cfg.messages?.queue, mode: "followup" } },
+      }),
+    });
+    const conversation = { id: "queued-followup-send", kind: "direct" as const };
+    const sessionKey = buildAgentSessionKey({
+      agentId: "qa",
+      channel: "qa-channel",
+      accountId: transport.accountId,
+      peer: { kind: "direct", id: `dm:${conversation.id}` },
+      dmScope: gateway.cfg.session?.dmScope,
+      identityLinks: gateway.cfg.session?.identityLinks,
+    });
+    try {
+      await transport.waitReady({ gateway });
+      const sinceIndex = state.getSnapshot().messages.length;
+      const first = await transport.sendInbound({
+        accountId: transport.accountId,
+        conversation,
+        senderId: conversation.id,
+        // The mock holds this turn's response so the second message is admitted
+        // as a queued follow-up while this reply run is still active.
+        text: `queued followup stall gateway qa check. Reply exactly: ${FIRST_REPLY_MARKER}`,
+      });
+      // Wait until the first turn's reply run has actually started (INFO log),
+      // not merely enqueued, so the second message is a genuine mid-run arrival.
+      await transport.waitForCondition(
+        () => (gateway.logs().includes("embedded run start: runId=") ? true : undefined),
+        60_000,
+        25,
+      );
+      // The first turn's response is held by the mock, so its reply is not
+      // delivered yet when the second message arrives. (The inbound message
+      // text itself carries the marker, so scan outbound messages only.)
+      expect(
+        state
+          .getSnapshot()
+          .messages.some(
+            (message) =>
+              message.direction === "outbound" && message.text.includes(FIRST_REPLY_MARKER),
+          ),
+      ).toBe(false);
+      const second = await transport.sendInbound({
+        accountId: transport.accountId,
+        conversation,
+        senderId: conversation.id,
+        text: "repeated request queued reply gateway qa check",
+      });
+
+      const firstReply = await transport.waitForOutbound({
+        conversation,
+        sinceIndex,
+        textIncludes: FIRST_REPLY_MARKER,
+        timeoutMs: 120_000,
+      });
+      expect(firstReply.replyToId).toBe(first.id);
+      const queuedReply = await transport.waitForOutbound({
+        conversation,
+        sinceIndex,
+        textIncludes: QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
+        timeoutMs: 120_000,
+      });
+      // The queued message runs as its own turn after the first finishes and its
+      // reply is delivered. (On CLI backends the pre-fix queued run threw at route
+      // binding and dropped the message; that boundary is covered RED/GREEN by
+      // followup-turn-admission.queued-handoff.test.ts.)
+      expect(queuedReply.replyToId).toBe(second.id);
+      expect(queuedReply.accountId).toBe(transport.accountId);
+
+      const snapshot = state.getSnapshot().messages;
+      const findTimestamp = (id: string) =>
+        snapshot.find((message) => message.id === id)?.timestamp ?? Number.NaN;
+      // Overlap: the second message was received before the first turn's reply
+      // was delivered, i.e. while the first run was still active.
+      expect(findTimestamp(second.id)).toBeLessThan(findTimestamp(firstReply.id));
+      // Ordering: the queued turn ran and replied after the first turn finished.
+      const outbound = snapshot
+        .slice(sinceIndex)
+        .filter((message) => message.direction === "outbound");
+      expect(outbound.findIndex((message) => message.id === firstReply.id)).toBeLessThan(
+        outbound.findIndex((message) => message.id === queuedReply.id),
+      );
+      expect(gateway.logs()).not.toContain(TOOL_AUTHORITY_SNAPSHOT_ERROR);
+      await transport.waitForCondition(
+        async () =>
+          (await readRawQaSessionStore({ gateway }))[sessionKey]?.status === "done"
+            ? true
+            : undefined,
+        30_000,
+        25,
+      );
+    } catch (error) {
+      const sessions = await Promise.allSettled([readRawQaSessionStore({ gateway })]);
+      throw new Error(
+        `${String(error)}\nsessions=${JSON.stringify(sessions)}\nbus=${JSON.stringify(state.getSnapshot())}\ngateway=${gateway.logs()}`,
+        { cause: error },
+      );
+    }
+  }, 600_000);
+});

--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -285,6 +285,10 @@ export const QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE = /repeated request recovery
 export const QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE =
   /repeated request queued reply gateway qa check/i;
 export const QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER = "GATEWAY_REPEATED_REQUEST_QUEUED_OK";
+export const QA_QUEUED_FOLLOWUP_STALL_PROMPT_RE = /queued followup stall gateway qa check/i;
+// Holds one reply run active long enough for a second inbound message to be
+// admitted as a queued follow-up while the first run is still running (#139847).
+export const QA_QUEUED_FOLLOWUP_STALL_RESPONSE_PAUSE_MS = 15_000;
 export const QA_STREAMING_PROMPT_RE = /(?:partial|quiet) streaming qa check/i;
 export const QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE = /final-only marker streaming qa check/i;
 export const QA_BLOCK_STREAMING_PROMPT_RE = /block streaming qa check/i;

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -51,6 +51,8 @@ import {
   QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE,
   QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE,
   QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
+  QA_QUEUED_FOLLOWUP_STALL_PROMPT_RE,
+  QA_QUEUED_FOLLOWUP_STALL_RESPONSE_PAUSE_MS,
   QA_STREAMING_PROMPT_RE,
   QA_FINAL_ONLY_MARKER_STREAMING_PROMPT_RE,
   QA_BLOCK_STREAMING_PROMPT_RE,
@@ -2935,6 +2937,10 @@ export async function startQaMockOpenAiServer(params?: {
                 ? QA_REPEATED_REQUEST_STALLED_RESPONSE_PAUSE_MS
                 : QA_REPEATED_REQUEST_RESPONSE_PAUSE_MS,
           }
+        : {}),
+      // Keep the first turn active while a mid-run follow-up is admitted (#139847).
+      ...(QA_QUEUED_FOLLOWUP_STALL_PROMPT_RE.test(prompt)
+        ? { responsePauseMs: QA_QUEUED_FOLLOWUP_STALL_RESPONSE_PAUSE_MS }
         : {}),
     };
   };

--- a/src/auto-reply/reply/followup-turn-admission.queued-handoff.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.queued-handoff.test.ts
@@ -1,0 +1,102 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { FollowupRun } from "./queue.js";
+import { forceClearReplyOperation, type ReplyOperation } from "./reply-run-registry.js";
+import {
+  prepareReplyToolAuthority,
+  resolveFollowupRunToolAuthorityFingerprint,
+} from "./reply-tool-authority.js";
+import { admitReplyTurn } from "./reply-turn-admission.js";
+
+// Only Gateway-backed secret resolution and preflight compaction are stubbed;
+// admission, the reply-run registry, and tool authority snapshots are real.
+vi.mock("./agent-runner-utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agent-runner-utils.js")>()),
+  resolveQueuedReplyExecutionConfig: async (config: OpenClawConfig) => config,
+}));
+vi.mock("./agent-runner-memory.js", () => ({
+  runSessionCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry: unknown }) => sessionEntry,
+}));
+
+const { admitFollowupTurn } = await import("./followup-turn-admission.js");
+
+const SESSION_KEY = "agent:main:telegram:direct:1";
+const ROUTE = { provider: "anthropic", model: "claude-opus-5" };
+
+function createRun(prompt: string): FollowupRun {
+  return {
+    prompt,
+    enqueuedAt: Date.now(),
+    originatingChannel: "telegram",
+    run: {
+      agentId: "main",
+      agentDir: "/tmp/agent",
+      sessionId: "session-1",
+      sessionKey: SESSION_KEY,
+      sessionFile: "/tmp/session-1.jsonl",
+      workspaceDir: "/tmp",
+      config: {} as OpenClawConfig,
+      provider: ROUTE.provider,
+      model: ROUTE.model,
+      messageProvider: "telegram",
+      timeoutMs: 1_000,
+      blockReplyBreak: "message_end",
+    },
+  };
+}
+
+describe("queued follow-up handoff after an active reply run", () => {
+  const operations: ReplyOperation[] = [];
+  afterEach(() => {
+    for (const operation of operations.splice(0)) {
+      forceClearReplyOperation(operation);
+    }
+  });
+
+  it("lets the queued turn bind its concrete route once the active run completes", async () => {
+    // Message #1 starts a foreground run and binds its authority like agent-runner-run does.
+    const foreground = await admitReplyTurn({
+      sessionId: "session-1",
+      sessionKey: SESSION_KEY,
+      kind: "visible",
+      resetTriggered: false,
+      waitForActive: false,
+    });
+    expect(foreground.status).toBe("owned");
+    if (foreground.status !== "owned") {
+      return;
+    }
+    operations.push(foreground.operation);
+    foreground.operation.bindToolAuthoritySnapshot(
+      prepareReplyToolAuthority(createRun("message #1")),
+    );
+    expect(foreground.operation.bindToolAuthorityRoute(ROUTE)).toBeTypeOf("string");
+
+    // Message #2 arrives while #1 is active: admission waits for the run to end.
+    const queued = createRun("message #2");
+    const queuedAdmission = admitFollowupTurn({
+      queued,
+      defaults: {
+        typing: {} as never,
+        typingMode: "never",
+        defaultModel: ROUTE.model,
+        sessionKey: SESSION_KEY,
+      },
+    });
+    await sleep(20);
+    foreground.operation.complete();
+
+    const result = await queuedAdmission;
+    expect(result.kind).toBe("admitted");
+    if (result.kind !== "admitted") {
+      return;
+    }
+    operations.push(result.turn.operation);
+    expect(result.turn.operation).not.toBe(foreground.operation);
+    // The queued turn's own authority must be bound before a backend selects its route.
+    expect(result.turn.operation.bindToolAuthorityRoute(ROUTE)).toBe(
+      resolveFollowupRunToolAuthorityFingerprint(result.turn.queued, ROUTE),
+    );
+  });
+});

--- a/src/auto-reply/reply/followup-turn-admission.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { FollowupRun } from "./queue.js";
+import { resolveFollowupRunToolAuthorityFingerprint } from "./reply-tool-authority.js";
 
 const state = vi.hoisted(() => ({
   admitLifecycle: vi.fn(),
@@ -96,6 +97,7 @@ function createOperation(sessionId = "queued-session") {
     fail: vi.fn(),
     complete: vi.fn(),
     updateSessionId: vi.fn(),
+    bindToolAuthoritySnapshot: vi.fn(),
   };
 }
 
@@ -123,6 +125,36 @@ beforeEach(() => {
 });
 
 describe("admitFollowupTurn", () => {
+  it("binds the admitted turn's tool authority snapshot to the reply operation", async () => {
+    const operation = createOperation("admitted-session");
+    const admittedEntry: SessionEntry = { sessionId: "admitted-session", updatedAt: 2 };
+    state.admitReply.mockResolvedValue({ status: "owned", operation, sessionEntry: admittedEntry });
+    state.loadEntry.mockReturnValue(admittedEntry);
+
+    const result = await admitFollowupTurn({
+      queued: createRun(),
+      defaults: createDefaults({ storePath: "/tmp/sessions.json" }),
+    });
+
+    expect(result.kind).toBe("admitted");
+    if (result.kind !== "admitted") {
+      return;
+    }
+    expect(operation.bindToolAuthoritySnapshot).toHaveBeenCalledOnce();
+    const snapshot = operation.bindToolAuthoritySnapshot.mock.calls[0]?.[0] as
+      | { fingerprint: (route?: { provider: string; model: string }) => string }
+      | undefined;
+    const route = { provider: "anthropic", model: "claude" };
+    // The snapshot must describe the admitted generation, not the enqueue-time run.
+    expect(result.turn.queued.run.sessionId).toBe("admitted-session");
+    expect(snapshot?.fingerprint(route)).toBe(
+      resolveFollowupRunToolAuthorityFingerprint(result.turn.queued, route),
+    );
+    expect(snapshot?.fingerprint(route)).not.toBe(
+      resolveFollowupRunToolAuthorityFingerprint(createRun(), route),
+    );
+  });
+
   it("reports each active-run deferral without adopting the queued source", async () => {
     state.admitReply.mockResolvedValue({ status: "skipped", reason: "active-run" });
     const onDeferredHeartbeat = vi.fn();

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -34,6 +34,7 @@ import {
   type FollowupRun,
 } from "./queue.js";
 import type { ReplyOperation } from "./reply-run-registry.js";
+import { prepareReplyToolAuthority } from "./reply-tool-authority.js";
 import { admitReplyTurn } from "./reply-turn-admission.js";
 import {
   createReplySessionEntryHandle,
@@ -253,6 +254,10 @@ export async function admitFollowupTurn(params: {
       sessionKey: replySessionKey,
     });
     const queued: FollowupRun = { ...params.queued, run };
+    // Queued turns own the same frozen caller policy as foreground admission
+    // (agent-runner-run.ts). Without it, CLI route binding throws before launch
+    // and embedded runs cannot be steered because their authority is unknown.
+    operation.bindToolAuthoritySnapshot(prepareReplyToolAuthority(queued));
     const sessionEntryHandle = createReplySessionEntryHandle({
       sessionEntry: activeEntry,
       sessionKey: replySessionKey,


### PR DESCRIPTION
Closes #139847

## What Problem This Solves

Fixes an issue where users who sent a chat message while the agent was still working on their previous message would, on 2026.9.2, get `⚠️ Something went wrong while processing your request.` as soon as the queued message started, and the message was lost rather than requeued. Gateway logs showed:

```
Embedded agent failed before reply: Reply operation has no active tool authority snapshot
```

The failure fired at model-route binding, before any provider request, so every fallback candidate that runs through a CLI backend died the same way. Reported on Telegram direct chats; the queued path is shared by every channel and by `chat.send`.

## Why This Change Was Made

**Root cause.** #134003 (commit e3ce08cd5ec, shipped in v2026.9.2) introduced `bindToolAuthoritySnapshot` / `bindToolAuthorityRoute` on the reply operation and bound the snapshot for foreground runs right after admission (`src/auto-reply/reply/agent-runner-run.ts:543`). Queued follow-up admission (`admitFollowupTurn` in `src/auto-reply/reply/followup-turn-admission.ts`) obtains its own fresh operation from `admitReplyTurn` and was never given the same binding. Two consumers then see an operation with no snapshot:

- `src/auto-reply/reply/agent-runner-cli-candidate.ts:141` calls `bindToolAuthorityRoute` unconditionally, and the registry throws the reported error for every CLI-backed candidate. This is the user-visible drop.
- `src/auto-reply/reply/agent-runner-embedded-candidate.ts:220` passes `replyOperation.toolAuthorityFingerprint`, which is `undefined`, so embedded candidates fall back to direct attempt authority and still run (which matches the reporter's log, where one hosted fallback made a real request).

**Fix.** In `admitFollowupTurn`, bind `prepareReplyToolAuthority(queued)` to the admitted operation immediately after the admitted `run` facts (session id, session file, model lock, fallback probe) are final and before the turn object is built. This is the same call and the same point in the lifecycle as foreground admission. The operation is fresh per admitted queued turn, so the once-only binding contract holds; session rotation after binding (preflight compaction, role-ordering reset) behaves exactly as it already does for foreground runs.

**Relation to #139925.** That PR (opened while this one was being validated) binds the same snapshot one stage later, in `executeFollowupTurn` right before `executeAgentTurn`. Binding at admission instead keeps the queued operation's authority known for its whole active lifetime, including preflight compaction, mirrors the foreground runner one-to-one, and is the repair boundary the ClawSweeper review identified.

**Non-goals.** No change to the guard itself, no retry of failed turns, no change to the embedded direct-authority fallback, no config or store changes. Production delta: +5 lines in one file.

## User Impact

Typing a follow-up while the agent is still working now behaves as documented in `docs/concepts/queue.md`: the queued message runs after the active turn finishes, on CLI and embedded backends alike, instead of being dropped with a generic error.

## Evidence

### Live Claude CLI backend proof, before and after (RED/GREEN)

New `extensions/qa-lab/src/gateway-queued-followup-send.claude-cli.live.test.ts` (live-gated: `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CLI_BACKEND=1`, needs a logged-in Claude Code executable) boots a child Gateway with the bundled `claude-cli` backend (`claude-cli/claude-opus-5`, subscription login, queue `mode: "followup"`). It sends message 1 over `chat.send`, waits until the Gateway log shows the CLI process launched (`cli exec: provider=claude-cli`), sends message 2 to the same session while that CLI turn is still running, and asserts both replies arrive as two separate CLI executions with no snapshot error.

Why `chat.send` and not a qa-channel message: the qa-channel poller hands inbound messages to the Gateway one at a time and waits for each reply (`extensions/qa-channel/src/gateway.ts`, `enqueueInbound`), so a channel message can never reach the reply pipeline mid-run in this harness. `chat.send` enters the same pipeline (`dispatchInboundMessage` -> reply runner -> `enqueueFollowupRun` -> `admitFollowupTurn`) without that serialization. The Gateway log confirms the overlap directly (`queueDepth=2 sessionState=processing` while the first `cli exec` is in flight).

**Before (RED).** Same test against a dist built from the unmodified `origin/main` copy of `followup-turn-admission.ts`. Message 2 was admitted mid-run, and the moment the first turn completed, the queued turn died at route binding and the user got the generic error:

```
bus (outbound only; both sends went through chat.send):
  + 0.0s outbound QA-CLI-QUEUED-FOLLOWUP-FIRST-OK
  + 0.1s outbound ⚠️ Something went wrong while processing your request. Please try again, or use /new to start a
gateway log:
  2026-09-06T10:04:39.234Z message received: channel=webchat chatId=unknown messageId=… sessionId=unknown sessionKey=agent:qa:main source=dispatchInboundMessage
  2026-09-06T10:04:39.260Z message queued: sessionId=unknown sessionKey=agent:qa:main source=dispatch queueDepth=1 sessionState=idle
  2026-09-06T10:04:40.195Z session state: sessionId=… sessionKey=agent:qa:main prev=processing new=processing reason="run_started" queueDepth=1
  2026-09-06T10:04:40.574Z [agent/cli-backend] cli exec: provider=claude-cli model=claude-opus-5 promptChars=252 trigger=user useResume=false session=none resumeSession=none reu
  2026-09-06T10:04:40.643Z message received: channel=webchat chatId=unknown messageId=… sessionId=unknown sessionKey=agent:qa:main source=dispatchInboundMessage
  2026-09-06T10:04:40.653Z message queued: sessionId=… sessionKey=agent:qa:main source=dispatch queueDepth=2 sessionState=processing
  2026-09-06T10:04:43.800Z [agent/cli-backend] cli turn: provider=claude-cli model=claude-opus-5 durationMs=3227 outBytes=31 outHash=62ffd8440fb2
  2026-09-06T10:04:44.120Z session state: sessionId=… sessionKey=agent:qa:main prev=idle new=idle reason="run_completed" queueDepth=0
  2026-09-06T10:04:44.336Z Embedded agent failed before reply: Reply operation has no active tool authority snapshot
```

Test result: `1 failed` (`Error: ⚠️ Something went wrong while processing your request…`).

**After (GREEN).** Same test on this branch. Message 2 was admitted mid-run, and after the first turn completed, the queued turn ran as its own CLI execution (second `cli exec`, `useResume=true`) and its reply was delivered:

```
bus (outbound only; both sends went through chat.send):
  + 0.0s outbound QA-CLI-QUEUED-FOLLOWUP-FIRST-OK
  + 2.1s outbound QA-CLI-QUEUED-FOLLOWUP-SECOND-OK
gateway log:
  2026-09-06T09:54:42.615Z message received: channel=webchat chatId=unknown messageId=… sessionId=unknown sessionKey=agent:qa:main source=dispatchInboundMessag
  2026-09-06T09:54:42.637Z message queued: sessionId=unknown sessionKey=agent:qa:main source=dispatch queueDepth=1 sessionState=idle
  2026-09-06T09:54:43.194Z session state: sessionId=… sessionKey=agent:qa:main prev=processing new=processing reason="run_started" queueDepth=1
  2026-09-06T09:54:43.659Z [agent/cli-backend] cli exec: provider=claude-cli model=claude-opus-5 promptChars=252 trigger=user useResume=false session=none resumeSession=non
  2026-09-06T09:54:43.713Z message received: channel=webchat chatId=unknown messageId=… sessionId=unknown sessionKey=agent:qa:main source=dispatchInboundMessag
  2026-09-06T09:54:43.719Z message queued: sessionId=… sessionKey=agent:qa:main source=dispatch queueDepth=2 sessionState=processing
  2026-09-06T09:54:46.224Z [agent/cli-backend] cli turn: provider=claude-cli model=claude-opus-5 durationMs=2567 outBytes=31 outHash=62ffd8440fb2
  2026-09-06T09:54:46.512Z lane task done: lane=session:agent:qa:main durationMs=3326 active=0 queued=0
  2026-09-06T09:54:46.529Z session state: sessionId=… sessionKey=agent:qa:main prev=idle new=idle reason="run_completed" queueDepth=0
  2026-09-06T09:54:46.730Z session state: sessionId=… sessionKey=agent:qa:main prev=idle new=processing reason="run_started" queueDepth=0
  2026-09-06T09:54:47.090Z [agent/cli-backend] cli exec: provider=claude-cli model=claude-opus-5 promptChars=253 trigger=user useResume=true session=present resumeSession=…
  2026-09-06T09:54:48.459Z [agent/cli-backend] cli turn: provider=claude-cli model=claude-opus-5 durationMs=1370 outBytes=32 outHash=02c025cecf7d
  2026-09-06T09:54:48.741Z lane task done: lane=session:agent:qa:main durationMs=2014 active=0 queued=0
  2026-09-06T09:54:48.752Z session state: sessionId=… sessionKey=agent:qa:main prev=processing new=idle reason="run_completed" queueDepth=0
```

Test result: `Test Files 1 passed (1) · Tests 1 passed (1)` (~22s per run; final run on the rebuilt branch dist 54.6s including Gateway boot). `grep "no active tool authority snapshot"` on the Gateway log: 0 matches.

### Boundary regression (RED/GREEN, unit)

`src/auto-reply/reply/followup-turn-admission.queued-handoff.test.ts` replays the issue's sequence through the unmocked admission path and reply-run registry: message 1 admitted as a visible run with its authority bound, message 2 admitted as `queued_followup` while message 1 is active, message 1 completes, message 2 admitted with a fresh operation, and `bindToolAuthorityRoute` on that operation succeeds. `followup-turn-admission.test.ts` also asserts the snapshot is bound once and fingerprints the admitted generation.

Before (tests on unmodified `origin/main`):

```
× followup-turn-admission.test.ts > binds the admitted turn's tool authority snapshot to the reply operation
   → expected "vi.fn()" to be called once, but got 0 times
× followup-turn-admission.queued-handoff.test.ts > lets the queued turn bind its concrete route once the active run completes
   → Reply operation has no active tool authority snapshot
```

After (this branch): `followup-turn-admission*.test.ts` 39 passed; owner and sibling suites (`followup-turn-execution`, `followup-runner`, `reply-run-registry`, `reply-turn-admission`) 240 passed.

### Mock-provider Gateway e2e (embedded runtime)

`extensions/qa-lab/src/gateway-queued-followup-send.e2e.test.ts` boots a child Gateway with the mock provider and queue `mode: "followup"`, holds the first reply for ~15s, sends a second message mid-run, and asserts both replies are delivered in order. This revision switches its two sends from qa-channel inbound messages to `chat.send` for the reason above; the earlier revision's second message was only delivered to the Gateway after the first turn had finished, so it did not exercise the queued path. The embedded runtime tolerates a missing snapshot (direct attempt authority), so this test is a regression guard for the queued flow itself, not the RED/GREEN boundary; the CLI live test above is.

Result: `Test Files 1 passed (1) · Tests 1 passed (1)` (47.2s), run against a dist rebuilt from this branch.

### Checks

- `followup-turn-admission*.test.ts`: 39 passed (rebased head). Owner/sibling suites: 240 passed (previous head; production file unchanged since).
- `extensions/qa-lab/src/gateway-queued-followup-send.e2e.test.ts` (chat.send revision): 1 passed (47.2s).
- `extensions/qa-lab/src/gateway-queued-followup-send.claude-cli.live.test.ts`: RED on main-built dist (fails with the reported error), GREEN on this branch (1 passed, 54.6s).
- `tsgo` extensions lane (`tsconfig.extensions.json`): clean. `oxfmt --check` and `oxlint` on both touched test files: clean. `git diff --check`: clean.
- `node scripts/check-changed.mjs`: 40 of its lanes green at push time (tsgo core/ui/test shards, dead-export scan, ratchets); the type-aware lint lane was still running and will be reported in a follow-up comment if it flags anything.

### Rebase onto `main` (`427abe8`)

#140018 landed, so the two cherry-picked CI commits are dropped and the branch is the three fix/proof commits rebased as `d6d1cdd`, with no conflicts and no content changes. Locally on the rebased head: `followup-turn-admission` and `followup-turn-admission.queued-handoff` pass (39 tests); the qa-lab Gateway e2e and the live CLI proof run in CI.
