### PR TITLE
fix(test): avoid false presence waiter timeouts

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
@@ -136,21 +136,6 @@ struct MacNodePresenceReporterTests {
         #expect(clear.unsupportedCalls == 0)
     }
 
-    /// Temporary controlled baseline; remove the manual clock/pause plumbing after before/after proof.
-    @Test func `completed clear is accepted when polling resumes after its deadline`() async {
-        let clear = PresenceClearRecorder()
-        _ = await clear.clear()
-        let started = ContinuousClock.now
-        var instant = started
-        await clear.waitForCallCount(2, now: { instant }, pause: {
-            _ = await clear.clear()
-            instant = started.advanced(by: .seconds(5))
-            let elapsed = started.duration(to: instant).components.seconds
-            print("PRESENCE_WAIT_PROOF calls=\(clear.calls) elapsedSeconds=\(elapsed)")
-        })
-        #expect(clear.calls == 2)
-    }
-
     @Test(arguments: [false, true])
     func `activity crossing opt out is followed by a clear`(retryClear: Bool) async {
         let sender = SuspendingPresenceSender()
@@ -348,15 +333,12 @@ private final class PresenceClearRecorder {
         self.unsupportedCalls += 1
     }
 
-    func waitForCallCount(
-        _ expected: Int,
-        now: @MainActor () -> ContinuousClock.Instant = { ContinuousClock.now },
-        pause: @MainActor () async -> Void = { try? await Task.sleep(for: .milliseconds(10)) }) async
-    {
-        let deadline = now().advanced(by: .seconds(4))
-        while now() < deadline {
+    func waitForCallCount(_ expected: Int) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(4))
+        while clock.now < deadline {
             if self.calls >= expected { return }
-            await pause()
+            try? await Task.sleep(for: .milliseconds(10))
         }
         // The final suspension may have completed the work before this waiter resumes.
         #expect(self.calls >= expected, "timed out waiting for \(expected) presence clear calls")

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
@@ -358,7 +358,8 @@ private final class PresenceClearRecorder {
             if self.calls >= expected { return }
             await pause()
         }
-        Issue.record("timed out waiting for \(expected) presence clear calls")
+        // The final suspension may have completed the work before this waiter resumes.
+        #expect(self.calls >= expected, "timed out waiting for \(expected) presence clear calls")
     }
 }
 
@@ -391,7 +392,7 @@ private final class SuspendingPresenceSender {
             if self.activityContinuation != nil { return }
             await Task.yield()
         }
-        Issue.record("timed out waiting for suspended activity send")
+        #expect(self.activityContinuation != nil, "timed out waiting for suspended activity send")
     }
 
     func finishActivitySend() {
@@ -404,6 +405,8 @@ private final class SuspendingPresenceSender {
             if self.payloadObjects.filter({ $0["idleSeconds"] != nil }).count >= expected { return }
             await Task.yield()
         }
-        Issue.record("timed out waiting for \(expected) activity samples")
+        #expect(
+            self.payloadObjects.filter { $0["idleSeconds"] != nil }.count >= expected,
+            "timed out waiting for \(expected) activity samples")
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodePresenceReporterTests.swift
@@ -136,6 +136,21 @@ struct MacNodePresenceReporterTests {
         #expect(clear.unsupportedCalls == 0)
     }
 
+    /// Temporary controlled baseline; remove the manual clock/pause plumbing after before/after proof.
+    @Test func `completed clear is accepted when polling resumes after its deadline`() async {
+        let clear = PresenceClearRecorder()
+        _ = await clear.clear()
+        let started = ContinuousClock.now
+        var instant = started
+        await clear.waitForCallCount(2, now: { instant }, pause: {
+            _ = await clear.clear()
+            instant = started.advanced(by: .seconds(5))
+            let elapsed = started.duration(to: instant).components.seconds
+            print("PRESENCE_WAIT_PROOF calls=\(clear.calls) elapsedSeconds=\(elapsed)")
+        })
+        #expect(clear.calls == 2)
+    }
+
     @Test(arguments: [false, true])
     func `activity crossing opt out is followed by a clear`(retryClear: Bool) async {
         let sender = SuspendingPresenceSender()
@@ -333,12 +348,15 @@ private final class PresenceClearRecorder {
         self.unsupportedCalls += 1
     }
 
-    func waitForCallCount(_ expected: Int) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(4))
-        while clock.now < deadline {
+    func waitForCallCount(
+        _ expected: Int,
+        now: @MainActor () -> ContinuousClock.Instant = { ContinuousClock.now },
+        pause: @MainActor () async -> Void = { try? await Task.sleep(for: .milliseconds(10)) }) async
+    {
+        let deadline = now().advanced(by: .seconds(4))
+        while now() < deadline {
             if self.calls >= expected { return }
-            try? await Task.sleep(for: .milliseconds(10))
+            await pause()
         }
         Issue.record("timed out waiting for \(expected) presence clear calls")
     }


### PR DESCRIPTION
## What Problem This Solves

Presence tests could report a timeout even after the expected clear or activity send had completed. Their waiters suspended, then unconditionally reported failure when the final wait interval ended.

## Why This Change Was Made

Each of the three waiters now checks its existing completion predicate after the final suspension. The original clock, four-second deadline, ten-millisecond sleep, yield limits, caller assertions and cleanup stay unchanged. All temporary clock controls and diagnostic tracing used to prove the race have been removed.

## User Impact

This corrects false failures in test support. Production behavior is unchanged; the final PR changes one test file by six added and three removed lines, with no new permanent test case or runtime hook.

## Evidence

A controlled before-fix [CI run 34022454546](https://github.com/openclaw/openclaw/actions/runs/34022454546) completed the second clear before advancing its logical clock past the deadline, then recorded the incorrect timeout. The unchanged controlled scenario [passed after the repair in CI 34024499221](https://github.com/openclaw/openclaw/actions/runs/34024499221): `calls=2 elapsedSeconds=5`, followed by the named case passing. All 14 ordinary presence functions (16 cases) also passed. These results prove the helper gap; they do not attribute every historical presence-test failure to it.

After removing the temporary controls, the complete current test file passed typechecking, formatting, lint and parsing, plus all 12 selected canonical check stages. Reversing only the three predicates and their comment reconstructs the original base file exactly. One independent managed P2 review found no actionable issue. The cleaned final head `a929799a35c6ad15331d9e61da92abd2a03ad376` passed [CI 34026464893](https://github.com/openclaw/openclaw/actions/runs/34026464893), including all 14 ordinary presence functions / 16 cases, the Mac Node shards and release build. Actual tested merge: `2bb527fda398bf459b26c671d30fc4b46bef480c`. This final run complements the retained controlled before/after proof.
