### PR TITLE
refactor(plugins): separate conversation binding approval state

### DIFF
--- a/src/plugins/conversation-binding-state.ts
+++ b/src/plugins/conversation-binding-state.ts
@@ -1,0 +1,137 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createDedupeCache, type DedupeCache } from "../infra/dedupe.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { normalizeChannel } from "./conversation-binding-session-key.js";
+
+const log = createSubsystemLogger("plugins/binding");
+
+export type PluginBindingApprovalEntry = {
+  pluginRoot: string;
+  pluginId: string;
+  pluginName?: string;
+  channel: string;
+  accountId: string;
+  approvedAt: number;
+};
+
+type PluginBindingApprovalsState = { approvals: PluginBindingApprovalEntry[] };
+type PluginBindingApprovalsDatabase = Pick<OpenClawStateKyselyDatabase, "plugin_binding_approvals">;
+
+type PluginBindingGlobalState = {
+  fallbackNoticeBindingIds: DedupeCache;
+  approvalsCache: PluginBindingApprovalsState | null;
+};
+
+const pluginBindingGlobalStateKey = Symbol.for("openclaw.plugins.binding.global-state");
+export const pluginBindingGlobalState = resolveGlobalSingleton<PluginBindingGlobalState>(
+  pluginBindingGlobalStateKey,
+  () => ({
+    // Retain recent outage notices without keeping every historical binding forever.
+    fallbackNoticeBindingIds: createDedupeCache({ ttlMs: 0, maxSize: 4_096 }),
+    approvalsCache: null,
+  }),
+  (state) => {
+    state.fallbackNoticeBindingIds.clear();
+    state.approvalsCache = null;
+  },
+);
+
+function buildApprovalScopeKey(params: {
+  pluginRoot: string;
+  channel: string;
+  accountId: string;
+}): string {
+  return [
+    params.pluginRoot,
+    normalizeChannel(params.channel),
+    params.accountId.trim() || "default",
+  ].join("::");
+}
+
+function loadApprovalsFromDatabase(): PluginBindingApprovalsState {
+  try {
+    const database = openOpenClawStateDatabase();
+    const approvalsDb = getNodeSqliteKysely<PluginBindingApprovalsDatabase>(database.db);
+    const rows = executeSqliteQuerySync(
+      database.db,
+      approvalsDb
+        .selectFrom("plugin_binding_approvals")
+        .select(["plugin_root", "plugin_id", "plugin_name", "channel", "account_id", "approved_at"])
+        .orderBy("plugin_root", "asc")
+        .orderBy("channel", "asc")
+        .orderBy("account_id", "asc"),
+    ).rows;
+    return {
+      approvals: rows.map((row) => ({
+        pluginRoot: row.plugin_root,
+        pluginId: row.plugin_id,
+        pluginName: row.plugin_name ?? undefined,
+        channel: normalizeChannel(row.channel),
+        accountId: normalizeOptionalString(row.account_id) ?? "default",
+        approvedAt: row.approved_at,
+      })),
+    };
+  } catch (error) {
+    log.warn(`plugin binding approvals load failed: ${String(error)}`);
+    return { approvals: [] };
+  }
+}
+
+function persistApprovalEntry(entry: PluginBindingApprovalEntry): void {
+  const row = {
+    plugin_root: entry.pluginRoot,
+    channel: normalizeChannel(entry.channel),
+    account_id: entry.accountId.trim() || "default",
+    plugin_id: entry.pluginId,
+    plugin_name: entry.pluginName ?? null,
+    approved_at: entry.approvedAt,
+  };
+  runOpenClawStateWriteTransaction(({ db }) => {
+    const approvalsDb = getNodeSqliteKysely<PluginBindingApprovalsDatabase>(db);
+    executeSqliteQuerySync(
+      db,
+      approvalsDb
+        .insertInto("plugin_binding_approvals")
+        .values(row)
+        .onConflict((conflict) =>
+          conflict.columns(["plugin_root", "channel", "account_id"]).doUpdateSet({
+            plugin_id: (eb) => eb.ref("excluded.plugin_id"),
+            plugin_name: (eb) => eb.ref("excluded.plugin_name"),
+            approved_at: (eb) => eb.ref("excluded.approved_at"),
+          }),
+        ),
+    );
+  });
+}
+
+function getApprovals(): PluginBindingApprovalsState {
+  return (pluginBindingGlobalState.approvalsCache ??= loadApprovalsFromDatabase());
+}
+
+export function hasPersistentApproval(params: {
+  pluginRoot: string;
+  channel: string;
+  accountId: string;
+}): boolean {
+  const key = buildApprovalScopeKey(params);
+  return getApprovals().approvals.some((entry) => buildApprovalScopeKey(entry) === key);
+}
+
+export function addPersistentApproval(entry: PluginBindingApprovalEntry): void {
+  // Persist before publishing the grant: a failed SQLite write must not leave the
+  // cache auto-approving later binds with permission that never reached disk.
+  persistApprovalEntry(entry);
+  const key = buildApprovalScopeKey(entry);
+  const approvals = getApprovals().approvals.filter(
+    (existing) => buildApprovalScopeKey(existing) !== key,
+  );
+  approvals.push(entry);
+  pluginBindingGlobalState.approvalsCache = { approvals };
+}

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -3,9 +3,7 @@ import crypto from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { ReplyPayload } from "../auto-reply/reply-payload.js";
 import { getChannelPlugin, normalizeChannelId } from "../channels/plugins/index.js";
