### PR TITLE
refactor(plugins): centralize install recovery metadata

### DIFF
--- a/src/cli/plugin-install-config-policy.test.ts
+++ b/src/cli/plugin-install-config-policy.test.ts
@@ -1,0 +1,144 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OfficialExternalPluginCatalogEntry } from "../plugins/official-external-plugin-catalog.js";
+import {
+  resolvePluginInstallInvalidConfigPolicy,
+  resolvePluginInstallPreactionRequest,
+  type PluginInstallRequestContext,
+} from "./plugin-install-config-policy.js";
+
+const fixture = vi.hoisted(() => ({
+  bundledPath: "",
+  entries: [] as OfficialExternalPluginCatalogEntry[],
+}));
+
+vi.mock("../plugins/bundled-sources.js", () => ({
+  findBundledPluginSource: () => ({ pluginId: "bundled-demo", localPath: fixture.bundledPath }),
+}));
+
+vi.mock("../plugins/official-external-plugin-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/official-external-plugin-catalog.js")>()),
+  listOfficialExternalPluginCatalogEntries: () => fixture.entries,
+}));
+
+function parseInstallRequest(
+  spec: string,
+  marketplace?: string,
+): PluginInstallRequestContext | null {
+  const argv = ["node", "openclaw", "plugins", "install", spec];
+  if (marketplace) {
+    argv.push("--marketplace", marketplace);
+  }
+  let request: PluginInstallRequestContext | null = null;
+  const program = new Command();
+  program
+    .command("plugins")
+    .command("install")
+    .argument("<spec>")
+    .option("--marketplace <source>")
+    .hook("preAction", (_command, actionCommand) => {
+      request = resolvePluginInstallPreactionRequest({
+        actionCommand,
+        commandPath: ["plugins", "install"],
+        argv,
+      });
+    })
+    .action(() => undefined);
+  program.parse(argv);
+  return request;
+}
+
+describe("plugin install recovery source ownership", () => {
+  beforeEach(() => {
+    fixture.bundledPath = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-recovery-owner-"));
+    fs.writeFileSync(
+      path.join(fixture.bundledPath, "package.json"),
+      JSON.stringify({ openclaw: { install: { allowInvalidConfigRecovery: true } } }),
+    );
+    fs.writeFileSync(
+      path.join(fixture.bundledPath, "openclaw.plugin.json"),
+      JSON.stringify({ id: "bundled-demo", configSchema: { type: "object" } }),
+    );
+    fixture.entries = [];
+  });
+
+  afterEach(() => {
+    fs.rmSync(fixture.bundledPath, { recursive: true, force: true });
+  });
+
+  it.each([false, true])("honors official recovery=%s before bundled recovery", (allowed) => {
+    fixture.entries = [
+      {
+        name: "@fixture/recovery",
+        openclaw: {
+          plugin: { id: "official-demo" },
+          install: { npmSpec: "@fixture/recovery", allowInvalidConfigRecovery: allowed },
+        },
+      },
+    ];
+    const request = parseInstallRequest("npm:@fixture/recovery@1.2.3");
+    expect(request).toMatchObject({
+      bundledPluginId: "official-demo",
+      allowInvalidConfigRecovery: allowed,
+    });
+    expect(resolvePluginInstallInvalidConfigPolicy(request)).toBe(
+      allowed ? "allow-plugin-recovery" : "deny",
+    );
+  });
+
+  it("uses bundled recovery when no official descriptor owns the spec", () => {
+    const request = parseInstallRequest("@fixture/recovery");
+    expect(request).toMatchObject({
+      bundledPluginId: "bundled-demo",
+      allowInvalidConfigRecovery: true,
+    });
+  });
+
+  it.each([
+    { prefix: "", allowed: false },
+    { prefix: "", allowed: true },
+    { prefix: "file:", allowed: false },
+    { prefix: "file:", allowed: true },
+  ])(
+    "uses local recovery=$allowed through $prefix without borrowing metadata",
+    ({ prefix, allowed }) => {
+      const localPath = path.join(fixture.bundledPath, "local-plugin");
+      fs.mkdirSync(localPath);
+      fs.writeFileSync(
+        path.join(localPath, "package.json"),
+        JSON.stringify({ openclaw: { install: { allowInvalidConfigRecovery: allowed } } }),
+      );
+      fs.writeFileSync(
+        path.join(localPath, "openclaw.plugin.json"),
+        JSON.stringify({ id: "local-demo", configSchema: { type: "object" } }),
+      );
+      const request = parseInstallRequest(`${prefix}${localPath}`);
+      expect(request).toMatchObject({
+        bundledPluginId: "local-demo",
+        allowInvalidConfigRecovery: allowed,
+      });
+      expect(resolvePluginInstallInvalidConfigPolicy(request)).toBe(
+        allowed ? "allow-plugin-recovery" : "deny",
+      );
+    },
+  );
+
+  it.each(["file:@fixture/recovery", "FILE:@fixture/recovery"])(
+    "does not borrow catalog recovery for missing local source %s",
+    (spec) => {
+      const request = parseInstallRequest(spec);
+      expect(request?.bundledPluginId).toBeUndefined();
+      expect(resolvePluginInstallInvalidConfigPolicy(request)).toBe("deny");
+    },
+  );
+
+  it("excludes marketplace requests from bundled recovery", () => {
+    const request = parseInstallRequest("@fixture/recovery", "fixture-marketplace");
+    expect(request).toMatchObject({ marketplace: "fixture-marketplace", installKind: "plugin" });
+    expect(request?.bundledPluginId).toBeUndefined();
+    expect(resolvePluginInstallInvalidConfigPolicy(request)).toBe("deny");
+  });
+});

