### PR TITLE
docs: keep ClawSweeper status inspection read-only

### DIFF
--- a/.agents/skills/clawsweeper/SKILL.md
+++ b/.agents/skills/clawsweeper/SKILL.md
@@ -71,8 +71,7 @@ evidence links, likely owners, and runtime details stay inside the collapsed
 `Review details` block.
 
 For a simple status request, read existing reports and bounded live workflow
-state. `pnpm run status` summarizes current state. A requested full audit can use
-`pnpm run audit`; it is a broader scan, not a prerequisite for reading one item.
+state. Use `pnpm run audit` only for a requested full audit.
 
 Reconciliation is a separate authorized mutation: bare `pnpm run reconcile`
 moves/deletes report and work-plan files. Inspect its dry-run only when that


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where maintainers asking for ClawSweeper status could be instructed to overwrite its workflow-status snapshot. The skill described `pnpm run status` as a summary command, but it publishes a new status record with default state and detail values.

## Why This Change Was Made

Remove that command from read-only inspection guidance. Keep the existing report and bounded workflow-state reads, and retain `pnpm run audit` for an explicitly requested full audit. The ClawSweeper publisher itself is unchanged; no new command or configuration is introduced.

## User Impact

Routine status questions no longer direct the agent to replace status evidence. Authorized full audits and workflow-owned status publication remain available.

## Evidence

- Traced the exact ClawSweeper source at `4e54e61804ec0da9f1a3572e536e7c6f95049190`: package script → `statusCommand` → `writeSweepStatus`. The writer replaces `results/sweep-status/<slug>.json`; the separate read owner parses that snapshot.
- `git diff --check` and targeted Oxfmt checking passed; the canonical `docs:list` script completed successfully. Skill frontmatter, headings, links, code fences and adjacent agent metadata are unchanged.
- Managed P2 review with the complete proposed skill and upstream owner evidence: scoped-clean, no accepted or actionable findings.

One documentation file, +1/−2 lines; no production changes. The mutating status command was not executed, and no live workflow state was changed.
