### PR TITLE
fix: ground exec approval requests in tool results

### DIFF
--- a/docs/tools/exec-approvals-advanced.md
+++ b/docs/tools/exec-approvals-advanced.md
@@ -192,6 +192,12 @@ Gateway approval resolution is guarded by the dedicated `operator.approvals` sco
 You can forward exec approval prompts to any chat channel (including plugin channels) and approve
 them with `/approve`. This uses the normal outbound delivery pipeline.
 
+For a command the user has authorized, the agent requests execution through the tool first. The
+execution host decides whether an approval is needed. The agent relays an `/approve` command only
+from an actual pending approval, using the exact request ID and reply instructions. A bare
+`/approve` or an invented ID cannot approve a command. An `allow-once` grant covers only its
+specific command; subsequent commands receive their own policy decision.
+
 Config:
 
 ```json5

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -245,10 +245,12 @@ function buildExecApprovalPromptGuidance(params: {
     params.inlineButtonsEnabled ||
     hasNativeApprovalPromptRuntimeCapability(params.runtimeCapabilities) ||
     isKnownNativeApprovalPromptChannel(runtimeChannel);
+  const policyGuidance =
+    "For task-authorized commands, make the execution request through the available tool and let its current policy decide whether approval is needed. Request exec approval only from an actual approval-pending result; never invent approval IDs or ask for a bare /approve.";
   if (usesNativeApprovalUi) {
-    return 'exec approval-pending: native card/buttons first. Plain /approve only when tool requires chat/manual approval; copy exact "Reply with:" command.';
+    return `${policyGuidance} exec approval-pending: native card/buttons first. Plain /approve only when tool requires chat/manual approval; copy exact "Reply with:" command.`;
   }
-  return 'exec approval-pending: send exact /approve from "Reply with:"; never ask for another code.';
+  return `${policyGuidance} exec approval-pending: send exact /approve from "Reply with:"; never ask for another code.`;
 }
 
 function buildSkillsSection(params: {
@@ -1297,7 +1299,7 @@ export function buildAgentSystemPrompt(params: {
               "Narrate only complex, sensitive/destructive, or requested steps.",
               "First-class tool exists: use it; never ask user for equivalent CLI/slash.",
               "/approve is user command; never execute via shell/tool.",
-              "allow-once = one command. Another elevated command needs fresh /approve.",
+              "allow-once covers only that exact command; later commands need their own exec policy decision.",
               "Approval preview: exact full command/script, including chains/multiline. Keep preview separate from /approve; never use script as approval id/slug.",
               "",
             ],


### PR DESCRIPTION
## What Problem This Solves

Fixes contradictory guidance that can make agents stop authorized shell work and ask for a bare `/approve` before submitting any execution request. The prompt previously said another elevated command always required fresh approval, even though the execution policy may allow it directly.

## Why This Change Was Made

The prompt now directs agents to obtain the current policy decision through the execution tool for task-authorized commands, and relay approval instructions only from an actual pending result. It keeps an allow-once grant tied to its exact command and preserves native approval cards and manual reply routing.

## User Impact

Agents can continue authorized work without inventing approval requests. Real approval requirements, denials, and user authorization remain enforced by their existing owners; no permission or execution logic changes.

## Evidence

- Inspected actual rendered prompts for manual approval, native UI, Code Mode, an unavailable exec tool, and a provider-owned tool-style override. The old unconditional fresh-approval statement appeared before the change; the new guidance is present only on the intended surfaces afterward.
- All 161 existing system-prompt and approval-command tests passed. All selected changed-file checks passed, including formatting, typechecks, lint, and repository guards.
- Independent review found no actionable P0–P2 issues. A benchmark score gain has not yet been measured for this prompt change.
