### PR TITLE
refactor(tests): table Ollama endpoint alias cases

### DIFF
--- a/extensions/ollama/doctor-contract-api.test.ts
+++ b/extensions/ollama/doctor-contract-api.test.ts
@@ -141,12 +141,34 @@ describe("ollama doctor contract", () => {
     expect(readOllamaCloudProvider(config)?.baseUrl).toBe("https://ai.ollama.com");
   });
 
-  it("removes retired Ollama Cloud provider baseURL aliases when canonical baseUrl is present", () => {
+  it.each([
+    {
+      name: "removes retired Ollama Cloud provider baseURL aliases when canonical baseUrl is present",
+      inputBaseUrl: "https://ollama.com",
+      expectedBaseUrl: "https://ollama.com",
+      expectedChange:
+        "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
+    },
+    {
+      name: "migrates retired Ollama Cloud provider baseURL aliases when canonical baseUrl is blank",
+      inputBaseUrl: " ",
+      expectedBaseUrl: "https://ollama.com",
+      expectedChange:
+        "Updated models.providers.ollama-cloud.baseURL from the retired Ollama Cloud endpoint to https://ollama.com.",
+    },
+    {
+      name: "preserves custom canonical baseUrl when removing retired baseURL aliases",
+      inputBaseUrl: "https://custom-ollama-cloud.example.test",
+      expectedBaseUrl: "https://custom-ollama-cloud.example.test",
+      expectedChange:
+        "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
+    },
+  ])("$name", ({ inputBaseUrl, expectedBaseUrl, expectedChange }) => {
     const config = {
       models: {
         providers: {
           "ollama-cloud": {
-            baseUrl: "https://ollama.com",
+            baseUrl: inputBaseUrl,
             baseURL: "https://ai.ollama.com/",
             api: "ollama",
             models: [],
@@ -157,80 +179,14 @@ describe("ollama doctor contract", () => {
 
     const result = normalizeCompatibilityConfig({ cfg: config });
 
-    expect(result.changes).toEqual([
-      "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
-    ]);
+    expect(result.changes).toEqual([expectedChange]);
     expect(readOllamaCloudProvider(result.config)).toEqual({
-      baseUrl: "https://ollama.com",
+      baseUrl: expectedBaseUrl,
       api: "ollama",
       models: [],
     });
     expect(readOllamaCloudProvider(config)).toEqual({
-      baseUrl: "https://ollama.com",
-      baseURL: "https://ai.ollama.com/",
-      api: "ollama",
-      models: [],
-    });
-  });
-
-  it("migrates retired Ollama Cloud provider baseURL aliases when canonical baseUrl is blank", () => {
-    const config = {
-      models: {
-        providers: {
-          "ollama-cloud": {
-            baseUrl: " ",
-            baseURL: "https://ai.ollama.com/",
-            api: "ollama",
-            models: [],
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    const result = normalizeCompatibilityConfig({ cfg: config });
-
-    expect(result.changes).toEqual([
-      "Updated models.providers.ollama-cloud.baseURL from the retired Ollama Cloud endpoint to https://ollama.com.",
-    ]);
-    expect(readOllamaCloudProvider(result.config)).toEqual({
-      baseUrl: "https://ollama.com",
-      api: "ollama",
-      models: [],
-    });
-    expect(readOllamaCloudProvider(config)).toEqual({
-      baseUrl: " ",
-      baseURL: "https://ai.ollama.com/",
-      api: "ollama",
-      models: [],
-    });
-  });
-
-  it("preserves custom canonical baseUrl when removing retired baseURL aliases", () => {
-    const config = {
-      models: {
-        providers: {
-          "ollama-cloud": {
-            baseUrl: "https://custom-ollama-cloud.example.test",
-            baseURL: "https://ai.ollama.com/",
-            api: "ollama",
-            models: [],
-          },
-        },
-      },
-    } as OpenClawConfig;
-
-    const result = normalizeCompatibilityConfig({ cfg: config });
-
-    expect(result.changes).toEqual([
-      "Removed retired models.providers.ollama-cloud.baseURL while preserving models.providers.ollama-cloud.baseUrl.",
-    ]);
-    expect(readOllamaCloudProvider(result.config)).toEqual({
-      baseUrl: "https://custom-ollama-cloud.example.test",
-      api: "ollama",
-      models: [],
-    });
-    expect(readOllamaCloudProvider(config)).toEqual({
-      baseUrl: "https://custom-ollama-cloud.example.test",
+      baseUrl: inputBaseUrl,
       baseURL: "https://ai.ollama.com/",
       api: "ollama",
       models: [],


### PR DESCRIPTION
## What Problem This Solves

Three Ollama Doctor migration tests repeat the same setup and assertions around retired endpoint aliases.

## Why This Change Was Made

Keep the three named scenarios in an explicit case table, with separate input URLs, expected URLs, and migration messages. Each case still checks the normalized provider and unchanged input config. This removes 44 net test lines.

## User Impact

No production behavior change. Existing endpoint migration coverage is easier to maintain.

## Evidence

All eight Doctor contract cases pass before and after. Expanding each table row reproduces its original callback structure; case order, assertions, fresh objects, and all unrelated source bytes are preserved. Independent review through P2 passed. Full changed-file validation passed after reconciling stale local dependencies to the existing lockfile; no dependency changes are part of this PR.
