### PR TITLE
refactor(slack): simplify media transport selection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1136,7 +1136,7 @@ extensions/slack/src/monitor/events/messages.ts	14
 extensions/slack/src/monitor/events/pins.ts	1
 extensions/slack/src/monitor/events/reactions.ts	2
 extensions/slack/src/monitor/ingress.ts	8
-extensions/slack/src/monitor/media.ts	2
+extensions/slack/src/monitor/media.ts	1
 extensions/slack/src/monitor/message-handler.ts	2
 extensions/slack/src/monitor/message-handler/dispatch-helpers.ts	2
 extensions/slack/src/monitor/message-handler/dispatch-streaming.ts	6

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -23,6 +23,15 @@ import {
   stopSlackMonitor,
 } from "./monitor.test-helpers.js";
 
+const mediaFetchMock = vi.hoisted(() =>
+  vi.fn<typeof import("./monitor/media.runtime.js").fetchWithRuntimeDispatcher>(),
+);
+
+vi.mock("./monitor/media.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./monitor/media.runtime.js")>()),
+  fetchWithRuntimeDispatcher: mediaFetchMock,
+}));
+
 const { monitorSlackProvider } = await import("./monitor/provider.js");
 
 const slackTestState = getSlackTestState();
@@ -30,6 +39,7 @@ const { sendMock, replyMock, reactMock, reactionAddMock, upsertPairingRequestMoc
   slackTestState;
 
 beforeEach(() => {
+  mediaFetchMock.mockReset().mockRejectedValue(new Error("Unexpected Slack media test request"));
   resetInboundDedupe();
   resetSlackTestState(defaultSlackTestConfig());
 });
@@ -413,24 +423,20 @@ describe("monitorSlackProvider tool results", () => {
       latestCtx = (ctx ?? {}) as { RawBody?: string };
       return { text: "ack" };
     });
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => new Response("Not Found", { status: 404 }));
-    globalThis.fetch = mockFetch as typeof fetch;
+    const mockFetch = mediaFetchMock.mockImplementation(
+      async () => new Response("Not Found", { status: 404 }),
+    );
 
-    try {
-      await runSlackMessageOnce(
-        monitorSlackProvider,
-        {
-          event: makeSlackMessageEvent({
-            text: "caption",
-            attachments: [{ is_share: true, image_url: "https://files.slack.com/forwarded.jpg" }],
-          }),
-        },
-        { awaitDispatch: true },
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await runSlackMessageOnce(
+      monitorSlackProvider,
+      {
+        event: makeSlackMessageEvent({
+          text: "caption",
+          attachments: [{ is_share: true, image_url: "https://files.slack.com/forwarded.jpg" }],
+        }),
+      },
+      { awaitDispatch: true },
+    );
 
     expect(replyMock).toHaveBeenCalledTimes(1);
     expect(latestCtx?.RawBody).toBe("caption\n\n[slack attachment unavailable]");

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -128,7 +128,7 @@ const saveRemoteMediaMock = vi.hoisted(() =>
     };
   }),
 );
-const fetchWithRuntimeDispatcherMock = vi.hoisted(() => vi.fn());
+const fetchWithRuntimeDispatcherMock = vi.hoisted(() => vi.fn<FetchMock>());
 const logVerboseMock = vi.hoisted(() => vi.fn());
 const mediaWarnMock = vi.hoisted(() => vi.fn());
 
@@ -142,18 +142,10 @@ vi.mock("./thread.runtime.js", () => ({
   logVerbose: logVerboseMock,
 }));
 
