### PR TITLE
refactor(agents): share embedded skill preparation

### DIFF
--- a/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/prepared-compaction-runtime.ts
@@ -4,7 +4,6 @@
  */
 import fs from "node:fs/promises";
 import os from "node:os";
-import path from "node:path";
 import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import {
   formatActiveNodeContextLabel,
@@ -18,12 +17,6 @@ import { extractModelCompat } from "../../plugins/provider-model-compat.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { transformProviderSystemPrompt } from "../../plugins/provider-runtime.js";
 import { getPluginToolMeta } from "../../plugins/tool-metadata.js";
-import { resolveSkillsPrompt } from "../../skills/loading/workspace-skill-prompt.js";
-import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
-import {
-  applySkillEnvOverrides,
-  applySkillEnvOverridesFromSnapshot,
-} from "../../skills/runtime/env-overrides.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { createBundleLspToolRuntime } from "../agent-bundle-lsp-runtime.js";
@@ -81,12 +74,7 @@ import { resolvePromptModeForSession } from "./run/attempt-prompt-helpers.js";
 import { resolveAttemptSpawnWorkspaceDir } from "./run/attempt-thread-helpers.js";
 import { applyEmbeddedAttemptToolsAllow } from "./run/attempt-tool-construction-plan.js";
 import { buildEmbeddedSandboxInfo, resolveEmbeddedSandboxInfoExecPolicy } from "./sandbox-info.js";
-import {
-  createSandboxPromptEntryLoader,
-  mapSandboxSkillEntriesForPrompt,
-  mapSandboxSkillUsagePaths,
-  resolveSandboxSkillRuntimeInputs,
-} from "./sandbox-skills.js";
+import { prepareEmbeddedSkills } from "./skill-runtime.js";
 import { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 import { collectAllowedToolNames } from "./tool-name-allowlist.js";
 import { mapThinkingLevelForProvider } from "./utils.js";
@@ -157,64 +145,19 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
   };
 
   try {
-    const {
-      skillsEligibility,
-      skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
-      skillsSnapshot: skillsSnapshotForRun,
-      skillsWorkspaceDir: effectiveSkillsWorkspace,
-      workspaceOnly: loadSkillsWorkspaceOnly,
-    } = resolveSandboxSkillRuntimeInputs({
-      sandbox,
-      skillsAnchorWorkspace: params.bootstrapWorkspaceDir ?? effectiveWorkspace,
-      skillsSnapshot: params.skillsSnapshot,
-    });
-    const { shouldLoadSkillEntries, skillEntries, loadSkillEntries, preserveEntryOrder } =
-      resolveEmbeddedRunSkillEntries({
-        workspaceDir: effectiveSkillsWorkspace,
+    const preparedSkills = prepareEmbeddedSkills({
+      attempt: {
         config: params.config,
-        agentId: sessionAgentId,
-        eligibility: skillsEligibility,
-        skillsSnapshot: skillsSnapshotForRun,
-        // Sandbox fallbacks stay inside their sandbox skill workspace;
-        // host execution skills are not mounted there.
-        ...(sandbox?.enabled === true
-          ? {}
-          : { executionSkillsDir: path.join(effectiveWorkspace, "skills") }),
-        workspaceOnly: loadSkillsWorkspaceOnly,
-      });
-    restoreSkillEnv = skillsSnapshotForRun
-      ? applySkillEnvOverridesFromSnapshot({
-          snapshot: skillsSnapshotForRun,
-          config: params.config,
-        })
-      : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
-          config: params.config,
-        });
-    const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
-      skillsWorkspaceDir: effectiveSkillsWorkspace,
-      skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
+        bootstrapWorkspaceDir: params.bootstrapWorkspaceDir,
+        skillsSnapshot: params.skillsSnapshot,
+      },
+      effectiveWorkspace,
+      sandbox,
+      sessionAgentId,
+      includeCodeModeSkills: false,
     });
