### PR TITLE
test: avoid CLI bootstrap in catalog window fixture

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1080,9 +1080,9 @@ describe("gateway session utils", () => {
   test("session rows project the selected catalog context window", () => {
     const catalog = [
       {
-        provider: "claude-cli",
-        id: "claude-fable-5",
-        name: "Claude Fable 5",
+        provider: "window-fixture",
+        id: "selectable-model",
+        name: "Selectable Model",
         contextWindow: 1_000_000,
         contextWindows: [
           { id: "200k", label: "200K", contextWindow: 200_000 },
@@ -1091,7 +1091,7 @@ describe("gateway session utils", () => {
         contextWindowDefault: "1m",
       },
     ];
-    const cfg = createModelDefaultsConfig({ primary: "claude-cli/claude-fable-5" });
+    const cfg = createModelDefaultsConfig({ primary: "window-fixture/selectable-model" });
 
     const defaults = getSessionDefaults(cfg, catalog);
     const row = buildGatewaySessionRow({


### PR DESCRIPTION
## What Problem This Solves

A generic session-row context-window test spends roughly 27 seconds discovering an unrelated CLI plugin before projecting its row. It only needs catalog-declared selectable windows.

## Why This Change Was Made

Give the existing fixture a synthetic provider/model identity. Four identifiers change; catalog windows, selection, defaults and every assertion remain unchanged. The real defaults and row projection owners still run. Dedicated tests retain CLI alias, standalone CLI, namespaced identity and native context-window behavior.

## User Impact

Faster tests with unchanged runtime behavior. No production changes, new test seams, mocks, timeouts, test deletions or shard changes.

## Evidence

Matched Node 24.19 fresh-process runs in the same source/dependency checkout passed all 242 cases. Full-file wall time fell **75.35 → 53.05 seconds**; the selected case fell **26.986 seconds → 108 ms**. Observation isolated 26.960 seconds in defaults construction versus 7.4 ms in row projection. Canonical cache files grew 12 → 1,717 before and 12 → 12 after. Observations were removed before final proof. These are local comparisons, not additive whole-CI savings.

The final patch passed **323 tests**: the full 242-case file, four CLI identity cases, 73 context cases, two CLI preparation cases and two Anthropic backend cases. Changing the selected input from 200k to 1m still failed the unchanged expected 200k/200,000 row assertion; that counterfactual was restored.

The complete changed-file gate passed, including Gateway test types, lint, dependency/architecture guards and all dead-export scans. Independent P2 review found no actionable issues. Production delta: zero; tests: +4/-4.