-function withFetchPreconnect(fetchMock: ReturnType<typeof vi.fn<FetchMock>>): typeof fetch {
-  return Object.assign(
-    ((input: RequestInfo | URL, init?: RequestInit) => fetchMock(input, init)) as typeof fetch,
-    { mock: fetchMock.mock },
-  );
-}
-
-// Store original fetch
-const originalFetch = globalThis.fetch;
 let mockFetch: ReturnType<typeof vi.fn<FetchMock>>;
 
 beforeEach(() => {
+  mockFetch = vi.fn();
   threadStarterIdentitySequence += 1;
   threadStarterIdentity = {
     channelId: `CMEDIA${threadStarterIdentitySequence}`,
@@ -164,7 +156,8 @@ beforeEach(() => {
     },
   };
   readRemoteMediaBufferMock.mockClear();
-  fetchWithRuntimeDispatcherMock.mockClear();
+  fetchWithRuntimeDispatcherMock.mockReset();
+  fetchWithRuntimeDispatcherMock.mockImplementation((input, init) => mockFetch(input, init));
   logVerboseMock.mockClear();
   mediaWarnMock.mockClear();
   saveMediaBufferMock.mockReset();
@@ -280,13 +273,7 @@ async function expectPrivateDownloadRedirect(params: {
 }
 
 describe("resolveSlackMedia", () => {
-  beforeEach(() => {
-    mockFetch = vi.fn();
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
-  });
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
@@ -996,48 +983,47 @@ describe("resolveSlackMedia", () => {
     expect([...unavailableFiles]).toEqual([[files[8], "omitted: 8-file limit"]]);
   });
 
-  it("routes dispatcher-backed Slack media requests through runtime fetch", async () => {
-    saveMediaBufferMock.mockResolvedValue(createSavedMedia("/tmp/test.jpg", "image/jpeg"));
-    globalThis.fetch = (async () => {
-      throw new Error("global fetch should not receive dispatcher-backed Slack media requests");
-    }) as typeof fetch;
-    fetchWithRuntimeDispatcherMock.mockImplementation(async () => {
-      return new Response(Buffer.from("image data"), {
-        status: 200,
-        headers: { "content-type": "image/jpeg" },
+  it.each([true, false])(
+    "selects the media transport by dispatcher presence even when global fetch is mocked (%s)",
+    async (hasDispatcher) => {
+      const globalFetchMock = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("global"));
+      fetchWithRuntimeDispatcherMock.mockResolvedValue(new Response("runtime"));
+      const dispatcher = {};
+      saveRemoteMediaMock.mockImplementationOnce(async ({ url, fetchImpl, requestInit }) => {
+        await fetchImpl(url, {
+          ...requestInit,
+          ...(hasDispatcher ? { dispatcher } : {}),
+        });
+        return { ...createSavedMedia("/tmp/test.jpg", "image/jpeg"), fileName: "test.jpg" };
       });
-    });
 
-    const result = await resolveSlackMedia({
-      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
-      token: "xoxb-test-token",
-      maxBytes: 1024 * 1024,
-    });
+      const result = await resolveSlackMedia({
+        files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
+        token: "xoxb-test-token",
+        maxBytes: 1024 * 1024,
+      });
 
-    expectSlackMediaResult(result);
-    expect(fetchWithRuntimeDispatcherMock).toHaveBeenCalled();
-    const runtimeFetchInit = requireRecord(
-      requireMockCall(fetchWithRuntimeDispatcherMock, 0, "runtime fetch")[1],
-      "runtime fetch init",
-    ) as RequestInit & { dispatcher?: unknown };
-    expect(runtimeFetchInit.redirect).toBe("manual");
-    expect("dispatcher" in runtimeFetchInit).toBe(true);
-    expect(new Headers(runtimeFetchInit.headers).get("Authorization")).toBe(
-      "Bearer xoxb-test-token",
-    );
-  });
+      expectSlackMediaResult(result);
+      const selectedFetch = hasDispatcher ? fetchWithRuntimeDispatcherMock : globalFetchMock;
+      const unusedFetch = hasDispatcher ? globalFetchMock : fetchWithRuntimeDispatcherMock;
+      expect(selectedFetch).toHaveBeenCalledOnce();
+      expect(unusedFetch).not.toHaveBeenCalled();
+      const fetchInit = requireRecord(
+        requireMockCall(selectedFetch, 0, "selected fetch")[1],
+        "fetch init",
+      ) as RequestInit & { dispatcher?: unknown };
+      expect(fetchInit.redirect).toBe("manual");
+      expect("dispatcher" in fetchInit).toBe(hasDispatcher);
+      expect(fetchInit.dispatcher).toBe(hasDispatcher ? dispatcher : undefined);
+      expect(new Headers(fetchInit.headers).get("Authorization")).toBe("Bearer xoxb-test-token");
+    },
+  );
 });
 
 describe("Slack media SSRF policy", () => {
-  const originalFetchLocal = globalThis.fetch;
-
-  beforeEach(() => {
-    mockFetch = vi.fn();
-    globalThis.fetch = withFetchPreconnect(mockFetch);
-  });
-
   afterEach(() => {
-    globalThis.fetch = originalFetchLocal;
     vi.restoreAllMocks();
   });
 
@@ -1216,18 +1202,16 @@ describe("Slack media SSRF policy", () => {
 
 describe("Slack message file intake", () => {
   beforeEach(() => {
-    mockFetch = vi.fn(
+    mockFetch.mockImplementation(
       async () =>
         new Response(Buffer.from("file contents"), {
           status: 200,
           headers: { "content-type": "image/png" },
         }),
     );
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 
@@ -1484,13 +1468,7 @@ describe("Slack message file intake", () => {
 });
 
 describe("resolveSlackAttachmentContent", () => {
-  beforeEach(() => {
-    mockFetch = vi.fn();
-    globalThis.fetch = mockFetch as unknown as typeof fetch;
-  });
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
 

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -82,17 +82,6 @@ function createSlackMediaRequest(
   };
 }
 
-function isMockedFetch(fetchImpl: typeof fetch | undefined): boolean {
-  if (typeof fetchImpl !== "function") {
-    return false;
-  }
-  const candidate = fetchImpl as typeof fetch & {
-    mock?: unknown;
-    _isMockFunction?: unknown;
-  };
-  return candidate.mock !== undefined || candidate["_isMockFunction"] === true;
-}
-
 function createSlackMediaFetch(govSlack: boolean): FetchLike {
   return async (input, init) => {
     const url = resolveRequestUrl(input);
@@ -100,10 +89,7 @@ function createSlackMediaFetch(govSlack: boolean): FetchLike {
       throw new Error("Unsupported fetch input: expected string, URL, or Request");
     }
     const parsed = assertSlackFileUrl(url, govSlack);
-    const fetchImpl =
-      "dispatcher" in (init ?? {}) && !isMockedFetch(globalThis.fetch)
-        ? fetchWithRuntimeDispatcher
-        : globalThis.fetch;
+    const fetchImpl = "dispatcher" in (init ?? {}) ? fetchWithRuntimeDispatcher : globalThis.fetch;
     return fetchImpl(parsed.href, { ...init, redirect: "manual" });
   };
 }

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -50,6 +50,19 @@ const {
   upsertChannelPairingRequestMock: vi.fn(),
 }));
 
+const mediaFetchMock = vi.hoisted(() =>
+  vi.fn<typeof import("../media.runtime.js").fetchWithRuntimeDispatcher>(),
+);
+
+vi.mock("../media.runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../media.runtime.js")>()),
+  fetchWithRuntimeDispatcher: mediaFetchMock,
+}));
+
+beforeEach(() => {
+  mediaFetchMock.mockReset().mockRejectedValue(new Error("Unexpected Slack media test request"));
+});
+
 vi.mock("../conversation.runtime.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../conversation.runtime.js")>();
   return {
@@ -1953,23 +1966,17 @@ describe("slack prepareSlackMessage inbound contract", () => {
   });
 
   it("surfaces forwarded shared image download failures in raw body", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => new Response("Not Found", { status: 404 }));
-    globalThis.fetch = mockFetch as typeof fetch;
+    mediaFetchMock.mockImplementation(async () => new Response("Not Found", { status: 404 }));
 
-    try {
-      const prepared = await prepareWithDefaultCtx(
-        createSlackMessage({
-          text: "caption",
-          attachments: [{ is_share: true, image_url: "https://files.slack.com/forwarded.jpg" }],
-        }),
-      );
+    const prepared = await prepareWithDefaultCtx(
+      createSlackMessage({
+        text: "caption",
+        attachments: [{ is_share: true, image_url: "https://files.slack.com/forwarded.jpg" }],
+      }),
+    );
 
-      assertPrepared(prepared);
-      expect(prepared.ctxPayload.RawBody).toBe("caption\n\n[slack attachment unavailable]");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    assertPrepared(prepared);
+    expect(prepared.ctxPayload.RawBody).toBe("caption\n\n[slack attachment unavailable]");
   });
 
   it.each([
@@ -2109,8 +2116,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   });
 
   it("keeps a failed file recoverable when a sibling download reaches the agent", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) =>
+    mediaFetchMock.mockImplementation(async (input: RequestInfo | URL) =>
       typeof input === "string" && input.includes("missing-contract.pdf")
         ? new Response("Not Found", { status: 404 })
         : new Response(Buffer.from("image contents"), {
@@ -2122,7 +2128,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
                 : {}),
             },
           }),
-    ) as typeof fetch;
+    );
     let downloadedPaths: string[] = [];
 
     try {
@@ -2165,7 +2171,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(prepared.ctxPayload.BodyForAgent).toContain("HTTP 404");
       expect(prepared.ctxPayload.BodyForAgent).toContain("[slack 2 attachments unavailable]");
     } finally {
-      globalThis.fetch = originalFetch;
       await Promise.all(
         downloadedPaths.map((downloadedPath) => fs.rm(downloadedPath, { force: true })),
       );
@@ -2173,15 +2178,13 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   });
 
   it("keeps the ninth file visible to the agent without downloading past the cap", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(
+    const mockFetch = mediaFetchMock.mockImplementation(
       async () =>
         new Response(Buffer.from("image contents"), {
           status: 200,
           headers: { "content-type": "image/png" },
         }),
     );
-    globalThis.fetch = mockFetch as typeof fetch;
     let downloadedPaths: string[] = [];
     try {
       const prepared = await prepareWithDefaultCtx(
@@ -2204,7 +2207,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
         "image-8.png (image/png, fileId: FCAP8) unavailable (omitted: 8-file limit)",
       );
     } finally {
-      globalThis.fetch = originalFetch;
       await Promise.all(downloadedPaths.map((filePath) => fs.rm(filePath, { force: true })));
     }
   });
@@ -2402,175 +2404,157 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   });
 
   it("records skipped no-mention room images as pending history media", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => {
+    mediaFetchMock.mockImplementation(async () => {
       return new Response(Buffer.from("image data"), {
         status: 200,
         headers: { "content-type": "image/png" },
       });
     });
-    globalThis.fetch = mockFetch as typeof fetch;
 
-    try {
-      const slackCtx = createInboundSlackCtx({
-        cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
-        defaultRequireMention: true,
-      });
-      slackCtx.historyLimit = 5;
-      slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    slackCtx.historyLimit = 5;
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
 
-      const prepared = await prepareMessageWith(
-        slackCtx,
-        createSlackAccount(),
-        createSlackMessage({
-          channel: "C123",
-          channel_type: "channel",
-          text: "",
-          ts: "500.000",
-          files: [
-            {
-              id: "F1",
-              name: "diagram.png",
-              mimetype: "image/png",
-              url_private: "https://files.slack.com/diagram.png",
-            },
-          ],
-        }),
-      );
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        text: "",
+        ts: "500.000",
+        files: [
+          {
+            id: "F1",
+            name: "diagram.png",
+            mimetype: "image/png",
+            url_private: "https://files.slack.com/diagram.png",
+          },
+        ],
+      }),
+    );
 
-      expect(prepared).toBeNull();
-      const entries = Array.from(slackCtx.channelHistories.values()).flat();
-      expect(entries).toHaveLength(1);
-      expect(entries[0]?.body).toBe("[Slack file: diagram.png (image/png, fileId: F1)]");
-      expect(entries[0]?.media).toHaveLength(1);
-      expect(entries[0]?.media?.[0]).toMatchObject({
-        contentType: "image/png",
-        kind: "image",
-        messageId: "500.000",
-      });
-      expect(entries[0]?.media?.[0]?.path).toEqual(expect.any(String));
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(prepared).toBeNull();
+    const entries = Array.from(slackCtx.channelHistories.values()).flat();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.body).toBe("[Slack file: diagram.png (image/png, fileId: F1)]");
+    expect(entries[0]?.media).toHaveLength(1);
+    expect(entries[0]?.media?.[0]).toMatchObject({
+      contentType: "image/png",
+      kind: "image",
+      messageId: "500.000",
+    });
+    expect(entries[0]?.media?.[0]?.path).toEqual(expect.any(String));
   });
 
   it("records skipped no-mention shared images as pending history media", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => {
+    mediaFetchMock.mockImplementation(async () => {
       return new Response(Buffer.from("shared image data"), {
         status: 200,
         headers: { "content-type": "image/png" },
       });
     });
-    globalThis.fetch = mockFetch as typeof fetch;
 
-    try {
-      const slackCtx = createInboundSlackCtx({
-        cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
-        defaultRequireMention: true,
-      });
-      slackCtx.historyLimit = 5;
-      slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    slackCtx.historyLimit = 5;
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
 
-      const prepared = await prepareMessageWith(
-        slackCtx,
-        createSlackAccount(),
-        createSlackMessage({
-          channel: "C123",
-          channel_type: "channel",
-          text: "",
-          ts: "501.000",
-          attachments: [
-            {
-              is_share: true,
-              image_url: "https://files.slack.com/shared.png",
-            },
-          ],
-        }),
-      );
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({
+        channel: "C123",
+        channel_type: "channel",
+        text: "",
+        ts: "501.000",
+        attachments: [
+          {
+            is_share: true,
+            image_url: "https://files.slack.com/shared.png",
+          },
+        ],
+      }),
+    );
 
-      expect(prepared).toBeNull();
-      const entries = Array.from(slackCtx.channelHistories.values()).flat();
-      expect(entries).toHaveLength(1);
-      expect(entries[0]?.body).toBe("[Slack media attachment]");
-      expect(entries[0]?.media).toHaveLength(1);
-      expect(entries[0]?.media?.[0]).toMatchObject({
-        contentType: "image/png",
-        kind: "image",
-        messageId: "501.000",
-      });
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(prepared).toBeNull();
+    const entries = Array.from(slackCtx.channelHistories.values()).flat();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.body).toBe("[Slack media attachment]");
+    expect(entries[0]?.media).toHaveLength(1);
+    expect(entries[0]?.media?.[0]).toMatchObject({
+      contentType: "image/png",
+      kind: "image",
+      messageId: "501.000",
+    });
   });
 
   it("does not record inherited thread-starter files as skipped reply history media", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => {
+    const mockFetch = mediaFetchMock.mockImplementation(async () => {
       throw new Error("inherited parent file should not be downloaded");
     });
-    globalThis.fetch = mockFetch as typeof fetch;
 
-    try {
-      const replies = vi.fn().mockResolvedValue({
-        messages: [
-          {
-            text: "starter",
-            user: "U2",
-            ts: "600.000",
-            files: [
-              {
-                id: "F-parent",
-                name: "parent.png",
-                mimetype: "image/png",
-              },
-            ],
-          },
-        ],
-      });
-      const slackCtx = createInboundSlackCtx({
-        cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
-        appClient: { conversations: { replies } } as unknown as App["client"],
-        defaultRequireMention: true,
-      });
-      slackCtx.historyLimit = 5;
-      slackCtx.resolveUserName = async () => ({ name: "Alice" });
-
-      const prepared = await prepareMessageWith(
-        slackCtx,
-        createSlackAccount(),
-        createSlackMessage({
-          channel: "C123",
-          channel_type: "channel",
-          text: "",
-          ts: "601.000",
-          thread_ts: "600.000",
+    const replies = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          text: "starter",
+          user: "U2",
+          ts: "600.000",
           files: [
             {
               id: "F-parent",
               name: "parent.png",
               mimetype: "image/png",
-              url_private: "https://files.slack.com/parent.png",
             },
           ],
-        }),
-      );
+        },
+      ],
+    });
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      appClient: { conversations: { replies } } as unknown as App["client"],
+      defaultRequireMention: true,
+    });
+    slackCtx.historyLimit = 5;
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
 
