### PR TITLE
refactor(plugins): share managed npm package traversal

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3373,7 +3373,7 @@ src/plugins/host-hook-runtime.ts	1
 src/plugins/host-hook-scheduled-turns.ts	7
 src/plugins/host-hook-state.ts	8
 src/plugins/host-hooks.ts	1
-src/plugins/install-managed-npm-state.ts	7
+src/plugins/install-managed-npm-state.ts	5
 src/plugins/install-npm-metadata.ts	1
 src/plugins/install-npm-pack.ts	2
 src/plugins/install-persistence.ts	1
@@ -3421,7 +3421,7 @@ src/plugins/plugin-config-trust.ts	1
 src/plugins/plugin-metadata-snapshot.runtime.ts	2
 src/plugins/plugin-module-loader-cache.ts	1
 src/plugins/plugin-package-update.ts	1
-src/plugins/plugin-peer-link.ts	6
+src/plugins/plugin-peer-link.ts	4
 src/plugins/plugin-sdk-native-resolver.ts	1
 src/plugins/prepared-message-tool-catalog.ts	1
 src/plugins/provider-api-key-auth.ts	2

--- a/src/plugins/install-managed-npm-state.ts
+++ b/src/plugins/install-managed-npm-state.ts
@@ -24,6 +24,7 @@ import { loadPluginInstallRuntime, resolveEffectiveInstallMode } from "./install
 import type { PluginInstallLogger } from "./install-types.js";
 import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
+import { listNpmPackageDirs } from "./npm-package-dirs.js";
 import { relinkOpenClawPeerDependenciesInManagedNpmRoot } from "./plugin-peer-link.js";
 
 const rollbackSnapshotCopyMode = fsConstants.COPYFILE_FICLONE;
