### PR TITLE
fix(update): clear source leases from the rehearsal state copy

### DIFF
--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, expect, it } from "vitest";
 import { runCommandBuffered } from "../process/exec.js";
+import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
+import { withAgentDatabaseMaintenanceLease } from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
@@ -19,6 +26,7 @@ beforeEach(async () => {
   root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "candidate-state-")));
 });
 afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
   await fs.rm(root, { recursive: true, force: true });
 });
 
@@ -55,7 +63,7 @@ async function runSnapshotWorker(input: Parameters<typeof snapshotUpdateCandidat
 }
 
 it.each(["DELETE", "WAL"])(
-  "copies registered databases in %s mode without changing source artifacts",
+  "copies registered databases in %s mode without source process leases or source artifact changes",
   async (journalMode) => {
     const source = path.join(root, "source");
     const target = path.join(root, "copy");
@@ -64,16 +72,37 @@ it.each(["DELETE", "WAL"])(
     const external = path.join(root, "external", "openclaw-agent.sqlite");
     await createDatabase(canonical);
     await createDatabase(external);
-    await createDatabase(
-      shared,
-      "CREATE TABLE agent_databases(agent_id TEXT, path TEXT, PRIMARY KEY(agent_id,path));",
+    const registry = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: source } }).db;
+    const insert = registry.prepare(
+      "INSERT INTO agent_databases (agent_id, path, schema_version, last_seen_at) VALUES (?, ?, 3, 0)",
     );
-    const registry = openNodeSqliteDatabase(shared);
-    const insert = registry.prepare("INSERT INTO agent_databases VALUES (?, ?)");
     insert.run("external", external);
     insert.run("main", canonical);
     insert.run("main", path.relative(source, canonical));
-    registry.close();
+    const now = Date.now();
+    registry
+      .prepare("INSERT INTO agent_database_leases VALUES (?, ?, ?, ?, ?, ?)")
+      .run(
+        "live-main",
+        "main",
+        canonical,
+        process.pid,
+        getFileLockProcessStartTime(process.pid),
+        now,
+      );
+    registry
+      .prepare("INSERT INTO state_leases VALUES (?, ?, ?, ?, ?, ?, ?, ?)")
+      .run(
+        "core:agent-database-maintenance",
+        "global",
+        "live-source-owner",
+        now + 60_000,
+        now,
+        null,
+        now,
+        now,
+      );
+    closeOpenClawStateDatabaseByPath(shared);
     const sources = [shared, canonical, external];
     for (const file of sources) {
       const database = openNodeSqliteDatabase(file);
@@ -89,16 +118,29 @@ it.each(["DELETE", "WAL"])(
       );
     const before = await artifacts();
     const inspected = await readUpdateStateSchemaVersions({ stateDir: source, config: {} });
-    expect(inspected.filter((entry) => entry.userVersion === 3)).toHaveLength(3);
+    expect(inspected.filter((entry) => entry.userVersion === 3)).toHaveLength(2);
     expect(await artifacts()).toEqual(before);
     const versions = await runSnapshotWorker({
       stateDir: source,
       targetStateDir: target,
       config: {},
     });
-    expect(versions.filter((entry) => entry.userVersion === 3)).toHaveLength(3);
+    expect(versions).toEqual(inspected);
+    await expect(
+      withAgentDatabaseMaintenanceLease(
+        {
+          env: {
+            OPENCLAW_STATE_DIR: target,
+            OPENCLAW_CONFIG_PATH: path.join(target, "openclaw.json"),
+          },
+        },
+        async (maintenance) => maintenance.assertOwned(),
+      ),
+    ).resolves.toBeUndefined();
     expect(await artifacts()).toEqual(before);
     const copiedRegistry = openNodeSqliteDatabase(path.join(target, "state", "openclaw.sqlite"));
+    expect(copiedRegistry.prepare("SELECT * FROM agent_database_leases").all()).toEqual([]);
+    expect(copiedRegistry.prepare("SELECT * FROM state_leases").all()).toEqual([]);
     expect(
       copiedRegistry
         .prepare("SELECT count(*) AS count FROM agent_databases WHERE agent_id = 'main'")

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -23,7 +23,10 @@ export const UpdateStateSchemaVersionsSchema = z.array(
 );
 export type UpdateStateSchemaVersion = z.infer<typeof UpdateStateSchemaVersionsSchema>[number];
 type StateInput = { stateDir: string; config: OpenClawConfig; env?: NodeJS.ProcessEnv };
-type Registry = Pick<DB, "agent_databases">;
+type CandidateStateDatabase = Pick<
+  DB,
+  "agent_databases" | "agent_database_leases" | "state_leases"
+>;
 
 export function updateStateSchemaVersionsMatch(
   before: readonly UpdateStateSchemaVersion[],
@@ -52,7 +55,7 @@ function collectRegisteredPaths(db: DatabaseSync, shared: string, files: string[
   const rows = tableExists(db, "agent_databases")
     ? executeSqliteQuerySync(
         db,
-        getNodeSqliteKysely<Registry>(db)
+        getNodeSqliteKysely<CandidateStateDatabase>(db)
           .selectFrom("agent_databases")
           .select("path")
           .orderBy("path"),
@@ -234,10 +237,16 @@ export async function snapshotUpdateCandidateState(
         ...(file === shared
           ? {
               transform: (db: DatabaseSync) => {
+                const queries = getNodeSqliteKysely<CandidateStateDatabase>(db);
+                // Source process leases cannot own the independently opened rehearsal copy.
+                for (const table of ["agent_database_leases", "state_leases"] as const) {
+                  if (tableExists(db, table)) {
+                    executeSqliteQuerySync(db, queries.deleteFrom(table));
+                  }
+                }
                 for (const { stored, source } of collectRegisteredPaths(db, shared, files)) {
                   const rebound = targetPath(source);
                   const reboundStored = path.relative(input.targetStateDir, rebound);
-                  const queries = getNodeSqliteKysely<Registry>(db);
                   if (
                     stored !== reboundStored &&
                     source === resolveOpenClawRegisteredAgentDatabasePath(shared, reboundStored)


### PR DESCRIPTION
Related: #139701, #138839

## What Problem This Solves

Fixes an issue where users updating a running Gateway would fail candidate migration rehearsal because the copied state still claimed that the serving Gateway owned its agent databases. The live Gateway correctly keeps serving through candidate validation, so its process remains alive and Doctor correctly refuses those copied claims.

## Why This Change Was Made

Clear source agent-database and state-coordination leases in the private shared-database snapshot before publishing the rehearsal copy. Candidate processes then acquire their own ownership through the existing maintenance and runtime paths.

This is separate from concern E in the #135868 split because the repair belongs to the candidate-state snapshot owner. This is an implementation repair under the existing ownership-routing carve-out: there is no schema, schema-version, table-definition, migration, stored-representation, retention-rule, or public-contract change. It only clears lease rows in the throwaway rehearsal copy created by the canary; the live store and its lease semantics are unchanged. The material SQLite/persistent-store review checkpoint does not apply to this copy-only repair.

## User Impact

Updates can validate a candidate while the previous Gateway remains running. Doctor continues to refuse maintenance against databases actually held by a live process.

## Evidence

- A packaged launchd A→B trial for #139701 reproduced the refusal before activation. The old Gateway stayed healthy on the same process through 200 post-failure samples over 206 seconds. An independent installed snapshot-worker probe confirmed that the copy retained the serving process's two live agent-database leases.
- The existing DELETE/WAL snapshot cases now initialize the canonical shared schema, seed a live PID/start identity and an unexpired maintenance claim, run the real snapshot worker, and require Doctor maintenance admission on the copy. Both copied lease tables must be empty; source database bytes and directory contents remain unchanged. Registry rebinding, durable data, schema versions, missing tables, and external-path coverage remain.
- Focused candidate-state tests: 6 passed. Snapshot/canary/lease-owner/heartbeat coverage: 75 passed, 2 existing platform skips, including built-candidate startup/readiness and process-group teardown. Local autoreview found no actionable P0–P2 findings. The full changed-file gate passed twice, including after rebase. Branch autoreview is clean at P0–P2. The lockfile is unchanged.
- Counterproof from committed checkpoint c535fab8e59: removing only the production repair makes both DELETE/WAL cases fail with the existing maintenance-lease timeout. Restoring the exact reviewed bytes makes both pass. The unchanged live-owner maintenance-refusal regression also passes.

- Fresh launchd A→B and cold-C trials follow when #139701 is rebased onto this repair, per the maintainer-requested sequence. They are not claimed as completed proof for this PR.

- Exact-head CI passed on `5df208c0cd5d7c6d24bb76df73faa13628eccceb`: [run 34026108855](https://github.com/openclaw/openclaw/actions/runs/34026108855). [ClawSweeper’s review of that head](https://github.com/openclaw/openclaw/pull/140004#issuecomment-5558503257) found no actionable or security findings and listed no before-merge or rank-up requests.

Production growth is limited to enforcing ownership in the private copy; there is no new abstraction or fallback. The broad archive sanitizer is intentionally unused because it also removes unrelated queued data and changes approval information.

| Class | Added | Deleted | Net | Before → after |
| --- | ---: | ---: | ---: | ---: |
| Production | 12 | 3 | +9 | 278 → 287 |
| Tests/support | 51 | 9 | +42 | 260 → 302 |
| Tooling | 0 | 0 | 0 | 0 → 0 |
| Docs | 0 | 0 | 0 | 0 → 0 |
