### PR TITLE
fix(cron): preserve paced next-check deadlines across restart

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -118,7 +118,7 @@ When a stream job also has `trigger.script`, the gate runs once per closed batch
 
 Recurring jobs can set `pacing.min` and/or `pacing.max` to duration strings such as `15m` or `4h`; at least one bound is required. Use `--pacing-min` and `--pacing-max` with `automations add|edit` (`--clear-pacing` removes both bounds).
 
-During an agent-turn run, a paced job can call the `automations` tool with `action: "next_check"` and `in: "30m"`. The proposal applies only to that currently running job and is measured from successful run completion. OpenClaw silently clamps it to the configured bounds.
+During an agent-turn run, a paced job can call the `automations` tool with `action: "next_check"` and `in: "30m"`. The proposal applies only to that currently running job and is measured from successful run completion. OpenClaw silently clamps it to the configured bounds. A future paced deadline remains the next scheduled check after a Gateway restart.
 
 Pacing without a proposal leaves the normal schedule unchanged. Failed, timed-out, and skipped runs discard the proposal, so existing retry and error-backoff behavior takes precedence. Manually forcing a recurring job is out-of-band and preserves its pending natural or paced slot. For condition-triggered jobs, the built-in minimum interval remains a lower bound even when a proposal requests an earlier check.
 

--- a/src/cron/service.restart-catchup-pacing.test.ts
+++ b/src/cron/service.restart-catchup-pacing.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import { CronService } from "./service.js";
+import { setupCronServiceSuite } from "./service.test-harness.js";
+import type { CronServiceDeps } from "./service/state.js";
+import { loadCronStore } from "./store.js";
+
+const FIRST_RUN_AT = Date.parse("2026-09-06T12:00:00.000Z");
+const MINUTE = 60_000;
+const PACED_DELAY = 30 * MINUTE;
+const { logger, makeStorePath } = setupCronServiceSuite({
+  prefix: "openclaw-cron-paced-restart-",
+  baseTimeIso: new Date(FIRST_RUN_AT - MINUTE).toISOString(),
+});
+
+type RestartCase = {
+  label: string;
+  scheduleKind: "cron" | "every";
+  paced: boolean;
+  restartAfterMs: number;
+  expectedNextAfterMs: number;
+  forceStatus?: "ok" | "error";
+  firstStatus?: "error";
+};
+
+describe("CronService restart catch-up with dynamic cadence", () => {
+  it.each<RestartCase>([
+    {
+      label: "a future paced cron deadline",
+      scheduleKind: "cron",
+      paced: true,
+      restartAfterMs: 10 * MINUTE,
+      expectedNextAfterMs: PACED_DELAY,
+    },
+    {
+      label: "a future paced every deadline",
+      scheduleKind: "every",
+      paced: true,
+      restartAfterMs: 10 * MINUTE,
+      expectedNextAfterMs: PACED_DELAY,
+    },
+    {
+      label: "a paced cron deadline after a successful force run",
+      scheduleKind: "cron",
+      paced: true,
+      forceStatus: "ok",
+      restartAfterMs: 10 * MINUTE + 1_000,
+      expectedNextAfterMs: PACED_DELAY,
+    },
+    {
+      label: "a paced cron deadline during a failed force run's backoff",
+      scheduleKind: "cron",
+      paced: true,
+      forceStatus: "error",
+      restartAfterMs: 10 * MINUTE + 1_000,
+      expectedNextAfterMs: PACED_DELAY,
+    },
+    {
+      label: "a paced every deadline during a failed force run's backoff",
+      scheduleKind: "every",
+      paced: true,
+      forceStatus: "error",
+      restartAfterMs: 10 * MINUTE + 1_000,
+      expectedNextAfterMs: PACED_DELAY,
+    },
+    {
+      label: "catch-up for an overdue paced cron deadline",
+      scheduleKind: "cron",
+      paced: true,
+      restartAfterMs: 31 * MINUTE,
+      expectedNextAfterMs: 33 * MINUTE,
+    },
+    {
+      label: "catch-up for an overdue paced every deadline",
+      scheduleKind: "every",
+      paced: true,
+      restartAfterMs: 31 * MINUTE,
+      expectedNextAfterMs: 33 * MINUTE,
+    },
+    {
+      label: "catch-up for an unpaced cron deadline",
+      scheduleKind: "cron",
+      paced: false,
+      restartAfterMs: 10 * MINUTE,
+      expectedNextAfterMs: 12 * MINUTE,
+    },
+    {
+      label: "backoff after a failed scheduled cron run",
+      scheduleKind: "cron",
+      paced: false,
+      firstStatus: "error",
+      restartAfterMs: 10_000,
+      expectedNextAfterMs: 30_000,
+    },
+  ])("preserves $label", async (scenario) => {
+    const store = await makeStorePath();
+    const runIsolatedAgentJob = vi.fn<CronServiceDeps["runIsolatedAgentJob"]>();
+    runIsolatedAgentJob.mockResolvedValue({ status: "ok" });
+    runIsolatedAgentJob.mockResolvedValueOnce(
+      scenario.firstStatus === "error"
+        ? { status: "error", error: "temporary timeout" }
+        : {
+            status: "ok",
+            ...(scenario.paced ? { nextCheck: { delayMs: PACED_DELAY } } : {}),
+          },
+    );
+    const createService = () =>
+      new CronService({
+        storePath: store.storePath,
+        cronEnabled: true,
+        log: logger,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        runIsolatedAgentJob,
+      });
+    const original = createService();
+    const restarted = createService();
+
+    try {
+      await original.start();
+      const job = await original.add({
+        enabled: true,
+        name: "paced reminder",
+        schedule:
+          scenario.scheduleKind === "cron"
+            ? { kind: "cron", expr: "* * * * *", tz: "UTC", staggerMs: 0 }
+            : { kind: "every", everyMs: MINUTE },
+        ...(scenario.paced ? { pacing: { min: "15m", max: "4h" } } : {}),
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message: "Check the reminder" },
+        delivery: { mode: "none" },
+      });
+      expect(job.state.nextRunAtMs).toBe(FIRST_RUN_AT);
+      vi.setSystemTime(FIRST_RUN_AT);
+      await expect(original.run(job.id, "due")).resolves.toMatchObject({ ok: true, ran: true });
+      if (scenario.forceStatus) {
+        vi.setSystemTime(FIRST_RUN_AT + 10 * MINUTE - 1_000);
+        runIsolatedAgentJob.mockResolvedValueOnce({
+          status: scenario.forceStatus,
+          ...(scenario.forceStatus === "error" ? { error: "temporary timeout" } : {}),
+        });
+        await expect(original.run(job.id, "force")).resolves.toMatchObject({ ok: true, ran: true });
+      }
+      original.stop();
+
+      const before = (await loadCronStore(store.storePath)).jobs[0];
+      const initialNextAfterMs = scenario.firstStatus
+        ? 30_000
+        : scenario.paced
+          ? PACED_DELAY
+          : MINUTE;
+      expect(before?.state.nextRunAtMs).toBe(FIRST_RUN_AT + initialNextAfterMs);
+      expect(before?.state.pacedNextRunAtMs).toBe(
+        scenario.paced ? FIRST_RUN_AT + PACED_DELAY : undefined,
+      );
+      const completedRuns = scenario.forceStatus ? 2 : 1;
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(completedRuns);
+
+      vi.setSystemTime(FIRST_RUN_AT + scenario.restartAfterMs);
+      await restarted.start();
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(completedRuns);
+      const after = (await loadCronStore(store.storePath)).jobs[0];
+      const expectedNextRunAtMs = FIRST_RUN_AT + scenario.expectedNextAfterMs;
+      expect(after?.state.nextRunAtMs).toBe(expectedNextRunAtMs);
+      expect(after?.state.lastRunAtMs).toBe(before?.state.lastRunAtMs);
+      expect(after?.state.pacedNextRunAtMs).toBe(
+        scenario.paced && scenario.restartAfterMs < PACED_DELAY
+          ? FIRST_RUN_AT + PACED_DELAY
+          : undefined,
+      );
+
+      vi.setSystemTime(expectedNextRunAtMs);
+      await expect(restarted.run(job.id, "due")).resolves.toMatchObject({ ok: true, ran: true });
+      expect(runIsolatedAgentJob).toHaveBeenCalledTimes(completedRuns + 1);
+    } finally {
+      original.stop();
+      restarted.stop();
+      await store.cleanup();
+    }
+  });
+});