@@ -474,47 +475,18 @@ export async function quarantineManagedNpmProjectRebuildArtifacts(params: {
 }
 
 export async function listManagedNpmRootPackageNames(npmRoot: string): Promise<Set<string>> {
-  const nodeModulesDir = path.join(npmRoot, "node_modules");
-  let entries: Dirent[];
-  try {
-    entries = await fs.readdir(nodeModulesDir, { withFileTypes: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return new Set();
-    }
-    throw error;
-  }
-
-  const packageNames = new Set<string>();
-  for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
-    if (entry.name === ".bin" || entry.name === "openclaw") {
-      continue;
-    }
-    if (entry.name.startsWith("@")) {
-      const scopeDir = path.join(nodeModulesDir, entry.name);
-      let scopedEntries: Dirent[];
-      try {
-        scopedEntries = await fs.readdir(scopeDir, { withFileTypes: true });
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-          continue;
-        }
-        throw error;
-      }
-      for (const scopedEntry of scopedEntries.toSorted((left, right) =>
-        left.name.localeCompare(right.name),
-      )) {
-        if (scopedEntry.isDirectory() || scopedEntry.isSymbolicLink()) {
-          packageNames.add(`${entry.name}/${scopedEntry.name}`);
-        }
-      }
-      continue;
-    }
-    if (entry.isDirectory() || entry.isSymbolicLink()) {
-      packageNames.add(entry.name);
-    }
-  }
-  return packageNames;
+  const packageDirs = await listNpmPackageDirs(npmRoot, {
+    sortEntries: true,
+    includeEntry: (entry, scoped) =>
+      (scoped || (entry.name !== ".bin" && entry.name !== "openclaw")) &&
+      // Scope reads must still report malformed directories, including regular files.
+      ((!scoped && entry.name.startsWith("@")) || entry.isDirectory() || entry.isSymbolicLink()),
+  });
+  return new Set(
+    packageDirs.map((dir) =>
+      path.relative(path.join(npmRoot, "node_modules"), dir).split(path.sep).join("/"),
+    ),
+  );
 }
 
 function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): string {

--- a/src/plugins/npm-package-dirs.ts
+++ b/src/plugins/npm-package-dirs.ts
@@ -1,0 +1,44 @@
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { hasErrnoCode } from "../infra/errno.js";
+
+export async function listNpmPackageDirs(
+  npmRoot: string,
+  options: {
+    includeEntry: (entry: Dirent, scoped: boolean) => boolean;
+    sortEntries?: boolean;
+  },
+): Promise<string[]> {
+  const readEntries = async (dir: string): Promise<Dirent[]> => {
+    try {
+      const entries = await fs.readdir(dir, { withFileTypes: true });
+      return options.sortEntries
+        ? entries.toSorted((left, right) => left.name.localeCompare(right.name))
+        : entries;
+    } catch (error) {
+      if (hasErrnoCode(error, "ENOENT")) {
+        return [];
+      }
+      throw error;
+    }
+  };
+  const nodeModulesDir = path.join(npmRoot, "node_modules");
+  const packageDirs: string[] = [];
+  for (const entry of await readEntries(nodeModulesDir)) {
+    if (!options.includeEntry(entry, false)) {
+      continue;
+    }
+    const entryPath = path.join(nodeModulesDir, entry.name);
+    if (entry.name.startsWith("@")) {
+      for (const scopedEntry of await readEntries(entryPath)) {
+        if (options.includeEntry(scopedEntry, true)) {
+          packageDirs.push(path.join(entryPath, scopedEntry.name));
+        }
+      }
+    } else {
+      packageDirs.push(entryPath);
+    }
+  }
+  return packageDirs;
+}

--- a/src/plugins/npm-package-traversal.test.ts
+++ b/src/plugins/npm-package-traversal.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  listManagedNpmRootPackageNames,
+  listNewManagedNpmRootPackageDirs,
+} from "./install-managed-npm-state.js";
+import {
+  auditOpenClawPeerDependenciesInManagedNpmRoot,
+  relinkOpenClawPeerDependenciesInManagedNpmRoot,
+} from "./plugin-peer-link.js";
+import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanupTrackedTempDirs(tempDirs);
+});
+
+function makeRoot() {
+  return makeTrackedTempDir("openclaw-npm-traversal", tempDirs);
+}
+
+function writePackage(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: path.basename(dir), peerDependencies: { openclaw: "*" } }),
+  );
+}
+
+describe("managed npm package traversal", () => {
+  it("preserves scan order and repairs only real package directories", async () => {
+    const npmRoot = makeRoot();
+    const modules = path.join(npmRoot, "node_modules");
+    const realNames = [
+      "zeta",
+      "@scope/zeta",
+      "@scope/alpha",
+      "alpha",
+      "openclaw",
+      ".hidden",
+      ".bin",
+    ];
+    for (const name of realNames) {
+      writePackage(path.join(modules, name));
+    }
+    fs.writeFileSync(path.join(modules, "plain-file"), "not a package");
+    fs.writeFileSync(path.join(modules, "@scope", "plain-file"), "not a package");
+
+    expect([...(await listManagedNpmRootPackageNames(npmRoot))]).toEqual([
+      ".hidden",
+      "@scope/alpha",
+      "@scope/zeta",
+      "alpha",
+      "zeta",
+    ]);
+    expect(
+      await listNewManagedNpmRootPackageDirs({
+        npmRoot,
+        beforeInstallPackageNames: new Set([".hidden", "alpha"]),
+      }),
+    ).toEqual(["@scope/alpha", "@scope/zeta", "zeta"].map((name) => path.join(modules, name)));
+    const repairNames = ["@scope/alpha", "@scope/zeta", "alpha", "openclaw", "zeta"];
+    const before = await auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot });
+    expect(before.checked).toBe(5);
+    expect(before.issues.map((issue) => issue.packageName)).toEqual(repairNames);
+    expect(await relinkOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot, logger: {} })).toEqual({
+      checked: 5,
+      attempted: 5,
+      repaired: 5,
+      skipped: 0,
+    });
+    for (const name of repairNames) {
+      expect(fs.realpathSync(path.join(modules, name, "node_modules", "openclaw"))).toBe(
+        fs.realpathSync(process.cwd()),
+      );
+    }
+    expect(fs.existsSync(path.join(modules, ".hidden", "node_modules"))).toBe(false);
+    expect(fs.existsSync(path.join(modules, ".bin", "node_modules"))).toBe(false);
+    expect(await auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot })).toEqual({
+      checked: 5,
+      broken: 0,
+      issues: [],
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "scans linked packages and scopes without repairing their targets",
+    async () => {
+      const npmRoot = makeRoot();
+      const modules = path.join(npmRoot, "node_modules");
+      const outside = makeRoot();
+      writePackage(path.join(outside, "package"));
+      writePackage(path.join(modules, "@scope", "real"));
+      fs.writeFileSync(path.join(outside, "file"), "not a directory");
+      for (const name of ["linked", "@scope/linked"]) {
+        fs.symlinkSync(path.join(outside, "package"), path.join(modules, name), "dir");
+      }
+      for (const name of ["broken", "@scope/broken"]) {
+        fs.symlinkSync(path.join(outside, "missing"), path.join(modules, name), "dir");
+      }
+      fs.symlinkSync(path.join(outside, "file"), path.join(modules, "file-link"), "file");
+      fs.symlinkSync(outside, path.join(modules, "@linked"), "dir");
+      fs.symlinkSync(path.join(outside, "missing-scope"), path.join(modules, "@missing"), "dir");
+      expect([...(await listManagedNpmRootPackageNames(npmRoot))]).toEqual([
+        "@linked/package",
+        "@scope/broken",
+        "@scope/linked",
+        "@scope/real",
+        "broken",
+        "file-link",
+        "linked",
+      ]);
+      const before = await auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot });
+      expect(before.issues.map((issue) => issue.packageName)).toEqual(["@scope/real"]);
+      expect(await relinkOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot, logger: {} })).toEqual(
+        {
+          checked: 1,
+          attempted: 1,
+          repaired: 1,
+          skipped: 0,
+        },
+      );
+      expect(fs.existsSync(path.join(outside, "package", "node_modules"))).toBe(false);
+      expect(await auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot })).toEqual({
+        checked: 1,
+        broken: 0,
+        issues: [],
+      });
+    },
+  );
+
+  it("reports an invalid installer scope while peer repair skips non-directories", async () => {
+    const npmRoot = makeRoot();
+    const modules = path.join(npmRoot, "node_modules");
+    fs.mkdirSync(modules);
+    fs.writeFileSync(path.join(modules, "@scope"), "not a directory");
+    await expect(listManagedNpmRootPackageNames(npmRoot)).rejects.toMatchObject({
+      code: "ENOTDIR",
+    });
+    expect(await auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot })).toEqual({
+      checked: 0,
+      broken: 0,
+      issues: [],
+    });
+    expect(await relinkOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot, logger: {} })).toEqual({
+      checked: 0,
+      attempted: 0,
+      repaired: 0,
+      skipped: 0,
+    });
+  });
+
+  for (const [owner, read, empty] of [
+    ["installer", (npmRoot: string) => listManagedNpmRootPackageNames(npmRoot), new Set()],
+    [
+      "peer audit",
+      (npmRoot: string) => auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot }),
+      { checked: 0, broken: 0, issues: [] },
+    ],
+    [
+      "peer repair",
+      (npmRoot: string) => relinkOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot, logger: {} }),
+      { checked: 0, attempted: 0, repaired: 0, skipped: 0 },
+    ],
+  ] as const) {
+    it.each(["missing", "file"] as const)(`${owner} preserves %s root errors`, async (kind) => {
+      const npmRoot = makeRoot();
+      if (kind === "file") {
+        fs.writeFileSync(path.join(npmRoot, "node_modules"), "not a directory");
+        await expect(read(npmRoot)).rejects.toMatchObject({ code: "ENOTDIR" });
+      } else {
+        await expect(read(npmRoot)).resolves.toEqual(empty);
+      }
+    });
+    it.each(["missing", "file"] as const)(
+      `${owner} preserves %s scoped entries after enumeration`,
+      async (kind) => {
+        const npmRoot = makeRoot();
+        const modules = path.join(npmRoot, "node_modules");
+        const scope = path.join(modules, "@scope");
+        fs.mkdirSync(scope, { recursive: true });
+        const readdir = fs.promises.readdir;
+        vi.spyOn(fs.promises, "readdir").mockImplementationOnce(async (dir, options) => {
+          const entries = await readdir(dir, options);
+          fs.rmdirSync(scope);
+          if (kind === "file") {
+            fs.writeFileSync(scope, "replaced after enumeration");
+          }
+          return entries;
+        });
+        if (kind === "file") {
+          await expect(read(npmRoot)).rejects.toMatchObject({ code: "ENOTDIR" });
+        } else {
+          await expect(read(npmRoot)).resolves.toEqual(empty);
+        }
+      },
+    );
+  }
+});

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -8,6 +8,7 @@ import { readRootJsonObjectSync } from "../infra/json-files.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { resolvePluginInstallDir } from "./install-paths.js";
+import { listNpmPackageDirs } from "./npm-package-dirs.js";
 
 type PluginPeerLinkLogger = {
   info?: (message: string) => void;
@@ -104,43 +105,9 @@ async function readPackageOpenClawLinkDependencies(
 }
 
 async function listManagedNpmRootPackageDirs(npmRoot: string): Promise<string[]> {
-  const nodeModulesDir = path.join(npmRoot, "node_modules");
-  let entries: import("node:fs").Dirent[];
-  try {
-    entries = await fs.readdir(nodeModulesDir, { withFileTypes: true });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return [];
-    }
-    throw error;
-  }
-
-  const packageDirs: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name === ".bin") {
-      continue;
-    }
-    const entryPath = path.join(nodeModulesDir, entry.name);
-    if (entry.name.startsWith("@")) {
-      const scopedEntries = await fs
-        .readdir(entryPath, { withFileTypes: true })
-        .catch((error: unknown) => {
-          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-            return [];
-          }
-          throw error;
-        });
-      for (const scopedEntry of scopedEntries) {
-        if (scopedEntry.isDirectory()) {
-          packageDirs.push(path.join(entryPath, scopedEntry.name));
-        }
-      }
-      continue;
-    }
-    if (!entry.name.startsWith(".")) {
-      packageDirs.push(entryPath);
-    }
-  }
+  const packageDirs = await listNpmPackageDirs(npmRoot, {
+    includeEntry: (entry, scoped) => entry.isDirectory() && (scoped || !entry.name.startsWith(".")),
+  });
   return packageDirs.toSorted((a, b) => a.localeCompare(b));
 }
 


