### PR TITLE
fix(plugins): avoid scoped pack failures and missing runtime entries

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -113,6 +113,11 @@ restart the Gateway and reload the browser. See
 writes an archive containing compiled code and UI with no install scripts or
 runtime package dependencies. `--json` returns its absolute path, SHA-256 digest,
 and exact `plugin_activate_artifact` request. The output file must not exist.
+The default filename is `<plugin-id>.tgz` in the project root, with `/` replaced
+by `__` for scoped ids (for example, `@author__tools.tgz`). Use `--out` to choose
+another path. Packing follows the package's runtime entry selection, including
+`runtimeExtensions`, and bundles a declared setup entry separately. Source/runtime
+entry paths are rewritten to the compiled files included in the archive.
 See [Feature plugins](/plugins/feature-plugins) for activation approval, reload,
 view lifecycle, and recovery.
 

--- a/src/cli/plugins-build-bundle.ts
+++ b/src/cli/plugins-build-bundle.ts
@@ -1,4 +1,5 @@
-import { isBuiltin } from "node:module";
+import { createRequire, isBuiltin } from "node:module";
+import { join } from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { BuildOptions, BuildResult, PluginBuild } from "esbuild";
 
@@ -21,16 +22,24 @@ type PluginBundleOptions = Omit<
   | "inject"
   | "plugins"
   | "minifySyntax"
-> & { platform: "node" | "browser" };
+> & { platform: "node" | "browser"; absWorkingDir: string };
 
 function isPluginBundleHostImport(specifier: string): boolean {
   return isBuiltin(specifier) || specifier === "openclaw" || specifier.startsWith("openclaw/");
 }
 
