### PR TITLE
refactor: consolidate command and provider helpers

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -901,11 +901,9 @@ extensions/openai/realtime-voice-session-policy.ts	4
 extensions/openai/speech-provider.ts	2
 extensions/openai/tts.ts	2
 extensions/openai/video-generation-provider.ts	3
-extensions/opencode-go/provider-policy-api.ts	1
 extensions/opencode-go/reasoning-sanitizer.ts	2
 extensions/opencode-go/stream-termination.ts	9
 extensions/opencode/provider-catalog.ts	2
-extensions/opencode/provider-policy-api.ts	1
 extensions/opencode/session-catalog-plugin.ts	1
 extensions/opencode/stream.ts	3
 extensions/openrouter/music-generation-provider.ts	2

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -868,6 +868,16 @@ catalog, API-key auth, and dynamic model resolution.
       - `normalizeResolvedModel(ctx)` can set `compactionThinkingDefault` on the returned `ProviderRuntimeModel` when the provider has a preferred embedded-summary effort. This is prepared runtime metadata, not an operator setting or catalog field. Explicit `agents.defaults.compaction.thinkingLevel` takes precedence; otherwise the host uses this preference and then `low`. The chosen effort is still clamped to the actual compaction candidate.
       - `resolveSystemPromptContribution` lets a provider inject cache-aware system-prompt guidance for a model family. Prefer it over the legacy plugin-wide `before_prompt_build` hook when the behavior belongs to one provider/model family and should preserve the stable/dynamic cache split.
 
+      Bundled and trusted official provider policies can use
+      `resolveEffortThinkingProfile(compat?.supportedReasoningEfforts)` from the
+      private `openclaw/plugin-sdk/provider-thinking-runtime` helper. It accepts
+      exact `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max` values,
+      maps `none` to `off`, and prepends `off` while preserving the first occurrence
+      of each remaining level. The default preference is `medium`, `high`, `low`,
+      then `off`. Missing, null, or empty metadata returns `undefined`; a nonempty
+      list without supported values returns an off-only profile. Keep model-specific
+      overrides and API fallbacks in the provider policy.
+
       Bundled and trusted official plugins can also export
       `resolveToolSearchMode(ctx)` from their lightweight `provider-policy-api`
       artifact. The context contains the final `provider`, `modelId`, `api`, and

