### PR TITLE
fix(models): defer downloaded catalog changes until restart

### DIFF
--- a/src/gateway/server-kernel.ts
+++ b/src/gateway/server-kernel.ts
@@ -3,6 +3,7 @@ import { isNixMode } from "../config/paths.js";
 import { clearGatewayAgentCliShim } from "../infra/openclaw-cli-shim.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
 import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js";
+import { captureRemoteModelCatalogStartupSnapshot } from "../model-catalog/remote-overlay.js";
 import { retainGatewayPluginMetadata } from "../plugins/plugin-metadata-lifecycle.js";
 import { clearSecretsRuntimeSnapshotState } from "../secrets/runtime-state.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
@@ -136,6 +137,8 @@ export async function createGatewayKernel(
     throw new Error("Gateway boot ID must contain 1 to 96 characters");
   }
   const bootId = suppliedBootId ?? randomUUID();
+  // Capture before bootstrap yields or creates workers; concurrent downloads need a restart.
+  captureRemoteModelCatalogStartupSnapshot();
   ensureOpenClawCliOnPath();
   const releasePluginMetadata = retainGatewayPluginMetadata();
   let lifecycleRuntime: Awaited<ReturnType<typeof prepareGatewayLifecycle>> | undefined;

--- a/src/gateway/server.catalog-startup.test.ts
+++ b/src/gateway/server.catalog-startup.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  getRemoteModelCatalogPricing,
+  getRemoteModelCatalogProviderOverlay,
+} from "../model-catalog/remote-overlay.js";
+import { setRemoteModelCatalogOverlaySourcesForTest } from "../model-catalog/remote-overlay.test-support.js";
+import { startGatewayServerCore } from "./server-start.js";
+import * as bootstrap from "./server-startup-bootstrap.js";
+
+describe("Gateway startup catalog", () => {
+  it.each([false, true])("captures metadata before bootstrap awaits, absent=%s", async (absent) => {
+    const bundle = {
+      schemaVersion: 1,
+      generatedAt: 200,
+      sourceCommit: "fixture",
+      providers: { anthropic: { models: [{ id: "startup-model" }] } },
+      pricing: { "anthropic/startup-model": { input: 1, output: 2 } },
+    };
+    const stored = {
+      id: 1,
+      bundle_json: JSON.stringify(bundle),
+      generated_at: 200,
+      min_version: null,
+      source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      etag: null,
+      last_modified: null,
+      checked_at: 200,
+    };
+    const read = vi.fn(() => (absent ? undefined : stored));
+    setRemoteModelCatalogOverlaySourcesForTest({
+      bundledGeneratedAt: () => 100,
+      readStoredCatalog: read,
+    });
+    const pending = createDeferred<never>();
+    const stopped = new Error("fixture stops bootstrap");
+    const prepare = vi
+      .spyOn(bootstrap, "prepareGatewayServerBootstrap")
+      .mockImplementationOnce(() => {
+        return pending.promise;
+      });
+    const startup = startGatewayServerCore(0).catch((error: unknown) => error);
+    try {
+      read.mockReturnValue({
+        ...stored,
+        bundle_json: JSON.stringify({
+          ...bundle,
+          providers: { anthropic: { models: [{ id: "downloaded-model" }] } },
+          pricing: { "anthropic/startup-model": { input: 3, output: 4 } },
+        }),
+      });
+      expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toEqual(
+        absent ? undefined : bundle.providers.anthropic,
+      );
+      expect(getRemoteModelCatalogPricing({})).toEqual(absent ? undefined : bundle.pricing);
+    } finally {
+      pending.reject(stopped);
+      const outcome = await startup;
+      prepare.mockRestore();
+      setRemoteModelCatalogOverlaySourcesForTest();
+      expect(outcome).toBe(stopped);
+    }
+  });
+});

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -1511,7 +1511,7 @@ export function createGatewayUpdateCheck(params: {
           if (result.status === "error") {
             params.log.info("remote model catalog refresh failed", { error: result.error });
           } else if (result.status === "updated") {
-            params.log.info("remote model catalog updated; restart the Gateway to apply it", {
+            params.log.info("remote model catalog downloaded; restart the Gateway to apply it", {
               providers: result.providers,
               models: result.models,
               generatedAt: result.generatedAt,

--- a/src/model-catalog/remote-overlay.test.ts
+++ b/src/model-catalog/remote-overlay.test.ts
@@ -1,3 +1,4 @@
+import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getRemoteModelCatalogPricing,
@@ -46,6 +47,57 @@ describe("remote model catalog overlay", () => {
     expect(mocks.read).toHaveBeenCalledOnce();
   });
 
+  it("keeps startup rows and prices when the configured source changes", () => {
+    const overlay = getRemoteModelCatalogProviderOverlay({}, "anthropic");
+    const pricing = getRemoteModelCatalogPricing({});
+    mocks.read.mockReturnValue({
+      bundle_json: JSON.stringify({
+        ...bundle,
+        generatedAt: 300,
+        providers: { anthropic: { models: [{ id: "downloaded" }] } },
+        pricing: { "openai/gpt-external": { input: 5, output: 20 } },
+      }),
+      source_url: "https://mirror.example.test/catalog.json",
+    });
+    expect(
+      getRemoteModelCatalogProviderOverlay(
+        { models: { catalogRefresh: { url: "https://mirror.example.test/catalog.json" } } },
+        "anthropic",
+      ),
+    ).toBeUndefined();
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toEqual(overlay);
+    expect(getRemoteModelCatalogPricing({})).toEqual(pricing);
+  });
+
+  it("keeps invalid startup metadata absent after a successful download", () => {
+    const valid = mocks.read();
+    mocks.read.mockReturnValue({ ...valid, bundle_json: "{" });
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBeUndefined();
+    mocks.read.mockReturnValue(valid);
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBeUndefined();
+    expect(getRemoteModelCatalogPricing({})).toBeUndefined();
+  });
+
+  it("passes the same startup rows and prices to later workers", async () => {
+    const expected = {
+      overlay: getRemoteModelCatalogProviderOverlay({}, "anthropic"),
+      pricing: getRemoteModelCatalogPricing({}),
+    };
+    mocks.read.mockReturnValue(undefined);
+    const worker = new Worker(new URL("./remote-overlay.worker.test-support.ts", import.meta.url), {
+      execArgv: ["--import", "tsx"],
+    });
+    try {
+      const actual = await new Promise((resolve, reject) => {
+        worker.once("message", resolve);
+        worker.once("error", reject);
+      });
+      expect(actual).toEqual(expected);
+    } finally {
+      await worker.terminate();
+    }
+  });
+
   it("fails closed when disabled, stale, or missing a build stamp", () => {
     expect(
       getRemoteModelCatalogProviderOverlay(
@@ -80,6 +132,6 @@ describe("remote model catalog overlay", () => {
         "anthropic",
       ),
     ).toBeUndefined();
-    expect(mocks.read).toHaveBeenCalledTimes(2);
+    expect(mocks.read).toHaveBeenCalledOnce();
   });
 });

--- a/src/model-catalog/remote-overlay.ts
+++ b/src/model-catalog/remote-overlay.ts
@@ -57,17 +57,16 @@ function readStartupSnapshot(): ActiveRemoteModelCatalog | null {
 }
 
 export function captureRemoteModelCatalogStartupSnapshot(): ActiveRemoteModelCatalog | null {
-  // SAFETY: This module alone sets the key to a validated startup snapshot or null.
+  // SAFETY: This module alone sets the key to a record containing a validated snapshot or null.
   const inherited = getEnvironmentData(STARTUP_SNAPSHOT_KEY) as
-    | ActiveRemoteModelCatalog
-    | null
+    | { catalog: ActiveRemoteModelCatalog | null }
     | undefined;
   if (inherited !== undefined) {
-    return inherited;
+    return inherited.catalog;
   }
   // New workers inherit the startup pair, including absence, rather than later downloads.
   const snapshot = readStartupSnapshot();
-  setEnvironmentData(STARTUP_SNAPSHOT_KEY, snapshot);
+  setEnvironmentData(STARTUP_SNAPSHOT_KEY, { catalog: snapshot });
   return snapshot;
 }
 

--- a/src/model-catalog/remote-overlay.ts
+++ b/src/model-catalog/remote-overlay.ts
@@ -1,3 +1,4 @@
+import { getEnvironmentData, setEnvironmentData } from "node:worker_threads";
 import {
   validateAndSanitizeRemoteModelCatalogBundle,
   type RemoteModelCatalogBundle,
@@ -14,11 +15,12 @@ import { readRemoteModelCatalog } from "./remote-store.js";
 
 type RemoteModelCatalogOverlay = Readonly<Record<string, ModelCatalogProvider>>;
 type ActiveRemoteModelCatalog = {
+  sourceUrl: string;
   providers: RemoteModelCatalogOverlay;
   pricing?: Readonly<Record<string, RemoteModelCatalogPricing>>;
 };
 
-let cachedOverlay: { sourceUrl: string; value: ActiveRemoteModelCatalog | null } | undefined;
+const STARTUP_SNAPSHOT_KEY = "openclaw.remoteModelCatalogStartupSnapshot";
 let readBundledGeneratedAt = bundledCatalogGeneratedAt;
 let readStoredCatalog = readRemoteModelCatalog;
 
@@ -30,40 +32,51 @@ function isCompatible(bundle: RemoteModelCatalogBundle): boolean {
   return comparison !== null && comparison >= 0;
 }
 
+function readStartupSnapshot(): ActiveRemoteModelCatalog | null {
+  try {
+    const bundledGeneratedAt = readBundledGeneratedAt();
+    if (bundledGeneratedAt === undefined) {
+      return null;
+    }
+    const stored = readStoredCatalog();
+    if (!stored) {
+      return null;
+    }
+    const bundle = validateAndSanitizeRemoteModelCatalogBundle(JSON.parse(stored.bundle_json));
+    if (bundle.generatedAt <= bundledGeneratedAt || !isCompatible(bundle)) {
+      return null;
+    }
+    return {
+      sourceUrl: stored.source_url,
+      providers: bundle.providers,
+      ...(bundle.pricing ? { pricing: bundle.pricing } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function captureRemoteModelCatalogStartupSnapshot(): ActiveRemoteModelCatalog | null {
+  // SAFETY: This module alone sets the key to a validated startup snapshot or null.
+  const inherited = getEnvironmentData(STARTUP_SNAPSHOT_KEY) as
+    | ActiveRemoteModelCatalog
+    | null
+    | undefined;
+  if (inherited !== undefined) {
+    return inherited;
+  }
+  // New workers inherit the startup pair, including absence, rather than later downloads.
+  const snapshot = readStartupSnapshot();
+  setEnvironmentData(STARTUP_SNAPSHOT_KEY, snapshot);
+  return snapshot;
+}
+
 function getActiveRemoteModelCatalog(config: OpenClawConfig): ActiveRemoteModelCatalog | undefined {
   if (!isRemoteModelCatalogRefreshEnabled(config)) {
     return undefined;
   }
-  try {
-    const sourceUrl = resolveRemoteCatalogUrl(config);
-    if (cachedOverlay?.sourceUrl === sourceUrl) {
-      return cachedOverlay.value ?? undefined;
-    }
-    const bundledGeneratedAt = readBundledGeneratedAt();
-    if (bundledGeneratedAt === undefined) {
-      cachedOverlay = { sourceUrl, value: null };
-      return undefined;
-    }
-    const stored = readStoredCatalog();
-    if (!stored || stored.source_url !== sourceUrl) {
-      cachedOverlay = { sourceUrl, value: null };
-      return undefined;
-    }
-    const bundle = validateAndSanitizeRemoteModelCatalogBundle(JSON.parse(stored.bundle_json));
-    if (bundle.generatedAt <= bundledGeneratedAt || !isCompatible(bundle)) {
-      cachedOverlay = { sourceUrl, value: null };
-      return undefined;
-    }
-    const value = {
-      providers: bundle.providers,
-      ...(bundle.pricing ? { pricing: bundle.pricing } : {}),
-    };
-    cachedOverlay = { sourceUrl, value };
-    return value;
-  } catch {
-    cachedOverlay = undefined;
-    return undefined;
-  }
+  const snapshot = captureRemoteModelCatalogStartupSnapshot();
+  return snapshot?.sourceUrl === resolveRemoteCatalogUrl(config) ? snapshot : undefined;
 }
 
 export function getRemoteModelCatalogProviderOverlay(
@@ -84,7 +97,7 @@ function setRemoteModelCatalogOverlaySourcesForTest(sources?: {
   bundledGeneratedAt?: typeof bundledCatalogGeneratedAt;
   readStoredCatalog?: typeof readRemoteModelCatalog;
 }): void {
-  cachedOverlay = undefined;
+  setEnvironmentData(STARTUP_SNAPSHOT_KEY, undefined);
   readBundledGeneratedAt = sources?.bundledGeneratedAt ?? bundledCatalogGeneratedAt;
   readStoredCatalog = sources?.readStoredCatalog ?? readRemoteModelCatalog;
 }

--- a/src/model-catalog/remote-overlay.worker.test-support.ts
+++ b/src/model-catalog/remote-overlay.worker.test-support.ts
@@ -1,0 +1,13 @@
+import { parentPort } from "node:worker_threads";
+import {
+  getRemoteModelCatalogPricing,
+  getRemoteModelCatalogProviderOverlay,
+} from "./remote-overlay.js";
+
+parentPort!.postMessage(
+  {
+    overlay: getRemoteModelCatalogProviderOverlay({}, "anthropic"),
+    pricing: getRemoteModelCatalogPricing({}),
+  },
+  [],
+);


### PR DESCRIPTION
## What Problem This Solves

After downloading a hosted catalog, config reload could expose new model rows while fresh requests still used old prices. Startup without a catalog had the same mismatch.

## Why This Change Was Made

Capture one rows/pricing snapshot, including absence, at Gateway startup and retain it across later catalog-process replacements. Current enablement and source checks still determine eligibility; download notices no longer imply activation.

## User Impact

Rows and price estimates become active together after a full restart. Downloads and config/plugin replacement retain the startup pair. Failed reloads can still interrupt availability.

## Evidence

Built Gateway model lists, new agent requests, usage, and real CLI reload reproduced the split on main and a published release. Candidate checks retained the original pair through actual process replacement and activated the new pair only after restart. Controls covered startup absence, source changes, disabled refresh, bad downloads, and failed reload recovery. All 285 focused tests passed. Prices used fixed synthetic usage, not actual charges.

Related: #136257.
