### PR TITLE
fix: finish chat-pane imports before UI test teardown

### DIFF
--- a/ui/src/pages/chat/chat-pane.test-support.ts
+++ b/ui/src/pages/chat/chat-pane.test-support.ts
@@ -416,7 +416,11 @@ export function createTestChatPane(params: {
   pane.state = state;
   pane.connectedClient = params.client;
   pane.connectionGeneration = 4;
-  onTestFinished(() => pane.disconnectedCallback());
+  onTestFinished(async () => {
+    pane.disconnectedCallback();
+    // Let lazy pane imports observe disconnect before Vitest removes their environment.
+    await vi.dynamicImportSettled();
+  });
   return {
     pane,
     requestUpdate,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the UI test shard could pass every assertion and then fail during environment teardown because a chat pane was still loading its Swarm module.

## Why This Change Was Made

The shared chat-pane fixture now disconnects the pane and awaits Vitest's pending-import drain. Disconnect invalidates the lazy callback before its module finishes loading.

## User Impact

Test-only cleanup; no production behavior changes (zero production LOC).

## Evidence

A controlled pending-import probe failed with the original cleanup and passed with this change. The exact intermittent `EnvironmentTeardownError` was not reproduced locally.

The original UI shard passed all 5,501 tests across 320 files with the fix and no unhandled errors. UI types, core test types, the repository's changed-file checks, and independent review passed. The temporary probe was removed; existing assertions are unchanged.

On the supporting branch based on current `main`, the invalidation and PR-refresh suites passed all 35 tests; UI types and formatting also passed.
