### PR TITLE
ci: record CPU time for Node test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3454,7 +3454,7 @@ jobs:
             runner=".ci-workflow/${runner}"
             [[ -f "$runner" ]]
           fi
-          node --import tsx "$runner"
+          time -p node --import tsx "$runner"
 
       - &runner_memory_peak_step
         name: Record runner memory peak

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -127,6 +127,8 @@ Use `pnpm ci:timings`, `pnpm ci:timings:recent`, or `node scripts/ci-run-timings
 
 Run the timing helper locally; there is no in-workflow timing-summary job (a permanently disabled one was removed once the local helper became the tool everyone actually used). For build timing, check the `build-artifacts` job's `Build dist` step: `pnpm build:ci-artifacts` prints `[build-all] phase timings:` and includes `ui:build`; the job also uploads the `startup-memory` artifact.
 
+The `Run Node test shard` step prints Bash `time -p` totals: elapsed (`real`), user CPU (`user`), and system CPU (`sys`) seconds, including waited-for child processes. Compare CPU totals with elapsed time across equivalent runs to distinguish extra CPU work from slower execution with similar CPU work. These totals alone do not establish runner contention.
+
 Node test shards that need a built CLI run `pnpm build qaRuntime` before starting
 Vitest. This profile builds runtime JavaScript, plugin assets, and freshness and
 provenance metadata. Private QA shards select their private runtime entries. The


### PR DESCRIPTION
## What Problem This Solves

Node test job logs show elapsed time and CPU counts but do not show how much CPU work the command actually consumed. In main run 34025969728, one job's test step rose from 252 to 562 seconds across all six invocations while another job with identical cache keys stayed near its prior time. The available evidence does not establish why.

## Why This Change Was Made

Wrap the existing Node shard command with Bash `time -p`. It reports elapsed, user CPU and system CPU seconds, including waited-for child processes. This adds evidence for future comparisons without changing the Node arguments, environment, worker policy, shards, caches or timeouts.

The documentation explains how to interpret the totals and avoids treating them as proof of runner contention. This is instrumentation, not a claimed speedup or a new resource policy.

## Evidence

- Existing workflow guards: 457 passed, two existing skips.
- Formatting, complete selected changed checks, pinned actionlint/zizmor, CI Git-owner and composite-action guards passed.
- The generic workflow-check wrapper could not bootstrap pre-commit 4.6.2 from the configured index; its repository-pinned linters and remaining checks were run directly without changing configuration or ignores.
- Actual Bash script-file entry probes preserve success, explicit failure and SIGTERM exit statuses (0/23/143), preserve Node arguments, and include a waited CPU-bound child's work.
- GNU Bash source confirms before/after self and waited-child CPU accounting and preservation of the command result.
- Independent P2 review found no actionable issues. Workflow +1/-1, documentation +2/-0, product and test code unchanged.

Exact-head [CI 34028696318](https://github.com/openclaw/openclaw/actions/runs/34028696318) passed: 96 successful jobs and nine conditional skips. All non-Windows execution completed by 7m12s; Windows extended aggregate completion to 14m41s. The wider workflow-change validation used 48 compact rows; this patch changes no shard plan.

Actual runner logs verify timing output for one-child and two-child commands. The two-child compact tail reported 281.08 seconds elapsed, 735.87 seconds user CPU and 108.84 seconds system CPU. These are measurements, not evidence by themselves of runner contention.
