### PR TITLE
test: close plugin HTTP fixtures reliably across runtimes

### DIFF
--- a/extensions/beam/src/mirror-retry.test.ts
+++ b/extensions/beam/src/mirror-retry.test.ts
@@ -1,9 +1,8 @@
-import { createServer } from "node:http";
 import {
   createPluginStateKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { useAutoCleanupTempDirTracker, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   beamTestNow,
@@ -204,63 +203,58 @@ describe("Beam terminal retry policy", () => {
       }),
       resolveControlUiBasePath: () => "",
     });
-    const server = createServer((request, response) => {
-      requestNumber += 1;
-      void handler(request, response).catch(() => {
-        if (!response.writableEnded) {
-          response.statusCode = 503;
-          response.end("temporary receiver failure");
-        }
-      });
-    });
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("capacity receiver did not expose a TCP port");
-    }
-
-    let activeSessions: BeamTestSession[] = [];
-    const catalog = createBeamTestCatalog({
-      sessions: () => activeSessions,
-      items: (threadId) => [{ type: "agentMessage", text: threadId }],
-    });
-    const runner = createBeamTestRunner({
-      endpoint: `http://127.0.0.1:${address.port}/api/v1/beam/sessions`,
-      listCatalogs: () => [catalog],
-    });
     try {
-      let createdSessions = 0;
-      for (let batch = 0; createdSessions < BEAM_MAX_SESSIONS; batch += 1) {
-        const batchSize = Math.min(32, BEAM_MAX_SESSIONS - createdSessions);
-        activeSessions = Array.from({ length: batchSize }, (_, index) => ({
-          threadId: `session-${createdSessions + index}`,
-          recencyAt: beamTestNow + batch,
-        }));
-        createdSessions += batchSize;
-        await runner.tick();
-      }
+      await withServer(
+        (request, response) => {
+          requestNumber += 1;
+          void handler(request, response).catch(() => {
+            if (!response.writableEnded) {
+              response.statusCode = 503;
+              response.end("temporary receiver failure");
+            }
+          });
+        },
+        async (baseUrl) => {
+          let activeSessions: BeamTestSession[] = [];
+          const catalog = createBeamTestCatalog({
+            sessions: () => activeSessions,
+            items: (threadId) => [{ type: "agentMessage", text: threadId }],
+          });
+          const runner = createBeamTestRunner({
+            endpoint: `${baseUrl}/api/v1/beam/sessions`,
+            listCatalogs: () => [catalog],
+          });
+          try {
+            let createdSessions = 0;
+            for (let batch = 0; createdSessions < BEAM_MAX_SESSIONS; batch += 1) {
+              const batchSize = Math.min(32, BEAM_MAX_SESSIONS - createdSessions);
+              activeSessions = Array.from({ length: batchSize }, (_, index) => ({
+                threadId: `session-${createdSessions + index}`,
+                recencyAt: beamTestNow + batch,
+              }));
+              createdSessions += batchSize;
+              await runner.tick();
+            }
 
-      activeSessions = [{ threadId: "session-500", recencyAt: beamTestNow + 101 }];
-      await runner.tick();
-      await expect(store.get(targetBeamId)).resolves.toMatchObject({ completed: false });
+            activeSessions = [{ threadId: "session-500", recencyAt: beamTestNow + 101 }];
+            await runner.tick();
+            await expect(store.get(targetBeamId)).resolves.toMatchObject({ completed: false });
 
-      activeSessions = [];
-      phase = "final";
-      for (let tick = 0; tick < 40; tick += 1) {
-        await runner.tick();
-      }
+            activeSessions = [];
+            phase = "final";
+            for (let tick = 0; tick < 40; tick += 1) {
+              await runner.tick();
+            }
 
-      expect(rejectedTargetWrites).toBe(1);
-      expect(acceptedTargetStates).toEqual([false, true]);
-      await expect(store.get(targetBeamId)).resolves.toMatchObject({ completed: true });
+            expect(rejectedTargetWrites).toBe(1);
+            expect(acceptedTargetStates).toEqual([false, true]);
+            await expect(store.get(targetBeamId)).resolves.toMatchObject({ completed: true });
+          } finally {
+            await runner.stop();
+          }
+        },
+      );
     } finally {
-      await runner.stop();
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
       resetPluginStateStoreForTests();
     }
   });

