### PR TITLE
fix(ui): stop background Inbox inventory refreshes

### DIFF
--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -142,6 +142,58 @@ describe("sidebar attention source publication", () => {
     },
   );
 
+  it.each(["settled", "pending"] as const)(
+    "defers hidden cron inventory and catches up once after a %s visible read",
+    async (initial) => {
+      let visibility: DocumentVisibilityState = "visible";
+      vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
+      vi.spyOn(Date, "now").mockReturnValue(120_000);
+      const pendingList = deferred<CronJobsListResult>();
+      let listCalls = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method === "cron.list") {
+          listCalls += 1;
+          return initial === "pending" && listCalls === 1
+            ? pendingList.promise
+            : cronPage(listCalls === 1 ? "previous" : "current");
+        }
+        return method === "cron.status"
+          ? { enabled: true, triggersEnabled: true, jobs: 1 }
+          : { ts: 120_000, providers: [] };
+      });
+      const harness = createGatewayHarness(mockClient(request));
+      store = createStore(harness.gateway);
+      store.activate(SidebarAttentionStoreController);
+      if (initial === "settled") {
+        await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "previous" }]));
+      } else {
+        // A visible invalidation queued behind the pending pair also retires on hide.
+        harness.emitEvent("cron", {});
+      }
+      visibility = "hidden";
+      document.dispatchEvent(new Event("visibilitychange"));
+      for (let index = 0; index < 20; index++) {
+        harness.emitEvent("cron", {});
+      }
+      pendingList.resolve(cronPage("previous"));
+      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "previous" }]));
+      for (const method of ["cron.list", "cron.status", "models.authStatus"]) {
+        expect(request.mock.calls.filter(([called]) => called === method)).toHaveLength(1);
+      }
+
+      visibility = "visible";
+      document.dispatchEvent(new Event("visibilitychange"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "current" }]));
+      for (const method of ["cron.list", "cron.status"]) {
+        expect(request.mock.calls.filter(([called]) => called === method)).toHaveLength(2);
+      }
+      expect(request.mock.calls.filter(([method]) => method === "models.authStatus")).toHaveLength(
+        1,
+      );
+    },
+  );
+
   it("publishes progress but retires dismissals only after a fresh complete inventory", async () => {
     vi.stubGlobal("localStorage", createStorageMock());
     const pages = Array.from({ length: 5 }, () => deferred<CronJobsListResult>());

--- a/ui/src/components/sidebar-attention-store.test.ts
+++ b/ui/src/components/sidebar-attention-store.test.ts
@@ -16,7 +16,7 @@ import {
 import { hiddenScopeUpgradeCapability } from "../test-helpers/application-context.ts";
 import { createStorageMock } from "../test-helpers/storage.ts";
 import { waitForFast } from "../test-helpers/wait-for.ts";
-import { loadDismissals } from "./sidebar-attention-dismissals.ts";
+import { dismissSidebarAttention, loadDismissals } from "./sidebar-attention-dismissals.ts";
 import { SidebarAttentionStoreController } from "./sidebar-attention-store.ts";
 
 function cronPage(id?: string): CronJobsListResult {
@@ -193,6 +193,48 @@ describe("sidebar attention source publication", () => {
       );
     },
   );
+
+  it("preserves another tab's dismissal when a hidden event invalidates a pending inventory", async () => {
+    vi.stubGlobal("localStorage", createStorageMock());
+    let visibility: DocumentVisibilityState = "visible";
+    vi.spyOn(document, "visibilityState", "get").mockImplementation(() => visibility);
+    vi.spyOn(Date, "now").mockReturnValue(120_000);
+    const pendingList = deferred<CronJobsListResult>();
+    let listCalls = 0;
+    const request = vi.fn(async (method: string) => {
+      if (method === "cron.list") {
+        return ++listCalls === 1 ? pendingList.promise : cronPage("newer-job");
+      }
+      return method === "cron.status"
+        ? { enabled: true, triggersEnabled: true, jobs: 1 }
+        : { ts: 120_000, providers: [] };
+    });
+    const harness = createGatewayHarness(mockClient(request));
+    store = createStore(harness.gateway);
+    store.activate(SidebarAttentionStoreController);
+    dismissSidebarAttention(harness.gateway.connection.gatewayUrl, {
+      kind: "cronFailed",
+      signature: "newer-job",
+    });
+    visibility = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
+    // The first invalidation arrives only after hiding, with no visible queued refresh.
+    harness.emitEvent("cron", {});
+    pendingList.resolve(cronPage("previous"));
+    await waitForFast(() => expect(store?.entries).toMatchObject([{ label: "previous" }]));
+    expect(listCalls).toBe(1);
+    expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
+      cronFailed: ["newer-job"],
+    });
+
+    visibility = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitForFast(() => expect(store?.entries).toEqual([]));
+    expect(listCalls).toBe(2);
+    expect(loadDismissals(harness.gateway.connection.gatewayUrl)).toEqual({
+      cronFailed: ["newer-job"],
+    });
+  });
 
   it("publishes progress but retires dismissals only after a fresh complete inventory", async () => {
     vi.stubGlobal("localStorage", createStorageMock());

--- a/ui/src/components/sidebar-attention-store.ts
+++ b/ui/src/components/sidebar-attention-store.ts
@@ -215,13 +215,13 @@ export class SidebarAttentionStoreController implements StoreController {
       this.reconcileDismissals(scope);
       this.onChange();
     };
-    if (document.visibilityState === "hidden") {
-      this.cronRefreshNeeded = true;
-    } else if (this.cronRefresh?.generation === generation) {
-      this.cronRefreshNeeded = false;
+    // Deferring dispatch still invalidates the pending inventory: its stale
+    // response must not retire dismissals saved since the request began.
+    if (this.cronRefresh?.generation === generation) {
       this.cronRefresh.requested = true;
-    } else {
-      this.cronRefreshNeeded = false;
+    }
+    this.cronRefreshNeeded = document.visibilityState === "hidden";
+    if (!this.cronRefreshNeeded && this.cronRefresh?.generation !== generation) {
       const refresh = { generation, requested: true };
       this.cronRefresh = refresh;
       void (async () => {

--- a/ui/src/components/sidebar-attention-store.ts
+++ b/ui/src/components/sidebar-attention-store.ts
@@ -52,6 +52,7 @@ export class SidebarAttentionStoreController implements StoreController {
   private dismissed: SidebarAttentionDismissals = {};
   private loadGeneration = 0;
   private cronRefresh: { generation: number; requested: boolean } | null = null;
+  private cronRefreshNeeded = false;
   private modelAuthRefresh: { generation: number; requested: boolean } | null = null;
   private readonly stopGateway: () => void;
   private readonly stopEvents: () => void;
@@ -214,9 +215,13 @@ export class SidebarAttentionStoreController implements StoreController {
       this.reconcileDismissals(scope);
       this.onChange();
     };
-    if (this.cronRefresh?.generation === generation) {
+    if (document.visibilityState === "hidden") {
+      this.cronRefreshNeeded = true;
+    } else if (this.cronRefresh?.generation === generation) {
+      this.cronRefreshNeeded = false;
       this.cronRefresh.requested = true;
     } else {
+      this.cronRefreshNeeded = false;
       const refresh = { generation, requested: true };
       this.cronRefresh = refresh;
       void (async () => {
@@ -224,6 +229,10 @@ export class SidebarAttentionStoreController implements StoreController {
           // One scope owns both reads. Events during either read request one
           // trailing inventory; retired scopes never drain queued network work.
           while (refresh.requested && current()) {
+            if (document.visibilityState === "hidden") {
+              this.cronRefreshNeeded = true;
+              break;
+            }
             refresh.requested = false;
             const cron = createInitialCronState({ client, connected: true });
             cron.cronAgentId = agentScope.scopeId;
@@ -343,11 +352,11 @@ export class SidebarAttentionStoreController implements StoreController {
     const loadedAtMs = this.sources.agentSelection.state.selectedId
       ? Math.min(this.cronLoadedAtMs, this.modelAuthLoadedAtMs)
       : this.cronLoadedAtMs;
-    if (
-      document.visibilityState === "visible" &&
-      Date.now() - loadedAtMs >= VISIBILITY_REFRESH_MIN_AGE_MS
-    ) {
-      this.load();
+    const stale = Date.now() - loadedAtMs >= VISIBILITY_REFRESH_MIN_AGE_MS;
+    if (document.visibilityState === "visible" && (this.cronRefreshNeeded || stale)) {
+      // Hidden cron events need an immediate catch-up even inside the freshness
+      // window, without refreshing independently current model authentication.
+      this.load(stale);
     }
   };
 

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -50,6 +50,63 @@ const MISSING_AUTH_RESPONSE = {
 };
 
 suite.define(() => {
+  it("defers hidden Inbox inventory and shows fresh cron attention on return", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await page.clock.setFixedTime(Date.now());
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "cron.list": FAILED_CRON_RESPONSE,
+        "models.authStatus": MISSING_AUTH_RESPONSE,
+      },
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      const badge = page.locator("openclaw-app-sidebar .sidebar-issues-button__count");
+      await expect.poll(() => badge.textContent()).toBe("2");
+      await page.locator("openclaw-app-sidebar .sidebar-issues-button").click();
+      await page.getByText("Failed settings transition", { exact: true }).waitFor();
+      await captureSidebarUiProof(suite, page, "inbox-before-hidden-events.png");
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      await gateway.setMethodResponse("cron.list", {
+        ...FAILED_CRON_RESPONSE,
+        jobs: [{ ...FAILED_CRON_RESPONSE.jobs[0], name: "Failure while away" }],
+      });
+      for (let index = 0; index < 20; index++) {
+        await gateway.emitGatewayEvent("cron", { action: "finished", jobId: `hidden-${index}` });
+      }
+      for (const method of ["cron.list", "cron.status", "models.authStatus"]) {
+        expect(await gateway.getRequests(method)).toHaveLength(1);
+      }
+      await page.getByText("Failed settings transition", { exact: true }).waitFor();
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          value: "visible",
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+        window.dispatchEvent(new Event("focus"));
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      await page.getByText("Failure while away", { exact: true }).waitFor();
+      expect(await badge.textContent()).toBe("2");
+      for (const method of ["cron.list", "cron.status"]) {
+        expect(await gateway.getRequests(method)).toHaveLength(2);
+      }
+      expect(await gateway.getRequests("models.authStatus")).toHaveLength(1);
+      await captureSidebarUiProof(suite, page, "inbox-after-hidden-events.png");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("refreshes stale auth attention after returning while the first auth read is pending", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -102,6 +102,41 @@ suite.define(() => {
       }
       expect(await gateway.getRequests("models.authStatus")).toHaveLength(1);
       await captureSidebarUiProof(suite, page, "inbox-after-hidden-events.png");
+
+      await gateway.deferNext("cron.list");
+      await gateway.emitGatewayEvent("cron", { action: "finished" });
+      await gateway.waitForRequest("cron.list", { after: 2 });
+      await page.getByRole("button", { name: "Dismiss Failure while away", exact: true }).click();
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      // The first event invalidating this pending inventory arrives while hidden.
+      await gateway.emitGatewayEvent("cron", { action: "finished" });
+      await gateway.resolveDeferred("cron.list", { ...FAILED_CRON_RESPONSE, jobs: [], total: 0 });
+      expect(await gateway.getRequests("cron.list")).toHaveLength(3);
+      await gateway.deferNext("cron.list");
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          value: "visible",
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      await gateway.waitForRequest("cron.list", { after: 3 });
+      await gateway.resolveDeferred("cron.list", {
+        ...FAILED_CRON_RESPONSE,
+        jobs: [
+          FAILED_CRON_RESPONSE.jobs[0],
+          { ...FAILED_CRON_RESPONSE.jobs[0], id: "fresh-job", name: "Fresh visible warning" },
+        ],
+        total: 2,
+      });
+      await page.getByText("Fresh visible warning", { exact: true }).waitFor();
+      expect(await page.locator('[data-attention-kind="cronFailed"]').count()).toBe(1);
+      expect(await badge.textContent()).toBe("2");
+      expect(await gateway.getRequests("cron.list")).toHaveLength(4);
+      await captureSidebarUiProof(suite, page, "inbox-dismissal-preserved-on-return.png");
     } finally {
       await suite.closeBrowserContext(context);
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users leaving the Control UI in a background tab would keep triggering Inbox automation-inventory requests as cron events arrived. A queued follow-up inventory could also start after the tab became hidden.

## Why This Change Was Made

The existing Inbox owner retains one pending refresh while hidden and redeems it as soon as the page becomes visible, including inside its normal freshness window. Hidden events invalidate any in-flight inventory before dispatch is deferred, so an outdated response cannot retire a newer saved dismissal.

The app-owned Inbox keeps its existing navigation lifetime and independently owned authentication, mention, approval, and notification behavior. The separate Automations-page loader queues are being repaired independently.

## User Impact

Background tabs stop issuing unnecessary Inbox cron inventory requests. Returning to a tab shows fresh automation attention immediately, while saved dismissals survive an old inventory response.

## Evidence

- 252 native tests passed on the exact final head, covering Inbox ownership, hidden settled/pending reads, authentication freshness, dismissals, and cron siblings.
- All 12 Chromium E2E tests passed against the production-built Control UI bundle and a synthetic Gateway. Twenty hidden events added no inventory/auth RPCs; return issued one list/status pair. The extended flow also dismissed a warning after a read began, hid/invalidated the pending inventory, settled its obsolete empty response, and verified the dismissal survived fresh visible data.
- The persisted-dismissal regression fails on the first candidate with an empty saved-dismissal map, then passes after the correction. The original hidden-read regressions also failed on pre-fix code.
- Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34034242530). The final standalone changed gate also passed, including formatting, core/UI typechecking, lint, and repository guards.
- Fresh independent P0–P2 review is clean. Production delta: +15/-6 lines; deferred visibility work stays in its existing owner.

ClawSweeper's pending-inventory finding and associated rank-up move are addressed in 0450859fe02967010b257a5f6f48fe1c2c440de3, with both persisted-state regression and browser coverage.

The screenshots below use synthetic fixtures. Visibility events are controlled in Chromium; this is not native OS visibility proof or attribution of any particular production Gateway stall.

![Before hiding the tab - synthetic Inbox](https://github.com/user-attachments/assets/af5351af-e2b7-4faf-96e3-cf4b5422149d)

![Fresh automation attention after returning - synthetic Inbox](https://github.com/user-attachments/assets/d4bb0942-bd01-4317-b93a-c479d80f94a8)

![Saved dismissal preserved with fresh visible data - synthetic Inbox](https://github.com/user-attachments/assets/69a10e21-5e44-4362-b989-20f98b900902)
