### PR TITLE
fix: completed replies hang when context-engine cleanup stalls

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -290,7 +290,13 @@ Optional members:
 | `afterTurn(params)`            | Method | Post-run lifecycle work (persist state, trigger background compaction).                                                                      |
 | `prepareSubagentSpawn(params)` | Method | Set up shared state for a child session before it starts.                                                                                    |
 | `onSubagentEnded(params)`      | Method | Clean up after a subagent ends.                                                                                                              |
-| `dispose()`                    | Method | Release resources. Called during gateway shutdown or plugin reload - not per-session.                                                        |
+| `dispose()`                    | Method | Release engine-instance resources when the logical turn retires, after any retained turn work finishes.                                      |
+
+Foreground engine disposal shares the agent cleanup deadline: 10 seconds by
+default, adjustable with `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS`. A stalled cleanup
+logs a warning and lets the completed reply return; it does not cancel the
+plugin's pending disposal. Cleanup failures and timeouts retain the existing
+one-shot CLI cleanup-failure outcome; they do not certify resource closure.
 
 ### Runtime settings
 

--- a/src/agents/embedded-agent-runner/run-entry.cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.cleanup.test.ts
@@ -1,4 +1,5 @@
 import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { registerContextEngineForOwner } from "../../context-engine/registry.js";
 import { captureContextEngineRegistryStateForTests } from "../../context-engine/registry.test-support.js";
 import { createAgentCleanupScope } from "../run-cleanup-timeout.js";
