### PR TITLE
fix: restore failed steer and redirect drafts in Control UI

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -1035,6 +1035,10 @@ unconfirmed message is resolved or discarded, and the queue explains that blocka
 earlier message lets the next queued message proceed when the session is ready. Unconfirmed local
 commands keep their retry/discard queue controls.
 
+If the Gateway reports that a `/steer` or `/redirect` message failed to start, the Control UI
+restores the submitted draft when the composer is still empty. It preserves newer text and
+attachments. If you switched conversations, recovery stays with the original conversation.
+
 Queued messages and drafts keep the conversation and agent selected when they were created.
 Switching agents, opening a split pane, or reloading does not move them to another destination.
 A literal `global` conversation keeps its captured agent; an agent's main conversation stays

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -832,7 +832,7 @@ async function executeSteer(
     );
     const terminalAckContent = formatTerminalSteerAckContent(ackStatus);
     if (terminalAckContent) {
-      return { content: terminalAckContent };
+      return { content: terminalAckContent, failed: true };
     }
     const result: SlashCommandResult = { content: t("chat.commandResults.steer.succeeded") };
     if (ackStatus === "started" || ackStatus === "in_flight") {
@@ -873,7 +873,7 @@ async function executeRedirect(
     const ackStatus = normalizeSteerChatSendAckStatus(resp);
     const terminalAckContent = formatTerminalRedirectAckContent(ackStatus);
     if (terminalAckContent) {
-      return { content: terminalAckContent };
+      return { content: terminalAckContent, failed: true };
     }
     const runId = typeof resp?.runId === "string" ? resp.runId : undefined;
     return {

--- a/ui/src/pages/chat/chat-send-command-recovery.test.ts
+++ b/ui/src/pages/chat/chat-send-command-recovery.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import { GatewayRequestError } from "../../api/gateway.ts";
+import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import {
+  captureChatOutboxAdmission,
+  storedChatOutboxScopeKey,
+} from "../../lib/chat/outbox-store.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import {
+  getChatAttachmentDataUrl,
+  registerChatAttachmentPayload,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
+import { findChatSendPayload, makeChatHost } from "./chat-host.test-support.ts";
+import { handleSendChat } from "./chat-send-submit.ts";
+import { installOutboxBrowserStorage } from "./outbox-browser.test-support.ts";
+
+const attachmentsToRelease: ChatAttachment[] = [];
+const attachmentDataUrl = "data:application/pdf;base64,JVBERi0xLjQK";
+
+beforeEach(() => {
+  installOutboxBrowserStorage();
+  vi.stubGlobal("sessionStorage", createStorageMock());
+  vi.stubGlobal("requestAnimationFrame", () => 1);
+  vi.stubGlobal("cancelAnimationFrame", () => undefined);
+});
+
+afterEach(() => {
+  releaseChatAttachmentPayloads(attachmentsToRelease);
+  attachmentsToRelease.length = 0;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function createStagedAttachment(id: string): ChatAttachment {
+  const file = new File(["%PDF-1.4\n"], "brief.pdf", { type: "application/pdf" });
+  const attachment = registerChatAttachmentPayload({
+    attachment: { id, mimeType: file.type, fileName: file.name, sizeBytes: file.size },
+    dataUrl: attachmentDataUrl,
+    file,
+  });
+  attachmentsToRelease.push(attachment);
+  return attachment;
+}
+
+describe.each(["steer", "redirect"] as const)("handleSendChat /%s recovery", (command) => {
+  const draft = `/${command} keep the correction available`;
+
+  it.each(["timeout", "error", "rejected"] as const)(
+    "restores submitted input after the %s acknowledgment",
+    async (outcome) => {
+      const attachment = createStagedAttachment(`${command}-${outcome}`);
+      const host = makeChatHost({
+        chatMessage: draft,
+        chatAttachments: [attachment],
+        requestHandlers: {
+          "chat.send": () => {
+            if (outcome === "rejected") {
+              throw new GatewayRequestError({ code: "UNAVAILABLE", message: "Request rejected" });
+            }
+            return { runId: "command-run", status: outcome };
+          },
+        },
+      });
+
+      await handleSendChat(host);
+
+      expect(findChatSendPayload(host)).toMatchObject({
+        message: "keep the correction available",
+        queueMode: command === "steer" ? "steer" : "interrupt",
+      });
+      expect(host.chatMessage).toBe(draft);
+      expect(host.chatAttachments).toEqual([expect.objectContaining({ id: attachment.id })]);
+      expect(getChatAttachmentDataUrl(host.chatAttachments[0]!)).toBe(attachmentDataUrl);
+      expect(host.chatError).toBeTruthy();
+      expect(host.chatQueue).toEqual([]);
+    },
+  );
+
+  it.each(["started", "in_flight", "ok"] as const)(
+    "retires the submitted draft after a successful %s acknowledgment",
+    async (status) => {
+      const host = makeChatHost({
+        chatMessage: draft,
+        chatRunId: "active-run",
+        requestHandlers: { "chat.send": { runId: "command-run", status } },
+      });
+
+      await handleSendChat(host);
+
+      expect(host.chatMessage).toBe("");
+      expect(host.chatComposerFallbackByScope).toEqual({});
+      expect(host.chatError).toBeFalsy();
+      expect(host.chatRunId).toBe(
+        command === "redirect" && status !== "ok" ? "command-run" : "active-run",
+      );
+    },
+  );
+
+  it("does not restore a failed command over a newer draft", async () => {
+    const acknowledgment = createDeferred<{ runId: string; status: "timeout" }>();
+    const newerAttachment = createStagedAttachment(`${command}-newer`);
+    const host = makeChatHost({
+      chatMessage: draft,
+      requestHandlers: { "chat.send": () => acknowledgment.promise },
+    });
+
+    const send = handleSendChat(host);
+    await vi.waitFor(() => expect(findChatSendPayload(host)).toBeDefined());
+    host.chatMessage = "Newer operator draft";
+    host.chatAttachments = [newerAttachment];
+    acknowledgment.resolve({ runId: "command-run", status: "timeout" });
+    await send;
+
+    expect(host.chatMessage).toBe("Newer operator draft");
+    expect(host.chatAttachments).toEqual([newerAttachment]);
+    expect(getChatAttachmentDataUrl(newerAttachment)).toBe(attachmentDataUrl);
+  });
+
+  it("retains a failed command in its submitted session after navigation", async () => {
+    const acknowledgment = createDeferred<{ runId: string; status: "timeout" }>();
+    const attachment = createStagedAttachment(`${command}-submitted-session`);
+    const host = makeChatHost({
+      sessionKey: "agent:main:first",
+      chatMessage: draft,
+      chatAttachments: [attachment],
+      requestHandlers: { "chat.send": () => acknowledgment.promise },
+    });
+    const submittedScopeKey = storedChatOutboxScopeKey(
+      captureChatOutboxAdmission(host, host.sessionKey).scope,
+    );
+
+    const send = handleSendChat(host);
+    await vi.waitFor(() => expect(findChatSendPayload(host)).toBeDefined());
+    host.sessionKey = "agent:main:second";
+    host.chatMessage = "Second session draft";
+    host.chatError = "Second session error";
+    acknowledgment.resolve({ runId: "command-run", status: "timeout" });
+    await send;
+
+    expect(host.chatMessage).toBe("Second session draft");
+    expect(host.chatError).toBe("Second session error");
+    const fallbacks = Object.entries(host.chatComposerFallbackByScope);
+    expect(fallbacks).toHaveLength(1);
+    const [scopeKey, fallback] = fallbacks[0]!;
+    expect(scopeKey).toBe(submittedScopeKey);
+    expect(fallback.message).toBe(draft);
+    expect(getChatAttachmentDataUrl(fallback.attachments[0]!)).toBe(attachmentDataUrl);
+  });
+});


### PR DESCRIPTION
Closes #139939. Related: #91049.

## What Problem This Solves

Fixes an issue where users submitting `/steer` or `/redirect` in the Control UI lose their draft when the Gateway returns a terminal timeout or error before accepting the input. The UI displays the failure, but previously treated the command as completed and discarded its recovery state.

## Why This Change Was Made

Both terminal-result branches now return the existing command-failure marker. This connects them to the established composer recovery owner, which restores submitted text and retained attachments, preserves newer input, and scopes delayed recovery to the original conversation. Successful acknowledgment handling stays intact.

Production is **+2/−2 (net 0)**, tests **+152**, and docs **+4**. No new configuration, protocol, storage format, dependency, or SDK surface is introduced.

## User Impact

A rejected correction remains available to edit or retry. An operator can type a newer draft or switch conversations while the request is pending without that newer input being overwritten or the failure being shown in the wrong conversation.

## Evidence

Exact candidate `30d74885a659bd02bbc7ce2ac3740171f2de224d`, based on `3b53aee5eeee96b48345af67678f353c10f0f2fd`.

- Before: six submission regressions failed while ten controls passed. A real isolated Gateway/native-runtime browser run on `95f963e342ab476912c23c0e7fb9660c69bb9980` displayed the terminal `/redirect` failure with an empty composer.
- After: **369 tests passed**: 317 UI recovery, executor, submission and Gateway-event cases, plus 52 projection cases. Coverage includes both commands, timeout/error/transport rejection, successful acknowledgment states, retained attachment payloads, newer input and conversation-scoped recovery.
- Current locked dependencies, targeted production/test types, lint/stylelint/format, and runtime/UI builds passed. Fresh complete-source managed Codex review at P0–P2 returned no findings across two passes. The earlier full changed gate is retained with the subsequent targeted corrections and qualification.
- Three final browser runs used this exact built candidate and a real isolated Gateway/native Codex runtime with a synthetic loopback provider: restore the rejected correction, preserve a newer draft, and preserve the second conversation while recovery remains with the original one. Each observed an actual `ok: true`, `status: "timeout"`, `summary: "aborted"` acknowledgment and exactly one model HTTP request. Owned processes, ports and temporary runtime state were cleaned up.
- The live producer proof covers `/redirect`; `/steer` is covered by the submission regressions. This is synthetic-provider runtime proof, not a hosted-model or external-channel test. The fixture briefly suspends only its own native process to expose the pre-acknowledgment abort race; it never rewrites the Gateway response.

The checked native contract is Codex `rust-v0.153.4`: `codex-rs/app-server/src/request_processors/turn_processor.rs` awaits steering submission and acknowledges an active-turn interrupt on `TurnAborted`. The Gateway's successful RPC transport therefore does not imply the correction was accepted; its terminal status must reach the composer owner.

Earlier failed fixture attempts are retained. Inactive panes remain in the DOM, so final navigation checks select the active, non-inert pane and separately check computed-visible alerts. All final screenshot/video evidence is inspected and cropped to synthetic content before publication.

![Before: terminal failure leaves the composer empty](https://github.com/user-attachments/assets/e6282053-21d2-4a1f-a1fa-c310bd16a6c2)

![After: the rejected correction is restored](https://github.com/user-attachments/assets/45582329-e382-464e-88f3-4311f645f640)

![A newer draft survives the delayed failure](https://github.com/user-attachments/assets/58ad1221-4d6c-4738-9042-a384cf568da5)

https://github.com/user-attachments/assets/d28217cd-e844-4c97-9d23-7b46954fa9ff


Hosted CI [34022193951](https://github.com/openclaw/openclaw/actions/runs/34022193951) passed on this exact head (102 jobs, no failed jobs). Current-main compatibility was checked through native baseline `8b37368a4e3fc7a7549f7a42dd50494f3be6ff2f`: direct recovery owners retain the same contracts, and the inspected newer outbox/native steering paths do not change immediate command recovery. The short video is a cropped, unretimed excerpt; the stills provide readable before/after states.
