### PR TITLE
fix(test): release memory search fixtures after failed phases

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-generation.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-generation.test.ts
@@ -1,0 +1,128 @@
+import type { DatabaseSync } from "node:sqlite";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it, vi } from "vitest";
+import type { EmbeddingProvider } from "./embeddings.js";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+import * as knnSubprocess from "./manager-search-knn-subprocess.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+
+describe("memory search generation", () => {
+  const { createConfig: createCfg, getPersistentManager } = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+
+  it("keeps one search generation while a concurrent reindex waits to publish", async ({
+    signal,
+  }) => {
+    const manager = await getPersistentManager(
+      createCfg({
+        vectorEnabled: true,
+        minScore: 0,
+      }),
+    );
+    await manager.sync({ reason: "test" });
+    const fields = manager as unknown as {
+      db: DatabaseSync;
+      provider: EmbeddingProvider;
+      syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
+    };
+    const queryStarted = createDeferred<void>();
+    const releaseQuery = createDeferred<void>();
+    const shadowReady = createDeferred<void>();
+    const releaseReindex = createDeferred<void>();
+    const childReady = createDeferred<void>();
+    const releaseChild = createDeferred<void>();
+    const publishedDb = fields.db;
+    const publishedChunks = manager.status().chunks;
+    let shadowDb: DatabaseSync | undefined;
+    const syncMemoryFiles = fields.syncMemoryFiles.bind(manager);
+    const runKnn = knnSubprocess.runVectorKnnInSubprocess;
+    const querySpy = vi.spyOn(fields.provider, "embed").mockImplementation(async () => {
+      queryStarted.resolve();
+      await releaseQuery.promise;
+      return [1, 0, 0, 0];
+    });
+    const syncSpy = vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (params) => {
+      shadowDb = fields.db;
+      expect(manager.status().chunks).toBe(publishedChunks);
+      const lexical = await manager.search("zebra", { lexicalOnly: true, minScore: 0 });
+      expect(lexical.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      const result = await syncMemoryFiles(params);
+      shadowReady.resolve();
+      await releaseReindex.promise;
+      return result;
+    });
+    const childSpy = vi
+      .spyOn(knnSubprocess, "runVectorKnnInSubprocess")
+      .mockImplementation(async (params) => {
+        try {
+          const result = await runKnn(params);
+          expect(result.rows.length).toBeGreaterThan(0);
+          childReady.resolve();
+          await releaseChild.promise;
+          return result;
+        } catch (error) {
+          childReady.reject(error);
+          throw error;
+        }
+      });
+    let search: ReturnType<typeof manager.search> | undefined;
+    let reindex: ReturnType<typeof manager.sync> | undefined;
+    const aborted = createDeferred<never>();
+    const releaseGates = () => {
+      releaseQuery.resolve();
+      releaseReindex.resolve();
+      releaseChild.resolve();
+    };
+    const abort = () => {
+      releaseGates();
+      aborted.reject(signal.reason);
+    };
+    const waitForSignal = async (
+      ready: Promise<void>,
+      operation: Promise<unknown>,
+      phase: string,
+    ) => {
+      await Promise.race([
+        ready,
+        aborted.promise,
+        operation.then(() => {
+          throw new Error(`Operation completed before ${phase}`);
+        }),
+      ]);
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    try {
+      signal.throwIfAborted();
+      search = manager.search("semantic needle without lexical overlap", { signal });
+      await waitForSignal(queryStarted.promise, search, "query embedding started");
+      reindex = manager.sync({ reason: "test", force: true });
+      await waitForSignal(shadowReady.promise, reindex, "shadow index ready");
+      expect(fields.db).toBe(publishedDb);
+      releaseQuery.resolve();
+      await waitForSignal(childReady.promise, search, "KNN child ready");
+      releaseReindex.resolve();
+      let reindexSettled = false;
+      void reindex.then(() => {
+        reindexSettled = true;
+      });
+      await Promise.resolve();
+      expect(reindexSettled).toBe(false);
+
+      releaseChild.resolve();
+      const results = await search;
+      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      await reindex;
+      expect(shadowDb?.isOpen).toBe(false);
+    } finally {
+      signal.removeEventListener("abort", abort);
+      releaseGates();
+      await Promise.allSettled([search, reindex]);
+      childSpy.mockRestore();
+      syncSpy.mockRestore();
+      querySpy.mockRestore();
+    }
+  });
+});

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -9,7 +9,6 @@ import { forgetMemoryEntries } from "../memory-forget.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { MemoryIndexRevisionConflictError } from "./manager-db.js";
 import { createManagerIndexFixture } from "./manager-index.test-support.js";
-import * as knnSubprocess from "./manager-search-knn-subprocess.js";
 
 const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
 const { MemoryIndexManager } = await import("./manager.js");
@@ -54,88 +53,6 @@ describe("memory index", () => {
       await expectHybridKeywordSearchFindsMemory(createCfg({ minScore }));
     },
   );
-
-  it("keeps one search generation while a concurrent reindex waits to publish", async () => {
-    const manager = await getPersistentManager(
-      createCfg({
-        vectorEnabled: true,
-        minScore: 0,
-      }),
-    );
-    await manager.sync({ reason: "test" });
-    const fields = manager as unknown as {
-      db: DatabaseSync;
-      provider: EmbeddingProvider;
-      syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
-    };
-    const queryStarted = createDeferred<void>();
-    const releaseQuery = createDeferred<void>();
-    const shadowReady = createDeferred<void>();
-    const releaseReindex = createDeferred<void>();
-    const childReady = createDeferred<void>();
-    const releaseChild = createDeferred<void>();
-    const publishedDb = fields.db;
-    const publishedChunks = manager.status().chunks;
-    let shadowDb: DatabaseSync | undefined;
-    const syncMemoryFiles = fields.syncMemoryFiles.bind(manager);
-    const runKnn = knnSubprocess.runVectorKnnInSubprocess;
-    const querySpy = vi.spyOn(fields.provider, "embed").mockImplementation(async () => {
-      queryStarted.resolve();
-      await releaseQuery.promise;
-      return [1, 0, 0, 0];
-    });
-    const syncSpy = vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (params) => {
-      shadowDb = fields.db;
-      expect(manager.status().chunks).toBe(publishedChunks);
-      const lexical = await manager.search("zebra", { lexicalOnly: true, minScore: 0 });
-      expect(lexical.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
-      const result = await syncMemoryFiles(params);
-      shadowReady.resolve();
-      await releaseReindex.promise;
-      return result;
-    });
-    const childSpy = vi
-      .spyOn(knnSubprocess, "runVectorKnnInSubprocess")
-      .mockImplementation(async (params) => {
-        const result = await runKnn(params);
-        expect(result.rows.length).toBeGreaterThan(0);
-        childReady.resolve();
-        await releaseChild.promise;
-        return result;
-      });
-    let search: ReturnType<typeof manager.search> | undefined;
-    let reindex: ReturnType<typeof manager.sync> | undefined;
-    try {
-      search = manager.search("semantic needle without lexical overlap");
-      await queryStarted.promise;
-      reindex = manager.sync({ reason: "test", force: true });
-      await shadowReady.promise;
-      expect(fields.db).toBe(publishedDb);
-      releaseQuery.resolve();
-      await childReady.promise;
-      releaseReindex.resolve();
-      let reindexSettled = false;
-      void reindex.then(() => {
-        reindexSettled = true;
-      });
-      await Promise.resolve();
-      expect(reindexSettled).toBe(false);
-
-      releaseChild.resolve();
-      const results = await search;
-      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
-      await reindex;
-      expect(shadowDb?.isOpen).toBe(false);
-    } finally {
-      releaseQuery.resolve();
-      releaseReindex.resolve();
-      releaseChild.resolve();
-      await Promise.allSettled([search, reindex]);
-      childSpy.mockRestore();
-      syncSpy.mockRestore();
-      querySpy.mockRestore();
-    }
-  });
 
   it("keeps a dirty status manager read-only while searching published results", async () => {
     const cfg = createCfg({ provider: "none", minScore: 0 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a failed memory-search child leaves a concurrency test waiting for a success-only signal. The timeout then blocks manager cleanup and causes unrelated tests to fail.

## Why This Change Was Made

Race readiness against the owned operation and test cancellation, propagate child errors, and release every fixture gate before awaiting cleanup. Move the existing concurrency case to a focused test file while preserving its publication-order, result, database-lifecycle, and timing assertions.

## User Impact

Test failures report the underlying error and release their owned work instead of causing a timeout cascade. Production memory, storage, and child-process environment behavior are unchanged.

## Evidence

- The final nine-file selection preserves all 120 original tests. Node passes 120/120.
- Bun 1.4.2 on macOS passes 115 and reports five remaining native SQLite/vector failures, with no timeout cascade, unhandled errors, or suite errors. Three failures directly report extension loading unavailable in the child; two lack expected vector results. These failures are preserved, not fixed or suppressed by this PR.
- [Linux Bun 1.4.2 proof](https://github.com/openclaw/openclaw/actions/runs/34026846609) passes all 120 tests at this exact commit with SQLite extension loading available, no preload or child-environment widening, and no unhandled or suite errors. The command exited successfully and its lease was stopped. The macOS limitation above remains.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34026139174) passes.
- Complete changed-file gate and fresh P0–P2 review pass. Both changed files pass formatting, lint, and type checks.
- No assertions or timeouts were weakened, and no production test hook was introduced. This is a fixture ownership repair, not a claim of complete Bun memory support.
