### PR TITLE
refactor(native): share Gateway payload decoding

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -188,6 +188,7 @@ class SettingsScreensContrastTest {
       observe("cron-help", "Open an automation to inspect its configuration and run history.", substring = true)
     }
     composeRule.runOnIdle { route.value = SettingsRoute.Approvals }
+    // Rows can render before the independently propagated refreshing flag settles.
     composeRule.waitUntil(10_000) {
       composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty() &&
         !model.execApprovalsRefreshing.value && model.execApprovals.value
@@ -209,7 +210,8 @@ class SettingsScreensContrastTest {
     gateway.terminal = true
     composeRule.onNodeWithText("Refresh").performScrollTo().performClick()
     composeRule.waitUntil(10_000) {
-      composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isNotEmpty()
+      composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isNotEmpty() &&
+        model.execApprovals.value.isEmpty() && model.execApprovalsNotice.value?.approvalId == "approval-1"
     }
     assertTrue(model.execApprovals.value.isEmpty() && model.execApprovalsNotice.value?.approvalId == "approval-1")
     assertTrue(gateway.methods.count { it == "approval.get" } > readsBeforeRefresh)

--- a/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
+++ b/apps/ios/Sources/Chat/IOSGatewayChatTransport.swift
@@ -122,15 +122,7 @@ struct IOSGatewayChatTransport: OpenClawChatTransport {
         return OpenClawChatNewSessionRouteLease(
             listAgents: {
                 let data = try await request(OpenClawChatGatewayRequests.agentsList())
-                let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
-                return OpenClawChatAgentsListResponse(
-                    defaultId: result.defaultid,
-                    agents: result.agents.filter(\.isSelectableAgent).map {
-                        OpenClawChatAgentChoice(
-                            id: $0.id,
-                            name: $0.name,
-                            workspaceGit: $0.workspacegit)
-                    })
+                return try OpenClawChatGatewayPayloadCodec.decodeAgentsList(data)
             },
             createSession: { key, label, agentID, parentSessionKey, worktree, worktreeBaseRef in
                 let createRequest = transport.createSessionRequest(

--- a/apps/ios/Sources/Design/ColorHexSupport.swift
+++ b/apps/ios/Sources/Design/ColorHexSupport.swift
@@ -1,27 +1,15 @@
+import OpenClawKit
 import SwiftUI
 
 enum ColorHexSupport {
     static func color(fromHex raw: String?) -> Color? {
-        guard let hex = normalizedHex(raw), let value = Int(hex.dropFirst(), radix: 16) else { return nil }
+        guard let hex = GatewayUserPreferences.normalizedAccentHex(raw),
+              let value = Int(hex.dropFirst(), radix: 16)
+        else { return nil }
         let r = Double((value >> 16) & 0xFF) / 255.0
         let g = Double((value >> 8) & 0xFF) / 255.0
         let b = Double(value & 0xFF) / 255.0
         return Color(red: r, green: g, blue: b)
-    }
-
-    /// Strict #rrggbb validation (leading "#" optional); returns canonical lowercase "#rrggbb".
-    static func normalizedHex(_ raw: String?) -> String? {
-        let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let hex = (trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed).lowercased()
-        guard hex.count == 6, hex.allSatisfy({ $0.isASCII && $0.isHexDigit }) else { return nil }
-        return "#\(hex)"
-    }
-
-    /// Per-profile accent from a users.prefs.get entries payload. nil for
-    /// missing or malformed values so callers fall back to the gateway accent.
-    static func profileAccentHex(entries: [String: Any]?) -> String? {
-        self.normalizedHex(entries?["ui.accent"] as? String)
     }
 
     /// Gateway user-accent contract shared with the Control UI and talk config:
@@ -29,7 +17,7 @@ enum ColorHexSupport {
     static func gatewayUserAccentHex(configUI ui: [String: Any]?) -> String? {
         let prefs = ui?["prefs"] as? [String: Any]
         for candidate in [prefs?["accent"] as? String, ui?["seamColor"] as? String] {
-            if let hex = normalizedHex(candidate) { return hex }
+            if let hex = GatewayUserPreferences.normalizedAccentHex(candidate) { return hex }
         }
         return nil
     }

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -1651,10 +1651,7 @@ final class NodeAppModel {
                 paramsJSON: #"{"keys":["ui.accent"]}"#,
                 timeoutSeconds: 8,
                 ifCurrentRoute: sourceRoute)
-            guard let json = try JSONSerialization.jsonObject(with: res) as? [String: Any],
-                  json["status"] as? String == "ok"
-            else { return nil }
-            return ColorHexSupport.profileAccentHex(entries: json["entries"] as? [String: Any])
+            return try GatewayUserPreferences.decodeProfileAccentHex(res)
         } catch {
             return nil
         }

--- a/apps/ios/Tests/GatewayAccentColorTests.swift
+++ b/apps/ios/Tests/GatewayAccentColorTests.swift
@@ -1,24 +1,7 @@
-import Foundation
 import Testing
 @testable import OpenClaw
 
 struct GatewayAccentColorTests {
-    @Test func `normalizes bare and prefixed hex`() {
-        #expect(ColorHexSupport.normalizedHex("#A1B2C3") == "#a1b2c3")
-        #expect(ColorHexSupport.normalizedHex("a1b2c3") == "#a1b2c3")
-        #expect(ColorHexSupport.normalizedHex("  #ff0000  ") == "#ff0000")
-    }
-
-    @Test func `rejects invalid hex`() {
-        #expect(ColorHexSupport.normalizedHex(nil) == nil)
-        #expect(ColorHexSupport.normalizedHex("") == nil)
-        #expect(ColorHexSupport.normalizedHex("#fff") == nil)
-        #expect(ColorHexSupport.normalizedHex("#ff0000aa") == nil)
-        #expect(ColorHexSupport.normalizedHex("red") == nil)
-        #expect(ColorHexSupport.normalizedHex("#12345g") == nil)
-        #expect(ColorHexSupport.normalizedHex("+abcde1") == nil)
-    }
-
     @Test func `user accent wins over seam color`() {
         let ui: [String: Any] = [
             "prefs": ["accent": "#123456"],
@@ -38,16 +21,5 @@ struct GatewayAccentColorTests {
     @Test func `missing UI returns nil`() {
         #expect(ColorHexSupport.gatewayUserAccentHex(configUI: nil) == nil)
         #expect(ColorHexSupport.gatewayUserAccentHex(configUI: [:]) == nil)
-    }
-
-    @Test func `profile accent reads ui accent entry`() {
-        #expect(ColorHexSupport.profileAccentHex(entries: ["ui.accent": "#A1B2C3"]) == "#a1b2c3")
-    }
-
-    @Test func `profile accent rejects missing or malformed entries`() {
-        #expect(ColorHexSupport.profileAccentHex(entries: nil) == nil)
-        #expect(ColorHexSupport.profileAccentHex(entries: [:]) == nil)
-        #expect(ColorHexSupport.profileAccentHex(entries: ["ui.accent": "not-a-color"]) == nil)
-        #expect(ColorHexSupport.profileAccentHex(entries: ["ui.accent": 42]) == nil)
     }
 }

--- a/apps/ios/Tests/IOSGatewayChatTransportTests.swift
+++ b/apps/ios/Tests/IOSGatewayChatTransportTests.swift
@@ -136,14 +136,18 @@ struct IOSGatewayChatTransportTests {
                 @unknown default: throw URLError(.cannotParseResponse)
                 }
                 let request = try await recorder.record(data)
-                let payload = request.method == "sessions.create" ? #"{"key":"forked"}"# : #"{"entry":{}}"#
+                let payload = switch request.method {
+                case "agents.list": GatewayWebSocketTestSupport.agentCatalogPayload
+                case "sessions.create": #"{"key":"forked"}"#
+                default: #"{"entry":{}}"#
+                }
                 socket.emitReceiveSuccess(.data(Data(
                     #"{"type":"res","id":"\#(request.id)","ok":true,"payload":\#(payload)}"#.utf8)))
             }, receiveHook: { socket, receiveIndex in
                 if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
                 let hello = GatewayWebSocketTestSupport.connectOkData(
                     id: socket.snapshotConnectRequestID() ?? "connect",
-                    methods: ["sessions.patch", "sessions.delete", "sessions.create"],
+                    methods: ["agents.list", "sessions.patch", "sessions.delete", "sessions.create"],
                     capabilities: unreadAckAdvertisement == true ? ["session-unread-ack-contract"] : [])
                 guard unreadAckAdvertisement == nil else { return .data(hello) }
                 var frame = try #require(JSONSerialization.jsonObject(with: hello) as? [String: Any])
@@ -172,6 +176,27 @@ struct IOSGatewayChatTransportTests {
         } catch {
             await gateway.disconnect()
             throw error
+        }
+    }
+
+    @Test func `new session roster preserves selectable choices on its captured connection`() async throws {
+        try await self.withSessionTransport { transport, recorder in
+            let lease = try #require(await transport.acquireNewSessionRouteLease())
+            let roster = try await lease.listAgents()
+            #expect(roster == OpenClawChatAgentsListResponse(
+                defaultId: "system",
+                agents: [
+                    OpenClawChatAgentChoice(id: "zeta", name: " Zeta ", workspaceGit: true),
+                    OpenClawChatAgentChoice(id: "legacy"),
+                    OpenClawChatAgentChoice(id: "alpha", workspaceGit: false),
+                ]))
+            await transport.gateway.disconnect()
+            await #expect(throws: Error.self) {
+                _ = try await lease.listAgents()
+            }
+            let requests = await recorder.all()
+            #expect(requests.map(\.method) == ["agents.list"])
+            #expect(requests.first?.params.isEmpty == true)
         }
     }
 

--- a/apps/macos/Sources/OpenClaw/ColorHexSupport.swift
+++ b/apps/macos/Sources/OpenClaw/ColorHexSupport.swift
@@ -1,21 +1,6 @@
 import SwiftUI
 
 enum ColorHexSupport {
-    /// Strict #rrggbb validation (leading "#" optional); canonical lowercase "#rrggbb".
-    static func normalizedHex(_ raw: String?) -> String? {
-        let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return nil }
-        let hex = (trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed).lowercased()
-        guard hex.count == 6, hex.allSatisfy({ $0.isASCII && $0.isHexDigit }) else { return nil }
-        return "#\(hex)"
-    }
-
-    /// Per-profile accent from a users.prefs.get entries payload. nil for
-    /// missing or malformed values so callers fall back to the gateway accent.
-    static func profileAccentHex(entries: [String: Any]?) -> String? {
-        self.normalizedHex(entries?["ui.accent"] as? String)
-    }
-
     static func color(fromHex raw: String?) -> Color? {
         let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }

--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -777,10 +777,7 @@ final class ControlChannel {
                 params: ["keys": OpenClawKit.AnyCodable(["ui.accent"])],
                 timeoutMs: 8000,
                 ifCurrentServerLease: serverLease)
-            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  json["status"] as? String == "ok"
-            else { return nil }
-            return ColorHexSupport.profileAccentHex(entries: json["entries"] as? [String: Any])
+            return try GatewayUserPreferences.decodeProfileAccentHex(data)
         } catch {
             return nil
         }

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -1,6 +1,5 @@
 import Foundation
 import OpenClawChatUI
-import OpenClawProtocol
 
 extension MacGatewayChatTransport {
     func acquireNewSessionRouteLease() async -> OpenClawChatNewSessionRouteLease? {

--- a/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayChatTransport+SessionActions.swift
@@ -16,15 +16,7 @@ extension MacGatewayChatTransport {
         return OpenClawChatNewSessionRouteLease(
             listAgents: {
                 let data = try await request(OpenClawChatGatewayRequests.agentsList())
-                let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
-                return OpenClawChatAgentsListResponse(
-                    defaultId: result.defaultid,
-                    agents: result.agents.filter(\.isSelectableAgent).map {
-                        OpenClawChatAgentChoice(
-                            id: $0.id,
-                            name: $0.name,
-                            workspaceGit: $0.workspacegit)
-                    })
+                return try OpenClawChatGatewayPayloadCodec.decodeAgentsList(data)
             },
             createSession: { key, label, explicitAgentID, parentSessionKey, worktree, worktreeBaseRef in
                 let agentID = explicitAgentID
@@ -121,7 +113,7 @@ extension MacGatewayChatTransport {
         entryId: String) async throws -> OpenClawChatRewindResponse
     {
         let target = self.sessionTarget(for: sessionKey)
-        let request = Self.rewindSessionRequest(
+        let request = OpenClawChatGatewayRequests.rewindSession(
             sessionKey: target.sessionKey,
             agentID: target.agentID,
             entryId: entryId)
@@ -134,7 +126,7 @@ extension MacGatewayChatTransport {
         entryId: String) async throws -> OpenClawChatForkAtMessageResponse
     {
         let target = self.sessionTarget(for: sessionKey)
-        let request = Self.forkSessionAtMessageRequest(
+        let request = OpenClawChatGatewayRequests.forkAtMessage(
             sessionKey: target.sessionKey,
             agentID: target.agentID,
             entryId: entryId)
@@ -161,27 +153,5 @@ extension MacGatewayChatTransport {
             agentID: agentID ?? target.agentID,
             leafEntryId: leafEntryId)
         _ = try await self.requestSessionAction(request)
-    }
-
-    static func rewindSessionRequest(
-        sessionKey: String,
-        agentID: String?,
-        entryId: String) -> OpenClawChatGatewayRequest
-    {
-        OpenClawChatGatewayRequests.rewindSession(
-            sessionKey: sessionKey,
-            agentID: agentID,
-            entryId: entryId)
-    }
-
-    static func forkSessionAtMessageRequest(
-        sessionKey: String,
-        agentID: String?,
-        entryId: String) -> OpenClawChatGatewayRequest
-    {
-        OpenClawChatGatewayRequests.forkAtMessage(
-            sessionKey: sessionKey,
-            agentID: agentID,
-            entryId: entryId)
     }
 }

--- a/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
+++ b/apps/macos/Sources/OpenClaw/WebChatSwiftUI.swift
@@ -363,15 +363,7 @@ struct MacGatewayChatTransport: OpenClawChatTransport {
 
     func listAgents() async throws -> OpenClawChatAgentsListResponse? {
         let data = try await connection.request(OpenClawChatGatewayRequests.agentsList())
-        let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
-        return OpenClawChatAgentsListResponse(
-            defaultId: result.defaultid,
-            agents: result.agents.filter(\.isSelectableAgent).map {
-                OpenClawChatAgentChoice(
-                    id: $0.id,
-                    name: $0.name,
-                    workspaceGit: $0.workspacegit)
-            })
+        return try OpenClawChatGatewayPayloadCodec.decodeAgentsList(data)
     }
 
     func listSessionGroups() async throws -> OpenClawChatSessionGroupsResponse? {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayWebSocketTestSupport.swift
@@ -10,6 +10,18 @@ extension WebSocketTasking {
 }
 
 enum GatewayWebSocketTestSupport {
+    static let agentCatalogPayload = """
+    {
+      "defaultId": "system", "mainKey": "main", "scope": "per-agent",
+      "agents": [
+        { "id": "system", "kind": "system" },
+        { "id": "zeta", "kind": "agent", "name": " Zeta ", "workspaceGit": true },
+        { "id": "legacy" },
+        { "id": "alpha", "kind": "agent", "name": null, "workspaceGit": false }
+      ]
+    }
+    """
+
     static let identityFreeOperatorConnectOptions = GatewayConnectOptions(
         role: "operator",
         scopes: GatewayChannelActor.defaultOperatorConnectScopes,

--- a/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacGatewayChatTransportMappingTests.swift
@@ -95,13 +95,16 @@ struct MacGatewayChatTransportMappingTests {
         }
     }
 
-    @Test func `mutation lease resolves the current global agent for each request`() async throws {
+    private func withSessionTransport(
+        _ run: (MacGatewayChatTransport, RequestRecorder) async throws -> Void) async throws
+    {
         let recorder = RequestRecorder()
         let session = GatewayTestWebSocketSession(taskFactory: {
             GatewayTestWebSocketTask(sendHook: { socket, message, sendIndex in
                 guard sendIndex > 0 else { return }
                 let id = try #require(GatewayWebSocketTestSupport.requestID(from: message))
-                if GatewayWebSocketTestSupport.requestMethod(from: message)?.hasPrefix("sessions.") == true {
+                let method = try #require(GatewayWebSocketTestSupport.requestMethod(from: message))
+                if method != "health" {
                     let data: Data = switch message {
                     case let .data(value): value
                     case let .string(value): Data(value.utf8)
@@ -109,12 +112,19 @@ struct MacGatewayChatTransportMappingTests {
                     }
                     await recorder.append(data)
                 }
-                socket.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+                let payload = switch method {
+                case "agents.list": GatewayWebSocketTestSupport.agentCatalogPayload
+                case "sessions.rewind": #"{"editorText":"rewound draft"}"#
+                case "sessions.fork": #"{"sessionKey":"forked","editorText":"continued draft"}"#
+                default: #"{"ok":true}"#
+                }
+                socket.emitReceiveSuccess(.data(Data(
+                    #"{"type":"res","id":"\#(id)","ok":true,"payload":\#(payload)}"#.utf8)))
             }, receiveHook: { socket, receiveIndex in
                 if receiveIndex == 0 { return .data(GatewayWebSocketTestSupport.connectChallengeData()) }
                 return .data(GatewayWebSocketTestSupport.connectOkData(
                     id: socket.snapshotConnectRequestID() ?? "connect",
-                    methods: ["sessions.patch", "sessions.delete"],
+                    methods: ["agents.list", "sessions.patch", "sessions.delete", "sessions.rewind", "sessions.fork"],
                     capabilities: ["session-unread-ack-contract"]))
             })
         })
@@ -124,6 +134,40 @@ struct MacGatewayChatTransportMappingTests {
         do {
             _ = try await gateway.request(method: "health", params: nil)
             let transport = MacGatewayChatTransport(connection: gateway, defaultGlobalAgentID: "agent-a")
+            try await run(transport, recorder)
+            await gateway.shutdown()
+        } catch {
+            await gateway.shutdown()
+            throw error
+        }
+    }
+
+    @Test func `new session rosters preserve selectable choices on their captured connection`() async throws {
+        try await self.withSessionTransport { transport, recorder in
+            let expected = OpenClawChatAgentsListResponse(
+                defaultId: "system",
+                agents: [
+                    OpenClawChatAgentChoice(id: "zeta", name: " Zeta ", workspaceGit: true),
+                    OpenClawChatAgentChoice(id: "legacy"),
+                    OpenClawChatAgentChoice(id: "alpha", workspaceGit: false),
+                ])
+            #expect(try await transport.listAgents() == expected)
+            let lease = try #require(await transport.acquireNewSessionRouteLease())
+            #expect(try await lease.listAgents() == expected)
+            await transport.connection.shutdown()
+            await #expect(throws: Error.self) {
+                _ = try await lease.listAgents()
+            }
+            let frames = try await recorder.snapshot().map {
+                try #require(JSONSerialization.jsonObject(with: $0) as? [String: Any])
+            }
+            #expect(frames.map { $0["method"] as? String } == ["agents.list", "agents.list"])
+            #expect(frames.allSatisfy { ($0["params"] as? [String: Any])?.isEmpty == true })
+        }
+    }
+
+    @Test func `mutation lease resolves the current global agent for each request`() async throws {
+        try await self.withSessionTransport { transport, recorder in
             let lease = try #require(await transport.acquireSessionMutationRouteLease())
             try await lease.patchSession(
                 key: "global",
@@ -158,10 +202,6 @@ struct MacGatewayChatTransportMappingTests {
             #expect(params[2]["key"] as? String == "agent:agent-b:work")
             #expect(params[2]["agentId"] == nil)
             #expect(params[2]["deleteTranscript"] as? Bool == true)
-            await gateway.shutdown()
-        } catch {
-            await gateway.shutdown()
-            throw error
         }
     }
 
@@ -261,24 +301,24 @@ struct MacGatewayChatTransportMappingTests {
         #expect(request.params["maxChars"]?.value as? Int == 500_000)
     }
 
-    @Test func `message rewind and fork requests map session targets`() {
-        let rewind = MacGatewayChatTransport.rewindSessionRequest(
-            sessionKey: "global",
-            agentID: "reviewer",
-            entryId: "msg-42")
-        let fork = MacGatewayChatTransport.forkSessionAtMessageRequest(
-            sessionKey: "agent:reviewer:main",
-            agentID: nil,
-            entryId: "msg-43")
+    @Test func `message rewind and fork dispatch resolved session targets`() async throws {
+        try await self.withSessionTransport { transport, recorder in
+            transport.updateDefaultGlobalAgentID(" Reviewer ")
+            let rewind = try await transport.rewindSession(sessionKey: "global", entryId: " msg-42 ")
+            let fork = try await transport.forkSessionAtMessage(sessionKey: "agent:reviewer:main", entryId: "msg-43")
 
-        #expect(rewind.method == "sessions.rewind")
-        #expect(rewind.params["sessionKey"]?.value as? String == "global")
-        #expect(rewind.params["agentId"]?.value as? String == "reviewer")
-        #expect(rewind.params["entryId"]?.value as? String == "msg-42")
-        #expect(fork.method == "sessions.fork")
-        #expect(fork.params["sessionKey"]?.value as? String == "agent:reviewer:main")
-        #expect(fork.params["agentId"] == nil)
-        #expect(fork.params["entryId"]?.value as? String == "msg-43")
+            #expect(rewind.editorText == "rewound draft")
+            #expect(fork.sessionKey == "forked")
+            #expect(fork.editorText == "continued draft")
+            let frames = try await recorder.snapshot().map {
+                try #require(JSONSerialization.jsonObject(with: $0) as? [String: Any])
+            }
+            #expect(frames.map { $0["method"] as? String } == ["sessions.rewind", "sessions.fork"])
+            #expect(frames.map { $0["params"] as? [String: String] } == [
+                ["sessionKey": "global", "agentId": "reviewer", "entryId": "msg-42"],
+                ["sessionKey": "agent:reviewer:main", "entryId": "msg-43"],
+            ])
+        }
     }
 
     @Test func `legacy trace preference migrates to independent defaults once`() throws {

--- a/apps/macos/Tests/OpenClawIPCTests/WebChatWindowLifetimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/WebChatWindowLifetimeTests.swift
@@ -181,6 +181,8 @@ func withWebChatManagerLifetime(
     primaryConnection: GatewayConnection = .shared,
     _ body: (WebChatManager) async throws -> Void) async throws
 {
+    // Callers inspect NSApp before opening their first window.
+    _ = AppKitTestSupport.application
     weak var retiredManager: WebChatManager?
     let suiteName = "WebChatSelectionTests.\(UUID().uuidString)"
     let defaults = try #require(UserDefaults(suiteName: suiteName))

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayPayloadCodec.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatGatewayPayloadCodec.swift
@@ -15,6 +15,18 @@ public enum OpenClawChatSessionKey {
 
 /// Canonical gateway payload mapping shared by the native Apple chat transports.
 public enum OpenClawChatGatewayPayloadCodec {
+    public static func decodeAgentsList(_ data: Data) throws -> OpenClawChatAgentsListResponse {
+        let result = try JSONDecoder().decode(AgentsListResult.self, from: data)
+        return OpenClawChatAgentsListResponse(
+            defaultId: result.defaultid,
+            agents: result.agents.filter(\.isSelectableAgent).map {
+                OpenClawChatAgentChoice(
+                    id: $0.id,
+                    name: $0.name,
+                    workspaceGit: $0.workspacegit)
+            })
+    }
+
     public static func decodeProgressCard(_ data: Data, agentID: String?) throws -> ProgressCard? {
         let result = try JSONDecoder().decode(ProgressCardGetResult.self, from: data)
         guard !(result.card.value is NSNull) else { return nil }

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayUserPreferences.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayUserPreferences.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum GatewayUserPreferences {
+    /// Strict #rrggbb validation (leading "#" optional); canonical lowercase "#rrggbb".
+    public static func normalizedAccentHex(_ raw: String?) -> String? {
+        let trimmed = (raw ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let hex = (trimmed.hasPrefix("#") ? String(trimmed.dropFirst()) : trimmed).lowercased()
+        guard hex.count == 6, hex.allSatisfy({ $0.isASCII && $0.isHexDigit }) else { return nil }
+        return "#\(hex)"
+    }
+
+    /// Only an available profile preference may override the caller's Gateway accent.
+    public static func decodeProfileAccentHex(_ data: Data) throws -> String? {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              json["status"] as? String == "ok"
+        else { return nil }
+        let entries = json["entries"] as? [String: Any]
+        return self.normalizedAccentHex(entries?["ui.accent"] as? String)
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayAgentCatalogTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatGatewayAgentCatalogTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import OpenClawChatUI
+import Testing
+
+struct ChatGatewayAgentCatalogTests {
+    @Test(arguments: ["[]", #"[{"id":"system","kind":"system"}]"#])
+    func `empty selectable rosters preserve the server default`(agents: String) throws {
+        let data = Data("""
+        {"defaultId":"system","mainKey":"main","scope":"per-agent","agents":\(agents)}
+        """.utf8)
+
+        #expect(try OpenClawChatGatewayPayloadCodec.decodeAgentsList(data) ==
+            OpenClawChatAgentsListResponse(defaultId: "system", agents: []))
+    }
+
+    @Test(arguments: [
+        #"{"defaultId":"main","scope":"per-agent","agents":[]}"#,
+        #"{"defaultId":"main","mainKey":"main","agents":[]}"#,
+        #"{"defaultId":"main","mainKey":"main","scope":"per-agent","agents":[{"id":"main","kind":"unknown"}]}"#,
+    ])
+    func `malformed gateway rosters retain protocol decoding failures`(payload: String) {
+        #expect(throws: DecodingError.self) {
+            try OpenClawChatGatewayPayloadCodec.decodeAgentsList(Data(payload.utf8))
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayUserPreferencesTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayUserPreferencesTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import OpenClawKit
+import Testing
+
+struct GatewayUserPreferencesTests {
+    @Test func `normalizes bare and prefixed hex`() {
+        #expect(GatewayUserPreferences.normalizedAccentHex("#A1B2C3") == "#a1b2c3")
+        #expect(GatewayUserPreferences.normalizedAccentHex("a1b2c3") == "#a1b2c3")
+        #expect(GatewayUserPreferences.normalizedAccentHex("  #ff0000  ") == "#ff0000")
+    }
+
+    @Test(arguments: [
+        nil,
+        "",
+        "#fff",
+        "#ff0000aa",
+        "red",
+        "#12345g",
+        "+abcde1",
+        "+12345",
+        "-12345",
+        "#ＦＦＦＦＦＦ"
+    ] as [String?])
+    func `rejects invalid hex`(value: String?) {
+        #expect(GatewayUserPreferences.normalizedAccentHex(value) == nil)
+    }
+
+    @Test func `profile accent reads its entry without rejecting unrelated fields`() throws {
+        let response = Data(##"{"status":"ok","entries":{"ui.accent":"#A1B2C3","ui.theme":"dark"},"extra":true}"##.utf8)
+
+        #expect(try GatewayUserPreferences.decodeProfileAccentHex(response) == "#a1b2c3")
+    }
+
+    @Test(arguments: [
+        #"{"status":"ok"}"#,
+        #"{"status":"ok","entries":null}"#,
+        #"{"status":"ok","entries":[]}"#,
+        #"{"status":"ok","entries":{}}"#,
+        #"{"status":"ok","entries":{"ui.accent":"not-a-color"}}"#,
+        #"{"status":"ok","entries":{"ui.accent":42}}"#,
+        #"{"status":"ok","entries":{"ui.accent":null}}"#,
+    ])
+    func `profile accent rejects missing or malformed entries`(payload: String) throws {
+        #expect(try GatewayUserPreferences.decodeProfileAccentHex(Data(payload.utf8)) == nil)
+    }
+
+    @Test(arguments: [
+        ##"{"entries":{"ui.accent":"#123456"}}"##,
+        ##"{"status":"no_durable_identity","entries":{"ui.accent":"#123456"}}"##,
+        ##"{"status":"OK","entries":{"ui.accent":"#123456"}}"##,
+        ##"[{"status":"ok","entries":{"ui.accent":"#123456"}}]"##,
+    ])
+    func `only an ok profile response can supply an accent`(payload: String) throws {
+        #expect(try GatewayUserPreferences.decodeProfileAccentHex(Data(payload.utf8)) == nil)
+    }
+
+    @Test(arguments: ["", "{"])
+    func `malformed JSON preserves the callers error path`(payload: String) {
+        #expect(throws: Error.self) {
+            try GatewayUserPreferences.decodeProfileAccentHex(Data(payload.utf8))
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Apple chat transports repeated the same agent-list projection, and Mac and iOS separately decoded and validated the same profile-accent response. Two private Mac session helpers also forwarded unchanged arguments to existing shared request builders.

## Why This Change Was Made

Use the existing shared chat payload codec for agent catalogs and the existing rewind/fork request builders directly. A small Foundation-only owner now decodes profile-accent responses and performs their identical strict hex normalization. Each platform keeps its request routing, eight-second timeout, current-route checks, fallback selection and color renderer.

Preserve generated protocol decoding, server default agent ID, list order, system-agent filtering, optional display/worktree metadata and captured connection leases. Profile responses retain exact status checks, permissive handling of unrelated fields, malformed-JSON error behavior and lowercase six-digit ASCII validation. The Mac renderer's different numeric acceptance and iOS's preference-over-seam precedence remain unchanged.

Production is **47 lines smaller** (+45/−92). Test source gains 130 lines and shared test support gains 12. New shared Swift methods are additive; no existing public API, wire protocol, configuration, storage, dependency or signing policy changes.

## User Impact

No intentional change to appearance or behavior. Agent choices, rewind/fork actions and profile accents retain the same meaning with fewer independent implementations.

## Evidence

Final source: `32db0dc02881cb038ff8631107eb94dce70952cb`.

- Independent P0–P2 reviews of the transport refactor, fixture fixes and full accent extension found no actionable issues. Committed source matches the frozen reviewed/compiled inputs.
- The original native refactor and fixture repairs passed full native CI at `d5efb43216baacc7e6c8b32a164d02a450ba3022` (run 34029283371). Shared, Mac, iOS and Android suites also passed on the complete accent head `df46dda0bfcafda865816549aee91ecb1e3e98c5` (run 34032828960). Its overall CI exposed a separate Darwin relay-reaping race, fixed and landed in #140134. This branch is now rebased onto main containing that repair. Range-diff confirms all production commits unchanged; main already absorbed part of the fixture readiness fix. The rebased head still requires its own green CI.
- Isolated iOS execution passed 29 transport test methods / 35 parameterized invocations, including selectable-agent projection and rejected dispatch after connection retirement. Connected synthetic Mac tests cover direct/leased lists and real rewind/fork wire mappings. Shared cases preserve empty lists and malformed envelopes.
- Accent preservation: original iOS tests passed 7/7; a fresh candidate iOS build and retained platform-precedence tests passed 3/3, with no failures or skips. Four normalization/profile tests moved to the shared owner, with full Data-response coverage added there: six methods / 25 invocations. Shared and Mac test bundles compile; their final runtime proof belongs to disposable Mac CI.
- Fresh accent-candidate shared test compilation, Mac product compilation, Mac test compilation and iOS build-for-testing all passed. Pinned SwiftFormat, strict SwiftLint and diff checks passed. All 1,623 recorded inputs stayed unchanged through validation. Normal simulator signing verified; the owned simulator was deleted, preserving all 36 pre-existing simulators.

## CI Follow-through

The earlier Dependency Guard request failed with a GitHub API 500 and passed on its targeted rerun. Periphery identified an unused Mac import, which was removed. An optional local Periphery scan crashed before findings; no passing local scan is claimed. Disposable CI subsequently passed the earlier native head.

CI also exposed two existing fixture failures, both present on inspected main. The Mac lifetime fixture read `NSApp.windows` before AppKit initialization; it now uses existing once-only `AppKitTestSupport.application`. Android's contrast fixture observed approval text before separately forwarded refresh state necessarily settled. The original Android test reproduced the exact CI assertion failure; its existing bounded waits now include their already-asserted state. The remaining fixture changes preserve the existing ten-second limits, cleanup and pixel checks; main already contains the earlier readiness predicates. All 31 themes / 155 measurements passed, minimum contrast 4.85:1 against the unchanged 4.5:1 threshold, with terminal readback/dismissal and zero approval-resolution requests. Full Mac and Android CI passed those fixes.

This PR uses disposable CI for Mac runtime proof and never launches against an operator Gateway. Exact-head native CI remains required after the rebase; prior-head results are not substituted for it.
