### PR TITLE
improve: avoid plugin bootstrap in focused test fixtures

### DIFF
--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -49,17 +49,17 @@ describe("models config input presence", () => {
     },
   ] as const)("$name in the final generated models.json", async ({ sourceModels, expected }) => {
     const configuredProvider = {
-      baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
-      apiKey: "AWS_PROFILE",
+      baseUrl: "https://model-input.example/v1",
+      apiKey: "MODEL_INPUT_FIXTURE_KEY",
       models: [model("vision-model")],
     };
     const cfg: OpenClawConfig = {
-      models: { providers: { "amazon-bedrock": configuredProvider } },
+      models: { providers: { "model-input-fixture": configuredProvider } },
     };
     const sourceConfigForSecrets = {
       models: {
         providers: {
-          "amazon-bedrock": {
+          "model-input-fixture": {
             baseUrl: configuredProvider.baseUrl,
             apiKey: configuredProvider.apiKey,
             models: sourceModels,
@@ -68,7 +68,7 @@ describe("models config input presence", () => {
       },
     } as unknown as OpenClawConfig;
     const resolveImplicitProviders = vi.fn<ResolveImplicitProviders>(async () => ({
-      "amazon-bedrock": {
+      "model-input-fixture": {
         ...configuredProvider,
         models: [model("vision-model", ["text", "image"])],
       },
@@ -82,7 +82,7 @@ describe("models config input presence", () => {
         agentDir: "/tmp/openclaw-model-input-presence",
         // Model-ID policies are part of this prepared merge fixture, not ambient discovery.
         pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
-        env: { AWS_PROFILE: "default" },
+        env: { MODEL_INPUT_FIXTURE_KEY: "default" },
         existingRaw: "",
         existingParsed: {},
       },
@@ -96,7 +96,7 @@ describe("models config input presence", () => {
     const generated = JSON.parse(plan.contents) as {
       providers: Record<string, { models?: Array<{ input?: string[] }> }>;
     };
-    expect(generated.providers["amazon-bedrock"]?.models?.[0]?.input).toEqual(expected);
+    expect(generated.providers["model-input-fixture"]?.models?.[0]?.input).toEqual(expected);
   });
 
   const liveCost = {

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -18,6 +18,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { GatewayClientRequestError } from "../../gateway/client.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import { extractStoredAssistantText } from "./chat-history-text.js";
 
 const callGatewayMock = vi.fn();
@@ -283,6 +284,7 @@ async function executeFireAndForgetA2AFrom(
     bindingTeamId?: string;
   },
 ) {
+  setActivePluginRegistry(createSessionConversationTestRegistry());
   const { runSessionsSendA2AFlow } = await import("./sessions-send-tool.a2a.js");
   vi.mocked(runSessionsSendA2AFlow).mockClear();
   const targetSessionKey = "agent:other:discord:group:ops";
@@ -1321,6 +1323,7 @@ describe("sessions_send gating", () => {
   });
 
   it("rejects direct thread session targets before dispatching an agent run", async () => {
+    setActivePluginRegistry(createSessionConversationTestRegistry());
     loadConfigMock.mockReturnValue({
       session: { scope: "per-sender", mainKey: "main" },
       tools: {
@@ -1388,6 +1391,7 @@ describe("sessions_send gating", () => {
   });
 
   it("rejects label targets that resolve to canonical thread sessions", async () => {
+    setActivePluginRegistry(createSessionConversationTestRegistry());
     loadConfigMock.mockReturnValue({
       session: { scope: "per-sender", mainKey: "main" },
       tools: {
@@ -1417,6 +1421,7 @@ describe("sessions_send gating", () => {
   });
 
   it("does not disclose a resolved thread session key from a sessionId target", async () => {
+    setActivePluginRegistry(createSessionConversationTestRegistry());
     loadConfigMock.mockReturnValue({
       session: { scope: "per-sender", mainKey: "main" },
       tools: {

--- a/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.progress.test-utils.ts
@@ -1,6 +1,8 @@
 // Imported by dispatch-from-config.test.ts to keep its mocked suite in one Vitest module graph.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
@@ -505,6 +507,8 @@ describe("dispatchReplyFromConfig", () => {
   });
 
   it("exposes live group tool-summary state to reply_dispatch hooks", async () => {
+    // Group policy needs the loaded fixture's conversation grammar.
+    setActivePluginRegistry(createSessionConversationTestRegistry());
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "off",

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -36,6 +36,7 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import { createAgentRuntimeApprovalAuthorityValidator } from "../agent-runtime-identity-token.js";
 import {
   mintMessageActionTurnCapability,
@@ -3645,6 +3646,8 @@ describe("gateway send mirroring", () => {
   });
 
   it("keeps a diverted terminal send fail closed instead of claiming a source reply", async () => {
+    // Group policy needs the loaded fixture's conversation grammar.
+    setActivePluginRegistry(createSessionConversationTestRegistry());
     mocks.dispatchChannelMessageAction.mockResolvedValueOnce(
       jsonResult({ ok: true, result: { messageId: "tg-diverted", receipt: {} } }),
     );

--- a/src/status/status-text.test.ts
+++ b/src/status/status-text.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -406,6 +407,7 @@ describe("buildStatusText thinking facts", () => {
 });
 
 describe("buildStatusText prepared context windows", () => {
+  afterEach(() => cliBackendsTesting.resetDepsForTest());
   const catalog = [
     {
       provider: "deepseek",
@@ -518,6 +520,18 @@ describe("buildStatusText prepared context windows", () => {
   });
 
   it("keeps Anthropic authored caps below the prepared Claude CLI window", async () => {
+    // Supply runtime alias metadata while exercising the authored context cap.
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [
+        {
+          id: "claude-cli",
+          modelProvider: "anthropic",
+          pluginId: "anthropic",
+          config: { command: "claude" },
+          bundleMcp: true,
+        },
+      ],
+    });
     const parts = await renderPreparedStatus({
       provider: "anthropic",
       model: "claude-haiku-4-5",


### PR DESCRIPTION
## What Problem This Solves

Resolves slow first cases in five core test suites that loaded unrelated provider or channel setup while checking model merging, status context caps, delivery receipts, and live group-summary state.

## Why This Change Was Made

Use a synthetic provider in the generic model-input table, supply existing runtime alias metadata for the status cap case, and register the existing synthetic channel grammars in the group-policy and session-tool fixtures. These fixtures preserve the real merge, alias, policy, receipt, and live-getter paths. Discovery and provider-specific behavior retain their dedicated owner coverage.

No production code or new production test seams are introduced. Test counts, assertions, timeouts, and shard settings stay unchanged. The generic input table changes its existing fixture identifiers; the other cases use existing fixture APIs with existing cleanup.

## User Impact

Faster focused tests and less incidental plugin bootstrap in CI. Runtime behavior is unchanged.

## Evidence

Same-host Node 24.19.0 comparisons with matching source/dependencies and fresh test processes:

| Case | Before | After |
| --- | ---: | ---: |
| Generic model input | 14.806 s | 222 ms |
| Authored status context cap | 24.237 s | 96 ms |
| Diverted terminal send | 18.818 s | 16 ms |
| Live group-summary hook | 19.548 s | 20 ms |
| Sessions-tool full file command | 49.18 s | 21.14 s |

Model-input observation recorded 1,418 Jiti cache files created before versus none after. Channel observations recorded two Telegram/one Matrix facade probes before versus none after, and 972 cache files before versus none after. Observations were removed from final source. Tests' canonical HOME/cache isolation was retained; outer cache-directory overrides were found ineffective and excluded from the claims.

The status comparison used the same source-only checkout on both sides; a separately built checkout was already faster and is not used as its baseline. Whole-command and transform times vary, so these case improvements are not added together as a whole-CI saving.

- The initial four fixtures passed 409 owner/sibling tests; the session-tool addition passed 123 tests, including all 101 original cases and grammar helpers, in the contained checkout with frozen-installed dependencies.
- Deliberate controls still failed the existing assertions: authored input, authored status cap, false terminal completion, and a frozen summary getter. All controls were reverted.
- Full changed-file gate, formatting, and independent P2 review passed.
- Test/test-support delta +33/-7; production zero. All original assertions and cases remain.

Relevant proof included model merge/discovery, status summary/runtime aliases, full send and dispatch files in original order, and session-conversation grammar. No live channel credentials or external provider requests were used.

Session-tool preparation covers all three generic thread guards and the existing A2A fixture helper. A single-case change only moved cold loading to later Discord/Feishu cases, so it was rejected. The final whole-file run made no real facade probes and kept every case at 100 milliseconds or less; the explicit Telegram topic fixture, privacy/DM-scope assertions, and RPC counts remain. Removing the real thread gate still failed all three guard tests, and that control was reverted.