-import { createDedupeCache, type DedupeCache } from "../infra/dedupe.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { buildChannelAccountKey } from "../infra/outbound/session-binding-normalization.js";
 import {
   getSessionBindingService,
@@ -13,12 +11,7 @@ import {
   type SessionBindingScope,
 } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { resolveGlobalMap, resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
-import {
-  openOpenClawStateDatabase,
-  runOpenClawStateWriteTransaction,
-} from "../state/openclaw-state-db.js";
+import { resolveGlobalMap } from "../shared/global-singleton.js";
 import {
   isPluginOwnedBindingMetadata,
   type PluginBindingMetadata,
@@ -28,6 +21,12 @@ import {
   normalizeChannel,
   PLUGIN_BINDING_SESSION_PREFIX,
 } from "./conversation-binding-session-key.js";
+import {
+  addPersistentApproval,
+  hasPersistentApproval,
+  pluginBindingGlobalState,
+  type PluginBindingApprovalEntry,
+} from "./conversation-binding-state.js";
 import type {
   PluginConversationBinding,
   PluginConversationBindingResolvedEvent,
@@ -48,18 +47,6 @@ const LEGACY_CODEX_PLUGIN_SESSION_PREFIXES = [
 // Runtime plugin conversation bindings are approval-driven and distinct from
 // configured channel bindings compiled from config.
 type PluginBindingApprovalDecision = PluginConversationBindingResolutionDecision;
-
-type PluginBindingApprovalEntry = {
-  pluginRoot: string;
-  pluginId: string;
-  pluginName?: string;
-  channel: string;
-  accountId: string;
-  approvedAt: number;
-};
-
-type PluginBindingApprovalsState = { approvals: PluginBindingApprovalEntry[] };
-type PluginBindingApprovalsDatabase = Pick<OpenClawStateKyselyDatabase, "plugin_binding_approvals">;
 
 type PluginBindingConversation = {
   channel: string;
@@ -161,25 +148,6 @@ function addPendingPluginBindingRequest(request: PendingPluginBindingRequest): v
   }
 }
 
-type PluginBindingGlobalState = {
-  fallbackNoticeBindingIds: DedupeCache;
-  approvalsCache: PluginBindingApprovalsState | null;
-};
-
-const pluginBindingGlobalStateKey = Symbol.for("openclaw.plugins.binding.global-state");
-const pluginBindingGlobalState = resolveGlobalSingleton<PluginBindingGlobalState>(
-  pluginBindingGlobalStateKey,
-  () => ({
-    // Retain recent outage notices without keeping every historical binding forever.
-    fallbackNoticeBindingIds: createDedupeCache({ ttlMs: 0, maxSize: 4_096 }),
-    approvalsCache: null,
-  }),
-  (state) => {
-    state.fallbackNoticeBindingIds.clear();
-    state.approvalsCache = null;
-  },
-);
-
 function normalizeConversation(params: PluginBindingConversation): PluginBindingConversation {
   return {
     channel: normalizeChannel(params.channel),
@@ -231,18 +199,6 @@ function toConversationRef(params: PluginBindingConversation): ConversationRef {
   };
 }
 
-function buildApprovalScopeKey(params: {
-  pluginRoot: string;
-  channel: string;
-  accountId: string;
-}): string {
-  return [
-    params.pluginRoot,
-    normalizeChannel(params.channel),
-    params.accountId.trim() || "default",
-  ].join("::");
-}
-
 function logPluginBindingLifecycleEvent(params: {
   event:
     | "migrating legacy record"
@@ -252,21 +208,18 @@ function logPluginBindingLifecycleEvent(params: {
     | "detached"
     | "denied"
     | "approved";
-  pluginId: string;
-  pluginRoot: string;
-  channel: string;
-  accountId: string;
-  conversationId: string;
+  identity: PluginBindingIdentity;
+  conversation: ConversationRef;
   decision?: PluginBindingApprovalDecision;
 }): void {
   const parts = [
     `plugin binding ${params.event}`,
-    `plugin=${params.pluginId}`,
-    `root=${params.pluginRoot}`,
+    `plugin=${params.identity.pluginId}`,
+    `root=${params.identity.pluginRoot}`,
     ...(params.decision ? [`decision=${params.decision}`] : []),
-    `channel=${params.channel}`,
-    `account=${params.accountId}`,
-    `conversation=${params.conversationId}`,
+    `channel=${params.conversation.channel}`,
+    `account=${params.conversation.accountId}`,
+    `conversation=${params.conversation.conversationId}`,
   ];
   log.info(parts.join(" "));
 }
@@ -322,99 +275,6 @@ function buildApprovalInteractiveReply(
 function createApprovalRequestId(): string {
   // Keep approval ids compact so Telegram callback_data stays under its 64-byte limit.
   return crypto.randomBytes(9).toString("base64url");
-}
-
-function loadApprovalsFromDatabase(): PluginBindingApprovalsState {
-  try {
-    const database = openOpenClawStateDatabase();
-    const approvalsDb = getNodeSqliteKysely<PluginBindingApprovalsDatabase>(database.db);
-    const rows = executeSqliteQuerySync(
-      database.db,
-      approvalsDb
-        .selectFrom("plugin_binding_approvals")
-        .select(["plugin_root", "plugin_id", "plugin_name", "channel", "account_id", "approved_at"])
-        .orderBy("plugin_root", "asc")
-        .orderBy("channel", "asc")
-        .orderBy("account_id", "asc"),
-    ).rows;
-    return {
-      approvals: rows.map((row) => ({
-        pluginRoot: row.plugin_root,
-        pluginId: row.plugin_id,
-        pluginName: row.plugin_name ?? undefined,
-        channel: normalizeChannel(row.channel),
-        accountId: normalizeOptionalString(row.account_id) ?? "default",
-        approvedAt: row.approved_at,
-      })),
-    };
-  } catch (error) {
-    log.warn(`plugin binding approvals load failed: ${String(error)}`);
-    return { approvals: [] };
-  }
-}
-
-function persistApprovalEntry(entry: PluginBindingApprovalEntry): void {
-  const row = {
-    plugin_root: entry.pluginRoot,
-    channel: normalizeChannel(entry.channel),
-    account_id: entry.accountId.trim() || "default",
-    plugin_id: entry.pluginId,
-    plugin_name: entry.pluginName ?? null,
-    approved_at: entry.approvedAt,
-  };
-  runOpenClawStateWriteTransaction(({ db }) => {
-    const approvalsDb = getNodeSqliteKysely<PluginBindingApprovalsDatabase>(db);
-    executeSqliteQuerySync(
-      db,
-      approvalsDb
-        .insertInto("plugin_binding_approvals")
-        .values(row)
-        .onConflict((conflict) =>
-          conflict.columns(["plugin_root", "channel", "account_id"]).doUpdateSet({
-            plugin_id: (eb) => eb.ref("excluded.plugin_id"),
-            plugin_name: (eb) => eb.ref("excluded.plugin_name"),
-            approved_at: (eb) => eb.ref("excluded.approved_at"),
-          }),
-        ),
-    );
-  });
-}
-
-function getApprovals(): PluginBindingApprovalsState {
-  return (pluginBindingGlobalState.approvalsCache ??= loadApprovalsFromDatabase());
-}
-
-function hasPersistentApproval(params: {
-  pluginRoot: string;
-  channel: string;
-  accountId: string;
-}): boolean {
-  const key = buildApprovalScopeKey(params);
-  return getApprovals().approvals.some(
-    (entry) =>
-      buildApprovalScopeKey({
-        pluginRoot: entry.pluginRoot,
-        channel: entry.channel,
-        accountId: entry.accountId,
-      }) === key,
-  );
-}
-
-function addPersistentApproval(entry: PluginBindingApprovalEntry): void {
-  // Persist before publishing the grant: a failed SQLite write must not leave the
-  // cache auto-approving later binds with permission that never reached disk.
-  persistApprovalEntry(entry);
-  const key = buildApprovalScopeKey(entry);
-  const approvals = getApprovals().approvals.filter(
-    (existing) =>
-      buildApprovalScopeKey({
-        pluginRoot: existing.pluginRoot,
-        channel: existing.channel,
-        accountId: existing.accountId,
-      }) !== key,
-  );
-  approvals.push(entry);
-  pluginBindingGlobalState.approvalsCache = { approvals };
 }
 
 function buildBindingMetadata(params: {
@@ -641,10 +501,6 @@ function buildPendingReply(request: PendingPluginBindingRequest): ReplyPayload {
   };
 }
 
-function encodeCustomIdValue(value: string): string {
-  return encodeURIComponent(value);
-}
-
 function decodeCustomIdValue(value: string): string {
   try {
     return decodeURIComponent(value);
@@ -658,7 +514,7 @@ export function buildPluginBindingApprovalCustomId(
   decision: PluginBindingApprovalDecision,
 ): string {
   const decisionCode = decision === "allow-once" ? "o" : decision === "allow-always" ? "a" : "d";
-  return `${PLUGIN_BINDING_CUSTOM_ID_PREFIX}:${encodeCustomIdValue(approvalId)}:${decisionCode}`;
+  return `${PLUGIN_BINDING_CUSTOM_ID_PREFIX}:${encodeURIComponent(approvalId)}:${decisionCode}`;
 }
 
 export function parsePluginBindingApprovalCustomId(
@@ -711,11 +567,8 @@ export async function requestPluginConversationBinding(params: {
     if (state.isLegacyForeignBinding) {
       logPluginBindingLifecycleEvent({
         event: "migrating legacy record",
-        pluginId: params.pluginId,
-        pluginRoot: params.pluginRoot,
-        channel: state.ref.channel,
-        accountId: state.ref.accountId,
-        conversationId: state.ref.conversationId,
+        identity: params,
+        conversation: state.ref,
       });
     } else {
       return {
@@ -749,11 +602,8 @@ export async function requestPluginConversationBinding(params: {
     });
     logPluginBindingLifecycleEvent({
       event: state.binding ? "auto-refresh" : "auto-approved",
-      pluginId: params.pluginId,
-      pluginRoot: params.pluginRoot,
-      channel: state.ref.channel,
-      accountId: state.ref.accountId,
-      conversationId: state.ref.conversationId,
+      identity: params,
+      conversation: state.ref,
     });
     return { status: "bound", binding: bound };
   }
@@ -772,11 +622,8 @@ export async function requestPluginConversationBinding(params: {
   addPendingPluginBindingRequest(request);
   logPluginBindingLifecycleEvent({
     event: "requested",
-    pluginId: params.pluginId,
-    pluginRoot: params.pluginRoot,
-    channel: state.ref.channel,
-    accountId: state.ref.accountId,
-    conversationId: state.ref.conversationId,
+    identity: params,
+    conversation: state.ref,
   });
   return {
     status: "pending",
@@ -807,11 +654,8 @@ export async function detachPluginConversationBinding(params: {
   });
   logPluginBindingLifecycleEvent({
     event: "detached",
-    pluginId: binding.pluginId,
-    pluginRoot: binding.pluginRoot,
-    channel: binding.channel,
-    accountId: binding.accountId,
-    conversationId: binding.conversationId,
+    identity: binding,
+    conversation: binding,
   });
   return { removed: true };
 }
@@ -845,11 +689,8 @@ export async function resolvePluginConversationBindingApproval(params: {
     });
     logPluginBindingLifecycleEvent({
       event: "denied",
-      pluginId: request.pluginId,
-      pluginRoot: request.pluginRoot,
-      channel: request.conversation.channel,
-      accountId: request.conversation.accountId,
-      conversationId: request.conversation.conversationId,
+      identity: request,
+      conversation: request.conversation,
     });
     return { status: "denied", request };
   }
@@ -865,12 +706,9 @@ export async function resolvePluginConversationBindingApproval(params: {
   });
   logPluginBindingLifecycleEvent({
     event: "approved",
-    pluginId: request.pluginId,
-    pluginRoot: request.pluginRoot,
+    identity: request,
+    conversation: request.conversation,
     decision: params.decision,
-    channel: request.conversation.channel,
-    accountId: request.conversation.accountId,
-    conversationId: request.conversation.conversationId,
   });
   dispatchPluginConversationBindingResolved({
     status: "approved",


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Plugin conversation binding combines durable approval state, pending request lifetime, and routing in a grandfathered oversized module. This is the maintainer-requested deletion and suppression-debt follow-up to the #135868 split campaign.

## Why This Change Was Made

Separate the existing approval store/cache and shared outage-notice state into one lifecycle state module. Remove redundant approval-scope projections, pass typed identity/conversation objects to the private lifecycle logger, and inline its single-use URI encoder wrapper.

The SQLite queries, transaction boundaries, cache representation, global singleton key, and persist-before-cache-publication ordering are unchanged. This is the first of two small splits; the pending-request lifetime owner still needs extraction before the original module can lose its max-lines suppression.

## User Impact

No behavior or public API changes. Production shrinks by 25 lines (164 added / 189 removed); tests and tooling are unchanged. Relocated code is included in both sides of that count. Legacy session-key migration remains because it is present in shipped v2026.9.2; history tracks the recognition through e357203be57.

## Evidence

Existing boundary tests protect root/channel/account approval scope, failed SQLite writes before cache publication, overlapping grants, rows outside the cache, duplicate module instances, and lifecycle drains. No tests or assertions were removed.

Validation: 38 focused tests passed across conversation-binding, its SQLite boundary suite, and global-singleton lifecycle tests. Full `node scripts/check-changed.mjs` exited 0, including core/core-test typechecks, lint, storage guards, all three dead-export scans, and zero runtime import cycles. Independent Codex review against the pinned merge base: scoped-clean through P2. `git diff --check` passed.

ClawSweeper reviewed exact head `f0adcd63b2aba7e74067e5afe6ead1dc9c867b7c`: no actionable correctness/security findings and no before-merge or rank-up requests.