--- a/extensions/feishu/src/media-chunk-idle.test.ts
+++ b/extensions/feishu/src/media-chunk-idle.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs/promises";
-import http, { createServer } from "node:http";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { captureEnv } from "openclaw/plugin-sdk/test-env";
+import { captureEnv, withServer } from "openclaw/plugin-sdk/test-env";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { saveMediaStreamWithIdleTimeout } from "./media-chunk-idle.js";
 
@@ -54,45 +54,30 @@ describe("saveMediaStreamWithIdleTimeout", () => {
 
   it("times out a stalled SDK-style HTTP stream and closes its connection", async () => {
     let serverSawClose = false;
-    const server = createServer((req, res) => {
-      res.writeHead(200, { "content-type": "image/jpeg", "content-length": "1048576" });
-      res.flushHeaders();
-      const markClose = () => {
-        serverSawClose = true;
-      };
-      req.on("close", markClose);
-      res.on("close", markClose);
-    });
-    await new Promise<void>((resolve, reject) => {
-      server.once("error", reject);
-      server.listen(0, "127.0.0.1", () => {
-        server.off("error", reject);
-        resolve();
-      });
-    });
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("server failed to bind");
-    }
-
-    try {
-      const stalled = await getHttpReadable(`http://127.0.0.1:${address.port}/media`);
-      await expect(
-        saveMediaStreamWithIdleTimeout(stalled, "image/jpeg", 1024, undefined, 50),
-      ).rejects.toMatchObject({
-        name: "FeishuInboundMediaTimeoutError",
-        chunkTimeoutMs: 50,
-      });
-      expect(stalled.destroyed).toBe(true);
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 20);
-      });
-      expect(serverSawClose).toBe(true);
-    } finally {
-      server.closeAllConnections?.();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+    await withServer(
+      (req, res) => {
+        res.writeHead(200, { "content-type": "image/jpeg", "content-length": "1048576" });
+        res.flushHeaders();
+        const markClose = () => {
+          serverSawClose = true;
+        };
+        req.on("close", markClose);
+        res.on("close", markClose);
+      },
+      async (baseUrl) => {
+        const stalled = await getHttpReadable(`${baseUrl}/media`);
+        await expect(
+          saveMediaStreamWithIdleTimeout(stalled, "image/jpeg", 1024, undefined, 50),
+        ).rejects.toMatchObject({
+          name: "FeishuInboundMediaTimeoutError",
+          chunkTimeoutMs: 50,
+        });
+        expect(stalled.destroyed).toBe(true);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 20);
+        });
+        expect(serverSawClose).toBe(true);
+      },
+    );
   });
 });

--- a/extensions/line/src/message-cards.test.ts
+++ b/extensions/line/src/message-cards.test.ts
@@ -1,7 +1,7 @@
 // Line tests cover message cards plugin behavior.
