### PR TITLE
fix(process): wait for subprocess cleanup on cancellation

### DIFF
--- a/src/process/exec-termination.test.ts
+++ b/src/process/exec-termination.test.ts
@@ -1,0 +1,195 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { constants as osConstants } from "node:os";
+import process from "node:process";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+import * as processIdentity from "../shared/pid-alive.js";
+import { killPidIfAlive, waitForPidToExit } from "../test-utils/process-tree.js";
+import { createCommandTerminationController } from "./exec-termination.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+async function withOwnedTree(
+  run: (tree: { parent: ReturnType<typeof spawn>; descendantPid: number }) => Promise<void>,
+) {
+  const descendant = `process.on('SIGTERM',()=>{});setInterval(()=>{},1000);process.send('ready');`;
+  const parent = spawn(
+    process.execPath,
+    [
+      "-e",
+      `const {spawn}=require('node:child_process');
+      process.on('SIGTERM',()=>{});
+      const child=spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:['ignore','ignore','ignore','ipc']});
+      child.once('message',()=>process.send(child.pid));setInterval(()=>{},1000);`,
+    ],
+    { detached: true, stdio: ["ignore", "ignore", "ignore", "ipc"] },
+  );
+  const closed = once(parent, "close");
+  let descendantPid: number | undefined;
+  try {
+    const [message] = await once(parent, "message", { signal: AbortSignal.timeout(2_000) });
+    descendantPid = Number(message);
+    expect(Number.isSafeInteger(descendantPid)).toBe(true);
+    await run({ parent, descendantPid });
+  } finally {
+    killPidIfAlive(parent.pid);
+    killPidIfAlive(descendantPid);
+    await closed;
+    if (descendantPid) {
+      expect(await waitForPidToExit(descendantPid)).toBe(true);
+    }
+  }
+}
+
+describe.skipIf(process.platform === "win32")("command process-group settlement", () => {
+  it.each(["graceful", "force"] as const)(
+    "joins observed group exit after a %s force-send receipt",
+    async (mode) => {
+      await withOwnedTree(async ({ parent, descendantPid }) => {
+        const kill = process.kill.bind(process);
+        const forced = createDeferredCore();
+        let observedAbsence = false;
+        const signals = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+          if (
+            pid === -parent.pid! &&
+            (signal === "SIGKILL" || signal === osConstants.signals.SIGKILL)
+          ) {
+            // A successful send is not an exit receipt. Keep this real group alive until released below.
+            forced.resolve();
+            return true;
+          }
+          try {
+            return kill(pid, signal);
+          } catch (error) {
+            if (
+              pid === -parent.pid! &&
+              signal === 0 &&
+              error instanceof Error &&
+              "code" in error &&
+              error.code === "ESRCH"
+            ) {
+              observedAbsence = true;
+            }
+            throw error;
+          }
+        });
+        const owner = createCommandTerminationController({
+          child: parent,
+          cancelController: new AbortController(),
+          processTree: { mode },
+          killGraceMs: 0,
+          isChildExited: () => parent.exitCode !== null || parent.signalCode !== null,
+          isCommandSettled: () => false,
+        });
+        owner.terminate();
+        await forced.promise;
+        let settled = false;
+        const completion = owner.settle().then((result) => {
+          settled = true;
+          return { result, observedAbsence };
+        });
+        await nextTurn();
+        expect(processIdentity.isPidAlive(descendantPid)).toBe(true);
+        expect.soft(settled).toBe(false);
+        kill(-parent.pid!, "SIGKILL");
+        const outcome = await completion;
+        expect(outcome.result).toBe(outcome.observedAbsence ? "forced" : "uncertain");
+        if (outcome.result === "forced") {
+          expect(processIdentity.isPidAlive(descendantPid)).toBe(false);
+        }
+        expect(
+          signals.mock.calls.filter(
+            ([, signal]) => signal === "SIGKILL" || signal === osConstants.signals.SIGKILL,
+          ),
+        ).toHaveLength(1);
+      });
+    },
+  );
+
+  it("reports forced cleanup when the original group is confirmed absent", async () => {
+    const parent = spawn(
+      process.execPath,
+      ["-e", "process.on('message',()=>process.exit(0));process.send('ready');"],
+      {
+        detached: true,
+        stdio: ["ignore", "ignore", "ignore", "ipc"],
+      },
+    );
+    const closed = once(parent, "close");
+    try {
+      await once(parent, "message", { signal: AbortSignal.timeout(2_000) });
+      const owner = createCommandTerminationController({
+        child: parent,
+        cancelController: new AbortController(),
+        processTree: { mode: "force" },
+        killGraceMs: 0,
+        isChildExited: () => parent.exitCode !== null || parent.signalCode !== null,
+        isCommandSettled: () => false,
+      });
+      parent.send("finish");
+      await closed;
+      owner.terminate();
+      expect(await owner.settle()).toBe("forced");
+    } finally {
+      killPidIfAlive(parent.pid);
+      await closed;
+    }
+  });
+
+  it.each([
+    { observation: "live", killSignal: undefined },
+    { observation: "unknown", killSignal: undefined },
+    { observation: "reused", killSignal: undefined },
+    { observation: "live", killSignal: "SIGKILL" },
+    { observation: "live", killSignal: osConstants.signals.SIGKILL },
+  ] as const)(
+    "reports uncertain when the original group remains $observation after force (initial signal=$killSignal)",
+    async ({ observation, killSignal }) => {
+      await withOwnedTree(async ({ parent, descendantPid }) => {
+        const kill = process.kill.bind(process);
+        const readStart = processIdentity.getFileLockProcessStartTime;
+        const originalStart = readStart(parent.pid!);
+        expect(originalStart).not.toBeNull();
+        let forced = false;
+        const signals = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
+          if (
+            pid === -parent.pid! &&
+            (signal === "SIGKILL" || signal === osConstants.signals.SIGKILL)
+          ) {
+            forced = true;
+            return true;
+          }
+          if (forced && pid === -parent.pid! && signal === 0 && observation === "unknown") {
+            throw Object.assign(new Error("fixture observation unavailable"), { code: "EPERM" });
+          }
+          return kill(pid, signal);
+        });
+        vi.spyOn(processIdentity, "getFileLockProcessStartTime").mockImplementation(
+          (pid, ...args) =>
+            forced && observation === "reused" && pid === parent.pid
+              ? originalStart! + 1
+              : readStart(pid, ...args),
+        );
+        const owner = createCommandTerminationController({
+          child: parent,
+          cancelController: new AbortController(),
+          processTree: { mode: "graceful" },
+          killSignal,
+          killGraceMs: 0,
+          isChildExited: () => parent.exitCode !== null || parent.signalCode !== null,
+          isCommandSettled: () => false,
+        });
+        owner.terminate();
+        expect(await owner.settle()).toBe("uncertain");
+        expect(processIdentity.isPidAlive(descendantPid)).toBe(true);
+        expect(
+          signals.mock.calls.filter(
+            ([, signal]) => signal === "SIGKILL" || signal === osConstants.signals.SIGKILL,
+          ),
+        ).toHaveLength(1);
+      });
+    },
+  );
+});

