### PR TITLE
fix(sessions): self-heal session-reset races instead of bricking the agent

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -5,6 +5,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { runSqliteImmediateTransactionSync } from "../../infra/sqlite-transaction.js";
 import { getChildLogger } from "../../logging/logger.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
@@ -391,20 +392,29 @@ function clearSqliteSessionEntryPreservingWindows(
         }
       : {}),
   } as const;
-  executeSqliteQuerySync(
-    database.db,
-    db
-      .insertInto("session_nodes")
-      .values({ session_key: params.sessionKey, ...cleared })
-      .onConflict((conflict) => conflict.column("session_key").doUpdateSet(cleared)),
-  );
-  executeSqliteQuerySync(
-    database.db,
-    db
-      .updateTable("session_nodes")
-      .set({ entry_valid: -1 })
-      .where("session_key", "=", params.sessionKey),
-  );
+  // Clear + settle must be atomic: the entry-validity triggers mark the row
+  // pending (entry_valid = 0) on the upsert, and the follow-up UPDATE settles
+  // the cleared row back to -1. If a concurrent flush interleaved its own
+  // entry_json write between the two statements, the reset's settle step would
+  // persist the terminal (non-empty entry + entry_valid = -1) shape that
+  // canonical validation rejects (issue #139960). Nesting is handled via
+  // SAVEPOINT when the caller already holds a transaction.
+  runSqliteImmediateTransactionSync(database.db, () => {
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .insertInto("session_nodes")
+        .values({ session_key: params.sessionKey, ...cleared })
+        .onConflict((conflict) => conflict.column("session_key").doUpdateSet(cleared)),
+    );
+    executeSqliteQuerySync(
+      database.db,
+      db
+        .updateTable("session_nodes")
+        .set({ entry_valid: -1 })
+        .where("session_key", "=", params.sessionKey),
+    );
+  });
 }
 
 export function deleteLifecycleTargetRows(

--- a/src/config/sessions/session-accessor.sqlite-transcript-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-state.ts
@@ -5,6 +5,7 @@ import {
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
 import { coerceRequiredSqliteNumber as sqliteNumber } from "../../infra/sqlite-number.js";
+import { runSqliteImmediateTransactionSync } from "../../infra/sqlite-transaction.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { publishSessionEntryCacheInvalidation } from "./session-accessor.sqlite-entry-cache.js";
 import { getSessionKysely, type ResolvedTranscriptScope } from "./session-accessor.sqlite-scope.js";
@@ -172,13 +173,20 @@ export function ensureTranscriptSessionRoot(
       .onConflict((conflict) => conflict.column("session_key").doNothing()),
   );
   if ((insertedNode.numAffectedRows ?? 0n) > 0n) {
-    executeSqliteQuerySync(
-      database.db,
-      db
-        .updateTable("session_nodes")
-        .set({ entry_valid: -1 })
-        .where("session_key", "=", scope.sessionKey),
-    );
+    // Insert + settle must be atomic (issue #139960): the insert fires the
+    // entry-validity trigger (marks the row pending), and the settle UPDATE
+    // writes the cleared root back to -1. A concurrent flush interleaving its
+    // entry_json write between the two would otherwise be settled to the
+    // terminal (non-empty entry + entry_valid = -1) shape.
+    runSqliteImmediateTransactionSync(database.db, () => {
+      executeSqliteQuerySync(
+        database.db,
+        db
+          .updateTable("session_nodes")
+          .set({ entry_valid: -1 })
+          .where("session_key", "=", scope.sessionKey),
+      );
+    });
     publishSessionEntryCacheInvalidation(database);
   }
   executeSqliteQuerySync(

--- a/src/config/sessions/session-canonical-key.test.ts
+++ b/src/config/sessions/session-canonical-key.test.ts
@@ -307,4 +307,69 @@ describe("cold canonical session validation", () => {
 
     expect(() => loadSessionEntryReadOnly(scope)).toThrow("openclaw doctor --fix");
   });
+
+  it("tolerates a reset racing a flush: complete payload with entry_valid = -1 over a retained window self-heals", () => {
+    const scope = createScope();
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 1, label: "before" });
+    runOpenClawAgentWriteTransaction((database) => {
+      ensureTranscriptSessionRoot(database, { ...scope, sessionId: "cold-key" }, 2);
+    }, scope);
+    // Live connection + racing raw writer mirrors the outage (issue #139960):
+    // the flush rewrites entry_json (the validity trigger marks the row
+    // pending), then the reset's settle step lands entry_valid = -1 over the
+    // flushed payload. The tuple must not brick reads.
+    const held = openOpenClawAgentDatabase({ ...scope, path: scope.storePath });
+    const writer = new DatabaseSync(scope.storePath);
+    try {
+      writer
+        .prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?")
+        .run(
+          JSON.stringify({ sessionId: "cold-key", updatedAt: 1, label: "flushed" }),
+          scope.sessionKey,
+        );
+      writer
+        .prepare("UPDATE session_nodes SET entry_valid = -1 WHERE session_key = ?")
+        .run(scope.sessionKey);
+      expect(() => listSessionEntriesReadOnly({ ...scope, projection: "list" })).not.toThrow();
+      expect(() => loadSessionEntryReadOnly(scope)).not.toThrow();
+    } finally {
+      writer.close();
+      void held;
+    }
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    // Cold listing tolerates the raced row (no repair error); the entry stays
+    // absent until the session's next turn rewrites it.
+    expect(listSessionEntriesReadOnly({ ...scope, projection: "list" })).toEqual([]);
+    // Recovery completes without an operator: the session's next turn settles
+    // the row back to a valid entry and it lists again.
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 3, label: "next-turn" });
+    const rows = listSessionEntriesReadOnly({ ...scope, projection: "list" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.entry).toMatchObject({ sessionId: "cold-key", label: "next-turn" });
+  });
+
+  it("still requires repair for an unparseable payload with entry_valid = -1, even over a retained window", () => {
+    const scope = createScope();
+    replaceSessionEntrySync(scope, { sessionId: "cold-key", updatedAt: 1, label: "before" });
+    runOpenClawAgentWriteTransaction((database) => {
+      ensureTranscriptSessionRoot(database, { ...scope, sessionId: "cold-key" }, 2);
+    }, scope);
+    const writer = new DatabaseSync(scope.storePath);
+    try {
+      writer
+        .prepare("UPDATE session_nodes SET entry_json = '{' WHERE session_key = ?")
+        .run(scope.sessionKey);
+      writer
+        .prepare("UPDATE session_nodes SET entry_valid = -1 WHERE session_key = ?")
+        .run(scope.sessionKey);
+    } finally {
+      writer.close();
+    }
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    expect(() => listSessionEntriesReadOnly({ ...scope, projection: "list" })).toThrow(
+      "openclaw doctor --fix",
+    );
+  });
 });

