### PR TITLE
fix: native worker turns fail to load WebSocket transport

### DIFF
--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -26,6 +26,11 @@ const UNDICI_REQUIRE_BOOTSTRAP = [
   'return requireUndici("undici/index.js") as typeof import("undici");',
 ] as const;
 const WORKER_UNDICI_IMPORT = 'import * as bundledUndici from "undici/index.js";';
+const WS_REQUIRE_BOOTSTRAP = `require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+)`;
+const WS_DYNAMIC_IMPORT =
+  'pathToFileURL(path.join(path.dirname(require.resolve("ws/package.json")), "wrapper.mjs")).href';
 
 export function resolveWorkerDeployGeneratorInputs(rootDir = process.cwd()) {
   const playwrightRoot = fs.realpathSync(path.resolve(rootDir, "node_modules/playwright-core"));
@@ -47,6 +52,14 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
   );
   const undiciDispatcherOptionsPath = fs.realpathSync(
     path.resolve("src/infra/net/undici-dispatcher-options.ts"),
+  );
+  const websocketRuntimePaths = new Set(
+    ["packages/gateway-client/src/websocket.ts", "src/gateway/server-runtime-state.ts"].map(
+      (source) => fs.realpathSync(path.resolve(source)),
+    ),
+  );
+  const transcriptionWebsocketPath = fs.realpathSync(
+    path.resolve("src/realtime-transcription/websocket-session.ts"),
   );
   const [packageJsonPath, browsersJsonPath] = resolveWorkerDeployGeneratorInputs(rootDir);
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8")) as {
@@ -77,6 +90,20 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
       }
       if (resolvedId === playwrightRuntimePath) {
         return WORKER_PLAYWRIGHT_RUNTIME;
+      }
+      // Installed ws paths avoid Bun's adapter; portable Node workers must bundle
+      // that same transport instead of resolving a missing package at runtime.
+      if (websocketRuntimePaths.has(resolvedId)) {
+        if (!code.includes(WS_REQUIRE_BOOTSTRAP)) {
+          this.error("ws bootstrap changed; update the worker deploy transform");
+        }
+        return `import * as bundledWebSocket from "ws";\n${code.replace(WS_REQUIRE_BOOTSTRAP, "bundledWebSocket")}`;
+      }
+      if (resolvedId === transcriptionWebsocketPath) {
+        if (!code.includes(WS_DYNAMIC_IMPORT)) {
+          this.error("ws dynamic bootstrap changed; update the worker deploy transform");
+        }
+        return code.replace(WS_DYNAMIC_IMPORT, '"ws"');
       }
       if (resolvedId === undiciDispatcherOptionsPath) {
         if (UNDICI_REQUIRE_BOOTSTRAP.some((fragment) => !code.includes(fragment))) {

--- a/test/scripts/tsdown-declaration-fixture.ts
+++ b/test/scripts/tsdown-declaration-fixture.ts
@@ -183,6 +183,9 @@ export function createFixture(
     "src/worker/worker-deploy-browser-runtime.ts",
     "extensions/browser/src/browser/playwright-core.runtime.ts",
     "src/infra/net/undici-dispatcher-options.ts",
+    "packages/gateway-client/src/websocket.ts",
+    "src/gateway/server-runtime-state.ts",
+    "src/realtime-transcription/websocket-session.ts",
   ]) {
     write(source, "export {};\n");
   }

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -1,7 +1,12 @@
+import { execFile } from "node:child_process";
+import { once } from "node:events";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import { rawDataToString } from "../../packages/gateway-client/src/websocket-data.js";
 import {
   createWorkerDeployBuildPlugin,
   WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID,
@@ -14,6 +19,137 @@ const fail = (message: string): never => {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("worker deploy build plugin", () => {
+  it("preserves WebSocket transport and lazy transcription in relocated worker output", async () => {
+    const { build } = await import("tsdown");
+    const { default: buildConfigs } = await import("../../tsdown.config.ts");
+    const configs = Array.isArray(buildConfigs) ? buildConfigs : [buildConfigs];
+    const workerConfig = configs.find(
+      (config) =>
+        typeof config.entry === "object" &&
+        config.entry !== null &&
+        !Array.isArray(config.entry) &&
+        config.entry["worker/worker"] === "src/worker/worker-deploy-entry.ts",
+    );
+    expect(workerConfig).toBeDefined();
+    const root = tempDirs.make("openclaw-worker-websocket-");
+    const source = path.join(root, "transport.ts");
+    const output = path.join(root, "output");
+    const relocated = path.join(root, "relocated");
+    fs.writeFileSync(
+      source,
+      [
+        `export { WebSocket } from ${JSON.stringify(path.resolve("packages/gateway-client/src/websocket.ts"))};`,
+        `export { createRealtimeTranscriptionWebSocketSession } from ${JSON.stringify(path.resolve("src/realtime-transcription/websocket-session.ts"))};`,
+      ].join("\n"),
+    );
+    const bundles = await build({
+      ...workerConfig,
+      config: false,
+      entry: { "worker/worker": source },
+      outDir: output,
+      dts: false,
+      logLevel: "silent",
+    });
+    const server = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    const requests: Array<{ path: string | undefined; header: string | string[] | undefined }> = [];
+    const closes: Promise<unknown>[] = [];
+    server.on("connection", (socket, request) => {
+      requests.push({ path: request.url, header: request.headers["x-worker-proof"] });
+      closes.push(once(socket, "close"));
+      socket.on("message", (data) => {
+        const text = rawDataToString(data);
+        if (request.url === "/transcription") {
+          socket.send(JSON.stringify({ transcript: text }));
+        } else {
+          socket.send(text);
+        }
+      });
+    });
+    try {
+      await once(server, "listening");
+      const address = server.address();
+      expect(address && typeof address === "object").toBeTruthy();
+      if (!address || typeof address === "string") {
+        throw new Error("WebSocket proof server has no bound port");
+      }
+      fs.renameSync(output, relocated);
+      const probe = `
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+const [entry, url] = process.argv.slice(1);
+assert.throws(() => createRequire(pathToFileURL(entry)).resolve("ws/package.json"), { code: "MODULE_NOT_FOUND" });
+const { WebSocket, createRealtimeTranscriptionWebSocketSession } = await import(pathToFileURL(entry).href);
+const socket = new WebSocket(url + "/client", { headers: { "x-worker-proof": "client-header" } });
+await once(socket, "open");
+const message = once(socket, "message");
+socket.send("worker echo");
+assert.equal((await message)[0].toString(), "worker echo");
+const closed = once(socket, "close");
+socket.close(1000, "proof complete");
+assert.equal((await closed)[0], 1000);
+let resolveTranscript, rejectTranscript;
+const transcript = new Promise((resolve, reject) => { resolveTranscript = resolve; rejectTranscript = reject; });
+const session = createRealtimeTranscriptionWebSocketSession({
+  providerId: "fixture", url: url + "/transcription", readyOnOpen: true,
+  headers: { "x-worker-proof": "transcription-header" },
+  callbacks: { onError: rejectTranscript },
+  sendAudio: (audio, transport) => transport.sendBinary(audio),
+  onMessage: event => resolveTranscript(event.transcript),
+  onClose: transport => transport.closeNow(),
+});
+try {
+  await session.connect();
+  assert.equal(session.isConnected(), true);
+  session.sendAudio(Buffer.from("worker audio"));
+  assert.equal(await transcript, "worker audio");
+} finally { session.close(); }
+console.log("relocated worker WebSocket and transcription passed");
+`;
+      const result = await promisify(execFile)(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          probe,
+          path.join(relocated, "worker/worker.mjs"),
+          `ws://127.0.0.1:${address.port}`,
+        ],
+        {
+          cwd: relocated,
+          timeout: 30_000,
+          env: {
+            PATH: process.env.PATH,
+            SystemRoot: process.env.SystemRoot,
+            WINDIR: process.env.WINDIR,
+            HOME: root,
+            USERPROFILE: root,
+            TMPDIR: root,
+            TMP: root,
+            TEMP: root,
+          },
+        },
+      );
+      expect(result.stdout.trim()).toBe("relocated worker WebSocket and transcription passed");
+      expect(requests).toEqual([
+        { path: "/client", header: "client-header" },
+        { path: "/transcription", header: "transcription-header" },
+      ]);
+      await Promise.all(closes);
+    } finally {
+      for (const client of server.clients) {
+        client.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+      for (const bundle of bundles) {
+        await bundle[Symbol.asyncDispose]();
+      }
+    }
+  });
+
   it("replaces optional host-native modules with a failing virtual module", () => {
     const plugin = createWorkerDeployBuildPlugin();
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where starting a native OpenClaw turn on a cloud or paired worker fails before its first reply because the transferred worker cannot find `ws/package.json`.

Related: #138724, #138900. Found during the requested post-merge main live validation.

## Why This Change Was Made

The installed WebSocket loaders deliberately select the real `ws` implementation to preserve options and receiver behavior under Bun. The portable worker build must bundle that same transport instead of resolving an installed package at runtime. Its existing dependency transform now covers the Gateway client, Gateway server, and lazy realtime-transcription loaders; ordinary installed runtime paths are unchanged.

The eager failure was introduced by #139919 (`56924648b69b97ee0d9eca5dcac9d3aa58fce3f4`), after the earlier cloud-session candidate proof. The deferred loaders share the same standalone-bundle requirement. No dependency, configuration, protocol, or SQLite schema changes.

## User Impact

Native worker turns can initialize their Gateway connection from the transferred bundle. Realtime transcription also retains its lazy transport without requiring a `ws` installation beside that bundle.

## Evidence

- Actual main `b72a36a77d1b9fe5b7acb4e94042fddf827d7e40`: repository-only creation and dispatch succeeded; the native turn failed in 907ms with the exact missing-package error. The session was reclaimed, pairing removed, processes joined, and preexisting state preserved.
- New executable regression selects the real worker build configuration, relocates its output without a resolvable `ws` installation, and verifies client headers, echo, normal close, and lazy transcription headers/audio exchange/close. It failed before the fix with the same `ws/package.json` error and passes afterward. All 10 focused tests pass.
- Final independent P0–P2 review is clean. All changed-file checks pass after correcting three lint errors in the new test fixture.
- Full `pnpm build` passed on exact candidate `01371e3fa0ade67a995b6b93471aeaecd8fa1349` in 3m35.8s. The emitted worker has no remaining `ws/package.json` lookups.
- Real paired-Mac native flow on that complete build passed: repository-only creation 51ms; initial dispatch 6.578s; write/read turn 8.088s; editor save; normal Stop and retained readback; new-environment restore 1.428s; exact restored read turn 5.999s; final Stop. Both source environments are destroyed with empty attachments, pairing removed, all owned processes absent, test port closed, and preexisting owners preserved. No Gateway project checkout, publication, or OAuth was requested. This is paired-Mac proof with separate HOME/state/workspace and colocated filesystems, not managed AWS provisioning.
- An earlier harness attempt observed pairing's transient uncertain record before confirmed delivery and stopped prematurely. The same setup subsequently confirmed; the harness now waits for confirmation with a bounded observation and retains uncertainty for exact cleanup only. Original failure evidence is retained. Gateway shutdown on the passing candidate exited naturally with code 0 in 11.985s.
- A prewarm-only invocation does not initialize the failing turn graph and is not claimed as regression proof. Exact-head CI remains required; the initial draft-only CI was skipped and supplies no validation.

Tooling/production: +27 lines in the existing build owner. Tests/support: +139 lines. The growth replaces three worker package lookups with bundled transport imports while retaining the installed-runtime contract. npm audit is non-blocking at the maintainer's request.

CI follow-through: the first ready-state run [34030297710](https://github.com/openclaw/openclaw/actions/runs/34030297710) passed 71 jobs but failed 37 declaration cases across four shards because the existing minimal declaration fixture omitted the new build inputs. Commit `707d1e9e4f5221463dab47dedf022f28b3c97c6e` adds those three paths to its canonical placeholder list. All four affected suites now pass locally (61 tests, two platform-specific skips), and scoped independent review is clean. This child changes only that test fixture; production and the full-build/live candidate above remain byte-identical. Required CI [34030846467](https://github.com/openclaw/openclaw/actions/runs/34030846467) passed on the new head: 76 jobs passed, 17 skipped, no failures or reruns.

ClawSweeper’s 11:36 UTC review found no actionable correctness/security findings and accepted the real native-flow proof. Its “Add data-model compatibility proof” item is not applicable: this diff changes the build plugin and two test files only; it changes no SQLite DDL, schema version, stored representation, migration, retention, projection, or runtime storage reader/writer. The worker archive remains the existing content-addressed JavaScript artifact with the same manifest and transfer protocol. No migration proof or schema approval is needed for this build-only repair. The intervening commit only corrects declaration fixtures.

**Landed and verified on main:** merged as [`8319778f3eb5601bbde4486c645051be0e5c4d7a`](https://github.com/openclaw/openclaw/commit/8319778f3eb5601bbde4486c645051be0e5c4d7a). A fresh full build of that main commit passed in 3m7.9s. The real paired-native lifecycle then passed again: creation 52ms, initial dispatch 7.867s, write/read turn 9.203s, accepted editor save, Stop and stopped readback, new-environment restore 1.402s, exact read 8.470s, and final Stop. Root independently read both canonical destroyed environment rows with empty attachments, matched the stopped editor bytes, and verified all owned processes absent and the test port closed. The Gateway exited naturally with code 0 in 14.406s. No additional Gateway checkout was created.
