### PR TITLE
fix: restore first-use permission actions in Mac settings

### DIFF
--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettings.swift
@@ -75,7 +75,7 @@ extension DashboardWindowController {
             cookieSyncEnabled: state.cookieSyncEnabled,
             cookieDomains: state.cookieSyncDomains,
             cookieProfile: state.cookieSyncIntoProfile,
-            locationMode: DeviceSettingsLocationMode(locationMode))
+            locationMode: locationMode)
     }
 
     private static let booleanStateSettings: [DeviceSettingKey: ReferenceWritableKeyPath<AppState, Bool>] = [
@@ -106,9 +106,9 @@ extension DashboardWindowController {
         case let (.wakeEnabled, .boolean(enabled)):
             await AppStateStore.shared.setVoiceWakeEnabled(enabled) { self.canUseDeviceSettings(sourceID: sourceID) }
         case let (.locationMode, .string(value)):
-            guard let mode = DeviceSettingsLocationMode(rawValue: value) else { return }
+            guard let mode = OpenClawLocationMode(rawValue: value) else { return }
             await AppStateStore.shared
-                .setLocationMode(mode.nativeMode) { self.canUseDeviceSettings(sourceID: sourceID) }
+                .setLocationMode(mode) { self.canUseDeviceSettings(sourceID: sourceID) }
         case let (_, .boolean(enabled)):
             self.setDeviceBoolean(key, enabled: enabled)
         case let (_, .string(value)):

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettingsSnapshot.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettingsSnapshot.swift
@@ -73,7 +73,7 @@ extension DashboardWindowController {
             permissions: .init(
                 entries: permissions,
                 location: .init(
-                    mode: DeviceSettingsLocationMode(locationMode),
+                    mode: locationMode,
                     precise: defaults.object(forKey: locationPreciseKey) as? Bool ?? true)),
             voice: .init(
                 supported: voiceWakeSupported && SpeechRecognitionRequestPolicy.supportsPassiveVoiceWake(

--- a/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettingsSnapshot.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardWindowController+DeviceSettingsSnapshot.swift
@@ -131,10 +131,13 @@ extension DashboardWindowController {
     }
 
     private static func devicePermissionEntries() async -> [DeviceSettingsSnapshot.Permissions.Entry] {
-        let monitored = await PermissionManager.authorizationStatus([.accessibility, .screenRecording, .appleScript])
+        let monitored = await PermissionManager.authorizationStatus([.accessibility, .screenRecording])
         var statuses = Dictionary(uniqueKeysWithValues: DeviceSettingsPermission.allCases.map {
             ($0, DeviceSettingsPermissionStatus(monitored[$0.capability]))
         })
+        // Automation distinguishes first-use consent from denial; the shared capability Boolean does not.
+        statuses[.automation] = await DeviceSettingsPermissionStatus(
+            automation: AppleEventPermissionProbe.live.state(askUserIfNeeded: false))
         if PermissionManager.notificationCenterAvailable {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             statuses[.notifications] = DeviceSettingsPermissionStatus(

--- a/apps/macos/Sources/OpenClaw/DeviceSettingsConsent.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceSettingsConsent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 
 @MainActor
 enum DeviceSettingsConsent: Equatable {
@@ -20,7 +21,7 @@ enum DeviceSettingsConsent: Equatable {
         cookieSyncEnabled: Bool,
         cookieDomains: [String],
         cookieProfile: String,
-        locationMode: DeviceSettingsLocationMode) -> Self?
+        locationMode: OpenClawLocationMode) -> Self?
     {
         switch (key, value) {
         case (.cookieSyncEnabled, .boolean(true)): .cookieSync
@@ -31,7 +32,7 @@ enum DeviceSettingsConsent: Equatable {
         case (.wakeEnabled, .boolean(true)): .voiceWake
         case (.locationPrecise, .boolean(true)): .preciseLocation
         case let (.locationMode, .string(mode)):
-            switch (locationMode, DeviceSettingsLocationMode(rawValue: mode)) {
+            switch (locationMode, OpenClawLocationMode(rawValue: mode)) {
             case (.off, .whileUsing): .locationWhileUsing
             case (.off, .always), (.whileUsing, .always): .locationAlways
             default: nil

--- a/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
@@ -71,7 +71,7 @@ enum DeviceSettingKey: String, CaseIterable {
         case .string, .nullableString, .provider, .location, .iconStyle:
             guard let value = raw as? String else { return nil }
             if self.valueType == .provider, ComputerControlProvider(rawValue: value) == nil { return nil }
-            if self.valueType == .location, DeviceSettingsLocationMode(rawValue: value) == nil { return nil }
+            if self.valueType == .location, OpenClawLocationMode(rawValue: value) == nil { return nil }
             if self.valueType == .iconStyle, AppIconStyle(rawValue: value) == nil { return nil }
             return .string(value)
         }
@@ -117,26 +117,6 @@ enum DeviceSettingsPermissionStatus: String, Encodable {
     init(automation state: AppleEventPermissionState) {
         self = state == .notDetermined ? .notDetermined :
             Self(TerminalAutomationPermission.authorizationStatus(for: state))
-    }
-}
-
-enum DeviceSettingsLocationMode: String, CaseIterable, Encodable {
-    case off, whileUsing, always
-
-    init(_ mode: OpenClawLocationMode) {
-        switch mode {
-        case .off: self = .off
-        case .whileUsing: self = .whileUsing
-        case .always: self = .always
-        }
-    }
-
-    var nativeMode: OpenClawLocationMode {
-        switch self {
-        case .off: .off
-        case .whileUsing: .whileUsing
-        case .always: .always
-        }
     }
 }
 
@@ -284,7 +264,7 @@ struct DeviceSettingsSnapshot: Encodable {
         }
 
         struct Location: Encodable {
-            let mode: DeviceSettingsLocationMode
+            let mode: OpenClawLocationMode
             let precise: Bool
         }
 

--- a/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
@@ -113,6 +113,15 @@ enum DeviceSettingsPermissionStatus: String, Encodable {
         case .unknown, nil: self = .unavailable
         }
     }
+
+    init(automation state: AppleEventPermissionState) {
+        switch state {
+        case .authorized: self = .granted
+        case .notDetermined: self = .notDetermined
+        case .denied: self = .denied
+        case .targetNotRunning, .targetNotAccessible, .failed: self = .unavailable
+        }
+    }
 }
 
 enum DeviceSettingsLocationMode: String, CaseIterable, Encodable {

--- a/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
+++ b/apps/macos/Sources/OpenClaw/DeviceSettingsContract.swift
@@ -115,12 +115,8 @@ enum DeviceSettingsPermissionStatus: String, Encodable {
     }
 
     init(automation state: AppleEventPermissionState) {
-        switch state {
-        case .authorized: self = .granted
-        case .notDetermined: self = .notDetermined
-        case .denied: self = .denied
-        case .targetNotRunning, .targetNotAccessible, .failed: self = .unavailable
-        }
+        self = state == .notDetermined ? .notDetermined :
+            Self(TerminalAutomationPermission.authorizationStatus(for: state))
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsBridgeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsBridgeTests.swift
@@ -167,10 +167,9 @@ struct DeviceSettingsBridgeTests {
         let locations: [(OpenClawLocationMode, String)] = [
             (.off, "off"), (.whileUsing, "whileUsing"), (.always, "always"),
         ]
-        for (native, wire) in locations {
-            let mapped = DeviceSettingsLocationMode(native)
-            #expect(mapped.nativeMode == native)
-            #expect(try String(decoding: JSONEncoder().encode(mapped), as: UTF8.self) == "\"\(wire)\"")
+        #expect(Set(OpenClawLocationMode.allCases.map(\.rawValue)) == Set(locations.map(\.1)))
+        for (mode, wire) in locations {
+            #expect(try String(decoding: JSONEncoder().encode(mode), as: UTF8.self) == "\"\(wire)\"")
         }
         #expect(DeviceSettingsPermissionStatus(.granted) == .granted)
         #expect(DeviceSettingsPermissionStatus(.notGranted) == .denied)

--- a/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsBridgeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsBridgeTests.swift
@@ -190,6 +190,21 @@ struct DeviceSettingsBridgeTests {
         #expect(actual == expected)
     }
 
+    @Test(arguments: [
+        (AppleEventPermissionState.authorized, DeviceSettingsPermissionStatus.granted),
+        (.notDetermined, .notDetermined),
+        (.denied, .denied),
+        (.targetNotRunning, .unavailable),
+        (.targetNotAccessible, .unavailable),
+        (.failed(-1), .unavailable),
+    ])
+    func `Automation preserves first-use consent separately from denial`(
+        state: AppleEventPermissionState,
+        expected: DeviceSettingsPermissionStatus)
+    {
+        #expect(DeviceSettingsPermissionStatus(automation: state) == expected)
+    }
+
     @Test func `published JavaScript assigns the global then dispatches the exact event with escaped values`() throws {
         let script = try Self.snapshot(withNullableValues: true).javaScript()
         let prefix = "window.__OPENCLAW_NATIVE_DEVICE_SETTINGS__ = "

--- a/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsConsentTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/DeviceSettingsConsentTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawKit
 import Testing
 @testable import OpenClaw
 
@@ -21,7 +22,7 @@ struct DeviceSettingsConsentTests {
     }
 
     @Test func `location increases need consent but unchanged access and decreases do not`() throws {
-        let transitions: [(DeviceSettingsLocationMode, DeviceSettingsLocationMode, DeviceSettingsConsent?)] = [
+        let transitions: [(OpenClawLocationMode, OpenClawLocationMode, DeviceSettingsConsent?)] = [
             (.off, .off, nil),
             (.off, .whileUsing, .locationWhileUsing),
             (.off, .always, .locationAlways),
@@ -76,7 +77,7 @@ struct DeviceSettingsConsentTests {
     private func consent(
         _ key: DeviceSettingKey, raw: Any,
         enabled: Bool = true,
-        locationMode: DeviceSettingsLocationMode = .off) throws -> DeviceSettingsConsent?
+        locationMode: OpenClawLocationMode = .off) throws -> DeviceSettingsConsent?
     {
         let request = try #require(DeviceSettingsRequest(body: ["type": "set", "key": key.rawValue, "value": raw]))
         guard case let .set(parsedKey, value) = request else {

--- a/ui/src/e2e/native-device-settings.e2e.test.ts
+++ b/ui/src/e2e/native-device-settings.e2e.test.ts
@@ -148,6 +148,17 @@ suite.define(() => {
           fullPage: true,
           path: path.join(artifactDir, "02-permissions.png"),
         });
+        const automation = permissionsPage.locator(".settings-row").filter({
+          has: page
+            .locator(".settings-row__title")
+            .filter({ hasText: /^Automation \(Terminal\)$/ }),
+        });
+        const recovery = automation.getByRole("button");
+        expect(await recovery.count()).toBe(1);
+        await recovery.click();
+        await expect
+          .poll(messages)
+          .toContainEqual({ type: "request-permission", id: "automation" });
 
         await sidebar.locator('a[href="/settings/updates"]').click();
         await page.getByRole("button", { name: "Check for Updates…", exact: true }).click();

--- a/ui/src/pages/device/device-pages.test.ts
+++ b/ui/src/pages/device/device-pages.test.ts
@@ -489,32 +489,43 @@ describe("native device settings pages", () => {
     expect(capability.requestPermission).toHaveBeenCalledExactlyOnceWith("notifications");
     expect(row(page, "Accessibility").textContent).toContain("Denied");
     row(page, "Accessibility").querySelector<HTMLButtonElement>("button")!.click();
-    expect(capability.requestPermission).toHaveBeenCalledWith("accessibility");
+    expect(capability.openSystemSettings).toHaveBeenCalledExactlyOnceWith("accessibility");
     expect(row(page, "Screen Recording").textContent).toContain("Granted");
     expect(row(page, "Screen Recording").querySelector("button")).toBeNull();
   });
 
   it.each([
-    ["automation", "Automation (Terminal)", "notDetermined"],
-    ["automation", "Automation (Terminal)", "denied"],
-    ["automation", "Automation (Terminal)", "unavailable"],
-    ["accessibility", "Accessibility", "denied"],
-    ["screenRecording", "Screen Recording", "denied"],
-  ] as const)(
-    "keeps %s recovery with its native permission owner when %s is %s",
-    async (id, title, status) => {
-      const snapshot = createNativeDeviceSettingsSnapshot();
-      const permission = snapshot.permissions.entries.find((entry) => entry.id === id)!;
-      permission.status = status;
-      const { capability } = createCapability(snapshot);
-      const page = await mount("openclaw-device-permissions-page", capability);
-      const action = row(page, title).querySelector<HTMLButtonElement>("button");
-      expect(action).not.toBeNull();
-      action!.click();
-      expect(capability.requestPermission).toHaveBeenCalledExactlyOnceWith(id);
-      expect(capability.openSystemSettings).not.toHaveBeenCalled();
-    },
-  );
+    ["automation", "Automation (Terminal)", "notDetermined", "requestPermission", "Grant…"],
+    [
+      "automation",
+      "Automation (Terminal)",
+      "denied",
+      "openSystemSettings",
+      "Open System Settings…",
+    ],
+    ["automation", "Automation (Terminal)", "unavailable", "requestPermission", "Retry"],
+    ["accessibility", "Accessibility", "denied", "openSystemSettings", "Open System Settings…"],
+    [
+      "screenRecording",
+      "Screen Recording",
+      "denied",
+      "openSystemSettings",
+      "Open System Settings…",
+    ],
+  ] as const)("routes %s recovery when %s is %s", async (id, title, status, method, label) => {
+    const snapshot = createNativeDeviceSettingsSnapshot();
+    const permission = snapshot.permissions.entries.find((entry) => entry.id === id)!;
+    permission.status = status;
+    const { capability } = createCapability(snapshot);
+    const page = await mount("openclaw-device-permissions-page", capability);
+    const action = row(page, title).querySelector<HTMLButtonElement>("button");
+    expect(action).not.toBeNull();
+    expect(action!.textContent?.trim()).toBe(label);
+    action!.click();
+    expect(capability[method]).toHaveBeenCalledExactlyOnceWith(id);
+    const other = method === "requestPermission" ? "openSystemSettings" : "requestPermission";
+    expect(capability[other]).not.toHaveBeenCalled();
+  });
 
   it("enables precision with location access and changes local location and activity preferences", async () => {
     const native = createCapability();

--- a/ui/src/pages/device/device-pages.test.ts
+++ b/ui/src/pages/device/device-pages.test.ts
@@ -489,15 +489,32 @@ describe("native device settings pages", () => {
     expect(capability.requestPermission).toHaveBeenCalledExactlyOnceWith("notifications");
     expect(row(page, "Accessibility").textContent).toContain("Denied");
     row(page, "Accessibility").querySelector<HTMLButtonElement>("button")!.click();
-    expect(capability.openSystemSettings).toHaveBeenCalledExactlyOnceWith("accessibility");
-    for (const [title, label] of [
-      ["Screen Recording", "Granted"],
-      ["Automation (Terminal)", "Unavailable"],
-    ] as const) {
-      expect(row(page, title).textContent).toContain(label);
-      expect(row(page, title).querySelector("button")).toBeNull();
-    }
+    expect(capability.requestPermission).toHaveBeenCalledWith("accessibility");
+    expect(row(page, "Screen Recording").textContent).toContain("Granted");
+    expect(row(page, "Screen Recording").querySelector("button")).toBeNull();
   });
+
+  it.each([
+    ["automation", "Automation (Terminal)", "notDetermined"],
+    ["automation", "Automation (Terminal)", "denied"],
+    ["automation", "Automation (Terminal)", "unavailable"],
+    ["accessibility", "Accessibility", "denied"],
+    ["screenRecording", "Screen Recording", "denied"],
+  ] as const)(
+    "keeps %s recovery with its native permission owner when %s is %s",
+    async (id, title, status) => {
+      const snapshot = createNativeDeviceSettingsSnapshot();
+      const permission = snapshot.permissions.entries.find((entry) => entry.id === id)!;
+      permission.status = status;
+      const { capability } = createCapability(snapshot);
+      const page = await mount("openclaw-device-permissions-page", capability);
+      const action = row(page, title).querySelector<HTMLButtonElement>("button");
+      expect(action).not.toBeNull();
+      action!.click();
+      expect(capability.requestPermission).toHaveBeenCalledExactlyOnceWith(id);
+      expect(capability.openSystemSettings).not.toHaveBeenCalled();
+    },
+  );
 
   it("enables precision with location access and changes local location and activity preferences", async () => {
     const native = createCapability();

--- a/ui/src/pages/device/permissions-page.ts
+++ b/ui/src/pages/device/permissions-page.ts
@@ -39,8 +39,7 @@ class DevicePermissionsPage extends OpenClawLightDomElement {
   private renderPermissions(snapshot: NativeDeviceSettingsSnapshot) {
     const capability = this.context.nativeDeviceSettings;
     const { permissions } = snapshot;
-    // Native owners distinguish first-use prompts, denied access, and recoverable missing targets.
-    // Coarse status alone cannot choose between requesting permission and opening System Settings.
+    // Preserve denial recovery; unavailable native targets may recover through another request.
     return html`
       ${renderSettingsSection(
         { title: t("configPage.deviceSettings.systemAccess") },
@@ -51,7 +50,7 @@ class DevicePermissionsPage extends OpenClawLightDomElement {
             stackedOnNarrow: true,
             control: html`
               ${renderSettingsStatus({ kind: status === "granted" ? "ok" : status === "denied" ? "danger" : "muted", label: t(`configPage.deviceSettings.permissionStatuses.${status}`) })}
-              ${status !== "granted" ? html`<button type="button" class="btn" @click=${() => capability?.requestPermission(id)}>${status === "unavailable" ? t("common.retry") : t("configPage.deviceSettings.grant")}</button>` : nothing}
+              ${status === "notDetermined" || status === "unavailable" ? html`<button type="button" class="btn" @click=${() => capability?.requestPermission(id)}>${status === "unavailable" ? t("common.retry") : t("configPage.deviceSettings.grant")}</button>` : status === "denied" ? html`<button type="button" class="btn" @click=${() => capability?.openSystemSettings(id)}>${t("configPage.deviceSettings.openSystemSettings")}</button>` : nothing}
             `,
           }),
         ),

--- a/ui/src/pages/device/permissions-page.ts
+++ b/ui/src/pages/device/permissions-page.ts
@@ -39,6 +39,8 @@ class DevicePermissionsPage extends OpenClawLightDomElement {
   private renderPermissions(snapshot: NativeDeviceSettingsSnapshot) {
     const capability = this.context.nativeDeviceSettings;
     const { permissions } = snapshot;
+    // Native owners distinguish first-use prompts, denied access, and recoverable missing targets.
+    // Coarse status alone cannot choose between requesting permission and opening System Settings.
     return html`
       ${renderSettingsSection(
         { title: t("configPage.deviceSettings.systemAccess") },
@@ -49,7 +51,7 @@ class DevicePermissionsPage extends OpenClawLightDomElement {
             stackedOnNarrow: true,
             control: html`
               ${renderSettingsStatus({ kind: status === "granted" ? "ok" : status === "denied" ? "danger" : "muted", label: t(`configPage.deviceSettings.permissionStatuses.${status}`) })}
-              ${status === "notDetermined" ? html`<button type="button" class="btn" @click=${() => capability?.requestPermission(id)}>${t("configPage.deviceSettings.grant")}</button>` : status === "denied" ? html`<button type="button" class="btn" @click=${() => capability?.openSystemSettings(id)}>${t("configPage.deviceSettings.openSystemSettings")}</button>` : nothing}
+              ${status !== "granted" ? html`<button type="button" class="btn" @click=${() => capability?.requestPermission(id)}>${status === "unavailable" ? t("common.retry") : t("configPage.deviceSettings.grant")}</button>` : nothing}
             `,
           }),
         ),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening Permissions in the Mac app could not retry Automation access when its native target was unavailable, or saw a denied status before first-use Automation consent had been requested.

## Why This Change Was Made

Preserve Automation’s raw `notDetermined` state in the native snapshot so first-use consent remains distinct from denial. Add request/retry for unavailable status while retaining the existing Open System Settings action for denied permissions. The UI chooses by status, with no permission-ID special cases or changes to native permission policy.

An earlier revision routed every non-granted status through a request. Review raised a Screen Recording recovery concern with that broader change. This revision removes the changed denied-request behavior rather than relying on unverified OS re-prompt behavior; the concern was not disproven.

The permission DTO also uses the existing shared `OpenClawLocationMode` directly, deleting the duplicate enum and identity converters. Its three raw wire strings, snapshot shape and all nine consent transitions remain covered. No alias, protocol field, configuration, default, storage behavior or OS permission grant changes.

Production LOC: +18/−28 (net −10); tests: +67/−13 (net +54).

## User Impact

Automation can present its first-use Grant action or retry an unavailable target. Denied permissions—including Screen Recording and Accessibility—keep their existing System Settings recovery action. Granted rows remain actionless.

## Evidence

- With the revised tests against the original UI owner, one case fails because unavailable Automation has no action; 39 pass. The revised candidate passes all 40 component/wire tests.
- Four denied-action cases fail against the earlier generalized request action. The revised tests preserve Settings labels/messages for denied statuses, request/retry for first-use/unavailable statuses, and absence of the wrong message.
- The isolated Chromium flow passes with synthetic native/Gateway fixtures. The new after capture shows denied rows with Open System Settings and unavailable Automation with Retry.
- Pinned Swift lint/format, UI changed gates, core-test/UI typechecks, i18n/structural guards, all three dead-export scans and changed-file lint pass. Fresh full-candidate managed P2 is scoped-clean on the source tree matching `78495f757267d68db4246cd7480452b98b26913d`.

| Before — synthetic fixture | After — synthetic fixture |
| --- | --- |
| ![Permissions before: Automation has no recovery action](https://github.com/user-attachments/assets/64582d32-1902-4a60-aefc-eb4462851e53) | ![Permissions after: denied statuses keep Settings and unavailable Automation offers Retry](https://github.com/user-attachments/assets/5b0be53a-ff99-440b-b3d3-8e4c0941a233) |

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34033095625) passed for `78495f757267d68db4246cd7480452b98b26913d`, including both native Swift phases: 1,661 shared tests, 2,067 default-profile app tests, 2 named-profile tests and 1 isolated health fixture. The updated location wire-encoding, frozen snapshot and consent-transition tests passed, along with all six Automation cases and the injected first-use/denied/Terminal-recovery tests.

[Earlier CI on `739a6593`](https://github.com/openclaw/openclaw/actions/runs/34026043071) is retained as superseded history, not proof of the current revision.

Actual correctly signed-app/TCC first-use, denial and grant behavior remains unperformed and unwaived pending the disposable macOS GUI/signing decision. Component tests, injected Swift tests and a signed Git commit are not signed-app/TCC proof. No operator app state, saved Keychain or OS permission interaction was used for this revision.
