### PR TITLE
refactor(auto-reply): keep model-selection fixtures in tests

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2145,7 +2145,7 @@ src/auto-reply/reply/get-reply.ts	2
 src/auto-reply/reply/history.ts	2
 src/auto-reply/reply/inbound-context.ts	8
 src/auto-reply/reply/mentions.ts	1
-src/auto-reply/reply/model-selection.ts	3
+src/auto-reply/reply/model-selection.ts	2
 src/auto-reply/reply/queue/drain.ts	2
 src/auto-reply/reply/queue/enqueue.ts	1
 src/auto-reply/reply/queue/settings.ts	1

--- a/src/auto-reply/reply.block-streaming.test.ts
+++ b/src/auto-reply/reply.block-streaming.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import { withFastReplyConfig } from "./reply/get-reply-fast-path.test-support.js";
 import { loadGetReplyModuleForTest } from "./reply/get-reply.test-loader.js";
+import { createModelSelectionStateFixture } from "./reply/model-selection.test-support.js";
 import { createMockTypingController } from "./reply/reply.test-helpers.js";
 import type { MsgContext } from "./templating.js";
 
@@ -56,11 +57,14 @@ vi.mock("./reply/directive-handling.defaults.js", () => ({
   resolveDefaultModel: vi.fn(() => ({
     defaultProvider: "anthropic",
     defaultModel: "claude-opus-4-6",
-    aliasIndex: new Map(),
+    aliasIndex: { byAlias: new Map(), byKey: new Map() },
   })),
 }));
