### PR TITLE
fix(tooling): validate squash preview credit

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -305,7 +305,7 @@ Usage:
     --auto-merge selects pinned immediate squash for MERGEABLE/CLEAN, auto for MERGEABLE/BEHIND.
     OPENCLAW_PR_AUTO_MERGE=1 is equivalent.
     --body-file snapshots a regular UTF-8 file relative to the caller, replacing squash prose.
-    Empty files are valid. Human source/server co-authors are retained; known machine credit is excluded. Queue merges reject it.
+    Empty files are valid. Explicit/source co-authors and preview credit backed by PR commits are retained; known machine credit is excluded. Queue merges reject it.
     Repeated merge-run reconciles retained outcomes; it never retries an uncertain dispatch.
   scripts/pr merge-recover <PR> <OUTCOME_OID> --confirmed-operator-recovery [--replacement-head <SHA>] [--body-file <path>]
     Explicitly authorize one new attempt after inspecting the retained outcome and remote history.

--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -63,11 +63,71 @@ function isMachineCredit(line) {
   );
 }
 
-function compose({ preview, source, captured }) {
+function coauthorEmail(line) {
+  const match = /^Co-authored-by:\s*[^<>]+<([^<>\r\n]+)>$/i.exec(line);
+  if (!match) {
+    throw new Error(`Cannot validate squash preview co-author: ${JSON.stringify(line)}.`);
+  }
+  return match[1].trim().toLowerCase();
+}
+
+function removeUnsupportedPreviewCredit(preview, unsupported) {
+  if (unsupported.length === 0) {
+    return preview;
+  }
+  const lines = preview.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? [];
+  const counts = new Map();
+  for (const credit of unsupported) {
+    const normalized = credit.toLowerCase();
+    counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+  }
+  for (const [expected, count] of counts) {
+    const matches = lines.flatMap((line, index) => {
+      const text = line.replace(/\r?\n$/, "");
+      return text.toLowerCase() === expected ? [index] : [];
+    });
+    if (matches.length !== count) {
+      throw new Error("Cannot remove unsupported squash preview credit unambiguously.");
+    }
+    for (const index of matches) {
+      lines[index] = "";
+    }
+  }
+  let body = lines.join("");
+  if (trailers(body).length === 0) {
+    body = body.replace(/\r?\n\r?\n---------\r?\n(?:[ \t]*\r?\n)*$/, "");
+  }
+  return body;
+}
+
+function compose({ preview, source, authors, captured, queue }) {
   const explicit = captured !== "";
+  const sourceTrailers = source.split("\n").filter(Boolean);
+  const eligibleEmails = new Set(
+    authors
+      .split("\n")
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  for (const line of sourceTrailers) {
+    if (/^Co-authored-by:/i.test(line) && !isMachineCredit(line)) {
+      eligibleEmails.add(coauthorEmail(line));
+    }
+  }
+  const previewTrailers = trailers(preview);
+  const previewCredits = previewTrailers.filter((line) => /^Co-authored-by:/i.test(line));
+  const unsupportedPreviewCredits = previewCredits.filter(
+    (line) => !isMachineCredit(line) && !eligibleEmails.has(coauthorEmail(line)),
+  );
+  const retainedPreviewCredits = previewCredits.filter(
+    (line) => !isMachineCredit(line) && eligibleEmails.has(coauthorEmail(line)),
+  );
+  if (queue && unsupportedPreviewCredits.length > 0) {
+    throw new Error("Cannot queue a squash message with unsupported preview co-author credit.");
+  }
   let body = explicit
     ? Buffer.from(JSON.parse(captured).base64, "base64").toString("utf8")
-    : preview;
+    : removeUnsupportedPreviewCredit(preview, unsupportedPreviewCredits);
   const original = trailers(body);
   if (original.some(isMachineCredit)) {
     throw new Error(
@@ -76,8 +136,8 @@ function compose({ preview, source, captured }) {
   }
   const required = [
     ...original,
-    ...(explicit ? trailers(preview).filter((line) => /^Co-authored-by:/i.test(line)) : []),
-    ...source.split("\n").filter(Boolean),
+    ...(explicit ? retainedPreviewCredits : []),
+    ...sourceTrailers,
   ].filter((line) => !isMachineCredit(line));
   const missing = [...new Set(required)].filter((line) => !original.includes(line));
   // Keep explicit bytes, including CRLF and trailing blank lines. Insert new
@@ -98,6 +158,13 @@ function compose({ preview, source, captured }) {
     throw new Error(
       "Cannot preserve squash credit: the final message lost a source or preview trailer.",
     );
+  }
+  const excludedEmails = new Set(unsupportedPreviewCredits.map(coauthorEmail));
+  if (
+    !explicit &&
+    final.some((line) => /^Co-authored-by:/i.test(line) && excludedEmails.has(coauthorEmail(line)))
+  ) {
+    throw new Error("Cannot remove unsupported squash preview credit.");
   }
   return body;
 }

--- a/scripts/pr-lib/merge.sh
+++ b/scripts/pr-lib/merge.sh
@@ -342,12 +342,16 @@ snapshot_merge_body() {
 
 prepare_squash_merge_body() {
   local pr="$1" captured="${2:-}" source_head="${LOCAL_PREP_HEAD_SHA:-$PREP_HEAD_SHA}"
-  local source_trailers
+  local source_trailers author_emails
   # GraphQL publication can collapse local fixups. Preserve their reviewed
   # trailers, excluding main's ancestry, rather than inspecting current HEAD.
   source_trailers=$(git -c trailer.separators=: -c trailer.co-authored-by.key=Co-authored-by log --reverse \
     --no-show-signature --no-notes --no-color --no-decorate --encoding=UTF-8 \
     --format='%(trailers:key=Co-authored-by,only,unfold)' "$PR_MAIN_SHA..$source_head") || return 1
+  # A merge commit can reflect whoever refreshed the branch, not a contributor.
+  # Preview credit must be backed by a published non-merge commit or explicit trailer.
+  author_emails=$(git log --no-merges --reverse --format='%ae' "$PR_MAIN_SHA..$PREP_HEAD_SHA") ||
+    return 1
 
   local repo_nwo preview
   repo_nwo=$(gh repo view --json nameWithOwner --jq .nameWithOwner) || return 1
@@ -371,8 +375,10 @@ prepare_squash_merge_body() {
 
   local body_file
   body_file=$(mktemp .local/merge-body.XXXXXX) || return 1
-  printf '%s\n' "$preview" | jq -c --arg source "$source_trailers" --arg captured "$captured" '
-    {preview:.data.repository.pullRequest.viewerMergeBodyText,source:$source,captured:$captured}
+  printf '%s\n' "$preview" | jq -c \
+    --arg source "$source_trailers" --arg authors "$author_emails" --arg captured "$captured" \
+    --argjson queue "$queue_enabled" '
+    {preview:.data.repository.pullRequest.viewerMergeBodyText,source:$source,authors:$authors,captured:$captured,queue:$queue}
   ' | node "${BASH_SOURCE[0]%/*}/merge-body.mjs" compose > "$body_file" || return 1
   # Queue admission cannot accept an override, but its preview still needs validation.
   if [ "$queue_enabled" = true ]; then

--- a/test/scripts/pr-crabbox-merge-bypass.test.ts
+++ b/test/scripts/pr-crabbox-merge-bypass.test.ts
@@ -423,6 +423,7 @@ else if (endpoint === "graphql" && args.includes("query=query { viewer { login }
       fetch|cat-file|merge-base) exit 0;;
       merge-tree) echo candidate-tree;;
       rev-parse) echo main-tree;;
+      log) echo fixture@example.com;;
       # The trailer parser writes stdin; drain it before exit to avoid EPIPE.
       -c) cat >/dev/null; exit 0;;
       *) echo "unexpected fixture git: $*" >&2; exit 19;;

--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -41,10 +41,10 @@ const supportsNoLazyFetch =
   spawnSync("git", ["--no-lazy-fetch", "--version"], { env: gitEnv }).status === 0;
 
 function createFixtureGit(repo: string) {
-  const git = (args: string[], input?: string, cwd = repo) =>
+  const git = (args: string[], input?: string, cwd = repo, env?: NodeJS.ProcessEnv) =>
     execFileSync("git", ["-c", "commit.gpgsign=false", "-c", "core.hooksPath=/dev/null", ...args], {
       cwd,
-      env: gitEnv,
+      env: { ...gitEnv, ...env },
       input,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -54,8 +54,25 @@ function createFixtureGit(repo: string) {
     const b = git(["hash-object", "-w", "--stdin"], sibling);
     return git(["mktree"], `100644 blob ${a}\towner.txt\n100644 blob ${b}\tsibling.txt\n`);
   };
-  const commit = (contents: string, parents: string[], message = "Fixture commit\n") =>
-    git(["commit-tree", contents, ...parents.flatMap((parent) => ["-p", parent])], message);
+  const commit = (
+    contents: string,
+    parents: string[],
+    message = "Fixture commit\n",
+    author?: { name: string; email: string },
+  ) =>
+    git(
+      ["commit-tree", contents, ...parents.flatMap((parent) => ["-p", parent])],
+      message,
+      repo,
+      author
+        ? {
+            GIT_AUTHOR_NAME: author.name,
+            GIT_AUTHOR_EMAIL: author.email,
+            GIT_COMMITTER_NAME: author.name,
+            GIT_COMMITTER_EMAIL: author.email,
+          }
+        : undefined,
+    );
   return { git, tree, commit };
 }
 
@@ -78,6 +95,7 @@ function fixture(
   sourceMessage?: string,
   sourceVersions: Array<[string, string?]> = [["after\n"]],
   promisor = false,
+  sourceAuthor?: { name: string; email: string },
 ) {
   const root = realpathSync(temps.make("pr-merge-outcome-"));
   const remote = join(root, "remote.git");
@@ -96,7 +114,7 @@ function fixture(
   const sourceCommits: string[] = [];
   let head = base;
   for (const [owner, sibling] of sourceVersions) {
-    head = commit(tree(owner, sibling), [head], sourceMessage);
+    head = commit(tree(owner, sibling), [head], sourceMessage, sourceAuthor);
     sourceCommits.push(head);
   }
   git(["update-ref", "refs/heads/topic", head]);
@@ -586,7 +604,10 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
   it("snapshots corrected squash prose once and retains source and server coauthors", () => {
     const source = "Co-authored-by: Source <source@example.com>";
     const server = "Co-authored-by: Server <server@example.com>";
-    const f = fixture(`Repair\n\n${source}`);
+    const f = fixture(`Repair\n\n${source}`, undefined, false, {
+      name: "Server",
+      email: "server@example.com",
+    });
     const body = join(f.repo, "operator body.md");
     writeFileSync(body, "Partial repair. Related: #42.\n");
     f.save({

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -10,6 +10,16 @@ const headSha = "0123456789abcdef0123456789abcdef01234567";
 const describePosix = process.platform === "win32" ? describe.skip : describe;
 type BodyScenario = {
   sourceMessages?: string[];
+  sourceCommits?: Array<{
+    message: string;
+    author?: { name: string; email: string };
+  }>;
+  refreshMergeAuthor?: { name: string; email: string };
+  refreshMergeMessage?: string;
+  localFixup?: {
+    message: string;
+    author: { name: string; email: string };
+  };
   previewBody?: string | null;
   previewHead?: string;
   previewQueue?: boolean;
@@ -32,23 +42,24 @@ function prepareBody(scenario: BodyScenario) {
     writeFileSync(override, scenario.overrideBody);
   }
   let localHead = headSha;
-  if (scenario.sourceMessages) {
+  let publishedHead = headSha;
+  if (scenario.sourceMessages || scenario.sourceCommits) {
     mkdirSync(sourceRepo);
-    const git = (args: string[]) => {
+    const git = (args: string[], env?: NodeJS.ProcessEnv) => {
       const result = spawnSync(
         "git",
         [
           "-c",
-          "user.name=Fixture",
+          "user.name=Maintainer",
           "-c",
-          "user.email=fixture@example.com",
+          "user.email=maintainer@example.com",
           "-c",
           "commit.gpgsign=false",
           "-c",
           "core.hooksPath=/dev/null",
           ...args,
         ],
-        { cwd: sourceRepo, encoding: "utf8" },
+        { cwd: sourceRepo, encoding: "utf8", env: { ...process.env, ...env } },
       );
       if (result.status !== 0) {
         throw new Error(`Git fixture failed: ${result.stderr}`);
@@ -62,7 +73,20 @@ function prepareBody(scenario: BodyScenario) {
       "-qm",
       "Main change\n\nCo-authored-by: Main Only <main@example.com>",
     ]);
-    git(["update-ref", "refs/remotes/origin/main", git(["rev-parse", "HEAD"])]);
+    const base = git(["rev-parse", "HEAD"]);
+    let main = base;
+    if (scenario.refreshMergeAuthor) {
+      git(["switch", "-qc", "main-refresh"]);
+      git(["commit", "--allow-empty", "-qm", "Main refresh"], {
+        GIT_AUTHOR_NAME: "Main Author",
+        GIT_AUTHOR_EMAIL: "main@example.com",
+        GIT_COMMITTER_NAME: "Main Author",
+        GIT_COMMITTER_EMAIL: "main@example.com",
+      });
+      main = git(["rev-parse", "HEAD"]);
+      git(["switch", "-qc", "pr", base]);
+    }
+    git(["update-ref", "refs/remotes/origin/main", main]);
     if (scenario.signedSource) {
       const key = join(root, "fixture-signing-key");
       const generated = spawnSync("ssh-keygen", ["-q", "-t", "ed25519", "-N", "", "-f", key]);
@@ -73,15 +97,59 @@ function prepareBody(scenario: BodyScenario) {
       git(["config", "user.signingKey", key]);
       git(["config", "gpg.ssh.allowedSignersFile", allowedSigners]);
     }
-    for (const message of scenario.sourceMessages) {
-      git([
-        "-c",
-        `commit.gpgsign=${scenario.signedSource ?? false}`,
-        "commit",
-        "--allow-empty",
-        "-qm",
+    const sourceCommits: NonNullable<BodyScenario["sourceCommits"]> =
+      scenario.sourceCommits ??
+      scenario.sourceMessages?.map((message) => ({
         message,
-      ]);
+      })) ??
+      [];
+    for (const { message, author } of sourceCommits) {
+      git(
+        [
+          "-c",
+          `commit.gpgsign=${scenario.signedSource ?? false}`,
+          "commit",
+          "--allow-empty",
+          "-qm",
+          message,
+        ],
+        author
+          ? {
+              GIT_AUTHOR_NAME: author.name,
+              GIT_AUTHOR_EMAIL: author.email,
+              GIT_COMMITTER_NAME: author.name,
+              GIT_COMMITTER_EMAIL: author.email,
+            }
+          : undefined,
+      );
+    }
+    if (scenario.refreshMergeAuthor) {
+      const author = scenario.refreshMergeAuthor;
+      git(
+        [
+          "merge",
+          "--no-ff",
+          "-qm",
+          scenario.refreshMergeMessage ?? "Merge branch 'main' into repair",
+          main,
+        ],
+        {
+          GIT_AUTHOR_NAME: author.name,
+          GIT_AUTHOR_EMAIL: author.email,
+          GIT_COMMITTER_NAME: author.name,
+          GIT_COMMITTER_EMAIL: author.email,
+        },
+      );
+    }
+    publishedHead = git(["rev-parse", "HEAD"]);
+    if (scenario.localFixup) {
+      const { author, message } = scenario.localFixup;
+      git(["commit", "--allow-empty", "-qm", message], {
+        GIT_AUTHOR_NAME: author.name,
+        GIT_AUTHOR_EMAIL: author.email,
+        GIT_COMMITTER_NAME: author.name,
+        GIT_COMMITTER_EMAIL: author.email,
+      });
     }
     localHead = git(["rev-parse", "HEAD"]);
     if (scenario.signedSource) {
@@ -144,7 +212,7 @@ file=$(prepare_squash_merge_body 123 "$snapshot")
         : {}),
       OPENCLAW_TEST_TRAILER_MARKER: trailerMarker,
       BODY_MERGE_SCRIPT: mergeScript,
-      BODY_HEAD: headSha,
+      BODY_HEAD: publishedHead,
       BODY_LOCAL_HEAD: localHead,
       BODY_SOURCE_REPO: sourceRepo,
       BODY_OUTPUT: body,
@@ -156,7 +224,7 @@ file=$(prepare_squash_merge_body 123 "$snapshot")
         data: {
           repository: {
             pullRequest: {
-              headRefOid: scenario.previewHead ?? headSha,
+              headRefOid: scenario.previewHead ?? publishedHead,
               isMergeQueueEnabled: scenario.previewQueue ?? false,
               viewerMergeBodyText:
                 scenario.previewBody === undefined
@@ -176,6 +244,77 @@ file=$(prepare_squash_merge_body 123 "$snapshot")
 }
 
 describePosix("native squash attribution", () => {
+  it("omits preview credit backed only by a refresh merge author", () => {
+    const previewCredit = "Co-authored-by: Vincent Koc <vincent@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: "Repair",
+          author: { name: "Contributor", email: "contributor@example.com" },
+        },
+      ],
+      refreshMergeAuthor: { name: "Vincent Koc", email: "vincent@example.com" },
+      previewBody: `Repair summary\n\n---------\n\n${previewCredit}`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe("Repair summary\n");
+  });
+
+  it("retains preview credit backed by a non-merge PR commit author", () => {
+    const previewCredit = "Co-authored-by: Second Author <second@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        { message: "Repair" },
+        {
+          message: "Second repair",
+          author: { name: "Second Author", email: "SECOND@example.com" },
+        },
+      ],
+      previewBody: `Repair summary\n\n${previewCredit}`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Repair summary\n\n${previewCredit}\n`);
+  });
+
+  it("does not trust an unpublished local fixup author for preview credit", () => {
+    const previewCredit = "Co-authored-by: Local Fixup <local@example.com>";
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      localFixup: {
+        message: "Local fixup",
+        author: { name: "Local Fixup", email: "local@example.com" },
+      },
+      previewBody: `Repair summary\n\n${previewCredit}`,
+      previewQueue: true,
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("Cannot queue");
+  });
+
+  it("retains explicit source credit carried by a merge commit", () => {
+    const sourceCredit = "Co-authored-by: Merge Helper <helper@example.com>";
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      refreshMergeAuthor: { name: "Refresh Author", email: "refresh@example.com" },
+      refreshMergeMessage: `Merge branch 'main' into repair\n\n${sourceCredit}`,
+      previewBody: "Repair summary",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Repair summary\n\n${sourceCredit}\n`);
+  });
+
+  it("refuses ambiguous removal of unsupported preview credit", () => {
+    const previewCredit = "Co-authored-by: Preview Only <preview@example.com>";
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      previewBody: `${previewCredit}\n\nQuoted example.\n\n${previewCredit}`,
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("unambiguously");
+  });
+
   it.each([
     "Co-authored-by: Claude <noreply@anthropic.com>",
     "co-authored-by: Claude <NOREPLY@ANTHROPIC.COM>",
@@ -253,12 +392,30 @@ describePosix("native squash attribution", () => {
     expect(result.mergeBody).toBeNull();
   });
 
+  it("rejects queue admission when preview credit requires removal", () => {
+    const previewCredit = "Co-authored-by: Refresh Author <refresh@example.com>";
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      refreshMergeAuthor: { name: "Refresh Author", email: "refresh@example.com" },
+      previewBody: `Repair summary\n\n${previewCredit}`,
+      previewQueue: true,
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("Cannot queue");
+  });
+
   it("replaces obsolete closing prose while preserving operator, server and source credit", () => {
     const source = "Co-authored-by: Source <source@example.com>";
     const server = "Co-authored-by: Server <server@example.com>";
     const operator = "Co-authored-by: Operator <operator@example.com>";
     const result = prepareBody({
-      sourceMessages: [`Repair\n\n${source}`],
+      sourceCommits: [
+        {
+          message: `Repair\n\n${source}`,
+          author: { name: "Server", email: "server@example.com" },
+        },
+      ],
       previewBody: `Obsolete complete fix.\n\nFixes #42\n\n${server}`,
       overrideBody: `Partial repair. Related: #42.\r\n\r\n${operator}\r\n\r\n`,
     });
@@ -287,7 +444,12 @@ describePosix("native squash attribution", () => {
   it("preserves only server credit for an empty explicit body and deduplicates supplied credit", () => {
     const credit = "Co-authored-by: Server <server@example.com>";
     const result = prepareBody({
-      sourceMessages: ["Repair"],
+      sourceCommits: [
+        {
+          message: "Repair",
+          author: { name: "Server", email: "server@example.com" },
+        },
+      ],
       previewBody: `Fixes: #42\n${credit}`,
       overrideBody: "",
     });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where native squash merges could attribute a maintainer as a co-author when that person only authored a branch-refresh merge commit.

## Why This Change Was Made

Treats GitHub `viewerMergeBodyText` as presentation text. Preview co-author trailers are retained only when their email is backed by a published non-merge PR commit or an explicit source trailer; unsupported credit is removed fail-closed, and merge queues reject previews that would require mutation.

## User Impact

Maintainers can squash contributor PRs without accidentally adding themselves as co-authors, while genuine commit authors and explicit reviewed credit remain intact.

## Evidence

- Regression proved the pre-fix body retained refresh-only credit and the orphan attribution separator.
- `node scripts/run-vitest.mjs test/scripts/pr-merge.test.ts test/scripts/pr-crabbox-merge-bypass.test.ts test/scripts/pr-merge-outcome.test.ts` (325 passed)
- Post-rebase owner suite against current machine-credit handling: 52 passed
- `pnpm lint:scripts`; focused test-root oxlint; shell/Node syntax; formatting; `git diff --check`
- Autoreview: scoped clean at P2 after resolving queue, published-head, and CI fixture findings
- First exact-head CI exposed three fixture/type gaps; all were repaired and the failed surfaces passed locally. This head is awaiting fresh exact-head CI.