-import { createServer } from "node:http";
 import { messagingApi } from "@line/bot-sdk";
 import { expectDefined } from "@openclaw/normalization-core";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import {
   datetimePickerAction,
@@ -123,45 +123,34 @@ async function withLineProvider(
   run: (client: messagingApi.MessagingApiClient, requests: LineProviderRequest[]) => Promise<void>,
 ): Promise<void> {
   const requests: LineProviderRequest[] = [];
-  const server = createServer((request, response) => {
-    const chunks: Buffer[] = [];
-    request.on("data", (chunk: Buffer) => {
-      chunks.push(chunk);
-    });
-    request.once("end", () => {
-      const payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
-        messages: Array<{ type: string; altText: string }>;
-      };
-      requests.push({
-        path: request.url ?? "",
-        authenticated: request.headers.authorization === "Bearer isolated-test-token",
-        type: payload.messages[0]?.type ?? "",
-        altText: payload.messages[0]?.altText ?? "",
+  await withServer(
+    (request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
       });
-      response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ sentMessages: [{ id: `card-${requests.length}` }] }));
-    });
-  });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  try {
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("LINE card provider did not bind a TCP port");
-    }
-    const client = new messagingApi.MessagingApiClient({
-      channelAccessToken: "isolated-test-token",
-      baseURL: `http://127.0.0.1:${address.port}`,
-    });
-    await run(client, requests);
-  } finally {
-    server.closeAllConnections();
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
+      request.once("end", () => {
+        const payload = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+          messages: Array<{ type: string; altText: string }>;
+        };
+        requests.push({
+          path: request.url ?? "",
+          authenticated: request.headers.authorization === "Bearer isolated-test-token",
+          type: payload.messages[0]?.type ?? "",
+          altText: payload.messages[0]?.altText ?? "",
+        });
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify({ sentMessages: [{ id: `card-${requests.length}` }] }));
+      });
+    },
+    async (baseUrl) => {
+      const client = new messagingApi.MessagingApiClient({
+        channelAccessToken: "isolated-test-token",
+        baseURL: baseUrl,
+      });
+      await run(client, requests);
+    },
+  );
 }
 
 describe("createConfirmTemplate", () => {

--- a/extensions/line/src/row-overflow-delivery.loopback.test.ts
+++ b/extensions/line/src/row-overflow-delivery.loopback.test.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { Socket } from "node:net";
 import {
   adaptMessagePresentationForChannel,
   type MessagePresentation,
@@ -60,6 +61,11 @@ async function listenLoopback(
       response.end(String(error));
     });
   });
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
   server.on("clientError", (_err, socket) => socket.destroy());
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -76,9 +82,11 @@ async function listenLoopback(
     server,
     port: address.port,
     close: async () => {
-      server.closeAllConnections?.();
       await new Promise<void>((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
+        for (const socket of sockets) {
+          socket.destroy();
+        }
       });
     },
   };

--- a/extensions/ollama/app-guided-setup.test.ts
+++ b/extensions/ollama/app-guided-setup.test.ts
@@ -1,7 +1,6 @@
-import { once } from "node:events";
-import { createServer } from "node:http";
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
 
