### PR TITLE
refactor(qa): simplify Mantis CLI contracts

### DIFF
--- a/extensions/qa-lab/src/mantis/cli.ts
+++ b/extensions/qa-lab/src/mantis/cli.ts
@@ -1,18 +1,10 @@
-// Qa Lab plugin module implements cli behavior.
 import type { Command } from "commander";
 import { createLazyCliRuntimeLoader } from "../live-transports/shared/live-transport-cli.js";
 import type { MantisDesktopBrowserSmokeOptions } from "./desktop-browser-smoke.runtime.js";
 import type { MantisDiscordSmokeOptions } from "./discord-smoke.runtime.js";
 import type { MantisBeforeAfterOptions } from "./run.runtime.js";
-import type {
-  MantisSlackDesktopHydrateMode,
-  MantisSlackDesktopSmokeOptions,
-} from "./slack-desktop-smoke.runtime.js";
-import type {
-  MantisVisualDriverOptions,
-  MantisVisualTaskOptions,
-  MantisVisualTaskVisionMode,
-} from "./visual-task.runtime.js";
+import type { MantisSlackDesktopSmokeOptions } from "./slack-desktop-smoke.runtime.js";
+import type { MantisVisualDriverOptions, MantisVisualTaskOptions } from "./visual-task.runtime.js";
 
 type MantisCliRuntime = typeof import("./cli.runtime.js");
 
@@ -20,141 +12,49 @@ const loadMantisCliRuntime = createLazyCliRuntimeLoader<MantisCliRuntime>(
   () => import("./cli.runtime.js"),
 );
 
-async function runDiscordSmoke(opts: MantisDiscordSmokeOptions) {
-  const runtime = await loadMantisCliRuntime();
-  await runtime.runMantisDiscordSmokeCommand(opts);
-}
+type MantisDiscordSmokeCommanderOptions = Omit<
+  MantisDiscordSmokeOptions,
+  "env" | "now" | "redactPublicMetadata" | "token"
+>;
 
-async function runBeforeAfter(opts: MantisBeforeAfterOptions) {
-  const runtime = await loadMantisCliRuntime();
-  await runtime.runMantisBeforeAfterCommand(opts);
-}
+type MantisBeforeAfterCommanderOptions = Omit<
+  MantisBeforeAfterOptions,
+  "allowFailures" | "commandRunner" | "fastMode" | "now"
+> & { fast?: boolean };
 
