### PR TITLE
fix(code-mode): preserve valid MCP inputs in generated declarations

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -986,6 +986,13 @@ declare namespace MCP.github {
 }
 ```
 
+Dictionary inputs retain their value types. Nullable enums and fields marked
+`nullable: true` include `null`, unless an explicit enum excludes it.
+Top-level fields with defaults may be omitted from calls.
+These declarations approximate JSON Schema; for constraints that TypeScript
+cannot express, inspect the original schema with
+`MCP.<server>.$api("<tool>", { schema: true })`.
+
 MCP tool calls return their original JSON-safe content blocks, including block
 annotations and block-level `_meta`, plus top-level `structuredContent` and
 `isError` when provided. Top-level MCP `_meta` and private app metadata never

--- a/src/agents/code-mode-mcp-api.ts
+++ b/src/agents/code-mode-mcp-api.ts
@@ -60,10 +60,6 @@ function normalizeDocLines(value: string | undefined): string[] {
     : [];
 }
 
-function collapseDocText(value: string | undefined): string {
-  return normalizeDocLines(value).join(" ");
-}
-
 function renderDocComment(
   summary: string | undefined,
   params: readonly McpApiParamDoc[],
@@ -77,7 +73,9 @@ function renderDocComment(
     lines.push(" *");
   }
   for (const param of params) {
-    const description = collapseDocText(param.description);
+    const suffix =
+      param.defaultValue === undefined ? "" : ` Default: ${JSON.stringify(param.defaultValue)}.`;
+    const description = `${normalizeDocLines(param.description).join(" ")}${suffix}`.trim();
     if (description) {
       lines.push(
         ` * @param ${param.name}${param.required ? "" : "?"} ${escapeDocComment(description)}`,
@@ -92,33 +90,75 @@ function tsPropertyName(name: string): string {
   return /^[A-Za-z_$][A-Za-z0-9_$]*$/u.test(name) ? name : JSON.stringify(name);
 }
 
-function renderInlineObjectType(schema: unknown): string {
-  const properties = readMcpSchemaProperties(schema);
-  const keys = Object.keys(properties);
-  if (keys.length === 0) {
-    return "Record<string, unknown>";
+function renderInlineObjectType(
+  schema: unknown,
+  params: readonly McpApiParamDoc[],
+  depth = 0,
+): string {
+  const additional = isRecord(schema) ? schema.additionalProperties : undefined;
+  const patterns = isRecord(schema) ? schema.patternProperties : undefined;
+  const extraType =
+    isRecord(patterns) && Object.keys(patterns).length > 0
+      ? "unknown"
+      : additional === false
+        ? "never"
+        : schemaType(additional, depth + 1);
+  if (params.length === 0) {
+    return `Record<string, ${extraType}>`;
   }
-  const required = new Set(readMcpRequiredKeys(schema));
-  return `{ ${keys
-    .map(
-      (key) =>
-        `${tsPropertyName(key)}${required.has(key) ? "" : "?"}: ${schemaType(properties[key])}`,
-    )
-    .join("; ")} }`;
+  const fields = params.map(
+    (param) => `${tsPropertyName(param.name)}${param.required ? "" : "?"}: ${param.type};`,
+  );
+  if (extraType !== "never") {
+    // TypeScript index signatures also cover named properties, unlike JSON Schema's
+    // additionalProperties. Include their types so valid named inputs remain expressible.
+    const types = new Set([extraType, ...params.map((param) => param.type)]);
+    if (params.some((param) => !param.required)) {
+      types.add("undefined");
+    }
+    fields.push(
+      `[key: string]: ${types.has("unknown") || types.size > 8 ? "unknown" : [...types].join(" | ")};`,
+    );
+  }
+  return `{ ${fields.join(" ")} }`;
 }
 
-function schemaType(schema: unknown): string {
-  if (!isRecord(schema)) {
+function schemaType(schema: unknown, depth = 0): string {
+  if (!isRecord(schema) || depth >= 8) {
     return "unknown";
   }
-  const enumValues = Array.isArray(schema.enum)
-    ? schema.enum.filter(
-        (entry): entry is string | number | boolean =>
-          typeof entry === "string" || typeof entry === "number" || typeof entry === "boolean",
+  const enumValues = Array.isArray(schema.enum) ? schema.enum : undefined;
+  const types = new Set(Array.isArray(schema.type) ? schema.type : [schema.type]);
+  // Ajv widens the declared types with nullable, then independently applies enum.
+  const allowsNull =
+    (types.has(undefined) || types.has("null") || schema.nullable === true) &&
+    (!enumValues || enumValues.includes(null));
+  if (allowsNull && schema.nullable === true) {
+    types.add("null");
+  }
+  if (!allowsNull) {
+    types.delete("null");
+  }
+  if (enumValues && enumValues.length > 0 && enumValues.length <= 16) {
+    const compatible = enumValues.filter((entry) => {
+      const type = entry === null ? "null" : Array.isArray(entry) ? "array" : typeof entry;
+      return (
+        types.has(undefined) ||
+        types.has(type) ||
+        (type === "number" && types.has("integer") && Number.isInteger(entry))
+      );
+    });
+    if (
+      compatible.every(
+        (entry) =>
+          entry === null ||
+          typeof entry === "string" ||
+          typeof entry === "boolean" ||
+          (typeof entry === "number" && Number.isFinite(entry)),
       )
-    : [];
-  if (enumValues.length > 0 && enumValues.length <= 16) {
-    return enumValues.map((entry) => JSON.stringify(entry)).join(" | ");
+    ) {
+      return compatible.map((entry) => JSON.stringify(entry)).join(" | ") || "never";
+    }
   }
   const union = Array.isArray(schema.oneOf)
     ? schema.oneOf
@@ -126,33 +166,32 @@ function schemaType(schema: unknown): string {
       ? schema.anyOf
       : undefined;
   if (union && union.length > 0 && union.length <= 8) {
-    return union.map(schemaType).join(" | ");
+    return union.map((variant) => schemaType(variant, depth + 1)).join(" | ");
   }
-  if (Array.isArray(schema.type)) {
-    return schema.type.map((type) => schemaType({ ...schema, type })).join(" | ");
-  }
-  switch (schema.type) {
-    case "string":
-      return "string";
-    case "integer":
-    case "number":
-      return "number";
-    case "boolean":
-      return "boolean";
-    case "array":
-      return `Array<${schemaType(schema.items)}>`;
-    case "object":
-      return renderInlineObjectType(schema);
-    case "null":
-      return "null";
-    default:
-      return Object.keys(readMcpSchemaProperties(schema)).length > 0
-        ? renderInlineObjectType(schema)
-        : "unknown";
-  }
+  return (
+    [...types]
+      .map((type) => {
+        switch (type) {
+          case "integer":
+          case "number":
+            return "number";
+          case "array":
+            return `Array<${schemaType(schema.items, depth + 1)}>`;
+          case "string":
+          case "boolean":
+          case "null":
+            return type;
+          case "object":
+            return renderInlineObjectType(schema, buildMcpParamDocs(schema, depth), depth);
+          default:
+            return "unknown";
+        }
+      })
+      .join(" | ") || "never"
+  );
 }
 
-export function buildMcpParamDocs(schema: unknown): McpApiParamDoc[] {
+export function buildMcpParamDocs(schema: unknown, depth = 0): McpApiParamDoc[] {
   const properties = readMcpSchemaProperties(schema);
   const requiredKeys = readMcpRequiredKeys(schema);
   const required = new Set(requiredKeys);
@@ -161,7 +200,7 @@ export function buildMcpParamDocs(schema: unknown): McpApiParamDoc[] {
     const doc: McpApiParamDoc = {
       name: key,
       required: required.has(key),
-      type: schemaType(descriptor),
+      type: schemaType(descriptor, depth + 1),
     };
     if (isRecord(descriptor)) {
       const description =
@@ -169,30 +208,12 @@ export function buildMcpParamDocs(schema: unknown): McpApiParamDoc[] {
       if (description) {
         doc.description = description;
       }
-      if ("default" in descriptor) {
+      if (Object.hasOwn(descriptor, "default")) {
         doc.defaultValue = descriptor.default;
       }
     }
     return doc;
   });
-}
-
-function renderMcpInputType(params: readonly McpApiParamDoc[]): string[] {
-  if (params.length === 0) {
-    return ["input?: Record<string, never>"];
-  }
-  const lines = ["input: {"];
-  for (const param of params) {
-    if (param.description || param.defaultValue !== undefined) {
-      const description = collapseDocText(param.description);
-      const suffix =
-        param.defaultValue === undefined ? "" : ` Default: ${JSON.stringify(param.defaultValue)}.`;
-      lines.push(`  /** ${escapeDocComment(`${description}${suffix}`.trim())} */`);
-    }
-    lines.push(`  ${tsPropertyName(param.name)}${param.required ? "" : "?"}: ${param.type};`);
-  }
-  lines.push("}");
-  return lines;
 }
 
 function renderMcpToolSignature(
@@ -206,10 +227,16 @@ function renderMcpToolSignature(
     prompts_list: "McpPromptsListResult",
     prompts_get: "McpPromptsGetResult",
   }[tool.operation];
+  // The invocation mapper supplies defaults only for top-level arguments.
+  const inputParams = tool.params.map((param) => ({
+    ...param,
+    required: param.required && param.defaultValue === undefined,
+  }));
+  const optional = inputParams.some((param) => param.required) ? "" : "?";
   return [
-    ...renderDocComment(tool.description, tool.params),
+    ...renderDocComment(tool.description, inputParams),
     `function ${functionName}(`,
-    ...renderMcpInputType(tool.params).map((line) => `  ${line}`),
+    `  input${optional}: ${renderInlineObjectType(tool.parameters, inputParams)}`,
     `): Promise<${resultType}>;`,
   ];
 }

--- a/src/agents/code-mode-namespaces.test.ts
+++ b/src/agents/code-mode-namespaces.test.ts
@@ -108,7 +108,7 @@ describe("Code Mode MCP namespace model", () => {
     {
       name: "object",
       items: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
-      declaration: "Array<{ id: string }>",
+      declaration: "Array<{ id: string; [key: string]: unknown; }>",
     },
   ])("preserves $name item grouping in MCP API declarations", async ({ items, declaration }) => {
     const parameters = {

--- a/src/agents/code-mode.mcp-declarations.test.ts
+++ b/src/agents/code-mode.mcp-declarations.test.ts
@@ -1,0 +1,241 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
+import { expectDefined } from "@openclaw/normalization-core";
+import ts from "typescript";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import {
+  resetCodeModeTestState,
+  mcpTool,
+  createCodeModeHarness,
+  runUntilCompleted,
+} from "./code-mode.test-support.js";
+import { projectMcpCallToolResult } from "./mcp-content.js";
+
+describe("Code Mode MCP declarations", () => {
+  afterEach(resetCodeModeTestState);
+  it("advertises dictionary and nullable inputs accepted through the MCP namespace", async () => {
+    const mixedSchema = {
+      type: "object",
+      properties: {
+        value: { properties: { nested: { type: "boolean" } }, enum: ["keep", { nested: true }] },
+      },
+      required: ["value"],
+    };
+    const defaultedSchema = {
+      type: "object",
+      properties: {
+        limit: { type: "number", default: 0 },
+        enabled: { type: "boolean", default: false },
+        value: { type: ["string", "null"], default: null },
+      },
+      required: ["limit", "enabled", "value"],
+    };
+    const fixtures = [
+      {
+        name: "defaulted",
+        schema: defaultedSchema,
+        input: {},
+        expected: { limit: 0, enabled: false, value: null },
+      },
+      {
+        name: "defaultedOmitted",
+        schema: defaultedSchema,
+        input: undefined,
+        expected: { limit: 0, enabled: false, value: null },
+      },
+      {
+        name: "dictionary",
+        schema: { type: "object", additionalProperties: { type: "string" } },
+        input: { topic: "synthetic" },
+      },
+      { name: "open", schema: { type: "object" }, input: { topic: null } },
+      {
+        name: "closed",
+        schema: { type: "object", patternProperties: {}, additionalProperties: false },
+        input: {},
+      },
+      {
+        name: "pattern",
+        schema: {
+          type: "object",
+          patternProperties: { "^x": { type: "string" } },
+          additionalProperties: false,
+        },
+        input: { xLabel: "synthetic" },
+      },
+      {
+        name: "nullable",
+        schema: {
+          type: "object",
+          properties: { value: { enum: ["keep", null] } },
+          required: ["value"],
+          additionalProperties: false,
+        },
+        input: { value: null },
+      },
+      {
+        name: "nullableKeyword",
+        schema: {
+          type: "object",
+          properties: {
+            scalar: { type: "string", nullable: true },
+            union: { type: ["number", "boolean"], nullable: true },
+            dictionary: {
+              type: "object",
+              additionalProperties: { type: "string" },
+              nullable: true,
+            },
+            restricted: { type: "string", nullable: true, enum: ["keep"] },
+            constrained: { type: "string", enum: ["keep", null] },
+            integer: { type: "integer", enum: [1, 1.5, { nested: true }] },
+            impossible: { type: "string", enum: [false, { nested: true }] },
+            options: {
+              type: "object",
+              properties: { limit: { type: "number", default: 10 } },
+              required: ["limit"],
+            },
+            mixed: { type: "string", nullable: true, enum: ["keep", { nested: true }] },
+            oversized: {
+              type: "string",
+              nullable: true,
+              enum: Array.from({ length: 17 }, (_, i) => `choice${i}`),
+            },
+          },
+          required: ["scalar", "union", "dictionary", "restricted"],
+        },
+        input: {
+          scalar: null,
+          union: null,
+          dictionary: null,
+          restricted: "keep",
+          constrained: "keep",
+          integer: 1,
+          options: { limit: 5 },
+          mixed: "keep",
+          oversized: "choice0",
+        },
+      },
+      { name: "mixed", schema: mixedSchema, input: { value: { nested: true } } },
+      { name: "mixedPrimitive", schema: mixedSchema, input: { value: "keep" } },
+      {
+        name: "named",
+        schema: {
+          type: "object",
+          properties: { id: { type: "number" }, label: { type: "string" } },
+          required: ["id"],
+          additionalProperties: { type: "boolean" },
+        },
+        input: { id: 1, extra: true },
+      },
+      {
+        name: "nested",
+        schema: {
+          type: "object",
+          properties: {
+            values: {
+              type: "array",
+              items: { type: "object", additionalProperties: { enum: ["keep", null] } },
+            },
+          },
+          required: ["values"],
+        },
+        input: { values: [{ topic: null }] },
+      },
+    ];
+    const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
+    const validator = new AjvJsonSchemaValidator();
+    const targets = fixtures.map(({ name, schema }) => {
+      const validate = validator.getValidator(structuredClone(schema));
+      return mcpTool({
+        name: `fixture__${name}`,
+        serverName: "fixture",
+        toolName: name,
+        parameters: schema,
+        execute: vi.fn(async (_toolCallId, input) => {
+          expect(validate(input).valid).toBe(true);
+          return projectMcpCallToolResult({
+            content: [{ type: "text", text: JSON.stringify(input) }],
+          });
+        }),
+      });
+    });
+    applyCodeModeCatalog({
+      tools: [...codeModeTools, ...targets],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+    const calls = fixtures.map(
+      ({ name, input }) =>
+        `MCP.fixture.${name}(${input === undefined ? "" : JSON.stringify(input)})`,
+    );
+    const details = await runUntilCompleted({
+      execTool: expectDefined(codeModeTools[0], "Code Mode exec test invariant"),
+      waitTool: expectDefined(codeModeTools[1], "Code Mode wait test invariant"),
+      code: `return { file: await API.read("mcp/fixture.d.ts"), api: await MCP.fixture.$api(), results: await Promise.all([${calls.join(",")}]) };`,
+    });
+    expect(details.status).toBe("completed");
+    const value = details.value as {
+      file: { content: string; bytes: number };
+      api: { header: string };
+      results: CallToolResult[];
+    };
+    expect(
+      value.results.map((result) => JSON.parse((result.content[0] as { text: string }).text)),
+    ).toEqual(fixtures.map(({ input, expected }) => expected ?? input));
+    expect(targets.every((target) => vi.mocked(target.execute).mock.calls.length === 1)).toBe(true);
+    expect(value.file.content).toBe(value.api.header);
+    expect(value.file.bytes).toBe(Buffer.byteLength(value.file.content));
+    // Compile real accepted calls against the advertised header, not a parallel expected renderer.
+    const fileName = "/mcp-declaration-consumer.ts";
+    const source = ts.createSourceFile(
+      fileName,
+      `${value.file.content}\n${calls.join(";\n")};
+// @ts-expect-error Dictionary values are strings.
+MCP.fixture.dictionary({ topic: 42 });
+// @ts-expect-error Closed objects have no extra properties.
+MCP.fixture.closed({ topic: "synthetic" });
+// @ts-expect-error Nullable enums still reject other literals.
+MCP.fixture.nullable({ value: "discard" });
+// @ts-expect-error Required fields remain required.
+MCP.fixture.nullable({});
+const nullableFields = { scalar: null, union: null, dictionary: null, restricted: "keep", constrained: "keep", mixed: "keep", oversized: "choice0" } as const;
+// @ts-expect-error Ajv nullable does not widen an enum that excludes null.
+MCP.fixture.nullableKeyword({ ...nullableFields, restricted: null });
+// @ts-expect-error A non-null type constrains even an enum containing null.
+MCP.fixture.nullableKeyword({ ...nullableFields, constrained: null });
+// @ts-expect-error A mixed enum still excludes null.
+MCP.fixture.nullableKeyword({ ...nullableFields, mixed: null });
+// @ts-expect-error A type-incompatible object enum member cannot widen valid strings.
+MCP.fixture.nullableKeyword({ ...nullableFields, mixed: "discard" });
+// @ts-expect-error Integer enum candidates must be integers.
+MCP.fixture.nullableKeyword({ ...nullableFields, integer: 1.5 });
+// @ts-expect-error An enum with no type-compatible values is never.
+MCP.fixture.nullableKeyword({ ...nullableFields, impossible: "discard" });
+// @ts-expect-error Defaults are only injected at the top level.
+MCP.fixture.nullableKeyword({ ...nullableFields, options: {} });
+// @ts-expect-error Non-defaulted required fields still require an argument.
+MCP.fixture.nullable();
+// @ts-expect-error An enum beyond the literal-rendering cap still excludes null.
+MCP.fixture.nullableKeyword({ ...nullableFields, oversized: null });
+// @ts-expect-error Nested dictionary values retain their enum type.
+MCP.fixture.nested({ values: [{ topic: 42 }] });`,
+      ts.ScriptTarget.ESNext,
+      true,
+    );
+    const options = { noEmit: true, strict: true, types: [], target: ts.ScriptTarget.ESNext };
+    const host = ts.createCompilerHost(options);
+    const getSourceFile = host.getSourceFile.bind(host);
+    host.getSourceFile = (name, ...args) =>
+      name === fileName ? source : getSourceFile(name, ...args);
+    const program = ts.createProgram([fileName], options, host);
+    expect(
+      ts
+        .getPreEmitDiagnostics(program)
+        .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n")),
+    ).toEqual([]);
+  });
+});

--- a/src/agents/code-mode.mcp-declarations.test.ts
+++ b/src/agents/code-mode.mcp-declarations.test.ts
@@ -1,4 +1,5 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { JsonSchemaType } from "@modelcontextprotocol/sdk/validation";
 import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv";
 import { expectDefined } from "@openclaw/normalization-core";
 import ts from "typescript";
@@ -31,7 +32,14 @@ describe("Code Mode MCP declarations", () => {
       },
       required: ["limit", "enabled", "value"],
     };
-    const fixtures = [
+    const fixtures: {
+      name: string;
+      schema: JsonSchemaType & {
+        properties?: Record<string, JsonSchemaType & { nullable?: boolean }>;
+      };
+      input?: Record<string, unknown>;
+      expected?: Record<string, unknown>;
+    }[] = [
       {
         name: "defaulted",
         schema: defaultedSchema,

--- a/src/agents/code-mode.mcp.test.ts
+++ b/src/agents/code-mode.mcp.test.ts
@@ -150,6 +150,7 @@ describe("Code Mode MCP namespace", () => {
     expect(value.apiHeader).toContain("@param title Issue title Shown in tracker");
     expect(value.apiHeader).not.toContain("@param title Issue title\n");
     expect(value.apiHeader).toContain("title: string;");
+    expect(value.apiHeader).toContain('@param body? Default: "".');
     expect(value.apiHeader).toContain('labels?: Array<"red" | "blue">;');
     expect(value.serverFileContent).toContain('labels?: Array<"red" | "blue">;');
     expect(githubCreate.execute).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users inspecting MCP tools through `API.read()` or a server's `$api()` would receive declarations that reject valid dictionary entries, nullable or mixed enum values, and arguments supplied by top-level defaults.

## Why This Change Was Made

Use one object renderer and one declared-type/enum decision for top-level and nested inputs, preserving compatible literals without dropping accepted compound values. Derive caller-requiredness separately at the tool signature boundary because the namespace supplies defaults only for top-level fields.

## User Impact

Agents and TypeScript consumers can use the valid inputs advertised by MCP schemas, including dictionary keys, nullable values, and omitted defaulted fields. Closed objects, compatible literal restrictions, non-defaulted required fields, and nested required fields remain represented in the generated API.

Declarations remain a bounded approximation of JSON Schema: general validation and existing `anyOf`/`oneOf` cross-constraint inference are outside this change. Original schemas and runtime validation are unchanged.

## Evidence

Before the repair, real namespace calls and SDK Ajv validation accepted inputs that the generated TypeScript header rejected, including dictionary keys narrowed to `never` and `null` removed from an enum. The regression compiles the actual `API.read()` header, verifies it matches `$api()`, and checks invocation results rather than a parallel expected renderer.

- **28 tests passed across three files:** real QuickJS guest execution, 12 accepted MCP/Ajv fixture tools, and 14 invalid TypeScript consumer controls. Coverage includes dictionary openness, nullable/type/enum intersections, integer candidates, empty enum intersections, mixed primitive/object values, falsey defaults, and preserved nested requiredness.
- **Six existing output-budget tests passed**, covering completed values, yielded output, and namespace draining.
- **Independent review is scoped-clean**, with no actionable P0/P1/P2 findings. Targeted formatting and whitespace checks pass.

Focused entry point, run with the pinned Node runtime and one worker:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/code-mode.mcp-declarations.test.ts \
  src/agents/code-mode.mcp.test.ts \
  src/agents/code-mode-namespaces.test.ts
```

