### PR TITLE
fix: keep failed tool turns out of context-engine memory

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -240,6 +240,11 @@ then see the exact transcript prefix before the admitted user message. The host
 calls `commitTurn` only for the accepted successful turn; failed or aborted
 turns do not advance context-engine state.
 
+For these admitted turns, embedded tool-loop `assemble()` receives the history
+before the current turn, with a token budget that reserves space for pending user
+and tool messages. The host appends those pending messages to the assembled history before
+the next model request, so they remain visible without entering the engine's store.
+
 Without the full declaration and method, OpenClaw uses the legacy context path
 for the whole logical turn, including retries. The configured context-engine
 slot is not changed, and OpenClaw tries the configured engine again on the next

--- a/src/agents/embedded-agent-runner/run/attempt-context-advancement.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-context-advancement.test.ts
@@ -1,0 +1,233 @@
+import {
+  createAssistantMessageEventStream,
+  type AssistantMessage,
+  type Model,
+  type Message,
+} from "openclaw/plugin-sdk/llm";
+import { describe, expect, it, vi } from "vitest";
+import type { ContextEngine } from "../../../context-engine/types.js";
+import { Agent, type AgentMessage } from "../../runtime/index.js";
+import { createToolResultPromptProjectionState } from "../session-prompt-state.js";
+import { installEmbeddedAttemptContextGuards } from "./attempt-setup.js";
+
+const model: Model = {
+  id: "synthetic-model",
+  name: "Synthetic",
+  api: "openai-responses",
+  provider: "synthetic",
+  baseUrl: "http://127.0.0.1:1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8192,
+  maxTokens: 1024,
+};
+const usage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+describe("context advancement through embedded attempt guards", () => {
+  it.each(
+    (["afterTurn", "ingestBatch", "ingest"] as const).flatMap((ingestion) =>
+      (["stop", "error", "aborted"] as const).flatMap((terminal) =>
+        (["stored-prefix", "live-input"] as const).map((assembly) => ({
+          ingestion,
+          terminal,
+          assembly,
+        })),
+      ),
+    ),
+  )(
+    "preserves live context with $assembly assembly and defers $ingestion after $terminal",
+    async ({ ingestion, terminal, assembly }) => {
+      const remembered: AgentMessage[] = [];
+      const history: AgentMessage[] = [
+        { role: "user", content: "Earlier accepted request.", timestamp: 0 },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Earlier accepted answer." }],
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage,
+          timestamp: 0,
+          stopReason: "stop",
+        },
+      ];
+      const storedPrefix: AgentMessage[] = [
+        { role: "user", content: "Summary of accepted history.", timestamp: 0 },
+      ];
+      const assemble = vi.fn<ContextEngine["assemble"]>(async ({ messages }) => ({
+        messages: assembly === "stored-prefix" ? storedPrefix : messages,
+        estimatedTokens: 0,
+      }));
+      const commitTurn = vi.fn<NonNullable<ContextEngine["commitTurn"]>>(async () => ({
+        status: "committed",
+      }));
+      const engine: ContextEngine = {
+        info: {
+          id: "synthetic-engine",
+          name: "Synthetic",
+          ownsCompaction: true,
+          transcriptSemantics: {
+            currentTurnFence: "before-current-turn-entry-v1",
+            turnAdvancementIdempotency: "atomic-idempotent-v1",
+          },
+        },
+        ingest: async ({ message }) => {
+          remembered.push(message);
+          return { ingested: true };
+        },
+        ...(ingestion === "afterTurn"
+          ? {
+              afterTurn: async ({
+                messages,
+                prePromptMessageCount,
+              }: Parameters<NonNullable<ContextEngine["afterTurn"]>>[0]) => {
+                remembered.push(...messages.slice(prePromptMessageCount));
+              },
+            }
+          : {}),
+        ...(ingestion === "ingestBatch"
+          ? {
+              ingestBatch: async ({
+                messages,
+              }: Parameters<NonNullable<ContextEngine["ingestBatch"]>>[0]) => {
+                remembered.push(...messages);
+                return { ingestedCount: messages.length };
+              },
+            }
+          : {}),
+        assemble,
+        compact: async () => ({ ok: true, compacted: false, reason: "fits" }),
+        commitTurn,
+      };
+      let providerCalls = 0;
+      let secondModelMessages: Message[] | undefined;
+      const execute = vi.fn(async () => ({
+        content: [{ type: "text" as const, text: "fixture observation" }],
+        details: {},
+      }));
+      const agent = new Agent({
+        initialState: {
+          model,
+          messages: history,
+          tools: [
+            {
+              name: "read_fixture",
+              label: "Read fixture",
+              description: "Read fixture",
+              parameters: { type: "object", properties: {} },
+              execute,
+            },
+          ],
+        },
+        streamFn: (_model, context) => {
+          providerCalls++;
+          if (providerCalls === 2) {
+            secondModelMessages = structuredClone(context.messages);
+          }
+          const stopReason = providerCalls === 1 ? "toolUse" : terminal;
+          if (stopReason === "aborted") {
+            agent.abort();
+          }
+          const message: AssistantMessage = {
+            role: "assistant",
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage,
+            timestamp: 1,
+            content:
+              stopReason === "toolUse"
+                ? [{ type: "toolCall", id: "read-1", name: "read_fixture", arguments: {} }]
+                : [{ type: "text", text: "done" }],
+            stopReason,
+          };
+          const stream = createAssistantMessageEventStream();
+          stream.push(
+            stopReason === "error" || stopReason === "aborted"
+              ? { type: "error", reason: stopReason, error: message }
+              : { type: "done", reason: stopReason, message },
+          );
+          stream.end();
+          return stream;
+        },
+      });
+      const guards = installEmbeddedAttemptContextGuards({
+        activeContextEngine: engine,
+        activeSession: { agent },
+        agentDir: process.cwd(),
+        attempt: {
+          config: {},
+          prompt: "Read the fixture.",
+          contextTokenBudget: 8192,
+          model,
+          modelId: model.id,
+          provider: model.provider,
+          sessionId: "synthetic-session",
+          sessionKey: "agent:synthetic:main",
+          sessionFile: "unused",
+          onContextEngineTurnCandidate: vi.fn(),
+        },
+        computerContextEpoch: { value: 0 },
+        dropThinkingBlocksForEstimate: false,
+        effectiveCwd: process.cwd(),
+        effectiveFsWorkspaceOnly: true,
+        effectiveWorkspace: process.cwd(),
+        getPrePromptMessageCount: () => history.length,
+        getPromptCache: () => ({ retention: "none" }),
+        getPromptCacheRetention: () => "none",
+        getCompactionReplayEnabled: () => false,
+        getServerToolClearingEnabled: () => false,
+        toolResultPromptProjectionState: createToolResultPromptProjectionState(),
+        getSystemPrompt: () => "",
+        isOpenAIResponsesApi: false,
+        repairToolUseResultPairing: false,
+        sessionAgentId: "synthetic",
+        sessionManager: {},
+        settingsManager: { getBlockImages: () => false, getCompactionReserveTokens: () => 64 },
+      } as never);
+      try {
+        await agent.prompt("Read the fixture.");
+        expect(providerCalls).toBe(2);
+        expect(execute).toHaveBeenCalledOnce();
+        expect(
+          agent.state.messages.toReversed().find((message) => message.role === "assistant")
+            ?.stopReason,
+        ).toBe(terminal);
+        expect(assemble).toHaveBeenCalledTimes(2);
+        expect(secondModelMessages).toMatchObject([
+          ...(assembly === "stored-prefix" ? storedPrefix : history),
+          { role: "user", content: [{ type: "text", text: "Read the fixture." }] },
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "read-1", name: "read_fixture", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "read-1",
+            content: [{ type: "text", text: "fixture observation" }],
+          },
+        ]);
+        expect(assemble.mock.calls[1]?.[0]).toMatchObject({
+          prompt: "Read the fixture.",
+          availableTools: new Set(["read_fixture"]),
+        });
+        expect(assemble.mock.calls[1]?.[0].tokenBudget).toBeLessThan(8192);
+        expect(commitTurn).not.toHaveBeenCalled();
+        expect(remembered).toEqual([]);
+        expect(guards.getAfterTurnCheckpoint()).toBeNull();
+      } finally {
+        agent.abort();
+        await agent.waitForIdle();
+        guards.remove();
+      }
+    },
+  );
+});

