### PR TITLE
fix: identify unawaited Code Mode output

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1025,6 +1025,12 @@ the bridge as JSON-compatible values with explicit size caps.
 type CodeModeOutput = { type: "text"; text: string } | { type: "json"; value: unknown };
 ```
 
+Await async values before emitting them or returning arrays or plain objects that
+contain them. Unawaited Promises appear as a diagnostic string with `await` and
+`Promise.all` guidance. For example, use
+`return await Promise.all(handles.map((tool) => tool.describe()));` to return tool
+descriptions. Output serialization does not await nested Promises for you.
+
 Output order matches guest calls. Each nested tool result is bounded separately
 by `maxOutputBytes`. Cumulative guest output and the final value or failure
 diagnostic share one `maxOutputBytes` serialized UTF-8 budget across all waits. Oversized errors retain their leading cause and end

--- a/src/agents/code-mode-controller-source.ts
+++ b/src/agents/code-mode-controller-source.ts
@@ -24,11 +24,17 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
   // can clear it; an unawaited failure must not become a successful cell.
   const unhandledRejections = new Map();
   let nextTimerId = 0;
+  const GuestPromise = Promise;
+  const promiseOutput = "[Unawaited Promise: use await or Promise.all(...) before emitting or returning values.]";
 
-  function safe(value) {
+  function outputReplacer(_key, value) {
+    return value instanceof GuestPromise ? promiseOutput : value;
+  }
+
+  function safe(value, diagnosePromises = false) {
     if (value === undefined) return null;
     try {
-      return JSON.parse(JSON.stringify(value));
+      return JSON.parse(JSON.stringify(value, diagnosePromises ? outputReplacer : undefined));
     } catch {
       if (value instanceof Error) {
         return { name: value.name, message: value.message };
@@ -42,7 +48,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
 
   function asText(value) {
     if (typeof value === "string") return value;
-    const encoded = JSON.stringify(safe(value));
+    const encoded = JSON.stringify(safe(value, true));
     return typeof encoded === "string" ? encoded : String(value);
   }
 
@@ -267,6 +273,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
   // Final values may nest handles (Promise.all of searches, keyed maps); an
   // unserialized handle dumps as null and the model never learns the tool name.
   function serializeCatalogHandles(value, seen = new Set()) {
+    if (value instanceof GuestPromise) return promiseOutput;
     const metadata = callableMetadata.get(value);
     if (metadata) return metadata;
     if (value === null || typeof value !== "object" || seen.has(value)) return value;
@@ -333,7 +340,7 @@ export const CODE_MODE_CONTROLLER_SOURCE = String.raw`
     setTimeout: { value: (callback, delay, ...args) => scheduleTimer(callback, delay, args), enumerable: true },
     clearTimeout: { value: cancelTimer, enumerable: true },
     text: { value: (value) => output.push({ type: "text", text: asText(value) }), enumerable: true },
-    json: { value: (value) => output.push({ type: "json", value: safe(value) }), enumerable: true },
+    json: { value: (value) => output.push({ type: "json", value: safe(value, true) }), enumerable: true },
     yield_control: { value: (reason) => request("yield", [reason]), enumerable: true },
     __openclawSettleBridge: { value: settle },
     __openclawDrainQueuedRequests: { value: drainQueuedRequests },

--- a/src/agents/code-mode.output.test.ts
+++ b/src/agents/code-mode.output.test.ts
@@ -23,6 +23,54 @@ import { jsonResult } from "./tools/common.js";
 const fakeTool = pluginToolWithExecute;
 afterEach(resetCodeModeTestState);
 describe("Code Mode output provenance", () => {
+  it("identifies unawaited catalog descriptions in output and final values", async () => {
+    const fixture = pluginTool("promise_fixture", "Describe a synthetic tool");
+    const result = await runCodeModeScriptHeadless({
+      ctx: createHeadlessCodeModeHarness([fixture]),
+      code: `const handles = await catalog.search("promise_fixture");
+        const descriptions = handles.map((tool) => tool.describe());
+        text({ descriptions }); json({ descriptions });
+        const awaited = await Promise.all(descriptions);
+        return { descriptions, awaited, handles };`,
+    });
+    const diagnostic = expect.stringMatching(/Promise.*await.*Promise\.all/u);
+    expect(result).toMatchObject({
+      status: "completed",
+      value: {
+        descriptions: [diagnostic],
+        awaited: [expect.objectContaining({ description: "Describe a synthetic tool" })],
+        handles: [expect.objectContaining({ callableName: "promise_fixture" })],
+      },
+      output: [
+        { type: "text", text: expect.stringMatching(/Promise.*await.*Promise\.all/u) },
+        { type: "json", value: { descriptions: [diagnostic] } },
+      ],
+    });
+    expect(fixture.execute).not.toHaveBeenCalled();
+  });
+
+  it("diagnoses pending Promises without awaiting them or invoking plain thenables", async () => {
+    const result = await runCodeModeScriptHeadless({
+      ctx: createHeadlessCodeModeHarness(),
+      code: `const pending = new Promise(() => {});
+        const plain = { label: "ordinary", then() { throw new Error("must not invoke"); } };
+        text(pending); json(pending); json(plain); text(plain);
+        return { nested: [{ pending }], plain };`,
+      overrides: { timeoutMs: 500 },
+    });
+    const diagnostic = expect.stringMatching(/Promise.*await.*Promise\.all/u);
+    expect(result).toMatchObject({
+      status: "completed",
+      value: { nested: [{ pending: diagnostic }], plain: { label: "ordinary" } },
+      output: [
+        { type: "text", text: diagnostic },
+        { type: "json", value: diagnostic },
+        { type: "json", value: { label: "ordinary" } },
+        { type: "text", text: '{"label":"ordinary"}' },
+      ],
+    });
+  });
+
   it.each([
     { name: "return escaped", surface: "return", character: String.fromCharCode(92) },
     { name: "return ASCII", surface: "return", character: "x" },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents receive empty objects after emitting or returning arrays of unawaited Code Mode results. For example, `return handles.map((tool) => tool.describe())` hides the description behind `{}` for every Promise, making discovery failures difficult to diagnose.

## Why This Change Was Made

Code Mode renders actual guest Promises as a short diagnostic pointing to `await` and `Promise.all`. This applies to text, JSON, and final structured values. Ordinary data and callable metadata keep their existing representation; nested values are not implicitly awaited and plain thenables are not invoked.

## User Impact

Agents can identify and correct missing awaits instead of treating empty output as missing tool information. Execution deadlines, bridge behavior, and output limits remain unchanged.

## Evidence

- Both real QuickJS regressions failed before the repair and passed afterward. A never-settling nested Promise produces the diagnostic without waiting; ordinary thenable-shaped data and callable handles remain intact.
- All 142 focused output, guest, and runtime tests passed. Changed-page MDX validation and all selected changed-file checks passed, including core/test typechecks and repository guards.
- Independent review found no actionable P0–P2 issues. Benchmark score improvement has not yet been measured for this change.
