### PR TITLE
fix(cron): surface skipped on-exit payloads when jobs are busy

### DIFF
--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -1,3 +1,4 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -18,6 +19,7 @@ import {
   PlatformMessageNotDispatchedError,
 } from "../infra/outbound/deliver-types.js";
 import { resolveSystemEventOptionsOwnerAgentId } from "../infra/system-event-ownership.js";
+import { flushLogger, resetLogger, setLoggerOverride } from "../logging/logger.js";
 import {
   getActiveGatewayRootWorkCount,
   resetGatewayWorkAdmission,
@@ -1178,6 +1180,93 @@ describe("buildGatewayCronService", () => {
       resetGatewayWorkAdmission();
     }
   });
+
+  it.each(["main", "isolated"] as const)(
+    "records a watched exit rejected behind an active %s run",
+    async (sessionTarget) => {
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), "cron-exit-admission-"));
+      const logFile = path.join(tempDir, "gateway.log");
+      setLoggerOverride({ file: logFile, level: "warn" });
+      const commandExit = createDeferred<RunExit>();
+      const predecessorStarted = createDeferred();
+      const predecessorRelease = createDeferred();
+      const holdPredecessor = async () => {
+        predecessorStarted.resolve();
+        await predecessorRelease.promise;
+      };
+      if (sessionTarget === "main") {
+        runHeartbeatOnceMock.mockImplementationOnce(async () => {
+          await holdPredecessor();
+          return { status: "ran", durationMs: 1 };
+        });
+      } else {
+        runCronIsolatedAgentTurnMock.mockImplementationOnce(async () => {
+          await holdPredecessor();
+          return { status: "ok", summary: "manual run finished" };
+        });
+      }
+      const spawn = vi.fn(async () => ({
+        runId: "watched-exit-admission",
+        startedAtMs: Date.now(),
+        cancel: vi.fn(),
+        wait: () => commandExit.promise,
+      }));
+      getProcessSupervisorMock.mockReturnValue({ spawn, cancelScope: vi.fn() });
+      const state = loadCronService(createCronConfig(`cron-exit-admission-${sessionTarget}`));
+      let predecessor: ReturnType<typeof state.cron.run> | undefined;
+
+      try {
+        const job = await addCronJob(
+          state,
+          "watch command while manually running",
+          sessionTarget === "main"
+            ? { kind: "systemEvent", text: "manual prompt" }
+            : { kind: "agentTurn", message: "manual prompt" },
+          {
+            schedule: { kind: "on-exit", command: "true" },
+            sessionTarget,
+            wakeMode: "now",
+            deleteAfterRun: false,
+          },
+        );
+        await state.reconcileExitWatchers();
+        predecessor = state.cron.run(job.id, "force");
+        await predecessorStarted.promise;
+        commandExit.resolve(runExit({ reason: "exit", exitCode: 3, stdout: "watched result" }));
+
+        await vi.waitFor(async () => {
+          await flushLogger();
+          expect(await readFile(logFile, "utf8")).toContain("already-running");
+        });
+        expect(state.cron.getJob(job.id)?.enabled).toBe(false);
+        predecessorRelease.resolve();
+        await expect(predecessor).resolves.toEqual({ ok: true, ran: true });
+        await flushLogger();
+        const recorded = await readFile(logFile, "utf8");
+        expect(recorded).toContain(job.id);
+        expect(recorded).toContain("Exit code: 3");
+        expect(recorded).toContain("watched result");
+        expect(runHeartbeatOnceMock).toHaveBeenCalledTimes(sessionTarget === "main" ? 1 : 0);
+        expect(runCronIsolatedAgentTurnMock).toHaveBeenCalledTimes(
+          sessionTarget === "isolated" ? 1 : 0,
+        );
+        expect(state.cron.getJob(job.id)?.state).toMatchObject(
+          sessionTarget === "main"
+            ? { lastRunStatus: "ok" }
+            : { lastRunStatus: "error", lastError: "Cron job disabled by operator." },
+        );
+        expect(spawn).toHaveBeenCalledOnce();
+      } finally {
+        predecessorRelease.resolve();
+        commandExit.resolve(runExit());
+        await predecessor;
+        await state.cron.stopAndDrain?.();
+        resetLogger();
+        setLoggerOverride(null);
+        await rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it.each(["update", "updateWithPrecondition", "add"] as const)(
     "honors an explicit %s disable while terminal persistence is settling",
@@ -4120,7 +4209,7 @@ describe("buildGatewayCronService", () => {
 });
 
 describe("fireOnExitJob (on-exit fire routing)", () => {
-  type ForceRunMock = (jobId: string, payload?: CronJob["payload"]) => Promise<void>;
+  type ForceRunMock = Parameters<typeof fireOnExitJob>[2]["run"];
 
   const job = (payload: unknown, extra: Partial<CronJob> = {}): CronJob =>
     ({ id: "job-x", payload, ...extra }) as unknown as CronJob;
@@ -4134,7 +4223,7 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
   };
 
   it("executes an agentTurn payload via the force-run path", async () => {
-    const run = vi.fn<ForceRunMock>(async () => {});
+    const run = vi.fn<ForceRunMock>(async () => ({ ok: true, ran: true }));
     await fireOnExitJob(job({ kind: "agentTurn", message: "go" }), exit, {
       run,
     });
@@ -4149,7 +4238,7 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
   });
 
   it("executes a command payload via the force-run path", async () => {
-    const run = vi.fn<ForceRunMock>(async () => {});
+    const run = vi.fn<ForceRunMock>(async () => ({ ok: true, ran: true }));
     await fireOnExitJob(job({ kind: "command", argv: ["echo", "hi"] }), exit, {
       run,
     });
@@ -4157,7 +4246,7 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
   });
 
   it("executes a systemEvent payload via the force-run path", async () => {
-    const run = vi.fn<ForceRunMock>(async () => {});
+    const run = vi.fn<ForceRunMock>(async () => ({ ok: true, ran: true }));
     await fireOnExitJob(
       job({ kind: "systemEvent", text: "done" }, { sessionKey: "sk-1", agentId: "agent-1" }),
       exit,
@@ -4172,5 +4261,15 @@ describe("fireOnExitJob (on-exit fire routing)", () => {
     });
     expect(run.mock.calls[0]?.[0]).toBe("job-x");
   });
+
+  it.each(["already-running", "stopped"] as const)(
+    "rejects %s admission so the watcher records the failed handoff",
+    async (reason) => {
+      const run = vi.fn<ForceRunMock>(async () => ({ ok: true, ran: false, reason }));
+      await expect(
+        fireOnExitJob(job({ kind: "systemEvent", text: "done" }), exit, { run }),
+      ).rejects.toThrow(reason);
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -105,6 +105,7 @@ import {
 } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import { truncateUtf16WithEllipsis } from "../shared/text-truncate.js";
 import { bumpSkillsSnapshotVersion } from "../skills/runtime/refresh-state.js";
 import { resolveSkillWorkshopConfig } from "../skills/workshop/config.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
@@ -172,17 +173,6 @@ function formatOnExitRunSummary(exit: CronExitResult): string {
   return output ? `${lines.join("\n")}\n\nOutput:\n${output}` : lines.join("\n");
 }
 
-function addOnExitRunSummary(payload: CronPayload, exit: CronExitResult): CronPayload {
-  const summary = formatOnExitRunSummary(exit);
-  if (payload.kind === "systemEvent") {
-    return { ...payload, text: `${payload.text}\n\n${summary}` };
-  }
-  if (payload.kind === "agentTurn") {
-    return { ...payload, message: `${payload.message}\n\n${summary}` };
-  }
-  return payload;
-}
-
 /**
  * On-exit jobs use the normal force-run path so every payload kind records
  * run state, history, notifications, and delivery outcomes consistently.
@@ -191,11 +181,25 @@ export async function fireOnExitJob(
   job: CronJob,
   exit: CronExitResult,
   deps: {
-    run: (jobId: string, payload?: CronPayload) => Promise<unknown>;
+    run: (jobId: string, payload?: CronPayload) => ReturnType<CronService["run"]>;
   },
 ): Promise<void> {
-  const payload = addOnExitRunSummary(job.payload, exit);
-  await deps.run(job.id, payload === job.payload ? undefined : payload);
+  const summary = formatOnExitRunSummary(exit);
+  const payload = job.payload;
+  const runPayload =
+    payload.kind === "systemEvent"
+      ? { ...payload, text: `${payload.text}\n\n${summary}` }
+      : payload.kind === "agentTurn"
+        ? { ...payload, message: `${payload.message}\n\n${summary}` }
+        : undefined;
+  const result = await deps.run(job.id, runPayload);
+  if (!result.ok || !("ran" in result && result.ran)) {
+    // Retiring a one-shot must not hide refused admission behind a fulfilled callback.
+    // Keep bounded terminal evidence in the watcher's existing failure log.
+    const reason = "reason" in result ? result.reason : "run did not start";
+    const evidence = truncateUtf16WithEllipsis(summary, 2_000);
+    throw new Error(`cron on-exit run was not admitted: ${reason}\n\n${evidence}`);
+  }
 }
 
 /** Fire one source batch through the normal trigger and payload pipeline. */


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators watching a command with an `on-exit` automation could lose the completion payload without a recorded explanation when another invocation of the same job was still running. A manual main-session run could subsequently finish successfully, leaving no indication that the watched command's completion payload was refused.

## Why This Change Was Made

The exit handoff discarded the cron service's non-run result and treated a fulfilled callback as an admitted run. It now consumes the typed disposition and passes refusals to the watcher's existing warning path, while preparing the payload and terminal summary in one place instead of using object identity to detect an override.

## User Impact

Gateway logs identify the refused on-exit attempt with its admission reason, watched command exit code and termination reason, and a bounded command-output summary. The one-shot stays disabled, and refused work is not queued for replay. Successful firing, normal manual-run admission, existing cancellation and suspension behavior, and run-history semantics stay unchanged.

## Evidence

- Reproduced against `b6a2e5b4eff71070a02e755d55aea0dd53904a20`: start and hold a manual invocation, let the watched command finish, then release the manual invocation. The actual service returned `already-running`, the watcher retired, and the manual heartbeat completed successfully without a separate refusal record.
- All four new regressions failed before the runtime change: real service/watcher cases for active main and isolated runs lacked the warning, and `already-running`/`stopped` callback cases incorrectly fulfilled.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-cron.test.ts src/gateway/cron-exit-watchers.test.ts` passed all 145 tests on Node 24.19.0. The suite includes normal payload firing, refusal, drain fencing, explicit disable, handoff/replacement, cancellation, and one-shot restart coverage.
- An isolated macOS process proof used the real cron service, exit watcher, supervised shell child, and Gateway file logger with a controlled heartbeat dependency. A command exiting with code 3 and `watched-done` output produced the refusal below; it remained recorded after the manual heartbeat finished successfully. The owned child settled and all temporary state was removed. This was scheduler/process/logger boundary proof, not a live provider or full HTTP/WebSocket Gateway test.
- Managed independent autoreview returned `scoped-clean` through P2 with no findings. Formatting and `git diff --check` passed. [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/34025033021/attempts/2) completed successfully, including the retried test shard and `openclaw/ci-gate`.

```text
cron-exit: fireOnExit after exit failed
Error: cron on-exit run was not admitted: already-running

Watched command finished.
Exit code: 3
Reason: exit

Output:
watched-done
```

Production changes are +18/-14 (net +4); tests are +103/-4. The four additional production lines provide the typed refusal check and bounded diagnostic evidence after removing the single-use payload helper and its identity sentinel. No queue, retry, configuration, schema, or persistent-state design is added.


The first CI attempt hit a 60-second child-process timeout in the unchanged managed-update handoff test. On the exact CI merge checkout, a private frozen install and the targeted test-runtime build supported the original isolated case: it passed in 2.27 seconds on macOS with the same timeout and journal/tree assertions. One authorized unchanged-head retry then passed in Linux CI. The initial timeout is retained as a historical failure; its Linux/load cause is not claimed fixed. No additional code change or timeout increase was made.
