### PR TITLE
fix(test): keep native filesystem access checks portable

### DIFF
--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -503,7 +503,7 @@ describe("installScheduledTask", () => {
       await expect(uninstallScheduledTask({ env, stdout: new PassThrough() })).rejects.toThrow(
         "schtasks delete failed: ERROR: Access is denied.",
       );
-      await expect(fs.access(scriptPath)).resolves.toBeUndefined();
+      await fs.access(scriptPath);
     });
   });
 

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -645,7 +645,7 @@ describe("Windows startup fallback", () => {
       expect(sanitizedError.cause).toEqual({ code: "EACCES" });
       expect(sanitizedError).not.toHaveProperty("path");
       expect(sanitizedError.stack).not.toContain(startupEntryPath);
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -902,7 +902,7 @@ describe("Windows startup fallback", () => {
       expect(spawnSync.mock.calls.some(([command]) => command.endsWith("taskkill.exe"))).toBe(
         false,
       );
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -935,7 +935,7 @@ describe("Windows startup fallback", () => {
       expect(spawnSync.mock.calls.some(([command]) => command.endsWith("taskkill.exe"))).toBe(
         false,
       );
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1006,7 +1006,7 @@ describe("Windows startup fallback", () => {
       );
 
       expect(killProcessTreeMock).not.toHaveBeenCalled();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1057,7 +1057,7 @@ describe("Windows startup fallback", () => {
       );
 
       expect(killProcessTreeMock).not.toHaveBeenCalled();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1092,7 +1092,7 @@ describe("Windows startup fallback", () => {
 
       expectGatewayTermination(4242);
       expectStartupFallbackSpawn();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1259,7 +1259,7 @@ describe("Windows startup fallback", () => {
       expect(decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) })).toBe(
         scriptBefore,
       );
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1312,7 +1312,7 @@ describe("Windows startup fallback", () => {
       expect(decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) })).toBe(
         scriptBefore,
       );
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1354,7 +1354,7 @@ describe("Windows startup fallback", () => {
       expect(decodeWindowsLauncherScript({ buffer: await fs.readFile(scriptPath) })).toBe(
         scriptBefore,
       );
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1414,7 +1414,7 @@ describe("Windows startup fallback", () => {
       await expect(installGatewayScheduledTask(env)).rejects.toThrow("refusing a direct fallback");
 
       expect(spawn).not.toHaveBeenCalled();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1464,7 +1464,7 @@ describe("Windows startup fallback", () => {
       );
 
       expect(spawn).not.toHaveBeenCalled();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1528,7 +1528,7 @@ describe("Windows startup fallback", () => {
       await expect(
         installGatewayScheduledTask(env, new PassThrough(), "18789", { status: "running" }),
       ).rejects.toThrow("previously running Windows login item has not exited cleanly");
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1611,7 +1611,7 @@ describe("Windows startup fallback", () => {
 
       await restartScheduledTask({ env: hiddenEnv, stdout: new PassThrough() });
 
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1631,7 +1631,7 @@ describe("Windows startup fallback", () => {
       );
 
       expect(spawn).not.toHaveBeenCalled();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1651,7 +1651,7 @@ describe("Windows startup fallback", () => {
       ).rejects.toThrow("refusing a direct fallback");
 
       expect(spawn).not.toHaveBeenCalled();
-      await expect(fs.access(startupEntryPath)).resolves.toBeUndefined();
+      await fs.access(startupEntryPath);
     });
   });
 
@@ -1661,7 +1661,7 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env);
 
-      await expect(fs.access(resolveStartupEntryPath(env))).resolves.toBeUndefined();
+      await fs.access(resolveStartupEntryPath(env));
       expectStartupFallbackSpawn();
     });
   });
@@ -1672,7 +1672,7 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env);
 
-      await expect(fs.access(resolveStartupEntryPath(env))).resolves.toBeUndefined();
+      await fs.access(resolveStartupEntryPath(env));
       expectStartupFallbackSpawn();
     });
   });
@@ -1685,7 +1685,7 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env);
 
-      await expect(fs.access(resolveStartupEntryPath(env))).resolves.toBeUndefined();
+      await fs.access(resolveStartupEntryPath(env));
       expectStartupFallbackSpawn();
     });
   });