@@ -28,52 +27,43 @@ async function withOllamaServer(
   run: (baseUrl: string, inspected: string[]) => Promise<void>,
 ) {
   const inspected: string[] = [];
-  const server = createServer((request, response) => {
-    let body = "";
-    request.setEncoding("utf8");
-    request.on("data", (chunk: string) => {
-      body += chunk;
-    });
-    request.on("end", () => {
-      response.setHeader("content-type", "application/json");
-      if (request.url === "/api/ps") {
-        response.end(
-          JSON.stringify({ models: (options.loaded ?? [selected]).map((name) => ({ name })) }),
-        );
-      } else if (request.url === "/api/tags") {
-        response.end(
-          JSON.stringify({ models: (options.models ?? [selected]).map((name) => ({ name })) }),
-        );
-      } else if (request.url === "/api/show") {
-        inspected.push((JSON.parse(body) as { model: string }).model);
-        options.onShow?.();
-        response.writeHead(options.showStatus ?? 200).end(
-          JSON.stringify(
-            options.show ?? {
-              model_info: { "model.context_length": 32_768 },
-              capabilities: ["completion", "tools"],
-            },
-          ),
-        );
-      } else {
-        response.writeHead(404).end();
-      }
-    });
-  });
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
-  try {
-    const address = server.address();
-    if (!address || typeof address === "string") {
-      throw new Error("Missing fixture server address");
-    }
-    await run(`http://127.0.0.1:${address.port}`, inspected);
-  } finally {
-    server.closeAllConnections();
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
+  await withServer(
+    (request, response) => {
+      let body = "";
+      request.setEncoding("utf8");
+      request.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        response.setHeader("content-type", "application/json");
+        if (request.url === "/api/ps") {
+          response.end(
+            JSON.stringify({ models: (options.loaded ?? [selected]).map((name) => ({ name })) }),
+          );
+        } else if (request.url === "/api/tags") {
+          response.end(
+            JSON.stringify({ models: (options.models ?? [selected]).map((name) => ({ name })) }),
+          );
+        } else if (request.url === "/api/show") {
+          inspected.push((JSON.parse(body) as { model: string }).model);
+          options.onShow?.();
+          response.writeHead(options.showStatus ?? 200).end(
+            JSON.stringify(
+              options.show ?? {
+                model_info: { "model.context_length": 32_768 },
+                capabilities: ["completion", "tools"],
+              },
+            ),
+          );
+        } else {
+          response.writeHead(404).end();
+        }
+      });
+    },
+    async (baseUrl) => {
+      await run(baseUrl, inspected);
+    },
+  );
 }
 
 function guidedSetup() {

--- a/extensions/ollama/src/node-inference.abort.test.ts
+++ b/extensions/ollama/src/node-inference.abort.test.ts
@@ -1,6 +1,7 @@
 /** Proves paired-node Ollama work stops at every node-local HTTP phase. */
-import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { createOllamaNodeHostCommands, createOllamaNodeInferenceTool } from "./node-inference.js";
 import {
@@ -16,78 +17,67 @@ type AbortTestServer = {
   canceled: string[];
 };
 
-async function withAbortTestServer<T>(
+async function withAbortTestServer(
   stallPath: string,
-  run: (server: AbortTestServer) => Promise<T>,
+  run: (server: AbortTestServer) => Promise<void>,
   options?: { stallCount?: number },
-): Promise<T> {
+): Promise<void> {
   const requests: string[] = [];
   const canceled: string[] = [];
   let stalls = 0;
-  const server = createServer((request: IncomingMessage, response: ServerResponse) => {
-    const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
-    requests.push(requestPath);
-    if (requestPath === stallPath && stalls < (options?.stallCount ?? Number.POSITIVE_INFINITY)) {
-      stalls += 1;
-      response.once("close", () => {
-        if (!response.writableFinished) {
-          canceled.push(requestPath);
-        }
+  await withServer(
+    (request: IncomingMessage, response: ServerResponse) => {
+      const requestPath = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+      requests.push(requestPath);
+      if (requestPath === stallPath && stalls < (options?.stallCount ?? Number.POSITIVE_INFINITY)) {
+        stalls += 1;
+        response.once("close", () => {
+          if (!response.writableFinished) {
+            canceled.push(requestPath);
+          }
+        });
+        return;
+      }
+
+      response.setHeader("Content-Type", "application/json");
+      if (requestPath === "/api/tags") {
+        response.end(
+          JSON.stringify({
+            models: [{ name: "node-local:small", digest: "sha256:node-local-small", size: 512 }],
+          }),
+        );
+        return;
+      }
+      if (requestPath === "/api/show") {
+        response.end(
+          JSON.stringify({
+            capabilities: ["completion", "tools"],
+            model_info: { "test.context_length": 8192 },
+          }),
+        );
+        return;
+      }
+      if (requestPath === "/api/chat") {
+        response.end(
+          JSON.stringify({
+            model: "node-local:small",
+            message: { content: "node-only inference" },
+            done_reason: "stop",
+          }),
+        );
+        return;
+      }
+      response.statusCode = 404;
+      response.end(JSON.stringify({ error: "not found" }));
+    },
+    async (baseUrl) => {
+      await run({
+        baseUrl,
+        requests,
+        canceled,
       });
-      return;
-    }
-
-    response.setHeader("Content-Type", "application/json");
-    if (requestPath === "/api/tags") {
-      response.end(
-        JSON.stringify({
-          models: [{ name: "node-local:small", digest: "sha256:node-local-small", size: 512 }],
-        }),
-      );
-      return;
-    }
-    if (requestPath === "/api/show") {
-      response.end(
-        JSON.stringify({
-          capabilities: ["completion", "tools"],
-          model_info: { "test.context_length": 8192 },
-        }),
-      );
-      return;
-    }
-    if (requestPath === "/api/chat") {
-      response.end(
-        JSON.stringify({
-          model: "node-local:small",
-          message: { content: "node-only inference" },
-          done_reason: "stop",
-        }),
-      );
-      return;
-    }
-    response.statusCode = 404;
-    response.end(JSON.stringify({ error: "not found" }));
-  });
-
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("node-local Ollama fixture did not expose a TCP address");
-  }
-  try {
-    return await run({
-      baseUrl: `http://127.0.0.1:${address.port}`,
-      requests,
-      canceled,
-    });
-  } finally {
-    server.closeAllConnections();
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => (error ? reject(error) : resolve()));
-    });
-  }
+    },
+  );
 }
 
 function requireNodeChatCommand(baseUrl: string) {

--- a/extensions/slack/src/client.web-api.test.ts
+++ b/extensions/slack/src/client.web-api.test.ts
@@ -1,6 +1,6 @@
 // Slack tests cover real Web API routing behavior.
 import { createServer, type Server } from "node:http";
-import type { AddressInfo } from "node:net";
+import type { AddressInfo, Socket } from "node:net";
 import { WebClient } from "@slack/web-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -143,6 +143,11 @@ async function startStalledHeadersSlackApiServer(requests: SlackApiRequest[]): P
     request.resume();
     request.socket.once("close", resolveSocketClosed);
   });
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
   await new Promise<void>((resolve) => {
     server.listen(0, "127.0.0.1", resolve);
   });
