### PR TITLE
fix(codex): validate file URL pathname encoding

### DIFF
--- a/extensions/codex/src/conversation-turn-input.ts
+++ b/extensions/codex/src/conversation-turn-input.ts
@@ -79,7 +79,10 @@ function normalizeFileUrl(value: string): string | undefined {
     return value;
   }
   try {
-    return fileURLToPath(value);
+    const fileUrl = new URL(value);
+    // Validate encoding explicitly because fileURLToPath validation differs by runtime.
+    decodeURIComponent(fileUrl.pathname);
+    return fileURLToPath(fileUrl);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## What Problem This Solves

Makes file-URL pathname encoding validation consistent before Codex conversation input is converted to a local image path, where runtime conversion behavior differs.

## Why This Change Was Made

Parse the recognized file URL and validate its pathname encoding explicitly. Discard the validation result and retain canonical fileURLToPath conversion of the original URL object, inside the existing catch-to-undefined behavior.

## User Impact

Valid image paths keep their existing representation. Invalid encoding can follow the existing rejected-input path without adding file access, changing path normalization, or altering the Codex input protocol.

## Evidence

- Local Node/Bun proof selected 18 unchanged benign valid-input cases per runtime; all passed.
- This is a source-reviewed defensive repair based on retained failure evidence. The 12 negative cases were not rerun locally; no local malformed-input probes, new tests, or file-access probes were performed. Required hosted CI is recorded separately and may cover different Node cases.
- Complete changed-file gate, full build, and fresh P0–P2 review pass.
- The caller and sibling local-image input contract were inspected. No dependency or configuration change is introduced, and complete URL-parsing parity is not claimed.
