### PR TITLE
refactor(plugins): isolate pending conversation binding requests

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -739,7 +739,6 @@ src/plugins/contracts/plugin-sdk-subpaths.test.ts
 src/plugins/contracts/scheduled-turns.contract.test.ts
 src/plugins/contracts/tts-contract-suites.ts
 src/plugins/conversation-binding.test.ts
-src/plugins/conversation-binding.ts
 src/plugins/discovery.test.ts
 src/plugins/discovery.ts
 src/plugins/hook-types.ts

--- a/src/plugins/conversation-binding-pending.ts
+++ b/src/plugins/conversation-binding-pending.ts
@@ -1,0 +1,85 @@
+import { resolveGlobalMap } from "../shared/global-singleton.js";
+import type { PluginConversationBindingResolvedEvent } from "./conversation-binding.types.js";
+
+export type PendingPluginBindingRequest = PluginConversationBindingResolvedEvent["request"] & {
+  id: string;
+  pluginId: string;
+  pluginName?: string;
+  pluginRoot: string;
+};
+
+type PendingPluginBindingRequestEntry = {
+  request: PendingPluginBindingRequest;
+  expiresAtMs: number;
+  timeoutId: ReturnType<typeof setTimeout>;
+};
+
+// Chat approvals get the exec-style 30-minute decision window, with abandoned payloads capped.
+const PENDING_PLUGIN_BINDING_REQUEST_TTL_MS = 30 * 60_000;
+const MAX_PENDING_PLUGIN_BINDING_REQUESTS = 512;
+const pendingRequests = resolveGlobalMap<string, PendingPluginBindingRequestEntry>(
+  Symbol.for("openclaw.pluginBindingPendingRequests"),
+  (requests) => {
+    for (const entry of requests.values()) {
+      clearTimeout(entry.timeoutId);
+    }
+    requests.clear();
+  },
+);
+
+function removePendingPluginBindingRequest(
+  approvalId: string,
+  expected?: PendingPluginBindingRequestEntry,
+): void {
+  const entry = pendingRequests.get(approvalId);
+  if (!entry || (expected && entry !== expected)) {
+    return;
+  }
+  pendingRequests.delete(approvalId);
+  clearTimeout(entry.timeoutId);
+}
+
+export function addPendingPluginBindingRequest(request: PendingPluginBindingRequest): void {
+  const expiresAtMs = Date.now() + PENDING_PLUGIN_BINDING_REQUEST_TTL_MS;
+  const entry: PendingPluginBindingRequestEntry = {
+    request,
+    expiresAtMs,
+    timeoutId: setTimeout(() => {
+      removePendingPluginBindingRequest(request.id, entry);
+    }, PENDING_PLUGIN_BINDING_REQUEST_TTL_MS),
+  };
+  entry.timeoutId.unref?.();
+  pendingRequests.set(request.id, entry);
+
+  // Oldest-first eviction keeps abandoned approval payloads bounded and fail-closed.
+  while (pendingRequests.size > MAX_PENDING_PLUGIN_BINDING_REQUESTS) {
+    const oldestId = pendingRequests.keys().next().value;
+    if (oldestId === undefined) {
+      break;
+    }
+    removePendingPluginBindingRequest(oldestId);
+  }
+}
+
+export function takePluginBindingRequestForApproval(params: {
+  approvalId: string;
+  senderId?: string;
+}): PendingPluginBindingRequest | undefined {
+  const entry = pendingRequests.get(params.approvalId);
+  if (!entry || Date.now() >= entry.expiresAtMs) {
+    if (entry) {
+      removePendingPluginBindingRequest(params.approvalId, entry);
+    }
+    return undefined;
+  }
+  const request = entry.request;
+  if (
+    request.requestedBySenderId &&
+    params.senderId?.trim() &&
+    request.requestedBySenderId !== params.senderId.trim()
+  ) {
+    return undefined;
+  }
+  removePendingPluginBindingRequest(params.approvalId, entry);
+  return request;
+}

--- a/src/plugins/conversation-binding.test.ts
+++ b/src/plugins/conversation-binding.test.ts
@@ -644,10 +644,17 @@ describe("plugin conversation binding approvals", () => {
     });
   });
 
