### PR TITLE
fix: reduce task maintenance stalls with large histories

### DIFF
--- a/src/tasks/task-registry-maintenance-snapshot.ts
+++ b/src/tasks/task-registry-maintenance-snapshot.ts
@@ -1,0 +1,19 @@
+import { collectCronHistoryOverflowTaskIds } from "./cron-history-retention.js";
+import { compareTasksNewestFirst, ensureTaskRegistryReady, tasks } from "./task-registry-state.js";
+
+// Raw records stay inside this synchronous snapshot. Maintenance carries only
+// IDs and retention decisions across awaits, then rereads and clones each task.
+export function getTaskRegistryMaintenanceSnapshot(): {
+  taskIds: readonly string[];
+  cronHistoryOverflowTaskIds: ReadonlySet<string>;
+} {
+  ensureTaskRegistryReady();
+  const ordered = [...tasks.values()]
+    .map((task, insertionIndex) => ({ task, createdAt: task.createdAt, insertionIndex }))
+    .toSorted(compareTasksNewestFirst)
+    .map(({ task }) => task);
+  return {
+    taskIds: ordered.map((task) => task.taskId),
+    cronHistoryOverflowTaskIds: collectCronHistoryOverflowTaskIds(ordered),
+  };
+}

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 import type { SessionEntry } from "../config/sessions.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
+import { collectCronHistoryOverflowTaskIds } from "./cron-history-retention.js";
 import { getDetachedTaskLifecycleRuntime } from "./detached-task-runtime.js";
 import {
   CRON_HISTORY_KEEP_PER_JOB,
@@ -131,6 +132,13 @@ function createTaskRegistryMaintenanceHarness(params: {
     ensureTaskRegistryReady: () => {},
     getTaskById: (taskId: string) => currentTasks.get(taskId),
     listTaskRecords: () => Array.from(currentTasks.values()),
+    getTaskRegistryMaintenanceSnapshot: () => {
+      const snapshotTasks = Array.from(currentTasks.values());
+      return {
+        taskIds: snapshotTasks.map((task) => task.taskId),
+        cronHistoryOverflowTaskIds: collectCronHistoryOverflowTaskIds(snapshotTasks),
+      };
+    },
     markTaskLostById: (patch) => {
       const current = currentTasks.get(patch.taskId);
       if (!current) {

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -60,6 +60,7 @@ import {
   setTaskCleanupAfterById,
 } from "./runtime-internal.js";
 import { runTaskFlowRegistryMaintenance } from "./task-flow-registry.maintenance.js";
+import { getTaskRegistryMaintenanceSnapshot } from "./task-registry-maintenance-snapshot.js";
 import {
   configureTaskAuditTaskProvider,
   listTaskAuditFindings,
@@ -116,6 +117,7 @@ type TaskRegistryMaintenanceRuntime = {
   deleteTaskRecordById: typeof deleteTaskRecordById;
   ensureTaskRegistryReady: typeof ensureTaskRegistryReady;
   getTaskById: typeof getTaskById;
+  getTaskRegistryMaintenanceSnapshot: typeof getTaskRegistryMaintenanceSnapshot;
   listTaskRecords: typeof listTaskRecords;
   markTaskLostById: typeof markTaskLostById;
   markTaskTerminalById: typeof markTaskTerminalById;
@@ -157,6 +159,7 @@ const defaultTaskRegistryMaintenanceRuntime: TaskRegistryMaintenanceRuntime = {
   deleteTaskRecordById,
   ensureTaskRegistryReady,
   getTaskById,
+  getTaskRegistryMaintenanceSnapshot,
   listTaskRecords,
   markTaskLostById,
   markTaskTerminalById,
@@ -1060,14 +1063,14 @@ export async function runTaskRegistryMaintenance(): Promise<TaskRegistryMaintena
   let recovered = 0;
   let cleanupStamped = 0;
   let pruned = 0;
-  const tasks = taskRegistryMaintenanceRuntime.listTaskRecords();
-  const cronHistoryOverflowTaskIds = collectCronHistoryOverflowTaskIds(tasks);
+  const { taskIds, cronHistoryOverflowTaskIds } =
+    taskRegistryMaintenanceRuntime.getTaskRegistryMaintenanceSnapshot();
   const cronRecoveryContext = createCronRecoveryContext();
   const backingSessionContext = createBackingSessionLookupContext();
   const recoveryHookRegistered = hasDetachedTaskRecoveryHook();
   let processed = 0;
-  for (const task of tasks) {
-    const current = taskRegistryMaintenanceRuntime.getTaskById(task.taskId);
+  for (const taskId of taskIds) {
+    const current = taskRegistryMaintenanceRuntime.getTaskById(taskId);
     if (!current) {
       continue;
     }

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -28,8 +28,13 @@ import {
   type OpenClawTestState,
   withOpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import {
+  collectCronHistoryOverflowTaskIds,
+  CRON_HISTORY_KEEP_PER_JOB,
+} from "./cron-history-retention.js";
 import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { getTaskRegistryMaintenanceSnapshot } from "./task-registry-maintenance-snapshot.js";
 import {
   createTaskRecord as createTaskRecordOrNull,
   deleteTaskRecordById,
@@ -44,6 +49,7 @@ import {
 import {
   getInspectableActiveTaskRestartBlockers,
   resetTaskRegistryMaintenanceRuntimeForTests,
+  runTaskRegistryMaintenance,
 } from "./task-registry.maintenance.js";
 import {
   configureTaskRegistryRuntime,
@@ -517,6 +523,124 @@ describe("task-registry store runtime", () => {
     } finally {
       clone.mockRestore();
     }
+  });
+
+  it("does not duplicate retained detail clones during maintenance", async () => {
+    const now = Date.now();
+    const detail = { output: "retained task output" };
+    const storedTasks: TaskRecord[] = Array.from({ length: 8 }, (_, index) => ({
+      ...createStoredTask(),
+      taskId: `retained-${index}`,
+      runtime: "cli",
+      status: "succeeded",
+      createdAt: now,
+      lastEventAt: now,
+      endedAt: now,
+      cleanupAfter: now + 24 * 60 * 60_000,
+      detail,
+    }));
+    const saveSnapshot = vi.fn();
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({
+          tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
+          deliveryStates: new Map(),
+        }),
+        saveSnapshot,
+      },
+      observers: null,
+    });
+    expect(getTaskById("retained-0")?.taskId).toBe("retained-0");
+    const clone = vi.spyOn(globalThis, "structuredClone");
+    try {
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expect(clone.mock.calls.filter(([value]) => value === detail).length).toBeLessThanOrEqual(
+        storedTasks.length,
+      );
+      expect(saveSnapshot).not.toHaveBeenCalled();
+    } finally {
+      clone.mockRestore();
+    }
+  });
+
+  it("preserves task order and raw cron partitions in maintenance snapshots", () => {
+    const base: TaskRecord = {
+      ...createStoredTask(),
+      runtime: "cron",
+      status: "succeeded",
+      endedAt: 100,
+    };
+    const partitions: { prefix: string; sourceId: string; detail: TaskRecord["detail"] }[] = [
+      { prefix: "empty-history", sourceId: "job", detail: { kind: "cron-run", storeKey: "" } },
+      { prefix: "empty-quiet", sourceId: "job", detail: { storeKey: "" } },
+      { prefix: "space-store", sourceId: "job", detail: { kind: "cron-run", storeKey: " " } },
+      { prefix: "missing-store", sourceId: "job", detail: { kind: "cron-run" } },
+      { prefix: "padded-job", sourceId: " job ", detail: { kind: "cron-run", storeKey: "" } },
+      { prefix: "space-job", sourceId: " ", detail: { kind: "cron-run", storeKey: "" } },
+    ];
+    const storedTasks: TaskRecord[] = [
+      ...partitions.flatMap(({ prefix, sourceId, detail }) =>
+        Array.from({ length: CRON_HISTORY_KEEP_PER_JOB + 1 }, (_, index) => ({
+          ...base,
+          taskId: `${prefix}-${String(index).padStart(4, "0")}`,
+          sourceId,
+          detail,
+        })),
+      ),
+      ...["newer-first", "newer-last"].map((taskId) => ({
+        ...base,
+        taskId,
+        runtime: "cli" as const,
+        createdAt: 200,
+        lastEventAt: 200,
+        endedAt: 200,
+      })),
+      { ...base, taskId: "older", createdAt: 50, lastEventAt: 50, endedAt: 50 },
+      { ...base, taskId: "missing-source", sourceId: undefined },
+      { ...base, taskId: "empty-source", sourceId: "" },
+      ...(["queued", "running", "lost"] as const).map((status) => ({
+        ...base,
+        taskId: `excluded-${status}`,
+        sourceId: "job",
+        status,
+        createdAt: 300,
+        lastEventAt: 300,
+        endedAt: status === "lost" ? 300 : undefined,
+        detail: { kind: "cron-run", storeKey: "" },
+      })),
+    ];
+    configureTaskRegistryRuntime({
+      store: {
+        loadSnapshot: () => ({
+          tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
+          deliveryStates: new Map(),
+        }),
+        saveSnapshot: vi.fn(),
+      },
+      observers: null,
+    });
+    const listed = listTaskRecords();
+    const snapshot = getTaskRegistryMaintenanceSnapshot();
+    expect(snapshot.taskIds).toEqual(listed.map((task) => task.taskId));
+    expect(snapshot.taskIds.slice(0, 5)).toEqual([
+      "excluded-lost",
+      "excluded-running",
+      "excluded-queued",
+      "newer-last",
+      "newer-first",
+    ]);
+    expect(snapshot.taskIds.at(-1)).toBe("older");
+    expect([...snapshot.cronHistoryOverflowTaskIds]).toEqual([
+      ...collectCronHistoryOverflowTaskIds(listed),
+    ]);
+    expect(snapshot.cronHistoryOverflowTaskIds).toEqual(
+      new Set(partitions.map(({ prefix }) => `${prefix}-0000`)),
+    );
   });
 
   it("rejects invalid persisted task enum values", () => {

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -592,7 +592,7 @@ describe("task-registry store runtime", () => {
           detail,
         })),
       ),
-      ...["newer-first", "newer-last"].map((taskId) => ({
+      ...Array.from(["newer-first", "newer-last"], (taskId) => ({
         ...base,
         taskId,
         runtime: "cli" as const,
@@ -603,7 +603,7 @@ describe("task-registry store runtime", () => {
       { ...base, taskId: "older", createdAt: 50, lastEventAt: 50, endedAt: 50 },
       { ...base, taskId: "missing-source", sourceId: undefined },
       { ...base, taskId: "empty-source", sourceId: "" },
-      ...(["queued", "running", "lost"] as const).map((status) => ({
+      ...Array.from(["queued", "running", "lost"] as const, (status) => ({
         ...base,
         taskId: `excluded-${status}`,
         sourceId: "job",

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -45,6 +45,7 @@ import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { collectCronHistoryOverflowTaskIds } from "./cron-history-retention.js";
 import { CRON_TASK_KIND } from "./cron-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import { ensureTaskRuntimeStateReady } from "./runtime-internal.js";
@@ -207,6 +208,7 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
     reason: string;
   }) => Promise<SessionBindingRecord[]>;
 }): void {
+  const listSnapshotTasks = params.listTaskRecords ?? (() => params.snapshotTasks);
   const emptyAcpEntry = {
     cfg: {} as never,
     storePath: "",
@@ -240,7 +242,14 @@ function configureTaskRegistryMaintenanceRuntimeForTest(params: {
     deleteTaskRecordById: (taskId: string) => params.currentTasks.delete(taskId),
     ensureTaskRegistryReady: () => {},
     getTaskById: (taskId: string) => params.currentTasks.get(taskId),
-    listTaskRecords: params.listTaskRecords ?? (() => params.snapshotTasks),
+    listTaskRecords: listSnapshotTasks,
+    getTaskRegistryMaintenanceSnapshot: () => {
+      const snapshotTasks = listSnapshotTasks();
+      return {
+        taskIds: snapshotTasks.map((task) => task.taskId),
+        cronHistoryOverflowTaskIds: collectCronHistoryOverflowTaskIds(snapshotTasks),
+      };
+    },
     markTaskLostById: (patch: {
       taskId: string;
       endedAt: number;
@@ -3603,7 +3612,7 @@ describe("task-registry", () => {
     },
   );
 
-  it("does not relist task records for each terminal ACP cleanup check", async () => {
+  it("acquires one task snapshot for terminal ACP cleanup", async () => {
     await withTaskRegistryTempDir(async () => {
       const now = Date.now();
       const tasks = Array.from({ length: 20 }, (_, index) => {
@@ -3931,9 +3940,10 @@ describe("task-registry", () => {
         deleteTaskRecordById: () => false,
         ensureTaskRegistryReady: () => {},
         getTaskById: () => undefined,
-        listTaskRecords: () => {
+        getTaskRegistryMaintenanceSnapshot: () => {
           throw new Error("maintenance boom");
         },
+        listTaskRecords: () => [],
         markTaskLostById: () => null,
         markTaskTerminalById: () => null,
         maybeDeliverTaskTerminalUpdate: async () => null,
@@ -3951,6 +3961,67 @@ describe("task-registry", () => {
       } finally {
         process.off("unhandledRejection", onUnhandledRejection);
       }
+    });
+  });
+
+  it("keeps sweep membership fixed while rereading tasks after awaited cleanup", async () => {
+    await withTaskRegistryTempDir(async () => {
+      const now = Date.now();
+      const parentSessionKey = "agent:main:main";
+      const childSessionKey = "agent:main:acp:snapshot-cleanup";
+      const closing = createTaskFixture("acp", {
+        ownerKey: parentSessionKey,
+        requesterSessionKey: parentSessionKey,
+        childSessionKey,
+        runId: "run-snapshot-cleanup",
+        task: "Close completed child",
+        status: "succeeded",
+        deliveryStatus: "delivered",
+      });
+      const retained = {
+        ...createTaskFixture("cli", {
+          runId: "run-snapshot-retained",
+          task: "Refresh retention during cleanup",
+          status: "succeeded",
+        }),
+        cleanupAfter: now - 1,
+      };
+      const arrived = { ...retained, taskId: "arrived-during-cleanup" };
+      const currentTasks = new Map([
+        [closing.taskId, closing],
+        [retained.taskId, retained],
+      ]);
+      let snapshotReads = 0;
+      const closeAcpSession = vi.fn(async () => {
+        await Promise.resolve();
+        currentTasks.set(retained.taskId, { ...retained, cleanupAfter: now + 86_400_000 });
+        currentTasks.set(arrived.taskId, arrived);
+      });
+      configureTaskRegistryMaintenanceRuntimeForTest({
+        currentTasks,
+        snapshotTasks: [closing, retained],
+        listTaskRecords: () => {
+          snapshotReads += 1;
+          return Array.from(currentTasks.values());
+        },
+        acpEntry: createAcpSessionStoreEntry({
+          sessionKey: childSessionKey,
+          parentSessionKey,
+          mode: "oneshot",
+        }),
+        closeAcpSession,
+      });
+
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expect(closeAcpSession).toHaveBeenCalledOnce();
+      expect(snapshotReads).toBe(1);
+      expect(currentTasks.get(retained.taskId)?.cleanupAfter).toBe(now + 86_400_000);
+      expect(currentTasks.has(arrived.taskId)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where periodic task maintenance spends a long synchronous span copying retained task output before it can yield, making other Gateway work wait when task history is large.

## Why This Change Was Made

Maintenance previously cloned every task detail for its initial list, then cloned each record again for the required fresh per-task read. A private synchronous registry snapshot now prepares only ordered task IDs and the existing cron-history overflow decisions. Raw records remain inside that snapshot; the sweep retains all existing fresh reads, awaits, batch yields, and cleanup behavior. Public task listings keep their returned-object isolation.

This adds 22 production lines for that narrow ownership boundary. Retention limits, raw cron partition keys, ordering, persistence, and configuration are unchanged.

## User Impact

Large retained histories cause less blocking and CPU work during maintenance. In an isolated Linux Node 24.19.0 run with 10,000 synthetic retained tasks and approximately 17 KiB of detail each, the synchronous prefix fell from 57.665 ms to 1.206 ms. First scheduled heartbeat delay fell from 57.789 ms to 1.291 ms; complete-sweep wall time fell from 97.015 ms to 31.004 ms and process CPU from 149.824 ms to 39.017 ms.

These are synthetic measurements of the actual public maintenance function, not attribution for a production stall. Each number is the median of five trial means, with three sweeps per trial, two warmups, and baseline followed by candidate on the same machine. Fixture shape and relative timestamps matched; absolute fixture timestamps differed.

## Evidence

- The real-registry regression failed before the change: eight retained records incurred 16 detail clones; it passes with at most one clone per fresh record read and no store writes.
- 241 tests across six maintenance, registry, recovery, projection, and lifecycle suites passed on an isolated Testbox.
- New cases preserve literal task ordering, six raw cron retention partitions and overflow order, fixed sweep membership across awaited cleanup, and fresh reads of subsequent tasks. Existing policy/recovery coverage remains intact.
- The uninstrumented public maintenance benchmark verified unchanged no-op summaries, no writes, and unchanged fixture input within each variant. Independent code reviews found no actionable issues. Initial CI caught two fixture-only `no-map-spread` lint errors. They were corrected with equivalent `Array.from` factories, without changing production or assertions; the two-line repair also passed independent review. The corrected store suite passed all 52 tests, all changed-file lint passed, and the remaining eight changed-plan guards passed. The original run had already passed every preceding check, including core and test typechecking and dead-export scans; its failed receipt is retained. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34028239226) passed at `42ed18a3d96ccf176bee07e4aa091da1f656357e`.

A separate source suspicion about a same-record update during awaited ACP cleanup remains unconfirmed: supported terminal-revival paths are fenced and existing cleanup deadlines survive finalization. No actual overlapping producer was established for restored records lacking a deadline, so this patch preserves that behavior rather than changing retention on a hypothetical trigger.
