### PR TITLE
fix(gateway): preserve empty tool outputs as completed results

### DIFF
--- a/src/gateway/agent-prompt.test.ts
+++ b/src/gateway/agent-prompt.test.ts
@@ -162,6 +162,14 @@ describe("gateway agent prompt", () => {
     expect(prompt).toContain("User: continue");
   });
 
+  it("renders a sole empty tool result as its sender line instead of an empty message", () => {
+    expect(
+      buildAgentMessageFromConversationEntries([
+        { role: "tool", entry: { sender: "Tool:call_1", body: "" } },
+      ]),
+    ).toBe("Tool:call_1: ");
+  });
+
   it("preserves current user text that looks like internal display metadata", () => {
     const body = "[Thu 2026-03-12 07:00 UTC] what happened then?";
     expect(

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -80,11 +80,18 @@ export function buildAgentMessageFromConversationEntries(entries: ConversationEn
   if (!currentPromptEntry) {
     return "";
   }
+  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${entry.body}`;
   if (historyEntries.length === 0) {
+    // A sole tool result with empty output still carries call identity the agent
+    // must see (empty string is a completed output, not absence): render its
+    // sender line instead of an empty message. Only tool entries can arrive here
+    // with an empty body; every other role is dropped upstream when bodiless.
+    if (!currentPromptEntry.body && currentConversationEntry.role === "tool") {
+      return formatEntry(currentPromptEntry);
+    }
     return currentPromptEntry.body;
   }
 
-  const formatEntry = (entry: HistoryEntry) => `${entry.sender}: ${entry.body}`;
   return buildHistoryContextFromEntries({
     entries: [...historyEntries, currentPromptEntry],
     currentMessage: formatEntry(currentPromptEntry),

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -677,9 +677,6 @@ function buildAgentPrompt(
     const messageContent = [baseMessageContent, assistantToolCallsSummary]
       .filter((part): part is string => Boolean(part))
       .join("\n");
-    if (!messageContent) {
-      continue;
-    }
 
     const name = normalizeOptionalString(msg.name) ?? "";
     const toolCallId = normalizeOptionalString(msg.tool_call_id) ?? "";
@@ -693,6 +690,13 @@ function buildAgentPrompt(
             : name
               ? `Tool:${name}`
               : "Tool";
+
+    // An empty string is a completed tool output, not an absent message: keep
+    // tool results carrying call identity so the agent sees them as the current
+    // tool-result input instead of replaying the earlier prompt.
+    if (!messageContent && !(normalizedRole === "tool" && (toolCallId || name))) {
+      continue;
+    }
 
     conversationEntries.push({
       role: normalizedRole,


### PR DESCRIPTION
Closes #139975

I traced both failure modes to empty tool outputs losing their call
identity. The chat formatter dropped bodiless messages before the
Tool:<id> sender was even computed, so the agent replayed the
earlier prompt. On the Responses side a sole empty tool output
assembled to an empty message and tripped the Missing user message
gate with a 400.

I kept tool results carrying tool_call_id or name even when the
body is empty, and made the shared builder render a sole empty
tool result as its sender line. This matches the existing
convention already tested for history entries ("Tool:call_1: ").

I could not run the repo suite here, so I verified with tsc plus a
standalone repro of the formatter loop, and added a unit test for
the sole-entry case. CI runs the full suite.