--- a/src/cron/service/timer-runnable.ts
+++ b/src/cron/service/timer-runnable.ts
@@ -19,8 +19,16 @@ import { isScheduledTerminalOneShotRetry } from "./timer-trigger.js";
  */
 export function hasMissedCronSlotSinceLastRun(job: CronJob, nowMs: number): boolean {
   const lastRunAtMs = job.state.lastRunAtMs;
-  // Only replay a "missed slot" when there is concrete run history.
-  if (typeof lastRunAtMs !== "number" || !Number.isFinite(lastRunAtMs)) {
+  const nextRunAtMs = job.state.nextRunAtMs;
+  // Pacing supersedes intervening natural slots. Both startup admission and
+  // backoff repair must retain that occurrence instead of inventing a miss.
+  if (
+    typeof lastRunAtMs !== "number" ||
+    !Number.isFinite(lastRunAtMs) ||
+    (hasScheduledNextRunAtMs(nextRunAtMs) &&
+      job.state.pacedNextRunAtMs === nextRunAtMs &&
+      nowMs < nextRunAtMs)
+  ) {
     return false;
   }
   let previousRunAtMs: number | undefined;


### PR DESCRIPTION
Closes #140080

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

A Gateway restart can treat cron-expression slots deliberately superseded by pacing as missed work, replacing the automation's accepted future next check. In the paired real Gateway/browser proof, the baseline executed the script again **49.591 seconds before its saved deadline**. The candidate retained that exact deadline through restart and ran naturally **8 milliseconds after it**.

## Why This Change Was Made

The shared missed-slot decision now recognizes the job's exact, valid future paced occurrence before either startup selection or the earlier startup backoff-repair path can replace it. This adds eight production lines in the existing owner: separate caller guards would duplicate the rule, while clamping an already rewritten timestamp would leave the incorrect missed-run classification in place.

## User Impact

Operators using dynamic cadence retain the next-check deadline their automation already accepted when the Gateway restarts. Genuinely overdue and unpaced jobs still catch up, and existing error backoff, schedule edits, and startup deferrals retain their behavior. No new setting, schema change, or migration is required; the pacing docs now state the restart guarantee explicitly.

## Evidence

Tested candidate: `f7b764fbca16af898f5f68013ad9e0141d52f3e6`, based on `9c0cf2b6a56f0da6c5c23928eb63f8223f980449`.

The paired live proof used real isolated Gateways, the supported CLI, and the actual `/automations` History tab. A naturally scheduled script incremented its persisted counter and returned `nextCheck: "60s"`, with an exact five-second cron expression and existing pacing bounds fixed at 60 seconds. After its first completion, a natural cron slot passed, then the Gateway restarted gracefully against the same state. No force run, fake clock, injected runner, direct database access, or model/provider call was used.

| Real run on 2026-09-06 (UTC) | Original saved deadline | Second natural run | Result |
| --- | --- | --- | --- |
| Baseline 9c | 11:21:10.221 | 11:20:20.630 | 49.591 seconds early during restart |
| Candidate f7 | 11:24:20.157 | 11:24:20.165 | 8 milliseconds after the preserved deadline |

All **32 post-restart observations before the candidate deadline** retained counter 1, the exact original deadline, one successful history entry, and no running marker. The last observation completed 292 milliseconds before the deadline. The candidate then reached counter 2 and two successful history entries. Each side passed on its first invocation. Exact timing comes from public CLI JSON; screenshots and videos show the corresponding History entries, whose UI time labels are less precise.

![Before: restart executes again while the original deadline is still in the future](https://github.com/user-attachments/assets/ffe6f65c-a42b-42ca-becc-6495386f79ec)

The candidate captures and both original-speed recordings are attached below.

All stills and video contact frames were inspected. Both Gateway generations on each side exited gracefully, the jobs were removed through the CLI, and independent cleanup checks found no owned process/listener/runtime-directory survivors. Source, dependency locks, build identities, artifact hashes, and symlink targets matched their seals before and after. Permission modes were not part of the seal inventory and are not claimed verified. The publication media is cropped to synthetic job content; private sidebar content is excluded.

Focused service/store proof also covers agent-turn restart deferral and force-run backoff: before the edit, three persisted-deadline assertions failed while six controls passed; after the fix, 76 tests passed across six owner/sibling suites. The final nine-case fixture passed again after making its required `enabled: true` field explicit. The complete changed-check gate passed after that fixture type correction, and the docs sentence passed page MDX, format, and diff checks. A fresh independent P0–P2 review returned scoped-clean. Supported `ciArtifacts` runtime/UI builds passed on both tested heads with matching source and installed dependency locks.

Focused regression command:

```sh
node scripts/run-vitest.mjs src/cron/service.restart-catchup-pacing.test.ts
```

Diff: production **+8**, tests **+181**, docs **net 0** across three files.

Source-only comparison against main `1421c216407515ad29061f67e99c50c68f57f1f3` found unchanged missed-slot, startup/backoff, and pacing owners. The candidate's production/test changes have no overlap; the new main docs paragraph is separate from its pacing sentence. Nearby manual-delivery, on-exit, agent-turn identity, and unawaited-Promise diagnostics changes do not alter the natural plain-JSON script route above. The tested head is retained; this is source-composition evidence for the advancing main branch.

[GitHub CI 34031876778](https://github.com/openclaw/openclaw/actions/runs/34031876778) completed successfully on the exact final published head `f7b764fbca16af898f5f68013ad9e0141d52f3e6`. Latest ClawSweeper review at 12:05 UTC has no findings or before-merge actions. A further source comparison against main `3c9b8602b79b2ae2f3c9a76ac7dfb9579ea8eefc` leaves the inspected cron owners and dependency lock unchanged; only unrelated package export metadata differs.

No introducing commit or last-known-good release has been established. The proven unpatched source is the baseline above; no release-publication or regression-attribution claim is made.

![candidate-preserved-after-restart](https://github.com/user-attachments/assets/337c8f83-5b01-4e57-8d6c-9408d7d34052)

![candidate-second-at-deadline](https://github.com/user-attachments/assets/3111909b-7f04-4210-ac60-cc97a10c4082)

https://github.com/user-attachments/assets/5249cd59-b06d-4242-aa10-77b079526a4b

https://github.com/user-attachments/assets/a0ca3354-0257-4325-87e9-d9c1420b14fa
