### PR TITLE
fix(process): release completed command output under Bun

### DIFF
--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -309,13 +309,19 @@ export function runServiceChildGroupAnchor(): void {
         await requestCleanup("lineage-lost");
       }
     };
-    // Own these private output descriptors: global stdio can keep them open after
-    // pipeline ends, while the control channel must retain descendant authority.
-    pipeline(command.stdout!, createWriteStream("", { fd: 1, autoClose: true }), () => {
+    // Bun's global streams retain output writers after pipeline completion. Node's
+    // stdio streams must preserve fd 1/2: closing them aborts its later Linux spawnSync census.
+    const stdout = process.versions.bun
+      ? createWriteStream("", { fd: 1, autoClose: true })
+      : process.stdout;
+    const stderr = process.versions.bun
+      ? createWriteStream("", { fd: 2, autoClose: true })
+      : process.stderr;
+    pipeline(command.stdout!, stdout, () => {
       stdoutDrained = true;
       void settleRoot();
     });
-    pipeline(command.stderr!, createWriteStream("", { fd: 2, autoClose: true }), () => {
+    pipeline(command.stderr!, stderr, () => {
       stderrDrained = true;
       void settleRoot();
     });

--- a/src/process/supervisor/service-child-group-anchor.ts
+++ b/src/process/supervisor/service-child-group-anchor.ts
@@ -309,20 +309,27 @@ export function runServiceChildGroupAnchor(): void {
         await requestCleanup("lineage-lost");
       }
     };
-    // Output EOF is independent of lineage EOF. Pipeline closes each forwarded stream
-    // after its final write while the control channel retains descendant authority.
-    pipeline(command.stdout!, process.stdout, () => {
+    // Own these private output descriptors: global stdio can keep them open after
+    // pipeline ends, while the control channel must retain descendant authority.
+    pipeline(command.stdout!, createWriteStream("", { fd: 1, autoClose: true }), () => {
       stdoutDrained = true;
       void settleRoot();
     });
-    pipeline(command.stderr!, process.stderr, () => {
+    pipeline(command.stderr!, createWriteStream("", { fd: 2, autoClose: true }), () => {
       stderrDrained = true;
       void settleRoot();
     });
     if (start.stdinMode !== "inherit" && command.stdin) {
-      process.stdin.pipe(command.stdin);
-      if (start.stdinMode === "pipe-closed" && process.stdin.readableEnded) {
-        command.stdin.end();
+      const input = process.stdin;
+      const destination = command.stdin;
+      const endInput = () => destination.end();
+      // Own EOF explicitly: pipe's default end check initializes global Bun output writers.
+      input.pipe(destination, { end: false });
+      destination.once("close", () => input.off("end", endInput));
+      if (input.readableEnded) {
+        endInput();
+      } else {
+        input.once("end", endInput);
       }
     }
     command.once("error", (error) => {

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -99,13 +99,18 @@ export function runServiceChildRelay(): void {
     anchor.once("spawn", () => {
       // The anchor inherited these outputs. Close only the relay's duplicate writers
       // so output EOF does not depend on either process giving up cleanup authority.
-      for (const fd of [1, 2]) {
-        const output = createWriteStream("", { fd, autoClose: true });
-        output.once("error", (error) => {
-          report({ type: "relay-error", generation: start.generation, error: error.message });
-          notifyParentLoss();
-        });
-        output.end();
+      if (process.versions.bun) {
+        for (const fd of [1, 2]) {
+          const output = createWriteStream("", { fd, autoClose: true });
+          output.once("error", (error) => {
+            report({ type: "relay-error", generation: start.generation, error: error.message });
+            notifyParentLoss();
+          });
+          output.end();
+        }
+      } else {
+        process.stdout.destroy();
+        process.stderr.destroy();
       }
       anchor?.send(start);
       if (parentLost) {

--- a/src/process/supervisor/service-child-relay.ts
+++ b/src/process/supervisor/service-child-relay.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { createWriteStream } from "node:fs";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import {
   resolveRuntimeWorkerArgv,
@@ -95,11 +96,17 @@ export function runServiceChildRelay(): void {
       process.exitCode = 1;
       return;
     }
-    // The anchor owns forwarded output lifetime. Drop the relay's duplicate writers so
-    // root output can reach EOF while the anchor retains descendant cleanup authority.
-    process.stdout.destroy();
-    process.stderr.destroy();
     anchor.once("spawn", () => {
+      // The anchor inherited these outputs. Close only the relay's duplicate writers
+      // so output EOF does not depend on either process giving up cleanup authority.
+      for (const fd of [1, 2]) {
+        const output = createWriteStream("", { fd, autoClose: true });
+        output.once("error", (error) => {
+          report({ type: "relay-error", generation: start.generation, error: error.message });
+          notifyParentLoss();
+        });
+        output.end();
+      }
       anchor?.send(start);
       if (parentLost) {
         anchor?.send({ type: "parent-loss", generation });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where service-managed commands finish under Bun but their result remains pending until retained descendants exit.

## Why This Change Was Made

Give Bun's private anchor ownership of its output streams and release the relay's inherited duplicates after successful spawn. Preserve Node's original standard-stream behavior, which its Linux process census requires. Forward stdin EOF explicitly because Bun's default pipe end check initializes extra output writers.

## User Impact

Completed command output reaches real EOF while descendant cleanup remains available. Root-result delivery, decoder flushing, lineage authority, input error handling, backpressure, and subsequent cleanup retain their existing contracts.

## Evidence

- The original two retained-descendant cases fail on the Bun baseline and pass after repair.
- All 148 selected process tests pass on Linux Node 24.19.0, Linux Bun 1.4.2, macOS Node 26.8.1, and macOS Bun 1.4.2.
- The first revision failed Linux CI: closing Node's standard descriptors caused its later native process census to abort before sending a closing receipt. A minimal native probe and the unchanged owned-stdio test reproduced that defect. The correction preserves Node's standard-stream semantics and limits explicit descriptor ownership to Bun.
- Fresh complete changed-file gate, full repository build, and independent P0–P2 review pass. No tracked tests, assertions, timeout limits, or host cleanup gates changed.
- Linux proof: [Node Testbox](https://github.com/openclaw/openclaw/actions/runs/34024136404), [Bun Testbox](https://github.com/openclaw/openclaw/actions/runs/34024764081). Both command wrappers exited successfully against the verified final candidate tree; both leases were stopped afterward.
- [Fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34025176828) passed after the Linux correction. This follows #139555 and does not claim the entire repository's Bun suite is green.
