### PR TITLE
fix(exec): preserve sandbox cleanup outcomes and Linux group retirement

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -97,6 +97,17 @@ command or closed output pipe alone does not establish that its descendants have
 stopped. Forced termination without confirmed cleanup remains uncertain. Local
 TUI shell shutdown uses the same cleanup owner for its own commands.
 
+One-shot tool cleanup keeps configured sandbox runtimes on their
+[session, agent, or shared lifetime](/gateway/sandboxing#modes-scope-and-backend). It joins the local
+command transport and backend cleanup for that command. It does not stop a shared
+sandbox or claim that every remote descendant has exited. Host commands, including
+elevated commands from sandboxed sessions, still require owned process-tree cleanup.
+
+When a host command requires process-tree cleanup, a `pty` request falls back to
+the child-process path before starting a native PTY and reports a warning. Commands
+that require a terminal may fail under that fallback. Cleanup failures remain
+uncertain rather than being reported as a clean shutdown.
+
 ## process tool
 
 Actions:

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -53,6 +53,7 @@ import {
 import type { AnyAgentTool } from "./agent-tools.types.js";
 import { isApplyPatchAllowedForModel } from "./apply-patch-model-policy.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { waitForExecScope } from "./bash-process-registry.js";
 import { resolveProcessToolScopeKey } from "./bash-process-scope.js";
 import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
 import type { ProcessToolDefaults } from "./bash-tools.process.js";
@@ -542,11 +543,18 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   });
   if (options?.oneShotCliRun && scopeKey && options.registerRunCleanup) {
     const supervisor = getProcessSupervisor();
-    // Register before launch: root completion can precede final cleanup,
-    // which must retain the tree and any earlier extinction failure.
-    options.registerRunCleanup(
-      supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true }),
-    );
+    // Sandbox runtimes retain their configured lifetime; host commands still
+    // need tree cleanup, including elevated commands from sandboxed sessions.
+    const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { processTree: "owned-only" });
+    options.registerRunCleanup(async () => {
+      // Transport closure can precede backend finalization. Join both owners
+      // before their local artifacts or the invocation state can be released.
+      const settled = await Promise.allSettled([cleanupScope(), waitForExecScope(scopeKey)]);
+      const failed = settled.find((result) => result.status === "rejected");
+      if (failed) {
+        throw failed.reason;
+      }
+    });
   }
   options?.recordToolPrepStage?.("tool-policy");
   const execConfig = resolveExecToolConfig({ cfg: options?.config, agentId });

--- a/src/agents/bash-tools.exec-runtime.cleanup.test.ts
+++ b/src/agents/bash-tools.exec-runtime.cleanup.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeAll, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { ManagedRun, SpawnInput } from "../process/supervisor/types.js";
+import { markBackgrounded, waitForExecScope } from "./bash-process-registry.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
+import { createAgentCleanupScope } from "./run-cleanup-timeout.js";
+
+const supervisorMock = vi.hoisted(() => ({ spawn: vi.fn() }));
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => supervisorMock,
+}));
+
+let runExecProcess: typeof import("./bash-tools.exec-runtime.js").runExecProcess;
+beforeAll(async () => {
+  ({ runExecProcess } = await import("./bash-tools.exec-runtime.js"));
+});
+beforeEach(() => {
+  resetProcessRegistryForTests();
+  supervisorMock.spawn.mockReset();
+});
+afterEach(() => {
+  resetProcessRegistryForTests();
+});
+
+function runtimeManagedRun(input: SpawnInput): ManagedRun {
+  return {
+    runId: input.runId ?? "test-run",
+    pid: 1234,
+    startedAtMs: Date.now(),
+    stdin: { write: vi.fn(), end: vi.fn(), destroy: vi.fn() },
+    cancel: vi.fn(),
+    wait: vi.fn(async () => ({
+      reason: "exit" as const,
+      exitCode: 0,
+      exitSignal: null,
+      durationMs: 1,
+      stdout: "",
+      stderr: "",
+      timedOut: false,
+      noOutputTimedOut: false,
+    })),
+  };
+}
+
+it.each([
+  { fails: false, beforeJoin: false, commandCode: 0 },
+  { fails: true, beforeJoin: false, commandCode: 0 },
+  { fails: true, beforeJoin: true, commandCode: 0 },
+  { fails: true, beforeJoin: false, commandCode: 127 },
+])(
+  "joins sandbox artifacts and retains cleanup failure (fails=$fails, beforeJoin=$beforeJoin, commandCode=$commandCode)",
+  async ({ fails, beforeJoin, commandCode }) => {
+    const finalization = createDeferred();
+    const entered = createDeferred();
+    const cleanupScope = createAgentCleanupScope();
+    const scopeKey = "scope:sandbox-artifact-cleanup";
+    supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => {
+      const managed = runtimeManagedRun(input);
+      return {
+        ...managed,
+        wait: async () => ({ ...(await managed.wait()), exitCode: commandCode }),
+      };
+    });
+    let run: Awaited<ReturnType<typeof runExecProcess>> | undefined;
+    const finalizeExec = vi.fn(async () => {
+      entered.resolve();
+      await finalization.promise;
+      if (fails) {
+        throw new Error("sandbox artifact cleanup failed");
+      }
+    });
+    try {
+      await cleanupScope.run(async () => {
+        run = await runExecProcess({
+          command: "sandbox-fixture",
+          workdir: "/tmp",
+          env: {},
+          scopeKey,
+          sandbox: {
+            containerName: "fixture",
+            workspaceDir: "/workspace",
+            containerWorkdir: "/workspace",
+            buildExecSpec: async () => ({
+              argv: ["sandbox-fixture"],
+              env: {},
+              stdinMode: "pipe-closed",
+            }),
+            finalizeExec,
+          },
+          usePty: false,
+          warnings: [],
+          maxOutput: 1000,
+          pendingMaxOutput: 1000,
+          notifyOnExit: false,
+          timeoutSec: null,
+        });
+        markBackgrounded(run.session);
+        await entered.promise;
+        if (beforeJoin) {
+          finalization.resolve();
+          await run.promise;
+        }
+        let joined = false;
+        const join = waitForExecScope(scopeKey).then(() => {
+          joined = true;
+        });
+        if (!beforeJoin) {
+          await Promise.resolve();
+          expect(joined).toBe(false);
+          expect(run.session.finalizing).toBe(true);
+          finalization.resolve();
+        }
+        await join;
+        const outcome = await run.promise;
+        expect(outcome.status).toBe(fails || commandCode !== 0 ? "failed" : "completed");
+        expect(finalizeExec).toHaveBeenCalledOnce();
+      });
+      expect(cleanupScope.outcome).toBe(fails ? "uncertain" : "closed");
+    } finally {
+      finalization.resolve();
+      await run?.promise;
+    }
+  },
+);

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -58,6 +58,7 @@ import type { BashSandboxConfig } from "./bash-tools.shared.js";
 import { chunkString, clampWithDefault, readEnvInt } from "./bash-tools.shared.js";
 import { buildGitHubExecLaunchArgv } from "./github-exec-launch.js";
 import { buildCursorPositionResponse, stripDsrRequests } from "./pty-dsr.js";
