### PR TITLE
fix(config): preserve authored settings across includes

### DIFF
--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -264,6 +264,7 @@ const writeCases: WriteCase[] = [
     current: roster({ main: { ...main, identity: { name: "Main", emoji: "🦞" } } }),
     authored: roster({ main: { ...main, identity: { $include: "./identity.json" } } }),
     next: roster({ main: { ...main, identity: { name: "Main", emoji: "🦞" } }, worker }),
+    options: { explicitSetPaths: [["agents"]] },
     expected: roster({ main: { ...main, identity: { $include: "./identity.json" } }, worker }),
   },
   {
@@ -273,6 +274,14 @@ const writeCases: WriteCase[] = [
     authored: listRoster([{ id: "main", ...main, identity: { $include: "./identity.json" } }]),
     next: roster({ main: { ...main, identity: { name: "Main", emoji: "🦞" } }, worker }),
     expected: roster({ main: { ...main, identity: { $include: "./identity.json" } }, worker }),
+  },
+  {
+    name: "preserves included tool arrays during explicit parent writes",
+    current: roster({ main: { ...main, tools: { allow: ["read"] } } }),
+    authored: roster({ main: { ...main, tools: { $include: "./tools.json" } } }),
+    next: roster({ main: { ...main, tools: { allow: ["read"] } }, worker }),
+    options: { explicitSetPaths: [["agents"]] },
+    expected: roster({ main: { ...main, tools: { $include: "./tools.json" } }, worker }),
   },
   {
     name: "rejects a roster write when a legacy whole-entry include owns the agent id",
@@ -582,6 +591,82 @@ const writeCases: WriteCase[] = [
     next: { gateway: { mode: "remote", legacyKey: "new" } },
     error: "Config write would flatten $include-owned config at gateway",
   },
+  ...[["fixture/replacement"], []].flatMap((fallbacks) =>
+    [false, true].map((envRef) => ({
+      name: `allows root-array replacement ${JSON.stringify(fallbacks)} (env ref: ${envRef})`,
+      current: {
+        agents: {
+          defaults: {
+            model: { primary: "fixture/primary", fallbacks: ["fixture/root"] },
+            maxConcurrent: 16,
+          },
+        },
+      },
+      source: {
+        agents: {
+          defaults: { model: { primary: "fixture/primary", fallbacks: ["fixture/root"] } },
+        },
+      },
+      before: envRef
+        ? {
+            agents: {
+              defaults: { model: { primary: "fixture/primary", fallbacks: ["fixture/root"] } },
+            },
+          }
+        : undefined,
+      authored: {
+        agents: {
+          $include: "./agents.json",
+          defaults: { model: { fallbacks: [envRef ? "${FALLBACK}" : "fixture/root"] } },
+        },
+      },
+      next: {
+        agents: {
+          defaults: { model: { primary: "fixture/primary", fallbacks }, maxConcurrent: 16 },
+        },
+      },
+      expected: { agents: { $include: "./agents.json", defaults: { model: { fallbacks } } } },
+    })),
+  ),
+  {
+    name: "rejects edits to arrays composed from both root and included values",
+    current: {
+      agents: { defaults: { model: { fallbacks: ["fixture/included", "fixture/root"] } } },
+    },
+    authored: {
+      agents: {
+        $include: "./agents.json",
+        defaults: { model: { fallbacks: ["fixture/root"] } },
+      },
+    },
+    next: { agents: { defaults: { model: { fallbacks: ["fixture/root"] } } } },
+    error: "Config write would flatten $include-owned config at agents",
+  },
+  {
+    name: "does not infer array ownership from a normalized baseline that dropped included values",
+    before: {
+      agents: { defaults: { model: { fallbacks: ["fixture/included", "fixture/root"] } } },
+    },
+    current: { agents: { defaults: { model: { fallbacks: ["fixture/root"] } } } },
+    authored: {
+      agents: { $include: "./agents.json", defaults: { model: { fallbacks: ["fixture/root"] } } },
+    },
+    next: { agents: { defaults: { model: { fallbacks: [] } } } },
+    error: "Config write would flatten $include-owned config at agents",
+  },
+  {
+    name: "rejects replacing root arrays that contain nested includes",
+    before: { agents: { defaults: { model: { fallbacks: ["fixture/root"] } } } },
+    current: { agents: { defaults: { model: { fallbacks: ["fixture/root"] } } } },
+    authored: {
+      agents: {
+        $include: "./agents.json",
+        defaults: { model: { fallbacks: [{ $include: "./fallback.json" }] } },
+      },
+    },
+    next: { agents: { defaults: { model: { fallbacks: [] } } } },
+    error: "Config write would flatten $include-owned config at agents",
+  },
   {
     name: "preserves include-owned array entries across runtime-only normalization",
     current: {
@@ -718,6 +803,119 @@ describe("config io write prepare", () => {
     const persisted = resolveWriteCase(testCase);
     expect(persisted).toEqual(testCase.expected);
     testCase.verify?.(persisted);
+  });
+
+  it.each(
+    ["root", "agents"].flatMap((includeAt) =>
+      [true, false].map((authoredDefaults) => ({ includeAt, authoredDefaults })),
+    ),
+  )(
+    "preserves explicit sibling intent beside a $includeAt include (authored defaults: $authoredDefaults)",
+    ({ includeAt, authoredDefaults }) => {
+      const authoredAgents = {
+        ownership: "explicit",
+        ...(authoredDefaults ? { defaults: { workspace: "/old" } } : {}),
+        entries: { main: {}, spare: {} },
+      };
+      const rootAuthoredConfig =
+        includeAt === "root"
+          ? { $include: "./base.json", agents: authoredAgents }
+          : { agents: { $include: "./base.json", ...authoredAgents } };
+      const sourceConfig = {
+        agents: {
+          ...authoredAgents,
+          defaults: { ...authoredAgents.defaults, model: { primary: "fixture/primary" } },
+        },
+      };
+      const runtimeConfig = {
+        commands: { restart: true },
+        agents: {
+          ...sourceConfig.agents,
+          defaults: { ...sourceConfig.agents.defaults, maxConcurrent: 16 },
+        },
+      };
+      const entries = { ...authoredAgents.entries, worker: {} };
+      expect(
+        resolvePersistCandidateForWrite({
+          sourceConfig,
+          rootAuthoredConfig,
+          runtimeConfig,
+          nextConfig: { ...runtimeConfig, agents: { ...runtimeConfig.agents, entries } },
+          explicitSetPaths: [
+            ["agents", "entries"],
+            ["agents", "defaults", "maxConcurrent"],
+            ["commands", "restart"],
+          ],
+          allowIncludeAncestorExplicitSetPaths: true,
+        }),
+      ).toEqual({
+        ...rootAuthoredConfig,
+        commands: { restart: true },
+        agents: {
+          ...rootAuthoredConfig.agents,
+          entries,
+          defaults: { ...authoredAgents.defaults, maxConcurrent: 16 },
+        },
+      });
+    },
+  );
+
+  it.each(
+    [
+      { name: "included", authored: undefined, resolved: ["included"], allowed: false },
+      { name: "mixed", authored: ["root"], resolved: ["included", "root"], allowed: false },
+      { name: "root-owned", authored: ["root"], resolved: ["root"], allowed: true },
+      { name: "empty include", authored: undefined, resolved: [], allowed: true },
+    ].flatMap((testCase) =>
+      ["array", "parent", "index"]
+        .filter((kind) => kind !== "index" || testCase.resolved.length > 0)
+        .map((kind) => ({ testCase, kind })),
+    ),
+  )("checks $testCase.name array ownership for explicit $kind writes", ({ testCase, kind }) => {
+    const sourceConfig = {
+      agents: { defaults: { model: { fallbacks: testCase.resolved } }, entries: { main: {} } },
+    };
+    const rootAuthoredConfig = {
+      agents: {
+        $include: "./agents.json",
+        entries: { main: {} },
+        ...(testCase.authored ? { defaults: { model: { fallbacks: testCase.authored } } } : {}),
+      },
+    };
+    const write = () =>
+      resolvePersistCandidateForWrite({
+        sourceConfig,
+        sourceConfigBeforeMigrations: sourceConfig,
+        runtimeConfig: sourceConfig,
+        rootAuthoredConfig,
+        nextConfig: { agents: { ...sourceConfig.agents, entries: { main: {}, worker: {} } } },
+        explicitSetPaths: [
+          ["agents", "entries"],
+          kind === "parent"
+            ? ["agents", "defaults"]
+            : [
+                "agents",
+                "defaults",
+                "model",
+                "fallbacks",
+                ...(kind === "index" ? [String(testCase.resolved.length - 1)] : []),
+              ],
+        ],
+        allowIncludeAncestorExplicitSetPaths: true,
+      });
+    const persisted = write();
+    expect(persisted).toMatchObject({
+      agents: {
+        $include: "./agents.json",
+        entries: { main: {}, worker: {} },
+      },
+    });
+    const authored = testCase.allowed ? testCase.resolved : testCase.authored;
+    if (authored === undefined) {
+      expect(persisted).not.toHaveProperty("agents.defaults.model.fallbacks");
+    } else {
+      expect(persisted).toHaveProperty("agents.defaults.model.fallbacks", authored);
+    }
   });
 
   it("uses recorded facts instead of placeholder-shaped roster bytes", () => {
@@ -1001,12 +1199,13 @@ describe("config io write prepare", () => {
   it("leaves untouched retired model maps for doctor instead of normalizing unrelated writes", () => {
     const retired = "google/gemini-3-pro-preview";
     const canonical = "google/gemini-3.1-pro-preview";
+    const entry = { alias: "Gemini", params: { temperature: 0.2 } };
     const sourceConfig = {
-      agents: { defaults: { models: { [retired]: { alias: "Gemini" } } } },
+      agents: { defaults: { models: { [retired]: entry } } },
       gateway: { port: 18789 },
     };
     const runtimeConfig = {
-      agents: { defaults: { models: { [canonical]: { alias: "Gemini" } } } },
+      agents: { defaults: { models: { [canonical]: entry } } },
       gateway: { port: 18789 },
     };
 
@@ -1017,7 +1216,7 @@ describe("config io write prepare", () => {
         nextConfig: { ...runtimeConfig, gateway: { port: 18888 } },
       }),
     ).toEqual({
-      agents: { defaults: { models: { [retired]: { alias: "Gemini" } } } },
+      agents: { defaults: { models: { [retired]: entry } } },
       gateway: { port: 18888 },
     });
   });
@@ -1025,11 +1224,12 @@ describe("config io write prepare", () => {
   it("canonicalizes an explicitly persisted model-map path even when runtime values are equal", () => {
     const retired = "google/gemini-3-pro-preview";
     const canonical = "google/gemini-3.1-pro-preview";
+    const entry = { alias: "Gemini", params: { temperature: 0.2 } };
     const sourceConfig = {
-      agents: { defaults: { models: { [retired]: { alias: "Gemini" } } } },
+      agents: { defaults: { models: { [retired]: entry } } },
     };
     const runtimeConfig = {
-      agents: { defaults: { models: { [canonical]: { alias: "Gemini" } } } },
+      agents: { defaults: { models: { [canonical]: entry } } },
     };
 
     expect(
@@ -1040,6 +1240,37 @@ describe("config io write prepare", () => {
         explicitSetPaths: [["agents", "defaults", "models"]],
       }),
     ).toEqual(runtimeConfig);
+  });
+
+  it("preserves untouched model rows that share a runtime identity", () => {
+    const shorthand = "google/gemini-3.1-pro";
+    const canonical = "google/gemini-3.1-pro-preview";
+    const sourceConfig = {
+      agents: {
+        defaults: {
+          models: {
+            [shorthand]: { alias: "Shorthand", params: { temperature: 0.2 } },
+            [canonical]: { alias: "Canonical", params: { topP: 0.8 } },
+          },
+        },
+      },
+    };
+    const runtimeConfig = {
+      agents: {
+        defaults: {
+          models: {
+            [canonical]: { alias: "Canonical", params: { temperature: 0.2, topP: 0.8 } },
+          },
+        },
+      },
+    };
+    expect(
+      resolvePersistCandidateForWrite({
+        sourceConfig,
+        runtimeConfig,
+        nextConfig: { ...runtimeConfig, gateway: { port: 18888 } },
+      }),
+    ).toEqual({ ...sourceConfig, gateway: { port: 18888 } });
   });
 
   it("canonicalizes only the model identity selected by an explicit descendant path", () => {

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -64,21 +64,28 @@ function hasOwnValidIncludeDirective(value: unknown): value is Record<string, un
   );
 }
 
-function collectIncludeOwnedPaths(value: unknown, path: string[] = []): string[][] {
-  if (Array.isArray(value)) {
-    return value.flatMap((child, index) =>
-      collectIncludeOwnedPaths(child, [...path, String(index)]),
-    );
-  }
-  if (!isRecord(value)) {
+function collectConfigPaths(
+  value: unknown,
+  path: string[],
+  matches: (value: unknown) => boolean,
+  skip?: (path: string[]) => boolean,
+): string[][] {
+  if (skip?.(path)) {
     return [];
   }
-  if (hasOwnValidIncludeDirective(value)) {
+  if (matches(value)) {
     return [path];
   }
+  if (!Array.isArray(value) && !isRecord(value)) {
+    return [];
+  }
   return Object.entries(value).flatMap(([key, child]) =>
-    collectIncludeOwnedPaths(child, [...path, key]),
+    collectConfigPaths(child, [...path, key], matches, skip),
   );
+}
+
+function collectIncludeOwnedPaths(value: unknown, path: string[] = []): string[][] {
+  return collectConfigPaths(value, path, hasOwnValidIncludeDirective);
 }
 
 function collectMutableSiblingPathsAtInclude(rootAuthoredConfig: unknown, includePath: string[]) {
@@ -113,8 +120,10 @@ function isMutableSiblingPathAtInclude(
   );
 }
 
-function formatConfigPath(path: string[]): string {
-  return path.length > 0 ? path.join(".") : "<root>";
+function createIncludeWriteError(path: string[]): Error {
+  return new Error(
+    `Config write would flatten $include-owned config at ${path.length > 0 ? path.join(".") : "<root>"}; edit that include file directly or remove the $include first.`,
+  );
 }
 
 function findContainingArrayPath(root: unknown, path: string[]): string[] | undefined {
@@ -218,16 +227,6 @@ function pathOverlapsAny(path: string[], candidates: readonly string[][] | undef
       (candidate) => pathStartsWith(path, candidate) || pathStartsWith(candidate, path),
     ),
   );
-}
-
-function isIncludeOwnedPath(rootAuthoredConfig: unknown, path: string[]): boolean {
-  return collectIncludeOwnedPaths(rootAuthoredConfig).some((includePath) => {
-    const overlapsInclude = pathStartsWith(path, includePath) || pathStartsWith(includePath, path);
-    if (!overlapsInclude) {
-      return false;
-    }
-    return !isMutableSiblingPathAtInclude(rootAuthoredConfig, includePath, path);
-  });
 }
 
 function findOverlappingIncludeOwnedPath(
@@ -398,7 +397,7 @@ function preserveSourceValueAtPath(params: {
   if (pathOverlapsAny(params.path, params.unsetPaths)) {
     return params.persistedCandidate;
   }
-  if (isIncludeOwnedPath(params.rootAuthoredConfig, params.path)) {
+  if (findOverlappingIncludeOwnedPath(params.rootAuthoredConfig, params.path)) {
     return params.persistedCandidate;
   }
   if (getPathValue(params.nextConfig, params.path) !== undefined) {
@@ -459,24 +458,12 @@ function preserveAuthoredAgentParams(params: {
     ) {
       continue;
     }
-    const paramsPath = [...modelPath, "params"];
-    if (modelPath.at(-1) !== modelId) {
-      next = deletePathValue(next, ["agents", "defaults", "models", modelId]);
-    }
-    if (getPathValue(next, modelPath) === undefined) {
-      next = preserveSourceValueAtPath({
-        ...params,
-        persistedCandidate: next,
-        path: modelPath,
-        sourceValue: modelEntry,
-      });
-      continue;
-    }
+    const preserveModel = getPathValue(next, modelPath) === undefined;
     next = preserveSourceValueAtPath({
       ...params,
       persistedCandidate: next,
-      path: paramsPath,
-      sourceValue: modelEntry.params,
+      path: preserveModel ? modelPath : [...modelPath, "params"],
+      sourceValue: preserveModel ? modelEntry : modelEntry.params,
     });
   }
   return next;
@@ -487,9 +474,22 @@ type IncludeSiblingProjection =
   | { ok: true; present: true; value: unknown }
   | { ok: false };
 
+function isRootOwnedArray(authored: unknown, baseline: unknown, sourceBeforeMigrations: unknown) {
+  // Includes concatenate; env resolution preserves slots. Only the pre-migration
+  // length can prove sole root ownership when authored and resolved bytes differ.
+  return (
+    (authored === undefined || Array.isArray(authored)) &&
+    collectIncludeOwnedPaths(authored).length === 0 &&
+    (Array.isArray(sourceBeforeMigrations)
+      ? (authored?.length ?? 0) === sourceBeforeMigrations.length
+      : Array.isArray(authored) && isDeepStrictEqual(authored, baseline))
+  );
+}
+
 function projectRootAuthoredIncludeSibling(params: {
   authored: unknown;
   baseline: unknown;
+  sourceBeforeMigrations: unknown;
   next: unknown;
   baselinePresent: boolean;
   nextPresent: boolean;
@@ -513,9 +513,13 @@ function projectRootAuthoredIncludeSibling(params: {
     return { ok: false };
   }
   if (Array.isArray(params.authored)) {
-    return Array.isArray(params.next)
-      ? { ok: false }
-      : { ok: true, present: true, value: structuredClone(params.next) };
+    return (
+      Array.isArray(params.next)
+        ? isRootOwnedArray(params.authored, params.baseline, params.sourceBeforeMigrations)
+        : collectIncludeOwnedPaths(params.authored).length === 0
+    )
+      ? { ok: true, present: true, value: structuredClone(params.next) }
+      : { ok: false };
   }
   if (!isRecord(params.authored)) {
     return { ok: true, present: true, value: structuredClone(params.next) };
@@ -564,6 +568,7 @@ function projectRootAuthoredIncludeSibling(params: {
     const projected = projectRootAuthoredIncludeSibling({
       authored: authoredPresent ? params.authored[key] : {},
       baseline: params.baseline[key],
+      sourceBeforeMigrations: getPathValue(params.sourceBeforeMigrations, [key]),
       next: params.next[key],
       baselinePresent,
       nextPresent,
@@ -583,6 +588,7 @@ function projectRootAuthoredIncludeSibling(params: {
 function preserveUntouchedIncludes(params: {
   runtimeConfig: unknown;
   sourceConfig: unknown;
+  sourceConfigBeforeMigrations?: unknown;
   nextConfig: unknown;
   rootAuthoredConfig: unknown;
   persistedCandidate: unknown;
@@ -610,11 +616,7 @@ function preserveUntouchedIncludes(params: {
       getPathValue(params.runtimeConfig, comparisonPath),
     );
     if (!isDeepStrictEqual(nextValue, sourceValue) && !isDeepStrictEqual(nextValue, runtimeValue)) {
-      throw new Error(
-        `Config write would flatten $include-owned config at ${formatConfigPath(
-          includePath,
-        )}; edit that include file directly or remove the $include first.`,
-      );
+      throw createIncludeWriteError(includePath);
     }
     if (includeIsArrayEntry) {
       const index = parseArrayIndexPathSegment(includePath.at(-1) ?? "");
@@ -628,22 +630,20 @@ function preserveUntouchedIncludes(params: {
           hasNewEquivalentArraySibling(sourceArray, nextArray, index) ||
           hasNewEquivalentArraySibling(runtimeArray, nextArray, index))
       ) {
-        throw new Error(
-          `Config write would flatten $include-owned config at ${formatConfigPath(
-            includePath,
-          )}; edit that include file directly or remove the $include first.`,
-        );
+        throw createIncludeWriteError(includePath);
       }
     }
     let authoredIncludeValue = getPathValue(params.rootAuthoredConfig, includePath);
     for (const siblingPath of mutableSiblingPaths) {
       const relativeSiblingPath = siblingPath.slice(includePath.length);
-      const nextPresent = hasPathValue(params.nextConfig, siblingPath);
+      // Reuse the source projection so unchanged runtime defaults never become authored siblings.
+      const nextPresent = hasPathValue(params.persistedCandidate, siblingPath);
       const projectAgainst = (baselineConfig: unknown) =>
         projectRootAuthoredIncludeSibling({
           authored: getPathValue(params.rootAuthoredConfig, siblingPath),
           baseline: getPathValue(baselineConfig, siblingPath),
-          next: getPathValue(params.nextConfig, siblingPath),
+          sourceBeforeMigrations: getPathValue(params.sourceConfigBeforeMigrations, siblingPath),
+          next: getPathValue(params.persistedCandidate, siblingPath),
           baselinePresent: hasPathValue(baselineConfig, siblingPath),
           nextPresent,
         });
@@ -652,11 +652,7 @@ function preserveUntouchedIncludes(params: {
         ? sourceProjection
         : projectAgainst(params.runtimeConfig);
       if (!projection.ok) {
-        throw new Error(
-          `Config write would flatten $include-owned config at ${formatConfigPath(
-            includePath,
-          )}; edit that include file directly or remove the $include first.`,
-        );
+        throw createIncludeWriteError(includePath);
       }
       authoredIncludeValue = projection.present
         ? setPathValue(authoredIncludeValue, relativeSiblingPath, projection.value)
@@ -696,6 +692,10 @@ function mergeMissingExplicitValues(
   changed: boolean;
   value: unknown;
 } {
+  // Explicit ancestor writes must not copy resolved descendants back into preserved includes.
+  if (hasOwnValidIncludeDirective(currentValue)) {
+    return { changed: false, value: currentValue };
+  }
   if (!isRecord(currentValue) || !isRecord(explicitValue)) {
     if (!Array.isArray(currentValue) || !Array.isArray(explicitValue)) {
       return { changed: false, value: currentValue };
@@ -743,6 +743,9 @@ function mergeMissingExplicitValues(
 function injectExplicitlySetPaths(params: {
   valueSource: unknown;
   persistedCandidate: unknown;
+  runtimeConfig: unknown;
+  sourceConfig: unknown;
+  sourceConfigBeforeMigrations?: unknown;
   explicitSetPaths?: readonly (readonly string[])[];
   rootAuthoredConfig?: unknown;
   preserveDescendantIncludes?: boolean;
@@ -752,8 +755,9 @@ function injectExplicitlySetPaths(params: {
     return params.persistedCandidate;
   }
 
+  const includePaths = collectIncludeOwnedPaths(params.rootAuthoredConfig);
   let next = params.persistedCandidate;
-  for (const path of params.explicitSetPaths) {
+  explicitPath: for (const path of params.explicitSetPaths) {
     if (path.length === 0 || path.some(isBlockedObjectKey)) {
       continue;
     }
@@ -771,15 +775,54 @@ function injectExplicitlySetPaths(params: {
       pathStartsWith(path, includeOwnedPath) &&
       params.allowIncludeAncestorExplicitSetPaths === true;
     if (includeOwnedPath && !preserveDescendantInclude && !allowIncludeAncestorOverride) {
-      throw new Error(
-        `Config write would flatten $include-owned config at ${formatConfigPath(
-          includeOwnedPath,
-        )}; edit that include file directly or remove the $include first.`,
-      );
+      throw createIncludeWriteError(includeOwnedPath);
     }
-    const nextValue = getPathValue(params.valueSource, [...path]);
+    let nextValue = getPathValue(params.valueSource, [...path]);
     if (nextValue === undefined) {
       continue;
+    }
+    const arrayPaths =
+      includePaths.length > 0
+        ? [
+            ...path.flatMap((_, index) => {
+              const parent = path.slice(0, index);
+              return Array.isArray(getPathValue(params.valueSource, parent)) ? [parent] : [];
+            }),
+            ...collectConfigPaths(nextValue, [...path], Array.isArray, (candidatePath) =>
+              hasOwnValidIncludeDirective(getPathValue(next, candidatePath)),
+            ),
+          ]
+        : [];
+    for (const arrayPath of arrayPaths) {
+      const owner = includePaths.find((includePath) => pathStartsWith(arrayPath, includePath));
+      if (
+        owner &&
+        !isRootOwnedArray(
+          getPathValue(params.rootAuthoredConfig, arrayPath),
+          getPathValue(params.sourceConfig, arrayPath),
+          getPathValue(params.sourceConfigBeforeMigrations, arrayPath),
+        )
+      ) {
+        const valuePath = arrayPath.length < path.length ? [...path] : arrayPath;
+        const requested = getPathValue(params.valueSource, valuePath);
+        if (
+          !isDeepStrictEqual(requested, getPathValue(params.sourceConfig, valuePath)) &&
+          !isDeepStrictEqual(requested, getPathValue(params.runtimeConfig, valuePath))
+        ) {
+          throw createIncludeWriteError(owner);
+        }
+        // An already-satisfied write retains the authored contribution; copying the
+        // composed array (or its index) would concatenate included entries again.
+        if (arrayPath.length <= path.length) {
+          continue explicitPath;
+        }
+        const retained = getPathValue(next, arrayPath);
+        const relativePath = arrayPath.slice(path.length);
+        nextValue =
+          retained === undefined
+            ? deletePathValue(nextValue, relativePath)
+            : setPathValue(nextValue, relativePath, retained);
+      }
     }
     if (!hasPathValue(next, path)) {
       next = setPathValueCreatingParents(next, [...path], nextValue);
@@ -1527,9 +1570,7 @@ export function resolvePersistCandidateForWrite(params: {
   if (includeOwnsRoster) {
     // Canonical roster writes replace the whole roster atomically. Any included contribution
     // therefore owns this boundary; flattening only its root-authored siblings is not safe.
-    throw new Error(
-      "Config write would flatten $include-owned config at agents; edit that include file directly or remove the $include first.",
-    );
+    throw createIncludeWriteError(["agents"]);
   }
   const projectedAuthoredRoster = persistCanonicalRoster
     ? projectAuthoredAgentRosterForWrite({
@@ -1545,18 +1586,8 @@ export function resolvePersistCandidateForWrite(params: {
           toAgentEntriesRecord(listAgentEntries(params.sourceConfig as OpenClawConfig)),
         )
       : projectedAuthoredRoster;
-  let persistedBase = preserveUntouchedIncludes({
-    runtimeConfig: params.runtimeConfig,
-    sourceConfig: params.sourceConfig,
-    nextConfig: params.nextConfig,
-    rootAuthoredConfig: includeProjectionRootAuthoredConfig,
-    persistedCandidate: applyMergePatch(projectedSource, patch),
-  });
   const explicitSetPaths = persistCanonicalRoster
-    ? [
-        ...(params.explicitSetPaths ?? []).filter((path) => !pathTargetsAgentRoster(path)),
-        ["agents", "entries"],
-      ]
+    ? params.explicitSetPaths?.filter((path) => !pathTargetsAgentRoster(path))
     : params.explicitSetPaths;
   const explicitSetValueSource = persistCanonicalRoster
     ? canonicalizeAgentRosterForExplicitWrite({
@@ -1570,35 +1601,42 @@ export function resolvePersistCandidateForWrite(params: {
         unsetPaths: params.unsetPaths,
       })
     : (params.explicitSetValueSource ?? params.nextConfig);
+  let persistedBase = applyMergePatch(projectedSource, patch);
   if (persistCanonicalRoster) {
     persistedBase = deletePathValue(persistedBase, ["agents", "entries"]);
     persistedBase = deletePathValue(persistedBase, ["agents", "list"]);
+    const entries = getPathValue(explicitSetValueSource, ["agents", "entries"]);
+    if (entries !== undefined) {
+      persistedBase = setPathValueCreatingParents(persistedBase, ["agents", "entries"], entries);
+    }
   }
+  const withPreservedIncludes = preserveUntouchedIncludes({
+    runtimeConfig: params.runtimeConfig,
+    sourceConfig: params.sourceConfig,
+    sourceConfigBeforeMigrations: params.sourceConfigBeforeMigrations,
+    nextConfig: params.nextConfig,
+    rootAuthoredConfig: includeProjectionRootAuthoredConfig,
+    persistedCandidate: persistedBase,
+  });
+  // Structural reconstruction finishes first so it cannot discard later explicit sibling writes.
   const persisted = injectExplicitlySetPaths({
     valueSource: explicitSetValueSource,
-    persistedCandidate: persistedBase,
+    persistedCandidate: withPreservedIncludes,
+    runtimeConfig: params.runtimeConfig,
+    sourceConfig: params.sourceConfig,
+    sourceConfigBeforeMigrations: params.sourceConfigBeforeMigrations,
     explicitSetPaths,
     rootAuthoredConfig: includeProjectionRootAuthoredConfig,
-    // This only postpones descendant include validation: the preservation pass below
-    // compares next against source/runtime and still rejects every changed include subtree.
+    // Includes were validated and restored above; ancestor merges retain their directives.
     preserveDescendantIncludes: persistCanonicalRoster,
     allowIncludeAncestorExplicitSetPaths: params.allowIncludeAncestorExplicitSetPaths,
   });
-  const withPreservedIncludes = persistCanonicalRoster
-    ? preserveUntouchedIncludes({
-        runtimeConfig: params.runtimeConfig,
-        sourceConfig: params.sourceConfig,
-        nextConfig: params.nextConfig,
-        rootAuthoredConfig: includeProjectionRootAuthoredConfig,
-        persistedCandidate: persisted,
-      })
-    : persisted;
   const preserveAuthoredRoster =
     canCanonicalizeAgentRoster(params.nextConfig) || params.preserveLegacyAgentRoster === true;
   const withAuthoredRoster =
     persistCanonicalRoster || !preserveAuthoredRoster
-      ? withPreservedIncludes
-      : restoreAuthoredAgentRoster(withPreservedIncludes, rootAuthoredConfig);
+      ? persisted
+      : restoreAuthoredAgentRoster(persisted, rootAuthoredConfig);
   if (persistCanonicalRoster) {
     // A roster rewrite must never drop entries the mutation did not explicitly delete.
     // A 2026-07-25 production incident lost agents.entries.main twice through silent rewrites.

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -1578,6 +1578,13 @@ export function resolvePersistCandidateForWrite(params: {
         sourceConfigBeforeMigrations: params.sourceConfigBeforeMigrations,
       })
     : rootAuthoredConfig;
+  // Include paths and their recorded evidence need the same roster coordinates.
+  // Reindex the pre-migration source without migrating its field values.
+  const includeProjectionSourceBeforeMigrations = persistCanonicalRoster
+    ? projectAuthoredAgentRosterForWrite({
+        rootAuthoredConfig: params.sourceConfigBeforeMigrations,
+      })
+    : params.sourceConfigBeforeMigrations;
   const includeProjectionRootAuthoredConfig =
     persistCanonicalRoster && !hasAgentRosterProperty(projectedAuthoredRoster)
       ? setPathValueCreatingParents(
@@ -1613,7 +1620,7 @@ export function resolvePersistCandidateForWrite(params: {
   const withPreservedIncludes = preserveUntouchedIncludes({
     runtimeConfig: params.runtimeConfig,
     sourceConfig: params.sourceConfig,
-    sourceConfigBeforeMigrations: params.sourceConfigBeforeMigrations,
+    sourceConfigBeforeMigrations: includeProjectionSourceBeforeMigrations,
     nextConfig: params.nextConfig,
     rootAuthoredConfig: includeProjectionRootAuthoredConfig,
     persistedCandidate: persistedBase,
@@ -1624,7 +1631,7 @@ export function resolvePersistCandidateForWrite(params: {
     persistedCandidate: withPreservedIncludes,
     runtimeConfig: params.runtimeConfig,
     sourceConfig: params.sourceConfig,
-    sourceConfigBeforeMigrations: params.sourceConfigBeforeMigrations,
+    sourceConfigBeforeMigrations: includeProjectionSourceBeforeMigrations,
     explicitSetPaths,
     rootAuthoredConfig: includeProjectionRootAuthoredConfig,
     // Includes were validated and restored above; ancestor merges retain their directives.


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Configuration updates could lose authored model aliases or parameters, discard explicit settings beside `$include`, or reject root-owned arrays. Explicit writes could also duplicate composed arrays on reload. These cases affect plugin migration writes, combined roster/settings changes, and Doctor's legacy-agent migration.

## Why This Change Was Made

Finish roster and include reconstruction once, then apply explicit settings. Keep model-key normalization with the touched-model owner. Projection and explicit copying share array ownership derived from the recorded pre-migration source; the writer reindexes that evidence when legacy agent lists move to canonical entries, without migrating its field values.

Already-satisfied array, object and index writes retain their authored contribution. Actual changes to included or mixed array contributions remain protected. Duplicate preservation, traversal and error-construction paths were removed.

## User Impact

Unrelated updates preserve model metadata. Root-owned arrays remain editable, including environment-backed arrays. Explicit settings survive combined roster writes, and Doctor preserves nested includes and environment references while migrating legacy agents. Catalog-suppressed models still require explicit repair.

## Evidence

- Final correction passes 149 focused tests: all 128 writer cases and the unchanged 21-case Doctor legacy-composition suite. Earlier component verification also covered include resolution, mutation and migration siblings.
- All 33 production filesystem mutation/reload scenarios pass again on the final source, including successful unchanged array/object/index writes and unsafe replacements refusing without modifying either file.
- A separate real Doctor configuration flow reproduced the CI failure before repair, then passed migration → atomic write → disk/reload → second no-op, preserving both include files and authored environment references.
- Independent P2 review and the complete changed gate pass. Writer source SHA256: `299f5072b866a4a127a2b5d6a26c501f5395c2e3fa008abedf670e5e0289e4e1`; final head: `c5325345b532beea56227d5e85c8bef8abf5e683`.
- Production delta: +45; tests: +231. Remaining growth enforces ownership during explicit copying and aligns ownership evidence with canonical roster paths.

The initial hosted run caught the legacy-list/include coordinate regression; the existing test and real Doctor flow now pass. [Fresh exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34024743909) on `c5325345b532beea56227d5e85c8bef8abf5e683`. Single-agent to multi-agent topology expansion under an include retains its existing refusal, verified on the base; supported explicit multi-agent roster changes are covered.