@@ -150,8 +155,11 @@ async function startStalledHeadersSlackApiServer(requests: SlackApiRequest[]): P
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
     close: async () => {
-      server.closeAllConnections();
-      await closeServer(server);
+      const closed = closeServer(server);
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await closed;
     },
     socketClosed,
   };

--- a/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
+++ b/extensions/telegram/src/telegram-ingress-drain-factory.test.ts
@@ -1,9 +1,8 @@
 /** Verifies callback admission and the grammY terminal outcome handoff. */
-import { once } from "node:events";
-import { createServer, type ServerResponse } from "node:http";
-import type { AddressInfo } from "node:net";
+import type { ServerResponse } from "node:http";
 import { Api } from "grammy";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ensureTelegramMessageProcessingResult,
@@ -87,92 +86,89 @@ describe("Telegram transport ingress outcome handoff", () => {
         response.writeHead(200, { "content-type": "application/json" });
         response.end(JSON.stringify({ ok: true, result: true }));
       };
-      const server = createServer((request, response) => {
-        let body = "";
-        request.setEncoding("utf8");
-        request.on("data", (chunk: string) => {
-          body += chunk;
-        });
-        request.on("end", () => {
-          const payload = JSON.parse(body) as { callback_query_id: string };
-          requestIds.push(payload.callback_query_id);
-          if (rejectNewAnswer && requestIds.length === 1) {
-            response.writeHead(503, { "content-type": "application/json" });
-            response.end(
-              JSON.stringify({ ok: false, error_code: 503, description: "ACK unavailable" }),
-            );
-            return;
-          }
-          pendingResponses.push(response);
-          pendingAnswer.resolve();
-          if (releaseAnswers) {
-            sendAnswer(response);
-          }
-        });
-      });
-      server.listen(0, "127.0.0.1");
-      await once(server, "listening");
-      const address = server.address() as AddressInfo;
-      const api = new Api("1000000:test-token", { apiRoot: `http://127.0.0.1:${address.port}` });
-      const bot = {
-        handleUpdate: vi.fn(async () => {}),
-        api: {
-          answerCallbackQuery: (id: string) => {
-            const answer = api.answerCallbackQuery(id);
-            answerRequests.push(answer);
-            return answer;
-          },
+      await withServer(
+        (request, response) => {
+          let body = "";
+          request.setEncoding("utf8");
+          request.on("data", (chunk: string) => {
+            body += chunk;
+          });
+          request.on("end", () => {
+            const payload = JSON.parse(body) as { callback_query_id: string };
+            requestIds.push(payload.callback_query_id);
+            if (rejectNewAnswer && requestIds.length === 1) {
+              response.writeHead(503, { "content-type": "application/json" });
+              response.end(
+                JSON.stringify({ ok: false, error_code: 503, description: "ACK unavailable" }),
+              );
+              return;
+            }
+            pendingResponses.push(response);
+            pendingAnswer.resolve();
+            if (releaseAnswers) {
+              sendAnswer(response);
+            }
+          });
         },
-      };
-      createTelegramTransportIngressMonitor({
-        spoolDir: "/tmp/telegram-ingress-proof",
-        bot,
-        cfg: {},
-        accountId: "default",
-      });
-      const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
-      const update = { update_id: 125, callback_query: { id: callbackId } };
-      try {
-        if (rejectNewAnswer) {
-          await monitor.onDurableAdmission(update, { isNew: true });
-          const initialAnswers = await Promise.allSettled(answerRequests);
-          expect(initialAnswers).toMatchObject([{ status: "rejected" }]);
-        }
-        if (startNewPending) {
-          await monitor.onDurableAdmission(update, { isNew: true });
-          await pendingAnswer.promise;
-          if (consumePending) {
-            expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeDefined();
+        async (baseUrl) => {
+          const api = new Api("1000000:test-token", { apiRoot: baseUrl });
+          const bot = {
+            handleUpdate: vi.fn(async () => {}),
+            api: {
+              answerCallbackQuery: (id: string) => {
+                const answer = api.answerCallbackQuery(id);
+                answerRequests.push(answer);
+                return answer;
+              },
+            },
+          };
+          createTelegramTransportIngressMonitor({
+            spoolDir: "/tmp/telegram-ingress-proof",
+            bot,
+            cfg: {},
+            accountId: "default",
+          });
+          const monitor = mocks.createTelegramIngressMonitor.mock.calls[0]?.[0] as CapturedMonitor;
+          const update = { update_id: 125, callback_query: { id: callbackId } };
+          try {
+            if (rejectNewAnswer) {
+              await monitor.onDurableAdmission(update, { isNew: true });
+              const initialAnswers = await Promise.allSettled(answerRequests);
+              expect(initialAnswers).toMatchObject([{ status: "rejected" }]);
+            }
+            if (startNewPending) {
+              await monitor.onDurableAdmission(update, { isNew: true });
+              await pendingAnswer.promise;
+              if (consumePending) {
+                expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeDefined();
+              }
+            }
+            await monitor.onDurableAdmission(update, { isNew: false });
+            await pendingAnswer.promise;
+            await monitor.onDurableAdmission(update, { isNew: false });
+            releaseAnswers = true;
+            for (const response of pendingResponses) {
+              sendAnswer(response);
+            }
+            await Promise.allSettled(answerRequests);
+            expect(requestIds).toEqual(Array.from({ length: expectedRequests }, () => callbackId));
+            expect(bot.handleUpdate).not.toHaveBeenCalled();
+            if (startNewPending && !consumePending) {
+              expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeDefined();
+            }
+            // Tombstones never dispatch; their settled answers must not remain per bot.
+            expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeUndefined();
+          } finally {
+            releaseAnswers = true;
+            for (const response of pendingResponses) {
+              if (!response.writableEnded) {
+                sendAnswer(response);
+              }
+            }
+            await Promise.allSettled(answerRequests);
           }
-        }
-        await monitor.onDurableAdmission(update, { isNew: false });
-        await pendingAnswer.promise;
-        await monitor.onDurableAdmission(update, { isNew: false });
-        releaseAnswers = true;
-        for (const response of pendingResponses) {
-          sendAnswer(response);
-        }
-        await Promise.allSettled(answerRequests);
-        expect(requestIds).toEqual(Array.from({ length: expectedRequests }, () => callbackId));
-        expect(bot.handleUpdate).not.toHaveBeenCalled();
-        if (startNewPending && !consumePending) {
-          expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeDefined();
-        }
-        // Tombstones never dispatch; their settled answers must not remain per bot.
-        expect(takeTelegramCallbackQueryAdmissionAnswer(bot, callbackId)).toBeUndefined();
-      } finally {
-        releaseAnswers = true;
-        for (const response of pendingResponses) {
-          if (!response.writableEnded) {
-            sendAnswer(response);
-          }
-        }
-        await Promise.allSettled(answerRequests);
-        server.closeAllConnections();
-        await new Promise<void>((resolve, reject) => {
-          server.close((error) => (error ? reject(error) : resolve()));
-        });
-      }
+        },
+      );
     },
   );
 

--- a/extensions/xai/video-generation-transport.test.ts
+++ b/extensions/xai/video-generation-transport.test.ts
@@ -1,5 +1,4 @@
-import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
+import { withServer } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it, vi } from "vitest";
 import { downloadXaiVideo } from "./video-generation-transport.js";
 
