### PR TITLE
fix: cloud provisioning stays failed after temporary storage recovers

### DIFF
--- a/src/gateway/server-http.event-loop-health.test.ts
+++ b/src/gateway/server-http.event-loop-health.test.ts
@@ -91,9 +91,6 @@ describe("Gateway HTTP event-loop sampling", () => {
             expect((after.eventLoop as { delayMaxMs: number }).delayMaxMs).toBeGreaterThanOrEqual(
               1_000,
             );
-            await delay(1_100);
-            const recovered = await readJson(url);
-            expect(recovered).toMatchObject({ ready: true, eventLoop: { degraded: false } });
           } finally {
             server.closeAllConnections();
             await new Promise<void>((resolve, reject) => {

--- a/src/gateway/server/event-loop-health.test.ts
+++ b/src/gateway/server/event-loop-health.test.ts
@@ -173,7 +173,11 @@ describe("createGatewayEventLoopHealthMonitor", () => {
       degraded: true,
       degradedSinceMs: 60_999,
     });
-    harness.samples(50);
+    const degraded = harness.monitor.snapshot();
+    harness.samples(49);
+    expect(harness.monitor.snapshot()).toBe(degraded);
+    expect(harness.monitor.persistentDegradationSnapshot()).toBe(degraded);
+    harness.sample();
     expect(harness.monitor.snapshot()).toMatchObject({ degraded: false, degradedSinceMs: null });
     expect(harness.monitor.persistentDegradationSnapshot()).toBeUndefined();
   });

--- a/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import * as tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import * as tmpDirs from "../../infra/tmp-openclaw-dir.js";
 import { createDeferredCore } from "../../shared/deferred.js";
 import { createNodeBootstrapArtifactProvider } from "./node-bootstrap-artifact.js";
 
@@ -242,18 +243,25 @@ describe("node bootstrap distribution", () => {
     await expect(provider.prepare()).resolves.toMatchObject({ buildId });
   });
 
-  it("retries preparation after temporary staging storage becomes available", async () => {
-    const { provider } = await fixture();
-    const makeTemp = vi
-      .spyOn(fs, "mkdtemp")
-      .mockRejectedValueOnce(new Error("temporary storage unavailable"));
-    try {
-      await expect(provider.prepare()).rejects.toThrow("temporary storage unavailable");
-    } finally {
-      makeTemp.mockRestore();
-    }
-    await expect(provider.prepare()).resolves.toMatchObject({ buildId });
-  });
+  it.each(["root resolution", "staging creation"])(
+    "retries preparation after temporary %s becomes available",
+    async (stage) => {
+      const { provider } = await fixture();
+      const failure = new Error("temporary storage unavailable");
+      const makeTemp =
+        stage === "root resolution"
+          ? vi.spyOn(tmpDirs, "resolvePreferredOpenClawTmpDir").mockImplementationOnce(() => {
+              throw failure;
+            })
+          : vi.spyOn(fs, "mkdtemp").mockRejectedValueOnce(failure);
+      try {
+        await expect(provider.prepare()).rejects.toThrow("temporary storage unavailable");
+      } finally {
+        makeTemp.mockRestore();
+      }
+      await expect(provider.prepare()).resolves.toMatchObject({ buildId });
+    },
+  );
 
   it("does not return an artifact when its lifecycle closes during preparation", async () => {
     const { provider } = await fixture();

--- a/src/gateway/worker-environments/node-bootstrap-artifact.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.ts
@@ -457,7 +457,8 @@ export function createNodeBootstrapArtifactProvider(options: ArtifactOptions) {
       if (closed) {
         throw new Error("Node bootstrap artifact provider is closed");
       }
-      prepared ??= (async () => {
+      // Assign the shared promise before synchronous scratch-root failures can clear it.
+      prepared ??= Promise.resolve().then(async () => {
         try {
           temporaryRoot = await fs.mkdtemp(
             path.join(resolvePreferredOpenClawTmpDir(), "openclaw-node-runtime-"),
@@ -478,7 +479,7 @@ export function createNodeBootstrapArtifactProvider(options: ArtifactOptions) {
           prepared = undefined;
           throw error;
         }
-      })();
+      });
       // Cancellation releases this consumer; process shutdown still drains the shared producer.
       const artifact = await racePromiseWithAbortSignal(prepared, signal);
       signal?.throwIfAborted();


### PR DESCRIPTION
Related: #139387

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users starting cloud sessions could keep seeing bootstrap preparation failures after temporary storage became available again. A failed attempt could leave the Gateway unable to retry preparation with its existing artifact provider.

## Why This Change Was Made

The artifact provider now assigns its shared preparation promise before running work that can fail synchronously, so its existing failure cleanup can reliably clear the rejected promise. This keeps preparation, retry, cancellation, and cleanup in the same lifecycle owner; it does not change worker protocols, authorization, storage formats, or temporary-directory policy.

## User Impact

Operators can retry cloud-session preparation after a temporary storage problem is resolved without restarting the Gateway solely to discard a failed artifact preparation promise. Concurrent callers still share preparation, and existing cancellation and artifact-retention behavior remains covered.

## Evidence

The existing retry test now covers both synchronous temporary-root resolution failure and asynchronous staging creation failure, followed by a retry on the same provider. On the pre-fix implementation the synchronous case failed on the second call; after the fix both cases passed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/worker-environments/node-bootstrap-artifact.test.ts \
  -t 'retries preparation after temporary' --reporter=verbose
```

Before: **1 failed, 1 passed, 13 skipped**. After: **2 passed, 13 skipped**.

Initial owner and sibling validation passed **80 tests across 3 files**, including artifact preparation, node enrollment lifecycle, and temporary-root resolution, and passed again after the full build. After the CI test-ownership follow-up below, combined bootstrap and health coverage passed **100 tests across 5 files**.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/worker-environments/node-bootstrap-artifact.test.ts \
  src/gateway/worker-environments/node-enrollment.test.ts \
  src/infra/tmp-openclaw-dir.test.ts \
  src/gateway/server/event-loop-health.test.ts \
  src/gateway/server-http.event-loop-health.test.ts --reporter=verbose

pnpm check:changed --base 88c754716145a623a7c2c28d50e19c84e21ff78d -- \
  src/gateway/worker-environments/node-bootstrap-artifact.ts \
  src/gateway/worker-environments/node-bootstrap-artifact.test.ts \
  src/gateway/server-http.event-loop-health.test.ts \
  src/gateway/server/event-loop-health.test.ts

pnpm build
```

All selected changed-file checks passed for the complete four-file candidate, including core and core-test typechecks. Fresh P2 autoreview of the complete candidate returned no accepted/actionable findings. The original full build passed, including declaration generation, SDK export checks, runtime postbuild validation, and Control UI budgets; production bytes are unchanged by the test-only follow-up, and the build was not rerun for that follow-up.

Complete-candidate validation used the reviewed patch on base `88c754716145a623a7c2c28d50e19c84e21ff78d`. A dependency-less worktree correctly rejected external declaration inputs; declaration and build proof then ran in a separate normal checkout with `pnpm install --frozen-lockfile`, without bypassing containment or changing the lockfile.

Production delta: **+1 line**, an invariant comment; **net-zero executable lines**. Complete test delta: **+9 lines**: +8 for the existing retry test and +1 for the health test-ownership follow-up. No new test file or production seam was added.

No live cloud provisioning or operator-filesystem fault injection was performed. The regression uses a one-shot synchronous failure in the existing isolated fixture; the real artifact packaging and enrollment lifecycle tests provide the local behavior proof.

### CI test-ownership follow-up

The first published head's [Linux CI job](https://github.com/openclaw/openclaw/actions/runs/34026917025/job/101469531763) failed an unchanged HTTP event-loop test's final assertion: after a fixed 1.1-second wait, it expected `eventLoop.degraded: false` but observed `true`, while readiness remained true. Actions associated head `23fde152adf532a80365c4f538a605b9de783295`; the tested checkout was merge `a8b0d7c2f0eadb8414e0c5cc74c757f40760b125`. The actual degradation reasons were omitted from the assertion output. Both the unchanged focused test and the original 30-file/359-test subgroup passed locally on macOS, so the Linux failure was not reproduced locally and no precise environmental trigger is claimed.

The follow-up removes only the unsupported wall-clock global-health recovery assumption. The HTTP test retains its real blocked request, 100 snapshot reads before the overdue sampler resumes, delay observation, readiness response, and cleanup. Recovery remains covered at the existing deterministic monitor owner: 49 ordinary samples retain the degraded snapshot and persistent projection; the 50th completes the 1,000 ms window and clears both. This changes **tests only** (+5/-4), not production health classification, timeouts, thresholds, or runtime behavior.

The original Linux failure and both local non-reproductions are preserved as evidence; the passing combined local tests are not a claim that Linux CI has already passed on the follow-up.
