### PR TITLE
fix(gateway): preserve empty client tool completions

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -226,6 +226,8 @@ If `stream_options.include_usage=true`, a trailing usage chunk is emitted before
 
 After receiving `tool_calls`, execute the requested function(s) and send a follow-up request that includes the prior assistant tool-call message plus one or more `role: "tool"` messages with matching `tool_call_id`. This continues the same agent reasoning loop to produce the final answer.
 
+If a tool produces no text, still include its result with `content: ""` or an empty text-part array. An empty result completes the call; omitting the result does not. Legacy `role: "function"` results may use `content: null` with their function `name`.
+
 ## Streaming (SSE)
 
 Streaming preserves repeated content from separate assistant messages. If a correction cannot be represented by appending to text already sent, the stream reports an error rather than completing with inconsistent content.

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -102,6 +102,8 @@ Provide tools with `tools: [{ type: "function", name, description?, parameters? 
 
 If the agent calls a tool, the response returns a `function_call` output item. Send a follow-up request with `function_call_output` to continue the turn.
 
+If a tool produces no text, return `output: ""` with its `call_id`. The empty result still completes that tool call and can be the only new input item in a continuation.
+
 Clients that manage their own history can append `response.output` to `input`, then append new user messages or `function_call_output` items. Keep returned assistant metadata and function-call IDs, names, and arguments unchanged. Alternatively, supply `previous_response_id` and only the new input items.
 
 For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client function-tool set, instructs the runtime to call a client tool before responding, and rejects the turn if it does not include a matching structured client-tool call, matching the `/v1/chat/completions` contract. Non-streaming requests return `502` with an `api_error`; streaming requests emit a `response.failed` event.

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -80,7 +80,8 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
   if (!currentPromptEntry) {
     return "";
   }
-  if (historyEntries.length === 0) {
+  // A completed tool call still needs its identity when its output is empty.
+  if (historyEntries.length === 0 && currentConversationEntry.role !== "tool") {
     return currentPromptEntry.body;
   }
 

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -185,6 +185,127 @@ function firstAgentCommandOptions() {
 }
 
 describe("OpenAI-compatible HTTP API (e2e)", () => {
+  it.each(
+    (
+      [
+        { name: "empty string", result: { role: "tool", tool_call_id: "call_1", content: "" } },
+        { name: "whitespace", result: { role: "tool", tool_call_id: "call_1", content: " \n " } },
+        { name: "empty array", result: { role: "tool", tool_call_id: "call_1", content: [] } },
+        {
+          name: "empty text part",
+          result: { role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: "" }] },
+        },
+        { name: "legacy empty string", result: { role: "function", name: "lookup", content: "" } },
+        { name: "legacy null", result: { role: "function", name: "lookup", content: null } },
+      ] satisfies Array<{
+        name: string;
+        result: OpenAI.ChatCompletionToolMessageParam | OpenAI.ChatCompletionFunctionMessageParam;
+      }>
+    ).flatMap(({ name, result }) => [false, true].map((stream) => ({ name, result, stream }))),
+  )("continues a client tool result with $name (stream=$stream)", async ({ result, stream }) => {
+    agentCommandMock.mockClear();
+    agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "Lookup completed." }] } as never);
+    const client = createOpenAiChatClient(enabledPort);
+    const request = {
+      model: "openclaw",
+      messages: [
+        { role: "user", content: "Check the account." },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "lookup", arguments: "{}" },
+            },
+          ],
+        },
+        result,
+      ] satisfies OpenAI.ChatCompletionMessageParam[],
+    };
+    const response = stream
+      ? await client.chat.completions.stream(request).finalChatCompletion()
+      : await client.chat.completions.create(request);
+    expect(response.choices[0]?.message.content).toBe("Lookup completed.");
+    expect(response.choices[0]?.finish_reason).toBe("stop");
+    expect(agentCommandMock).toHaveBeenCalledTimes(1);
+    const message = firstAgentCommandOptions()?.message;
+    expect(message).toContain("tool_call id=call_1 name=lookup arguments={}");
+    expect(message?.split(CURRENT_MESSAGE_MARKER)[1]).toBe(
+      `\nTool:${result.role === "function" ? result.name : result.tool_call_id}: `,
+    );
+  });
+
+  it.each([false, true])(
+    "preserves each parallel client tool result (emptyFirst=%s)",
+    async (emptyFirst) => {
+      agentCommandMock.mockClear();
+      agentCommandMock.mockResolvedValueOnce({
+        payloads: [{ text: "Both lookups completed." }],
+      } as never);
+      const results: OpenAI.ChatCompletionToolMessageParam[] = [
+        { role: "tool", tool_call_id: "call_1", content: "" },
+        { role: "tool", tool_call_id: "call_2", content: "0" },
+      ];
+      const response = await createOpenAiChatClient(enabledPort).chat.completions.create({
+        model: "openclaw",
+        messages: [
+          { role: "user", content: "Compare the accounts." },
+          {
+            role: "assistant",
+            content: null,
+            tool_calls: ["call_1", "call_2"].map((id) => ({
+              id,
+              type: "function",
+              function: { name: "lookup", arguments: "{}" },
+            })),
+          },
+          ...(emptyFirst ? results : results.toReversed()),
+        ],
+      });
+      expect(response.choices[0]?.message.content).toBe("Both lookups completed.");
+      const message = firstAgentCommandOptions()?.message;
+      expect(message).toContain("Tool:call_1: ");
+      expect(message).toContain("Tool:call_2: 0");
+      expect(message?.split(CURRENT_MESSAGE_MARKER)[1]).toBe(
+        emptyFirst ? "\nTool:call_2: 0" : "\nTool:call_1: ",
+      );
+    },
+  );
+
+  it.each([
+    { role: "tool", tool_call_id: "call_1" },
+    { role: "tool", tool_call_id: "call_1", content: null },
+    { role: "tool", tool_call_id: "call_1", content: 0 },
+    { role: "tool", tool_call_id: "call_1", content: {} },
+    { role: "tool", tool_call_id: "call_1", content: [null] },
+    { role: "tool", tool_call_id: "call_1", content: [{}] },
+    { role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: 0 }] },
+    { role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: "" }, {}] },
+    { role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: " \n " }, {}] },
+    { role: "tool", content: "" },
+    { role: "tool", tool_call_id: " ", content: "" },
+    { role: "function", name: "lookup" },
+    { role: "function", name: "lookup", content: [] },
+    { role: "function", name: "lookup", content: [{ type: "text", text: "" }] },
+    { role: "function", content: null },
+    { role: "user", content: "" },
+    { role: "assistant", content: "" },
+  ])(
+    "does not invent a client tool result for malformed or missing content: %j",
+    async (message) => {
+      agentCommandMock.mockClear();
+      const response = await postChatCompletions(enabledPort, {
+        model: "openclaw",
+        messages: [message],
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: { type: "invalid_request_error" } });
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    },
+  );
+
   it("binds the Gateway lifecycle resolver to chat-completion runs", async () => {
     const started = await startGatewayServerWithRetries({
       port: await getGatewayTestPort(),

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -410,34 +410,27 @@ function asMessages(val: unknown): OpenAiChatMessage[] {
   return Array.isArray(val) ? (val as OpenAiChatMessage[]) : [];
 }
 
-function extractTextContent(content: unknown): string {
+function extractTextContent(content: unknown): string | undefined {
   if (typeof content === "string") {
     return content;
   }
   if (Array.isArray(content)) {
-    return content
-      .map((part) => {
-        if (!part || typeof part !== "object") {
-          return "";
-        }
-        const type = (part as { type?: unknown }).type;
-        const text = (part as { text?: unknown }).text;
-        const inputText = (part as { input_text?: unknown }).input_text;
-        if (type === "text" && typeof text === "string") {
-          return text;
-        }
-        if (type === "input_text" && typeof text === "string") {
-          return text;
-        }
-        if (typeof inputText === "string") {
-          return inputText;
-        }
-        return "";
-      })
-      .filter(Boolean)
-      .join("\n");
+    const parts = content.map((part) => {
+      if (!part || typeof part !== "object") {
+        return undefined;
+      }
+      const type = (part as { type?: unknown }).type;
+      const text = (part as { text?: unknown }).text;
+      const inputText = (part as { input_text?: unknown }).input_text;
+      if ((type === "text" || type === "input_text") && typeof text === "string") {
+        return text;
+      }
+      return typeof inputText === "string" ? inputText : undefined;
+    });
+    const text = parts.filter(Boolean).join("\n");
+    return text.trim() || parts.every((part) => part !== undefined) ? text : undefined;
   }
-  return "";
+  return undefined;
 }
 
 function stringifyToolCallArguments(value: unknown): string {
@@ -646,7 +639,9 @@ function buildAgentPrompt(
       continue;
     }
     const role = normalizeOptionalString(msg.role) ?? "";
-    const content = extractTextContent(msg.content).trim();
+    const content = (
+      role === "function" && msg.content === null ? "" : extractTextContent(msg.content)
+    )?.trim();
     if (!role) {
       continue;
     }
@@ -677,12 +672,18 @@ function buildAgentPrompt(
     const messageContent = [baseMessageContent, assistantToolCallsSummary]
       .filter((part): part is string => Boolean(part))
       .join("\n");
-    if (!messageContent) {
+    const name = normalizeOptionalString(msg.name) ?? "";
+    const toolCallId = normalizeOptionalString(msg.tool_call_id) ?? "";
+    // Empty output completes a named call; absent or malformed content does not.
+    const isToolResult =
+      normalizedRole === "tool" &&
+      Boolean(role === "function" ? name : toolCallId) &&
+      content !== undefined &&
+      (role !== "function" || typeof msg.content === "string" || msg.content === null);
+    if (!messageContent && !isToolResult) {
       continue;
     }
 
-    const name = normalizeOptionalString(msg.name) ?? "";
-    const toolCallId = normalizeOptionalString(msg.tool_call_id) ?? "";
     const sender =
       normalizedRole === "assistant"
         ? "Assistant"

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -3484,50 +3484,83 @@ describe("OpenResponses HTTP API (e2e)", () => {
     },
   );
 
-  it("reuses the prior session when previous_response_id is provided", async () => {
-    const port = enabledPort;
-    agentCommandMock.mockClear();
-    agentCommandMock.mockResolvedValueOnce({
-      payloads: [{ text: "Let me check that." }],
-      meta: {
-        stopReason: "tool_calls",
-        pendingToolCalls: [
-          {
-            id: "call_1",
-            name: "get_weather",
-            arguments: '{"city":"Taipei"}',
-          },
-        ],
-      },
-    } as never);
+  it.each([
+    { stream: false, output: "" },
+    { stream: true, output: "" },
+    { stream: false, output: " \n " },
+    { stream: true, output: "0" },
+    { stream: false, output: "Sunny, 70F." },
+  ])(
+    "continues a client tool result (stream=$stream, output=$output)",
+    async ({ stream, output }) => {
+      const port = enabledPort;
+      const client = new OpenAI({
+        apiKey: "test",
+        baseURL: `http://127.0.0.1:${port}/v1`,
+        defaultHeaders: { "x-openclaw-scopes": "operator.write" },
+        maxRetries: 0,
+      });
+      agentCommandMock.mockClear();
+      agentCommandMock.mockResolvedValueOnce({
+        payloads: [{ text: "Let me check that." }],
+        meta: {
+          stopReason: "tool_calls",
+          pendingToolCalls: [
+            {
+              id: "call_1",
+              name: "get_weather",
+              arguments: '{"city":"Taipei"}',
+            },
+          ],
+        },
+      } as never);
 
