### PR TITLE
perf: speed up bulk queue overflow summaries

### DIFF
--- a/src/utils/queue-helpers.test.ts
+++ b/src/utils/queue-helpers.test.ts
@@ -63,6 +63,46 @@ describe("applyQueueRuntimeSettings", () => {
 });
 
 describe("queue summary helpers", () => {
+  it.each([
+    { limit: undefined, retained: ["new"], elided: ["first", "second"] },
+    { limit: 1.5, retained: ["new"], elided: ["first", "second"] },
+    { limit: 1 - Number.EPSILON / 2, retained: [], elided: ["first", "second", "new"] },
+    { limit: 2, retained: ["second", "new"], elided: ["first"] },
+    { limit: 0, retained: [], elided: ["first", "second", "new"] },
+    { limit: -1, retained: [], elided: ["first", "second", "new"] },
+    { limit: -Infinity, retained: [], elided: ["first", "second", "new"] },
+    { limit: Infinity, retained: ["first", "second", "new"], elided: [] },
+    { limit: Number.NaN, retained: ["first", "second", "new"], elided: [] },
+  ])("preserves ordered summary elisions at limit $limit", ({ limit, retained, elided }) => {
+    const queue = {
+      items: ["new"],
+      cap: 1,
+      dropPolicy: "summarize" as const,
+      droppedCount: 2,
+      summaryLines: ["first", "second"],
+    };
+    const calls: Array<[string, string[]]> = [];
+
+    expect(
+      applyQueueDropPolicy({
+        queue,
+        summaryLimit: limit,
+        summarize: (item) => item,
+        onDrop: (items) => calls.push(["drop", items]),
+        onSummaryElide: (lines) => calls.push(["elide", lines]),
+      }),
+    ).toBe(true);
+
+    expect(queue).toEqual({
+      items: [],
+      cap: 1,
+      dropPolicy: "summarize",
+      droppedCount: 3,
+      summaryLines: retained,
+    });
+    expect(calls).toEqual([["drop", ["new"]], ...(elided.length > 0 ? [["elide", elided]] : [])]);
+  });
+
   it("renders pending summary state without mutating it", () => {
     const state = {
       droppedCount: 2,

--- a/src/utils/queue-helpers.ts
+++ b/src/utils/queue-helpers.ts
@@ -157,14 +157,10 @@ export function applyQueueDropPolicy<T>(params: {
     }
     // Summary memory is bounded independently from the item cap to avoid prompt blowups.
     const limit = Math.max(0, params.summaryLimit ?? cap);
-    const elidedLines: string[] = [];
-    while (params.queue.summaryLines.length > limit) {
-      const line = params.queue.summaryLines.shift();
-      if (line !== undefined) {
-        elidedLines.push(line);
-      }
-    }
-    if (elidedLines.length > 0) {
+    const summaryLines = params.queue.summaryLines;
+    if (summaryLines.length > limit) {
+      // Round the cutoff first; subtraction can erase a fraction just below an integer.
+      const elidedLines = summaryLines.splice(0, summaryLines.length - Math.floor(limit));
       params.onSummaryElide?.(elidedLines);
     }
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintaining overflow summaries does unnecessary work when a busy session drops many queued messages, particularly after lowering its queue cap. This affects follow-up queues and the local TUI's pending-message workflow.

## Why This Change Was Made

Trim the expired summary prefix in one operation, using the dense strings produced by the existing formatter. Preserve summary/source ordering, callback behavior, and fractional-limit semantics by rounding the cutoff before subtraction. There are no configuration, persistence, protocol, or SDK changes. Production code is four lines smaller; tests add 40 lines.

## User Impact

Large overflow batches require less local processing. Ordinary small cases are not uniformly faster: the default one-elision and no-elision cases retain the measured costs below. Queue behavior and summary contents remain unchanged. No general Gateway, model-turn, or network-latency improvement is claimed.

## Evidence

Local validation passed 287 tests across the five complete queue-helper, drain/restart, pending-input, collect, and embedded-TUI suites, plus all 29 normal changed checks. Fresh managed P2 review completed both evidence passes with no findings. An independent data audit reconciled the retained outputs, arithmetic, and every adverse result.

The fixed 20-cohort component run used fresh processes in B0/C0/C1/B1 order, after separate baseline/candidate proofs: 41,080 checked calls, 40,960 timed calls, and 1,280 batch times. All calls checked state, ordering, and identity in process; only 120 successful setup outputs are serialized, alongside all times and failure-state evidence. Times include callback instrumentation; batch extrema are not latency percentiles.

| Case | Forward median change | Reverse median change |
|---|---:|---:|
| Cap shrinks from 200 to 20 | −17.44% | −36.12% |
| 2,000-item cap-shrink stress case | −14.42% | −17.03% |
| Default one-elision case | +95.05 ns (+7.99%) | +5.23 ns (+0.43%) |
| No summary elision | +190.11 ns (+22.65%) | +57.94 ns (+7.19%) |

All rows and controls remain included: 16/40 adverse medians, 68/160 adverse summary metrics, and 268/640 adverse same-index comparisons. Reverse kernel peak RSS increased by 7,651,328 bytes (+2.21%); this is the only adverse whole-child resource comparison, whose scope includes imports, setup, verification, and output.

An earlier unlanded prototype remains separate, including its 22/38 adverse medians. A new fractional-cutoff case failed on that prototype and passed on the original baseline; the corrected implementation passes. The initial reporter-verification failure and redundant functional run are retained. No r1 timings are pooled with r2, and no unfavorable row was removed; the boundary row was added before new data.

Exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/34032955191) passed after one diagnostic rerun of the failed jobs. The first attempt timed out in the unchanged test-profiler CLI test, before configuration or queue code loads. That unrelated timeout is retained for follow-up; the passing rerun is not claimed as a root-cause fix.
