### PR TITLE
perf(acp): reuse prepared replay ledger queries

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1585,7 +1585,6 @@ src/acp/control-plane/manager.runtime-resume-state.ts	2
 src/acp/control-plane/manager.ts	1
 src/acp/control-plane/manager.utils.ts	1
 src/acp/control-plane/runtime-options.ts	2
-src/acp/event-ledger.ts	5
 src/acp/event-ledger.types.ts	1
 src/acp/event-mapper.ts	1
 src/acp/permission-relay.ts	1

--- a/src/acp/event-ledger.prepared.test.ts
+++ b/src/acp/event-ledger.prepared.test.ts
@@ -1,0 +1,207 @@
+import path from "node:path";
+import { constants } from "node:sqlite";
+import { SqliteQueryCompiler } from "kysely";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { createSqliteAcpEventLedger } from "./event-ledger.js";
+import { expectAcpReplayUtf8Accounting } from "./event-ledger.test-support.js";
+
+const update = (text: string) => ({
+  sessionUpdate: "agent_message_chunk" as const,
+  content: { type: "text" as const, text },
+});
+
+describe("ACP prepared queries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    closeOpenClawStateDatabaseForTest();
+  });
+
+  it("reuses warm append queries while binding fresh metadata, sequence and payload values", async () => {
+    await withTestDir({ prefix: "openclaw-acp-prepared-" }, async (dir) => {
+      const options = { path: path.join(dir, "state.sqlite") };
+      let now = 100;
+      const ledger = createSqliteAcpEventLedger({ ...options, now: () => now++ });
+      const session = { sessionId: "session", sessionKey: "key", cwd: "/work", complete: true };
+      await ledger.startSession(session);
+      for (let index = 0; index < 3; index++) {
+        await ledger.recordUpdate({ ...session, update: update(`warm-${index}`) });
+      }
+      const { db } = openOpenClawStateDatabase(options);
+      const prepare = vi.spyOn(db, "prepare");
+      const compile = vi.spyOn(SqliteQueryCompiler.prototype, "compileQuery");
+      try {
+        for (let index = 0; index < 4; index++) {
+          await ledger.recordUpdate({
+            sessionId: session.sessionId,
+            sessionKey: `key-${index}-漢😀`,
+            runId: index % 2 ? `run-${index}` : undefined,
+            update: update(`payload-${index}-漢\0\ud800`),
+          });
+        }
+        expect(prepare.mock.calls.filter(([sql]) => sql.includes("acp_replay_"))).toHaveLength(0);
+        expect(
+          compile.mock.results.filter(
+            (result) => result.type === "return" && result.value.sql.includes("acp_replay_"),
+          ),
+        ).toHaveLength(0);
+      } finally {
+        prepare.mockRestore();
+        compile.mockRestore();
+      }
+      const replay = await ledger.readReplayBySessionId(session);
+      expect(replay).toMatchObject({ complete: true, sessionKey: "key-3-漢😀" });
+      expect(db.prepare("SELECT updated_at, next_seq FROM acp_replay_sessions").get()).toEqual({
+        updated_at: 114,
+        next_seq: 8,
+      });
+      expect(
+        replay.events
+          .slice(3)
+          .map((event) => [event.seq, event.sessionKey, event.runId, event.update]),
+      ).toEqual(
+        Array.from({ length: 4 }, (_, index) => [
+          index + 4,
+          `key-${index}-漢😀`,
+          index % 2 ? `run-${index}` : undefined,
+          update(`payload-${index}-漢\0\ud800`),
+        ]),
+      );
+      expect(replay.events.slice(3).map((event) => event.at)).toEqual([108, 110, 112, 114]);
+      expectAcpReplayUtf8Accounting(db);
+
+      closeOpenClawStateDatabaseForTest();
+      await ledger.recordUpdate({ ...session, update: update("after reopen") });
+      const reopened = await ledger.readReplayBySessionId(session);
+      expect(reopened.events.at(-1)).toMatchObject({ seq: 8, update: update("after reopen") });
+      expectAcpReplayUtf8Accounting(openOpenClawStateDatabase(options).db);
+    });
+  });
+
+  it("keeps oversized bindings fresh and honors authorization after statements warm", async () => {
+    await withTestDir({ prefix: "openclaw-acp-prepared-" }, async (dir) => {
+      const options = { path: path.join(dir, "state.sqlite") };
+      const ledger = createSqliteAcpEventLedger(options);
+      const session = { sessionId: "session", sessionKey: "key", cwd: "/work", complete: true };
+      await ledger.startSession(session);
+      for (let index = 0; index < 3; index++) {
+        await ledger.recordUpdate({ ...session, update: update(`warm-${index}`) });
+      }
+      const large = "漢".repeat(32 * 1024);
+      await ledger.recordUpdate({ ...session, update: update(large) });
+      await ledger.recordUpdate({ ...session, update: update("small after large") });
+      const { db } = openOpenClawStateDatabase(options);
+      db.setAuthorizer((action, table) =>
+        action === constants.SQLITE_INSERT && table === "acp_replay_events"
+          ? constants.SQLITE_DENY
+          : constants.SQLITE_OK,
+      );
+      try {
+        await expect(
+          ledger.recordUpdate({ ...session, update: update("refused") }),
+        ).rejects.toThrow(/not authorized/i);
+      } finally {
+        db.setAuthorizer(null);
+      }
+      await ledger.recordUpdate({ ...session, update: update("accepted") });
+      const replay = await ledger.readReplayBySessionId(session);
+      expect(replay.events.slice(3).map((event) => [event.seq, event.update])).toEqual([
+        [4, update(large)],
+        [5, update("small after large")],
+        [6, update("accepted")],
+      ]);
+      expectAcpReplayUtf8Accounting(db);
+    });
+  });
+
+  it("retains the later prompt block after an earlier block exhausts the byte budget", async () => {
+    await withTestDir({ prefix: "openclaw-acp-prepared-" }, async (dir) => {
+      const options = { path: path.join(dir, "state.sqlite") };
+      const ledger = createSqliteAcpEventLedger({ ...options, maxSerializedBytes: 1024 });
+      const session = { sessionId: "s", sessionKey: "k", cwd: "", complete: true };
+      await ledger.startSession(session);
+      await ledger.recordUserPrompt({
+        ...session,
+        runId: "run",
+        prompt: [
+          { type: "text", text: "漢".repeat(400) },
+          { type: "text", text: "tail" },
+        ],
+      });
+      const { db } = openOpenClawStateDatabase(options);
+      expect(db.prepare("SELECT seq, update_json FROM acp_replay_events").all()).toEqual([
+        {
+          seq: 2,
+          update_json: JSON.stringify({
+            sessionUpdate: "user_message_chunk",
+            content: { type: "text", text: "tail" },
+          }),
+        },
+      ]);
+      await expect(ledger.readReplayBySessionId(session)).resolves.toEqual({
+        complete: false,
+        events: [],
+      });
+      expectAcpReplayUtf8Accounting(db);
+    });
+  });
+
+  it("uses each ledger's current caps when sharing a connection with gapped event sequences", async () => {
+    await withTestDir({ prefix: "openclaw-acp-prepared-" }, async (dir) => {
+      const options = { path: path.join(dir, "state.sqlite"), now: () => 100 };
+      const roomy = createSqliteAcpEventLedger({
+        ...options,
+        maxEventsPerSession: 10,
+        maxSessions: 3,
+      });
+      const narrow = createSqliteAcpEventLedger({
+        ...options,
+        maxEventsPerSession: 2,
+        maxSessions: 2,
+      });
+      for (const sessionId of ["a", "b", "c"]) {
+        const session = { sessionId, sessionKey: `key-${sessionId}`, cwd: "/work", complete: true };
+        await roomy.startSession(session);
+        for (let index = 0; index < 3; index++) {
+          await roomy.recordUpdate({ ...session, update: update(`${sessionId}-${index}`) });
+        }
+      }
+      const { db } = openOpenClawStateDatabase(options);
+      // Imported/retained history can have gaps; next_seq is not an event count.
+      db.exec(
+        "UPDATE acp_replay_events SET seq = seq * 10; UPDATE acp_replay_sessions SET next_seq = 31",
+      );
+      await narrow.startSession({
+        sessionId: "a",
+        sessionKey: "key-a",
+        cwd: "/narrow",
+        complete: true,
+      });
+      expect(
+        db.prepare("SELECT session_id FROM acp_replay_sessions ORDER BY session_id").all(),
+      ).toEqual([{ session_id: "a" }, { session_id: "b" }]);
+      expect(
+        db.prepare("SELECT session_id, seq FROM acp_replay_events ORDER BY session_id, seq").all(),
+      ).toEqual([
+        { session_id: "a", seq: 20 },
+        { session_id: "a", seq: 30 },
+        { session_id: "b", seq: 20 },
+        { session_id: "b", seq: 30 },
+      ]);
+      expectAcpReplayUtf8Accounting(db);
+      await roomy.recordUpdate({ sessionId: "b", sessionKey: "key-b", update: update("new") });
+      expect(
+        db.prepare("SELECT seq FROM acp_replay_events WHERE session_id = 'b' ORDER BY seq").all(),
+      ).toEqual([{ seq: 20 }, { seq: 30 }, { seq: 31 }]);
+      await expect(roomy.readReplayBySessionId({ sessionId: "b" })).resolves.toEqual({
+        complete: false,
+        events: [],
+      });
+      expectAcpReplayUtf8Accounting(db);
+    });
+  });
+});

