### PR TITLE
perf(tasks): avoid cloning unrelated session task history

### DIFF
--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -71,6 +71,7 @@ import {
   resetTaskFlowRegistryForTests,
   resetTaskRegistryForTests,
 } from "./task-runtime.test-helpers.js";
+import { listTasksForOwnerOrRequesterSessionKeyForStatus } from "./task-status-access.js";
 
 function createTaskRecord(params: Parameters<typeof createTaskRecordOrNull>[0]): TaskRecord {
   const task = createTaskRecordOrNull(params);
@@ -467,6 +468,55 @@ describe("task-registry store runtime", () => {
     }
     returnedDetail.push("caller mutation");
     expect(listTaskRecords()[0]?.detail).toEqual(["active detail"]);
+  });
+
+  it("selects session status tasks before cloning unrelated details", () => {
+    const sessionKey = "agent:main:cron:job:run:run-id";
+    const unrelatedDetail = { history: "unrelated task output" };
+    const base: TaskRecord = {
+      ...createStoredTask(),
+      requesterSessionKey: "other-requester",
+      ownerKey: "other-owner",
+      detail: [["selected detail"]],
+    };
+    const storedTasks: TaskRecord[] = [
+      { ...base, taskId: "older", ownerKey: sessionKey, createdAt: 50 },
+      { ...base, taskId: "owner-only", ownerKey: sessionKey },
+      { ...base, taskId: "unrelated", createdAt: 500, detail: unrelatedDetail },
+      { ...base, taskId: "requester-only", requesterSessionKey: sessionKey },
+      { ...base, taskId: "child-only", childSessionKey: sessionKey, detail: unrelatedDetail },
+      { ...base, taskId: "padded-owner", ownerKey: ` ${sessionKey} `, detail: unrelatedDetail },
+    ];
+    const saveSnapshot = vi.fn();
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({
+          tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
+          deliveryStates: new Map(),
+        }),
+        saveSnapshot,
+      },
+    });
+    expect(getTaskById("owner-only")?.taskId).toBe("owner-only");
+    const clone = vi.spyOn(globalThis, "structuredClone");
+    try {
+      const selected = listTasksForOwnerOrRequesterSessionKeyForStatus(sessionKey);
+      expect(selected.map((task) => task.taskId)).toEqual([
+        "requester-only",
+        "owner-only",
+        "older",
+      ]);
+      expect(clone).not.toHaveBeenCalledWith(unrelatedDetail);
+      const detail = selected[0]?.detail;
+      if (!Array.isArray(detail) || !Array.isArray(detail[0])) {
+        throw new Error("expected nested task detail");
+      }
+      detail[0].push("caller mutation");
+      expect(getTaskById("requester-only")?.detail).toEqual([["selected detail"]]);
+      expect(saveSnapshot).not.toHaveBeenCalled();
+    } finally {
+      clone.mockRestore();
+    }
   });
 
   it("rejects invalid persisted task enum values", () => {

--- a/src/tasks/task-status-access.ts
+++ b/src/tasks/task-status-access.ts
@@ -48,7 +48,7 @@ export function listTasksForSessionKeyForStatus(
 }
 
 export function listTasksForOwnerOrRequesterSessionKeyForStatus(sessionKey: string): TaskRecord[] {
-  return listTaskRecords().filter(
+  return listTaskRecords(
     (task) => task.requesterSessionKey === sessionKey || task.ownerKey === sessionKey,
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Generated-media replay guards and completion-required task waits spend unnecessary synchronous work copying unrelated task history. A session lookup currently clones and sorts every task before selecting matching requester/owner keys, so retained detail payloads from other sessions slow each check.

## Why This Change Was Made

Pass the same exact requester/owner predicate into the registry's existing filter-before-clone API. Selected records still receive independent nested-detail copies and retain creation-time/reverse-insertion ordering. Exact key comparison remains unchanged: child-only and whitespace-normalized matches are intentionally excluded.

This is one production-line replacement, using the existing query owner. No new API, index, cache, persistence, retention or concurrency behavior is introduced.

## User Impact

Generated-media snapshot checks, session task-status reads and completion waits avoid cloning unrelated session details. Replay guards still reread current tasks and keep their separate plugin-owned admission marker.

## Evidence

- **RED/GREEN:** the new real-registry regression fails before the fix because `structuredClone` receives unrelated task detail (six clones for six fixture records). It passes after the fix, also proving requester/owner inclusion, child-only/padded-key exclusion, equal-time ordering, nested returned-detail isolation and no store writes.
- **114 tests in seven files pass on isolated Linux Node 24.19.0**, including the actual registry, status access, paged/indexed queries, timestamp normalization, completion-required waits and cron continuation cleanup.
- An uninstrumented benchmark invokes the actual public source functions with a configured synthetic store in isolated processes on the same Testbox. With eight selected tasks among 10,000 records containing approximately 17 KiB details, median generated-media snapshot cost falls from **110.955 to 0.285 ms process CPU/call** and **64.163 to 0.261 ms wall/call**. At 2,000 records, CPU falls from **9.896 to 0.042 ms/call**. Session-status output and generated-media ID hashes remain identical at 100, 2,000 and 10,000 records. Each variant uses five trials after warmup; the baseline batch precedes the fixed batch. These are synthetic measurements, not production latency attribution.
- Independent source review and isolated Codex P2 autoreview found no actionable findings. Pinned formatter and `git diff --check` pass. The complete applicable changed check passes on isolated Linux (13m28s), and exact-head [CI 34025214349](https://github.com/openclaw/openclaw/actions/runs/34025214349) is green.

The completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/139992#issuecomment-5558403158) was read in full: no actionable findings, pre-merge requirements or Rank-up moves.
