### PR TITLE
refactor(gateway): isolate Serve hello lifecycle tests

### DIFF
--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -8,8 +8,6 @@ import {
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { createDeferredCore } from "../../../shared/deferred.js";
 import { resolveGatewayAuth } from "../../auth-resolve.js";
-import { listGatewayMethods } from "../../server-methods-list.js";
-import { LEGACY_ADVERTISED_GATEWAY_METHODS } from "../../server-methods-list.test-fixtures.js";
 import { startGatewayTailscaleExposure } from "../../server-tailscale.js";
 import { prepareTailscalePublishedOrigin } from "../../tailscale-published-origin.js";
 
@@ -286,6 +284,7 @@ describe("sendGatewayHello update detail scope", () => {
   it.each(["exit", "cleanup", "replacement"] as const)(
     "retires an announced Serve connection on route %s and renews its hello",
     async (withdrawal) => {
+      const gatewayMethods = ["health", "config.get"];
       const exited = createDeferredCore();
       tailscaleClaim.mockResolvedValue({
         exited: exited.promise,
@@ -322,7 +321,7 @@ describe("sendGatewayHello update detail scope", () => {
             ...context,
             handler: {
               ...context.handler,
-              gatewayMethods: listGatewayMethods(),
+              gatewayMethods,
               socket,
               close: (code?: number, reason?: string) => socket.close(code, reason),
             },
@@ -340,18 +339,7 @@ describe("sendGatewayHello update detail scope", () => {
       };
       try {
         const original = await connect();
-        expect(original.hello.features.methods).toEqual([
-          ...LEGACY_ADVERTISED_GATEWAY_METHODS,
-          "plugins.controlUi.list",
-          "plugins.controlUi.reload",
-          "plugins.controlUi.report",
-          "plugins.controlUi.status",
-          "update.runs.get",
-          "update.runs.list",
-          "gateway.suspend.handoff",
-          "update.report",
-          "skills.workshop.read",
-        ]);
+        expect(original.hello.features.methods).toEqual(gatewayMethods);
         expect(original.hello.snapshot.controlUiIdentityUrl).toBe(
           "https://gateway.tailnet.ts.net/",
         );
@@ -372,7 +360,7 @@ describe("sendGatewayHello update detail scope", () => {
           expect(original.close).toHaveBeenCalledWith(1012, expect.anything()),
         );
         const renewed = await connect();
-        expect(renewed.hello.features.methods).toEqual(original.hello.features.methods);
+        expect(renewed.hello.features.methods).toEqual(gatewayMethods);
         expect(renewed.hello.snapshot.controlUiIdentityUrl).toBe(
           withdrawal === "replacement" ? "https://replacement.tailnet.ts.net/" : undefined,
         );


### PR DESCRIPTION
Related: #130860, #139875.

## What Problem This Solves

Adding Gateway RPCs currently requires unrelated edits to the Serve connection lifecycle tests because they duplicate the full advertised method inventory. Those edits create avoidable merge conflicts.

## Why This Change Was Made

The three route exit, cleanup, and replacement cases now supply `health` and `config.get` to the handler and verify that both the original and renewed hello preserve that exact list. The dedicated `server-methods-list.test.ts` continues to check the complete legacy prefix and appended inventory.

## User Impact

No runtime behavior changes. Existing Serve withdrawal, identity, close-code, and renewed-socket assertions remain intact.

## Evidence

All 62 focused hello and method-inventory tests passed before and after the cleanup. The canonical changed-file gate passed, including the owning Gateway test typecheck, lint, and repository guards. Independent P0–P2 review found no actionable issues.
