### PR TITLE
refactor(macos): defer private voice debug formatting

### DIFF
--- a/apps/macos/Sources/OpenClaw/VoiceWakeRecognitionDebugSupport.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRecognitionDebugSupport.swift
@@ -75,6 +75,14 @@ enum VoiceWakeRecognitionDebugSupport {
             timingCount: segments.count(where: { $0.start > 0 || $0.duration > 0 }))
     }
 
+    static func segmentSummary(_ segments: [WakeWordSegment]) -> String {
+        segments.map { seg in
+            let start = String(format: "%.2f", seg.start)
+            let end = String(format: "%.2f", seg.end)
+            return "\(seg.text)@\(start)-\(end)"
+        }.joined(separator: ", ")
+    }
+
     static func matchSummary(_ match: WakeWordGateMatch?) -> String {
         match.map {
             "match=true gap=\(String(format: "%.2f", $0.postGap))s cmdLen=\($0.command.count)"

--- a/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeRuntime.swift
@@ -410,17 +410,13 @@ actor VoiceWakeRuntime {
             triggers: triggers,
             segments: segments)
         let matchSummary = VoiceWakeRecognitionDebugSupport.matchSummary(match)
-        let segmentSummary = segments.map { seg in
-            let start = String(format: "%.2f", seg.start)
-            let end = String(format: "%.2f", seg.end)
-            return "\(seg.text)@\(start)-\(end)"
-        }.joined(separator: ", ")
 
         self.logger.debug(
             "voicewake runtime transcript='\(transcript, privacy: .private)' textOnly=\(summary.textOnly) " +
                 "isFinal=\(isFinal) timing=\(summary.timingCount)/\(segments.count) " +
                 "capturing=\(capturing) fallback=\(usedFallback) " +
-                "\(matchSummary) segments=[\(segmentSummary, privacy: .private)]")
+                "\(matchSummary) " +
+                "segments=[\(VoiceWakeRecognitionDebugSupport.segmentSummary(segments), privacy: .private)]")
     }
 
     private func noteAudioTap(rms: Double) {

--- a/apps/macos/Sources/OpenClaw/VoiceWakeTester.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeTester.swift
@@ -302,22 +302,14 @@ final class VoiceWakeTester {
             transcript: transcript,
             triggers: triggers,
             segments: segments)
-        let gaps = Self.debugCandidateGaps(triggers: triggers, segments: segments)
-        let segmentSummary = Self.debugSegments(segments)
         let matchSummary = VoiceWakeRecognitionDebugSupport.matchSummary(match)
 
         self.logger.debug(
             "voicewake test transcript='\(transcript, privacy: .private)' textOnly=\(summary.textOnly) " +
                 "isFinal=\(isFinal) timing=\(summary.timingCount)/\(segments.count) " +
-                "\(matchSummary) gaps=[\(gaps, privacy: .private)] segments=[\(segmentSummary, privacy: .private)]")
-    }
-
-    private static func debugSegments(_ segments: [WakeWordSegment]) -> String {
-        segments.map { seg in
-            let start = String(format: "%.2f", seg.start)
-            let end = String(format: "%.2f", seg.end)
-            return "\(seg.text)@\(start)-\(end)"
-        }.joined(separator: ", ")
+                "\(matchSummary) " +
+                "gaps=[\(Self.debugCandidateGaps(triggers: triggers, segments: segments), privacy: .private)] " +
+                "segments=[\(VoiceWakeRecognitionDebugSupport.segmentSummary(segments), privacy: .private)]")
     }
 
     private static func debugCandidateGaps(triggers: [String], segments: [WakeWordSegment]) -> String {

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawLoggingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawLoggingTests.swift
@@ -34,13 +34,20 @@ struct OpenClawLoggingTests {
     @Test
     func `private values are not described`() {
         let value = DescribedValue()
-        let hidden: Logger.Message = "value=\(value, privacy: .private)"
+        var factoryCalls = 0
+        func makeValue() -> DescribedValue {
+            factoryCalls += 1
+            return value
+        }
+        let hidden: Logger.Message = "value=\(makeValue(), privacy: .private)"
         #expect(hidden.description == "value=<private>")
         #expect(value.descriptionReads == 0)
+        #expect(factoryCalls == 0)
 
-        let visible: Logger.Message = "value=\(value, privacy: .public)"
+        let visible: Logger.Message = "value=\(makeValue(), privacy: .public)"
         #expect(visible.description == "value=synthetic-description")
         #expect(value.descriptionReads == 1)
+        #expect(factoryCalls == 1)
     }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Voice Wake's runtime and settings tester duplicate segment-summary formatting and eagerly calculate private debug values that the logger discards. This leaves presentation ownership split and performs unnecessary preparation even though the private output stays redacted.

## Why This Change Was Made

Share the existing typed segment formatter in the common debug-support owner. Invoke segment and tester-specific gap formatting inside the logger's existing private interpolation, which controls whether a value is evaluated. Public summaries, logging cadence and speech/recognition paths remain unchanged.

## User Impact

Log text and privacy behavior are preserved. The change removes four production lines and extends one existing logging test by seven lines; it adds no test case, configuration option, dependency or public API. No measured performance or speech-correctness improvement is claimed.

## Evidence

The seven relevant source/test files match a prior exact CI baseline whose 21 runtime, four tester and three logging methods passed. The logging methods include one parameterized method; method counts are not total executions.

The extended privacy test checks that a private value factory is not invoked while a public one is invoked once. Scoped formatting/lint and bounded shared-helper/test-file typechecks passed. All 13 selected tooling stages passed, including 1,125 Node tooling tests across 21 files. Independent managed review found no actionable issue. No microphone or operator-app scenario was run.

The candidate [CI run 34024465035](https://github.com/openclaw/openclaw/actions/runs/34024465035) passed the native release build and app tests, including all three affected suites and the extended private-value factory assertion. The seven relevant files match tested merge `75c5ffd9b18e749782037596cbeb62cb5ec8dcd7`. The default Mac suite retained its three unrelated skips; the separate health-render test ran, while the other two skipped cases remained unexecuted.

The first run failed the separate `macos-node-3` process-group cleanup case and its downstream CI gate. Source-bound triage found that this owner discards the original OS error; the exact Darwin failure cause remains unknown. That diagnostic loss is fixed by [PR #140015](https://github.com/openclaw/openclaw/pull/140015). The single targeted retry also failed: this time the service-managed argv0 case reached the same cleanup-error branch. Both original logs are retained. No further retry is queued; the underlying OS error still needs evidence. This PR does not claim to repair the process-cleanup event.

The subsequent [CI run 34028802408](https://github.com/openclaw/openclaw/actions/runs/34028802408) passed all three Node tooling jobs and the affected Voice Wake/logging methods, but its full native suite failed one unrelated catalog peer-readiness assertion. That test is now repaired and verified on main by [PR #140088](https://github.com/openclaw/openclaw/pull/140088).

The branch is now mechanically refreshed as `f1c15aeacce668392e8b8692e462ff3849c00acc` onto that landed repair. The four-file patch and all seven relevant Voice Wake/logging source and test files remain byte-identical to the independently reviewed candidate. [Fresh CI 34034362651](https://github.com/openclaw/openclaw/actions/runs/34034362651) passed 9 jobs with 25 skipped, testing merge 2f3594bb3feb8a2a87e816211541a31ee2e53a0a (parents 897013c7 + f1c15aec). All seven source blobs match. All 28 affected methods and all 3 suites passed, including the private factory assertion. Separate Kit 1661/124 and app 2066/225 test/suite summaries passed, plus AppState 2 and health 1 launches; the other two native execution/handshake skips remain unexecuted. Counts are not summed as unique tests. No further retry of either old failing run was requested, and no original OS-cleanup cause is inferred from the later passing tooling run.
