### PR TITLE
test(agents): consolidate cleanup timeout and revocation coverage

### DIFF
--- a/src/agents/cli-runner/cli-live-session-registry.test.ts
+++ b/src/agents/cli-runner/cli-live-session-registry.test.ts
@@ -4,10 +4,7 @@ import type {
   CliBackendLiveSessionCapability,
   CliBackendLiveSessionHandle,
 } from "../../plugins/cli-backend.types.js";
-import {
-  prepareSystemAgentRunAdmission,
-  resolveAdmittedRunActiveAssertion,
-} from "../admitted-run-context.js";
+import { prepareSystemAgentRunAdmission } from "../admitted-run-context.js";
 import { buildPreparedCliRunContext } from "../cli-runner.test-helpers.js";
 import { hasModelFallbackStop } from "../failover-error.js";
 import { createAgentCleanupScope } from "../run-cleanup-timeout.js";
@@ -266,23 +263,14 @@ describe("generic plugin-owned live session registry", () => {
     expect(owner.capability.current()).toBe(owner.session);
     owner.revokeCaller();
     expect(owner.controller.signal.aborted).toBe(false);
-    expect(resolveAdmittedRunActiveAssertion(owner.context.params.admittedRunContext)).toBeTypeOf(
-      "function",
-    );
     expect(() => owner.capability.current()).toThrow("caller is no longer active");
     expect(() => owner.capability.activate(owner.session)).toThrow("caller is no longer active");
-    await closeCliLiveSession(owner.context, "restart");
-    expect(owner.close).toHaveBeenCalledOnce();
-  });
-
-  it("rejects a caller-revoked restart before closing the registered process", async () => {
-    const owner = await createOwner();
-    owner.register();
-    owner.revokeCaller();
     await expect(restartCliLiveSession(owner.context)).rejects.toThrow(
       "caller is no longer active",
     );
     expect(owner.close).not.toHaveBeenCalled();
+    await closeCliLiveSession(owner.context, "restart");
+    expect(owner.close).toHaveBeenCalledOnce();
   });
 
   it.each([false, true])(
@@ -309,9 +297,6 @@ describe("generic plugin-owned live session registry", () => {
           restarting.revokeCaller();
         }
         expect(restarting.controller.signal.aborted).toBe(false);
-        expect(
-          resolveAdmittedRunActiveAssertion(restarting.context.params.admittedRunContext),
-        ).toBeTypeOf("function");
       } finally {
         held.resolve();
       }

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -8,7 +8,6 @@ import type {
   CliBackendLiveSessionHandle,
   CliBackendToolPermissionResult,
 } from "../../plugins/cli-backend.types.js";
-import { resolveAdmittedRunActiveAssertion } from "../admitted-run-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import {
   closeCliLiveSession,
@@ -261,9 +260,6 @@ describe("plugin-owned CLI execution host boundary", () => {
     try {
       await entered.promise;
       callerCurrent = false;
-      expect(resolveAdmittedRunActiveAssertion(context.params.admittedRunContext)).toBeTypeOf(
-        "function",
-      );
     } finally {
       held.resolve();
     }

--- a/src/agents/run-cleanup-timeout.test.ts
+++ b/src/agents/run-cleanup-timeout.test.ts
@@ -31,49 +31,83 @@ describe("agent cleanup timeout", () => {
     vi.useRealTimers();
   });
 
-  it("returns after the cleanup timeout when a cleanup step stalls", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
-
+  it.each<{
+    name: string;
+    step: string;
+    env?: NodeJS.ProcessEnv;
+    timeoutMs?: number;
+    expectedTimeoutMs: number;
+  }>([
+    {
+      name: "default budget",
+      step: "bundle-mcp-retire",
+      env: {},
+      expectedTimeoutMs: AGENT_CLEANUP_STEP_TIMEOUT_MS,
+    },
+    {
+      name: "trajectory environment override",
+      step: "openclaw-trajectory-flush",
+      env: { OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000" },
+      expectedTimeoutMs: 25_000,
+    },
+    {
+      name: "general environment override",
+      step: "bundle-mcp-retire",
+      env: { OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "1500" },
+      expectedTimeoutMs: 1_500,
+    },
+    {
+      name: "explicit budget before environment overrides",
+      step: "openclaw-trajectory-flush",
+      timeoutMs: 2_000,
+      env: {
+        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
+        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "15000",
+      },
+      expectedTimeoutMs: 2_000,
+    },
+    {
+      name: "explicit zero clamped to one millisecond",
+      step: "openclaw-trajectory-flush",
+      timeoutMs: 0,
+      env: { OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000" },
+      expectedTimeoutMs: 1,
+    },
+    {
+      name: "invalid environment numbers ignored",
+      step: "openclaw-trajectory-flush",
+      env: {
+        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "0",
+        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "not-a-number",
+      },
+      expectedTimeoutMs: AGENT_CLEANUP_STEP_TIMEOUT_MS,
+    },
+    {
+      name: "invalid environment formats ignored",
+      step: "openclaw-trajectory-flush",
+      env: {
+        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "1e3",
+        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "0x10",
+      },
+      expectedTimeoutMs: AGENT_CLEANUP_STEP_TIMEOUT_MS,
+    },
+  ])("bounds stalled cleanup with $name", async ({ step, env, timeoutMs, expectedTimeoutMs }) => {
     const result = runAgentCleanupStep({
       runId: "run-1",
       sessionId: "session-1",
-      step: "bundle-mcp-retire",
-      cleanup,
+      step,
+      cleanup: () => new Promise<never>(() => {}),
       log,
+      env,
+      timeoutMs,
     });
 
-    await vi.advanceTimersByTimeAsync(AGENT_CLEANUP_STEP_TIMEOUT_MS);
-    await expect(result).resolves.toBeUndefined();
-
-    expect(cleanup).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenCalledWith(
-      "agent cleanup timed out: runId=run-1 sessionId=session-1 step=bundle-mcp-retire timeoutMs=10000",
-    );
-  });
-
-  it("uses the trajectory flush timeout environment override for trajectory cleanup", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
-
-    const result = runAgentCleanupStep({
-      runId: "run-trajectory",
-      sessionId: "session-trajectory",
-      step: "openclaw-trajectory-flush",
-      cleanup,
-      log,
-      env: {
-        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
-      },
-    });
-
-    await vi.advanceTimersByTimeAsync(24_999);
+    await vi.advanceTimersByTimeAsync(expectedTimeoutMs - 1);
     expect(log.warn).not.toHaveBeenCalled();
-
     await vi.advanceTimersByTimeAsync(1);
     await expect(result).resolves.toBeUndefined();
-
-    expect(cleanup).toHaveBeenCalledTimes(1);
-    expect(log.warn).toHaveBeenCalledWith(
-      "agent cleanup timed out: runId=run-trajectory sessionId=session-trajectory step=openclaw-trajectory-flush timeoutMs=25000",
+    expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+      `agent cleanup timed out: runId=run-1 sessionId=session-1 step=${step} timeoutMs=${expectedTimeoutMs}`,
     );
   });
 
@@ -180,78 +214,6 @@ describe("agent cleanup timeout", () => {
     );
   });
 
-  it("uses the general cleanup timeout environment override for other cleanup steps", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
-
-    const result = runAgentCleanupStep({
-      runId: "run-general",
-      sessionId: "session-general",
-      step: "bundle-mcp-retire",
-      cleanup,
-      log,
-      env: {
-        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "1500",
-      },
-    });
-
-    await vi.advanceTimersByTimeAsync(1_500);
-    await expect(result).resolves.toBeUndefined();
-
-    expect(log.warn).toHaveBeenCalledWith(
-      "agent cleanup timed out: runId=run-general sessionId=session-general step=bundle-mcp-retire timeoutMs=1500",
-    );
-  });
-
-  it("prefers explicit cleanup timeout values over environment overrides", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
-
-    const result = runAgentCleanupStep({
-      runId: "run-explicit",
-      sessionId: "session-explicit",
-      step: "openclaw-trajectory-flush",
-      timeoutMs: 2_000,
-      cleanup,
-      log,
-      env: {
-        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
-        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "15000",
-      },
-    });
-
-    await vi.advanceTimersByTimeAsync(1_999);
-    expect(log.warn).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    await expect(result).resolves.toBeUndefined();
-
-    expect(log.warn).toHaveBeenCalledWith(
-      "agent cleanup timed out: runId=run-explicit sessionId=session-explicit step=openclaw-trajectory-flush timeoutMs=2000",
-    );
-  });
-
-  it("keeps explicit zero cleanup timeouts as a one millisecond timeout", async () => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
-
-    const result = runAgentCleanupStep({
-      runId: "run-zero",
-      sessionId: "session-zero",
-      step: "openclaw-trajectory-flush",
-      timeoutMs: 0,
-      cleanup,
-      log,
-      env: {
-        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "25000",
-      },
-    });
-
-    await vi.advanceTimersByTimeAsync(1);
-    await expect(result).resolves.toBeUndefined();
-
-    expect(log.warn).toHaveBeenCalledWith(
-      "agent cleanup timed out: runId=run-zero sessionId=session-zero step=openclaw-trajectory-flush timeoutMs=1",
-    );
-  });
-
   it.each([false, true])(
     "preserves nested cleanup uncertainty and the original run outcome (fails=%s)",
     async (fails) => {
@@ -284,46 +246,6 @@ describe("agent cleanup timeout", () => {
       expect(outer.outcome).toBe("uncertain");
     },
   );
-
-  it.each([
-    {
-      runId: "run-invalid-env-number",
-      sessionId: "session-invalid-env-number",
-      env: {
-        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "0",
-        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "not-a-number",
-      },
-    },
-    {
-      runId: "run-invalid-env-format",
-      sessionId: "session-invalid-env-format",
-      env: {
-        OPENCLAW_TRAJECTORY_FLUSH_TIMEOUT_MS: "1e3",
-        OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS: "0x10",
-      },
-    },
-  ])("ignores invalid cleanup timeout environment values", async ({ runId, sessionId, env }) => {
-    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
-
-    const result = runAgentCleanupStep({
-      runId,
-      sessionId,
-      step: "openclaw-trajectory-flush",
-      cleanup,
-      log,
-      env,
-    });
-
-    await vi.advanceTimersByTimeAsync(AGENT_CLEANUP_STEP_TIMEOUT_MS - 1);
-    expect(log.warn).not.toHaveBeenCalled();
-
-    await vi.advanceTimersByTimeAsync(1);
-    await expect(result).resolves.toBeUndefined();
-
-    expect(log.warn).toHaveBeenCalledWith(
-      `agent cleanup timed out: runId=${runId} sessionId=${sessionId} step=openclaw-trajectory-flush timeoutMs=10000`,
-    );
-  });
 
   it("logs cleanup rejection without throwing", async () => {
     await expect(


### PR DESCRIPTION
Related: #135868, #139657

## What Problem This Solves

The Stage 3 cleanup-evidence suite repeated timeout setup and inspected authority callback shapes alongside tests of the actual caller boundary. This is the maintainer-requested test-debt follow-up for concern C of the #135868 split.

## Why This Change Was Made

Put all seven timeout-policy cases in one table with the same before-deadline and exact-deadline assertions. Combine the revoked-restart case with the existing revoked-access/owned-cleanup case, and retain observable caller errors and successor usability instead of checking whether an internal assertion callback is a function.

## User Impact

No runtime behavior changes. Test code shrinks by 97 lines (70 added / 167 deleted); production, tooling and docs each change by zero. Of that reduction, 19 lines are in the new Stage 3 CLI tests; 78 remove older policy repetition in the cleanup suite Stage 3 extended.

## Evidence

All removed cases retain named coverage in the final files:

| Removed repetition/assertion | Remaining coverage |
| --- | --- |
| Default budget, trajectory override, general override, explicit-over-env precedence, explicit zero, invalid numbers, invalid formats | `src/agents/run-cleanup-timeout.test.ts:94`, “bounds stalled cleanup with $name”, seven named table rows |
| Cleanup callback call-count assertions in default/trajectory cases | Same table: a callback that never starts cannot produce its required timeout warning |
| Standalone “rejects a caller-revoked restart before closing the registered process” | `src/agents/cli-runner/cli-live-session-registry.test.ts:259`, “fences caller-revoked live access while allowing its owned cleanup”, now includes restart rejection and no premature close |
| Registry callback-function introspection | Same revoked-access test and `src/agents/cli-runner/cli-live-session-registry.test.ts:277`, “rechecks caller authority after registered process cleanup” |
| Plugin callback-function introspection | `src/agents/cli-runner/execute-plugin.test.ts:239`, “does not close a successor or execute after caller revocation during restart cleanup” |

The nested-uncertainty and original-result cases (`run-cleanup-timeout.test.ts:218,273`), distinct CLI retirement races, and real-process cleanup suites remain intact. `execute-plugin.test-support.ts` has two consumers, so inlining it would duplicate fixtures.

Validation: 88 focused tests passed across the three edited suites; full `node scripts/check-changed.mjs` exited 0, including both agent test type graphs, lint and all three dead-export scans. Independent Codex autoreview: scoped-clean through P2. `git diff --check` passed.
