### PR TITLE
fix(diagnostics): preserve the local exporter flush window

### DIFF
--- a/src/plugins/one-shot-diagnostics.test.ts
+++ b/src/plugins/one-shot-diagnostics.test.ts
@@ -1,6 +1,10 @@
 // One-shot diagnostics exporter start/flush lifecycle for embedded CLI runs.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginServicesHandle } from "./services.js";
+import type { OpenClawPluginService, OpenClawPluginServiceContext } from "./types.js";
 
 const loadOpenClawPlugins = vi.hoisted(() => vi.fn());
 const startPluginServices = vi.hoisted(() => vi.fn());
@@ -36,6 +40,22 @@ function mockRegistryWithServices(serviceIds: string[]) {
   };
   loadOpenClawPlugins.mockReturnValue(registry);
   return registry;
+}
+
+async function mockRealExporter(service: OpenClawPluginService, origin: "bundled" | "workspace") {
+  const { startPluginServices: startRealServices } =
+    await vi.importActual<typeof import("./services.js")>("./services.js");
+  const registry = createEmptyPluginRegistry();
+  registry.services.push({ pluginId: "diagnostics-otel", service, source: "test", origin });
+  loadOpenClawPlugins.mockReturnValue(registry);
+  let servicesHandle: PluginServicesHandle | undefined;
+  startPluginServices.mockImplementationOnce(
+    async (params: Parameters<typeof startRealServices>[0]) => {
+      servicesHandle = await startRealServices(params);
+      return servicesHandle;
+    },
+  );
+  return { stop: () => servicesHandle?.stop() };
 }
 
 beforeEach(() => {
@@ -135,63 +155,124 @@ describe("startOneShotDiagnosticsExporters", () => {
   });
 
   it("drains queued diagnostic events before stopping services on flush", async () => {
-    mockRegistryWithServices(["diagnostics-otel"]);
-    const servicesStop = vi.fn(async () => {});
-    startPluginServices.mockResolvedValue({ stop: servicesStop });
-    let releaseDrain = () => {};
-    waitForDiagnosticEventsDrained.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          releaseDrain = resolve;
-        }),
+    const exporterStop = vi.fn();
+    const services = await mockRealExporter(
+      { id: "diagnostics-otel", start: () => {}, stop: exporterStop },
+      "bundled",
     );
-
-    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
-    const stopPromise = handle?.stop();
-    await Promise.resolve();
-
-    expect(waitForDiagnosticEventsDrained).toHaveBeenCalledTimes(1);
-    expect(servicesStop).not.toHaveBeenCalled();
-
-    releaseDrain();
-    await stopPromise;
-
-    expect(servicesStop).toHaveBeenCalledTimes(1);
-  });
-
-  it("swallows service stop failures", async () => {
-    mockRegistryWithServices(["diagnostics-otel"]);
-    startPluginServices.mockResolvedValue({
-      stop: vi.fn(async () => {
-        throw new Error("exporter shutdown failed");
-      }),
+    const drain = createDeferredCore();
+    const draining = createDeferredCore();
+    waitForDiagnosticEventsDrained.mockImplementation(() => {
+      draining.resolve();
+      return drain.promise;
     });
-
-    const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
-
-    await expect(handle?.stop()).resolves.toBeUndefined();
-  });
-
-  it("still flushes the exporter when the diagnostic-event drain hangs", async () => {
-    vi.useFakeTimers();
+    let stopping: Promise<void> | undefined;
     try {
-      mockRegistryWithServices(["diagnostics-otel"]);
-      const servicesStop = vi.fn(async () => {});
-      startPluginServices.mockResolvedValue({ stop: servicesStop });
-      waitForDiagnosticEventsDrained.mockImplementation(() => new Promise<void>(() => {}));
-
       const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
-      const stopPromise = handle?.stop();
-      await vi.advanceTimersByTimeAsync(5_000);
-
-      await expect(stopPromise).resolves.toBeUndefined();
-      // A stalled drain must not consume the flush window: telemetry already
-      // buffered still has to reach the collector.
-      expect(servicesStop).toHaveBeenCalledTimes(1);
+      stopping = handle?.stop();
+      await draining.promise;
+      expect(exporterStop).not.toHaveBeenCalled();
+      drain.resolve();
+      await stopping;
+      expect(exporterStop).toHaveBeenCalledOnce();
     } finally {
-      vi.useRealTimers();
+      drain.resolve();
+      await stopping;
+      await services.stop();
     }
   });
+
+  it("reports drain and exporter failures without failing the CLI shutdown", async () => {
+    const exporterStop = vi.fn(() => {
+      throw new Error("exporter shutdown failed");
+    });
+    const services = await mockRealExporter(
+      { id: "diagnostics-otel", start: () => {}, stop: exporterStop },
+      "bundled",
+    );
+    waitForDiagnosticEventsDrained.mockRejectedValue(new Error("event drain failed"));
+    try {
+      const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+      await expect(handle?.stop()).resolves.toBeUndefined();
+      expect(exporterStop).toHaveBeenCalledOnce();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/one-shot diagnostics .*event drain failed/),
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/one-shot diagnostics .*exporter shutdown failed/),
+      );
+    } finally {
+      await Promise.allSettled([services.stop()]);
+    }
+  });
+
+  it.each([
+    { drainOutcome: "immediate completion", drainWaitMs: 0, origin: "bundled" },
+    { drainOutcome: "early completion", drainWaitMs: 2_000, origin: "bundled" },
+    { drainOutcome: "timeout", drainWaitMs: 5_000, origin: "bundled" },
+    { drainOutcome: "timeout", drainWaitMs: 5_000, origin: "workspace" },
+  ] as const)(
+    "gives the $origin exporter a separate flush window after drain $drainOutcome",
+    async ({ drainWaitMs, origin }) => {
+      const drain = createDeferredCore();
+      const flush = createDeferredCore();
+      const exporterStop = vi.fn(() => flush.promise);
+      let internalDiagnostics: OpenClawPluginServiceContext["internalDiagnostics"];
+      const services = await mockRealExporter(
+        {
+          id: "diagnostics-otel",
+          start: (context) => {
+            internalDiagnostics = context.internalDiagnostics;
+          },
+          stop: exporterStop,
+        },
+        origin,
+      );
+      waitForDiagnosticEventsDrained.mockImplementation(() => drain.promise);
+      let stopping: Promise<void> | undefined;
+      let stopped = false;
+      vi.useFakeTimers();
+      try {
+        const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
+        expect(handle).not.toBeNull();
+        expect(Boolean(internalDiagnostics)).toBe(origin === "bundled");
+        stopping = handle?.stop().then(() => {
+          stopped = true;
+        });
+        if (drainWaitMs > 0) {
+          await vi.advanceTimersByTimeAsync(drainWaitMs - 1);
+          expect(exporterStop).not.toHaveBeenCalled();
+          await vi.advanceTimersByTimeAsync(1);
+        }
+        if (drainWaitMs < 5_000) {
+          drain.resolve();
+          await vi.advanceTimersByTimeAsync(0);
+        }
+
+        // Observe the exporter itself: a service-manager stop can still be waiting on another drain.
+        expect(exporterStop).toHaveBeenCalledOnce();
+        expect(stopped).toBe(false);
+        await vi.advanceTimersByTimeAsync(9_999);
+        expect(stopped).toBe(false);
+        await vi.advanceTimersByTimeAsync(1);
+        await stopping;
+        expect(stopped).toBe(true);
+        if (internalDiagnostics) {
+          expect(internalDiagnostics.getRuntimeIdentity).toThrow("no longer active");
+        }
+      } finally {
+        drain.resolve();
+        flush.resolve();
+        try {
+          await vi.advanceTimersByTimeAsync(0);
+          await stopping;
+          await services.stop();
+        } finally {
+          vi.useRealTimers();
+        }
+      }
+    },
+  );
 
   it("warns when otel is configured but the diagnostics-otel plugin is absent", async () => {
     mockRegistryWithServices(["other-service"]);
@@ -201,23 +282,5 @@ describe("startOneShotDiagnosticsExporters", () => {
     expect(handle).toBeNull();
     expect(startPluginServices).not.toHaveBeenCalled();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("diagnostics-otel plugin is not"));
-  });
-
-  it("bounds the flush with a timeout so a hung exporter cannot block exit", async () => {
-    vi.useFakeTimers();
-    try {
-      mockRegistryWithServices(["diagnostics-otel"]);
-      const servicesStop = vi.fn(() => new Promise<void>(() => {}));
-      startPluginServices.mockResolvedValue({ stop: servicesStop });
-
-      const handle = await startOneShotDiagnosticsExporters({ config: otelEnabledConfig });
-      const stopPromise = handle?.stop();
-      await vi.advanceTimersByTimeAsync(10_000);
-
-      await expect(stopPromise).resolves.toBeUndefined();
-      expect(servicesStop).toHaveBeenCalledTimes(1);
-    } finally {
-      vi.useRealTimers();
-    }
   });
 });

