### PR TITLE
fix: package checks fail on fresh runners and Bun installs

### DIFF
--- a/scripts/check-docker-e2e-boundaries.mts
+++ b/scripts/check-docker-e2e-boundaries.mts
@@ -5,7 +5,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import packageJson from "../package.json" with { type: "json" };
-import { laneResources, laneWeight } from "./lib/docker-e2e-plan.mts";
+import { laneResources, lanesNeedOpenClawPackage, laneWeight } from "./lib/docker-e2e-plan.mts";
 import {
   allReleasePathLanes,
   mainLanes,
@@ -112,6 +112,8 @@ function validateUniqueLanes(label: string, lanes: readonly (typeof mainLanes)[n
 function validateLane(label: string, lane: (typeof mainLanes)[number]) {
   const resources = laneResources(lane);
   const sourceCheckoutImageLane = sourceCheckoutImageLanes.has(lane.name);
+  const needsPackage = lanesNeedOpenClawPackage([lane]);
+  const localImageBuild = sourceCheckoutImageLane || (needsPackage && !lane.e2eImageKind);
   if (!lane.name || typeof lane.name !== "string") {
     errors.push(`${label}: Docker E2E lane is missing a string name`);
   }
@@ -128,15 +130,17 @@ function validateLane(label: string, lane: (typeof mainLanes)[number]) {
       `${label}: Docker E2E lane '${lane.name}' has invalid image kind '${invalidImageKind}'`,
     );
   }
-  if (lane.live && lane.e2eImageKind && !livePackageBackedLanes.has(lane.name)) {
+  if (lane.live && needsPackage && !livePackageBackedLanes.has(lane.name)) {
     errors.push(`${label}: live Docker E2E lane '${lane.name}' must not require a package image`);
   }
-  if (!lane.live && !lane.e2eImageKind && !sourceCheckoutImageLane) {
-    errors.push(`${label}: package Docker E2E lane '${lane.name}' must declare an e2e image kind`);
-  }
-  if (sourceCheckoutImageLane && !/\bOPENCLAW_SKIP_DOCKER_BUILD=0\b/u.test(lane.command)) {
+  if (!lane.live && !needsPackage && !sourceCheckoutImageLane) {
     errors.push(
-      `${label}: source-checkout Docker E2E lane '${lane.name}' must force a local image build`,
+      `${label}: package Docker E2E lane '${lane.name}' must request package preparation`,
+    );
+  }
+  if (localImageBuild && !/\bOPENCLAW_SKIP_DOCKER_BUILD=0\b/u.test(lane.command)) {
+    errors.push(
+      `${label}: locally built Docker E2E lane '${lane.name}' must force a local image build`,
     );
   }
   if (laneWeight(lane) < 1) {

--- a/scripts/docker/verify-fs-safe-native.mjs
+++ b/scripts/docker/verify-fs-safe-native.mjs
@@ -25,7 +25,8 @@ function parseArgs(argv) {
       "usage: verify-fs-safe-native.mjs --package-root <path> --mode <require|fallback>",
     );
   }
-  return { mode, packageRoot: path.resolve(packageRoot) };
+  // createRequire keeps symlinked bases; pnpm dependencies belong to the physical package.
+  return { mode, packageRoot: fs.realpathSync(packageRoot) };
 }
 
 const { mode, packageRoot } = parseArgs(process.argv.slice(2));

--- a/scripts/e2e/Dockerfile
+++ b/scripts/e2e/Dockerfile
@@ -48,6 +48,8 @@ CMD ["bash"]
 
 FROM ${OPENCLAW_NODE_ALPINE_IMAGE} AS musl
 
+RUN apk add --no-cache bash
+COPY --from=e2e-runner /opt/openclaw-e2e /opt/openclaw-e2e
 COPY scripts/docker/verify-fs-safe-native.mjs /tmp/verify-fs-safe-native.mjs
 
 CMD ["sh"]

--- a/scripts/e2e/docker-package-install.sh
+++ b/scripts/e2e/docker-package-install.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
-IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-docker-e2e-bare:local")"
-MUSL_IMAGE_NAME="openclaw-docker-e2e-musl:local"
+# This mixed-platform lane owns its images; shared bare/functional tags belong to other lanes.
+IMAGE_NAME="openclaw-package-install-bare:$$"
+MUSL_IMAGE_NAME="openclaw-package-install-musl:$$"
 PACKAGE_TGZ="$(docker_e2e_prepare_package_tgz docker-package-install "${OPENCLAW_CURRENT_PACKAGE_TGZ:-}")"
 IDENTITY_PATH="${OPENCLAW_DOCKER_ARTIFACT_IDENTITY_PATH:-$ROOT_DIR/.artifacts/docker-tests/docker-package-install-identities.json}"
 NPM_PROOF_CONTAINER="openclaw-package-npm-proof-$$"
@@ -22,6 +23,7 @@ cleanup() {
     "$PNPM_PROOF_CONTAINER" \
     "$BUN_PROOF_CONTAINER" \
     "$MUSL_PROOF_CONTAINER" >/dev/null 2>&1 || true
+  docker_e2e_docker_cmd image rm "$IMAGE_NAME" "$MUSL_IMAGE_NAME" >/dev/null 2>&1 || true
   docker_e2e_cleanup_package_tgz "$PACKAGE_TGZ"
   rm -rf "$PACKAGE_HARNESS_DIR"
 }
@@ -144,7 +146,7 @@ DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
 echo "Installing the real OpenClaw package artifact with npm on musl..."
 DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run -d \
   --name "$MUSL_PROOF_CONTAINER" \
-  -v "$PACKAGE_TGZ:/tmp/openclaw-current.tgz:ro" \
+  "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   "$MUSL_IMAGE_NAME" \
   sh -lc '
     set -eu

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -475,7 +475,7 @@ export function lanesNeedE2eImageKind(
 }
 
 export function lanesNeedOpenClawPackage(poolLanes: DockerE2eLane[]): boolean {
-  return poolLanes.some((poolLane) => poolLane.e2eImageKind);
+  return poolLanes.some((poolLane) => poolLane.needsPackage || poolLane.e2eImageKind);
 }
 
 export function findLaneByName(name: string): DockerE2eLane | undefined {

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -14,6 +14,7 @@ export type DockerE2eLane = {
   estimateSeconds?: number;
   live: boolean;
   name: string;
+  needsPackage?: boolean;
   needsLiveImage?: boolean;
   noOutputTimeoutMs?: number;
   prepublishPluginPackages?: string[];
@@ -114,6 +115,7 @@ function lane(name: string, command: string, options: LaneOptions = {}): DockerE
     live: options.live === true,
     noOutputTimeoutMs: options.noOutputTimeoutMs,
     name,
+    ...(options.needsPackage ? { needsPackage: true } : {}),
     needsLiveImage: options.needsLiveImage,
     prepublishPluginPackages: options.prepublishPluginPackages,
     retryPatterns: options.retryPatterns ?? [],
@@ -392,8 +394,10 @@ export const mainLanes: DockerE2eLane[] = [
   ),
   npmLane(
     "docker-package-install",
-    "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:package-install",
+    "OPENCLAW_SKIP_DOCKER_BUILD=0 pnpm test:docker:package-install",
     {
+      e2eImageKind: false,
+      needsPackage: true,
       stateScenario: "empty",
       timeoutMs: 20 * 60 * 1000,
       weight: 3,

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -230,10 +230,10 @@ openclaw_e2e_print_log() {
   fi
   if ! { tail -c "$max_bytes" "$path" 2>/dev/null | tail -n "$max_lines" || tail -n "$max_lines" "$path" || true; } | \
     node --input-type=module -e '
-      import fs from "node:fs";
+      import { text } from "node:stream/consumers";
       import { pathToFileURL } from "node:url";
       const { redactSensitiveText } = await import(pathToFileURL(process.argv[1]).href);
-      process.stdout.write(redactSensitiveText(fs.readFileSync(0, "utf8"), { mode: "tools" }));
+      process.stdout.write(redactSensitiveText(await text(process.stdin), { mode: "tools" }));
     ' "$redactor_module"; then
     echo "[failure log omitted: canonical redaction failed]"
   fi

--- a/src/plugins/plugin-sdk-native-resolver.test.ts
+++ b/src/plugins/plugin-sdk-native-resolver.test.ts
@@ -479,9 +479,10 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
       probePath,
       [
         'import fs from "node:fs";',
+        'import Module from "node:module";',
         'import path from "node:path";',
         'import { pathToFileURL } from "node:url";',
-        `import { installOpenClawPluginSdkNativeResolver } from ${JSON.stringify(resolverModuleUrl)};`,
+        `import { installOpenClawInternalCorePackageNativeResolver, installOpenClawPluginSdkNativeResolver } from ${JSON.stringify(resolverModuleUrl)};`,
         `const root = ${JSON.stringify(root)};`,
         "const writeJson = (targetPath, value) => {",
         "  fs.mkdirSync(path.dirname(targetPath), { recursive: true });",
@@ -503,6 +504,10 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
         'const loaderModulePath = path.join(root, "dist", "plugins", "loader.js");',
         "fs.mkdirSync(path.dirname(loaderModulePath), { recursive: true });",
         'fs.writeFileSync(loaderModulePath, "export default {};\\n", "utf8");',
+        "const originalResolver = Module._resolveFilename;",
+        "installOpenClawInternalCorePackageNativeResolver({ moduleUrl: pathToFileURL(loaderModulePath).href });",
+        "installOpenClawPluginSdkNativeResolver({ modulePath: loaderModulePath });",
+        "const aliasFreeUnchanged = Module._resolveFilename === originalResolver;",
         'const pluginRoot = path.join(root, "external-plugin");',
         'writeJson(path.join(pluginRoot, "package.json"), { name: "external-plugin", type: "module" });',
         'const entryPath = path.join(pluginRoot, "dist", "runtime-api.js");',
@@ -525,7 +530,7 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
         "});",
         "const module = await import(pathToFileURL(entryPath).href);",
         "const lazy = await module.loadLazy();",
-        "console.log(`${module.eager}:${lazy.lazy}`);",
+        "console.log(JSON.stringify({ aliasFreeUnchanged, eager: module.eager, lazy: lazy.lazy }));",
         "",
       ].join("\n"),
       "utf8",
@@ -546,7 +551,14 @@ describe("installOpenClawPluginSdkNativeResolver", () => {
   it("keeps SDK aliases available for native ESM lazy imports", () => {
     expect(nativeEsmLazyImportProbe.stderr).toBe("");
     expect(nativeEsmLazyImportProbe.status).toBe(0);
-    expect(nativeEsmLazyImportProbe.stdout.trim()).toBe("adapter:late-adapter");
+    expect(JSON.parse(nativeEsmLazyImportProbe.stdout)).toMatchObject({
+      eager: "adapter",
+      lazy: "late-adapter",
+    });
+  });
+
+  it("leaves native resolution untouched until aliases are registered", () => {
+    expect(JSON.parse(nativeEsmLazyImportProbe.stdout).aliasFreeUnchanged).toBe(true);
   });
 
   it("does not resolve SDK aliases for parents outside registered plugin roots", () => {

--- a/src/plugins/plugin-sdk-native-resolver.ts
+++ b/src/plugins/plugin-sdk-native-resolver.ts
@@ -105,7 +105,6 @@ const INTERNAL_CORE_PACKAGE_ALIASES = [
   },
 ] as const;
 let installed = false;
-let previousResolveFilename: ResolveFilename | undefined;
 
 function resolveLoaderModulePath(options: InstallOpenClawPluginSdkNativeResolverOptions): string {
   return options.modulePath ?? fileURLToPath(options.moduleUrl ?? import.meta.url);
@@ -349,17 +348,15 @@ function listInternalCorePackageNativeAliases(
 }
 
 function installResolver(): void {
-  if (installed || !moduleWithResolver[nodeResolveFilenameProperty]) {
+  const native = getPluginCache().sdk.native;
+  const previousResolveFilename = moduleWithResolver[nodeResolveFilenameProperty];
+  // Packaged runtimes without aliases must retain the runtime's native resolution path.
+  if (installed || !previousResolveFilename || !(native.aliases.size || native.sdkProviders.size)) {
     return;
   }
-  previousResolveFilename = moduleWithResolver[nodeResolveFilenameProperty];
-  moduleWithResolver[nodeResolveFilenameProperty] = ((request, parent, isMain, options) => {
-    const aliasTarget = resolveAliasTargetForParent(request, parent);
-    if (aliasTarget) {
-      return aliasTarget;
-    }
-    return previousResolveFilename?.(request, parent, isMain, options) ?? request;
-  }) satisfies ResolveFilename;
+  moduleWithResolver[nodeResolveFilenameProperty] = ((request, parent, isMain, options) =>
+    resolveAliasTargetForParent(request, parent) ??
+    previousResolveFilename(request, parent, isMain, options)) satisfies ResolveFilename;
   moduleWithResolver.registerHooks?.({
     resolve(specifier, context, nextResolve) {
       const aliasTarget = resolveAliasTargetForParentUrl(specifier, context.parentURL);

--- a/test/scripts/docker-all-harness.test.ts
+++ b/test/scripts/docker-all-harness.test.ts
@@ -55,6 +55,7 @@ fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
   lane: process.env.OPENCLAW_DOCKER_ALL_LANE_NAME,
   cwd: process.cwd(),
   phase: process.argv[2],
+  skipDockerBuild: process.env.OPENCLAW_SKIP_DOCKER_BUILD,
   registry: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
   registryVersion: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION,
   registrySha256: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256,
@@ -225,21 +226,34 @@ function runFixture(
 }
 
 describe("Docker scheduler trusted harness execution", () => {
-  posixIt("preserves prepared core dependencies for a package-only lane", () => {
-    const fixture = setupFixture("split", false, true);
-    const { result } = runFixture(fixture, "split", ["docker-package-install"], {
-      env: { OPENCLAW_CURRENT_PACKAGE_VERSION: "", OPENCLAW_CURRENT_PACKAGE_SHA256: "" },
-    });
+  posixIt(
+    "preserves prepared core dependencies without shared builds for a package-only lane",
+    () => {
+      const fixture = setupFixture("split", false, true);
+      const { result } = runFixture(fixture, "split", ["docker-package-install"], {
+        env: {
+          OPENCLAW_CURRENT_PACKAGE_VERSION: "",
+          OPENCLAW_CURRENT_PACKAGE_SHA256: "",
+          OPENCLAW_DOCKER_ALL_BUILD: "1",
+        },
+      });
 
-    expect(result.status, result.stdout + result.stderr).toBe(0);
-    expect(JSON.parse(readFileSync(fixture.marker, "utf8").trim())).toMatchObject({
-      lane: "docker-package-install",
-      package: fixture.tarball,
-      registry: fixture.registry,
-      registryVersion: "2026.8.1",
-      registrySha256: fixture.registrySha256,
-    });
-  });
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      const calls = readFileSync(fixture.marker, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({
+        lane: "docker-package-install",
+        package: fixture.tarball,
+        registry: fixture.registry,
+        registryVersion: "2026.8.1",
+        registrySha256: fixture.registrySha256,
+        skipDockerBuild: "0",
+      });
+    },
+  );
 
   posixIt.each([
     { failure: "timeout", attempts: 1, passed: false },

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -18,6 +18,7 @@ import { basename, dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { mainLanes } from "../../scripts/lib/docker-e2e-scenarios.mts";
 import { buildSystemdUnit } from "../../src/daemon/systemd-unit.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -6124,11 +6125,157 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     expect(dockerfile).toContain(
       "node /tmp/verify-fs-safe-native.mjs --package-root /app --mode require",
     );
-    expect(packageRunner).toContain('MUSL_IMAGE_NAME="openclaw-docker-e2e-musl:local"');
     expect(packageRunner.match(/verify-fs-safe-native\.mjs[^\n]+--mode require/gu)).toHaveLength(3);
     expect(packageRunner).toContain("bash scripts/e2e/bun-global-install-smoke.sh");
     expect(updateRunner).toContain('mv "$platform_package" "$platform_package.omitted"');
     expect(updateRunner).toContain("--mode fallback");
+  });
+
+  it("verifies fs-safe through a pnpm-style linked package root", () => {
+    const root = realpathSync(tempDirs.make("openclaw-linked-package-proof-"));
+    const modules = join(root, "node_modules");
+    const virtualModules = join(modules, ".pnpm/openclaw@fixture/node_modules");
+    const physicalRoot = join(virtualModules, "openclaw");
+    const logicalRoot = join(modules, "openclaw");
+    const fsSafe = join(virtualModules, "@openclaw/fs-safe");
+    mkdirSync(physicalRoot, { recursive: true });
+    mkdirSync(fsSafe, { recursive: true });
+    writeFileSync(join(physicalRoot, "package.json"), '{"name":"openclaw"}');
+    writeFileSync(
+      join(physicalRoot, "cli.cjs"),
+      'process.stdout.write(require.resolve("@openclaw/fs-safe/package.json"));',
+    );
+    writeFileSync(
+      join(fsSafe, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/fs-safe",
+        type: "module",
+        exports: {
+          "./package.json": "./package.json",
+          "./config": "./config.js",
+          "./durability": "./durability.js",
+        },
+      }),
+    );
+    writeFileSync(
+      join(fsSafe, "config.js"),
+      'export function configureFsSafeNative({ mode }) { if (mode !== "off") throw new Error("fixture requires fallback mode"); }',
+    );
+    writeFileSync(
+      join(fsSafe, "durability.js"),
+      `
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+export async function sha256File(file) {
+  return { digest: createHash("sha256").update(await readFile(file)).digest("hex") };
+}
+`,
+    );
+    symlinkSync(physicalRoot, logicalRoot, process.platform === "win32" ? "junction" : "dir");
+    expect(
+      execFileSync(process.execPath, [join(logicalRoot, "cli.cjs")], { encoding: "utf8" }),
+    ).toBe(join(fsSafe, "package.json"));
+    for (const packageRoot of [physicalRoot, logicalRoot]) {
+      const result = spawnSync(
+        process.execPath,
+        [
+          "scripts/docker/verify-fs-safe-native.mjs",
+          "--package-root",
+          packageRoot,
+          "--mode",
+          "fallback",
+        ],
+        { encoding: "utf8", timeout: 10_000 },
+      );
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+    }
+  });
+
+  it("builds and cleans package-lane images without touching shared image tags", () => {
+    const root = realpathSync(tempDirs.make("openclaw-package-image-owner-"));
+    for (const file of [
+      DOCKER_PACKAGE_INSTALL_E2E_PATH,
+      DOCKER_E2E_IMAGE_HELPER_PATH,
+      DOCKER_E2E_PACKAGE_HELPER_PATH,
+      HELPER_PATH,
+      "scripts/lib/docker-e2e-logs.sh",
+      "scripts/lib/docker-e2e-container.sh",
+      "scripts/lib/docker-e2e-resource-diagnostics.sh",
+      PREPUBLISH_PLUGIN_REGISTRY_HELPER_PATH,
+    ]) {
+      mkdirSync(dirname(join(root, file)), { recursive: true });
+      copyFileSync(file, join(root, file));
+    }
+    mkdirSync(join(root, "packages/normalization-core/src"), { recursive: true });
+    const tarball = join(root, "candidate.tgz");
+    writeFileSync(tarball, "synthetic package admission fixture");
+    const registry = join(root, "registry");
+    mkdirSync(registry);
+    writeFileSync(
+      join(registry, "prepublish-plugin-registry.json"),
+      JSON.stringify({
+        sourceSha: "a".repeat(40),
+        candidateVersion: "2026.9.1",
+        packages: [],
+      }),
+    );
+    const log = join(root, "docker.jsonl");
+    const bin = join(root, "bin");
+    writeExecutables(bin, {
+      pnpm: '#!/bin/bash\n[[ "$*" == test:docker:package-install ]] || exit 97\nexec bash scripts/e2e/docker-package-install.sh\n',
+      docker: `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify(args) + '\\n');
+if (args[0] === 'build') process.exit(0);
+if (args[0] === 'image' && args[1] === 'inspect') process.exit(args[2] === 'shared-bare:fixture' ? 0 : 1);
+if (args[0] === 'image' && args[1] === 'rm' || args[0] === 'rm') process.exit(0);
+// No container body runs. Fail the final creation to exercise the real owner's cleanup.
+if (args[0] === 'run' && fs.readFileSync(${JSON.stringify(log)}, 'utf8').trim().split('\\n').map(JSON.parse).filter(call => call[0] === 'run').length < 4) process.exit(0);
+process.exit(73);
+`,
+    });
+    const command = mainLanes.find((lane) => lane.name === "docker-package-install")?.command;
+    expect(command).toBeDefined();
+    const result = spawnSync("bash", ["-c", command!], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 10_000,
+      env: {
+        PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+        TMPDIR: root,
+        OPENCLAW_CURRENT_PACKAGE_TGZ: tarball,
+        OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registry,
+        OPENCLAW_DOCKER_E2E_IMAGE: "shared-bare:fixture",
+        OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1",
+        OPENCLAW_DOCKER_BUILD_ON_MISSING: "0",
+      },
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(73);
+    const calls = readFileSync(log, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as string[]);
+    const builds = calls.filter((args) => args[0] === "build");
+    expect(builds.map((args) => args[args.indexOf("--target") + 1])).toEqual(["bare", "musl"]);
+    const tags = builds.map((args) => args[args.indexOf("-t") + 1]);
+    expect(new Set(tags).size).toBe(2);
+    expect(calls.flat()).not.toContain("shared-bare:fixture");
+    expect(
+      calls
+        .filter((args) => args[0] === "image" && args[1] === "rm")
+        .flatMap((args) => args.slice(2)),
+    ).toEqual(tags);
+    expect(calls.findIndex((args) => args[0] === "run")).toBeGreaterThan(calls.indexOf(builds[1]!));
+    const runs = calls.filter((args) => args[0] === "run");
+    expect(runs).toHaveLength(4);
+    for (const args of runs) {
+      expect(args).toContain(`${tarball}:/tmp/openclaw-current.tgz:ro`);
+      expect(args).toContain(`${registry}:/tmp/openclaw-prepublish-plugin-registry:ro`);
+      expect(args[args.indexOf("--entrypoint") + 1]).toBe(
+        "/opt/openclaw-e2e/scripts/e2e/lib/prepublish-plugin-registry.sh",
+      );
+    }
   });
 
   it("keeps the shared e2e image on the packaged tarball install path", () => {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1,5 +1,5 @@
 // Docker E2E Plan tests cover docker e2e plan script behavior.
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -138,6 +138,54 @@ function bundledPluginSweepLane(index: number): ReturnType<typeof summarizeLane>
 }
 
 describe("scripts/lib/docker-e2e-plan", () => {
+  it.each([
+    ["catalog", "docker-package-install", {}, 0, ""],
+    ["missing package", "docker-package-install", { needsPackage: false }, 1, "package Docker"],
+    [
+      "package-only reused image",
+      "docker-package-install",
+      { command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:package-install" },
+      1,
+      "must force a local image build",
+    ],
+    [
+      "source reused image",
+      "docker-selected-plugins",
+      { command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:selected-plugins" },
+      1,
+      "must force a local image build",
+    ],
+    ["unapproved live package", "live-models", { needsPackage: true }, 1, "must not require"],
+    [
+      "shared package image",
+      "docker-package-install",
+      {
+        e2eImageKind: "bare",
+        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:package-install",
+      },
+      0,
+      "",
+    ],
+  ] as const)("validates Docker boundary ownership: %s", (_label, name, overrides, exit, error) => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "./scripts/tsx.mjs",
+        "--input-type=module",
+        "-e",
+        `import { mainLanes } from './scripts/lib/docker-e2e-scenarios.mts';
+Object.assign(mainLanes.find(lane => lane.name === ${JSON.stringify(name)}), ${JSON.stringify(overrides)});
+await import('./scripts/check-docker-e2e-boundaries.mts');`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status, result.stderr).toBe(exit);
+    if (error) {
+      expect(result.stderr).toContain(error);
+    }
+  });
+
   it.each([
     ["codex-media-path", ["@openclaw/codex"]],
     ["live-mcp-code-mode-gateway", ["@openclaw/codex"]],
@@ -330,8 +378,8 @@ describe("scripts/lib/docker-e2e-plan", () => {
         weight: 3,
       },
       {
-        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:package-install",
-        imageKind: "bare",
+        command: "OPENCLAW_SKIP_DOCKER_BUILD=0 pnpm test:docker:package-install",
+        imageKind: undefined,
         live: false,
         name: "docker-package-install",
         resources: ["docker", "npm"],
@@ -347,6 +395,12 @@ describe("scripts/lib/docker-e2e-plan", () => {
       liveImage: false,
       package: true,
       prepublishPluginRegistry: false,
+    });
+    expect(planFor({ selectedLaneNames: ["docker-package-install"] }).needs).toMatchObject({
+      package: true,
+      bareImage: false,
+      functionalImage: false,
+      e2eImage: false,
     });
   });
 

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -1008,37 +1008,41 @@ exit 1
     });
   });
 
-  it("redacts logged command failures before replay", () => {
-    withTempDir("openclaw-e2e-instance-run-log-redact-", (tempDir) => {
-      const redactorPath = path.join(tempDir, "redactor.mjs");
-      fs.writeFileSync(
-        redactorPath,
-        'export const redactSensitiveText = (value) => value.replaceAll("fixture-secret", "***");\n',
-        "utf8",
-      );
-      writeFakeTimeout(path.join(tempDir, "timeout"), true);
-      writeBashExecutable(path.join(tempDir, "fixture-command"), [
-        'printf "actionable failure fixture-secret\\n"',
-        "exit 23",
-      ]);
+  it.each([false, true])(
+    "redacts logged command failures before replay (stdin initialized: %s)",
+    (initializeStdin) => {
+      withTempDir("openclaw-e2e-instance-run-log-redact-", (tempDir) => {
+        const redactorPath = path.join(tempDir, "redactor.mjs");
+        fs.writeFileSync(
+          redactorPath,
+          `${initializeStdin ? "void process.stdin;\n" : ""}export const redactSensitiveText = (value) => value.replaceAll("fixture-secret", "***");\n`,
+          "utf8",
+        );
+        writeFakeTimeout(path.join(tempDir, "timeout"), true);
+        writeBashExecutable(path.join(tempDir, "fixture-command"), [
+          'for ((i = 0; i < 120; i += 1)); do printf "%02000d\\n" 0; done',
+          'printf "actionable failure fixture-secret\\n"',
+          "exit 23",
+        ]);
 
-      const result = runBashWithHelper(
-        ["openclaw_e2e_run_logged redacted-failure fixture-command"],
-        {
-          PATH: `${tempDir}${path.delimiter}${hostPath}`,
-          OPENCLAW_E2E_LOG_DIR: path.join(tempDir, "logs"),
-          OPENCLAW_E2E_REDACTOR_MODULE: redactorPath,
-          OPENCLAW_TEST_TIMEOUT_ARGS: path.join(tempDir, "timeout-args.txt"),
-        },
-        undefined,
-        "; ",
-      );
+        const result = runBashWithHelper(
+          ["openclaw_e2e_run_logged redacted-failure fixture-command"],
+          {
+            PATH: `${tempDir}${path.delimiter}${hostPath}`,
+            OPENCLAW_E2E_LOG_DIR: path.join(tempDir, "logs"),
+            OPENCLAW_E2E_REDACTOR_MODULE: redactorPath,
+            OPENCLAW_TEST_TIMEOUT_ARGS: path.join(tempDir, "timeout-args.txt"),
+          },
+          undefined,
+          "; ",
+        );
 
-      expect(result.status).toBe(1);
-      expect(result.stdout).toContain("actionable failure ***");
-      expect(result.stdout).not.toContain("fixture-secret");
-    });
-  });
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain("actionable failure ***");
+        expect(result.stdout).not.toContain("fixture-secret");
+      });
+    },
+  );
 
   it("installs the trash shim under isolated test state", () => {
     withTempDir("openclaw-e2e-trash-shim-", (tempDir) => {


### PR DESCRIPTION
Related: #137893 (partially overlapping pnpm verifier-root correction; legacy fs-safe compatibility remains separate). Related: #138085 (independent per-manager version-identity hardening).

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where package acceptance on a fresh runner could fail before completing its npm, pnpm, Bun, and musl checks, and failure diagnostics could themselves fail during redaction. Separately, the same installation flow exposed Bun CLI startup failing even when no plugin SDK aliases needed resolution. The pnpm failure was in the verifier's resolution base, not evidence of a broken pnpm installation.

## Why This Change Was Made

Keep each repair at its owner: package preparation is independent of shared-image preparation; the package lane builds and cleans its own uniquely tagged bare/musl images, including Bash and the existing musl harness prerequisites. The catalog guard enforces that ownership without a lane-name exception. Native verification canonicalizes the installed package root before creating its require resolver. The plugin resolver leaves native resolution untouched until aliases or providers exist, and diagnostic replay consumes initialized stdin asynchronously before applying the existing redactor.

This groups the failures proven along one real package-installation acceptance flow while retaining their distinct owners. It adds no JavaScript dependency, configuration/env option, public Docker-plan field/version, workflow job, resource cap, retry, or timeout. The lane retains docker+npm resource accounting, weight 3, and its 20-minute timeout; local image ownership has a cold-build cost. The Bun repair is the alias-free path, not a general workaround for Bun's active-alias resolver behavior. Main's complete functional-image postinstall and consolidated package-image test from #139754, and per-alias lazy resolution, provider precedence, and late-entry coverage from #139997 are preserved.

Runtime code is **−3 lines**; tooling is **+13**, for **+10 runtime/tooling overall**. Tests are **+231 lines**. The additions express image/package ownership and retain boundary regressions rather than adding consumer bypasses.

## User Impact

Maintainers can validate the actual package through npm, pnpm, Bun, and musl on a clean runner without relying on an unprepared shared image or misresolving pnpm's linked package root. Alias-free Bun CLI startup no longer installs an unnecessary global resolver hook. Failed commands retain bounded, canonically redacted diagnostics. Installation coverage and existing security/ownership guards remain intact.

## Evidence

- **Final real Linux package payload passed** on source `d7217198496ef64b4c2f0e24fefce7ecd814b6c1` plus exact tree `28a62f8f31bbbaa238dded01ac6c53391fa28785` (source carrier `1a9d1fb938ada6ca7355a2dcc7d6b03c8d8b4bcd`). [Testbox carrier run 34028009656](https://github.com/openclaw/openclaw/actions/runs/34028009656). The receiver verified that identity before execution. Canonical build, package inventory and dist-import integrity passed; package preparation took **224 seconds**, then the npm/pnpm/Bun/musl lane passed in **41 seconds**. Native timing reports **payload exit 0**, `runStatus: succeeded`, command **431.464 seconds**, and total **438.144 seconds**. The wrapper also joined with exit 0. Complete wrapper stdout/stderr and timing JSON were retained.
- Cleanup is explicit: the native client reported that it **stopped the one-shot Testbox after success**, and independent status returned `completed` for `tbx_01m1v4se4sheh9er6jpzyapdy5`. Portal sync subsequently warned `context deadline exceeded`. The backing Actions carrier concluded **cancelled**, separately from the successful payload and documented one-shot cleanup; this is not a claim that the workflow succeeded. Its workflow head is not the tested-source identity above. No downloaded runner artifact or package SHA256 is claimed.
- **288 focused tests passed**, with one existing Windows-specific cache-root case skipped on macOS. This includes the resolver, SDK alias, lazy-loader, cache, redactor, planner, scheduler and selected package-helper owners. Actual private probes also passed under **Node 24.20.0 and Bun 1.4.0**, retaining native resolution with no aliases/providers. The full `pnpm check:changed --base d7217198496ef64b4c2f0e24fefce7ecd814b6c1` gate passed. Fresh managed review was **scoped-clean through P2 across eight complete evidence passes**, with scanner/isolation and final source verification enabled. Local hashes remained unchanged after remote proof.
- Before/after reproductions cover missing musl-image admission, logical versus physical pnpm roots, Bun 1.4.0 alias-free resolution, initialized-stdin redaction and the real catalog guard. The current-main integration additionally captured the old JSON lazy expectation failing against main's distinct `late-adapter` fixture, then passed with that value and the alias-free assertion both preserved.
- Earlier integrations had successful Linux payloads [34010796653](https://github.com/openclaw/openclaw/actions/runs/34010796653) on `a887336b1e6b05ccd2f8db03592a5631e69af14d` (183 focused tests) and [34024692688](https://github.com/openclaw/openclaw/actions/runs/34024692688) on `87ceec92ecdcbf259c6f0a0d7c3a45f49e8d9e98` (184 focused tests). Those historical payload successes are distinct from cancelled carrier conclusions; the final d721 run above supplies current-candidate proof.

The open #137893 contains the same physical-root canonicalization and pnpm-layout coverage; this PR does not claim that component is unique or close its broader legacy compatibility work. #138085 changes version-identity checks, not these image, resolver or redaction owners.

### Data-model compatibility review follow-through

The automated serialized-state checkbox for `scripts/lib/openclaw-e2e-instance.sh` is not applicable. Its complete production diff only replaces synchronous stdin reading inside `openclaw_e2e_print_log` with `node:stream/consumers` while retaining the same redactor and output. It changes no stored representation, table, schema version, migration, configuration default, or runtime-state writer; the helper's state/environment-writing functions are unchanged. No data migration or upgrade conversion is therefore required. The initialized/uninitialized-stdin regression, 39 helper tests, and matching-tree Linux package run verify the affected diagnostic path. ClawSweeper separately reported no introduced code/security finding and accepted the real-behavior proof.
