### PR TITLE
fix(chat): show command instructions while pending

### DIFF
--- a/src/gateway/server-methods/chat-assistant-content.ts
+++ b/src/gateway/server-methods/chat-assistant-content.ts
@@ -11,6 +11,7 @@ import { renderQrPngDataUrl } from "../../media/qr-image.js";
 import { renderQrTerminal } from "../../media/qr-terminal.js";
 import { stripInlineDirectiveTagsForDelivery } from "../../utils/directive-tags.js";
 import { stripEnvelopeFromMessage } from "../chat-sanitize.js";
+import { isSuppressedControlReplyText } from "../control-reply-text.js";
 import {
   buildManagedMediaFailureBlock,
   createManagedOutgoingMediaBlocks,
@@ -165,7 +166,7 @@ export async function buildAssistantDisplayContentFromReplyPayloads(params: {
         preserveBoundaries: preserveTextBoundaries,
       },
     );
-    if (text) {
+    if (text && !isSuppressedControlReplyText(text)) {
       const previousBlock = content.at(-1);
       if (previousBlock?.type === "text" && typeof previousBlock.text === "string") {
         previousBlock.text = combineNonStreamingReplyParts([previousBlock.text, text]);

--- a/src/gateway/server-methods/chat-broadcast.test.ts
+++ b/src/gateway/server-methods/chat-broadcast.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
+import { createChatRunState } from "../server-chat-state.js";
+import { broadcastChatDelta, broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import type { GatewayRequestContext } from "./types.js";
 
 function createContext(seq = 0) {
@@ -30,6 +31,70 @@ function createContext(seq = 0) {
 }
 
 describe("chat terminal broadcasts", () => {
+  it.each([
+    { sessionKey: "agent:main:main", agentId: "main", keys: ["agent:main:main"] },
+    { sessionKey: "global", agentId: "work", keys: ["agent:work:global"] },
+  ])(
+    "keeps pending snapshots scoped and retires them with $sessionKey",
+    ({ sessionKey, agentId, keys }) => {
+      const { context: base, deleteSpy } = createContext();
+      const context = { ...base, chatRunState: createChatRunState() };
+      let current = true;
+      const request = { context, runId: "run-1", sessionKey, agentId, isCurrent: () => current };
+
+      broadcastChatDelta({ ...request, text: "First instruction" });
+      const first = context.broadcast.mock.calls[0];
+      expect(first?.[1]).toMatchObject({
+        state: "delta",
+        deltaText: "First instruction",
+        replace: true,
+        seq: 1,
+      });
+      expect(first?.[2]?.sessionKeys).toEqual(keys);
+      expect(context.nodeSendToSession.mock.calls.map(([key]) => key)).toEqual(keys);
+      expect(deleteSpy).not.toHaveBeenCalled();
+
+      broadcastChatDelta({ ...request, text: "First instruction\n\nSecond instruction" });
+      const second = context.broadcast.mock.calls[1];
+      const liveText = second?.[2]?.liveText;
+      expect(liveText?.group).toBe(first?.[2]?.liveText?.group);
+      expect(liveText?.coalesce?.merge(first?.[1], second?.[1])).toBe(second?.[1]);
+      expect(context.chatRunState.resolveBuffer("run-1").text).toBe(
+        "First instruction\n\nSecond instruction",
+      );
+
+      broadcastChatFinal({
+        ...request,
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      });
+      expect(context.broadcast.mock.calls[2]?.[1]).toMatchObject({ state: "final", seq: 3 });
+      expect(context.broadcast.mock.calls[2]?.[2]?.liveText).toEqual({ group: liveText?.group });
+      expect(deleteSpy).toHaveBeenCalledOnce();
+
+      current = false;
+      context.chatRunState.clearRun("run-1");
+      expect(liveText?.group.aborted).toBe(true);
+      expect(liveText?.isCurrent?.()).toBe(false);
+      broadcastChatDelta({ ...request, text: "late instruction" });
+      expect(context.broadcast).toHaveBeenCalledTimes(3);
+    },
+  );
+
+  it("bounds live command text", () => {
+    const { context: base } = createContext();
+    const context = { ...base, chatRunState: createChatRunState() };
+    const text = "x".repeat(500_001);
+    broadcastChatDelta({
+      context,
+      runId: "run-1",
+      sessionKey: "agent:main:main",
+      text,
+      isCurrent: () => true,
+    });
+    expect(context.chatRunState.resolveBuffer("run-1").text).toHaveLength(500_000);
+    expect(context.broadcast.mock.calls[0]?.[1]).toHaveProperty("deltaText.length", 500_000);
+  });
+
   it("projects global final payloads and fans out one object to both delivery keys", () => {
     const { context, order, deleteSpy } = createContext(7);
     const message = {

--- a/src/gateway/server-methods/chat-broadcast.ts
+++ b/src/gateway/server-methods/chat-broadcast.ts
@@ -2,6 +2,8 @@ import { getReplyPayloadMetadata, type ReplyPayload } from "../../auto-reply/rep
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../../routing/session-key.js";
 import { projectChatDisplayMessage } from "../chat-display-projection.js";
+import { capLiveAssistantText } from "../live-chat-projector.js";
+import type { GatewayBroadcastOpts } from "../server-broadcast-types.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -96,32 +98,47 @@ type ChatTerminal =
   | { state: "final" | "aborted"; message?: Record<string, unknown>; stopReason?: string }
   | { state: "error"; errorMessage?: string; stopReason?: string; errorKind?: "timeout" };
 
-export function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal): void {
+type ChatFrame = ChatTerminal | { state: "delta"; text: string };
+
+function broadcastChatFrame(
+  params: ChatBroadcastParams & ChatFrame,
+  liveText?: GatewayBroadcastOpts["liveText"],
+): void {
   const seq = nextChatSeq(params.context, params.runId);
   const payloadAgentId = parseAgentSessionKey(params.sessionKey) ? undefined : params.agentId;
-  const terminal =
-    params.state !== "error"
+  const frame =
+    params.state === "delta"
       ? {
           state: params.state,
-          message: projectChatDisplayMessage(params.message),
-          ...(params.stopReason ? { stopReason: params.stopReason } : {}),
+          deltaText: params.text,
+          replace: true,
+          message: projectChatDisplayMessage({
+            role: "assistant",
+            content: [{ type: "text", text: params.text }],
+          }),
         }
-      : {
-          state: params.state,
-          errorMessage: params.errorMessage,
-          ...(params.stopReason ? { stopReason: params.stopReason } : {}),
-          ...(params.errorKind ? { errorKind: params.errorKind } : {}),
-        };
+      : params.state !== "error"
+        ? {
+            state: params.state,
+            message: projectChatDisplayMessage(params.message),
+            ...(params.stopReason ? { stopReason: params.stopReason } : {}),
+          }
+        : {
+            state: params.state,
+            errorMessage: params.errorMessage,
+            ...(params.stopReason ? { stopReason: params.stopReason } : {}),
+            ...(params.errorKind ? { errorKind: params.errorKind } : {}),
+          };
   const payload = {
     runId: params.runId,
     sessionKey: params.sessionKey,
     ...(payloadAgentId ? { agentId: payloadAgentId } : {}),
     seq,
-    ...terminal,
+    ...frame,
   };
   const group = params.context.chatRunState?.runs.get(params.runId)?.liveTextGroup?.signal;
   params.context.broadcast("chat", payload, {
-    ...(group ? { liveText: { group } } : {}),
+    ...(liveText ? { liveText, dropIfSlow: true } : group ? { liveText: { group } } : {}),
     sessionKeys: resolveChatSessionKeys({
       context: params.context,
       sessionKey: params.sessionKey,
@@ -135,6 +152,40 @@ export function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal
     event: "chat",
     payload,
   });
+}
+
+export function broadcastChatDelta(
+  params: ChatBroadcastParams & {
+    context: ChatBroadcastContext & Pick<GatewayRequestContext, "chatRunState">;
+    text: string;
+    isCurrent: () => boolean;
+  },
+): void {
+  if (!params.isCurrent()) {
+    return;
+  }
+  const text = capLiveAssistantText({ text: params.text });
+  const run = params.context.chatRunState.getOrCreate(params.runId);
+  run.buffer = text;
+  run.bufferIsCurrent = params.isCurrent;
+  run.bufferUpdatedAt = Date.now();
+  run.liveTextGroup ??= new AbortController();
+  // Command snapshots share the run's bounded queue and retire with its abort owner.
+  broadcastChatFrame(
+    { ...params, state: "delta", text },
+    {
+      group: run.liveTextGroup.signal,
+      isCurrent: params.isCurrent,
+      coalesce: {
+        key: JSON.stringify(["chat", params.sessionKey, params.agentId]),
+        merge: (_previous, next) => next,
+      },
+    },
+  );
+}
+
+export function broadcastChatTerminal(params: ChatBroadcastParams & ChatTerminal): void {
+  broadcastChatFrame(params);
   params.context.agentRunSeq.delete(params.runId);
 }
 

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -230,6 +230,7 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
     admission,
     classifyFailure: classifyDispatchFailure,
     context,
+    isAgentRunStarted: () => agentRunStarted,
     isQueuedFollowupEnqueued: queuedFollowup.isEnqueued,
     persistUserTurnTranscript: persistGatewayUserTurnTranscript,
     session,

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -23,7 +23,7 @@ import { chatRunBelongsToSelectedAgent } from "../chat-run-owner.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { buildAbortedChatSendPayload } from "./chat-abort-authorization.js";
-import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
+import { broadcastChatDelta, broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
 import type { RestartSafeChatTerminalState } from "./chat-restart-recovery.js";
 import type { AdmittedChatSend } from "./chat-send-admission.js";
 import type { prepareChatSendAttachments } from "./chat-send-attachments.js";
@@ -173,13 +173,25 @@ export function startChatDispatch(params: StartChatDispatchParams): void {
 
   let agentRunStarted = false;
   let replyDispatchRun: ReplyDispatchRun | undefined;
+  const isRunCurrent = () =>
+    !activeRunAbort.controller.signal.aborted &&
+    context.chatAbortControllers.get(clientRunId) === activeRunAbort.entry;
   const replyDispatch = createChatSendReplyDispatch({
     accountId,
     prepareAssistantTranscriptMessage: params.prepareAssistantTranscriptMessage,
     isAgentRunStarted: () => agentRunStarted,
-    isRunCurrent: () =>
-      !activeRunAbort.controller.signal.aborted &&
-      context.chatAbortControllers.get(clientRunId) === activeRunAbort.entry,
+    isRunCurrent,
+    onCommandBlock: isInternalTextSlashCommandTurn
+      ? (text) =>
+          broadcastChatDelta({
+            context,
+            runId: clientRunId,
+            sessionKey,
+            agentId,
+            text,
+            isCurrent: isRunCurrent,
+          })
+      : undefined,
     getReplyDispatchRun: () => replyDispatchRun,
     logGateway: context.logGateway,
     session,

--- a/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
@@ -15,6 +15,7 @@ import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { abortChatRunById, registerChatAbortController } from "../chat-abort.js";
 import { createChatRunState } from "../server-chat-state.js";
 import * as sessionLifecycleState from "../session-lifecycle-state.js";
+import { broadcastChatDelta } from "./chat-broadcast.js";
 import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
 import {
   createChatSendDispatchErrorLifecycle,
@@ -103,6 +104,17 @@ describe("createChatSendDispatchErrorLifecycle", () => {
           await persistUserTurnTranscript();
         }
         const warn = vi.fn();
+        const chatRunState = createChatRunState();
+        const broadcast = vi.fn();
+        const agentRunSeq = new Map<string, number>();
+        broadcastChatDelta({
+          context: { chatRunState, broadcast, agentRunSeq, nodeSendToSession: vi.fn() },
+          runId,
+          sessionKey: target.sessionKey,
+          text: "Command instructions",
+          isCurrent: () => true,
+        });
+        const previewGroup = chatRunState.runs.get(runId)?.liveTextGroup;
         const lifecycle = createChatSendDispatchErrorLifecycle({
           admission: {
             activeRunAbort: {
@@ -118,11 +130,11 @@ describe("createChatSendDispatchErrorLifecycle", () => {
               : undefined,
           },
           context: {
-            agentRunSeq: new Map(),
-            broadcast: vi.fn(),
+            agentRunSeq,
+            broadcast,
             broadcastToConnIds: vi.fn(),
             chatAbortControllers: new Map(),
-            chatRunState: createChatRunState(),
+            chatRunState,
             dedupe: new Map(),
             getRuntimeConfig: () => ({}),
             getSessionEventSubscriberConnIds: () => new Set<string>(),
@@ -131,6 +143,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
             removeChatRun: vi.fn(),
           } as never,
           isQueuedFollowupEnqueued: () => false,
+          isAgentRunStarted: () => false,
           persistUserTurnTranscript,
           session: {
             agentId: target.agentId,
@@ -153,7 +166,15 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         });
 
         await lifecycle.handleError(new Error("Cloud worker unavailable"));
+        expect(broadcast).toHaveBeenLastCalledWith(
+          "chat",
+          expect.objectContaining({ state: "error" }),
+          expect.objectContaining({ liveText: { group: previewGroup?.signal } }),
+        );
+        expect(previewGroup?.signal.aborted).toBe(false);
         await lifecycle.finalize();
+        expect(chatRunState.runs.has(runId)).toBe(false);
+        expect(previewGroup?.signal.aborted).toBe(true);
 
         expect(warn).not.toHaveBeenCalled();
         expect(loadSessionEntry(target)).toMatchObject({ status: "failed", lastRunId: runId });
@@ -260,6 +281,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         removeChatRun,
       } as never,
       isQueuedFollowupEnqueued: () => true,
+      isAgentRunStarted: () => false,
       persistUserTurnTranscript: vi.fn(),
       session: {
         agentId: "main",
@@ -358,6 +380,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
           removeChatRun,
         } as never,
         isQueuedFollowupEnqueued: () => false,
+        isAgentRunStarted: () => false,
         persistUserTurnTranscript: vi.fn(),
         session: {
           agentId: "main",
@@ -425,6 +448,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         removeChatRun: vi.fn(),
       } as never,
       isQueuedFollowupEnqueued: () => false,
+      isAgentRunStarted: () => false,
       persistUserTurnTranscript: vi.fn(),
       session: {
         agentId: "main",
@@ -474,6 +498,8 @@ describe("createChatSendDispatchErrorLifecycle", () => {
     };
     const dedupe = new Map([[`chat:${runId}`, terminalEntry]]);
     const broadcast = vi.fn();
+    const chatRunState = createChatRunState();
+    chatRunState.getOrCreate(runId).buffer = "Native-owned output";
     const lifecycle = createChatSendDispatchErrorLifecycle({
       admission: {
         activeRunAbort: registration,
@@ -484,7 +510,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
       context: {
         agentRunSeq: new Map(),
         broadcast,
-        chatRunState: createChatRunState(),
+        chatRunState,
         dedupe,
         getRuntimeConfig: () => ({}),
         logGateway: { warn: vi.fn() },
@@ -492,6 +518,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         removeChatRun: vi.fn(),
       } as never,
       isQueuedFollowupEnqueued: () => false,
+      isAgentRunStarted: () => true,
       persistUserTurnTranscript: vi.fn(),
       session: {
         agentId: "main",
@@ -507,8 +534,10 @@ describe("createChatSendDispatchErrorLifecycle", () => {
     });
 
     await lifecycle.handleError(new Error("dispatch rejected after agent terminal"));
+    await lifecycle.finalize();
 
     expect(dedupe.get(`chat:${runId}`)).toBe(terminalEntry);
+    expect(chatRunState.runs.get(runId)?.buffer).toBe("Native-owned output");
     expect(broadcast).not.toHaveBeenCalledWith(
       "chat",
       expect.objectContaining({ runId, state: "error" }),
@@ -574,6 +603,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
           removeChatRun: vi.fn(),
         } as never,
         isQueuedFollowupEnqueued: () => false,
+        isAgentRunStarted: () => false,
         persistUserTurnTranscript: vi.fn(),
         session: {
           agentId: "ops",

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -105,6 +105,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
     "activeRunAbort" | "cleanupAdmittedRun" | "lifecycleGeneration" | "restartSafeAdmission"
   >;
   context: GatewayRequestContext;
+  isAgentRunStarted: () => boolean;
   isQueuedFollowupEnqueued: () => boolean;
   classifyFailure?: (error: unknown) => AcceptedChatSendFailureDisposition;
   isReplyDispatchRun?: () => boolean;
@@ -285,14 +286,16 @@ export function createChatSendDispatchErrorLifecycle(params: {
 
   const finalize = async () => {
     const dispatchError = pendingDispatchLifecycleError;
+    // Commands and reply-dispatch runtimes have already published their terminal.
+    // Native agent events keep ownership until their own terminal delivery completes.
+    if (!params.isAgentRunStarted() || params.isReplyDispatchRun?.()) {
+      context.chatRunState.clearRun(clientRunId);
+      context.agentRunSeq.delete(clientRunId);
+    }
     if (!dispatchError) {
       cleanupAdmittedRun();
       // Reply-dispatch lifecycle events deliberately retain these until delivery settles.
       clearAgentRunContext(clientRunId, lifecycleGeneration);
-      if (params.isReplyDispatchRun?.()) {
-        context.chatRunState.clearRun(clientRunId);
-        context.agentRunSeq.delete(clientRunId);
-      }
       context.removeChatRun(clientRunId, clientRunId, sessionKey);
       return;
     }

--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -4,12 +4,28 @@ import { buildAssistantMessage, buildUsageWithNoCost } from "../../agents/stream
 import { setReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
 import { projectChatDisplayMessage } from "../chat-display-projection.js";
+import { buildAssistantDisplayContentFromReplyPayloads } from "./chat-assistant-content.js";
 import {
   buildTranscriptReplyText,
   createChatSendReplyDispatch,
 } from "./chat-send-reply-dispatch.js";
 
 describe("buildTranscriptReplyText", () => {
+  it.each(["NO_REPLY", "ANNOUNCE_SKIP", "REPLY_SKIP"])(
+    "keeps %s out of combined command display text",
+    async (controlText) => {
+      const payloads = [{ text: "First instruction" }, { text: controlText }, { text: "Done" }];
+      expect(buildTranscriptReplyText(payloads)).toBe("First instruction\n\nDone");
+      expect(
+        await buildAssistantDisplayContentFromReplyPayloads({
+          sessionKey: "agent:main:main",
+          agentId: "main",
+          payloads,
+        }),
+      ).toEqual([{ type: "text", text: "First instruction\n\nDone" }]);
+    },
+  );
+
   it("preserves authored indentation across split fenced-code reply payloads", () => {
     expect(
       buildTranscriptReplyText([

--- a/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.test.ts
@@ -115,9 +115,12 @@ describe("createChatSendReplyDispatch", () => {
 
   it("captures visible replies, promotes tool media, and marks blocked turns", async () => {
     const markBlocked = vi.fn();
+    const onCommandBlock = vi.fn();
     const dispatch = createChatSendReplyDispatch({
       accountId: undefined,
       isAgentRunStarted: () => false,
+      isRunCurrent: () => true,
+      onCommandBlock,
       logGateway: { warn: vi.fn() } as never,
       session: {
         agentId: "main",
@@ -142,9 +145,10 @@ describe("createChatSendReplyDispatch", () => {
       mediaUrl: "https://example.test/audio.mp3",
     });
     dispatcher.sendFinalReply({ text: "done" });
-    dispatcher.markComplete();
     await dispatcher.waitForIdle();
 
+    expect(onCommandBlock).toHaveBeenCalledExactlyOnceWith("blocked");
+    dispatcher.markComplete();
     expect(markBlocked).toHaveBeenCalledOnce();
     expect(dispatch.deliveredReplies).toEqual([
       { payload: blockedPayload, kind: "block" },
@@ -157,6 +161,56 @@ describe("createChatSendReplyDispatch", () => {
       },
       { payload: { text: "done" }, kind: "final" },
     ]);
+  });
+
+  it("publishes ordered command text while pending and suppresses hidden or retired output", async () => {
+    let current = true;
+    let agentRunStarted = false;
+    const onCommandBlock = vi.fn();
+    const dispatch = createChatSendReplyDispatch({
+      accountId: undefined,
+      isAgentRunStarted: () => agentRunStarted,
+      isRunCurrent: () => current,
+      onCommandBlock,
+      logGateway: { warn: vi.fn() } as never,
+      session: {
+        agentId: "main",
+        backingSessionId: undefined,
+        cfg: {},
+        clientRunId: "run-command",
+        sessionKey: "agent:main:main",
+        sessionLoadOptions: undefined,
+      },
+      userTurnRecorder: { markBlocked: vi.fn() },
+    });
+    const dispatcher = createReplyDispatcher(dispatch.dispatcherOptions);
+    dispatcher.sendBlockReply({ text: "[[reply_to_current]] First instruction" });
+    await dispatcher.waitForIdle();
+    expect(onCommandBlock).toHaveBeenLastCalledWith("First instruction");
+    dispatcher.sendBlockReply({ text: "Second instruction" });
+    await dispatcher.waitForIdle();
+    expect(onCommandBlock).toHaveBeenLastCalledWith("First instruction\n\nSecond instruction");
+
+    onCommandBlock.mockClear();
+    dispatcher.sendBlockReply({ text: "hidden reasoning", isReasoning: true });
+    dispatcher.sendBlockReply({ text: "NO_REPLY" });
+    dispatcher.sendBlockReply({ text: "ANNOUNCE_SKIP" });
+    dispatcher.sendBlockReply({ text: "side answer", btw: { question: "side question" } });
+    await dispatcher.waitForIdle();
+    expect(onCommandBlock).not.toHaveBeenCalled();
+
+    current = false;
+    dispatcher.sendBlockReply({ text: "retired command" });
+    await dispatcher.waitForIdle();
+    expect(onCommandBlock).not.toHaveBeenCalled();
+
+    current = true;
+    agentRunStarted = true;
+    dispatcher.sendBlockReply({ text: "native agent stream" });
+    dispatcher.sendFinalReply({ text: "native final" });
+    dispatcher.markComplete();
+    await dispatcher.waitForIdle();
+    expect(onCommandBlock).not.toHaveBeenCalled();
   });
 
   it("keeps every capture and media side effect behind beforeDeliver cancellation", async () => {

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -36,8 +36,9 @@ import {
   hasAssistantDisplayMediaContent,
   isMediaBearingPayload,
   replaceAssistantContentTextBlocks,
+  sanitizeAssistantDisplayText,
 } from "./chat-assistant-content.js";
-import { isSourceReplyTranscriptMirrorPayload } from "./chat-broadcast.js";
+import { isBtwReplyPayload, isSourceReplyTranscriptMirrorPayload } from "./chat-broadcast.js";
 import { normalizeWebchatReplyMediaPathsForDisplay } from "./chat-reply-media.js";
 import type { PreparedChatSendSession } from "./chat-send-session.js";
 import {
@@ -107,6 +108,7 @@ export function buildTranscriptReplyText(payloads: ReplyPayload[]): string {
 export function createChatSendReplyDispatch(params: {
   accountId: string | undefined;
   isAgentRunStarted: () => boolean;
+  onCommandBlock?: (text: string) => void;
   isRunCurrent?: () => boolean;
   getReplyDispatchRun?: () => ReplyDispatchRun | undefined;
   prepareAssistantTranscriptMessage?: PrepareAssistantTranscriptMessage;
@@ -427,6 +429,23 @@ export function createChatSendReplyDispatch(params: {
         case "block":
         case "final":
           deliveredReplies.push({ payload, kind: info.kind });
+          if (
+            info.kind === "block" &&
+            params.onCommandBlock &&
+            !isAgentRunStarted() &&
+            params.isRunCurrent?.()
+          ) {
+            const parts = deliveredReplies.map(({ payload: reply, kind }) => {
+              if (kind !== "block" || reply.isReasoning === true || isBtwReplyPayload(reply)) {
+                return "";
+              }
+              const text = sanitizeAssistantDisplayText(reply.text, { preserveBoundaries: true });
+              return text && !isSuppressedControlReplyText(text) ? text : "";
+            });
+            if (parts.at(-1)) {
+              params.onCommandBlock(combineNonStreamingReplyParts(parts));
+            }
+          }
           break;
         case "tool":
           // TTS tool media becomes a final payload so downstream audio extraction sees it.

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { expectDefined } from "@openclaw/normalization-core";
+import { asOptionalRecord, expectDefined } from "@openclaw/normalization-core";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -1356,13 +1356,12 @@ async function runNonStreamingChatSend(params: {
     return undefined;
   }
 
-  await waitForAssertion(() => {
-    expect(params.context.broadcast.mock.calls.length).toBe(1);
-  });
-
-  const chatCall = mockCallAt(params.context.broadcast, 0);
-  expect(chatCall?.[0]).toBe("chat");
-  return chatCall?.[1] as Record<string, any> | undefined;
+  const terminalCalls = () =>
+    params.context.broadcast.mock.calls.filter(
+      ([event, payload]) => event === "chat" && asOptionalRecord(payload)?.state !== "delta",
+    );
+  await waitForAssertion(() => expect(terminalCalls()).toHaveLength(1));
+  return asOptionalRecord(terminalCalls()[0]?.[1]);
 }
 
 async function expectUnpersistedAgentRunFinal(params: {
@@ -4662,6 +4661,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     expect(broadcastText).toContain("Trajectory exports can include");
     expect(broadcastText).toContain("through exec approval");
     expect(broadcastText).toContain("Approve once");
+    await waitForAssertion(() =>
+      expect(context.chatRunState.runs.has("idem-command-block")).toBe(false),
+    );
   });
 
   it("keeps slash-command block text when the final payload only adds media", async () => {


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

WebChat hid a private command's instructions until completion, even when the command was waiting for the user. Combined final text could also expose internal control tokens.

## Why This Change Was Made

Visible command blocks use the existing chat-delta delivery while the command is active. The shared finalizer retains terminal delivery and history ownership. Each display payload is filtered before combination, and preview state is released after completion.

## User Impact

Instructions appear while commands wait. Stop suppresses late blocks; completion stays single and ordered. Agent and global-session boundaries remain intact.

## Evidence

Real Gateway and browser checks reproduced the hidden instructions, then verified pending visibility, ordering, cancellation, replacement, restart history, and one final response. All 542 focused tests passed, including regressions for display filtering and preview cleanup. Before/after browser captures showed instructions during the pending command. Authentication and model responses were synthetic.
