### PR TITLE
perf(plugins): resolve SDK aliases on demand

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3425,7 +3425,7 @@ src/plugins/plugin-metadata-snapshot.runtime.ts	2
 src/plugins/plugin-module-loader-cache.ts	1
 src/plugins/plugin-package-update.ts	1
 src/plugins/plugin-peer-link.ts	6
-src/plugins/plugin-sdk-native-resolver.ts	3
+src/plugins/plugin-sdk-native-resolver.ts	1
 src/plugins/prepared-message-tool-catalog.ts	1
 src/plugins/provider-api-key-auth.ts	2
 src/plugins/provider-auth-choice-helpers.ts	12

--- a/src/plugins/loader.lazy-alias.test.ts
+++ b/src/plugins/loader.lazy-alias.test.ts
@@ -91,7 +91,7 @@ describe("native plugin alias preparation", () => {
     });
   });
 
-  it("prepares the complete map once on a late alias request and reuses it for CJS and ESM", async () => {
+  it("resolves late CJS and ESM aliases without reading artifacts until demanded", async () => {
     const f = fixture();
     const read = vi.spyOn(fs, "readFileSync");
     const load = createPluginModuleLoader({ devSourceRoot: f.root });
@@ -101,14 +101,18 @@ describe("native plugin alias preparation", () => {
     };
     expect(read.mock.calls.filter(([target]) => target === f.unused)).toEqual([]);
     expect(metadata.load("openclaw/plugin-sdk/used")).toMatchObject({ value: "dist" });
-    expect(read.mock.calls.filter(([target]) => target === f.unused)).toHaveLength(1);
+    expect(read.mock.calls.filter(([target]) => target === f.unused)).toEqual([]);
     expect(await metadata.loadEsm("@openclaw/plugin-sdk/used.js")).toMatchObject({ value: "dist" });
+    expect(read.mock.calls.filter(([target]) => target === f.unused)).toEqual([]);
+    expect(await metadata.loadEsm("@openclaw/plugin-sdk/unused.js")).toMatchObject({
+      value: "unused",
+    });
     expect(createRequire(f.entry).resolve("openclaw/plugin-sdk/unused")).toBe(f.unused);
-    expect(read.mock.calls.filter(([target]) => target === f.unused)).toHaveLength(1);
+    expect(metadata.load("openclaw/plugin-sdk/unused")).toMatchObject({ value: "unused" });
   });
 
   it.each(["cjs", "mjs"])(
-    "prepares all aliases before evaluating an alias-using %s target",
+    "resolves the demanded alias before evaluating an alias-using %s target",
     (extension) => {
       const f = fixture();
       const entry = writeFile(
@@ -120,9 +124,13 @@ describe("native plugin alias preparation", () => {
       );
       const read = vi.spyOn(fs, "readFileSync");
       const load = createPluginModuleLoader({ devSourceRoot: f.root });
-      expect(load(entry)).toMatchObject({ value: "dist" });
-      expect(load(entry)).toBe(load(entry));
-      expect(read.mock.calls.filter(([target]) => target === f.unused)).toHaveLength(1);
+      const loaded = load(entry);
+      expect(loaded).toMatchObject({ value: "dist" });
+      expect(load(entry)).toBe(loaded);
+      expect(read.mock.calls.filter(([target]) => target === f.unused)).toEqual([]);
+      expect(createRequire(entry)("@openclaw/plugin-sdk/unused")).toMatchObject({
+        value: "unused",
+      });
     },
   );
 
@@ -155,7 +163,7 @@ describe("native plugin alias preparation", () => {
     expect(load(f.entry)).toMatchObject({ marker: "metadata" });
     expect(read.mock.calls.filter(([target]) => target === f.unused)).toEqual([]);
     expect(load(entry)).toMatchObject({ value: "family" });
-    expect(read.mock.calls.filter(([target]) => target === f.unused)).toHaveLength(1);
+    expect(read.mock.calls.some(([target]) => target === f.unused)).toBe(true);
   });
 
   it("does not prepare aliases for unrelated requests or unregistered parents", () => {
@@ -264,9 +272,13 @@ describe("native plugin alias preparation", () => {
     const read = vi.spyOn(fs, "readFileSync");
     installOpenClawPluginSdkNativeResolver({ pluginModulePath: a.entry, devSourceRoot: a.root });
     installOpenClawPluginSdkNativeResolver({ pluginModulePath: a.entry, devSourceRoot: b.root });
-    expect(createRequire(a.entry).resolve("@openclaw/plugin-sdk/used")).toBe(b.used);
+    const fromPlugin = createRequire(a.entry);
+    expect(fromPlugin.resolve("@openclaw/plugin-sdk/used")).toBe(b.used);
+    expect(fromPlugin("@openclaw/plugin-sdk/used")).toMatchObject({ value: "dist" });
+    expect(read.mock.calls.filter(([target]) => target === b.unused)).toEqual([]);
+    expect(fromPlugin.resolve("@openclaw/plugin-sdk/unused")).toBe(b.unused);
+    expect(fromPlugin("@openclaw/plugin-sdk/unused")).toMatchObject({ value: "unused" });
     expect(read.mock.calls.filter(([target]) => target === a.unused)).toEqual([]);
-    expect(read.mock.calls.filter(([target]) => target === b.unused)).toHaveLength(1);
   });
 
   it("does not reuse a bundled private alias grant for an external plugin", () => {

--- a/src/plugins/plugin-cache-sdk.ts
+++ b/src/plugins/plugin-cache-sdk.ts
@@ -45,7 +45,6 @@ type PluginSdkHostFacts = {
   privateSubpaths?: string[];
   workspaceExports: Map<string, WorkspacePackageAliasEntry[]>;
   subpathsByOwner: Map<string, string[]>;
-  aliasesByOwner: Map<string, PluginSdkAliasMap>;
   bundledAliasesByMode: Map<string, PluginSdkAliasMap>;
   workspaceAliasesByMode: Map<string, PluginSdkAliasMap>;
 };
@@ -54,7 +53,6 @@ function createPluginSdkHostFacts(): PluginSdkHostFacts {
   return {
     workspaceExports: new Map(),
     subpathsByOwner: new Map(),
-    aliasesByOwner: new Map(),
     bundledAliasesByMode: new Map(),
     workspaceAliasesByMode: new Map(),
   };
@@ -86,9 +84,12 @@ export function createPluginCacheSdk() {
       WeakMap<PluginSdkAliasMap, WeakMap<PluginSdkAliasMap, PluginSdkAliasMap>>
     >(),
     native: {
-      sdkProviders: new Map<string, () => void>(),
+      sdkProviders: new Map<
+        string,
+        { resolveAlias: (specifier: string) => string | undefined; order?: number }
+      >(),
+      nextSdkProviderOrder: 0,
       aliases: new Map<string, Array<{ parentRoot: string; target: string }>>(),
-      aliasesByMap: new WeakMap<PluginSdkAliasMap, Array<readonly [string, string]>>(),
       registeredHosts: new Set<string>(),
       hostRoots: new Map<string, string>(),
       nearestPackageRoots: new Map<string, string>(),

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -372,6 +372,48 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
     expect(() => requireFromPlugin.resolve("openclaw/plugin-sdk/stable-extra")).toThrow();
   });
 
+  it("keeps overlapping parent precedence across first demand and reinstallation", () => {
+    const broadHost = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-broad-host-"));
+    const narrowHost = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-narrow-host-"));
+    const broad = writeFakeOpenClawPackage(broadHost);
+    const narrow = writeFakeOpenClawPackage(narrowHost);
+    const broadEntry = writeExternalPluginEntry(path.join(broadHost, "external-plugin"));
+    const narrowEntry = writeExternalPluginEntry(path.join(broadHost, "external-plugin", "nested"));
+    const narrowOptions = {
+      modulePath: narrow.loaderModulePath,
+      pluginModulePath: narrowEntry,
+      devSourceRoot: narrowHost,
+    };
+    const broadOptions = {
+      modulePath: broad.loaderModulePath,
+      pluginModulePath: broadEntry,
+      devSourceRoot: broadHost,
+    };
+    installOpenClawPluginSdkNativeResolver(narrowOptions);
+    installOpenClawPluginSdkNativeResolver(broadOptions);
+    const fromBroad = createRequire(broadEntry);
+    const fromNarrow = createRequire(narrowEntry);
+    const expected = (host: string, subpath: string) =>
+      fs.realpathSync(path.join(host, "dist", "plugin-sdk", `${subpath}.js`));
+
+    // A demand outside the nested root gives the broad host precedence even
+    // though it was installed second; the later path was not demanded yet.
+    expect(fs.realpathSync(fromBroad.resolve("openclaw/plugin-sdk/agent-runtime"))).toBe(
+      expected(broadHost, "agent-runtime"),
+    );
+    expect(fs.realpathSync(fromNarrow.resolve("openclaw/plugin-sdk/channel-outbound.js"))).toBe(
+      expected(broadHost, "channel-outbound"),
+    );
+
+    installOpenClawPluginSdkNativeResolver(broadOptions);
+    expect(fs.realpathSync(fromNarrow.resolve("openclaw/plugin-sdk/channel-message"))).toBe(
+      expected(narrowHost, "channel-message"),
+    );
+    expect(fs.realpathSync(fromBroad.resolve("openclaw/plugin-sdk/channel-message"))).toBe(
+      expected(broadHost, "channel-message"),
+    );
+  });
+
   it("keeps native aliases on JS dist artifacts when source files exist", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sdk-native-source-resolver-"));
     const { loaderModulePath } = writeFakeOpenClawPackage(root);
@@ -451,10 +493,12 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
         '  bin: { openclaw: "./openclaw.mjs" },',
         "  exports: {",
         '    "./plugin-sdk/channel-outbound": "./dist/plugin-sdk/channel-outbound.js",',
+        '    "./plugin-sdk/late-entry": "./dist/plugin-sdk/late-entry.js",',
         "  },",
         "});",
         'fs.writeFileSync(path.join(root, "openclaw.mjs"), "#!/usr/bin/env node\\n", "utf8");',
         'fs.mkdirSync(path.join(root, "dist", "plugin-sdk"), { recursive: true });',
+        'fs.writeFileSync(path.join(root, "dist", "plugin-sdk", "late-entry.js"), "export const late = \\"late-adapter\\";\\n", "utf8");',
         'fs.writeFileSync(path.join(root, "dist", "plugin-sdk", "channel-outbound.js"), "export const defineChannelMessageAdapter = () => \\"adapter\\";\\n", "utf8");',
         'const loaderModulePath = path.join(root, "dist", "plugins", "loader.js");',
         "fs.mkdirSync(path.dirname(loaderModulePath), { recursive: true });",
@@ -471,7 +515,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
         ");",
         "fs.writeFileSync(",
         "  lazyPath,",
-        '  "import { defineChannelMessageAdapter } from \\"openclaw/plugin-sdk/channel-outbound\\"; export const lazy = defineChannelMessageAdapter();\\n",',
+        '  "export { late as lazy } from \\"openclaw/plugin-sdk/late-entry.js\\";\\n",',
         '  "utf8",',
         ");",
         "installOpenClawPluginSdkNativeResolver({",
@@ -502,7 +546,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   it("keeps SDK aliases available for native ESM lazy imports", () => {
     expect(nativeEsmLazyImportProbe.stderr).toBe("");
     expect(nativeEsmLazyImportProbe.status).toBe(0);
-    expect(nativeEsmLazyImportProbe.stdout.trim()).toBe("adapter:adapter");
+    expect(nativeEsmLazyImportProbe.stdout.trim()).toBe("adapter:late-adapter");
   });
 
   it("does not resolve SDK aliases for parents outside registered plugin roots", () => {

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -279,41 +279,28 @@ function resolveAliasTargetForParentPath(
 ): string | undefined {
   const native = getPluginCache().sdk.native;
   if (parentFilename && isPluginSdkAliasSpecifier(request)) {
-    for (const [root, prepare] of native.sdkProviders) {
-      if (isWithinRoot(parentFilename, root)) {
-        prepare();
+    let first: { target: string; order: number } | undefined;
+    for (const [root, provider] of native.sdkProviders) {
+      if (!isWithinRoot(parentFilename, root)) {
+        continue;
+      }
+      // Eager registration used the first SDK demand, not installation order,
+      // to break ties between overlapping roots. Preserve that order lazily.
+      provider.order ??= native.nextSdkProviderOrder++;
+      const target = provider.resolveAlias(
+        request.endsWith(".js") ? request.slice(0, -3) : request,
+      );
+      if (target && isNativeLoadableSdkTarget(target) && (!first || provider.order < first.order)) {
+        first = { target, order: provider.order };
       }
     }
+    return first?.target;
   }
   const entries = native.aliases.get(request);
   if (!entries || !parentFilename) {
     return undefined;
   }
   return entries.find((entry) => isWithinRoot(parentFilename, entry.parentRoot))?.target;
-}
-
-function listPluginSdkNativeAliases(
-  aliasMap: Record<string, string>,
-): Array<readonly [string, string]> {
-  const pluginSdkNativeAliasesByMap = getPluginCache().sdk.native.aliasesByMap;
-  const cached = pluginSdkNativeAliasesByMap.get(aliasMap);
-  if (cached) {
-    return cached;
-  }
-  const aliases = Object.entries(aliasMap)
-    .filter(([specifier]) => isPluginSdkAliasSpecifier(specifier))
-    .filter(([, target]) => isNativeLoadableSdkTarget(target))
-    .flatMap(([specifier, target]) => {
-      if (specifier.endsWith(".js")) {
-        return [[specifier, target]] as Array<readonly [string, string]>;
-      }
-      return [
-        [specifier, target],
-        [`${specifier}.js`, target],
-      ] as Array<readonly [string, string]>;
-    });
-  pluginSdkNativeAliasesByMap.set(aliasMap, aliases);
-  return aliases;
 }
 
 function listInternalCorePackageNativeAliases(
@@ -456,13 +443,7 @@ export function installOpenClawPluginSdkNativeResolver(
   });
   const native = getPluginCache().sdk.native;
   for (const parentRoot of parentRoots) {
-    native.sdkProviders.set(parentRoot, () => {
-      const resolved = listPluginSdkNativeAliases(aliases.getAliasMap());
-      native.sdkProviders.delete(parentRoot);
-      for (const [request, target] of resolved) {
-        registerNativeAlias({ request, target, parentRoots: [parentRoot] });
-      }
-    });
+    native.sdkProviders.set(parentRoot, { resolveAlias: aliases.resolveAlias });
   }
   registerInternalCorePackageNativeAliases(options);
   installResolver();

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/test-fixtures";
 import { afterAll, describe, expect, it, vi } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
+import { createPluginCache, withPluginCache } from "./plugin-cache.js";
 import {
   buildPluginLoaderAliasMap,
   createPluginLoaderModuleCacheKey,
@@ -1688,6 +1689,30 @@ describe("plugin sdk alias helpers", () => {
     });
 
     expect(second).toBe(first);
+  });
+
+  it("retains missing SDK targets until a new generation, including deferred complete maps", () => {
+    const { fixture, distPluginEntryPath } = createPluginSdkAliasTargetFixture();
+    const owner = createPluginCache();
+    const other = createPluginCache();
+    const params = {
+      modulePath: writePluginEntry(fixture.root, bundledDistPluginFile("demo", "index.js")),
+      pluginSdkResolution: "dist" as const,
+    };
+    fs.unlinkSync(distPluginEntryPath);
+    fs.unlinkSync(path.join(fixture.root, "src", "plugin-sdk", "plugin-entry.ts"));
+    const prepared = withPluginCache(owner, () => preparePluginLoaderAliases(params));
+    expect(prepared.resolveAlias("openclaw/plugin-sdk/plugin-entry")).toBeUndefined();
+    fs.writeFileSync(distPluginEntryPath, "export const marker = 'new-generation';\n", "utf8");
+
+    withPluginCache(other, () => {
+      expect(prepared.resolveAlias("openclaw/plugin-sdk/plugin-entry")).toBeUndefined();
+      expect(prepared.getAliasMap()["openclaw/plugin-sdk/plugin-entry"]).toBeUndefined();
+      const fresh = preparePluginLoaderAliases(params);
+      expect(fs.realpathSync(fresh.resolveAlias("openclaw/plugin-sdk/plugin-entry") ?? "")).toBe(
+        fs.realpathSync(distPluginEntryPath),
+      );
+    });
   });
 
   it("scopes prepared alias authority by effective resolution", () => {

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -1117,16 +1117,6 @@ function shouldIncludePrivateLocalOnlyPluginSdkSubpath(
   );
 }
 
-function hasPluginSdkSubpathArtifact(packageRoot: string, subpath: string) {
-  const distPath = path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`);
-  if (isUsableDistPluginSdkArtifact(distPath)) {
-    return true;
-  }
-  return PLUGIN_SDK_SOURCE_CANDIDATE_EXTENSIONS.some((ext) =>
-    pluginCacheExistsSync(path.join(packageRoot, "src", "plugin-sdk", `${subpath}${ext}`)),
-  );
-}
-
 function listDistPluginSdkArtifactSubpaths(packageRoot: string): Set<string> {
   try {
     const distPluginSdkDir = path.join(packageRoot, "dist", "plugin-sdk");
@@ -1159,10 +1149,8 @@ function listPluginSdkExportedSubpaths(context: PluginLoaderAliasContext): strin
   const subpaths = [
     ...new Set([
       ...(readPluginSdkSubpathsFromPackageRoot(packageRoot) ?? []),
-      ...readPrivateLocalOnlyPluginSdkSubpaths(packageRoot).filter(
-        (subpath) =>
-          shouldIncludePrivateLocalOnlyPluginSdkSubpath(context, subpath) &&
-          hasPluginSdkSubpathArtifact(packageRoot, subpath),
+      ...readPrivateLocalOnlyPluginSdkSubpaths(packageRoot).filter((subpath) =>
+        shouldIncludePrivateLocalOnlyPluginSdkSubpath(context, subpath),
       ),
     ]),
   ].toSorted();
@@ -1170,53 +1158,62 @@ function listPluginSdkExportedSubpaths(context: PluginLoaderAliasContext): strin
   return subpaths;
 }
 
-function resolvePluginSdkScopedAliasMap(context: PluginLoaderAliasContext): Record<string, string> {
+function createPluginSdkScopedAliases(context: PluginLoaderAliasContext) {
   const { packageRoot, orderedKinds } = context;
-  if (!packageRoot) {
-    return {};
-  }
-  const cacheKey = `${pluginSdkAuthorityCacheKey(context)}::${orderedKinds.join(",")}`;
-  const cachedPluginSdkScopedAliasMaps = sdkHost(packageRoot).aliasesByOwner;
-  const cached = cachedPluginSdkScopedAliasMaps.get(cacheKey);
-  if (cached) {
-    return cached;
-  }
-  const aliasMap: Record<string, string> = {};
-  const distPluginSdkArtifacts = orderedKinds.includes("dist")
-    ? listDistPluginSdkArtifactSubpaths(packageRoot)
-    : new Set<string>();
-  for (const subpath of listPluginSdkExportedSubpaths(context)) {
+  // Only permitted inventory names enter the cache; missing targets are also
+  // generation-owned facts. A first import must not validate every SDK artifact.
+  const targets = new Map<string, string | null | undefined>(
+    listPluginSdkExportedSubpaths(context).map((subpath) => [subpath, undefined]),
+  );
+  let distArtifacts: Set<string> | undefined;
+  let aliasMap: Record<string, string> | undefined;
+  const resolveSubpath = (subpath: string): string | undefined => {
+    if (!packageRoot || !targets.has(subpath)) {
+      return undefined;
+    }
+    const cachedTarget = targets.get(subpath);
+    if (cachedTarget !== undefined) {
+      return cachedTarget ?? undefined;
+    }
     for (const kind of orderedKinds) {
       if (kind === "dist") {
-        if (!distPluginSdkArtifacts.has(subpath)) {
-          continue;
-        }
+        distArtifacts ??= listDistPluginSdkArtifactSubpaths(packageRoot);
         const candidate = path.join(packageRoot, "dist", "plugin-sdk", `${subpath}.js`);
-        if (isUsableDistPluginSdkArtifact(candidate)) {
-          for (const packageName of PLUGIN_SDK_PACKAGE_NAMES) {
-            aliasMap[`${packageName}/${subpath}`] = candidate;
-          }
-          break;
+        if (distArtifacts.has(subpath) && isUsableDistPluginSdkArtifact(candidate)) {
+          targets.set(subpath, candidate);
+          return candidate;
         }
         continue;
       }
       for (const ext of PLUGIN_SDK_SOURCE_CANDIDATE_EXTENSIONS) {
         const candidate = path.join(packageRoot, "src", "plugin-sdk", `${subpath}${ext}`);
-        if (!pluginCacheExistsSync(candidate)) {
-          continue;
+        if (pluginCacheExistsSync(candidate)) {
+          targets.set(subpath, candidate);
+          return candidate;
         }
-        for (const packageName of PLUGIN_SDK_PACKAGE_NAMES) {
-          aliasMap[`${packageName}/${subpath}`] = candidate;
-        }
-        break;
-      }
-      if (Object.hasOwn(aliasMap, `openclaw/plugin-sdk/${subpath}`)) {
-        break;
       }
     }
-  }
-  cachedPluginSdkScopedAliasMaps.set(cacheKey, aliasMap);
-  return aliasMap;
+    targets.set(subpath, null);
+    return undefined;
+  };
+  return {
+    resolveSubpath,
+    getAliasMap: (): Record<string, string> => {
+      if (aliasMap) {
+        return aliasMap;
+      }
+      aliasMap = {};
+      for (const subpath of targets.keys()) {
+        const target = resolveSubpath(subpath);
+        if (target) {
+          for (const packageName of PLUGIN_SDK_PACKAGE_NAMES) {
+            aliasMap[`${packageName}/${subpath}`] = target;
+          }
+        }
+      }
+      return aliasMap;
+    },
+  };
 }
 
 const JITI_NORMALIZED_ALIAS_SYMBOL = Symbol.for("pathe:normalizedAlias");
@@ -1399,6 +1396,8 @@ export function preparePluginLoaderAliases(
     return cached;
   }
   let aliasMap: Record<string, string> | undefined;
+  let sdkAliases: ReturnType<typeof createPluginSdkScopedAliases> | undefined;
+  const getSdkAliases = () => (sdkAliases ??= createPluginSdkScopedAliases(context));
   const getAliasMap = () =>
     withPluginCache(
       cache,
@@ -1406,7 +1405,7 @@ export function preparePluginLoaderAliases(
         (aliasMap ??= mergeAliasMaps(
           resolveBundledPluginPackagePublicSurfaceAliasMap(context),
           resolveWorkspacePackageAliasMap(context),
-          normalizeAliasTargets(resolvePluginSdkScopedAliasMap(context)),
+          normalizeAliasTargets(getSdkAliases().getAliasMap()),
         )),
     );
   const prepared = {
@@ -1414,8 +1413,22 @@ export function preparePluginLoaderAliases(
     // stable for the loader lifecycle. Key the captured authority, not raw hints.
     cacheKey,
     getAliasMap,
-    resolveAlias: (specifier: string): string | undefined =>
-      isPluginLoaderAliasSpecifier(specifier) ? getAliasMap()[specifier] : undefined,
+    resolveAlias: (specifier: string): string | undefined => {
+      if (!isPluginLoaderAliasSpecifier(specifier)) {
+        return undefined;
+      }
+      if (aliasMap) {
+        return aliasMap[specifier];
+      }
+      return withPluginCache(cache, () => {
+        const prefix = PLUGIN_SDK_PACKAGE_NAMES.find((name) => specifier.startsWith(`${name}/`));
+        if (!prefix) {
+          return getAliasMap()[specifier];
+        }
+        const target = getSdkAliases().resolveSubpath(specifier.slice(prefix.length + 1));
+        return target ? normalizeJitiAliasTargetPath(target) : undefined;
+      });
+    },
   };
   cache.sdk.contexts.set(cacheKey, prepared);
   return prepared;


### PR DESCRIPTION
## What Problem This Solves

A plugin importing one SDK entry pays to discover and validate targets for the entire SDK inventory. This adds avoidable cold import work and delays development Gateway readiness.

## Why This Change Was Made

Resolve only the requested, permitted SDK subpath and keep the result (including a miss) within the existing loader generation. Native CommonJS and late ESM resolution use this prepared resolver; Jiti and build consumers still receive the complete alias map when they request it. Preserve source/dist selection, private-owner eligibility, both package spellings, parent-root boundaries and first-demand precedence for overlapping roots.

Remove the eager native alias enumerator and redundant map caches. Production changes total −5 lines; tests +81. The assertion budget also shrinks by two to reflect removed casts. No configuration, defaults, schemas, persisted state or public exports change.

## User Impact

Less work when loading a small part of the SDK, with unchanged import and plugin behavior. Full-map consumers retain their existing path; this does not claim faster model inference.

## Evidence

- 172 focused tests passed, with one existing Windows-only skip; two complete matched normal builds passed. All 32 normal changed checks and a fresh independent P2 review passed. The initial check required shrinking the assertion budget from three to one; that failure and the generated correction are preserved.
- Fixed cold-loader cohort: 384 actual resolver/import observations on a synthetic 330-entry inventory. Single-alias medians improved 71.6–75.2%, native CJS 32.0–33.0%, late ESM 33.2–33.6%, and 24 native imports 15.1–17.0%. Complete semantic witnesses matched. Five of 24 owner medians worsened, including Jiti-dist +0.35%/+0.04%; all adverse values remain recorded.
- Matched real OpenAI development Gateways ran B0/C0/C1/B1, then a separate baseline/candidate CPU-profile pair. Identical nine-turn workloads exercised text, reads, writes, a real web fetch, recall, expected file failure and concurrent sessions. All 36 unprofiled answers passed. Readiness improved 3,394.9→2,999.7 ms and 3,185.5→3,002.2 ms (11.64%/5.75%). Whole-phase duration was +8.60%/−6.45%; no overall turn-latency improvement is established. All 36 adverse comparisons among 90 primary metrics are retained.
- Across all six Gateways: 53/54 strict answers, all 36 paired tool calls, 84 observed successful provider HTTP requests. The profiled baseline's web answer said “documentation examples” instead of required exact “documentation”; its tool passed. That failure was not rerun or reclassified. Four profiles are structurally valid; original hit-count discrepancies remain. SDK alias-map stacks had 28→13 inclusive samples and artifact checking 13→6; these overlapping single-pair samples are diagnostic, not percentage speedup claims.
- All 211 observed processes/48 groups, the credential holder and six task ports closed; exact API/service-value scans found no matches in retained evidence. No operator Gateway or user state was touched.

The cold cohort was interrupted after observation 92 by an incorrect output-size projection, then continued only the remaining observations. Original outcomes and the interrupted receipt are preserved; the helper workload did not change. Its initial environment inherited a service credential; an exact scan found zero output occurrences, and continuation excluded it. This is qualified, interrupted component evidence, distinct from the uninterrupted per-phase live measurements. Normal-build elapsed times are not treated as performance measurements. Two live observations per variant do not establish significance or population tails.