--- a/src/process/exec-termination.ts
+++ b/src/process/exec-termination.ts
@@ -1,3 +1,4 @@
+import { constants as osConstants } from "node:os";
 import process from "node:process";
 import { getWindowsSystem32ExePath } from "../infra/windows-install-roots.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
@@ -36,40 +37,34 @@ export function createCommandTerminationController(params: {
 
   const isDirectChildAlive = () =>
     !params.isChildExited() && params.child.exitCode == null && params.child.signalCode == null;
-  const spawnTaskkill = (args: string[]) => {
+  const spawnTaskkill = async (args: string[]) => {
     try {
-      return spawnCommand([getWindowsSystem32ExePath("taskkill.exe"), ...args], {
+      await spawnCommand([getWindowsSystem32ExePath("taskkill.exe"), ...args], {
         baseEnv: params.baseEnv,
         env: params.env,
         forceKillAfterDelay: COMMAND_PROCESS_TREE_KILL_GRACE_MS,
         reject: false,
         stdio: "ignore",
         timeout: WINDOWS_TASKKILL_TIMEOUT_MS,
-      }).catch(() => undefined);
+      });
     } catch {
-      return undefined;
+      // Best-effort Windows cleanup still joins every attempted helper.
     }
   };
   const startWindowsTermination = (childPid: number, graceful: boolean): void => {
     const taskkills: Promise<unknown>[] = [];
-    const startTaskkill = (args: string[]) => {
-      const taskkill = spawnTaskkill(args);
-      if (taskkill) {
-        taskkills.push(taskkill);
-      }
-    };
     windowsTerminationPromise = (async () => {
       if (graceful) {
-        startTaskkill(["/PID", String(childPid), "/T"]);
+        taskkills.push(spawnTaskkill(["/PID", String(childPid), "/T"]));
         await new Promise<void>((resolve) => {
           const timer = setTimeout(resolve, params.killGraceMs);
           timer.unref();
         });
         if (isDirectChildAlive()) {
-          startTaskkill(["/PID", String(childPid), "/T", "/F"]);
+          taskkills.push(spawnTaskkill(["/PID", String(childPid), "/T", "/F"]));
         }
       } else {
-        startTaskkill(["/PID", String(childPid), "/T", "/F"]);
+        taskkills.push(spawnTaskkill(["/PID", String(childPid), "/T", "/F"]));
       }
       // Failed helpers still join here before root cancellation; a sibling taskkill
       // may still be enumerating descendants through that live PID.
@@ -89,18 +84,16 @@ export function createCommandTerminationController(params: {
       return false;
     }
     if (params.processTree && typeof childPid === "number") {
-      const force = params.processTree.mode === "force";
       if (process.platform === "win32") {
-        startWindowsTermination(childPid, !force);
+        startWindowsTermination(childPid, params.processTree.mode !== "force");
         return true;
       }
-      if (force) {
-        cleanup = "forced";
-        terminateProcessTree(childPid, { force: true, detached: true });
-        return false;
-      }
+      const force =
+        params.processTree.mode === "force" ||
+        params.killSignal === "SIGKILL" ||
+        params.killSignal === osConstants.signals.SIGKILL;
       if (processTreeSettlement) {
-        return true;
+        return !force;
       }
       cleanup = "cooperative";
       const groupAlive = () => {
@@ -112,6 +105,35 @@ export function createCommandTerminationController(params: {
           return (error as NodeJS.ErrnoException).code !== "ESRCH";
         }
       };
+      const forceAndObserve = async () => {
+        const start = getFileLockProcessStartTime(childPid);
+        if (start !== null && start !== originalStart) {
+          cleanup = "uncertain";
+          if (isDirectChildAlive()) {
+            params.cancelController.abort();
+          }
+          return;
+        }
+        cleanup = "forced";
+        terminateProcessTree(childPid, { force: true, detached: true });
+        const deadline = Date.now() + COMMAND_PROCESS_TREE_KILL_GRACE_MS;
+        // Signal delivery is not exit. Observe only this group; never re-signal a retired PID.
+        while (groupAlive()) {
+          const currentStart = getFileLockProcessStartTime(childPid);
+          const remaining = deadline - Date.now();
+          if ((currentStart !== null && currentStart !== originalStart) || remaining <= 0) {
+            cleanup = "uncertain";
+            return;
+          }
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, Math.min(25, remaining));
+          });
+        }
+      };
+      if (force) {
+        processTreeSettlement = forceAndObserve();
+        return false;
+      }
       try {
         process.kill(-childPid, params.killSignal ?? "SIGTERM");
       } catch (error) {
@@ -131,20 +153,7 @@ export function createCommandTerminationController(params: {
             setTimeout(check, Math.min(25, deadline - Date.now()));
             return;
           }
-          // Never signal a recycled group leader. A forced fallback cannot certify
-          // cleanup of independently detached descendants of this invocation.
-          const start = getFileLockProcessStartTime(childPid);
-          if (start !== null && start !== originalStart) {
-            cleanup = "uncertain";
-            if (isDirectChildAlive()) {
-              params.cancelController.abort();
-            }
-            resolve();
-            return;
-          }
-          cleanup = "forced";
-          terminateProcessTree(childPid, { force: true, detached: true });
-          resolve();
+          void forceAndObserve().then(resolve);
         };
         check();
       });

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -654,6 +654,8 @@ describe("runCommandBuffered", () => {
           expect(settled).toBe(false);
 
           await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
+          // Force delivery now has a separate bounded exit-observation phase.
+          await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
           expect(await command).toMatchObject({ code: null, termination: "timeout" });
           vi.useRealTimers();
           expect(await waitForPidToExit(descendantPid)).toBe(true);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cancelling a command or SCP media transfer could finish while its subprocesses were still exiting. Successful delivery of a force signal was treated as completed cleanup.

## Why This Change Was Made

The command termination owner now observes the original process group after its one force signal, for up to an additional 300 ms using the existing default cleanup duration. It reports forced cleanup only after the group is absent; a live group, unavailable observation, or changed process identity returns the existing uncertain result. An explicitly requested SIGKILL enters this phase directly instead of being sent again during escalation.

## User Impact

Cancellation preserves its original reason and captured output while waiting for observable cleanup. The existing Windows helper contract is preserved. A redundant taskkill adapter was removed as part of the same owner refactor; the remaining nine production lines implement bounded exit observation and initial-SIGKILL handling without adding an option or increasing test deadlines.

## Evidence

- Controlled local process groups reproduced premature settlement in both force modes, incorrect cleanup classification, and duplicate string/numeric SIGKILL sends before the repair.
- Final focused run: 102 passed, one skipped, including eight process-group cases, existing command/Windows coverage, and all 11 unchanged SCP tests. The send-receipt regression uses a real parent and descendant with a gated force signal; confirmed absence and uncertainty have separate assertions.
- Normal typed lint and declaration generation passed from an isolated checkout with its own dependencies. The existing fake-clock test advances the added cleanup-observation phase; its timeout and result assertions are unchanged.
- Independent P2 review found no actionable issues.
- The complete changed-file gate passed, including core and test type checking, ratchets, import-cycle and ownership guards.

Related: #135599. This repairs the process settlement failure observed while splitting and validating plugin lifecycle work.
