### PR TITLE
refactor(runtime): share cleanup deadline waiting

### DIFF
--- a/src/agents/agent-bundle-lsp-runtime.ts
+++ b/src/agents/agent-bundle-lsp-runtime.ts
@@ -12,6 +12,7 @@ import {
   type OwnedStdioProcess,
 } from "../process/owned-stdio.js";
 import { createPendingRequestRegistry } from "../shared/pending-request-registry.js";
+import { settlesWithin } from "../shared/settle-within.js";
 import {
   defaultBundleLspRuntimeDependencies,
   type BundleLspRuntimeDependencies,
@@ -67,13 +68,6 @@ type LspPositionParams = {
 const LSP_SHUTDOWN_GRACE_MS = 500;
 const LSP_PROCESS_TREE_KILL_GRACE_MS = 1_000;
 const activeBundleLspSessions = new Set<LspSession>();
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => {
-    const timeout = setTimeout(resolve, Math.max(1, ms));
-    timeout.unref?.();
-  });
-}
 
 function createLspSession(serverName: string, child: OwnedStdioProcess): LspSession {
   return {
@@ -377,7 +371,7 @@ function disposeSession(session: LspSession): Promise<void> {
     if (session.initialized && !session.failure) {
       try {
         const shutdown = sendRequest(session, "shutdown").catch(() => undefined);
-        await Promise.race([shutdown, delay(LSP_SHUTDOWN_GRACE_MS)]);
+        await settlesWithin(shutdown, LSP_SHUTDOWN_GRACE_MS);
         session.process.stdin?.write(
           encodeLspMessage({ jsonrpc: "2.0", method: "exit", params: null }),
         );

--- a/src/agents/mcp-client-lifecycle.ts
+++ b/src/agents/mcp-client-lifecycle.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamable
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { settlesWithin } from "../shared/settle-within.js";
 import { OpenClawStreamableHTTPClientTransport } from "./mcp-http-transport.js";
 import { OpenClawStdioClientTransport } from "./mcp-stdio-transport.js";
 import { recordAgentCleanupFailure } from "./run-cleanup-timeout.js";
@@ -85,17 +86,6 @@ export async function connectMcpClient(params: {
   }
 }
 
-async function settleWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  return await Promise.race([
-    promise.then(() => true),
-    new Promise<false>((resolve) => {
-      timer = setTimeout(() => resolve(false), timeoutMs);
-      timer.unref?.();
-    }),
-  ]).finally(() => clearTimeout(timer));
-}
-
 export async function disposeMcpClient(
   session: LifecycleSession,
   timeoutMs = 5_000,
@@ -120,7 +110,7 @@ export async function disposeMcpClient(
       await ignoreCloseFailure(() => session.transport.close());
       await ignoreCloseFailure(() => session.client.close());
     })();
-    const closed = await settleWithin(graceful, timeoutMs);
+    const closed = await settlesWithin(graceful, timeoutMs);
     if (closed) {
       return failed ? "uncertain" : "closed";
     }
@@ -131,7 +121,7 @@ export async function disposeMcpClient(
       session.transportType === "stdio" && transport instanceof OpenClawStdioClientTransport
         ? () => transport.forceClose()
         : () => transport.close();
-    const forced = await settleWithin(
+    const forced = await settlesWithin(
       Promise.all([
         graceful,
         ignoreCloseFailure(closeTransport),

--- a/src/process/owned-stdio.ts
+++ b/src/process/owned-stdio.ts
@@ -1,4 +1,5 @@
 import type { Writable } from "node:stream";
+import { settlesWithin } from "../shared/settle-within.js";
 import { createChildAdapter } from "./supervisor/adapters/child.js";
 import type { SpawnProcessAdapter } from "./supervisor/types.js";
 
@@ -42,21 +43,6 @@ export async function createOwnedStdioProcess(params: {
       });
     }
     throw error;
-  }
-}
-
-async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise.then(() => true),
-      new Promise<false>((resolve) => {
-        timer = setTimeout(() => resolve(false), timeoutMs);
-        timer.unref?.();
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
   }
 }
 

--- a/src/shared/settle-within.ts
+++ b/src/shared/settle-within.ts
@@ -1,0 +1,18 @@
+/** A deadline bounds waiting; fulfillment alone does not certify resource cleanup. */
+export async function settlesWithin(
+  promise: Promise<unknown>,
+  timeoutMs: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Related: #135868, #139517, #139657

## What Problem This Solves

MCP and owned stdio duplicated the same cleanup deadline implementation, while LSP kept a third grace timer alive after an early shutdown reply. This is the maintainer-requested production compression follow-up for concern C of the #135868 split.

## Why This Change Was Made

Use one internal `settlesWithin` helper for all three waits. It returns false on timeout, propagates rejection, unrefs and clears its timer. It does not decide whether resources are closed: protocol owners and the process owner's extinction join retain those decisions. LSP keeps its 500 ms shutdown grace and subsequent owned-process cleanup.

## User Impact

No change to shutdown budgets, escalation order, error propagation or cleanup evidence. The losing LSP grace timer is now cleared after an early reply. Production shrinks by 12 lines; tests, tooling and docs are unchanged. No public API, dependency or configuration changes.

## Evidence

Existing boundary coverage is retained: `src/agents/mcp-stdio-transport.test.ts:195,218` covers failed cleanup replay and confirmed/unconfirmed forced shutdown; `src/agents/agent-bundle-lsp-runtime.test.ts:544,575,651` covers descendant joining, uncertainty, and shutdown ordering. `src/process/owned-stdio.real.test.ts:4` uses a real process and drains 8,192 Unicode diagnostic lines before cleanup completes; `src/process/owned-stdio.test.ts:11` covers startup cleanup outcomes. The full MCP runtime suite also covers hung shutdown and remote transports.

Validation: 163 focused tests passed across six suites; full `node scripts/check-changed.mjs` exited 0, including core and all core-test typechecks, lint, guards, and dead-export scans. Import-cycle check: zero runtime value cycles. Independent Codex autoreview against the pinned merge base: scoped-clean through P2. `git diff --check` passed. Windows launch paths used fixtures; real stdio ran on macOS.

ClawSweeper reviewed exact head `1739b1af99be13546e7ab63ae4ebd36861d6df80`: no actionable correctness/security findings and no before-merge or rank-up requests.