-      expect(prepared).toBeNull();
-      expect(replies).toHaveBeenCalledWith({
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount(),
+      createSlackMessage({
         channel: "C123",
-        ts: "600.000",
-        limit: 1,
-        inclusive: true,
-      });
-      const entries = Array.from(slackCtx.channelHistories.values()).flat();
-      expect(entries).toHaveLength(1);
-      expect(entries[0]?.body).toBe("[Slack file: parent.png (image/png, fileId: F-parent)]");
-      expect(entries[0]?.media).toBeUndefined();
-      expect(mockFetch).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+        channel_type: "channel",
+        text: "",
+        ts: "601.000",
+        thread_ts: "600.000",
+        files: [
+          {
+            id: "F-parent",
+            name: "parent.png",
+            mimetype: "image/png",
+            url_private: "https://files.slack.com/parent.png",
+          },
+        ],
+      }),
+    );
+
+    expect(prepared).toBeNull();
+    expect(replies).toHaveBeenCalledWith({
+      channel: "C123",
+      ts: "600.000",
+      limit: 1,
+      inclusive: true,
+    });
+    const entries = Array.from(slackCtx.channelHistories.values()).flat();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.body).toBe("[Slack file: parent.png (image/png, fileId: F-parent)]");
+    expect(entries[0]?.media).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("allows bot-authored room messages with explicit mention when allowBots is mentions", async () => {
@@ -3439,8 +3423,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   });
 
   it("keeps unavailable thread-root files visible beside hydrated media", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) =>
