### PR TITLE
refactor(watch): share legacy status decoding

### DIFF
--- a/apps/ios/WatchApp/Sources/WatchInboxMessages.swift
+++ b/apps/ios/WatchApp/Sources/WatchInboxMessages.swift
@@ -586,7 +586,7 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
             gatewayStatus: Self.parseStatus(
                 payload["gatewayStatus"],
                 fallbackText: payload["gatewayStatusText"] as? String)
-                ?? Self.decodeLegacyGatewayStatus(
+                ?? OpenClawWatchAppStatus.decodeLegacyGateway(
                     text: payload["gatewayStatusText"] as? String,
                     connected: gatewayConnected),
             gatewayConnected: gatewayConnected,
@@ -598,7 +598,7 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
             talkStatus: Self.parseStatus(
                 payload["talkStatus"],
                 fallbackText: payload["talkStatusText"] as? String)
-                ?? Self.decodeLegacyTalkStatus(
+                ?? OpenClawWatchAppStatus.decodeLegacyTalk(
                     text: payload["talkStatusText"] as? String,
                     enabled: talkEnabled,
                     listening: talkListening,
@@ -611,7 +611,7 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
             chatStatus: Self.parseStatus(
                 payload["chatStatus"],
                 fallbackText: payload["chatStatusText"] as? String)
-                ?? Self.decodeLegacyChatStatus(
+                ?? OpenClawWatchAppStatus.decodeLegacyChat(
                     code: payload["chatStatusCode"] as? String,
                     text: payload["chatStatusText"] as? String),
             sentAtMs: sentAtMs,
@@ -696,7 +696,7 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
                 code: .legacy,
                 verbatim: gatewayStatusText)
         } else {
-            self.gatewayStatus = Self.decodeLegacyGatewayStatus(
+            self.gatewayStatus = OpenClawWatchAppStatus.decodeLegacyGateway(
                 text: gatewayStatusText,
                 connected: self.gatewayConnected)
         }
@@ -713,7 +713,7 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
                 code: .legacy,
                 verbatim: talkStatusText)
         } else {
-            self.talkStatus = Self.decodeLegacyTalkStatus(
+            self.talkStatus = OpenClawWatchAppStatus.decodeLegacyTalk(
                 text: talkStatusText,
                 enabled: self.talkEnabled,
                 listening: self.talkListening,
@@ -721,7 +721,7 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
         }
         self.chatStatus = (try? container.decode(
             OpenClawWatchAppStatus.self,
-            forKey: .chatStatus)) ?? Self.decodeLegacyChatStatus(
+            forKey: .chatStatus)) ?? OpenClawWatchAppStatus.decodeLegacyChat(
             code: chatStatusCode,
             text: chatStatusText)
     }
@@ -767,61 +767,6 @@ struct WatchAppSnapshotMessage: Codable, Equatable {
             localizationKey: payload["localizationKey"] as? String,
             arguments: payload["arguments"] as? [String] ?? [],
             verbatim: verbatim)
-    }
-
-    private static func decodeLegacyGatewayStatus(
-        text: String?,
-        connected: Bool) -> OpenClawWatchAppStatus
-    {
-        if connected {
-            return OpenClawWatchAppStatus(code: .gatewayConnected)
-        }
-        guard let text, !text.isEmpty else {
-            return OpenClawWatchAppStatus(code: .gatewayOffline)
-        }
-        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
-    }
-
-    private static func decodeLegacyTalkStatus(
-        text: String?,
-        enabled: Bool,
-        listening: Bool,
-        speaking: Bool) -> OpenClawWatchAppStatus
-    {
-        if speaking {
-            return OpenClawWatchAppStatus(code: .talkSpeaking)
-        }
-        if listening {
-            return OpenClawWatchAppStatus(code: .talkListening)
-        }
-        if !enabled {
-            return OpenClawWatchAppStatus(code: .talkOff)
-        }
-        guard let text, !text.isEmpty else {
-            return OpenClawWatchAppStatus(code: .talkReady)
-        }
-        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
-    }
-
-    private static func decodeLegacyChatStatus(
-        code: String?,
-        text: String?) -> OpenClawWatchAppStatus?
-    {
-        let statusCode: OpenClawWatchAppStatusCode? = switch code {
-        case "connectIPhone":
-            OpenClawWatchAppStatusCode.chatConnectIPhone
-        case "noMessages":
-            OpenClawWatchAppStatusCode.chatNoMessages
-        case "unavailable":
-            OpenClawWatchAppStatusCode.chatUnavailable
-        default:
-            nil
-        }
-        if let statusCode {
-            return OpenClawWatchAppStatus(code: statusCode)
-        }
-        guard let text, !text.isEmpty else { return nil }
-        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
     }
 
     private static func parseChatItem(_ item: Any) -> WatchChatItem? {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/WatchCommands.swift
@@ -330,6 +330,61 @@ public struct OpenClawWatchAppStatus: Codable, Sendable, Equatable {
         self.arguments = arguments
         self.verbatim = verbatim
     }
+
+    public static func decodeLegacyGateway(
+        text: String?,
+        connected: Bool) -> OpenClawWatchAppStatus
+    {
+        if connected {
+            return OpenClawWatchAppStatus(code: .gatewayConnected)
+        }
+        guard let text, !text.isEmpty else {
+            return OpenClawWatchAppStatus(code: .gatewayOffline)
+        }
+        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
+    }
+
+    public static func decodeLegacyTalk(
+        text: String?,
+        enabled: Bool,
+        listening: Bool,
+        speaking: Bool) -> OpenClawWatchAppStatus
+    {
+        if speaking {
+            return OpenClawWatchAppStatus(code: .talkSpeaking)
+        }
+        if listening {
+            return OpenClawWatchAppStatus(code: .talkListening)
+        }
+        if !enabled {
+            return OpenClawWatchAppStatus(code: .talkOff)
+        }
+        guard let text, !text.isEmpty else {
+            return OpenClawWatchAppStatus(code: .talkReady)
+        }
+        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
+    }
+
+    public static func decodeLegacyChat(
+        code: String?,
+        text: String?) -> OpenClawWatchAppStatus?
+    {
+        let statusCode: OpenClawWatchAppStatusCode? = switch code {
+        case "connectIPhone":
+            OpenClawWatchAppStatusCode.chatConnectIPhone
+        case "noMessages":
+            OpenClawWatchAppStatusCode.chatNoMessages
+        case "unavailable":
+            OpenClawWatchAppStatusCode.chatUnavailable
+        default:
+            nil
+        }
+        if let statusCode {
+            return OpenClawWatchAppStatus(code: statusCode)
+        }
+        guard let text, !text.isEmpty else { return nil }
+        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
+    }
 }
 
 public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
