### PR TITLE
fix(agents): bounded transport-level retry for pre-stream 5xx model responses

### DIFF
--- a/src/agents/provider-transport-5xx-retry.ts
+++ b/src/agents/provider-transport-5xx-retry.ts
@@ -1,0 +1,107 @@
+import { emitModelTransportDebug } from "@openclaw/ai/transports";
+import type { GuardedFetchOptions, GuardedFetchResult } from "../infra/net/fetch-guard.js";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import type { Model } from "../llm/types.js";
+import type { SubsystemLogger } from "../logging/subsystem.js";
+
+/**
+ * Pre-stream 5xx statuses eligible for the bounded transport-level retry.
+ * Transient gateway/provider blunders (500/502/503/504) returned as plain
+ * error bodies before any SSE stream starts mean the provider never began
+ * processing the request, so a bounded replay is safe.
+ */
+const TRANSPORT_5XX_RETRY_STATUSES = new Set([500, 502, 503, 504]);
+
+/** Bounded backoff schedule (ms) for the transport-level 5xx retry. */
+const TRANSPORT_5XX_RETRY_DELAY_MS = [2_000, 5_000];
+
+function isReplayableModelFetchBody(init: GuardedFetchOptions["init"]): boolean {
+  const body = (init as { body?: unknown } | undefined)?.body;
+  return (
+    body == null ||
+    typeof body === "string" ||
+    body instanceof Uint8Array ||
+    body instanceof ArrayBuffer
+  );
+}
+
+function isPreStreamPlainErrorResponse(response: Response): boolean {
+  return (
+    TRANSPORT_5XX_RETRY_STATUSES.has(response.status) &&
+    !/\btext\/event-stream\b/i.test(response.headers.get("content-type") ?? "")
+  );
+}
+
+function sleepAbortable(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal || signal.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    timer.unref?.();
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Retry transient pre-stream 5xx responses up to twice with bounded backoff.
+ *
+ * Only plain (non-SSE) error bodies are retried — an SSE response means the
+ * provider accepted and started the request, where a replay could duplicate
+ * model work. Only replayable request bodies (string/Uint8Array/ArrayBuffer/
+ * null) are retried. Each retry re-issues the same guarded fetch options, so
+ * SSRF policy, dispatcher pool, and the per-attempt timeout budget all apply;
+ * the discarded attempt's dispatcher lease is released before re-fetching, and
+ * the final attempt's result is returned so the caller wires its release into
+ * the managed response as usual.
+ */
+export async function retryTransientPreStream5xx(params: {
+  model: Model;
+  result: GuardedFetchResult;
+  response: Response;
+  guardedFetchOptions: GuardedFetchOptions;
+  log: SubsystemLogger;
+  fetchStartedAt: number;
+  signal?: AbortSignal;
+}): Promise<{ result: GuardedFetchResult; response: Response }> {
+  const { model, guardedFetchOptions, log } = params;
+  let current = params.result;
+  let response = params.response;
+  if (!isReplayableModelFetchBody(guardedFetchOptions.init)) {
+    return { result: current, response };
+  }
+  for (const [attempt, delay] of TRANSPORT_5XX_RETRY_DELAY_MS.entries()) {
+    if (params.signal?.aborted || !isPreStreamPlainErrorResponse(response)) {
+      return { result: current, response };
+    }
+    log.warn(
+      `[model-fetch] transient ${response.status} from provider=${model.provider} ` +
+        `api=${model.api} model=${model.id} — transport retry ` +
+        `${attempt + 1}/${TRANSPORT_5XX_RETRY_DELAY_MS.length} in ${delay}ms`,
+    );
+    await sleepAbortable(delay, params.signal);
+    if (params.signal?.aborted) {
+      return { result: current, response };
+    }
+    // The discarded attempt's dispatcher lease is released together with its
+    // unread error body; the retried request re-enters the guarded fetch with
+    // the same options (SSRF policy, dispatcher pool, timeout budget).
+    await current.release().catch(() => undefined);
+    current = await fetchWithSsrFGuard(guardedFetchOptions);
+    response = current.response;
+    emitModelTransportDebug(
+      log,
+      `[model-fetch] response provider=${model.provider} api=${model.api} model=${model.id} ` +
+        `status=${response.status} elapsedMs=${Date.now() - params.fetchStartedAt} ` +
+        `dispatcher=${current.dispatcherReused ? "reused" : "new"} ` +
+        `contentType=${response.headers.get("content-type") ?? ""} ` +
+        `transportRetry=${attempt + 1}`,
+    );
+  }
+  return { result: current, response };
+}

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -2366,5 +2366,119 @@ describe("buildGuardedModelFetch", () => {
       },
     );
   });
