### PR TITLE
fix(android): restore selected Talk agent on same-gateway reconnect

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1395,6 +1395,12 @@ class NodeRuntime private constructor(
   // Preserve an explicit user choice across metadata refreshes. Gateway reconnects
   // clear it so the newly connected gateway's canonical main agent wins again.
   @Volatile private var selectedChatAgentId: String? = null
+
+  // Snapshot of (gateway stableId, agentId) captured before a gateway scope change clears
+  // selectedChatAgentId, so a reconnect to the SAME gateway can restore the Talk binding
+  // instead of silently reverting to the default agent. A different-gateway connect still
+  // lets the new gateway's canonical main agent win.
+  @Volatile private var pendingSelectedChatAgentRestore: Pair<String, String>? = null
   private val chatSelectionSeq = AtomicLong(0)
   private val _cronStatus = MutableStateFlow(GatewayCronStatus(enabled = false, jobs = 0, nextWakeAtMs = null))
   val cronStatus: StateFlow<GatewayCronStatus> = _cronStatus.asStateFlow()
@@ -1886,6 +1892,13 @@ class NodeRuntime private constructor(
     }
     skillsSummary.reset()
     synchronized(gatewayDataScopeLock) {
+      // Preserve the user's explicit agent choice for same-gateway reconnects. The
+      // reconnect resync (refreshAgentsFromGateway) restores it when the gateway
+      // stableId matches; a different gateway still wins its canonical default.
+      pendingSelectedChatAgentRestore =
+        selectedChatAgentId?.let { agentId ->
+          connectedEndpoint?.stableId?.let { stableId -> stableId to agentId }
+        }
       selectedChatAgentId = null
       chatSelectionSeq.incrementAndGet()
       sessionCatalogRefreshSeq.incrementAndGet()
@@ -5359,6 +5372,8 @@ class NodeRuntime private constructor(
       // Agent selection owns every main-session consumer; switching chat alone would
       // leave Talk mode bound to the previous agent.
       selectedChatAgentId = normalizedAgentId
+      // An explicit selection supersedes any pending restore snapshot.
+      pendingSelectedChatAgentRestore = null
       selectMainSessionKey(normalizedAgentId)
       selectedMainSessionKey = mainSessionKey.value
     }
@@ -6554,7 +6569,13 @@ class NodeRuntime private constructor(
       publishGatewayData(gatewayScope) {
         updateGatewayDefaultAgentId(defaultAgentId)
         _gatewayAgents.value = agents
-        val selectedAgentId = selectedChatAgentId?.takeIf { id -> agents.any { it.id == id } }
+        // Restore the user's explicit agent choice when reconnecting to the same gateway.
+        val restoredAgentId =
+          pendingSelectedChatAgentRestore?.let { (stableId, agentId) ->
+            if (stableId == connectedEndpoint?.stableId) agentId else null
+          }
+        if (restoredAgentId != null) pendingSelectedChatAgentRestore = null
+        val selectedAgentId = (restoredAgentId ?: selectedChatAgentId)?.takeIf { id -> agents.any { it.id == id } }
         selectedChatAgentId = selectedAgentId
         syncMainSessionKey(selectedAgentId ?: resolveAgentIdFromMainSessionKey(mainKey) ?: gatewayDefaultAgentId.value)
       }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1895,10 +1895,16 @@ class NodeRuntime private constructor(
       // Preserve the user's explicit agent choice for same-gateway reconnects. The
       // reconnect resync (refreshAgentsFromGateway) restores it when the gateway
       // stableId matches; a different gateway still wins its canonical default.
-      pendingSelectedChatAgentRestore =
-        selectedChatAgentId?.let { agentId ->
-          connectedEndpoint?.stableId?.let { stableId -> stableId to agentId }
-        }
+      //
+      // Only capture a new snapshot when the user still has an active selection.
+      // Repeated disconnect callbacks (finishTransport + runLoop) call this
+      // multiple times; the second call must not erase a snapshot saved by the
+      // first, otherwise ordinary reconnect falls back to the default agent.
+      val currentSelection = selectedChatAgentId
+      if (currentSelection != null) {
+        pendingSelectedChatAgentRestore =
+          connectedEndpoint?.stableId?.let { stableId -> stableId to currentSelection }
+      }
       selectedChatAgentId = null
       chatSelectionSeq.incrementAndGet()
       sessionCatalogRefreshSeq.incrementAndGet()

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -1028,7 +1029,7 @@ class NodeRuntimeAgentSelectionTest {
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentsRefreshed(runtime)
+        waitUntilAgentBindingRestored(runtime, "scout")
 
         // The user's explicit agent choice is restored on same-gateway reconnect.
         assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
@@ -1065,7 +1066,7 @@ class NodeRuntimeAgentSelectionTest {
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("10.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentsRefreshed(runtime)
+        waitUntilAgentBindingRestored(runtime, "main")
 
         // A different gateway wins its canonical default agent; the stale choice is NOT carried over.
         assertEquals("main", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
@@ -1106,10 +1107,72 @@ class NodeRuntimeAgentSelectionTest {
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentsRefreshed(runtime)
+        waitUntilAgentBindingRestored(runtime, "writer")
 
         // The explicit selection while disconnected wins; the stale pending restore is NOT used.
         assertEquals("writer", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+
+  /**
+   * Real disconnect callbacks fire multiple times: finishTransport invokes
+   * onDisconnected, then GatewaySession.runLoop invokes it again before
+   * connectOnce, and explicit shutdown has a terminal Offline callback. The
+   * second clearOperatorGatewayState call must not erase the snapshot saved
+   * by the first, otherwise the pending restore is lost and reconnect falls
+   * back to the default agent. See issue #139277 / PR #140060 P1 finding.
+   */
+  @Test
+  fun repeatedDisconnectCallbacksPreserveRestoreSnapshot() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      try {
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"}]}"""
+        }
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+
+        runtime.selectChatAgent("scout")
+        assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+
+        // First disconnect callback (finishTransport → onDisconnected).
+        runtime.javaClass
+          .getDeclaredMethod("clearOperatorGatewayState", java.lang.Boolean.TYPE)
+          .apply { isAccessible = true }
+          .invoke(runtime, true)
+        // The snapshot is captured and the in-memory selection cleared.
+        assertNull(ReflectionHelpers.getField<String?>(runtime, "selectedChatAgentId"))
+        val snapshotAfterFirst =
+          ReflectionHelpers.getField<Pair<String, String>?>(runtime, "pendingSelectedChatAgentRestore")
+        assertNotNull(snapshotAfterFirst)
+        assertEquals("scout", snapshotAfterFirst!!.second)
+
+        // Second disconnect callback (runLoop → onDisconnected) — selectedChatAgentId
+        // is already null; the snapshot must NOT be erased.
+        runtime.javaClass
+          .getDeclaredMethod("clearOperatorGatewayState", java.lang.Boolean.TYPE)
+          .apply { isAccessible = true }
+          .invoke(runtime, true)
+        val snapshotAfterSecond =
+          ReflectionHelpers.getField<Pair<String, String>?>(runtime, "pendingSelectedChatAgentRestore")
+        assertNotNull(snapshotAfterSecond)
+        assertEquals("scout", snapshotAfterSecond!!.second)
+
+        ReflectionHelpers.setField(runtime, "operatorConnected", false)
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", null)
+
+        // Reconnect to the same gateway.
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
+        ReflectionHelpers.setField(runtime, "operatorConnected", true)
+        runtime.refreshAgents()
+        waitUntilAgentBindingRestored(runtime, "scout")
+
+        // The user's explicit agent choice is restored despite repeated disconnect callbacks.
+        assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
       } finally {
         closeNodeRuntimeTestFixture(runtime)
       }
@@ -1121,6 +1184,28 @@ class NodeRuntimeAgentSelectionTest {
       Thread.sleep(10)
     }
     error("Expected agents list to be refreshed")
+  }
+
+  /**
+   * Waits until refreshAgentsFromGateway has fully completed, including agent-list
+   * publication AND session-binding restoration. The gatewayAgents list is
+   * published before the selection is restored within publishGatewayData, so
+   * checking only gatewayAgents can observe stale session bindings.
+   */
+  private fun waitUntilAgentBindingRestored(
+    runtime: NodeRuntime,
+    expectedAgentId: String,
+  ) {
+    repeat(500) {
+      if (
+        runtime.gatewayAgents.value.isNotEmpty() &&
+        resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value) == expectedAgentId
+      ) {
+        return
+      }
+      Thread.sleep(10)
+    }
+    error("Expected agent binding to be restored to '$expectedAgentId'")
   }
 
   private fun createConnectedRuntime(): NodeRuntime {

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
@@ -1025,11 +1025,22 @@ class NodeRuntimeAgentSelectionTest {
         // but mainSessionKey is not yet reset — it is only re-synced on the next refreshAgentsFromGateway.
         assertNull(ReflectionHelpers.getField<String?>(runtime, "selectedChatAgentId"))
 
-        // Simulate a reconnect to the SAME gateway.
+        // Simulate a reconnect to the SAME gateway — capture the refresh
+        // coroutine's Job so we can await its full completion before asserting
+        // the restored binding. gatewayAgents is published before the session
+        // binding is restored within publishGatewayData, so polling
+        // mainSessionKey can observe the stale pre-disconnect value.
+        val sameGatewayRefreshStarted = CompletableDeferred<Job>()
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          sameGatewayRefreshStarted.complete(currentCoroutineContext().job)
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"}]}"""
+        }
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentBindingRestored(runtime, "scout")
+        val sameGatewayJob = withTimeout(2_000) { sameGatewayRefreshStarted.await() }
+        withTimeout(2_000) { sameGatewayJob.join() }
 
         // The user's explicit agent choice is restored on same-gateway reconnect.
         assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
@@ -1062,11 +1073,19 @@ class NodeRuntimeAgentSelectionTest {
         ReflectionHelpers.setField(runtime, "connectedEndpoint", null)
         assertNull(ReflectionHelpers.getField<String?>(runtime, "selectedChatAgentId"))
 
-        // Reconnect to a DIFFERENT gateway (different stableId) that also has "scout".
+        // Reconnect to a DIFFERENT gateway (different stableId) that also has
+        // "scout". Capture the refresh Job to await its full completion.
+        val diffGatewayRefreshStarted = CompletableDeferred<Job>()
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          diffGatewayRefreshStarted.complete(currentCoroutineContext().job)
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"}]}"""
+        }
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("10.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentBindingRestored(runtime, "main")
+        val diffGatewayJob = withTimeout(2_000) { diffGatewayRefreshStarted.await() }
+        withTimeout(2_000) { diffGatewayJob.join() }
 
         // A different gateway wins its canonical default agent; the stale choice is NOT carried over.
         assertEquals("main", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
@@ -1103,11 +1122,19 @@ class NodeRuntimeAgentSelectionTest {
         runtime.selectChatAgent("writer")
         assertEquals("writer", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
 
-        // Reconnect to the same gateway.
+        // Reconnect to the same gateway — capture the refresh Job to await
+        // its full completion before asserting the restored binding.
+        val explicitRefreshStarted = CompletableDeferred<Job>()
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          explicitRefreshStarted.complete(currentCoroutineContext().job)
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"},{"id":"writer","name":"Writer"}]}"""
+        }
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentBindingRestored(runtime, "writer")
+        val explicitJob = withTimeout(2_000) { explicitRefreshStarted.await() }
+        withTimeout(2_000) { explicitJob.join() }
 
         // The explicit selection while disconnected wins; the stale pending restore is NOT used.
         assertEquals("writer", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
@@ -1165,11 +1192,19 @@ class NodeRuntimeAgentSelectionTest {
         ReflectionHelpers.setField(runtime, "operatorConnected", false)
         ReflectionHelpers.setField(runtime, "connectedEndpoint", null)
 
-        // Reconnect to the same gateway.
+        // Reconnect to the same gateway — capture the refresh Job to await
+        // its full completion before asserting the restored binding.
+        val repeatedRefreshStarted = CompletableDeferred<Job>()
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          repeatedRefreshStarted.complete(currentCoroutineContext().job)
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"}]}"""
+        }
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
         runtime.refreshAgents()
-        waitUntilAgentBindingRestored(runtime, "scout")
+        val repeatedJob = withTimeout(2_000) { repeatedRefreshStarted.await() }
+        withTimeout(2_000) { repeatedJob.join() }
 
         // The user's explicit agent choice is restored despite repeated disconnect callbacks.
         assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
@@ -1184,28 +1219,6 @@ class NodeRuntimeAgentSelectionTest {
       Thread.sleep(10)
     }
     error("Expected agents list to be refreshed")
-  }
-
-  /**
-   * Waits until refreshAgentsFromGateway has fully completed, including agent-list
-   * publication AND session-binding restoration. The gatewayAgents list is
-   * published before the selection is restored within publishGatewayData, so
-   * checking only gatewayAgents can observe stale session bindings.
-   */
-  private fun waitUntilAgentBindingRestored(
-    runtime: NodeRuntime,
-    expectedAgentId: String,
-  ) {
-    repeat(500) {
-      if (
-        runtime.gatewayAgents.value.isNotEmpty() &&
-        resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value) == expectedAgentId
-      ) {
-        return
-      }
-      Thread.sleep(10)
-    }
-    error("Expected agent binding to be restored to '$expectedAgentId'")
   }
 
   private fun createConnectedRuntime(): NodeRuntime {

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -990,6 +991,136 @@ class NodeRuntimeAgentSelectionTest {
       }
     }
     ReflectionHelpers.setField(chat, "requestGatewayForGateway", request)
+  }
+
+  @Test
+  fun reconnectToSameGatewayRestoresTalkAgentChoice() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      val stableId = GatewayEndpoint.manual("127.0.0.1", 18789).stableId
+      try {
+        // Seed the agent list with a custom agent the user will select.
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"}]}"""
+        }
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+        assertEquals(2, runtime.gatewayAgents.value.size)
+
+        // User explicitly selects the non-default agent.
+        runtime.selectChatAgent("scout")
+        assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+
+        // Simulate a gateway scope change: clearOperatorGatewayState captures the
+        // (stableId, agentId) snapshot and clears the in-memory selection.
+        runtime.javaClass
+          .getDeclaredMethod("clearOperatorGatewayState", java.lang.Boolean.TYPE)
+          .apply { isAccessible = true }
+          .invoke(runtime, true)
+        ReflectionHelpers.setField(runtime, "operatorConnected", false)
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", null)
+        // After clearing, selectedChatAgentId is null (captured into pendingSelectedChatAgentRestore)
+        // but mainSessionKey is not yet reset — it is only re-synced on the next refreshAgentsFromGateway.
+        assertNull(ReflectionHelpers.getField<String?>(runtime, "selectedChatAgentId"))
+
+        // Simulate a reconnect to the SAME gateway.
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
+        ReflectionHelpers.setField(runtime, "operatorConnected", true)
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+
+        // The user's explicit agent choice is restored on same-gateway reconnect.
+        assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+
+  @Test
+  fun reconnectToDifferentGatewayDoesNotCarryOverAgentChoice() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      try {
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"}]}"""
+        }
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+
+        runtime.selectChatAgent("scout")
+        assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+
+        // Disconnect from gateway A.
+        runtime.javaClass
+          .getDeclaredMethod("clearOperatorGatewayState", java.lang.Boolean.TYPE)
+          .apply { isAccessible = true }
+          .invoke(runtime, true)
+        ReflectionHelpers.setField(runtime, "operatorConnected", false)
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", null)
+        assertNull(ReflectionHelpers.getField<String?>(runtime, "selectedChatAgentId"))
+
+        // Reconnect to a DIFFERENT gateway (different stableId) that also has "scout".
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("10.0.0.1", 18789))
+        ReflectionHelpers.setField(runtime, "operatorConnected", true)
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+
+        // A different gateway wins its canonical default agent; the stale choice is NOT carried over.
+        assertEquals("main", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+
+  @Test
+  fun explicitSelectionWhileDisconnectedSupersedesPendingRestore() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      try {
+        runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
+          check(method == "agents.list")
+          """{"defaultId":"main","mainKey":"agent:main:node-test","agents":[{"id":"main","name":"Main"},{"id":"scout","name":"Scout"},{"id":"writer","name":"Writer"}]}"""
+        }
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+
+        runtime.selectChatAgent("scout")
+        assertEquals("scout", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+
+        // Disconnect: pending restore captures (stableId, "scout").
+        runtime.javaClass
+          .getDeclaredMethod("clearOperatorGatewayState", java.lang.Boolean.TYPE)
+          .apply { isAccessible = true }
+          .invoke(runtime, true)
+        ReflectionHelpers.setField(runtime, "operatorConnected", false)
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", null)
+        assertNull(ReflectionHelpers.getField<String?>(runtime, "selectedChatAgentId"))
+
+        // User selects a different agent while disconnected.
+        runtime.selectChatAgent("writer")
+        assertEquals("writer", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+
+        // Reconnect to the same gateway.
+        ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
+        ReflectionHelpers.setField(runtime, "operatorConnected", true)
+        runtime.refreshAgents()
+        waitUntilAgentsRefreshed(runtime)
+
+        // The explicit selection while disconnected wins; the stale pending restore is NOT used.
+        assertEquals("writer", resolveAgentIdFromMainSessionKey(runtime.mainSessionKey.value))
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+
+  private fun waitUntilAgentsRefreshed(runtime: NodeRuntime) {
+    repeat(200) {
+      if (runtime.gatewayAgents.value.isNotEmpty()) return
+      Thread.sleep(10)
+    }
+    error("Expected agents list to be refreshed")
   }
 
   private fun createConnectedRuntime(): NodeRuntime {


### PR DESCRIPTION
## What Problem This Solves

Closes #139277 — Android Talk voice silently reverts to the default agent after a gateway scope change.

**Root cause:** `NodeRuntime.selectedChatAgentId` is an `@Volatile private var` (in-memory only). When the gateway scope changes, `clearOperatorGatewayState()` unconditionally clears `selectedChatAgentId = null`. On reconnect, `refreshAgentsFromGateway()` falls through to the default agent because no record of the user's explicit choice survives the disconnect.

**User-visible impact:** A user selects "Scout" (or any non-default agent) in Talk, experiences a brief network/gateway blip, and the Talk binding silently reverts to the default "Main" agent — with no indication or undo.

## Fix

Four-part change in `NodeRuntime.kt` + test file:

1. **Snapshot before clearing** — In `clearOperatorGatewayState()`, before setting `selectedChatAgentId = null`, capture a `pendingSelectedChatAgentRestore: Pair<String, String>?` holding `(connectedEndpoint.stableId, selectedChatAgentId)`. This pairs the agent choice with the gateway that was active when the user made it.

2. **Preserve snapshot across repeated disconnect callbacks (P1 fix)** — Real disconnect callbacks fire multiple times: `finishTransport` invokes `onDisconnected`, then `GatewaySession.runLoop` invokes it again before `connectOnce`, and explicit shutdown has a terminal Offline callback. The second `clearOperatorGatewayState` call found `selectedChatAgentId` already null (cleared by the first call), so `selectedChatAgentId?.let { ... }` returned null and **erased the snapshot** saved by the first call. Fix: only capture a new snapshot when `selectedChatAgentId` is still non-null. Repeated callbacks leave the first-captured snapshot intact.

3. **Restore on same-gateway reconnect** — In `refreshAgentsFromGateway()`, after receiving the fresh agent list, if `pendingSelectedChatAgentRestore` is non-null and its `stableId` matches the current `connectedEndpoint.stableId` (reconnected to the *same* gateway), restore `selectedChatAgentId` from the snapshot and clear the pending field. A different-gateway reconnect leaves the snapshot untouched so the new gateway's canonical default agent wins.

4. **Clear on explicit selection** — In `selectChatAgent()`, clear `pendingSelectedChatAgentRestore = null` so that a user who explicitly picks a different agent while disconnected is not overridden by a stale restore on the next reconnect.

The fix is scoped to Android only and does not touch the `src/auto-reply/reply/` dependency graph, so it avoids the known CI preflight output-size limitation.

## Evidence

### Regression tests (4 tests in `NodeRuntimeAgentSelectionTest.kt`)

| Test | Scenario | Expected behavior |
|------|----------|-------------------|
| `reconnectToSameGatewayRestoresTalkAgentChoice` | Select "scout" → disconnect → reconnect to same gateway | `mainSessionKey` restores to `agent:scout:*` |
| `reconnectToDifferentGatewayDoesNotCarryOverAgentChoice` | Select "scout" → disconnect → reconnect to different gateway (10.0.0.1) | `mainSessionKey` stays at `agent:main:*` (new gateway default) |
| `explicitSelectionWhileDisconnectedSupersedesPendingRestore` | Select "scout" → disconnect → select "writer" → reconnect to same gateway | `mainSessionKey` stays at `agent:writer:*` (explicit selection wins) |
| `repeatedDisconnectCallbacksPreserveRestoreSnapshot` | Select "scout" → 2× disconnect callbacks → reconnect to same gateway | `mainSessionKey` restores to `agent:scout:*` (snapshot preserved across repeated callbacks) |

### Await refresh coroutine completion before asserting (P2 fix)

The original `waitUntilAgentsRefreshed` test helper polled `gatewayAgents.value` until non-empty. But `refreshAgentsFromGateway` publishes `_gatewayAgents.value = agents` **before** restoring `selectedChatAgentId` from the pending snapshot. A test that only waits for agents to appear can race the restoration and assert a stale (not-yet-restored) binding.

Fix: replaced the polling helper with a `CompletableDeferred<Job>` pattern. Each reconnect test now obtains the `refreshAgentsFromGateway` coroutine Job and calls `.join()` to deterministically wait for the full refresh (agent list publish **and** session binding restore) before asserting `mainSessionKey`. This eliminates the race without flaky `Thread.sleep`.

### Behavior proof (without fix vs with fix)

**Without fix:** `clearOperatorGatewayState` sets `selectedChatAgentId = null` with no snapshot. After reconnect, `refreshAgentsFromGateway` evaluates `selectedChatAgentId?.takeIf { ... }` → `null`, so `syncMainSessionKey` receives the resolved default agent → Talk binding reverts to default.

**With fix:** `clearOperatorGatewayState` captures `(stableId, "scout")` before clearing. After same-gateway reconnect, the `stableId` check passes → `selectedChatAgentId` is restored to `"scout"` → `syncMainSessionKey("scout")` preserves the Talk binding.

### CI status

| Check | Result |
|-------|--------|
| `android-ktlint` | ✅ success |
| `android-build-play` | ✅ success |
| `android-build-wear` | ✅ success |
| `android-test-wear` | ✅ success |
| `android-test-third-party` | ✅ success |
| `android-test-play` | ✅ success (only pre-existing flaky `SettingsScreensContrastTest` unaffected by this PR) |

### Files changed

- `apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt` — snapshot capture (guarded against repeated callbacks), restore, and clear logic
- `apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt` — 4 regression tests + `CompletableDeferred<Job>` await pattern
