### PR TITLE
refactor(webhooks): isolate request schemas and trim duplicate plumbing

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -252,7 +252,6 @@ extensions/voice-call/src/webhook.test.ts
 extensions/voice-call/src/webhook.ts
 extensions/voice-call/src/webhook/realtime-handler.test.ts
 extensions/voice-call/src/webhook/realtime-handler.ts
-extensions/webhooks/src/http.ts
 extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.test.ts
 extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts
 extensions/whatsapp/src/connection-controller.ts

--- a/extensions/webhooks/src/http-request-schema.ts
+++ b/extensions/webhooks/src/http-request-schema.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+
+const jsonValueSchema = z.json();
+export type JsonValue = z.infer<typeof jsonValueSchema>;
+
+const nullableStringSchema = z.string().trim().min(1).nullable().optional();
+
+const createFlowRequestSchema = z.strictObject({
+  action: z.literal("create_flow"),
+  controllerId: z.string().trim().min(1).optional(),
+  goal: z.string().trim().min(1),
+  status: z.enum(["queued", "running", "waiting", "blocked"]).optional(),
+  notifyPolicy: z.enum(["done_only", "state_changes", "silent"]).optional(),
+  currentStep: nullableStringSchema,
+  stateJson: jsonValueSchema.nullable().optional(),
+  waitJson: jsonValueSchema.nullable().optional(),
+});
+
+const getFlowRequestSchema = z.strictObject({
+  action: z.literal("get_flow"),
+  flowId: z.string().trim().min(1),
+});
+const listFlowsRequestSchema = z.strictObject({ action: z.literal("list_flows") });
+const findLatestFlowRequestSchema = z.strictObject({ action: z.literal("find_latest_flow") });
+const resolveFlowRequestSchema = z.strictObject({
+  action: z.literal("resolve_flow"),
+  token: z.string().trim().min(1),
+});
+const getTaskSummaryRequestSchema = z.strictObject({
+  action: z.literal("get_task_summary"),
+  flowId: z.string().trim().min(1),
+});
+
+const setWaitingRequestSchema = z.strictObject({
+  action: z.literal("set_waiting"),
+  flowId: z.string().trim().min(1),
+  expectedRevision: z.number().int().nonnegative(),
+  currentStep: nullableStringSchema,
+  stateJson: jsonValueSchema.nullable().optional(),
+  waitJson: jsonValueSchema.nullable().optional(),
+  blockedTaskId: nullableStringSchema,
+  blockedSummary: nullableStringSchema,
+});
+
+const resumeFlowRequestSchema = z.strictObject({
+  action: z.literal("resume_flow"),
+  flowId: z.string().trim().min(1),
+  expectedRevision: z.number().int().nonnegative(),
+  status: z.enum(["queued", "running"]).optional(),
+  currentStep: nullableStringSchema,
+  stateJson: jsonValueSchema.nullable().optional(),
+});
+
+const finishFlowRequestSchema = z.strictObject({
+  action: z.literal("finish_flow"),
+  flowId: z.string().trim().min(1),
+  expectedRevision: z.number().int().nonnegative(),
+  stateJson: jsonValueSchema.nullable().optional(),
+});
+
+const failFlowRequestSchema = z.strictObject({
+  action: z.literal("fail_flow"),
+  flowId: z.string().trim().min(1),
+  expectedRevision: z.number().int().nonnegative(),
+  stateJson: jsonValueSchema.nullable().optional(),
+  blockedTaskId: nullableStringSchema,
+  blockedSummary: nullableStringSchema,
+});
+
+const requestCancelRequestSchema = z.strictObject({
+  action: z.literal("request_cancel"),
+  flowId: z.string().trim().min(1),
+  expectedRevision: z.number().int().nonnegative(),
+});
+
+const cancelFlowRequestSchema = z.strictObject({
+  action: z.literal("cancel_flow"),
+  flowId: z.string().trim().min(1),
+});
+
+const runTaskRequestSchema = z
+  .strictObject({
+    action: z.literal("run_task"),
+    flowId: z.string().trim().min(1),
+    runtime: z.enum(["subagent", "acp"]),
+    sourceId: z.string().trim().min(1).optional(),
+    childSessionKey: z.string().trim().min(1).optional(),
+    parentTaskId: z.string().trim().min(1).optional(),
+    agentId: z.string().trim().min(1).optional(),
+    runId: z.string().trim().min(1).optional(),
+    label: z.string().trim().min(1).optional(),
+    task: z.string().trim().min(1),
+    preferMetadata: z.boolean().optional(),
+    notifyPolicy: z.enum(["done_only", "state_changes", "silent"]).optional(),
+    status: z.enum(["queued", "running"]).optional(),
+    startedAt: z.number().int().nonnegative().optional(),
+    lastEventAt: z.number().int().nonnegative().optional(),
+    progressSummary: nullableStringSchema,
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.status !== "running" &&
+      (value.startedAt !== undefined ||
+        value.lastEventAt !== undefined ||
+        value.progressSummary !== undefined)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "status must be running when startedAt, lastEventAt, or progressSummary is provided",
+        path: ["status"],
+      });
+    }
+  });
+
+export const webhookActionSchema = z.discriminatedUnion("action", [
+  createFlowRequestSchema,
+  getFlowRequestSchema,
+  listFlowsRequestSchema,
+  findLatestFlowRequestSchema,
+  resolveFlowRequestSchema,
+  getTaskSummaryRequestSchema,
+  setWaitingRequestSchema,
+  resumeFlowRequestSchema,
+  finishFlowRequestSchema,
+  failFlowRequestSchema,
+  requestCancelRequestSchema,
+  cancelFlowRequestSchema,
+  runTaskRequestSchema,
+]);
+
+export type WebhookAction = z.infer<typeof webhookActionSchema>;
+
+export function formatZodError(error: z.ZodError): string {
+  const firstIssue = error.issues[0];
+  if (!firstIssue) {
+    return "invalid request";
+  }
+  const path = firstIssue.path.length > 0 ? `${firstIssue.path.join(".")}: ` : "";
+  return `${path}${firstIssue.message}`;
+}