--- a/src/acp/event-ledger.ts
+++ b/src/acp/event-ledger.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { SessionUpdate } from "@agentclientprotocol/sdk";
 import {
   executeSqliteQuerySync,
+  prepareSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "../infra/kysely-sync.js";
@@ -42,6 +43,203 @@ type AcpReplayEventRow = Pick<
   "session_id" | "seq" | "at" | "session_key" | "run_id" | "update_json"
 >;
 
+type AcpReplaySessionRow = Pick<
+  AcpLedgerDatabase["acp_replay_sessions"],
+  "session_id" | "session_key" | "cwd" | "complete" | "next_seq"
+>;
+
+function createSqliteLedgerQueries(db: DatabaseSync) {
+  const query = getNodeSqliteKysely<AcpLedgerDatabase>(db);
+  return {
+    readSession: prepareSqliteQuerySync<string, AcpReplaySessionRow>(db, (parameter) =>
+      sqliteSessionMetadataQuery(db).where(
+        "session_id",
+        "=",
+        parameter((sessionId) => sessionId),
+      ),
+    ),
+    updateSessionMetadata: prepareSqliteQuerySync<{
+      sessionId: string;
+      sessionKey: string;
+      cwd: string;
+      complete: number;
+      now: number;
+      metadataDelta: number;
+    }>(db, (parameter) =>
+      query
+        .updateTable("acp_replay_sessions")
+        .set((eb) => ({
+          estimated_bytes: eb(
+            "estimated_bytes",
+            "+",
+            parameter((params) => params.metadataDelta),
+          ),
+          session_key: parameter((params) => params.sessionKey),
+          cwd: parameter((params) => params.cwd),
+          complete: parameter((params) => params.complete),
+          updated_at: parameter((params) => params.now),
+        }))
+        .where(
+          "session_id",
+          "=",
+          parameter((params) => params.sessionId),
+        ),
+    ),
+    insertEvent: prepareSqliteQuerySync<{
+      sessionId: string;
+      seq: number;
+      at: number;
+      sessionKey: string;
+      runId: string | null;
+      updateJson: string;
+      eventBytes: number;
+    }>(db, (parameter) =>
+      query.insertInto("acp_replay_events").values({
+        session_id: parameter((params) => params.sessionId),
+        seq: parameter((params) => params.seq),
+        at: parameter((params) => params.at),
+        session_key: parameter((params) => params.sessionKey),
+        run_id: parameter((params) => params.runId),
+        update_json: parameter((params) => params.updateJson),
+        estimated_bytes: parameter((params) => params.eventBytes),
+      }),
+    ),
+    updateSessionAfterAppend: prepareSqliteQuerySync<{
+      sessionId: string;
+      eventBytes: number;
+      now: number;
+      nextSeq: number;
+    }>(db, (parameter) =>
+      query
+        .updateTable("acp_replay_sessions")
+        .set((eb) => ({
+          estimated_bytes: eb(
+            "estimated_bytes",
+            "+",
+            parameter((params) => params.eventBytes),
+          ),
+          updated_at: parameter((params) => params.now),
+          next_seq: parameter((params) => params.nextSeq),
+        }))
+        .where(
+          "session_id",
+          "=",
+          parameter((params) => params.sessionId),
+        ),
+    ),
+    readOverCapSessions: prepareSqliteQuerySync<
+      number,
+      { session_id: string; event_count: number }
+    >(db, (parameter) =>
+      query
+        .selectFrom(
+          query
+            .selectFrom("acp_replay_sessions as s")
+            .leftJoin("acp_replay_events as e", "e.session_id", "s.session_id")
+            .select("s.session_id")
+            .select((eb) => eb.fn.count<number>("e.seq").as("event_count"))
+            .groupBy("s.session_id")
+            .as("counts"),
+        )
+        .select(["session_id", "event_count"])
+        .where(
+          "event_count",
+          ">",
+          parameter((limit) => limit),
+        ),
+    ),
+    readExcessSessions: prepareSqliteQuerySync<number, { session_id: string }>(db, (parameter) =>
+      query
+        .selectFrom("acp_replay_sessions")
+        .select("session_id")
+        .orderBy("updated_at", "desc")
+        .orderBy("session_id", "asc")
+        .limit(-1)
+        .offset(parameter((limit) => limit)),
+    ),
+    readTotalBytes: prepareSqliteQuerySync<void, { total: number }>(db, () =>
+      query
+        .selectFrom("acp_replay_sessions")
+        .select((eb) =>
+          eb.fn.coalesce(eb.fn.sum<number>("estimated_bytes"), eb.val(0)).as("total"),
+        ),
+    ),
+    readOldestSession: prepareSqliteQuerySync<void, { session_id: string }>(db, () =>
+      query
+        .selectFrom("acp_replay_sessions")
+        .select("session_id")
+        .orderBy("updated_at", "asc")
+        .orderBy("session_id", "asc")
+        .limit(1),
+    ),
+    deleteOldestEvents: prepareSqliteQuerySync<
+      { sessionId: string; limit: number },
+      { estimated_bytes: number }
+    >(db, (parameter) => {
+      const sessionId = parameter((params) => params.sessionId);
+      return query
+        .deleteFrom("acp_replay_events")
+        .where("session_id", "=", sessionId)
+        .where(
+          "seq",
+          "in",
+          query
+            .selectFrom("acp_replay_events")
+            .select("seq")
+            .where("session_id", "=", sessionId)
+            .orderBy("seq", "asc")
+            .limit(parameter((params) => params.limit)),
+        )
+        .returning("estimated_bytes");
+    }),
+    subtractSessionBytes: prepareSqliteQuerySync<{ sessionId: string; freed: number }>(
+      db,
+      (parameter) =>
+        query
+          .updateTable("acp_replay_sessions")
+          .set((eb) => ({
+            estimated_bytes: eb.fn<number>("max", [
+              eb.val(0),
+              eb(
+                "estimated_bytes",
+                "-",
+                parameter((params) => params.freed),
+              ),
+            ]),
+            complete: 0,
+          }))
+          .where(
+            "session_id",
+            "=",
+            parameter((params) => params.sessionId),
+          ),
+    ),
+    deleteSession: prepareSqliteQuerySync<string>(db, (parameter) =>
+      query.deleteFrom("acp_replay_sessions").where(
+        "session_id",
+        "=",
+        parameter((sessionId) => sessionId),
+      ),
+    ),
+  };
+}
+
+const sqliteLedgerQueries = new WeakMap<
+  DatabaseSync,
+  ReturnType<typeof createSqliteLedgerQueries>
+>();
+
+function getSqliteLedgerQueries(db: DatabaseSync) {
+  let queries = sqliteLedgerQueries.get(db);
+  if (!queries) {
+    // Retain compilation per physical connection; native statements and their
+    // invalidation remain owned by the bounded shared executor cache.
+    queries = createSqliteLedgerQueries(db);
+    sqliteLedgerQueries.set(db, queries);
+  }
+  return queries;
+}
+
 function sqliteRowToLedgerEvent(row: AcpReplayEventRow): AcpEventLedgerEntry | undefined {
   let update: unknown;
   try {
@@ -66,10 +264,7 @@ function sqliteSessionMetadataQuery(db: DatabaseSync) {
 }
 
 function readSqliteSessionById(db: DatabaseSync, sessionId: string) {
-  return executeSqliteQueryTakeFirstSync(
-    db,
-    sqliteSessionMetadataQuery(db).where("session_id", "=", sessionId),
-  );
+  return getSqliteLedgerQueries(db).readSession(sessionId).rows[0];
 }
 
 function readLatestCompleteSqliteSessionByKey(db: DatabaseSync, sessionKey: string) {
@@ -107,19 +302,14 @@ function upsertSqliteSession(
         sessionKey: existing.session_key,
         cwd: existing.cwd,
       });
-    executeSqliteQuerySync(
-      db,
-      getNodeSqliteKysely<AcpLedgerDatabase>(db)
-        .updateTable("acp_replay_sessions")
-        .set((eb) => ({
-          estimated_bytes: eb("estimated_bytes", "+", metadataDelta),
-          session_key: params.sessionKey,
-          cwd,
-          complete,
-          updated_at: now,
-        }))
-        .where("session_id", "=", params.sessionId),
-    );
+    getSqliteLedgerQueries(db).updateSessionMetadata({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      cwd,
+      complete,
+      now,
+      metadataDelta,
+    });
     return normalizeSqliteInteger(existing.next_seq);
   }
 
@@ -165,9 +355,7 @@ function upsertSqliteSession(
 // sums over at most maxSessions rows instead of scanning every event per
 // append, which was O(events) per message and quadratic while trimming.
 function estimateSqliteLedgerBytes(db: DatabaseSync): number {
-  const row = db
-    .prepare("SELECT COALESCE(SUM(estimated_bytes), 0) AS total FROM acp_replay_sessions")
-    .get() as { total?: number | bigint } | undefined;
+  const row = getSqliteLedgerQueries(db).readTotalBytes().rows[0];
   return normalizeSqliteInteger(row?.total ?? 0);
 }
 
@@ -176,28 +364,13 @@ const LEDGER_TRIM_EVENT_BATCH = 64;
 // Deletes up to `limit` oldest events for one session and returns the bytes
 // released, keeping the session aggregate in sync in the same statement pair.
 function deleteOldestSqliteEvents(db: DatabaseSync, sessionId: string, limit: number): number {
-  const rows = db
-    .prepare(
-      `DELETE FROM acp_replay_events
-        WHERE session_id = ?
-          AND seq IN (
-            SELECT seq FROM acp_replay_events
-             WHERE session_id = ?
-             ORDER BY seq ASC
-             LIMIT ?
-          )
-        RETURNING estimated_bytes`,
-    )
-    .all(sessionId, sessionId, limit) as Array<{ estimated_bytes: number | bigint }>;
+  const queries = getSqliteLedgerQueries(db);
+  const rows = queries.deleteOldestEvents({ sessionId, limit }).rows;
   if (rows.length === 0) {
     return 0;
   }
   const freed = rows.reduce((sum, row) => sum + normalizeSqliteInteger(row.estimated_bytes), 0);
-  db.prepare(
-    `UPDATE acp_replay_sessions
-        SET estimated_bytes = MAX(0, estimated_bytes - ?), complete = 0
-      WHERE session_id = ?`,
-  ).run(freed, sessionId);
+  queries.subtractSessionBytes({ sessionId, freed });
   return rows.length;
 }
 
@@ -207,16 +380,8 @@ function trimSqliteLedger(
 ): void {
   // Cheap precheck: only sessions actually above the per-session cap pay for
   // event deletion (Codex log-partition pattern).
-  const overCapSessions = db
-    .prepare(
-      `SELECT session_id, event_count FROM (
-         SELECT s.session_id AS session_id, COUNT(e.seq) AS event_count
-           FROM acp_replay_sessions s
-           LEFT JOIN acp_replay_events e ON e.session_id = s.session_id
-          GROUP BY s.session_id
-       ) WHERE event_count > ?`,
-    )
-    .all(state.maxEventsPerSession) as Array<{ session_id: string; event_count: number | bigint }>;
+  const queries = getSqliteLedgerQueries(db);
+  const overCapSessions = queries.readOverCapSessions(state.maxEventsPerSession).rows;
   for (const row of overCapSessions) {
     const overage = normalizeSqliteInteger(row.event_count) - state.maxEventsPerSession;
     if (overage > 0) {
@@ -224,16 +389,9 @@ function trimSqliteLedger(
     }
   }
 
-  const oldSessions = db
-    .prepare(
-      `SELECT session_id
-         FROM acp_replay_sessions
-        ORDER BY updated_at DESC, session_id ASC
-        LIMIT -1 OFFSET ?`,
-    )
-    .all(state.maxSessions) as Array<{ session_id: string }>;
+  const oldSessions = queries.readExcessSessions(state.maxSessions).rows;
   for (const session of oldSessions) {
-    db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+    queries.deleteSession(session.session_id);
   }
 
   // Byte budget: evict from the least-recently-updated session in bounded
@@ -241,20 +399,13 @@ function trimSqliteLedger(
   // Aggregates keep every recheck O(maxSessions); no event scans occur.
   let serializedBytes = estimateSqliteLedgerBytes(db);
   while (serializedBytes > state.maxSerializedBytes) {
-    const session = db
-      .prepare(
-        `SELECT session_id
-           FROM acp_replay_sessions
-          ORDER BY updated_at ASC, session_id ASC
-          LIMIT 1`,
-      )
-      .get() as { session_id: string } | undefined;
+    const session = queries.readOldestSession().rows[0];
     if (!session) {
       break;
     }
     const deleted = deleteOldestSqliteEvents(db, session.session_id, LEDGER_TRIM_EVENT_BATCH);
     if (deleted === 0) {
-      db.prepare("DELETE FROM acp_replay_sessions WHERE session_id = ?").run(session.session_id);
+      queries.deleteSession(session.session_id);
     }
     serializedBytes = estimateSqliteLedgerBytes(db);
   }
@@ -287,30 +438,23 @@ function appendSqliteUpdate(
     ...(params.runId !== undefined ? { runId: params.runId } : {}),
     updateJson,
   });
-  db.prepare(
-    `INSERT INTO acp_replay_events (session_id, seq, at, session_key, run_id, update_json, estimated_bytes)
-     VALUES (?, ?, ?, ?, ?, ?, ?)`,
-  ).run(
-    params.sessionId,
-    nextSeq,
-    now,
-    params.sessionKey,
-    params.runId ?? null,
+  const queries = getSqliteLedgerQueries(db);
+  queries.insertEvent({
+    sessionId: params.sessionId,
+    seq: nextSeq,
+    at: now,
+    sessionKey: params.sessionKey,
+    runId: params.runId ?? null,
     updateJson,
     eventBytes,
-  );
+  });
   // Upsert already accounted for metadata; only the new event remains.
-  executeSqliteQuerySync(
-    db,
-    getNodeSqliteKysely<AcpLedgerDatabase>(db)
-      .updateTable("acp_replay_sessions")
-      .set((eb) => ({
-        estimated_bytes: eb("estimated_bytes", "+", eventBytes),
-        updated_at: now,
-        next_seq: nextSeq + 1,
-      }))
-      .where("session_id", "=", params.sessionId),
-  );
+  queries.updateSessionAfterAppend({
+    sessionId: params.sessionId,
+    eventBytes,
+    now,
+    nextSeq: nextSeq + 1,
+  });
   trimSqliteLedger(db, state);
 }
 

--- a/src/infra/kysely-sync-cache-state.ts
+++ b/src/infra/kysely-sync-cache-state.ts
@@ -135,6 +135,10 @@ function queryFitsStatementCache(sql: string, parameters: readonly SQLInputValue
   }
   for (const parameter of parameters) {
     if (typeof parameter === "string") {
+      // UTF-8 is never shorter than UTF-16 code units; skip an already oversized value.
+      if (parameter.length > statementCacheEntryBytes - bytes) {
+        return false;
+      }
       bytes += Buffer.byteLength(parameter);
     } else if (ArrayBuffer.isView(parameter)) {
       bytes += parameter.byteLength;

--- a/src/infra/kysely-sync.test.ts
+++ b/src/infra/kysely-sync.test.ts
@@ -399,13 +399,15 @@ describe("kysely sync helpers", () => {
     expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
     expect(prepares.calls()).toBe(2);
 
-    const oversized = "x".repeat(64 * 1024 + 1);
-    expect(executeSqliteQuerySync(database, lengthOf(oversized)).rows).toEqual([
-      { value: oversized.length },
-    ]);
-    expect(prepares.calls()).toBe(3);
-    expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
-    expect(prepares.calls()).toBe(3);
+    for (const oversized of ["x".repeat(64 * 1024 + 1), "漢".repeat(24 * 1024)]) {
+      const before = prepares.calls();
+      expect(executeSqliteQuerySync(database, lengthOf(oversized)).rows).toEqual([
+        { value: oversized.length },
+      ]);
+      expect(prepares.calls()).toBe(before + 1);
+      expect(executeSqliteQuerySync(database, lengthOf("small")).rows).toEqual([{ value: 5 }]);
+      expect(prepares.calls()).toBe(before + 1);
+    }
 
     const oversizedSql = db.selectNoFrom(
       /* kysely-allow-raw: admission-gate test needs an oversized SQL text, only reachable via raw. */
@@ -413,7 +415,7 @@ describe("kysely sync helpers", () => {
     );
     expect(executeSqliteQuerySync(database, oversizedSql).rows).toEqual([{ value: 1 }]);
     expect(executeSqliteQuerySync(database, oversizedSql).rows).toEqual([{ value: 1 }]);
-    expect(prepares.calls()).toBe(5);
+    expect(prepares.calls()).toBe(6);
   });
 
   it("invalidates prepared statements when the database is deserialized", () => {


### PR DESCRIPTION
Related: #139768

## What Problem This Solves

ACP replay writes repeatedly rebuild the same queries and prepare native statements while appending events and enforcing the existing history limits. This adds avoidable work to every update.

## Why This Change Was Made

Eleven fixed query shapes now retain their Kysely compilation per physical SQLite connection. Each invocation binds current session IDs, sequences, timestamps, metadata and payloads. Native statement retention, authorization, re-entry, size limits and invalidation remain owned by the existing bounded shared executor cache.

The raw runtime SQL in the affected append/trim operations is replaced with typed Kysely queries. The unchanged retention owner still enforces global counts, sequence gaps, session tie ordering and intermediate prompt-block eviction. No schema, configuration, cap, migration, or dependency changes are introduced.

An equivalent shared cache-admission shortcut also avoids UTF-8 scanning an obviously oversized string: when its UTF-16 code-unit length already exceeds the remaining byte budget, its UTF-8 representation cannot fit. Shorter strings still receive exact byte sizing. The cache admits exactly the same inputs as before.

## User Impact

Warm ordinary appends use zero new native prepare calls and zero Kysely compilations instead of four and three respectively. Oversized payloads retain their existing uncached behavior and still require one native preparation. The trimming fixture drops from 840 native preparations to zero over 120 appends.

The first operation compiles all eleven shapes, and unchanged history-count scans can still dominate large histories. Local process-CPU samples before the shared sizing shortcut improved ordinary small writes by about 21–22% and byte trimming by about 15–23%; wall-clock samples were noisy. Final oversized-only comparisons put Node 24 roughly flat (+1.08% paired CPU) and Node 26 modestly faster (−4.25%). Both sides of those final oversized comparisons use the equivalent improved sizing helper. These are scoped local measurements, not uniform production latency claims.

## Evidence

- Before the repair, the warm-reuse regression observed 16 native preparations across four warmed appends. Its behavioral companions passed, isolating preparation overhead from data correctness.
- The original reviewed five-file candidate passed 53 focused tests, the full changed-file gate and independent P0–P2 review. Cases cover fresh bindings, close/reopen with the same ledger object, authorizer invalidation, oversized-to-small transitions, shared-connection caps, sequence gaps, stable session ordering and prompt-block eviction.
- Paired Node 24.20.0 and 26.8.1 benchmarks preserve every canonical row digest. The oversized-byte case also covers CJK text whose code-unit length fits while UTF-8 bytes exceed the cache limit.
- Final integration on landed Unicode accounting repair #124476 passed 76 tests, including transaction/post-commit composition. The full changed-file gate passed in 395.3 s. Refreshed real ACP stdio/GatewayClient proof on Node 24/26 passed two restarts, below-cap exact replay and over-cap fallback using the current WebSocket loader. All four TypeScript files match the independently reviewed candidate byte-for-byte; the assertion baseline changes only by removal of its five obsolete casts.

Proof uses synthetic local SQLite and the real ACP stdio/GatewayClient against a local mock WebSocket Gateway; no production provider, user data or packaged-build performance is claimed.
