### PR TITLE
fix(test): preserve IRC import smoke under Bun

### DIFF
--- a/extensions/irc/runtime-api.test.ts
+++ b/extensions/irc/runtime-api.test.ts
@@ -7,8 +7,17 @@ describe("irc bundled api seams", () => {
 
   beforeAll(async () => {
     directSmokeStdout = await runDirectImportSmoke(
-      `const channel = await import("./extensions/irc/channel-plugin-api.ts");
-const runtime = await import("./extensions/irc/runtime-api.ts");
+      `import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+const loadModule = process.versions.bun
+  ? (await import("./scripts/lib/import-tooling-typescript.mts")).importToolingTypeScript
+  : (url) => import(url);
+const channel = await loadModule(
+  pathToFileURL(resolve("./extensions/irc/channel-plugin-api.ts")).href, import.meta.url,
+);
+const runtime = await loadModule(
+  pathToFileURL(resolve("./extensions/irc/runtime-api.ts")).href, import.meta.url,
+);
 process.stdout.write(JSON.stringify({
   channel: { keys: Object.keys(channel).sort(), id: channel.ircPlugin.id },
   runtime: { keys: Object.keys(runtime).sort(), type: typeof runtime.setIrcRuntime },

--- a/src/plugin-sdk/test-helpers/direct-smoke.ts
+++ b/src/plugin-sdk/test-helpers/direct-smoke.ts
@@ -18,7 +18,8 @@ const SHARED_IMPORT_ENV = {
 } satisfies NodeJS.ProcessEnv;
 
 export async function runDirectImportSmoke(code: string): Promise<string> {
-  const { stdout } = await execFileAsync(process.execPath, ["--import", "tsx", "-e", code], {
+  const runtimeArgs = process.versions.bun ? [] : ["--import", "tsx"];
+  const { stdout } = await execFileAsync(process.execPath, [...runtimeArgs, "-e", code], {
     cwd: repoRoot,
     env: SHARED_IMPORT_ENV,
     timeout: 40_000,

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -1112,6 +1112,33 @@ if (process.argv[1]?.endsWith("vitest-worker-compiler.mts")) {
         "-e",
         `await import(${JSON.stringify(pathToFileURL(config).href)});`,
       ]);
+      expect(
+        imported.error === undefined,
+        JSON.stringify({
+          errors: [
+            imported.error,
+            imported.error instanceof Error ? imported.error.cause : undefined,
+          ]
+            .filter((error) => error !== undefined)
+            .map((error) =>
+              error instanceof Error
+                ? {
+                    name: error.name.slice(0, 128),
+                    message: error.message.slice(0, 2_048),
+                    code:
+                      "code" in error && typeof error.code === "string"
+                        ? error.code.slice(0, 128)
+                        : undefined,
+                  }
+                : {
+                    type: typeof error,
+                    message: typeof error === "string" ? error.slice(0, 2_048) : undefined,
+                  },
+            ),
+          stdout: imported.stdout.slice(-4_096),
+          stderr: imported.stderr.slice(-4_096),
+        }),
+      ).toBe(true);
       expect(imported.code, imported.stderr).toBe(0);
       expect(imported.stderr).not.toContain("[vitest-workers] prepared");
       for (const args of [


### PR DESCRIPTION
## What Problem This Solves

Fixes the IRC public-module import smoke test under Bun, where Node-only tsx preload hooks do not provide the required source loading behavior.

## Why This Change Was Made

Keep Node's existing tsx arguments and let Bun launch natively. In the IRC fixture only, use the existing tooling TypeScript loader for its two public module imports. The exported-key, plugin-id, and function-type assertion remains unchanged.

A hosted Node config-import check also reported a null command result with no stderr. Add bounded error details at that existing assertion so any recurrence exposes the caught command failure. Its hard success and no-build assertions, timeout, and execution behavior remain unchanged.

## User Impact

The IRC import fixture runs with its selected runtime without switching Bun execution to Node. No new loader, alias resolver, dependency, runtime flag, or production plugin behavior is introduced.

## Evidence

- The retained original Bun report contains the import-resolution failure.
- The unchanged benign import-only case passes on Node and true Bun.
- The one selected benign config-import diagnostic case passes locally; the original hosted failure did not recur, and its underlying cause remains unknown.
- Complete three-file changed gate and fresh whole-candidate P0–P2 review pass.
- The earlier exact-head CI run failed at the config-import assertion; fresh CI must pass on this revised head. The diagnostic addition is not claimed to fix the unknown cause.
- No network, live, authentication, broader plugin-transform, or blocked core cases were rerun. This does not claim full repository Bun compatibility.