Proof was run against baseline `b6a2e5b4eff71070a02e755d55aea0dd53904a20` plus this patch. Source drift was checked against available main `7969f4992a8ab53f8fdd003c5ab3dc5cd1163d74`; the five-file patch applies without conflicts, preserving main’s separate listing-tools documentation addition, and MCP schema/default mapping remains unchanged. The original 28-test run used QuickJS 3.5.0 and remains historical. The private QuickJS 3.6.0/Vitest 5 integration proof below now passes; full exact-head hosted CI remains pending on the corrected head.

Production is **+27 lines** after deleting duplicate object and description rendering paths; the remaining growth preserves the existing schema and invocation contracts. Tests are **+250 lines** and documentation **+7 lines**. No transport, configuration, dependency, persistence, or protocol change is included.


### CI correction and current QuickJS proof

Exact-head CI on `c439749dc46dc8c137e5b738035cc71cfe876c64` found a fixture-type inference error in `check-test-types-core-1`: the heterogeneous schema array inferred undefined entries for an empty `patternProperties` record. The correction types fixtures against the SDK schema contract with the supported Ajv nullable property extension. Production code, fixture data, and assertions are unchanged.

Correction commit: [9c5e3d632a95eb36d3dbcb00f1f8e68d7506f728](https://github.com/openclaw/openclaw/commit/9c5e3d632a95eb36d3dbcb00f1f8e68d7506f728).

- Canonical owning type graph passed: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.agents-root.json --builders 1`.
- Full-file lint and formatting passed; the correction's independent review is scoped-clean.
- The affected guest test passed privately with **QuickJS 3.6.0, Vitest 5.0.0, MCP SDK 1.30.0, and TypeScript 6.0.3**. It executes the real `API.read()`/`$api()` and namespace/default paths for all **12 accepted Ajv fixtures**, then compiles the header with **14 invalid-input TypeScript controls**. This was a synthetic, isolated guest/runtime proof, not an external-provider test.

The earlier hosted type failure is preserved as provenance. It is not described as green; required CI must complete on the correction head before landing.
