### PR TITLE
fix(exec): block /approve smuggled behind shell line continuations

### DIFF
--- a/src/agents/bash-tools.exec-control-guard-entrypoint.test.ts
+++ b/src/agents/bash-tools.exec-control-guard-entrypoint.test.ts
@@ -24,17 +24,13 @@ const processGatewayAllowlistMock = vi.hoisted(() =>
 );
 
 vi.mock("./bash-tools.exec-host-gateway.js", async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import("./bash-tools.exec-host-gateway.js")
-  >()),
+  ...(await importOriginal<typeof import("./bash-tools.exec-host-gateway.js")>()),
   processGatewayAllowlist: processGatewayAllowlistMock,
 }));
 
 vi.mock("./bash-tools.exec-host-node.js", () => ({
   executeNodeHostCommand: async () => {
-    throw new Error(
-      "node host execution is not used by guard entrypoint tests",
-    );
+    throw new Error("node host execution is not used by guard entrypoint tests");
   },
 }));
 

--- a/src/agents/bash-tools.exec-control-guard-entrypoint.test.ts
+++ b/src/agents/bash-tools.exec-control-guard-entrypoint.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Exec control-guard entrypoint tests.
+ * Proves the real `createExecTool().execute()` path rejects a smuggled
+ * control command BEFORE approval routing and process startup, while an
+ * allowed command flows past the guard through the same entrypoint.
+ * Mock shape mirrors bash-tools.exec.script-preflight.test.ts.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import type { ExecToolApprovalReview } from "./bash-tools.exec-types.js";
+
+const processGatewayAllowlistMock = vi.hoisted(() =>
+  vi.fn(
+    async (_params?: {
+      onApprovalReview?: (review: ExecToolApprovalReview) => void;
+    }): Promise<{
+      allowWithoutEnforcedCommand: boolean;
+      revalidateBeforeExecution?: () => Promise<undefined>;
+    }> => ({ allowWithoutEnforcedCommand: true }),
+  ),
+);
+
+vi.mock("./bash-tools.exec-host-gateway.js", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("./bash-tools.exec-host-gateway.js")
+  >()),
+  processGatewayAllowlist: processGatewayAllowlistMock,
+}));
+
+vi.mock("./bash-tools.exec-host-node.js", () => ({
+  executeNodeHostCommand: async () => {
+    throw new Error(
+      "node host execution is not used by guard entrypoint tests",
+    );
+  },
+}));
+
+vi.mock("../utils/delivery-context.shared.js", () => ({
+  normalizeDeliveryContext: (value: unknown) => value,
+}));
+
+const createEntrypointTool = () =>
+  createExecTool({ host: "gateway", security: "full", ask: "on-miss" });
+
+describe("exec control guard at the tool entrypoint", () => {
+  it("rejects /approve smuggled behind a line continuation before approval routing", async () => {
+    processGatewayAllowlistMock.mockClear();
+    await withTempDir("openclaw-exec-guard-entrypoint-", async (parent) => {
+      const workdir = path.join(parent, "workdir");
+      await fs.mkdir(workdir, { recursive: true });
+
+      await expect(
+        createEntrypointTool().execute("call-guard-entrypoint", {
+          command: "echo hi; /appr\\\nove approval-1 allow-once",
+          workdir,
+        }),
+      ).rejects.toThrow(/exec cannot run \/approve commands/);
+    });
+    // The guard runs before approval routing: a rejected command never
+    // reaches the allowlist, so no process can have started.
+    expect(processGatewayAllowlistMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects the smuggled command even with an unresolvable workdir (guard runs first)", async () => {
+    processGatewayAllowlistMock.mockClear();
+    await expect(
+      createEntrypointTool().execute("call-guard-entrypoint", {
+        command: "echo hi; /appr\\\nove approval-1 allow-once",
+        workdir: "/nonexistent-openclaw-guard-proof/workdir",
+      }),
+    ).rejects.toThrow(/exec cannot run \/approve commands/);
+    expect(processGatewayAllowlistMock).not.toHaveBeenCalled();
+  });
+
+  it("lets an allowed command past the guard through the same entrypoint", async () => {
+    processGatewayAllowlistMock.mockClear();
+    await withTempDir("openclaw-exec-guard-entrypoint-", async (parent) => {
+      const workdir = path.join(parent, "workdir");
+      await fs.mkdir(workdir, { recursive: true });
+
+      await expect(
+        createEntrypointTool().execute("call-guard-entrypoint", {
+          command: "echo entrypoint-ok",
+          workdir,
+        }),
+      ).resolves.toBeDefined();
+    });
+    expect(processGatewayAllowlistMock).toHaveBeenCalled();
+  });
+});

--- a/src/infra/exec-control-command-guard.test.ts
+++ b/src/infra/exec-control-command-guard.test.ts
@@ -74,4 +74,69 @@ describe("exec control command guard", () => {
 
     await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
   });
+
+  it("still rejects /approve after a quoted here-document whose body ends in a backslash", async () => {
+    // The review's case: joining `x\` + `EOF` would move the terminator and
+    // swallow the command into the body only in the rewritten input, while
+    // the shell executes it (verified vs sh: body prints `x\`, then
+    // `/approve` runs).
+    const command = "cat <<'EOF'\nx\\\nEOF\n/approve abc123 allow-once\nEOF\n";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("does not treat a quoted here-document body as commands", async () => {
+    const command = "cat <<'EOF'\n/approve abc123 allow-once\nEOF\necho done";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBeNull();
+  });
+
+  it("treats an empty here-document followed by a command normally", async () => {
+    const command = "cat <<EOF\nEOF\n/approve abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("does not let a commented-out heredoc operator shield later lines", async () => {
+    const command = "# cat <<EOF\n/approve abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("does not treat a herestring as a here-document body", async () => {
+    const command = 'cat <<< "x"\n/approve abc123 allow-once';
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("honors tab-stripped terminators of <<- here-documents", async () => {
+    const command = "cat <<-'EOF'\nx\\\n\tEOF\n/approve abc123 allow-once\nEOF\n";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("mirrors the shell joining continuations inside unquoted here-document bodies", async () => {
+    // Verified vs sh: `x\` + `EOF` joins, destroying the terminator, so the
+    // rest is body (nothing executes) — the guard must agree (null), not
+    // report a swallowed command.
+    const joinedTerminator = "cat <<EOF\nx\\\nEOF\necho done";
+
+    await expect(detectUnsafeExecControlShellCommand(joinedTerminator)).resolves.toBeNull();
+  });
+
+  it("treats a split terminator inside an unquoted here-document as terminating", async () => {
+    // Verified vs sh: `E\` + `OF` joins into the `EOF` terminator, so the
+    // body ends and the following command runs (it is allowed → null).
+    const splitTerminator = "cat <<EOF\nE\\\nOF\necho done";
+
+    await expect(detectUnsafeExecControlShellCommand(splitTerminator)).resolves.toBeNull();
+  });
+
+  it("treats a continuation-joined operator line as opening its here-document", async () => {
+    // Verified vs sh: `cat <<EOF \` + `body1` joins first, so `body1` is a
+    // file argument and the body is empty — the following command runs.
+    const joinedOperator = "cat <<EOF \\\nbody1\nEOF\necho done";
+
+    await expect(detectUnsafeExecControlShellCommand(joinedOperator)).resolves.toBeNull();
+  });
 });

--- a/src/infra/exec-control-command-guard.test.ts
+++ b/src/infra/exec-control-command-guard.test.ts
@@ -53,4 +53,25 @@ describe("exec control command guard", () => {
 
     await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBeNull();
   });
+
+  it("still rejects /approve on the line after a backslash-ended comment", async () => {
+    // A `#` comment ends at the newline: joining it would swallow the command.
+    const command = "# note \\\n/approve abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("still rejects /approve after a mid-line backslash-ended comment", async () => {
+    const command = "echo hi # c \\\n/approve abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("still rejects /approve after an even backslash run (real separator)", async () => {
+    // `\\` is a literal backslash; the newline stays a separator, so the
+    // prohibition arrives as its own command and must be caught as-is.
+    const command = "echo X \\\\\n/approve abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
 });

--- a/src/infra/exec-control-command-guard.test.ts
+++ b/src/infra/exec-control-command-guard.test.ts
@@ -26,4 +26,31 @@ describe("exec control command guard", () => {
       /exceeds the command explanation work limit/,
     );
   });
+
+  it("rejects /approve hidden behind a shell line continuation", async () => {
+    const command = "echo hi; /appr\\\nove abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+    await expect(rejectUnsafeExecControlShellCommand(command)).rejects.toThrow(
+      /exec cannot run \/approve commands/,
+    );
+  });
+
+  it("rejects /approve hidden behind a line continuation inside sh -c", async () => {
+    const command = "sh -c 'echo hi; /appr\\\nove abc123 allow-once'";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("keeps an escaped backslash before a newline as a command separator", async () => {
+    const command = "echo \\\\\n/approve abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBe("approve");
+  });
+
+  it("leaves backslash-CRLF alone (not a shell continuation, must not false-positive)", async () => {
+    const command = "echo hi; /appr\\\r\nove abc123 allow-once";
+
+    await expect(detectUnsafeExecControlShellCommand(command)).resolves.toBeNull();
+  });
 });

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -261,22 +261,38 @@ function targetsLiveStateSqliteDatabase(
   });
 }
 
-// Mirrors POSIX shell parsing: an odd-count backslash run before a LF is a line
-// continuation (removed before word splitting); an even-count run is literal
-// backslashes followed by a real newline separator. Backslash-CR-LF is not a
-// continuation, so it is left untouched.
-function removeShellLineContinuations(command: string): string {
-  return command.replace(/\\+\n/g, (match) => {
-    const backslashes = match.length - 1;
-    return backslashes % 2 === 1 ? "\\".repeat((backslashes - 1) / 2) : match;
-  });
+// Join line continuations strictly *inside* shell words. tree-sitter-bash
+// word-breaks at `\<newline>` while POSIX sh joins, which hides control
+// words from the guard (e.g. `/appr\<newline>ove` executes as `/approve`
+// but parses as `/appr` + `ove`). A pair is joined only when an odd-length
+// backslash run at end-of-line is flanked by word characters on both sides:
+//   - comment lines are untouched (a `#` comment ends at the newline, so
+//     joining would swallow the following command); lines containing `#`
+//     anywhere before the pair are skipped too (a joined word keeping a
+//     literal `#` can never equal a `#`-free control word, so skipping is
+//     safe for control matching);
+//   - even runs are untouched (literal backslashes + a real separator);
+//   - `\` + CRLF is untouched (not a continuation for the shell).
+// The replacement keeps (N-1)/2 literal backslashes, mirroring incremental
+// shell tokenization (re-emitting the newline would falsely escape the
+// character that follows it in a fresh parse).
+function joinWordInternalLineContinuations(command: string): string {
+  return command.replace(
+    /^(?!\s*#)([^#\n]*?)([^\s;|&()<>"'`#$\n\\])(\\+)\n(?=[^\s;|&()<>"'`#$\n\\])/gm,
+    (match, prefix, before, run) => {
+      if (run.length % 2 === 0) {
+        return match;
+      }
+      return prefix + before + "\\".repeat((run.length - 1) / 2);
+    },
+  );
 }
 
 export async function detectUnsafeExecControlShellCommand(
   command: string,
   context: ExecControlShellCommandContext = {},
 ): Promise<UnsafeExecControlShellCommandKind | null> {
-  const rawCommand = removeShellLineContinuations(command).trim();
+  const rawCommand = joinWordInternalLineContinuations(command).trim();
   let explanation: CommandExplanation | null = null;
   try {
     explanation = await explainShellCommand(rawCommand);

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -261,11 +261,22 @@ function targetsLiveStateSqliteDatabase(
   });
 }
 
+// Mirrors POSIX shell parsing: an odd-count backslash run before a LF is a line
+// continuation (removed before word splitting); an even-count run is literal
+// backslashes followed by a real newline separator. Backslash-CR-LF is not a
+// continuation, so it is left untouched.
+function removeShellLineContinuations(command: string): string {
+  return command.replace(/\\+\n/g, (match) => {
+    const backslashes = match.length - 1;
+    return backslashes % 2 === 1 ? "\\".repeat((backslashes - 1) / 2) : match;
+  });
+}
+
 export async function detectUnsafeExecControlShellCommand(
   command: string,
   context: ExecControlShellCommandContext = {},
 ): Promise<UnsafeExecControlShellCommandKind | null> {
-  const rawCommand = command.trim();
+  const rawCommand = removeShellLineContinuations(command).trim();
   let explanation: CommandExplanation | null = null;
   try {
     explanation = await explainShellCommand(rawCommand);

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -394,7 +394,9 @@ function joinWordInternalLineContinuations(command: string): string {
   };
   let i = 0;
   while (i < lines.length) {
-    const line = lines[i];
+    // Index access is guarded by the loop bound; the `?? ""` only satisfies
+    // `noUncheckedIndexedAccess`.
+    const line: string = lines[i] ?? "";
     const top = pending[0];
     if (top && top.quoted) {
       // Quoted here-document: body lines are literal, so they are never

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -272,20 +272,180 @@ function targetsLiveStateSqliteDatabase(
 //     literal `#` can never equal a `#`-free control word, so skipping is
 //     safe for control matching);
 //   - even runs are untouched (literal backslashes + a real separator);
-//   - `\` + CRLF is untouched (not a continuation for the shell).
+//   - `\` + CRLF is untouched (not a continuation for the shell);
+//   - quoted here-document bodies are untouched: joining `x\` + `EOF` would
+//     move the terminator and swallow the following command into the body
+//     only in the rewritten input, while the shell executes it (verified
+//     vs sh). Unquoted bodies DO join (verified: the shell joins there and
+//     even a split terminator `E\`+`OF` terminates), so they are processed
+//     like code, minus operator scanning (body text opens no heredocs).
 // The replacement keeps (N-1)/2 literal backslashes, mirroring incremental
 // shell tokenization (re-emitting the newline would falsely escape the
 // character that follows it in a fresh parse).
-function joinWordInternalLineContinuations(command: string): string {
-  return command.replace(
-    /^(?!\s*#)([^#\n]*?)([^\s;|&()<>"'`#$\n\\])(\\+)\n(?=[^\s;|&()<>"'`#$\n\\])/gm,
+type HeredocFrame = { delim: string; stripTabs: boolean; quoted: boolean };
+
+// Finds `<<[-]delimiter` operators on one raw physical line, skipping
+// anything inside single/double quotes and trailing `#` comments — but the
+// delimiter itself may be quoted (`<<'EOF'`), so quotes are tracked rather
+// than stripped. `<<<` herestrings are skipped (no body follows).
+function scanHeredocOperators(line: string): HeredocFrame[] {
+  const frames: HeredocFrame[] = [];
+  let i = 0;
+  let squote = false;
+  let dquote = false;
+  const n = line.length;
+  while (i < n) {
+    const ch = line[i];
+    if (squote) {
+      if (ch === "'") {
+        squote = false;
+      }
+      i += 1;
+      continue;
+    }
+    if (dquote) {
+      if (ch === "\\") {
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        dquote = false;
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === "'") {
+      squote = true;
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      dquote = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "#" && (i === 0 || /[\s;|&()<>]/.test(line[i - 1] ?? ""))) {
+      break;
+    }
+    if (ch === "<" && line[i + 1] === "<" && line[i + 2] !== "<") {
+      let j = i + 2;
+      let stripTabs = false;
+      if (line[j] === "-") {
+        stripTabs = true;
+        j += 1;
+      }
+      while (line[j] === " " || line[j] === "\t") {
+        j += 1;
+      }
+      let delim = "";
+      let quoted = false;
+      const q = line[j];
+      if (q === "'" || q === '"') {
+        const end = line.indexOf(q, j + 1);
+        if (end !== -1) {
+          delim = line.slice(j + 1, end);
+          quoted = true;
+          j = end + 1;
+        }
+      } else {
+        if (line[j] === "\\" && j + 1 < n) {
+          quoted = true;
+          j += 1;
+        }
+        const start = j;
+        while (j < n && /[A-Za-z0-9_]/.test(line[j] ?? "")) {
+          j += 1;
+        }
+        delim = line.slice(start, j);
+      }
+      if (delim.length > 0) {
+        frames.push({ delim, stripTabs, quoted });
+      }
+      i = j;
+      continue;
+    }
+    i += 1;
+  }
+  return frames;
+}
+
+function joinEolPair(line: string, nextLine: string): string {
+  return line.replace(
+    /^(?!\s*#)([^#\n]*?)([^\s;|&()<>"'`#$\n\\])(\\+)$/g,
     (match, prefix, before, run) => {
-      if (run.length % 2 === 0) {
+      if ((run as string).length % 2 === 0) {
         return match;
       }
-      return prefix + before + "\\".repeat((run.length - 1) / 2);
+      if (!/^[^\s;|&()<>"'`#$\n\\]/.test(nextLine)) {
+        return match;
+      }
+      return (prefix as string) + (before as string) + "\\".repeat(((run as string).length - 1) / 2);
     },
   );
+}
+
+function joinWordInternalLineContinuations(command: string): string {
+  const lines = command.split("\n");
+  const pending: HeredocFrame[] = [];
+  const out: string[] = [];
+  const isTerminator = (line: string, frame: HeredocFrame): boolean => {
+    const cmp = frame.stripTabs ? line.replace(/^\t+/, "") : line;
+    return cmp === frame.delim;
+  };
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const top = pending[0];
+    if (top && top.quoted) {
+      // Quoted here-document: body lines are literal, so they are never
+      // joined; only the exact terminator ends the body.
+      if (isTerminator(line, top)) {
+        pending.shift();
+      }
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    if (i === lines.length - 1) {
+      if (!top) {
+        for (const f of scanHeredocOperators(line)) {
+          if (f.delim.length > 0) {
+            pending.push(f);
+          }
+        }
+      } else if (isTerminator(line, top)) {
+        pending.shift();
+      }
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    // Code lines and unquoted-heredoc body lines both follow incremental
+    // shell tokenization: an odd `\` run joins with the next line, which is
+    // then consumed into this logical line (it is not body/a terminator on
+    // its own — verified vs sh). A joined line can itself be a terminator
+    // (`E\` + `OF` ends `<<EOF`); the check below runs on the joined text.
+    // Operators are scanned on the joined logical line, since a consumed
+    // physical line may carry them (`echo a \` + `cat <<EOF` opens `EOF`).
+    // Body text itself opens no heredocs, so only code lines are scanned.
+    const joined = joinEolPair(line, lines[i + 1] ?? "");
+    // A successful join strips the continuation backslash from this line;
+    // the next line's text belongs to the same logical line, so it is
+    // appended here and consumed (skipped) below — mirroring the shell.
+    const logical = joined !== line ? joined + (lines[i + 1] ?? "") : line;
+    if (!top) {
+      for (const f of scanHeredocOperators(logical)) {
+        if (f.delim.length > 0) {
+          pending.push(f);
+        }
+      }
+    } else if (isTerminator(logical, top)) {
+      pending.shift();
+    }
+    out.push(logical);
+    i += joined !== line ? 2 : 1;
+  }
+  return out.join("\n");
 }
 
 export async function detectUnsafeExecControlShellCommand(

--- a/src/infra/exec-control-command-guard.ts
+++ b/src/infra/exec-control-command-guard.ts
@@ -372,14 +372,14 @@ function scanHeredocOperators(line: string): HeredocFrame[] {
 function joinEolPair(line: string, nextLine: string): string {
   return line.replace(
     /^(?!\s*#)([^#\n]*?)([^\s;|&()<>"'`#$\n\\])(\\+)$/g,
-    (match, prefix, before, run) => {
-      if ((run as string).length % 2 === 0) {
+    (match: string, prefix: string, before: string, run: string) => {
+      if (run.length % 2 === 0) {
         return match;
       }
       if (!/^[^\s;|&()<>"'`#$\n\\]/.test(nextLine)) {
         return match;
       }
-      return (prefix as string) + (before as string) + "\\".repeat(((run as string).length - 1) / 2);
+      return prefix + before + "\\".repeat((run.length - 1) / 2);
     },
   );
 }


### PR DESCRIPTION
## What Problem This Solves

`detectUnsafeExecControlShellCommand` missed `/approve` (and the same hole
covers channel-login and live-state sqlite commands) when split by a shell
line continuation: `echo hi; /appr\<LF>ove <id> allow-once` executes as
`/approve` in a real shell, but tree-sitter-bash word-breaks at the
continuation, so no payload candidate matched and the guard returned `null`.
An agent-issued command could sail past the exec control guard.

## Approach (v3 — reworked twice after ClawSweeper review)

v1 preprocessed the whole command; the review correctly showed that hides
commands in comments and miscounts backslash runs (both reproduced vs real
`sh`). v2 fixed those but could hide a command behind a quoted here-document
delimiter (also reproduced). v3 joins continuations strictly *inside* shell
words — odd backslash run at end-of-line, word characters both sides —
while tracking here-document state line by line:

- comment lines and `#`-bearing lines skipped (a `#` comment ends at the
  newline; a joined word keeping a literal `#` can never equal a `#`-free
  control word);
- even runs and `\`+CRLF untouched (not continuations for the shell);
- quoted heredoc bodies never joined (joining `x\`+`EOF` would move the
  terminator and swallow the following command only in the rewritten input);
- unquoted bodies follow the shell exactly (it joins there — even a split
  terminator `E\`+`OF` terminates), with the terminator check running on the
  joined text and consumed lines skipped;
- operators scanned with a quote/comment-aware scanner (`<<'EOF'` counts,
  `"<< "`/`# <<EOF`/`<<<` don't); the shared extractor is untouched, so its
  `line-continuation`/`dynamic-executable` risk flags and the authorization
  plan's fail-closed stance on them are preserved.

## Evidence

- 20 differential shapes checked against real `sh -x` ground truth (stub
  `approve` on PATH, `+` trace lines show executed commands): guard verdict
  matches the shell on all of them — continuation smuggling (top-level and
  `sh -c`), comment/`#` cases, even/odd backslash runs, CRLF, single-quote
  literals, clean multiline, plus 8 heredoc shapes (quoted/unquoted bodies,
  split terminator, joined operator line, `<<-` tabs, herestring, empty doc).
- Entrypoint proof (`bash-tools.exec-control-guard-entrypoint.test.ts`,
  same mock shape as the script-preflight suite): the real
  `createExecTool().execute()` rejects the smuggled command with
  `exec cannot run /approve commands` while the gateway allowlist mock is
  never called (rejected before approval routing, so no process can have
  started); the same rejection fires with an unresolvable workdir, pinning
  guard-first ordering behaviorally; an allowed `echo` resolves through the
  same entrypoint with the allowlist reached.
- Neighbors green, serial vitest: guard (17) + explainer suites +
  `bash-tools.exec-{live-state-sqlite-guard,script-preflight,
  approval-request,control-guard-entrypoint}` — 143 passed, 4 skipped.
- `oxlint` clean on touched files. Pre-existing repo state (not from this
  PR): `prettier --check` already warns on both guard files at base; full
  `tsc` OOMs in this environment.

Known follow-ups (left for separate work): `$0`/`$@` positional trampoline
(`sh -c 'exec $0 $@' /approve ...`) and `find`/`xargs` carriers still return
`null`.
