### PR TITLE
refactor(gateway): remove unused response schemas

### DIFF
--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -235,150 +235,60 @@ export type CreateResponseBody = z.infer<typeof CreateResponseBodySchema>;
 // Response Resource
 // ─────────────────────────────────────────────────────────────────────────────
 
-const ResponseStatusSchema = z.enum([
-  "in_progress",
-  "completed",
-  "failed",
-  "cancelled",
-  "incomplete",
-]);
+type OutputTextContentPart = Extract<ContentPart, { type: "output_text" }>;
+type OutputStatus = "in_progress" | "completed";
 
-const OutputItemSchema = z.discriminatedUnion("type", [
-  // Output items are replayable input; narrow required output fields without
-  // duplicating the supported item shape or dropping assistant phase validation.
-  MessageItemSchema.safeExtend({
-    id: z.string(),
-    role: z.literal("assistant"),
-    content: z.array(OutputTextContentPartSchema),
-    status: z.enum(["in_progress", "completed"]).optional(),
-  }),
-  FunctionCallItemSchema.extend({
-    id: z.string(),
-    call_id: z.string(),
-    status: z.enum(["in_progress", "completed"]).optional(),
-  }),
-  z
-    .object({
-      type: z.literal("reasoning"),
-      id: z.string(),
-      content: z.string().optional(),
-      summary: z.string().optional(),
+export type OutputItem =
+  | (Omit<Extract<ItemParam, { type: "message" }>, "id" | "role" | "content" | "status"> & {
+      id: string;
+      role: "assistant";
+      content: OutputTextContentPart[];
+      status?: OutputStatus | undefined;
     })
-    .strict(),
-]);
-
-export type OutputItem = z.infer<typeof OutputItemSchema>;
-
-const UsageSchema = z.object({
-  input_tokens: z.number().int().nonnegative(),
-  input_tokens_details: z.object({
-    cached_tokens: z.number().int().nonnegative(),
-    cache_write_tokens: z.number().int().nonnegative(),
-  }),
-  output_tokens: z.number().int().nonnegative(),
-  output_tokens_details: z.object({
-    reasoning_tokens: z.number().int().nonnegative(),
-  }),
-  total_tokens: z.number().int().nonnegative(),
-});
-
-export type Usage = z.infer<typeof UsageSchema>;
-
-const ResponseResourceSchema = z.object({
-  id: z.string(),
-  object: z.literal("response"),
-  created_at: z.number().int(),
-  status: ResponseStatusSchema,
-  model: z.string(),
-  output: z.array(OutputItemSchema),
-  usage: UsageSchema,
-  // Optional fields for future phases
-  error: z
-    .object({
-      code: z.string(),
-      message: z.string(),
+  | (Omit<Extract<ItemParam, { type: "function_call" }>, "id" | "call_id" | "status"> & {
+      id: string;
+      call_id: string;
+      status?: OutputStatus | undefined;
     })
-    .optional(),
-});
+  | { type: "reasoning"; id: string; content?: string | undefined; summary?: string | undefined };
 
-export type ResponseResource = z.infer<typeof ResponseResourceSchema>;
+export type Usage = {
+  input_tokens: number;
+  input_tokens_details: { cached_tokens: number; cache_write_tokens: number };
+  output_tokens: number;
+  output_tokens_details: { reasoning_tokens: number };
+  total_tokens: number;
+};
+
+export type ResponseResource = {
+  id: string;
+  object: "response";
+  created_at: number;
+  status: "in_progress" | "completed" | "failed" | "cancelled" | "incomplete";
+  model: string;
+  output: OutputItem[];
+  usage: Usage;
+  error?: { code: string; message: string } | undefined;
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Streaming Event Types
 // ─────────────────────────────────────────────────────────────────────────────
 
-const ResponseCreatedEventSchema = z.object({
-  type: z.literal("response.created"),
-  response: ResponseResourceSchema,
-});
-
-const ResponseInProgressEventSchema = z.object({
-  type: z.literal("response.in_progress"),
-  response: ResponseResourceSchema,
-});
-
-const ResponseCompletedEventSchema = z.object({
-  type: z.literal("response.completed"),
-  response: ResponseResourceSchema,
-});
-
-const ResponseFailedEventSchema = z.object({
-  type: z.literal("response.failed"),
-  response: ResponseResourceSchema,
-});
-
-const OutputItemAddedEventSchema = z.object({
-  type: z.literal("response.output_item.added"),
-  output_index: z.number().int().nonnegative(),
-  item: OutputItemSchema,
-});
-
-const OutputItemDoneEventSchema = z.object({
-  type: z.literal("response.output_item.done"),
-  output_index: z.number().int().nonnegative(),
-  item: OutputItemSchema,
-});
-
-const ContentPartAddedEventSchema = z.object({
-  type: z.literal("response.content_part.added"),
-  item_id: z.string(),
-  output_index: z.number().int().nonnegative(),
-  content_index: z.number().int().nonnegative(),
-  part: OutputTextContentPartSchema,
-});
-
-const ContentPartDoneEventSchema = z.object({
-  type: z.literal("response.content_part.done"),
-  item_id: z.string(),
-  output_index: z.number().int().nonnegative(),
-  content_index: z.number().int().nonnegative(),
-  part: OutputTextContentPartSchema,
-});
-
-const OutputTextDeltaEventSchema = z.object({
-  type: z.literal("response.output_text.delta"),
-  item_id: z.string(),
-  output_index: z.number().int().nonnegative(),
-  content_index: z.number().int().nonnegative(),
-  delta: z.string(),
-});
-
-const OutputTextDoneEventSchema = z.object({
-  type: z.literal("response.output_text.done"),
-  item_id: z.string(),
-  output_index: z.number().int().nonnegative(),
-  content_index: z.number().int().nonnegative(),
-  text: z.string(),
-});
+type ContentEventPosition = {
+  item_id: string;
+  output_index: number;
+  content_index: number;
+};
 
 export type StreamingEvent =
-  | z.infer<typeof ResponseCreatedEventSchema>
-  | z.infer<typeof ResponseInProgressEventSchema>
-  | z.infer<typeof ResponseCompletedEventSchema>
-  | z.infer<typeof ResponseFailedEventSchema>
-  | z.infer<typeof OutputItemAddedEventSchema>
-  | z.infer<typeof OutputItemDoneEventSchema>
-  | z.infer<typeof ContentPartAddedEventSchema>
-  | z.infer<typeof ContentPartDoneEventSchema>
-  | z.infer<typeof OutputTextDeltaEventSchema>
-  | z.infer<typeof OutputTextDoneEventSchema>;
+  | { type: "response.created"; response: ResponseResource }
+  | { type: "response.in_progress"; response: ResponseResource }
+  | { type: "response.completed"; response: ResponseResource }
+  | { type: "response.failed"; response: ResponseResource }
+  | { type: "response.output_item.added"; output_index: number; item: OutputItem }
+  | { type: "response.output_item.done"; output_index: number; item: OutputItem }
+  | (ContentEventPosition & { type: "response.content_part.added"; part: OutputTextContentPart })
+  | (ContentEventPosition & { type: "response.content_part.done"; part: OutputTextContentPart })
+  | (ContentEventPosition & { type: "response.output_text.delta"; delta: string })
+  | (ContentEventPosition & { type: "response.output_text.done"; text: string });


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

The Gateway's Responses endpoint constructs output and streaming-event schemas that are never used to validate data. Keeping those private runtime objects obscures the real validation boundary and duplicates the TypeScript contracts used by response writers.

This is a cleanup companion to the #135868 split campaign; it contains no recovery feature content.

## Why This Change Was Made

Replace the 14 private, type-only schemas with equivalent output types and a direct discriminated union for streaming events. Output message and function-call types still derive from the canonical input types, preserving the replay relationship. The live request validator and all of its dependencies remain unchanged.

Deletion evidence: global references end at schema construction and type inference. The HTTP writer and output factories use these contracts only as types and emit plain objects. No parse, registration, code generation, or public barrel consumes the removed schemas. #106038 already removed their unused exports; this removes the remaining private construction. Required usage details from #117533 and stateless replay fields from #131197 are preserved.

## User Impact

No user-visible behavior change. Request rejection, assistant phase handling, replay metadata, usage fields, response shapes, and all ten streaming-event variants retain their existing contracts.

## Evidence

- All 139 existing HTTP, replay, and phase tests pass before and after the change.
- Strict before/after proof preserves all seven exported aliases, every output/event variant, both assignment directions, and live-schema input/output with exact optional properties both enabled and disabled. A deliberately wrong token-count type failed ten equivalence checks.
- 2,405 before/after request-validation cases match (310 accepted), including errors and input preservation. Runtime exports and generated JSON schema are identical.
- Complete selected changed-check plan passed, including core/test typing, all three export scans, lint, native-state/database guards, and zero runtime import cycles.
- Full `pnpm build` passed in 7m40s, including SDK exports, native module loads, and the UI build. Generated bundled plugin assets match committed bytes.
- Fresh-main rebases preserve all 12 recorded source, consumer, test, lockfile, and check-plan inputs.
- Independent Codex local and branch reviews found no accepted/actionable findings through P2.

| Judged class | Added | Deleted | Net | Touched file before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 48 | 138 | −90 | 384 → 294 lines |
| Tests | 0 | 0 | 0 | unchanged |
| Tooling | 0 | 0 | 0 | unchanged |
| Docs | 0 | 0 | 0 | unchanged |

No permanent tests, suppressions, baselines, dependencies, configuration options, or protocol/schema versions changed.

ClawSweeper disposition: reviewed `4d1dfe073648edf82d91e423e31817be49c63380` with no correctness/security findings, before-merge requests, or rank-up moves. Final freshness rebase `14084a7fb2e9992657010453ebb7710f6fa43fce` preserves all recorded proof inputs and the lockfile; no review finding required a code change.
