### PR TITLE
fix: cancelling a task or killing a session can still deliver the child's completion

### DIFF
--- a/src/agents/subagents/registry/subagent-control-kill.ts
+++ b/src/agents/subagents/registry/subagent-control-kill.ts
@@ -516,6 +516,7 @@ export async function killSubagentRunAdmin(
         cfg: params.cfg,
         tree,
         scope,
+        suppressTaskDelivery: params.suppressTaskDelivery,
         beforeSessionKill: control?.beforeSessionKill,
         expectedRunId: params.expectedRunId?.trim() || undefined,
         expectedGeneration: params.expectedGeneration,

--- a/src/agents/subagents/registry/subagent-control.precise-cancel-suppression.test.ts
+++ b/src/agents/subagents/registry/subagent-control.precise-cancel-suppression.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Precise cancel entries must suppress the child's completion delivery.
+ *
+ * The bulk stop paths (`chat.abort`, `/stop`) already pass
+ * `suppressTaskDelivery: true`; the cancel-by-task-id and HTTP admin kill entries
+ * reach `killSubagentRunAdmin` and previously could not express it at all, so a
+ * completion that raced the cancel could still be delivered after reconciliation.
+ */
+import { expect, it } from "vitest";
+import { getRuntimeConfig } from "../../../config/config.js";
+import { killSubagentRunAdmin } from "./subagent-control.js";
+import { useSubagentControlFixture } from "./subagent-control.test-support.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import { registerSubagentRun } from "./subagent-registry.js";
+import { writeSubagentSessionEntry } from "./subagent-registry.persistence.test-support.js";
+
+const fixture = useSubagentControlFixture();
+
+const CHILD_SESSION_KEY = "agent:main:subagent:precise-cancel";
+const REQUESTER_SESSION_KEY = "agent:main:main";
+
+async function registerCancellableChild(runId: string) {
+  await writeSubagentSessionEntry({
+    stateDir: fixture.stateDir,
+    sessionKey: CHILD_SESSION_KEY,
+    agentId: "main",
+    defaultSessionId: "sess-precise-cancel",
+  });
+  registerSubagentRun({
+    runId,
+    childSessionKey: CHILD_SESSION_KEY,
+    requesterSessionKey: REQUESTER_SESSION_KEY,
+    requesterAgentId: "main",
+    requesterDisplayKey: "main",
+    task: "work that races its own cancellation",
+    cleanup: "keep",
+    expectsCompletionMessage: true,
+  });
+  return subagentRuns.get(runId);
+}
+
+it.each([
+  {
+    name: "an operator cancel that asks for suppression",
+    suppressTaskDelivery: true,
+    expectedSuppression: true,
+  },
+  {
+    name: "a caller that does not ask for suppression",
+    suppressTaskDelivery: undefined,
+    expectedSuppression: false,
+  },
+])(
+  "carries $name through killSubagentRunAdmin into the kill reconciliation window",
+  async ({ suppressTaskDelivery, expectedSuppression }) => {
+    const runId = "precise-cancel-run";
+    const entry = await registerCancellableChild(runId);
+    expect(entry).toBeDefined();
+
+    await killSubagentRunAdmin({
+      cfg: getRuntimeConfig(),
+      sessionKey: CHILD_SESSION_KEY,
+      agentId: "main",
+      ...(suppressTaskDelivery === undefined ? {} : { suppressTaskDelivery }),
+    });
+
+    const cancelled = subagentRuns.get(runId);
+    // The suppression request has to survive as durable cancellation ownership,
+    // otherwise a completion racing the cancel reconciles and delivers anyway.
+    const carrier = cancelled?.killIntent ?? cancelled?.killReconciliation;
+    expect(carrier).toBeDefined();
+    expect(carrier?.suppressTaskDelivery ?? false).toBe(expectedSuppression);
+  },
+);

--- a/src/gateway/session-kill-http.test.ts
+++ b/src/gateway/session-kill-http.test.ts
@@ -210,6 +210,9 @@ describe("POST /sessions/:sessionKey/kill", () => {
       cfg,
       sessionKey: WORKER_SESSION_KEY,
       agentId: "main",
+      // An operator kill must suppress the child's completion delivery, matching
+      // the bulk stop paths, so a racing completion cannot be announced after it.
+      suppressTaskDelivery: true,
     });
   });
 
@@ -266,6 +269,9 @@ describe("POST /sessions/:sessionKey/kill", () => {
       cfg,
       sessionKey: WORKER_SESSION_KEY,
       agentId: "main",
+      // An operator kill must suppress the child's completion delivery, matching
+      // the bulk stop paths, so a racing completion cannot be announced after it.
+      suppressTaskDelivery: true,
     });
   });
 

--- a/src/gateway/session-kill-http.ts
+++ b/src/gateway/session-kill-http.ts
@@ -115,6 +115,7 @@ export async function handleSessionKillHttpRequest(
     cfg,
     sessionKey: canonicalKey,
     agentId: requestedAgent.agentId,
+    suppressTaskDelivery: true,
   });
 
   if (result.found && result.error) {

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -1161,6 +1161,9 @@ describe("task-executor", () => {
         cfg: {} as never,
         sessionKey: "agent:codex:subagent:child",
         expectedRunId: "run-subagent-cancel",
+        // Cancel-by-task-id is an explicit operator cancel: it must suppress the
+        // child's completion delivery the way the bulk stop paths already do.
+        suppressTaskDelivery: true,
         onResult: expect.any(Function),
       });
     });