-async function runDesktopBrowserSmoke(opts: MantisDesktopBrowserSmokeOptions) {
-  const runtime = await loadMantisCliRuntime();
-  await runtime.runMantisDesktopBrowserSmokeCommand(opts);
-}
-
-async function runSlackDesktopSmoke(opts: MantisSlackDesktopSmokeOptions) {
-  const runtime = await loadMantisCliRuntime();
-  await runtime.runMantisSlackDesktopSmokeCommand(opts);
-}
-
-async function runVisualDriver(opts: MantisVisualDriverOptions) {
-  const runtime = await loadMantisCliRuntime();
-  await runtime.runMantisVisualDriverCommand(opts);
-}
-
-async function runVisualTask(opts: MantisVisualTaskOptions) {
-  const runtime = await loadMantisCliRuntime();
-  await runtime.runMantisVisualTaskCommand(opts);
-}
-
-type MantisDiscordSmokeCommanderOptions = {
-  channelId?: string;
-  guildId?: string;
-  message?: string;
-  outputDir?: string;
-  repoRoot?: string;
-  skipPost?: boolean;
-  tokenFile?: string;
-  tokenFileEnv?: string;
-  tokenEnv?: string;
-};
-
-type MantisBeforeAfterCommanderOptions = {
-  baseline?: string;
-  candidate?: string;
-  credentialRole?: string;
-  credentialSource?: string;
-  fast?: boolean;
-  outputDir?: string;
-  providerMode?: string;
-  repoRoot?: string;
-  scenario?: string;
-  skipBuild?: boolean;
-  skipInstall?: boolean;
-  transport?: string;
-};
-
-type MantisDesktopBrowserSmokeCommanderOptions = {
-  browserProfileArchiveEnv?: string;
-  browserProfileDir?: string;
-  browserUrl?: string;
+type MantisDesktopBrowserSmokeCommanderOptions = Omit<
+  MantisDesktopBrowserSmokeOptions,
+  "commandRunner" | "env" | "now" | "videoDurationSeconds"
+> & {
   class?: string;
-  crabboxBin?: string;
-  htmlFile?: string;
-  idleTimeout?: string;
-  keepLease?: boolean;
-  leaseId?: string;
-  machineClass?: string;
-  outputDir?: string;
-  provider?: string;
-  repoRoot?: string;
-  ttl?: string;
   videoDuration?: string;
 };
 
-type MantisSlackDesktopSmokeCommanderOptions = {
+type MantisSlackDesktopSmokeCommanderOptions = Omit<
+  MantisSlackDesktopSmokeOptions,
+  "alternateModel" | "commandRunner" | "env" | "fastMode" | "now" | "primaryModel" | "scenarioIds"
+> & {
   altModel?: string;
-  approvalCheckpoints?: boolean;
   class?: string;
-  crabboxBin?: string;
-  credentialRole?: string;
-  credentialSource?: string;
   fast?: boolean;
-  freshPr?: string;
-  gatewaySetup?: boolean;
-  hydrateMode?: MantisSlackDesktopHydrateMode;
-  idleTimeout?: string;
-  keepLease?: boolean;
-  leaseId?: string;
-  machineClass?: string;
-  market?: string;
   model?: string;
-  outputDir?: string;
-  provider?: string;
-  providerMode?: string;
-  repoRoot?: string;
   scenario?: string[];
-  slackChannelId?: string;
-  slackUrl?: string;
-  ttl?: string;
 };
 
-type MantisVisualTaskCommanderOptions = {
-  browserUrl?: string;
+type MantisVisualTaskCommanderOptions = Omit<
+  MantisVisualTaskOptions,
+  "commandRunner" | "env" | "now" | "settleMs" | "visionTimeoutMs"
+> & {
   class?: string;
-  crabboxBin?: string;
-  duration?: string;
-  expectText?: string;
-  idleTimeout?: string;
-  keepLease?: boolean;
-  leaseId?: string;
-  machineClass?: string;
-  outputDir?: string;
-  provider?: string;
-  repoRoot?: string;
   settleMs?: string;
-  ttl?: string;
-  visionMode?: MantisVisualTaskVisionMode;
-  visionModel?: string;
-  visionPrompt?: string;
   visionTimeoutMs?: string;
 };
 
-type MantisVisualDriverCommanderOptions = {
-  browserUrl?: string;
-  crabboxBin?: string;
-  expectText?: string;
-  leaseId?: string;
-  outputDir?: string;
-  provider?: string;
-  repoRoot?: string;
+type MantisVisualDriverCommanderOptions = Omit<
+  MantisVisualDriverOptions,
+  "commandRunner" | "env" | "settleMs" | "visionTimeoutMs"
+> & {
   settleMs?: string;
-  visionMode?: MantisVisualTaskVisionMode;
-  visionModel?: string;
-  visionPrompt?: string;
   visionTimeoutMs?: string;
 };
 
@@ -194,7 +94,7 @@ export function registerMantisCli(qa: Command) {
     .option("--skip-install", "Skip pnpm install in baseline/candidate worktrees", false)
     .option("--skip-build", "Skip pnpm build in baseline/candidate worktrees", false)
     .action(async (opts: MantisBeforeAfterCommanderOptions) => {
-      await runBeforeAfter({
+      const options = {
         baseline: opts.baseline,
         candidate: opts.candidate,
         credentialRole: opts.credentialRole,
@@ -207,7 +107,9 @@ export function registerMantisCli(qa: Command) {
         skipBuild: opts.skipBuild,
         skipInstall: opts.skipInstall,
         transport: opts.transport,
-      });
+      };
+      const runtime = await loadMantisCliRuntime();
+      await runtime.runMantisBeforeAfterCommand(options);
     });
 
   mantis
@@ -223,7 +125,7 @@ export function registerMantisCli(qa: Command) {
     .option("--message <text>", "Smoke message to post")
     .option("--skip-post", "Only check Discord API visibility; do not post or react", false)
     .action(async (opts: MantisDiscordSmokeCommanderOptions) => {
-      await runDiscordSmoke({
+      const options = {
         channelId: opts.channelId,
         guildId: opts.guildId,
         message: opts.message,
@@ -233,7 +135,9 @@ export function registerMantisCli(qa: Command) {
         tokenFile: opts.tokenFile,
         tokenFileEnv: opts.tokenFileEnv,
         tokenEnv: opts.tokenEnv,
-      });
+      };
+      const runtime = await loadMantisCliRuntime();
+      await runtime.runMantisDiscordSmokeCommand(options);
     });
 
   mantis
@@ -263,7 +167,7 @@ export function registerMantisCli(qa: Command) {
     .option("--video-duration <seconds>", "Visible desktop recording duration in seconds")
     .option("--keep-lease", "Keep a lease created by this run after a passing smoke")
     .action(async (opts: MantisDesktopBrowserSmokeCommanderOptions) => {
-      await runDesktopBrowserSmoke({
+      const options = {
         browserProfileArchiveEnv: opts.browserProfileArchiveEnv,
         browserProfileDir: opts.browserProfileDir,
         browserUrl: opts.browserUrl,
@@ -278,7 +182,9 @@ export function registerMantisCli(qa: Command) {
         repoRoot: opts.repoRoot,
         ttl: opts.ttl,
         videoDurationSeconds: parseOptionalInteger(opts.videoDuration, "--video-duration"),
-      });
+      };
+      const runtime = await loadMantisCliRuntime();
+      await runtime.runMantisDesktopBrowserSmokeCommand(options);
     });
 
   mantis
@@ -323,7 +229,7 @@ export function registerMantisCli(qa: Command) {
       if (opts.approvalCheckpoints && opts.gatewaySetup) {
         throw new Error("--approval-checkpoints cannot be used with --gateway-setup.");
       }
-      await runSlackDesktopSmoke({
+      const options = {
         alternateModel: opts.altModel,
         approvalCheckpoints: opts.approvalCheckpoints,
         crabboxBin: opts.crabboxBin,
@@ -347,7 +253,9 @@ export function registerMantisCli(qa: Command) {
         slackChannelId: opts.slackChannelId,
         slackUrl: opts.slackUrl,
         ttl: opts.ttl,
-      });
+      };
+      const runtime = await loadMantisCliRuntime();
+      await runtime.runMantisSlackDesktopSmokeCommand(options);
     });
 
   mantis
@@ -374,7 +282,7 @@ export function registerMantisCli(qa: Command) {
     .option("--vision-timeout-ms <ms>", "Image understanding timeout in milliseconds")
     .option("--expect-text <text>", "Case-insensitive text expected in the vision output")
     .action(async (opts: MantisVisualTaskCommanderOptions) => {
-      await runVisualTask({
+      const options = {
         browserUrl: opts.browserUrl,
         crabboxBin: opts.crabboxBin,
         duration: opts.duration,
@@ -392,7 +300,9 @@ export function registerMantisCli(qa: Command) {
         visionModel: opts.visionModel,
         visionPrompt: opts.visionPrompt,
         visionTimeoutMs: parseOptionalInteger(opts.visionTimeoutMs, "--vision-timeout-ms"),
-      });
+      };
+      const runtime = await loadMantisCliRuntime();
+      await runtime.runMantisVisualTaskCommand(options);
     });
 
   mantis
@@ -413,7 +323,7 @@ export function registerMantisCli(qa: Command) {
     .option("--vision-timeout-ms <ms>", "Image understanding timeout in milliseconds")
     .option("--expect-text <text>", "Case-insensitive text expected in the vision output")
     .action(async (opts: MantisVisualDriverCommanderOptions) => {
-      await runVisualDriver({
+      const options = {
         browserUrl: opts.browserUrl,
         crabboxBin: opts.crabboxBin,
         expectText: opts.expectText,
@@ -426,6 +336,8 @@ export function registerMantisCli(qa: Command) {
         visionModel: opts.visionModel,
         visionPrompt: opts.visionPrompt,
         visionTimeoutMs: parseOptionalInteger(opts.visionTimeoutMs, "--vision-timeout-ms"),
-      });
+      };
+      const runtime = await loadMantisCliRuntime();
+      await runtime.runMantisVisualDriverCommand(options);
     });
 }

--- a/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
+++ b/extensions/qa-lab/src/mantis/slack-desktop-smoke.runtime.ts
@@ -54,7 +54,7 @@ export type MantisSlackDesktopSmokeOptions = {
   ttl?: string;
 };
 
-export type MantisSlackDesktopHydrateMode = "prehydrated" | "source";
+type MantisSlackDesktopHydrateMode = "prehydrated" | "source";
 
 type MantisSlackDesktopSmokeResult = {
   approvalCheckpointScreenshotPaths?: string[];

--- a/extensions/qa-lab/src/mantis/visual-task.runtime.ts
+++ b/extensions/qa-lab/src/mantis/visual-task.runtime.ts
@@ -18,7 +18,7 @@ import {
 } from "./crabbox-runtime.js";
 import { renderMantisCrabboxReport, type MantisCrabboxReportSummary } from "./report.js";
 
-export type MantisVisualTaskVisionMode = "image-describe" | "metadata";
+type MantisVisualTaskVisionMode = "image-describe" | "metadata";
 
 export type MantisVisualTaskOptions = {
   browserUrl?: string;


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Mantis CLI duplicates its runtime option definitions and routes each command through a private helper that only loads the runtime and forwards an options object. Those copies add maintenance work without owning additional policy.

This is a cleanup companion to the #135868 split campaign; it contains no recovery feature content.

## Why This Change Was Made

Derive the six private Commander option types from their existing runtime owners, retaining the exact CLI-only aliases, numeric strings, and excluded injected fields. Each action now prepares the same explicit options object before awaiting the unchanged memoized loader and invoking the same runtime command.

Deletion evidence: each removed wrapper has one caller and no transformation beyond load/forward/await. The original file is byte-identical in current stable `v2026.9.2` and the inspected main baseline. This preserves the existing CLI rather than retiring a compatibility contract. The runtime projection still excludes injected environment, token, clock, and command-runner fields. Removing the CLI type imports also made two mode aliases unused exports; they now remain private in their existing runtime owners. No API barrel exposes them, and runtime JavaScript in both files is byte-identical.

## User Impact

No CLI flag, default, error, or runtime behavior change. Numeric parsing and mutually exclusive Slack flags still reject before execution code loads. Omitted options continue to defer to runtime environment defaults.

## Evidence

- All 86 existing CLI/shared live-transport CLI tests pass before and after; the expanded final run passes 111 tests including the Slack and visual runtime owners.
- Exact equality and bidirectional assignment of all six private option types pass with exact optional properties enabled and disabled. A separate compiler bridge verifies the extracted runtime declarations against the actual owners; a deliberately wrong numeric option type fails the proof.
- 428 differential cases exercise the actual CLI through real Commander with a stubbed execution-runtime import. Help/error output, option values, own-key order, explicit undefined, method receivers, and load/call events match. All 82 help/rejection cases stay cold; three six-command sequences preserve cached loading and error propagation.
- A negative control that imports runtime before parsing an invalid duration fails at the intended boundary. The applied source passes again.
- Targeted script, production, and full-tree export scans pass after removing the two newly unused exports.
- Full selected changed-check plan passed on Blacksmith Testbox `tbx_01m1v9a4kes3fw9rr6p7qf2h4w` ([run](https://github.com/openclaw/openclaw/actions/runs/34031719324)); command exit 0, lease stopped. Its verified overlay tree exactly matched the first committed candidate.
- Full private-QA build passed with `OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1`; both private SDK files and QA plugin directories were present. All seven built Mantis help entrypoints passed and their output was inspected. Generated assets match committed bytes.
- Fresh-main rebases preserve every recorded source, consumer, test, API, documentation, lockfile, and check-plan input.
- Independent Codex local and branch reviews: no accepted/actionable findings through P2.

| Judged class | Added | Deleted | Net | Touched file before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 52 | 140 | −88 | 2,736 → 2,648 lines across three files |
| Tests | 0 | 0 | 0 | unchanged |
| Tooling | 0 | 0 | 0 | unchanged |
| Docs | 0 | 0 | 0 | unchanged |

No permanent tests, test-only exports, dependencies, new configuration, schema changes, suppressions, or baseline edits. CLI proof does not claim live transport, model, credential, or desktop validation.

ClawSweeper disposition: reviewed `629e2769ff10e427ffbf8b6bea75bbc57cae5c3a` with no correctness/security findings, before-merge requests, or rank-up moves. Final freshness rebase `b3d93777094afb9f2ace41d58711613f9c10aa81` preserves all recorded proof inputs and the lockfile; no review finding required a code change.