--- a/src/cli/plugin-install-config-policy.ts
+++ b/src/cli/plugin-install-config-policy.ts
@@ -37,7 +37,7 @@ function isPluginInstallCommand(commandPath: string[]): boolean {
   return commandPath[0] === "plugins" && commandPath[1] === "install";
 }
 
-function readBundledInstallRecoveryMetadata(rootDir: string): {
+function readPluginInstallRecoveryMetadata(rootDir: string): {
   pluginId?: string;
   allowInvalidConfigRecovery: boolean;
 } {
@@ -60,83 +60,25 @@ function readBundledInstallRecoveryMetadata(rootDir: string): {
   };
 }
 
-function resolveBundledInstallRecoveryMetadata(
-  request: Pick<
-    PluginInstallRequestContext,
-    "rawSpec" | "normalizedSpec" | "resolvedPath" | "marketplace"
-  >,
+function resolvePluginInstallRecoveryMetadata(
+  rawSpec: string,
+  localPath: string | undefined,
 ): {
   pluginId?: string;
   allowInvalidConfigRecovery?: boolean;
 } {
-  if (request.marketplace) {
-    return {};
+  // A local or file: request must never inherit recovery authority from a catalog name.
+  if (localPath !== undefined) {
+    const direct = readPluginInstallRecoveryMetadata(localPath);
+    return direct.pluginId || direct.allowInvalidConfigRecovery ? direct : {};
   }
-  if (request.resolvedPath && fs.existsSync(path.join(request.resolvedPath, "package.json"))) {
-    const direct = readBundledInstallRecoveryMetadata(request.resolvedPath);
-    if (direct.pluginId || direct.allowInvalidConfigRecovery) {
-      return direct;
-    }
-  }
-  if (
-    resolveFileNpmSpecToLocalPath(request.rawSpec) !== null ||
-    (request.resolvedPath !== undefined && fs.existsSync(request.resolvedPath))
-  ) {
-    return {};
-  }
-  const rawNpmPrefixSpec = parseNpmPrefixSpec(request.rawSpec);
-  const normalizedNpmPrefixSpec = parseNpmPrefixSpec(request.normalizedSpec);
-  for (const value of [
-    request.rawSpec.trim(),
-    request.normalizedSpec.trim(),
-    rawNpmPrefixSpec ?? "",
-    normalizedNpmPrefixSpec ?? "",
-  ]) {
-    if (!value) {
-      continue;
-    }
-    const bundled = findBundledPluginSource({
-      lookup: { kind: "npmSpec", value },
-    });
-    if (!bundled) {
-      continue;
-    }
-    const recovered = readBundledInstallRecoveryMetadata(bundled.localPath);
-    return {
-      pluginId: recovered.pluginId ?? bundled.pluginId,
-      allowInvalidConfigRecovery: recovered.allowInvalidConfigRecovery,
-    };
-  }
-  return {};
-}
-
-function resolveOfficialExternalInstallRecoveryMetadata(
-  request: Pick<PluginInstallRequestContext, "rawSpec" | "normalizedSpec" | "marketplace">,
-): {
-  pluginId?: string;
-  allowInvalidConfigRecovery?: boolean;
-} {
-  if (request.marketplace) {
-    return {};
-  }
-  if (resolveFileNpmSpecToLocalPath(request.rawSpec) !== null) {
-    return {};
-  }
-  if (fs.existsSync(resolveUserPath(request.rawSpec))) {
-    return {};
-  }
-  const rawNpmPrefixSpec = parseNpmPrefixSpec(request.rawSpec);
-  const normalizedNpmPrefixSpec = parseNpmPrefixSpec(request.normalizedSpec);
+  const npmPrefixSpec = parseNpmPrefixSpec(rawSpec);
   const values = new Set(
     normalizeStringEntries([
-      request.rawSpec,
-      request.normalizedSpec,
-      rawNpmPrefixSpec ?? "",
-      normalizedNpmPrefixSpec ?? "",
-      parseRegistryNpmSpec(request.rawSpec)?.name ?? "",
-      parseRegistryNpmSpec(request.normalizedSpec)?.name ?? "",
-      rawNpmPrefixSpec ? parseRegistryNpmSpec(rawNpmPrefixSpec)?.name : "",
-      normalizedNpmPrefixSpec ? parseRegistryNpmSpec(normalizedNpmPrefixSpec)?.name : "",
+      rawSpec,
+      npmPrefixSpec ?? "",
+      parseRegistryNpmSpec(rawSpec)?.name ?? "",
+      npmPrefixSpec ? parseRegistryNpmSpec(npmPrefixSpec)?.name : "",
     ]),
   );
   if (values.size === 0) {
@@ -149,10 +91,24 @@ function resolveOfficialExternalInstallRecoveryMetadata(
       continue;
     }
     const pluginId = resolveOfficialExternalPluginId(entry);
+    // An official descriptor owns this decision even when recovery is explicitly disabled.
     return {
       ...(pluginId ? { pluginId } : {}),
       allowInvalidConfigRecovery: install?.allowInvalidConfigRecovery === true,
     };
+  }
+  for (const value of [rawSpec.trim(), npmPrefixSpec ?? ""]) {
+    if (!value) {
+      continue;
+    }
+    const bundled = findBundledPluginSource({ lookup: { kind: "npmSpec", value } });
+    if (bundled) {
+      const recovered = readPluginInstallRecoveryMetadata(bundled.localPath);
+      return {
+        pluginId: recovered.pluginId ?? bundled.pluginId,
+        allowInvalidConfigRecovery: recovered.allowInvalidConfigRecovery,
+      };
+    }
   }
   return {};
 }
@@ -229,27 +185,15 @@ export function resolvePluginInstallRequestContext(params: {
     };
   }
   const normalizedSpec = fileSpec && fileSpec.ok ? fileSpec.path : params.rawSpec;
-  const bundledRecovered = resolveBundledInstallRecoveryMetadata({
-    rawSpec: params.rawSpec,
-    normalizedSpec,
-    resolvedPath: resolveUserPath(normalizedSpec),
-    marketplace: params.marketplace,
-  });
-  const officialRecovered = resolveOfficialExternalInstallRecoveryMetadata({
-    rawSpec: params.rawSpec,
-    normalizedSpec,
-    marketplace: params.marketplace,
-  });
-  const recovered =
-    officialRecovered.pluginId || officialRecovered.allowInvalidConfigRecovery !== undefined
-      ? officialRecovered
-      : bundledRecovered;
+  const resolvedPath = resolveUserPath(normalizedSpec);
+  const localPath = fileSpec || fs.existsSync(resolvedPath) ? resolvedPath : undefined;
+  const recovered = resolvePluginInstallRecoveryMetadata(params.rawSpec, localPath);
   return {
     ok: true,
     request: {
       rawSpec: params.rawSpec,
       normalizedSpec,
-      resolvedPath: resolveUserPath(normalizedSpec),
+      resolvedPath,
       ...(params.installKind === "plugin" || recovered.pluginId ? { installKind: "plugin" } : {}),
       ...(recovered.pluginId ? { bundledPluginId: recovered.pluginId } : {}),
       ...(recovered.allowInvalidConfigRecovery !== undefined


### PR DESCRIPTION
## What Problem This Solves

Plugin installation classified local sources and npm names separately for bundled and official recovery metadata, then merged the answers. That duplicated the policy deciding whether plugin-owned recovery may run with invalid config.

## Why This Change Was Made

One resolver now determines source ownership once. Local and file requests use their own package metadata; catalog requests use the official descriptor before bundled metadata. An explicit official refusal still wins over bundled recovery permission. This removes 56 production lines.

## User Impact

Recovery decisions remain consistent across direct paths, file specs, versioned npm names, and marketplace requests. The CLI parser, exported helpers, invalid-file errors and config mutation rules retain their existing behavior.

## Evidence

- 84 tests passed across recovery policy, install config, and mutation-free CLI preflight. Ten focused cases use real Commander pre-action parsing and generated package manifests. Seven initial characterization cases also passed against the original code.
- The complete changed-file gate passed, including core/test types, typed lint, dead exports and ownership boundaries.
- Independent P2 review found no actionable issues. Production is −56 LOC; tests are +144, with no file moves counted as savings.

Related: #135599. This refactor is independently landable from the Gateway lifecycle changes.

## Real CLI validation

Real CLI proof passed on `47806ba38447fbeacd18d5cd5c3ee77b73a1fdef` with Node 24.19.0. The normal source launcher built the runtime artifacts, then six actual CLI install invocations ran in three independent synthetic HOME/state directories. Each case first installed version 1 and created a genuinely owned stale source path using the resulting SQLite install record.

- Allowed local/file recovery: `plugins install file:<replacement> --force --accept-capabilities` exited 0, installed version 2, removed the owned missing load path, and updated the canonical SQLite source/version record. The initial invalid-config diagnostic was printed before successful recovery.
- Explicit recovery refusal: the replacement package declared recovery=false; install exited 1 and preserved the config bytes, complete installed-index value, and installed version 1 files.
- Unrelated invalid config: recovery=true did not authorize invalid gateway.mode; install exited 1 with “Config invalid outside the plugin recovery path” and preserved the same config/index/files.

All six CLI process groups closed. Source remained clean and unchanged, and all 10,800 regular dist/dist-runtime files stayed byte-identical across the runs. No Gateway, real credentials, npm/ClawHub registry, or operator state was used. This proves the actual local CLI recovery/install/persistence path; it does not claim hosted catalog or remote install coverage.

Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34025781230).
