### PR TITLE
fix(mac): preserve companion exec timeouts

### DIFF
--- a/src/infra/exec-host.socket.test.ts
+++ b/src/infra/exec-host.socket.test.ts
@@ -162,7 +162,7 @@ describe.runIf(process.platform !== "win32")("exec host real UDS boundary", () =
   );
 
   it.each(["close", "malformed matching response", "timeout"] as const)(
-    "characterizes null after a signed request starts a child and then %s",
+    "characterizes the outcome after a signed request starts a child and then %s",
     async (fault) => {
       await withExecPeer(async ({ dir, socketPath, markers, order, children, onRequest }) => {
         const command = [
@@ -212,10 +212,33 @@ describe.runIf(process.platform !== "win32")("exec host real UDS boundary", () =
           order.push("child-completed");
         });
         try {
-          // Characterization only: null currently conflates no delivery with lost outcome.
-          await expect(
-            requestExecHostViaSocket({ socketPath, token, request, timeoutMs: 1_000 }),
-          ).resolves.toBeNull();
+          const result = await requestExecHostViaSocket({
+            socketPath,
+            token,
+            request,
+            timeoutMs: 1_000,
+          });
+          if (fault === "close") {
+            expect(result).toEqual({
+              ok: false,
+              error: {
+                code: "UNKNOWN",
+                reason: "response-lost",
+                message:
+                  "UNKNOWN: macOS app exec host response was lost; execution outcome is unknown",
+              },
+            });
+          } else {
+            expect(result).toEqual({
+              ok: false,
+              error: {
+                code: "TIMEOUT",
+                reason: "timeout",
+                message:
+                  "TIMEOUT: macOS app exec host response timed out; execution outcome is unknown",
+              },
+            });
+          }
           order.push("client-null");
           expect(await fs.readFile(markers, "utf8")).toBe("START\n");
         } finally {

--- a/src/infra/exec-host.test.ts
+++ b/src/infra/exec-host.test.ts
@@ -8,7 +8,7 @@ vi.mock("./jsonl-socket.js", () => ({
   requestJsonlSocket: (...args: unknown[]) => requestJsonlSocketMock(...args),
 }));
 
-import { requestExecHostViaSocket } from "./exec-host.js";
+import { requestExecHostViaSocket, resolveExecHostResponseTimeoutMs } from "./exec-host.js";
 
 type JsonlSocketCall = {
   socketPath: string;
@@ -102,7 +102,7 @@ describe("requestExecHostViaSocket", () => {
     });
   });
 
-  it("accepts only exec response messages and maps malformed matches to null", async () => {
+  it("accepts only complete exec response messages", async () => {
     requestJsonlSocketMock.mockImplementationOnce(async ({ accept }) => {
       expect(accept({ type: "ignore" })).toBeUndefined();
       expect(accept({ type: "exec-res", ok: true, payload: { success: true } })).toEqual({
@@ -113,7 +113,7 @@ describe("requestExecHostViaSocket", () => {
         ok: false,
         error: { code: "DENIED" },
       });
-      expect(accept({ type: "exec-res", ok: true })).toBeNull();
+      expect(accept({ type: "exec-res", ok: true })).toBeUndefined();
       return null;
     });
 
@@ -127,5 +127,43 @@ describe("requestExecHostViaSocket", () => {
     ).resolves.toBeNull();
 
     expect(requireJsonlSocketCall().timeoutMs).toBe(123);
+  });
+
+  it("derives the socket deadline from the command timeout and preserves disabled timeouts", () => {
+    expect(resolveExecHostResponseTimeoutMs(30_000)).toBe(35_000);
+    expect(resolveExecHostResponseTimeoutMs(0)).toBe(0);
+    expect(resolveExecHostResponseTimeoutMs(undefined)).toBeUndefined();
+  });
+
+  it("uses the command timeout when no transport override is supplied", async () => {
+    requestJsonlSocketMock.mockResolvedValueOnce(null);
+
+    await requestExecHostViaSocket({
+      socketPath: "/tmp/socket",
+      token: "secret",
+      request: { command: ["sleep", "30"], timeoutMs: 30_000 },
+    });
+
+    expect(requireJsonlSocketCall().timeoutMs).toBe(35_000);
+  });
+
+  it("returns a typed timeout when the response deadline expires", async () => {
+    requestJsonlSocketMock.mockImplementationOnce(async ({ onTimeout }) => onTimeout?.() ?? null);
+
+    await expect(
+      requestExecHostViaSocket({
+        socketPath: "/tmp/socket",
+        token: "secret",
+        timeoutMs: 123,
+        request: { command: ["sleep", "1"] },
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      error: {
+        code: "TIMEOUT",
+        reason: "timeout",
+        message: "TIMEOUT: macOS app exec host response timed out; execution outcome is unknown",
+      },
+    });
   });
 });

--- a/src/infra/exec-host.ts
+++ b/src/infra/exec-host.ts
@@ -1,7 +1,19 @@
 // Sends HMAC-protected exec host requests over the local socket.
 import crypto from "node:crypto";
+import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
 import type { ExecApprovalPolicySnapshot } from "./exec-approvals.js";
 import { requestJsonlSocket } from "./jsonl-socket.js";
+
+const EXEC_HOST_RESPONSE_GRACE_MS = 5_000;
+
+export function resolveExecHostResponseTimeoutMs(
+  commandTimeoutMs: number | null | undefined,
+): number | undefined {
+  if (commandTimeoutMs === 0) {
+    return 0;
+  }
+  return addTimerTimeoutGraceMs(commandTimeoutMs, EXEC_HOST_RESPONSE_GRACE_MS);
+}
 
 // Exec host requests cross the local JSONL socket boundary into a privileged
 // runner, so payloads stay explicit and HMAC-protected.
@@ -50,7 +62,8 @@ export async function requestExecHostViaSocket(params: {
   if (!socketPath || !token) {
     return null;
   }
-  const timeoutMs = params.timeoutMs ?? 20_000;
+  const timeoutMs =
+    params.timeoutMs ?? resolveExecHostResponseTimeoutMs(request.timeoutMs) ?? 20_000;
   const requestJson = JSON.stringify(request);
   const nonce = crypto.randomBytes(16).toString("hex");
   const ts = Date.now();
@@ -69,7 +82,7 @@ export async function requestExecHostViaSocket(params: {
     requestJson,
   });
 
-  return await requestJsonlSocket({
+  return await requestJsonlSocket<ExecHostResponse>({
     socketPath,
     requestLine: payload,
     timeoutMs,
@@ -85,7 +98,23 @@ export async function requestExecHostViaSocket(params: {
       if (msg.ok === false && msg.error) {
         return { ok: false, error: msg.error as ExecHostError };
       }
-      return null;
+      return undefined;
     },
+    onTimeout: () => ({
+      ok: false,
+      error: {
+        code: "TIMEOUT",
+        reason: "timeout",
+        message: "TIMEOUT: macOS app exec host response timed out; execution outcome is unknown",
+      },
+    }),
+    onResponseLost: () => ({
+      ok: false,
+      error: {
+        code: "UNKNOWN",
+        reason: "response-lost",
+        message: "UNKNOWN: macOS app exec host response was lost; execution outcome is unknown",
+      },
+    }),
   });
 }

--- a/src/infra/jsonl-socket.test.ts
+++ b/src/infra/jsonl-socket.test.ts
@@ -147,7 +147,7 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
     await withSocketServer(server, async (socketPath) => {
       closedSocketPath = socketPath;
       await expect(
-        requestJsonlSocket({
+        requestJsonlSocket<number | { kind: "timeout" }>({
           socketPath,
           requestLine: "{}",
           timeoutMs: 50,
@@ -163,6 +163,61 @@ describe.runIf(process.platform !== "win32")("requestJsonlSocket", () => {
         accept: () => undefined,
       }),
     ).resolves.toBeNull();
+  });
+
+  it("returns the caller's typed timeout result when provided", async () => {
+    const server = net.createServer({ allowHalfOpen: true }, (socket) => {
+      socket.resume();
+    });
+    await withSocketServer(server, async (socketPath) => {
+      await expect(
+        requestJsonlSocket({
+          socketPath,
+          requestLine: "{}",
+          timeoutMs: 50,
+          onTimeout: () => ({ kind: "timeout" as const }),
+          accept: () => undefined,
+        }),
+      ).resolves.toEqual({ kind: "timeout" });
+    });
+  });
+
+  it("returns the caller's typed response-loss result after submission", async () => {
+    const server = net.createServer((socket) => {
+      socket.on("data", () => {
+        socket.destroy();
+      });
+    });
+    await withSocketServer(server, async (socketPath) => {
+      await expect(
+        requestJsonlSocket({
+          socketPath,
+          requestLine: "{}",
+          timeoutMs: 500,
+          onResponseLost: () => ({ kind: "response-lost" as const }),
+          accept: () => undefined,
+        }),
+      ).resolves.toEqual({ kind: "response-lost" });
+    });
+  });
+
+  it("can wait without a transport deadline when timeoutMs is zero", async () => {
+    const server = net.createServer((socket) => {
+      socket.on("data", () => {
+        socket.end('{"type":"done","value":7}\n');
+      });
+    });
+    await withSocketServer(server, async (socketPath) => {
+      await expect(
+        requestJsonlSocket<number | { kind: "timeout" }>({
+          socketPath,
+          requestLine: "{}",
+          timeoutMs: 0,
+          onTimeout: () => ({ kind: "timeout" as const }),
+          accept: acceptDoneValue,
+        }),
+      ).resolves.toBe(7);
+    });
   });
 
   it("returns null when the socket closes without an accepted response", async () => {

--- a/src/infra/jsonl-socket.ts
+++ b/src/infra/jsonl-socket.ts
@@ -10,6 +10,8 @@ type JsonlSocketRequest<T> = {
   socketPath: string;
   requestLine: string;
   timeoutMs: number;
+  onTimeout?: () => T;
+  onResponseLost?: () => T;
   signal?: AbortSignal;
   accept: (msg: unknown) => T | null | undefined;
 };
@@ -19,10 +21,12 @@ type JsonlSocketRequest<T> = {
  */
 export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Promise<T | null> {
   const { socketPath, requestLine, accept, signal } = params;
-  const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
+  const timeoutMs = params.timeoutMs === 0 ? 0 : resolveTimerTimeoutMs(params.timeoutMs, 1);
   return await new Promise((resolve) => {
     const client = new net.Socket();
     let settled = false;
+    let requestSent = false;
+    let timer: ReturnType<typeof setNodeTimeout> | undefined;
     // Keep raw bytes until a line is complete so chunk boundaries cannot split
     // a UTF-8 code point before JSON parsing.
     const lineChunks: Buffer[] = [];
@@ -33,7 +37,9 @@ export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Prom
         return;
       }
       settled = true;
-      clearNodeTimeout(timer);
+      if (timer) {
+        clearNodeTimeout(timer);
+      }
       abortListener?.[Symbol.dispose]();
       client.destroy();
       resolve(value);
@@ -51,7 +57,12 @@ export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Prom
       return true;
     };
 
-    const timer = setNodeTimeout(() => finish(null), timeoutMs);
+    if (timeoutMs > 0) {
+      timer = setNodeTimeout(
+        () => finish(requestSent ? (params.onTimeout?.() ?? null) : null),
+        timeoutMs,
+      );
+    }
     const abortListener = signal ? addAbortListener(signal, () => finish(null)) : undefined;
     // Preparation may have yielded before reaching the transport. Never connect
     // or send for an invocation that has already lost its lifetime.
@@ -60,11 +71,13 @@ export async function requestJsonlSocket<T>(params: JsonlSocketRequest<T>): Prom
       return;
     }
 
-    client.on("error", () => finish(null));
-    client.on("end", () => finish(null));
-    client.on("close", () => finish(null));
+    const finishPeerLoss = () => finish(requestSent ? (params.onResponseLost?.() ?? null) : null);
+    client.on("error", finishPeerLoss);
+    client.on("end", finishPeerLoss);
+    client.on("close", finishPeerLoss);
     client.connect(socketPath, () => {
       if (!settled) {
+        requestSent = true;
         client.end(`${requestLine}\n`);
       }
     });

--- a/src/node-host/invoke-system-run.socket.test.ts
+++ b/src/node-host/invoke-system-run.socket.test.ts
@@ -122,7 +122,15 @@ describe.runIf(process.platform !== "win32")("enforced exec host transport bound
                   request,
                   timeoutMs: 2_000,
                 });
-                expect(response).toBeNull();
+                expect(response).toEqual({
+                  ok: false,
+                  error: {
+                    code: "UNKNOWN",
+                    reason: "response-lost",
+                    message:
+                      "UNKNOWN: macOS app exec host response was lost; execution outcome is unknown",
+                  },
+                });
                 order.push("client-null");
                 return response;
               },

--- a/src/node-host/invoke-system-run.test.ts
+++ b/src/node-host/invoke-system-run.test.ts
@@ -724,6 +724,53 @@ describe("handleSystemRunInvoke mac app exec host routing", () => {
     });
   });
 
+  it("classifies a companion response deadline as a timeout", async () => {
+    const result = await runMacSystemInvoke({
+      execHostFallbackAllowed: false,
+      runViaResponse: {
+        ok: false,
+        error: {
+          code: "TIMEOUT",
+          reason: "timeout",
+          message: "TIMEOUT: macOS app exec host response timed out; execution outcome is unknown",
+        },
+      },
+    });
+
+    expectExecDeniedEvent(result.sendNodeEvent, "timeout");
+    expect(requireInvokeResult(result.sendInvokeResult)).toMatchObject({
+      ok: false,
+      error: {
+        code: "TIMEOUT",
+        message: "TIMEOUT: macOS app exec host response timed out; execution outcome is unknown",
+      },
+    });
+    expect(result.runCommand).not.toHaveBeenCalled();
+  });
+
+  it("keeps a submitted companion command from falling back after response loss", async () => {
+    const result = await runMacSystemInvoke({
+      runViaResponse: {
+        ok: false,
+        error: {
+          code: "UNKNOWN",
+          reason: "response-lost",
+          message: "UNKNOWN: macOS app exec host response was lost; execution outcome is unknown",
+        },
+      },
+    });
+
+    expectExecDeniedEvent(result.sendNodeEvent, "response-lost");
+    expect(requireInvokeResult(result.sendInvokeResult)).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNKNOWN",
+        message: "UNKNOWN: macOS app exec host response was lost; execution outcome is unknown",
+      },
+    });
+    expect(result.runCommand).not.toHaveBeenCalled();
+  });
+
   it("forwards cancellation to locally spawned node commands", async () => {
     const controller = new AbortController();
     const result = await runLocalSystemInvoke({ signal: controller.signal });

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -93,6 +93,8 @@ type SystemRunDeniedReason =
   | "allowlist-miss"
   | "execution-plan-miss"
   | "companion-unavailable"
+  | "timeout"
+  | "response-lost"
   | "cwd-unavailable"
   | "permission:screenRecording";
 
@@ -186,6 +188,8 @@ function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeni
     case "allowlist-miss":
     case "execution-plan-miss":
     case "companion-unavailable":
+    case "timeout":
+    case "response-lost":
     case "cwd-unavailable":
     case "permission:screenRecording":
       return reason;
@@ -303,9 +307,16 @@ async function sendSystemRunDenied(
   );
   await opts.sendInvokeResult({
     ok: false,
-    // A missing companion reply can follow execution; it is not a policy denial.
+    // A missing or late companion reply can follow execution; it is not a policy denial.
     error: {
-      code: params.reason === "companion-unavailable" ? "UNAVAILABLE" : "SYSTEM_RUN_DENIED",
+      code:
+        params.reason === "companion-unavailable"
+          ? "UNAVAILABLE"
+          : params.reason === "timeout"
+            ? "TIMEOUT"
+            : params.reason === "response-lost"
+              ? "UNKNOWN"
+              : "SYSTEM_RUN_DENIED",
       message: params.message,
     },
   });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -30,6 +30,7 @@ import {
 import { planShellAuthorization } from "../infra/exec-authorization-plan.js";
 import {
   requestExecHostViaSocket,
+  resolveExecHostResponseTimeoutMs,
   type ExecHostRequest,
   type ExecHostResponse,
 } from "../infra/exec-host.js";
@@ -481,6 +482,7 @@ async function runViaMacAppExecHost(params: {
     socketPath: approvals.socketPath,
     token: approvals.token,
     request,
+    timeoutMs: resolveExecHostResponseTimeoutMs(request.timeoutMs),
     signal: params.signal,
   });
 }


### PR DESCRIPTION
Closes #139706

## What Problem This Solves

Fixes an issue where users running long commands through the macOS companion would hit an unexplained failure after about 20 seconds, even when the requested command timeout was much longer. The Gateway reported the companion as unavailable and could not return the command's real result.

## Why This Change Was Made

The companion request already carries the caller's command timeout, so the socket response deadline now follows it with a 5-second grace period. The transport also distinguishes pre-send unavailability, post-send response loss, and response timeout; submitted commands remain fail-closed and are never replayed locally. A zero command timeout disables the transport deadline as well.

## User Impact

Long-running macOS companion commands can now wait for their requested lifetime and return their actual result. A late response is reported as `TIMEOUT`, while a lost response is reported as an unknown outcome instead of being mislabeled as an unreachable companion. Safe fallback remains available only when the request was never submitted.

## Evidence

- Before fix, base `9e5bb4a3ecd`: the real UDS regression suite passed while its `timeout` case observed `null` after a signed request had started a child; the direct probe returned: `{"result":null}`
- After fix, commit `eb8b824922a`: the same 50 ms transport probe with a 30 s command timeout returned: `{"result":{"ok":false,"error":{"code":"TIMEOUT","reason":"timeout","message":"TIMEOUT: macOS app exec host response timed out; execution outcome is unknown"}}}`
- Response-loss probe changed from `{"result":null}` before the fix to typed `UNKNOWN / response-lost` after the fix.
- Real UDS transport tests: **21 passed**, including child-started timeout, response-loss, malformed-response, zero-timeout, signing, and cancellation cases.
- Node-host system-run tests: **87 passed**; enforced response-loss path confirms `runCommand` was not called (no local replay).
- `pnpm test:changed`: passed.
- `pnpm check`: passed.
- `pnpm check:changed`: passed.
- `pnpm build`: passed.
- Autoreview: `scoped-clean`, no accepted/actionable P0/P1 findings.
- No screenshot is applicable; this is a transport/runtime behavior change with no UI surface.
