### PR TITLE
refactor(cli): align resume with session resolution

### DIFF
--- a/src/cli/resume-cli.runtime.ts
+++ b/src/cli/resume-cli.runtime.ts
@@ -1,7 +1,7 @@
 // Resolves recent Gateway sessions and attaches the existing TUI to the selected key.
 import { cancel, isCancel } from "@clack/prompts";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { ErrorShape } from "../../packages/gateway-protocol/src/frame-guards.js";
+import { lazyCompile } from "../../packages/gateway-protocol/src/protocol-validator.js";
+import { SessionsResolveResultSchema } from "../../packages/gateway-protocol/src/schema/sessions-resolve.js";
 import { selectStyled } from "../../packages/terminal-core/src/prompt-select-styled.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
@@ -20,100 +20,10 @@ import { isTerminalInteractive } from "./terminal-interactivity.js";
 
 const RESUME_INTERACTIVE_TERMINAL_GUIDANCE =
   "Attaching to a session requires an interactive terminal. Re-run `openclaw resume [query]` from an interactive terminal.";
-const RESUME_HANDOFF_MISSING =
-  "This session is no longer available. Copy a fresh command from the Control UI.";
 const RESUME_HANDOFF_UNRESOLVED =
   "Could not resolve the session handoff. Copy a fresh command from the Control UI.";
 
