### PR TITLE
fix(cron): complete timeout test observation phase

### DIFF
--- a/src/cron/command-runner.test.ts
+++ b/src/cron/command-runner.test.ts
@@ -180,6 +180,8 @@ describe("runCronCommandJob", () => {
 
         await vi.advanceTimersByTimeAsync(500);
         await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
+        // Force delivery now has a separate bounded exit-observation phase.
+        await vi.advanceTimersByTimeAsync(execSpawn.COMMAND_PROCESS_TREE_KILL_GRACE_MS);
         const result = await command;
         expect(result.status).toBe("error");
         expect(result.error).toBe("command timed out");


### PR DESCRIPTION
Related: #139957, #138411

## What Problem This Solves

Resolves a problem where the cron process-group timeout test hangs after process cleanup gains a separate exit-observation phase. This caused a 120-second CI failure on an otherwise unrelated PR.

## Why This Change Was Made

Advance the fixture clock through both existing cleanup phases, matching the sibling execution test. The test still waits for a real descendant before firing the same command deadline, then checks the timeout result and descendant exit. Production code, timeout values, and existing assertions are unchanged.

## User Impact

No runtime behavior change. The cron test now completes the existing cleanup lifecycle instead of waiting on a frozen observation timer.

## Evidence

Secretless Linux proof used the same source base, Node 24.20.0 and pnpm 12.3.4 for both runs. The controlled probe keeps the real shell and descendant and holds only the owned process group's visibility through the first grace phase; actual termination signals are forwarded.

- [Baseline proof](https://github.com/steipete/openclaw/actions/runs/34028447384): the original timer order leaves one observation poll queued and the command unsettled. Only the intended clock-freeze assertion fails; cleanup confirms the descendant is gone. The force attempt returns ESRCH, so this is not claimed as signal-delivery proof.
- [Candidate proof](https://github.com/steipete/openclaw/actions/runs/34030276700): the same pending observation completes after the second phase, with the command settled and descendant gone. After removing all instrumentation, 79 cron, execution, termination and stdio tests pass; the existing Windows-only command-resolution case is skipped on Linux.
- The required changed checks pass, including core test types, dead exports and lint. The final test hash matches the reviewed candidate, and production hashes are unchanged. Independent autoreview found no actionable P0–P2 findings.

Production delta: 0. Test delta: +2 lines.