@@ -15,8 +16,8 @@ it.each(cleanupCases)(
   "settles $kind replies and cleanup ownership for $settlement",
   async ({ kind, settlement }) => {
     const restoreRegistry = captureContextEngineRegistryStateForTests();
-    const disposal = Promise.withResolvers<void>();
-    const disposalStarted = Promise.withResolvers<void>();
+    const disposal = createDeferred();
+    const disposalStarted = createDeferred();
     const dispose = vi.fn(async () => {
       disposalStarted.resolve();
       await disposal.promise;

--- a/src/agents/embedded-agent-runner/run-entry.cleanup.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.cleanup.test.ts
@@ -1,0 +1,115 @@
+import { expect, it, vi } from "vitest";
+import { registerContextEngineForOwner } from "../../context-engine/registry.js";
+import { captureContextEngineRegistryStateForTests } from "../../context-engine/registry.test-support.js";
+import { createAgentCleanupScope } from "../run-cleanup-timeout.js";
+import { runEmbeddedAgentEntry } from "./run-entry.js";
+
+const cleanupCases = (["command-rpc", "channel-delivery"] as const).flatMap((kind) =>
+  (["success", "failure", "late-success", "late-failure"] as const).map((settlement) => ({
+    kind,
+    settlement,
+  })),
+);
+
+it.each(cleanupCases)(
+  "settles $kind replies and cleanup ownership for $settlement",
+  async ({ kind, settlement }) => {
+    const restoreRegistry = captureContextEngineRegistryStateForTests();
+    const disposal = Promise.withResolvers<void>();
+    const disposalStarted = Promise.withResolvers<void>();
+    const dispose = vi.fn(async () => {
+      disposalStarted.resolve();
+      await disposal.promise;
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+    vi.stubEnv("OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS", "25");
+    registerContextEngineForOwner(
+      "cleanup-probe",
+      () => ({
+        info: { id: "cleanup-probe", name: "Cleanup probe" },
+        ingest: async () => ({ ingested: false }),
+        assemble: async ({ messages }) => ({ messages, estimatedTokens: 0 }),
+        compact: async () => ({ ok: true, compacted: false }),
+        dispose,
+      }),
+      "test:cleanup-probe",
+    );
+    const cleanupScope = createAgentCleanupScope();
+    let returned = false;
+    const entry = cleanupScope
+      .run(() =>
+        runEmbeddedAgentEntry({
+          selection: {
+            cfg: { plugins: { slots: { contextEngine: "cleanup-probe" } } },
+            provider: "synthetic",
+            model: "synthetic-model",
+            fallbacksOverride: [],
+          },
+          identity: { runId: "cleanup-run", agentId: "main", sessionId: "cleanup-session" },
+          harness: {
+            workspaceDir: process.cwd(),
+            preparation: { kind: "direct" },
+            resolveRuntimeOverride: () => "openclaw",
+          },
+          behavior:
+            kind === "command-rpc"
+              ? { kind, hasCommittedSideEffect: () => false }
+              : {
+                  kind,
+                  readDeliveryEvidence: () => ({
+                    hasDirectlySentBlockReply: false,
+                    hasBlockReplyPipelineOutput: false,
+                  }),
+                },
+          sessionOverride: { kind: "preserve" },
+          runCandidate: async (provider, model) => ({
+            payloads: [{ text: "Completed answer" }],
+            meta: {
+              durationMs: 1,
+              aborted: false,
+              providerStarted: true,
+              stopReason: "completed",
+              agentMeta: { sessionId: "cleanup-session", provider, model },
+            },
+          }),
+        }),
+      )
+      .then((result) => {
+        returned = true;
+        return result;
+      });
+    try {
+      await disposalStarted.promise;
+      if (settlement === "success") {
+        disposal.resolve();
+      } else if (settlement === "failure") {
+        disposal.reject(new Error("Context engine disposal failed"));
+      }
+      await vi.advanceTimersByTimeAsync(25);
+      expect(returned).toBe(true);
+      expect((await entry).result.payloads).toEqual([{ text: "Completed answer" }]);
+      expect(dispose).toHaveBeenCalledOnce();
+      expect(cleanupScope.outcome).toBe(settlement === "success" ? "closed" : "uncertain");
+      if (settlement.startsWith("late-")) {
+        expect(warn).toHaveBeenCalledWith(
+          "agent cleanup timed out: runId=cleanup-run sessionId=cleanup-session step=context-engine-dispose timeoutMs=25",
+        );
+        if (settlement === "late-failure") {
+          disposal.reject(new Error("Context engine disposal failed after timeout"));
+        } else {
+          disposal.resolve();
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(cleanupScope.outcome).toBe("uncertain");
+      }
+    } finally {
+      disposal.resolve();
+      await entry.catch(() => {});
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+      warn.mockRestore();
+      restoreRegistry();
+    }
+  },
+);

--- a/src/agents/embedded-agent-runner/run-entry.ts
+++ b/src/agents/embedded-agent-runner/run-entry.ts
@@ -372,6 +372,7 @@ export async function runEmbeddedAgentEntry<T extends EmbeddedAgentRunResult>(
   params: EmbeddedAgentRunEntryParams<T>,
 ): Promise<EmbeddedAgentRunEntryResult<T>> {
   const contextEngineLogicalTurnLease = await createContextEngineLogicalTurnLease({
+    identity: params.identity,
     config: params.selection.cfg,
     agentDir: params.selection.agentDir,
     workspaceDir: params.harness.workspaceDir,

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -272,6 +272,7 @@ export async function runPreparedEmbeddedLoop(
       "context-engine",
       () =>
         createContextEngineLogicalTurnLease({
+          identity: params,
           config: params.config,
           agentDir,
           workspaceDir: resolvedWorkspace,

--- a/src/agents/embedded-agent-runner/run/run-settlement.ts
+++ b/src/agents/embedded-agent-runner/run/run-settlement.ts
@@ -102,17 +102,7 @@ export async function settleEmbeddedRun(input: {
   forgetPromptBuildDrainCacheForRun(params.runId);
   clearProviderPromptState(params.runId);
   runtime.stopRuntimeAuthRefreshTimer();
-  if (ownedContextEngineLease) {
-    await runAgentCleanupStep({
-      runId: params.runId,
-      sessionId: params.sessionId,
-      step: "context-engine-dispose",
-      log,
-      cleanup: async () => {
-        await ownedContextEngineLease.dispose();
-      },
-    });
-  }
+  await ownedContextEngineLease?.dispose();
   if (params.cleanupBundleMcpOnRunEnd === true) {
     await runAgentCleanupStep({
       runId: params.runId,

--- a/src/agents/harness/context-engine-logical-turn.ts
+++ b/src/agents/harness/context-engine-logical-turn.ts
@@ -9,6 +9,7 @@ import { ensureContextEnginesInitialized } from "../../context-engine/init.js";
 import { resolveLogicalTurnContextEngines } from "../../context-engine/registry.js";
 import type { ContextEngine, ContextEngineOperation } from "../../context-engine/types.js";
 import type { UserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.types.js";
+import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 
 type LogicalTurnSelectionState = "unselected" | "selected" | "started" | "disposed";
 
@@ -63,11 +64,13 @@ export function selectContextEngineForTranscriptHost(params: {
 }
 
 export async function createContextEngineLogicalTurnLease(params: {
+  identity: { runId: string; sessionId: string };
   config?: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
   warn?: (message: string) => void;
 }): Promise<ContextEngineLogicalTurnLease> {
+  const { runId, sessionId } = params.identity;
   ensureContextEnginesInitialized();
   const resolution = await resolveLogicalTurnContextEngines(params.config, {
     agentDir: params.agentDir,
@@ -225,8 +228,22 @@ export async function createContextEngineLogicalTurnLease(params: {
         resolution.configured.engine,
         resolution.fallback.engine,
       ]);
+      // Dispose instances in parallel so their deadlines do not stack. The
+      // shared helper records each failure before one-shot cleanup checks ownership.
       const disposeEngines = async () => {
-        await Promise.allSettled([...engines].map(async (engine) => await engine.dispose?.()));
+        await Promise.allSettled(
+          [...engines].map((engine) =>
+            runAgentCleanupStep({
+              runId,
+              sessionId,
+              step: "context-engine-dispose",
+              log: { warn: params.warn ?? console.warn },
+              cleanup: async () => {
+                await engine.dispose?.();
+              },
+            }),
+          ),
+        );
       };
       if (disposalHolds.size > 0) {
         void Promise.allSettled(disposalHolds).then(disposeEngines);

--- a/src/agents/runtime-plugins.context-engine.integration.test.ts
+++ b/src/agents/runtime-plugins.context-engine.integration.test.ts
@@ -80,7 +80,11 @@ it("keeps the configured context engine active in a prepared agent registry", as
 
   expect(preparedRegistry).not.toBe(activeRegistry);
   await withPluginRuntimeRegistryScope(preparedRegistry, async () => {
-    const lease = await createContextEngineLogicalTurnLease({ config, workspaceDir: plugin.dir });
+    const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
+      config,
+      workspaceDir: plugin.dir,
+    });
     expect(lease.degraded).toBe(false);
     expect(lease.effectiveEngineId).toBe(engineId);
     expect(lease.effectiveEnginePluginId).toBe(engineId);
@@ -196,7 +200,12 @@ it("selects a full-mode-only context engine on caller-owned handles without full
   };
   // Cron prepare loads this handle, then run-executor selects the engine inside the scoped registry.
   const lease = await withPluginRuntimeRegistryScope(handle, () =>
-    createContextEngineLogicalTurnLease({ config, warn, workspaceDir }),
+    createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
+      config,
+      warn,
+      workspaceDir,
+    }),
   );
   try {
     expect(lease.effectiveEngineId).toBe("ce-probe");

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1,6 +1,7 @@
 // Context engine tests cover context extraction and prompt context assembly.
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import {
   createContextEngineLogicalTurnLease,
   selectContextEngineForTranscriptHost,
@@ -827,8 +828,8 @@ describe("Default engine selection", () => {
     "disposes once after retained turn work settles with %s",
     async (settlement) => {
       const engineId = uniqueEngineId("logical-turn-retained-work");
-      const hold = Promise.withResolvers<void>();
-      const disposed = Promise.withResolvers<void>();
+      const hold = createDeferred();
+      const disposed = createDeferred();
       const engine = new MockContextEngine();
       const dispose = vi.spyOn(engine, "dispose").mockImplementation(async () => {
         disposed.resolve();
@@ -862,8 +863,8 @@ describe("Default engine selection", () => {
       const registry = await import("./registry.js");
       const configured = new MockContextEngine();
       const fallback = new MockContextEngine();
-      const configuredGate = Promise.withResolvers<void>();
-      const fallbackGate = Promise.withResolvers<void>();
+      const configuredGate = createDeferred();
+      const fallbackGate = createDeferred();
       const configuredDispose = vi.spyOn(configured, "dispose").mockImplementation(async () => {
         if (fastFailure) {
           throw new Error("configured engine disposal failed");

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -5,6 +5,7 @@ import {
   createContextEngineLogicalTurnLease,
   selectContextEngineForTranscriptHost,
 } from "../agents/harness/context-engine-logical-turn.js";
+import { createAgentCleanupScope } from "../agents/run-cleanup-timeout.js";
 import { SessionTranscriptReadFenceError } from "../config/sessions/session-transcript-read-fence.js";
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -738,7 +739,11 @@ describe("Default engine selection", () => {
     },
   ])("keeps $label configured without a warning", async ({ config, admission }) => {
     const warn = vi.fn();
-    const lease = await createContextEngineLogicalTurnLease({ config, warn });
+    const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
+      config,
+      warn,
+    });
 
     const selected = selectContextEngineForTranscriptHost({
       lease,
@@ -757,7 +762,10 @@ describe("Default engine selection", () => {
 
   it("keeps repeated baseline host selection stable after the turn starts", async () => {
     const warn = vi.fn();
-    const lease = await createContextEngineLogicalTurnLease({ warn });
+    const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
+      warn,
+    });
     const selection = {
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
       operation: "agent-run" as const,
@@ -777,7 +785,10 @@ describe("Default engine selection", () => {
 
   it("keeps repeated baseline transcript-host selection stable after the turn starts", async () => {
     const warn = vi.fn();
-    const lease = await createContextEngineLogicalTurnLease({ warn });
+    const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
+      warn,
+    });
     const selection = {
       lease,
       host: { id: "agent-harness:test", label: "test harness", capabilities: [] },
@@ -797,7 +808,9 @@ describe("Default engine selection", () => {
   });
 
   it("rejects baseline transcript-host selection after disposal", async () => {
-    const lease = await createContextEngineLogicalTurnLease({});
+    const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
+    });
     await lease.dispose();
 
     expect(() =>
@@ -809,6 +822,100 @@ describe("Default engine selection", () => {
       }),
     ).toThrow("context-engine logical turn selection is already pinned");
   });
+
+  it.each(["resolve", "reject"] as const)(
+    "disposes once after retained turn work settles with %s",
+    async (settlement) => {
+      const engineId = uniqueEngineId("logical-turn-retained-work");
+      const hold = Promise.withResolvers<void>();
+      const disposed = Promise.withResolvers<void>();
+      const engine = new MockContextEngine();
+      const dispose = vi.spyOn(engine, "dispose").mockImplementation(async () => {
+        disposed.resolve();
+      });
+      registerTestContextEngine(engineId, () => engine);
+      const lease = await createContextEngineLogicalTurnLease({
+        identity: { runId: "retained-run", sessionId: "retained-session" },
+        config: configWithSlot(engineId),
+      });
+      lease.deferDisposalUntil(hold.promise);
+
+      await lease.dispose();
+      await lease.dispose();
+      expect(dispose).not.toHaveBeenCalled();
+      expect(() => lease.begin()).toThrow("already disposed");
+
+      if (settlement === "reject") {
+        hold.reject(new Error("pending turn work failed"));
+      } else {
+        hold.resolve();
+      }
+      await disposed.promise;
+      await lease.dispose();
+      expect(dispose).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([false, true])(
+    "bounds configured and fallback disposal in parallel (fast failure=%s)",
+    async (fastFailure) => {
+      const registry = await import("./registry.js");
+      const configured = new MockContextEngine();
+      const fallback = new MockContextEngine();
+      const configuredGate = Promise.withResolvers<void>();
+      const fallbackGate = Promise.withResolvers<void>();
+      const configuredDispose = vi.spyOn(configured, "dispose").mockImplementation(async () => {
+        if (fastFailure) {
+          throw new Error("configured engine disposal failed");
+        }
+        await configuredGate.promise;
+      });
+      const fallbackDispose = vi
+        .spyOn(fallback, "dispose")
+        .mockImplementation(() => fallbackGate.promise);
+      const resolve = vi.spyOn(registry, "resolveLogicalTurnContextEngines").mockResolvedValue({
+        configured: { engine: configured, registeredId: "configured" },
+        configuredId: "configured",
+        fallback: { engine: fallback, registeredId: "legacy" },
+      });
+      vi.useFakeTimers();
+      vi.stubEnv("OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS", "25");
+      const scope = createAgentCleanupScope();
+      const lease = await createContextEngineLogicalTurnLease({
+        identity: { runId: "parallel-run", sessionId: "parallel-session" },
+        warn: vi.fn(),
+      });
+      let settled = false;
+      const cleanup = scope
+        .run(() => lease.dispose())
+        .then(() => {
+          settled = true;
+        });
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        expect(configuredDispose).toHaveBeenCalledOnce();
+        expect(fallbackDispose).toHaveBeenCalledOnce();
+        if (fastFailure) {
+          expect(scope.outcome).toBe("uncertain");
+        }
+        await vi.advanceTimersByTimeAsync(24);
+        expect(settled).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(settled).toBe(true);
+        expect(scope.outcome).toBe("uncertain");
+        await lease.dispose();
+        expect(configuredDispose).toHaveBeenCalledOnce();
+        expect(fallbackDispose).toHaveBeenCalledOnce();
+      } finally {
+        configuredGate.resolve();
+        fallbackGate.resolve();
+        await cleanup;
+        vi.useRealTimers();
+        vi.unstubAllEnvs();
+        resolve.mockRestore();
+      }
+    },
+  );
 
   it("still rejects an attempted custom-engine transition after the turn starts", async () => {
     const engineId = uniqueEngineId("logical-turn-late-transition");
@@ -835,6 +942,7 @@ describe("Default engine selection", () => {
       },
     }));
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
     });
     lease.begin();
@@ -850,6 +958,7 @@ describe("Default engine selection", () => {
     const warn = vi.fn();
 
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });
@@ -871,6 +980,7 @@ describe("Default engine selection", () => {
     const warn = vi.fn();
 
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });
@@ -891,6 +1001,7 @@ describe("Default engine selection", () => {
     const warn = vi.fn();
 
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });
@@ -917,6 +1028,7 @@ describe("Default engine selection", () => {
     }));
     const warn = vi.fn();
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });
@@ -954,6 +1066,7 @@ describe("Default engine selection", () => {
     }));
     const warn = vi.fn();
     const first = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });
@@ -970,6 +1083,7 @@ describe("Default engine selection", () => {
     await first.dispose();
 
     const second = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });
@@ -1010,6 +1124,7 @@ describe("Default engine selection", () => {
       },
     }));
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
     });
 
@@ -1091,6 +1206,7 @@ describe("Default engine selection", () => {
     }));
     const warn = vi.fn();
     const lease = await createContextEngineLogicalTurnLease({
+      identity: { runId: "test-run", sessionId: "test-session" },
       config: configWithSlot(engineId),
       warn,
     });

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -425,13 +425,14 @@ function createCronPromptExecutor(
             errorContext: "cron user turn transcript",
           });
     pendingUserTurn = { promptText, recorder: userTurnTranscriptRecorder };
+    const runId = params.cronSession.sessionEntry.sessionId;
     const contextEngineLogicalTurnLease = await createContextEngineLogicalTurnLease({
+      identity: { runId, sessionId: runId },
       config: params.cfgWithAgentDefaults,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
     });
     let acceptedContextEngineTurnCandidate: ContextEngineTurnAttemptFacts | undefined;
-    const runId = params.cronSession.sessionEntry.sessionId;
     const basePreparedRunAdmission = prepareAgentRunAdmission({
       operationalRunInstance: createOperationalRunInstanceRef(runId),
       cfg: params.cfgWithAgentDefaults,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users waiting for a completed agent reply could wait indefinitely when a context-engine plugin stalled while releasing its resources. Command/chat runs and isolated cron turns waited in their outer logical-turn cleanup after the model had finished. Individual disposal failures could also be swallowed before the existing cleanup scope recorded them.

## Why This Change Was Made

The logical lease now runs each configured/fallback engine disposal through the existing cleanup helper in parallel, and the redundant inner-run timeout wrapper is removed. This places the deadline and failed-disposal observation at their shared owner while preserving main's cleanup outcome helper and tests unchanged.

Both disposals start together, so their deadlines do not stack. Disposal remains once-only; retained turn work settles before disposal starts. The existing 10-second default and `OPENCLAW_AGENT_CLEANUP_TIMEOUT_MS` override are preserved.

## User Impact

Ordinary command and channel results no longer wait indefinitely for plugin cleanup. Failure and timeout remain recorded as uncertain even if a pending disposer finishes later. One-shot CLI commands retain their existing cleanup-failure reporting and state-ownership behavior; a bounded result does not certify resource closure.

The shared host lease covers Codex-backed turns too. Native Codex turn/thread cleanup keeps its existing owners and operations.

## Evidence

- On immutable main `f4bde51ed1c0519631efec33e8aa2bc78b1e0d38`, the real entry/registry table failed six of eight cases: four stalled-result failures and two fast failures incorrectly reported as closed. Success controls passed. Both configured/fallback parallel cases also failed for the intended deadline/uncertainty reasons.
- With the repair, **117 tests passed across six complete owner/consumer/sibling files**. Coverage includes success, fast rejection, timeout followed by success or rejection, sticky uncertainty, once-only disposal, retained-work resolution/rejection, real registry/fallback/entry flow, inner settlement and the one-shot CLI state-lock consumer.
- The two-engine cases verify that both disposers start at time zero, the wait remains pending at 24 ms, and it completes at the unchanged 25 ms fixture deadline. Both-stalled and fast-failure-plus-stalled combinations pass; a fast failure records uncertainty immediately while the sibling still settles.
- A separate Node 24.19.0 process proof used the real registry, model-fallback orchestrator, logical lease, cleanup scope and entry. Only the provider result was synthetic. With the existing timeout override set to 10 ms, exact main passed the success control but failed the other three outcomes; the repaired candidate passed all four. The script released every held disposer and exited cleanly. No network or credentials were used.
- Fresh managed independent review completed `scoped-clean` through P2 with no actionable findings. Targeted lint, nine-file formatting, docs MDX/index checks and diff whitespace checks passed. Final-head hosted CI is recorded below; no live Codex inference or Gateway UI proof is claimed.

CI fixture correction (`4bdbd0b8ebce`): the core test-type job exposed six direct `Promise.withResolvers` calls incompatible with the existing ES2023 declarations. They now use the shared typed deferred helper; production, assertions and deadlines are unchanged. This separate correction passed **86 tests** across the two affected files, both complete `agents-other`/`other` type graphs, type-aware lint across all eight changed TypeScript files, formatting, and fresh scoped-clean P2 review. The original 117-test and four-process proof above is retained; hosted CI for `4bdbd0b8ebce701f584fe9d8aa0d93d11e6370a2` passed in [run 34028154769](https://github.com/openclaw/openclaw/actions/runs/34028154769).

Focused proof command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run-entry.cleanup.test.ts \
  src/context-engine/context-engine.test.ts \
  src/agents/run-cleanup-timeout.test.ts \
  src/commands/agent-exec.state-lock.test.ts \
  src/agents/embedded-agent-runner/run/run-settlement.test.ts \
  src/agents/runtime-plugins.context-engine.integration.test.ts
```

Production: +23/-13, net **+10 lines**. The growth binds the existing deadline and failure recording to each actual engine at the shared lease owner; main already contains the earlier helper simplification. Tests: +248/-6, net +242. Docs: net +6. No configuration, schema, stored representation, authentication, authorization, public plugin API or native RPC change.
