### PR TITLE
test: make failed iOS approval readback explicit

### DIFF
--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -7480,6 +7480,7 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let appModel = NodeAppModel(notificationCenter: MockBootstrapNotificationCenter())
         appModel.connectedGatewayID = "gateway-a"
+        appModel._test_setExecApprovalPromptFetchFailure("gateway unavailable")
         let gatewayA = ExecApprovalNotificationPrompt(
             approvalId: "shared-approval-id",
             gatewayDeviceId: "gateway-device-a")


### PR DESCRIPTION
## What Problem This Solves

The iOS test “resolved push without canonical readback preserves gateway recoveries” waits for a disconnected operator connection before reaching the failed-readback state it asserts. The recorded main CI case took 12.359 seconds, including the existing 12-second connection deadline.

## Why This Change Was Made

Configure the existing failed-readback fixture hook after assigning the gateway owner. The real resolved-push handler still receives a failed canonical readback and must preserve both gateway-scoped recovery entries with the same approval ID.

The neighboring operator-event route test remains unchanged. No production code, new test seam, timeout, assertion, test count, workflow or shard setting changes.

## User Impact

Faster native test setup with unchanged application behavior.

## Evidence

- Baseline: [iOS main CI job](https://github.com/openclaw/openclaw/actions/runs/34018955666/job/101448637294), case passed in 12.359 seconds. The log records failed connection acquisition immediately before the existing recovery assertion.
- Existing failure-hook and handler paths inspected, including neighboring failed-readback and route-admission coverage.
- One test setup line added; zero production changes. Diff check and independent P2 review passed with no actionable findings.
- Candidate [native test job](https://github.com/openclaw/openclaw/actions/runs/34027652988/job/101471486792) passed: the changed case took **0.179 seconds**, versus **12.359 seconds** in the baseline. The retained outer operator-event case took **12.098 seconds**, versus 12.153 seconds previously.
- The same selected 324 Swift tests across eight suites passed, plus six logic and 48 Watch tests; the Watch settings UI check and Release build also passed. Proof ran on disposable GitHub-hosted macOS.
- GitHub tested merge commit `a12ae66c5cf7743b8f4ee593ec711194a5821d47`, containing this exact PR head. The changed test file matches the head. Unrelated main updates changed the Rust toolchain and added one Rust test (13 versus 12), so whole-job timing is not a same-source comparison. The claim is the removed incidental connection wait, not a whole-iOS speedup.
