### PR TITLE
perf(msteams): skip unused formatting work

### DIFF
--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -92,6 +92,11 @@ describe("formatMSTeamsMarkdown", () => {
       after: "> Run `status` now.",
     },
     {
+      name: "keeps merged nested quotes aligned with Unicode styles and inline code",
+      before: "> > **😀** `one`\n> > `two` **tail**",
+      after: "> **😀** `one`\n> `two` **tail**",
+    },
+    {
       name: "keeps escaped markdown literal",
       before: String.raw`\*literal\*`,
       after: String.raw`\*literal\*`,

--- a/extensions/msteams/src/format.ts
+++ b/extensions/msteams/src/format.ts
@@ -47,6 +47,10 @@ function createTokenPrefix(text: string, label: string): string {
 }
 
 function restoreTokens(text: string, prefix: string, values: readonly string[]): string {
+  // Empty value tables can still have matching markers after normalization.
+  if (!text.includes(prefix)) {
+    return text;
+  }
   const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
   return text.replace(
     new RegExp(`${escapedPrefix}(\\d+)${TOKEN_END}`, "gu"),
@@ -57,22 +61,20 @@ function restoreTokens(text: string, prefix: string, values: readonly string[]):
 type TextEdit = { start: number; end: number; text: string };
 
 function rewriteMarkdownIR(ir: MarkdownIR, edits: readonly TextEdit[]): MarkdownIR {
-  const ordered = [...edits].toSorted((a, b) => a.start - b.start);
+  const ordered = edits.toSorted((a, b) => a.start - b.start);
+  const cumulativeDeltas: number[] = [];
+  const exactEdits = new Map<string, TextEdit>();
   let text = "";
   let cursor = 0;
+  let delta = 0;
   for (const edit of ordered) {
     text += ir.text.slice(cursor, edit.start) + edit.text;
     cursor = edit.end;
-  }
-  text += ir.text.slice(cursor);
-
-  const cumulativeDeltas: number[] = [];
-  let delta = 0;
-  for (const edit of ordered) {
     delta += edit.text.length - (edit.end - edit.start);
     cumulativeDeltas.push(delta);
+    exactEdits.set(`${edit.start}:${edit.end}`, edit);
   }
-  const exactEdits = new Map(ordered.map((edit) => [`${edit.start}:${edit.end}`, edit]));
+  text += ir.text.slice(cursor);
   const mapOffset = (offset: number): number => {
     let low = 0;
     let high = ordered.length;
@@ -486,6 +488,9 @@ function protectMSTeamsCode(
 }
 
 export function formatMSTeamsMarkdown(markdown: string, tableMode: MarkdownTableMode): string {
+  if (markdown === "") {
+    return markdown;
+  }
   const rawTables: string[] = [];
   const escapedMarkdown: string[] = [];
   const codeRegions: string[] = [];


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Teams prepares outbound Markdown even when the message is empty, and repeatedly prepares token-restoration expressions for token categories absent from the current text. Code-heavy messages repeat this unnecessary work for each protected code span as well as during final restoration.

## Why This Change Was Made

Return early for strictly empty Markdown, and skip a restoration pass only when its literal prefix is absent. Keep matching-token behavior, missing-value fallback and restoration order unchanged. The same formatter cleanup also prepares text, cumulative offsets and exact-edit lookup in one sorted pass without changing the delta formula or range semantics.

The combined change adds five production lines. The small guards avoid unnecessary UUID/parser/array and regular-expression preparation; loop fusion removes intermediate work. An empty value table alone is deliberately not used as a no-match condition.

## User Impact

Teams formatting and reply preparation perform less work while preserving the same message bytes. Inline code, quotes, tables, mentions, images, escapes and native Markdown remain on their existing rendering paths. No configuration, authentication, storage, transport or appearance contract changes.

## Evidence

At base `ce7eb85ae413282d0d46b2b661d11788d5fde671`, one fixed baseline/candidate verification pair followed by B0/C0/C1/B1 covered **44 unchanged workload rows**. All **24,200 outcomes** matched complete baseline output, including 22,528 timed calls. Eight batches of 16 calls were measured per row and phase; validation and raw-output persistence occurred outside timing.

Representative **nonempty** median timings:

| Case | Forward µs/call | Reverse µs/call |
| --- | --- | --- |
| Plain formatter | 52.124 → 13.470 (74.16% lower) | 48.932 → 18.592 (62.00% lower) |
| Formatter, 128 inline-code spans | 494.763 → 148.858 (69.91% lower) | 487.717 → 149.576 (69.33% lower) |
| Reply preparation, 128 inline-code spans | 494.098 → 146.641 (70.32% lower) | 487.867 → 144.365 (70.41% lower) |

Empty formatter and empty reply-preparation rows improved by more than 99% and are kept separate from these nonempty results. All **88 median comparisons improved**. Three of 352 metric comparisons regressed, all maximum observed batch means: nested-quote reply preparation forward **+33.961 µs (+16.26%)**, and fenced-only formatting forward **+2.406 µs (+3.01%)** / reverse **+22.047 µs (+26.74%)**. All samples and adverse results are retained. These are component measurements, not individual-call population tails, traffic-weighted totals, or network/delivery latency. Reply measurements use the actual reply formatter with explicit table mode and chunking disabled.

The earlier **fusion-only** cohort remains archived: it had 53/88 adverse medians and did not establish an overall formatter gain. It is not relabeled as proof of the combined candidate. An initially incorrect nested-quote golden failed once on both baseline and candidate, which returned identical one-prefix output. Only that expected value was corrected; production quote behavior was not changed. The five-line test addition now preserves that observed behavior.

Fresh combined-source validation passed **103/103 focused tests** (formatter 57, messenger 46), **25 normal checks** including six doctor-contract tests, and an isolated **Codex P2 review with no findings**. Every measurement phase closed cleanly, all source pins held, and the candidate was restored. No full build is claimed. No live Teams send was attempted because no Teams test recipient was authorized. Transport code is unchanged; the actual formatter/reply exports and messenger boundary tests verify the outgoing bytes. A separate independent audit reconciled all 24,200 saved outcomes, all 352 metrics, pins and closure records. Commit `0cbf5d662bfd3bfddaf52748d53020c3b3b5d338` contains the same tested source/test bytes; execution remains attributed to the original ce7eb85 candidate. No newer-main execution or CI result is implied by these local results.