@@ -421,7 +476,7 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
     {
         // Preserve the shipped source API while producers migrate to semantic statuses.
         self.init(
-            gatewayStatus: Self.decodeLegacyGatewayStatus(
+            gatewayStatus: OpenClawWatchAppStatus.decodeLegacyGateway(
                 text: gatewayStatusText,
                 connected: gatewayConnected),
             gatewayStatusText: gatewayStatusText,
@@ -431,7 +486,7 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
             agentAvatarText: agentAvatarText,
             sessionKey: sessionKey,
             gatewayStableID: gatewayStableID,
-            talkStatus: Self.decodeLegacyTalkStatus(
+            talkStatus: OpenClawWatchAppStatus.decodeLegacyTalk(
                 text: talkStatusText,
                 enabled: talkEnabled,
                 listening: talkListening,
@@ -442,7 +497,7 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
             talkSpeaking: talkSpeaking,
             pendingApprovalCount: pendingApprovalCount,
             chatItems: chatItems,
-            chatStatus: Self.decodeLegacyChatStatus(code: nil, text: chatStatusText),
+            chatStatus: OpenClawWatchAppStatus.decodeLegacyChat(code: nil, text: chatStatusText),
             chatStatusText: chatStatusText,
             sentAtMs: sentAtMs,
             snapshotId: snapshotId,
@@ -507,7 +562,7 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
                 code: .legacy,
                 verbatim: gatewayStatusText)
         } else {
-            self.gatewayStatus = Self.decodeLegacyGatewayStatus(
+            self.gatewayStatus = OpenClawWatchAppStatus.decodeLegacyGateway(
                 text: gatewayStatusText,
                 connected: self.gatewayConnected)
         }
@@ -526,7 +581,7 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
                 code: .legacy,
                 verbatim: talkStatusText)
         } else {
-            self.talkStatus = Self.decodeLegacyTalkStatus(
+            self.talkStatus = OpenClawWatchAppStatus.decodeLegacyTalk(
                 text: talkStatusText,
                 enabled: self.talkEnabled,
                 listening: self.talkListening,
@@ -537,7 +592,7 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
         let chatStatusCode = try container.decodeIfPresent(String.self, forKey: .chatStatusCode)
         self.chatStatus = (try? container.decode(
             OpenClawWatchAppStatus.self,
-            forKey: .chatStatus)) ?? Self.decodeLegacyChatStatus(
+            forKey: .chatStatus)) ?? OpenClawWatchAppStatus.decodeLegacyChat(
             code: chatStatusCode,
             text: chatStatusText)
         self.chatStatusText = chatStatusText ?? self.chatStatus.map(Self.legacyText)
@@ -568,61 +623,6 @@ public struct OpenClawWatchAppSnapshotMessage: Codable, Sendable, Equatable {
         try container.encodeIfPresent(self.sentAtMs, forKey: .sentAtMs)
         try container.encodeIfPresent(self.snapshotId, forKey: .snapshotId)
         try container.encodeIfPresent(self.chatDeliveryContext, forKey: .chatDeliveryContext)
-    }
-
-    private static func decodeLegacyGatewayStatus(
-        text: String?,
-        connected: Bool) -> OpenClawWatchAppStatus
-    {
-        if connected {
-            return OpenClawWatchAppStatus(code: .gatewayConnected)
-        }
-        guard let text, !text.isEmpty else {
-            return OpenClawWatchAppStatus(code: .gatewayOffline)
-        }
-        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
-    }
-
-    private static func decodeLegacyTalkStatus(
-        text: String?,
-        enabled: Bool,
-        listening: Bool,
-        speaking: Bool) -> OpenClawWatchAppStatus
-    {
-        if speaking {
-            return OpenClawWatchAppStatus(code: .talkSpeaking)
-        }
-        if listening {
-            return OpenClawWatchAppStatus(code: .talkListening)
-        }
-        if !enabled {
-            return OpenClawWatchAppStatus(code: .talkOff)
-        }
-        guard let text, !text.isEmpty else {
-            return OpenClawWatchAppStatus(code: .talkReady)
-        }
-        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
-    }
-
-    private static func decodeLegacyChatStatus(
-        code: String?,
-        text: String?) -> OpenClawWatchAppStatus?
-    {
-        let statusCode: OpenClawWatchAppStatusCode? = switch code {
-        case "connectIPhone":
-            OpenClawWatchAppStatusCode.chatConnectIPhone
-        case "noMessages":
-            OpenClawWatchAppStatusCode.chatNoMessages
-        case "unavailable":
-            OpenClawWatchAppStatusCode.chatUnavailable
-        default:
-            nil
-        }
-        if let statusCode {
-            return OpenClawWatchAppStatus(code: statusCode)
-        }
-        guard let text, !text.isEmpty else { return nil }
-        return OpenClawWatchAppStatus(code: .legacy, verbatim: text)
     }
 
     private static func legacyText(for status: OpenClawWatchAppStatus) -> String {


### PR DESCRIPTION
## What Problem This Solves

The Watch app and shared iPhone/Watch snapshot type each maintained the same legacy gateway, Talk, and chat status decoders. Compatibility changes had to keep both copies aligned.

## Why This Change Was Made

The existing shared status type now owns the three unchanged decoders, and all twelve callers use that owner. This removes 52 production code lines (55 physical lines), with no test changes or new package/project wiring.

## User Impact

No intended behavior change. Semantic status precedence, unknown verbatim text, Watch-local localization, persisted snapshot shape, and the legacy wire fields needed for staggered iPhone/Watch upgrades remain unchanged.

## Evidence

- All 14 selected repository checks passed, including 1,125 macOS tooling/process tests across 21 files and SwiftLint over 768 files.
- Fourteen existing Swift behavior tests passed for snapshot compatibility, persistence decoding and localization. They compiled byte-identical real sources in an isolated Swift package with separate shared and Watch-consumer modules; no mocks or rewritten source.
- Pinned SwiftFormat, diff checks and independent P2 review passed. Source hashes remained unchanged through verification.
- The local Swift proof is not a full iOS/watchOS app build or device test; exact-head hosted platform checks remain part of landing.
