### PR TITLE
fix(codex): preserve exec-server WebSocket backpressure under Bun

### DIFF
--- a/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.test-helpers.ts
@@ -4,7 +4,8 @@
  */
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
 import { vi } from "vitest";
-import WebSocket from "ws";
+import type { RawData, WebSocket } from "ws";
+import { websocket } from "./sandbox-exec-server.websocket.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
 type RpcResponse = {
@@ -147,7 +148,7 @@ export function globPath(pattern: string): unknown {
 /** Opens a WebSocket connection and resolves only after the socket is ready. */
 export function openSocket(url: string): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const socket = new WebSocket(url);
+    const socket = new websocket.WebSocket(url);
     socket.once("open", () => resolve(socket));
     socket.once("error", reject);
   });
@@ -236,7 +237,7 @@ export async function waitForHttpBodyDeltas(
 export function rpc(socket: WebSocket, method: string, params: unknown): Promise<unknown> {
   const id = Math.floor(Math.random() * 1_000_000);
   return new Promise((resolve, reject) => {
-    const onMessage = (data: WebSocket.RawData) => {
+    const onMessage = (data: RawData) => {
       const response = JSON.parse(Buffer.from(data as Buffer).toString("utf8")) as RpcResponse;
       if (response.id !== id) {
         return;

--- a/extensions/codex/src/app-server/sandbox-exec-server.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.ts
@@ -9,7 +9,7 @@ import { isIP, type AddressInfo } from "node:net";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import type { SandboxContext } from "openclaw/plugin-sdk/sandbox";
-import { WebSocketServer, type RawData, type WebSocket } from "ws";
+import type { RawData, WebSocket } from "ws";
 import type { CodexAppServerClient } from "./client.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import {
@@ -17,6 +17,7 @@ import {
   startCodexNodeExecServerRelay,
 } from "./sandbox-exec-server-node-relay.js";
 import { sandboxExecServerRegistry } from "./sandbox-exec-server-registry.js";
+import { websocket } from "./sandbox-exec-server.websocket.js";
 import { parseRequest } from "./sandbox-exec-server/json-rpc.js";
 import type { SandboxChildOwner } from "./sandbox-exec-server/sandbox-child.js";
 import { CodexSandboxExecSession } from "./sandbox-exec-server/session.js";
@@ -251,7 +252,7 @@ async function startOpenClawExecServer(sandbox: SandboxContext): Promise<OpenCla
     }
     connection = { kind: "sandbox", backend, fsBridge };
   }
-  const server = new WebSocketServer({
+  const server = new websocket.WebSocketServer({
     host: "127.0.0.1",
     port: 0,
     // Match ws' historical default: Codex fs/writeFile sends one base64 JSON-RPC

--- a/extensions/codex/src/app-server/sandbox-exec-server.websocket.test.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.websocket.test.ts
@@ -1,0 +1,44 @@
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import { websocket } from "./sandbox-exec-server.websocket.js";
+
+it("preserves an initialization frame while pausing and resuming the accepted socket", async () => {
+  const server = new websocket.WebSocketServer({ host: "127.0.0.1", port: 0 });
+  let client: WebSocket | undefined;
+  try {
+    await once(server, "listening");
+    const connected = once(server, "connection");
+    client = new websocket.WebSocket(`ws://127.0.0.1:${(server.address() as AddressInfo).port}`);
+    await once(client, "open");
+    const [socket] = (await connected) as [WebSocket];
+    const frame = JSON.stringify({
+      id: "initialize",
+      method: "initialize",
+      params: { clientName: "test-client" },
+    });
+    const incoming = once(socket, "message");
+    client.send(frame);
+    const [data, binary] = await incoming;
+    expect(binary).toBe(false);
+    expect(data.toString()).toBe(frame);
+
+    socket.pause();
+    const echoed = once(client, "message");
+    socket.send(data, { binary: false });
+    socket.resume();
+    const [echo, echoBinary] = await echoed;
+    expect(echoBinary).toBe(false);
+    expect(echo.toString()).toBe(frame);
+  } finally {
+    const closed = new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    client?.terminate();
+    for (const socket of server.clients) {
+      socket.terminate();
+    }
+    await closed;
+  }
+});

--- a/extensions/codex/src/app-server/sandbox-exec-server.websocket.ts
+++ b/extensions/codex/src/app-server/sandbox-exec-server.websocket.ts
@@ -1,0 +1,8 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+
+// Bun's accepted ws sockets lack pause(); keep the installed receiver's backpressure.
+const require = createRequire(import.meta.url);
+export const websocket: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex exec-server WebSocket handling under Bun receives sockets without the pause/resume methods required by the existing backpressure path.

## Why This Change Was Made

Load the plugin's declared installed ws implementation through one private module binding used by the production server and its fixture client. Preserve server options, message framing, limits, and the existing lazy plugin boundary.

## User Impact

Codex exec-server sockets retain their expected WebSocket backpressure behavior when OpenClaw runs under Bun. No protocol, authentication, timeout, dependency version, or policy changes are introduced.

## Evidence

- The ordinary initialization-frame regression passes on Node before the fix and fails on Bun because the accepted socket lacks pause. It passes on both runtimes after repair, preserving exact text bytes through pause/resume.
- The initialization frame matches the inspected sibling exec-server contract. No test-only production export was added; the shared binding is consumed by the real server.
- Complete four-file changed gate, full repository build, and fresh P0–P2 review pass.
- The built plugin keeps installed-package resolution inside its existing dynamic-tools chunk.
- Local proof covers this WebSocket implementation boundary. Broader execution, authentication, and node transport scenarios are not claimed covered, and the full repository is not claimed green under Bun.