### PR DESCRIPTION
## What Problem This Solves

Managed npm installation scans and host peer-link repair duplicated the same root/scoped package traversal, making their filesystem error handling and ordering harder to maintain consistently.

## Why This Change Was Made

One directory walker now serves both owners. Each caller retains its own entry policy and ordering: installation scans include package symlinks, while peer repair operates only on real directories. Missing directories remain tolerated; other native errors remain visible. Production decreases by 17 lines.

## User Impact

Package discovery and peer repair preserve their existing behavior, including malformed installer scopes and packages whose directories disappear during enumeration. The installer rollback and quarantine paths are unchanged.

## Evidence

- Before/after characterization uses generated filesystem trees and the real installer, peer audit, and peer repair entry points. Actual audit → repair → audit verifies five broken host links become valid; linked package targets and excluded directories remain untouched.
- Cases preserve root/scoped ordering, missing directories, disappearing scopes, and native ENOTDIR errors—including a root scope that is a regular file, which installer scanning rejects and peer repair skips.
- 26 baseline checks passed on unchanged owners. Final validation passed 123 tests, including the full existing npm-spec/quarantine regression suite.
- Typed lint, the complete changed-file gate, and independent P2 review passed. Production is −17 LOC, tests +201; two assertion-baseline entries only shrink after duplicate casts are removed.

Related: #135599. This is an independent installer-owner refactor with real filesystem proof; no registry download or Gateway behavior is claimed.

The rebase onto main resolved only an assertion-baseline conflict, preserving both main's unrelated reductions and this PR's two reduced entries. All three production files and the characterization test are byte-identical to the reviewed and tested commit. The exact assertion ratchet passed again after resolution.