--- a/extensions/opencode-go/provider-policy-api.ts
+++ b/extensions/opencode-go/provider-policy-api.ts
@@ -3,6 +3,7 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveEffortThinkingProfile } from "openclaw/plugin-sdk/provider-thinking-runtime";
 
 const KIMI_K2_THINKING_PROFILE = {
   levels: [{ id: "off" }],
@@ -23,30 +24,6 @@ const FIXED_ANTHROPIC_REASONING_PROFILE = {
 const KIMI_K2_MODEL_IDS = new Set(["kimi-k2.5", "kimi-k2.6", "kimi-k2.7-code"]);
 const FIXED_ANTHROPIC_REASONING_MODEL_IDS = new Set(["minimax-m2.5", "minimax-m2.7"]);
 const BINARY_REASONING_MODEL_IDS = new Set(["minimax-m3"]);
-const THINKING_LEVEL_IDS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
-
-function resolveEffortThinkingProfile(
-  efforts: readonly string[] | null | undefined,
-): ProviderThinkingProfile | undefined {
-  if (!efforts || efforts.length === 0) {
-    return undefined;
-  }
-  const acceptedLevelIds = ["off", ...efforts.map((effort) => (effort === "none" ? "off" : effort))]
-    .filter((id) => THINKING_LEVEL_IDS.has(id))
-    .filter((id, index, values) => values.indexOf(id) === index) as Array<
-    "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
-  >;
-  const levels = acceptedLevelIds.map((id) => ({ id }));
-  const levelIdSet = new Set(acceptedLevelIds);
-  const defaultLevel = levelIdSet.has("medium")
-    ? "medium"
-    : levelIdSet.has("high")
-      ? "high"
-      : levelIdSet.has("low")
-        ? "low"
-        : "off";
-  return { levels, defaultLevel };
-}
 
 export function isOpencodeGoFixedAnthropicReasoningModelId(modelId: unknown): boolean {
   return (

--- a/extensions/opencode/provider-policy-api.test.ts
+++ b/extensions/opencode/provider-policy-api.test.ts
@@ -8,6 +8,7 @@ describe("opencode provider policy public artifact", () => {
       resolveThinkingProfile({
         provider: "opencode",
         modelId: "claude-opus-4-7",
+        compat: { supportedReasoningEfforts: ["low"] },
       }),
     ).toEqual({
       levels: [

--- a/extensions/opencode/provider-policy-api.ts
+++ b/extensions/opencode/provider-policy-api.ts
@@ -3,36 +3,12 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { resolveEffortThinkingProfile } from "openclaw/plugin-sdk/provider-thinking-runtime";
 
 const FIXED_REASONING_PROFILE = {
   levels: [{ id: "off", label: "always on" }],
   defaultLevel: "off",
 } as const satisfies ProviderThinkingProfile;
-
-const THINKING_LEVEL_IDS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
-
-function resolveEffortThinkingProfile(
-  efforts: readonly string[] | null | undefined,
-): ProviderThinkingProfile | undefined {
-  if (!efforts || efforts.length === 0) {
-    return undefined;
-  }
-  const acceptedLevelIds = ["off", ...efforts.map((effort) => (effort === "none" ? "off" : effort))]
-    .filter((id) => THINKING_LEVEL_IDS.has(id))
-    .filter((id, index, values) => values.indexOf(id) === index) as Array<
-    "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max"
-  >;
-  const levels = acceptedLevelIds.map((id) => ({ id }));
-  const levelIdSet = new Set(acceptedLevelIds);
-  const defaultLevel = levelIdSet.has("medium")
-    ? "medium"
-    : levelIdSet.has("high")
-      ? "high"
-      : levelIdSet.has("low")
-        ? "low"
-        : "off";
-  return { levels, defaultLevel };
-}
 
 export function resolveThinkingProfile(params: ProviderDefaultThinkingPolicyContext) {
   const modelId = params.modelId.trim().toLowerCase();

--- a/extensions/telegram/src/command-ui.ts
+++ b/extensions/telegram/src/command-ui.ts
@@ -42,19 +42,6 @@ export function buildTelegramModelsMenuButtons(params: { providers: ProviderInfo
   return buildProviderKeyboard(params.providers);
 }
 
-export function buildTelegramModelsMenuChannelData(params: {
-  providers: ProviderInfo[];
-}): ReplyPayload["channelData"] | null {
-  if (params.providers.length === 0) {
-    return null;
-  }
-  return {
-    telegram: {
-      buttons: buildTelegramModelsMenuButtons(params),
-    },
-  };
-}
-
 export function buildTelegramCommandsListChannelData(params: {
   currentPage: number;
   totalPages: number;

--- a/extensions/telegram/src/shared.test.ts
+++ b/extensions/telegram/src/shared.test.ts
@@ -30,25 +30,30 @@ function resolveAccount(cfg: OpenClawConfig, accountId: string): ResolvedTelegra
 }
 
 describe("createTelegramPluginBase config duplicate token guard", () => {
-  it("wires the top-level models menu adapter into the production plugin", () => {
-    const channelData = telegramPluginBase.commands?.buildModelsMenuChannelData?.({
-      providers: [
-        { id: "anthropic", count: 2 },
-        { id: "openai", count: 3 },
-      ],
-    });
-
-    expect(channelData).toEqual({
-      telegram: {
-        buttons: [
-          [
-            { text: "anthropic (2)", callback_data: "mdl_list_anthropic_1" },
-            { text: "openai (3)", callback_data: "mdl_list_openai_1" },
-          ],
+  it.each(["buildModelsMenuChannelData", "buildModelsProviderChannelData"] as const)(
+    "%s renders providers and preserves the empty fallback",
+    (hook) => {
+      const render = telegramPluginBase.commands?.[hook];
+      const channelData = render?.({
+        providers: [
+          { id: "anthropic", count: 2 },
+          { id: "openai", count: 3 },
         ],
-      },
-    });
-  });
+      });
+
+      expect(channelData).toEqual({
+        telegram: {
+          buttons: [
+            [
+              { text: "anthropic (2)", callback_data: "mdl_list_anthropic_1" },
+              { text: "openai (3)", callback_data: "mdl_list_openai_1" },
+            ],
+          ],
+        },
+      });
+      expect(render?.({ providers: [] })).toBeNull();
+    },
+  );
 
   it("wires the guided add-provider adapter into the production plugin", () => {
     const channelData = telegramPluginBase.commands?.buildModelsAddProviderChannelData?.({

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -6,7 +6,6 @@ import {
   buildTelegramModelBrowseChannelData,
   buildTelegramModelsAddProviderChannelData,
   buildTelegramModelsListChannelData,
-  buildTelegramModelsMenuChannelData,
   buildTelegramModelsProviderChannelData,
 } from "./command-ui.js";
 import { telegramDoctor } from "./doctor.js";
@@ -37,7 +36,7 @@ export function createTelegramPluginBase(params: {
       nativeCommandsAutoEnabled: true,
       nativeSkillsAutoEnabled: true,
       buildCommandsListChannelData: buildTelegramCommandsListChannelData,
-      buildModelsMenuChannelData: buildTelegramModelsMenuChannelData,
+      buildModelsMenuChannelData: buildTelegramModelsProviderChannelData,
       buildModelsProviderChannelData: buildTelegramModelsProviderChannelData,
       buildModelsAddProviderChannelData: buildTelegramModelsAddProviderChannelData,
       buildModelsListChannelData: buildTelegramModelsListChannelData,

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -909,6 +909,9 @@
       ],
       "openclaw/plugin-sdk/realtime-voice-provider": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/realtime-voice-provider.d.ts"
+      ],
+      "openclaw/plugin-sdk/provider-thinking-runtime": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/provider-thinking-runtime.d.ts"
       ]
     }
   }

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -893,6 +893,9 @@
       ],
       "openclaw/plugin-sdk/realtime-voice-provider": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/realtime-voice-provider.d.ts"
+      ],
+      "openclaw/plugin-sdk/provider-thinking-runtime": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/provider-thinking-runtime.d.ts"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -396,7 +396,8 @@
     "!dist/plugin-sdk/blob-runtime.d.ts",
     "!dist/plugin-sdk/realtime-transcription-session.d.ts",
     "!dist/plugin-sdk/speech-provider.d.ts",
-    "!dist/plugin-sdk/realtime-voice-provider.d.ts"
+    "!dist/plugin-sdk/realtime-voice-provider.d.ts",
+    "!dist/plugin-sdk/provider-thinking-runtime.d.ts"
   ],
   "type": "module",
   "main": "dist/index.js",
@@ -1401,6 +1402,9 @@
     },
     "./plugin-sdk/provider-stream-shared": {
       "default": "./dist/plugin-sdk/provider-stream-shared.js"
+    },
+    "./plugin-sdk/provider-thinking-runtime": {
+      "default": "./dist/plugin-sdk/provider-thinking-runtime.js"
     },
     "./plugin-sdk/provider-transport-runtime": {
       "default": "./dist/plugin-sdk/provider-transport-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -309,6 +309,7 @@
   "provider-onboard",
   "provider-stream-family",
   "provider-stream-shared",
+  "provider-thinking-runtime",
   "provider-transport-runtime",
   "provider-stream",
   "provider-tools",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -128,6 +128,7 @@
   "provider-stream-family",
   "provider-stream-shared",
   "provider-test-contracts",
+  "provider-thinking-runtime",
   "provider-tools",
   "provider-transport-runtime",
   "provider-usage",

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -19,20 +19,18 @@ import {
 
 const MAX_TOOL_POLICY_WARNING_CACHE = 256;
 const seenToolPolicyWarnings = new Set<string>();
-const toolPolicyWarningOrder: string[] = [];
 
 function rememberToolPolicyWarning(warning: string): boolean {
   if (seenToolPolicyWarnings.has(warning)) {
     return false;
   }
   if (seenToolPolicyWarnings.size >= MAX_TOOL_POLICY_WARNING_CACHE) {
-    const oldest = toolPolicyWarningOrder.shift();
+    const oldest = seenToolPolicyWarnings.values().next().value;
     if (oldest) {
       seenToolPolicyWarnings.delete(oldest);
     }
   }
   seenToolPolicyWarnings.add(warning);
-  toolPolicyWarningOrder.push(warning);
   return true;
 }
 

--- a/src/cli/update-cli/update-command-report.test.ts
+++ b/src/cli/update-cli/update-command-report.test.ts
@@ -3,6 +3,23 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { runInteractiveUpdateFailureAction } from "./update-command-report.js";
 
+const mocks = vi.hoisted(() => ({
+  select: vi.fn<() => Promise<string | symbol>>(),
+  confirm: vi.fn<() => Promise<boolean | symbol>>(),
+  prepare:
+    vi.fn<typeof import("../../infra/update-failure-report.js").prepareUpdateFailureReport>(),
+  submit: vi.fn<typeof import("../../infra/update-failure-report.js").submitUpdateFailureReport>(),
+}));
+
+vi.mock("../../commands/configure.shared.js", () => ({
+  select: mocks.select,
+  confirm: mocks.confirm,
+}));
+vi.mock("../../infra/update-failure-report.js", () => ({
+  prepareUpdateFailureReport: mocks.prepare,
+  submitUpdateFailureReport: mocks.submit,
+}));
+
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const failure: UpdateRunResult = {
@@ -33,31 +50,24 @@ function setup(
     title: "Update failure",
     url: "https://github.com/openclaw/openclaw/issues/new",
   };
-  const prepare = vi.fn(async () => prepared);
-  const submit = vi.fn<
-    typeof import("../../infra/update-failure-report.js").submitUpdateFailureReport
-  >(async () => ({
+  const prepare = mocks.prepare.mockReset().mockResolvedValue(prepared);
+  const submit = mocks.submit.mockReset().mockResolvedValue({
     savedReportPath: prepared.savedReportPath,
     status: "created" as const,
     url: "https://github.com/openclaw/openclaw/issues/123",
-  }));
+  });
   const runtime = { log: vi.fn(), error: vi.fn() };
   const actions = Array.isArray(action) ? [...action] : [action];
-  const chooseAction = vi.fn(async () => actions.shift() ?? "dismiss");
+  const chooseAction = mocks.select
+    .mockReset()
+    .mockImplementation(async () => actions.shift() ?? "dismiss");
+  mocks.confirm.mockReset().mockResolvedValue(confirmed);
   const run = () =>
     runInteractiveUpdateFailureAction({
       attemptId: "attempt-cli",
       env: { OPENCLAW_STATE_DIR: stateDir },
       result: failure,
       runtime,
-      dependencies: {
-        prepare,
-        prompts: {
-          chooseAction,
-          confirmSubmission: async () => confirmed,
-        },
-        submit,
-      },
     });
   return { chooseAction, prepare, prepared, run, runtime, submit };
 }
@@ -77,6 +87,7 @@ describe("interactive update failure action", () => {
     await expect(fixture.run()).resolves.toBe("handled");
     expect(fixture.prepare).toHaveBeenCalledOnce();
     expect(fixture.runtime.log).toHaveBeenCalledWith("sanitized preview");
+    expect(mocks.confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
     expect(fixture.runtime.log).toHaveBeenCalledWith("Update failure report cancelled.");
     expect(fixture.submit).not.toHaveBeenCalled();
   });
@@ -113,6 +124,8 @@ describe("interactive update failure action", () => {
     await expect(fixture.run()).resolves.toBe("handled");
     expect(fixture.prepare).toHaveBeenCalledTimes(2);
     expect(fixture.submit).toHaveBeenCalledTimes(2);
+    expect(fixture.chooseAction).toHaveBeenCalledTimes(2);
+    expect(mocks.confirm).toHaveBeenCalledTimes(2);
     expect(fixture.runtime.log).toHaveBeenCalledWith("spawn gh EAGAIN");
     expect(fixture.runtime.log).toHaveBeenCalledWith(
       "Created GitHub issue: https://github.com/openclaw/openclaw/issues/123",

--- a/src/cli/update-cli/update-command-report.ts
+++ b/src/cli/update-cli/update-command-report.ts
@@ -6,53 +6,12 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import {
   prepareUpdateFailureReport,
   submitUpdateFailureReport,
-  type PreparedUpdateFailureReport,
-  type UpdateFailureReportInput,
   type UpdateFailureReportSubmitResult,
 } from "../../infra/update-failure-report.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 type UpdateFailureAction = "triage" | "report" | "dismiss";
-
-type UpdateFailureReportPrompts = {
-  chooseAction: () => Promise<UpdateFailureAction | symbol>;
-  confirmSubmission: () => Promise<boolean | symbol>;
-};
-
-type UpdateFailureReportDependencies = {
-  prepare: (
-    input: UpdateFailureReportInput,
-    options: { env: NodeJS.ProcessEnv; stateDir: string },
-  ) => Promise<PreparedUpdateFailureReport>;
-  prompts: UpdateFailureReportPrompts;
-  submit: (
-    prepared: PreparedUpdateFailureReport,
-    previewDigest: string,
-    options: { env: NodeJS.ProcessEnv; stateDir: string },
-  ) => Promise<UpdateFailureReportSubmitResult>;
-};
-
-const defaultDependencies: UpdateFailureReportDependencies = {
-  prepare: prepareUpdateFailureReport,
-  prompts: {
-    chooseAction: async () =>
-      await select<UpdateFailureAction>({
-        message: "Choose the next action for this failed update",
-        options: [
-          { value: "triage", label: "Diagnose update failure" },
-          { value: "report", label: "Report update failure" },
-          { value: "dismiss", label: "Exit" },
-        ],
-      }),
-    confirmSubmission: async () =>
-      await confirm({
-        message: "Submit this sanitized report to openclaw/openclaw now?",
-        initialValue: false,
-      }),
-  },
-  submit: submitUpdateFailureReport,
-};
 
 function renderSubmissionResult(result: UpdateFailureReportSubmitResult): string[] {
   if (result.status === "created") {
@@ -83,15 +42,16 @@ export async function runInteractiveUpdateFailureAction(params: {
   error?: string;
   result?: UpdateRunResult;
   runtime: Pick<RuntimeEnv, "error" | "log">;
-  dependencies?: Partial<UpdateFailureReportDependencies>;
 }): Promise<"triage" | "handled"> {
-  const dependencies: UpdateFailureReportDependencies = {
-    ...defaultDependencies,
-    ...params.dependencies,
-    prompts: params.dependencies?.prompts ?? defaultDependencies.prompts,
-  };
   while (true) {
-    const action = await dependencies.prompts.chooseAction();
+    const action = await select<UpdateFailureAction>({
+      message: "Choose the next action for this failed update",
+      options: [
+        { value: "triage", label: "Diagnose update failure" },
+        { value: "report", label: "Report update failure" },
+        { value: "dismiss", label: "Exit" },
+      ],
+    });
     if (isCancel(action) || action === "dismiss") {
       return "handled";
     }
@@ -107,7 +67,7 @@ export async function runInteractiveUpdateFailureAction(params: {
         durationMs: 0,
       };
       const stateDir = resolveStateDir(params.env);
-      const prepared = await dependencies.prepare(
+      const prepared = await prepareUpdateFailureReport(
         {
           attemptId: params.attemptId,
           ...(params.error ? { error: params.error } : {}),
@@ -118,12 +78,15 @@ export async function runInteractiveUpdateFailureAction(params: {
       );
       params.runtime.log("Sanitized update failure report preview:");
       params.runtime.log(prepared.body);
-      const confirmed = await dependencies.prompts.confirmSubmission();
+      const confirmed = await confirm({
+        message: "Submit this sanitized report to openclaw/openclaw now?",
+        initialValue: false,
+      });
       if (isCancel(confirmed) || !confirmed) {
         params.runtime.log("Update failure report cancelled.");
         return "handled";
       }
-      const submitted = await dependencies.submit(prepared, prepared.previewDigest, {
+      const submitted = await submitUpdateFailureReport(prepared, prepared.previewDigest, {
         env: params.env,
         stateDir,
       });

--- a/src/gateway/server-methods/update-report-run.test.ts
+++ b/src/gateway/server-methods/update-report-run.test.ts
@@ -24,6 +24,14 @@ import type { GatewayRequestHandlerOptions, RespondFn } from "./types.js";
 const mocks = vi.hoisted(() => ({
   runGh: vi.fn<RunGithubCli>(),
   sentinel: vi.fn<() => Promise<RestartSentinelPayload | null>>(),
+  select: vi.fn<() => Promise<string | symbol>>(),
+  confirm: vi.fn<() => Promise<boolean | symbol>>(),
+}));
+
+vi.mock("../../commands/configure.shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../commands/configure.shared.js")>()),
+  select: mocks.select,
+  confirm: mocks.confirm,
 }));
 
 vi.mock("../../infra/github-issue.js", async () => {
@@ -154,6 +162,8 @@ async function reportFiles() {
 
 beforeEach(async () => {
   home = await createTempHomeEnv("openclaw-update-report-run-");
+  mocks.select.mockReset().mockResolvedValue("report");
+  mocks.confirm.mockReset().mockResolvedValue(true);
   mocks.sentinel.mockReset().mockResolvedValue(null);
   mocks.runGh.mockReset().mockImplementation(async (args) => ({
     started: true,
@@ -313,12 +323,6 @@ describe("Report action from the authoritative update ledger", () => {
             durationMs: 1,
           },
           runtime,
-          dependencies: {
-            prompts: {
-              chooseAction: async () => "report",
-              confirmSubmission: async () => true,
-            },
-          },
         }),
       ).resolves.toBe("handled");
       expect(runtime.error).not.toHaveBeenCalled();

--- a/src/plugin-sdk/provider-thinking-runtime.ts
+++ b/src/plugin-sdk/provider-thinking-runtime.ts
@@ -1,0 +1,26 @@
+import type { ProviderThinkingProfile } from "../plugins/provider-thinking.types.js";
+
+const THINKING_LEVEL_IDS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+// Provider policies load eagerly; keep this module free of runtime imports.
+export function resolveEffortThinkingProfile(
+  efforts: readonly string[] | null | undefined,
+): ProviderThinkingProfile | undefined {
+  if (!efforts || efforts.length === 0) {
+    return undefined;
+  }
+  const acceptedLevelIds = ["off", ...efforts.map((effort) => (effort === "none" ? "off" : effort))]
+    .filter((id): id is ProviderThinkingProfile["levels"][number]["id"] =>
+      THINKING_LEVEL_IDS.has(id),
+    )
+    .filter((id, index, values) => values.indexOf(id) === index);
+  const levels = acceptedLevelIds.map((id) => ({ id }));
+  const defaultLevel = acceptedLevelIds.includes("medium")
+    ? "medium"
+    : acceptedLevelIds.includes("high")
+      ? "high"
+      : acceptedLevelIds.includes("low")
+        ? "low"
+        : "off";
+  return { levels, defaultLevel };
+}

--- a/src/plugins/provider-public-artifacts.test.ts
+++ b/src/plugins/provider-public-artifacts.test.ts
@@ -184,18 +184,78 @@ describe("provider public artifacts", () => {
     });
   });
 
-  it("loads OpenCode Go DeepSeek V4 thinking policy before runtime registration", () => {
+  it.each(["opencode", "opencode-go"])(
+    "preserves %s effort metadata before runtime registration",
+    (provider) => {
+      const surface = resolveBundledProviderPolicySurface(provider);
+      const cases = [
+        [undefined, undefined, undefined],
+        [null, undefined, undefined],
+        [[], undefined, undefined],
+        [["none", "off"], ["off"], "off"],
+        [["max", "high", "low", "high", "none"], ["off", "max", "high", "low"], "high"],
+        [
+          ["high", "medium", "low", "minimal", "xhigh"],
+          ["off", "high", "medium", "low", "minimal", "xhigh"],
+          "medium",
+        ],
+        [["low"], ["off", "low"], "low"],
+        [["minimal", "xhigh", "max"], ["off", "minimal", "xhigh", "max"], "off"],
+        [["adaptive", "ultra", "HIGH", " low ", "provider-native", ""], ["off"], "off"],
+      ] as const;
+      for (const [efforts, levelIds, defaultLevel] of cases) {
+        expect(
+          surface?.resolveThinkingProfile?.({
+            provider,
+            modelId: "effort-fixture",
+            compat: { supportedReasoningEfforts: efforts },
+          }),
+          JSON.stringify(efforts),
+        ).toEqual(levelIds ? { levels: levelIds.map((id) => ({ id })), defaultLevel } : undefined);
+      }
+      expect(
+        surface?.resolveThinkingProfile?.({
+          provider,
+          modelId: "effort-fixture",
+          api: "openai-responses",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: [] },
+        }),
+      ).toEqual(
+        provider === "opencode"
+          ? { levels: [{ id: "off", label: "always on" }], defaultLevel: "off" }
+          : undefined,
+      );
+    },
+  );
+
+  it("loads OpenCode Go model overrides before runtime registration", () => {
     const surface = resolveBundledProviderPolicySurface("opencode-go");
 
-    expect(
-      surface?.resolveThinkingProfile?.({
-        provider: "opencode-go",
-        modelId: "deepseek-v4-pro",
-      }),
-    ).toEqual({
-      levels: [{ id: "off" }, { id: "high" }, { id: "max" }],
-      defaultLevel: "high",
-    });
+    for (const [modelId, levelIds, defaultLevel] of [
+      ["deepseek-v4-pro", ["off", "high", "max"], "high"],
+      ["kimi-k3", ["off", "max"], "off"],
+      ["kimi-k2.6", ["off"], "off"],
+    ] as const) {
+      expect(
+        surface?.resolveThinkingProfile?.({
+          provider: "opencode-go",
+          modelId,
+          compat: { supportedReasoningEfforts: ["low"] },
+        }),
+      ).toEqual({ levels: levelIds.map((id) => ({ id })), defaultLevel });
+    }
+    for (const modelId of ["minimax-m2.7", "minimax-m3"]) {
+      expect(
+        surface?.resolveThinkingProfile?.({
+          provider: "opencode-go",
+          modelId,
+          api: "anthropic-messages",
+          reasoning: true,
+          compat: { supportedReasoningEfforts: ["low"] },
+        }),
+      ).toEqual({ levels: [{ id: "off" }, { id: "low" }], defaultLevel: "low" });
+    }
     expect(
       surface?.resolveThinkingProfile?.({ provider: "opencode-go", modelId: "glm-5" }),
     ).toBeUndefined();


### PR DESCRIPTION
## What Problem This Solves

Command rendering and diagnostics retained duplicate plumbing, and OpenCode Zen and Go separately interpreted the same reasoning-effort metadata. This maintenance batch consolidates those owners while preserving their existing output and operator flows.

## Why This Change Was Made

Update reporting now calls the existing styled prompts and report functions directly, removing a dependency bag used only by tests. Both Telegram provider-menu hooks reuse the existing provider renderer. Warning deduplication uses its Set's insertion order instead of maintaining a second FIFO array. The two OpenCode policies share a small effort-profile helper with no runtime imports; their model overrides, provider admission, and API fallbacks stay local and unchanged.

The report flow retains sanitized preview, default-false confirmation, fresh choice after retry, and durable cross-surface receipts. Telegram keeps both public hooks, callback bytes, keyboard order and empty-list fallback. Warnings retain the 256-entry FIFO and do not refresh duplicates. Effort profiles preserve exact spelling, order, deduplication, defaults, and the distinction between absent metadata and an explicit off-only result.

Runtime TypeScript is **74 lines smaller**. Registration metadata adds 12 lines, so production is **net −62**. Existing tests gain 83 lines and docs gain 10; two obsolete guard-inventory entries are removed; the complete 19-file diff is +29 lines. No configuration option, schema, external dependency, or third-party typed API is added.

## User Impact

No intentional change to menu choices, reporting behavior, warnings, or thinking defaults. There is one new private official-plugin runtime entry, documented alongside provider policy hooks.

Separately published OpenCode plugins gain a host SDK dependency. This change must ship with the next synchronized core/plugin release, whose existing release sync advances their plugin API floors. It must not be published independently with the current older API floor. No version or compatibility-floor change is made here; release preparation and installer enforcement retain their existing ownership.

## Evidence

Final source: `e9970d6416b535aca3ba9f8cab96ddcc0b1a7c1c`.

- **236 focused tests passed**: 139 command/Telegram/warning/receipt tests plus 97 provider/artifact/install/release tests. The new provider preservation cases also passed on the original implementations. The existing CLI/Gateway matrix still uses real report preparation and SQLite receipts with the existing mocked GitHub transport.
- The Gateway report suite passed all 23 cases before and after: 31.02s / 2,091,204,608-byte max RSS before; 24.51s / 2,092,367,872-byte max RSS after. These single runs establish comparable scope, not a performance claim.
- Independent P0–P2 review of the complete final diff found no actionable issue.
- Full final-commit build passed in 4m57s, including SDK export checks and built control-plane loading. The emitted Telegram entrypoint passed four exact public-hook payload checks in network-denied synthetic state, with stable source/build fingerprints.
- Original and final emitted OpenCode policy artifacts each passed 72 explicit cases in separate cold processes, with identical complete output tables. Actual module-load tracing found no forbidden transport or registration owner; source/build fingerprints remained stable.
- Both canonical package-local builds passed. Staged packages use canonical manifest augmentation and peer links, then plain Node package exports; they resolve the exact new host SDK export and pass the same 72-case fixture with baseline parity. The sandbox denies networking and confines writes to synthetic state. This proves the candidate host only.
- The complete final changed gate passed: SDK exports/surface, package boundaries, docs, all typecheck lanes, full lint and zero runtime import cycles. It first identified the two obsolete assertion allowances; those were pruned canonically and independently reviewed without changing runtime or test source. Required exact-head CI also passed: run 34031010753, including `openclaw/ci-gate`.

## Review Follow-through

ClawSweeper found no actionable correctness or security issue. Its remaining compatibility move is resolved by selecting the recommended synchronized core/plugin release. The new host dependency is recorded in the commit and this PR; canonical release preparation advances both plugin API floors before publication, and the installer rejects older hosts. No independent plugin publication with the current older floor is authorized or planned. The final package-level proof exercises this exact candidate host, without claiming compatibility with older releases.
