### PR TITLE
fix(process): preserve the cause of cleanup observation failures

### DIFF
--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -466,11 +466,15 @@ it.each(["EPERM", "EIO", "still present"])(
   "keeps graceful cleanup uncertain when the kernel group is %s",
   async (failure) => {
     const { adapter, completeRoot, emit, close, groupProbe } = await createRelay("linux");
+    const cause =
+      failure === "still present"
+        ? undefined
+        : Object.assign(new Error(`synthetic ${failure}`), { code: failure });
     groupProbe.mockImplementation(() => {
-      if (failure === "still present") {
-        return true;
+      if (cause) {
+        throw cause;
       }
-      throw Object.assign(new Error(`synthetic ${failure}`), { code: failure });
+      return true;
     });
     completeRoot();
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
@@ -480,6 +484,9 @@ it.each(["EPERM", "EIO", "still present"])(
     vi.spyOn(Date, "now").mockReturnValueOnce(10_000).mockReturnValue(15_000);
     close();
     await expect(adapter.waitForExtinction()).rejects.toThrow("owned process group");
+    await expect(adapter.waitForExtinction()).rejects.toSatisfy(
+      (error: unknown) => error instanceof Error && error.cause === cause,
+    );
     await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
     expect(groupProbe).toHaveBeenCalledWith(-1235, 0);
     expect(groupProbe.mock.calls.every(([, signal]) => signal === 0)).toBe(true);

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -255,12 +255,12 @@ export async function createServiceChildRelayAdapter(
   child.stderr?.once("end", settleWait);
   child.stderr?.once("close", settleWait);
 
-  const loseIdentity = (message: string) => {
+  const loseIdentity = (message: string, options?: ErrorOptions) => {
     if (state === "closed" || state === "identity-lost") {
       return;
     }
     state = "identity-lost";
-    waitError = new Error(`service child cleanup identity lost: ${message}`);
+    waitError = new Error(`service child cleanup identity lost: ${message}`, options);
     events.emitError(waitError, "process");
     if (!commandPid) {
       startup.reject(waitError);
@@ -347,12 +347,12 @@ export async function createServiceChildRelayAdapter(
       try {
         // Observation only: signalling a retired numeric PGID could hit a reused group.
         process.kill(-anchorPid, 0);
-      } catch (error) {
+      } catch (cause) {
         // SAFETY: process.kill throws Node system errors; only the exact ESRCH code certifies absence.
-        if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+        if ((cause as NodeJS.ErrnoException).code === "ESRCH") {
           finishAuthorityClose(missingReceiptError);
         } else {
-          loseIdentity("owned process group disappearance could not be confirmed");
+          loseIdentity("owned process group disappearance could not be confirmed", { cause });
         }
         return;
       }


### PR DESCRIPTION
## What Problem This Solves

Process-group cleanup can report that disappearance could not be confirmed while discarding the original OS error. Two macOS CI failures reached that same generic message in different ordinary lifecycle cases, leaving the actual cause unavailable for diagnosis.

## Why This Change Was Made

Preserve the original observation error as the existing cleanup error's standard `cause`. The existing owner continues to retain and propagate that error; its message, cleanup decisions, deadline and requirement for confirmed group disappearance remain unchanged.

## User Impact

Callers and error reporting can inspect the underlying error and code when cleanup observation fails. This repairs diagnostic loss; it does not claim to resolve the underlying macOS event. Production LOC is unchanged, and one existing test table grows by seven lines.

## Evidence

The existing mocked EPERM/EIO/still-present table reproduced the diagnostic defect against unchanged production: the two original-error identity assertions failed, while the still-present control passed. After the repair all 29 existing mock cases passed, including the refreshed unknown-safe identity assertion. No real process scenario was added or run for this proof.

All 29 selected check phases have passing evidence: 19 unchanged earlier phases, a refreshed core-test typecheck, and the exact nine-phase continuation after correcting the test callback's lint finding. This is combined evidence, not a claimed monolithic rerun. Independent managed P2 review found no actionable issue.

The motivating [CI run 34024465035](https://github.com/openclaw/openclaw/actions/runs/34024465035) belongs to the separate Voice Wake PR. Its first attempt failed the overall-timeout case, and its single targeted retry failed the service-managed argv0 case. Both logs lacked the original OS error. Their shared cause remains unknown; the diagnostic change preserves useful error evidence if the event recurs.

Candidate `f93d85954e71444bc0f6b95e80fd50113850efbc` passed [CI 34026709522](https://github.com/openclaw/openclaw/actions/runs/34026709522): 109 successful jobs and 16 skips, with both changed files matching tested merge `cfb29a444c8a81840b7d037f57ae7033ac7e749c`. This normal PR lane did not select macOS Node tests, so it does not identify or resolve the motivating Darwin error.
