### PR TITLE
fix: preserve models when OAuth preparation fails

### DIFF
--- a/docs/auth-credential-semantics.md
+++ b/docs/auth-credential-semantics.md
@@ -91,6 +91,11 @@ catalog discovery. Configured subscription modes remain attached to direct
 credentials, and successful OAuth preparation supplies the resolved current token
 to its catalog consumer rather than the captured store's older token.
 
+When every eligible OAuth candidate fails preparation, discovery reports
+`unavailable` with the attempted profile identities instead of treating the
+provider as unconfigured. Compatible prior inventory remains available. A usable
+fallback credential still supplies its own catalog result.
+
 API-key-oriented and full-auth catalog callbacks retain their existing source
 priorities. Plugins must keep credential bytes and their authentication mode from
 the same selection. Catalog failure and recovery preserve the

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -306,6 +306,13 @@ catalog, API-key auth, and dynamic model resolution.
     authentication scheme; a separate `resolveProviderAuth()` call may select a
     different profile. Omitted mode metadata does not change existing callback behavior.
 
+    `ctx.resolveProviderAuth()` may set `preparationFailed: true` when OAuth
+    preparation exhausted its candidates. Do not treat that flag as absent
+    configuration or restart resolution of the same profiles. A hook may still
+    choose another credential source. Its returned provider configuration or
+    explicit outcome remains authoritative; otherwise the catalog owner reports
+    the consumed preparation failure with the attempted profile identities.
+
     For a non-Bearer or nonstandard list endpoint, pass options instead of
     `true`:
 

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -938,6 +938,9 @@ export function buildOpenAIProvider(): ProviderPlugin {
           return null;
         }
         const auth = ctx.resolveProviderAuth(PROVIDER_ID);
+        if (auth.preparationFailed) {
+          return null;
+        }
         const { resolveApiKeyForProvider, resolveProviderAuthProfileMetadata } =
           await import("openclaw/plugin-sdk/provider-auth-runtime");
         let runtimeAuth: Awaited<ReturnType<typeof resolveApiKeyForProvider>> | undefined;