--- a/src/tasks/task-registry-cancel.ts
+++ b/src/tasks/task-registry-cancel.ts
@@ -238,6 +238,7 @@ export async function cancelTaskById(params: {
           cfg: params.cfg,
           sessionKey: childSessionKey,
           expectedRunId: task.runId,
+          suppressTaskDelivery: true,
           ...(managedBacking?.runtime === "subagent"
             ? { expectedGeneration: managedBacking.generation, expectedOwnerKey: task.ownerKey }
             : {}),

--- a/src/tasks/task-registry-control.types.ts
+++ b/src/tasks/task-registry-control.types.ts
@@ -43,6 +43,8 @@ export type TaskRegistryControlRuntime = {
     expectedRunId?: string;
     expectedGeneration?: number;
     expectedOwnerKey?: string;
+    /** Operator cancel: suppress the child's completion delivery like the bulk stop paths. */
+    suppressTaskDelivery?: boolean;
     /** Consume the result synchronously while its exact run ownership is still held. */
     onResult?: (result: SubagentAdminKillResult) => undefined;
   }) => Promise<SubagentAdminKillResult>;


### PR DESCRIPTION
fix: cancelling a task or killing a session can still deliver the child's completion

Closes #139964

## What Problem This Solves

Fixes an issue where operators who cancel a task by id (`openclaw tasks` cancel path) or
kill a session through the HTTP admin endpoint could still receive the child subagent's
completion notification afterwards. The cancel appears to succeed, then a completion for
the very run that was just cancelled is delivered anyway.

This only happens when the child's completion races the cancellation. The bulk stop
surfaces (`/stop`, chat abort) are not affected.

## Why This Change Was Made

Cancellation intentionally opens a bounded `killReconciliation` window so a run that
genuinely finished while the cancel was in flight is not thrown away. Inside that window a
real success reconciles the killed run back to `subagent-complete`
(`subagent-registry-lifecycle-completion.ts:307-341`). That part is by design.

The mechanism for honouring the operator's intent already exists:
`killReconciliation.suppressTaskDelivery` propagates into `suppressCompletionDelivery`
(`subagent-registry-lifecycle-completion.ts:381-383`). The bulk paths feed it —
`chat-abort-runtime.ts:85` and `auto-reply/reply/abort.ts:178` both pass
`suppressTaskDelivery: true`.

The two precise-cancel entries could not. Both go through `killSubagentRunAdmin`, whose
params type (`task-registry-control.types.ts:39-48`) had no field for suppression, so
`task-registry-cancel.ts` and `session-kill-http.ts` had no way to express it and
`killSubagentRunAdmin` passed nothing down to `killSubagentRoot`. The wiring below that
point already supports it (`killLatestSubagentRun` spreads params into `killSubagentRun`).

## Shipped Solution

Five production lines, no refactor:

- `task-registry-control.types.ts` — add `suppressTaskDelivery?: boolean` to the
  `killSubagentRunAdmin` params type.
- `subagent-control-kill.ts` — forward `params.suppressTaskDelivery` into
  `killSubagentRoot`; the rest of the chain already spreads it.
- `task-registry-cancel.ts`, `session-kill-http.ts` — pass `suppressTaskDelivery: true`,
  matching the bulk stop paths.

Behaviour for callers that do not ask for suppression is unchanged.

## User Impact

An explicit cancel now suppresses the child's completion delivery on the cancel-by-task-id
and HTTP admin kill paths, so operators stop seeing a completion notification for work they
just cancelled. No change to the reconciliation window itself: a run that really finished
still reconciles to `subagent-complete`, it just no longer announces after an explicit
cancel. No API removals; the new field is optional.

## Evidence

New test `src/agents/subagents/registry/subagent-control.precise-cancel-suppression.test.ts`
drives the **real** registry/SQLite fixture (`useSubagentControlFixture`) and the real
`killSubagentRunAdmin`, asserting that a suppression request survives as durable
cancellation ownership on `killIntent`/`killReconciliation`, and that a caller which does
not ask for suppression is unchanged.

**Negative control** — with the four production lines reverted and the test unchanged, the
suppression case fails (`expected false to be true`) while the non-suppression case still
passes. The test therefore proves the gap rather than restating the implementation.

Both call sites are covered by updating the existing exact-argument assertions:
`session-kill-http.test.ts` (2 assertions) and `task-executor.test.ts` ("cancels active
subagent child tasks"). These fail without the fix.

```
node scripts/run-vitest.mjs \
  src/tasks/task-executor.test.ts src/gateway/session-kill-http.test.ts \
  src/agents/subagents/registry/subagent-control.precise-cancel-suppression.test.ts \
  src/tasks/task-registry.test.ts \
  src/agents/subagents/registry/subagent-control.retirement.test.ts \
  src/agents/subagents/registry/subagent-control.recovery.test.ts \
  src/agents/subagents/registry/subagent-control.test.ts \
  src/agents/subagents/registry/subagent-control.concurrency.test.ts \
  src/gateway/server-methods/chat.abort-errors.test.ts
→ exit 0, 328 passed (2 + 33 + 184 + 109)

pnpm tsgo:core                          → exit 0
node scripts/run-tsgo-core-test-shards.mjs → exit 0
oxfmt --check (all 7 touched files)     → exit 0
```

Scope note: this closes the wiring gap reported in #139964. The end-to-end delivery of a
late completion notification to a real channel was not reproduced end-to-end there and is
not claimed here either; the fix is justified by the wiring asymmetry against the bulk
paths plus the test-pinned reconciliation behaviour.
