### PR TITLE
fix(cron): keep manually forced disabled reminders paused

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -158,6 +158,8 @@ Automation jobs, pending runtime state, and run history live in the shared SQLit
 
 ### Manual runs
 
+Manually running a disabled job does not enable its schedule or create automatic retries. Use `openclaw automations enable <job-id>` to resume scheduled runs.
+
 `openclaw automations run <job-id>` force-runs by default and returns as soon as the manual run is queued. Successful responses include `{ ok: true, enqueued: true, runId }`. Use the returned `runId` to inspect the later result:
 
 ```bash

--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -11,6 +11,7 @@ import {
   seedMainSessionStore,
   setupTelegramHeartbeatPluginRuntimeForTests,
 } from "../infra/heartbeat-runner.test-utils.js";
+import { setHeartbeatsEnabled } from "../infra/heartbeat-wake.js";
 import {
   enqueueSystemEventWithReceipt,
   peekSystemEventEntries,
@@ -21,11 +22,13 @@ import { CommandLane } from "../process/lanes.js";
 import { resetCronActiveJobs, waitForActiveCronJobs } from "./active-jobs.js";
 import { CronService, type CronEvent } from "./service.js";
 import type { CronServiceDeps } from "./service/state.js";
+import { loadCronJobsStoreSync } from "./store.js";
 
 setupTelegramHeartbeatPluginRuntimeForTests();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 afterEach(() => {
+  setHeartbeatsEnabled(true);
   resetSystemEventsForTest();
   resetCronActiveJobs();
   vi.restoreAllMocks();
@@ -47,7 +50,13 @@ type WakeNowRunMode = "direct" | "queued" | "scheduled";
 async function runMainCronCase(
   mode: WakeNowRunMode,
   wakeMode: "now" | "next-heartbeat" = "now",
-  options: { heartbeatEvery?: string; deleteAfterRun?: boolean } = {},
+  options: {
+    heartbeatEvery?: string;
+    deleteAfterRun?: boolean;
+    heartbeatPaused?: boolean;
+    disableBeforeRun?: boolean;
+    scheduleKind?: "at" | "every";
+  } = {},
 ) {
   const sandbox = makeSandbox();
   const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
@@ -110,18 +119,30 @@ async function runMainCronCase(
   await cron.start();
 
   try {
+    if (options.heartbeatPaused) {
+      setHeartbeatsEnabled(false);
+    }
     const job = await cron.add({
       enabled: true,
       name: "nightly report",
-      schedule: {
-        kind: "at",
-        at: new Date(Date.now() + (mode === "scheduled" ? 250 : 60 * 60_000)).toISOString(),
-      },
+      schedule:
+        options.scheduleKind === "every"
+          ? { kind: "every", everyMs: 60 * 60_000 }
+          : {
+              kind: "at",
+              at: new Date(Date.now() + (mode === "scheduled" ? 250 : 60 * 60_000)).toISOString(),
+            },
       sessionTarget: "main",
       wakeMode,
       payload: { kind: "systemEvent", text: "Reminder: Send the nightly report" },
       ...(options.deleteAfterRun === undefined ? {} : { deleteAfterRun: options.deleteAfterRun }),
     });
+    const scheduledNextRunAtMs = job.state.nextRunAtMs;
+    if (options.disableBeforeRun) {
+      const disabled = await cron.update(job.id, { enabled: false });
+      expect(disabled.enabled).toBe(false);
+      expect(disabled.state.nextRunAtMs).toBeUndefined();
+    }
 
     if (mode === "direct") {
       await cron.run(job.id, "force");
@@ -142,6 +163,31 @@ async function runMainCronCase(
         );
       }),
     ]).finally(() => clearTimeout(finishTimeout));
+    if (options.heartbeatPaused) {
+      expect(terminal).toMatchObject({ status: "skipped", error: "disabled" });
+      expect(getReplySpy).not.toHaveBeenCalled();
+      expect(sendTelegram).not.toHaveBeenCalled();
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+      expect(peekSystemEventEntries(expectedMainSessionKey)).toHaveLength(0);
+
+      const expectedNextRunAtMs = options.disableBeforeRun
+        ? undefined
+        : mode === "scheduled"
+          ? terminal.runAtMs! + terminal.durationMs! + 30_000
+          : scheduledNextRunAtMs;
+      const persisted = loadCronJobsStoreSync(sandbox.cronStorePath).jobs.find(
+        (entry) => entry.id === job.id,
+      );
+      for (const completed of [cron.getJob(job.id), persisted, terminal.job]) {
+        expect(completed).toMatchObject({
+          enabled: !options.disableBeforeRun,
+          state: { lastRunStatus: "skipped", lastError: "disabled", consecutiveSkipped: 1 },
+        });
+        expect(completed?.state.nextRunAtMs).toBe(expectedNextRunAtMs);
+      }
+      expect(terminal.nextRunAtMs).toBe(expectedNextRunAtMs);
+      return;
+    }
     expect(terminal.status).toBe("ok");
     if (wakeMode === "next-heartbeat") {
       expect(getReplySpy).not.toHaveBeenCalled();
@@ -184,6 +230,30 @@ async function runMainCronCase(
 }
 
 describe("main cron with the real heartbeat runner", () => {
+  it.each([
+    { mode: "direct", scheduleKind: "at" },
+    { mode: "queued", scheduleKind: "at" },
+    { mode: "direct", scheduleKind: "every" },
+    { mode: "queued", scheduleKind: "every" },
+  ] as const)(
+    "keeps an operator-disabled $scheduleKind job disabled after a $mode force run while heartbeats are globally paused",
+    async ({ mode, scheduleKind }) => {
+      await runMainCronCase(mode, "now", {
+        heartbeatPaused: true,
+        disableBeforeRun: true,
+        scheduleKind,
+        deleteAfterRun: false,
+      });
+    },
+  );
+
+  it.each(["direct", "queued", "scheduled"] as const)(
+    "preserves an enabled one-shot's schedule policy after a %s run while heartbeats are globally paused",
+    async (mode) => {
+      await runMainCronCase(mode, "now", { heartbeatPaused: true, deleteAfterRun: false });
+    },
+  );
+
   it("delivers during a direct manual run", async () => {
     await runMainCronCase("direct");
   });

--- a/src/cron/service/timer-outcomes.ts
+++ b/src/cron/service/timer-outcomes.ts
@@ -244,14 +244,13 @@ export function applyJobResult(
     } else if (opts?.replaySchedule && job.schedule.kind === "at") {
       applyReplaySchedule();
       job.enabled = job.state.nextRunAtMs !== undefined;
-    } else if (job.schedule.kind === "at") {
+    } else if (job.schedule.kind === "at" && isJobEnabled(job)) {
       if (shouldRetryDisabledHeartbeatOneShot(job, result)) {
         const retryDecision = resolveDisabledHeartbeatOneShotRetryDecision({
           cronConfig: state.deps.cronConfig,
           consecutiveSkipped: job.state.consecutiveSkipped,
         });
         if (retryDecision.retryable && retryDecision.backoffMs !== undefined) {
-          job.enabled = true;
           if (
             assignNextRunAtMs({
               state,
@@ -340,8 +339,8 @@ export function applyJobResult(
         }
       }
     } else if (opts?.scheduleMode === "preserve") {
-      // Forced recurring runs do not consume, replace, or repair a scheduled
-      // slot. Preserve the timestamp and its paced provenance as one unit.
+      // Forced recurring or disabled one-shot runs cannot change a scheduled
+      // slot. Preserve its absence, or its timestamp and paced provenance.
       job.state.nextRunAtMs = previousScheduleState.nextRunAtMs;
       job.state.pacedNextRunAtMs = previousScheduleState.pacedNextRunAtMs;
       job.state.forcePreservedNextRunAtMs = previousScheduleState.nextRunAtMs;


### PR DESCRIPTION
Closes #139945. Related: #131590 (one-shot terminal-disable visibility).

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where users manually running an already-disabled one-shot reminder would re-enable its schedule when heartbeats were globally paused. The run correctly reported `skipped` with reason `disabled`, but the saved job became active and acquired a retry 30 seconds later. The Automations page showed the unexpected active state and next run even after reload.

## Why This Change Was Made

The one-shot outcome branch treated a disabled-heartbeat result as permission to enable the job; disabled jobs have no next-run timestamp, so the earlier future-occurrence preservation gate could not protect them. Restricting that branch to enabled jobs removes the redundant enablement assignment and lets disabled manual runs use the existing schedule-preservation owner, while keeping successful deletion, replay, and in-flight schedule ownership in their existing order.

## User Impact

Running a paused reminder once keeps its schedule paused and does not add automatic retries. Enabled one-shot retries and recurring manual-run behavior retain their existing policy. The manual-run CLI reference now explains this distinction.

## Evidence

Real isolated Gateway, public CLI, and Control UI proof compared baseline `95f963e342ab` with candidate `8ee16bcf586a`. The baseline's affected admission, heartbeat execution, outcome, and persistence owners match the unpatched parent. Each build's installed dependencies were checked against its own lockfile; the candidate was rebuilt and recorded after a frozen install of the current graph.

| After the forced run | Baseline | Candidate |
| --- | --- | --- |
| Saved job enabled | `true` | `false` |
| Next run | Run end + 30 seconds | Absent |
| Run result | `skipped` / `disabled` | `skipped` / `disabled` |
| UI after reload | Active, retry visible | Paused, no next run |
| Synthetic model endpoint requests | 0 | 0 |

- Both disabled one-shot regressions failed on the original code for the enablement mismatch; five controls passed.
- Current-lock focused proof: 15 passed, covering the 12 real-heartbeat cases, the enabled retry/event-cleanup control, and direct/queued admission of jobs disabled before reservation. Other cases were intentionally filtered.
- Targeted type-aware lint, formatting, canonical runtime and UI builds passed. Independent full-source Codex review found no P0–P2 findings.
- Production change: +3/-4 lines. Tests: +75/-5. Documentation: +2. No new configuration, schema, or stored representation.

Cron stayed enabled throughout the live scenarios. Each Gateway, browser, and synthetic endpoint was isolated and fully cleaned up. The proof covers the first forced invocation and persisted/UI state through reload; it does not claim a resumed-heartbeat soak or external channel delivery.

![Before: the skipped force run re-enables the paused reminder](https://github.com/user-attachments/assets/dbd1d5e7-c741-411f-8463-d67e003f4ace)

https://github.com/user-attachments/assets/4bdc1397-f588-4712-bcc7-1cdbada39629

![After: the skipped force run preserves the paused schedule](https://github.com/user-attachments/assets/f6fac1bd-04cb-4e6e-8400-e952cfa63668)

https://github.com/user-attachments/assets/a5a0f419-39b8-4384-b4f1-1dc46f38a2db


Hosted CI [34022608834](https://github.com/openclaw/openclaw/actions/runs/34022608834) passed on exact head `8ee16bcf586ad99a6a2928c7bcc5fa38e98517b1`. Native main `56924648b69b97ee0d9eca5dcac9d3aa58fce3f4` retains identical affected scheduling, heartbeat and CLI-doc owner bodies, so the repair remains necessary and composes without changing those contracts.