-    const firstResponse = await postResponses(port, {
-      stream: false,
-      model: "openclaw",
-      input: "check the weather",
-      tools: WEATHER_TOOL,
-    });
-    expect(firstResponse.status).toBe(200);
-    const firstJson = (await firstResponse.json()) as { id?: string };
-    const firstOpts = firstAgentOpts() as { sessionKey?: string } | undefined;
-    expect(firstJson.id).toMatch(/^resp_/);
-    const firstSessionKey = requireSessionKey(firstOpts?.sessionKey, "first response");
+      const firstJson = await client.responses.create({
+        stream: false,
+        model: "openclaw",
+        input: "check the weather",
+        tools: [{ ...WEATHER_TOOL[0], parameters: {}, strict: false }],
+      });
+      expect(firstJson.status).toBe("completed");
+      const firstOpts = firstAgentOpts() as { sessionKey?: string } | undefined;
+      expect(firstJson.id).toMatch(/^resp_/);
+      const firstSessionKey = requireSessionKey(firstOpts?.sessionKey, "first response");
 
-    agentCommandMock.mockResolvedValueOnce({
-      payloads: [{ text: "It is sunny." }],
-    } as never);
+      agentCommandMock.mockResolvedValueOnce({
+        payloads: [{ text: "It is sunny." }],
+      } as never);
 
