### PR TITLE
fix(catalog): avoid node discovery for local-only pages

### DIFF
--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -409,6 +409,43 @@ afterEach(async () => {
 const itWithCli = it.runIf(process.platform !== "win32");
 
 describe("OpenCode session catalog", () => {
+  itWithCli.each(["runtime", "request"] as const)(
+    "discovers paired nodes only for selected hosts through the %s node runtime",
+    async (discovery) => {
+      await installFakeOpenCode();
+      const nodes = [pairedNode([OPENCODE_SESSIONS_LIST_COMMAND])];
+      const invoke = vi.fn().mockResolvedValue(pairedNodeSessionPage(pairedNodeSession()));
+      const { listNodes: runtimeListNodes, provider } = capturePairedNodeCatalog(nodes, invoke);
+      const requestListNodes = vi.fn().mockResolvedValue({ nodes });
+      const options = discovery === "request" ? { listNodes: requestListNodes } : {};
+      for (const hostIds of [["gateway"], [], ["unknown"]]) {
+        const hosts = await provider!.list({ ...options, hostIds });
+        expect(hosts.map((host) => host.hostId)).toEqual(
+          hostIds[0] === "gateway" ? ["gateway"] : [],
+        );
+        if (hostIds[0] === "gateway") {
+          expect(hosts[0]?.sessions[0]?.threadId).toBe("ses_test");
+        }
+        expect(runtimeListNodes).not.toHaveBeenCalled();
+        expect(requestListNodes).not.toHaveBeenCalled();
+        expect(invoke).not.toHaveBeenCalled();
+      }
+
+      for (const hostIds of [undefined, ["gateway", "node:node-1"], ["node:node-1"]]) {
+        const hosts = await provider!.list({ ...options, ...(hostIds ? { hostIds } : {}) });
+        expect(hosts.map((host) => host.hostId)).toEqual(
+          hostIds?.length === 1 ? ["node:node-1"] : ["gateway", "node:node-1"],
+        );
+        expect(hosts.at(-1)?.sessions[0]?.threadId).toBe("ses_remote");
+      }
+      expect(discovery === "request" ? requestListNodes : runtimeListNodes).toHaveBeenCalledTimes(
+        3,
+      );
+      expect(discovery === "request" ? runtimeListNodes : requestListNodes).not.toHaveBeenCalled();
+      expect(invoke).toHaveBeenCalledTimes(3);
+    },
+  );
+
   itWithCli("lists and reads sessions through the official CLI JSON surfaces", async () => {
     await installFakeOpenCode();
     const listed = await listLocalOpenCodeSessionPage({ limit: 20 });

--- a/extensions/opencode/session-catalog.test.ts
+++ b/extensions/opencode/session-catalog.test.ts
@@ -438,11 +438,20 @@ describe("OpenCode session catalog", () => {
         );
         expect(hosts.at(-1)?.sessions[0]?.threadId).toBe("ses_remote");
       }
+      const hostIds = ["gateway", "node:node-1"];
+      const hosts = await provider!.list({
+        ...options,
+        hostIds,
+        onHost: () => {
+          hostIds.length = 0;
+        },
+      });
+      expect(hosts.map((host) => host.hostId)).toEqual(["gateway", "node:node-1"]);
       expect(discovery === "request" ? requestListNodes : runtimeListNodes).toHaveBeenCalledTimes(
-        3,
+        4,
       );
       expect(discovery === "request" ? runtimeListNodes : requestListNodes).not.toHaveBeenCalled();
-      expect(invoke).toHaveBeenCalledTimes(3);
+      expect(invoke).toHaveBeenCalledTimes(4);
     },
   );
 

--- a/src/plugins/session-catalog-family.ts
+++ b/src/plugins/session-catalog-family.ts
@@ -355,8 +355,8 @@ async function listHosts(
       query.onHost?.(host);
     }
   }
-  // Local-only pages do not depend on pairing-store discovery or its latency.
-  if (query.hostIds && !query.hostIds.some((hostId) => hostId.startsWith("node:"))) {
+  // Use the captured host selection after local discovery and progress callbacks.
+  if (requested && !Array.from(requested).some((hostId) => hostId.startsWith("node:"))) {
     return hosts;
   }
   let nodes: CatalogNode[];

--- a/src/plugins/session-catalog-family.ts
+++ b/src/plugins/session-catalog-family.ts
@@ -355,6 +355,10 @@ async function listHosts(
       query.onHost?.(host);
     }
   }
+  // Local-only pages do not depend on pairing-store discovery or its latency.
+  if (query.hostIds && !query.hostIds.some((hostId) => hostId.startsWith("node:"))) {
+    return hosts;
+  }
   let nodes: CatalogNode[];
   try {
     nodes = (await (query.listNodes?.() ?? options.runtime.nodes.list())).nodes;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users loading only local OpenCode or Pi catalog sessions would still wait for paired-node discovery. Expanded sidebar pages request one host at a time, so a local page could depend on unrelated node-registry work.

## Why This Change Was Made

The shared catalog family now applies the captured host selection before discovering paired nodes, matching the existing Claude and Codex catalog behavior. Progress callbacks can modify the caller-owned array without changing that original selection. Default, mixed, and remote selections retain their normal discovery and results.

## User Impact

Local catalog pages avoid an unnecessary dependency on node discovery. This changes neither the catalog API nor stored session data.

## Evidence

- Clean Linux Crabbox/Testbox proof on the corrected head, Node 24.19.0 and pnpm 12.3.4: both regression cases fail against the original source because node discovery is still called; the first guard separately fails both callback-mutation cases; all 51 focused OpenCode, Pi, and shared catalog tests pass with the final implementation.
- The regression exercises the registered OpenCode plugin and its real spawned synthetic CLI fixture, covering runtime and request-owned node discovery with local-only, empty, unknown-only, default, mixed, and remote host selections. Pi's filesystem-backed catalog and paired-node sibling suites also pass.
- A separate execution of the original family function with synthetic dependencies proves the local-only result remains pending until unrelated node discovery settles.
- Fresh independent Codex review found no actionable P0–P2 issues. The full corrected-head changed-scope gate and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34033283163) passed.

Production change: +4 lines; regression coverage: +46 lines. The guard belongs in the existing shared family, so both callers inherit the fix without duplicate provider policy.