-export async function buildPluginBundle(
-  builder: Pick<typeof import("esbuild"), "build">,
-  options: PluginBundleOptions,
-) {
+export async function buildPluginBundle(options: PluginBundleOptions) {
+  const require = createRequire(join(options.absWorkingDir, "package.json"));
+  let builder: typeof import("esbuild");
+  try {
+    // SAFETY: Resolve the compiler installed by the author in the plugin package.
+    builder = require("esbuild") as typeof import("esbuild");
+  } catch (cause) {
+    throw new Error(
+      "Install esbuild in this plugin's devDependencies, then run plugins build again.",
+      { cause },
+    );
+  }
   const backend = options.platform === "node";
   const recovery = backend
     ? "Use literal import or require paths and embed runtime resources, or use the regular package-install flow."
@@ -123,13 +132,13 @@ export async function buildPluginBundle(
   }
   if (
     imports.some((item) => item.external && (!backend || !isPluginBundleHostImport(item.path))) ||
-    (backend && result.outputFiles.length !== 1)
+    (backend && result.outputFiles.some((file) => !file.path.endsWith(".js")))
   ) {
     throw new Error(
       backend
-        ? "Plugin artifact must bundle all dependencies into its backend entrypoint."
+        ? "Plugin artifact must bundle all dependencies into its JavaScript runtime files."
         : "Control UI builds must bundle their browser dependencies.",
     );
   }
-  return result.outputFiles;
+  return result.outputFiles.toSorted((left, right) => left.path.localeCompare(right.path));
 }

--- a/src/cli/plugins-control-ui-build.ts
+++ b/src/cli/plugins-control-ui-build.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
@@ -36,18 +35,7 @@ export async function buildPluginControlUi(params: {
   if (relative.startsWith(`..${path.sep}`) || relative === ".." || path.isAbsolute(relative)) {
     throw new Error("Control UI source must stay inside the plugin package.");
   }
-  const require = createRequire(path.join(rootDir, "package.json"));
-  let builder: typeof import("esbuild");
-  try {
-    // SAFETY: Node resolves the plugin's installed esbuild package with this public API.
-    builder = require("esbuild") as typeof import("esbuild");
-  } catch (cause) {
-    throw new Error(
-      "Install esbuild in this plugin's devDependencies, then run plugins build again.",
-      { cause },
-    );
-  }
-  const outputFiles = await buildPluginBundle(builder, {
+  const files = await buildPluginBundle({
     absWorkingDir: rootDir,
     entryPoints: { index: entry },
     outdir: path.join(rootDir, "dist/control-ui/build"),
@@ -61,7 +49,6 @@ export async function buildPluginControlUi(params: {
     },
     alias: buildPluginLoaderAliasMap(entry, process.argv[1], import.meta.url),
   });
-  const files = outputFiles.toSorted((left, right) => left.path.localeCompare(right.path));
   if (
     files.some((file) => file.contents.length > CONTROL_UI_PLUGIN_MAX_ASSET_BYTES) ||
     files.reduce((total, file) => total + file.contents.length, 0) >

--- a/src/cli/plugins-feature-artifact.test.ts
+++ b/src/cli/plugins-feature-artifact.test.ts
@@ -6,6 +6,11 @@ import { pathToFileURL } from "node:url";
 import { build } from "esbuild";
 import { extract } from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  validatePackageExtensionEntriesForInstall,
+  resolvePackageRuntimeExtensionSources,
+  resolvePackageSetupSource,
+} from "../plugins/package-entry-resolution.js";
 import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { getCachedPluginSourceModuleLoader } from "../plugins/plugin-module-loader-cache.js";
 import { buildPluginLoaderAliasMap } from "../plugins/sdk-alias.js";
@@ -132,6 +137,154 @@ describe("plugin artifact authoring", () => {
     await fs.writeFile(path.join(rootDir, "src/control-ui.ts"), "export default null;");
     expect(await fs.readFile(archive)).toEqual(bytes);
   });
+
+  it.each([
+    {
+      id: "inferred-tools",
+      filename: "inferred-tools.tgz",
+      runtime: false,
+      inferred: true,
+      setup: true,
+    },
+    { id: "@author/tools", filename: "@author__tools.tgz", runtime: false, setup: false },
+    { id: "runtime-tools", filename: "runtime-tools.tgz", runtime: true, setup: false },
+    { id: "setup-tools", filename: "setup-tools.tgz", runtime: true, setup: true },
+  ])(
+    "packs $id with its installed runtime and metadata intact",
+    async ({ id, filename, runtime, setup, inferred = false }) => {
+      const parent = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tool-pack-")),
+      );
+      directories.push(parent);
+      const rootDir = path.join(parent, "project");
+      await fs.mkdir(path.join(rootDir, "dist"), { recursive: true });
+      await fs.symlink(path.resolve("node_modules"), path.join(rootDir, "node_modules"), "dir");
+      const packageManifest = {
+        name: id,
+        version: "1.0.0",
+        type: "module",
+        openclaw: {
+          extensions: [inferred ? "./src/index.ts" : "./dist/index.js"],
+          ...(runtime ? { runtimeExtensions: ["./dist/compiled.js"] } : {}),
+          ...(setup
+            ? {
+                setupEntry: "./dist/setup-source.js",
+                ...(runtime ? { runtimeSetupEntry: "./dist/setup-runtime.js" } : {}),
+              }
+            : {}),
+          compat: { pluginApi: ">=2026.5.17" },
+        },
+      };
+      await fs.writeFile(path.join(rootDir, "package.json"), JSON.stringify(packageManifest));
+      await fs.writeFile(
+        path.join(rootDir, "dist/shared.js"),
+        "export const shared = { ready: false };",
+      );
+      const entry = (
+        marker: string,
+        sharedPath = "./shared.js",
+      ) => `import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+import { shared } from ${JSON.stringify(sharedPath)}; shared.ready = true;
+export default Object.assign(defineToolPlugin({ id: ${JSON.stringify(id)}, name: "Packed tool", description: "Artifact fixture", tools: (tool) => [tool({ name: "artifact_echo", description: "Echo", optional: true, parameters: { type: "object", properties: {} }, execute: async () => ({ ok: true }) })] }), { artifactMarker: ${JSON.stringify(marker)}, shared });`;
+      await fs.writeFile(
+        path.join(rootDir, "dist/index.js"),
+        entry(inferred ? "runtime" : "source"),
+      );
+      if (inferred) {
+        await fs.mkdir(path.join(rootDir, "src"));
+        await fs.writeFile(
+          path.join(rootDir, "src/index.ts"),
+          entry("source", "../dist/shared.js"),
+        );
+      }
+      if (runtime) {
+        await fs.writeFile(path.join(rootDir, "dist/compiled.js"), entry("runtime"));
+      }
+      if (setup) {
+        await fs.writeFile(
+          path.join(rootDir, "dist/setup-source.js"),
+          'import { shared } from "./shared.js"; export default { artifactMarker: "setup-source", shared };',
+        );
+        await fs.writeFile(
+          path.join(rootDir, "dist/setup-runtime.js"),
+          'import { shared } from "./shared.js"; export default { artifactMarker: "setup-runtime", shared };',
+        );
+      }
+      await runPluginsBuildCommand({ root: rootDir });
+      const sourceManifest = await fs.readFile(path.join(rootDir, "openclaw.plugin.json"));
+      const writeJson = vi.spyOn(defaultRuntime, "writeJson").mockImplementation(() => {});
+      await runPluginsPackCommand({ root: rootDir, json: true });
+      const archive = path.join(rootDir, filename);
+      expect(writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({ pluginId: id, path: archive }),
+      );
+      const extracted = path.join(parent, "extracted");
+      await fs.mkdir(extracted);
+      await extract({ file: archive, cwd: extracted, strict: true });
+      const packageDir = path.join(extracted, "package");
+      const manifest = JSON.parse(await fs.readFile(path.join(packageDir, "package.json"), "utf8"));
+      expect(await fs.readFile(path.join(packageDir, "openclaw.plugin.json"))).toEqual(
+        sourceManifest,
+      );
+      expect(manifest.openclaw.compat).toEqual(packageManifest.openclaw.compat);
+      expect(
+        await validatePackageExtensionEntriesForInstall({
+          packageDir,
+          manifest,
+          extensions: manifest.openclaw.extensions,
+        }),
+      ).toEqual({ ok: true });
+      const resolution = {
+        packageDir,
+        manifest,
+        origin: "global" as const,
+        sourceLabel: packageDir,
+        diagnostics: [],
+      };
+      const [entryPath] = resolvePackageRuntimeExtensionSources({
+        ...resolution,
+        extensions: manifest.openclaw.extensions,
+      });
+      const loaded = await loadToolPlugin({ rootDir: packageDir, entryPath: entryPath! });
+      expect(loaded.entry).toMatchObject({
+        artifactMarker: runtime || inferred ? "runtime" : "source",
+      });
+      expect(loaded.metadata).toMatchObject({
+        id,
+        tools: [{ name: "artifact_echo", optional: true }],
+      });
+      if (setup) {
+        const setupPath = resolvePackageSetupSource(resolution);
+        expect(setupPath).toBeTruthy();
+        withPluginCache(createPluginCache(), () => {
+          const load = getCachedPluginSourceModuleLoader({
+            modulePath: entryPath!,
+            rootDir: packageDir,
+            importerUrl: import.meta.url,
+            aliasMap: buildPluginLoaderAliasMap(
+              entryPath!,
+              process.argv[1],
+              import.meta.url,
+              "src",
+            ),
+            transformOpenClawDependencies: true,
+          });
+          expect(load(entryPath!)).toMatchObject({ default: { shared: { ready: true } } });
+          expect(load(setupPath!)).toMatchObject({
+            default: {
+              artifactMarker: runtime ? "setup-runtime" : "setup-source",
+              shared: { ready: true },
+            },
+          });
+        });
+      }
+      const files = await fs.readdir(path.join(packageDir, "dist"));
+      expect(files.filter((file) => !file.startsWith("chunk-")).toSorted()).toEqual(
+        setup ? ["index.js", "setup.js"] : ["index.js"],
+      );
+      expect(files.filter((file) => file.startsWith("chunk-"))).toHaveLength(setup ? 1 : 0);
+    },
+  );
 
   it("rejects opaque prebundles with guidance to use the regular package-install flow", async () => {
     const { rootDir, parent } = await fixture();

--- a/src/cli/plugins-feature-artifact.ts
+++ b/src/cli/plugins-feature-artifact.ts
@@ -1,13 +1,19 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { create as createArchive } from "tar";
 import { root } from "../infra/fs-safe.js";
 import { readPluginControlUiAssets } from "../plugins/control-ui-assets.js";
+import { safePluginInstallFileName } from "../plugins/install-paths.js";
+import type { PluginDiagnostic } from "../plugins/manifest-types.js";
 import { loadPluginManifest, resolvePackageExtensionEntries } from "../plugins/manifest.js";
+import {
+  resolvePackageRuntimeExtensionSources,
+  resolvePackageSetupSource,
+  validatePackageExtensionEntriesForInstall,
+} from "../plugins/package-entry-resolution.js";
 import { createPluginCache, withPluginCache } from "../plugins/plugin-cache.js";
 import { defaultRuntime } from "../runtime.js";
 import { collectPluginsValidationResult } from "./plugins-authoring-command.js";
@@ -31,24 +37,40 @@ async function packFeaturePlugin(opts: PluginsPackOptions) {
   if (extensions.status !== "ok" || extensions.entries.length !== 1) {
     throw new Error("Plugin artifacts require exactly one backend entrypoint.");
   }
-  const entry = extensions.entries[0]!;
+  const entriesValid = await validatePackageExtensionEntriesForInstall({
+    packageDir: rootDir,
+    manifest: packageManifest,
+    extensions: extensions.entries,
+    allowSourceTypeScriptEntries: true,
+  });
+  if (!entriesValid.ok) {
+    throw new Error(entriesValid.error);
+  }
+  const diagnostics: PluginDiagnostic[] = [];
+  const resolution = {
+    packageDir: rootDir,
+    manifest: packageManifest,
+    origin: "config" as const,
+    requireBuiltRuntimeEntry: false,
+    sourceLabel: rootDir,
+    diagnostics,
+  };
+  const [entry] = resolvePackageRuntimeExtensionSources({
+    ...resolution,
+    extensions: extensions.entries,
+  });
+  const setupEntry = resolvePackageSetupSource(resolution);
+  if (!entry || diagnostics.length > 0) {
+    throw new Error(diagnostics.map((diagnostic) => diagnostic.message).join("\n"));
+  }
   const loaded = withPluginCache(createPluginCache(), () => loadPluginManifest(rootDir, false));
   if (!loaded.ok) {
     throw new Error(loaded.error);
   }
-  const require = createRequire(path.join(rootDir, "package.json"));
-  // SAFETY: Node resolves the plugin's installed esbuild package with this public API.
-  const builder = require("esbuild") as typeof import("esbuild");
-  const files = await buildPluginBundle(builder, {
-    absWorkingDir: rootDir,
-    entryPoints: [entry],
-    outfile: "dist/index.js",
-    platform: "node",
-    target: "node22",
-    external: ["openclaw", "openclaw/*"],
-  });
   const pluginId = loaded.manifest.id;
-  const outputPath = path.resolve(opts.out ?? path.join(rootDir, `${pluginId}.tgz`));
+  const outputPath = path.resolve(
+    opts.out ?? path.join(rootDir, `${safePluginInstallFileName(pluginId)}.tgz`),
+  );
   if (!/\.(?:tgz|tar\.gz)$/u.test(outputPath)) {
     throw new Error("Plugin artifact output must end in .tgz or .tar.gz.");
   }
@@ -61,7 +83,12 @@ async function packFeaturePlugin(opts: PluginsPackOptions) {
       hardlinks: "reject",
     });
     await destination.ensureRoot();
-    const { controlUi: _source, ...openclaw } = packageManifest.openclaw;
+    const {
+      controlUi: _source,
+      runtimeExtensions: _runtime,
+      runtimeSetupEntry: _runtimeSetup,
+      ...openclaw
+    } = packageManifest.openclaw;
     // Only runtime package metadata travels with the archive. Build-time dependencies
     // and scripts cannot trigger additional executable downloads after approval.
     const packedPackage = {
@@ -76,15 +103,32 @@ async function packFeaturePlugin(opts: PluginsPackOptions) {
       typeof packageManifest.peerDependencies.openclaw === "string"
         ? { peerDependencies: { openclaw: packageManifest.peerDependencies.openclaw } }
         : {}),
-      openclaw: { ...openclaw, extensions: ["./dist/index.js"] },
+      openclaw: {
+        ...openclaw,
+        extensions: ["./dist/index.js"],
+        ...(setupEntry ? { setupEntry: "./dist/setup.js" } : {}),
+      },
     };
     await destination.create("package.json", `${JSON.stringify(packedPackage, null, 2)}\n`);
     await destination.create(
       "openclaw.plugin.json",
       await source.readBytes("openclaw.plugin.json"),
     );
-    await destination.mkdir("dist");
-    await destination.create("dist/index.js", Buffer.from(files[0]!.contents));
+    // One build keeps modules shared by setup and runtime in the same artifact graph.
+    const files = await buildPluginBundle({
+      absWorkingDir: rootDir,
+      entryPoints: { index: entry, ...(setupEntry ? { setup: setupEntry } : {}) },
+      outdir: "dist",
+      splitting: true,
+      platform: "node",
+      target: "node22",
+      external: ["openclaw", "openclaw/*"],
+    });
+    for (const file of files) {
+      const relativePath = path.relative(rootDir, file.path);
+      await destination.mkdir(path.dirname(relativePath));
+      await destination.create(relativePath, Buffer.from(file.contents));
+    }
     const controlUi = loaded.manifest.controlUi;
     if (controlUi) {
       const { directory, assets } = await readPluginControlUiAssets(rootDir, controlUi);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where plugin authors running `openclaw plugins pack` would get `ENOENT` for a valid scoped plugin ID such as `@author/tools`. It also fixes successful packs that could not be installed because the archive was missing the package's declared runtime entry.

## Why This Change Was Made

The artifact producer now encodes only the output filename, resolves backend and setup roles through the canonical package runtime resolver, and rewrites package entry metadata to the files actually emitted. One multi-entry ESM build preserves modules shared by backend and setup; compiler loading and output ordering move into the existing shared bundler, removing duplicate caller logic while retaining browser-build and artifact validation.

## User Impact

Authors can pack scoped plugins and packages with explicit or inferred compiled runtime entries. Declared setup entries remain usable, shared runtime/setup state stays shared, and native manifests retain their exact plugin identity and tool metadata.

## Evidence

- Before the repair, the scoped-ID regression failed with `ENOENT`; runtime-entry regressions produced an archive that failed ordinary installation validation with `runtime extension entry not found`. Both defects were independently reproduced on `b6a2e5b4eff71070a02e755d55aea0dd53904a20` before production edits.
- **60 focused tests passed** across artifact authoring, metadata authoring, browser builds, and the canonical package runtime resolver. The artifact matrix extracts real archives and checks explicit/inferred runtime selection, setup roles, shared module state, manifest preservation, and emitted files. Existing CommonJS, browser asset, unresolved import/resource, stale-source, digest, and overwrite-protection coverage remains green.

  ```sh
  OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
    src/cli/plugins-feature-artifact.test.ts \
    src/cli/plugins-control-ui-build.test.ts \
    src/cli/plugins-authoring-command.test.ts \
    src/plugins/package-entry-resolution.runtime.test.ts
  ```

- **Canonical `pnpm build` passed**, including CLI bootstrap imports, native control-plane module loading, Plugin SDK checks, and Control UI compilation.
- **Compiled CLI proof passed** for disposable scoped and unscoped tool packages: `node openclaw.mjs plugins build`, `plugins pack --json`, and `plugins install --force --accept-capabilities`, followed by native imports of the installed backend/setup entries and an exact shared-module identity check. Native imports bind the built host OpenClaw SDK, the bundler's existing external dependency. No additional runtime dependencies were installed. Temporary projects and state were removed. An initial probe without the documented capability-consent flag correctly stopped at that gate; no product change or gate bypass was used.
- Scoped formatting, lint, and diff checks passed. Managed independent review returned **scoped-clean**, with no actionable P0–P2 findings.
- **Production +81/-41 (net +40); tests +153; docs +5.** Compiler acquisition and output ordering now have one owner for backend and browser builds. The net growth preserves the existing runtime/setup roles and emits their shared module graph; source metadata validation remains separate from installed-runtime selection.

Current local-main boundary inspection at `bc6c22ebafe3762007d4f46635f92bc6805727f3` found no concrete packing integration gap. The SDK-alias optimization retains the full-map behavior used by these callers; nearby Doctor/transcript-source metadata does not affect the packer's consumed fields or raw manifest copy. The reviewed patch applies cleanly.

Exact-head [CI run34026477486, attempt2](https://github.com/openclaw/openclaw/actions/runs/34026477486/attempts/2) and the aggregate gate passed. Attempt1 timed out in an untouched cron process-group test. One aligned macOS case and one instrumented isolated Linux case passed; Linux captured the shell/child start identities and verified empty groups and stopped-lease cleanup. These observations supported one failed-job retry, not a diagnosed cause or code fix. No production/test correction or second retry was made.

[ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/140016#issuecomment-5558550927) reports no findings or before-merge actions. A local full `check:changed` pass is not claimed; hosted CI supplies the exact-head broad gates.