-    const secondResponse = await postResponses(port, {
-      stream: false,
-      model: "openclaw",
-      previous_response_id: firstJson.id,
-      input: [{ type: "function_call_output", call_id: "call_1", output: "Sunny, 70F." }],
-    });
-    expect(secondResponse.status).toBe(200);
-    const secondOpts = firstAgentOpts(1) as { sessionKey?: string } | undefined;
-    expect(secondOpts?.sessionKey).toBe(firstSessionKey);
-    await ensureResponseConsumed(secondResponse);
-  });
+      const request = {
+        model: "openclaw",
+        previous_response_id: firstJson.id,
+        input: [{ type: "function_call_output" as const, call_id: "call_1", output }],
+      };
+      const secondResponse = stream
+        ? await client.responses.stream(request).finalResponse()
+        : await client.responses.create(request);
+      expect(secondResponse.status).toBe("completed");
+      expect(secondResponse.output_text).toBe("It is sunny.");
+      expect(agentCommandMock).toHaveBeenCalledTimes(2);
+      expect(firstAgentOpts(1)).toMatchObject({
+        sessionKey: firstSessionKey,
+        message: `Tool:call_1: ${output}`,
+      });
+    },
+  );
+
+  it.each([undefined, null, 0, {}, []].map((output) => ({ output })))(
+    "rejects malformed function output: %j",
+    async ({ output }) => {
+      agentCommandMock.mockClear();
+      const response = await postResponses(enabledPort, {
+        model: "openclaw",
+        input: [{ type: "function_call_output", call_id: "call_1", output }],
+      });
+      expect(response.status).toBe(400);
+      expect(await response.json()).toMatchObject({ error: { type: "invalid_request_error" } });
+      expect(agentCommandMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("reuses prior sessions across different user values when auth scope matches", async () => {
     const port = enabledPort;


### PR DESCRIPTION
Closes #139975. Related: #131197.

## What Problem This Solves

Fixes an issue where clients returning a valid empty tool output would replay the previous question through Chat Completions or receive HTTP 400 through Responses. A sole nonempty tool output also lost its call identity in the current-message projection.

## Why This Change Was Made

Current tool results now use the existing sender-aware conversation formatter even when no history accompanies them. Chat's input extractor distinguishes recognized empty text from missing/malformed content and preserves valid empty completions with their correlation ID. The separately nullable legacy function result keeps its named contract.

This reuses the canonical projection instead of adding placeholder prose, retries or a parallel tool-result path. Production is **+30/−28 (net +2)**, tests **+195/−41 (net +154)**, and docs **+4**. No new configuration, dependency, schema, stored format, public protocol or SDK export is introduced.

## User Impact

Empty tool completions reach the agent as the current identified tool result. Chat history, parallel result ordering, Responses `previous_response_id`, JSON and streaming flows retain the completion instead of silently dropping it.

Input validation policy stays bounded: Chat skips malformed/null modern tool entries and rejects only when no usable prompt/image remains; it does not globally reject a request containing other valid history. Responses retains its existing string-only output schema and rejects malformed output fields. Explicit legacy `function` null is a valid empty result when its required name is present.

## Evidence

Exact candidate `2bfe36971a6e26daf648e8d60e3a07e88909bfef`, based on `0c74e5e040d16b16f0df979578ea4260ef66e769`.

- Before production edits: 12 Chat valid-empty HTTP/SDK cases failed while 14 malformed/missing controls passed; five corrected Responses continuation cases failed; both mixed parallel-result orders lost the empty completion. An initial Responses fixture accidentally changed authentication/session scope between requests; it was corrected to reuse the same SDK client before editing production code, and the confounded attempt is retained separately.
- **277 sibling tests passed** across the prompt and both HTTP endpoint suites, including ordinary/history/media behavior and existing cancellation/streaming cases. Five SDK continuation cases passed again after a fixture-only type correction. The full changed gate and both edited API-page checks passed.
- Fresh complete-source managed Codex review at P0–P2 returned zero findings. The supported `pnpm build ciArtifacts` runtime/UI build passed in **115.257 seconds**; artifact stamps bind the exact candidate, and all 1,227 UI manifest entries were hash-verified. Installed dependencies match the committed workspace lock, including OpenAI SDK 7.8.0.
- **Eight real built-Gateway/SDK flows passed**, with 16 actual model requests: Chat and Responses, empty/nonempty results, JSON/SSE continuations. The Gateway, OpenClaw runtime, built OpenAI plugin, client-tool pending/yield flow and session continuity were real; only the upstream model endpoint was synthetic loopback. No agent-command mock or Gateway response rewrite was used. Independent capture inspection verified returned SDK call IDs, continuation IDs and actual model current input. Responses retained the prior session input.

The existing Gateway projection sends an identified tool-result string inside the model's current `role: user` message. Empty runs reached that boundary as `Tool:<returned-call-id>:`; healthy controls retained their output after the same prefix. This proof does not claim native provider `role: tool` messages, native Codex execution, a hosted model or external-channel delivery.

The first built-runtime attempt stopped on an incorrect fixture assumption that provider call IDs survive unchanged. The existing terminal owner allocates public call IDs; the corrected driver uses the unmodified SDK-returned ID. That failure is retained, and no source change or rebuild was needed. All owned processes, listeners and runtime directories were cleaned up; source/build/dependency hashes remained unchanged.

Direct contracts were inspected in OpenAI SDK 7.8.0 and Codex's function-call-output serialization. Empty strings are valid output values; the repair preserves the distinction between empty output and missing/malformed input. Current-main inspection found the affected input projection owners, schemas and dependency pins unchanged.


Hosted CI [34025055116](https://github.com/openclaw/openclaw/actions/runs/34025055116) passed on this exact head. Native main `36330a54fb11dc30a5349659ca455f2e6a75b54d` retains identical affected projection, schema and history-owner bodies; the repair remains necessary and compatible with that current source.