--- a/extensions/webhooks/src/http.test.ts
+++ b/extensions/webhooks/src/http.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import type { IncomingMessage } from "node:http";
 import { createRuntimeTaskFlow } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { createMockServerResponse } from "openclaw/plugin-sdk/test-env";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { createTaskFlowWebhookRequestHandler, type TaskFlowWebhookTarget } from "./http.js";
 
@@ -114,10 +114,6 @@ function parseJsonBody(res: { body?: string | Buffer | null }) {
   return JSON.parse(String(res.body ?? ""));
 }
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("createTaskFlowWebhookRequestHandler", () => {
   it("rejects requests with the wrong secret", async () => {
     const { handler, target } = createHandler();
@@ -152,37 +148,16 @@ describe("createTaskFlowWebhookRequestHandler", () => {
     };
     const handler = createHandlerWithTarget(target);
 
-    const first = await dispatchJsonRequest({
-      handler,
-      path: target.path,
-      secret: "shared-secret",
-      body: {
-        action: "list_flows",
-      },
-    });
-    const second = await dispatchJsonRequest({
-      handler,
-      path: target.path,
-      secret: "shared-secret",
-      body: {
-        action: "list_flows",
-      },
-    });
-    const third = await dispatchJsonRequest({
-      handler,
-      path: target.path,
-      secret: "rotated-secret",
-      body: {
-        action: "list_flows",
-      },
-    });
-
-    expect([first, second, third].map((response) => response.statusCode)).toEqual([401, 401, 401]);
-    expect([first, second, third].map((response) => response.body)).toEqual([
-      "unauthorized",
-      "unauthorized",
-      "unauthorized",
-    ]);
+    for (const secret of ["shared-secret", "shared-secret", "rotated-secret"]) {
+      const response = await dispatchJsonRequest({
+        handler,
+        path: target.path,
+        secret,
+        body: { action: "list_flows" },
+      });
+      expect(response.statusCode).toBe(401);
+      expect(response.body).toBe("unauthorized");
+    }
   });
 
   it("accepts a resolved secret that has env-template syntax", async () => {

--- a/extensions/webhooks/src/http.ts
+++ b/extensions/webhooks/src/http.ts
@@ -2,7 +2,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { z } from "zod";
 import type { PluginRuntime } from "../api.js";
 import {
   createFixedWindowRateLimiter,
@@ -17,139 +16,14 @@ import {
   type WebhookInFlightLimiter,
 } from "../runtime-api.js";
 import type { WebhookSecretInput } from "./config.js";
+import {
+  formatZodError,
+  webhookActionSchema,
+  type JsonValue,
+  type WebhookAction,
+} from "./http-request-schema.js";
 
 type BoundTaskFlowRuntime = ReturnType<PluginRuntime["tasks"]["managedFlows"]["bindSession"]>;
-
-const jsonValueSchema = z.json();
-type JsonValue = z.infer<typeof jsonValueSchema>;
-
-const nullableStringSchema = z.string().trim().min(1).nullable().optional();
-
-const createFlowRequestSchema = z.strictObject({
-  action: z.literal("create_flow"),
-  controllerId: z.string().trim().min(1).optional(),
-  goal: z.string().trim().min(1),
-  status: z.enum(["queued", "running", "waiting", "blocked"]).optional(),
-  notifyPolicy: z.enum(["done_only", "state_changes", "silent"]).optional(),
-  currentStep: nullableStringSchema,
-  stateJson: jsonValueSchema.nullable().optional(),
-  waitJson: jsonValueSchema.nullable().optional(),
-});
-
-const getFlowRequestSchema = z.strictObject({
-  action: z.literal("get_flow"),
-  flowId: z.string().trim().min(1),
-});
-const listFlowsRequestSchema = z.strictObject({ action: z.literal("list_flows") });
-const findLatestFlowRequestSchema = z.strictObject({ action: z.literal("find_latest_flow") });
-const resolveFlowRequestSchema = z.strictObject({
-  action: z.literal("resolve_flow"),
-  token: z.string().trim().min(1),
-});
-const getTaskSummaryRequestSchema = z.strictObject({
-  action: z.literal("get_task_summary"),
-  flowId: z.string().trim().min(1),
-});
-
-const setWaitingRequestSchema = z.strictObject({
-  action: z.literal("set_waiting"),
-  flowId: z.string().trim().min(1),
-  expectedRevision: z.number().int().nonnegative(),
-  currentStep: nullableStringSchema,
-  stateJson: jsonValueSchema.nullable().optional(),
-  waitJson: jsonValueSchema.nullable().optional(),
-  blockedTaskId: nullableStringSchema,
-  blockedSummary: nullableStringSchema,
-});
-
-const resumeFlowRequestSchema = z.strictObject({
-  action: z.literal("resume_flow"),
-  flowId: z.string().trim().min(1),
-  expectedRevision: z.number().int().nonnegative(),
-  status: z.enum(["queued", "running"]).optional(),
-  currentStep: nullableStringSchema,
-  stateJson: jsonValueSchema.nullable().optional(),
-});
-
-const finishFlowRequestSchema = z.strictObject({
-  action: z.literal("finish_flow"),
-  flowId: z.string().trim().min(1),
-  expectedRevision: z.number().int().nonnegative(),
-  stateJson: jsonValueSchema.nullable().optional(),
-});
-
-const failFlowRequestSchema = z.strictObject({
-  action: z.literal("fail_flow"),
-  flowId: z.string().trim().min(1),
-  expectedRevision: z.number().int().nonnegative(),
-  stateJson: jsonValueSchema.nullable().optional(),
-  blockedTaskId: nullableStringSchema,
-  blockedSummary: nullableStringSchema,
-});
-
-const requestCancelRequestSchema = z.strictObject({
-  action: z.literal("request_cancel"),
-  flowId: z.string().trim().min(1),
-  expectedRevision: z.number().int().nonnegative(),
-});
-
-const cancelFlowRequestSchema = z.strictObject({
-  action: z.literal("cancel_flow"),
-  flowId: z.string().trim().min(1),
-});
-
-const runTaskRequestSchema = z
-  .strictObject({
-    action: z.literal("run_task"),
-    flowId: z.string().trim().min(1),
-    runtime: z.enum(["subagent", "acp"]),
-    sourceId: z.string().trim().min(1).optional(),
-    childSessionKey: z.string().trim().min(1).optional(),
-    parentTaskId: z.string().trim().min(1).optional(),
-    agentId: z.string().trim().min(1).optional(),
-    runId: z.string().trim().min(1).optional(),
-    label: z.string().trim().min(1).optional(),
-    task: z.string().trim().min(1),
-    preferMetadata: z.boolean().optional(),
-    notifyPolicy: z.enum(["done_only", "state_changes", "silent"]).optional(),
-    status: z.enum(["queued", "running"]).optional(),
-    startedAt: z.number().int().nonnegative().optional(),
-    lastEventAt: z.number().int().nonnegative().optional(),
-    progressSummary: nullableStringSchema,
-  })
-  .superRefine((value, ctx) => {
-    if (
-      value.status !== "running" &&
-      (value.startedAt !== undefined ||
-        value.lastEventAt !== undefined ||
-        value.progressSummary !== undefined)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          "status must be running when startedAt, lastEventAt, or progressSummary is provided",
-        path: ["status"],
-      });
-    }
-  });
-
-const webhookActionSchema = z.discriminatedUnion("action", [
-  createFlowRequestSchema,
-  getFlowRequestSchema,
-  listFlowsRequestSchema,
-  findLatestFlowRequestSchema,
-  resolveFlowRequestSchema,
-  getTaskSummaryRequestSchema,
-  setWaitingRequestSchema,
-  resumeFlowRequestSchema,
-  finishFlowRequestSchema,
-  failFlowRequestSchema,
-  requestCancelRequestSchema,
-  cancelFlowRequestSchema,
-  runTaskRequestSchema,
-]);
-
-type WebhookAction = z.infer<typeof webhookActionSchema>;
 
 export type TaskFlowWebhookTarget = {
   routeId: string;
@@ -297,30 +171,6 @@ function extractSharedSecret(req: IncomingMessage): string {
   return Array.isArray(sharedHeader) ? (sharedHeader[0] ?? "").trim() : (sharedHeader ?? "").trim();
 }
 
-function formatZodError(error: z.ZodError): string {
-  const firstIssue = error.issues[0];
-  if (!firstIssue) {
-    return "invalid request";
-  }
-  const path = firstIssue.path.length > 0 ? `${firstIssue.path.join(".")}: ` : "";
-  return `${path}${firstIssue.message}`;
-}
-
-function mapMutationResult(
-  result:
-    | {
-        applied: true;
-        flow: FlowView;
-      }
-    | {
-        applied: false;
-        code: string;
-        current?: FlowView;
-      },
-): unknown {
-  return result;
-}
-
 function mapFlowMutationResult(
   result:
     | {
@@ -333,15 +183,13 @@ function mapFlowMutationResult(
         current?: Parameters<typeof toFlowView>[0];
       },
 ): unknown {
-  return mapMutationResult(
-    result.applied
-      ? { applied: true, flow: toFlowView(result.flow) }
-      : {
-          applied: false,
-          code: result.code,
-          ...(result.current ? { current: toFlowView(result.current) } : {}),
-        },
-  );
+  return result.applied
+    ? { applied: true, flow: toFlowView(result.flow) }
+    : {
+        applied: false,
+        code: result.code,
+        ...(result.current ? { current: toFlowView(result.current) } : {}),
+      };
 }
 
 function mapMutationStatus(result: {
@@ -794,4 +642,3 @@ export function createTaskFlowWebhookRequestHandler(params: {
     });
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Maintainer-requested deletion follow-up for the #135868 split campaign: the webhooks HTTP owner exceeded its line budget and carried a redundant response adapter plus repetitive cold-route test setup.

## Why This Change Was Made

Move the existing strict action schemas and validation-error formatter into one private request-schema module, keeping authentication, limits, execution, and response projection in the HTTP owner. Remove the private identity mapper and retire the exact max-lines exception. Production −12, tests −25, tooling −1; 368 changed lines including relocation.

## User Impact

No behavior or public API change. Request validation, session ownership, response scrubbing, status codes, and cold-route rejection remain unchanged.

## Evidence

- All 21 focused webhook and TaskFlow tests passed.
- Exact source comparison verified moved schemas and error formatting differ only by import/export declarations.
- Independent Codex review: no actionable P0–P2 findings.
- Full local build passed. Full changed gate passed on clean Blacksmith Testbox ([run 34032177660](https://github.com/openclaw/openclaw/actions/runs/34032177660)), command exit 0; lease confirmed completed. Local extension lint was blocked by declaration resolution into the dirty ancestor checkout; no install or guard was modified.

Test-deletion coverage: the retained `extensions/webhooks/src/http.test.ts:134` test, “keeps an unresolved SecretRef-backed route cold,” still sends the same three requests sequentially through one handler and asserts 401 plus `unauthorized` for each. Only repeated request blocks were consolidated. The removed `vi.clearAllMocks()` hook had no remaining mock to clear; #109715 (`c13925b3875`) removed the last resolver mock. No test case or protected invariant was removed.

The deleted private `mapMutationResult` had one caller and returned its argument unchanged. `mapFlowMutationResult` still applies the same `toFlowView` projection. Remaining HTTP coverage includes missing-flow mapping at `http.test.ts:231`, revision conflicts/current flow at `:253`, and schema/error rejection at `:280`; owner transitions and fencing remain covered by `src/plugins/runtime/runtime-taskflow.test.ts:158` and `:227`.

Initial CI run 34032717795 failed the unrelated event-loop timing assertion at `src/gateway/server-http.event-loop-health.test.ts:96`. Rebased patch-identically onto main containing #140021 (merge `aa4fbd93cf4`); no source workaround or blind rerun. Fresh exact-head CI [34033143209](https://github.com/openclaw/openclaw/actions/runs/34033143209) is green. Lockfile unchanged.

ClawSweeper reviewed current head `60e3ea2d4e745e33c57cc87d4b3f355b4f873e5b`: no actionable findings, before-merge requests, or rank-up moves.
