### PR TITLE
fix(kimi-coding): self-hosted Kimi K3 models only expose off/on thinking levels

### DIFF
--- a/extensions/kimi-coding/provider-catalog.test.ts
+++ b/extensions/kimi-coding/provider-catalog.test.ts
@@ -66,12 +66,15 @@ describe("kimi provider catalog", () => {
 
   it("covers every K3 catalog row with the K3 thinking policy", () => {
     // The manifest owns the rows and `provider-policy-api` owns the thinking
-    // profile, so a new K3 variant must land in both or lose its levels.
+    // profile, so a new bundled K3 variant must land in both or lose its
+    // levels. The policy list may additionally carry self-hosted wire ids
+    // (e.g. "kimi-k3") that have no bundled catalog row.
     const thinkingRows = buildKimiCodingProvider()
       .models.filter((model) => model.thinkingLevelMap)
       .map((model) => model.id);
 
-    expect(thinkingRows).toEqual([...KIMI_K3_MODEL_IDS]);
+    expect(KIMI_K3_MODEL_IDS).toEqual(expect.arrayContaining(thinkingRows));
+    expect(KIMI_K3_MODEL_IDS).toContain("kimi-k3");
   });
 
   it("normalizes legacy Kimi coding model ids to the stable API model id", () => {

--- a/extensions/kimi-coding/provider-policy-api.test.ts
+++ b/extensions/kimi-coding/provider-policy-api.test.ts
@@ -2,22 +2,25 @@ import { describe, expect, it } from "vitest";
 import { isKimiK3ModelId, resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("Kimi Code provider policy", () => {
-  it.each(["k3", "k3-256k"])("exposes adaptive K3 thinking levels for %s", (modelId) => {
-    expect(resolveThinkingProfile({ provider: "kimi", modelId })).toEqual({
-      levels: [
-        { id: "off" },
-        { id: "minimal" },
-        { id: "low" },
-        { id: "medium" },
-        { id: "high" },
-        { id: "adaptive" },
-        { id: "xhigh" },
-        { id: "max" },
-      ],
-      defaultLevel: "high",
-      preserveWhenCatalogReasoningFalse: true,
-    });
-  });
+  it.each(["k3", "k3-256k", "kimi-k3", "Kimi-K3"])(
+    "exposes adaptive K3 thinking levels for %s",
+    (modelId) => {
+      expect(resolveThinkingProfile({ provider: "kimi", modelId })).toEqual({
+        levels: [
+          { id: "off" },
+          { id: "minimal" },
+          { id: "low" },
+          { id: "medium" },
+          { id: "high" },
+          { id: "adaptive" },
+          { id: "xhigh" },
+          { id: "max" },
+        ],
+        defaultLevel: "high",
+        preserveWhenCatalogReasoningFalse: true,
+      });
+    },
+  );
 
   it("keeps legacy Kimi Code thinking binary and off by default", () => {
     expect(resolveThinkingProfile({ provider: "kimi", modelId: "kimi-for-coding" })).toEqual({
@@ -32,6 +35,8 @@ describe("Kimi Code provider policy", () => {
   it("recognizes K3 wire ids case-insensitively", () => {
     expect(isKimiK3ModelId("K3")).toBe(true);
     expect(isKimiK3ModelId("K3-256K")).toBe(true);
+    expect(isKimiK3ModelId("Kimi-K3")).toBe(true);
+    expect(isKimiK3ModelId("kimi-k3")).toBe(true);
     expect(isKimiK3ModelId("kimi-for-coding")).toBe(false);
   });
 });

--- a/extensions/kimi-coding/provider-policy-api.ts
+++ b/extensions/kimi-coding/provider-policy-api.ts
@@ -4,7 +4,9 @@ import type {
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
 
-export const KIMI_K3_MODEL_IDS = ["k3", "k3-256k"] as const;
+// Includes the bare kimi.com short ids and the Moonshot upstream wire id ("kimi-k3"),
+// which self-hosted Kimi K3 gateways register verbatim under the kimi provider.
+export const KIMI_K3_MODEL_IDS = ["k3", "k3-256k", "kimi-k3"] as const;
 const KIMI_K3_LEGACY_MODEL_IDS = ["k3[1m]"] as const;
 
 const KIMI_K3_THINKING_LEVELS = [


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running a self-hosted Kimi K3 gateway (e.g. an internal vLLM deployment) and registering it under the `kimi` provider with the upstream wire model id `Kimi-K3`/`kimi-k3` could not select any thinking level beyond `off`/`on`. The UI and `--thinking` flag reject every other level with `Thinking level "max" is not supported for kimi/Kimi-K3. Use one of: off, on.`

The bundled `@openclaw/kimi-provider` policy only treats the kimi.com short ids (`k3`, `k3-256k`, `k3[1m]`) as K3. The Moonshot upstream wire id `kimi-k3` — which self-hosted mirrors pass through verbatim as their model id — falls through to the binary off/low profile, even though it is the same K3 model behind a custom endpoint.

## Why This Change Was Made

The fix recognizes the Moonshot upstream wire id `kimi-k3` alongside the existing short ids in `KIMI_K3_MODEL_IDS`, so self-hosted registrations receive the same 8-level adaptive profile (`off`/`minimal`/`low`/`medium`/`high`/`adaptive`/`xhigh`/`max`).

The strict round-trip assertion between bundled catalog rows and the policy list is relaxed to a containment check: the bundled K3 rows (`k3`, `k3-256k`) must still appear in the policy list, while the policy list may additionally carry self-hosted wire ids that have no bundled catalog row. The existing "a new K3 variant must land in both" guardrail keeps working.

## User Impact

Users who self-host Kimi K3 behind their own gateway and configure it under the `kimi` provider can now select and persist every thinking level (including `max`) from the UI picker and the `--thinking`/directive surfaces, instead of being pinned to on/off.

No change for kimi.com-hosted models: `k3`, `k3-256k`, `kimi-for-coding`, and `kimi-for-coding-highspeed` behave exactly as before.

## Evidence

- Repro before this change (OpenClaw 2026.9.2, config: `models.providers.kimi` with model `Kimi-K3`, `api: openai-completions`, custom `baseUrl` pointing at a self-hosted Kimi K3 gateway):

  ```
  $ openclaw agent -m "13*17=?" --model kimi/Kimi-K3 --thinking max --json
  "error": "Thinking level \"max\" is not supported for kimi/Kimi-K3. Use one of: off, on."
  ```

- Same invocation after this change (identical config, policy list patched locally): accepted, `requestShaping.thinking: "max"`, run completes with the correct answer.
- `pnpm test:extension kimi-coding`: 7 files / 56 tests pass, including the updated policy and catalog tests covering `kimi-k3` and `Kimi-K3`.
- `oxlint` and `oxfmt --check` clean on the touched extension.