### PR TITLE
refactor(doctor): reuse subagent migration receipts

### DIFF
--- a/src/infra/state-migrations.subagent-registry-db.ts
+++ b/src/infra/state-migrations.subagent-registry-db.ts
@@ -1,18 +1,11 @@
 import { createHash } from "node:crypto";
-import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import {
-  executeSqliteQuerySync,
-  executeSqliteQueryTakeFirstSync,
-  getNodeSqliteKysely,
-} from "./kysely-sync.js";
+  readLegacyMigrationReceiptFromDatabase,
+  recordLegacyMigrationReceipt,
+} from "./state-migrations.receipts.js";
 
 const MIGRATION_KIND = "legacy-subagent-registry-json";
-
-type SubagentRegistryMigrationDatabase = Pick<
-  OpenClawStateKyselyDatabase,
-  "migration_runs" | "migration_sources"
->;
 
 type SubagentRegistryMigrationDecision = "receipt-authoritative" | "retired-source-discarded";
 
@@ -32,14 +25,7 @@ export function recordLegacySubagentRegistryDiscard(params: {
   let decision: SubagentRegistryMigrationDecision = "retired-source-discarded";
   runOpenClawStateWriteTransaction(
     ({ db }) => {
-      const stateDb = getNodeSqliteKysely<SubagentRegistryMigrationDatabase>(db);
-      const receipt = executeSqliteQueryTakeFirstSync(
-        db,
-        stateDb
-          .selectFrom("migration_sources")
-          .select("source_key")
-          .where("source_key", "=", sourceKey),
-      );
+      const receipt = readLegacyMigrationReceiptFromDatabase(db, sourceKey);
       if (receipt) {
         decision = "receipt-authoritative";
       }
@@ -52,77 +38,21 @@ export function recordLegacySubagentRegistryDiscard(params: {
         importedRecordCount: 0,
         reason: "retired transient state is never imported into the canonical SQLite registry",
       });
-      executeSqliteQuerySync(
-        db,
-        stateDb
-          .insertInto("migration_runs")
-          .values({
-            id: runId,
-            started_at: now,
-            finished_at: now,
-            status: "completed",
-            report_json: reportJson,
-          })
-          .onConflict((conflict) =>
-            conflict.column("id").doUpdateSet({
-              finished_at: now,
-              status: "completed",
-              report_json: reportJson,
-            }),
-          ),
-      );
-      executeSqliteQuerySync(
-        db,
-        stateDb
-          .insertInto("migration_sources")
-          .values({
-            source_key: sourceKey,
-            migration_kind: MIGRATION_KIND,
-            source_path: params.sourcePath,
-            target_table: "subagent_runs",
-            source_sha256: params.sourceSha256,
-            source_size_bytes: params.sourceSize,
-            source_record_count: null,
-            last_run_id: runId,
-            status: "completed",
-            imported_at: now,
-            removed_source: 0,
-            report_json: reportJson,
-          })
-          .onConflict((conflict) =>
-            conflict.column("source_key").doUpdateSet({
-              source_sha256: params.sourceSha256,
-              source_size_bytes: params.sourceSize,
-              source_record_count: null,
-              last_run_id: runId,
-              status: "completed",
-              imported_at: now,
-              removed_source: 0,
-              report_json: reportJson,
-            }),
-          ),
-      );
+      recordLegacyMigrationReceipt(db, {
+        sourceKey,
+        migrationKind: MIGRATION_KIND,
+        sourcePath: params.sourcePath,
+        targetTable: "subagent_runs",
+        sourceSha256: params.sourceSha256,
+        sourceSizeBytes: params.sourceSize,
+        sourceRecordCount: null,
+        runId,
+        now,
+        reportJson,
+        upsert: true,
+      });
     },
     { env: params.env },
   );
   return { decision, sourceKey };
-}
-
-export function markLegacySubagentRegistrySourceRemoved(
-  sourceKey: string,
-  env: NodeJS.ProcessEnv,
-): void {
-  runOpenClawStateWriteTransaction(
-    ({ db }) => {
-      const stateDb = getNodeSqliteKysely<SubagentRegistryMigrationDatabase>(db);
-      executeSqliteQuerySync(
-        db,
-        stateDb
-          .updateTable("migration_sources")
-          .set({ removed_source: 1 })
-          .where("source_key", "=", sourceKey),
-      );
-    },
-    { env },
-  );
 }

--- a/src/infra/state-migrations.subagent-registry.ts
+++ b/src/infra/state-migrations.subagent-registry.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { root, type Root } from "@openclaw/fs-safe";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
+import { markLegacyMigrationSourceRemoved } from "./state-migrations.receipts.js";
 import {
   LegacyMigrationSourceClaim,
   legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
@@ -9,10 +10,7 @@ import {
   readLegacyMigrationSourceSnapshot,
   type LegacyMigrationSourceSnapshot as LegacySourceSnapshot,
 } from "./state-migrations.source-snapshot.js";
-import {
-  markLegacySubagentRegistrySourceRemoved,
-  recordLegacySubagentRegistryDiscard,
-} from "./state-migrations.subagent-registry-db.js";
+import { recordLegacySubagentRegistryDiscard } from "./state-migrations.subagent-registry-db.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_SUBAGENT_REGISTRY_MAX_BYTES = 16 * 1024 * 1024;
@@ -59,7 +57,7 @@ async function recoverInterruptedClaim(params: {
     sourceSize: claimed.size,
   });
   await params.source.remove({ skipSourceCheck: true });
-  markLegacySubagentRegistrySourceRemoved(result.sourceKey, params.env);
+  markLegacyMigrationSourceRemoved(result.sourceKey, params.env);
 }
 
 async function migrateWithExclusiveStateOwnership(params: {
@@ -154,7 +152,7 @@ async function migrateWithExclusiveStateOwnership(params: {
   }
 
   try {
-    markLegacySubagentRegistrySourceRemoved(result.sourceKey, params.env);
+    markLegacyMigrationSourceRemoved(result.sourceKey, params.env);
   } catch (error) {
     warnings.push(
       `Legacy subagent registry was removed, but its receipt could not be finalized: ${String(error)}`,


### PR DESCRIPTION
## What Problem This Solves

Doctor's retired subagent-registry cleanup duplicates the shared migration-receipt queries and writes, leaving two implementations of the same retry and receipt bookkeeping.

Cleanup companion to #135868; no recovery feature content is included.

## Why This Change Was Made

Use the existing receipt reader and writer on the same transaction connection, and call the existing source-removal helper directly from both cleanup paths. This removes the duplicate SQL, its database type, and the redundant removal wrapper.

The retirement contract introduced in #105793 remains intact; the shared receipt owner introduced in #117142 already performs the same updates. Source-key hashing deliberately stays unchanged: the shared key helper resolves paths, while this owner hashes the original path bytes. Run IDs, timestamps, report bytes, conflict updates, source-removal ordering, claim checks, and exclusive state ownership are preserved.

## User Impact

Doctor still discards retired transient JSON without importing or resurrecting runs, records the decision before removal, and resumes interrupted cleanup using its receipt. No schema, persistence behavior, configuration, or public API changes.

Production shrinks by 72 lines (+21/−93) across two files, 328 → 256 lines. Tests, tooling, and docs are unchanged. The old removal helper had only two callers; both now use the canonical owner. No compatibility or migration path is removed.

## Evidence

- All 35 existing tests passed across subagent-registry migration, shared receipts, source snapshots, and commitments migration. They protect exact source digests, retries, claim recovery, no resurrection, canonical rows, exclusive ownership, and hostile filesystem inputs.
- 18 complete SQLite receipt snapshots matched between the actual old and new functions, covering initial writes, same-run retries, changed digests, interrupted receipts, removal flags, and absolute, relative, and Unicode source paths. The probe used owned temporary databases and cleaned them up.
- Source/history inspection confirms the same synchronous transaction, connection, status/report updates, preserved original start time on conflict, and null subagent record count.
- Independent local and branch Codex reviews through P2 found no actionable defects.
- The full `node scripts/check-changed.mjs` plan passed (exit 0), including production and core/UI test typing, exports, lint, native schema/legacy-store guards, and zero runtime import cycles.
- Exact-head CI passed for `20d06da6325ffa6efc6eb8711587c4a3901176d4` in [run 34021878111](https://github.com/openclaw/openclaw/actions/runs/34021878111).
