### PR TITLE
refactor(meetings): share browser audio device inspection

### DIFF
--- a/extensions/teams-meetings/src/transports/teams-meetings-selectors.ts
+++ b/extensions/teams-meetings/src/transports/teams-meetings-selectors.ts
@@ -46,6 +46,7 @@ export const TEAMS_MEETING_SELECTORS = {
     'select[data-tid="microphone-select"]',
   ],
   microphoneDeviceMenu: ['[data-tid="microphone-settings"][role="listbox"]'],
+  microphoneDeviceScope: '[data-tid="device-settings-microphone"]',
   selectedMicrophoneDevice: ["option:checked", '[role="option"][aria-selected="true"]'],
   audioDeviceOptions: ["option", '[role="option"]'],
   leave: [

--- a/extensions/teams-meetings/src/transports/teams-meetings-status-prejoin-source.ts
+++ b/extensions/teams-meetings/src/transports/teams-meetings-status-prejoin-source.ts
@@ -133,47 +133,7 @@ export function teamsMeetingStatusPreludeSource(params: MeetingStatusPreludePara
   if (identityVerified && !inCall && join && cameraState !== "off") {
     controlManualAction = manualActionFor("teams-camera-required", "Turn the Teams camera off and verify the camera control shows it is off, then retry joining.");
   }
-  const isVirtualAudioDevice = (value) =>
-    /^(?:blackhole 2ch(?: \\(virtual\\))?|openclaw meeting audio)$/i.test(
-      String(value || "").replace(/\\s+/g, " ").trim()
-    );
-  const isVirtualAudioDeviceNode = (node) => [
-    node?.getAttribute?.("aria-label"),
-    node?.getAttribute?.("title"),
-    node?.label,
-    node?.value,
-    text(node),
-  ].some(isVirtualAudioDevice);
-  const microphoneDeviceRoots = () => {
-    // Consumer in-call controls expose the listbox itself, without the prejoin
-    // selected-device button/combobox wrapper.
-    const control = firstRaw(selectors.microphoneDevice) || firstRaw(selectors.microphoneDeviceMenu);
-    if (!control) return { control, roots: [] };
-    const roots = [control];
-    const scope = control.closest?.('[data-tid="device-settings-microphone"]');
-    if (scope && !roots.includes(scope)) roots.push(scope);
-    const listboxId = control.getAttribute?.("aria-controls");
-    const listbox = listboxId ? document.getElementById?.(listboxId) : undefined;
-    if (listbox && !roots.includes(listbox)) roots.push(listbox);
-    const liveMenu = firstRaw(selectors.microphoneDeviceMenu);
-    if (liveMenu && !roots.includes(liveMenu)) roots.push(liveMenu);
-    return { control, roots };
-  };
-  const selectedMicrophoneLabel = () => {
-    const { control, roots } = microphoneDeviceRoots();
-    const selectedOption = control?.selectedOptions?.[0];
-    if (selectedOption && isVirtualAudioDeviceNode(selectedOption)) {
-      return label(selectedOption) || selectedOption.value;
-    }
-    if (control && isVirtualAudioDeviceNode(control)) return label(control) || control.value;
-    for (const root of roots) {
-      const selected = firstWithin(root, selectors.selectedMicrophoneDevice);
-      if (selected && isVirtualAudioDeviceNode(selected)) {
-        return label(selected) || selected.value;
-      }
-    }
-    return undefined;
-  };
+  const { isVirtualAudioDevice, isVirtualAudioDeviceNode, microphoneDeviceRoots, selectedMicrophoneLabel } = meetingAudioInput;
   let audioInputRouted;
   let audioInputDeviceLabel;
   let audioInputRouteError;

--- a/extensions/zoom-meetings/src/transports/zoom-meetings-selectors.ts
+++ b/extensions/zoom-meetings/src/transports/zoom-meetings-selectors.ts
@@ -14,6 +14,7 @@ export const ZOOM_MEETING_SELECTORS = {
   deviceSettings: ['button[aria-label="More audio controls" i]'],
   microphoneDevice: ['[aria-label*="microphone" i][role="combobox"]'],
   microphoneDeviceMenu: [".audio-option-menu__pop-menu", '[role="listbox"]', '[role="menu"]'],
+  microphoneDeviceScope: '[data-tid="device-settings-microphone"]',
   selectedMicrophoneDevice: [
     'a[role="button"][aria-label^="Select a microphone" i][aria-label$="selected" i]',
     "option:checked",

--- a/extensions/zoom-meetings/src/transports/zoom-meetings-status-prejoin-source.ts
+++ b/extensions/zoom-meetings/src/transports/zoom-meetings-status-prejoin-source.ts
@@ -189,47 +189,7 @@ export function zoomMeetingStatusPreludeSource(params: MeetingStatusPreludeParam
   ) {
     controlManualAction = manualActionFor("zoom-camera-required", inCall ? "Turn the Zoom camera off and verify the in-call camera control shows it is off." : "Turn the Zoom camera off and verify the camera control shows it is off, then retry joining.");
   }
-  const isVirtualAudioDevice = (value) =>
-    /^(?:blackhole 2ch(?: \\(virtual\\))?|openclaw meeting audio)$/i.test(
-      String(value || "").replace(/\\s+/g, " ").trim()
-    );
-  const isVirtualAudioDeviceNode = (node) => [
-    node?.getAttribute?.("aria-label"),
-    node?.getAttribute?.("title"),
-    node?.label,
-    node?.value,
-    text(node),
-  ].some(isVirtualAudioDevice);
-  const microphoneDeviceRoots = () => {
-    // Consumer in-call controls expose the listbox itself, without the prejoin
-    // selected-device button/combobox wrapper.
-    const control = firstRaw(selectors.microphoneDevice) || firstRaw(selectors.microphoneDeviceMenu);
-    if (!control) return { control, roots: [] };
-    const roots = [control];
-    const scope = control.closest?.('[data-tid="device-settings-microphone"]');
-    if (scope && !roots.includes(scope)) roots.push(scope);
-    const listboxId = control.getAttribute?.("aria-controls");
-    const listbox = listboxId ? document.getElementById?.(listboxId) : undefined;
-    if (listbox && !roots.includes(listbox)) roots.push(listbox);
-    const liveMenu = firstRaw(selectors.microphoneDeviceMenu);
-    if (liveMenu && !roots.includes(liveMenu)) roots.push(liveMenu);
-    return { control, roots };
-  };
-  const selectedMicrophoneLabel = () => {
-    const { control, roots } = microphoneDeviceRoots();
-    const selectedOption = control?.selectedOptions?.[0];
-    if (selectedOption && isVirtualAudioDeviceNode(selectedOption)) {
-      return label(selectedOption) || selectedOption.value;
-    }
-    if (control && isVirtualAudioDeviceNode(control)) return label(control) || control.value;
-    for (const root of roots) {
-      const selected = firstWithin(root, selectors.selectedMicrophoneDevice);
-      if (selected && isVirtualAudioDeviceNode(selected)) {
-        return label(selected) || selected.value;
-      }
-    }
-    return undefined;
-  };
+  const { isVirtualAudioDevice, isVirtualAudioDeviceNode, microphoneDeviceRoots, selectedMicrophoneLabel } = meetingAudioInput;
   let audioInputRouted;
   let audioInputDeviceLabel;
   let audioInputRouteError;

--- a/src/meeting-bot/status-prejoin-source.ts
+++ b/src/meeting-bot/status-prejoin-source.ts
@@ -91,6 +91,51 @@ export function createMeetingStatusPreludeSource(
     }
     return undefined;
   };
+  // Keep these names scoped: older plugin lifecycle fragments declare their own helpers.
+  const meetingAudioInput = (() => {
+    const isVirtualAudioDevice = (value) =>
+      /^(?:blackhole 2ch(?: \\(virtual\\))?|openclaw meeting audio)$/i.test(
+        String(value || "").replace(/\\s+/g, " ").trim()
+      );
+    const isVirtualAudioDeviceNode = (node) => [
+      node?.getAttribute?.("aria-label"),
+      node?.getAttribute?.("title"),
+      node?.label,
+      node?.value,
+      text(node),
+    ].some(isVirtualAudioDevice);
+    const microphoneDeviceRoots = () => {
+      // Consumer in-call controls expose the listbox itself, without the prejoin
+      // selected-device button/combobox wrapper.
+      const control = firstRaw(selectors.microphoneDevice) || firstRaw(selectors.microphoneDeviceMenu);
+      if (!control) return { control, roots: [] };
+      const roots = [control];
+      const scope = control.closest?.(selectors.microphoneDeviceScope);
+      if (scope && !roots.includes(scope)) roots.push(scope);
+      const listboxId = control.getAttribute?.("aria-controls");
+      const listbox = listboxId ? document.getElementById?.(listboxId) : undefined;
+      if (listbox && !roots.includes(listbox)) roots.push(listbox);
+      const liveMenu = firstRaw(selectors.microphoneDeviceMenu);
+      if (liveMenu && !roots.includes(liveMenu)) roots.push(liveMenu);
+      return { control, roots };
+    };
+    const selectedMicrophoneLabel = () => {
+      const { control, roots } = microphoneDeviceRoots();
+      const selectedOption = control?.selectedOptions?.[0];
+      if (selectedOption && isVirtualAudioDeviceNode(selectedOption)) {
+        return label(selectedOption) || selectedOption.value;
+      }
+      if (control && isVirtualAudioDeviceNode(control)) return label(control) || control.value;
+      for (const root of roots) {
+        const selected = firstWithin(root, selectors.selectedMicrophoneDevice);
+        if (selected && isVirtualAudioDeviceNode(selected)) {
+          return label(selected) || selected.value;
+        }
+      }
+      return undefined;
+    };
+    return { isVirtualAudioDevice, isVirtualAudioDeviceNode, microphoneDeviceRoots, selectedMicrophoneLabel };
+  })();
   ${options.controlLookupSource}
   const waitForUi = () => new Promise((resolve) => setTimeout(resolve, 120));
   const bridgeOwnedBySession = (entry) => Boolean(

--- a/src/meeting-bot/status-source-parity.test.ts
+++ b/src/meeting-bot/status-source-parity.test.ts
@@ -1,3 +1,4 @@
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import { createMeetingStatusCallSource } from "./status-call-source.js";
 import { createMeetingStatusPreludeSource } from "./status-prejoin-source.js";
@@ -26,6 +27,31 @@ const platforms = [
 ] as const;
 
 describe.each(platforms)("$name meeting status source parity", (platform) => {
+  const preludeOptions = {
+    controlLookupSource: "const findTextButton = () => undefined;",
+    lifecycleSource: ["const microphoneState = undefined;", "const cameraState = undefined;"].join(
+      "\n",
+    ),
+    manualActionSource: "const clickedJoin = false;",
+    platform: {
+      displayName: platform.name,
+      globals: platform.globals,
+      manualActionReasonPrefix: platform.token,
+    },
+  };
+  const preludeParams = {
+    allowMicrophone: false,
+    allowSessionAdoption: false,
+    autoJoin: false,
+    captureCaptions: false,
+    expectedIdentity: `${platform.token}:meeting`,
+    guestName: "OpenClaw",
+    pageIdentitySource: "const meetingIdentity = () => undefined;",
+    selectors: "{}",
+    toggleStateFunction: "() => undefined",
+    waitForInCallMs: 30_000,
+  };
+
   it("threads typed platform globals and reasons through deterministic shared sources", () => {
     const callOptions = {
       captionEnableSource: "captionsEnabledNow = true;",
@@ -40,32 +66,6 @@ describe.each(platforms)("$name meeting status source parity", (platform) => {
         manualActionReasonPrefix: platform.token,
       },
     };
-    const preludeOptions = {
-      controlLookupSource: "const findTextButton = () => undefined;",
-      lifecycleSource: [
-        "const microphoneState = undefined;",
-        "const cameraState = undefined;",
-      ].join("\n"),
-      manualActionSource: "const clickedJoin = false;",
-      platform: {
-        displayName: platform.name,
-        globals: platform.globals,
-        manualActionReasonPrefix: platform.token,
-      },
-    };
-    const preludeParams = {
-      allowMicrophone: false,
-      allowSessionAdoption: false,
-      autoJoin: false,
-      captureCaptions: false,
-      expectedIdentity: `${platform.token}:meeting`,
-      guestName: "OpenClaw",
-      pageIdentitySource: "const meetingIdentity = () => undefined;",
-      selectors: "{}",
-      toggleStateFunction: "() => undefined",
-      waitForInCallMs: 30_000,
-    };
-
     const callSource = createMeetingStatusCallSource(callOptions);
     const preludeSource = createMeetingStatusPreludeSource(preludeParams, preludeOptions);
 
@@ -75,5 +75,30 @@ describe.each(platforms)("$name meeting status source parity", (platform) => {
     expect(preludeSource).toContain(`"${platform.token}-session-conflict"`);
     expect(createMeetingStatusCallSource(callOptions)).toBe(callSource);
     expect(createMeetingStatusPreludeSource(preludeParams, preludeOptions)).toBe(preludeSource);
+  });
+
+  it("preserves audio helper declarations supplied by released plugin lifecycle fragments", async () => {
+    const source = createMeetingStatusPreludeSource(preludeParams, {
+      ...preludeOptions,
+      // Published plugin fragments declare these names in the generated function's body.
+      lifecycleSource: `
+        const isVirtualAudioDevice = (value) => value === "plugin device";
+        const isVirtualAudioDeviceNode = (node) => isVirtualAudioDevice(node.label);
+        const microphoneDeviceRoots = () => ({ control: { label: "plugin device" }, roots: [] });
+        const selectedMicrophoneLabel = () => {
+          const { control } = microphoneDeviceRoots();
+          return isVirtualAudioDeviceNode(control) ? control.label : undefined;
+        };
+        const microphoneState = "off";
+        const cameraState = "off";`,
+      manualActionSource: "return selectedMicrophoneLabel();",
+    });
+    await expect(
+      runInNewContext(`(${source}})()`, {
+        document: {},
+        location: { href: "https://example.test/meeting" },
+        window: {},
+      }),
+    ).resolves.toBe("plugin device");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Teams and Zoom maintained identical browser audio-device inspection helpers. Keeping both copies aligned made microphone selection and device-label fixes harder to maintain.

## Why This Change Was Made

The shared meeting prelude now owns DOM device inspection. Each plugin keeps its selectors and audio lifecycle decisions. The shared helpers are scoped so older published plugin fragments can retain their own declarations without a generated-script collision. This removes 32 production code lines (33 physical lines), with the existing public SDK signature unchanged.

## User Impact

No intended behavior change. Teams still accepts verified prepared input during read-only inspection, while Zoom still requires the current live selection. Microphone/speaker separation, native selects, live listboxes, ancestor scopes and exact device labels retain their behavior. The existing release version synchronization keeps new plugin packages paired with a supporting host; no versions change in this PR.

## Evidence

- 102 baseline and 104 final VM cases passed, including older plugin declarations with the new host prelude.
- Real Chromium passed 36 scenarios / 108 executions comparing baseline, candidate and older-plugin/new-host behavior, including DOM effects, speaker routing, ancestor-only and wrong-ancestor selection.
- Seventeen release/packaging cases and both plugin runtime builds passed before the final selector-only move. Isolated release composition preserved the pluginApi/peer installation floor. Public prelude declarations remain byte-identical (992 bytes).
- The complete 34-stage selected gate passed before moving the selector literal into plugin metadata. Final-source extension types, typed lint, VM/Chromium comparisons and fresh P2 review passed afterward. Exact-head CI will cover the complete final patch before landing.