--- a/src/agents/embedded-agent-runner/run/attempt-setup.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-setup.ts
@@ -372,7 +372,7 @@ export function installEmbeddedAttemptContextGuards(input: {
     };
   }
 
-  let removeLoopGuard: () => void;
+  let removeContextEngineLoopHook: (() => void) | undefined;
   if (activeContextEngine?.info.ownsCompaction === true) {
     const selectedContextEngineId = activeContextEngine.info.id;
     const runtimeSettings = buildContextEngineRuntimeSettings({
@@ -386,7 +386,7 @@ export function installEmbeddedAttemptContextGuards(input: {
       fallbackReason: attempt.fallbackReason,
       degradedReason: attempt.degradedReason,
     });
-    const removeContextEngineLoopHook = installContextEngineLoopHook({
+    removeContextEngineLoopHook = installContextEngineLoopHook({
       agent: activeSession.agent,
       contextEngine: activeContextEngine,
       sessionId: attempt.sessionId,
@@ -402,6 +402,15 @@ export function installEmbeddedAttemptContextGuards(input: {
           }
         : {}),
       getPrePromptMessageCount: input.getPrePromptMessageCount,
+      // Only the outer accepted-turn owner may advance an admitted engine.
+      deferredTurn: attempt.onContextEngineTurnCandidate
+        ? {
+            prompt: attempt.prompt,
+            get availableTools() {
+              return new Set(activeSession.agent.state.tools.map((tool) => tool.name));
+            },
+          }
+        : undefined,
       onAfterTurnCheckpoint: (messageCount) => {
         afterTurnCheckpoint = messageCount;
       },
@@ -427,22 +436,12 @@ export function installEmbeddedAttemptContextGuards(input: {
       runtimeSettings,
       isHeartbeat: isHeartbeatLifecycleRunKind(attempt.bootstrapContextRunKind),
     });
-    const removeToolResultGuard = installToolResultContextGuard({
-      agent: activeSession.agent,
-      contextWindowTokens: contextTokenBudget,
-      ...midTurnPrecheckOptions,
-    });
-    removeLoopGuard = () => {
-      removeToolResultGuard();
-      removeContextEngineLoopHook();
-    };
-  } else {
-    removeLoopGuard = installToolResultContextGuard({
-      agent: activeSession.agent,
-      contextWindowTokens: contextTokenBudget,
-      ...midTurnPrecheckOptions,
-    });
   }
+  const removeToolResultGuard = installToolResultContextGuard({
+    agent: activeSession.agent,
+    contextWindowTokens: contextTokenBudget,
+    ...midTurnPrecheckOptions,
+  });
 
   const removeHistoryImagePruneContextTransform = installHistoryImagePruneContextTransform(
     activeSession.agent,
@@ -481,7 +480,8 @@ export function installEmbeddedAttemptContextGuards(input: {
     remove: () => {
       activeSession.agent.transformContext = previousComputerFrameTransform;
       removeHistoryImagePruneContextTransform();
-      removeLoopGuard();
+      removeToolResultGuard();
+      removeContextEngineLoopHook?.();
       activeSession.agent.transformContext = previousCacheTtlTransform;
     },
     takePendingMidTurnPrecheckRequest: () => {

--- a/src/agents/embedded-agent-runner/tool-result-context-guard.ts
+++ b/src/agents/embedded-agent-runner/tool-result-context-guard.ts
@@ -7,7 +7,7 @@ import type {
   ContextEngineRuntimeSettings,
   ContextEngineSessionTarget,
 } from "../../context-engine/types.js";
-import type { AgentMessage } from "../runtime/index.js";
+import { estimateTokens, type AgentMessage } from "../runtime/index.js";
 import { resolveToolResultContextMaxChars } from "../tool-result-limits.js";
 import { formatContextLimitTruncationNotice } from "./context-truncation-notice.js";
 import { log } from "./logger.js";
@@ -299,9 +299,9 @@ function toMidTurnPrecheckRequest(
 }
 
 /**
- * Per-iteration `afterTurn` + `assemble` wrapper for sessions where
- * the context engine owns compaction. Lets the engine compact inside
- * a long tool loop instead of only at end of attempt.
+ * Reassemble each tool-loop iteration for engines that own compaction.
+ * Admitted turns advance through their accepted-turn owner; standalone
+ * attempts retain their eager lifecycle and finalization checkpoint.
  */
 export function installContextEngineLoopHook(params: {
   agent: GuardableAgent;
@@ -315,6 +315,7 @@ export function installContextEngineLoopHook(params: {
   repairAssembledMessages?: (messages: AgentMessage[]) => AgentMessage[];
   getPrePromptMessageCount?: () => number;
   onAfterTurnCheckpoint?: (messageCount: number) => void;
+  deferredTurn?: { prompt: string; readonly availableTools: Set<string> };
   getRuntimeContext?: (params: {
     messages: AgentMessage[];
     prePromptMessageCount: number;
@@ -338,21 +339,16 @@ export function installContextEngineLoopHook(params: {
       : messages;
     signal?.throwIfAborted();
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
-    const transcriptMessages = projectTranscriptPromptMessages(
-      sourceMessages,
-      transcriptProjectionCache,
-    );
+    const transcriptMessages = params.deferredTurn
+      ? sourceMessages
+      : projectTranscriptPromptMessages(sourceMessages, transcriptProjectionCache);
     const providerMessages = stripTranscriptPromptMarkers(sourceMessages);
-    const checkedPrefixLength =
-      lastSeenLength == null ? 0 : Math.min(lastSeenLength, transcriptMessages.length);
     const sourceHistoryChanged =
       lastSeenLength != null &&
       lastSourceMessages != null &&
       (transcriptMessages.length < lastSeenLength ||
         (transcriptMessages.length === lastSeenLength &&
-          transcriptMessages
-            .slice(0, checkedPrefixLength)
-            .some((message, index) => message !== lastSourceMessages?.[index])));
+          transcriptMessages.some((message, index) => message !== lastSourceMessages?.[index])));
     if (sourceHistoryChanged) {
       lastSeenLength = null;
       lastAssembledView = null;
@@ -369,32 +365,31 @@ export function installContextEngineLoopHook(params: {
       ),
     );
 
-    const hasNewMessages = transcriptMessages.length > prePromptMessageCount;
-    if (!hasNewMessages) {
+    if (transcriptMessages.length <= prePromptMessageCount) {
       lastSeenLength = prePromptMessageCount;
       lastSourceMessages = transcriptMessages;
       return lastAssembledView ?? providerMessages;
     }
     try {
-      if (typeof contextEngine.afterTurn === "function") {
-        await contextEngine.afterTurn({
-          sessionId,
-          sessionKey,
-          sessionTarget: params.sessionTarget,
-          sessionFile,
-          messages: transcriptMessages,
-          prePromptMessageCount,
-          tokenBudget,
-          runtimeContext: params.getRuntimeContext?.({
+      if (!params.deferredTurn) {
+        if (typeof contextEngine.afterTurn === "function") {
+          await contextEngine.afterTurn({
+            sessionId,
+            sessionKey,
+            sessionTarget: params.sessionTarget,
+            sessionFile,
             messages: transcriptMessages,
             prePromptMessageCount,
-          }),
-          runtimeSettings: params.runtimeSettings,
-          isHeartbeat: params.isHeartbeat,
-        });
-      } else {
-        const newMessages = transcriptMessages.slice(prePromptMessageCount);
-        if (newMessages.length > 0) {
+            tokenBudget,
+            runtimeContext: params.getRuntimeContext?.({
+              messages: transcriptMessages,
+              prePromptMessageCount,
+            }),
+            runtimeSettings: params.runtimeSettings,
+            isHeartbeat: params.isHeartbeat,
+          });
+        } else {
+          const newMessages = transcriptMessages.slice(prePromptMessageCount);
           if (typeof contextEngine.ingestBatch === "function") {
             await contextEngine.ingestBatch({
               sessionId,
@@ -414,27 +409,38 @@ export function installContextEngineLoopHook(params: {
             }
           }
         }
+        signal?.throwIfAborted();
+        params.onAfterTurnCheckpoint?.(transcriptMessages.length);
       }
-      signal?.throwIfAborted();
       lastSeenLength = transcriptMessages.length;
-      params.onAfterTurnCheckpoint?.(lastSeenLength);
       lastSourceMessages = transcriptMessages;
+      // An admitted turn is not in the engine's store yet. Assemble accepted
+      // history separately, then retain the host-owned user/tool exchange.
+      const historyLength = params.deferredTurn
+        ? (params.getPrePromptMessageCount?.() ?? 0)
+        : providerMessages.length;
+      const pendingMessages = providerMessages.slice(historyLength);
+      const pendingTokens = pendingMessages.reduce(
+        (sum, message) => sum + estimateTokens(message),
+        0,
+      );
       const assembled = await contextEngine.assemble({
         sessionId,
         sessionKey,
-        messages: providerMessages.slice(),
-        tokenBudget,
+        messages: providerMessages.slice(0, historyLength),
+        ...params.deferredTurn,
+        tokenBudget:
+          tokenBudget === undefined ? undefined : Math.max(1, tokenBudget - pendingTokens),
         model: modelId,
         runtimeSettings: params.runtimeSettings,
       });
       signal?.throwIfAborted();
       if (assembled && Array.isArray(assembled.messages)) {
-        const repairedMessages =
-          params.repairAssembledMessages?.(assembled.messages) ?? assembled.messages;
-        if (repairedMessages !== providerMessages || assembled.messages !== providerMessages) {
-          lastAssembledView = repairedMessages;
-          return repairedMessages;
-        }
+        const modelMessages = pendingMessages.length
+          ? [...assembled.messages, ...pendingMessages]
+          : assembled.messages;
+        lastAssembledView = params.repairAssembledMessages?.(modelMessages) ?? modelMessages;
+        return lastAssembledView;
       }
       lastAssembledView = null;
     } catch {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled so maintainers can update this branch.

</details>

## What Problem This Solves

Fixes an issue where users cancelling a tool-driven turn could leave its unfinished user and tool messages in a configured context engine's memory. Failed attempts had the same problem: the embedded loop sent messages to the engine before the logical turn was accepted.

## Why This Change Was Made

The accepted-turn owner already commits successful turns atomically. The embedded loop now leaves those writes to that owner, assembles earlier history within a budget that reserves room for pending messages, and appends the current user/tool exchange before the next model request. This keeps store-backed engines from dropping unfinished context merely because it has not been committed yet.

The loop passes the existing current-prompt and tool metadata for engines that distinguish earlier assistant replies from a pending turn. Standalone attempts without the outer acceptance owner keep their existing lifecycle. Duplicate guard setup and redundant bookkeeping are removed. Production changes are +66/-60 (net +6), needed for the pending-turn boundary, token reservation, and existing engine contract; tests add 233 lines and docs add 5. No configuration, schema, migration, or persisted representation changes.

## User Impact

Users can cancel or recover from a failed tool turn without committing its unfinished messages to context-engine memory. During a running turn, the model still sees its current user request, tool call, and matching result after either stored-summary or pass-through assembly.

This change applies to the OpenClaw embedded Agent loop, historically the Pi-backed path. Applicability follows the selected harness, not the model/provider name. The Codex app-server path has separate prompt projection and native turn execution; this PR does not claim a Codex runtime repair or live Codex verification.

## Evidence

- The real installer/Agent baseline reproduced eager retention across `afterTurn`, `ingestBatch`, and individual `ingest`; cancelled turns retained user/tool-call/tool-result messages with zero accepted commits. The original nine-case regression failed before the repair.
- An additional model-boundary regression demonstrated why simply disabling ingestion was insufficient: all nine stored-prefix cases dropped the current exchange before the host overlay, while pass-through cases retained it.
- Final focused run: **97 passed** — 18 real-Agent cases across three ingestion forms, successful/error/aborted terminals, and stored-prefix/pass-through assembly; 70 existing loop/compaction/cancellation/cache cases; 9 installer cases. The tests capture the actual second model request and assert ordered history/summary, current user, assistant tool call, and matching result, plus correct prompt/tool metadata and reserved budget.
- Separate source-process proof uses the real registry, lease, entry orchestration, Agent/guards, transcript API, and SQLite outbox with a synthetic no-network model. Both second requests preserve the current exchange; success commits once, cancellation commits zero times, and neither eagerly ingests. It does not run an entire Gateway or a live external provider.
- Managed independent review: **scoped-clean through P2**, zero findings. Targeted lint, formatting, one-page MDX, and whitespace checks passed.

Focused test command (Node 24.19.0):

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run/attempt-context-advancement.test.ts \
  src/agents/embedded-agent-runner/tool-result-context-guard.test.ts \
  src/agents/embedded-agent-runner/run/attempt-context-guards.test.ts
```

The context-engine API, initial pre-prompt assembly, accepted owner, and representative Lossless Claw assembly contract were inspected directly. Against pinned main `7969f4992a8ab53f8fdd003c5ab3dc5cd1163d74`, the changed installer function, eager loop, accepted owner, and token estimator preserve the relevant invariants; the staged patch applies cleanly. New terminal-error transcript settlement and cache-pruning changes preserve this acceptance boundary. The separate cleanup repair at `5d9905af9090b9d4ee0286929c6977502b85c5bf` also composes cleanly: it bounds engine disposal after retained work, while this change leaves accepted commits with their existing owner. The only shared file is this concept page, in different sections.

Remaining verification: hosted broad CI and any required Gateway/channel proof must complete on the publication head before landing. Source tests and synthetic provider proof are not presented as a live-provider or packaged-build result. The pre-existing question of ambient transcript-read fencing during loop assembly remains an unproven follow-up, not an additional claimed fix.