@@ -1699,7 +1699,7 @@ describe("Windows startup fallback", () => {
 
       await installGatewayScheduledTask(env);
 
-      await expect(fs.access(resolveStartupEntryPath(env))).resolves.toBeUndefined();
+      await fs.access(resolveStartupEntryPath(env));
       expectStartupFallbackSpawn();
     });
   });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -2684,7 +2684,7 @@ describe("stageSystemdService", () => {
         installSystemdService(gatewayPortSystemdServiceFixture(env, "18789")),
       ).rejects.toThrow("system ownership appeared before activation");
 
-      await expect(fs.access(unitPath)).resolves.toBeUndefined();
+      await fs.access(unitPath);
       expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledTimes(4);
       expect(execFileMock).toHaveBeenCalledTimes(1);
     });
@@ -3912,8 +3912,8 @@ describe("uninstallLegacySystemdUnits", () => {
         await expect(uninstallLegacySystemdUnits({ env, stdout })).rejects.toThrow(
           "systemctl disable failed: Permission denied",
         );
-        await expect(fs.access(unitPath)).resolves.toBeUndefined();
-        await expect(fs.access(`${unitPath}.bak`)).resolves.toBeUndefined();
+        await fs.access(unitPath);
+        await fs.access(`${unitPath}.bak`);
       } finally {
         await fs.rm(tempHomeRoot, { recursive: true, force: true });
       }
@@ -4070,7 +4070,7 @@ describe("uninstallUserSystemdGatewayUnit", () => {
         await expect(uninstallUserSystemdGatewayUnit({ env, stdout })).rejects.toThrow(
           "systemctl disable failed: Permission denied",
         );
-        await expect(fs.access(unitPath)).resolves.toBeUndefined();
+        await fs.access(unitPath);
         expect(execFileMock).toHaveBeenCalledTimes(2);
       });
     },

