### PR TITLE
refactor(policy): reuse authored policy value helpers

### DIFF
--- a/extensions/policy/src/doctor/exec-approval-rules.ts
+++ b/extensions/policy/src/doctor/exec-approval-rules.ts
@@ -3,6 +3,7 @@ import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { EXEC_APPROVALS_POLICY_URI, execApprovalsPolicyUri } from "../exec-approvals-uri.js";
 import type { PolicyExecApprovalEvidence } from "../policy-state.js";
+import { getPolicyPath } from "../policy-value.js";
 import { policyShapeFinding, unsupportedPolicyKey } from "./shape-helpers.js";
 import { ocPathSegment } from "./utils.js";
 
@@ -50,13 +51,7 @@ export function readExecApprovalAllowlistRequirements(
   policy: unknown,
   path: readonly string[],
 ): readonly ExecApprovalAllowlistRequirement[] | undefined {
-  let current: unknown = policy;
-  for (const part of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[part];
-  }
+  const current = getPolicyPath(policy, path);
   if (!Array.isArray(current)) {
     return undefined;
   }

--- a/extensions/policy/src/doctor/strictness.test.ts
+++ b/extensions/policy/src/doctor/strictness.test.ts
@@ -4,6 +4,73 @@ import { POLICY_RULE_METADATA } from "./metadata.js";
 import { isPolicyValueAtLeastAsStrict } from "./strictness.js";
 
 describe("policy doctor strictness", () => {
+  it.each<[string, unknown, unknown, boolean]>([
+    ["normalizes string and object requirements", [" deploy "], [{ pattern: "deploy" }], true],
+    [
+      "trims argument constraints",
+      [{ pattern: " deploy ", argPattern: " ^--prod$ " }],
+      [{ pattern: "deploy", argPattern: "^--prod$" }],
+      true,
+    ],
+    [
+      "treats blank optional arguments as absent",
+      [{ pattern: "deploy", argPattern: " " }],
+      ["deploy"],
+      true,
+    ],
+    ["ignores list order", ["status", "deploy", "deploy"], ["deploy", "status", "deploy"], true],
+    ["preserves duplicate cardinality", ["deploy", "deploy"], ["deploy"], false],
+    [
+      "requires identical argument constraints",
+      [{ pattern: "deploy", argPattern: "^--stage$" }],
+      [{ pattern: "deploy", argPattern: "^--prod$" }],
+      false,
+    ],
+    [
+      "rejects a removed argument constraint",
+      ["deploy"],
+      [{ pattern: "deploy", argPattern: "^--prod$" }],
+      false,
+    ],
+    ["preserves pattern case", ["Deploy"], ["deploy"], false],
+    [
+      "preserves argument pattern case",
+      [{ pattern: "deploy", argPattern: "^--PROD$" }],
+      [{ pattern: "deploy", argPattern: "^--prod$" }],
+      false,
+    ],
+    ["accepts matching empty requirements", [], [], true],
+    ["keeps empty requirements meaningful", [], ["deploy"], false],
+    ["rejects blank entries instead of dropping them", ["deploy", " "], ["deploy"], false],
+    [
+      "rejects unsupported requirement keys",
+      [{ pattern: "deploy", argpattern: "^--prod$" }],
+      ["deploy"],
+      false,
+    ],
+    [
+      "rejects null argument constraints",
+      [{ pattern: "deploy", argPattern: null }],
+      ["deploy"],
+      false,
+    ],
+    [
+      "rejects non-string argument constraints",
+      [{ pattern: "deploy", argPattern: 1 }],
+      ["deploy"],
+      false,
+    ],
+    ["rejects missing patterns", [{ argPattern: "^--prod$" }], [], false],
+    ["rejects non-array requirements", {}, [], false],
+  ])("exec approval requirements: %s", (_name, candidate, baseline, expected) => {
+    const rule = POLICY_RULE_METADATA.find(
+      (entry) => entry.policyPath.join(".") === "execApprovals.agents.allowlist.expected",
+    );
+    expect(rule).toBeDefined();
+    expect(isPolicyValueAtLeastAsStrict(rule!, candidate, baseline)).toBe(expected);
+    expect(isPolicyValueAtLeastAsStrict(rule!, baseline, candidate)).toBe(expected);
+  });
+
   it("compares policy values through strictness metadata", () => {
     const allowHosts = POLICY_RULE_METADATA.find(
       (rule) => rule.policyPath.join(".") === "tools.exec.allowHosts",

--- a/extensions/policy/src/doctor/strictness.ts
+++ b/extensions/policy/src/doctor/strictness.ts
@@ -8,14 +8,9 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { ROUTING_MATCH_KINDS } from "../policy-routing.js";
 import { expandPolicyToolRequirement, toolListCoversTool } from "../tool-policy-conformance.js";
+import { readExecApprovalAllowlistRequirements } from "./exec-approval-rules.js";
 import type { PolicyRuleMetadata } from "./metadata.js";
 import { isChannelDenyRule } from "./shape-helpers.js";
-
-type ExecApprovalAllowlistRequirement = {
-  readonly key: string;
-  readonly pattern: string;
-  readonly argPattern?: string;
-};
 
 export function isPolicyValueAtLeastAsStrict(
   metadata: PolicyRuleMetadata,
@@ -263,11 +258,7 @@ function policyStringList(
     return undefined;
   }
   if (metadata.policyPath.join(".") === "execApprovals.agents.allowlist.expected") {
-    const entries = value.map(execApprovalAllowlistRequirement);
-    if (!entries.every((entry): entry is ExecApprovalAllowlistRequirement => entry !== undefined)) {
-      return undefined;
-    }
-    return entries.map((entry) => entry.key);
+    return readExecApprovalAllowlistRequirements(value, [])?.map((entry) => entry.key);
   }
   if (!value.every((entry) => typeof entry === "string")) {
     return undefined;
@@ -311,50 +302,4 @@ function policyString(value: unknown, metadata: PolicyRuleMetadata): string | un
   }
   const trimmed = value.trim();
   return metadata.caseSensitive === true ? trimmed : trimmed.toLowerCase();
-}
-
-function execApprovalAllowlistRequirement(
-  value: unknown,
-): ExecApprovalAllowlistRequirement | undefined {
-  if (typeof value === "string") {
-    const pattern = value.trim();
-    return pattern === "" ? undefined : execApprovalAllowlistRequirementFromParts(pattern);
-  }
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const keys = Object.keys(value);
-  if (keys.some((key) => key !== "argPattern" && key !== "pattern")) {
-    return undefined;
-  }
-  const pattern = typeof value.pattern === "string" ? value.pattern.trim() : "";
-  if (pattern === "") {
-    return undefined;
-  }
-  const argPattern = typeof value.argPattern === "string" ? value.argPattern.trim() : undefined;
-  if (value.argPattern !== undefined && argPattern === undefined) {
-    return undefined;
-  }
-  return execApprovalAllowlistRequirementFromParts(
-    pattern,
-    argPattern === "" ? undefined : argPattern,
-  );
-}
-
-function execApprovalAllowlistRequirementFromParts(
-  pattern: string,
-  argPattern?: string,
-): ExecApprovalAllowlistRequirement {
-  return {
-    key: execApprovalAllowlistRequirementKey(pattern, argPattern),
-    pattern,
-    ...(argPattern === undefined ? {} : { argPattern }),
-  };
-}
-
-function execApprovalAllowlistRequirementKey(
-  pattern: string,
-  argPattern: string | undefined,
-): string {
-  return `${pattern}\0${argPattern ?? ""}`;
 }

--- a/extensions/policy/src/doctor/utils.ts
+++ b/extensions/policy/src/doctor/utils.ts
@@ -1,5 +1,5 @@
 // Shared policy doctor value readers.
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { getPolicyPath } from "../policy-value.js";
 export { readBooleanPath as readPolicyBoolean } from "../policy-state-helpers.js";
 
 export function readPolicyStringArray(
@@ -7,13 +7,7 @@ export function readPolicyStringArray(
   path: readonly string[],
   options: { readonly lowercase?: boolean } = {},
 ): readonly string[] | undefined {
-  let current: unknown = policy;
-  for (const part of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[part];
-  }
+  const current = getPolicyPath(policy, path);
   if (!Array.isArray(current) || !current.every((entry) => typeof entry === "string")) {
     return undefined;
   }
@@ -35,13 +29,7 @@ export function readStringList(
 }
 
 export function readPolicyPathString(policy: unknown, path: readonly string[]): string | undefined {
-  let current: unknown = policy;
-  for (const part of path) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[part];
-  }
+  const current = getPolicyPath(policy, path);
   return typeof current === "string" ? current.trim().toLowerCase() : undefined;
 }
 

--- a/extensions/policy/src/policy-conformance.ts
+++ b/extensions/policy/src/policy-conformance.ts
@@ -5,6 +5,7 @@ import JSON5 from "json5";
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { readExecApprovalAllowlistRequirements } from "./doctor/exec-approval-rules.js";
 import {
   isPolicyValueAtLeastAsStrict,
   policyContainerShapeFindings,
@@ -325,9 +326,9 @@ function conformanceFinding(
 function baselineRuleIsNoOp(metadata: PolicyRuleMetadata, baseline: unknown): boolean {
   switch (metadata.strictness) {
     case "allowlist-subset":
-      return metadata.emptyList === "disabled" && policyRuleListIsEmpty(baseline, metadata);
+      return metadata.emptyList === "disabled" && policyRuleListIsEmpty(baseline);
     case "denylist-superset":
-      return policyRuleListIsEmpty(baseline, metadata);
+      return policyRuleListIsEmpty(baseline);
     case "requires-true":
       return baseline !== true;
     case "requires-false":
@@ -336,7 +337,7 @@ function baselineRuleIsNoOp(metadata: PolicyRuleMetadata, baseline: unknown): bo
     case "ordered-string":
       return false;
     case "routing-probes":
-      return policyRuleListIsEmpty(baseline, metadata);
+      return policyRuleListIsEmpty(baseline);
   }
   return false;
 }
@@ -363,7 +364,7 @@ function policyRuleValueIsValid(metadata: PolicyRuleMetadata, value: unknown): b
         return false;
       }
       if (isExecApprovalAllowlistExpectedRule(metadata)) {
-        return value.every(isExecApprovalAllowlistRequirement);
+        return readExecApprovalAllowlistRequirements(value, []) !== undefined;
       }
       return value.every(
         (entry) =>
@@ -379,29 +380,6 @@ function policyRuleValueIsValid(metadata: PolicyRuleMetadata, value: unknown): b
 
 function isExecApprovalAllowlistExpectedRule(metadata: PolicyRuleMetadata): boolean {
   return metadata.policyPath.join(".") === "execApprovals.agents.allowlist.expected";
-}
-
-function unsupportedPolicyKey(
-  value: Record<string, unknown>,
-  supported: readonly string[],
-): string | undefined {
-  return Object.keys(value).find((key) => !supported.includes(key));
-}
-
-function isExecApprovalAllowlistRequirement(value: unknown): boolean {
-  if (typeof value === "string") {
-    return value.trim() !== "";
-  }
-  if (!isRecord(value)) {
-    return false;
-  }
-  if (unsupportedPolicyKey(value, ["argPattern", "pattern"]) !== undefined) {
-    return false;
-  }
-  if (typeof value.pattern !== "string" || value.pattern.trim() === "") {
-    return false;
-  }
-  return value.argPattern === undefined || typeof value.argPattern === "string";
 }
 
 function policyStringIsAllowed(metadata: PolicyRuleMetadata, value: string): boolean {
@@ -424,17 +402,8 @@ function policyStringIsAllowed(metadata: PolicyRuleMetadata, value: string): boo
   return allowed.includes(normalized);
 }
 
-function policyRuleListIsEmpty(value: unknown, metadata: PolicyRuleMetadata): boolean {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-  if (metadata.valueType === "channel-provider-deny-rules") {
-    return value.length === 0;
-  }
-  if (metadata.valueType === "routing-probes") {
-    return value.length === 0;
-  }
-  return value.length === 0;
+function policyRuleListIsEmpty(value: unknown): boolean {
+  return Array.isArray(value) && value.length === 0;
 }
 
 function missingConformanceFinding(

--- a/extensions/policy/src/policy-conformance.ts
+++ b/extensions/policy/src/policy-conformance.ts
@@ -13,6 +13,7 @@ import {
   type PolicyRuleMetadata,
   type PolicyScopeSelectorKind,
 } from "./doctor/register.js";
+import { ocPathSegment } from "./doctor/utils.js";
 import { getPolicyPath, scopedPolicyValue } from "./policy-value.js";
 
 const POLICY_CONFORMANCE_CHECK_IDS = {
@@ -578,11 +579,4 @@ async function readPolicyDocument(path: string): Promise<PolicyDocumentReadResul
 
 function resolvePolicyPath(path: string, cwd: string | undefined): string {
   return isAbsolute(path) ? path : resolve(cwd ?? process.cwd(), path);
-}
-
-function ocPathSegment(value: string): string {
-  if (/^(?:[A-Za-z0-9_-]+|#\d+)$/.test(value)) {
-    return value;
-  }
-  return JSON.stringify(value);
 }

--- a/extensions/policy/src/policy-value.ts
+++ b/extensions/policy/src/policy-value.ts
@@ -8,8 +8,7 @@ export function scopedPolicyValue(
   if (!root) {
     return undefined;
   }
-  const scopedRoot = root === "agents" ? overlay.agents : overlay[root];
-  return getPolicyPath(scopedRoot, remainingPath);
+  return getPolicyPath(overlay[root], remainingPath);
 }
 
 export function getPolicyPath(value: unknown, path: readonly string[]): unknown {


### PR DESCRIPTION
## What Problem This Solves

Policy comparison, scoped strictness checks, and Doctor repeated the interpretation of the same authored exec-approval requirements. They also duplicated nested-value traversal and diagnostic path escaping, leaving several implementations to keep aligned.

## Why This Change Was Made

Reuse the existing exec-approval parser, `getPolicyPath`, and Doctor path formatter. Remove duplicate parsers, a metadata parameter whose branches returned the same result, and a scoped lookup whose special case selected the same property.

Preserve accepted and rejected input shapes, whitespace normalization, case-sensitive argument constraints, duplicate cardinality, meaningful empty requirements, diagnostic targets, and exit codes. The observed-state reader keeps its distinct metadata and escaping behavior. No new helpers, exports, configuration, schema, dependency, or policy semantics are introduced.

Production: **−110 lines** (+16/−126) across five files. Tests: +67 lines containing 17 preservation cases. Total: **−43 lines**.

## User Impact

No intentional behavior change. Existing policies, scoped overrides, comparison results, and Doctor diagnostics retain their current meaning without requiring operator action.

## Evidence

Final source: `9ba5e8b84dc52b73dd7725250393d8a1ef136cd4`.

- **362 focused tests passed** across strictness, CLI, Doctor registration, and policy-value boundaries. The 17 new preservation cases also passed against the pre-refactor implementation.
- Full changed-file checks passed, including plugin declarations/closures, extension and test types, SDK boundaries, lint, all three dead-export scans, and source guards. Runtime and Madge cycle checks both report zero cycles.
- Full `pnpm build` passed on the clean final commit in 4m38s. Build information, runtime stamps, and built policy entrypoints were verified before and after CLI execution.
- Seven real built-CLI comparison scenarios passed in fresh synthetic state: normalized equal requirements; removed and changed argument constraints; an unsupported requirement key; and equal, changed, and missing meaningful empty lists. Both expected success and failure exit codes, finding classes, rule counts, and the malformed-member target were asserted. The same scenarios passed before the final helper extraction.
- Independent P0–P2 review of the complete final diff found no actionable issues. The committed patch matches the reviewed/tested input.

CLI proof used the canonical built Policy plugin and isolated authored files. Network access was denied; writes were confined to the synthetic state and its exact lifecycle lock files. No real approvals, provider, channel, or Gateway operation was exercised. Hosted exact-head CI remains a separate landing gate.


## Review Follow-through

Required CI passed on the final source above: run 34027695587, including `openclaw/ci-gate`. The PR is ready for review.

ClawSweeper's completed review found no actionable correctness or security issue. Its automatic data-model flag refers to Doctor file paths, but this diff changes pure authored-policy readers and comparisons only: no schema, persisted representation, migration, store writer, or observed-state behavior changes. The review's own technical evidence confirms no persistent-store contract change, so migration/upgrade proof does not apply. The preserved strictness and CLI cases cover the affected comparison contracts.