+    mediaFetchMock.mockImplementation(async (input: RequestInfo | URL) =>
       (typeof input === "string" ? input : input instanceof URL ? input.href : input.url).includes(
         "missing.pdf",
       )
@@ -3449,7 +3432,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
             status: 200,
             headers: { "content-type": "image/png" },
           }),
-    ) as typeof fetch;
+    );
     let downloadedPaths: string[] = [];
     const rootMessage = {
       text: `${"Root context. ".repeat(200)}Inspect both attachments`,
@@ -3521,7 +3504,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(prepared.ctxPayload.RawBody).not.toContain("missing.pdf");
       expect(prepared.ctxPayload.CommandBody).toBe("Please use the files from the root");
     } finally {
-      globalThis.fetch = originalFetch;
       await Promise.all(downloadedPaths.map((filePath) => fs.rm(filePath, { force: true })));
     }
   });
@@ -4739,15 +4721,13 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   }
 
   it("admits a spoken-name audio root once and keeps its follow-up on the seeded thread session", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(
+    const mockFetch = mediaFetchMock.mockImplementation(
       async (_input: string | URL | Request) =>
         new Response(Buffer.from("voice clip"), {
           status: 200,
           headers: { "content-type": "audio/mp4" },
         }),
     );
-    globalThis.fetch = mockFetch as typeof fetch;
     const { storePath } = storeFixture.makeTmpStorePath();
     const rootTs = "1777244692.409919";
     const expectedSessionKey = `agent:main:slack:channel:c0ahzfcas1k:thread:${rootTs}`;
@@ -4818,7 +4798,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(fetchedUrls.filter((url) => url.includes("FVOICE"))).toHaveLength(1);
       expect(fetchedUrls.filter((url) => url.includes("FPDF"))).toHaveLength(1);
     } finally {
-      globalThis.fetch = originalFetch;
       const pathsToRemove = new Set([
         ...downloadedPaths,
         ...(downloadedPath ? [downloadedPath] : []),
@@ -4830,62 +4809,48 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
   });
 
   it("does not download or transcribe denied senders' captionless audio", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => {
+    const mockFetch = mediaFetchMock.mockImplementation(async () => {
       throw new Error("denied audio must not be downloaded");
     });
-    globalThis.fetch = mockFetch as typeof fetch;
     const slackCtx = createAudioMentionSlackCtx({ channelUsers: ["U_OWNER"] });
 
-    try {
-      const prepared = await prepareMessageWith(
-        slackCtx,
-        createSlackAccount({ replyToMode: "all" }),
-        createCaptionlessSlackAudioMessage(),
-      );
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "all" }),
+      createCaptionlessSlackAudioMessage(),
+    );
 
-      expect(prepared).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
-      expect(slackCtx.channelHistories.size).toBe(0);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(prepared).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+    expect(slackCtx.channelHistories.size).toBe(0);
   });
 
   it("does not download captionless audio when audio understanding is disabled", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(async () => {
+    const mockFetch = mediaFetchMock.mockImplementation(async () => {
       throw new Error("disabled audio must not be downloaded");
     });
-    globalThis.fetch = mockFetch as typeof fetch;
     const slackCtx = createAudioMentionSlackCtx({ audioEnabled: false });
 
-    try {
-      const prepared = await prepareMessageWith(
-        slackCtx,
-        createSlackAccount({ replyToMode: "all" }),
-        createCaptionlessSlackAudioMessage(),
-      );
+    const prepared = await prepareMessageWith(
+      slackCtx,
+      createSlackAccount({ replyToMode: "all" }),
+      createCaptionlessSlackAudioMessage(),
+    );
 
-      expect(prepared).toBeNull();
-      expect(mockFetch).not.toHaveBeenCalled();
-      expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    expect(prepared).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
   });
 
   it("drops nonmatching audio transcripts, keeps only the file marker, and removes the download", async () => {
-    const originalFetch = globalThis.fetch;
-    const mockFetch = vi.fn(
+    const mockFetch = mediaFetchMock.mockImplementation(
       async (_input: string | URL | Request) =>
         new Response(Buffer.from("voice clip"), {
           status: 200,
           headers: { "content-type": "audio/mp4" },
         }),
     );
-    globalThis.fetch = mockFetch as typeof fetch;
     const slackCtx = createAudioMentionSlackCtx({});
     slackCtx.historyLimit = 5;
     let downloadedPath: string | undefined;
@@ -4916,7 +4881,6 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(entries[0]?.body).toBe("[Slack file: report.pdf (application/pdf, fileId: FPDF)]");
       expect(entries[0]?.media).toBeUndefined();
     } finally {
-      globalThis.fetch = originalFetch;
       if (downloadedPath) {
         await fs.rm(downloadedPath, { force: true });
       }


### PR DESCRIPTION
## What Problem This Solves

Slack media transport selection inspected global fetch for test-mock metadata and bypassed the runtime dispatcher when it found a mock. Tests therefore exercised a different production branch from normal dispatcher-backed downloads.

## Why This Change Was Made

Dispatcher presence now selects the existing runtime transport directly. The media, message-preparation and monitor caller tests inject that existing boundary, removing the global-fetch wrapper and repeated fixture plumbing. This includes all twelve affected caller fixture scopes found during review. Actual downloaded-file cleanup and existing assertions remain intact. The obsolete detector removes 13 production code lines; the complete change removes 66 physical lines. The assertion-safety ratchet shrinks exactly from two assertions to one to match the removed cast.

## User Impact

Normal download behavior is preserved: dispatcher-backed requests retain runtime proxy/TLS handling, other requests use global fetch, and Slack/GovSlack host checks, authorization and manual redirects remain unchanged. No shared runtime implementation, SDK export, dependency, configuration or store changes.

## Evidence

The expanded transport case failed on original production because the mocked global fetch bypassed the dispatcher; its no-dispatcher control passed. The original boundary suite passed 254 cases before and 255 after, covering media intake, redirects, host/DNS policy and shared fetch.

The reported caller failures were reproduced with runtime HTTP blocked, then repaired by migrating eleven preparation fixtures and one monitor fixture. The complete final candidate passes all 2,884 Slack tests across 153 files, including 340 focused media/preparation/context/monitor cases. All 1,244 assertion expressions in the two migrated caller files are preserved in order.

All 27 selected checks pass, including production/test types, typed extension/script lint, doctor cases, unused-export scans and import-cycle guards. Fresh complete-candidate P2 review is clean. Final source hashes match the passing gate; no test cases or timeouts were removed or weakened. This is boundary proof with synthetic responses, not a live Slack download claim.