-    const skillUsagePaths = mapSandboxSkillUsagePaths({
-      paths: sandbox?.skillUsagePaths,
-      skillsWorkspaceDir: effectiveSkillsWorkspace,
-      skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
-    });
-    const skillsPrompt = resolveSkillsPrompt({
-      skillsSnapshot: skillsSnapshotForRun,
-      entries: promptSkillEntries,
-      loadEntries: createSandboxPromptEntryLoader({
-        loadEntries: loadSkillEntries,
-        skillsWorkspaceDir: effectiveSkillsWorkspace,
-        skillsPromptWorkspaceDir: effectiveSkillsPromptWorkspace,
-      }),
-      config: params.config,
-      workspaceDir: effectiveSkillsPromptWorkspace,
-      agentId: sessionAgentId,
-      eligibility: skillsEligibility,
-      preserveEntryOrder,
-    });
+    restoreSkillEnv = preparedSkills.restoreSkillEnv;
+    const { skillsSnapshotForRun, skillUsagePaths, skillsPrompt } = preparedSkills;
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
     const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
@@ -304,10 +247,10 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
             sandbox,
             resolvedWorkspace,
           });
-    const runtimeCapabilityProfile = resolveConversationCapabilityProfile({
+    // Policy and tool construction share facts, while their distinct agent owners stay explicit.
+    const conversationContext = {
       config: params.config,
       sessionKey: sandboxSessionKey,
-      agentId: sandboxAgentId,
       runSessionKey:
         params.sessionKey && params.sessionKey !== sandboxSessionKey
           ? params.sessionKey
@@ -318,7 +261,6 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       agentAccountId: params.agentAccountId,
       messageProvider: resolvedMessageProvider,
       chatType: params.chatType,
-      conversationToolPolicy: params.conversationToolPolicy,
       groupId: params.groupId,
       groupChannel: params.groupChannel,
       groupSpace: params.groupSpace,
@@ -327,7 +269,6 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       senderName: params.senderName,
       senderUsername: params.senderUsername,
       senderE164: params.senderE164,
-      senderIsOwner: params.senderIsOwner,
       modelProvider: effectiveModel.provider,
       modelId,
       modelApi: effectiveModel.api,
@@ -336,6 +277,12 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
       cwd: effectiveCwd,
       spawnWorkspaceDir,
       skillsSnapshot: skillsSnapshotForRun,
+    };
+    const runtimeCapabilityProfile = resolveConversationCapabilityProfile({
+      ...conversationContext,
+      agentId: sandboxAgentId,
+      conversationToolPolicy: params.conversationToolPolicy,
+      senderIsOwner: params.senderIsOwner,
       sandboxToolPolicy: sandbox?.tools,
       inputProvenance: params.inputProvenance,
       trustedInternalHandoff: params.trustedInternalHandoff,
@@ -345,6 +292,7 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
     const skillInstructionDeliveryCache = createSkillInstructionDeliveryCache();
     const toolsRaw = toolsEnabled
       ? createOpenClawCodingTools({
+          ...conversationContext,
           agentId: sessionAgentId,
           exec: {
             ...execOverrides,
@@ -354,43 +302,15 @@ export async function buildPreparedCompactionRuntime(prepared: DirectCompactionP
           sandbox,
           sessionPermissionPolicy,
           requireWorkspaceOnly: params.requireWorkspaceOnly,
-          messageProvider: resolvedMessageProvider,
           clientCaps: params.clientCaps,
           pinnedWidgetAuthoring: params.pinnedWidgetAuthoring,
-          chatType: params.chatType,
-          agentAccountId: params.agentAccountId,
-          sessionKey: sandboxSessionKey,
-          runSessionKey:
-            params.sessionKey && params.sessionKey !== sandboxSessionKey
-              ? params.sessionKey
-              : undefined,
-          sessionId: params.sessionId,
-          runId: params.runId,
           oneShotCliRun: params.oneShotCliRun,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
           allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-          agentDir,
-          cwd: effectiveCwd,
-          workspaceDir: effectiveWorkspace,
-          spawnWorkspaceDir,
-          config: params.config,
           webSearchEnabled: params.toolOverrides?.webSearch !== false,
           abortSignal: runAbortController.signal,
           sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
-          modelProvider: effectiveModel.provider,
-          modelId,
           modelHasVision: effectiveModel.input?.includes("image") ?? false,
           modelCompat: extractModelCompat(effectiveModel),
-          modelApi: effectiveModel.api,
-          modelContextWindowTokens: contextTokenBudget,
-          skillsSnapshot: skillsSnapshotForRun,
           skillUsagePaths,
           skillInstructionDeliveryCache,
           conversationCapabilityProfile: runtimeCapabilityProfile,

--- a/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.test.ts
@@ -9,6 +9,7 @@ import { resolveSandboxContext as resolveRealSandboxContext } from "../../sandbo
 import type { SandboxContext } from "../../sandbox/types.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
 import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
+import { prepareEmbeddedSkills } from "../skill-runtime.js";
 import { buildEmbeddedForegroundPromptContext } from "./agent-end-context.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
@@ -26,7 +27,6 @@ vi.mock("../../sandbox.js", () => ({ resolveSandboxContext }));
 
 import {
   installEmbeddedAttemptContextGuards,
-  prepareEmbeddedAttemptSkills,
   prepareEmbeddedAttemptSetup,
   resolveAttemptWorkspaceSandbox,
 } from "./attempt-setup.js";
@@ -334,7 +334,7 @@ describe("prepareEmbeddedAttemptSetup", () => {
   });
 });
 
-describe("prepareEmbeddedAttemptSkills", () => {
+describe("prepareEmbeddedSkills", () => {
   it.each([
     { label: "unrestricted", toolExecutionAllow: undefined, readable: true },
     { label: "read allowed", toolExecutionAllow: ["read"], readable: true },
@@ -359,7 +359,8 @@ describe("prepareEmbeddedAttemptSkills", () => {
     await writeSkill(executionWorkspace, "execution-workspace-skill");
 
     try {
-      const prepared = prepareEmbeddedAttemptSkills({
+      const prepared = prepareEmbeddedSkills({
+        includeCodeModeSkills: true,
         attempt: {
           bootstrapWorkspaceDir: agentWorkspace,
           config: {},

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -28,16 +28,9 @@ import {
   resolveProviderRuntimePluginHandle,
   type ProviderRuntimePluginHandle,
 } from "../../../plugins/provider-hook-runtime.js";
-import { resolveSkillsPrompt } from "../../../skills/loading/workspace-skill-prompt.js";
-import { resolveEmbeddedRunSkillEntries } from "../../../skills/runtime/embedded-run-entries.js";
-import {
-  applySkillEnvOverrides,
-  applySkillEnvOverridesFromSnapshot,
-} from "../../../skills/runtime/env-overrides.js";
 import { resolveUserPath } from "../../../utils.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { isHeartbeatLifecycleRunKind } from "../../bootstrap-mode.js";
-import { resolveCodeModeSkills, type CodeModeSkillReader } from "../../code-mode-skills.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import type { EmbeddedContextFile } from "../../embedded-agent-helpers.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
@@ -46,16 +39,9 @@ import type { SandboxContext } from "../../sandbox/types.js";
 import type { guardSessionManager } from "../../session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairingForModel } from "../../session-transcript-repair.js";
 import type { AgentSession } from "../../sessions/index.js";
-import { isToolExecutionAllowed } from "../../tool-policy-shared.js";
 import { invalidateComputerFrameIfMissing } from "../../tools/computer-tool.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "../cache-ttl.js";
 import { log } from "../logger.js";
-import {
-  createSandboxPromptEntryLoader,
-  mapSandboxSkillEntriesForPrompt,
-  mapSandboxSkillUsagePaths,
-  resolveSandboxSkillRuntimeInputs,
-} from "../sandbox-skills.js";
 import type { ToolResultPromptProjectionState } from "../session-prompt-state.js";
 import {
   installContextEngineLoopHook,
@@ -495,121 +481,6 @@ export function installEmbeddedAttemptContextGuards(input: {
       return request;
     },
   };
-}
-
-export function prepareEmbeddedAttemptSkills(params: {
-  attempt: EmbeddedRunAttemptParams;
-  effectiveWorkspace: string;
-  sandbox: EmbeddedAttemptSetup["sandbox"];
-  sessionAgentId: string;
-}) {
-  const executionAllow = params.attempt.toolExecutionAllow;
-  // Retained schemas are not execution permission. An unreadable skill catalog
-  // creates impossible prerequisites and exposes an ungated Code Mode reader.
-  if (
-    params.attempt.operation === "settled-tool-finalization" ||
-    (executionAllow && !isToolExecutionAllowed(executionAllow, "read"))
-  ) {
-    return {
-      restoreSkillEnv: () => {},
-      skillUsagePaths: undefined,
-      skillsPrompt: "",
-      skillsSnapshotForRun: undefined,
-      codeModeSkills: [],
-    };
-  }
-  const {
-    skillsEligibility,
-    skillsPromptWorkspaceDir,
-    skillsSnapshot,
-    skillsWorkspaceDir,
-    workspaceOnly,
-  } = resolveSandboxSkillRuntimeInputs({
-    sandbox: params.sandbox,
-    skillsAnchorWorkspace: params.attempt.bootstrapWorkspaceDir ?? params.effectiveWorkspace,
-    skillsSnapshot: params.attempt.skillsSnapshot,
-  });
-  const { shouldLoadSkillEntries, skillEntries, loadSkillEntries, preserveEntryOrder } =
-    resolveEmbeddedRunSkillEntries({
-      workspaceDir: skillsWorkspaceDir,
-      config: params.attempt.config,
-      agentId: params.sessionAgentId,
-      eligibility: skillsEligibility,
-      skillsSnapshot,
-      // Sandbox fallbacks stay inside their sandbox skill workspace;
-      // host execution skills are not mounted there.
-      ...(params.sandbox?.enabled === true
-        ? {}
-        : { executionSkillsDir: path.join(params.effectiveWorkspace, "skills") }),
-      workspaceOnly,
-    });
-  const restoreSkillEnv = skillsSnapshot
-    ? applySkillEnvOverridesFromSnapshot({
-        snapshot: skillsSnapshot,
-        config: params.attempt.config,
-      })
-    : applySkillEnvOverrides({
-        skills: skillEntries ?? [],
-        config: params.attempt.config,
-      });
-  try {
-    const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
-      skillsWorkspaceDir,
-      skillsPromptWorkspaceDir,
-    });
-    const skillUsagePaths = mapSandboxSkillUsagePaths({
-      paths: params.sandbox?.skillUsagePaths,
-      skillsWorkspaceDir,
-      skillsPromptWorkspaceDir,
-    });
-    const skillsPrompt = resolveSkillsPrompt({
-      contextTokenBudget: params.attempt.contextTokenBudget,
-      skillsSnapshot,
-      entries: promptSkillEntries,
-      loadEntries: createSandboxPromptEntryLoader({
-        loadEntries: loadSkillEntries,
-        skillsWorkspaceDir,
-        skillsPromptWorkspaceDir,
-      }),
-      config: params.attempt.config,
-      workspaceDir: skillsPromptWorkspaceDir,
-      agentId: params.sessionAgentId,
-      eligibility: skillsEligibility,
-      preserveEntryOrder,
-    });
-    const sandbox = params.sandbox;
-    const sandboxSkillReader: CodeModeSkillReader | undefined = sandbox?.enabled
-      ? async ({ location, signal }) => {
-          const bridge = sandbox.fsBridge;
-          if (!bridge) {
-            throw new Error("Sandbox filesystem bridge is unavailable for skill reads.");
-          }
-          return (
-            await bridge.readFile({
-              filePath: location,
-              cwd: sandbox.containerWorkdir,
-              signal,
-            })
-          ).toString("utf8");
-        }
-      : undefined;
-    const codeModeSkills = resolveCodeModeSkills({
-      skillsPrompt,
-      candidates: skillsSnapshot?.resolvedSkills ?? skillEntries.map((entry) => entry.skill),
-      reader: sandboxSkillReader,
-    });
-    return {
-      restoreSkillEnv,
-      skillUsagePaths,
-      skillsPrompt,
-      skillsSnapshotForRun: skillsSnapshot,
-      codeModeSkills,
-    };
-  } catch (error) {
-    restoreSkillEnv();
-    throw error;
-  }
 }
 
 export type EmitDiagnosticRunCompleted = (

--- a/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-startup.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { prepareEmbeddedSkills } from "../skill-runtime.js";
 import type { EmbeddedRunAttemptParams } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
@@ -38,9 +39,7 @@ vi.mock("../sandbox-skills.js", () => ({
   mapSandboxSkillUsagePaths: vi.fn(() => []),
 }));
 
-import { prepareEmbeddedAttemptSkills } from "./attempt-setup.js";
-
-describe("prepareEmbeddedAttemptSkills", () => {
+describe("prepareEmbeddedSkills", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -53,7 +52,8 @@ describe("prepareEmbeddedAttemptSkills", () => {
     });
 
     expect(() =>
-      prepareEmbeddedAttemptSkills({
+      prepareEmbeddedSkills({
+        includeCodeModeSkills: true,
         attempt: { config: {} } as EmbeddedRunAttemptParams,
         effectiveWorkspace: "/tmp/workspace",
         sandbox: null,
@@ -64,7 +64,8 @@ describe("prepareEmbeddedAttemptSkills", () => {
   });
 
   it("does not load skills or apply their environment during settled finalization", () => {
-    const prepared = prepareEmbeddedAttemptSkills({
+    const prepared = prepareEmbeddedSkills({
+      includeCodeModeSkills: true,
       attempt: { operation: "settled-tool-finalization" } as EmbeddedRunAttemptParams,
       effectiveWorkspace: "/tmp/workspace",
       sandbox: null,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -19,6 +19,7 @@ import {
 } from "../../tool-search.js";
 import { log } from "../logger.js";
 import { remapSkillReferencePaths } from "../sandbox-skills.js";
+import { prepareEmbeddedSkills } from "../skill-runtime.js";
 import { prepareEmbeddedAttemptBootstrap } from "./attempt-bootstrap-prepare.js";
 import { prepareEmbeddedAttemptBundleTools } from "./attempt-bundle-tools.js";
 import { runEmbeddedAttemptExecutionPhase } from "./attempt-execution-phase.js";
@@ -36,7 +37,6 @@ import {
 } from "./attempt-sessions-yield.js";
 import {
   prepareEmbeddedAttemptSetup,
-  prepareEmbeddedAttemptSkills,
   startEmbeddedAttemptDiagnostics,
   type EmitDiagnosticRunCompleted,
 } from "./attempt-setup.js";
@@ -129,7 +129,8 @@ export async function runEmbeddedAttempt(
   });
   try {
     const preparedSkills = await prepare("attempt.skills", () =>
-      prepareEmbeddedAttemptSkills({
+      prepareEmbeddedSkills({
+        includeCodeModeSkills: true,
         attempt: params,
         effectiveWorkspace,
         sandbox,

--- a/src/agents/embedded-agent-runner/skill-runtime.ts
+++ b/src/agents/embedded-agent-runner/skill-runtime.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+import { resolveSkillsPrompt } from "../../skills/loading/workspace-skill-prompt.js";
+import { resolveEmbeddedRunSkillEntries } from "../../skills/runtime/embedded-run-entries.js";
+import {
+  applySkillEnvOverrides,
+  applySkillEnvOverridesFromSnapshot,
+} from "../../skills/runtime/env-overrides.js";
+import { resolveCodeModeSkills, type CodeModeSkillReader } from "../code-mode-skills.js";
+import type { SandboxContext } from "../sandbox/types.js";
+import { isToolExecutionAllowed } from "../tool-policy-shared.js";
+import type { EmbeddedRunAttemptParams } from "./run/types.js";
+import {
+  createSandboxPromptEntryLoader,
+  mapSandboxSkillEntriesForPrompt,
+  mapSandboxSkillUsagePaths,
+  resolveSandboxSkillRuntimeInputs,
+} from "./sandbox-skills.js";
+
+/** Prepares readable skills and owns environment rollback until the caller takes custody. */
+export function prepareEmbeddedSkills(params: {
+  attempt: Pick<
+    EmbeddedRunAttemptParams,
+    | "config"
+    | "bootstrapWorkspaceDir"
+    | "skillsSnapshot"
+    | "contextTokenBudget"
+    | "toolExecutionAllow"
+    | "operation"
+  >;
+  effectiveWorkspace: string;
+  sandbox: SandboxContext | null | undefined;
+  sessionAgentId: string;
+  includeCodeModeSkills: boolean;
+}) {
+  const executionAllow = params.attempt.toolExecutionAllow;
+  // Retained schemas are not execution permission. An unreadable skill catalog
+  // creates impossible prerequisites and exposes an ungated Code Mode reader.
+  if (
+    params.attempt.operation === "settled-tool-finalization" ||
+    (executionAllow && !isToolExecutionAllowed(executionAllow, "read"))
+  ) {
+    return {
+      restoreSkillEnv: () => {},
+      skillUsagePaths: undefined,
+      skillsPrompt: "",
+      skillsSnapshotForRun: undefined,
+      codeModeSkills: [],
+    };
+  }
+  const {
+    skillsEligibility,
+    skillsPromptWorkspaceDir,
+    skillsSnapshot,
+    skillsWorkspaceDir,
+    workspaceOnly,
+  } = resolveSandboxSkillRuntimeInputs({
+    sandbox: params.sandbox,
+    skillsAnchorWorkspace: params.attempt.bootstrapWorkspaceDir ?? params.effectiveWorkspace,
+    skillsSnapshot: params.attempt.skillsSnapshot,
+  });
+  const { shouldLoadSkillEntries, skillEntries, loadSkillEntries, preserveEntryOrder } =
+    resolveEmbeddedRunSkillEntries({
+      workspaceDir: skillsWorkspaceDir,
+      config: params.attempt.config,
+      agentId: params.sessionAgentId,
+      eligibility: skillsEligibility,
+      skillsSnapshot,
+      // Sandbox fallbacks stay inside their sandbox skill workspace;
+      // host execution skills are not mounted there.
+      ...(params.sandbox?.enabled === true
+        ? {}
+        : { executionSkillsDir: path.join(params.effectiveWorkspace, "skills") }),
+      workspaceOnly,
+    });
+  const restoreSkillEnv = skillsSnapshot
+    ? applySkillEnvOverridesFromSnapshot({
+        snapshot: skillsSnapshot,
+        config: params.attempt.config,
+      })
+    : applySkillEnvOverrides({
+        skills: skillEntries ?? [],
+        config: params.attempt.config,
+      });
+  try {
+    const promptSkillEntries = mapSandboxSkillEntriesForPrompt({
+      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      skillsWorkspaceDir,
+      skillsPromptWorkspaceDir,
+    });
+    const skillUsagePaths = mapSandboxSkillUsagePaths({
+      paths: params.sandbox?.skillUsagePaths,
+      skillsWorkspaceDir,
+      skillsPromptWorkspaceDir,
+    });
+    const skillsPrompt = resolveSkillsPrompt({
+      contextTokenBudget: params.attempt.contextTokenBudget,
+      skillsSnapshot,
+      entries: promptSkillEntries,
+      loadEntries: createSandboxPromptEntryLoader({
+        loadEntries: loadSkillEntries,
+        skillsWorkspaceDir,
+        skillsPromptWorkspaceDir,
+      }),
+      config: params.attempt.config,
+      workspaceDir: skillsPromptWorkspaceDir,
+      agentId: params.sessionAgentId,
+      eligibility: skillsEligibility,
+      preserveEntryOrder,
+    });
+    const sandbox = params.sandbox;
+    const sandboxSkillReader: CodeModeSkillReader | undefined = sandbox?.enabled
+      ? async ({ location, signal }) => {
+          const bridge = sandbox.fsBridge;
+          if (!bridge) {
+            throw new Error("Sandbox filesystem bridge is unavailable for skill reads.");
+          }
+          return (
+            await bridge.readFile({
+              filePath: location,
+              cwd: sandbox.containerWorkdir,
+              signal,
+            })
+          ).toString("utf8");
+        }
+      : undefined;
+    const codeModeSkills = params.includeCodeModeSkills
+      ? resolveCodeModeSkills({
+          skillsPrompt,
+          candidates: skillsSnapshot?.resolvedSkills ?? skillEntries.map((entry) => entry.skill),
+          reader: sandboxSkillReader,
+        })
+      : [];
+    return {
+      restoreSkillEnv,
+      skillUsagePaths,
+      skillsPrompt,
+      skillsSnapshotForRun: skillsSnapshot,
+      codeModeSkills,
+    };
+  } catch (error) {
+    restoreSkillEnv();
+    throw error;
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Ordinary embedded attempts and direct compaction separately prepared the same skill catalog, sandbox paths, prompt, and temporary environment overrides. Direct compaction also projected the same conversation facts twice for capability policy and tool construction.

## Why This Change Was Made

One shared preparation owner now handles skills and environment rollback until its caller takes custody. Callers retain their existing Code Mode, read-permission, prompt-budget and cleanup behavior. Direct compaction reuses its prepared conversation facts while keeping the distinct policy and session agent identities explicit. This removes 64 production code lines.

## User Impact

No intended user-visible change. Sandbox skill paths, catalog ordering, readable-tool restrictions, environment restoration, compaction prompts and tool capabilities retain their current behavior. There are no public API, configuration, storage or dependency changes.

## Evidence

- 53 focused cases passed, including skill/compaction behavior and 16 cleanup-ownership cases covering newer upstream lifecycle work.
- The complete selected gate passed all 29 checks, including production types, every core-test type graph, zero unused exports, lint and runtime import-cycle checks.
- The normal full build passed all 16 phases in 7m 21s, including 90 plugins and 53 native control-plane module loads.
- Independent P2 review found no actionable issue. The committed tree matches the tested source; no assertions were weakened.