@@ -47,34 +46,26 @@ describe("downloadXaiVideo", () => {
     const socketClosed = new Promise<boolean>((resolve) => {
       notifySocketClosed = resolve;
     });
-    const server = createServer((request, response) => {
-      request.socket.once("close", () => notifySocketClosed?.(true));
-      response.writeHead(200, { "content-type": "application/json" });
-      // Headers land, then the body never ends: only an explicit cancel closes this.
-      response.write('{"error":"still streaming');
-    });
-    await new Promise<void>((resolve) => {
-      server.listen(0, "127.0.0.1", resolve);
-    });
+    await withServer(
+      (request, response) => {
+        request.socket.once("close", () => notifySocketClosed?.(true));
+        response.writeHead(200, { "content-type": "application/json" });
+        // Headers land, then the body never ends: only an explicit cancel closes this.
+        response.write('{"error":"still streaming');
+      },
+      async (baseUrl) => {
+        await expect(
+          downloadXaiVideo({
+            url: `${baseUrl}/generated.mp4`,
+            defaultTimeoutMs: 5_000,
+            fetchFn: fetch,
+            maxBytes: 10 * 1024 * 1024,
+            allowPrivateNetwork: true,
+          }),
+        ).rejects.toThrow("xAI generated video download: malformed video response");
 
-    try {
-      const { port } = server.address() as AddressInfo;
-      await expect(
-        downloadXaiVideo({
-          url: `http://127.0.0.1:${port}/generated.mp4`,
-          defaultTimeoutMs: 5_000,
-          fetchFn: fetch,
-          maxBytes: 10 * 1024 * 1024,
-          allowPrivateNetwork: true,
-        }),
-      ).rejects.toThrow("xAI generated video download: malformed video response");
-
-      await expect(socketClosed).resolves.toBe(true);
-    } finally {
-      server.closeAllConnections();
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-    }
+        await expect(socketClosed).resolves.toBe(true);
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

Several plugin HTTP fixtures called `closeAllConnections()` before registering `server.close()` completion. Under Bun, that cleared the listener handle and made otherwise successful tests fail during cleanup with `ERR_SERVER_NOT_RUNNING`.

Use the existing public `withServer` helper for callback-scoped fixtures in Telegram, LINE cards, Ollama setup/cancellation, xAI video, Beam retry, and Feishu media tests. LINE row-overflow and Slack stalled-header fixtures retain their existing start/close lifecycles, track accepted sockets, and register close completion before destroying those sockets. Pending responses and requests, Beam runner/state cleanup, payload and delivery assertions, and the existing timeout values are preserved. Production behavior and public APIs are unchanged.

## Validation

- 42 explicitly selected synthetic cases passed under Node; the same 42 passed under the actual Bun runtime. Each invocation's executed names and count were checked against the recorded allowlist, with outbound networking limited to loopback.
- Historical native reports retain the original cleanup failures. Two initial commands selected zero cases because of a Vitest matcher-name formatting mismatch, and one failed before collection because of an incorrect config path; none is counted as proof. The selectors and maintained config routing were corrected, and successful runtime/file pairs were preserved.
- Fresh independent P2 review of the complete nine-file candidate found no actionable issues.
- The full changed-file gate passed for all nine paths against the original PR base, including the committed Telegram change and staged additions.
