### PR TITLE
fix: clarify background command timeouts

### DIFF
--- a/docs/gateway/background-process.md
+++ b/docs/gateway/background-process.md
@@ -30,6 +30,7 @@ Behavior:
 - Foreground runs return retained output directly and disclose when earlier output exceeded the aggregate cap.
 - When backgrounded (explicit or via `yieldMs` timeout), the tool returns `status: "running"` + `sessionId` and a short output tail.
 - Backgrounded and `yieldMs` runs inherit `tools.exec.timeoutSeconds` unless the call passes an explicit `timeoutSeconds`.
+- Returning a background session ID does not stop the process timeout. For a persistent service on the gateway or in a sandbox, use `background: true` with `timeoutSeconds: 0`, then stop it with `process` action `kill` when finished. Host and worker lifecycle limits still apply.
 - Output stays in memory up to the per-session aggregate cap until the session is polled or cleared.
 - Finished sessions expire after their configured TTL. The registry also retains at most 50 finished sessions and 2,000,000 total retained output characters, evicting the oldest records first. The newest completed session retains its capped per-session aggregate even when that record alone exceeds the global limit.
 - If the `process` tool is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -29,13 +29,13 @@ Auto-background the command after this delay (ms).
 </ParamField>
 
 <ParamField path="background" type="boolean" default="false">
-Background the command immediately instead of waiting for `yieldMs`.
+Background the command immediately instead of waiting for `yieldMs`. The process timeout still applies after the tool returns.
 </ParamField>
 
 <ParamField path="timeoutSeconds" type="number" default="tools.exec.timeoutSeconds">
-Override the configured exec timeout for this call, in **seconds**. Note the sibling `yieldMs` is in
-milliseconds, and the `process` tool's identically named `timeout` is also in milliseconds - pass
-`timeoutSeconds` so the unit is explicit at the call site. Applies to foreground, background, `yieldMs`, gateway, sandbox, and node `system.run` execution. `timeoutSeconds: 0` disables the exec process timeout for that call.
+Limit the command's total lifetime, in **seconds**, overriding the configured exec timeout for this call. Expiry terminates the process even after `background` or `yieldMs` returns a session ID. `yieldMs` controls how long the tool waits before backgrounding; the `process` tool's `timeout` controls how long a poll waits, also in milliseconds.
+
+Applies to gateway, sandbox, and node `system.run` execution. `timeoutSeconds: 0` disables the exec process timeout for that call. For a persistent service on the gateway or in a sandbox, use `background: true` with `timeoutSeconds: 0`, then stop it with `process` action `kill` when finished. Disabling this timeout does not make the process survive its host or worker shutting down.
 </ParamField>
 
 <ParamField path="pty" type="boolean" default="false">

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -32,35 +32,32 @@ export const execSchema = Type.Object({
   ),
   env: Type.Optional(
     Type.Record(Type.String(), Type.String(), {
-      description: "Env overrides. Literal values; no expansion. Omit to inherit.",
+      description: "Literal overrides; no expansion. Omit to inherit.",
     }),
   ),
   yieldMs: Type.Optional(
     Type.Number({
-      description:
-        "Milliseconds before backgrounding; default 10000. Does not change timeoutSeconds.",
+      description: "Milliseconds before backgrounding; default 10000.",
     }),
   ),
   background: Type.Optional(
     Type.Boolean({
-      description:
-        "Return immediately while the command runs. timeoutSeconds still applies; use timeoutSeconds: 0 for persistent services.",
+      description: "Background now; timeoutSeconds applies.",
     }),
   ),
   timeoutSeconds: Type.Optional(
     Type.Number({
-      description:
-        "Total command lifetime in seconds; expiry terminates the process. Omit to use the configured default; 0 disables this timeout.",
+      description: "Process lifetime in seconds; 0 disables.",
     }),
   ),
   pty: Type.Optional(
     Type.Boolean({
-      description: "Use PTY for TTY-required CLIs and coding agents.",
+      description: "PTY for TTY-required CLIs/coding agents.",
     }),
   ),
   elevated: Type.Optional(
     Type.Boolean({
-      description: "Run on host with elevated permissions if allowed.",
+      description: "Host elevation if allowed.",
     }),
   ),
   host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -37,13 +37,20 @@ export const execSchema = Type.Object({
   ),
   yieldMs: Type.Optional(
     Type.Number({
-      description: "Milliseconds before backgrounding; default 10000.",
+      description:
+        "Milliseconds before backgrounding; default 10000. Does not change timeoutSeconds.",
     }),
   ),
-  background: Type.Optional(Type.Boolean({ description: "Background now." })),
+  background: Type.Optional(
+    Type.Boolean({
+      description:
+        "Return immediately while the command runs. timeoutSeconds still applies; use timeoutSeconds: 0 for persistent services.",
+    }),
+  ),
   timeoutSeconds: Type.Optional(
     Type.Number({
-      description: "Timeout in seconds.",
+      description:
+        "Total command lifetime in seconds; expiry terminates the process. Omit to use the configured default; 0 disables this timeout.",
     }),
   ),
   pty: Type.Optional(


### PR DESCRIPTION
## What Problem This Solves

Resolves unclear exec guidance for agents starting background services: a short timeout still terminates the process after the tool has returned a running session.

## Why This Change Was Made

Clarifies that `timeoutSeconds` limits total command lifetime, while `background` and `yieldMs` control when the tool returns. Documents the existing zero-timeout option and how to stop a persistent service explicitly. Shared timeout guidance remains valid for node-only and completion-only surfaces; background-service examples are scoped to gateway or sandbox execution.

## User Impact

Agents and operators can distinguish a process deadline from an output wait and choose the appropriate lifetime for a background service. Runtime behavior and configured defaults are unchanged.

## Evidence

- Real exec/process proof on macOS with Node 26.8.1: the same two-second command returned a background session in both cases. A one-second deadline produced `overall-timeout` and SIGTERM; `timeoutSeconds: 0` bypassed the configured one-second default and completed with exit code 0.
- Actual Code Mode `catalog.search("exec")[0].describe()` exposed the corrected parameter guidance. The same probe failed its missing-lifetime-guidance assertion before the change and passed afterward; process behavior stayed the same.
- All 84 existing tests passed across `agent-tools.schema.test.ts`, `bash-tools.schemas.test.ts`, `bash-tools.exec-timeout-seconds.test.ts`, and `bash-tools.exec.background-abort.test.ts`.
- CI caught an initial description-budget regression at 788 characters. The revised schema is 547 characters under the unchanged 550-character limit; the exact failing test was reproduced locally and now passes. Existing environment, PTY, elevation, approval, and other parameter constraints remain documented.
- `node scripts/check-changed.mjs` passed, including formatting, core and core-test typechecks, lint, and repository guards. Fresh independent review of the complete staged candidate found no actionable P0–P2 issues.
