### PR TITLE
refactor(auth): share profile failure state reset

### DIFF
--- a/src/agents/auth-profiles.ts
+++ b/src/agents/auth-profiles.ts
@@ -107,7 +107,6 @@ export {
   markAuthProfileBlockedUntil,
   markAuthProfileFailure,
   markInlineProviderApiKeyFailure,
-  resolveInlineProviderApiKeyUnusableUntil,
   resolveInlineProviderApiKeyUsageId,
   resolveProfilesUnavailableReason,
   resolveProfileUnusableUntilForDisplay,

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -34,6 +34,7 @@ import {
   isActiveUnusableWindow,
   isAuthCooldownBypassedForProvider,
   isModelScopedCooldownReason,
+  resetAuthProfileFailureState,
   resolveProfileUnusableUntil,
 } from "./usage-state.js";
 
@@ -847,43 +848,6 @@ export function resolveProfileUnusableUntilForDisplay(
   return resolveProfileUnusableUntil(stats);
 }
 
-export function resolveInlineProviderApiKeyUnusableUntil(
-  store: AuthProfileStore,
-  provider: string,
-): number | null {
-  if (isAuthCooldownBypassedForProvider(provider)) {
-    return null;
-  }
-  const stats = store.usageStats?.[resolveInlineProviderApiKeyUsageId(provider)];
-  if (!stats) {
-    return null;
-  }
-  return resolveProfileUnusableUntil(stats);
-}
-
-function resetUsageStats(
-  existing: ProfileUsageStats | undefined,
-  overrides?: Partial<ProfileUsageStats>,
-): ProfileUsageStats {
-  return {
-    ...existing,
-    errorCount: 0,
-    blockedUntil: undefined,
-    blockedReason: undefined,
-    blockedSource: undefined,
-    blockedModel: undefined,
-    blockedScope: undefined,
-    cooldownUntil: undefined,
-    cooldownReason: undefined,
-    cooldownClassification: undefined,
-    cooldownModel: undefined,
-    disabledUntil: undefined,
-    disabledReason: undefined,
-    failureCounts: undefined,
-    ...overrides,
-  };
-}
-
 function updateUsageStatsEntry(
   store: AuthProfileStore,
   profileId: string,
@@ -1336,11 +1300,12 @@ export async function clearAuthProfileCooldown(params: {
   const updated = await updateOwnedAuthProfileUsage(store, profileId, {
     agentDir,
     updater: (freshStore) => {
-      if (!freshStore.usageStats?.[profileId]) {
+      const existing = freshStore.usageStats?.[profileId];
+      if (!existing) {
         return false;
       }
 
-      updateUsageStatsEntry(freshStore, profileId, (existing) => resetUsageStats(existing));
+      updateUsageStatsEntry(freshStore, profileId, () => resetAuthProfileFailureState(existing));
       return true;
     },
   });

--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -658,9 +658,6 @@ export function createModelAuthAvailabilityResolver(
     // Config-backed inline provider keys have no auth profile, so a recorded
     // billing/auth cooldown must hide them from browse availability the same way
     // it blocks their resolution — otherwise a cooled key still looks usable.
-    // Mirrors resolveInlineProviderApiKeyUnusableUntil, but reads the cooldown
-    // via usage-state primitives so this hot browse path stays independent of
-    // the auth-profiles usage module that many callers mock in tests.
     const inlineUsageStats = isAuthCooldownBypassedForProvider(provider)
       ? undefined
       : store.usageStats?.[`inline-api-key:${normalizeProviderId(provider)}`];

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -571,11 +571,7 @@ export function isConfigBackedInlineProviderApiKey(params: {
   return Boolean(perEntryRawKey && !params.store?.profiles[perEntryRawKey]);
 }
 
-// Reads the inline provider API-key cooldown via usage-state primitives instead
-// of the auth-profiles usage module, so model-auth keeps working in the many
-// tests that partially mock that module. Mirrors the usage-module helper of the
-// same intent, using the same provider normalization as the write side so the
-// `inline-api-key:<provider>` usage id matches what the failure marker records.
+// Use the same normalized usage id as the inline-key failure writer.
 export function resolveInlineProviderApiKeyCooldownUntil(
   store: AuthProfileStore,
   provider: string,


### PR DESCRIPTION
## What Problem This Solves

Manual auth cooldown clearing maintained a second copy of the failure-state reset already used by successful login and profile updates. The auth usage module also retained an unused inline-key cooldown reader and internal barrel export.

## Why This Change Was Made

Manual clearing now uses the existing pure reset after the same locked-store presence check. The unused reader and stale comments are removed. This deletes 34 production code lines (43 physical lines), with no test changes or new import edge.

## User Impact

No intended behavior change. Missing records remain a no-op, usage history is preserved, and updates still target the credential owner's store. Availability, failure windows and the public Plugin SDK are unchanged; no schema, stored-data or migration change is involved.

## Evidence

The same 348 focused cases passed before and after, covering cooldown clearing, inherited credential owners with isolated SQLite, profile resets and model-auth resolution. The full selected changed-file gate passed, including production/test types, typed lint, guards, unused-export scans and runtime import cycles. Fresh P2 review is clean, and final source hashes match reviewed/tested files.
