### PR TITLE
fix(agents): resolve transcript replay policies fresh so plugin package swaps take effect

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -4,6 +4,7 @@
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderPlugin } from "../plugins/provider-plugin.types.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { validateAnthropicTurns } from "./embedded-agent-helpers/turns.js";
 
@@ -269,9 +270,15 @@ describe("resolveTranscriptPolicy", () => {
     const mockedResolve = vi.mocked(resolveProviderRuntimePlugin);
     // Same provider id and config after an in-process plugin package swap: the first
     // resolution must not pin the previous package's policy for the second one.
+    const stubPlugin = (sanitizeToolCallIds: boolean): ProviderPlugin => ({
+      id: "demo",
+      label: "Demo",
+      auth: [],
+      buildReplayPolicy: () => ({ sanitizeToolCallIds }),
+    });
     mockedResolve
-      .mockImplementationOnce(() => ({ buildReplayPolicy: () => ({ sanitizeToolCallIds: false }) }))
-      .mockImplementationOnce(() => ({ buildReplayPolicy: () => ({ sanitizeToolCallIds: true }) }));
+      .mockImplementationOnce(() => stubPlugin(false))
+      .mockImplementationOnce(() => stubPlugin(true));
 
     const stalePolicy = resolveTranscriptPolicy({
       provider: "demo",
@@ -279,7 +286,7 @@ describe("resolveTranscriptPolicy", () => {
       modelApi: "openai-completions",
     });
 
-    await invalidatePluginRuntimeDiscoveryAfterConfigMutation();
+    await invalidatePluginRuntimeDiscoveryAfterConfigMutation({});
 
     const refreshedPolicy = resolveTranscriptPolicy({
       provider: "demo",

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -1,11 +1,15 @@
 /**
  * Regression coverage for transcript replay policy resolution.
- * Exercises provider-family fallbacks, plugin replay hooks, and policy caching.
+ * Exercises provider-family fallbacks, plugin replay hooks, and policy freshness.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { validateAnthropicTurns } from "./embedded-agent-helpers/turns.js";
+
+vi.mock("../plugins/loader.js", () => ({
+  clearPluginRegistryLoadCache: vi.fn(),
+}));
 import type { AgentMessage } from "./runtime/index.js";
 
 vi.mock("../plugins/provider-hook-runtime.js", async () => {
@@ -257,23 +261,34 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.toolCallIdMode).toBe("strict");
   });
 
-  it("memoizes replay policy resolution for the same config and process env", () => {
+  it("resolves fresh replay policies after plugin runtime discovery invalidation", async () => {
     const config = {} as OpenClawConfig;
+    const { resolveProviderRuntimePlugin } = await import("../plugins/provider-hook-runtime.js");
+    const { invalidatePluginRuntimeDiscoveryAfterConfigMutation } =
+      await import("../plugins/registry-refresh.js");
+    const mockedResolve = vi.mocked(resolveProviderRuntimePlugin);
+    // Same provider id and config after an in-process plugin package swap: the first
+    // resolution must not pin the previous package's policy for the second one.
+    mockedResolve
+      .mockImplementationOnce(() => ({ buildReplayPolicy: () => ({ sanitizeToolCallIds: false }) }))
+      .mockImplementationOnce(() => ({ buildReplayPolicy: () => ({ sanitizeToolCallIds: true }) }));
 
-    const firstPolicy = resolveTranscriptPolicy({
-      provider: "mistral",
-      modelId: "mistral-large-latest",
+    const stalePolicy = resolveTranscriptPolicy({
+      provider: "demo",
       config,
-      env: process.env,
-    });
-    const secondPolicy = resolveTranscriptPolicy({
-      provider: "mistral",
-      modelId: "mistral-large-latest",
-      config,
-      env: process.env,
+      modelApi: "openai-completions",
     });
 
-    expect(secondPolicy).toBe(firstPolicy);
+    await invalidatePluginRuntimeDiscoveryAfterConfigMutation();
+
+    const refreshedPolicy = resolveTranscriptPolicy({
+      provider: "demo",
+      config,
+      modelApi: "openai-completions",
+    });
+
+    expect(stalePolicy.sanitizeToolCallIds).toBe(false);
+    expect(refreshedPolicy.sanitizeToolCallIds).toBe(true);
   });
 
   it("does not reuse cached replay policies across custom env objects", () => {

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -6,7 +6,6 @@
 import { bindsClaudeThinkingPrefix } from "@openclaw/llm-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import type { ProviderRuntimePluginHandle } from "../plugins/provider-hook-runtime.js";
 import { resolveProviderRuntimePlugin } from "../plugins/provider-hook-runtime.js";
 import { shouldDropClaudeThinkingBlocks } from "../plugins/provider-replay-helpers.js";
@@ -289,47 +288,18 @@ function mergeTranscriptPolicy(
   };
 }
 
-const transcriptPolicyCache = new WeakMap<OpenClawConfig, Map<string, TranscriptPolicy>>();
-
-function canCacheTranscriptPolicy(params: {
-  config?: OpenClawConfig;
-  env?: NodeJS.ProcessEnv;
-}): params is { config: OpenClawConfig; env?: NodeJS.ProcessEnv } {
-  if (!params.config) {
-    return false;
-  }
-  return !params.env || params.env === process.env;
-}
-
-function resolveTranscriptPolicyCacheKey(params: {
-  modelApi?: string | null;
-  provider: string;
-  modelId?: string | null;
-  model?: ProviderRuntimeModel;
-  config: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-}): string {
-  return JSON.stringify({
-    provider: params.provider,
-    modelApi: params.modelApi ?? "",
-    modelId: params.modelId ?? "",
-    canonicalModelId:
-      typeof params.model?.params?.canonicalModelId === "string"
-        ? params.model.params.canonicalModelId
-        : "",
-    dropsThinkingForReasoningCompat: modelDisablesReasoningEffort(params.model),
-    preservesReasoningContentReplay: params.model?.reasoning === true,
-    workspaceDir: params.workspaceDir ?? "",
-    pluginControlPlane: resolvePluginControlPlaneFingerprint({
-      config: params.config,
-      workspaceDir: params.workspaceDir,
-      env: params.env,
-    }),
-  });
-}
-
-/** Resolve and cache the effective replay policy for a provider/model/config tuple. */
+/**
+ * Resolves the effective replay policy for a provider/model tuple on every call.
+ *
+ * Deliberately uncached: the previous config-keyed memo served policies from whichever plugin
+ * package owned the provider at first resolution, and its fingerprint ignored the installed
+ * plugin inventory, so an in-process plugin package swap (e.g. the setup-inference Codex
+ * generation install, which clears the loader/metadata caches via
+ * `invalidatePluginRuntimeDiscoveryAfterConfigMutation`) kept replaying with the previous
+ * package's policy until the config object itself was replaced. Plugin hook invocation is cheap
+ * and registry lookups reuse the current runtime snapshots, so resolving fresh on every call
+ * keeps policy ownership current.
+ */
 export function resolveTranscriptPolicy(params: {
   modelApi?: string | null;
   provider?: string | null;
@@ -341,16 +311,6 @@ export function resolveTranscriptPolicy(params: {
   runtimeHandle?: ProviderRuntimePluginHandle;
 }): TranscriptPolicy {
   const provider = normalizeProviderId(params.provider ?? "");
-  const cacheConfig = canCacheTranscriptPolicy(params) ? params.config : undefined;
-  const cacheKey = cacheConfig
-    ? resolveTranscriptPolicyCacheKey({ ...params, provider, config: cacheConfig })
-    : undefined;
-  if (cacheConfig && cacheKey) {
-    const cached = transcriptPolicyCache.get(cacheConfig)?.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-  }
   const runtimePlugin =
     params.runtimeHandle?.plugin ??
     (provider
@@ -384,13 +344,5 @@ export function resolveTranscriptPolicy(params: {
           model: params.model,
         }),
       );
-  if (cacheConfig && cacheKey) {
-    let configCache = transcriptPolicyCache.get(cacheConfig);
-    if (!configCache) {
-      configCache = new Map();
-      transcriptPolicyCache.set(cacheConfig, configCache);
-    }
-    configCache.set(cacheKey, policy);
-  }
   return policy;
 }


### PR DESCRIPTION
### What Problem This Solves

Closes #139978.

`resolveTranscriptPolicy` memoized replay policies in a config-keyed WeakMap whose key fingerprint ignores the installed plugin inventory, so an in-process plugin package swap for the same provider id (setup-inference Codex generation install, onboarding plugin install) kept replaying with the previous package's `buildReplayPolicy` output until the config object itself was replaced. Those swap paths call `invalidatePluginRuntimeDiscoveryAfterConfigMutation` to clear the loader/metadata caches precisely so subsequent resolution observes the new package — the memo silently bypassed that invalidation.

### Why This Change Was Made

- The memo is net-negative even on its own terms: every cached-path call pays a control-plane fingerprint hash plus `JSON.stringify` of the key to save one warm registry snapshot lookup, and the loader's own load cache (which *is* invalidated on swaps) already absorbs the cold path.
- Call sites are per model turn, not per message, so fresh resolution costs nothing measurable.
- Deleting the memo restores the documented invalidation contract instead of adding a second invalidation owner for the WeakMap.

### User Impact

Replay policy decides sanitization, tool-call-id rewriting, thinking-block handling, and turn validation. After this change, an in-process plugin package swap takes effect on the next turn instead of serving transcript hygiene from the previous package for the rest of the process.

### Evidence

- **Pre-fix red** (main's memoized version + the new regression test): `1 failed | 65 skipped` — `resolves fresh replay policies after plugin runtime discovery invalidation` fails because the second resolution returns the memoized policy.
- **Post-fix green**: `66 passed (66)` for `src/agents/transcript-policy.test.ts`.
- **Mechanism source**: `src/plugins/plugin-control-plane-context.ts:59-73` — `inventoryFingerprint` is only included when an installed-plugin `index` is passed, and the memo key passes none; `src/plugins/registry-refresh.ts:60-69` — the invalidation contract the memo bypassed; swap paths at `src/system-agent/setup-inference-persist.ts:125` and `src/commands/onboarding-plugin-install.ts:132`.
- **Consumers checked for object-identity reliance**: all four call sites (`embedded-agent-runner/replay-history.ts:710,898`, `run/attempt-history.ts:419`, `runtime-plan/build.ts:197`) consume the policy by value; none compare identity.
- **LOC**: net −48 production (`git diff --numstat`: transcript-policy.ts 12+/60−), +16 net test lines.
- **Checks**: `oxfmt` clean, `oxlint --type-aware` clean on both files.
- **Competition**: no open issue/PR matches (searched "transcript policy cache", "replay policy cache", "buildReplayPolicy stale", "memoize transcript"); no open PR touches `src/agents/transcript-policy.ts`.

Co-Authored-By: Claude <noreply@anthropic.com>


### CI note (preflight red is main-inherited, not from this diff)

`preflight` fails on this fork PR with GitHub's job-outputs limit, not a test failure: every step succeeds and the job annotation is `Job outputs exceed 1,048,576 bytes` (e.g. check-run 101474152723, run 34028685031).

- Cause sits in the workflow, not this diff: `preflight` ships the whole compact Node test plan as the `checks_node_core_nondist_matrix` output (~98% of the job's total output bytes; measured locally by re-running the manifest planner for this PR's inputs: 522,685 bytes total, 513,351 of them that matrix).
- Fork PRs take `runner_profile=github` (hosted-runner-profile-contract in the `runner_profile` step), which packs 79 compact rows + 31 fallback rows instead of blacksmith's 50, and each row embeds the full test-file inventory in `groups[].includePatterns` (largest row ≈ 40KB).
- Contrast on the same day: same-repo PRs #140038 / #140040 (blacksmith profile, ~453KB) pass preflight; fork PRs #139979, #140008, #140045 fail with the same annotation. A retrigger of this same branch passed preflight once (run 34025126956) and failed twice — the payload sits at the cap edge, so fork-PR preflight is now a coin flip.
- All substantive checks on this PR's head are green (`check-test-types-*`, lint, node test shards that ran in earlier attempts); only `preflight` + the `ci-gate` aggregate are red.
