### PR TITLE
fix(security): parse gpt generation numbers in the audit tier check

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -179,17 +179,14 @@ function isGptModel(id: string): boolean {
 }
 
 function isGpt5OrHigher(id: string): boolean {
-  // Parse the generation number so newer majors (gpt-6, gpt-7, gpt-10+) are
-  // not misread as below the GPT-5 threshold, while Azure-style two-digit
-  // legacy aliases (gpt-35-turbo = GPT-3.5) stay flagged (#139751).
+  // Numeric generation comparison so newer majors (gpt-6, gpt-10, gpt-20+)
+  // are not misread as below the GPT-5 threshold; gpt-35-turbo is the Azure
+  // GPT-3.5 alias, not a generation, and stays flagged (#139751).
   const generation = /\bgpt-(\d+)(?:\b|[.-])/i.exec(id)?.[1];
   if (generation === undefined) {
     return false;
   }
-  if (generation.length === 1) {
-    return Number.parseInt(generation, 10) >= 5;
-  }
-  return generation.startsWith("1");
+  return generation !== "35" && Number.parseInt(generation, 10) >= 5;
 }
 
 function isClaudeModel(id: string): boolean {

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -179,7 +179,17 @@ function isGptModel(id: string): boolean {
 }
 
 function isGpt5OrHigher(id: string): boolean {
-  return /\bgpt-5(?:\b|[.-])/i.test(id);
+  // Parse the generation number so newer majors (gpt-6, gpt-7, gpt-10+) are
+  // not misread as below the GPT-5 threshold, while Azure-style two-digit
+  // legacy aliases (gpt-35-turbo = GPT-3.5) stay flagged (#139751).
+  const generation = /\bgpt-(\d+)(?:\b|[.-])/i.exec(id)?.[1];
+  if (generation === undefined) {
+    return false;
+  }
+  if (generation.length === 1) {
+    return Number.parseInt(generation, 10) >= 5;
+  }
+  return generation.startsWith("1");
 }
 
 function isClaudeModel(id: string): boolean {

--- a/src/security/audit-model-hygiene.test.ts
+++ b/src/security/audit-model-hygiene.test.ts
@@ -32,6 +32,27 @@ describe("security audit model hygiene findings", () => {
         },
         expectedAbsentCheckId: "models.weak_tier",
       },
+      {
+        name: "gpt-6 generation",
+        cfg: {
+          agents: { defaults: { model: { primary: "github-copilot/gpt-6-astra" } } },
+        },
+        expectedAbsentCheckId: "models.weak_tier",
+      },
+      {
+        name: "gpt-4.1 stays below threshold",
+        cfg: {
+          agents: { defaults: { model: { primary: "openai/gpt-4.1" } } },
+        },
+        expectedPresent: [{ checkId: "models.weak_tier", severity: "warn" }],
+      },
+      {
+        name: "azure gpt-35-turbo alias stays below threshold",
+        cfg: {
+          agents: { defaults: { model: { primary: "azure-openai/gpt-35-turbo" } } },
+        },
+        expectedPresent: [{ checkId: "models.weak_tier", severity: "warn" }],
+      },
     ];
 
     for (const testCase of cases) {


### PR DESCRIPTION
## What Problem This Solves

`openclaw security audit --deep` flags first-party GPT-6 models (e.g. `github-copilot/gpt-6-astra`, support merged in #137550) as **"Below GPT-5 family"** in the `models.weak_tier` finding, because `isGpt5OrHigher()` name-matched only `gpt-5`-prefixed ids.

Fixes #139751 (includes the reporter's isolated repro matrix).

## Why This Change Was Made

The audit's stated threshold is "GPT-5 or higher" — the check should parse the **generation number** instead of name-matching a single generation:

- single-digit generations `gpt-5`…`gpt-9` → at-or-above;
- two-digit generations starting with `1` (gpt-10+) → at-or-above;
- Azure-style two-digit legacy aliases (`gpt-35-turbo` = GPT-3.5) → stays flagged below;
- `gpt-4.1` / `gpt-4o` / other gpt-4 forms → stays flagged below (unchanged).

## User Impact

GPT-6-era primary models no longer produce a false `models.weak_tier` warning on every audit run; genuinely older generations keep the warn. Pure classification change in `src/security/audit-extra.sync.ts` — no policy, config, or delivery changes.

## Evidence

- Table-driven regression in `audit-model-hygiene.test.ts`: `github-copilot/gpt-6-astra` → `models.weak_tier` **absent**; `openai/gpt-4.1` and `azure-openai/gpt-35-turbo` → present (warn). **Fails on the pre-fix parser** (verified via `git stash` checkout: 1 failed | 1 passed).
- Gates: `pnpm tsgo`, `pnpm check:test-types`, `oxfmt`, `oxlint` clean; `git diff --check` clean.
- Second-model review: autoreview (pi, `zai-coding-cn/glm-5.3`, thinking=high) → **scoped-clean**; its one observed edge (Azure `gpt-35-turbo` alias parsing as generation 35) is handled in this revision.
- LOC: +18/−1 across the classification function and the test table.


## After-fix CLI proof (security audit, isolated state dirs)

Ran `openclaw security audit` against the built CLI (head `1fa08a1bf02`) with one-model configs in disposable state dirs:

- `github-copilot/gpt-6-astra` → `models.weak_tier` **absent** (`Summary: 2 critical · 3 warn · 1 info` — no models section warnings at all).
- `openai/gpt-4.1` → **retained**: `models.weak_tier ... openai/gpt-4.1 (Below GPT-5 family) @ agents.defaults.model.primary` (`4 warn`).
- `azure-openai/gpt-35-turbo` → **retained**: `models.weak_tier ... azure-openai/gpt-35-turbo (Below GPT-5 family) @ agents.defaults.model.primary` (`4 warn`).

The predicate is also collapsed to a single numeric `>= 5` comparison with the `gpt-35-turbo` alias carve-out (1fa08a1bf02, +4/−7), which additionally gives `gpt-20`+ the correct future-generation reading.
