### PR TITLE
refactor(plugins): unify install config snapshot preparation

### DIFF
--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -910,6 +910,20 @@ describe("loadConfigForInstall", () => {
     );
   });
 
+  it("reports unrelated config errors before an unsupported recovery include", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { $include: "./external.json5", plugins: {} },
+        issues: [{ path: "gateway.mode", message: "invalid mode" }],
+      }),
+    );
+
+    await expect(loadConfigForInstall(discordNpmRequest)).rejects.toMatchObject({
+      code: "INVALID_CONFIG",
+      message: expect.stringContaining("Config invalid outside the plugin recovery path"),
+    });
+  });
+
   it("rejects non-Discord install requests when config is invalid", async () => {
     readConfigFileSnapshotMock.mockResolvedValue(makeSnapshot());
 

--- a/src/cli/plugins-install-config.ts
+++ b/src/cli/plugins-install-config.ts
@@ -96,42 +96,6 @@ function isAllowedPluginRecoveryIssue(
   );
 }
 
-function collectRequestedPluginInstallPaths(
-  cfg: OpenClawConfig,
-  installRecords: Awaited<ReturnType<typeof loadInstalledPluginIndexInstallRecords>>,
-  request: PluginInstallRequestContext,
-  env: NodeJS.ProcessEnv,
-): Set<string> {
-  const pluginId = request.bundledPluginId?.trim();
-  if (!pluginId) {
-    return new Set();
-  }
-  const paths = new Set<string>();
-  const record = installRecords[pluginId] ?? cfg.plugins?.installs?.[pluginId];
-  for (const value of [record?.sourcePath, record?.installPath]) {
-    if (typeof value === "string" && value.trim()) {
-      paths.add(resolveUserPath(value, env));
-    }
-  }
-  return paths;
-}
-
-async function collectRequestedPluginLocationBridgePaths(
-  request: PluginInstallRequestContext,
-  env: NodeJS.ProcessEnv,
-): Promise<Set<string>> {
-  const pluginId = request.bundledPluginId?.trim();
-  if (!pluginId) {
-    return new Set();
-  }
-  const locations = await listPersistedBundledPluginRecoveryLocations({ env });
-  return new Set(
-    locations
-      .filter((location) => location.pluginId === pluginId)
-      .flatMap((location) => location.loadPaths.map((loadPath) => resolveUserPath(loadPath, env))),
-  );
-}
-
 function removeOwnedMissingPluginLoadPaths(
   cfg: OpenClawConfig,
   issues: readonly ConfigValidationIssue[],
@@ -181,7 +145,17 @@ async function resolveRequestedPluginInstallPaths(
     return new Set();
   }
   const installRecords = await loadInstalledPluginIndexInstallRecords();
-  const ownedLoadPaths = collectRequestedPluginInstallPaths(cfg, installRecords, request, env);
+  const ownedLoadPaths = new Set<string>();
+  const pluginId = request.bundledPluginId?.trim();
+  if (!pluginId) {
+    return ownedLoadPaths;
+  }
+  const record = installRecords[pluginId] ?? cfg.plugins?.installs?.[pluginId];
+  for (const value of [record?.sourcePath, record?.installPath]) {
+    if (typeof value === "string" && value.trim()) {
+      ownedLoadPaths.add(resolveUserPath(value, env));
+    }
+  }
   const stillNeedsLocationBridge = issues.some(
     (issue) =>
       extractMissingPluginLoadPath(issue) !== null &&
@@ -189,19 +163,21 @@ async function resolveRequestedPluginInstallPaths(
   );
   if (stillNeedsLocationBridge) {
     // Registry ownership, not a matching requested id, authorizes repairing a removed path.
-    for (const loadPath of await collectRequestedPluginLocationBridgePaths(request, env)) {
-      ownedLoadPaths.add(loadPath);
+    const locations = await listPersistedBundledPluginRecoveryLocations({ env });
+    const loadPaths = locations
+      .filter((location) => location.pluginId === pluginId)
+      .flatMap((location) => location.loadPaths);
+    for (const loadPath of loadPaths) {
+      ownedLoadPaths.add(resolveUserPath(loadPath, env));
     }
   }
   return ownedLoadPaths;
 }
 
-async function loadConfigFromSnapshotForInstall(
+async function recoverPluginInstallConfig(
   request: PluginInstallRequestContext,
-  prepared: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>,
-): Promise<ConfigSnapshotForInstallExecution> {
-  const { snapshot, writeOptions } = prepared;
-  const mutationWriteOptions = selectInstallMutationWriteOptions(writeOptions);
+  snapshot: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["snapshot"],
+): Promise<OpenClawConfig> {
   if (resolvePluginInstallInvalidConfigPolicy(request) !== "allow-plugin-recovery") {
     throw buildInvalidPluginInstallConfigError(
       "Config invalid; run `openclaw doctor --fix` before installing plugins.",
@@ -234,24 +210,12 @@ async function loadConfigFromSnapshotForInstall(
       "Config plugin recovery uses an unsupported $include shape; use a single-file top-level plugins include or run `openclaw doctor --fix` before reinstalling it.",
     );
   }
-  const { hookMutation, pluginMutation } = resolveInstallConfigMutationPreflights({
-    parsed,
-    snapshotPath: snapshot.path,
-    writeOptions: mutationWriteOptions,
-  });
-  assertPluginConfigMutationAllowed(pluginMutation);
-  return {
-    config: removeOwnedMissingPluginLoadPaths(
-      snapshot.config,
-      snapshot.issues,
-      ownedLoadPaths,
-      process.env,
-    ),
-    baseHash: snapshot.hash,
-    writeOptions: mutationWriteOptions,
-    hookMutation,
-    pluginMutation,
-  };
+  return removeOwnedMissingPluginLoadPaths(
+    snapshot.config,
+    snapshot.issues,
+    ownedLoadPaths,
+    process.env,
+  );
 }
 
 /** Read and authorize install configuration only after mutation-free request preflight. */
@@ -265,20 +229,20 @@ export async function loadConfigForInstall(
   );
   const { snapshot, writeOptions } = prepared;
   const mutationWriteOptions = selectInstallMutationWriteOptions(writeOptions);
-  if (!snapshot.valid) {
-    return await loadConfigFromSnapshotForInstall(request, prepared);
-  }
+  const config = snapshot.valid
+    ? snapshot.sourceConfig
+    : await recoverPluginInstallConfig(request, snapshot);
   const parsed = (snapshot.parsed ?? {}) as Record<string, unknown>;
   const { hookMutation, pluginMutation } = resolveInstallConfigMutationPreflights({
     parsed,
     snapshotPath: snapshot.path,
     writeOptions: mutationWriteOptions,
   });
-  if (request.installKind === "plugin") {
+  if (!snapshot.valid || request.installKind === "plugin") {
     assertPluginConfigMutationAllowed(pluginMutation);
   }
   return {
-    config: snapshot.sourceConfig,
+    config,
     baseHash: snapshot.hash,
     writeOptions: mutationWriteOptions,
     hookMutation,


### PR DESCRIPTION
Plugin installation built its authorized config snapshot twice: once for valid config and again after plugin-owned recovery. The recovery branch also split install-record and persisted-location path ownership across separate single-caller collectors.

Make `loadConfigForInstall` the single producer of the original config hash, write options, and mutation preflights. Recovery returns only the repaired config, and the existing path owner collects both authoritative install paths and location bridges. Invalid snapshots still require plugin-write permission; unrelated errors and unsupported include shapes retain their original precedence. Valid ambiguous plugin/hook requests continue to return the relevant mutation block.

This refactor preserves the existing CLI/API, npm quarantine and rollback behavior, and configuration surface. It prepares the install owner for #135599 without introducing a second Gateway path.

Validation: all 50 existing config-owner tests passed on the baseline, then 85 recovery/policy/parser tests passed on the candidate, including one added check that unrelated config errors outrank unsupported recovery includes. Independent Codex review was scoped-clean at P2 with no findings. Production: 31 added, 67 removed (net −36); tests: 14 added.

The complete changed-file gate passed. Live CLI proof on the committed candidate passed all four recovery/refusal cases, including single-file plugins-include recovery that kept the root config byte-identical. Eight actual CLI install processes exited and their groups closed; source and 10,810 regular build files stayed unchanged. Proof used synthetic local packages and private state, without a Gateway or credentials.

Exact proof commit: `02cdbd99edbfe6fde8e2596dccff029df2b82e6e`. Live report SHA256: `7d807a1135b0671cfc56dc62efde185beff5445432962fb932df5a72b42a4219`.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34031635935) passed on attempt 2. The initial run had three jobs that never acquired a self-hosted runner; the unchanged failed-job rerun completed on the repository’s hosted fallback.