--- a/src/agents/models-config.providers.catalog-context.ts
+++ b/src/agents/models-config.providers.catalog-context.ts
@@ -1,10 +1,18 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
-import type { runProviderCatalog } from "../plugins/provider-discovery.js";
+import type {
+  ProviderCatalogOutcome,
+  ProviderCatalogResult,
+} from "../plugins/provider-catalog.types.js";
+import {
+  normalizePluginDiscoveryResult,
+  type runProviderCatalog,
+} from "../plugins/provider-discovery.js";
 import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
 import { isTrustedSecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { ProviderConfig } from "./models-config.providers.secret-helpers.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 type CatalogContext = {
   config?: OpenClawConfig;
@@ -35,7 +43,12 @@ export async function prepareProviderCatalogRun(
     isActive: () => boolean;
     timeoutMs?: number | null;
   },
-): Promise<Parameters<typeof runProviderCatalog>[0] & { timeoutMs?: number | null }> {
+): Promise<
+  Parameters<typeof runProviderCatalog>[0] & {
+    timeoutMs?: number | null;
+    finalizeCatalogResult?: (result: ProviderCatalogResult) => ProviderCatalogResult;
+  }
+> {
   const { authStore, isActive, ...catalogParams } = params;
   if (
     !params.provider.auth.some((method) => method.kind === "oauth") ||
@@ -50,18 +63,60 @@ export async function prepareProviderCatalogRun(
   // materialization unless this catalog's selected credential is expiring OAuth.
   const { prepareProviderCatalogOAuthAuth } =
     await import("./models-config.providers.discovery-auth.runtime.js");
+  const failedProfileIds = new Set<string>();
+  const reportedOutcomes: ProviderCatalogOutcome[] = [];
   return {
     ...catalogParams,
+    reportCatalogOutcome: (outcome) => {
+      reportedOutcomes.push({ ...outcome });
+      params.reportCatalogOutcome?.(outcome);
+    },
     resolveProviderAuth: await prepareProviderCatalogOAuthAuth(
       {
         agentDir: params.agentDir,
         authStore,
+        env: params.env,
         provider: params.provider.id,
         resolveProviderAuth: params.resolveProviderAuth,
         isActive,
+        onPreparationFailure: (profileIds) => {
+          for (const profileId of profileIds) {
+            failedProfileIds.add(profileId);
+          }
+        },
       },
       params.config,
     ),
+    finalizeCatalogResult: (result) => {
+      if (failedProfileIds.size === 0) {
+        return result;
+      }
+      const providers = normalizePluginDiscoveryResult({ provider: params.provider, result });
+      const providersWithOutcomes = new Set(
+        reportedOutcomes.map((outcome) => normalizeProviderId(outcome.provider)),
+      );
+      const aliasContext = { config: params.config, env: params.env };
+      const authProvider = resolveProviderIdForAuth(params.provider.id, aliasContext);
+      for (const provider of params.providerIds ?? [params.provider.id]) {
+        const normalized = normalizeProviderId(provider);
+        if (
+          resolveProviderIdForAuth(provider, aliasContext) !== authProvider ||
+          providers[normalized] ||
+          providersWithOutcomes.has(normalized)
+        ) {
+          continue;
+        }
+        // A plugin's selected result wins; only otherwise-unreported exhaustion
+        // carries every attempted profile into compatible inventory retention.
+        for (const profileId of failedProfileIds) {
+          const outcome: ProviderCatalogOutcome = { provider, profileId, status: "unavailable" };
+          reportedOutcomes.push(outcome);
+          params.reportCatalogOutcome?.(outcome);
+        }
+      }
+      // Carry the accepted snapshot forward without evaluating plugin getters again.
+      return result ? { providers, outcomes: reportedOutcomes } : result;
+    },
   };
 }
 

--- a/src/agents/models-config.providers.discovery-auth.runtime.ts
+++ b/src/agents/models-config.providers.discovery-auth.runtime.ts
@@ -10,6 +10,7 @@ import type {
   ProviderApiKeyResolver,
   ProviderAuthResolver,
 } from "./models-config.providers.secret-helpers.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 const unavailableDiscoveryAuthProfiles = new WeakMap<object, string>();
 
@@ -100,15 +101,19 @@ export async function prepareProviderCatalogOAuthAuth(
   {
     agentDir,
     authStore,
+    env,
     provider,
     resolveProviderAuth,
     isActive,
+    onPreparationFailure,
   }: {
     agentDir: string;
     authStore: AuthProfileStore;
+    env: NodeJS.ProcessEnv;
     provider: string;
     resolveProviderAuth: ProviderAuthResolver;
     isActive: () => boolean;
+    onPreparationFailure: (profileIds: readonly string[]) => void;
   },
   config?: OpenClawConfig,
 ) {
@@ -153,10 +158,20 @@ export async function prepareProviderCatalogOAuthAuth(
     failedProfileIds.push(auth.profileId);
   }
   return (requestedProvider?: string, options?: { oauthMarker?: string }) => {
-    const auth = resolveProviderAuth(requestedProvider?.trim() || provider, {
+    const target = requestedProvider?.trim() || provider;
+    const auth = resolveProviderAuth(target, {
       ...options,
       excludeProfileIds: failedProfileIds,
     });
+    if (
+      auth.mode === "none" &&
+      failedProfileIds.length > 0 &&
+      resolveProviderIdForAuth(target, { config, env }) ===
+        resolveProviderIdForAuth(provider, { config, env })
+    ) {
+      onPreparationFailure(failedProfileIds);
+      return { ...auth, preparationFailed: true };
+    }
     // Refresh owns a separate store; the captured catalog snapshot can still
     // contain the old token. Carry the resolved value for this exact profile.
     return preparedProfile && auth.profileId === preparedProfile.profileId

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -378,7 +378,11 @@ async function runProviderCatalogWithTimeout(
   };
   const runCatalog = async () => {
     const prepared = await prepareProviderCatalogRun(catalogParams);
-    return active ? runProviderCatalog(prepared) : undefined;
+    if (!active) {
+      return undefined;
+    }
+    const result = await runProviderCatalog(prepared);
+    return prepared.finalizeCatalogResult ? prepared.finalizeCatalogResult(result) : result;
   };
   try {
     if (!timeoutMs) {

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -59,6 +59,7 @@ export type ProviderAuthResolver = (
   mode: "api_key" | "aws-sdk" | "oauth" | "token" | "none";
   source: "env" | "profile" | "none";
   profileId?: string;
+  preparationFailed?: boolean;
 };
 
 const ENV_VAR_NAME_RE = /^[A-Z_][A-Z0-9_]*$/;

--- a/src/plugins/provider-catalog.types.ts
+++ b/src/plugins/provider-catalog.types.ts
@@ -36,6 +36,8 @@ export type ProviderCatalogContext = {
     mode: "api_key" | "aws-sdk" | "oauth" | "token" | "none";
     source: "env" | "profile" | "none";
     profileId?: string;
+    /** Credential preparation exhausted its candidates; not an unconfigured provider. */
+    preparationFailed?: boolean;
   };
 };
 

--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -10,6 +10,7 @@ import {
 import type { AuthProfileStore, OAuthCredential } from "../src/agents/auth-profiles/types.js";
 import { planOpenClawModelsJson } from "../src/agents/models-config.plan.js";
 import * as catalogContext from "../src/agents/models-config.providers.catalog-context.js";
+import { prepareModelCatalogPublication } from "../src/agents/prepared-model-runtime.full-catalog.js";
 import type { ModelProviderConfig } from "../src/config/types.models.js";
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { createTestPluginApi } from "../src/plugin-sdk/plugin-test-api.js";
@@ -39,6 +40,10 @@ describe("Provider model discovery auth preparation", () => {
     state = await createOpenClawTestState({ prefix: "catalog-auth-order-", agentEnv: "main" });
     agentDir = state.agentDir();
     discovery.providers = [buildOpenAIProvider()];
+    vi.spyOn(providerRuntime, "formatProviderAuthProfileApiKeyWithPlugin").mockImplementation(
+      async ({ provider, context }) =>
+        discovery.providers.find((candidate) => candidate.id === provider)?.formatApiKey?.(context),
+    );
   });
 
   afterEach(async () => {
@@ -82,10 +87,6 @@ describe("Provider model discovery auth preparation", () => {
           discovery.providers = [provider];
         },
       }),
-    );
-    vi.spyOn(providerRuntime, "formatProviderAuthProfileApiKeyWithPlugin").mockImplementation(
-      async ({ provider, context }) =>
-        discovery.providers.find((candidate) => candidate.id === provider)?.formatApiKey?.(context),
     );
     const profileId = "chutes:oauth";
     const config: OpenClawConfig = { auth: { order: { chutes: [profileId] } } };
@@ -355,6 +356,104 @@ describe("Provider model discovery auth preparation", () => {
   });
 
   it.each([
+    { providerId: "chutes", profileCount: 1 },
+    { providerId: "chutes", profileCount: 2 },
+    { providerId: "openai", profileCount: 1 },
+  ])(
+    "retains the $providerId catalog when all $profileCount OAuth profiles fail preparation",
+    async ({ providerId, profileCount }) => {
+      if (providerId === "chutes") {
+        chutesPlugin.register(
+          createTestPluginApi({
+            registerProvider: (provider) => {
+              discovery.providers = [provider];
+            },
+          }),
+        );
+      }
+      const profileIds = Array.from(
+        { length: profileCount },
+        (_, index) => `${providerId}:oauth-${index}`,
+      );
+      const profiles = Object.fromEntries(
+        profileIds.map((profileId) => [
+          profileId,
+          {
+            type: "oauth" as const,
+            provider: providerId,
+            access: `expired-${profileId}`,
+            refresh: `refresh-${profileId}`,
+            expires: Date.now() - 60_000,
+          },
+        ]),
+      );
+      const store: AuthProfileStore = { version: 1, profiles };
+      const config: OpenClawConfig = { auth: { order: { [providerId]: profileIds } } };
+      await state.writeAuthProfiles(store);
+      vi.spyOn(providerRuntime, "buildProviderAuthDoctorHintWithPlugin").mockResolvedValue(
+        undefined,
+      );
+      const refresh = vi
+        .spyOn(providerRuntime, "resolveProviderOAuthCredentialWithPlugin")
+        .mockRejectedValue(new Error("synthetic OAuth refresh failure"));
+      const runtimeAuth = vi.spyOn(providerAuthRuntime, "resolveApiKeyForProvider");
+      const fetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected HTTP"));
+      const outcomes: ProviderCatalogOutcome[] = [];
+      const previousProfileId = profileIds[profileIds.length - 1];
+      const previousCredential = previousProfileId && profiles[previousProfileId];
+      if (!previousProfileId || !previousCredential) {
+        throw new Error("OAuth fixture requires a previous profile");
+      }
+      const auth = {
+        authStore: store,
+        authModes: { [providerId]: "oauth" as const },
+        credentials: { [providerId]: previousCredential },
+      };
+      const priorModel = {
+        id: "prior-account-only-model",
+        name: "Prior Account Model",
+        provider: providerId,
+      };
+      const previous = prepareModelCatalogPublication(
+        {
+          entries: [priorModel],
+          routeVariants: [],
+          providerOutcomes: [
+            { provider: providerId, profileId: previousProfileId, status: "ready" },
+          ],
+        },
+        undefined,
+        auth,
+        (provider) => provider,
+      );
+
+      const plan = await planCatalog(config, store, { providerId, outcomes });
+      const published = prepareModelCatalogPublication(
+        {
+          entries: [],
+          routeVariants: [],
+          staticEntries: readPlannedProvider(plan, providerId)?.models.map((model) =>
+            Object.assign(model, { provider: providerId }),
+          ),
+          providerOutcomes: outcomes,
+        },
+        { ...previous, key: "same-config", pluginFingerprint: "same-plugins" },
+        auth,
+        (provider) => provider,
+      );
+
+      expect(published.catalog.entries).toContainEqual(priorModel);
+      expect(published.discoveryOrigins).toEqual(previous.discoveryOrigins);
+      expect(outcomes).toEqual(
+        profileIds.map((profileId) => ({ provider: providerId, profileId, status: "unavailable" })),
+      );
+      expect(refresh).toHaveBeenCalledTimes(profileCount);
+      expect(runtimeAuth).not.toHaveBeenCalled();
+      expect(fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
     { completion: "success", timedOut: true },
     { completion: "failure", timedOut: true },
     { completion: "failure", timedOut: false },
@@ -482,6 +581,85 @@ describe("Provider model discovery auth preparation", () => {
           "late-account-model",
         );
       }
+    },
+  );
+
+  it.each(["outcome", "provider"] as const)(
+    "preserves a plugin-owned %s after probing exhausted OAuth",
+    async (resultKind) => {
+      const { config, store } = await createChutesCatalogFixture();
+      const otherProfileId = "openai:other-source";
+      store.profiles[otherProfileId] = {
+        type: "api_key",
+        provider: "openai",
+        key: "independent-source-key",
+      };
+      await state.writeAuthProfiles(store);
+      vi.spyOn(providerRuntime, "buildProviderAuthDoctorHintWithPlugin").mockResolvedValue(
+        undefined,
+      );
+      vi.spyOn(providerRuntime, "resolveProviderOAuthCredentialWithPlugin").mockRejectedValue(
+        new Error("synthetic OAuth refresh failure"),
+      );
+      const fetch = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected HTTP"));
+      const provider = discovery.providers[0];
+      if (!provider) {
+        throw new Error("Chutes fixture did not register a provider");
+      }
+      const independentModel = {
+        id: "independent-source-model",
+        name: "Independent Source Model",
+        reasoning: false,
+        input: ["text" as const],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_768,
+        maxTokens: 8_192,
+      };
+      const explicitOutcome: ProviderCatalogOutcome = {
+        provider: "chutes",
+        profileId: otherProfileId,
+        status: "unavailable",
+      };
+      let reads = 0;
+      provider.catalog = {
+        order: "profile",
+        run: async (ctx) => {
+          ctx.resolveProviderAuth("CHUTES");
+          const other = ctx.resolveProviderAuth("openai");
+          expect(other.profileId).toBe(otherProfileId);
+          expect(other.preparationFailed).not.toBe(true);
+          if (resultKind === "outcome") {
+            return {
+              providers: {},
+              get outcomes() {
+                return reads++ === 0 ? [explicitOutcome] : [];
+              },
+            };
+          }
+          return {
+            get provider() {
+              return {
+                baseUrl: "https://api.chutes.ai/v1",
+                apiKey: other.apiKey,
+                models: reads++ === 0 ? [independentModel] : [],
+              };
+            },
+          };
+        },
+      };
+      const outcomes: ProviderCatalogOutcome[] = [];
+
+      const plan = await planCatalog(config, store, { providerId: "chutes", outcomes });
+
+      if (resultKind === "outcome") {
+        expect(outcomes).toEqual([explicitOutcome]);
+      } else {
+        expect(outcomes).toEqual([]);
+        expect(readPlannedProvider(plan, "chutes")?.models.map((model) => model.id)).toContain(
+          independentModel.id,
+        );
+      }
+      expect(fetch).not.toHaveBeenCalled();
     },
   );
 });


### PR DESCRIPTION
Related: #137033

Follow-up to #137120.

## What Problem This Solves

Fixes an issue where users refreshing provider models could lose their previously discovered full-catalog inventory when every eligible OAuth profile failed credential preparation. OpenAI could also restart unrestricted credential resolution after those candidates had already failed.

## Why This Change Was Made

Preserve terminal preparation failure as an optional auth-resolution fact, then report the attempted profiles through existing unavailable outcomes when the consuming plugin has not supplied its own result. OpenAI does not reinterpret that fact as unconfigured auth.

Plugin-owned results and outcomes remain authoritative, including hooks that probe more than one credential source. Failure finalization uses already-reported outcomes and carries one accepted provider snapshot forward instead of rereading stateful plugin getters. The existing inventory publication policy is unchanged.

## User Impact

Compatible previously discovered models survive in the full catalog after failed OAuth preparation, while the failed profiles remain visible in discovery outcomes. Usable fallback credentials, genuinely unconfigured providers, successful empty catalogs and account invalidation retain their existing behavior.

This does not make failed credentials usable or change picker filtering. In the recorded Chutes case, the unavailable wildcard-only model remains hidden in the configured picker in both builds; the full read-only catalog is what the fix preserves.

There are no new settings, dependencies or schema changes. The optional callback metadata does not require existing plugins to change. The separate timeout-admission repair in #139924 is included in the base.

## Evidence

- Three planner/publication regressions fail on baseline `9e5bb4a3ecd03772156fdbf3201ab54af5c6be98`: one or two failed Chutes profiles, and one failed OpenAI profile, each loses the prior account-only model.
- Exact head `7da685e646c67b342a93cb439cc6d41b658f28ba` passes 191 affected Linux tests, including the 13-case integration suite, auth provenance, permitted fallback, provider contracts, plugin-owned results and stateful getters, authoritative empty recovery, account invalidation and timeout controls.
- The complete changed-path gate passed on the exact head, including core, extension and test type graphs, lint, boundaries, ratchets and six doctor-contract tests.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34024738461), and fresh independent review is clean through P2.
- Matched built-Gateway/CLI/browser runs on the actual PR base `cb22e0704114ed5d05c5f6e3fa699298f5e9402a` and final head each observed one credential-matched token POST returning 503. The baseline lost the full-inventory witness and outcome; the candidate retained it with `available:false` and the exact profile-scoped `unavailable` outcome.
- Neither arm changed any persisted profile field or made a later provider request. Exact runtime/build identities, 35 served UI asset hashes per arm, and test-owned cleanup passed. No real provider credentials or operator state were used.

The evidence below shows the actual picker interaction and separately labeled final API observations, not a claim that unavailable credentials become selectable.

## Visual evidence

| Before | After |
| --- | --- |
| ![Baseline picker hides the witness; the separate API diagnostic reports absent full inventory and no failure outcome](https://github.com/user-attachments/assets/83302ec2-ad73-4269-8abd-da19a703335b) | ![Candidate picker still hides the witness; the separate API diagnostic reports retained full inventory with available false and an unavailable outcome for the same profile](https://github.com/user-attachments/assets/47fed0ec-8567-48d2-a28e-9c479e61be14) |

### Matched real picker refresh and search with final API observations outside product UI

https://github.com/user-attachments/assets/13a3052a-d1c3-4d40-b351-40e83494d9c8

### Visual verification

- Baseline: cb22e0704114ed5d05c5f6e3fa699298f5e9402a
- Exact head: `7da685e646c67b342a93cb439cc6d41b658f28ba`
- Scenario: One persisted synthetic Chutes OAuth profile discovers a nonstarter witness through controlled HTTPS, then naturally enters the five-minute refresh margin without credential or identity edits. A real configured-picker click forces models.list refresh. One token POST returns 503; a passive full-inventory read observes the resulting publication without further provider I/O.
- Runtime/build: Built OpenClaw 2026.9.2; Linux x64; Node v24.19.0; pnpm 12.3.4; Chromium 144.0.7559.0; exact runtime build IDs and 35 served UI asset hashes verified per arm
- Successful initial catalog: One credential-matched GET200 and one nonstarter witness in each arm
- Actual natural aging: 83.689s before; 83.826s after; same unedited credential entered its 300000ms margin
- Terminal preparation failure: Exactly one credential-matched POST503 to api.chutes.ai/idp/token in each arm
- Later provider I/O: 0 requests after token503 in each arm, including the passive full-inventory read and settled observation
- Full-inventory witness: Before absent; after retained with available:false
- Profile outcome: Before none; after unavailable for chutes:catalog-failure-proof
- Protected picker behavior: Wildcard-only witness hidden in both; explicitly configured starter remains available:false
- Persisted profile: One profile; all fields identical across five snapshots per arm, including after failure and recording
- Served UI: All 35 observed JS/CSS assets match the exact build per arm; authenticated bootstrap build IDs match
- Test-owned cleanup: Both Gateways, CLI children, browsers, HTTPS servers and isolated state stopped/removed; cleanup errors:0
- Both real Gateway/CLI/browser arms exited 0; verified-comparison.json records the successful retained-lease run
- Native Node24 main and Worker env-proxy coverage was positively verified using only reserved .invalid hosts and loopback HTTP
- No production selection, refresh, publication, visibility or auth functions were replaced
- models.list configured refresh and chat.metadata were captured from the real browser WebSocket
- Read-only verification used preparedOnly:true/view:all immediately after the completed picker replies
- Screenshots inspected at original resolution; every frame of the focused 151-frame comparison inspected in sequence
- Both complete 90.4s/90.6s source recordings decoded and reviewed across their full timelines; decisive interaction frames reviewed at 25fps
- All raw source captures retained; presentation labels are final recorded API observations, not live product UI
- Presentation screenshot browser pixels exactly equal the original screenshots after removing only the added 164px header (absolute pixel error:0)
- All media and retained JSON contain synthetic state only, without credentials or private pairing URLs
