### PR TITLE
fix(channels): keep ACP configured bindings authoritative over stale non-ACP runtime bindings

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -490,6 +490,15 @@ metadata. Replacing either starts fresh target metadata, so a new session cannot
 inherit the previous plugin owner, agent, or label. Keep conversation transport
 details and explicit lifecycle settings separate from target metadata.
 
+Every record the generic bind API writes is stamped with
+`metadata.bindingOrigin: "generic-bind-api"` provenance. Routing uses that
+provenance to distinguish intentional SDK bindings from legacy rows persisted
+by the removed catch-all writer: a fresh generic binding keeps its runtime
+precedence over a configured binding, while a provenance-less generic
+session-kind record that conflicts with a configured binding is treated as
+stale and ignored. Do not strip or forge `bindingOrigin` when projecting,
+copying, or rebinding records through the service.
+
 Preserve opaque plugin ownership metadata when projecting binding records.
 Plugin-owned targets do not require an OpenClaw agent id; use
 `isPluginOwnedSessionBindingRecord(...)` from

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -921,6 +921,7 @@ export async function handleFeishuMessage(params: {
       // configured ACP bindings may still inherit the shared `chat:topic:root` topic session.
       const runtimeRoute = resolveRuntimeConversationBindingRoute({
         route,
+        configuredBindingRoute: configuredRoute,
         conversation: {
           channel: "feishu",
           accountId: account.accountId,

--- a/extensions/imessage/src/conversation-route.test.ts
+++ b/extensions/imessage/src/conversation-route.test.ts
@@ -90,6 +90,45 @@ describe("resolveIMessageConversationRoute", () => {
     expect(result.bindingResolution?.record.targetSessionKey).toBe(result.route.sessionKey);
   });
 
+  it("keeps the configured ACP binding when a stale non-ACP runtime binding exists", () => {
+    const touch = vi.fn();
+    registerSessionBindingAdapter({
+      channel: "imessage",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: (ref) =>
+        ref.conversationId === "+15555550123"
+          ? {
+              bindingId: "default:+15555550123",
+              // Stale catch-all row predating the configured ACP binding.
+              targetSessionKey: "agent:main:imessage:default:direct:+15555550123",
+              targetKind: "session",
+              conversation: {
+                channel: "imessage",
+                accountId: "default",
+                conversationId: "+15555550123",
+              },
+              status: "active",
+              boundAt: 1,
+            }
+          : null,
+      touch,
+    });
+
+    const result = resolveIMessageConversationRoute({
+      cfg: configuredCfg,
+      accountId: "default",
+      isGroup: false,
+      peerId: "+15555550123",
+      sender: "+15555550123",
+    });
+
+    expect(result.route.agentId).toBe("codex");
+    expect(result.route.sessionKey).toMatch(/^agent:codex:acp:binding:imessage:/);
+    expect(result.bindingResolution?.record.targetSessionKey).toBe(result.route.sessionKey);
+    expect(touch).not.toHaveBeenCalled();
+  });
+
   it("lets runtime iMessage conversation bindings override default routing", () => {
     const touch = vi.fn();
     registerSessionBindingAdapter({

--- a/extensions/imessage/src/conversation-route.ts
+++ b/extensions/imessage/src/conversation-route.ts
@@ -49,6 +49,7 @@ export function resolveIMessageConversationRoute(params: {
 
   const runtimeRoute = resolveRuntimeConversationBindingRoute({
     route: configuredRoute.route,
+    configuredBindingRoute: configuredRoute,
     conversation,
   });
   if (runtimeRoute.bindingRecord && !runtimeRoute.boundSessionKey) {

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -20,8 +20,6 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   ensureConfiguredBindingRouteReady,
   resolvePinnedMainDmOwnerFromAllowlist,
-  resolveConfiguredBindingRoute,
-  resolveRuntimeConversationBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
@@ -33,6 +31,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeAllowFrom } from "./bot-access.js";
+import { resolveLineConversationRoute } from "./conversation-route.js";
 import { resolveLineGroupConfigEntry } from "./group-keys.js";
 import { resolveLineMentionStrippedText } from "./mentions.js";
 import { getLineGroupName, getUserProfile } from "./send.js";
@@ -126,46 +125,12 @@ async function resolveLineInboundRoute(params: {
 
   const { userId, groupId, roomId, isGroup } = getLineSourceInfo(params.source);
   const peerId = buildPeerId(params.source);
-  let route = resolveAgentRoute({
+  const { route, configuredBinding, configuredBindingSessionKey } = resolveLineConversationRoute({
     cfg: params.cfg,
-    channel: "line",
     accountId: params.account.accountId,
-    peer: {
-      kind: isGroup ? "group" : "direct",
-      id: peerId,
-    },
+    peerId,
+    isGroup,
   });
-
-  const configuredRoute = resolveConfiguredBindingRoute({
-    cfg: params.cfg,
-    route,
-    conversation: {
-      channel: "line",
-      accountId: params.account.accountId,
-      conversationId: peerId,
-    },
-  });
-  let configuredBinding = configuredRoute.bindingResolution;
-  const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
-  route = configuredRoute.route;
-
-  const runtimeRoute = resolveRuntimeConversationBindingRoute({
-    route,
-    conversation: {
-      channel: "line",
-      accountId: params.account.accountId,
-      conversationId: peerId,
-    },
-  });
-  route = runtimeRoute.route;
-  if (runtimeRoute.bindingRecord) {
-    configuredBinding = null;
-    logVerbose(
-      runtimeRoute.boundSessionKey
-        ? `line: routed via bound conversation ${peerId} -> ${runtimeRoute.boundSessionKey}`
-        : `line: plugin-bound conversation ${peerId}`,
-    );
-  }
 
   if (configuredBinding) {
     const ensured = await ensureConfiguredBindingRouteReady({

--- a/extensions/line/src/conversation-route.test.ts
+++ b/extensions/line/src/conversation-route.test.ts
@@ -1,0 +1,150 @@
+// Line tests cover conversation route plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  registerSessionBindingAdapter,
+  testing as sessionBindingTesting,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import {
+  createTestRegistry,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { lineBindingsAdapter } from "./bindings.js";
+import { resolveLineConversationRoute } from "./conversation-route.js";
+
+const lineBindingsPlugin = {
+  id: "line",
+  bindings: lineBindingsAdapter,
+  conversationBindings: {
+    defaultTopLevelPlacement: "current",
+    supportsCurrentConversationBinding: true,
+  },
+};
+
+const configuredAcpCfg = (store: string): OpenClawConfig =>
+  ({
+    session: { store, mainKey: "main", scope: "per-sender" },
+    agents: { list: [{ id: "main" }, { id: "codex" }] },
+    bindings: [
+      { agentId: "main", match: { channel: "line", accountId: "default" } },
+      {
+        type: "acp",
+        agentId: "codex",
+        match: {
+          channel: "line",
+          accountId: "default",
+          peer: { kind: "direct", id: "user-1" },
+        },
+      },
+    ],
+  }) satisfies OpenClawConfig;
+
+describe("resolveLineConversationRoute", () => {
+  let tmpDir: string;
+  let cfg: OpenClawConfig;
+
+  beforeEach(async () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: lineBindingsPlugin.id,
+          plugin: lineBindingsPlugin,
+          source: "test",
+        },
+      ]),
+    );
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-line-route-"));
+    cfg = configuredAcpCfg(path.join(tmpDir, "sessions.json"));
+  });
+
+  afterEach(async () => {
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    await fs.rm(tmpDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 50,
+    });
+  });
+
+  it("keeps the configured ACP binding when a stale non-ACP runtime binding exists", () => {
+    const touch = vi.fn();
+    registerSessionBindingAdapter({
+      channel: "line",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: (ref) =>
+        ref.conversationId === "user-1"
+          ? {
+              bindingId: "default:user-1",
+              // Stale catch-all row predating the configured ACP binding.
+              targetSessionKey: "agent:main:line:default:direct:user-1",
+              targetKind: "session",
+              conversation: {
+                channel: "line",
+                accountId: "default",
+                conversationId: "user-1",
+              },
+              status: "active",
+              boundAt: 1,
+            }
+          : null,
+      touch,
+    });
+
+    const result = resolveLineConversationRoute({
+      cfg,
+      accountId: "default",
+      peerId: "user-1",
+      isGroup: false,
+    });
+
+    expect(result.route.agentId).toBe("codex");
+    expect(result.route.sessionKey).toMatch(/^agent:codex:acp:binding:line:/);
+    expect(result.configuredBinding).not.toBeNull();
+    expect(touch).not.toHaveBeenCalled();
+  });
+
+  it("keeps a live subagent runtime binding over the configured ACP binding", () => {
+    const touch = vi.fn();
+    registerSessionBindingAdapter({
+      channel: "line",
+      accountId: "default",
+      listBySession: () => [],
+      resolveByConversation: (ref) =>
+        ref.conversationId === "user-1"
+          ? {
+              bindingId: "default:user-1",
+              // Active subagent thread binding created by bindThreadForSubagentSpawn.
+              targetSessionKey: "agent:main:subagent:spawn-4",
+              targetKind: "subagent",
+              conversation: {
+                channel: "line",
+                accountId: "default",
+                conversationId: "user-1",
+              },
+              status: "active",
+              boundAt: Date.now(),
+            }
+          : null,
+      touch,
+    });
+
+    const result = resolveLineConversationRoute({
+      cfg,
+      accountId: "default",
+      peerId: "user-1",
+      isGroup: false,
+    });
+
+    expect(result.route.agentId).toBe("main");
+    expect(result.route.sessionKey).toBe("agent:main:subagent:spawn-4");
+    expect(result.route.matchedBy).toBe("binding.channel");
+    expect(result.configuredBinding).toBeNull();
+    expect(touch).toHaveBeenCalled();
+  });
+});

--- a/extensions/line/src/conversation-route.ts
+++ b/extensions/line/src/conversation-route.ts
@@ -1,0 +1,68 @@
+// Line plugin module implements conversation route resolution.
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  resolveConfiguredBindingRoute,
+  resolveRuntimeConversationBindingRoute,
+} from "openclaw/plugin-sdk/conversation-runtime";
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+
+/**
+ * Resolves the LINE conversation route: configured ACP bindings first, then runtime
+ * conversation bindings. Passing the configured result into the runtime resolver keeps
+ * LINE ingress on the same precedence as the Gateway generic ownership evaluator.
+ */
+export function resolveLineConversationRoute(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  peerId: string;
+  isGroup: boolean;
+}): {
+  route: ReturnType<typeof resolveAgentRoute>;
+  configuredBinding: ReturnType<typeof resolveConfiguredBindingRoute>["bindingResolution"];
+  configuredBindingSessionKey: string;
+} {
+  let route = resolveAgentRoute({
+    cfg: params.cfg,
+    channel: "line",
+    accountId: params.accountId,
+    peer: {
+      kind: params.isGroup ? "group" : "direct",
+      id: params.peerId,
+    },
+  });
+
+  const configuredRoute = resolveConfiguredBindingRoute({
+    cfg: params.cfg,
+    route,
+    conversation: {
+      channel: "line",
+      accountId: params.accountId,
+      conversationId: params.peerId,
+    },
+  });
+  let configuredBinding = configuredRoute.bindingResolution;
+  const configuredBindingSessionKey = configuredRoute.boundSessionKey ?? "";
+  route = configuredRoute.route;
+
+  const runtimeRoute = resolveRuntimeConversationBindingRoute({
+    route,
+    configuredBindingRoute: configuredRoute,
+    conversation: {
+      channel: "line",
+      accountId: params.accountId,
+      conversationId: params.peerId,
+    },
+  });
+  route = runtimeRoute.route;
+  if (runtimeRoute.bindingRecord) {
+    configuredBinding = null;
+    logVerbose(
+      runtimeRoute.boundSessionKey
+        ? `line: routed via bound conversation ${params.peerId} -> ${runtimeRoute.boundSessionKey}`
+        : `line: plugin-bound conversation ${params.peerId}`,
+    );
+  }
+
+  return { route, configuredBinding, configuredBindingSessionKey };
+}

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -163,6 +163,7 @@ function resolveTelegramConversationRouteWithRuntimePolicy(
   const runtimeBindingConversationId = conversationId;
   const runtimeRoute = resolveRuntimeConversationBindingRoute({
     route,
+    configuredBindingRoute: configuredRoute,
     touchBinding: touchRuntimeBinding,
     conversation: {
       channel: "telegram",

--- a/src/channels/plugins/binding-routing.test.ts
+++ b/src/channels/plugins/binding-routing.test.ts
@@ -10,6 +10,7 @@ import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
 import {
   ensureConfiguredBindingRouteReady,
   resolveRuntimeConversationBindingRoute,
+  type ConfiguredBindingRouteResult,
   type RuntimeConversationBindingRouteResult,
 } from "./binding-routing.js";
 import { registerStatefulBindingTargetDriver } from "./stateful-target-drivers.js";
@@ -215,6 +216,160 @@ describe("runtime conversation binding route", () => {
     expect(result.bindingRecord).toBeNull();
     expect(result.boundSessionKey).toBeUndefined();
     expect(result.route).toBe(route);
+  });
+
+  it("keeps a configured binding route when a non-ACP runtime binding targets a different session", () => {
+    const route = createRoute();
+    const binding = createBinding({
+      // Stale catch-all row: non-ACP target recorded before the configured binding existed.
+      targetSessionKey: "agent:main:demo:default:direct:room-1",
+    });
+    const { touch } = registerAdapter(binding);
+    const configuredBindingRoute: ConfiguredBindingRouteResult = {
+      bindingResolution: null,
+      route,
+      boundSessionKey: "agent:claude:acp:binding:demo:default:hash-1",
+      boundAgentId: "claude",
+    };
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      configuredBindingRoute,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    expect(touch).not.toHaveBeenCalled();
+    expect(result.bindingRecord).toBeNull();
+    expect(result.boundSessionKey).toBeUndefined();
+    expect(result.route).toBe(route);
+    expect(result.route.sessionKey).toBe("agent:main:main");
+  });
+
+  it("still lets a runtime binding that targets an ACP session override the configured route", () => {
+    const route = createRoute();
+    const binding = createBinding({
+      // Explicit /acp spawn bind: runtime record targeting an ACP session.
+      targetSessionKey: "agent:claude:acp:spawn-9",
+    });
+    const { touch } = registerAdapter(binding);
+    const configuredBindingRoute: ConfiguredBindingRouteResult = {
+      bindingResolution: null,
+      route,
+      boundSessionKey: "agent:claude:acp:binding:demo:default:hash-1",
+      boundAgentId: "claude",
+    };
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      configuredBindingRoute,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    expect(touch).toHaveBeenCalled();
+    expect(result.bindingRecord).toBe(binding);
+    expect(result.boundSessionKey).toBe("agent:claude:acp:spawn-9");
+    expect(result.route.sessionKey).toBe("agent:claude:acp:spawn-9");
+  });
+
+  it("still lets a live subagent runtime binding override the configured route", () => {
+    const route = createRoute();
+    const binding = createBinding({
+      // Active subagent thread binding created by bindThreadForSubagentSpawn.
+      targetSessionKey: "agent:main:subagent:spawn-9",
+      targetKind: "subagent",
+    });
+    const { touch } = registerAdapter(binding);
+    const configuredBindingRoute: ConfiguredBindingRouteResult = {
+      bindingResolution: null,
+      route,
+      boundSessionKey: "agent:claude:acp:binding:demo:default:hash-1",
+      boundAgentId: "claude",
+    };
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      configuredBindingRoute,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    expect(touch).toHaveBeenCalled();
+    expect(result.bindingRecord).toBe(binding);
+    expect(result.boundSessionKey).toBe("agent:main:subagent:spawn-9");
+    expect(result.route.sessionKey).toBe("agent:main:subagent:spawn-9");
+    expect(result.route.agentId).toBe("main");
+  });
+
+  it("still lets a fresh generic bind-API runtime binding override the configured route", () => {
+    const route = createRoute();
+    const binding = createBinding({
+      // Fresh explicit bind written by the public bind API (bindGenericCurrentConversation
+      // stamps bindingOrigin provenance); intentional SDK bindings keep runtime precedence.
+      targetSessionKey: "agent:codex:demo:default:direct:room-1",
+      metadata: { bindingOrigin: "generic-bind-api" },
+    });
+    const { touch } = registerAdapter(binding);
+    const configuredBindingRoute: ConfiguredBindingRouteResult = {
+      bindingResolution: null,
+      route,
+      boundSessionKey: "agent:claude:acp:binding:demo:default:hash-1",
+      boundAgentId: "claude",
+    };
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      configuredBindingRoute,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    expect(touch).toHaveBeenCalled();
+    expect(result.bindingRecord).toBe(binding);
+    expect(result.boundSessionKey).toBe("agent:codex:demo:default:direct:room-1");
+    expect(result.route.sessionKey).toBe("agent:codex:demo:default:direct:room-1");
+    expect(result.route.agentId).toBe("codex");
+  });
+
+  it("still applies a non-ACP runtime binding that matches the configured target", () => {
+    const route = createRoute();
+    const binding = createBinding({
+      targetSessionKey: "agent:main:demo:default:bound-1",
+    });
+    const { touch } = registerAdapter(binding);
+    const configuredBindingRoute: ConfiguredBindingRouteResult = {
+      bindingResolution: null,
+      route,
+      boundSessionKey: "agent:main:demo:default:bound-1",
+      boundAgentId: "main",
+    };
+
+    const result = resolveRuntimeConversationBindingRoute({
+      route,
+      configuredBindingRoute,
+      conversation: {
+        channel: "demo",
+        accountId: "default",
+        conversationId: "room-1",
+      },
+    });
+
+    expect(touch).toHaveBeenCalled();
+    expect(result.bindingRecord).toBe(binding);
+    expect(result.route.sessionKey).toBe("agent:main:demo:default:bound-1");
   });
 });
 

--- a/src/channels/plugins/binding-routing.ts
+++ b/src/channels/plugins/binding-routing.ts
@@ -12,14 +12,17 @@ import {
   type ConversationRef,
   type SessionBindingRecord,
 } from "../../infra/outbound/session-binding-service.js";
-import { isPluginOwnedBindingMetadata } from "../../plugins/conversation-binding-metadata.js";
+import {
+  isGenericBindApiBindingMetadata,
+  isPluginOwnedBindingMetadata,
+} from "../../plugins/conversation-binding-metadata.js";
 import type { ResolvedAgentRoute } from "../../routing/resolve-route.js";
 import { deriveLastRoutePolicy } from "../../routing/resolve-route.js";
 import {
   isUnscopedSessionKeySentinel,
   resolveAgentIdFromSessionKey,
 } from "../../routing/session-key.js";
-import { isCronRunSessionKey } from "../../sessions/session-key-utils.js";
+import { isAcpSessionKey, isCronRunSessionKey } from "../../sessions/session-key-utils.js";
 import { ensureConfiguredBindingTargetReady } from "./binding-targets.js";
 import type { ConfiguredBindingResolution } from "./binding-types.js";
 import { resolveConfiguredBinding } from "./configured-binding-registry.js";
@@ -133,6 +136,13 @@ export function resolveRuntimeConversationBindingRoute(
     route: ResolvedAgentRoute;
     /** Set false for read-only ownership checks that must not extend binding liveness. */
     touchBinding?: boolean;
+    /**
+     * Configured-binding resolution that already produced `params.route`, when the caller ran
+     * `resolveConfiguredBindingRoute` first. Obsolete generic runtime records must not
+     * override it; live runtime overrides (ACP targets, active subagent thread bindings,
+     * plugin-owned records) keep their runtime precedence.
+     */
+    configuredBindingRoute?: ConfiguredBindingRouteResult | null;
   } & ConfiguredBindingRouteConversationInput,
 ): RuntimeConversationBindingRouteResult {
   const inspection = inspectSessionBindingByConversation(
@@ -167,6 +177,35 @@ export function resolveRuntimeConversationBindingRoute(
     };
   }
 
+  const configuredBoundSessionKey = params.configuredBindingRoute?.boundSessionKey?.trim();
+  const pluginId = isPluginOwnedBindingMetadata(bindingRecord.metadata)
+    ? bindingRecord.metadata.pluginId.trim()
+    : undefined;
+  if (
+    !pluginId &&
+    !isGenericBindApiBindingMetadata(bindingRecord.metadata) &&
+    configuredBoundSessionKey &&
+    boundSessionKey !== configuredBoundSessionKey &&
+    !isAcpSessionKey(boundSessionKey) &&
+    bindingRecord.targetKind === "session"
+  ) {
+    // A configured binding already claimed this conversation. Generic session-kind runtime
+    // records without bind-API provenance can only originate from the removed legacy
+    // catch-all writer, so they are stale rows that must not nullify the configured route.
+    // Live overrides keep runtime precedence: fresh generic bindings written by the public
+    // bind API (bindGenericCurrentConversation stamps bindingOrigin provenance), records
+    // targeting an ACP session (explicit /acp spawn binds), and active subagent thread
+    // bindings (targetKind "subagent" created by bindThreadForSubagentSpawn).
+    logVerbose(
+      `ignored non-ACP runtime conversation binding ${bindingRecord.bindingId} to ${boundSessionKey} because configured binding targets ${configuredBoundSessionKey}`,
+    );
+    return {
+      bindingOwnerAvailable: true,
+      bindingRecord: null,
+      route: params.route,
+    };
+  }
+
   if (params.touchBinding !== false) {
     getSessionBindingService().touch(
       bindingRecord.bindingId,
@@ -174,9 +213,6 @@ export function resolveRuntimeConversationBindingRoute(
       bindingRecord.conversation,
     );
   }
-  const pluginId = isPluginOwnedBindingMetadata(bindingRecord.metadata)
-    ? bindingRecord.metadata.pluginId.trim()
-    : undefined;
   if (pluginId) {
     // Plugin-owned binding records are observed but not route-rewritten by core; the owning
     // plugin is responsible for its runtime target handoff.

--- a/src/gateway/conversation-route-ownership.test.ts
+++ b/src/gateway/conversation-route-ownership.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SessionBindingRecord } from "../infra/outbound/session-binding-service.js";
+import {
+  registerSessionBindingAdapter,
+  testing as sessionBindingTesting,
+} from "../infra/outbound/session-binding-service.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { resolveConversationRouteEligibilityForAgent } from "./conversation-route-ownership.js";
 
 const baseConversation = {
@@ -100,5 +108,129 @@ describe("resolveConversationRouteEligibilityForAgent", () => {
         conversation: { ...baseConversation, routeContextObserved: true },
       }),
     ).toBe("eligible");
+  });
+});
+
+describe("resolveConversationRouteEligibilityForAgent with LINE-style generic routing", () => {
+  const lineConversation = {
+    accountId: "default",
+    channel: "line",
+    kind: "direct" as const,
+    peerId: "user-1",
+    target: "line:user-1",
+  };
+
+  function configWithLineAcpBinding(): OpenClawConfig {
+    return {
+      agents: { entries: { main: { default: true }, codex: {} } },
+      bindings: [
+        { agentId: "main", match: { channel: "line", accountId: "default" } },
+        {
+          type: "acp",
+          agentId: "codex",
+          match: {
+            channel: "line",
+            accountId: "default",
+            peer: { kind: "direct", id: "user-1" },
+          },
+        },
+      ],
+    };
+  }
+
+  function registerLineRuntimeBinding(record: SessionBindingRecord): ReturnType<typeof vi.fn> {
+    const touch = vi.fn();
+    registerSessionBindingAdapter({
+      channel: record.conversation.channel,
+      accountId: record.conversation.accountId,
+      listBySession: () => [],
+      resolveByConversation: (ref) =>
+        ref.conversationId === record.conversation.conversationId ? record : null,
+      touch,
+    });
+    return touch;
+  }
+
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: {
+            id: "line",
+            bindings: {
+              compileConfiguredBinding: ({ conversationId }) =>
+                conversationId ? { conversationId } : null,
+              matchInboundConversation: ({ compiledBinding, conversationId }) =>
+                conversationId && compiledBinding.conversationId === conversationId
+                  ? { conversationId, matchPriority: 2 }
+                  : null,
+            } satisfies NonNullable<ChannelPlugin["bindings"]>,
+          },
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("authorizes the configured ACP owner and rejects the competing agent when only a stale generic runtime record exists", () => {
+    const config = configWithLineAcpBinding();
+    // Stale catch-all row: a generic session-kind record no live producer can create anymore.
+    registerLineRuntimeBinding({
+      bindingId: "default:user-1",
+      targetSessionKey: "agent:main:line:default:direct:user-1",
+      targetKind: "session",
+      conversation: { channel: "line", accountId: "default", conversationId: "user-1" },
+      status: "active",
+      boundAt: 1,
+    });
+
+    expect(
+      resolveConversationRouteEligibilityForAgent({
+        config,
+        agentId: "codex",
+        conversation: lineConversation,
+      }),
+    ).toBe("eligible");
+    expect(
+      resolveConversationRouteEligibilityForAgent({
+        config,
+        agentId: "main",
+        conversation: lineConversation,
+      }),
+    ).toBe("denied");
+  });
+
+  it("follows a live subagent runtime binding instead of the configured ACP owner after reassignment", () => {
+    const config = configWithLineAcpBinding();
+    // Active subagent thread binding created by bindThreadForSubagentSpawn.
+    registerLineRuntimeBinding({
+      bindingId: "default:user-1",
+      targetSessionKey: "agent:main:subagent:spawn-4",
+      targetKind: "subagent",
+      conversation: { channel: "line", accountId: "default", conversationId: "user-1" },
+      status: "active",
+      boundAt: 1,
+    });
+
+    expect(
+      resolveConversationRouteEligibilityForAgent({
+        config,
+        agentId: "main",
+        conversation: lineConversation,
+      }),
+    ).toBe("eligible");
+    expect(
+      resolveConversationRouteEligibilityForAgent({
+        config,
+        agentId: "codex",
+        conversation: lineConversation,
+      }),
+    ).toBe("denied");
   });
 });

--- a/src/gateway/conversation-route-ownership.ts
+++ b/src/gateway/conversation-route-ownership.ts
@@ -140,6 +140,7 @@ function resolveGenericRouteOwner(params: {
   });
   const runtime = resolveRuntimeConversationBindingRoute({
     route: configured.route,
+    configuredBindingRoute: configured,
     conversation,
     touchBinding: false,
   });

--- a/src/gateway/conversation-send-binding-precedence.test.ts
+++ b/src/gateway/conversation-send-binding-precedence.test.ts
@@ -1,0 +1,270 @@
+// Gateway send and queued-recovery boundary tests for binding precedence.
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import {
+  beginConversationDeliveryOperation,
+  markConversationDeliveryQueued,
+} from "../config/sessions/conversation-delivery-store.js";
+import { registerConversationAddresses } from "../config/sessions/conversation-registry.js";
+import { resolveConversationRouteFingerprint } from "../config/sessions/conversation-route-fingerprint.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { defaultConversationDeliveryDeps } from "../infra/outbound/conversation-delivery.js";
+import { PlatformMessageNotDispatchedError } from "../infra/outbound/deliver-types.js";
+import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
+import {
+  registerSessionBindingAdapter,
+  testing as sessionBindingTesting,
+  type SessionBindingRecord,
+} from "../infra/outbound/session-binding-service.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { buildConversationRef } from "../routing/conversation-ref.js";
+import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { ConversationInputError } from "./conversation-errors.js";
+import { assertQueuedConversationDeliveryAttemptAuthorized } from "./conversation-route-ownership.js";
+import { runGatewayConversationSend } from "./conversation-send.js";
+
+const address = {
+  channel: "line",
+  accountId: "default",
+  kind: "direct" as const,
+  peerId: "user-1",
+};
+
+const conversation = {
+  ...address,
+  conversationRef: buildConversationRef(address),
+  target: "line:user-1",
+  sessionId: "line-session",
+  sessionKey: "agent:main:line:direct:user-1",
+  role: "participant" as const,
+  firstSeenAt: 100,
+  lastSeenAt: 200,
+};
+
+function configWithLineAcpBinding(): OpenClawConfig {
+  return {
+    agents: { entries: { main: { default: true }, codex: {} } },
+    bindings: [
+      { agentId: "main", match: { channel: "line", accountId: "default" } },
+      {
+        type: "acp",
+        agentId: "codex",
+        match: {
+          channel: "line",
+          accountId: "default",
+          peer: { kind: "direct", id: "user-1" },
+        },
+      },
+    ],
+  };
+}
+
+function createSendDeps(agentId: string) {
+  const dirs = createTempDirTracker();
+  const agentDir = path.join(dirs.make("openclaw-gateway-binding-precedence-"), "agents", agentId);
+  const scope = { agentId, storePath: path.join(agentDir, "sessions", "sessions.json") };
+  onTestFinished(() => {
+    closeOpenClawAgentDatabaseByPath(path.join(agentDir, "agent", "openclaw-agent.sqlite"));
+    dirs.cleanup();
+  });
+  registerConversationAddresses(scope, [{ ...conversation, deliveryTarget: conversation.target }]);
+
+  const runMessageActionMock = vi.fn(async (input: Record<string, unknown>) => {
+    const onDeliveryIntent = input.onDeliveryIntent as (intent: {
+      id: string;
+      channel: string;
+      to: string;
+      durability: "required";
+    }) => void;
+    onDeliveryIntent({
+      id: "queue-1",
+      channel: "line",
+      to: "line:user-1",
+      durability: "required",
+    });
+    const sent: Extract<MessageActionResult, { kind: "send" }> = {
+      kind: "send",
+      channel: "line",
+      action: "send",
+      to: conversation.target,
+      handledBy: "core",
+      payload: {},
+      sendResult: {
+        channel: "line",
+        to: conversation.target,
+        via: "direct",
+        mediaUrl: null,
+        result: { messageId: "line-outbound-1" },
+        deliveryStatus: "sent",
+      },
+      dryRun: false,
+    };
+    return sent;
+  });
+
+  return {
+    ...defaultConversationDeliveryDeps,
+    scope,
+    config: {
+      ...configWithLineAcpBinding(),
+      session: { store: scope.storePath },
+    },
+    resolveConversation: vi.fn(() => conversation),
+    runMessageAction: runMessageActionMock as never,
+    runMessageActionMock,
+  };
+}
+
+function registerLineRuntimeBinding(record: SessionBindingRecord): void {
+  registerSessionBindingAdapter({
+    channel: record.conversation.channel,
+    accountId: record.conversation.accountId,
+    listBySession: () => [],
+    resolveByConversation: (ref) =>
+      ref.conversationId === record.conversation.conversationId ? record : null,
+    touch: vi.fn(),
+  });
+}
+
+function staleGenericRuntimeBinding(): SessionBindingRecord {
+  // Legacy catch-all row: session-kind target with no bind-API provenance.
+  return {
+    bindingId: "default:user-1",
+    targetSessionKey: "agent:main:line:default:direct:user-1",
+    targetKind: "session",
+    conversation: { channel: "line", accountId: "default", conversationId: "user-1" },
+    status: "active",
+    boundAt: 1,
+  };
+}
+
+describe("gateway send authorization with binding precedence", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: {
+            id: "line",
+            bindings: {
+              compileConfiguredBinding: ({ conversationId }) =>
+                conversationId ? { conversationId } : null,
+              matchInboundConversation: ({ compiledBinding, conversationId }) =>
+                conversationId && compiledBinding.conversationId === conversationId
+                  ? { conversationId, matchPriority: 2 }
+                  : null,
+            } satisfies NonNullable<ChannelPlugin["bindings"]>,
+          },
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    resetPluginRuntimeStateForTest();
+  });
+
+  it("delivers for the configured ACP owner when only a stale generic runtime record exists", async () => {
+    registerLineRuntimeBinding(staleGenericRuntimeBinding());
+    const deps = createSendDeps("codex");
+
+    await expect(
+      runGatewayConversationSend(
+        {
+          config: deps.config,
+          agentId: "codex",
+          senderIsOwner: true,
+          operationId: "send-owner",
+          conversationRef: conversation.conversationRef,
+          message: "hello from the configured owner",
+        },
+        deps,
+      ),
+    ).resolves.toEqual({
+      status: "sent",
+      conversationRef: conversation.conversationRef,
+      channel: "line",
+      messageId: "line-outbound-1",
+      queueId: "queue-1",
+    });
+    expect(deps.runMessageActionMock).toHaveBeenCalledOnce();
+  });
+
+  it("rejects the competing agent before any transport attempt", async () => {
+    registerLineRuntimeBinding(staleGenericRuntimeBinding());
+    const deps = createSendDeps("main");
+
+    await expect(
+      runGatewayConversationSend(
+        {
+          config: deps.config,
+          agentId: "main",
+          senderIsOwner: true,
+          operationId: "send-competing",
+          conversationRef: conversation.conversationRef,
+          message: "hello from the competing agent",
+        },
+        deps,
+      ),
+    ).rejects.toMatchObject({
+      name: ConversationInputError.name,
+      message: expect.stringContaining("not available to this agent"),
+    });
+    expect(deps.runMessageActionMock).not.toHaveBeenCalled();
+  });
+
+  it("follows a live subagent reassignment through queued delivery recovery", () => {
+    registerLineRuntimeBinding(staleGenericRuntimeBinding());
+    const configuredOwnerDeps = createSendDeps("codex");
+    const reassignedOwnerDeps = createSendDeps("main");
+
+    // Both agents hold a durable queued delivery that has not been sent yet.
+    for (const deps of [configuredOwnerDeps, reassignedOwnerDeps]) {
+      beginConversationDeliveryOperation(deps.scope, {
+        operationId: "send-queued",
+        operationKind: "send",
+        conversationRef: conversation.conversationRef,
+        message: "queued before reassignment",
+      });
+      markConversationDeliveryQueued(deps.scope, "send-queued", "queue-1");
+    }
+    const routeFingerprint = resolveConversationRouteFingerprint(conversation);
+
+    // The conversation is reassigned to a live subagent thread binding.
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    registerLineRuntimeBinding({
+      bindingId: "default:user-1",
+      targetSessionKey: "agent:main:subagent:spawn-4",
+      targetKind: "subagent",
+      conversation: { channel: "line", accountId: "default", conversationId: "user-1" },
+      status: "active",
+      boundAt: 2,
+    });
+
+    // Queued recovery now authorizes the reassigned owner and rejects the previous one
+    // before any transport attempt.
+    expect(() =>
+      assertQueuedConversationDeliveryAttemptAuthorized({
+        config: reassignedOwnerDeps.config,
+        agentId: "main",
+        operationId: "send-queued",
+        routeFingerprint,
+        storePath: reassignedOwnerDeps.scope.storePath,
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertQueuedConversationDeliveryAttemptAuthorized({
+        config: configuredOwnerDeps.config,
+        agentId: "codex",
+        operationId: "send-queued",
+        routeFingerprint,
+        storePath: configuredOwnerDeps.scope.storePath,
+      }),
+    ).toThrow(PlatformMessageNotDispatchedError);
+  });
+});

--- a/src/infra/outbound/current-conversation-bindings.test.ts
+++ b/src/infra/outbound/current-conversation-bindings.test.ts
@@ -357,10 +357,40 @@ describe("generic current-conversation bindings", () => {
       expect(binding.metadata).toEqual({
         ...(replace ? {} : metadata),
         label: "updated",
+        bindingOrigin: "generic-bind-api",
         lastActivityAt: expect.any(Number),
       });
     },
   );
+
+  it("stamps bind-API provenance on every record it writes", async () => {
+    const bound = await bindWorkspaceConversation("user:provenance", {
+      targetSessionKey: "agent:codex:demo:default:direct:provenance",
+    });
+    expectBindingMetadata(bound, { bindingOrigin: "generic-bind-api" });
+
+    // Rebinding a legacy provenance-less row onto the same target must also stamp it:
+    // the explicit bind is itself the evidence of intent.
+    seedPersistedBinding({
+      bindingId: "generic:workspace\u241fdefault\u241f\u241fuser:legacy",
+      targetSessionKey: "agent:main:demo:default:direct:legacy",
+      targetKind: "session",
+      conversation: workspaceConversation("user:legacy"),
+      status: "active",
+      boundAt: 1,
+      metadata: { lastActivityAt: 1 },
+    });
+    expectBindingMetadata(resolveWorkspaceConversation("user:legacy"), {
+      bindingOrigin: undefined,
+    });
+
+    await bindWorkspaceConversation("user:legacy", {
+      targetSessionKey: "agent:main:demo:default:direct:legacy",
+    });
+    expectBindingMetadata(resolveWorkspaceConversation("user:legacy"), {
+      bindingOrigin: "generic-bind-api",
+    });
+  });
 
   describe("independent SQLite owners", () => {
     it.each(["bind", "touch", "expiry cleanup", "unbind"] as const)(

--- a/src/infra/outbound/current-conversation-bindings.ts
+++ b/src/infra/outbound/current-conversation-bindings.ts
@@ -9,6 +9,7 @@ import {
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeConversationText } from "../../acp/conversation-id.js";
 import { normalizeAnyChannelId } from "../../channels/registry.js";
+import { GENERIC_BIND_API_BINDING_ORIGIN } from "../../plugins/conversation-binding-metadata.js";
 import { getActivePluginChannelRegistryFromState } from "../../plugins/runtime-channel-state.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../../state/openclaw-state-db.generated.js";
 import {
@@ -472,6 +473,9 @@ export async function bindGenericCurrentConversation(
         ? existing.metadata
         : undefined),
       ...input.metadata,
+      // Every record this API writes is an intentional bind; stamp provenance so routing
+      // can distinguish it from legacy rows persisted by the removed catch-all writer.
+      bindingOrigin: GENERIC_BIND_API_BINDING_ORIGIN,
       lastActivityAt: now,
     },
   })).current;

--- a/src/plugins/conversation-binding-metadata.ts
+++ b/src/plugins/conversation-binding-metadata.ts
@@ -9,6 +9,22 @@ export type PluginBindingMetadata = {
   bindingAttemptId?: string;
 };
 
+/**
+ * Provenance stamped on records written by the public generic bind API
+ * (`bindGenericCurrentConversation`). Its presence distinguishes intentional SDK
+ * bindings from legacy rows persisted by the removed catch-all writer, which never
+ * recorded a binding origin.
+ */
+export const GENERIC_BIND_API_BINDING_ORIGIN = "generic-bind-api";
+
+export function isGenericBindApiBindingMetadata(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object") {
+    return false;
+  }
+  // SAFETY: The object guard permits property inspection.
+  return (metadata as Record<string, unknown>).bindingOrigin === GENERIC_BIND_API_BINDING_ORIGIN;
+}
+
 export function isPluginOwnedBindingMetadata(metadata: unknown): metadata is PluginBindingMetadata {
   if (!metadata || typeof metadata !== "object") {
     return false;


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #115354

## What Problem This Solves

- Fixes an issue where users who have a per-peer ACP configured binding (e.g. `{type: "acp", agentId: "claude", match: {channel: "feishu", peer: {kind: "direct", id: "ou_user_a"}}}`) would have their messages routed to the wrong agent whenever a persisted non-ACP runtime binding record (stale `agent:{agentId}:{channel}:{accountId}:direct:{peerId}` rows previously written by catch-all bindings) also exists for that conversation — the stale runtime record silently nullified the configured ACP binding.
- **Related:** #133694 (closed — unbind-on-session-delete approach rejected in favor of a generation-aware design, tracked separately); per the source trace in the issue discussion, the catch-all creation path was already removed by #126424, but the resolver-level precedence flaw remained latent for stale rows.
- Trigger: any message from a conversation that matches both a configured ACP binding and a leftover generic non-ACP runtime binding record in the channel binding store.

## Why This Change Was Made

- **Intended outcome:** `resolveRuntimeConversationBindingRoute` now refuses to rewrite a route that a configured binding already claimed only for generic `targetKind: "session"` records **that lack bind-API provenance**. `bindGenericCurrentConversation` stamps `metadata.bindingOrigin: "generic-bind-api"` on every record it writes (including refreshes of legacy rows onto the same target — an explicit rebind is itself evidence of intent), so records created through the public SDK bind API keep their runtime precedence over configured bindings, while provenance-less generic session rows can only originate from the removed legacy catch-all writer (#126424) and are treated as stale. Live runtime overrides keep their existing precedence: fresh generic SDK bindings, records targeting an ACP session (explicit `/acp spawn --bind here`), active subagent thread bindings (`targetKind: "subagent"` created by `bindThreadForSubagentSpawn`), and plugin-owned records. The guard sits next to the existing cron-run and plugin-owned checks. Callers that run configured-first (generic gateway ingress, Feishu, Telegram, iMessage, and now LINE) pass the configured-binding result through so the resolver can enforce this precedence.
- Deliberately preserved behaviors: fresh generic bindings written through the public bind API still take precedence over configured bindings (addressing the review's SDK-compatibility finding — `getSessionBindingService().bind()` / `bindGenericCurrentConversation()` remain authoritative for intentional runtime binds); runtime records targeting an ACP session still take precedence; active subagent thread bindings still override a configured ACP binding (an intentionally spawned subagent keeps receiving follow-ups); plugin-owned records are still observed without rewriting; records whose target equals the configured target are still applied and touched; with no configured binding context the resolver behaves exactly as before.
- LINE ingress previously resolved runtime bindings without the configured-binding result, so inbound messages followed a stale runtime record while Gateway conversation-send and queued-recovery authorization followed the configured ACP owner. LINE now feeds the configured route into the shared resolver (`resolveLineConversationRoute`), keeping ingress and delivery authorization on the same precedence at both boundaries.
- **Out of scope:** Discord and Slack use channel-owned resolvers with intentionally different (runtime-first) precedence and are unchanged. Session-liveness/generation-aware unbinding of stale records (issue "Bug 2" direction) is a separate, larger design per the #133694 discussion; this PR only stops stale generic rows from overriding configured bindings. Records created through the public bind API *before* this change carry no provenance and are therefore treated as stale; an intentional rebind through the same API restores their runtime precedence.
- **Highest-risk area:** routing precedence between binding layers; mitigated by regression tests covering all guard branches (stale suppression, fresh-SDK override, ACP override, subagent override, matching-target apply), LINE ingress agreement tests, and gateway send/ownership tests that authorize the configured owner while rejecting the competing agent before any transport I/O, including queued-recovery after reassignment.

## User Impact

- **Success criteria:** a conversation that matches a configured ACP binding keeps routing to that binding's agent/session when a stale generic non-ACP runtime binding row exists for it; the ignored row is not touched (no liveness extension). Fresh SDK binds, explicit ACP runtime binds, active subagent thread bindings, and plugin-owned bindings behave exactly as before, and LINE ingress now selects the same owner that Gateway delivery authorization enforces.
- **What should reviewers focus on:** `src/channels/plugins/binding-routing.ts` (guard next to the cron/plugin-owned checks, scoped to provenance-less generic `targetKind: "session"` records), `src/plugins/conversation-binding-metadata.ts` (`bindingOrigin` provenance constant and predicate), `src/infra/outbound/current-conversation-bindings.ts` (`bindGenericCurrentConversation` stamping provenance), `extensions/line/src/bot-message-context.ts` (`resolveLineConversationRoute` passing `configuredBindingRoute`), and the tests in `src/channels/plugins/binding-routing.test.ts` ("still lets a fresh generic bind-API runtime binding override the configured route"), `src/infra/outbound/current-conversation-bindings.test.ts` ("stamps bind-API provenance on every record it writes"), `src/gateway/conversation-send-binding-precedence.test.ts` (allowed delivery, competing agent rejected before transport, queued recovery after reassignment), and `src/gateway/conversation-route-ownership.test.ts` (configured owner eligible / competing agent denied; reassignment to a live subagent binding followed by the evaluator).

## Evidence

- **Real environment tested:** No live Feishu/Telegram/LINE credentials were available; verification is at the deterministic routing and delivery-authorization layer with real compiled config bindings, real registered channel binding adapters (LINE uses its real `lineBindingsAdapter`), a real per-agent conversation registry and delivery store for the send/queued-recovery boundary tests, and the real resolver/ownership chain (no mocks of the code under test; only the transport action is replaced) in an isolated worktree at commit 7b3178d6445 (rebased onto the latest `main`).
- **Exact steps or commands run after this patch:**
  ```bash
  # regression tests (RED for the new provenance case on the previous head 9a06ed9ce9f, GREEN after the fix)
  node scripts/run-vitest.mjs run src/channels/plugins/binding-routing.test.ts \
    src/infra/outbound/current-conversation-bindings.test.ts \
    src/gateway/conversation-send-binding-precedence.test.ts \
    src/gateway/conversation-route-ownership.test.ts \
    extensions/line/src/conversation-route.test.ts \
    extensions/imessage/src/conversation-route.test.ts
  # type-checked test shards covering every changed file
  node --import ./scripts/tsx.mjs scripts/run-tsgo-core-test-shards.mts --changed-paths-json '[<6 changed files>]'
  # format + lint + same-directory tests for all changed files + tsgo:core
  skills/fix-pr/scripts/validate.sh <changed files>
  ```
- **Evidence after fix:**
  ```text
  $ node scripts/run-vitest.mjs run src/channels/plugins/binding-routing.test.ts
   ✯ |channels| binding-routing > keeps a configured binding route when a non-ACP runtime binding targets a different session  (stale provenance-less row ignored)
   ✯ |channels| binding-routing > still lets a runtime binding that targets an ACP session override the configured route
   ✯ |channels| binding-routing > still lets a live subagent runtime binding override the configured route  (targetKind "subagent" keeps runtime precedence)
   ✯ |channels| binding-routing > still lets a fresh generic bind-API runtime binding override the configured route  (provenance-stamped SDK bind keeps runtime precedence)
   ✯ |channels| binding-routing > still applies a non-ACP runtime binding that matches the configured target
       Tests  15 passed (15)

  $ node scripts/run-vitest.mjs run src/infra/outbound/current-conversation-bindings.test.ts
   ✯ |infra| generic current-conversation bindings > stamps bind-API provenance on every record it writes  (new binds stamped; rebinding a legacy row stamps it too)
       (full suite green)

  $ node scripts/run-vitest.mjs run src/gateway/conversation-send-binding-precedence.test.ts
   ✯ |gateway-core| ... > delivers for the configured ACP owner when only a stale generic runtime record exists  (send authorized, transport invoked once)
   ✯ |gateway-core| ... > rejects the competing agent before any transport attempt  (ConversationInputError, transport never invoked)
   ✯ |gateway-core| ... > follows a live subagent reassignment through queued delivery recovery  (reassigned owner recovers, previous owner throws PlatformMessageNotDispatchedError)
       Tests  3 passed (3)

  $ node --import ./scripts/tsx.mjs scripts/run-tsgo-core-test-shards.mts --changed-paths-json '[...]'
  [check:changed] core test graphs: agents-root, agents-other, agents-tools, gateway-root, gateway-other, infra, commands, plugins-platform, config-cli, messaging, services, other, ui-pages, ui-e2e, ui-other, packages
  (exit 0 — all 16 affected graphs)

  $ skills/fix-pr/scripts/validate.sh <changed files>
  [test] passed 3 Vitest shards in 33.11s
  [validate] 4/4 tsgo:core 类型检查
  [validate] 全部通过 ✅
  ```
- **Observed result after fix:** a stale generic non-ACP runtime binding record no longer redirects a conversation that a configured ACP binding claims (message routes to the configured ACP agent, ignored row untouched); a fresh binding written through the public bind API keeps routing the conversation to its intentional target; a live subagent thread binding keeps receiving follow-ups; and LINE ingress selects the same owner that the Gateway send boundary (entry eligibility + pre-transport delivery authorization) and queued-recovery boundary enforce — the approved owner is eligible and delivered while the competing agent is denied before any transport I/O, and after reassignment to a live subagent binding the reassigned owner's queued operation recovers while the previous owner's is rejected.
- **Before evidence (optional, visual changes encouraged):** on the previous head (9a06ed9ce9f) the new provenance regression test failed — a fresh generic bind-API binding was suppressed (`touch` never called; the configured route won) — reproducing the review's SDK-compatibility finding. On the head before that (953eef2b) the subagent/LINE/ownership regression tests failed as previously documented. On unpatched origin/main the original end-to-end test failed with `expected 'main' to be 'codex'` — the stale row routed the conversation to agent `main` and the configured ACP binding was never honored.
- **What was not tested:** live message delivery through a real Feishu/Telegram/LINE/iMessage account — no credentials are available in this environment; the Telegram Test Server E2E (qa-lab live transport with a Convex-leased real-user driver, `proof: telegram-e2e`) requires maintainer/CI Convex credentials that are not available to contributors, so real Telegram routing proof cannot be produced here. Discord/Slack channel-owned resolvers (unchanged by design), and the generation-aware stale-record cleanup direction discussed in #133694 are also not covered. CI lanes (changed-project tests, full test-type check) pending on GitHub Actions.
- **Proof tier:** L2
- **Proof limitations:** Routing and delivery-authorization behavior is proven deterministically at the resolver/ingress/send/queued-recovery layers (real gateway send and recovery authorization chains, real per-agent conversation registry and delivery stores, transport replaced) rather than through a live channel account.
- **Review state:** Awaiting CI + maintainer review