--- a/src/plugins/one-shot-diagnostics.ts
+++ b/src/plugins/one-shot-diagnostics.ts
@@ -1,6 +1,5 @@
 /** Starts diagnostics exporter plugin services for one-shot CLI embedded agent runs. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { waitForDiagnosticEventsDrained } from "../infra/diagnostic-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("plugins");
@@ -9,9 +8,8 @@ const log = createSubsystemLogger("plugins");
 // diagnostics-prometheus is pull-based (scrape server) and would bind a port
 // that races the gateway on the same host, so it stays gateway-only.
 const ONE_SHOT_DIAGNOSTICS_SERVICE_IDS = new Set(["diagnostics-otel"]);
-// Each exit step is bounded on its own so an unreachable OTLP endpoint cannot
-// hang the CLI, and a stalled drain cannot consume the flush window: sharing one
-// budget would drop telemetry that was already buffered and ready to send.
+// Separate drain and flush waits preserve buffered telemetry after a stalled drain.
+// These limits do not cancel exporter-owned work or replace its network request timeout.
 const ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS = 5_000;
 const ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS = 10_000;
 
@@ -46,32 +44,6 @@ function isOtelExportConfigured(config: OpenClawConfig): boolean {
   // configs skip plugin loading entirely on the CLI hot path.
   const diagnostics = config.diagnostics;
   return Boolean(diagnostics && diagnostics.enabled !== false && diagnostics.otel?.enabled);
-}
-
-/**
- * Bounds how long the CLI waits for one exit step. Timing out stops the wait but
- * cannot cancel the work: a collector that accepts a connection and never answers
- * keeps its socket open until the exporter's own request timeout
- * (`OTEL_EXPORTER_OTLP_TIMEOUT`). Accepted — that bound is the exporter's to own,
- * and cancelling an in-flight export would mean reaching into the OTel SDK.
- */
-async function runBoundedExitStep(
-  label: string,
-  timeoutMs: number,
-  run: () => Promise<void>,
-): Promise<void> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new Error(`timed out after ${timeoutMs}ms`)), timeoutMs);
-    timer.unref?.();
-  });
-  try {
-    await Promise.race([run(), timeout]);
-  } catch (err) {
-    log.warn(`one-shot diagnostics ${label} failed: ${String(err)}`);
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 /**
@@ -126,20 +98,20 @@ export async function startOneShotDiagnosticsExporters(params: {
   const handle = await startPluginServices({
     registry: { ...registry, services },
     config,
+    oneShotStopTimeouts: {
+      eventDrainMs: ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS,
+      serviceStopMs: ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS,
+    },
   });
   return {
     stop: async () => {
-      // Drain first: run-end diagnostic events dispatch async, and the exporter
-      // unsubscribes as its first stop step. The flush still runs when the drain
-      // stalls, so already-buffered telemetry is exported instead of lost.
-      await runBoundedExitStep(
-        "event drain",
-        ONE_SHOT_DIAGNOSTICS_DRAIN_TIMEOUT_MS,
-        waitForDiagnosticEventsDrained,
-      );
-      await runBoundedExitStep("exporter flush", ONE_SHOT_DIAGNOSTICS_FLUSH_TIMEOUT_MS, () =>
-        handle.stop(),
-      );
+      try {
+        await handle.stop();
+      } catch (error) {
+        for (const failure of error instanceof AggregateError ? error.errors : [error]) {
+          log.warn(`one-shot diagnostics shutdown failed: ${String(failure)}`);
+        }
+      }
     },
   };
 }

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -33,7 +33,7 @@ import type { OpenClawPluginServiceContext, PluginLogger } from "./types.js";
 const log = createSubsystemLogger("plugins");
 export const PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS = 5_000;
 
-class PluginServiceReplacementTimeoutError extends Error {}
+class PluginServiceStopTimeoutError extends Error {}
 
 type TrustedExporterInternalDiagnostics = NonNullable<
   OpenClawPluginServiceContext["internalDiagnostics"]
@@ -204,6 +204,7 @@ export async function startPluginServices(params: {
   startupTrace?: PluginServiceStartupTrace;
   broadcastPluginEvent?: GatewayPluginEventBroadcastFn;
   getCronService?: () => PluginServiceCronHost | null | undefined;
+  oneShotStopTimeouts?: { eventDrainMs: number; serviceStopMs: number };
   onHandle?: (handle: PluginServicesHandle) => void;
 }): Promise<PluginServicesHandle> {
   const healthGeneration = createPluginServiceHealthGeneration(params.registry);
@@ -230,8 +231,8 @@ export async function startPluginServices(params: {
     }
     const remaining = deadline - Date.now();
     const timeoutError = () =>
-      new PluginServiceReplacementTimeoutError(
-        `${label} timed out after ${PLUGIN_SERVICE_REPLACEMENT_STOP_TIMEOUT_MS}ms${owner ? ` (${owner})` : ""}`,
+      new PluginServiceStopTimeoutError(
+        `${label} timed out after ${Math.max(0, remaining)}ms${owner ? ` (${owner})` : ""}`,
       );
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
@@ -278,7 +279,7 @@ export async function startPluginServices(params: {
           ? err
           : new Error(
               `plugin service stop failed (plugin=${entry.pluginId}, service=${entry.id}): ${
-                err instanceof PluginServiceReplacementTimeoutError
+                err instanceof PluginServiceStopTimeoutError
                   ? err.message
                   : `rejected: ${String(err)}`
               }`,
@@ -299,32 +300,36 @@ export async function startPluginServices(params: {
       entry.stopping = true;
     }
     const reversed = entries.toReversed();
-    const diagnosticsExporters = reversed.filter((entry) => entry.diagnosticsExporter);
-    for (const entry of reversed.filter((candidate) => !candidate.diagnosticsExporter)) {
+    const oneShotTimeouts = deadline === undefined ? params.oneShotStopTimeouts : undefined;
+    // One-shot registries are already scoped; every cleanup follows the drain, without changing grants.
+    const afterDrain = oneShotTimeouts
+      ? reversed
+      : reversed.filter((entry) => entry.diagnosticsExporter);
+    for (const entry of oneShotTimeouts
+      ? []
+      : reversed.filter((candidate) => !candidate.diagnosticsExporter)) {
       await stopService(entry, strict ? failures : undefined, deadline);
     }
-    if (diagnosticsExporters.length > 0) {
+    if (afterDrain.length > 0) {
       // Producers stop first; this barrier preserves their queued tail before exporters detach.
       try {
         await runBeforeDeadline(
           waitForDiagnosticEventsDrained,
-          deadline,
+          oneShotTimeouts ? Date.now() + oneShotTimeouts.eventDrainMs : deadline,
           "plugin diagnostic event drain",
-          diagnosticsExporters
-            .map((entry) => `plugin=${entry.pluginId}, service=${entry.id}`)
-            .join("; "),
+          afterDrain.map((entry) => `plugin=${entry.pluginId}, service=${entry.id}`).join("; "),
         );
       } catch (error) {
-        if (!strict) {
+        if (!strict && !oneShotTimeouts) {
           throw error;
         }
         failures.push(error);
       }
     }
-    // Ordinary plugin cleanup stays warn-and-continue. Trusted diagnostics
-    // exporter failures propagate because they can mean telemetry was lost.
-    for (const entry of diagnosticsExporters) {
-      await stopService(entry, failures, deadline);
+    // Fresh one-shot flush budgets start after drain; absolute replacement deadlines span all phases.
+    const stopDeadline = oneShotTimeouts ? Date.now() + oneShotTimeouts.serviceStopMs : deadline;
+    for (const entry of afterDrain) {
+      await stopService(entry, failures, stopDeadline);
     }
   };
   let stopRequested = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a local agent command with diagnostics enabled could finish its exporter-flush wait without starting exporter shutdown when the diagnostic-event drain was slow. The documented policy gives event draining five seconds and then ten additional seconds for flushing buffered telemetry.

## Why This Change Was Made

The CLI wrapper drained events before asking the plugin service manager to stop, and the manager drained them again. The second wait could consume the entire flush window. The service manager now owns both phases with independent deadlines; the CLI supplies its existing durations and delegates once. This removes the duplicate drain and outer timer implementation.

Ordinary Gateway shutdown, strict replacement deadlines, scoped exporter selection, trust grants, retained cleanup and lease/health retirement keep their existing owners. There is no new operator configuration, environment variable, persistence schema or public SDK option. Timeout messages now describe the actual remaining wait for the phase. Production code is 23 lines smaller.

## User Impact

When a local run's diagnostic drain times out or rejects, exporter shutdown still starts with its full separate flush allowance. Failures remain visible as warnings and do not replace the agent command's result. The exporter continues to own its network request timeout.

## Evidence

The regression uses the real service manager with a synthetic loader/exporter and controlled event drain. Against unchanged production, the existing test file reported 13 passes and one intended failure: after five seconds, the actual exporter stop callback had never run. The identical two-row regression passed after the repair, including an early drain followed by its own ten-second flush window.

Final coverage includes immediate, early and timed-out drains; workspace registrations without extra diagnostics grants; both drain and exporter failures; ordinary/concurrent shutdown, reload/replacement, queue snapshot behavior, CLI lifecycle and the existing feature-plugin consumer. It totals 224 unique passing cases and one existing procfs platform skip. All 29 selected checks passed, including full production/test typechecks, lint, import-cycle and SDK-boundary guards. Independent source and managed P2 reviews found no actionable issue.

The tests prove shutdown composition and retirement through real host owners. They do not claim delivery to a real OTLP collector or cancellation of exporter-owned network work. No distribution build or live collector call was run. The existing public diagnostics documentation already describes the preserved five-second/ten-second contract.

Published head `54073b7baa07083cdd6f3bea97c5f63e31b71f03` passed [CI 34028468641](https://github.com/openclaw/openclaw/actions/runs/34028468641): 107 successful jobs, 17 skips and no failures. Actual checkout `b85f9addd2e4997e2befd2f6c3a910d33cd527a0` contains all three reviewed source/test blobs unchanged. Skipped native/UI scopes are not counted as executed tests. The latest complete review has no remaining findings or actions.