-  it("requires a fresh approval again after allow-once is consumed", async () => {
+  it("keeps allow-once approval scoped to its requester and conversation", async () => {
     const firstRequest = await requestPendingBinding(
       createDiscordCodexBindRequest("channel:1", "Bind this conversation to Codex thread 123."),
     );
+    await expect(
+      resolvePluginConversationBindingApproval({
+        approvalId: firstRequest.approvalId,
+        decision: "allow-once",
+        senderId: "another-user",
+      }),
+    ).resolves.toEqual({ status: "expired" });
     const approved = await approveBindingRequest(firstRequest.approvalId, "allow-once");
 
     expect(approved.status).toBe("approved");

--- a/src/plugins/conversation-binding.ts
+++ b/src/plugins/conversation-binding.ts
@@ -11,11 +11,15 @@ import {
   type SessionBindingScope,
 } from "../infra/outbound/session-binding-service.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { resolveGlobalMap } from "../shared/global-singleton.js";
 import {
   isPluginOwnedBindingMetadata,
   type PluginBindingMetadata,
 } from "./conversation-binding-metadata.js";
+import {
+  addPendingPluginBindingRequest,
+  takePluginBindingRequestForApproval,
+  type PendingPluginBindingRequest,
+} from "./conversation-binding-pending.js";
 import {
   buildPluginBindingSessionKey,
   normalizeChannel,
@@ -48,31 +52,7 @@ const LEGACY_CODEX_PLUGIN_SESSION_PREFIXES = [
 // configured channel bindings compiled from config.
 type PluginBindingApprovalDecision = PluginConversationBindingResolutionDecision;
 
-type PluginBindingConversation = {
-  channel: string;
-  accountId: string;
-  conversationId: string;
-  parentConversationId?: string;
-  threadId?: string | number;
-};
-
-type PendingPluginBindingRequest = {
-  id: string;
-  pluginId: string;
-  pluginName?: string;
-  pluginRoot: string;
-  conversation: PluginBindingConversation;
-  requestedBySenderId?: string;
-  summary?: string;
-  detachHint?: string;
-  data?: Record<string, unknown>;
-};
-
-type PendingPluginBindingRequestEntry = {
-  request: PendingPluginBindingRequest;
-  expiresAtMs: number;
-  timeoutId: ReturnType<typeof setTimeout>;
-};
+type PluginBindingConversation = PluginConversationBindingResolvedEvent["request"]["conversation"];
 
 type PluginBindingApprovalAction = {
   approvalId: string;
@@ -99,54 +79,6 @@ type PluginBindingResolveResult =
   | {
       status: "expired";
     };
-
-// Chat approvals get the exec-style 30-minute decision window, with abandoned payloads capped.
-const PENDING_PLUGIN_BINDING_REQUEST_TTL_MS = 30 * 60_000;
-const MAX_PENDING_PLUGIN_BINDING_REQUESTS = 512;
-const pendingRequests = resolveGlobalMap<string, PendingPluginBindingRequestEntry>(
-  Symbol.for("openclaw.pluginBindingPendingRequests"),
-  (requests) => {
-    for (const entry of requests.values()) {
-      clearTimeout(entry.timeoutId);
-    }
-    requests.clear();
-  },
-);
-
-function takePendingPluginBindingRequest(
-  approvalId: string,
-  expected?: PendingPluginBindingRequestEntry,
-): PendingPluginBindingRequest | undefined {
-  const entry = pendingRequests.get(approvalId);
-  if (!entry || (expected && entry !== expected)) {
-    return undefined;
-  }
-  pendingRequests.delete(approvalId);
-  clearTimeout(entry.timeoutId);
-  return entry.request;
-}
-
-function addPendingPluginBindingRequest(request: PendingPluginBindingRequest): void {
-  const expiresAtMs = Date.now() + PENDING_PLUGIN_BINDING_REQUEST_TTL_MS;
-  const entry: PendingPluginBindingRequestEntry = {
-    request,
-    expiresAtMs,
-    timeoutId: setTimeout(() => {
-      takePendingPluginBindingRequest(request.id, entry);
-    }, PENDING_PLUGIN_BINDING_REQUEST_TTL_MS),
-  };
-  entry.timeoutId.unref?.();
-  pendingRequests.set(request.id, entry);
-
-  // Oldest-first eviction keeps abandoned approval payloads bounded and fail-closed.
-  while (pendingRequests.size > MAX_PENDING_PLUGIN_BINDING_REQUESTS) {
-    const oldestId = pendingRequests.keys().next().value;
-    if (oldestId === undefined) {
-      break;
-    }
-    takePendingPluginBindingRequest(oldestId);
-  }
-}
 
 function normalizeConversation(params: PluginBindingConversation): PluginBindingConversation {
   return {
@@ -340,10 +272,8 @@ function withConversationBindingContext(
   };
 }
 
-function resolvePluginConversationBindingState(params: {
-  conversation: PluginBindingConversation;
-}) {
-  const ref = toConversationRef(params.conversation);
+function resolvePluginConversationBindingState(conversation: PluginBindingConversation) {
+  const ref = toConversationRef(conversation);
   const record = getSessionBindingService().resolveByConversation(ref);
   const binding = toPluginConversationBinding(record);
   return {
@@ -358,9 +288,7 @@ function resolveOwnedPluginConversationBinding(params: {
   pluginRoot: string;
   conversation: PluginBindingConversation;
 }): PluginConversationBinding | null {
-  const state = resolvePluginConversationBindingState({
-    conversation: params.conversation,
-  });
+  const state = resolvePluginConversationBindingState(params.conversation);
   if (!state.binding || state.binding.pluginRoot !== params.pluginRoot) {
     return null;
   }
@@ -560,9 +488,7 @@ export async function requestPluginConversationBinding(params: {
   binding: PluginConversationBindingRequestParams | undefined;
 }): Promise<PluginConversationBindingRequestResult> {
   const conversation = normalizeConversation(params.conversation);
-  const state = resolvePluginConversationBindingState({
-    conversation,
-  });
+  const state = resolvePluginConversationBindingState(conversation);
   if (state.record && !state.binding) {
     if (state.isLegacyForeignBinding) {
       logPluginBindingLifecycleEvent({
@@ -665,22 +591,10 @@ export async function resolvePluginConversationBindingApproval(params: {
   decision: PluginBindingApprovalDecision;
   senderId?: string;
 }): Promise<PluginBindingResolveResult> {
-  const entry = pendingRequests.get(params.approvalId);
-  if (!entry || Date.now() >= entry.expiresAtMs) {
-    if (entry) {
-      takePendingPluginBindingRequest(params.approvalId, entry);
-    }
+  const request = takePluginBindingRequestForApproval(params);
+  if (!request) {
     return { status: "expired" };
   }
-  const request = entry.request;
-  if (
-    request.requestedBySenderId &&
-    params.senderId?.trim() &&
-    request.requestedBySenderId !== params.senderId.trim()
-  ) {
-    return { status: "expired" };
-  }
-  takePendingPluginBindingRequest(params.approvalId, entry);
   if (params.decision === "deny") {
     dispatchPluginConversationBindingResolved({
       status: "denied",
@@ -788,4 +702,3 @@ export function buildPluginBindingResolvedText(params: PluginBindingResolveResul
   }
   return `Allowed ${params.request.pluginName ?? params.request.pluginId} to bind this conversation once.${summarySuffix}`;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #135868, #139984

## What Problem This Solves

The conversation-binding owner still mixed pending approval lifetime with routing and needed a grandfathered max-lines exception after its persistent state was separated in #139984.

## Why This Change Was Made

Move pending-request expiry, capacity eviction, sender matching, timer cleanup and consumption into one internal owner. Reuse the existing event request/conversation types and remove a redundant private argument bag and unused removal return value. The original module now passes the configured 700-code-line limit, allowing its suppression and exact baseline entry to be removed.

The 30-minute deadline, 512-request bound, oldest-first eviction, sender rules, global singleton identity and lifecycle drain remain unchanged. Binding decisions and side effects remain in the original public owner.

## User Impact

No public behavior or API changes. Production shrinks by 2 lines; tests grow by 7 lines to extend the existing allow-once scenario with rejection of a different sender before the original requester succeeds. One max-lines baseline entry is removed. Combined with #139984, this removes 27 production lines while splitting one oversized module into coherent owners. Relocated code is counted on both sides.

## Evidence

The existing boundary suites cover deadline expiry before timer dispatch, capacity eviction, lifecycle shutdown, SQLite restart, and approval scope. The extended allow-once case verifies that another sender cannot consume the request and that approval remains limited to its original conversation.

Validation: 38 focused tests passed across conversation-binding, SQLite restart, and global-singleton suites. Full `node scripts/check-changed.mjs` exited 0, including core/core-test typechecks, full core lint, tooling lint, the shrink-only max-lines ratchet, all dead-export scans, storage guards, and zero runtime import cycles. Targeted lint also passed with the suppression removed (about 655 nonblank/noncomment lines in the original module). Independent pinned-base Codex review: scoped-clean through P2. `git diff --check` passed.

ClawSweeper reviewed exact head `3d217c3e03fe75b19fe13ad4ab3b8dab6b421988`: no actionable correctness/security findings and no before-merge or rank-up requests.