--- a/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.archive-worktree-lifecycle.test.ts
@@ -305,7 +305,7 @@ test.each(["identity", "label-owner", "participants", "removed"] as const)(
         });
         await expect(fs.access(worktree.path)).rejects.toThrow();
       } else {
-        await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+        await fs.access(worktree.path);
       }
     } finally {
       restore.mockRestore();
@@ -440,7 +440,7 @@ test.each(["accepted", "revoked", "replacement"] as const)(
       expect(successorApply).not.toHaveBeenCalled();
       expect(successorAbort).not.toHaveBeenCalled();
       expect(isSessionPermissionChangePending(earlier.sessionId)).toBe(false);
-      await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+      await fs.access(worktree.path);
     } finally {
       release.resolve();
       await Promise.allSettled([pending]);
@@ -789,7 +789,7 @@ test.each(["unarchived", "rearchived"] as const)(
       expect(archivedBeforeCleanup).toEqual(expect.any(Number));
       expect(loadSessionEntry({ storePath, sessionKey: key })?.archivedAt).toBe(successorArchive);
       expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();
-      await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+      await fs.access(worktree.path);
       await expect(loadSeededTranscriptEvents(fixture.transcriptScope)).resolves.toEqual(
         transcript,
       );

--- a/src/gateway/server.sessions.create.test.ts
+++ b/src/gateway/server.sessions.create.test.ts
@@ -2175,7 +2175,7 @@ test("sessions.create rolls back failed provisioning before a same-key creator p
     const successorWorktree = successor.payload!.worktree;
     successorWorktreeId = successorWorktree.id;
     expect(successorWorktree.id).not.toBe(failedWorktreeId);
-    await expect(fs.access(successorWorktree.path)).resolves.toBeUndefined();
+    await fs.access(successorWorktree.path);
     expect(loadSessionEntry({ sessionKey: key, storePath })?.worktree).toEqual({
       id: successorWorktree.id,
       branch: successorWorktree.branch,
@@ -3763,7 +3763,7 @@ test.each([
         expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("retained-dirty"));
       } else if (outcome === "failed") {
         expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();
-        await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+        await fs.access(worktree.path);
         expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
           "failed to finalize session worktree lifecycle: simulated cleanup failure",
         );
@@ -3915,7 +3915,7 @@ test("sessions.create reset-in-place detaches the prior worktree permission boun
     const successorWorktree = successor.payload!.worktree;
     expect(successorWorktree.id).not.toBe(worktree?.id);
     worktreeId = successorWorktree.id;
-    await expect(fs.access(successorWorktree.path)).resolves.toBeUndefined();
+    await fs.access(successorWorktree.path);
     expect(loadSessionEntry({ sessionKey: "agent:main:main", storePath })).toMatchObject({
       spawnedCwd: successorWorktree.path,
       worktree: {

--- a/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
+++ b/src/gateway/server.sessions.delete-worktree-lifecycle.test.ts
@@ -419,7 +419,7 @@ test("sessions.delete keeps same-key successor worktree creation behind exact cl
     successorWorktreeId = successorWorktree.id;
     expect(successorSessionId).not.toBe(predecessorSessionId);
     expect(successorWorktree.id).not.toBe(predecessorWorktree.id);
-    await expect(fs.access(successorWorktree.path)).resolves.toBeUndefined();
+    await fs.access(successorWorktree.path);
     expect(getRegistryWorktree(process.env, successorWorktree.id)?.id).toBe(successorWorktree.id);
     expect(getRegistryWorktree(process.env, successorWorktree.id)?.removedAt).toBeUndefined();
     const persisted = loadSessionEntry({ sessionKey: key, storePath });
@@ -544,7 +544,7 @@ test.each([
       await expect(fs.access(worktree.path)).rejects.toThrow();
     } else {
       expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();
-      await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+      await fs.access(worktree.path);
     }
   } finally {
     removeSpy.mockRestore();
@@ -598,7 +598,7 @@ test("sessions.delete reports a busy preserved worktree while a live run lease e
       },
     });
     expect(getRegistryWorktree(process.env, worktree.id)?.removedAt).toBeUndefined();
-    await expect(fs.access(worktree.path)).resolves.toBeUndefined();
+    await fs.access(worktree.path);
   } finally {
     await runLease?.release();
     if (worktreeId && getRegistryWorktree(process.env, worktreeId)?.removedAt === undefined) {
@@ -667,7 +667,7 @@ test("sessions.delete preserves an entry-bound worktree owned by another princip
       ownerId: "foreign-owner",
     });
     expect(getRegistryWorktree(process.env, foreignWorktree.id)?.removedAt).toBeUndefined();
-    await expect(fs.access(foreignWorktree.path)).resolves.toBeUndefined();
+    await fs.access(foreignWorktree.path);
   } finally {
     removeSpy.mockRestore();
     if (getRegistryWorktree(process.env, foreignWorktree.id)?.removedAt === undefined) {

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1193,7 +1193,7 @@ describe("createBackupArchive", () => {
             db.prepare("DELETE FROM durable_records WHERE value LIKE ?").run(`${deletedMarker}%`);
             db.prepare("INSERT INTO durable_records (value) VALUES (?)").run("committed-in-wal");
             expect((await fs.readFile(dbPath)).includes(Buffer.from(deletedMarker))).toBe(true);
-            await expect(fs.access(`${dbPath}-wal`)).resolves.toBeUndefined();
+            await fs.access(`${dbPath}-wal`);
 
             archive = await createBackupArchive({
               output: state.path("owned-agent.tar.gz"),
@@ -2159,7 +2159,7 @@ describe("createBackupArchive", () => {
             PRAGMA wal_checkpoint(TRUNCATE);
             INSERT INTO markers (value) VALUES ('committed-in-wal');
           `);
-          await expect(fs.access(`${dbPath}-wal`)).resolves.toBeUndefined();
+          await fs.access(`${dbPath}-wal`);
 
           const result = await createBackupArchive({
             output: outputDir,
@@ -2602,8 +2602,8 @@ describe("createBackupArchive", () => {
         await fs.writeFile(`${dbPath}-journal`, "");
 
         try {
-          await expect(fs.access(`${dbPath}-wal`)).resolves.toBeUndefined();
-          await expect(fs.access(`${dbPath}-shm`)).resolves.toBeUndefined();
+          await fs.access(`${dbPath}-wal`);
+          await fs.access(`${dbPath}-shm`);
           const result = await createBackupArchive({
             output: outputDir,
             includeWorkspace: false,

--- a/src/infra/gateway-lock.state-dir.test.ts
+++ b/src/infra/gateway-lock.state-dir.test.ts
@@ -76,8 +76,8 @@ describe("gateway lock state directory", () => {
         expect(lock.stateLockPath).toBe(stateLockPath);
         expect(path.dirname(lock.lockPath)).toBe(lockDir);
         expect(path.basename(lock.lockPath)).toMatch(/^gateway\.[0-9a-f]{8}\.lock$/u);
-        await expect(fs.access(`${lock.lockPath}.sqlite`)).resolves.toBeUndefined();
-        await expect(fs.access(`${lock.stateLockPath}.sqlite`)).resolves.toBeUndefined();
+        await fs.access(`${lock.lockPath}.sqlite`);
+        await fs.access(`${lock.stateLockPath}.sqlite`);
       } finally {
         await lock.release();
       }

--- a/src/infra/gateway-lock.test.ts
+++ b/src/infra/gateway-lock.test.ts
@@ -560,7 +560,7 @@ describe("gateway lock", () => {
     expect(acquired).toHaveLength(1);
     expect(rejected).toHaveLength(1);
     expect(rejected[0]?.reason).toBeInstanceOf(GatewayLockError);
-    await expect(fs.access(stateLockPath)).resolves.toBeUndefined();
+    await fs.access(stateLockPath);
 
     const acquiredResult = acquired[0];
     if (!acquiredResult) {
@@ -902,7 +902,7 @@ describe("gateway lock", () => {
 
     try {
       expect(lock.lockPath).toBe(stateLockPath);
-      await expect(fs.access(stateLockPath)).resolves.toBeUndefined();
+      await fs.access(stateLockPath);
       await expect(fs.access(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
       await expect(
         acquireGatewayLock({

--- a/src/infra/node-pairing-migration.test.ts
+++ b/src/infra/node-pairing-migration.test.ts
@@ -83,8 +83,8 @@ describe("migrateLegacyNodePairingStore", () => {
       "node-kept",
     ]);
     await expect(fs.access(pairedPath)).rejects.toThrow();
-    await expect(fs.access(`${pairedPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${pendingPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${pairedPath}.migrated`);
+    await fs.access(`${pendingPath}.migrated`);
     await expect(migrateLegacyNodePairingStore({ baseDir })).resolves.toBeNull();
   });
 

--- a/src/infra/push-apns.store.test.ts
+++ b/src/infra/push-apns.store.test.ts
@@ -92,7 +92,7 @@ describe("push APNs registration store", () => {
     );
 
     await expect(loadApnsRegistration("legacy-node", baseDir)).resolves.toBeNull();
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
   });
 
   it("round-trips direct and sandbox relay fields including relay origin", async () => {

--- a/src/infra/state-migrations.audit-logs.test.ts
+++ b/src/infra/state-migrations.audit-logs.test.ts
@@ -242,7 +242,7 @@ describe("legacy core audit log migration", () => {
 
       expect(result.warnings.join("\n")).toContain("no longer matches its restore journal target");
       await expect(fs.readFile(raw, "utf8")).resolves.toBe(replacementContent);
-      await expect(fs.access(restore)).resolves.toBeUndefined();
+      await fs.access(restore);
     });
   });
 
@@ -258,7 +258,7 @@ describe("legacy core audit log migration", () => {
 
       expect(result.warnings).toEqual([]);
       await expect(fs.access(claim)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.access(raw)).resolves.toBeUndefined();
+      await fs.access(raw);
       expect(audit.systemEntries()).toHaveLength(1);
 
       const tenthRawArchive = `${source}.migrated.10.raw`;
@@ -387,7 +387,7 @@ describe("legacy core audit log migration", () => {
       const result = await audit.migrate();
 
       expect(result.warnings).toEqual([]);
-      await expect(fs.access(raw)).resolves.toBeUndefined();
+      await fs.access(raw);
       await expect(fs.access(`${source}.migrated.2.raw`)).rejects.toMatchObject({
         code: "ENOENT",
       });
@@ -410,7 +410,7 @@ describe("legacy core audit log migration", () => {
       expect(repeated.warnings).toEqual([]);
       expect(repeated.changes.join("\n")).toContain("1 new row");
       await expect(fs.readFile(sanitized, "utf8")).resolves.toBe(firstSanitized);
-      await expect(fs.access(`${source}.migrated.2.raw`)).resolves.toBeUndefined();
+      await fs.access(`${source}.migrated.2.raw`);
       expect(audit.systemEntries()).toHaveLength(2);
     });
   });
@@ -441,7 +441,7 @@ describe("legacy core audit log migration", () => {
       const resumed = await audit.migrate(detected);
 
       expect(resumed.warnings).toEqual([]);
-      await expect(fs.access(`${source}.migrated.2.raw`)).resolves.toBeUndefined();
+      await fs.access(`${source}.migrated.2.raw`);
       expect(audit.systemEntries()).toHaveLength(2);
     });
   });
@@ -454,7 +454,7 @@ describe("legacy core audit log migration", () => {
 
       const result = await audit.migrate(detected);
       expect(result.warnings.join("\n")).toContain("Failed reading system-agent audit log");
-      await expect(fs.access(source)).resolves.toBeUndefined();
+      await fs.access(source);
       expect(audit.systemEntries()).toEqual([]);
     });
   });
@@ -469,7 +469,7 @@ describe("legacy core audit log migration", () => {
 
       expect(blocked.changes).toEqual([]);
       expect(blocked.warnings.join("\n")).toContain("Failed reading system-agent audit log");
-      await expect(fs.access(source)).resolves.toBeUndefined();
+      await fs.access(source);
       expect(audit.systemEntries()).toEqual([]);
 
       await audit.writeJsonLines(raw, [systemAuditEvent("repaired older generation")]);
@@ -503,7 +503,7 @@ describe("legacy core audit log migration", () => {
       const recovered = await audit.migrate();
       expect(recovered.warnings).toEqual([]);
       await expect(fs.access(source)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.access(raw)).resolves.toBeUndefined();
+      await fs.access(raw);
     });
   });
 
@@ -530,7 +530,7 @@ describe("legacy core audit log migration", () => {
       }
 
       expect(result.warnings.join("\n")).toContain("exclusive state ownership is unavailable");
-      await expect(fs.access(source)).resolves.toBeUndefined();
+      await fs.access(source);
       expect(audit.systemEntries()).toEqual([]);
     });
   });

--- a/src/infra/state-migrations.audit-recovery.test.ts
+++ b/src/infra/state-migrations.audit-recovery.test.ts
@@ -139,7 +139,7 @@ describe("legacy audit recovery byte handling", () => {
 
       expect(result.warnings.join("\n")).toContain("no longer matches its restore journal target");
       await expect(fs.readFile(rawPath, "utf8")).resolves.toBe(replacementContent);
-      await expect(fs.access(restorePath)).resolves.toBeUndefined();
+      await fs.access(restorePath);
     });
   });
 

--- a/src/infra/state-migrations.managed-outgoing-images.test.ts
+++ b/src/infra/state-migrations.managed-outgoing-images.test.ts
@@ -105,7 +105,7 @@ describe("legacy managed outgoing image migration", () => {
       "Migrated 1 managed outgoing image record(s) → shared SQLite state",
     );
     await expect(fsp.access(legacy.sourcePath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fsp.access(legacy.originalPath)).resolves.toBeUndefined();
+    await fsp.access(legacy.originalPath);
     expect(readManagedImageRecord(legacy.record.attachmentId, stateDir)).toEqual({
       ...legacy.record,
       original: {
@@ -188,8 +188,8 @@ describe("legacy managed outgoing image migration", () => {
     }
 
     expect(result.warnings.join("\n")).toContain("synthetic attachment remove failure");
-    await expect(fsp.access(legacy.sourcePath)).resolves.toBeUndefined();
-    await expect(fsp.access(legacy.originalPath)).resolves.toBeUndefined();
+    await fsp.access(legacy.sourcePath);
+    await fsp.access(legacy.originalPath);
     expect(readManagedImageRecord(legacy.record.attachmentId, stateDir)).toBeNull();
   });
 
@@ -222,8 +222,8 @@ describe("legacy managed outgoing image migration", () => {
 
     expect(result.warnings.join("\n")).toContain("conflicts with shared SQLite state");
     expect(readManagedImageRecord(first.record.attachmentId, stateDir)).toBeNull();
-    await expect(fsp.access(first.sourcePath)).resolves.toBeUndefined();
-    await expect(fsp.access(second.sourcePath)).resolves.toBeUndefined();
+    await fsp.access(first.sourcePath);
+    await fsp.access(second.sourcePath);
   });
 
   it("retains malformed and symlinked sources", async () => {
@@ -234,7 +234,7 @@ describe("legacy managed outgoing image migration", () => {
 
     const malformed = migrate(stateDir);
     expect(malformed.warnings.join("\n")).toContain("Failed reading legacy managed outgoing");
-    await expect(fsp.access(malformedPath)).resolves.toBeUndefined();
+    await fsp.access(malformedPath);
 
     await fsp.rm(malformedPath);
     const targetPath = path.join(stateDir, "target.json");
@@ -259,7 +259,7 @@ describe("legacy managed outgoing image migration", () => {
     expect(result.warnings).toEqual([
       `Failed reading legacy managed outgoing image state: Error: legacy managed image record has unexpected field ${field}`,
     ]);
-    await expect(fsp.access(legacy.originalPath)).resolves.toBeUndefined();
+    await fsp.access(legacy.originalPath);
     expect(fs.readdirSync(path.dirname(legacy.sourcePath))).toEqual([
       path.basename(legacy.sourcePath),
     ]);
@@ -276,7 +276,7 @@ describe("legacy managed outgoing image migration", () => {
     });
 
     expect(result.warnings.join("\n")).toContain("Failed claiming legacy managed outgoing");
-    await expect(fsp.access(legacy.sourcePath)).resolves.toBeUndefined();
+    await fsp.access(legacy.sourcePath);
     expect(readManagedImageRecord(legacy.record.attachmentId, stateDir)).toBeNull();
   });
 
@@ -289,7 +289,7 @@ describe("legacy managed outgoing image migration", () => {
       },
     });
     expect(failed.warnings.join("\n")).toContain("synthetic remove failure");
-    await expect(fsp.access(legacy.sourcePath)).resolves.toBeUndefined();
+    await fsp.access(legacy.sourcePath);
 
     const retried = migrate(stateDir);
     expect(retried.warnings).toEqual([]);

--- a/src/infra/state-migrations.test.ts
+++ b/src/infra/state-migrations.test.ts
@@ -3843,7 +3843,7 @@ describe("state migrations", () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("Failed reading legacy voice wake triggers");
     expect(result.notices).toBeUndefined();
-    await expect(fs.access(triggersPath)).resolves.toBeUndefined();
+    await fs.access(triggersPath);
     await expectMissingPath(`${triggersPath}.migrated`);
   });
 
@@ -3943,7 +3943,7 @@ describe("state migrations", () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("Failed reading legacy voice wake routing");
     expect(result.notices).toBeUndefined();
-    await expect(fs.access(routingPath)).resolves.toBeUndefined();
+    await fs.access(routingPath);
     await expectMissingPath(`${routingPath}.migrated`);
   });
 
@@ -4593,7 +4593,7 @@ describe("state migrations", () => {
     expect(result.changes).toContain("plugin state migrated");
     expect(detectedStateDirs).toStrictEqual([canonicalStateDir]);
     expect(migratedStateDirs).toStrictEqual([canonicalStateDir]);
-    await expect(fs.access(path.join(canonicalStateDir, "legacy.txt"))).resolves.toBeUndefined();
+    await fs.access(path.join(canonicalStateDir, "legacy.txt"));
   });
 
   it("routes explicit Doctor repair through the APNs SQLite importer", async () => {
@@ -5067,7 +5067,7 @@ describe("state migrations", () => {
       },
     ]);
     await expectMissingPath(sourcePath);
-    await expect(fs.access(`${sourcePath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${sourcePath}.migrated`);
   });
 
   it("removes a regenerated config health source when its archive already exists", async () => {
@@ -5118,7 +5118,7 @@ describe("state migrations", () => {
 
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("Failed reading legacy config health state");
-    await expect(fs.access(sourcePath)).resolves.toBeUndefined();
+    await fs.access(sourcePath);
     await expectMissingPath(`${sourcePath}.migrated`);
   });
 
@@ -5428,7 +5428,7 @@ describe("state migrations", () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("Failed reading legacy plugin binding approvals");
     expect(result.notices).toBeUndefined();
-    await expect(fs.access(sourcePath)).resolves.toBeUndefined();
+    await fs.access(sourcePath);
     await expectMissingPath(`${sourcePath}.migrated`);
   });
 
@@ -5513,8 +5513,8 @@ describe("state migrations", () => {
     const result = await runLegacyStateMigrations({ detected, config: cfg, env });
     expect(result.changes.some((change) => change.includes("exec approvals"))).toBe(false);
     expect(result.changes.some((change) => change.includes("plugin binding approval"))).toBe(false);
-    await expect(fs.access(execApprovalsPath)).resolves.toBeUndefined();
-    await expect(fs.access(pluginApprovalsPath)).resolves.toBeUndefined();
+    await fs.access(execApprovalsPath);
+    await fs.access(pluginApprovalsPath);
     await expectMissingPath(path.join(stateDir, "exec-approvals.json"));
     expect(readPluginBindingApprovalRows(env)).toEqual([]);
   });
@@ -5795,7 +5795,7 @@ describe("state migrations", () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("Failed reading legacy current-conversation bindings");
     expect(result.notices).toBeUndefined();
-    await expect(fs.access(sourcePath)).resolves.toBeUndefined();
+    await fs.access(sourcePath);
     await expectMissingPath(`${sourcePath}.migrated`);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes false filesystem-access failures in daemon, Gateway, backup, and migration tests under Bun. Successful native access calls can fulfill with a different return value from Node even though the path is accessible.

## Why This Change Was Made

Await the same native access calls directly at 73 sites in 15 tests. A missing or inaccessible path still rejects and fails the test. All substantive return, error, content, permission, retention, and cleanup assertions remain unchanged.

## User Impact

No production or storage behavior changes. The existing tests validate accessible paths consistently across both runtimes. This follows #139859 in separate files without duplicating its changes.

## Evidence

- All 871 tests in the 15 affected files pass on Node and all 871 on true Bun, with no failures or skips. The current-main selection includes six cases beyond the initial 865-case inventory.
- Bun proof uses the existing canonical SQLite test preload and supported filesystem-cache-off mode with one worker.
- Complete changed-file gate, formatting/diff checks, and fresh P0–P2 review pass.
- No helper, coercion, timeout, production code, or rejection assertion changed. The broader repository is not claimed fully green under Bun.
