### PR TITLE
refactor(voice-call): remove unused event schemas

### DIFF
--- a/extensions/voice-call/src/types.ts
+++ b/extensions/voice-call/src/types.ts
@@ -16,45 +16,9 @@ export type ProviderName = z.infer<typeof ProviderNameSchema>;
 /** Internal call identifier (UUID) */
 export type CallId = string;
 
-/** Provider-specific call identifier */
-type ProviderCallId = string;
-
 // -----------------------------------------------------------------------------
 // Call Lifecycle States
 // -----------------------------------------------------------------------------
-
-const CallStateSchema = z.enum([
-  // Non-terminal states
-  "initiated",
-  "ringing",
-  "answered",
-  "active",
-  "speaking",
-  "listening",
-  // Terminal states
-  "completed",
-  "hangup-user",
-  "hangup-bot",
-  "timeout",
-  "error",
-  "failed",
-  "no-answer",
-  "busy",
-  "voicemail",
-]);
-export type CallState = z.infer<typeof CallStateSchema>;
-
-export const TerminalStates = new Set<CallState>([
-  "completed",
-  "hangup-user",
-  "hangup-bot",
-  "timeout",
-  "error",
-  "failed",
-  "no-answer",
-  "busy",
-  "voicemail",
-]);
 
 const EndReasonSchema = z.enum([
   "completed",
@@ -69,71 +33,54 @@ const EndReasonSchema = z.enum([
 ]);
 export type EndReason = z.infer<typeof EndReasonSchema>;
 
+const CallStateSchema = z.enum([
+  "initiated",
+  "ringing",
+  "answered",
+  "active",
+  "speaking",
+  "listening",
+  ...EndReasonSchema.options,
+]);
+export type CallState = z.infer<typeof CallStateSchema>;
+
+export const TerminalStates = new Set<CallState>(EndReasonSchema.options);
+
 // -----------------------------------------------------------------------------
 // Normalized Call Events
 // -----------------------------------------------------------------------------
 
-const BaseEventSchema = z.object({
-  id: z.string(),
+export type NormalizedEvent = {
+  id: string;
   // Stable provider-derived key for idempotency/replay dedupe.
-  dedupeKey: z.string().optional(),
-  callId: z.string(),
-  providerCallId: z.string().optional(),
-  timestamp: z.number(),
+  dedupeKey?: string | undefined;
+  callId: string;
+  providerCallId?: string | undefined;
+  timestamp: number;
   // Optional per-turn nonce for speech events (Twilio <Gather> replay hardening).
-  turnToken: z.string().optional(),
+  turnToken?: string | undefined;
   // Optional fields for inbound call detection
-  direction: z.enum(["inbound", "outbound"]).optional(),
-  from: z.string().optional(),
-  to: z.string().optional(),
-});
-
-const NormalizedEventSchema = z.discriminatedUnion("type", [
-  BaseEventSchema.extend({
-    type: z.literal("call.initiated"),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.ringing"),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.answered"),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.active"),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.speaking"),
-    text: z.string(),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.assistant-speech"),
-    transcript: z.string(),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.speech"),
-    transcript: z.string(),
-    isFinal: z.boolean(),
-    confidence: z.number().min(0).max(1).optional(),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.silence"),
-    durationMs: z.number(),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.dtmf"),
-    digits: z.string(),
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.ended"),
-    reason: EndReasonSchema,
-  }),
-  BaseEventSchema.extend({
-    type: z.literal("call.error"),
-    error: z.string(),
-    retryable: z.boolean().optional(),
-  }),
-]);
-export type NormalizedEvent = z.infer<typeof NormalizedEventSchema>;
+  direction?: "inbound" | "outbound" | undefined;
+  from?: string | undefined;
+  to?: string | undefined;
+} & (
+  | { type: "call.initiated" }
+  | { type: "call.ringing" }
+  | { type: "call.answered" }
+  | { type: "call.active" }
+  | { type: "call.speaking"; text: string }
+  | { type: "call.assistant-speech"; transcript: string }
+  | {
+      type: "call.speech";
+      transcript: string;
+      isFinal: boolean;
+      confidence?: number | undefined;
+    }
+  | { type: "call.silence"; durationMs: number }
+  | { type: "call.dtmf"; digits: string }
+  | { type: "call.ended"; reason: EndReason }
+  | { type: "call.error"; error: string; retryable?: boolean | undefined }
+);
 
 // -----------------------------------------------------------------------------
 // Call Direction
@@ -236,19 +183,20 @@ export type InitiateCallInput = {
 };
 
 export type InitiateCallResult = {
-  providerCallId: ProviderCallId;
+  providerCallId: string;
   status: "initiated" | "queued";
 };
 