-vi.mock("./reply/inbound-context.js", () => ({
-  finalizeInboundContext: vi.fn((ctx: unknown) => ctx),
+vi.mock("./reply/model-selection.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./reply/model-selection.js")>()),
+  createModelSelectionState: vi.fn<
+    typeof import("./reply/model-selection.js").createModelSelectionState
+  >(async (params) => createModelSelectionStateFixture(params)),
 }));
 vi.mock("./reply/session-reset-model.runtime.js", () => ({
   applyResetModelOverride: vi.fn(async () => undefined),

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -331,6 +331,7 @@ import {
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { ElevatedLevel } from "../thinking.js";
+import { createModelSelectionStateFixture } from "./model-selection.test-support.js";
 
 let handleDirectiveOnly: typeof import("./directive-handling.impl.js").handleDirectiveOnly;
 let maybeHandleModelDirectiveInfo: typeof import("./directive-handling.model.js").maybeHandleModelDirectiveInfo;
@@ -339,7 +340,6 @@ let buildModelAliasIndex: typeof import("../../agents/model-selection.js").build
 let resolveModelSelectionFromDirective: typeof import("./directive-handling.model-selection.js").resolveModelSelectionFromDirective;
 let parseInlineSessionDirectives: typeof import("./directive-handling.parse.js").parseInlineSessionDirectives;
 let applyInlineDirectiveOverrides: typeof import("./get-reply-directives-apply.js").applyInlineDirectiveOverrides;
-let createFastTestModelSelectionState: typeof import("./model-selection.js").createFastTestModelSelectionState;
 
 beforeAll(async () => {
   ({ handleDirectiveOnly } = await import("./directive-handling.impl.js"));
@@ -350,7 +350,6 @@ beforeAll(async () => {
     await import("./directive-handling.model-selection.js"));
   ({ parseInlineSessionDirectives } = await import("./directive-handling.parse.js"));
   ({ applyInlineDirectiveOverrides } = await import("./get-reply-directives-apply.js"));
-  ({ createFastTestModelSelectionState } = await import("./model-selection.js"));
 });
 const queueMocks = vi.hoisted(() => ({
   refreshQueuedFollowupSession: vi.fn(),
@@ -619,7 +618,7 @@ async function persistModelDirectiveForTest(params: {
   const model = params.model ?? "claude-opus-4-6";
   const agentId = params.agentId ?? "main";
   const sessionKey = `agent:${agentId}:dm:1`;
-  const modelState = createFastTestModelSelectionState({
+  const modelState = createModelSelectionStateFixture({
     agentCfg: cfg.agents?.defaults,
     provider,
     model,

--- a/src/auto-reply/reply/get-reply-directive-aliases.test.ts
+++ b/src/auto-reply/reply/get-reply-directive-aliases.test.ts
@@ -5,9 +5,14 @@ import {
   createOpenAiResponsesPartial,
   createOpenAiResponsesTextEvent,
 } from "../../agents/embedded-agent-subscribe.openai-responses.test-helpers.js";
+import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import type { ModelDefinitionConfig, OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
+import { withPluginMetadataSnapshotScope } from "../../plugins/current-plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
+import * as activeThinkingPolicy from "../../plugins/provider-thinking-active.js";
+import { prepareModelCatalogThinkingPolicies } from "../../plugins/provider-thinking.js";
 import type { FinalizedTemplateContext as TemplateContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
 import { parseInlineSessionDirectives } from "./directive-handling.parse.js";
@@ -32,6 +37,27 @@ const textRoutingMocks = vi.hoisted(() => ({
 const skillCommandMocks = vi.hoisted(() => ({
   listForWorkspace: vi.fn(),
 }));
+
+const directiveModel: ModelDefinitionConfig = {
+  id: "claude-opus-4-6",
+  name: "Directive fixture",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+};
+const directiveCatalog = [{ provider: "anthropic", ...directiveModel }];
+const directiveMetadata = createPluginMetadataSnapshotFixture();
+const preparedDirectiveCatalog: ModelCatalogSnapshot = {
+  entries: directiveCatalog,
+  routeVariants: directiveCatalog,
+};
+prepareModelCatalogThinkingPolicies({
+  catalog: preparedDirectiveCatalog,
+  metadataSnapshot: directiveMetadata,
+  providers: [{ provider: { id: "anthropic", resolveThinkingProfile: () => undefined } }],
+});
 
 vi.mock("./get-reply-directives-apply.js", () => ({
   applyInlineDirectiveOverrides: (...args: unknown[]) => directiveApplyMocks.apply(...args),
@@ -119,39 +145,62 @@ async function resolveModelDirective(params: {
     Provider: surface,
     Surface: surface,
   } as TemplateContext;
-  const result = await resolveReplyDirectives({
-    ctx: buildTestCtx({
-      Body: agentText,
-      CommandBody: body,
-      CommandAuthorized: authorized,
-      Provider: surface,
-      Surface: surface,
-    }),
-    cfg: withFastReplyConfig(params.cfg ?? configWithModelAlias("fable")),
-    agentId: "main",
-    agentDir: "/tmp/main-agent",
-    workspaceDir: "/tmp",
-    agentCfg: params.agentCfg ?? {},
-    opts: params.opts,
-    sessionCtx,
-    sessionEntry,
-    sessionStore: { [sessionKey]: sessionEntry },
-    sessionKey,
-    sessionScope: "per-sender",
-    conversation: prepareReplyConversation({ ctx: sessionCtx, sessionEntry }),
-    isGroup: false,
-    triggerBodyNormalized: body,
-    resetTriggered: false,
-    commandAuthorized: authorized,
-    defaultProvider: "anthropic",
-    defaultModel: "claude-opus-4-6",
-    aliasIndex: createAliasIndex(),
-    provider: "anthropic",
-    model: "claude-opus-4-6",
-    hasResolvedHeartbeatModelOverride: false,
-    typing: makeTypingController(),
+  const cfg = withFastReplyConfig({
+    ...(params.cfg ?? configWithModelAlias("fable")),
+    models: {
+      providers: {
+        anthropic: { baseUrl: "https://directive.invalid", models: [directiveModel] },
+      },
+    },
   });
-  return { result, sessionEntry, sessionCtx };
+  const ambientPolicy = vi
+    .spyOn(activeThinkingPolicy, "resolveActiveProviderThinkingProfile")
+    .mockImplementation(() => {
+      throw new Error("Directive fixture attempted ambient model-policy discovery.");
+    });
+  try {
+    const result = await withPluginMetadataSnapshotScope(
+      directiveMetadata,
+      () =>
+        resolveReplyDirectives({
+          ctx: buildTestCtx({
+            Body: agentText,
+            CommandBody: body,
+            CommandAuthorized: authorized,
+            Provider: surface,
+            Surface: surface,
+          }),
+          cfg,
+          agentId: "main",
+          agentDir: "/tmp/main-agent",
+          workspaceDir: "/tmp",
+          agentCfg: params.agentCfg ?? {},
+          opts: params.opts,
+          sessionCtx,
+          sessionEntry,
+          sessionStore: { [sessionKey]: sessionEntry },
+          sessionKey,
+          sessionScope: "per-sender",
+          conversation: prepareReplyConversation({ ctx: sessionCtx, sessionEntry }),
+          isGroup: false,
+          triggerBodyNormalized: body,
+          resetTriggered: false,
+          commandAuthorized: authorized,
+          defaultProvider: "anthropic",
+          defaultModel: "claude-opus-4-6",
+          aliasIndex: createAliasIndex(),
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+          hasResolvedHeartbeatModelOverride: false,
+          preparedModelCatalog: preparedDirectiveCatalog,
+          typing: makeTypingController(),
+        }),
+      { config: cfg, trustConfigIdentity: true },
+    );
+    return { result, sessionEntry, sessionCtx };
+  } finally {
+    ambientPolicy.mockRestore();
+  }
 }
 
 describe("reply directive resolution", () => {

--- a/src/auto-reply/reply/get-reply-directives-apply.test.ts
+++ b/src/auto-reply/reply/get-reply-directives-apply.test.ts
@@ -6,7 +6,7 @@ import { parseInlineSessionDirectives } from "./directive-handling.parse.js";
 import { resolveDirectiveRuntimeContext } from "./directive-runtime-context.js";
 import { applyInlineDirectiveOverrides } from "./get-reply-directives-apply.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
-import { createFastTestModelSelectionState } from "./model-selection.js";
+import { createModelSelectionStateFixture } from "./model-selection.test-support.js";
 import { prepareReplyConversation } from "./prompt-session-context.js";
 import { buildTestCtx } from "./test-ctx.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -193,7 +193,7 @@ describe("applyInlineDirectiveOverrides", () => {
         agentRuntimeOverride: "codex",
         modelSelectionLocked: true,
       };
-      const modelState = createFastTestModelSelectionState({
+      const modelState = createModelSelectionStateFixture({
         agentCfg: {},
         provider: "openai",
         model: "gpt-5.5",
@@ -335,7 +335,7 @@ describe("applyInlineDirectiveOverrides", () => {
         aliasIndex: { byAlias: new Map(), byKey: new Map() },
         provider: "openai",
         model,
-        modelState: createFastTestModelSelectionState({
+        modelState: createModelSelectionStateFixture({
           agentCfg: {},
           provider: "openai",
           model,

--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -267,7 +267,6 @@ vi.mock("./groups.js", () => ({
 }));
 
 vi.mock("./model-selection.js", () => ({
-  createFastTestModelSelectionState: vi.fn(),
   createModelSelectionState: (...args: unknown[]) => mocks.createModelSelectionState(...args),
   resolveContextTokens: vi.fn(() => 4096),
 }));

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -7,7 +7,7 @@ import { listAgentEntries } from "../../agents/agent-scope.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveFastModeState } from "../../agents/fast-mode.js";
 import type { ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
-import { type ModelAliasIndex, resolveModelRefFromString } from "../../agents/model-selection.js";
+import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import { resolveSandboxRuntimeStatus } from "../../agents/sandbox/runtime-status.js";
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -51,11 +51,7 @@ import { resolveReplyDirectiveRouting } from "./get-reply-directives-routing.js"
 import { type ReplyExecOverrides, resolveReplyExecOverrides } from "./get-reply-exec-overrides.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { defaultGroupActivation, resolveGroupRequireMention } from "./groups.js";
-import {
-  createFastTestModelSelectionState,
-  createModelSelectionState,
-  resolveContextTokens,
-} from "./model-selection.js";
+import { createModelSelectionState, resolveContextTokens } from "./model-selection.js";
 import type { PreparedReplyConversation } from "./prompt-session-context.js";
 import { formatElevatedUnavailableMessage, resolveElevatedPermissions } from "./reply-elevated.js";
 import { resolveRuntimePolicySessionKey } from "./runtime-policy-session-key.js";
@@ -69,24 +65,6 @@ const commandsRegistryLoader = createLazyImportLoader(
 const skillCommandsLoader = createLazyImportLoader(
   () => import("../../skills/discovery/chat-commands.runtime.js"),
 );
-
-function canUseFastExplicitModelDirective(params: {
-  directives: InlineDirectives;
-  defaultProvider: string;
-  aliasIndex: ModelAliasIndex;
-}): boolean {
-  const raw = normalizeOptionalString(params.directives.rawModelDirective);
-  if (!raw || /^[0-9]+$/.test(raw)) {
-    return false;
-  }
-  return Boolean(
-    resolveModelRefFromString({
-      raw,
-      defaultProvider: params.defaultProvider,
-      aliasIndex: params.aliasIndex,
-    }),
-  );
-}
 
 type ReplyDirectiveContinuation = {
   commandSource: string;
@@ -446,52 +424,31 @@ export async function resolveReplyDirectives(params: {
     isFastTestEnv: isFastTestRuntimeEnv(),
   });
 
-  const useFastModelSelection =
-    useFastReplyRuntime &&
-    !hasResolvedHeartbeatModelOverride &&
-    !(agentCfg?.models && Object.keys(agentCfg.models).length > 0) &&
-    !normalizeOptionalString(targetSessionEntry?.modelOverride) &&
-    !normalizeOptionalString(targetSessionEntry?.providerOverride) &&
-    (!directives.hasModelDirective ||
-      canUseFastExplicitModelDirective({
-        directives,
-        defaultProvider,
-        aliasIndex: params.aliasIndex,
-      }));
-
   let modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   try {
-    modelState = useFastModelSelection
-      ? createFastTestModelSelectionState({
-          agentCfg,
-          provider,
-          model,
-        })
-      : await createModelSelectionState({
-          cfg,
-          agentId,
-          agentCfg,
-          sessionEntry: targetSessionEntry,
-          sessionStore,
-          sessionKey,
-          parentSessionKey:
-            targetSessionEntry?.parentSessionKey ??
-            ctx.ModelParentSessionKey ??
-            ctx.ParentSessionKey,
-          storePath,
-          defaultProvider,
-          defaultModel,
-          primaryProvider,
-          primaryModel,
-          provider,
-          model,
-          hasModelDirective: directives.hasModelDirective,
-          hasOneTurnModelOverride,
-          skipStoredModelOverride,
-          hasResolvedHeartbeatModelOverride,
-          isHeartbeat: opts?.isHeartbeat === true,
-          preparedModelCatalog: params.preparedModelCatalog,
-        });
+    modelState = await createModelSelectionState({
+      cfg,
+      agentId,
+      agentCfg,
+      sessionEntry: targetSessionEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey:
+        targetSessionEntry?.parentSessionKey ?? ctx.ModelParentSessionKey ?? ctx.ParentSessionKey,
+      storePath,
+      defaultProvider,
+      defaultModel,
+      primaryProvider,
+      primaryModel,
+      provider,
+      model,
+      hasModelDirective: directives.hasModelDirective,
+      hasOneTurnModelOverride,
+      skipStoredModelOverride,
+      hasResolvedHeartbeatModelOverride,
+      isHeartbeat: opts?.isHeartbeat === true,
+      preparedModelCatalog: params.preparedModelCatalog,
+    });
   } catch (error) {
     if (
       !(error instanceof ModelSelectionLockedError) &&

--- a/src/auto-reply/reply/get-reply-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-fast-path.ts
@@ -1,12 +1,8 @@
 // Runs lightweight get-reply fast-path commands before full agent setup.
 import crypto from "node:crypto";
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { resolveSessionParentSessionKey } from "../../channels/plugins/session-conversation.js";
-import { normalizeAnyChannelId } from "../../channels/registry.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { resolveResetPreservedSelection } from "../../config/sessions/reset-preserved-selection.js";
@@ -26,14 +22,11 @@ import {
   ModelSelectionLockedError,
 } from "../../sessions/model-overrides.js";
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
-import { normalizeCommandBody } from "../commands-registry.js";
 import type {
   FinalizedRuntimeMsgContext as MsgContext,
   FinalizedTemplateContext as TemplateContext,
 } from "../templating.js";
 import { isFormattedGoalContinuationPrompt } from "./commands-goal.js";
-import type { CommandContext } from "./commands-types.js";
-import { stripMentions } from "./mentions.js";
 import {
   isCompleteReplyConfig,
   markReplyConfigRuntimeMode,
@@ -109,68 +102,6 @@ export function shouldUseReplyFastTestRuntime(params: {
   return (
     params.isFastTestEnv && isCompleteReplyConfig(params.cfg) && !usesFullReplyRuntime(params.cfg)
   );
-}
-
-export function shouldUseReplyFastDirectiveExecution(params: {
-  isFastTestBootstrap: boolean;
-  isGroup: boolean;
-  isHeartbeat: boolean;
-  resetTriggered: boolean;
-  triggerBodyNormalized: string;
-}): boolean {
-  if (
-    !params.isFastTestBootstrap ||
-    params.isGroup ||
-    params.isHeartbeat ||
-    params.resetTriggered
-  ) {
-    return false;
-  }
-  return !params.triggerBodyNormalized.includes("/");
-}
-
-export function buildFastReplyCommandContext(params: {
-  ctx: MsgContext;
-  cfg: OpenClawConfig;
-  agentId?: string;
-  sessionKey?: string;
-  isGroup: boolean;
-  triggerBodyNormalized: string;
-  commandAuthorized: boolean;
-}): CommandContext {
-  const { ctx, cfg, agentId, sessionKey, isGroup, triggerBodyNormalized, commandAuthorized } =
-    params;
-  const originatingChannel = normalizeOptionalLowercaseString(ctx.OriginatingChannel);
-  const surface = normalizeOptionalLowercaseString(ctx.Surface ?? ctx.Provider) ?? "";
-  const channel =
-    originatingChannel ?? normalizeOptionalLowercaseString(ctx.Provider ?? surface) ?? "";
-  const from = normalizeOptionalString(ctx.From ?? ctx.SenderId);
-  const to = normalizeOptionalString(ctx.To ?? ctx.OriginatingTo);
-  return {
-    surface,
-    channel,
-    channelId: normalizeAnyChannelId(channel) ?? normalizeAnyChannelId(surface) ?? undefined,
-    accountId: normalizeOptionalString(ctx.AccountId),
-    ownerList: [],
-    senderIsOwner: false,
-    isAuthorizedSender: commandAuthorized,
-    senderId: from,
-    abortKey: sessionKey ?? from ?? to,
-    rawBodyNormalized: triggerBodyNormalized,
-    commandBodyNormalized: normalizeCommandBody(
-      isGroup ? stripMentions(triggerBodyNormalized, ctx, cfg, agentId) : triggerBodyNormalized,
-      { botUsername: ctx.BotUsername },
-    ),
-    from,
-    to,
-  };
-}
-
-export function shouldHandleFastReplyTextCommands(params: {
-  cfg: OpenClawConfig;
-  commandSource?: string;
-}): boolean {
-  return params.commandSource === "native" || params.cfg.commands?.text !== false;
 }
 
 export function initFastReplySessionState(params: {

--- a/src/auto-reply/reply/get-reply.fast-path.runtime.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.runtime.test.ts
@@ -2,7 +2,10 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
-import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import {
   createReplyRuntimeMocks,
   createTempHomeHarness,
@@ -12,6 +15,14 @@ import {
   resetReplyRuntimeMocks,
 } from "../reply.test-harness.js";
 import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
+import { createModelSelectionStateFixture } from "./model-selection.test-support.js";
+
+vi.mock("./model-selection.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./model-selection.js")>()),
+  createModelSelectionState: vi.fn<typeof import("./model-selection.js").createModelSelectionState>(
+    async (params) => createModelSelectionStateFixture(params),
+  ),
+}));
 
 let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
 const agentMocks = createReplyRuntimeMocks();
@@ -19,8 +30,21 @@ const { withTempHome } = createTempHomeHarness({ prefix: "openclaw-getreply-fast
 
 installReplyRuntimeMocks(agentMocks);
 
+function installRuntimeChannels() {
+  setActivePluginRegistry(
+    createTestRegistry(
+      (["whatsapp", "telegram"] as const).map((id) => ({
+        pluginId: id,
+        plugin: createChannelTestPluginBase({ id }),
+        source: "test",
+      })),
+    ),
+  );
+}
+
 describe("getReplyFromConfig fast-path runtime", () => {
   beforeAll(async () => {
+    installRuntimeChannels();
     ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     resetReplyRuntimeMocks(agentMocks);
@@ -49,10 +73,11 @@ describe("getReplyFromConfig fast-path runtime", () => {
   beforeEach(async () => {
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
     resetReplyRuntimeMocks(agentMocks);
-    setActivePluginRegistry(createTestRegistry([]));
+    installRuntimeChannels();
   });
 
   afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
     vi.clearAllMocks();
     vi.unstubAllEnvs();
   });

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -97,11 +97,7 @@ async function loadGetReplyRuntimeForTest() {
 }
 
 function requirePreparedReplyParams() {
-  const preparedReplyParams = vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0];
-  if (!preparedReplyParams) {
-    throw new Error("expected prepared reply params");
-  }
-  return preparedReplyParams;
+  return expectDefined(vi.mocked(runPreparedReplyMock).mock.calls[0]?.[0], "prepared reply params");
 }
 
 function requireDirectiveParams() {

--- a/src/auto-reply/reply/get-reply.fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply.fast-path.test.ts
@@ -20,8 +20,9 @@ import {
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
+import { buildCommandContext } from "./commands-context.js";
 import { handleGoalCommand } from "./commands-goal.js";
-import { buildFastReplyCommandContext, initFastReplySessionState } from "./get-reply-fast-path.js";
+import { initFastReplySessionState } from "./get-reply-fast-path.js";
 import {
   markCompleteReplyConfig,
   withFastReplyConfig,
@@ -53,14 +54,7 @@ const mocks = vi.hoisted(() => ({
   handleCommands: vi.fn(),
   handleInlineActions: vi.fn(),
   initSessionState: vi.fn(),
-  loadModelCatalog: vi.fn<LoadModelCatalogFn>(async () => [
-    {
-      provider: "openai",
-      id: "gpt-5.5",
-      name: "GPT-5.5",
-      reasoning: true,
-    },
-  ]),
+  loadModelCatalog: vi.fn<LoadModelCatalogFn>(),
   resolveReplyDirectives: vi.fn(),
 }));
 
@@ -123,6 +117,26 @@ function requireDirectiveParams() {
     throw new Error("expected directive params");
   }
   return directiveParams;
+}
+
+function continuePlainTextReply() {
+  mocks.resolveReplyDirectives.mockResolvedValueOnce(
+    createGetReplyContinueDirectivesResult({
+      body: "hello",
+      commandSource: "hello",
+      abortKey: "agent:main:telegram:123",
+      from: "telegram:user:42",
+      to: "telegram:123",
+      senderId: "telegram:user:42",
+      senderIsOwner: false,
+      resetHookTriggered: false,
+    }),
+  );
+  mocks.handleInlineActions.mockResolvedValueOnce({
+    kind: "continue",
+    directives: {},
+    cleanedBody: "hello",
+  });
 }
 
 async function seedFastPathSessionStore(
@@ -235,32 +249,39 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(vi.mocked(loadConfigMock)).not.toHaveBeenCalled();
   });
 
-  it("skips getRuntimeConfig, workspace bootstrap, and session bootstrap for marked test configs", async () => {
-    const cfg = markCompleteReplyConfig({
-      agents: {
-        defaults: {
-          model: "anthropic/claude-opus-4-6",
-          workspace: state.workspaceDir,
+  it.each([
+    { mode: "complete", mark: markCompleteReplyConfig },
+    { mode: "fast", mark: withFastReplyConfig },
+  ])(
+    "uses $mode configs through directives without config, workspace, or session bootstrap",
+    async ({ mark }) => {
+      continuePlainTextReply();
+      const cfg = mark({
+        agents: {
+          defaults: {
+            model: "anthropic/claude-opus-4-6",
+            workspace: state.workspaceDir,
+          },
         },
-      },
-      channels: { telegram: { allowFrom: ["*"] } },
-      session: { store: isolatedStorePath },
-    } as OpenClawConfig);
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: isolatedStorePath },
+      } as OpenClawConfig);
 
-    // Check the mocked runtime resolver before fast bootstrap can create its workspace.
-    expect(isPathInside(state.root, resolveAgentWorkspaceDirMock(cfg, "main"))).toBe(true);
+      // Check the mocked runtime resolver before fast bootstrap can create its workspace.
+      expect(isPathInside(state.root, resolveAgentWorkspaceDirMock(cfg, "main"))).toBe(true);
 
-    await expect(getReplyFromConfig(buildGetReplyCtx(), undefined, cfg)).resolves.toEqual({
-      text: "ok",
-    });
-    expect(vi.mocked(loadConfigMock)).not.toHaveBeenCalled();
-    expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
-    expect(mocks.initSessionState).not.toHaveBeenCalled();
-    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
-    expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
-    const preparedReplyParams = requirePreparedReplyParams();
-    expect(preparedReplyParams.cfg).toBe(cfg);
-  });
+      await expect(getReplyFromConfig(buildGetReplyCtx(), undefined, cfg)).resolves.toEqual({
+        text: "ok",
+      });
+      expect(vi.mocked(loadConfigMock)).not.toHaveBeenCalled();
+      expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
+      expect(mocks.initSessionState).not.toHaveBeenCalled();
+      expect(mocks.resolveReplyDirectives).toHaveBeenCalledOnce();
+      expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
+      const preparedReplyParams = requirePreparedReplyParams();
+      expect(preparedReplyParams.cfg).toBe(cfg);
+    },
+  );
 
   it("still merges partial config overrides against getRuntimeConfig()", async () => {
     vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
@@ -335,20 +356,6 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(result).toEqual({ text: MODEL_SELECTION_LOCKED_RESET_MESSAGE });
     expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
     expect(vi.mocked(runPreparedReplyMock)).not.toHaveBeenCalled();
-  });
-
-  it("marks configs through withFastReplyConfig()", async () => {
-    const cfg = withFastReplyConfig({
-      agents: { defaults: { workspace: state.workspaceDir } },
-      session: { store: isolatedStorePath },
-    } satisfies OpenClawConfig);
-
-    await expect(getReplyFromConfig(buildGetReplyCtx(), undefined, cfg)).resolves.toEqual({
-      text: "ok",
-    });
-    expect(vi.mocked(loadConfigMock)).not.toHaveBeenCalled();
-    expect(mocks.resolveReplyDirectives).not.toHaveBeenCalled();
-    expect(vi.mocked(runPreparedReplyMock)).toHaveBeenCalledOnce();
   });
 
   it("clears stale ack-only heartbeat pending delivery before running heartbeat", async () => {
@@ -982,7 +989,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
     expect(result.initialSessionEntry).not.toBe(result.sessionEntry);
   });
   it("maps explicit gateway origin into command context", () => {
-    const command = buildFastReplyCommandContext({
+    const command = buildCommandContext({
       ctx: buildGetReplyCtx({
         Provider: "internal",
         Surface: "internal",
@@ -1007,7 +1014,7 @@ describe("getReplyFromConfig fast test bootstrap", () => {
 
   it("preserves multiline slash skill payloads in fast command context", () => {
     const body = "/skill demo_skill first line\nsecond line";
-    const command = buildFastReplyCommandContext({
+    const command = buildCommandContext({
       ctx: buildGetReplyCtx({
         Body: body,
         RawBody: body,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -50,20 +50,15 @@ import type { GetReplyOptions } from "../get-reply-options.types.js";
 import { DEFAULT_HEARTBEAT_ACK_MAX_CHARS, stripHeartbeatToken } from "../heartbeat.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { RuntimeMsgContext as MsgContext } from "../templating.js";
-import { normalizeThinkLevel, normalizeVerboseLevel } from "../thinking.js";
+import { normalizeThinkLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import { resolveDefaultModel } from "./directive-handling.defaults.js";
 import { resolveActiveExplicitSteerSessionKey } from "./explicit-steer-routing.js";
-import { clearInlineDirectives } from "./get-reply-directives-utils.js";
 import { resolveReplyDirectives } from "./get-reply-directives.js";
 import {
   initFastReplySessionState,
-  buildFastReplyCommandContext,
-  shouldHandleFastReplyTextCommands,
-  shouldUseReplyFastDirectiveExecution,
   resolveGetReplyConfig,
   shouldUseReplyFastTestBootstrap,
-  shouldUseReplyFastTestRuntime,
 } from "./get-reply-fast-path.js";
 import { handleInlineActions } from "./get-reply-inline-actions.js";
 import { maybeResolveNativeSlashCommandFastReply } from "./get-reply-native-slash-fast-path.js";
@@ -79,7 +74,7 @@ import {
   hasInboundMediaForUnderstanding,
 } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
-import { createFastTestModelSelectionState, createModelSelectionState } from "./model-selection.js";
+import { createModelSelectionState } from "./model-selection.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
   PENDING_FINAL_DELIVERY_CLEAR_PATCH,
@@ -319,12 +314,6 @@ export async function getReplyFromConfig(
     shouldUseReplyFastTestBootstrap({
       isFastTestEnv,
       configOverride,
-    }),
-  );
-  const useFastTestRuntime = resolverTiming.measureSync("reply.resolve_fast_test_runtime", () =>
-    shouldUseReplyFastTestRuntime({
-      cfg,
-      isFastTestEnv,
     }),
   );
   const inboundMediaWasAlreadyStaged = hasStagedMediaFacts(ctx.media);
@@ -907,106 +896,6 @@ export async function getReplyFromConfig(
       groupResolution,
       isHeartbeat: opts?.isHeartbeat,
     });
-
-  if (
-    shouldUseReplyFastDirectiveExecution({
-      isFastTestBootstrap: useFastTestRuntime,
-      isGroup,
-      isHeartbeat: opts?.isHeartbeat === true,
-      resetTriggered,
-      triggerBodyNormalized,
-    })
-  ) {
-    const fastCommand = buildFastReplyCommandContext({
-      ctx: finalized,
-      cfg,
-      agentId,
-      sessionKey,
-      isGroup,
-      triggerBodyNormalized,
-      commandAuthorized,
-    });
-    if (
-      enableLocalPathSelfServe &&
-      canSelfServeLocalPaths({
-        ctx: sessionCtx,
-        cfg,
-        agentId,
-        agentDir,
-        sessionKey,
-        workspaceDir,
-        provider: autoFallbackPrimaryProbe?.provider ?? provider,
-        model: autoFallbackPrimaryProbe?.model ?? model,
-        opts: resolvedOpts,
-        senderIsOwner: fastCommand.senderIsOwner,
-        spawnedBy: normalizeOptionalString(sessionEntry.spawnedBy),
-        stagedPathsAvailable: false,
-      })
-    ) {
-      enableLocalPathSelfServe([finalized, sessionCtx]);
-    }
-    logResolverTiming("milestone", "before_fast_directive_prepared_reply");
-    const fastReplyResult = await traceGetReplyPhase("reply.run_prepared_reply", () =>
-      runPreparedReply({
-        ctx,
-        sessionCtx,
-        conversation,
-        cfg,
-        agentId,
-        agentDir,
-        agentCfg,
-        sessionCfg,
-        commandAuthorized,
-        command: fastCommand,
-        commandSource: finalized.commandText,
-        allowTextCommands: shouldHandleFastReplyTextCommands({
-          cfg,
-          commandSource: finalized.CommandSource,
-        }),
-        directives: clearInlineDirectives(finalized.commandText),
-        defaultActivation: "always",
-        resolvedThinkLevel: undefined,
-        resolvedVerboseLevel: normalizeVerboseLevel(agentCfg?.verboseDefault),
-        resolvedReasoningLevel: "off",
-        resolvedElevatedLevel: "off",
-        execOverrides: undefined,
-        elevatedEnabled: false,
-        elevatedAllowed: false,
-        blockStreamingEnabled: false,
-        blockReplyChunking: undefined,
-        resolvedBlockStreamingBreak: "text_end",
-        modelState: createFastTestModelSelectionState({
-          agentCfg,
-          provider: autoFallbackPrimaryProbe?.provider ?? provider,
-          model: autoFallbackPrimaryProbe?.model ?? model,
-        }),
-        provider: autoFallbackPrimaryProbe?.provider ?? provider,
-        model: autoFallbackPrimaryProbe?.model ?? model,
-        perMessageQueueMode: undefined,
-        perMessageQueueOptions: undefined,
-        typing,
-        opts: withExtractedFileImages(resolvedOpts, extractedFileImages),
-        defaultModel,
-        timeoutMs,
-        isNewSession,
-        resetTriggered,
-        systemSent,
-        sessionEntry,
-        sessionEntryHandle,
-        sessionStore,
-        sessionKey,
-        sessionId,
-        storePath,
-        workspaceDir,
-        abortedLastRun,
-        autoFallbackPrimaryProbe,
-      }),
-    );
-    if (profilerEnabled) {
-      logResolverTiming("completed", "fast_directive_prepared_reply");
-    }
-    return fastReplyResult;
-  }
 
   const directiveResult = await traceGetReplyPhase("reply.resolve_directives", () =>
     resolveReplyDirectives({

--- a/src/auto-reply/reply/model-selection.test-support.ts
+++ b/src/auto-reply/reply/model-selection.test-support.ts
@@ -1,0 +1,38 @@
+import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { ThinkLevel } from "../thinking.shared.js";
+import type { createModelSelectionState } from "./model-selection.js";
+
+/** Supplies selected-model facts to tests outside the model-selection owner. */
+export function createModelSelectionStateFixture(params: {
+  agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
+  provider: string;
+  model: string;
+}): Awaited<ReturnType<typeof createModelSelectionState>> {
+  return {
+    provider: params.provider,
+    model: params.model,
+    requestedRouteResolution: "resolved",
+    modelPolicy: createModelVisibilityPolicy({
+      cfg: { agents: { defaults: params.agentCfg } },
+      catalog: [],
+      defaultProvider: params.provider,
+      defaultModel: params.model,
+    }),
+    allowedModelKeys: new Set<string>(),
+    allowedModelCatalog: [],
+    policyAliasIndex: { byAlias: new Map(), byKey: new Map() },
+    resetModelOverride: false,
+    resetModelOverrideRef: undefined,
+    resetModelOverrideReason: undefined,
+    modelPolicyConfigPath: undefined,
+    modelPolicyRepairConfigPath: undefined,
+    resolveThinkingCatalog: async () => [],
+    resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
+    hasConfiguredThinkingDefault: params.agentCfg?.thinkingDefault !== undefined,
+    resolveDefaultReasoningLevel: async () => "off",
+    needsModelCatalog: false,
+    modelContextWindow: undefined,
+    modelContextTokens: undefined,
+  };
+}

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -98,40 +98,6 @@ function resolveConfiguredModelThinkingDefault(raw: unknown): ThinkLevel | undef
   return typeof raw === "string" ? normalizeThinkLevel(raw) : undefined;
 }
 
-/** Creates minimal model-selection state for fast test mode. */
-export function createFastTestModelSelectionState(params: {
-  agentCfg: NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]> | undefined;
-  provider: string;
-  model: string;
-}): ModelSelectionState {
-  return {
-    provider: params.provider,
-    model: params.model,
-    requestedRouteResolution: "resolved",
-    modelPolicy: createModelVisibilityPolicy({
-      cfg: { agents: { defaults: params.agentCfg } },
-      catalog: [],
-      defaultProvider: params.provider,
-      defaultModel: params.model,
-    }),
-    allowedModelKeys: new Set<string>(),
-    allowedModelCatalog: [],
-    policyAliasIndex: { byAlias: new Map(), byKey: new Map() },
-    resetModelOverride: false,
-    resetModelOverrideRef: undefined,
-    resetModelOverrideReason: undefined,
-    modelPolicyConfigPath: undefined,
-    modelPolicyRepairConfigPath: undefined,
-    resolveThinkingCatalog: async () => [],
-    resolveDefaultThinkingLevel: async () => params.agentCfg?.thinkingDefault as ThinkLevel,
-    hasConfiguredThinkingDefault: params.agentCfg?.thinkingDefault !== undefined,
-    resolveDefaultReasoningLevel: async () => "off",
-    needsModelCatalog: false,
-    modelContextWindow: undefined,
-    modelContextTokens: undefined,
-  };
-}
-
 const modelCatalogRuntimeLoader = createLazyImportLoader(
   () => import("../../agents/model-catalog.runtime.js"),
 );


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Marked reply tests could bypass normal directive handling and model selection through alternate branches in production code. Those branches constructed a synthetic command context and model state, so passing tests could miss regressions in the owners used by real replies.

## Why This Change Was Made

Remove both alternate selection paths, their unused command helpers, and the production test-state factory. Tests outside model selection use a narrow fixture in test support. Model and directive tests exercise the real selection owner with prepared catalog, plugin metadata, and thinking-policy facts; routing tests supply synthetic transport plugins to the normal directive and inline-action flow.

## User Impact

This maintainer-requested cleanup improves regression coverage without changing normal reply or native-status behavior. Production code decreases by 257 lines; tests and test support grow by 117 lines. The assertion-safety ratchet records one removed assertion.

## Evidence

The current-main baseline and candidate both pass all 560 cases across the same 18-file cohort. The normal model-selection function is unchanged, and retained alias cases reject accidental ambient provider-policy discovery. Independent P2 review is scoped-clean for the production change and final test-only helper consolidation.

Separate Linux Testbox runs pass trigger handling (21/21), a visible turn while an independent heartbeat is held (1/1), and cron/task CRUD, heartbeat wake and cancellation through both Gateway RPC and CLI (2/2). The final two runs bind to `d7d56619f1c299e8b0dbad85a48b3ff4733416b1` and tree `020bd04d440c03e2f8560e8a36b60a5b4f27df9f`; the trigger run used the preceding commit with byte-identical production and E2E inputs. [Final Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34029880357). All native report inventories and source hashes were checked, and the leases are stopped.

The first full changed-file gate stopped on a one-line test-file size excess. Reusing the existing presence-assertion helper fixed it without removing assertions; the final file passed 26/26 cases and focused lint. The complete final gate passed production/test types, lint, formatting, dead-export checks and architecture/storage guards. [Exact-head CI 34030056097](https://github.com/openclaw/openclaw/actions/runs/34030056097) passed.

[ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/140069#issuecomment-5558914666) has no findings or before-merge actions. The native maintainer review is validated ready. Timing comparisons are omitted because local runs include cache effects.