--- a/src/config/sessions/session-canonical-key.ts
+++ b/src/config/sessions/session-canonical-key.ts
@@ -165,6 +165,7 @@ export function scanCanonicalSqliteSessionEntries(
         "session_nodes.fork_source_session_key",
         "session_nodes.parent_session_key",
         "session_nodes.spawned_by",
+        "session_nodes.updated_at",
         "retained_window.session_id as retained_window_id",
       ])
       // Key validation needs metadata; Doctor visitors still own complete saved entries.
@@ -183,12 +184,23 @@ export function scanCanonicalSqliteSessionEntries(
   )) {
     // Retained windows have no entry, but their keys remain part of a listing snapshot.
     metadata?.keys.push(row.session_key);
-    if (
-      row.entry_json === "{}" &&
-      row.entry_valid === -1 &&
-      row.retained_window_id === row.current_session_id
-    ) {
-      continue;
+    // An invalid logical entry (entry_valid = -1) carrying a complete,
+    // self-consistent payload over the retained window is the signature of a
+    // reset settling entry_valid = -1 over a concurrent flush's write
+    // (issue #139960). It is rebuildable from the retained window; payloads
+    // that are unparseable or inconsistent with the row identity/timestamp
+    // remain terminal corruption requiring repair.
+    if (row.entry_valid === -1 && row.retained_window_id === row.current_session_id) {
+      const racedPayload =
+        row.entry_json === "{}" ||
+        parseSqliteSessionEntryRecord({
+          entry_json: row.entry_json,
+          current_session_id: row.current_session_id,
+          updated_at: row.updated_at,
+        });
+      if (racedPayload) {
+        continue;
+      }
     }
     const record =
       row.entry_valid === 1


### PR DESCRIPTION
Closes #139960

## What Problem This Solves

Fixes an issue where users whose session reset raced a live turn's flush would see the affected agent fail on **every** surface — chat channels, bridges, webchat, cron, and subagent recovery — with an unrecoverable `SessionCanonicalKeyMigrationRequiredError` until an operator manually ran `openclaw doctor --fix`. The same misclassification also silently fallbacked healthy models on every turn.

## Why This Change Was Made

The raced row shape (a complete entry payload invalidated by `entry_valid = -1` over a retained window) is rebuildable, not corruption: it is exactly what `doctor --fix` repairs. Validation now tolerates that tuple (empty sentinel **or** a complete, self-consistent payload over the retained window) while unparseable or identity/timestamp-inconsistent payloads still require repair. To close the race at the source, the reset and root-creation statement pairs (trigger-driven pending write + settle) are wrapped in an immediate transaction (SAVEPOINT-nested when already inside one), so a concurrent flush can no longer interleave its `entry_json` write between them.

## User Impact

A session reset racing a turn flush self-heals instead of bricking the agent: messages keep flowing (or the session transparently rebuilds from its retained window on next use), and the row returns to a valid state on the session's next turn — no operator, no downtime. Headless/bridge sessions that cannot run `/reset` or `doctor` mid-incident benefit the most.

## Evidence

- Regression tests (`src/config/sessions/session-canonical-key.test.ts`):
  - the raced tuple no longer throws on a live connection, stays tolerated on a cold listing, and returns to a listed, valid entry after the session's next turn;
  - an unparseable payload with `entry_valid = -1` over a retained window **still** throws `openclaw doctor --fix` (repair path preserved);
  - the pre-existing corruption pins (malformed row partial-snapshot protection, mismatched-time target, readonly pending-row summary) all pass unchanged.
- Full `src/config/sessions/` suite: 1538 passed; the only 2 failures (`session-transcript-reconcile.lease.test.ts`) reproduce on unmodified `main` at `279d42d4be3`.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean.
- Operational evidence: this self-heal + atomic-settle behavior has been running on our production fleet since 2026-09-05 after the same race produced a real multi-surface outage there; no recurrence since.