-export type HangupCallInput = {
+type CallControlInput = {
   callId: CallId;
-  providerCallId: ProviderCallId;
+  providerCallId: string;
+};
+
+export type HangupCallInput = CallControlInput & {
   reason: EndReason;
 };
 
-export type AnswerCallInput = {
-  callId: CallId;
-  providerCallId: ProviderCallId;
+export type AnswerCallInput = CallControlInput & {
   /**
    * Optional `wss://` URL the carrier should open for bidirectional Media
    * Streaming on answer. Used by carriers (e.g. Telnyx) that attach
@@ -260,9 +208,7 @@ export type AnswerCallInput = {
   streamAuthToken?: string;
 };
 
-export type PlayTtsInput = {
-  callId: CallId;
-  providerCallId: ProviderCallId;
+export type PlayTtsInput = CallControlInput & {
   text: string;
   voice?: string;
   locale?: string;
@@ -270,32 +216,23 @@ export type PlayTtsInput = {
   listenAfterPlayback?: boolean;
 };
 
-export type SendDtmfInput = {
-  callId: CallId;
-  providerCallId: ProviderCallId;
+export type SendDtmfInput = CallControlInput & {
   digits: string;
 };
 
-export type StartListeningInput = {
-  callId: CallId;
-  providerCallId: ProviderCallId;
+export type StartListeningInput = CallControlInput & {
   language?: string;
   /** Optional per-turn nonce for provider callbacks (replay hardening). */
   turnToken?: string;
 };
 
-export type StopListeningInput = {
-  callId: CallId;
-  providerCallId: ProviderCallId;
-};
+export type StopListeningInput = CallControlInput;
 
 // -----------------------------------------------------------------------------
 // Call Status Verification (used on restart to verify persisted calls)
 // -----------------------------------------------------------------------------
 
-export type GetCallStatusInput = {
-  providerCallId: ProviderCallId;
-};
+export type GetCallStatusInput = Pick<CallControlInput, "providerCallId">;
 
 export type GetCallStatusResult = {
   /** Provider-specific status string (e.g. "completed", "in-progress") */


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Voice Call maintains runtime schemas that are never used to validate events, alongside repeated call-state literals and provider input fields. This adds initialization and maintenance work without protecting a runtime boundary.

This is a cleanup companion to the #135868 split campaign; it contains no recovery feature content.

## Why This Change Was Made

Replace the private, type-only event schemas with the equivalent writable discriminated union. Reuse the existing end-reason options for terminal call states and share the required call-control identifiers. Keep the live persisted-call validator and every exported type contract.

Deletion evidence: repository-wide references to `BaseEventSchema` and `NormalizedEventSchema` end at schema construction and `z.infer`; neither schema is exported or parsed. The plugin's public barrels do not expose them. History (`git log -S NormalizedEventSchema`) and stable `v2026.9.2` confirm the same private type-only usage. The live `CallRecordSchema.parse` calls remain in the store owner. No compatibility contract is retired.

## User Impact

No user-visible behavior change. Provider event handling, replay protection, persisted-call validation, schema defaults, and mutable terminal-state behavior are preserved.

## Evidence

- 169 existing tests passed across 12 provider, manager, persistence, restore, lifecycle, and replay suites.
- Before/after compiler proof passed for all 22 exported aliases, every event variant, partial events, schema input/output, and the terminal Set with exact optional properties both enabled and disabled. A deliberately wrong speech-confidence type failed the proof.
- 5,012 before/after persisted-call parse cases matched outputs, rejection issues, and input preservation. Runtime exports, JSON schema, enum ordering, and terminal Set mutation behavior also matched.
- Full changed-check plan passed on Blacksmith Testbox `tbx_01m1v39k30j8bgxw05mbgdvspd` ([run](https://github.com/openclaw/openclaw/actions/runs/34026787374)); verified source `dbcb9fe1c9e36df79e4d923b13a314dc3ecadabc`, command exit 0, lease stopped. Subsequent main refresh left all Voice Call source, lockfile, and selected-check inputs unchanged.
- Generated bundled plugin assets match committed bytes.
- Independent Codex local and branch reviews: no accepted/actionable findings through P2.

| Judged class | Added | Deleted | Net | Touched file before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 52 | 115 | −63 | 324 → 261 lines |
| Tests | 0 | 0 | 0 | unchanged |
| Tooling | 0 | 0 | 0 | unchanged |
| Docs | 0 | 0 | 0 | unchanged |

No new tests, suppressions, baseline edits, dependencies, configuration options, or persistence/schema-version changes.

ClawSweeper disposition: reviewed head `5dc6c8fd9451bab5664cbec495dfcbcfbf1a4874` with no correctness/security findings, before-merge requests, or rank-up moves. Final freshness rebase `16b057d4cec89086560e287a3688f3f85b77bf1f` preserves the exact Voice Call plugin and lockfile; no review finding required a code change.
