### PR TITLE
fix(telegram): preserve styled links inside rich message containers

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/features/runtime-reference.md
+++ b/.agents/skills/telegram-e2e-userbot/features/runtime-reference.md
@@ -116,7 +116,10 @@ not the model.
 
 ## Runtime facts
 
-- TDLib ids are shifted: raw TDLib message id equals Bot API id `<< 20`; compare `botApiMessageId`.
+- `botApiMessageId` is the recorder's historical name for the observing account's server message ID (`messageId >> 20`). Keep that artifact field, but do not equate it with another account's Bot API receipt in a DM or basic group: those message ID sequences are account-specific. Channels/supergroups share their sequence. See [Telegram's message-ID contract](https://core.telegram.org/api/updates#message-id-sequences).
+- Correlate a DM send with a unique run marker in the observed content. Keep the bot receipt for bot-side edits; use the original raw observer `messageId`, edit kind, and a fresh marker to prove the observer saw that same message change. Formatting assertions must still inspect the full native tree; a marker alone is not formatting proof.
+- Uploaded QA artifacts are not private. Retain raw identities only in memory; export run-local labels and measured relationships. Export bounded, metadata-free trees only for marker-correlated synthetic fixtures, and counts/types only for unmatched observations.
+- Serve-mode observations stay within the selected chat and fetch incomplete content with `getFullRichMessage` using the observing account's chat/message pair before emitting a complete snapshot. Intervening updates remain queued; the response has no revision token, so this is not a revision-perfect historical snapshot. Raw recording and transcript normalization preserve the original partial content instead of fetching or relabeling it.
 - TDLib replays cached updates after connect; judge only events after the run's sent action.
 - The driver pins `@prebuilt-tdlib` `0.1008067.0`, which reports TDLib `1.8.67`.
 - TDLib 1.8.6 and later take the existing base64 database key in `setTdlibParameters`; re-encoding changes the key.

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.py
@@ -996,35 +996,99 @@ def serve_message(message, users):
         "contentType": normalized["contentType"],
         "text": normalized["text"],
         "entities": normalized["entities"],
+        "richMessage": normalized["richMessage"],
     }
 
 
-def serve_update(update, users, known_messages):
+def update_chat_id(update):
+    message = update.get("message")
+    if isinstance(message, dict) and "chat_id" in message:
+        return message["chat_id"]
+    return update.get("chat_id")
+
+
+def serve_update(update, client, known_messages):
     update_type = update.get("@type")
     if update_type == "updateNewMessage":
         message = update.get("message") or {}
-        normalized = serve_message(message, users)
-        if isinstance(normalized["messageId"], int):
-            known_messages[normalized["messageId"]] = normalized
-        return {"kind": "message", **normalized}
-    if update_type != "updateMessageContent":
+        normalized = serve_message(message, client.users)
+        kind = "message"
+    elif update_type == "updateMessageContent":
+        known = known_messages.get((update["chat_id"], update["message_id"]))
+        if not known:
+            return None
+        normalized = {**known, **message_content(update.get("new_content") or {})}
+        kind = "edit"
+    else:
         return None
-    message_id = update.get("message_id")
-    known = known_messages.get(message_id)
-    if not known:
-        return None
-    content = update.get("new_content") or {}
-    normalized = {**known, **message_content(content)}
-    known_messages[message_id] = normalized
-    return {"kind": "edit", **normalized}
+    key = (normalized["chatId"], normalized["messageId"])
+    rich_message = normalized["richMessage"]
+    if rich_message is not None and not rich_message["is_full"]:
+        # Serve exposes complete snapshots, unlike the raw recorder. request()
+        # queues intervening updates; publish this result before draining them.
+        rich_message = client.request({
+            "@type": "getFullRichMessage", "chat_id": key[0], "message_id": key[1],
+        })
+        if rich_message.get("@type") != "richMessage" or rich_message.get("is_full") is not True:
+            raise DriverError("getFullRichMessage did not return a complete rich message")
+        normalized = {**normalized, **message_content({
+            "@type": "messageRichMessage", "message": rich_message,
+        })}
+    known_messages[key] = normalized
+    return {"kind": kind, **normalized}
+
+
+def rich_text(value):
+    if not isinstance(value, dict):
+        return ""
+    kind = value.get("@type", "")
+    if kind == "richTextPlain":
+        return value.get("text", "")
+    if kind == "richTextCustomEmoji":
+        return value.get("alternative_text", "")
+    if kind == "richTextMathematicalExpression":
+        return value.get("expression", "")
+    if kind == "richTexts":
+        return "".join(rich_text(item) for item in value.get("texts") or [])
+    return rich_text(value.get("text"))
+
+
+def rich_message_text(value):
+    if not isinstance(value, dict):
+        return ""
+    parts = []
+
+    def visit(node):
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        if str(node.get("@type", "")).startswith("richText"):
+            text = rich_text(node)
+            if text:
+                parts.append(text)
+            return
+        for child in node.values():
+            visit(child)
+
+    visit(value.get("blocks") or [])
+    return "\n".join(parts)
 
 
 def message_content(content):
+    if content.get("@type") == "messageRichMessage":
+        message = content["message"]
+        return {
+            "contentType": "messageRichMessage", "text": rich_message_text(message),
+            "entities": [], "richMessage": message,
+        }
     key = "text" if content.get("@type") == "messageText" else "caption"
     formatted = content.get(key)
     if isinstance(formatted, dict) and isinstance(formatted.get("text"), str):
-        return {"contentType": content.get("@type"), "text": formatted["text"], "entities": formatted["entities"]}
-    return {"contentType": content.get("@type"), "text": "", "entities": []}
+        return {"contentType": content.get("@type"), "text": formatted["text"], "entities": formatted["entities"], "richMessage": None}
+    return {"contentType": content.get("@type"), "text": "", "entities": [], "richMessage": None}
 
 
 def write_ndjson(payload):
@@ -1047,8 +1111,8 @@ def command_serve(args):
     known_messages = {}
     while True:
         update = driver.client.next_update(timeout=0.1)
-        if update:
-            event = serve_update(update, driver.client.users, known_messages)
+        if update and update_chat_id(update) == chat_id:
+            event = serve_update(update, driver.client, known_messages)
             if event:
                 write_ndjson({"type": "update", "update": event})
         readable, _, _ = select.select([sys.stdin], [], [], 0)
@@ -1071,7 +1135,7 @@ def command_serve(args):
             reply_to = request.get("replyToMessageId")
             sent = driver.send_text(chat_id, text, reply_to=reply_to)
             normalized = serve_message(sent, driver.client.users)
-            known_messages[normalized["messageId"]] = normalized
+            known_messages[(normalized["chatId"], normalized["messageId"])] = normalized
             write_ndjson({"type": "response", "id": request_id, "result": normalized})
         except (DriverError, ValueError, TypeError) as error:
             write_ndjson(

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -1,8 +1,12 @@
 import importlib.util
+import io
 import sys
 import tempfile
 import unittest
+from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 
 DRIVER_PATH = Path(__file__).with_name("user-driver.py")
@@ -10,6 +14,32 @@ SPEC = importlib.util.spec_from_file_location("tg_user_driver_test_target", DRIV
 driver = importlib.util.module_from_spec(SPEC)
 sys.modules["tg_user_driver_test_target"] = driver
 SPEC.loader.exec_module(driver)
+
+
+def observation_client(users=None):
+    return SimpleNamespace(
+        users=users or {},
+        request=Mock(side_effect=AssertionError("unexpected TDLib request")),
+    )
+
+
+def rich_content(text, full=True):
+    return {
+        "@type": "messageRichMessage",
+        "message": {
+            "@type": "richMessage", "is_full": full, "is_rtl": False,
+            "blocks": [{"@type": "pageBlockParagraph", "text": {
+                "@type": "richTextPlain", "text": text,
+            }}],
+        },
+    }
+
+
+def native_message(content, chat_id=-1001, message_id=42 << 20, sender_id=101):
+    return {
+        "id": message_id, "chat_id": chat_id, "sender_id": {"user_id": sender_id},
+        "date": 123, "reply_to": {"message_id": 7}, "content": content,
+    }
 
 
 class PhotoContentTest(unittest.TestCase):
@@ -25,7 +55,7 @@ class PhotoContentTest(unittest.TestCase):
 
         archive = FakeTar()
         with self.assertRaisesRegex(driver.DriverError, "unsafe member"):
-            driver.extract_prebuilt_archive(archive, tempfile.mkdtemp())
+            driver.extract_prebuilt_archive(archive, tempfile.gettempdir())
         self.assertFalse(archive.extracted)
 
     def test_uses_current_tdlib_photo_shape(self):
@@ -115,9 +145,9 @@ class PhotoContentTest(unittest.TestCase):
                 "text": {"@type": "formattedText", "text": text, "entities": entities},
             },
         }
-        users = {101: {"username": "sut_bot"}}
+        client = observation_client({101: {"username": "sut_bot"}})
         created = driver.serve_update(
-            {"@type": "updateNewMessage", "message": message}, users, known
+            {"@type": "updateNewMessage", "message": message}, client, known
         )
         self.assertEqual(created["kind"], "message")
         self.assertEqual(created["botApiMessageId"], 42)
@@ -148,7 +178,7 @@ class PhotoContentTest(unittest.TestCase):
                             },
                         },
                     },
-                    users,
+                    client,
                     known,
                 )
                 self.assertEqual(edited["kind"], "edit")
@@ -156,7 +186,7 @@ class PhotoContentTest(unittest.TestCase):
                 self.assertEqual(edited["text"], edited_text)
                 self.assertEqual(edited["entities"], edited_entities)
                 self.assertEqual(edited["senderId"], 101)
-                self.assertEqual(known[message_id]["entities"], edited_entities)
+                self.assertEqual(known[(-1001, message_id)]["entities"], edited_entities)
 
     def test_preserves_native_content_type_and_caption_entities_in_messages_and_edits(self):
         entities = [{"offset": 3, "length": 5, "type": {"@type": "textEntityTypeCode"}}]
@@ -171,8 +201,9 @@ class PhotoContentTest(unittest.TestCase):
             },
         }
         known = {}
+        client = observation_client()
         created = driver.serve_update(
-            {"@type": "updateNewMessage", "message": message}, {}, known
+            {"@type": "updateNewMessage", "message": message}, client, known
         )
         normalized = driver.normalize_message(message)
         self.assertEqual(created["contentType"], "messagePhoto")
@@ -183,17 +214,18 @@ class PhotoContentTest(unittest.TestCase):
         edited = driver.serve_update(
             {
                 "@type": "updateMessageContent",
+                "chat_id": -1001,
                 "message_id": message["id"],
                 "new_content": {
                     "@type": "messageVideo",
                     "caption": {"@type": "formattedText", "text": "😀 a   b", "entities": []},
                 },
             },
-            {},
+            client,
             known,
         )
         self.assertEqual(edited["contentType"], "messageVideo")
-        self.assertEqual(known[message["id"]]["contentType"], "messageVideo")
+        self.assertEqual(known[(-1001, message["id"])]["contentType"], "messageVideo")
         self.assertEqual(edited["text"], "😀 a   b")
         self.assertEqual(edited["entities"], [])
 
@@ -210,8 +242,9 @@ class PhotoContentTest(unittest.TestCase):
                         "content": content,
                     }
                     known = {}
+                    client = observation_client()
                     created = driver.serve_update(
-                        {"@type": "updateNewMessage", "message": message}, {}, known
+                        {"@type": "updateNewMessage", "message": message}, client, known
                     )
                     self.assertEqual(created["text"], "plain")
                     self.assertEqual(created["entities"], [])
@@ -228,8 +261,8 @@ class PhotoContentTest(unittest.TestCase):
                         }
                     )
                     with self.assertRaisesRegex(KeyError, "entities"):
-                        driver.serve_update(update, {}, known)
-                    self.assertEqual(known[message["id"]]["entities"], [])
+                        driver.serve_update(update, client, known)
+                    self.assertEqual(known[(-1001, message["id"])]["entities"], [])
 
     def test_ignores_unknown_edit_in_serve_mode(self):
         event = driver.serve_update(
@@ -239,11 +272,214 @@ class PhotoContentTest(unittest.TestCase):
                 "message_id": 99,
                 "new_content": {},
             },
-            {},
+            observation_client(),
             {},
         )
 
         self.assertIsNone(event)
