### PR TITLE
fix(android): keep automation and approval details readable

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -329,7 +329,7 @@ private fun CronJobsSettingsScreen(
     Text(
       text = nativeString("Open an automation to inspect its configuration and run history. Admin-scoped connections can also run, edit, enable, disable, or delete it."),
       style = ClawTheme.type.caption,
-      color = ClawTheme.colors.textSubtle,
+      color = ClawTheme.colors.textMuted,
     )
     cronErrorText?.let { errorText ->
       ClawPanel {
@@ -371,7 +371,7 @@ private fun CronSummaryStrip(rows: List<SettingsMetric>) {
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xs)) {
       rows.forEach { row ->
         Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(3.dp)) {
-          Text(text = row.title, style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle, maxLines = 1)
+          Text(text = row.title, style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 1)
           Text(text = row.value, style = ClawTheme.type.label, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
       }
@@ -2642,7 +2642,7 @@ private fun ExecApprovalCard(
       approval.warningText?.let { warningText ->
         Text(text = warningText, style = ClawTheme.type.body, color = ClawTheme.colors.warning)
       }
-      Text(text = execApprovalMetadata(approval), style = ClawTheme.type.caption, color = ClawTheme.colors.textSubtle, maxLines = 2, overflow = TextOverflow.Ellipsis)
+      Text(text = execApprovalMetadata(approval), style = ClawTheme.type.caption, color = ClawTheme.colors.textMuted, maxLines = 2, overflow = TextOverflow.Ellipsis)
       approval.errorText?.let { errorText ->
         Text(text = gatewayExecApprovalTextForDisplay(errorText), style = ClawTheme.type.caption, color = ClawTheme.colors.warning)
       }
@@ -2721,7 +2721,7 @@ private fun ExecApprovalNotice(
         Text(
           text = nativeString("Approval \${notice.approvalId}", notice.approvalId),
           style = ClawTheme.type.caption,
-          color = ClawTheme.colors.textSubtle,
+          color = ClawTheme.colors.textMuted,
           maxLines = 1,
           overflow = TextOverflow.Ellipsis,
         )

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeTestCleanup.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeTestCleanup.kt
@@ -16,6 +16,17 @@ import org.robolectric.util.ReflectionHelpers
 
 internal fun closeNodeRuntimeTestFixture(runtime: NodeRuntime) = drainWithMainLooper { closeRuntime(runtime) }
 
+// Robolectric has no AndroidKeyStore. UI fixtures bind a real runtime with test-backed SecurePrefs.
+internal fun bindNodeRuntimeTestFixture(
+  app: NodeApp,
+  runtime: NodeRuntime?,
+) {
+  NodeApp::class.java
+    .getDeclaredField("runtimeInstance")
+    .apply { isAccessible = true }
+    .set(app, runtime)
+}
+
 internal fun closeNodeServiceTestFixture(
   controller: ServiceController<NodeForegroundService>,
   app: NodeApp,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -1,0 +1,361 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.bindNodeRuntimeTestFixture
+import ai.openclaw.app.closeNodeRuntimeTestFixture
+import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import ai.openclaw.app.ui.design.contrastThemeCases
+import ai.openclaw.app.ui.design.renderedLabelContrast
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExternalResource
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+import java.net.InetAddress
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [36], qualifiers = "en-rUS-w360dp-h800dp-mdpi")
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+class SettingsScreensContrastTest {
+  private val composeRule = createComposeRule()
+  private val models = ViewModelStore()
+  private lateinit var app: NodeApp
+  private lateinit var runtime: NodeRuntime
+  private var previousRuntime: NodeRuntime? = null
+  private lateinit var gateway: OperationalCaptionsGateway
+
+  // Dispose Compose before joining the actual runtime and socket, including on the contrast red.
+  @get:Rule
+  val fixtureRules: RuleChain =
+    RuleChain
+      .outerRule(
+        object : ExternalResource() {
+          override fun after() {
+            try {
+              models.clear()
+            } finally {
+              try {
+                if (::runtime.isInitialized) closeNodeRuntimeTestFixture(runtime)
+              } finally {
+                try {
+                  if (::app.isInitialized) bindNodeRuntimeTestFixture(app, previousRuntime)
+                } finally {
+                  if (::gateway.isInitialized) gateway.close()
+                }
+              }
+            }
+          }
+        },
+      ).around(composeRule)
+
+  @Test
+  fun operationalCaptionsRemainReadableThroughTheirSettingsCallers() {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    previousRuntime = app.peekRuntime()
+    gateway = OperationalCaptionsGateway()
+    val prefs = SecurePrefs(app, app.getSharedPreferences("captions-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    prefs.setManualTls(false)
+    prefs.saveGatewayCredentials(gateway.endpoint.stableId, token = "synthetic-caption-proof")
+    runtime = NodeRuntime(app, prefs)
+    bindNodeRuntimeTestFixture(app, runtime)
+    val model = MainViewModel(app, prefs, SavedStateHandle())
+    models.put("operational-captions", model)
+    model.setForeground(true)
+    val route = mutableStateOf(SettingsRoute.CronJobs)
+    val themes = contrastThemeCases()
+    val currentTheme = mutableStateOf(themes.first())
+    val evidence = File("build/outputs/operational-caption-contrast", UUID.randomUUID().toString())
+    check(!evidence.exists() && evidence.mkdirs())
+    val observations = JSONArray()
+    val failures = mutableListOf<String>()
+    composeRule.setContent {
+      val theme = currentTheme.value
+      ClawDesignTheme(dark = theme.dark, family = theme.family, accentArgb = theme.accentArgb) {
+        SettingsDetailScreen(viewModel = model, route = route.value, onBack = {})
+      }
+    }
+    composeRule.runOnIdle { model.connect(gateway.endpoint) }
+    try {
+      composeRule.waitUntil(10_000) {
+        composeRule.onAllNodesWithText("Enabled").fetchSemanticsNodes().isNotEmpty()
+      }
+    } finally {
+      File(evidence, "cron-readiness.json").writeText(
+        JSONObject()
+          .put("connected", model.isConnected.value)
+          .put("status", model.statusText.value)
+          .put("cronEnabled", model.cronStatus.value.enabled)
+          .put("cronRefreshing", model.cronRefreshing.value)
+          .put("runtimeConnected", runtime.isConnected.value)
+          .put("runtimeStatus", runtime.statusText.value)
+          .put("cronError", model.cronErrorText.value)
+          .put("methods", JSONArray(gateway.methods))
+          .toString(2),
+      )
+    }
+    assertTrue(model.isConnected.value && !model.cronRefreshing.value && model.cronStatus.value.enabled)
+    assertTrue(gateway.methods.containsAll(listOf("cron.status", "cron.list")))
+
+    fun observe(
+      name: String,
+      label: String,
+      substring: Boolean = false,
+    ) {
+      val theme = currentTheme.value
+      val capture = "${theme.family.rawValue}-${if (theme.dark) "dark" else "light"}-${theme.accentArgb?.toString(16) ?: "default"}-$name"
+      val node = composeRule.onNodeWithText(label, substring = substring, useUnmergedTree = true)
+      val observation = renderedLabelContrast(node)
+      val contrast = observation.ratio
+      val bounds = node.fetchSemanticsNode().boundsInRoot
+      val crop = node.captureToImage().asAndroidBitmap()
+      File(evidence, "$capture-crop.png").outputStream().use { stream ->
+        assertTrue(crop.compress(Bitmap.CompressFormat.PNG, 100, stream))
+      }
+      val bitmap = composeRule.onRoot().captureToImage().asAndroidBitmap()
+      File(evidence, "$capture.png").outputStream().use { stream ->
+        assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream))
+      }
+      observations.put(
+        JSONObject()
+          .put("caption", name)
+          .put("family", theme.family.rawValue)
+          .put("dark", theme.dark)
+          .put("accentArgb", theme.accentArgb)
+          .put("contrast", contrast.toDouble())
+          .put("image", "$capture.png")
+          .put("crop", "$capture-crop.png")
+          .put("foregroundArgb", "%08X".format(observation.foreground.toArgb()))
+          .put("backgroundArgb", "%08X".format(observation.background.toArgb()))
+          .put("sampleX", observation.sampleX)
+          .put("sampleY", observation.sampleY)
+          .put("boundsInRoot", JSONArray(listOf(bounds.left, bounds.top, bounds.right, bounds.bottom))),
+      )
+      if (contrast < 4.5f) failures += "$capture: $contrast:1"
+    }
+
+    themes.forEach { theme ->
+      composeRule.runOnIdle { currentTheme.value = theme }
+      observe("cron-status", "Status")
+      observe("cron-next-wake", "Next Wake")
+      observe("cron-help", "Open an automation to inspect its configuration and run history.", substring = true)
+    }
+    composeRule.runOnIdle { route.value = SettingsRoute.Approvals }
+    composeRule.waitUntil(10_000) {
+      composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty()
+    }
+    assertTrue(
+      !model.execApprovalsRefreshing.value && model.execApprovals.value
+        .singleOrNull()
+        ?.commandPreview == "echo",
+    )
+    composeRule
+      .onNodeWithText("Deny")
+      .performScrollTo()
+      .assertIsDisplayed()
+      .assertIsEnabled()
+    themes.forEach { theme ->
+      composeRule.runOnIdle { currentTheme.value = theme }
+      observe("approval-metadata", "Gateway · Agent main · Waiting", substring = true)
+    }
+
+    // Readback of a previously visible approval publishes the terminal notice; no resolution is sent.
+    val readsBeforeRefresh = gateway.methods.count { it == "approval.get" }
+    gateway.terminal = true
+    composeRule.onNodeWithText("Refresh").performScrollTo().performClick()
+    composeRule.waitUntil(10_000) {
+      composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isNotEmpty()
+    }
+    assertTrue(model.execApprovals.value.isEmpty() && model.execApprovalsNotice.value?.approvalId == "approval-1")
+    assertTrue(gateway.methods.count { it == "approval.get" } > readsBeforeRefresh)
+    composeRule.onNodeWithText("A prior response already denied this approval.").performScrollTo().assertIsDisplayed()
+    themes.forEach { theme ->
+      composeRule.runOnIdle { currentTheme.value = theme }
+      observe("approval-notice-id", "Approval approval-1")
+    }
+    composeRule.onNodeWithContentDescription("Dismiss approval notice").performClick()
+    composeRule.waitUntil(10_000) { composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isEmpty() }
+    assertEquals(null, model.execApprovalsNotice.value)
+    assertTrue(composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isEmpty())
+    assertFalse(gateway.methods.any { it in setOf("approval.resolve", "exec.approval.resolve", "chat.send", "cron.run") })
+    File(evidence, "observations.json").writeText(
+      JSONObject()
+        .put("observations", observations)
+        .put("methods", JSONArray(gateway.methods))
+        .put("themeCount", themes.size)
+        .put("createdAtMs", gateway.createdAtMs)
+        .put("expiresAtMs", gateway.expiresAtMs)
+        .put("terminalReadbackObserved", true)
+        .put("noticeDismissed", true)
+        .put("approvalResolutionRequests", 0)
+        .toString(2),
+    )
+    assertTrue("Operational captions must retain 4.5:1 contrast:\n${failures.joinToString("\n")}", failures.isEmpty())
+  }
+}
+
+private class OperationalCaptionsGateway : AutoCloseable {
+  private val json = Json { ignoreUnknownKeys = true }
+  private val server = MockWebServer()
+  private val startedAtMs = System.currentTimeMillis()
+  val createdAtMs = startedAtMs - 60_000
+  val expiresAtMs = startedAtMs + 600_000
+  val methods = CopyOnWriteArrayList<String>()
+
+  @Volatile var terminal = false
+  val endpoint: GatewayEndpoint
+
+  init {
+    server.dispatcher =
+      object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse =
+          if (request.getHeader("Upgrade").equals("websocket", ignoreCase = true)) {
+            MockResponse().withWebSocketUpgrade(listener())
+          } else {
+            MockResponse().setResponseCode(404)
+          }
+      }
+    server.start(InetAddress.getByName("127.0.0.1"), 0)
+    endpoint = GatewayEndpoint.manual("127.0.0.1", server.port)
+  }
+
+  private fun listener() =
+    object : WebSocketListener() {
+      override fun onOpen(
+        webSocket: WebSocket,
+        response: Response,
+      ) {
+        webSocket.send("""{"type":"event","event":"connect.challenge","payload":{"nonce":"caption-proof","ts":1700000000123}}""")
+      }
+
+      override fun onMessage(
+        webSocket: WebSocket,
+        text: String,
+      ) {
+        val frame = json.parseToJsonElement(text).jsonObject
+        if (frame["type"]?.jsonPrimitive?.content != "req") return
+        val id = frame.getValue("id")
+        val method = frame["method"]?.jsonPrimitive?.content.orEmpty()
+        methods += method
+        val params = frame["params"] as? JsonObject ?: JsonObject(emptyMap())
+        val payload: JsonElement? =
+          when (method) {
+            "connect" -> {
+              val role = params.getValue("role").jsonPrimitive.content
+              json.parseToJsonElement(
+                """{"type":"hello-ok","protocol":3,"server":{"host":"caption-proof","version":"proof"},"features":{"methods":["cron.status","cron.list","exec.approval.list","approval.get","approval.resolve","chat.history","chat.metadata","health","sessions.list"],"events":[]},"auth":{"role":"$role","scopes":${if (role == "operator") "[\"operator.read\",\"operator.write\",\"operator.approvals\"]" else "[]"}},"snapshot":{"sessionDefaults":{"mainSessionKey":"agent:main:main"}}}""",
+              )
+            }
+
+            "cron.status" -> {
+              json.parseToJsonElement("""{"enabled":true,"jobs":0,"nextWakeAtMs":null}""")
+            }
+
+            "cron.list" -> {
+              json.parseToJsonElement("""{"jobs":[],"total":0,"hasMore":false,"nextOffset":null}""")
+            }
+
+            "exec.approval.list" -> {
+              json.parseToJsonElement("""[{"id":"approval-1","createdAtMs":$createdAtMs,"expiresAtMs":$expiresAtMs}]""")
+            }
+
+            "approval.get" -> {
+              if (params["id"]?.jsonPrimitive?.content == "approval-1") approval() else null
+            }
+
+            "chat.history" -> {
+              json.parseToJsonElement("""{"sessionId":"caption-chat","messages":[]}""")
+            }
+
+            "chat.metadata" -> {
+              json.parseToJsonElement("""{"commands":[],"models":[]}""")
+            }
+
+            "sessions.list" -> {
+              json.parseToJsonElement("""{"sessions":[]}""")
+            }
+
+            "health", "sessions.subscribe", "sessions.messages.subscribe" -> {
+              JsonObject(emptyMap())
+            }
+
+            else -> {
+              null
+            }
+          }
+        webSocket.send(
+          buildJsonObject {
+            put("type", JsonPrimitive("res"))
+            put("id", id)
+            put("ok", JsonPrimitive(payload != null))
+            if (payload != null) {
+              put("payload", payload)
+            } else {
+              put(
+                "error",
+                buildJsonObject {
+                  put("code", JsonPrimitive("INVALID_REQUEST"))
+                  put("message", JsonPrimitive("Read-only caption fixture does not implement $method"))
+                },
+              )
+            }
+          }.toString(),
+        )
+      }
+    }
+
+  private fun approval(): JsonElement {
+    val terminalFields = if (terminal) ",\"resolvedAtMs\":${System.currentTimeMillis()},\"reason\":\"user\",\"decision\":\"deny\"" else ""
+    return json.parseToJsonElement(
+      """{"approval":{"id":"approval-1","urlPath":"/approve/approval-1","status":"${if (terminal) "denied" else "pending"}","createdAtMs":$createdAtMs,"expiresAtMs":$expiresAtMs,"presentation":{"kind":"exec","commandText":"echo ok","commandPreview":"echo","warningText":null,"host":"gateway","nodeId":null,"agentId":"main","allowedDecisions":["allow-once","allow-always","deny"]}$terminalFields}}""",
+    )
+  }
+
+  override fun close() = server.shutdown()
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/WorkspaceFilesShareLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/WorkspaceFilesShareLayoutTest.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeApp
 import ai.openclaw.app.NodeRuntime
 import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.bindNodeRuntimeTestFixture
 import ai.openclaw.app.closeNodeRuntimeTestFixture
 import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.ui.design.ClawDesignTheme
@@ -126,7 +127,7 @@ class WorkspaceFilesShareLayoutTest {
     prefs.setManualTls(false)
     prefs.saveGatewayCredentials(gateway.endpoint.stableId, token = "synthetic-workspace-share-proof")
     runtime = NodeRuntime(app, prefs)
-    bindRuntime(runtime)
+    bindNodeRuntimeTestFixture(app, runtime)
     val model = MainViewModel(app, prefs, SavedStateHandle())
     models.put("workspace", model)
     model.setForeground(true)
@@ -288,13 +289,6 @@ class WorkspaceFilesShareLayoutTest {
 
   private fun readExport(uri: Uri): ByteArray = requireNotNull(app.contentResolver.openInputStream(uri)).use { it.readBytes() }
 
-  private fun bindRuntime(value: NodeRuntime?) {
-    NodeApp::class.java
-      .getDeclaredField("runtimeInstance")
-      .apply { isAccessible = true }
-      .set(app, value)
-  }
-
   private fun tearDown() {
     try {
       models.clear()
@@ -303,7 +297,7 @@ class WorkspaceFilesShareLayoutTest {
         if (::runtime.isInitialized) closeNodeRuntimeTestFixture(runtime)
       } finally {
         try {
-          if (::app.isInitialized) bindRuntime(previousRuntime)
+          if (::app.isInitialized) bindNodeRuntimeTestFixture(app, previousRuntime)
         } finally {
           try {
             if (::gateway.isInitialized) gateway.close()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
@@ -26,6 +28,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsNotSelected
@@ -35,6 +38,7 @@ import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.unit.dp
@@ -89,16 +93,13 @@ class ClawComponentsTest {
 
   @Test
   fun selectedLabelsStayReadableAcrossThemeFamiliesAndLightAccents() {
-    val cases =
-      AppearanceThemeFamily.entries.flatMap { family ->
-        listOf(ThemeCase(dark = true, family = family), ThemeCase(dark = false, family = family))
-      } + appearanceAccentPalette.map { ThemeCase(dark = false, accentArgb = it) }
+    val cases = contrastThemeCases()
     val current = mutableStateOf(cases.first())
     composeRule.setContent {
       val theme = current.value
       ClawDesignTheme(dark = theme.dark, family = theme.family, accentArgb = theme.accentArgb) {
         Surface(color = ClawTheme.colors.surface) {
-          Column(Modifier.width(320.dp).padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+          Column(Modifier.width(320.dp).verticalScroll(rememberScrollState()).padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
             ClawSegmentedControl(options = listOf("Segment", "Other"), selected = "Segment", onSelect = {})
             ClawPill(text = "Pill", selected = true, onClick = {})
             Surface(
@@ -154,7 +155,11 @@ class ClawComponentsTest {
         "Paragraph link" to "markdown-links",
         "Table link" to "markdown-links",
       ).forEach { (label, containerTag) ->
-        val contrast = renderedLabelContrast(label, containerTag)
+        val contrast =
+          renderedLabelContrast(
+            label = composeRule.onNodeWithText(label, useUnmergedTree = true),
+            container = if (containerTag == null) composeRule.onNodeWithText(label) else composeRule.onNodeWithTag(containerTag),
+          ).ratio
         if (contrast < 4.5f) failures += "$theme, $label: $contrast:1"
       }
     }
@@ -246,41 +251,56 @@ class ClawComponentsTest {
     assertEquals(listOf(4, 3, 3), rows.map { it.size })
     assertEquals((1..10).map(Int::toString), rows.flatten())
   }
+}
 
-  private fun renderedLabelContrast(
-    label: String,
-    containerTag: String?,
-  ): Float {
-    val layouts = mutableListOf<TextLayoutResult>()
-    composeRule
-      .onNodeWithText(label, useUnmergedTree = true)
-      .assertIsDisplayed()
-      .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
-    val layout = layouts.single().layoutInput
-    val foreground =
-      layout.text
-        .getLinkAnnotations(0, layout.text.length)
-        .firstOrNull()
-        ?.item
-        ?.styles
-        ?.style
-        ?.color ?: layout.style.color
-    assertTrue("$label must resolve its rendered foreground", foreground != Color.Unspecified)
-    val container =
-      if (containerTag == null) composeRule.onNodeWithText(label) else composeRule.onNodeWithTag(containerTag)
-    val pixels = container.captureToImage().toPixelMap()
-    // Sample painted padding, away from text, rounded corners, and one-pixel borders.
-    val background = pixels[pixels.width / 2, 2]
-    assertEquals("$label must have an opaque rendered background", 1f, background.alpha, 0.001f)
-    val foregroundLuminance = foreground.compositeOver(background).luminance()
-    val backgroundLuminance = background.luminance()
-    return (maxOf(foregroundLuminance, backgroundLuminance) + 0.05f) /
+internal data class ContrastThemeCase(
+  val dark: Boolean,
+  val family: AppearanceThemeFamily = AppearanceThemeFamily.Claw,
+  val accentArgb: Long? = null,
+)
+
+internal fun contrastThemeCases(): List<ContrastThemeCase> =
+  AppearanceThemeFamily.entries.flatMap { family ->
+    listOf(ContrastThemeCase(dark = true, family = family), ContrastThemeCase(dark = false, family = family))
+  } + appearanceAccentPalette.map { ContrastThemeCase(dark = false, accentArgb = it) }
+
+internal data class RenderedLabelContrast(
+  val foreground: Color,
+  val background: Color,
+  val sampleX: Int,
+  val sampleY: Int,
+  val ratio: Float,
+)
+
+internal fun renderedLabelContrast(
+  label: SemanticsNodeInteraction,
+  container: SemanticsNodeInteraction = label,
+): RenderedLabelContrast {
+  container.performScrollTo()
+  val layouts = mutableListOf<TextLayoutResult>()
+  label
+    .assertIsDisplayed()
+    .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
+  val layout = layouts.single().layoutInput
+  val foreground =
+    layout.text
+      .getLinkAnnotations(0, layout.text.length)
+      .firstOrNull()
+      ?.item
+      ?.styles
+      ?.style
+      ?.color ?: layout.style.color
+  assertTrue("${layout.text} must resolve its rendered foreground", foreground != Color.Unspecified)
+  val pixels = container.captureToImage().toPixelMap()
+  // Sample painted padding, away from text, rounded corners, and one-pixel borders.
+  val sampleX = pixels.width / 2
+  val sampleY = 2
+  val background = pixels[sampleX, sampleY]
+  assertEquals("${layout.text} must have an opaque rendered background", 1f, background.alpha, 0.001f)
+  val foregroundLuminance = foreground.compositeOver(background).luminance()
+  val backgroundLuminance = background.luminance()
+  val ratio =
+    (maxOf(foregroundLuminance, backgroundLuminance) + 0.05f) /
       (minOf(foregroundLuminance, backgroundLuminance) + 0.05f)
-  }
-
-  private data class ThemeCase(
-    val dark: Boolean,
-    val family: AppearanceThemeFamily = AppearanceThemeFamily.Claw,
-    val accentArgb: Long? = null,
-  )
+  return RenderedLabelContrast(foreground, background, sampleX, sampleY, ratio)
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users inspecting automations or command approvals would see faint status labels, help, age/expiry metadata, and approval identifiers on several themes. These are meaningful operational details, not disabled or decorative text.

## Why This Change Was Made

Use the existing readable secondary-text color at four caption sites. Keep palettes, backgrounds, layout, disabled styling, approval actions, and runtime behavior unchanged. Production is four substitutions (+4/−4), with no new API, configuration, schema, or dependency.

The regression reaches the real settings callers, reuses the existing 31-case theme/accent matrix and contrast calculation, and shares the existing joined runtime fixture cleanup. Its generic component fixture can scroll each label into view; no test-only production hook is added.

## User Impact

Automation summaries and help are easier to read. Approval age, expiry, and terminal identifiers retain readable contrast, so users can distinguish the details and associate a completed outcome with its approval.

## Evidence

- The original same-caller reproduction at `26a8611` measured **115 of 155 captions below 4.5:1**. The caption owners are unchanged on the independent main baseline `83d1f53c`; the identical caller test now measures **155/155 passing**, with a minimum of **4.85:1**.
- **88 tests passed** across Cron and approval parsing/runtime, Settings, workspace sharing, generic components, and the new caller regression. **All 14 changed checks passed**, including Android lint. Codex review through P2 found no actionable issues.
- The caller follows real MainViewModel/NodeRuntime rendering with a loopback Gateway fixture: load automations, discover a pending approval, observe its terminal result through Refresh, then dismiss the notice. It sends no approval resolution or command execution.
- The attached before/after captures are inspected, synthetic-only **native-graphics Compose/Robolectric renders**. They are not installed-device evidence or a claim of full-app accessibility conformance. Before captures preserve the original reproduction; after captures come from this independent-main candidate.

This is a caption-only follow-up to the Android audit. It does not include the separate row-layout changes in #139789.

![Automations and help — Before (synthetic rendered UI)](https://github.com/user-attachments/assets/2c67e66b-a316-4fe1-9195-2e3bfaafa5e7)

![Automations and help — After (synthetic rendered UI)](https://github.com/user-attachments/assets/0c1f6e8f-2106-4676-a964-b8bea699d802)

![Approval age and expiry — Before (synthetic rendered UI)](https://github.com/user-attachments/assets/fdbcfe3f-22c7-4eea-be18-356e8a572fa1)

![Approval age and expiry — After (synthetic rendered UI)](https://github.com/user-attachments/assets/9fb32d30-127d-4a6a-ba06-477ccbf1c9ae)

![Terminal approval identifier — Before (synthetic rendered UI)](https://github.com/user-attachments/assets/b760324e-69aa-4b01-a8bc-0b866b2a7b94)

![Terminal approval identifier — After (synthetic rendered UI)](https://github.com/user-attachments/assets/7feb0102-841d-425c-9f03-e36686cebd05)

## Maintainer verification

[Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34021394189), including Play and third-party unit tests, Wear tests, Play/Wear builds, Android lint, native translations, security, and the required CI gate. The current main baseline was also checked: its Android sources are unchanged from the independently tested base.

The six full-size before/after captures were inspected for legibility, correct attribution, preserved controls, and synthetic-only contents. Independent pixel verification corroborates the 155 measurements. This addresses the visual inspection requested in [ClawSweeper's review](https://github.com/openclaw/openclaw/pull/139931#issuecomment-5557999852); its image-fetch cache miss does not indicate a product defect. The evidence remains rendered Compose/Robolectric proof, not installed-device verification.
