### PR TITLE
fix(run): keep host overflow precheck active when the context engine estimate exceeds the attempt budget

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-history-prepare.ts
@@ -30,6 +30,8 @@ import { estimateRenderedLlmBoundaryTokenPressure } from "./preemptive-compactio
 type PreparedEmbeddedAttemptHistory = {
   contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]>;
   contextEngineAssemblySucceeded: boolean;
+  /** Engine-assembly token estimate; keeps the host overflow precheck active when it exceeds the attempt budget. */
+  contextEngineEstimatedTokens?: number;
   unwindowedContextEngineMessagesForPrecheck?: AgentMessage[];
 };
 
@@ -196,6 +198,7 @@ export async function prepareEmbeddedAttemptHistory(
 
   let contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]> = "assembled";
   let contextEngineAssemblySucceeded = false;
+  let contextEngineEstimatedTokens: number | undefined;
   let unwindowedContextEngineMessagesForPrecheck: AgentMessage[] | undefined;
   if (activeContextEngine) {
     try {
@@ -252,6 +255,12 @@ export async function prepareEmbeddedAttemptHistory(
       }
       contextEnginePromptAuthority = assembled.promptAuthority ?? "assembled";
       contextEngineAssemblySucceeded = true;
+      if (
+        typeof assembled.estimatedTokens === "number" &&
+        Number.isFinite(assembled.estimatedTokens)
+      ) {
+        contextEngineEstimatedTokens = assembled.estimatedTokens;
+      }
       if (contextEnginePromptAuthority === "preassembly_may_overflow") {
         unwindowedContextEngineMessagesForPrecheck = preassemblyMessages;
       }
@@ -274,6 +283,7 @@ export async function prepareEmbeddedAttemptHistory(
   return {
     contextEnginePromptAuthority,
     contextEngineAssemblySucceeded,
+    ...(contextEngineEstimatedTokens !== undefined ? { contextEngineEstimatedTokens } : {}),
     ...(unwindowedContextEngineMessagesForPrecheck
       ? { unwindowedContextEngineMessagesForPrecheck }
       : {}),

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-phase.ts
@@ -90,6 +90,7 @@ export async function runEmbeddedAttemptPromptPhase(
     history: {
       contextEngineAssemblySucceeded,
       contextEnginePromptAuthority,
+      contextEngineEstimatedTokens,
       unwindowedContextEngineMessagesForPrecheck,
     },
     promptActiveSession,
@@ -324,6 +325,7 @@ export async function runEmbeddedAttemptPromptPhase(
       compactionReplayEnabled,
       contextEngineAssemblySucceeded,
       contextEnginePromptAuthority,
+      ...(contextEngineEstimatedTokens !== undefined ? { contextEngineEstimatedTokens } : {}),
       includeBoundaryTimestamp,
       ...(boundaryTimezone ? { timezone: boundaryTimezone } : {}),
       ...(unwindowedContextEngineMessagesForPrecheck

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.test.ts
@@ -355,6 +355,54 @@ describe("attempt prompt preflight", () => {
     expect(result).toEqual(state);
   });
 
+  it("keeps host precheck active when the engine estimate exceeds the attempt budget", async () => {
+    const makeState = (): Parameters<typeof prepareEmbeddedAttemptPromptPreflight>[0]["state"] => ({
+      contextBudgetStatus: undefined,
+      preflightRecovery: undefined,
+      promptError: null,
+      promptErrorSource: null,
+      skipPromptSubmission: false,
+    });
+    const baseInput = {
+      attempt,
+      compactionReplayEnabled: true,
+      activeContextEngine: {
+        info: { id: "owner", name: "Owner", ownsCompaction: true },
+      },
+      contextEngineAssemblySucceeded: true,
+      contextEnginePromptAuthority: "assembled" as const,
+      contextTokenBudget: 100,
+      hookMessagesForCurrentPrompt: [],
+      includeBoundaryTimestamp: false,
+      promptForPrecheck: "x".repeat(4_000),
+      reserveTokens: 20,
+      sessionMessageCount: 0,
+      systemPrompt: "",
+      toolResultMaxChars: 1_000,
+    };
+
+    // The engine's own assembly already exceeds the CURRENT attempt's budget
+    // (e.g. a fallback chain moved the run to a smaller-context model); the
+    // host precheck must stay active instead of shipping a doomed prompt.
+    const overBudget = await prepareEmbeddedAttemptPromptPreflight({
+      ...baseInput,
+      contextEngineEstimatedTokens: 5_000,
+      state: makeState(),
+    });
+    expect(overBudget.skipPromptSubmission).toBe(false);
+    expect(overBudget.contextBudgetStatus?.shouldCompact).toBe(true);
+    expect(overBudget.contextBudgetStatus?.overflowTokens).toBeGreaterThan(0);
+
+    // A fitting estimate keeps the deferral behavior byte-identical.
+    const state = makeState();
+    const fitting = await prepareEmbeddedAttemptPromptPreflight({
+      ...baseInput,
+      contextEngineEstimatedTokens: 50,
+      state,
+    });
+    expect(fitting).toEqual(state);
+  });
+
   it("does not persist heuristic pre-prompt tool-result truncation", async () => {
     const toolResult = makeToolResultMessage("alpha beta gamma delta epsilon ".repeat(2_200));
     const messages = [toolResult];

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-preflight.ts
@@ -169,6 +169,8 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
   compactionReplayEnabled: boolean;
   contextEngineAssemblySucceeded: boolean;
   contextEnginePromptAuthority: NonNullable<AssembleResult["promptAuthority"]>;
+  /** Engine-assembly token estimate; keeps the host precheck active when it exceeds the attempt budget. */
+  contextEngineEstimatedTokens?: number;
   contextTokenBudget: number;
   hookMessagesForCurrentPrompt: AgentMessage[];
   includeBoundaryTimestamp: boolean;
@@ -227,9 +229,28 @@ export async function prepareEmbeddedAttemptPromptPreflight(input: {
       };
     }
   }
+  // Even when the context engine owns compaction, its own assembly estimate can
+  // exceed the CURRENT attempt's per-model budget (e.g. a fallback chain moved
+  // the run to a smaller-context model). Shipping that prompt is a guaranteed
+  // billed terminal overflow, so the host precheck stays active in that case.
+  const contextEngineEstimateExceedsBudget =
+    typeof input.contextEngineEstimatedTokens === "number" &&
+    Number.isFinite(input.contextEngineEstimatedTokens) &&
+    input.contextEngineEstimatedTokens > 0 &&
+    input.contextTokenBudget > 0 &&
+    input.contextEngineEstimatedTokens > input.contextTokenBudget;
+  if (contextEngineEstimateExceedsBudget) {
+    log.warn(
+      `[context-overflow-precheck] engine estimate ${input.contextEngineEstimatedTokens} exceeds ` +
+        `attempt budget ${input.contextTokenBudget}; keeping host precheck active ` +
+        `provider=${input.attempt.provider}/${input.attempt.modelId} ` +
+        `sessionKey=${input.attempt.sessionKey ?? input.attempt.sessionId}`,
+    );
+  }
   const shouldSkipPrecheck =
     skipPromptSubmission ||
-    (input.contextEngineAssemblySucceeded &&
+    (!contextEngineEstimateExceedsBudget &&
+      input.contextEngineAssemblySucceeded &&
       input.activeContextEngine?.info.ownsCompaction &&
       input.contextEnginePromptAuthority !== "preassembly_may_overflow" &&
       !preemptiveCompaction?.compactionReplay);


### PR DESCRIPTION
Closes #139961

## What Problem This Solves

Fixes an issue where users running a context-engine plugin that owns compaction would have a prompt that is **already known** to exceed the active model's context window shipped to the provider anyway — billed, then failed with a context-overflow error, losing the turn. This routinely bites after a model fallback chain moves a run to a smaller-context model.

## Why This Change Was Made

The pre-submission precheck skipped itself unconditionally whenever a context engine owned compaction, without consulting the engine's own assembly estimate. The estimate is now plumbed into the preflight; the skip stays false only when the estimate is finite, positive, and exceeds the current attempt's budget (with a warn log carrying provider/model/session). When the estimate fits or is missing, behavior is byte-identical — pinned by a dedicated assertion.

## User Impact

Turns on context-engine-owned sessions no longer pay for requests that cannot succeed. When the assembled context does not fit the active model's budget, the existing overflow machinery runs instead (recovery/guidance), so the failure is handled before spend happens rather than after.

## Evidence

- New test (`attempt-prompt-preflight.test.ts`): with `ownsCompaction: true` and `contextEngineEstimatedTokens: 5000` vs a 100-token budget, the host precheck runs (`contextBudgetStatus.shouldCompact` with positive overflow tokens) instead of skipping; with a fitting estimate (50), the deferral result is byte-identical to the previous behavior (pinned via state equality).
- All 28 tests in `attempt-prompt-preflight.test.ts` + `attempt-prompt-phase.test.ts` pass; `attempt-history.test.ts` and `attempt-execution-phase.test.ts` pass; `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean.
- Operational evidence: this gate has been running on our production fleet since 2026-09-06, where the incident described in #139961 (an ~800K-token session assembled against a 524K-context fallback model) is now gated before submission instead of billed and lost.