+
+    def test_preserves_rich_tree_revisions_and_clears_it_on_plain_replacement(self):
+        known = {}
+        client = observation_client()
+        message_id = 45 << 20
+        rich = {
+            "@type": "richMessage", "is_full": True, "is_rtl": False,
+            "blocks": [{"@type": "pageBlockParagraph", "text": {
+                "@type": "richTextUrl", "url": "https://example.com/qa", "is_cached": False,
+                "text": {"@type": "richTextSpoiler", "text": {
+                    "@type": "richTextMathematicalExpression", "expression": "x",
+                }},
+            }}],
+        }
+        content = {"@type": "messageRichMessage", "message": rich}
+        created = driver.serve_update({"@type": "updateNewMessage", "message": {
+            "id": message_id, "chat_id": -1001, "sender_id": {"user_id": 101},
+            "content": content,
+        }}, client, known)
+        self.assertEqual(created["richMessage"], rich)
+        self.assertEqual(created["text"], "x")
+        self.assertEqual(created["entities"], [])
+        replacement = {**rich, "blocks": [{
+            "@type": "pageBlockParagraph", "text": {
+                "@type": "richTextCustomEmoji", "custom_emoji_id": "5368324170671202286",
+                "alternative_text": "😀",
+            },
+        }]}
+        for next_content, expected_text, expected_rich in [
+            ({"@type": "messageRichMessage", "message": replacement}, "😀", replacement),
+            ({"@type": "messageText", "text": {"text": "final", "entities": []}}, "final", None),
+            ({"@type": "messageUnsupported"}, "", None),
+        ]:
+            with self.subTest(content_type=next_content["@type"]):
+                edited = driver.serve_update({
+                    "@type": "updateMessageContent", "chat_id": -1001,
+                    "message_id": message_id,
+                    "new_content": next_content,
+                }, client, known)
+                self.assertEqual(edited["richMessage"], expected_rich)
+                self.assertEqual(edited["text"], expected_text)
+                self.assertEqual(edited["botApiMessageId"], 45)
+                self.assertEqual(known[(-1001, message_id)]["richMessage"], expected_rich)
+
+
+class RichObservationTest(unittest.TestCase):
+    def test_serve_hydrates_selected_chat_messages_and_edits_before_emitting(self):
+        partial = rich_content("preview", full=False)
+        plain = {"@type": "messageText", "text": {"text": "plain replacement", "entities": []}}
+        updates = [
+            {"@type": "updateNewMessage", "message": native_message(partial, chat_id=-2002)},
+            {"@type": "updateNewMessage", "message": native_message(partial)},
+            {"@type": "updateMessageContent", "chat_id": -1001,
+             "message_id": 42 << 20, "new_content": partial},
+            {"@type": "updateMessageContent", "chat_id": -1001,
+             "message_id": 42 << 20, "new_content": plain},
+        ]
+        raw_updates = deepcopy(updates)
+        pending = list(updates)
+        full = [rich_content(text)["message"] for text in ("full send", "full edit")]
+        client = observation_client({101: {"username": "sut_bot"}})
+        responses = iter(full)
+
+        def request(payload, timeout=20):
+            if payload["@type"] == "getMe":
+                return {"id": 303}
+            self.assertEqual(payload, {
+                "@type": "getFullRichMessage", "chat_id": -1001, "message_id": 42 << 20,
+            })
+            return next(responses)
+
+        client.request.side_effect = request
+        client.next_update = lambda timeout: pending.pop(0) if pending else None
+        instance = SimpleNamespace(
+            client=client, authorize=lambda *_: None, resolve_chat=lambda *_: -1001,
+        )
+        events = []
+        with patch.object(driver, "load_config", return_value=({}, {})), \
+                patch.object(driver, "UserDriver", return_value=instance), \
+                patch.object(driver, "write_ndjson", side_effect=events.append), \
+                patch.object(driver.sys, "stdin", io.StringIO("")), \
+                patch.object(driver.select, "select", side_effect=lambda *_: (
+                    [] if pending else [driver.sys.stdin], [], []
+                )):
+            driver.command_serve(SimpleNamespace(chat="-1001", timeout_ms=1000))
+
+        observed = [event["update"] for event in events if event["type"] == "update"]
+        self.assertEqual([event["kind"] for event in observed], ["message", "edit", "edit"])
+        self.assertEqual([event["text"] for event in observed], ["full send", "full edit", "plain replacement"])
+        self.assertEqual([event["richMessage"] for event in observed], [*full, None])
+        for event in observed:
+            self.assertEqual((event["chatId"], event["messageId"], event["senderId"]), (-1001, 42 << 20, 101))
+            self.assertEqual(event["senderUsername"], "sut_bot")
+            self.assertEqual(event["replyToMessageId"], 7)
+        self.assertEqual([call.args[0]["@type"] for call in client.request.call_args_list],
+                         ["getMe", "getFullRichMessage", "getFullRichMessage"])
+        self.assertEqual(updates, raw_updates)
+
+    def test_same_message_id_in_different_chats_keeps_its_own_edit_and_fetch(self):
+        client = observation_client()
+        known = {}
+        for chat_id, sender_id in [(-1001, 101), (-2002, 202)]:
+            driver.serve_update({
+                "@type": "updateNewMessage",
+                "message": native_message(rich_content(str(chat_id)), chat_id=chat_id, sender_id=sender_id),
+            }, client, known)
+        other = deepcopy(known[(-2002, 42 << 20)])
+        full = rich_content("updated first chat")["message"]
+        client.request.side_effect = None
+        client.request.return_value = full
+        edited = driver.serve_update({
+            "@type": "updateMessageContent", "chat_id": -1001, "message_id": 42 << 20,
+            "new_content": rich_content("preview", full=False),
+        }, client, known)
+
+        client.request.assert_called_once_with({
+            "@type": "getFullRichMessage", "chat_id": -1001, "message_id": 42 << 20,
+        })
+        self.assertEqual((edited["kind"], edited["chatId"], edited["senderId"]), ("edit", -1001, 101))
+        self.assertEqual(edited["richMessage"], full)
+        self.assertEqual(known[(-1001, 42 << 20)]["text"], "updated first chat")
+        self.assertEqual(known[(-2002, 42 << 20)], other)
+
+    def test_failed_or_incomplete_fetch_does_not_commit_a_partial_observation(self):
+        for kind in ("message", "edit"):
+            for outcome in ("request-error", "incomplete", "wrong-type"):
+                with self.subTest(kind=kind, outcome=outcome):
+                    client = observation_client()
+                    known = {}
+                    if kind == "edit":
+                        driver.serve_update({"@type": "updateNewMessage", "message": native_message(
+                            rich_content("previous complete content"),
+                        )}, client, known)
+                    before = deepcopy(known)
+                    if outcome == "request-error":
+                        client.request.side_effect = driver.DriverError("synthetic lookup failure")
+                    else:
+                        client.request.side_effect = None
+                        client.request.return_value = (
+                            rich_content("still partial", full=False)["message"]
+                            if outcome == "incomplete" else {"@type": "ok"}
+                        )
+                    partial = rich_content("preview", full=False)
+                    update = (
+                        {"@type": "updateNewMessage", "message": native_message(partial)}
+                        if kind == "message" else {
+                            "@type": "updateMessageContent", "chat_id": -1001,
+                            "message_id": 42 << 20, "new_content": partial,
+                        }
+                    )
+                    with self.assertRaises(driver.DriverError):
+                        driver.serve_update(update, client, known)
+                    self.assertEqual(known, before)
+                    self.assertFalse(partial["message"]["is_full"])
+
+    def test_full_fetch_preserves_native_update_fifo_on_success_and_failure(self):
+        for failed in (False, True):
+            with self.subTest(failed=failed):
+                client = driver.TdClient.__new__(driver.TdClient)
+                client.users = {}
+                earlier = {"@type": "updateChatAction", "chat_id": -1001}
+                other = {"@type": "updateNewMessage", "message": native_message(
+                    rich_content("other chat"), chat_id=-2002, sender_id=202,
+                )}
+                later = {
+                    "@type": "updateMessageContent", "chat_id": -1001,
+                    "message_id": 42 << 20, "new_content": {
+                        "@type": "messageText", "text": {"text": "later plain edit", "entities": []},
+                    },
+                }
+                client.updates = [earlier]
+                client.send = Mock(return_value="full-request")
+                response = (
+                    {"@type": "error", "code": 400, "message": "synthetic lookup failure"}
+                    if failed else rich_content("fetched snapshot")["message"]
+                )
+                client.receive = Mock(side_effect=[other, later, {**response, "@extra": "full-request"}])
+                known = {}
+                driver.serve_update({"@type": "updateNewMessage", "message": native_message(
+                    rich_content("original"),
+                )}, client, known)
+                partial_edit = {
+                    "@type": "updateMessageContent", "chat_id": -1001,
+                    "message_id": 42 << 20, "new_content": rich_content("preview", full=False),
+                }
+                if failed:
+                    with self.assertRaisesRegex(driver.DriverError, "synthetic lookup failure"):
+                        driver.serve_update(partial_edit, client, known)
+                    self.assertEqual(known[(-1001, 42 << 20)]["text"], "original")
+                else:
+                    event = driver.serve_update(partial_edit, client, known)
+                    self.assertEqual((event["kind"], event["text"]), ("edit", "fetched snapshot"))
+                client.send.assert_called_once_with({
+                    "@type": "getFullRichMessage", "chat_id": -1001, "message_id": 42 << 20,
+                })
+                for expected in (earlier, other, later):
+                    update = client.next_update()
+                    self.assertIs(update, expected)
+                    driver.serve_update(update, client, known)
+                self.assertEqual(client.updates, [])
+                self.assertEqual(known[(-1001, 42 << 20)]["text"], "later plain edit")
+                self.assertIsNone(known[(-1001, 42 << 20)]["richMessage"])
+                self.assertEqual(known[(-2002, 42 << 20)]["senderId"], 202)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-driver.test.py
@@ -352,6 +352,7 @@ class RichObservationTest(unittest.TestCase):
         client.next_update = lambda timeout: pending.pop(0) if pending else None
         instance = SimpleNamespace(
             client=client, authorize=lambda *_: None, resolve_chat=lambda *_: -1001,
+            check_group_write_access=Mock(return_value=True),
         )
         events = []
         with patch.object(driver, "load_config", return_value=({}, {})), \

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-record.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-record.py
@@ -4,9 +4,8 @@
 # ///
 """Record every observable Telegram event as the QA user, not just new messages.
 
-`user-driver.py` handles only updateNewMessage, and no bot can observe deletions
-at all. Progress drafts are built on edit-in-place plus delete-on-cleanup, so
-proving them needs the full update stream:
+`user-driver.py` serves normalized message/edit snapshots. Progress drafts also
+need raw revisions and delete-on-cleanup evidence from the full update stream:
 
   updateNewMessage      -> message
   updateMessageContent  -> edit      (carries the new body; one per revision)
@@ -36,52 +35,13 @@ def formatted_text(value):
     return value.get("text", "") if isinstance(value, dict) else ""
 
 
-def rich_text(value):
-    if not isinstance(value, dict):
-        return ""
-    kind = value.get("@type", "")
-    if kind == "richTextPlain":
-        return value.get("text", "")
-    if kind == "richTextCustomEmoji":
-        return value.get("alternative_text", "")
-    if kind == "richTextMathematicalExpression":
-        return value.get("expression", "")
-    if kind == "richTexts":
-        return "".join(rich_text(item) for item in value.get("texts") or [])
-    return rich_text(value.get("text"))
-
-
-def rich_message_text(value):
-    if not isinstance(value, dict):
-        return ""
-    parts = []
-
-    def visit(node):
-        if isinstance(node, list):
-            for item in node:
-                visit(item)
-            return
-        if not isinstance(node, dict):
-            return
-        if str(node.get("@type", "")).startswith("richText"):
-            text = rich_text(node)
-            if text:
-                parts.append(text)
-            return
-        for child in node.values():
-            visit(child)
-
-    visit(value.get("blocks") or [])
-    return "\n".join(parts)
-
-
 def content_text(content):
     for key in ("text", "caption"):
         value = content.get(key)
         if isinstance(value, dict) and isinstance(value.get("text"), str):
             return value["text"]
     if content.get("@type") == "messageRichMessage":
-        return rich_message_text(content.get("message") or {})
+        return driver.rich_message_text(content.get("message") or {})
     return ""
 
 
@@ -118,8 +78,8 @@ class EventRecorder:
             "elapsedMs": int((time.time() - self.started_at) * 1000),
             "kind": kind,
             "messageId": message_id,
-            # Bot API ids are TDLib ids >> 20; keep both so bot-lane and
-            # userbot-lane recordings can be correlated by message.
+            # Historical field name: this is the observing account's server ID,
+            # not another account's Bot API receipt in DMs or basic groups.
             "botApiMessageId": (message_id >> 20) if isinstance(message_id, int) else None,
             **fields,
         }
@@ -168,17 +128,10 @@ class EventRecorder:
             self.record_handle = None
 
     def ingest(self, update):
-        if self._chat_id_of(update) != self.chat_id:
+        if driver.update_chat_id(update) != self.chat_id:
             return
         for kind, message_id, fields in self._events_for(update):
             self._append(kind, message_id, **fields)
-
-    def _chat_id_of(self, update):
-        """updateNewMessage nests chat_id under message; the rest keep it top level."""
-        message = update.get("message")
-        if isinstance(message, dict) and "chat_id" in message:
-            return message["chat_id"]
-        return update.get("chat_id")
 
     def _events_for(self, update):
         """One update yields zero or more events; a delete batch yields many."""

--- a/.agents/skills/telegram-e2e-userbot/scripts/user-record.test.py
+++ b/.agents/skills/telegram-e2e-userbot/scripts/user-record.test.py
@@ -23,6 +23,44 @@ class FakeClient:
 
 
 class CallbackScenarioTest(unittest.TestCase):
+    def test_records_partial_rich_revisions_raw_without_fetching_full_content(self):
+        client = FakeClient()
+        rich = {
+            "@type": "richMessage", "is_full": False, "is_rtl": False,
+            "blocks": [{"@type": "pageBlockParagraph", "text": {
+                "@type": "richTextPlain", "text": "partial send",
+            }}],
+        }
+        replacement = {
+            **rich, "blocks": [{"@type": "pageBlockParagraph", "text": {
+                "@type": "richTextPlain", "text": "partial edit",
+            }}],
+        }
+        updates = [
+            {"@type": "updateNewMessage", "message": {
+                "id": 42 << 20, "chat_id": -1001,
+                "sender_id": {"@type": "messageSenderUser", "user_id": 42},
+                "content": {"@type": "messageRichMessage", "message": rich},
+            }},
+            {"@type": "updateMessageContent", "chat_id": -1001,
+             "message_id": 42 << 20,
+             "new_content": {"@type": "messageRichMessage", "message": replacement}},
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            target = Path(directory) / "events.jsonl"
+            recorder = record.EventRecorder(client, -1001, target, 42)
+            try:
+                for update in updates:
+                    recorder.ingest(update)
+            finally:
+                recorder.close()
+            events = [json.loads(line) for line in target.read_text().splitlines()]
+        self.assertEqual([event["kind"] for event in events], ["message", "edit"])
+        self.assertEqual([event["text"] for event in events], ["partial send", "partial edit"])
+        self.assertEqual([event["richMessageIsFull"] for event in events], [False, False])
+        self.assertEqual([event["raw"] for event in events], updates)
+        self.assertEqual(client.requests, [])
+
     def test_waits_for_prior_gateway_barriers(self):
         actions = [
             {"type": "patchConfig", "atMs": 0},

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -439,6 +439,8 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     When enabled: the agent is told rich messages are available for this bot/account (with the supported Markdown + HTML-island authoring contract); Markdown text renders through OpenClaw's Markdown IR as typed Bot API 10.3 rich blocks (headings, tables, details, checklists, rich media, formulas, maps, collages); media captions still use Telegram HTML captions (rich messages do not replace captions, and captions cap at 1024 characters).
 
+    Ordinary rich body text, including list items, quotes, and disclosure bodies, preserves parsed Markdown spaces and newlines. Entities decode once: `&amp;` displays `&`, while `\&amp;` and `&amp;amp;` display literal `&amp;`. Escaped tags such as `&lt;b&gt;` stay visible text, and image alternatives stay plain text; neither becomes an HTML island. Unsupported HTML stays visible without suppressing Markdown formatting inside it. HTML attributes and recognized inline comments retain their literal source during Markdown parsing; supported attributes are then decoded by the HTML mapper. HTML-island summaries and figure captions keep their separate HTML normalization.
+
     This keeps model text away from Telegram's rich-Markdown sigils, so currency like `$400-600K` is not parsed as math. Long rich text splits automatically across Telegram's limits. Tables over the 20-column limit fall back to a code block.
 
     Default: off, for client compatibility — some current Desktop, Web, Android, and third-party clients render accepted rich messages as unsupported. Keep this off unless every client used with the bot can render them. `/status` shows whether the current session has rich messages on or off.

--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -26,6 +26,13 @@ splits formatting mid-span.
 3. **Render per channel** (`renderMarkdownWithMarkers`) - a style-marker map
    turns spans into the channel's native markup.
 
+Raw inline HTML lexemes retain their original bytes during parsing. Markdown
+markers and entities inside attribute values or recognized inline comments are
+not parsed as Markdown content. Non-serialized authored-tag ranges let
+HTML-aware renderers interpret those tags; other renderers keep them literal or
+escape them. HTML block parsing stays disabled so Markdown inside containers
+still works, and bare URLs in their bodies retain normal linkification.
+
 Examples of shared IR renderers:
 
 | Channel  | Renderer                                                                             | Notes                                                                                    |

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.test.ts
@@ -32,6 +32,21 @@ describe("Telegram userbot driver runtime", () => {
       },
     ];
     const editedEntities = [{ offset: 3, length: 5, type: { "@type": "textEntityTypeBold" } }];
+    const richMessage = {
+      "@type": "richMessage",
+      is_full: true,
+      is_rtl: false,
+      blocks: [
+        {
+          "@type": "pageBlockParagraph",
+          text: {
+            "@type": "richTextUrl",
+            url: "https://example.com/qa",
+            text: { "@type": "richTextMathematicalExpression", expression: "x" },
+          },
+        },
+      ],
+    };
     fs.writeFileSync(
       scriptPath,
       [
@@ -39,6 +54,7 @@ describe("Telegram userbot driver runtime", () => {
         "import sys",
         `entities = json.loads(${JSON.stringify(JSON.stringify(entities))})`,
         `edited_entities = json.loads(${JSON.stringify(JSON.stringify(editedEntities))})`,
+        `rich_message = json.loads(${JSON.stringify(JSON.stringify(richMessage))})`,
         "print(json.dumps({'type':'ready','chatId':-1001,'user':{'id':100}}), flush=True)",
         "for line in sys.stdin:",
         "    request = json.loads(line)",
@@ -47,6 +63,9 @@ describe("Telegram userbot driver runtime", () => {
         "    print(json.dumps({'type':'update','update':update}), flush=True)",
         "    for replacement in [edited_entities, []]:",
         "        update = {**update, 'kind':'edit', 'entities':replacement, 'contentType':'messageVideo'}",
+        "        print(json.dumps({'type':'update','update':update}), flush=True)",
+        "    for rich in [rich_message, {**rich_message, 'is_full':False}, None]:",
+        "        update = {**update, 'richMessage':rich, 'text':'x', 'entities':[], 'contentType':'messageRichMessage' if rich else 'messageText'}",
         "        print(json.dumps({'type':'update','update':update}), flush=True)",
         "    result = {'chatId':-1001,'messageId':message_id,'senderId':100,'timestamp':1000,'text':request['text'],'entities':entities,'contentType':'messageText'}",
         "    print(json.dumps({'type':'response','id':request['id'],'result':result}), flush=True)",
@@ -72,7 +91,7 @@ describe("Telegram userbot driver runtime", () => {
         text,
         entities,
       });
-      await vi.waitFor(() => expect(updates).toHaveLength(3));
+      await vi.waitFor(() => expect(updates).toHaveLength(6));
       expect(updates).toMatchObject([
         {
           kind: "message",
@@ -90,7 +109,16 @@ describe("Telegram userbot driver runtime", () => {
           entities: editedEntities,
         },
         { kind: "edit", messageId: 12, contentType: "messageVideo", text, entities: [] },
+        { kind: "edit", messageId: 12, contentType: "messageRichMessage", richMessage },
+        {
+          kind: "edit",
+          messageId: 12,
+          contentType: "messageRichMessage",
+          richMessage: { ...richMessage, is_full: false },
+        },
+        { kind: "edit", messageId: 12, contentType: "messageText", text: "x", entities: [] },
       ]);
+      expect(updates[5]).not.toHaveProperty("richMessage");
       expect(() => driver.assertHealthy()).not.toThrow();
     } finally {
       await driver.close();

--- a/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
@@ -14,6 +14,7 @@ export type TelegramUserbotUpdate = {
   botApiMessageId?: number;
   chatId: number;
   contentType?: string;
+  richMessage?: Record<string, unknown>;
   kind: "edit" | "message";
   messageId: number;
   replyToMessageId?: number;
@@ -79,6 +80,16 @@ function parseUserbotUpdate(value: unknown): TelegramUserbotUpdate {
   if (typeof value.text !== "string") {
     throw new Error("Telegram userbot update has invalid text.");
   }
+  const richMessage = value.contentType === "messageRichMessage" ? value.richMessage : undefined;
+  if (
+    value.contentType === "messageRichMessage" &&
+    (!isRecord(richMessage) ||
+      !Array.isArray(richMessage.blocks) ||
+      typeof richMessage.is_full !== "boolean" ||
+      typeof richMessage.is_rtl !== "boolean")
+  ) {
+    throw new Error("Telegram userbot update has an invalid rich message.");
+  }
   return {
     kind,
     chatId,
@@ -87,6 +98,8 @@ function parseUserbotUpdate(value: unknown): TelegramUserbotUpdate {
     timestamp,
     text: value.text,
     entities: parseTextEntities(value.entities, value.text),
+    // Keep TDLib's observed tree and completeness flag; text alone loses URL/style evidence.
+    ...(isRecord(richMessage) ? { richMessage } : {}),
     ...(typeof value.contentType === "string" ? { contentType: value.contentType } : {}),
     ...(typeof value.botApiMessageId === "number"
       ? { botApiMessageId: value.botApiMessageId }

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -193,6 +193,9 @@ export const telegramRichObservationCases = [
   "unmatched-after-reset",
   "duplicate-run-message",
   "lost-literal-ancestor",
+  "emoji-degraded",
+  "first-content-failed",
+  "send-error",
 ] as const;
 
 export async function assertTelegramRichObservationFlow(
@@ -307,7 +310,11 @@ export async function assertTelegramRichObservationFlow(
               ? paragraph(wrap("richTextBold", plain("literal")))
               : testCase === "lost-literal-ancestor" && id === 11
                 ? literalScope(wrap("richTextSuperscript", wrap("richTextBold", plain("x"))))
-                : block,
+                : testCase === "emoji-degraded" && id === 6
+                  ? paragraph(url(plain("😀")))
+                  : testCase === "first-content-failed" && id === 1 && kind === "message"
+                    ? paragraph(plain("Download"))
+                    : block,
           paragraph(plain(marker)),
           ...(testCase === "oversized-tree" && id === 1 && kind === "message"
             ? [paragraph(plain("x".repeat(20_000)))]
@@ -360,6 +367,9 @@ export async function assertTelegramRichObservationFlow(
               assert.equal(method, "send");
               const block = nativeBlocks[sends];
               const id = ++sends;
+              if (testCase === "send-error") {
+                throw new Error("synthetic transport failure");
+              }
               const marker = readMarker(args.message);
               deliver("message", () => {
                 observed.push(
@@ -425,14 +435,18 @@ export async function assertTelegramRichObservationFlow(
     if (rejects) {
       await assert.rejects(
         pending,
-        testCase === "missing-content-type" ||
-          testCase === "reactivated-literal" ||
-          testCase === "lost-literal-ancestor" ||
-          flattenedIndex >= 0
-          ? /Native rich composition failed/
-          : testCase === "duplicate-run-message"
-            ? /editing must preserve the styled link/
-            : /timed out after 30000ms/,
+        testCase === "send-error"
+          ? /synthetic transport failure/
+          : testCase === "missing-content-type" ||
+              testCase === "reactivated-literal" ||
+              testCase === "lost-literal-ancestor" ||
+              testCase === "emoji-degraded" ||
+              testCase === "first-content-failed" ||
+              flattenedIndex >= 0
+            ? /Native rich composition failed/
+            : testCase === "duplicate-run-message"
+              ? /editing must preserve the styled link/
+              : /timed out after 30000ms/,
       );
     } else {
       const result = await pending;
@@ -447,7 +461,58 @@ export async function assertTelegramRichObservationFlow(
       "utf8",
     );
     const evidence = JSON.parse(exported);
-    assert.equal(evidence.edit.verified, !rejects);
+    if (testCase === "emoji-degraded" || testCase === "first-content-failed") {
+      assert.equal(sends, 11, "content failure must not skip independent sends");
+      assert.equal(edits, 1, "content failure must not skip the original-message edit");
+      assert.equal(evidence.edit.verified, true);
+      assert.equal(evidence.cases.length, 10);
+      const failedLabel = testCase === "emoji-degraded" ? "message-6" : "message-1";
+      assert.deepEqual(
+        evidence.failures.map((failure: { label: string }) => failure.label),
+        [failedLabel],
+      );
+      assert.equal(
+        evidence.cases.some((proof: { label: string }) => proof.label === failedLabel),
+        false,
+      );
+      assert.equal(evidence.cases.at(-1).label, "message-11");
+      assert.deepEqual(
+        {
+          contentType: evidence.failures[0].contentType,
+          full: evidence.failures[0].full,
+          matchesPattern: evidence.failures[0].matchesPattern,
+          block: evidence.failures[0].richMessage.blocks[0],
+        },
+        {
+          contentType: "messageRichMessage",
+          full: true,
+          matchesPattern: false,
+          block:
+            testCase === "emoji-degraded"
+              ? paragraph(url(plain("😀")))
+              : paragraph(plain("Download")),
+        },
+      );
+      assert.equal(
+        evidence.candidates.find((candidate: { phase: string }) => candidate.phase === "edit")
+          .observerIdStayedEqual,
+        true,
+      );
+    }
+    const contentFailure =
+      flattenedIndex >= 0 ||
+      [
+        "reactivated-literal",
+        "lost-literal-ancestor",
+        "emoji-degraded",
+        "first-content-failed",
+      ].includes(testCase);
+    assert.equal(evidence.edit.verified, !rejects || contentFailure);
+    if (testCase === "send-error") {
+      assert.equal(sends, 1);
+      assert.equal(edits, 0);
+      assert.equal(evidence.cases.length, 0);
+    }
     assert.ok(exported.length < 400_000);
     for (const privateValue of [
       "626262626",

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -230,7 +230,7 @@ export async function assertTelegramRichObservationFlow(
   const emoji = {
     "@type": "richTextCustomEmoji",
     custom_emoji_id: "5368324170671202286",
-    alternative_text: "😀",
+    alternative_text: "👍",
   };
   const annotation = (wrapper: (text: unknown) => unknown) =>
     paragraph({
@@ -312,7 +312,7 @@ export async function assertTelegramRichObservationFlow(
               : testCase === "lost-literal-ancestor" && id === 11
                 ? literalScope(wrap("richTextSuperscript", wrap("richTextBold", plain("x"))))
                 : testCase === "emoji-degraded" && id === 6
-                  ? paragraph(url(plain("😀")))
+                  ? paragraph(url(plain("👍")))
                   : testCase === "first-content-failed" && id === 1 && kind === "message"
                     ? paragraph(plain("Download"))
                     : block,
@@ -497,7 +497,7 @@ export async function assertTelegramRichObservationFlow(
           matchesPattern: false,
           block:
             testCase === "emoji-degraded"
-              ? paragraph(url(plain("😀")))
+              ? paragraph(url(plain("👍")))
               : paragraph(plain("Download")),
         },
       );

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -1,7 +1,13 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { createQaBusState } from "./bus-state.js";
+import type { TelegramUserbotUpdate } from "./live-transports/telegram/userbot-driver.runtime.js";
+import { waitForQaTransportCondition } from "./qa-transport.js";
 import { readQaScenarioById, type QaScenarioFlow } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
 import type { QaSuiteStep } from "./suite-types.js";
+import { createTempDirHarness } from "./temp-dir.test-helper.js";
 
 function formatTestTranscript(state: ReturnType<typeof createQaBusState>) {
   return state
@@ -167,4 +173,335 @@ export async function runLoadedScenarioFlow(
     scenarioTitle: scenario.title,
     flow: params.flow ?? loadedFlow,
   });
+}
+
+export const telegramRichObservationCases = [
+  "message",
+  "edit",
+  "stale-send",
+  "stale-edit",
+  "wrong-edit-marker",
+  "wrong-edit-id",
+  "wrong-edit-kind",
+  "oversized-tree",
+  "missing-content-type",
+  "untyped-stale-send",
+  "flattened-details",
+  "flattened-list",
+  "flattened-quote",
+  "reactivated-literal",
+  "unmatched-after-reset",
+  "duplicate-run-message",
+  "lost-literal-ancestor",
+] as const;
+
+export async function assertTelegramRichObservationFlow(
+  testCase: (typeof telegramRichObservationCases)[number],
+) {
+  const fixtureRunId = "00000000-0000-4000-8000-000000000000";
+  const delayedKind = testCase === "message" ? "message" : "edit";
+  const rejects = !["message", "edit", "oversized-tree", "unmatched-after-reset"].includes(
+    testCase,
+  );
+  const staleSend = testCase === "stale-send" || testCase === "untyped-stale-send";
+  const untyped = testCase === "missing-content-type" || testCase === "untyped-stale-send";
+  const flattenedIndex = ["flattened-details", "flattened-list", "flattened-quote"].indexOf(
+    testCase,
+  );
+  const tempDirs = createTempDirHarness();
+  const outputDir = await tempDirs.makeTempDir("telegram-rich-flow-");
+  const plain = (text: string) => ({ "@type": "richTextPlain", text });
+  const wrap = (kind: string, text: unknown) => ({ "@type": kind, text });
+  const url = (text: unknown) => ({
+    ...wrap("richTextUrl", text),
+    url: "https://example.com/qa",
+  });
+  const paragraph = (text: unknown) => ({ "@type": "pageBlockParagraph", text });
+  const styled = {
+    ...url(wrap("richTextBold", plain("Download"))),
+    url: "https://example.com/qa?x=1",
+  };
+  const list = { "@type": "pageBlockList", items: [{ blocks: [paragraph(styled)] }] };
+  const math = { "@type": "richTextMathematicalExpression", expression: "x" };
+  const emoji = {
+    "@type": "richTextCustomEmoji",
+    custom_emoji_id: "5368324170671202286",
+    alternative_text: "😀",
+  };
+  const annotation = (wrapper: (text: unknown) => unknown) =>
+    paragraph({
+      "@type": "richTexts",
+      texts: [
+        wrapper(plain("\n")),
+        wrap("richTextFixed", plain("user[Thu]")),
+        wrapper(plain(" trailing")),
+      ],
+    });
+  const literalScope = (text: unknown) => ({
+    "@type": "pageBlockDetails",
+    header: plain("Scope"),
+    blocks: [
+      paragraph(plain("<custom>")),
+      { "@type": "pageBlockBlockQuote", blocks: [paragraph(text)] },
+      paragraph(plain("</custom>")),
+    ],
+  });
+  const nativeBlocks = [
+    { "@type": "pageBlockDetails", header: plain("More"), blocks: [paragraph(styled)] },
+    list,
+    { "@type": "pageBlockBlockQuote", blocks: [paragraph(styled)] },
+    paragraph(url(math)),
+    paragraph(wrap("richTextSpoiler", math)),
+    paragraph(url(emoji)),
+    paragraph(wrap("richTextSpoiler", emoji)),
+    annotation(url),
+    annotation((text) => wrap("richTextBold", text)),
+    paragraph({
+      "@type": "richTexts",
+      texts: [
+        url({
+          "@type": "richTexts",
+          texts: [
+            plain("<custom><sup>"),
+            wrap("richTextBold", plain("marked")),
+            plain("</sup></custom>"),
+          ],
+        }),
+        plain(" <b>"),
+        wrap("richTextBold", plain("literal")),
+        plain("</b> <i>alt</i> <b"),
+        url(plain("r")),
+        plain(">tail <!A "),
+        wrap("richTextBold", plain("declared")),
+        plain(">"),
+      ],
+    }),
+    literalScope({
+      "@type": "richTexts",
+      texts: [plain("<sup>"), wrap("richTextBold", plain("x")), plain("</sup>")],
+    }),
+  ];
+  type Observation = Pick<
+    TelegramUserbotUpdate,
+    "messageId" | "botApiMessageId" | "contentType" | "kind" | "text" | "richMessage"
+  >;
+  const observed: Observation[] = [];
+  const observation = (
+    id: number,
+    block: unknown,
+    kind: "message" | "edit",
+    marker: string,
+  ): Observation => {
+    const frame: Observation = {
+      messageId: (9_000 + id) * 2 ** 20,
+      botApiMessageId: 9_000 + id,
+      kind,
+      text: `PRIVATE_UNMATCHED_BODY\n${marker}`,
+      contentType: "messageRichMessage",
+      richMessage: {
+        "@type": "richMessage",
+        blocks: [
+          kind === "message" && id === flattenedIndex + 1
+            ? paragraph(styled)
+            : testCase === "reactivated-literal" && id === 10
+              ? paragraph(wrap("richTextBold", plain("literal")))
+              : testCase === "lost-literal-ancestor" && id === 11
+                ? literalScope(wrap("richTextSuperscript", wrap("richTextBold", plain("x"))))
+                : block,
+          paragraph(plain(marker)),
+          ...(testCase === "oversized-tree" && id === 1 && kind === "message"
+            ? [paragraph(plain("x".repeat(20_000)))]
+            : []),
+        ],
+        sender_id: 626262626,
+        chat_id: 727272727,
+        message_id: 828282828,
+        is_full: true,
+        is_rtl: false,
+      },
+    };
+    if (untyped) {
+      delete frame.contentType;
+      delete frame.richMessage;
+    }
+    return frame;
+  };
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  const deliver = (kind: "message" | "edit", action: () => void) => {
+    // Receipts settle first; native updates arrive on a later event-loop turn.
+    if (kind === delayedKind) {
+      timers.push(setTimeout(action, 1));
+    } else {
+      action();
+    }
+  };
+  let sends = 0;
+  let edits = 0;
+  const markers = new Set<string>();
+  const readMarker = (message: string | undefined) => {
+    assert.ok(typeof message === "string");
+    const marker = message.split("\n").at(-1) ?? "";
+    assert.equal(markers.has(marker), false);
+    markers.add(marker);
+    return marker;
+  };
+  try {
+    const pending = runLoadedScenarioFlow("telegram-rich-inline-composition", {
+      api: {
+        fs,
+        path,
+        randomUUID: () => fixtureRunId,
+        env: {
+          outputDir,
+          providerMode: "mock-openai",
+          cfg: { channels: { telegram: { accounts: { sut: { richMessages: true } } } } },
+          gateway: {
+            call: async (method: string, args: { message: string }) => {
+              assert.equal(method, "send");
+              const block = nativeBlocks[sends];
+              const id = ++sends;
+              const marker = readMarker(args.message);
+              deliver("message", () => {
+                observed.push(
+                  observation(
+                    id,
+                    block,
+                    "message",
+                    staleSend ? marker.replace(fixtureRunId, "prior-run") : marker,
+                  ),
+                );
+                if (
+                  id === 1 &&
+                  (testCase === "unmatched-after-reset" || testCase === "duplicate-run-message")
+                ) {
+                  observed.push(
+                    observation(
+                      80,
+                      block,
+                      "message",
+                      testCase === "unmatched-after-reset" ? "PRIOR-RUN-MARKER" : marker,
+                    ),
+                  );
+                }
+              });
+              return { messageId: id };
+            },
+          },
+        },
+        transport: {
+          id: "telegram",
+          accountId: "sut",
+          reset() {},
+          buildAgentDelivery: () => ({ to: "123" }),
+        },
+        readTelegramMessages: () => structuredClone(observed),
+        waitForCondition: waitForQaTransportCondition,
+        runQaCli: async (_env: unknown, args: string[]) => {
+          assert.deepEqual(args.slice(0, 2), ["message", "edit"]);
+          const id = Number(args[args.indexOf("--message-id") + 1]);
+          assert.equal(id, 1);
+          edits += 1;
+          const firstMarker = [...markers][0];
+          assert.ok(firstMarker !== undefined);
+          const marker = readMarker(args[args.indexOf("--message") + 1]);
+          deliver("edit", () => {
+            observed[0] = observation(
+              testCase === "wrong-edit-id" ? id + 40 : id,
+              list,
+              testCase === "wrong-edit-kind" ? "message" : "edit",
+              testCase === "wrong-edit-marker"
+                ? marker + "-wrong"
+                : testCase === "stale-edit"
+                  ? firstMarker
+                  : marker,
+            );
+          });
+        },
+        runAgentPrompt: () => {
+          throw new Error("direct delivery must not invoke a model");
+        },
+      },
+    });
+    if (rejects) {
+      await assert.rejects(
+        pending,
+        testCase === "missing-content-type" ||
+          testCase === "reactivated-literal" ||
+          testCase === "lost-literal-ancestor" ||
+          flattenedIndex >= 0
+          ? /Native rich composition failed/
+          : testCase === "duplicate-run-message"
+            ? /editing must preserve the styled link/
+            : /timed out after 30000ms/,
+      );
+    } else {
+      const result = await pending;
+      assert.equal(result.status, "pass");
+      assert.equal(sends, 11);
+      assert.equal(edits, 1);
+      assert.equal(observed.length, testCase === "unmatched-after-reset" ? 12 : 11);
+      assert.equal(observed[0]?.kind, "edit");
+    }
+    const exported = await fs.readFile(
+      path.join(outputDir, "telegram-rich-inline-composition.json"),
+      "utf8",
+    );
+    const evidence = JSON.parse(exported);
+    assert.equal(evidence.edit.verified, !rejects);
+    assert.ok(exported.length < 400_000);
+    for (const privateValue of [
+      "626262626",
+      "727272727",
+      "828282828",
+      "PRIVATE_UNMATCHED_BODY",
+      ...observed.map((message) => String(message.messageId)),
+    ]) {
+      assert.equal(exported.includes(privateValue), false);
+    }
+    assert.equal(
+      /"(?:botMessageId|observerMessageId|botApiMessageId|messageId|sender_id|chat_id|message_id)"/.test(
+        exported,
+      ),
+      false,
+    );
+    if (staleSend || testCase === "wrong-edit-marker" || testCase === "unmatched-after-reset") {
+      assert.equal(evidence.unmatched.count, 1);
+    }
+    if (testCase === "wrong-edit-id") {
+      assert.equal(
+        evidence.candidates.find((candidate: { phase: string }) => candidate.phase === "edit")
+          .observerIdStayedEqual,
+        false,
+      );
+    }
+    if (!rejects) {
+      assert.equal(evidence.cases.length, 11);
+      assert.ok(
+        evidence.cases.every(
+          (proof: { accountMessageIdsDiffer: boolean }) => proof.accountMessageIdsDiffer,
+        ),
+      );
+      assert.equal(evidence.edit.completedWithBotReceipt, true);
+      assert.equal(
+        evidence.candidates.find((candidate: { phase: string }) => candidate.phase === "edit")
+          .observerIdStayedEqual,
+        true,
+      );
+    }
+    if (untyped) {
+      assert.deepEqual(
+        staleSend ? evidence.unmatched.contentTypes : [evidence.candidates[0].contentType],
+        ["unknown"],
+      );
+      assert.equal(evidence.cases.length, 0);
+    }
+    if (testCase === "oversized-tree") {
+      assert.equal(evidence.cases[0].richMessage.truncated, true);
+    }
+  } finally {
+    for (const timer of timers) {
+      clearTimeout(timer);
+    }
+    await tempDirs.cleanup();
+  }
 }

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createOutboundPayloadPlan } from "openclaw/plugin-sdk/channel-outbound";
 import { createQaBusState } from "./bus-state.js";
 import type { TelegramUserbotUpdate } from "./live-transports/telegram/userbot-driver.runtime.js";
 import { waitForQaTransportCondition } from "./qa-transport.js";
@@ -365,6 +366,13 @@ export async function assertTelegramRichObservationFlow(
           gateway: {
             call: async (method: string, args: { message: string }) => {
               assert.equal(method, "send");
+              // Telegram extracts Markdown images before dispatching to its renderer.
+              const [planned] = createOutboundPayloadPlan([{ text: args.message }], {
+                extractMarkdownImages: true,
+              });
+              assert.ok(planned);
+              assert.deepEqual(planned.parts.mediaUrls, [], "rich fixtures must not fetch media");
+              assert.equal(planned.parts.text, args.message);
               const block = nativeBlocks[sends];
               const id = ++sends;
               if (testCase === "send-error") {

--- a/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test-support.ts
@@ -229,8 +229,8 @@ export async function assertTelegramRichObservationFlow(
   const math = { "@type": "richTextMathematicalExpression", expression: "x" };
   const emoji = {
     "@type": "richTextCustomEmoji",
-    custom_emoji_id: "5368324170671202286",
-    alternative_text: "👍",
+    custom_emoji_id: "4929292553544531969",
+    alternative_text: "👋",
   };
   const annotation = (wrapper: (text: unknown) => unknown) =>
     paragraph({
@@ -312,7 +312,7 @@ export async function assertTelegramRichObservationFlow(
               : testCase === "lost-literal-ancestor" && id === 11
                 ? literalScope(wrap("richTextSuperscript", wrap("richTextBold", plain("x"))))
                 : testCase === "emoji-degraded" && id === 6
-                  ? paragraph(url(plain("👍")))
+                  ? paragraph(url(plain("👋")))
                   : testCase === "first-content-failed" && id === 1 && kind === "message"
                     ? paragraph(plain("Download"))
                     : block,
@@ -497,7 +497,7 @@ export async function assertTelegramRichObservationFlow(
           matchesPattern: false,
           block:
             testCase === "emoji-degraded"
-              ? paragraph(url(plain("👍")))
+              ? paragraph(url(plain("👋")))
               : paragraph(plain("Download")),
         },
       );

--- a/extensions/qa-lab/src/scenario-flow-runner.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.test.ts
@@ -12,7 +12,11 @@ import {
   type QaSeedScenarioWithSource,
 } from "./scenario-catalog.js";
 import { runScenarioFlow } from "./scenario-flow-runner.js";
-import { runLoadedScenarioFlow } from "./scenario-flow-runner.test-support.js";
+import {
+  runLoadedScenarioFlow,
+  assertTelegramRichObservationFlow,
+  telegramRichObservationCases,
+} from "./scenario-flow-runner.test-support.js";
 import type { QaSuiteStep } from "./suite-types.js";
 
 function readWebchatTranscriptWaitFlow() {
@@ -299,6 +303,11 @@ const planningEvidenceFixtures = readQaScenarioPack()
   .map(createPlanningEvidenceFixture);
 
 describe("scenario-flow-runner", () => {
+  it.each(telegramRichObservationCases)(
+    "correlates Telegram rich observations without crossing account IDs: %s",
+    assertTelegramRichObservationFlow,
+  );
+
   it("ignores stale provider prompt mismatches when the current run matches", async () => {
     const currentObservation = {
       egress: "responses-sdk",

--- a/extensions/telegram/src/rich-blocks-html.test.ts
+++ b/extensions/telegram/src/rich-blocks-html.test.ts
@@ -48,6 +48,43 @@ describe("block HTML islands", () => {
     expect(serialized).not.toContain("<details>");
   });
 
+  it.each(
+    [
+      ["details", "<details><summary>More</summary><p>", "</p></details>", "More\n"],
+      ["list items", "<ul><li>", "</li></ul>", "• "],
+      ["blockquotes", "<blockquote>", "</blockquote>", ""],
+    ].flatMap(([container, open, close, prefix]) =>
+      [
+        ["styled text", "Download", "Download"],
+        ["entities decoded once", "A &amp; &#38; &amp;amp;", "A & & &amp;"],
+        ["escaped entity", String.raw`\&amp;`, "&amp;"],
+        ["parsed whitespace", "A   B\nC&nbsp;D", "A   B\nC\u00a0D"],
+      ].map(([label, source, expected]) => ({
+        container,
+        open,
+        close,
+        prefix,
+        label,
+        source,
+        expected,
+      })),
+    ),
+  )(
+    "keeps inline HTML links across Markdown styles inside $container ($label)",
+    ({ open, close, prefix, source, expected }) => {
+      const { blocks, plainText } = markdownToTelegramRichBlocks(
+        `${open}<a href="https://example.com">**${source}**</a>${close}`,
+      );
+
+      expect(JSON.stringify(blocks)).toContain('"type":"url"');
+      expect(JSON.stringify(blocks)).toContain('"url":"https://example.com"');
+      expect(JSON.stringify(blocks)).toContain('"type":"bold"');
+      expect(plainText).toBe(`${prefix}${expected}`);
+      expect(plainText).not.toContain("<a ");
+      expect(plainText).not.toContain("</a>");
+    },
+  );
+
   it.each([
     ["headings", "# Steps", "heading"],
     ["fenced code", "```bash\nopenclaw doctor\n```", "pre"],
@@ -472,6 +509,28 @@ describe("block HTML islands", () => {
     expect(blocks.map((block) => block.type)).toEqual(["paragraph", "divider", "paragraph"]);
   });
 
+  it.each([
+    { attributes: "href=https://example.com/?x&#61;1", url: "https://example.com/?x=1" },
+    {
+      attributes: 'href="https://example.com/?q=&quot;hi&quot;"',
+      url: 'https://example.com/?q="hi"',
+    },
+    {
+      attributes: "href='https://example.com/?q=&#39;hi&#39;'",
+      url: "https://example.com/?q='hi'",
+    },
+    { attributes: 'href="https://example.com/**path**"', url: "https://example.com/**path**" },
+  ])("preserves authored attribute data: $attributes", ({ attributes, url }) => {
+    for (const skipEntityDetection of [true, false]) {
+      expect(
+        markdownToTelegramRichBlocks(`<a ${attributes}>**label**</a>`, { skipEntityDetection })
+          .blocks,
+      ).toEqual([
+        { type: "paragraph", text: { type: "url", url, text: { type: "bold", text: "label" } } },
+      ]);
+    }
+  });
+
   it("leaves unsupported or unclosed HTML as literal text", () => {
     const blocks = blocksFor("<details><summary>oops</summary> and <custom>tag</custom>");
     expect(blocks.every((block) => block.type === "paragraph")).toBe(true);
@@ -524,16 +583,46 @@ describe("block HTML islands", () => {
   });
 
   it.each(["custom", "constructor"])(
-    "keeps the entire subtree of unsupported <%s> wrappers literal",
+    "keeps unsupported <%s> HTML literal without discarding Markdown spans",
     (tag) => {
-      const markdown = `a <${tag}><sup>x</sup></${tag}> here`;
-      const { blocks, plainText } = markdownToTelegramRichBlocks(markdown);
-      expect(plainText).toBe(markdown);
-      const serialized = JSON.stringify(blocks);
-      expect(serialized).toContain("<sup>x</sup>");
-      expect(serialized).not.toContain('"superscript"');
+      for (const close of [`</${tag}>`, ""]) {
+        const markdown = `a <${tag}><sup>**x**</sup>${close} here`;
+        const { blocks, plainText } = markdownToTelegramRichBlocks(markdown);
+        expect(plainText).toBe(`a <${tag}><sup>x</sup>${close} here`);
+        expect(blocks).toMatchObject([
+          { type: "paragraph", text: expect.arrayContaining([{ type: "bold", text: "x" }]) },
+        ]);
+      }
     },
   );
+
+  it.each([
+    { body: "> <sup>**x**</sup>", kind: "blockquote" },
+    { body: "| Header |\n| --- |\n| <sup>**x**</sup> |", kind: "table" },
+  ])("keeps unsupported HTML ownership across a Markdown $kind", ({ body, kind }) => {
+    const { blocks, plainText } = markdownToTelegramRichBlocks(`<custom>\n\n${body}\n\n</custom>`);
+    expect(plainText).toContain("<sup>x</sup>");
+    const block = blocks.find((value) => value.type === kind);
+    expect(block).toBeDefined();
+    const text =
+      block?.type === "blockquote" && block.blocks[0]?.type === "paragraph"
+        ? block.blocks[0].text
+        : block?.type === "table"
+          ? block.cells[1]?.[0]?.text
+          : undefined;
+    expect(text).toEqual(expect.arrayContaining([{ type: "bold", text: "x" }]));
+  });
+
+  it("keeps HTML active in a table before an unsupported wrapper", () => {
+    const blocks = blocksFor("| Header |\n| --- |\n| <sup>**x**</sup> |\n\n<custom>after</custom>");
+    expect(blocks[0]).toMatchObject({
+      type: "table",
+      cells: [
+        [{ text: "Header" }],
+        [{ text: { type: "superscript", text: { type: "bold", text: "x" } } }],
+      ],
+    });
+  });
 
   it("counts rowspan carryover toward the table column limit", () => {
     const secondRow = Array.from({ length: 20 }, (_, i) => `<td>c${i}</td>`).join("");

--- a/extensions/telegram/src/rich-blocks-html.ts
+++ b/extensions/telegram/src/rich-blocks-html.ts
@@ -3,7 +3,7 @@
 // of HTML islands (see agentPrompt.inboundFormattingHints "markdown_telegram_rich");
 // this module owns the tolerant parser and inline (RichText-level) mapping,
 // while rich-blocks-html-map.ts owns block-level island mapping.
-import { tokenizeHtmlTags } from "openclaw/plugin-sdk/text-chunking";
+import type { MarkdownIR } from "openclaw/plugin-sdk/text-chunking";
 import { decodeTelegramHtmlEntities } from "./format-html.js";
 import type { RichText } from "./rich-block-model.js";
 
@@ -57,10 +57,12 @@ export function parseHtmlAttrs(raw: string): Map<string, string> {
 }
 
 /** Parse an HTML fragment into a light node tree; unmatched tags stay text. */
-export function parseHtmlFragment(
-  text: string,
-  literalRanges: readonly { start: number; end: number }[] = [],
-): HtmlNode[] {
+export function parseHtmlFragment(ir: MarkdownIR): HtmlNode[] {
+  const text = ir.text;
+  const literalRanges = [
+    ...ir.styles.filter((span) => span.style === "code" || span.style === "code_block"),
+    ...(ir.annotations ?? []),
+  ];
   const root: HtmlNode[] = [];
   const stack: Array<{ name: string; node: Extract<HtmlNode, { kind: "element" }> }> = [];
   const childrenOf = () => (stack.length > 0 ? stack[stack.length - 1]!.node.children : root);
@@ -70,7 +72,7 @@ export function parseHtmlFragment(
       childrenOf().push({ kind: "text", text: text.slice(from, to), start: from, end: to });
     }
   };
-  for (const tag of tokenizeHtmlTags(text)) {
+  for (const tag of ir.htmlTags ?? []) {
     const parent = stack.at(-1);
     // Code examples are text, including tag-shaped examples inside a disclosure.
     // Keep them out of matching so they cannot close or create an authored container.
@@ -146,39 +148,66 @@ function serializeHtmlNodes(nodes: readonly HtmlNode[]): string {
     .join("");
 }
 
-/** Convert island children into RichText, honoring documented inline tags. */
-export function htmlNodesToRichText(nodes: readonly HtmlNode[]): RichText {
+type HtmlRichTextRenderer = {
+  text: (node: Extract<HtmlNode, { kind: "text" }>) => RichText;
+  literal: (range: { start: number; end: number }, serialize: () => string) => RichText;
+  wrap: (
+    range: { start: number; end: number },
+    wrap: (text: RichText) => RichText,
+    children: () => RichText,
+  ) => RichText;
+  atom: (range: { start: number; end: number }, value: RichText) => RichText;
+};
+
+const defaultHtmlRenderer: HtmlRichTextRenderer = {
+  text: (node) => decodeTelegramHtmlEntities(node.text.replace(/\s+/g, " ")),
+  literal: (_range, serialize) => serialize(),
+  wrap: (_range, wrap, children) => wrap(children()),
+  atom: (_range, value) => value,
+};
+
+/** The same tag mapping serves standalone HTML and Markdown source-range composition. */
+export function htmlNodesToRichText(
+  nodes: readonly HtmlNode[],
+  renderer: HtmlRichTextRenderer = defaultHtmlRenderer,
+): RichText {
   const parts: RichText[] = [];
   for (const node of nodes) {
     if (node.kind === "text") {
-      const value = decodeTelegramHtmlEntities(node.text.replace(/\s+/g, " "));
+      const value = renderer.text(node);
       if (value) {
         parts.push(value);
       }
       continue;
     }
-    if (!node.closed) {
-      parts.push(node.raw, htmlNodesToRichText(node.children));
-      continue;
-    }
+    const children = () => htmlNodesToRichText(node.children, renderer);
+    const emit = (build: () => RichText): RichText =>
+      node.closed
+        ? build()
+        : [
+            renderer.atom({ start: node.start, end: node.start + node.raw.length }, node.raw),
+            children(),
+          ];
+    const wrap = (build: (text: RichText) => RichText) =>
+      emit(() => renderer.wrap(node, build, children));
+    const atom = (value: RichText) => emit(() => renderer.atom(node, value));
     const style = Object.hasOwn(INLINE_STYLE_TAGS, node.name) && INLINE_STYLE_TAGS[node.name];
     if (style) {
-      parts.push({ type: style, text: htmlNodesToRichText(node.children) });
+      parts.push(wrap((text) => ({ type: style, text })));
       continue;
     }
     if (node.name === "a") {
       const href = parseHtmlAttrs(node.raw).get("href");
-      const inner = htmlNodesToRichText(node.children);
       if (href?.startsWith("#")) {
         // In-message fragments are RichTextAnchorLink, not RichTextUrl.
-        parts.push({ type: "anchor_link", text: inner, anchor_name: href.slice(1) });
+        parts.push(wrap((text) => ({ type: "anchor_link", text, anchor_name: href.slice(1) })));
       } else {
-        parts.push(href ? { type: "url", text: inner, url: href } : inner);
+        parts.push(href ? wrap((text) => ({ type: "url", text, url: href })) : emit(children));
       }
       continue;
     }
     if (node.name === "tg-math") {
-      parts.push({ type: "mathematical_expression", expression: nodeText(node.children) });
+      parts.push(atom({ type: "mathematical_expression", expression: nodeText(node.children) }));
       continue;
     }
     if (node.name === "tg-emoji") {
@@ -187,33 +216,30 @@ export function htmlNodesToRichText(nodes: readonly HtmlNode[]): RichText {
       // Wire contract: custom_emoji_id must be a valid Number (live-verified
       // 400 otherwise); unknown-but-numeric IDs degrade server-side.
       if (emojiId && /^\d+$/.test(emojiId) && alternative) {
-        parts.push({
-          type: "custom_emoji",
-          custom_emoji_id: emojiId,
-          alternative_text: alternative,
-        });
+        parts.push(
+          atom({
+            type: "custom_emoji",
+            custom_emoji_id: emojiId,
+            alternative_text: alternative,
+          }),
+        );
         continue;
       }
-      parts.push(alternative);
+      parts.push(atom(alternative));
       continue;
     }
     if (node.name === "br") {
-      parts.push("\n");
+      parts.push(atom("\n"));
       continue;
     }
     if (node.name === "p" || node.name === "span" || node.name === "div") {
       // Transparent containers: content only.
-      parts.push(htmlNodesToRichText(node.children));
+      parts.push(emit(children));
       continue;
     }
-    // Unsupported element: its ENTIRE subtree stays literal so agent mistakes
-    // remain visible; converting recognized descendants would mix typed nodes
-    // into a literal wrapper and lose their markup from the plain projection.
-    const selfContained = VOID_TAGS.has(node.name) || node.raw.trimEnd().endsWith("/>");
-    parts.push(node.raw, serializeHtmlNodes(node.children));
-    if (!selfContained) {
-      parts.push(`</${node.name}>`);
-    }
+    // Unsupported HTML and its HTML descendants stay literal, but independently
+    // authored Markdown spans must still apply inside that text range.
+    parts.push(renderer.literal(node, () => serializeHtmlNodes([node])));
   }
   if (parts.length === 0) {
     return "";
@@ -223,21 +249,3 @@ export function htmlNodesToRichText(nodes: readonly HtmlNode[]): RichText {
   }
   return parts;
 }
-
-/** Parse inline islands (<sup>, <tg-math>, <tg-emoji>, …) out of a text leaf. */
-export function parseInlineHtmlIslands(leaf: string): RichText {
-  if (!leaf.includes("<")) {
-    return leaf;
-  }
-  const nodes = parseHtmlFragment(leaf);
-  const hasElement = (children: readonly HtmlNode[]): boolean =>
-    children.some((node) => node.kind === "element" && (node.closed || hasElement(node.children)));
-  if (!hasElement(nodes)) {
-    return leaf;
-  }
-  // Preserve raw whitespace when no islands parse; only island-bearing leaves
-  // go through the normalizing HTML text model.
-  return htmlNodesToRichText(nodes);
-}
-
-// Prompt contract: media islands are https-only.

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -276,6 +276,183 @@ describe("markdownToTelegramRichBlocks", () => {
     expect(collectLinkTargets(text)).toEqual([]);
   });
 
+  it.each([
+    "&lt;b&gt;**literal**&lt;/b&gt;",
+    "&#60;b&#62;**literal**&#x3c;/b&#x3e;",
+    "\\<b\\>**literal**\\</b\\>",
+    "<&#98;>**literal**</&#98;>",
+    "<b&gt;**literal**</b&gt;",
+  ])("keeps decoded literal tag syntax visible: %s", (markdown) => {
+    const result = markdownToTelegramRichBlocks(markdown);
+    expect(result.blocks).toEqual([
+      { type: "paragraph", text: ["<b>", { type: "bold", text: "literal" }, "</b>"] },
+    ]);
+    expect(result.plainText).toBe("<b>literal</b>");
+  });
+
+  it("does not synthesize HTML tags across Markdown formatting boundaries", () => {
+    const result = markdownToTelegramRichBlocks("<**b**>literal</**b**>");
+    expect(result.plainText).toBe("<b>literal</b>");
+    expect(result.blocks).toEqual([
+      {
+        type: "paragraph",
+        text: ["<", { type: "bold", text: "b" }, ">literal</", { type: "bold", text: "b" }, ">"],
+      },
+    ]);
+  });
+
+  it("keeps image alternatives literal and Markdown links in tag-shaped text", () => {
+    const result = markdownToTelegramRichBlocks(
+      "&lt;b&gt;**literal**&lt;/b&gt; ![<i>alt</i>](https://example.com/image.png) <b[r](https://example.com/qa)>tail",
+    );
+    expect(result.blocks).toEqual([
+      {
+        type: "paragraph",
+        text: [
+          "<b>",
+          { type: "bold", text: "literal" },
+          "</b> <i>alt</i> <b",
+          { type: "url", url: "https://example.com/qa", text: "r" },
+          ">tail",
+        ],
+      },
+    ]);
+    expect(result.plainText).toBe("<b>literal</b> <i>alt</i> <br>tail");
+  });
+
+  it("keeps authored HTML and encoded attribute data beside literal tags", () => {
+    const result = markdownToTelegramRichBlocks(
+      '<a href="https://example.com/?a=1&amp;b=2">**literal**</a> &lt;i&gt;text&lt;/i&gt;',
+    );
+    expect(result.blocks).toEqual([
+      {
+        type: "paragraph",
+        text: [
+          {
+            type: "url",
+            url: "https://example.com/?a=1&b=2",
+            text: { type: "bold", text: "literal" },
+          },
+          " <i>text</i>",
+        ],
+      },
+    ]);
+    expect(result.plainText).toBe("literal <i>text</i>");
+  });
+
+  it("does not hide authored tags inside decoded literal comment delimiters", () => {
+    expect(markdownToTelegramRichBlocks("&lt;!-- <b>literal</b> --&gt;").blocks).toEqual([
+      { type: "paragraph", text: ["<!-- ", { type: "bold", text: "literal" }, " -->"] },
+    ]);
+  });
+
+  it.each([
+    {
+      markdown: "<!-- **<b>literal</b>** &amp; -->",
+      text: "<!-- **<b>literal</b>** &amp; -->",
+    },
+    {
+      markdown: "<**!**-- <b>literal</b> -->",
+      text: ["<", { type: "bold", text: "!" }, "-- ", { type: "bold", text: "literal" }, " -->"],
+    },
+    {
+      markdown: "<!&#65; <b>literal</b>>",
+      text: ["<!A ", { type: "bold", text: "literal" }, ">"],
+    },
+    {
+      markdown: "<!**A** <b>literal</b>>",
+      text: ["<!", { type: "bold", text: "A" }, " ", { type: "bold", text: "literal" }, ">"],
+    },
+    {
+      markdown: "<!A &amp; <b>literal</b>>",
+      text: "<!A &amp; <b>literal</b>>",
+    },
+  ])("preserves opaque construct syntax provenance: $markdown", ({ markdown, text }) => {
+    expect(markdownToTelegramRichBlocks(markdown).blocks).toEqual([{ type: "paragraph", text }]);
+  });
+
+  it.each([
+    "- &lt;b&gt;**literal**&lt;/b&gt;",
+    "> &lt;b&gt;**literal**&lt;/b&gt;",
+    "<details><summary>More</summary><p>&lt;b&gt;**literal**&lt;/b&gt;</p></details>",
+  ])("keeps literal provenance inside nested blocks: %s", (markdown) => {
+    const result = markdownToTelegramRichBlocks(markdown);
+    expect(result.plainText).toContain("<b>literal</b>");
+    const block = result.blocks[0];
+    const body =
+      block?.type === "list"
+        ? block.items[0]?.blocks
+        : block?.type === "blockquote" || block?.type === "details"
+          ? block.blocks
+          : [];
+    expect(body).toEqual([
+      { type: "paragraph", text: ["<b>", { type: "bold", text: "literal" }, "</b>"] },
+    ]);
+  });
+
+  it("keeps literal provenance in native table cells", () => {
+    const { blocks } = markdownToTelegramRichBlocks(
+      "| Value |\n| --- |\n| &lt;b&gt;**literal**&lt;/b&gt; |",
+    );
+    expect(blocks[0]).toMatchObject({
+      type: "table",
+      cells: [[{ text: "Value" }], [{ text: ["<b>", { type: "bold", text: "literal" }, "</b>"] }]],
+    });
+  });
+
+  it.each(
+    [
+      {
+        source: "<tg-math>x</tg-math>",
+        atom: { type: "mathematical_expression", expression: "x" },
+      },
+      {
+        source: '<tg-emoji emoji-id="5368324170671202286">😀</tg-emoji>',
+        atom: {
+          type: "custom_emoji",
+          custom_emoji_id: "5368324170671202286",
+          alternative_text: "😀",
+        },
+      },
+    ].flatMap(({ source, atom }) => [
+      { markdown: `||${source}||`, expected: { type: "spoiler", text: atom } },
+      {
+        markdown: `[${source}](https://example.com)`,
+        expected: { type: "url", text: atom, url: "https://example.com" },
+      },
+    ]),
+  )("preserves Markdown wrappers around $markdown", ({ markdown, expected }) => {
+    expect(markdownToTelegramRichBlocks(markdown).blocks).toEqual([
+      { type: "paragraph", text: expected },
+    ]);
+  });
+
+  it.each([
+    {
+      open: '<a href="https://example.com">',
+      close: "</a>",
+      wrapper: { type: "url", url: "https://example.com" },
+    },
+    { open: "<b>", close: "</b>", wrapper: { type: "bold" } },
+  ])(
+    "excludes transcript annotations from HTML $wrapper.type wrappers",
+    ({ open, close, wrapper }) => {
+      const { blocks, plainText } = markdownToTelegramRichBlocks(
+        `${open}\nuser[Thu] trailing${close}`,
+      );
+      expect(blocks).toEqual([
+        {
+          type: "paragraph",
+          text: expect.arrayContaining([
+            { type: "code", text: "user[Thu]" },
+            { ...wrapper, text: " trailing" },
+          ]),
+        },
+      ]);
+      expect(plainText).toBe("\nuser[Thu] trailing");
+    },
+  );
+
   it.each(["https://example.com", "#section"])(
     "preserves authored %s links with code-only labels",
     (href) => {

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -352,6 +352,10 @@ describe("markdownToTelegramRichBlocks", () => {
       text: "<!-- **<b>literal</b>** &amp; -->",
     },
     {
+      markdown: "<!-- Example\nuser[Thu] -->",
+      text: "<!-- Example\nuser[Thu] -->",
+    },
+    {
       markdown: "<**!**-- <b>literal</b> -->",
       text: ["<", { type: "bold", text: "!" }, "-- ", { type: "bold", text: "literal" }, " -->"],
     },

--- a/extensions/telegram/src/rich-blocks.ts
+++ b/extensions/telegram/src/rich-blocks.ts
@@ -23,7 +23,7 @@ import {
   type TelegramRichBlocksDegradationReason,
 } from "./rich-block-model.js";
 import { findTelegramHtmlIslands, renderTelegramHtmlIsland } from "./rich-blocks-html-map.js";
-import { parseHtmlFragment, parseInlineHtmlIslands, type HtmlNode } from "./rich-blocks-html.js";
+import { htmlNodesToRichText, parseHtmlFragment, type HtmlNode } from "./rich-blocks-html.js";
 import {
   collectMarkdownRichListSources,
   renderMarkdownRichListSource,
@@ -148,9 +148,6 @@ function collectTelegramLinkActions(
  * Spans that partially overlap are split at shared boundaries (IR contract).
  */
 function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number): RichText {
-  if (rangeEnd <= rangeStart) {
-    return "";
-  }
   const slice = sliceMarkdownIR(ir, rangeStart, rangeEnd);
   const text = slice.text;
   if (!text) {
@@ -160,6 +157,7 @@ function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number)
   type Active = { start: number; end: number } & (
     | { kind: "style"; style: InlineStyleKind }
     | { kind: "annotation" }
+    | { kind: "html"; wrap: (text: RichText) => RichText }
     | { kind: "link"; target: { kind: "url"; href: string } | { kind: "anchor"; name: string } }
   );
   const spans: Active[] = [];
@@ -178,13 +176,45 @@ function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number)
         : { start: link.start, end: link.end, kind: "link", target: link.action },
     );
   }
+  type Leaf = { start: number; end: number } & (
+    | { kind: "text" }
+    | { kind: "atom"; value: RichText }
+  );
+  const leaves: Leaf[] = [];
+  const nodes = text.includes("<") ? parseHtmlFragment(slice) : [];
+  const hasElement = (children: readonly HtmlNode[]): boolean =>
+    children.some((node) => node.kind === "element" && (node.closed || hasElement(node.children)));
+  if (hasElement(nodes)) {
+    // Keep HTML wrappers and atomic islands on the same source axis as Markdown.
+    // One sweep can then apply annotation dominance without breaking authored HTML.
+    const recordText = ({ start, end }: { start: number; end: number }) => {
+      leaves.push({ kind: "text", start, end });
+      return "";
+    };
+    htmlNodesToRichText(nodes, {
+      text: recordText,
+      literal: recordText,
+      wrap: ({ start, end }, wrap, children) => {
+        spans.push({ kind: "html", start, end, wrap });
+        return children();
+      },
+      atom: ({ start, end }, value) => {
+        // An indivisible replacement must not hide a protected source annotation.
+        const annotated = slice.annotations?.some((span) => span.start < end && span.end > start);
+        leaves.push(annotated ? { kind: "text", start, end } : { kind: "atom", start, end, value });
+        return "";
+      },
+    });
+  } else {
+    leaves.push({ kind: "text", start: 0, end: text.length });
+  }
   const rank = (span: Active) =>
-    span.kind === "style" ? INLINE_STYLE_RANK[span.style] : span.kind === "link" ? 50 : 0;
+    span.kind === "style" ? INLINE_STYLE_RANK[span.style] : span.kind === "annotation" ? 0 : 50;
   spans.sort(
     (left, right) => left.start - right.start || right.end - left.end || rank(left) - rank(right),
   );
   const points = [
-    ...new Set([0, text.length, ...spans.flatMap((span) => [span.start, span.end])]),
+    ...new Set([...spans, ...leaves].flatMap((span) => [span.start, span.end])),
   ].toSorted((left, right) => left - right);
   const stack: Active[] = [];
   const root: RichText[] = [];
@@ -192,8 +222,12 @@ function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number)
 
   for (let i = 0; i < points.length - 1; i += 1) {
     const start = points[i] ?? 0;
-    const end = points[i + 1] ?? start;
-    const covering = spans.filter((span) => span.start <= start && span.end > start);
+    const leaf = leaves.find((entry) => entry.start <= start && entry.end > start);
+    if (!leaf || (leaf.kind === "atom" && leaf.start !== start)) {
+      continue;
+    }
+    const end = leaf.kind === "atom" ? leaf.end : (points[i + 1] ?? start);
+    const covering = spans.filter((span) => span.start <= start && span.end >= end);
     const annotation = covering.find((span) => span.kind === "annotation");
     // Dominance applies only to the covered range. Surrounding formatting resumes
     // after a transcript header. Code is already literal in IR; its merged range
@@ -210,41 +244,24 @@ function irRangeToRichText(ir: MarkdownIR, rangeStart: number, rangeEnd: number)
     for (const item of active.slice(shared)) {
       const container: RichText[] = [];
       const node: RichText =
-        item.kind === "link"
-          ? item.target.kind === "url"
-            ? { type: "url", text: container, url: item.target.href }
-            : { type: "anchor_link", text: container, anchor_name: item.target.name }
-          : { type: item.kind === "annotation" ? "code" : item.style, text: container };
+        item.kind === "html"
+          ? item.wrap(container)
+          : item.kind === "link"
+            ? item.target.kind === "url"
+              ? { type: "url", text: container, url: item.target.href }
+              : { type: "anchor_link", text: container, anchor_name: item.target.name }
+            : { type: item.kind === "annotation" ? "code" : item.style, text: container };
       frameStack.at(-1)?.push(node);
       stack.push(item);
       frameStack.push(container);
     }
     if (end > start) {
       // Unlike Bot API HTML mode, rich paragraphs preserve bare newlines verbatim.
-      frameStack.at(-1)?.push(text.slice(start, end));
+      frameStack.at(-1)?.push(leaf.kind === "atom" ? leaf.value : text.slice(start, end));
     }
   }
 
-  return normalizeRichText(applyInlineHtmlIslands(root));
-}
-
-// Inline islands (<sup>, <tg-math>, <tg-emoji>, …) live in plain string leaves;
-// code spans keep their content literal.
-function applyInlineHtmlIslands(node: RichText): RichText {
-  if (typeof node === "string") {
-    return parseInlineHtmlIslands(node);
-  }
-  if (Array.isArray(node)) {
-    return node.map(applyInlineHtmlIslands);
-  }
-  if (
-    node.type === "code" ||
-    node.type === "mathematical_expression" ||
-    node.type === "custom_emoji"
-  ) {
-    return node;
-  }
-  return { ...node, text: applyInlineHtmlIslands(node.text) };
+  return normalizeRichText(root);
 }
 
 function pushParagraph(
@@ -298,13 +315,7 @@ function cellToRichText(cell: MarkdownTableCell | undefined): RichText | undefin
   if (!cell?.text) {
     return undefined;
   }
-  const ir: MarkdownIR = {
-    text: cell.text,
-    styles: cell.styles,
-    links: cell.links,
-    ...(cell.annotations ? { annotations: cell.annotations } : {}),
-  };
-  const rich = irRangeToRichText(ir, 0, cell.text.length);
+  const rich = irRangeToRichText(cell, 0, cell.text.length);
   return rich === "" ? undefined : rich;
 }
 
@@ -393,6 +404,50 @@ function collectStructuralSegments(
   return segments;
 }
 
+function preserveLiteralHtmlOwners(
+  ir: MarkdownIR,
+  segments: readonly StructuralSegment[],
+  htmlNodes: readonly HtmlNode[],
+): void {
+  const islands = new Set<HtmlNode>(findTelegramHtmlIslands(htmlNodes));
+  const owners: Array<{ start: number; end: number }> = [];
+  htmlNodesToRichText(
+    htmlNodes.filter((node) => !islands.has(node)),
+    {
+      text: () => "",
+      literal: (range) => {
+        owners.push(range);
+        return "";
+      },
+      wrap: (_range, _wrap, children) => children(),
+      atom: () => "",
+    },
+  );
+  if (!owners.length) {
+    return;
+  }
+  // Markdown block slices must not reactivate tags whose HTML ancestor is literal.
+  ir.htmlTags = ir.htmlTags?.filter(
+    (tag) => !owners.some((owner) => tag.start >= owner.start && tag.end <= owner.end),
+  );
+  for (const segment of segments) {
+    if (
+      segment.kind !== "table" ||
+      !owners.some((owner) => segment.start > owner.start && segment.start < owner.end)
+    ) {
+      continue;
+    }
+    // A preceding zero-width table may share the opener's offset; only body tables belong to it.
+    for (const row of [segment.table.headerCells, ...segment.table.rowCells]) {
+      for (const cell of row) {
+        if (cell.htmlTags) {
+          cell.htmlTags = [];
+        }
+      }
+    }
+  }
+}
+
 function emitSegments(
   ir: MarkdownIR,
   segments: readonly StructuralSegment[],
@@ -401,6 +456,7 @@ function emitSegments(
   degradationReasons: Set<TelegramRichBlocksDegradationReason>,
   htmlNodes: readonly HtmlNode[] = [],
 ): InputRichBlock[] {
+  preserveLiteralHtmlOwners(ir, segments, htmlNodes);
   const containerRank = (segment: StructuralSegment) =>
     segment.kind === "blockquote" ? 0 : segment.kind === "list" ? 1 : 2;
   const orderedSegments = [
@@ -568,10 +624,7 @@ export function markdownToTelegramRichBlocks(
   });
 
   let degradationReasons = new Set<TelegramRichBlocksDegradationReason>();
-  const htmlNodes = parseHtmlFragment(
-    ir.text,
-    ir.styles.filter((span) => span.style === "code" || span.style === "code_block"),
-  );
+  const htmlNodes = parseHtmlFragment(ir);
   const segments = collectStructuralSegments(ir, tables, htmlNodes);
   const hasMarkdownLists = segments.some((segment) => segment.kind === "list");
   const flattenedSegments = segments.filter((segment) => segment.kind !== "list");

--- a/extensions/telegram/src/send-rich-editing.test.ts
+++ b/extensions/telegram/src/send-rich-editing.test.ts
@@ -17,6 +17,33 @@ const listItems = (count: number) =>
   Array.from({ length: count }, (_, index) => `L${String(index + 1).padStart(3, "0")}`);
 
 describe("Telegram rich message edits", () => {
+  it.each([false, true])(
+    "retains styled HTML links on edits (plain recovery: %s)",
+    async (plain) => {
+      const text =
+        '<details><summary>More</summary><p><a href="https://example.com">**Download**</a></p></details>';
+      if (plain) {
+        botRawApi.editMessageText.mockRejectedValueOnce(
+          new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+        );
+        botApi.editMessageText.mockResolvedValueOnce(editedMessage);
+      } else {
+        botRawApi.editMessageText.mockResolvedValueOnce(editedMessage);
+      }
+
+      await editMessageTelegram("123", 321, text, { cfg: richConfig, token: "tok" });
+
+      const richMessage = botRawApi.editMessageText.mock.calls[0]?.[0].rich_message;
+      expect(JSON.stringify(richMessage)).toContain('"type":"url"');
+      expect(JSON.stringify(richMessage)).toContain('"url":"https://example.com"');
+      if (plain) {
+        expect(botApi.editMessageText.mock.calls[0]?.[2]).toBe("More\nDownload");
+      } else {
+        expect(botApi.editMessageText).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it.each([
     { name: "501 paragraphs", tokens: paragraphs(501), separator: "\n\n", prefix: "" },
     { name: "251 list items", tokens: listItems(251), separator: "\n", prefix: "- " },

--- a/packages/markdown-core/src/assistant-transcript.ts
+++ b/packages/markdown-core/src/assistant-transcript.ts
@@ -5,6 +5,7 @@ import {
   type AssistantTranscriptRoleHeaderSpan,
 } from "./assistant-transcript-headers.js";
 import { tokenizeHtmlTags } from "./html-tags.js";
+import { appendHtmlTags, copyHtmlTags, RAW_HTML_TOKEN_TYPE } from "./ir-metadata.js";
 
 export const ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE = "assistant_transcript_role_text";
 
@@ -74,7 +75,7 @@ function visibleTokenProjection(
   if (token.type === "html_inline" && options.isStructuralHtmlInline?.(token) === true) {
     return null;
   }
-  if (token.type === "text" || token.type === "html_inline") {
+  if (token.type === "text" || token.type === "html_inline" || token.type === RAW_HTML_TOKEN_TYPE) {
     return { text: token.content, excludedRanges: [] };
   }
   if (token.type === "code_inline") {
@@ -112,7 +113,8 @@ function visibleTokensProjection(
 function cloneToken(
   TokenType: StateCore["Token"],
   source: Token,
-  content: string,
+  start: number,
+  end: number,
   type: string = source.type,
 ): Token {
   const token = new TokenType(
@@ -122,18 +124,19 @@ function cloneToken(
   );
   Object.assign(token, source);
   token.type = type;
-  token.content = content;
+  token.content = source.content.slice(start, end);
   token.children = null;
-  return token;
+  return copyHtmlTags(source, token, start, end);
 }
 
 function annotatedToken(
   TokenType: StateCore["Token"],
   source: Token,
-  content: string,
+  start: number,
+  end: number,
   span: AssistantTranscriptRoleHeaderSpan,
 ): Token {
-  const token = cloneToken(TokenType, source, content, ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE);
+  const token = cloneToken(TokenType, source, start, end, ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE);
   token.meta = {
     ...(source.meta && typeof source.meta === "object" ? source.meta : {}),
     assistantTranscriptRoleHeader: {
@@ -171,24 +174,15 @@ function splitVisibleToken(params: {
     const overlapStart = Math.max(span.start, visibleStart) - visibleStart;
     const overlapEnd = Math.min(span.end, visibleEnd) - visibleStart;
     if (overlapStart > localCursor) {
-      result.push(
-        cloneToken(params.TokenType, token, token.content.slice(localCursor, overlapStart)),
-      );
+      result.push(cloneToken(params.TokenType, token, localCursor, overlapStart));
     }
     if (overlapEnd > overlapStart) {
-      result.push(
-        annotatedToken(
-          params.TokenType,
-          token,
-          token.content.slice(overlapStart, overlapEnd),
-          span,
-        ),
-      );
+      result.push(annotatedToken(params.TokenType, token, overlapStart, overlapEnd, span));
     }
     localCursor = overlapEnd;
   }
   if (localCursor < token.content.length) {
-    result.push(cloneToken(params.TokenType, token, token.content.slice(localCursor)));
+    result.push(cloneToken(params.TokenType, token, localCursor, token.content.length));
   }
   return result;
 }
@@ -222,7 +216,11 @@ function annotateInlineChildren(
       }
       spanCursor += 1;
     }
-    if (token.type === "text" || token.type === "html_inline") {
+    if (
+      token.type === "text" ||
+      token.type === "html_inline" ||
+      token.type === RAW_HTML_TOKEN_TYPE
+    ) {
       result.push(
         ...splitVisibleToken({
           TokenType,
@@ -301,6 +299,7 @@ function removeLinksContainingAssistantTranscriptRoles(tokens: Token[]): Token[]
       previous?.type === ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE &&
       token.type === ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE
     ) {
+      appendHtmlTags(previous, token, previous.content.length);
       previous.content += token.content;
       continue;
     }

--- a/packages/markdown-core/src/assistant-transcript.ts
+++ b/packages/markdown-core/src/assistant-transcript.ts
@@ -75,10 +75,11 @@ function visibleTokenProjection(
   if (token.type === "html_inline" && options.isStructuralHtmlInline?.(token) === true) {
     return null;
   }
-  if (token.type === "text" || token.type === "html_inline" || token.type === RAW_HTML_TOKEN_TYPE) {
+  if (token.type === "text" || token.type === "html_inline") {
     return { text: token.content, excludedRanges: [] };
   }
-  if (token.type === "code_inline") {
+  // Raw lexemes own their contents but still contribute length to later text offsets.
+  if (token.type === "code_inline" || token.type === RAW_HTML_TOKEN_TYPE) {
     return { text: token.content, excludedRanges: [{ start: 0, end: token.content.length }] };
   }
   if (token.type === "image") {
@@ -216,11 +217,7 @@ function annotateInlineChildren(
       }
       spanCursor += 1;
     }
-    if (
-      token.type === "text" ||
-      token.type === "html_inline" ||
-      token.type === RAW_HTML_TOKEN_TYPE
-    ) {
+    if (token.type === "text" || token.type === "html_inline") {
       result.push(
         ...splitVisibleToken({
           TokenType,

--- a/packages/markdown-core/src/construct-fallbacks.test.ts
+++ b/packages/markdown-core/src/construct-fallbacks.test.ts
@@ -45,6 +45,25 @@ function markdownToTaskIR(markdown: string): MarkdownIR {
   return markdownToIR(markdown, { enableTaskLists: true });
 }
 
+it("preserves authored tags through projection and list-marker removal", () => {
+  const parsed = markdownToIR("- **<b>x</b>**");
+  const native = applyConstructFallbacks(parsed, ALL_NATIVE);
+  const stripped = applyConstructFallbacks(parsed, withSupport("bulletList", "strip"));
+
+  expect(native.htmlTags).toEqual([
+    { start: 2, end: 5, raw: "<b>", name: "b", closing: false, selfClosing: false },
+    { start: 6, end: 10, raw: "</b>", name: "b", closing: true, selfClosing: false },
+  ]);
+  expect(stripped.text).toBe("<b>x</b>");
+  expect(stripped.styles).toEqual([{ start: 0, end: 8, style: "bold" }]);
+  expect(stripped.htmlTags).toEqual([
+    { start: 0, end: 3, raw: "<b>", name: "b", closing: false, selfClosing: false },
+    { start: 4, end: 8, raw: "</b>", name: "b", closing: true, selfClosing: false },
+  ]);
+  expect(Object.keys(native)).not.toContain("htmlTags");
+  expect(Object.keys(stripped)).not.toContain("htmlTags");
+});
+
 type FallbackCase = {
   name: string;
   construct: FormatConstruct;

--- a/packages/markdown-core/src/construct-fallbacks.ts
+++ b/packages/markdown-core/src/construct-fallbacks.ts
@@ -1,4 +1,5 @@
 import type { FormatCapabilityProfile, FormatConstruct } from "./format-capabilities.js";
+import { copyHtmlTags } from "./ir-metadata.js";
 import {
   createStyleSpan,
   mergeAnnotationSpans,
@@ -112,12 +113,12 @@ function applyTextEdits(ir: MarkdownIR, edits: TextEdit[]): MarkdownIR {
       return !previous || edit.start !== previous.start || edit.end !== previous.end;
     });
   // Edited output drops list metadata, so do not rebuild it for every slice.
-  const content: MarkdownIR = {
+  const content: MarkdownIR = copyHtmlTags(ir, {
     text: ir.text,
     styles: ir.styles,
     links: ir.links,
     annotations: ir.annotations,
-  };
+  });
   const result: MarkdownIR = { text: "", styles: [], links: [] };
   let cursor = 0;
   for (const edit of ordered) {
@@ -140,11 +141,14 @@ export function applyConstructFallbacks(
 ): MarkdownIR {
   // Tables stay in convertMarkdownTables; images and mentions are already plain
   // text in this flat IR, so those constructs have no shared fallback work here.
-  const styled: MarkdownIR = {
+  const styled: MarkdownIR = copyHtmlTags(ir, {
     ...ir,
     styles: projectStyles(ir.styles, profile),
-  };
+  });
   const listProjected = applyTextEdits(styled, collectListFallbacks(styled, profile));
   const linkProjection = collectLinkFallbacks(listProjected, profile);
-  return applyTextEdits({ ...listProjected, links: linkProjection.links }, linkProjection.edits);
+  return applyTextEdits(
+    copyHtmlTags(listProjected, { ...listProjected, links: linkProjection.links }),
+    linkProjection.edits,
+  );
 }

--- a/packages/markdown-core/src/html-tags.ts
+++ b/packages/markdown-core/src/html-tags.ts
@@ -7,7 +7,7 @@ export function matchMarkdownHtmlTag(source: string): string | undefined {
   return MARKDOWN_HTML_TAG_RE.exec(source)?.[0];
 }
 
-type HtmlTagToken = {
+export type HtmlTagToken = {
   raw: string;
   start: number;
   end: number;

--- a/packages/markdown-core/src/ir-annotations.ts
+++ b/packages/markdown-core/src/ir-annotations.ts
@@ -3,6 +3,7 @@ import type {
   AssistantTranscriptRoleImageMeta,
   AssistantTranscriptRoleTokenMeta,
 } from "./assistant-transcript.js";
+import { copyHtmlTags } from "./ir-metadata.js";
 import { mergeAnnotationSpans, type MarkdownAnnotationSpan } from "./ir-spans.js";
 import type { MarkdownIR } from "./ir.js";
 
@@ -35,13 +36,13 @@ export function annotateAssistantTranscriptRoleMessageBoundary(ir: MarkdownIR): 
     ...boundarySpan,
     type: "assistant_transcript_role",
   };
-  return {
+  return copyHtmlTags(ir, {
     ...ir,
     // A role-looking link must not remain clickable after its label becomes a
     // message-leading transcript header.
     links: ir.links.filter((link) => !rangesOverlap(link, annotation)),
     annotations: mergeAnnotationSpans([...(ir.annotations ?? []), annotation]),
-  };
+  });
 }
 
 export function appendAssistantTranscriptRoleText(
@@ -63,7 +64,8 @@ export function appendAssistantTranscriptRoleText(
   });
 }
 
-export function appendAssistantTranscriptRoleImage(
+/** Image alternatives are plain text, including labels projected for annotations. */
+export function appendImageAlternative(
   target: AnnotationTarget,
   meta: AssistantTranscriptRoleImageMeta["assistantTranscriptRoleImage"],
 ): void {

--- a/packages/markdown-core/src/ir-metadata.ts
+++ b/packages/markdown-core/src/ir-metadata.ts
@@ -1,0 +1,66 @@
+import type { HtmlTagToken } from "./html-tags.js";
+
+export const RAW_HTML_TOKEN_TYPE = "markdown_core_html";
+
+export type MarkdownHtmlMetadata = {
+  /** Complete authored HTML tags in UTF-16 offsets; omitted from serialized IR. */
+  htmlTags?: HtmlTagToken[];
+};
+
+export function defineMetadata<T extends object, K extends keyof T>(
+  target: T,
+  key: K,
+  value: T[K],
+): void;
+export function defineMetadata(
+  target: object,
+  key: "htmlTags",
+  value: HtmlTagToken[] | undefined,
+): void;
+export function defineMetadata(target: object, key: PropertyKey, value: unknown): void {
+  if (value !== undefined) {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: false,
+      value,
+      writable: true,
+    });
+  }
+}
+
+function htmlTags(source: object | undefined): HtmlTagToken[] | undefined {
+  // SAFETY: This owner writes the metadata; upstream Token lacks the declared IR field.
+  return (source as MarkdownHtmlMetadata | undefined)?.htmlTags;
+}
+
+/** A fragment cannot inherit a whole tag's meaning; spreads omit these parser-owned facts. */
+export function copyHtmlTags<T extends object>(
+  source: object,
+  target: T,
+  start = 0,
+  end = Number.POSITIVE_INFINITY,
+): T {
+  const tags: HtmlTagToken[] = [];
+  for (const tag of htmlTags(source) ?? []) {
+    if (tag.start >= start && tag.end <= end) {
+      tags.push({ ...tag, start: tag.start - start, end: tag.end - start });
+    }
+  }
+  if (tags.length) {
+    defineMetadata(target, "htmlTags", tags);
+  }
+  return target;
+}
+
+/** Keep separate tag facts and fresh offsets so appending cannot mutate the source. */
+export function appendHtmlTags(target: object, source: object | undefined, offset: number): void {
+  const incoming = htmlTags(source);
+  if (!incoming?.length) {
+    return;
+  }
+  const tags = htmlTags(target) ?? [];
+  for (const tag of incoming) {
+    tags.push({ ...tag, start: offset + tag.start, end: offset + tag.end });
+  }
+  defineMetadata(target, "htmlTags", tags);
+}

--- a/packages/markdown-core/src/ir.raw-html.test.ts
+++ b/packages/markdown-core/src/ir.raw-html.test.ts
@@ -1,7 +1,172 @@
 import { describe, expect, it } from "vitest";
-import { markdownToIR } from "./ir.js";
+import { appendMarkdownIR, markdownToIR, markdownToIRWithMeta, sliceMarkdownIR } from "./ir.js";
+import { renderMarkdownIRChunksWithinLimit } from "./render-aware-chunking.js";
 
 describe("markdownToIR raw HTML", () => {
+  describe.each([undefined, false])("authored attribute grammar with linkify=%s", (linkify) => {
+    it.each([
+      "<b data-value=x&#61;1>",
+      '<b title="&quot;x&quot;">',
+      '<b title="**label** &amp; ||part||">',
+    ])("preserves authored attribute grammar before decoding: %s", (opening) => {
+      const ir = markdownToIR(`${opening}**body**</b>`, { enableSpoilers: true, linkify });
+
+      expect(ir.text).toBe(`${opening}body</b>`);
+      expect(ir.styles).toEqual([
+        { start: opening.length, end: opening.length + 4, style: "bold" },
+      ]);
+      expect(ir.htmlTags).toEqual([
+        {
+          start: 0,
+          end: opening.length,
+          raw: opening,
+          name: "b",
+          closing: false,
+          selfClosing: false,
+        },
+        {
+          start: opening.length + 4,
+          end: opening.length + 8,
+          raw: "</b>",
+          name: "b",
+          closing: true,
+          selfClosing: false,
+        },
+      ]);
+    });
+  });
+
+  it("keeps a complete opaque lexeme intact without inner tag facts", () => {
+    const raw = "<!-- **note** &amp; <b>inside</b> -->";
+    const ir = markdownToIR(`before ${raw} after`);
+
+    expect(ir.text).toBe(`before ${raw} after`);
+    expect(ir.styles).toEqual([]);
+    expect(ir.htmlTags).toBeUndefined();
+  });
+
+  it.each([false, true])(
+    "preserves raw anchor body autolinks with underline=%s",
+    (enableHtmlUnderline) => {
+      const ir = markdownToIR(
+        '<a href="https://example.com/">https://example.com/body **bold**</a>',
+        {
+          enableHtmlUnderline,
+        },
+      );
+
+      expect(ir.links.map((link) => ir.text.slice(link.start, link.end))).toEqual([
+        "https://example.com/body",
+      ]);
+      expect(ir.styles.map((span) => ir.text.slice(span.start, span.end))).toEqual(["bold"]);
+    },
+  );
+
+  it.each(["r", "&#114;"])("keeps Markdown links in incomplete HTML syntax: %s", (label) => {
+    const ir = markdownToIR(`<b[${label}](https://example.com)>tail`);
+
+    expect(ir.text).toBe("<br>tail");
+    expect(ir.styles).toEqual([]);
+    expect(ir.links).toEqual([{ start: 2, end: 3, href: "https://example.com" }]);
+    expect(ir.htmlTags).toBeUndefined();
+  });
+
+  it.each(["<b>diagram</b>", "&lt;b&gt;diagram&lt;/b&gt;", "\\<b>diagram\\</b>"])(
+    "keeps image alternatives plain without changing their text: %s",
+    (label) => {
+      const ir = markdownToIR(`before **![${label}](https://example.com/diagram.png)** after`);
+
+      expect(ir.text).toBe(`before ${label} after`);
+      expect(ir.styles).toEqual([{ start: 7, end: 7 + label.length, style: "bold" }]);
+      expect(ir.htmlTags).toBeUndefined();
+    },
+  );
+
+  it.each([
+    "&lt;b&gt;**literal**&lt;/b&gt; tail",
+    "&#60;b&#62;**literal**&#x3c;/b&#x3e; tail",
+    "\\<b\\>**literal**\\</b\\> tail",
+  ])("does not classify decoded literal text as authored HTML: %s", (source) => {
+    const ir = markdownToIR(source);
+
+    expect(ir.text).toBe("<b>literal</b> tail");
+    expect(ir.styles).toEqual([{ start: 3, end: 10, style: "bold" }]);
+    expect(ir.htmlTags).toBeUndefined();
+    expect(Object.keys(ir)).toEqual(["text", "styles", "links"]);
+    const serialized = JSON.stringify(ir);
+    expect(JSON.parse(serialized)).toEqual({
+      text: "<b>literal</b> tail",
+      styles: [{ start: 3, end: 10, style: "bold" }],
+      links: [],
+    });
+  });
+
+  it("keeps authored tags aligned through spoiler token splitting", () => {
+    const ir = markdownToIR("before <b>x</b> ||<i>y</i>|| after", { enableSpoilers: true });
+
+    expect(ir.text).toBe("before <b>x</b> <i>y</i> after");
+    expect(ir.styles).toEqual([{ start: 16, end: 24, style: "spoiler" }]);
+    expect(ir.htmlTags).toEqual([
+      { start: 7, end: 10, raw: "<b>", name: "b", closing: false, selfClosing: false },
+      { start: 11, end: 15, raw: "</b>", name: "b", closing: true, selfClosing: false },
+      { start: 16, end: 19, raw: "<i>", name: "i", closing: false, selfClosing: false },
+      { start: 20, end: 24, raw: "</i>", name: "i", closing: true, selfClosing: false },
+    ]);
+  });
+
+  it("transfers only whole tags with the text's complete code points", () => {
+    const source = markdownToIR("a🐱<b>x</b>");
+    const sliced = sliceMarkdownIR(source, 2, 6);
+    const target = markdownToIR("prefix");
+    appendMarkdownIR(target, sliced);
+
+    expect(sliced.text).toBe("🐱<b>");
+    expect(target.text).toBe("prefix🐱<b>");
+    expect(target.htmlTags).toEqual([
+      { start: 8, end: 11, raw: "<b>", name: "b", closing: false, selfClosing: false },
+    ]);
+    expect(source.htmlTags?.[0]?.start).toBe(3);
+    expect(sliceMarkdownIR(source, 4, 6).htmlTags).toBeUndefined();
+    expect(Object.keys(target)).not.toContain("htmlTags");
+    expect(JSON.stringify(target)).not.toContain("htmlTags");
+  });
+
+  it("does not turn chunked tag fragments into authored tags", () => {
+    const chunks = renderMarkdownIRChunksWithinLimit({
+      ir: markdownToIR("a<b>x</b>"),
+      limit: 4,
+      measureRendered: (text: string) => text.length,
+      renderChunk: (ir) => ir.text,
+    });
+
+    expect(chunks.map(({ rendered, source }) => ({ rendered, tags: source.htmlTags }))).toEqual([
+      {
+        rendered: "a<b>",
+        tags: [{ start: 1, end: 4, raw: "<b>", name: "b", closing: false, selfClosing: false }],
+      },
+      { rendered: "x</b", tags: undefined },
+      { rendered: ">", tags: undefined },
+    ]);
+  });
+
+  it("carries authored tags through table cells and bullet projection", () => {
+    const source = "| Value |\n| --- |\n| **<b>x</b>** |";
+    const { tables } = markdownToIRWithMeta(source, { tableMode: "block" });
+    const cell = tables[0]?.rowCells[0]?.[0];
+    expect(cell?.text).toBe("<b>x</b>");
+    expect(cell?.htmlTags).toEqual([
+      { start: 0, end: 3, raw: "<b>", name: "b", closing: false, selfClosing: false },
+      { start: 4, end: 8, raw: "</b>", name: "b", closing: true, selfClosing: false },
+    ]);
+    expect(Object.keys(cell ?? {})).not.toContain("htmlTags");
+    const bullets = markdownToIR(source, { tableMode: "bullets" });
+    expect(bullets.text).toBe("• Value: <b>x</b>");
+    expect(bullets.htmlTags).toEqual([
+      { start: 9, end: 12, raw: "<b>", name: "b", closing: false, selfClosing: false },
+      { start: 13, end: 17, raw: "</b>", name: "b", closing: true, selfClosing: false },
+    ]);
+  });
+
   it("does not linkify URLs inside raw HTML tag attributes", () => {
     const ir = markdownToIR(
       '<img src="https://example.com/diagram.png" alt="Diagram"> https://example.com/page',

--- a/packages/markdown-core/src/ir.raw-html.test.ts
+++ b/packages/markdown-core/src/ir.raw-html.test.ts
@@ -8,8 +8,14 @@ describe("markdownToIR raw HTML", () => {
       "<b data-value=x&#61;1>",
       '<b title="&quot;x&quot;">',
       '<b title="**label** &amp; ||part||">',
+      '<b title="first line\nsecond line &amp; **label**">',
+      '<b title="Example\nuser[Thu] note">',
     ])("preserves authored attribute grammar before decoding: %s", (opening) => {
-      const ir = markdownToIR(`${opening}**body**</b>`, { enableSpoilers: true, linkify });
+      const ir = markdownToIR(`${opening}**body**</b>`, {
+        enableSpoilers: true,
+        assistantTranscriptRoleHeaders: true,
+        linkify,
+      });
 
       expect(ir.text).toBe(`${opening}body</b>`);
       expect(ir.styles).toEqual([
@@ -37,8 +43,8 @@ describe("markdownToIR raw HTML", () => {
   });
 
   it("keeps a complete opaque lexeme intact without inner tag facts", () => {
-    const raw = "<!-- **note** &amp; <b>inside</b> -->";
-    const ir = markdownToIR(`before ${raw} after`);
+    const raw = "<!-- **note**\nuser[Thu] &amp; <b>inside</b> -->";
+    const ir = markdownToIR(`before ${raw} after`, { assistantTranscriptRoleHeaders: true });
 
     expect(ir.text).toBe(`before ${raw} after`);
     expect(ir.styles).toEqual([]);

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -14,10 +14,14 @@ import {
 } from "./assistant-transcript.js";
 import { chunkText } from "./chunk-text.js";
 import { matchMarkdownHtmlTag, tokenizeHtmlTags } from "./html-tags.js";
+import { appendAssistantTranscriptRoleText, appendImageAlternative } from "./ir-annotations.js";
 import {
-  appendAssistantTranscriptRoleImage,
-  appendAssistantTranscriptRoleText,
-} from "./ir-annotations.js";
+  appendHtmlTags,
+  copyHtmlTags,
+  defineMetadata,
+  RAW_HTML_TOKEN_TYPE,
+  type MarkdownHtmlMetadata,
+} from "./ir-metadata.js";
 import { computeNextMappedBlockStarts, sourceBlockNewlineCount } from "./ir-source-spacing.js";
 import {
   clampAnnotationSpans,
@@ -54,8 +58,6 @@ type LinkState = {
   labelStart: number;
   autoLinked: boolean;
 };
-
-const OPEN_MARKDOWN_HTML_TAG_PATTERN = /<\/?[a-zA-Z][a-zA-Z0-9-]*\b[^<>]*$/;
 
 const INLINE_STYLE_BY_TOKEN = new Map<string, MarkdownStyle>([
   ["underline_open", "underline"],
@@ -147,7 +149,7 @@ type MarkdownBlockSpan = {
   sourceEndLine?: number;
 };
 
-export type MarkdownIR = {
+export type MarkdownIR = MarkdownHtmlMetadata & {
   text: string;
   styles: MarkdownStyleSpan[];
   links: MarkdownLinkSpan[];
@@ -168,7 +170,7 @@ export type MarkdownTableData = {
   aligns?: (MarkdownTableAlignment | undefined)[];
 };
 
-export type MarkdownTableCell = {
+export type MarkdownTableCell = MarkdownHtmlMetadata & {
   text: string;
   styles: MarkdownStyleSpan[];
   links: MarkdownLinkSpan[];
@@ -251,18 +253,6 @@ type RenderState = RenderTarget & {
   source: string;
   sourceIndex: ReturnType<typeof indexSourceLines> | undefined;
 };
-
-function defineMetadata<T extends object, K extends keyof T>(target: T, key: K, value: T[K]): void {
-  if (value === undefined) {
-    return;
-  }
-  Object.defineProperty(target, key, {
-    configurable: true,
-    enumerable: false,
-    value,
-    writable: true,
-  });
-}
 
 function attachListItemMetadata(
   item: MarkdownListItemMarker,
@@ -368,9 +358,10 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
   if (options.enableTaskLists) {
     md.core.ruler.before("inline", "markdown_core_task_lists", protectTaskListMarkers);
   }
-  if (options.enableHtmlUnderline) {
-    md.inline.ruler.before("html_inline", "markdown_core_html_underline", parseHtmlUnderline);
-  }
+  const enableHtmlUnderline = options.enableHtmlUnderline === true;
+  md.inline.ruler.before("html_inline", RAW_HTML_TOKEN_TYPE, (state, silent) =>
+    parseHtmlLexeme(state, silent, enableHtmlUnderline),
+  );
   if (options.enableSpoilers) {
     // Spoiler delimiters can surround a line-leading role header. Normalize
     // them before semantic detection so later rendering cannot expose a role
@@ -456,7 +447,7 @@ function protectTaskListMarkers(state: StateCore): void {
   }
 }
 
-function parseHtmlUnderline(state: StateInline, silent: boolean): boolean {
+function parseHtmlLexeme(state: StateInline, silent: boolean, enableUnderline: boolean): boolean {
   if (state.src.charCodeAt(state.pos) !== 0x3c) {
     return false;
   }
@@ -466,11 +457,11 @@ function parseHtmlUnderline(state: StateInline, silent: boolean): boolean {
   }
   const tag = tokenizeHtmlTags(raw).next().value;
   const underlineTag =
-    tag && tag.start === 0 && (tag.name === "u" || tag.name === "ins") ? tag : undefined;
+    enableUnderline && tag && (tag.name === "u" || tag.name === "ins") ? tag : undefined;
   if (!silent) {
     const token = state.push(
       !underlineTag || underlineTag.selfClosing
-        ? "text"
+        ? RAW_HTML_TOKEN_TYPE
         : underlineTag.closing
           ? "underline_close"
           : "underline_open",
@@ -478,7 +469,12 @@ function parseHtmlUnderline(state: StateInline, silent: boolean): boolean {
       0,
     );
     if (!underlineTag || underlineTag.selfClosing) {
+      // Preserve the complete lexeme before entity decoding or text joining; raw
+      // anchors intentionally leave linkLevel unchanged so their bodies still linkify.
       token.content = raw;
+      if (tag) {
+        defineMetadata(token, "htmlTags", [tag]);
+      }
     }
   }
   state.pos += raw.length;
@@ -607,11 +603,12 @@ function resolveRenderTarget(state: RenderState): RenderTarget {
   return state.table?.currentCell ?? state;
 }
 
-function appendText(state: RenderState, value: string) {
+function appendText(state: RenderState, value: string, provenance?: object) {
   if (!value) {
     return;
   }
   const target = resolveRenderTarget(state);
+  appendHtmlTags(target, provenance, target.text.length);
   target.text += value;
 }
 
@@ -849,17 +846,6 @@ function handleLinkClose(state: RenderState) {
   target.links.push(span);
 }
 
-function isInsideMarkdownHtmlTag(text: string): boolean {
-  const openTagStart = text.lastIndexOf("<");
-  if (openTagStart === -1) {
-    return false;
-  }
-  return (
-    text.lastIndexOf(">") < openTagStart &&
-    OPEN_MARKDOWN_HTML_TAG_PATTERN.test(text.slice(openTagStart))
-  );
-}
-
 function initTableState(): TableState {
   return {
     sourceHeaders: [],
@@ -876,12 +862,12 @@ function initTableState(): TableState {
 
 function finishTableCell(cell: RenderTarget): TableCell {
   closeRemainingStyles(cell);
-  return {
+  return copyHtmlTags(cell, {
     text: cell.text,
     styles: cell.styles,
     links: cell.links,
     ...(cell.annotations.length > 0 ? { annotations: cell.annotations } : {}),
-  };
+  });
 }
 
 function trimCell(cell: TableCell): TableCell {
@@ -903,6 +889,7 @@ function appendCell(state: RenderState, cell: TableCell) {
     return;
   }
   const start = state.text.length;
+  appendHtmlTags(state, cell, start);
   state.text += cell.text;
   for (const span of cell.styles) {
     state.styles.push({
@@ -1025,15 +1012,17 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "text":
         recordTaskMarker(state, token.content ?? "");
-        appendText(state, token.content ?? "");
+        appendText(state, token.content ?? "", token);
         break;
       case ASSISTANT_TRANSCRIPT_ROLE_NODE_TYPE: {
         const meta = (token.meta as AssistantTranscriptRoleTokenMeta | undefined)
           ?.assistantTranscriptRoleHeader;
         if (meta) {
-          appendAssistantTranscriptRoleText(resolveRenderTarget(state), token.content ?? "", meta);
+          const target = resolveRenderTarget(state);
+          appendHtmlTags(target, token, target.text.length);
+          appendAssistantTranscriptRoleText(target, token.content ?? "", meta);
         } else {
-          appendText(state, token.content ?? "");
+          appendText(state, token.content ?? "", token);
         }
         break;
       }
@@ -1042,7 +1031,7 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "link_open": {
         const target = resolveRenderTarget(state);
-        const href = isInsideMarkdownHtmlTag(target.text) ? "" : (getAttr(token, "href") ?? "");
+        const href = getAttr(token, "href") ?? "";
         target.linkStack.push({
           href,
           labelStart: target.text.length,
@@ -1056,11 +1045,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
       case "image": {
         const meta = (token.meta as AssistantTranscriptRoleImageMeta | undefined)
           ?.assistantTranscriptRoleImage;
-        if (meta) {
-          appendAssistantTranscriptRoleImage(resolveRenderTarget(state), meta);
-        } else {
-          appendText(state, token.content ?? "");
-        }
+        appendImageAlternative(
+          resolveRenderTarget(state),
+          meta ?? { text: token.content ?? "", spans: [] },
+        );
         break;
       }
       case "softbreak":
@@ -1232,7 +1220,8 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         break;
       case "html_block":
       case "html_inline":
-        appendText(state, token.content ?? "");
+      case RAW_HTML_TOKEN_TYPE:
+        appendText(state, token.content ?? "", token);
         break;
 
       // Table handling
@@ -1358,6 +1347,7 @@ function appendSpans<T extends { start: number; end: number }>(
 /** Transfers a separately owned IR slice, including its metadata, into an accumulator. */
 export function appendMarkdownIR(target: MarkdownIR, source: MarkdownIR): void {
   const offset = target.text.length;
+  appendHtmlTags(target, source, offset);
   target.text += source.text;
   appendSpans(target.styles, source.styles, offset);
   appendSpans(target.links, source.links, offset);
@@ -1491,7 +1481,7 @@ export function sliceMarkdownIR(ir: MarkdownIR, start: number, end: number): Mar
     ...(annotations.length > 0 ? { annotations } : {}),
     ...(listItems.length > 0 ? { listItems } : {}),
   };
-  return attachBlockMetadata(sliced, blocks);
+  return copyHtmlTags(ir, attachBlockMetadata(sliced, blocks), normalizedStart, normalizedEnd);
 }
 
 export function markdownToIR(markdown: string, options: MarkdownParseOptions = {}): MarkdownIR {
@@ -1641,6 +1631,7 @@ export function markdownToIRWithMeta(
     ...(listItems.length > 0 ? { listItems } : {}),
   };
   attachBlockMetadata(ir, blocks);
+  copyHtmlTags(state, ir, 0, finalLength);
   return {
     ir,
     hasTables: state.hasTables,

--- a/qa/scenarios/channels/telegram-rich-inline-composition.yaml
+++ b/qa/scenarios/channels/telegram-rich-inline-composition.yaml
@@ -78,7 +78,7 @@ flow:
                 ];
                 for (const [id, html, atom] of [
                   ['math', '<tg-math>x</tg-math>', { '@type': 'richTextMathematicalExpression', expression: 'x' }],
-                  ['emoji', '<tg-emoji emoji-id="5368324170671202286">😀</tg-emoji>', { '@type': 'richTextCustomEmoji', custom_emoji_id: '5368324170671202286', alternative_text: '😀' }]
+                  ['emoji', '<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>', { '@type': 'richTextCustomEmoji', custom_emoji_id: '5368324170671202286', alternative_text: '👍' }]
                 ]) {
                   fixtures.push({ id: `${id}-link`, markdown: `[${html}](https://example.com/qa)`, pattern: url(atom) });
                   fixtures.push({ id: `${id}-spoiler`, markdown: `||${html}||`, pattern: wrap('richTextSpoiler', atom) });

--- a/qa/scenarios/channels/telegram-rich-inline-composition.yaml
+++ b/qa/scenarios/channels/telegram-rich-inline-composition.yaml
@@ -127,6 +127,8 @@ flow:
           value: []
         - set: receipts
           value: []
+        - set: failures
+          value: []
         - set: editCliCompleted
           value: false
         - set: editVerified
@@ -165,14 +167,15 @@ flow:
                       label: isEdit ? 'message-1' : `message-${index + 1}`,
                       phase: isEdit ? 'edit' : 'send', kind: message.kind,
                       contentType,
-                      ...(isEdit ? { observerIdStayedEqual: message.messageId === vars.proofs[0]?.observerMessageId } : { accountMessageIdsDiffer: message.botApiMessageId === undefined ? null : String(vars.receipts[index].botMessageId) !== String(message.botApiMessageId) }),
+                      ...(isEdit ? { observerIdStayedEqual: message.messageId === vars.editTarget?.observerMessageId } : { accountMessageIdsDiffer: message.botApiMessageId === undefined ? null : String(vars.receipts[index].botMessageId) !== String(message.botApiMessageId) }),
                       richMessage: tree(message.richMessage)
                     });
                   }
                   const artifact = {
                     transport: 'Telegram Test Server', topology: 'leased DM', scenarioInvokesModel: false,
                     receipts: vars.receipts.slice(0, 11).map((receipt, index) => ({ case: receipt.case, label: `message-${index + 1}` })),
-                    cases: vars.proofs.slice(0, 11).map((proof, index) => ({ case: proof.case, label: `message-${index + 1}`, accountMessageIdsDiffer: proof.accountMessageIdsDiffer, richMessage: tree(proof.richMessage) })),
+                    cases: vars.proofs.slice(0, 11).map(proof => ({ case: proof.case, label: proof.label, accountMessageIdsDiffer: proof.accountMessageIdsDiffer, richMessage: tree(proof.richMessage) })),
+                    failures: vars.failures.map(failure => ({ case: failure.case, label: failure.label, contentType: failure.contentType, full: failure.full, matchesPattern: failure.matchesPattern, richMessage: tree(failure.richMessage) })),
                     edit: { completedWithBotReceipt: vars.editCliCompleted, verified: vars.editVerified },
                     candidates, unmatched: { count: unmatchedCount, contentTypes: [...unmatchedTypes] }
                   };
@@ -185,6 +188,7 @@ flow:
               - forEach:
                   items: { ref: fixtures }
                   item: fixture
+                  index: fixtureIndex
                   actions:
                     - set: marker
                       value:
@@ -215,16 +219,27 @@ flow:
                             expr: |
                               readTelegramMessages().find(message => message.kind === 'message' && message.text.split('\n').includes(marker))
                         - 30000
-                    - assert:
-                        expr: "received.contentType === 'messageRichMessage' && received.richMessage?.is_full === true && containsPattern(received.richMessage.blocks, fixture.pattern)"
-                        message:
-                          expr: "`Native rich composition failed: ${fixture.id}; content=${received.contentType}; full=${received.richMessage?.is_full}`"
-                    - set: proofs
+                    - set: observation
                       value:
-                        expr: "proofs.concat([{ case: fixture.id, botMessageId: receipt.messageId, observerMessageId: received.messageId, marker, accountMessageIdsDiffer: received.botApiMessageId === undefined ? null : String(receipt.messageId) !== String(received.botApiMessageId), richMessage: received.richMessage }])"
-              - set: editTarget
-                value:
-                  expr: "proofs[0]"
+                        expr: "({ case: fixture.id, label: `message-${fixtureIndex + 1}`, botMessageId: receipt.messageId, observerMessageId: received.messageId, marker, accountMessageIdsDiffer: received.botApiMessageId === undefined ? null : String(receipt.messageId) !== String(received.botApiMessageId), richMessage: received.richMessage })"
+                    - if:
+                        expr: "fixtureIndex === 0"
+                        then:
+                          - set: editTarget
+                            value: { ref: observation }
+                    - set: verdict
+                      value:
+                        expr: "({ contentType: received.contentType?.slice(0, 64) ?? 'unknown', full: received.richMessage?.is_full === true, matchesPattern: containsPattern(received.richMessage?.blocks, fixture.pattern) })"
+                    - if:
+                        expr: "verdict.contentType === 'messageRichMessage' && verdict.full && verdict.matchesPattern"
+                        then:
+                          - set: proofs
+                            value:
+                              expr: "proofs.concat([observation])"
+                        else:
+                          - set: failures
+                            value:
+                              expr: "failures.concat([{ ...observation, ...verdict }])"
               - set: editMarker
                 value:
                   expr: "`QA-RICH-${runId}-edit-END`"
@@ -244,16 +259,18 @@ flow:
                       expr: |
                         readTelegramMessages().find(message => message.kind === 'edit' && message.messageId === editTarget.observerMessageId && message.text.split('\n').includes(editMarker))
                   - 30000
-              - assert:
+              - set: editVerified
+                value:
                   expr: |
                     edited.kind === 'edit' && edited.contentType === 'messageRichMessage' && edited.richMessage?.is_full === true &&
                     containsPattern(edited.richMessage.blocks, { '@type': 'pageBlockList' }) && containsPattern(edited.richMessage.blocks, fixtures[1].pattern) &&
                     readTelegramMessages().filter(message => message.text.split('\n').some(line =>
                       line === editMarker || receipts.some(receipt => receipt.marker === line)
                     )).length === fixtures.length
-                  message: editing must preserve the styled link on the same native message without a replacement bubble
-              - set: editVerified
-                value: true
+              - assert:
+                  expr: "failures.length === 0 && proofs.length === fixtures.length && editVerified"
+                  message:
+                    expr: "`Native rich composition failed: ${failures.map(failure => failure.case).join(', ') || 'edit'}; editing must preserve the styled link on the same native message without a replacement bubble`"
             finally:
               - call: captureEvidence
                 saveAs: evidenceSummary

--- a/qa/scenarios/channels/telegram-rich-inline-composition.yaml
+++ b/qa/scenarios/channels/telegram-rich-inline-composition.yaml
@@ -93,7 +93,7 @@ flow:
                     }
                   }});
                 }
-                fixtures.push({ id: 'literal-tags', markdown: '[<custom><sup>**marked**</sup></custom>](https://example.com/qa) &lt;b&gt;**literal**&lt;/b&gt; ![<i>alt</i>](https://example.com/image.png) <b[r](https://example.com/qa)>tail <!&#65; <b>declared</b>>', pattern: {
+                fixtures.push({ id: 'literal-tags', markdown: '[<custom><sup>**marked**</sup></custom>](https://example.com/qa) &lt;b&gt;**literal**&lt;/b&gt; ![<i>alt</i>]() <b[r](https://example.com/qa)>tail <!&#65; <b>declared</b>>', pattern: {
                   '@type': 'pageBlockParagraph', text: {
                     '@type': 'richTexts', texts: [url({ '@type': 'richTexts', texts: [plain('<custom><sup>'), wrap('richTextBold', plain('marked')), plain('</sup></custom>')] }), plain(' <b>'), wrap('richTextBold', plain('literal')), plain('</b> <i>alt</i> <b'), url(plain('r')), plain('>tail <!A '), wrap('richTextBold', plain('declared')), plain('>')]
                   }

--- a/qa/scenarios/channels/telegram-rich-inline-composition.yaml
+++ b/qa/scenarios/channels/telegram-rich-inline-composition.yaml
@@ -1,0 +1,260 @@
+title: Telegram rich inline composition
+
+scenario:
+  id: telegram-rich-inline-composition
+  surface: channels
+  coverage:
+    primary:
+      - telegram.conversation-routing-and-delivery
+  objective: Preserve HTML and Markdown formatting around atomic rich text through native Telegram sends and edits.
+  successCriteria:
+    - Full TDLib rich-message trees retain styled HTML links in details, lists, and quotes.
+    - Markdown links and spoilers retain mathematical expressions and custom emoji as wrapped atoms.
+    - Transcript headers remain standalone fixed-width text outside HTML link and bold wrappers.
+    - Escaped tags and image alternatives stay literal; tag-shaped Markdown links do not activate HTML.
+    - Unsupported HTML ancestors stay literal across Markdown block boundaries.
+    - An edit replaces the same native message and preserves the same rich composition.
+  docsRefs:
+    - docs/channels/telegram.md
+    - docs/concepts/markdown-formatting.md
+  codeRefs:
+    - extensions/telegram/src/rich-blocks.ts
+    - extensions/telegram/src/rich-blocks-html.ts
+    - extensions/qa-lab/src/live-transports/telegram/userbot-driver.runtime.ts
+  gatewayConfigPatch:
+    channels:
+      telegram:
+        accounts:
+          $selectedAccount:
+            richMessages: true
+            linkPreview: false
+  execution:
+    kind: flow
+    channel: telegram
+    retryCount: 0
+    timeoutMs: 240000
+    suiteIsolation: isolated
+    isolationReason: Rich-message account configuration and native message revisions belong to this leased DM.
+    transportPolicy:
+      directMessageOnly: true
+    summary: Send eleven synthetic formatting cases through the Gateway and edit one through the normal CLI; inspect full TDLib trees from the leased Test Server DM. This proves direct operator delivery, not model generation. The CLI harness and package candidate must contain the same reviewed renderer.
+    config:
+      requiredProviderMode: mock-openai
+      requiredChannelDriver: live
+
+flow:
+  steps:
+    - name: preserves typed formatting through native sends and an edit
+      actions:
+        - assert:
+            expr: "transport.id === 'telegram' && env.providerMode === config.requiredProviderMode && typeof readTelegramMessages === 'function'"
+            message: this proof requires the leased Telegram Test Server observer
+        - assert:
+            expr: "env.cfg.channels.telegram.accounts[transport.accountId].richMessages === true"
+            message: this proof requires rich messages on the selected SUT account
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: delivery
+          value:
+            expr: "transport.buildAgentDelivery({ target: 'direct' })"
+        - call: randomUUID
+          saveAs: runId
+        - set: fixtures
+          value:
+            expr: |
+              (() => {
+                const plain = text => ({ '@type': 'richTextPlain', text });
+                const wrap = (kind, text) => ({ '@type': kind, text });
+                const url = text => ({ ...wrap('richTextUrl', text), url: 'https://example.com/qa' });
+                const link = '<a href=https://example.com/qa?x&#61;1>**Download**</a>';
+                const linkBlock = { '@type': 'pageBlockParagraph', text: { ...url(wrap('richTextBold', plain('Download'))), url: 'https://example.com/qa?x=1' } };
+                const fixtures = [
+                  { id: 'details', markdown: `<details><summary>More</summary><p>${link}</p></details>`, pattern: { '@type': 'pageBlockDetails', blocks: [linkBlock] } },
+                  { id: 'list', markdown: `<ul><li>${link}</li></ul>`, pattern: { '@type': 'pageBlockList', items: [{ blocks: [linkBlock] }] } },
+                  { id: 'quote', markdown: `<blockquote>${link}</blockquote>`, pattern: { '@type': 'pageBlockBlockQuote', blocks: [linkBlock] } }
+                ];
+                for (const [id, html, atom] of [
+                  ['math', '<tg-math>x</tg-math>', { '@type': 'richTextMathematicalExpression', expression: 'x' }],
+                  ['emoji', '<tg-emoji emoji-id="5368324170671202286">😀</tg-emoji>', { '@type': 'richTextCustomEmoji', custom_emoji_id: '5368324170671202286', alternative_text: '😀' }]
+                ]) {
+                  fixtures.push({ id: `${id}-link`, markdown: `[${html}](https://example.com/qa)`, pattern: url(atom) });
+                  fixtures.push({ id: `${id}-spoiler`, markdown: `||${html}||`, pattern: wrap('richTextSpoiler', atom) });
+                }
+                for (const [id, open, close, trailing] of [
+                  ['annotation-link', '<a href="https://example.com/qa">', '</a>', url(plain(' trailing'))],
+                  ['annotation-bold', '<b>', '</b>', wrap('richTextBold', plain(' trailing'))]
+                ]) {
+                  fixtures.push({ id, markdown: `${open}\nuser[Thu] trailing${close}`, pattern: {
+                    '@type': 'pageBlockParagraph', text: {
+                      '@type': 'richTexts', texts: [{ ...trailing, text: plain('\n') }, wrap('richTextFixed', plain('user[Thu]')), trailing]
+                    }
+                  }});
+                }
+                fixtures.push({ id: 'literal-tags', markdown: '[<custom><sup>**marked**</sup></custom>](https://example.com/qa) &lt;b&gt;**literal**&lt;/b&gt; ![<i>alt</i>](https://example.com/image.png) <b[r](https://example.com/qa)>tail <!&#65; <b>declared</b>>', pattern: {
+                  '@type': 'pageBlockParagraph', text: {
+                    '@type': 'richTexts', texts: [url({ '@type': 'richTexts', texts: [plain('<custom><sup>'), wrap('richTextBold', plain('marked')), plain('</sup></custom>')] }), plain(' <b>'), wrap('richTextBold', plain('literal')), plain('</b> <i>alt</i> <b'), url(plain('r')), plain('>tail <!A '), wrap('richTextBold', plain('declared')), plain('>')]
+                  }
+                }});
+                fixtures.push({ id: 'literal-block-ancestor', markdown: '<details><summary>Scope</summary><custom>\n\n> <sup>**x**</sup>\n\n</custom></details>', pattern: {
+                  '@type': 'pageBlockDetails', header: plain('Scope'), blocks: [
+                    { '@type': 'pageBlockParagraph', text: plain('<custom>') },
+                    { '@type': 'pageBlockBlockQuote', blocks: [{ '@type': 'pageBlockParagraph', text: {
+                      '@type': 'richTexts', texts: [plain('<sup>'), wrap('richTextBold', plain('x')), plain('</sup>')]
+                    } }] },
+                    { '@type': 'pageBlockParagraph', text: plain('</custom>') }
+                  ]
+                }});
+                return fixtures;
+              })()
+        - set: containsPattern
+          value:
+            lambda:
+              params: [tree, pattern]
+              expr: |
+                (() => {
+                  const matches = (value, expected) => {
+                    if (Array.isArray(expected)) return Array.isArray(value) && value.length === expected.length && expected.every((item, index) => matches(value[index], item));
+                    if (expected && typeof expected === 'object') return value && typeof value === 'object' && Object.entries(expected).every(([key, item]) => matches(value[key], item));
+                    return value === expected;
+                  };
+                  const visit = value => matches(value, pattern) || (value && typeof value === 'object' && Object.values(value).some(visit));
+                  return Boolean(visit(tree));
+                })()
+        - set: proofs
+          value: []
+        - set: receipts
+          value: []
+        - set: editCliCompleted
+          value: false
+        - set: editVerified
+          value: false
+        - set: captureEvidence
+          value:
+            lambda:
+              params: []
+              async: true
+              expr: |
+                (async () => {
+                  const { publishQaSuiteArtifactFiles } = await qaImport('./suite-artifacts.js');
+                  const { redactQaGatewayDebugText } = await qaImport('./gateway-log-redaction.js');
+                  // Export only this run's synthetic formatting, never observer/account metadata.
+                  const fields = new Set(['@type', 'blocks', 'is_full', 'is_rtl', 'text', 'texts', 'header', 'items', 'label', 'caption', 'credit', 'url', 'is_cached', 'expression', 'custom_emoji_id', 'alternative_text', 'is_open']);
+                  // Diagnostic limits never affect the complete trees used by assertions.
+                  const tree = value => {
+                    const json = JSON.stringify(value, function (key, child) { return key === '' || Array.isArray(this) || fields.has(key) ? child : undefined; });
+                    return json === undefined ? null : json.length > 16384 ? { truncated: true, serializedCharacters: json.length } : JSON.parse(json);
+                  };
+                  const observed = readTelegramMessages();
+                  const candidates = [];
+                  const unmatchedTypes = new Set();
+                  let unmatchedCount = 0;
+                  for (const message of observed) {
+                    const contentType = message.contentType?.slice(0, 64) ?? 'unknown';
+                    const lines = message.text.split('\n');
+                    const index = vars.receipts.findIndex(receipt => lines.includes(receipt.marker));
+                    const isEdit = Boolean(vars.editMarker && lines.includes(vars.editMarker));
+                    if (index < 0 && !isEdit) {
+                      unmatchedCount++;
+                      if (unmatchedTypes.size < 8) unmatchedTypes.add(contentType);
+                      continue;
+                    }
+                    if (candidates.length < 12) candidates.push({
+                      label: isEdit ? 'message-1' : `message-${index + 1}`,
+                      phase: isEdit ? 'edit' : 'send', kind: message.kind,
+                      contentType,
+                      ...(isEdit ? { observerIdStayedEqual: message.messageId === vars.proofs[0]?.observerMessageId } : { accountMessageIdsDiffer: message.botApiMessageId === undefined ? null : String(vars.receipts[index].botMessageId) !== String(message.botApiMessageId) }),
+                      richMessage: tree(message.richMessage)
+                    });
+                  }
+                  const artifact = {
+                    transport: 'Telegram Test Server', topology: 'leased DM', scenarioInvokesModel: false,
+                    receipts: vars.receipts.slice(0, 11).map((receipt, index) => ({ case: receipt.case, label: `message-${index + 1}` })),
+                    cases: vars.proofs.slice(0, 11).map((proof, index) => ({ case: proof.case, label: `message-${index + 1}`, accountMessageIdsDiffer: proof.accountMessageIdsDiffer, richMessage: tree(proof.richMessage) })),
+                    edit: { completedWithBotReceipt: vars.editCliCompleted, verified: vars.editVerified },
+                    candidates, unmatched: { count: unmatchedCount, contentTypes: [...unmatchedTypes] }
+                  };
+                  const content = redactQaGatewayDebugText(JSON.stringify(artifact).replaceAll(runId, 'run'));
+                  await publishQaSuiteArtifactFiles({ outputDir: env.outputDir, files: [{ filePath: path.join(env.outputDir, 'telegram-rich-inline-composition.json'), content }] });
+                  return { artifact: 'telegram-rich-inline-composition.json', completedCases: vars.proofs.length, editVerified: vars.editVerified, observedCount: observed.length };
+                })()
+        - try:
+            actions:
+              - forEach:
+                  items: { ref: fixtures }
+                  item: fixture
+                  actions:
+                    - set: marker
+                      value:
+                        expr: "`QA-RICH-${runId}-${fixture.id}-END`"
+                    - call: env.gateway.call
+                      saveAs: receipt
+                      args:
+                        - send
+                        - channel: telegram
+                          accountId: { ref: transport.accountId }
+                          to: { ref: delivery.to }
+                          message:
+                            expr: "`${fixture.markdown}\n\n${marker}`"
+                          idempotencyKey:
+                            expr: "`${runId}:${fixture.id}`"
+                        - timeoutMs: 30000
+                    - set: receipts
+                      value:
+                        expr: "receipts.concat([{ case: fixture.id, marker, botMessageId: receipt.messageId }])"
+                    - assert:
+                        expr: "Number.isSafeInteger(Number(receipt.messageId)) && Number(receipt.messageId) > 0"
+                        message: Gateway send must return an accepted native message ID
+                    - call: waitForCondition
+                      saveAs: received
+                      args:
+                        - lambda:
+                            params: []
+                            expr: |
+                              readTelegramMessages().find(message => message.kind === 'message' && message.text.split('\n').includes(marker))
+                        - 30000
+                    - assert:
+                        expr: "received.contentType === 'messageRichMessage' && received.richMessage?.is_full === true && containsPattern(received.richMessage.blocks, fixture.pattern)"
+                        message:
+                          expr: "`Native rich composition failed: ${fixture.id}; content=${received.contentType}; full=${received.richMessage?.is_full}`"
+                    - set: proofs
+                      value:
+                        expr: "proofs.concat([{ case: fixture.id, botMessageId: receipt.messageId, observerMessageId: received.messageId, marker, accountMessageIdsDiffer: received.botApiMessageId === undefined ? null : String(receipt.messageId) !== String(received.botApiMessageId), richMessage: received.richMessage }])"
+              - set: editTarget
+                value:
+                  expr: "proofs[0]"
+              - set: editMarker
+                value:
+                  expr: "`QA-RICH-${runId}-edit-END`"
+              - call: runQaCli
+                args:
+                  - ref: env
+                  - expr: "['message', 'edit', '--channel', 'telegram', '--account', transport.accountId, '--target', delivery.to, '--message-id', String(editTarget.botMessageId), '--message', `${fixtures[1].markdown}\n\n${editMarker}`, '--json']"
+                  - timeoutMs: 60000
+                    json: true
+              - set: editCliCompleted
+                value: true
+              - call: waitForCondition
+                saveAs: edited
+                args:
+                  - lambda:
+                      params: []
+                      expr: |
+                        readTelegramMessages().find(message => message.kind === 'edit' && message.messageId === editTarget.observerMessageId && message.text.split('\n').includes(editMarker))
+                  - 30000
+              - assert:
+                  expr: |
+                    edited.kind === 'edit' && edited.contentType === 'messageRichMessage' && edited.richMessage?.is_full === true &&
+                    containsPattern(edited.richMessage.blocks, { '@type': 'pageBlockList' }) && containsPattern(edited.richMessage.blocks, fixtures[1].pattern) &&
+                    readTelegramMessages().filter(message => message.text.split('\n').some(line =>
+                      line === editMarker || receipts.some(receipt => receipt.marker === line)
+                    )).length === fixtures.length
+                  message: editing must preserve the styled link on the same native message without a replacement bubble
+              - set: editVerified
+                value: true
+            finally:
+              - call: captureEvidence
+                saveAs: evidenceSummary
+      detailsExpr: "JSON.stringify(evidenceSummary)"

--- a/qa/scenarios/channels/telegram-rich-inline-composition.yaml
+++ b/qa/scenarios/channels/telegram-rich-inline-composition.yaml
@@ -78,7 +78,7 @@ flow:
                 ];
                 for (const [id, html, atom] of [
                   ['math', '<tg-math>x</tg-math>', { '@type': 'richTextMathematicalExpression', expression: 'x' }],
-                  ['emoji', '<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>', { '@type': 'richTextCustomEmoji', custom_emoji_id: '5368324170671202286', alternative_text: '👍' }]
+                  ['emoji', '<tg-emoji emoji-id="4929292553544531969">👋</tg-emoji>', { '@type': 'richTextCustomEmoji', custom_emoji_id: '4929292553544531969', alternative_text: '👋' }]
                 ]) {
                   fixtures.push({ id: `${id}-link`, markdown: `[${html}](https://example.com/qa)`, pattern: url(atom) });
                   fixtures.push({ id: `${id}-spoiler`, markdown: `||${html}||`, pattern: wrap('richTextSpoiler', atom) });


### PR DESCRIPTION
## What Problem This Solves

Fixes literal HTML link tags and lost formatting when HTML containers and Markdown styles are mixed inside Telegram rich-message disclosures, lists, or quotations. Escaped tag examples and image alternative text stay literal, while supported authored HTML retains its attribute values and formatting.

## Why This Change Was Made

HTML containers, atomic inline content, and Markdown formatting now compose over the same parsed text ranges. One renderer owns that composition, replacing `applyInlineHtmlIslands` / `parseInlineHtmlIslands` and their per-string-leaf reparsing. The renderer preserves Markdown link/spoiler wrappers around formulas and custom emoji; transcript-role annotations remain outside surrounding active formatting. Native acceptance below uses the existing disabled-preview scenario setting.

The Markdown parser generalizes its existing underline lexical rule to recognize complete authored HTML lexemes before entity decoding or text joining. It records complete tags and their original bytes in non-enumerable `htmlTags` metadata, carrying those facts through token transformations, IR slicing/appending, construct fallbacks, and table cells. Partial tag fragments do not inherit a whole tag’s meaning. Telegram consumes these recorded facts rather than rescanning decoded text: there are no decoded `literalRanges`, post-decoding admission callbacks, sentinel strings, or second decoder. The private token leaves `html: false` and HTML block parsing unchanged, preserves ordinary anchor-body autolinks, and retains the existing underline opt-in.

This also preserves valid attribute grammar such as unquoted `x&#61;1`, quoted entity-delimiters, and Markdown punctuation inside URL values. The HTML mapper decodes supported attribute values after parsing their authored syntax; both entity-detection modes are covered. The obsolete tag-prefix link-suppression heuristic is removed, so a real Markdown link within incomplete tag-shaped text remains a link without manufacturing an HTML tag. Image alternatives use one plain-text owner; existing role-annotation metadata remains intact.

Unsupported HTML wrappers and their HTML descendants remain literal without discarding independently authored Markdown links or bold text. Their literal ownership is retained across Markdown blockquote/table slices, including inside disclosures. A table preceding a wrapper is not incorrectly assigned to it. The mapper reuses its text-range recorder and existing serializer instead of flattening unsupported subtrees into formatting-free atoms.

The QA observer retains actual TDLib rich trees. Serve mode filters the selected chat, keys observations by the observer’s exact chat/message pair, and retrieves partial content with `getFullRichMessage` before caching or emitting a complete snapshot. Failed or incomplete retrieval is a visible terminal failure; no full flag is invented. Intervening updates remain in the client FIFO. The getter has no revision token, so this does **not** claim revision-perfect historical snapshots during concurrent edits. Raw recording and generic history normalization remain pure and retain the original partial updates.

## User Impact and Preservation

Styled links remain clickable inside rich-message containers. Ordinary rich body text follows one Markdown parse: `&amp;` displays `&`, while escaped `\&amp;` and double-encoded `&amp;amp;` display literal `&amp;`. Parsed repeated spaces, newlines, and nonbreaking spaces remain intact. This differs intentionally from the previous HTML leaf mapper’s second entity decode and whitespace collapse; it is not normalization equivalence. HTML-island summaries and figure captions retain their separate HTML normalization.

Shared raw-HTML lexing is also intentionally corrected: Markdown markers and entities inside valid tag attributes or recognized inline comments remain original source bytes rather than being parsed as body content. Non-HTML renderers continue to keep those lexemes literal or escape them. Markdown inside container bodies still parses normally. Matrix’s ordinary plain body remains projected source Markdown, not text stripped from its independently rendered HTML body.

No new configuration option, dependency, database schema, or operator setup is introduced. Telegram’s default HTML delivery path is not switched to rich messages: the existing `richMessages` opt-in remains unchanged.

The final follow-up keeps complete raw HTML lexemes outside transcript-style detection while retaining their full offset length. Multiline attributes no longer lose opening-tag metadata, and comments do not acquire transcript styling. The repair reuses the existing excluded-range owner and removes three production lines.

## Current Verification

Current PR head: [d9b00043](https://github.com/openclaw/openclaw/commit/d9b00043b90453d1c9c65b757e094b4cddf4fb00). Its only difference from the live-tested product head is the one-line Python test-fixture correction; production and native payload code are byte-identical.

**Native acceptance is complete on product head [cdbd3015](https://github.com/openclaw/openclaw/commit/cdbd30153616bc0fc88c2ec788e977b4638c6130): all eleven original cases, the original-message edit, and two additional raw-lexeme regressions passed.** [Exact-head CI34192088152](https://github.com/openclaw/openclaw/actions/runs/34192088152) passed on d9b00043, whose only change after live proof is the test-fixture correction below.

The operator explicitly authorized an existing production Telegram setup after the Test Server subscription seller failed. The real candidate renderer and frozen dependencies produced all eleven original fixtures and their exact structural assertions. Only the environment-specific emoji pair changed to the production-resolvable `5368324170671202286` / 👍. The committed Test Server scenario is unchanged.

The exporter follows the scenario's existing `richMessages: true` and `linkPreview: false` settings, passing the same `skipEntityDetection: true` option as the normal send/edit owner. An earlier task-only export omitted that option, and Telegram's entity-detection pass removed both math wrappers. That failed attempt remains recorded, not counted as a pass. No production Gateway configuration or default was changed.

A receiving user client fetched each message with `messages.getRichMessage`, rejected partial trees, and verified the selected private peer, unique marker, and observer-account-local message identity. Eleven distinct run-marked messages were observed both before and after editing, with no extra run-marked message in the inspected window. The first message changed from details to the list body, retaining its observer ID and advancing its edit timestamp. Custom emoji remained actual custom nodes, not plaintext fallbacks. All thirteen task-created messages were deleted.

| Case | Native full-tree result |
| --- | --- |
| Details / styled link | Pass |
| List / styled link | Pass |
| Quote / styled link | Pass |
| Math inside link | Pass |
| Math inside spoiler | Pass |
| Custom emoji inside link | Pass |
| Custom emoji inside spoiler | Pass |
| Annotation outside link | Pass |
| Annotation outside bold | Pass |
| Literal tags / image alternative | Pass |
| Literal block ancestor | Pass |
| Original-message edit into list | Pass; same observer message |
| Additional multiline attribute | Pass |
| Additional multiline comment | Pass |

Scope: exact candidate renderer → production Bot API → receiving native Telegram snapshots. This is not a new Gateway deployment, a TDLib event stream, revision-perfect concurrent-edit proof, or a model-generation test. No bot update polling, Gateway restart/configuration change, new login, persisted user-session copy, or assertion waiver was used.

### Tests and Review

- **129 canonical owner/sibling tests pass** across Markdown annotation/raw-HTML and Telegram rich-block suites. Three presentation regressions fail against the exact pre-fix owner and pass after repair.
- Pinned formatting and lint checks pass. Fresh complete-PR P0–P2 review found the raw-lexeme issue; the follow-up review is scoped-clean.
- Historical comprehensive verification remains: 915 TypeScript checks across 40 files, 19 Python checks, full changed gate, and independent review. These cohorts overlap and are not additive.
- [CI 34190587002](https://github.com/openclaw/openclaw/actions/runs/34190587002) exposed a merge-integration failure: main added a group-access precondition missing from the hydration test's fake driver. A one-line test-only repair reproduces the exact 18-test failure and passes 18/18 afterward; production access checks remain unchanged. That correction is pushed in d9b00043. Exact-head CI34192088152 attempt2 passed, including `openclaw/ci-gate`. Attempt1 hit an unchanged Gateway client teardown timeout after all52assertions passed; one exact-job rerun passed without changing timeouts or assertions. The timing root cause remains a named follow-up.

### Complete Synthetic Native Evidence

This is a metadata-free projection of the actual receiving-client trees, not expected fixtures. It contains no account/chat IDs, usernames, access hashes, credentials, or unrelated messages. Native `Part: false` comes from the full response; ordinal 1 identifies the same receiver-side message before and after editing. SHA256: `a2c83664f697d30f64a6f854d8e5ffba8f4c0f1d5a27d0d5bea7dc8650c0635e`.

<details>
<summary>All eleven received trees, the edit, and both added regressions</summary>

```json
{"head":"cdbd30153616bc0fc88c2ec788e977b4638c6130","scope":"Owner-authorized production Telegram private DM; exact candidate-rendered payloads and native user snapshots; no Gateway deployment or TDLib event-stream claim","rendererOptions":{"skipEntityDetection":true},"caseCount":11,"markedMessageCountBefore":11,"markedMessageCountAfter":11,"before":[{"case":"details","observerMessageOrdinal":1,"rich":{"Blocks":[{"Blocks":[{"Text":{"Text":{"Text":{"Text":"Download","_":"textPlain"},"_":"textBold"},"URL":"https://example.com/qa?x=1","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"}],"Open":false,"Title":{"Text":"More","_":"textPlain"},"_":"pageBlockDetails"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-details-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"list","observerMessageOrdinal":2,"rich":{"Blocks":[{"Items":[{"Blocks":[{"Text":{"Text":{"Text":{"Text":"Download","_":"textPlain"},"_":"textBold"},"URL":"https://example.com/qa?x=1","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"}],"Checkbox":false,"Checked":false,"_":"pageListItemBlocks"}],"_":"pageBlockList"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-list-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"quote","observerMessageOrdinal":3,"rich":{"Blocks":[{"Blocks":[{"Text":{"Text":{"Text":{"Text":"Download","_":"textPlain"},"_":"textBold"},"URL":"https://example.com/qa?x=1","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"}],"Caption":{"_":"textEmpty"},"_":"pageBlockBlockquoteBlocks"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-quote-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"math-link","observerMessageOrdinal":4,"rich":{"Blocks":[{"Text":{"Text":{"Source":"x","_":"textMath"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-math-link-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"math-spoiler","observerMessageOrdinal":5,"rich":{"Blocks":[{"Text":{"Text":{"Source":"x","_":"textMath"},"_":"textSpoiler"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-math-spoiler-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"emoji-link","observerMessageOrdinal":6,"rich":{"Blocks":[{"Text":{"Text":{"Alt":"👍","DocumentID":"5368324170671202286","_":"textCustomEmoji"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-emoji-link-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"emoji-spoiler","observerMessageOrdinal":7,"rich":{"Blocks":[{"Text":{"Text":{"Alt":"👍","DocumentID":"5368324170671202286","_":"textCustomEmoji"},"_":"textSpoiler"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-emoji-spoiler-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"annotation-link","observerMessageOrdinal":8,"rich":{"Blocks":[{"Text":{"Texts":[{"Text":{"Text":"\n","_":"textPlain"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"},{"Text":{"Text":"user[Thu]","_":"textPlain"},"_":"textFixed"},{"Text":{"Text":" trailing","_":"textPlain"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"}],"_":"textConcat"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-annotation-link-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"annotation-bold","observerMessageOrdinal":9,"rich":{"Blocks":[{"Text":{"Texts":[{"Text":{"Text":"\n","_":"textPlain"},"_":"textBold"},{"Text":{"Text":"user[Thu]","_":"textPlain"},"_":"textFixed"},{"Text":{"Text":" trailing","_":"textPlain"},"_":"textBold"}],"_":"textConcat"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-annotation-bold-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"literal-tags","observerMessageOrdinal":10,"rich":{"Blocks":[{"Text":{"Texts":[{"Text":{"Texts":[{"Text":"<custom><sup>","_":"textPlain"},{"Text":{"Text":"marked","_":"textPlain"},"_":"textBold"},{"Text":"</sup></custom>","_":"textPlain"}],"_":"textConcat"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"},{"Text":" <b>","_":"textPlain"},{"Text":{"Text":"literal","_":"textPlain"},"_":"textBold"},{"Text":"</b> <i>alt</i> <b","_":"textPlain"},{"Text":{"Text":"r","_":"textPlain"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"},{"Text":">tail <!A ","_":"textPlain"},{"Text":{"Text":"declared","_":"textPlain"},"_":"textBold"},{"Text":">","_":"textPlain"}],"_":"textConcat"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-literal-tags-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"literal-block-ancestor","observerMessageOrdinal":11,"rich":{"Blocks":[{"Blocks":[{"Text":{"Text":"<custom>","_":"textPlain"},"_":"pageBlockParagraph"},{"Blocks":[{"Text":{"Texts":[{"Text":"<sup>","_":"textPlain"},{"Text":{"Text":"x","_":"textPlain"},"_":"textBold"},{"Text":"</sup>","_":"textPlain"}],"_":"textConcat"},"_":"pageBlockParagraph"}],"Caption":{"_":"textEmpty"},"_":"pageBlockBlockquoteBlocks"},{"Text":{"Text":"</custom>","_":"textPlain"},"_":"pageBlockParagraph"}],"Open":false,"Title":{"Text":"Scope","_":"textPlain"},"_":"pageBlockDetails"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-literal-block-ancestor-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0}],"edit":{"case":"details","observerMessageOrdinal":1,"rich":{"Blocks":[{"Items":[{"Blocks":[{"Text":{"Text":{"Text":{"Text":"Download","_":"textPlain"},"_":"textBold"},"URL":"https://example.com/qa?x=1","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"}],"Checkbox":false,"Checked":false,"_":"pageListItemBlocks"}],"_":"pageBlockList"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-edit-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0,"sameObserverMessageAsBefore":true,"editDateAdvanced":true},"additionalCases":[{"case":"multiline-title","observerMessageOrdinal":1,"rich":{"Blocks":[{"Text":{"Text":{"Text":{"Text":"Download","_":"textPlain"},"_":"textBold"},"URL":"https://example.com/qa","WebpageID":"0","_":"textUrl"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-multiline-title-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0},{"case":"multiline-comment","observerMessageOrdinal":2,"rich":{"Blocks":[{"Text":{"Text":"<!-- Example\nuser[Thu] -->","_":"textPlain"},"_":"pageBlockParagraph"},{"Text":{"Text":{"Text":"Download","_":"textPlain"},"_":"textBold"},"_":"pageBlockParagraph"},{"Text":{"Text":"QA-RICH-0d902530-8552-4b0f-805f-960b5529a645-multiline-comment-END","_":"textPlain"},"_":"pageBlockParagraph"}],"Part":false,"Rtl":false,"_":"richMessage"},"photoCount":0,"documentCount":0}]}
```

</details>

## Scope, Compatibility, and History

The whole PR is **+120 production**, **+30 QA tooling**, **+1,486 tests/support/scenario**, and **+12 documentation** lines. The latest production repair is net **−3**. The remaining growth records authored-tag ownership and composes Markdown, HTML, and atoms in one coordinate system; decoded-string reparsing cannot distinguish authored tags from decoded literal examples.

The latest leased [Test Server run 34086247182](https://github.com/openclaw/openclaw/actions/runs/34086247182) remains a historical failure: nine cases and the edit passed, but both custom-emoji cases became plain alternatives. Direct API controls reproduced that filtering without OpenClaw. [Subsequent diagnosis](https://github.com/openclaw/openclaw/pull/139976#issuecomment-5577373669) recovered `BOT_PRECHECKOUT_TIMEOUT` from the external subscription seller. Those failures are not relabeled; the explicitly authorized production proof above resolves the native custom-node acceptance gap.

Earlier [package/native run 34054793366](https://github.com/openclaw/openclaw/actions/runs/34054793366), [fixture follow-through 34059606748](https://github.com/openclaw/openclaw/actions/runs/34059606748), and [alternative-alignment run 34071479029](https://github.com/openclaw/openclaw/actions/runs/34071479029) remain retained diagnostics. The d333 integration preserved main's table-helper removal and table-source ownership from #139892. Original renderer/observer history remains at [a74e5d1c](https://github.com/openclaw/openclaw/commit/a74e5d1c732af5360f973c8b13d66540a7fef68f) and [696b46dd](https://github.com/openclaw/openclaw/commit/696b46dd70c7f9d8c4bd24e62e3ea7f3f58c315c).

### Named Follow-ups

- `telegram-semantic-formatting-boundaries` retains a separate preexisting boolean-wait misuse; it is not claimed fixed here.
- Investigate/document Telegram automatic entity detection removing math wrappers with previews enabled. This proof follows the already-committed disabled-preview scenario and does not change preview defaults.
- Restore Test Server subscription/eligibility for unattended reuse of the unchanged leased scenario.

The latest ClawSweeper rank-up request—complete custom-emoji composition and preserve the original-message edit—is addressed by the full native evidence above. Earlier author holds tied to that missing proof are superseded. Exact-head CI and the native maintainer landing gates still apply.