-type ParsedHandoffSessionResolveResult =
-  | { kind: "success"; key: string; agentId: string }
-  | { kind: "missing" }
-  | {
-      kind: "ambiguous";
-      candidates: Array<{ key: string; agentId: string; displayName?: string }>;
-    }
-  | { kind: "error"; error: ErrorShape }
-  | { kind: "malformed" };
-
-function hasExactKeys(
-  value: unknown,
-  requiredKeys: readonly string[],
-  optionalKeys: readonly string[] = [],
-): value is Record<string, unknown> {
-  if (!isRecord(value)) {
-    return false;
-  }
-  const keys = Object.keys(value);
-  return (
-    requiredKeys.every((key) => Object.hasOwn(value, key)) &&
-    keys.every((key) => requiredKeys.includes(key) || optionalKeys.includes(key))
-  );
-}
-
-function isHandoffSessionCandidate(
-  value: unknown,
-): value is { key: string; agentId: string; displayName?: string } {
-  return (
-    hasExactKeys(value, ["key", "agentId"], ["displayName"]) &&
-    typeof value.key === "string" &&
-    value.key.length > 0 &&
-    typeof value.agentId === "string" &&
-    value.agentId.length > 0 &&
-    (!Object.hasOwn(value, "displayName") || typeof value.displayName === "string")
-  );
-}
-
-function isHandoffErrorShape(value: unknown): value is ErrorShape {
-  if (
-    !hasExactKeys(value, ["code", "message"], ["details", "retryable", "retryAfterMs"]) ||
-    typeof value.code !== "string" ||
-    value.code.length === 0 ||
-    typeof value.message !== "string" ||
-    value.message.length === 0 ||
-    (Object.hasOwn(value, "retryable") && typeof value.retryable !== "boolean")
-  ) {
-    return false;
-  }
-  return (
-    !Object.hasOwn(value, "retryAfterMs") ||
-    (typeof value.retryAfterMs === "number" &&
-      Number.isInteger(value.retryAfterMs) &&
-      value.retryAfterMs >= 0)
-  );
-}
-
-function parseHandoffSessionResolveResult(value: unknown): ParsedHandoffSessionResolveResult {
-  if (
-    hasExactKeys(value, ["ok", "key", "agentId"]) &&
-    value.ok === true &&
-    typeof value.key === "string" &&
-    value.key.length > 0 &&
-    typeof value.agentId === "string" &&
-    value.agentId.length > 0
-  ) {
-    return { kind: "success", key: value.key, agentId: value.agentId };
-  }
-  if (hasExactKeys(value, ["ok", "missing"]) && value.ok === true && value.missing === true) {
-    return { kind: "missing" };
-  }
-  if (
-    hasExactKeys(value, ["ok", "ambiguous", "candidates"]) &&
-    value.ok === true &&
-    value.ambiguous === true &&
-    Array.isArray(value.candidates) &&
-    value.candidates.every(isHandoffSessionCandidate)
-  ) {
-    return { kind: "ambiguous", candidates: value.candidates };
-  }
-  if (
-    hasExactKeys(value, ["ok", "error"]) &&
-    value.ok === false &&
-    isHandoffErrorShape(value.error)
-  ) {
-    return { kind: "error", error: value.error };
-  }
-  return { kind: "malformed" };
-}
+const validateHandoffSessionResolveResult = lazyCompile(SessionsResolveResultSchema);
 
 function requireInteractiveResumeTerminal() {
   if (!isTerminalInteractive()) {
@@ -190,18 +100,14 @@ async function resolveHandoffConnection(
     } catch {
       throw new Error(RESUME_HANDOFF_UNRESOLVED);
     }
-    const parsed = parseHandoffSessionResolveResult(result);
-    if (parsed.kind === "success") {
-      const canonicalKeyOwner = parseAgentSessionKey(parsed.key)?.agentId;
-      if (parsed.agentId !== handoff.agentId || canonicalKeyOwner !== parsed.agentId) {
-        throw new Error(RESUME_HANDOFF_UNRESOLVED);
-      }
-      return { connection: client.connection, sessionKey: parsed.key };
+    if (!validateHandoffSessionResolveResult(result) || !result.ok) {
+      throw new Error(RESUME_HANDOFF_UNRESOLVED);
     }
-    if (parsed.kind === "missing") {
-      throw new Error(RESUME_HANDOFF_MISSING);
+    const canonicalKeyOwner = parseAgentSessionKey(result.key)?.agentId;
+    if (result.agentId !== handoff.agentId || canonicalKeyOwner !== result.agentId) {
+      throw new Error(RESUME_HANDOFF_UNRESOLVED);
     }
-    throw new Error(RESUME_HANDOFF_UNRESOLVED);
+    return { connection: client.connection, sessionKey: result.key };
   } finally {
     await client.stop();
   }

--- a/src/cli/resume-cli.test.ts
+++ b/src/cli/resume-cli.test.ts
@@ -181,7 +181,15 @@ describe("runResumeCommand", () => {
     expect(mocks.runTui).not.toHaveBeenCalled();
   });
 
-  it("passes an exact handoff target and explicit auth directly into the bound TUI", async () => {
+  it.each([
+    { name: "bare success", presentation: {} },
+    { name: "display name", presentation: { displayName: "Handoff session" } },
+    { name: "chat face", presentation: { boardFace: "chat" } },
+    {
+      name: "named dashboard face",
+      presentation: { displayName: "Handoff session", boardFace: "dashboard" },
+    },
+  ])("binds an exact handoff and explicit auth with canonical $name", async ({ presentation }) => {
     const sessionKey = "agent:main: hostile-'\"$&;|<>^()%![]{}\\`-%PATH% ";
     const url = "wss://gateway.example/openclaw/$&;=()+,![]{}'`/%25PATH%25";
     const handoff = encodeResumeHandoff({ sessionKey, gatewayUrl: url });
@@ -191,7 +199,12 @@ describe("runResumeCommand", () => {
       password: "explicit-password",
       tlsFingerprint: "sha256:explicit-pin",
     });
-    client.resolveSession.mockResolvedValue({ ok: true, key: sessionKey, agentId: "main" });
+    client.resolveSession.mockResolvedValue({
+      ok: true,
+      key: sessionKey,
+      agentId: "main",
+      ...presentation,
+    });
 
     await runResumeCommand(undefined, {
       handoff,
@@ -228,7 +241,11 @@ describe("runResumeCommand", () => {
   });
 
   it.each([
-    ["missing", { ok: true, missing: true }, "This session is no longer available."],
+    [
+      "internal missing shape",
+      { ok: true, missing: true },
+      "Could not resolve the session handoff.",
+    ],
     [
       "ambiguous",
       {
@@ -246,7 +263,10 @@ describe("runResumeCommand", () => {
     ["projected missing", { ok: false }, "Could not resolve the session handoff."],
     [
       "projected ambiguity",
-      { ok: false, candidates: [{ key: "agent:main:one" }] },
+      {
+        ok: false,
+        candidates: [{ key: "agent:main:one", agentId: "main", boardFace: "dashboard" }],
+      },
       "Could not resolve the session handoff.",
     ],
     ["malformed success", { ok: true }, "Could not resolve the session handoff."],
@@ -258,6 +278,16 @@ describe("runResumeCommand", () => {
     [
       "extra success field",
       { ok: true, key: "agent:main:alpha", agentId: "main", extra: true },
+      "Could not resolve the session handoff.",
+    ],
+    [
+      "invalid success display name",
+      { ok: true, key: "agent:main:alpha", agentId: "main", displayName: 42 },
+      "Could not resolve the session handoff.",
+    ],
+    [
+      "invalid success board face",
+      { ok: true, key: "agent:main:alpha", agentId: "main", boardFace: "grid" },
       "Could not resolve the session handoff.",
     ],
     [
@@ -282,6 +312,11 @@ describe("runResumeCommand", () => {
     [
       "mismatched returned agent",
       { ok: true, key: "agent:main:alpha", agentId: "work" },
+      "Could not resolve the session handoff.",
+    ],
+    [
+      "different but internally consistent returned owner",
+      { ok: true, key: "agent:work:alpha", agentId: "work" },
       "Could not resolve the session handoff.",
     ],
     [
@@ -323,6 +358,7 @@ describe("runResumeCommand", () => {
       await expect(runResumeCommand(undefined, { handoff })).rejects.toThrow(message);
       expect(client.listSessions).not.toHaveBeenCalled();
       expect(mocks.runTui).not.toHaveBeenCalled();
+      expect(client.stop).toHaveBeenCalledOnce();
     },
   );
 
@@ -451,24 +487,79 @@ describe("real Gateway session boundary", () => {
     );
   });
 
-  it("canonicalizes a case-variant handoff through the real sessions.resolve boundary", async () => {
+  it("preserves real handoff wire outcomes and closes each client before returning", async () => {
     const { GatewayChatClient } =
       await vi.importActual<typeof import("../tui/gateway-chat.js")>("../tui/gateway-chat.js");
-    mocks.connect.mockImplementation((options) => GatewayChatClient.connect(options));
-    const rawSessionKey = "Agent:Main:ALPHA";
-    const handoff = encodeResumeHandoff({ sessionKey: rawSessionKey, gatewayUrl: harness.url });
-
-    await runResumeCommand(undefined, { handoff, token: harness.token });
-
-    expect(harness.sessionResolveRequests).toContainEqual({
-      key: rawSessionKey,
-      agentId: "main",
-      includeGlobal: true,
-      allowMissing: true,
+    const responses: unknown[] = [];
+    const errors: unknown[] = [];
+    const lifecycle: string[] = [];
+    const resolveStart = harness.sessionResolveRequests.length;
+    const listStart = harness.sessionListRequests.length;
+    mocks.connect.mockImplementation(async (options) => {
+      const client = await GatewayChatClient.connect(options);
+      const resolveSession = client.resolveSession.bind(client);
+      const stop = client.stop.bind(client);
+      vi.spyOn(client, "resolveSession").mockImplementation(async (params) => {
+        try {
+          const response = await resolveSession(params);
+          responses.push(response);
+          return response;
+        } catch (error) {
+          errors.push(error);
+          throw error;
+        }
+      });
+      vi.spyOn(client, "stop").mockImplementation(async () => {
+        await stop();
+        lifecycle.push("stopped");
+      });
+      return client;
     });
-    expect(mocks.runTui).toHaveBeenCalledWith(
+    mocks.runTui.mockImplementation(async () => {
+      lifecycle.push("tui");
+    });
+    const cases = [
+      { key: "Agent:Main:ALPHA", agentId: "main", found: true },
+      { key: "agent:main:resume-missing", agentId: "main", found: false },
+      {
+        key: "agent:resume-unconfigured:missing",
+        agentId: "resume-unconfigured",
+        found: false,
+      },
+    ];
+    for (const [index, scenario] of cases.entries()) {
+      const handoff = encodeResumeHandoff({ sessionKey: scenario.key, gatewayUrl: harness.url });
+      const result = runResumeCommand(undefined, { handoff, token: harness.token });
+      if (scenario.found) {
+        await result;
+      } else {
+        await expect(result).rejects.toThrow(
+          new Error(
+            "Could not resolve the session handoff. Copy a fresh command from the Control UI.",
+          ),
+        );
+      }
+      expect(lifecycle.filter((event) => event === "stopped")).toHaveLength(index + 1);
+    }
+
+    expect(responses).toEqual([
+      { ok: true, key: "agent:main:alpha", agentId: "main" },
+      { ok: false },
+    ]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      gatewayCode: "INVALID_REQUEST",
+      message: 'Unknown agent id "resume-unconfigured"',
+    });
+    expect(harness.sessionResolveRequests.slice(resolveStart)).toEqual(
+      cases.map(({ key, agentId }) => ({ key, agentId, includeGlobal: true, allowMissing: true })),
+    );
+    expect(harness.sessionListRequests).toHaveLength(listStart);
+    expect(mocks.connect).toHaveBeenCalledTimes(3);
+    expect(mocks.runTui).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({ session: "agent:main:alpha", forceProcessExitOnReturn: true }),
     );
+    expect(lifecycle).toEqual(["stopped", "tui", "stopped", "stopped"]);
   });
 
   it("accepts a bootstrap-signed identity and rejects a mismatched signature", async () => {

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -11,7 +11,6 @@ import {
   ConnectErrorDetailCodes,
   readConnectErrorDetailCode,
 } from "../../packages/gateway-protocol/src/connect-error-details.js";
-import type { ErrorShape } from "../../packages/gateway-protocol/src/frame-guards.js";
 import {
   type HelloOk,
   GATEWAY_SERVER_CAPS,
@@ -23,6 +22,7 @@ import {
   type EnvironmentsListResult,
   type SessionsListParams,
   type SessionsResolveParams,
+  type SessionsResolveResult,
   type SessionsPatchResult,
   type SessionsPatchParams,
   type TaskSuggestionsAcceptResult,
@@ -165,15 +165,6 @@ type GatewayModelChoice = TuiModelChoice;
 type HandoffSessionResolveParams = Required<
   Pick<SessionsResolveParams, "key" | "agentId" | "includeGlobal" | "allowMissing">
 >;
-type HandoffSessionResolveResult =
-  | { ok: true; key: string; agentId: string }
-  | { ok: true; missing: true }
-  | {
-      ok: true;
-      ambiguous: true;
-      candidates: Array<{ key: string; agentId: string; displayName?: string }>;
-    }
-  | { ok: false; error: ErrorShape };
 
 export class GatewayChatClient implements TuiBackend {
   private client: GatewayClient;
@@ -396,8 +387,8 @@ export class GatewayChatClient implements TuiBackend {
     return await this.client.request<GatewaySessionList>("sessions.list", opts ?? {});
   }
 
-  async resolveSession(opts: HandoffSessionResolveParams): Promise<HandoffSessionResolveResult> {
-    return await this.client.request<HandoffSessionResolveResult>("sessions.resolve", opts);
+  async resolveSession(opts: HandoffSessionResolveParams): Promise<SessionsResolveResult> {
+    return await this.client.request<SessionsResolveResult>("sessions.resolve", opts);
   }
 
   async listAgents() {


### PR DESCRIPTION
Related: #122870

## What Problem This Solves

The terminal-continuation client rejects otherwise valid `sessions.resolve` successes when they include the public schema's optional `displayName` or `boardFace`. Its private decoder also describes internal server outcomes that are not the public wire response.

The current exact-key server emits bare success, so this is a consumer-contract mismatch, not a claim that the existing default handoff is broken.

## Why This Change Was Made

Use the existing canonical result schema and public result type instead of maintaining a second decoder/type. Keep both independent agent-owner checks and await client shutdown before returning or launching the bound TUI. Missing and RPC-error handoffs retain the existing fresh-command guidance.

Production: **+12/−115 (net −103)**. Tests: **+108/−17 (net +91)**. No public schema, configuration, storage, dependency or protocol-version change.

## User Impact

Resume accepts supported presentation metadata without rejecting a valid handoff. Exact-target authentication, canonical session ownership, query/picker behavior and stale-session handling remain unchanged.

## Evidence

- Original acceptance regression: bare success passed; the three schema-supported presentation cases failed at the old decoder. The restored candidate passed all **47 focused tests** (43 CLI, 4 schema).
- Three independent controls removed handoff ownership, key ownership and schema validation in turn; exactly **1, 2 and 3** intended rejection assertions failed. Each was restored before the next run.
- The normal configured **29-check changed gate passed** on the verified source tree, including core/test typechecking, formatting and lint. The delegated receiver completed and stopped; its portal-sync timeout warning was retained. [Run context](https://github.com/openclaw/openclaw/actions/runs/34026354520).
- Original and candidate **full 16-phase builds** passed. Both real Chrome → rendered handoff → parsed built CLI → TUI flows showed the intended session, `/status`, and natural exit 0. After exact seed deletion, the same handoff exited 1 with fresh-command guidance and no TUI. Owned Gateways shut down cleanly.
- Precommit and signed-commit P2 reviews were scoped-clean, each across both native evidence batches. Public exact-head CI and repository-native landing gates remain required.

The final test-only formatting change expands one table row without changing tokens or assertions. The 47-test/build/operator evidence retains its exact pre-format attribution; production and emitted bytes are unchanged. Existing build stamps identify the base plus dirty candidate, not a newly run build of the signed commit. TTY input-mode qualifications and finite PID-sampling limits are retained. No native Codex integration or provider/model turn was exercised by the operator proof.