+import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
 import type { AgentToolResult } from "./runtime/index.js";
 import { createSessionSlug } from "./session-slug.js";
 import { maybeWrapCommandWithShellSnapshot } from "./shell-snapshot.js";
@@ -824,6 +825,7 @@ export async function runExecProcess({
         timedOut: outcome.timedOut,
       });
     } catch (error) {
+      recordAgentCleanupFailure();
       if (outcome.status === "completed") {
         finalOutcome = buildExecRuntimeErrorOutcome({
           error,

--- a/src/commands/agent-exec.ts
+++ b/src/commands/agent-exec.ts
@@ -361,7 +361,7 @@ export async function agentExecCommand(
     if (processScopeKey) {
       const { getProcessSupervisor } = await import("../process/supervisor/index.js");
       cleanupProcessScope = getProcessSupervisor().acquireScopeCleanup(processScopeKey, {
-        requireProcessTree: true,
+        processTree: "required-all",
       });
     }
     restoreEnvironment = setAgentExecEnvironment({ stateDir, cwd });

--- a/src/process/supervisor/adapters/child.service-lifecycle.test.ts
+++ b/src/process/supervisor/adapters/child.service-lifecycle.test.ts
@@ -230,7 +230,7 @@ describe.skipIf(process.platform === "win32")("service-managed child lifecycle",
     `;
     const supervisor = createProcessSupervisor();
     const runId = "service-secret-construction";
-    const cleanupScope = supervisor.acquireScopeCleanup(runId, { requireProcessTree: true });
+    const cleanupScope = supervisor.acquireScopeCleanup(runId, { processTree: "required-all" });
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     const pendingRun = supervisor.spawn({
       runId,

--- a/src/process/supervisor/service-child-group-ownership.test.ts
+++ b/src/process/supervisor/service-child-group-ownership.test.ts
@@ -1,61 +1,138 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
-const { census, definitelyDead } = vi.hoisted(() => ({
+const { census, definitelyDead, directory, readStat } = vi.hoisted(() => ({
   census: vi.fn(),
   definitelyDead: vi.fn(),
+  directory: vi.fn(),
+  readStat: vi.fn(),
 }));
 vi.mock("node:child_process", () => ({ spawnSync: census }));
+vi.mock("node:fs", () => ({ readdirSync: directory, readFileSync: readStat }));
 vi.mock("../../shared/pid-alive.js", () => ({ isPidDefinitelyDead: definitelyDead }));
 import { hasLiveOwnedProcessGroupMembers } from "./service-child-group-ownership.js";
 
+const owner = process.pid;
+let rows: Map<number, string | Error>;
+function stat(pid: number, group: number, state = "S", name = "worker") {
+  return `${pid} (${name}) ${state} 1 ${group} 0 0`;
+}
+
 beforeEach(() => {
-  census.mockReset();
+  census.mockReset().mockReturnValue({ error: new Error("ps is unavailable") });
   definitelyDead.mockReset().mockReturnValue(false);
+  rows = new Map([[owner, stat(owner, owner)]]);
+  directory.mockReset().mockImplementation(() => ["self", ...Array.from(rows.keys(), String)]);
+  readStat.mockReset().mockImplementation((file: string) => {
+    const match = /^\/proc\/(\d+)\/stat$/.exec(file);
+    const value = match ? rows.get(Number(match[1])) : undefined;
+    if (value === undefined || value instanceof Error) {
+      throw value ?? new Error(`Unexpected fixture read: ${file}`);
+    }
+    return value;
+  });
   mockProcessPlatform("linux");
 });
 afterEach(() => vi.restoreAllMocks());
+
+it.each(["S", "D", "U", "R"])("observes a Linux %s group member without ps", (state) => {
+  rows.set(owner + 1, stat(owner + 1, owner, state, "worker ) (with\nname"));
+  expect(hasLiveOwnedProcessGroupMembers()).toBe(true);
+  expect(census).not.toHaveBeenCalled();
+});
+
+it.each([false, true])("uses the shared Linux zombie/thread decision (dead=%s)", (dead) => {
+  rows.set(owner + 1, stat(owner + 1, owner, "Z"));
+  definitelyDead.mockReturnValue(dead);
+  expect(hasLiveOwnedProcessGroupMembers()).toBe(!dead);
+  expect(definitelyDead).toHaveBeenCalledExactlyOnceWith(owner + 1);
+});
+
+it("allows an observed Linux owner to retire without requiring a ps executable", () => {
+  rows.set(owner + 1, stat(owner + 1, owner + 1));
+  expect(hasLiveOwnedProcessGroupMembers()).toBe(false);
+  expect(census).not.toHaveBeenCalled();
+});
+
+it.each(["ENOENT", "ESRCH"])(
+  "tolerates a foreign PID disappearing during the census (%s)",
+  (code) => {
+    rows.set(owner + 1, Object.assign(new Error("gone"), { code }));
+    expect(hasLiveOwnedProcessGroupMembers()).toBe(false);
+  },
+);
+
+it.each([
+  "missing owner",
+  "wrong group",
+  "malformed stat",
+  "inaccessible row",
+  "inaccessible directory",
+])("keeps the Linux census uncertain with %s", (failure) => {
+  if (failure === "missing owner") {
+    rows.clear();
+  }
+  if (failure === "wrong group") {
+    rows.set(owner, stat(owner, owner + 1));
+  }
+  if (failure === "malformed stat") {
+    rows.set(owner + 1, "invalid stat");
+  }
+  if (failure === "inaccessible row") {
+    rows.set(owner + 1, Object.assign(new Error("denied"), { code: "EACCES" }));
+  }
+  if (failure === "inaccessible directory") {
+    directory.mockImplementation(() => {
+      throw new Error("denied");
+    });
+  }
+  expect(hasLiveOwnedProcessGroupMembers()).toBeUndefined();
+});
+
+it("does not report an empty Linux group after its existing census budget expires", () => {
+  let now = 0;
+  vi.spyOn(Date, "now").mockImplementation(() => now);
+  readStat.mockImplementation(() => {
+    now = 51;
+    return stat(owner, owner);
+  });
+  expect(hasLiveOwnedProcessGroupMembers(50)).toBeUndefined();
+  expect(census).not.toHaveBeenCalled();
+});
 
 it.each([
   { state: "S", expected: true },
   { state: "D", expected: true },
   { state: "U", expected: true },
-  { state: "Z", expected: true },
-  { state: "Z+", expected: true },
-  { state: "Zl", expected: true },
-  { state: "Zsl", expected: true },
-  { state: "Zl+", expected: true },
-])("observes a $state descendant as live=$expected", ({ state, expected }) => {
+  { state: "Z", expected: false },
+  { state: "Z+", expected: false },
+])("preserves Darwin ps state $state as live=$expected", ({ state, expected }) => {
+  mockProcessPlatform("darwin");
   census.mockReturnValue({
     status: 0,
-    stdout: `${process.pid} ${process.pid} S\n${process.pid + 1} ${process.pid} ${state}\n`,
+    stdout: `${owner} ${owner} S\n${owner + 1} ${owner} ${state}\n`,
   });
   expect(hasLiveOwnedProcessGroupMembers()).toBe(expected);
-});
-
-it("allows retirement only after the shared check confirms a Linux zombie's threads exited", () => {
-  census.mockReturnValue({
-    status: 0,
-    stdout: `${process.pid} ${process.pid} S\n${process.pid + 1} ${process.pid} Z\n`,
-  });
-  definitelyDead.mockReturnValue(true);
-  expect(hasLiveOwnedProcessGroupMembers()).toBe(false);
+  expect(directory).not.toHaveBeenCalled();
+  expect(readStat).not.toHaveBeenCalled();
 });
 
 it.each([
   { status: 1, stdout: "" },
   { status: 0, stdout: "malformed census" },
   { status: 0, stdout: "" },
-  { status: 0, stdout: `${process.pid} ${process.pid + 1} S\n` },
-])("keeps failed or missing group ownership uncertain (%j)", (result) => {
+  { status: 0, stdout: `${owner} ${owner + 1} S\n` },
+])("keeps failed Darwin ownership uncertain (%j)", (result) => {
+  mockProcessPlatform("darwin");
   census.mockReturnValue(result);
   expect(hasLiveOwnedProcessGroupMembers()).toBeUndefined();
 });
 
-it.each([false, true])("excludes only its exact inspector PID (other group member=%s)", (other) => {
+it.each([false, true])("excludes only Darwin's exact inspector PID (other member=%s)", (other) => {
+  mockProcessPlatform("darwin");
   census.mockReturnValue({
-    pid: process.pid + 1,
+    pid: owner + 1,
     status: 0,
-    stdout: `${process.pid} ${process.pid} S\n${process.pid + 1} ${process.pid} R\n${process.pid + 2} ${other ? process.pid : process.pid + 2} S\n`,
+    stdout: `${owner} ${owner} S\n${owner + 1} ${owner} R\n${owner + 2} ${other ? owner : owner + 2} S\n`,
   });
   expect(hasLiveOwnedProcessGroupMembers()).toBe(other);
 });

--- a/src/process/supervisor/service-child-group-ownership.ts
+++ b/src/process/supervisor/service-child-group-ownership.ts
@@ -1,41 +1,89 @@
 import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import { extractErrorCode } from "@openclaw/normalization-core/error-coercion";
 import { isPidDefinitelyDead } from "../../shared/pid-alive.js";
 
-/** Advisory retirement timing only; the host owns kernel group-disappearance proof. */
-export function hasLiveOwnedProcessGroupMembers(timeoutMs = 1_000): boolean | undefined {
+type GroupMember = { pid: number; pgid: number; state: string };
+
+function* readProcessGroupMembers(timeoutMs: number): Generator<GroupMember> {
+  if (process.platform === "linux") {
+    const deadline = Date.now() + timeoutMs;
+    for (const name of readdirSync("/proc")) {
+      if (Date.now() >= deadline) {
+        throw new Error("Process group census exceeded its deadline");
+      }
+      if (!/^\d+$/.test(name)) {
+        continue;
+      }
+      const pid = Number(name);
+      let stat: string;
+      try {
+        stat = readFileSync(`/proc/${name}/stat`, "utf8");
+      } catch (error) {
+        // Foreign processes may disappear between enumeration and their stat read.
+        if (pid !== process.pid && ["ENOENT", "ESRCH"].includes(extractErrorCode(error) ?? "")) {
+          continue;
+        }
+        throw error;
+      }
+      // comm can contain spaces, newlines and parentheses; pgrp follows PPID
+      // after its final closing parenthesis (Linux procfs stat fields 1..5).
+      const match = /^(\d+) \([\s\S]*\) (\S) \d+ (\d+)(?:\s|$)/.exec(stat);
+      if (!match || Number(match[1]) !== pid || Date.now() >= deadline) {
+        throw new Error("Process group census is unavailable");
+      }
+      yield { pid, pgid: Number(match[3]), state: match[2]! };
+    }
+    if (Date.now() >= deadline) {
+      throw new Error("Process group census exceeded its deadline");
+    }
+    return;
+  }
   const census = spawnSync("/bin/ps", ["-A", "-o", "pid=,pgid=,stat="], {
     encoding: "utf8",
-    timeout: Math.max(1, Math.min(1_000, timeoutMs)),
+    timeout: timeoutMs,
     maxBuffer: 4 * 1024 * 1024,
   });
   if (census.error || census.status !== 0) {
-    return undefined;
+    throw new Error("Process group census is unavailable");
   }
-  let observedOwner = false;
   for (const line of census.stdout.split("\n")) {
     if (!line.trim()) {
       continue;
     }
     const match = /^\s*(\d+)\s+(\d+)\s+(\S+)\s*$/.exec(line);
     if (!match) {
-      return undefined;
+      throw new Error("Process group census is unavailable");
     }
     const pid = Number(match[1]);
-    const pgid = Number(match[2]);
-    const state = match[3]!;
-    if (pid === process.pid) {
-      if (pgid !== process.pid) {
-        return undefined;
-      }
-      observedOwner = true;
-    } else if (
-      pid !== census.pid &&
-      pgid === process.pid &&
-      // BusyBox omits procps's thread marker; use the shared Linux thread check.
-      (!state.startsWith("Z") || (process.platform === "linux" && !isPidDefinitelyDead(pid)))
-    ) {
-      return true;
+    if (pid !== census.pid) {
+      yield { pid, pgid: Number(match[2]), state: match[3]! };
     }
+  }
+}
+
+/** Advisory retirement timing only; the host owns kernel group-disappearance proof. */
+export function hasLiveOwnedProcessGroupMembers(timeoutMs = 1_000): boolean | undefined {
+  let observedOwner = false;
+  try {
+    for (const { pid, pgid, state } of readProcessGroupMembers(
+      Math.max(1, Math.min(1_000, timeoutMs)),
+    )) {
+      if (pid === process.pid) {
+        if (pgid !== process.pid) {
+          return undefined;
+        }
+        observedOwner = true;
+      } else if (
+        pgid === process.pid &&
+        // A zombie leader may retain live Linux threads; share the existing check.
+        (!state.startsWith("Z") || (process.platform === "linux" && !isPidDefinitelyDead(pid)))
+      ) {
+        return true;
+      }
+    }
+  } catch {
+    return undefined;
   }
   return observedOwner ? false : undefined;
 }

--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -235,7 +235,7 @@ it.each(["linux", "win32"] as const)(
     mocks.spawn.mockReturnValue(stub.child);
     const supervisor = createProcessSupervisor();
     const scopeKey = "scope:rejected-construction";
-    const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+    const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
     const pending = supervisor.spawn({
       runId: "rejected-construction",
       mode: "anchored-shell",

--- a/src/process/supervisor/supervisor.anchored-shell.real.test.ts
+++ b/src/process/supervisor/supervisor.anchored-shell.real.test.ts
@@ -110,7 +110,7 @@ async function createDescendantScope(
   }
   const supervisor = createProcessSupervisor();
   const scopeKey = `anchored-shell:${cwd}`;
-  const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+  const cleanup = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
   const run = await supervisor.spawn({
     ...(options.oneShot
       ? {

--- a/src/process/supervisor/supervisor.one-shot-tools.test.ts
+++ b/src/process/supervisor/supervisor.one-shot-tools.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createAgentToolsSandboxContext } from "../../agents/test-helpers/agent-tools-sandbox-context.js";
+import {
+  createSilentIdleArgv,
+  createStubChildAdapter,
+  spawnChild,
+} from "./supervisor.test-support.js";
+
+const { createChildAdapterMock, createPtyAdapterMock, getProcessSupervisorMock } = vi.hoisted(
+  () => ({
+    createChildAdapterMock: vi.fn(),
+    createPtyAdapterMock: vi.fn(),
+    getProcessSupervisorMock: vi.fn(),
+  }),
+);
+
+vi.mock("./adapters/child.js", () => ({
+  createChildAdapter: createChildAdapterMock,
+}));
+
+vi.mock("./adapters/pty.js", () => ({ createPtyAdapter: createPtyAdapterMock }));
+vi.mock("../../agents/shell-snapshot.js", () => ({
+  maybeWrapCommandWithShellSnapshot: async ({ command }: { command: string }) => command,
+}));
+
+vi.mock("./index.js", () => ({
+  getProcessSupervisor: getProcessSupervisorMock,
+}));
+
+let runExecProcess: typeof import("../../agents/bash-tools.exec-runtime.js").runExecProcess;
+let createProcessSupervisor: typeof import("./supervisor.js").createProcessSupervisor;
+let createOpenClawCodingTools: typeof import("../../agents/agent-tools.js").createOpenClawCodingTools;
+
+function prepareOneShotTools(
+  scopeKey: string,
+  generationCleanups: Array<(reason: string) => Promise<void>>,
+) {
+  createOpenClawCodingTools({
+    config: { plugins: { enabled: false } },
+    sessionKey: scopeKey,
+    workspaceDir: "/workspace",
+    cwd: "/workspace",
+    sandbox: createAgentToolsSandboxContext({ workspaceDir: "/workspace" }),
+    oneShotCliRun: true,
+    registerRunCleanup: (cleanup) => {
+      generationCleanups.push(cleanup);
+    },
+    toolConstructionPlan: {
+      includeBaseCodingTools: false,
+      includeShellTools: false,
+      includeChannelTools: false,
+      includeOpenClawTools: false,
+      includePluginTools: false,
+    },
+  });
+  expect(generationCleanups).toHaveLength(1);
+  return generationCleanups[0]!;
+}
+
+describe("one-shot tool-generation process cleanup", () => {
+  beforeAll(async () => {
+    vi.resetModules();
+    ({ createProcessSupervisor } = await import("./supervisor.js"));
+    ({ createOpenClawCodingTools } = await import("../../agents/agent-tools.js"));
+    ({ runExecProcess } = await import("../../agents/bash-tools.exec-runtime.js"));
+  });
+
+  beforeEach(() => {
+    createChildAdapterMock.mockReset();
+    createPtyAdapterMock.mockReset();
+    getProcessSupervisorMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it.each([false, true])(
+    "joins one-shot tool-generation backend and host cleanup (hostFails=%s)",
+    async (hostFails) => {
+      const supervisor = createProcessSupervisor();
+      getProcessSupervisorMock.mockReturnValue(supervisor);
+      const scopeKey = "scope:mixed-owned-lifetimes";
+      const generationCleanups: Array<(reason: string) => Promise<void>> = [];
+      const external = createStubChildAdapter();
+      const extinction = createDeferred();
+      const host = Object.assign(createStubChildAdapter(), {
+        waitForExtinction: () => extinction.promise,
+      });
+      createChildAdapterMock.mockResolvedValueOnce(external).mockResolvedValueOnce(host);
+      try {
+        const cleanup = prepareOneShotTools(scopeKey, generationCleanups);
+        const externalRun = await supervisor.spawn({
+          mode: "child",
+          argv: createSilentIdleArgv(),
+          sessionId: scopeKey,
+          scopeKey,
+          backendId: "sandbox-transport",
+          cleanupOwnership: "external",
+        });
+        const hostRun = await spawnChild(supervisor, {
+          sessionId: scopeKey,
+          scopeKey,
+          argv: createSilentIdleArgv(),
+        });
+        expect(createChildAdapterMock.mock.calls[0]?.[0].ownProcessTree).toBeUndefined();
+        expect(createChildAdapterMock.mock.calls[1]?.[0].ownProcessTree).toBe(true);
+        external.settle(0);
+        host.settle(0);
+        await Promise.all([externalRun.wait(), hostRun.wait()]);
+        const joined = vi.fn();
+        const closing = cleanup("completed");
+        void closing.then(joined, joined);
+        await Promise.resolve();
+        expect(joined).not.toHaveBeenCalled();
+        expect(host.killMock).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+        if (hostFails) {
+          extinction.reject(new Error("owned host cleanup failed"));
+          await expect(closing).rejects.toThrow("owned host cleanup failed");
+          await expect(supervisor.shutdown()).rejects.toThrow("owned host cleanup failed");
+        } else {
+          extinction.resolve();
+          await expect(closing).resolves.toBeUndefined();
+          await expect(supervisor.shutdown()).resolves.toBeUndefined();
+        }
+      } finally {
+        external.settle(0);
+        host.settle(0);
+        extinction.resolve();
+        await Promise.allSettled([
+          ...generationCleanups.map((cleanup) => cleanup("test cleanup")),
+          supervisor.shutdown(),
+        ]);
+      }
+    },
+  );
+
+  it("runs a one-shot host PTY request once through the owned child fallback", async () => {
+    const supervisor = createProcessSupervisor();
+    getProcessSupervisorMock.mockReturnValue(supervisor);
+    const scopeKey = "scope:pty-owned-fallback";
+    const generationCleanups: Array<(reason: string) => Promise<void>> = [];
+    const extinction = createDeferred();
+    const child = Object.assign(createStubChildAdapter(), {
+      waitForExtinction: () => extinction.promise,
+    });
+    const pty = createStubChildAdapter();
+    pty.settle(0);
+    createPtyAdapterMock.mockResolvedValue(pty);
+    createChildAdapterMock.mockResolvedValue(child);
+    const warnings: string[] = [];
+    let run: Awaited<ReturnType<typeof runExecProcess>> | undefined;
+    try {
+      const cleanup = prepareOneShotTools(scopeKey, generationCleanups);
+      run = await runExecProcess({
+        command: "fixture-command",
+        workdir: "/tmp",
+        env: {},
+        usePty: true,
+        scopeKey,
+        warnings,
+        maxOutput: 1000,
+        pendingMaxOutput: 1000,
+        notifyOnExit: false,
+        timeoutSec: null,
+      });
+      expect(createPtyAdapterMock).not.toHaveBeenCalled();
+      expect(createChildAdapterMock).toHaveBeenCalledOnce();
+      expect(createChildAdapterMock.mock.calls[0]?.[0].ownProcessTree).toBe(true);
+      expect(warnings).toEqual([
+        expect.stringContaining("PTY is unavailable when execution requires process-tree cleanup"),
+      ]);
+      child.emitStdout("command ran once");
+      child.settle(0);
+      await expect(run.promise).resolves.toMatchObject({
+        status: "completed",
+        aggregated: "command ran once",
+      });
+      const closed = vi.fn();
+      const closing = cleanup("completed");
+      void closing.then(closed, closed);
+      await Promise.resolve();
+      expect(closed).not.toHaveBeenCalled();
+      expect(child.killMock).toHaveBeenCalledExactlyOnceWith("SIGTERM");
+      extinction.resolve();
+      await expect(closing).resolves.toBeUndefined();
+    } finally {
+      child.settle(0);
+      extinction.resolve();
+      await Promise.allSettled([
+        run?.promise,
+        ...generationCleanups.map((cleanup) => cleanup("test cleanup")),
+        supervisor.shutdown(),
+      ]);
+    }
+  });
+});

--- a/src/process/supervisor/supervisor.scope-extinction.test.ts
+++ b/src/process/supervisor/supervisor.scope-extinction.test.ts
@@ -72,7 +72,7 @@ describe("process supervisor scope extinction", () => {
     createChildAdapterMock.mockResolvedValue(adapter);
     const supervisor = createProcessSupervisor();
     const scopeKey = "scope:one-shot-late-join";
-    const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+    const cleanup = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
     const run = await spawnChild(supervisor, {
       sessionId: scopeKey,
       scopeKey,
@@ -92,7 +92,7 @@ describe("process supervisor scope extinction", () => {
     }
     // The released owner must neither poison a new run nor retain the old admission.
     await expect(
-      supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true })(),
+      supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" })(),
     ).resolves.toBeUndefined();
     if (failed) {
       await expect(supervisor.shutdown()).rejects.toThrow("cleanup identity lost");
@@ -101,7 +101,7 @@ describe("process supervisor scope extinction", () => {
     }
   });
 
-  it.each(["child", "pty", "external"] as const)(
+  it.each(["child", "external"] as const)(
     "keeps %s execution available but reports unsupported one-shot cleanup",
     async (mode) => {
       const adapter = createStubChildAdapter();
@@ -109,9 +109,9 @@ describe("process supervisor scope extinction", () => {
       createPtyAdapterMock.mockResolvedValue(adapter);
       const supervisor = createProcessSupervisor();
       const scopeKey = `scope:unsupported-${mode}`;
-      const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+      const cleanup = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
       const run = await supervisor.spawn({
-        mode: mode === "pty" ? "pty" : "child",
+        mode: "child",
         argv: createSilentIdleArgv(),
         backendId: "test",
         sessionId: scopeKey,
@@ -137,7 +137,7 @@ describe("process supervisor scope extinction", () => {
     createChildAdapterMock.mockResolvedValue(adapter);
     const supervisor = createProcessSupervisor();
     const scopeKey = "scope:graceful-one-shot";
-    const cleanup = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+    const cleanup = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
     const run = await spawnChild(supervisor, {
       sessionId: scopeKey,
       scopeKey,
@@ -164,7 +164,9 @@ describe("process supervisor scope extinction", () => {
       createChildAdapterMock.mockReturnValueOnce(startup.promise);
       const supervisor = createProcessSupervisor();
       const scopeKey = "scope:timed-out-construction";
-      const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: false });
+      const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, {
+        processTree: "transport-only",
+      });
       const pending = spawnChild(supervisor, {
         sessionId: "timed-out-construction",
         scopeKey,
@@ -287,7 +289,7 @@ describe("process supervisor scope extinction", () => {
 
       const supervisor = createProcessSupervisor();
       const cleanupScope = supervisor.acquireScopeCleanup("scope:failed-drain", {
-        requireProcessTree: false,
+        processTree: "transport-only",
       });
       const sharedId = reuseRunId ? { runId: "same-agent-run" } : {};
       const firstPending = spawnChild(supervisor, {
@@ -350,6 +352,67 @@ describe("process supervisor scope extinction", () => {
       sibling.settle(0);
       await replacement.wait();
       await supervisor.shutdown();
+    }
+  });
+  it.each([false, true])(
+    "preserves native PTY without a tree requirement (scoped=%s)",
+    async (scoped) => {
+      const supervisor = createProcessSupervisor();
+      const scopeKey = "scope:pty-transport";
+      const cleanup = scoped
+        ? supervisor.acquireScopeCleanup(scopeKey, { processTree: "transport-only" })
+        : undefined;
+      const pty = createStubChildAdapter();
+      createPtyAdapterMock.mockResolvedValue(pty);
+      const run = await supervisor.spawn({
+        mode: "pty",
+        argv: createSilentIdleArgv(),
+        sessionId: scopeKey,
+        scopeKey,
+        backendId: "test",
+      });
+      try {
+        expect(createPtyAdapterMock).toHaveBeenCalledOnce();
+        expect(createChildAdapterMock).not.toHaveBeenCalled();
+        pty.emitStdout("interactive output");
+        pty.settle(0);
+        await expect(run.wait()).resolves.toMatchObject({
+          exitCode: 0,
+          stdout: "interactive output",
+        });
+        await cleanup?.();
+      } finally {
+        pty.settle(0);
+        await supervisor.shutdown();
+      }
+    },
+  );
+
+  it("keeps a required-all scope dominant over owned-only backend cleanup", async () => {
+    const supervisor = createProcessSupervisor();
+    const scopeKey = "scope:strict-backend-owner";
+    const ownedCleanup = supervisor.acquireScopeCleanup(scopeKey, { processTree: "owned-only" });
+    const strictCleanup = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
+    const external = createStubChildAdapter();
+    createChildAdapterMock.mockResolvedValue(external);
+    try {
+      const run = await supervisor.spawn({
+        mode: "child",
+        argv: createSilentIdleArgv(),
+        sessionId: scopeKey,
+        scopeKey,
+        backendId: "sandbox-transport",
+        cleanupOwnership: "external",
+      });
+      external.settle(0);
+      await run.wait();
+      await expect(ownedCleanup()).resolves.toBeUndefined();
+      await expect(strictCleanup()).rejects.toThrow(
+        "cannot confirm owned execution-tree settlement",
+      );
+    } finally {
+      external.settle(0);
+      await Promise.allSettled([ownedCleanup(), strictCleanup(), supervisor.shutdown()]);
     }
   });
 });

--- a/src/process/supervisor/supervisor.ts
+++ b/src/process/supervisor/supervisor.ts
@@ -14,6 +14,7 @@ import { createRunRegistry } from "./registry.js";
 import type {
   ManagedRun,
   ProcessSupervisor,
+  ProcessScopeCleanupPolicy,
   RunExit,
   SpawnInput,
   SpawnProcessAdapter,
@@ -30,7 +31,11 @@ type OwnedRun = {
   cleanupOwners: ScopeCleanupOwner[];
 };
 
-type ScopeCleanupOwner = { requireProcessTree: boolean; failure?: { error: unknown } };
+type ScopeCleanupOwner = { processTree: ProcessScopeCleanupPolicy; failure?: { error: unknown } };
+
+function requiresProcessTree(scope: ScopeCleanupOwner, external: boolean): boolean {
+  return scope.processTree === "required-all" || (scope.processTree === "owned-only" && !external);
+}
 
 function recordScopeCleanupFailure(owner: OwnedRun, error: unknown): void {
   for (const cleanupOwner of owner.cleanupOwners) {
@@ -184,9 +189,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   };
   const acquireScopeCleanup = (
     scopeKey: string,
-    options: { requireProcessTree: boolean },
+    options: { processTree: ProcessScopeCleanupPolicy },
   ): (() => Promise<void>) => {
-    const cleanupOwner: ScopeCleanupOwner = { requireProcessTree: options.requireProcessTree };
+    const cleanupOwner: ScopeCleanupOwner = { processTree: options.processTree };
     const owners = scopeCleanupOwners.get(scopeKey) ?? new Set<ScopeCleanupOwner>();
     owners.add(cleanupOwner);
     scopeCleanupOwners.set(scopeKey, owners);
@@ -211,9 +216,18 @@ export function createProcessSupervisor(): ProcessSupervisor & {
   };
 
   const startRun = async (input: SpawnInput, owner: OwnedRun): Promise<ManagedRun> => {
+    const external = input.cleanupOwnership === "external";
+    const requireProcessTree = owner.cleanupOwners.some((scope) =>
+      requiresProcessTree(scope, external),
+    );
     // A queued replacement must still own authority before stopping the surviving run.
     if (!owner.terminationReason) {
       input.assertCurrent?.();
+      // Native PTY has no tree-extinction owner. Reject before spawning so exec's
+      // existing PTY-unavailable fallback can run once under the child anchor.
+      if (input.mode === "pty" && requireProcessTree) {
+        throw new Error("PTY is unavailable when execution requires process-tree cleanup");
+      }
     }
     const { runId, scopeKey } = owner;
     const startedAtMs = Date.now();
@@ -394,10 +408,7 @@ export function createProcessSupervisor(): ProcessSupervisor & {
               })
             : createChildAdapter({
                 assertCurrent: input.assertCurrent,
-                ...(owner.cleanupOwners.some((scope) => scope.requireProcessTree) &&
-                input.cleanupOwnership !== "external"
-                  ? { ownProcessTree: true as const }
-                  : {}),
+                ...(requireProcessTree && !external ? { ownProcessTree: true as const } : {}),
                 argv: input.argv,
                 argv0: input.argv0,
                 cwd: input.cwd,
@@ -414,9 +425,9 @@ export function createProcessSupervisor(): ProcessSupervisor & {
         .then(
           async (started) => {
             ownedAdapter = started;
-            if (input.cleanupOwnership === "external" || !started.waitForExtinction) {
+            if (external || !started.waitForExtinction) {
               for (const scope of owner.cleanupOwners) {
-                if (scope.requireProcessTree) {
+                if (requiresProcessTree(scope, external)) {
                   scope.failure ??= {
                     error: new Error(
                       "process cleanup cannot confirm owned execution-tree settlement",
@@ -491,7 +502,6 @@ export function createProcessSupervisor(): ProcessSupervisor & {
       };
 
       cancelAdapter = (reason: TerminationReason) => {
-        const requireProcessTree = owner.cleanupOwners.some((scope) => scope.requireProcessTree);
         if (
           cleanupSettled ||
           (cancelRequested && (requireProcessTree || !(resultSettled && forceKillTimer)))

--- a/src/process/supervisor/types.ts
+++ b/src/process/supervisor/types.ts
@@ -145,11 +145,17 @@ type SpawnAnchoredShellInput = SpawnBaseInput & {
 
 export type SpawnInput = SpawnChildInput | SpawnPtyInput | SpawnAnchoredShellInput;
 
+/**
+ * required-all includes external execution; owned-only leaves explicit backend
+ * lifetimes with that backend; transport-only makes no execution-tree claim.
+ */
+export type ProcessScopeCleanupPolicy = "required-all" | "owned-only" | "transport-only";
+
 export interface ProcessSupervisor {
   /** Register before spawning; close caller admission before joining this exact cleanup owner. */
   acquireScopeCleanup(
     scopeKey: string,
-    options: { requireProcessTree: boolean },
+    options: { processTree: ProcessScopeCleanupPolicy },
   ): () => Promise<void>;
   spawn(input: SpawnInput): Promise<ManagedRun>;
   cancel(runId: string, reason?: TerminationReason): void;

--- a/src/tui/tui-local-shell.test.ts
+++ b/src/tui/tui-local-shell.test.ts
@@ -254,7 +254,7 @@ describe("createLocalShellRunner", () => {
     const harness = createShellHarness();
     expect(harness.supervisor.acquireScopeCleanup).toHaveBeenCalledExactlyOnceWith(
       expect.any(String),
-      { requireProcessTree: true },
+      { processTree: "required-all" },
     );
     const run = harness.runLocalShellLine("!echo late");
     const selector = harness.getLastSelector();

--- a/src/tui/tui-local-shell.ts
+++ b/src/tui/tui-local-shell.ts
@@ -36,7 +36,7 @@ export function createLocalShellRunner(deps: LocalShellDeps) {
   let cancelPendingApproval: (() => void) | undefined;
   const supervisor = getProcessSupervisor();
   const scopeKey = `tui-local:${randomUUID()}`;
-  const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { requireProcessTree: true });
+  const cleanupScope = supervisor.acquireScopeCleanup(scopeKey, { processTree: "required-all" });
   const createSelector = deps.createSelector ?? createSearchableSelectList;
   const getCwd = deps.getCwd ?? tryProcessCwd;
   const env = deps.env ?? process.env;

--- a/src/worker/worker.runtime.ts
+++ b/src/worker/worker.runtime.ts
@@ -73,7 +73,7 @@ export async function createWorkerRuntimeEnvironment(sessionId: string) {
   // Worker state owns command completion and exec finalizers; its parent owns
   // process placement. This lease does not infer remote or PTY tree extinction.
   const cleanupScope = getProcessSupervisor().acquireScopeCleanup(scopeKey, {
-    requireProcessTree: false,
+    processTree: "transport-only",
   });
   process.env.OPENCLAW_STATE_DIR = stateDir;
   process.env.OPENCLAW_CONFIG_PATH = path.join(stateDir, "openclaw.json");

--- a/test/tsconfig/tsconfig.core.test.agents-root.json
+++ b/test/tsconfig/tsconfig.core.test.agents-root.json
@@ -6,5 +6,12 @@
   "include": [
     "../../src/agents/*.test.ts",
     "../../src/agents/*.test.tsx"
+  ],
+  "exclude": [
+    "../../node_modules",
+    "../../dist",
+    "../../**/dist/**",
+    "../../src/agents/bash-tools.exec-runtime*.test.ts",
+    "../../src/agents/bash-tools.exec-runtime*.test.tsx"
   ]
 }

--- a/test/tsconfig/tsconfig.core.test.agents-tools.json
+++ b/test/tsconfig/tsconfig.core.test.agents-tools.json
@@ -5,6 +5,8 @@
   },
   "include": [
     "../../src/agents/tools/**/*.test.ts",
-    "../../src/agents/tools/**/*.test.tsx"
+    "../../src/agents/tools/**/*.test.tsx",
+    "../../src/agents/bash-tools.exec-runtime*.test.ts",
+    "../../src/agents/bash-tools.exec-runtime*.test.tsx"
   ]
 }


### PR DESCRIPTION
Related: #135868, #139517, #139657

## What Problem This Solves

Fixes an issue where one-shot agent commands could report uncertain cleanup after a successful command in a reusable sandbox. A backend finalizer failure could conversely leave the cleanup outcome marked closed. On Linux installations without `/bin/ps`, normal owned command cleanup could not observe that its process group was ready to retire.

This is a focused follow-up to the landed process and runtime stages of #135868. The active update and recovery stages remain separate.

## Why This Change Was Made

The supervisor now distinguishes cleanup of all execution, locally owned execution, and command transport. Ordinary one-shot tools preserve the backend's configured sandbox lifetime while still joining command finalization and requiring host process-tree cleanup. Strict outer executors retain their requirement. Backend-finalizer errors record uncertainty at the finalizer owner before the exec registry retires the session.

Host commands requiring tree cleanup reject the unsupported native PTY capability before starting it, allowing the existing exec fallback to run the command once as an owned child and show a warning. Linux group observation reads procfs, sharing the existing zombie/thread decision; the external host still owns proof that the kernel process group has disappeared. Darwin keeps its existing process census.

## User Impact

Reusable sandbox commands can complete without a false cleanup failure, actual finalizer failures remain visible to the cleanup owner, and Linux group retirement works without a fixed `ps` executable path. Terminal-dependent commands may fail when the existing non-PTY fallback is required; this behavior is documented.

## Evidence

- On main-based production, the Linux regression had 10 intended failures, the public one-shot builder had 3, and the finalizer suite had 3 failures with 1 passing control. The unchanged regression files pass after the fix: 26 Linux cases, 3 builder cases, and 4 finalizer cases.
- 99 additional tests passed across supervisor scope ownership, mocked relay cleanup, registry, cleanup timeouts, local TUI, and temporary worker state.
- Fresh independent review found no actionable P0–P2 findings. Targeted formatting and diff checks passed.
- Native Linux validation passed four selected cases on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34021609907), using Node 24.19.0 and pnpm 12.3.4: ordinary child-group cancellation, retained descendant cleanup, real exec completion waiting on a controlled finalizer, and temporary backend env-file deletion. The exact runtime/test tree was verified before execution; the lease stopped successfully. Docker operations were mocked in the env-file case. The final source differs from the native-test tree only in the two typecheck shard configurations.
- Full changed-file checks passed, including core and all test types, lint, guards, dead exports, and runtime import cycles. Their initial failure identified agents-root at 721 files against the unchanged 720 cap. The three related exec-runtime tests now belong to the existing agents-tools graph (root 718, tools 146); the compiler ownership check passes. No tests are omitted or compiler settings relaxed.

The focused tests use controlled adapters and finalizers; they are not live Docker, SSH, or NixOS installation proof. No configuration, SQLite schema, protocol, public plugin SDK, or MCP cleanup API changes are introduced.

Production delta: +112/-38 (net +74). Linux procfs support accounts for +48; explicit cleanup ownership, joining the existing finalizer registry, and preserving failure facts account for +26. Tests and support: +509/-36; docs: +11/-0.

### Maintainer review resolution

Retain the documented PTY fallback for scopes requiring process-tree cleanup. It refuses an unsupported cleanup capability before execution and runs once through the existing owned-child path with a visible warning. Unscoped and transport-only PTY execution remain available and covered; terminal-dependent commands in strict scopes retain the stated limitation. A native PTY tree owner is separate work, not a compatibility shim in this repair.

No stored data model changes: `service-child-group-ownership.ts` only reads the kernel's transient `/proc` process census (or existing Darwin `ps` output). Its `GroupMember` values are local iteration results; they are neither serialized nor persisted. No database, table, schema version, record shape, migration, configuration format, or upgrade reader/writer changes. The automated data-model classification is a false positive, so no migration is required. The native state-schema guard and all core/test typecheck graphs passed.