+
+  describe("transient pre-stream 5xx transport retry", () => {
+    type GuardedResult = {
+      response: Response;
+      finalUrl: string;
+      release: ReturnType<typeof vi.fn>;
+    };
+
+    function guardedResult(status: number, contentType = "application/json"): GuardedResult {
+      return {
+        response: new Response(JSON.stringify({ error: { message: "boom" } }), {
+          status,
+          headers: { "content-type": contentType },
+        }),
+        finalUrl: "https://api.openai.com/v1/responses",
+        release: vi.fn(async () => undefined),
+      };
+    }
+
+    function queueResults(...results: GuardedResult[]): void {
+      let index = 0;
+      fetchWithSsrFGuardMock.mockImplementation(async () => {
+        const result = results[Math.min(index, results.length - 1)];
+        index += 1;
+        return result;
+      });
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function postJson(): Promise<Response> {
+      const fetcher = buildGuardedModelFetch(sentinelModel());
+      const pending = fetcher("https://api.openai.com/v1/responses", {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-5.5", input: "hi" }),
+      });
+      await vi.runAllTimersAsync();
+      return await pending;
+    }
+
+    it("retries a transient 500 and wires the final attempt's release", async () => {
+      vi.useFakeTimers();
+      const first = guardedResult(500);
+      const second = guardedResult(200);
+      queueResults(first, second);
+      const response = await postJson();
+
+      expect(response.status).toBe(200);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(2);
+      expect(first.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("bounds the retry at two attempts before surfacing the 5xx", async () => {
+      vi.useFakeTimers();
+      const attempts = [guardedResult(503), guardedResult(503), guardedResult(503)];
+      queueResults(...attempts);
+      const response = await postJson();
+      await response.text();
+
+      expect(response.status).toBe(503);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(3);
+      expect(attempts[0]?.release).toHaveBeenCalledTimes(1);
+      expect(attempts[1]?.release).toHaveBeenCalledTimes(1);
+      // Consuming the final response's body runs the final attempt's release,
+      // proving the managed response wired the last attempt (not an earlier one).
+      expect(attempts[2]?.release).toHaveBeenCalledTimes(1);
+    });
+
+    it("never retries SSE responses", async () => {
+      vi.useFakeTimers();
+      const only = guardedResult(500, "text/event-stream");
+      queueResults(only);
+      const response = await postJson();
+
+      expect(response.status).toBe(500);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+      expect(only.release).not.toHaveBeenCalled();
+    });
+
+    it("does not retry non-5xx error responses", async () => {
+      vi.useFakeTimers();
+      const only = guardedResult(400);
+      queueResults(only);
+      const response = await postJson();
+
+      expect(response.status).toBe(400);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+      expect(only.release).not.toHaveBeenCalled();
+    });
+
+    it("does not retry non-replayable request bodies", async () => {
+      vi.useFakeTimers();
+      const only = guardedResult(500);
+      queueResults(only);
+      const fetcher = buildGuardedModelFetch(sentinelModel());
+      const pending = fetcher("https://api.openai.com/v1/responses", {
+        method: "POST",
+        body: new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("chunk"));
+            controller.close();
+          },
+        }),
+      });
+      await vi.runAllTimersAsync();
+      const response = await pending;
+
+      expect(response.status).toBe(500);
+      expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+      expect(only.release).not.toHaveBeenCalled();
+    });
+  });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -48,6 +48,7 @@ import {
   mergeModelProviderRequestOverrides,
   resolveProviderRequestPolicyConfig,
 } from "./provider-request-config.js";
+import { retryTransientPreStream5xx } from "./provider-transport-5xx-retry.js";
 import { getProviderTransportDispatcherPool } from "./provider-transport-dispatcher-pool.js";
 
 const DEFAULT_MAX_SDK_RETRY_WAIT_SECONDS = 60;
@@ -908,6 +909,19 @@ export function buildGuardedModelFetch(
         `dispatcher=${result.dispatcherReused ? "reused" : "new"} ` +
         `contentType=${response.headers.get("content-type") ?? ""}`,
     );
+    // A single transient pre-stream 5xx from a transport that does not
+    // self-retry would otherwise terminate the run outright, even with
+    // fallback models configured. Bounded transport-level retry for plain
+    // error bodies; see retryTransientPreStream5xx for the safety bounds.
+    ({ result, response } = await retryTransientPreStream5xx({
+      model,
+      result,
+      response,
+      guardedFetchOptions,
+      log,
+      fetchStartedAt,
+      signal: localServiceSignal,
+    }));
     if (shouldBypassLongSdkRetry(response)) {
       const headers = new Headers(response.headers);
       headers.set("x-should-retry", "false");


### PR DESCRIPTION
Closes #139962

## What Problem This Solves

Fixes an issue where users running long embedded agent turns could lose the entire run to a single transient provider blip: one HTTP 500 (or 502/503/504) returned as a plain error body a few seconds into a request terminated a 33-minute QA run on 2026-09-04, despite two fallback models being configured. The failover policy defers to plugin/harness-owned transports for timeout-classified failures, and some transports do not self-retry — so nothing redeemed the run.

## Why This Change Was Made

SDK-based routes already get stainless-style retries with Retry-After handling, but the shared guarded fetch used by non-SDK/custom transports had none. The retry is deliberately bounded and conservative: only pre-stream 500/502/503/504 plain error bodies (the provider never started processing), only replayable request bodies, never SSE responses (a replay could duplicate model work), and each attempt re-enters the same guarded fetch so SSRF policy, dispatcher pool, and the per-attempt timeout budget all still apply. It lives in its own module so the grandfathered oversized transport file does not grow.

## User Impact

A momentary provider 5xx no longer destroys long-running work. The transport absorbs up to two replays with 2s/5s backoff before surfacing, after which existing failover behavior applies unchanged. Runs that previously died to a single blip now complete.

## Evidence

- New tests (`provider-transport-fetch.test.ts`, guarded-fetch seam mocked):
  - a 500 followed by 200 is retried once and the final attempt's release is the one wired into the managed response;
  - persistent 503s are bounded at 2 retries (3 guarded calls total), with each discarded attempt's dispatcher lease released and the final release firing on body consumption;
  - SSE 500 responses, non-5xx responses, and non-replayable request bodies are never retried (call count pinned at 1).
- All 106 tests in `provider-transport-fetch.test.ts` pass; `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean.
- Operational evidence: running on our production fleet since 2026-09-04; no 5xx-killed runs since, after several occurrences in the weeks before.
