### PR TITLE
test(plugins): make native fixture outcomes portable

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -422,7 +422,7 @@ describe("codex doctor contract", () => {
         }),
       ),
     ).resolves.toMatchObject({ state: "active", binding: { threadId: "thread-1" } });
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${fixture.sidecarPath}.migrated`);
     expect(
       getSessionEntry({
         agentId: "main",
@@ -635,7 +635,7 @@ describe("codex doctor contract", () => {
     expect(JSON.stringify(stored)).not.toContain("user-mcp-marker");
     expect(JSON.stringify(stored)).not.toContain("legacy-secret");
     await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${fixture.sidecarPath}.migrated`);
     await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
       changes: [],
       warnings: [],
@@ -713,7 +713,7 @@ describe("codex doctor contract", () => {
       binding: { dynamicToolsFingerprint: expectedFingerprint },
     });
     await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${fixture.sidecarPath}.migrated`);
     await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
       changes: [],
       warnings: [],
@@ -785,7 +785,7 @@ describe("codex doctor contract", () => {
       binding: { dynamicToolsFingerprint: expectedFingerprint },
     });
     await expect(fs.access(fixture.sidecarPath)).rejects.toThrow();
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${fixture.sidecarPath}.migrated`);
     await expect(fixture.migration.migrateLegacyState(fixture.params)).resolves.toEqual({
       changes: [],
       warnings: [],
@@ -1116,7 +1116,7 @@ describe("codex doctor contract", () => {
     expect(result.warnings).toEqual([
       expect.stringContaining(`canonical plugin state changed at ${sessionBindingKey}`),
     ]);
-    await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
+    await fs.access(fixture.sidecarPath);
     await expect(store.lookup(sessionBindingKey)).resolves.toEqual(retired);
     await expect(
       fs.readFile(path.join(fixture.sessionsDir, "sessions.json"), "utf8").then(JSON.parse),
@@ -1307,7 +1307,7 @@ describe("codex doctor contract", () => {
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("session index");
     expect(result.warnings[0]).toContain(detail);
-    await expect(fs.access(fixture.sidecarPath)).resolves.toBeUndefined();
+    await fs.access(fixture.sidecarPath);
     await expect(fs.access(`${fixture.sidecarPath}.migrated`)).rejects.toThrow();
     await expect(openBindingStore(fixture.env).entries()).resolves.toEqual([]);
 

--- a/extensions/codex/src/migration/provider.test.ts
+++ b/extensions/codex/src/migration/provider.test.ts
@@ -2138,19 +2138,13 @@ describe("buildCodexMigrationProvider", () => {
       }),
     );
 
-    await expect(
-      fs.access(path.join(fixture.workspaceDir, "skills", "tweet-helper", "SKILL.md")),
-    ).resolves.toBeUndefined();
-    await expect(
-      fs.access(path.join(fixture.workspaceDir, "skills", "personal-style", "SKILL.md")),
-    ).resolves.toBeUndefined();
-    await expect(
-      fs.access(path.join(reportDir, "archive", "config.toml")),
-    ).resolves.toBeUndefined();
+    await fs.access(path.join(fixture.workspaceDir, "skills", "tweet-helper", "SKILL.md"));
+    await fs.access(path.join(fixture.workspaceDir, "skills", "personal-style", "SKILL.md"));
+    await fs.access(path.join(reportDir, "archive", "config.toml"));
     expectRecordFields(findItem(result.items, "plugin:documents:1"), { status: "skipped" });
     expectRecordFields(findItem(result.items, "skill:tweet-helper"), { status: "migrated" });
     expectRecordFields(findItem(result.items, "archive:config.toml"), { status: "migrated" });
-    await expect(fs.access(path.join(reportDir, "report.json"))).resolves.toBeUndefined();
+    await fs.access(path.join(reportDir, "report.json"));
   });
 
   it("installs selected curated plugins during apply and writes codexPlugins config", async () => {

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -586,7 +586,7 @@ describe("memory-core doctor dreaming migration", () => {
       .entries();
     expect(cursors).toHaveLength(1);
     expect(cursors[0]?.value).toEqual({ kind: "cursor", lastSequence: 1 });
-    await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${eventPath}.migrated`);
   });
 
   it("keeps identical events recreated by an older writer as a new archive generation", async () => {
@@ -611,8 +611,8 @@ describe("memory-core doctor dreaming migration", () => {
       expect.stringContaining("events.jsonl.migrated.2"),
     ]);
     await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toHaveLength(2);
-    await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${eventPath}.migrated.2`)).resolves.toBeUndefined();
+    await fs.access(`${eventPath}.migrated`);
+    await fs.access(`${eventPath}.migrated.2`);
   });
 
   it("recovers appends written through an open legacy descriptor after archival", async () => {
@@ -789,7 +789,7 @@ describe("memory-core doctor dreaming migration", () => {
       expect.stringContaining("invalid rows still require repair"),
     ]);
     await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toEqual([]);
-    await expect(fs.access(eventPath)).resolves.toBeUndefined();
+    await fs.access(eventPath);
     await expect(fs.access(`${eventPath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -815,7 +815,7 @@ describe("memory-core doctor dreaming migration", () => {
       expect.stringContaining("invalid rows still require repair"),
     ]);
     await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toEqual([]);
-    await expect(fs.access(eventPath)).resolves.toBeUndefined();
+    await fs.access(eventPath);
 
     await fs.writeFile(
       archivedPath,
@@ -870,7 +870,7 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(readMemoryHostEventRecords({ workspaceDir, env })).resolves.toMatchObject([
       { query: "stable after repair" },
     ]);
-    await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${eventPath}.migrated`);
   });
 
   it("preserves legacy host event append order when timestamps move backward", async () => {
@@ -945,7 +945,7 @@ describe("memory-core doctor dreaming migration", () => {
       await expect(
         readMemoryHostEventRecords({ workspaceDir: workspaceAlias, env }),
       ).resolves.toMatchObject([{ query: "canonical alias" }]);
-      await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
+      await fs.access(`${eventPath}.migrated`);
     },
   );
 
@@ -1050,8 +1050,8 @@ describe("memory-core doctor dreaming migration", () => {
     expect(afterRepeated).toHaveLength(10_000);
     expect(afterRepeated[0]).toMatchObject({ query: "oversized-3" });
     expect(afterRepeated.at(-1)).toMatchObject({ query: "newer recreated generation" });
-    await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${eventPath}.migrated.2`)).resolves.toBeUndefined();
+    await fs.access(`${eventPath}.migrated`);
+    await fs.access(`${eventPath}.migrated.2`);
   });
 
   it("resumes a partially committed host event import before archiving the source", async () => {
@@ -1100,7 +1100,7 @@ describe("memory-core doctor dreaming migration", () => {
     const recovered = await readMemoryHostEventRecords({ workspaceDir, env });
     expect(recovered).toHaveLength(events.length);
     expect(recovered).toMatchObject(events);
-    await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${eventPath}.migrated`);
     await expect(hostEventsMigration().migrateLegacyState(migrationParams())).resolves.toEqual({
       changes: [],
       warnings: [],
@@ -1131,7 +1131,7 @@ describe("memory-core doctor dreaming migration", () => {
 
     expect(result.changes).toEqual([]);
     expect(result.warnings).toEqual([expect.stringContaining("no room for its workspace cursor")]);
-    await expect(fs.access(eventPath)).resolves.toBeUndefined();
+    await fs.access(eventPath);
     await expect(fs.access(`${eventPath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
@@ -1193,7 +1193,7 @@ describe("memory-core doctor dreaming migration", () => {
       .openPluginStateKeyedStore({ namespace: "memory-host.events", maxEntries: 10_000 })
       .entries();
     expect(entries).toEqual([]);
-    await expect(fs.access(`${eventPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${eventPath}.migrated`);
   });
 
   it("migrates and recovers persistent legacy dreaming state", async () => {
@@ -1304,11 +1304,11 @@ describe("memory-core doctor dreaming migration", () => {
     ]);
 
     configureMemoryCoreDreamingState(context().openPluginStateKeyedStore);
-    await expect(fs.access(`${dailyPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${sessionPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${recallPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${phasePath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(lockPath)).resolves.toBeUndefined();
+    await fs.access(`${dailyPath}.migrated`);
+    await fs.access(`${sessionPath}.migrated`);
+    await fs.access(`${recallPath}.migrated`);
+    await fs.access(`${phasePath}.migrated`);
+    await fs.access(lockPath);
 
     const daily = await dreamingTesting.readDailyIngestionState(workspaceDir);
     expect(daily.files["memory/2026-04-05.md"]?.mtimeMs).toBe(1);
@@ -1432,7 +1432,7 @@ describe("memory-core doctor dreaming migration", () => {
     expect(result.warnings).toEqual([
       expect.stringContaining("Skipped Memory Core short-term recall import"),
     ]);
-    await expect(fs.access(recallPath)).resolves.toBeUndefined();
+    await fs.access(recallPath);
     await expect(fs.access(`${recallPath}.migrated`)).rejects.toThrow();
     configureMemoryCoreDreamingState(context().openPluginStateKeyedStore);
     const recall = await shortTermTesting.readRecallStore(workspaceDir, new Date().toISOString());
@@ -1507,7 +1507,7 @@ describe("memory-core doctor dreaming migration", () => {
       chunks: [{ id: "chunk-1", text: "remember this" }],
       cache: [{ provider: "openai", hash: "chunk-hash" }],
     });
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("removes an empty legacy memory sidecar placeholder without warning", async () => {
@@ -1614,7 +1614,7 @@ describe("memory-core doctor dreaming migration", () => {
     // WAL companion's state is unknown (ELOOP).  No removal change and no
     // crash — the migration should skip the empty-sidecar cleanup path.
     expect(result.changes).toEqual([]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
   });
 
   it("preserves the main sidecar when a companion stat fails with EACCES", async () => {
@@ -1642,7 +1642,7 @@ describe("memory-core doctor dreaming migration", () => {
 
       // Fail-closed: the migration must NOT remove the main file.
       expect(result.changes).toEqual([]);
-      await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+      await fs.access(legacyPath);
     } finally {
       vi.restoreAllMocks();
     }
@@ -1665,7 +1665,7 @@ describe("memory-core doctor dreaming migration", () => {
     expect(result.warnings).toEqual([
       "Skipped Memory Core legacy memory index import for agent main because the sidecar schema is not a legacy memory index",
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
   });
 
   it("creates migrated FTS tables with the configured legacy tokenizer", async () => {
@@ -1692,7 +1692,7 @@ describe("memory-core doctor dreaming migration", () => {
 
     expect(result.warnings).toEqual([]);
     expect(readMemoryFtsSql(agentPath)).toContain("tokenize='trigram case_sensitive 0'");
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("migrates retired configured legacy memory sidecar paths", async () => {
@@ -1733,7 +1733,7 @@ describe("memory-core doctor dreaming migration", () => {
       chunks: [{ id: "chunk-1", text: "remember this" }],
       cache: [{ provider: "openai", hash: "chunk-hash" }],
     });
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("migrates all retired configured legacy memory sidecar paths", async () => {
@@ -1796,8 +1796,8 @@ describe("memory-core doctor dreaming migration", () => {
         .chunks.map((chunk) => String(chunk.id))
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(["chunk-defaults", "chunk-top"]);
-    await expect(fs.access(`${defaultsPath}.migrated`)).resolves.toBeUndefined();
-    await expect(fs.access(`${topLevelPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${defaultsPath}.migrated`);
+    await fs.access(`${topLevelPath}.migrated`);
   });
 
   it("does not infer agent ownership from configured sidecar filenames", async () => {
@@ -1909,7 +1909,7 @@ describe("memory-core doctor dreaming migration", () => {
         cache: [{ provider: "openai", hash: "chunk-hash" }],
       });
     }
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("restores legacy sidecar vector rows for vector-backed search", async () => {
@@ -1926,7 +1926,7 @@ describe("memory-core doctor dreaming migration", () => {
     );
     const rows = await searchMigratedVectorRows(agentPath);
     expect(rows.map((row) => row.id)).toEqual(["chunk-1"]);
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("archives empty legacy vector sidecars when sqlite-vec cannot load", async () => {
@@ -1963,7 +1963,7 @@ describe("memory-core doctor dreaming migration", () => {
       "Migrated Memory Core legacy memory index for agent main -> per-agent SQLite (1 source(s), 1 chunk(s), 1 cache row(s))",
       expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("leaves malformed legacy vector sidecars retryable", async () => {
@@ -1990,7 +1990,7 @@ describe("memory-core doctor dreaming migration", () => {
     expect(result.changes).toEqual([
       "Migrated Memory Core legacy memory index for agent main -> per-agent SQLite (1 source(s), 1 chunk(s), 1 cache row(s))",
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
@@ -2033,7 +2033,7 @@ describe("memory-core doctor dreaming migration", () => {
     });
     const keywordRows = await searchMigratedKeywordRows(agentPath, "remember");
     expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
@@ -2069,7 +2069,7 @@ describe("memory-core doctor dreaming migration", () => {
     ]);
     const keywordRows = await searchMigratedKeywordRows(agentPath, "remember");
     expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("copies custom vector sidecars to the canonical retry path when sqlite-vec cannot load", async () => {
@@ -2122,8 +2122,8 @@ describe("memory-core doctor dreaming migration", () => {
         "openclaw-agent.sqlite",
       )}`,
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(retryPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
+    await fs.access(retryPath);
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
@@ -2190,8 +2190,8 @@ describe("memory-core doctor dreaming migration", () => {
         "openclaw-agent.sqlite",
       )}`,
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(alternateRetryPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
+    await fs.access(alternateRetryPath);
 
     const retryEntriesBefore = (await fs.readdir(path.join(stateDir, "memory")))
       .filter((entry) => entry.startsWith("main.retry-"))
@@ -2230,7 +2230,7 @@ describe("memory-core doctor dreaming migration", () => {
       cache: [],
     });
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("archives conflicting custom derived indexes without creating a retry copy", async () => {
@@ -2273,7 +2273,7 @@ describe("memory-core doctor dreaming migration", () => {
     expect(retryPreview).toBeNull();
     await expect(fs.access(legacyPath)).rejects.toThrow();
     await expect(fs.access(retryPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("copies custom sidecars to the retry path when canonical database setup fails", async () => {
@@ -2319,8 +2319,8 @@ describe("memory-core doctor dreaming migration", () => {
     expect(retryPreview?.preview).toEqual([
       `- Memory Core legacy memory index: ${retryPath} -> ${agentPath}`,
     ]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
-    await expect(fs.access(retryPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
+    await fs.access(retryPath);
   });
 
   it("keeps canonical metadata and archives a conflicting derived legacy index", async () => {
@@ -2341,7 +2341,7 @@ describe("memory-core doctor dreaming migration", () => {
       { id: "canonical-other-chunk", text: "canonical unrelated memory" },
     ]);
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
 
     const secondRun = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
     expect(secondRun).toEqual({ changes: [], warnings: [] });
@@ -2375,7 +2375,7 @@ describe("memory-core doctor dreaming migration", () => {
       cache: [],
     });
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("merges legacy sidecar rows into a non-empty canonical index when rows do not conflict", async () => {
@@ -2405,7 +2405,7 @@ describe("memory-core doctor dreaming migration", () => {
     });
     const keywordRows = await searchMigratedKeywordRows(agentPath, "remember");
     expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("retains an exact canonical FTS row without duplicating it", async () => {
@@ -2424,7 +2424,7 @@ describe("memory-core doctor dreaming migration", () => {
     ]);
     const keywordRows = await searchMigratedKeywordRows(agentPath, "remember");
     expect(keywordRows.map((row) => row.id)).toEqual(["chunk-1"]);
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("keeps canonical cache collisions while importing remaining legacy rows", async () => {
@@ -2494,7 +2494,7 @@ describe("memory-core doctor dreaming migration", () => {
       },
     ]);
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
 
     const secondRun = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
     expect(secondRun).toEqual({ changes: [], warnings: [] });
@@ -2580,7 +2580,7 @@ describe("memory-core doctor dreaming migration", () => {
         },
       ]);
       await expect(fs.access(legacyPath)).rejects.toThrow();
-      await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+      await fs.access(`${legacyPath}.migrated`);
     },
   );
 
@@ -2599,7 +2599,7 @@ describe("memory-core doctor dreaming migration", () => {
       ),
     ]);
     expect(result.changes).toEqual([]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
@@ -2618,7 +2618,7 @@ describe("memory-core doctor dreaming migration", () => {
       expect.stringContaining("Archived Memory Core legacy memory index sidecar"),
     ]);
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("leaves legacy vector sidecars in place when vector rows have no chunk", async () => {
@@ -2640,7 +2640,7 @@ describe("memory-core doctor dreaming migration", () => {
       ),
     ]);
     expect(result.changes).toEqual([]);
-    await expect(fs.access(legacyPath)).resolves.toBeUndefined();
+    await fs.access(legacyPath);
     await expect(fs.access(`${legacyPath}.migrated`)).rejects.toThrow();
   });
 
@@ -2678,7 +2678,7 @@ describe("memory-core doctor dreaming migration", () => {
       cache: [],
     });
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("keeps canonical vector metadata and archives a conflicting derived legacy index", async () => {
@@ -2699,7 +2699,7 @@ describe("memory-core doctor dreaming migration", () => {
       { id: "canonical-other-chunk", text: "canonical unrelated memory" },
     ]);
     await expect(fs.access(legacyPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("removes retired QMD workspace homes without following model or home symlinks", async () => {
@@ -2819,7 +2819,7 @@ describe("memory-core doctor dreaming migration", () => {
       fs.access(path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite")),
     ).rejects.toMatchObject({ code: "ENOENT" });
     for (const filePath of ignoredPaths) {
-      await expect(fs.access(filePath)).resolves.toBeUndefined();
+      await fs.access(filePath);
     }
     await expect(migration.detectLegacyState(migrationParams())).resolves.toBeNull();
     await expect(migration.migrateLegacyState(migrationParams())).resolves.toEqual({

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -158,6 +158,7 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  process.exitCode = 0;
   getMemorySearchManager.mockReset();
   forgetMemoryEntries.mockReset();
   getRuntimeConfig.mockReset().mockReturnValue({});
@@ -172,7 +173,7 @@ afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
   vi.restoreAllMocks();
   vi.unstubAllEnvs();
-  process.exitCode = undefined;
+  process.exitCode = 0;
   setVerbose(false);
 });
 
@@ -790,7 +791,7 @@ describe("memory cli", () => {
     params.beforeExpect?.();
     expect(close).toHaveBeenCalled();
     expect(error).toHaveBeenCalledWith("Memory manager close failed: close boom");
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   }
 
   it("prints vector status when available", async () => {
@@ -1748,7 +1749,7 @@ describe("memory cli", () => {
     expectNotLogged(log, "Memory index complete");
     await expectPathMissing(path.join(workspaceDir, "memory"));
     expect(close).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it("reports a truthful no-op when the memory directory is missing", async () => {
@@ -1783,7 +1784,7 @@ describe("memory cli", () => {
     expectNotLogged(log, "Memory index updated");
     await expectPathMissing(path.join(workspaceDir, "memory"));
     expect(close).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it("reports the indexed file count and closes the manager after index", async () => {
@@ -1856,7 +1857,7 @@ describe("memory cli", () => {
       "Memory index WARNING (main): chunks_vec not updated — sqlite-vec unavailable: load failed. Vector recall degraded.",
     );
     expect(close).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it("warns on stderr when index has vector store but no semantic vectors", async () => {
@@ -1891,7 +1892,7 @@ describe("memory cli", () => {
       "Memory index WARNING (main): chunks_vec not updated — semantic vector embeddings unavailable — no vector dimensions resolved. Vector recall degraded.",
     );
     expect(close).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it("logs close failures without failing the command", async () => {
@@ -2113,7 +2114,7 @@ describe("memory cli", () => {
     });
     expect(log).toHaveBeenCalledWith("No matches.");
     expect(close).toHaveBeenCalled();
-    expect(process.exitCode).toBeUndefined();
+    expect(process.exitCode).toBe(0);
   });
 
   it("prefers --query when positional and flag are both provided", async () => {
@@ -2223,7 +2224,7 @@ describe("memory cli", () => {
 
       expect(log).toHaveBeenCalledWith("No short-term recall candidates.");
       expect(close).toHaveBeenCalled();
-      expect(process.exitCode).toBeUndefined();
+      expect(process.exitCode).toBe(0);
     });
   });
 

--- a/extensions/memory-core/src/memory/manager-db.test.ts
+++ b/extensions/memory-core/src/memory/manager-db.test.ts
@@ -546,6 +546,6 @@ describe("memory manager database publication", () => {
     await expectPathMissing(oldShadow);
     await expectPathMissing(`${oldShadow}-wal`);
     await expectPathMissing(`${oldShadow}-journal`);
-    await expect(fs.access(youngShadow)).resolves.toBeUndefined();
+    await fs.access(youngShadow);
   });
 });


### PR DESCRIPTION
Plugin migration and database tests failed under Bun because they asserted Node's exact `fs.access` success value. Await the native operation directly so inaccessible paths still fail, preserving all content, migration, retention, and cleanup assertions.

Memory CLI tests also leaked an earlier error status because Bun ignores `process.exitCode = undefined`. Initialize and restore status zero in the fixture, and assert zero for successful commands. Every error-status assertion remains unchanged. This changes five test files only.

Validation: 69 selected cases pass under Node 26.8.1 and Bun 1.4.2. The original CLI error-to-success sequence passes in Node and reproduces two failures in Bun before the repair; all 13 selected CLI cases pass in both runtimes afterward. Tests use isolated homes, one worker, disabled FS module cache, and the campaign's installed SQLite preload for Bun. Other cases in these files were not rerun; no skip annotations or substantive assertions were changed. Formatting and independent P2 review pass. The complete changed-file gate passes, including extension-test typechecking, repository guards, dead-export scans, and lint.
