### PR TITLE
fix(ci): avoid false macOS catalog timeout failures

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -1330,31 +1330,63 @@ extension MacNodeCodexThreadCatalogTests {
         await client.shutdown()
     }
 
-    @Test func `timeout restarts the client without dropping the next request`() async throws {
-        let fake = try makeBlockedRequestServer(warmup: true)
+    @Test func `timeout recovers with a best-effort concurrent successor`() async throws {
+        let fake = try makeBlockedRequestServer(warmup: true, requestGate: true)
+        defer { withExtendedLifetime(fake) {} }
         let client = CodexAppServerThreadClient(idleTimeoutSeconds: 10)
-        // Complete the real handshake before exercising an active or queued deadline.
-        _ = try await self.requestEmptyList(client: client, executable: fake.executable)
+        do {
+            _ = try await self.requestEmptyList(client: client, executable: fake.executable)
+        } catch {
+            await client.shutdown()
+            throw error
+        }
 
+        let readiness = Task {
+            try await self.openFIFOForWriting(
+                URL(fileURLWithPath: fake.executable.path + ".request-gate"))
+        }
         let first = Task {
-            try await self.requestEmptyList(
+            defer { readiness.cancel() }
+            return try await self.requestEmptyList(
                 client: client,
                 executable: fake.executable,
                 timeoutSeconds: 0.5)
         }
-        #expect(await self.waitForFile(
-            URL(fileURLWithPath: fake.executable.path + ".request-started")))
-        let second = Task {
-            try await self.requestEmptyList(client: client, executable: fake.executable)
-        }
+        var requestGate: FileHandle?
+        defer { try? requestGate?.close() }
+        var second: Task<Data, Error>?
+        do {
+            do {
+                requestGate = try await readiness.value
+                // Peer receipt permits overlap; Task creation does not prove queue admission.
+                second = Task {
+                    try await self.requestEmptyList(client: client, executable: fake.executable)
+                }
+            } catch is CancellationError {
+                // The first deadline may precede receipt; require its typed timeout below.
+            }
 
-        await #expect(throws: MacNodeCodexThreadCatalog.CatalogError.timedOut) {
-            try await first.value
+            await #expect(throws: MacNodeCodexThreadCatalog.CatalogError.timedOut) {
+                try await first.value
+            }
+            let result: Data = if let second {
+                try await second.value
+            } else {
+                try await self.requestEmptyList(client: client, executable: fake.executable)
+            }
+            #expect(try (JSONSerialization.jsonObject(with: result) as? [String: Any])?["data"] != nil)
+            #expect(try self.readTrimmed(
+                URL(fileURLWithPath: fake.executable.path + ".processes")) == "2")
+        } catch {
+            readiness.cancel()
+            first.cancel()
+            second?.cancel()
+            _ = await first.result
+            _ = await readiness.result
+            _ = await second?.result
+            await client.shutdown()
+            throw error
         }
-        let result = try await second.value
-        #expect(try (JSONSerialization.jsonObject(with: result) as? [String: Any])?["data"] != nil)
-        #expect(try self.readTrimmed(
-            URL(fileURLWithPath: fake.executable.path + ".processes")) == "2")
         await client.shutdown()
     }
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where macOS CI reports a catalog timeout test failure even though the request times out correctly and the next request succeeds on a fresh connection. The test independently required the fake peer to record receipt within two seconds, although the request itself had a half-second deadline.

## Why This Change Was Made

Use the fake server’s existing FIFO readiness signal within the first request’s lifetime. If the peer is ready, start the successor while the first request is outstanding. If the first request finishes before readiness, require its typed timeout result before continuing. Keep the original request deadlines, successful successor response, two-process assertion and joined cleanup.

Task creation never proved that the successor had entered the private pending queue before timeout. The test preserves best-effort concurrent recovery coverage and names that limit explicitly. The existing queued-deadline test retains its gated receipt, queued timeout and no-unexpected-frame assertions unchanged. No production hook, timeout increase or scheduling override is introduced.

## User Impact

No application behavior changes. This repairs CI orchestration while retaining the timeout and connection-recovery contract.

## Evidence

The unchanged test failed only its peer-receipt assertion in [CI 34028802408](https://github.com/openclaw/openclaw/actions/runs/34028802408/job/101474528642), repeating an earlier failure in [CI 34009813126](https://github.com/openclaw/openclaw/actions/runs/34009813126). Its typed timeout, successor response and two-process checks reported no additional failure. The exact historical scheduling interval remains unknown.

Source inspection confirms the client starts its deadline at queue admission, before asynchronous peer receipt. Codex’s initialize/initialized and JSONL transport contracts provide no peer-receipt deadline. This remains a synthetic shell-peer test, not a live Codex test.

SwiftFormat, parsing, complete-file Swift 6 typechecking with the real application modules and test helpers, and all 12 canonical changed-check stages pass. One independent P2 review is clean. The change is test-only: +48/−16 lines, with all later sibling cases byte-identical. The prior optional strict lint run against this test file reported six pre-existing diagnostics outside the configured production lint scope; those receipts are retained, not described as green.

[Exact CI 34032521153](https://github.com/openclaw/openclaw/actions/runs/34032521153) passed on head `c00c9045acdbd0ccf2fee83005cba6301036bbfc` through tested merge `2cbb2cc37f094eef420f17a1a8763d24d4439e78` (parents 7e6fd5d1 + c00c9045). The repaired timeout case, queued-deadline sibling and cancellation/restart sibling all passed in the native log. Test and unchanged client blobs match the reviewed source. Eight CI jobs executed and passed; 26 were skipped.

Independent OpenClawKit 1661/124 and app 2066/225 test/suite summaries passed, plus separate AppState 2 and health-render 1 launches. The default run still skips native execution after caller response loss and embedded-runtime socket handshake; those remain unexecuted. These counts are not summed as unique tests. No native test executable or application was run against the operator desktop.
