### PR TITLE
fix(ui): stop automation refreshes in hidden tabs

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -629,6 +629,7 @@ are Gateway settings and remain available in every browser.
 
   </Accordion>
   <Accordion title="Automations panel notes">
+    - Scheduler status, automation lists, and run history pause background refreshes while the browser tab is hidden and catch up when you return. Your current filters and unsaved draft stay in place; saves and runs already submitted continue.
     - Selecting a row opens a full-page detail view with an Active/Paused switch and Run now in the header (run-if-due, clone, and remove in its menu); the Settings tab edits the automation inline (prompt, details, frequency, advanced overrides) and the Run history tab shows that automation's runs.
     - Cloning an agent task retains its stored tool allowlist, model fallback list, lightweight-context setting, and external-content setting, including empty lists and explicit `false` values. Fields you change in the copy's form take precedence. The new task is authorized by the current operator; captured execution grants are not copied.
     - Both Run history views show a recorded delivery-suppression reason alongside the delivery status when available. Intentional suppression remains separate from delivery errors; the history does not infer a reason from a successful run.

--- a/ui/src/e2e/cron-loading.e2e.test.ts
+++ b/ui/src/e2e/cron-loading.e2e.test.ts
@@ -136,7 +136,12 @@ suite.define(() => {
       await gateway.resolveDeferred("cron.list");
       await gateway.resolveDeferred("cron.runs");
       await page.getByText("No automations yet").waitFor({ state: "visible" });
-      await page.evaluate(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, 0);
+          }),
+      );
       expect(await counts()).toEqual(before);
       await page.screenshot({ path: path.join(suite.artifactDir, "hidden-refresh-paused.png") });
       await page.evaluate(() => {

--- a/ui/src/e2e/cron-loading.e2e.test.ts
+++ b/ui/src/e2e/cron-loading.e2e.test.ts
@@ -104,6 +104,59 @@ suite.define(() => {
     );
   });
 
+  it("pauses queued automation reads while hidden and catches up once on show", async () => {
+    await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        heldMethods: ["cron.list", "cron.runs"],
+        methodResponses: {
+          "cron.list": emptyList,
+          "cron.runs": { entries: [], total: 0, offset: 0, limit: 50, hasMore: false },
+          "cron.status": { enabled: true, jobs: 0, nextWakeAtMs: null },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}cron`);
+      await page.locator('[data-test-id="cron-jobs-loading"]').waitFor({ state: "visible" });
+      await gateway.waitForRequest("cron.runs");
+      const counts = async () => ({
+        table: tableListRequests(await gateway.getRequests("cron.list")).length,
+        runs: (await gateway.getRequests("cron.runs")).length,
+      });
+      const before = await counts();
+      for (let event = 0; event < 20; event += 1) {
+        await gateway.emitGatewayEvent("cron", { jobId: "synthetic-job", action: "finished" });
+      }
+      // Exercise the document visibility contract deterministically in Chromium.
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          get: () => "hidden",
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      await gateway.resolveDeferred("cron.list");
+      await gateway.resolveDeferred("cron.runs");
+      await page.getByText("No automations yet").waitFor({ state: "visible" });
+      await page.evaluate(() => new Promise<void>((resolve) => setTimeout(resolve, 0)));
+      expect(await counts()).toEqual(before);
+      await page.screenshot({ path: path.join(suite.artifactDir, "hidden-refresh-paused.png") });
+      await page.evaluate(() => {
+        Object.defineProperty(document, "visibilityState", {
+          configurable: true,
+          get: () => "visible",
+        });
+        document.dispatchEvent(new Event("visibilitychange"));
+        globalThis.dispatchEvent(new Event("focus"));
+      });
+      await expect.poll(counts).toEqual({ table: before.table + 1, runs: before.runs + 1 });
+      await page.getByText("No automations yet").waitFor({ state: "visible" });
+      writeFileSync(
+        path.join(suite.artifactDir, "hidden-refresh-requests.json"),
+        JSON.stringify({ before, after: await counts() }, null, 2),
+      );
+      await page.screenshot({ path: path.join(suite.artifactDir, "visible-refresh-complete.png") });
+    });
+  });
+
   it("shows pending before empty and keeps empty visible after a run-history failure", async () => {
     await suite.withPage(
       {

--- a/ui/src/lib/cron/index.ts
+++ b/ui/src/lib/cron/index.ts
@@ -198,6 +198,8 @@ export type CronJobsLastStatusFilter = "all" | CronRunStatus | "unknown";
 type CronRunsLoadStatus = "ok" | "error" | "skipped";
 
 export type CronState = {
+  // Read admission belongs to the page; accepted mutation chains remain independent.
+  canRefresh?: () => boolean;
   client: GatewayBrowserClient | null;
   connected: boolean;
   cronLoading: boolean;
@@ -427,7 +429,7 @@ export async function loadCronStatus(
   opts?: { coalesce?: boolean },
 ): Promise<void> {
   const client = state.client;
-  if (!client || !state.connected) {
+  if (!client || !state.connected || state.canRefresh?.() === false) {
     return;
   }
   const active = activeCronStatusRequests.get(state);
@@ -668,7 +670,7 @@ export async function loadCronJobsPage(
   state: CronState,
   opts?: { append?: boolean; tableFilters?: boolean },
 ) {
-  if (!state.client || !state.connected) {
+  if (!state.client || !state.connected || state.canRefresh?.() === false) {
     return;
   }
   const append = opts?.append === true;
@@ -1437,7 +1439,7 @@ export async function loadCronRuns(
   opts?: { append?: boolean; coalesce?: boolean },
 ): Promise<CronRunsLoadStatus> {
   const client = state.client;
-  if (!client || !state.connected) {
+  if (!client || !state.connected || state.canRefresh?.() === false) {
     return "skipped";
   }
   const scope = state.cronRunsScope;

--- a/ui/src/lib/cron/refresh.test.ts
+++ b/ui/src/lib/cron/refresh.test.ts
@@ -113,6 +113,29 @@ describe.each(["cron.status", "cron.runs"] as const)("%s event refresh ownership
     },
   );
 
+  it("settles a queued refresh without dispatch when page read admission closes", async () => {
+    const harness = createRefreshHarness(method);
+    let visible = true;
+    harness.state.canRefresh = () => visible;
+    try {
+      const initial = harness.load();
+      const queued = harness.load();
+      visible = false;
+      harness.response(0).resolve(harness.payload(1));
+      await Promise.all([initial, queued]);
+      expect(harness.request).toHaveBeenCalledTimes(1);
+      expect(harness.revision()).toBe(1);
+      visible = true;
+      const resumed = harness.load();
+      expect(harness.request).toHaveBeenCalledTimes(2);
+      harness.response(1).resolve(harness.payload(2));
+      await resumed;
+      expect(harness.revision()).toBe(2);
+    } finally {
+      await harness.close();
+    }
+  });
+
   it("completes an explicit read without waiting for its queued event refresh", async () => {
     const harness = createRefreshHarness(method);
     try {

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -69,6 +69,7 @@ class CronPage extends OpenClawLightDomElement {
   private pendingRunScroll = false;
   private modelSuggestionsRequest: { state: CronState; agentId: string } | null = null;
   private heartbeatScratchRequest = 0;
+  private pageHidden = document.visibilityState === "hidden";
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
     invalidateRequests: (change) => this.resetGatewayState(change.snapshot),
@@ -80,6 +81,14 @@ class CronPage extends OpenClawLightDomElement {
       }
     },
     ensureInitialData: () => this.ensureInitialData(),
+    onPageActivation: () => {
+      const hidden = document.visibilityState === "hidden";
+      const resumed = this.pageHidden && !hidden;
+      this.pageHidden = hidden;
+      if (resumed) {
+        this.ensureInitialData(true);
+      }
+    },
   });
   private readonly observeAgentScope = watchAgentScope((scopeId) => {
     this.pendingRouteData = null;
@@ -145,10 +154,13 @@ class CronPage extends OpenClawLightDomElement {
     this.clearHeartbeatScratch();
     invalidateCronRefresh(this.cron);
     const connected = snapshot?.phase === "connected";
-    this.cron = createInitialCronState({
+    const cron = createInitialCronState({
       client: snapshot?.client ?? null,
       connected,
     });
+    cron.canRefresh = () => this.canRefreshCron(cron);
+    this.cron = cron;
+    this.pageHidden = document.visibilityState === "hidden";
     this.cron.cronAgentId = this.context.agentSelection.state.scopeId;
     this.agentsList = connected ? this.context.agents.state.agentsList : null;
     this.cronModelSuggestions = [];
@@ -160,14 +172,18 @@ class CronPage extends OpenClawLightDomElement {
     this.agentsList = this.context.agents.state.agentsList;
   }
 
-  private ensureInitialData() {
-    if (!this.cron.connected || !this.cron.client) {
+  private canRefreshCron(cron: CronState = this.cron) {
+    return this.isConnected && this.cron === cron && document.visibilityState !== "hidden";
+  }
+
+  private ensureInitialData(forceRefresh = false) {
+    if (!this.canRefreshCron() || !this.cron.connected || !this.cron.client) {
       return;
     }
     if (!this.agentsList && !this.context.agents.state.agentsLoading) {
       void this.context.agents.ensureList();
     }
-    if (!this.cron.cronStatus && !this.cron.cronLoading) {
+    if (forceRefresh || (!this.cron.cronStatus && !this.cron.cronLoading)) {
       void this.refreshCron({ tableFilters: true, coalesce: true });
     } else if (!this.cron.cronRuns.length && !this.cron.cronRunsLoadingMore) {
       void this.loadRuns(this.cron.cronRunsScope === "all" ? null : this.cron.cronRunsJobId);
@@ -242,7 +258,7 @@ class CronPage extends OpenClawLightDomElement {
 
   private async refreshCron(options: { tableFilters: boolean; coalesce?: boolean }) {
     const cronState = this.cron;
-    if (!cronState.connected || !cronState.client) {
+    if (!this.canRefreshCron(cronState) || !cronState.connected || !cronState.client) {
       return;
     }
     const activeCronJobId = cronState.cronRunsScope === "job" ? cronState.cronRunsJobId : null;

--- a/ui/src/pages/cron/cron-page.visibility.test.ts
+++ b/ui/src/pages/cron/cron-page.visibility.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import {
+  createContext,
+  createGateway,
+  createPage,
+  createRequest,
+  waitForCronPage,
+} from "./cron-page.test-support.ts";
+import "./cron-page.ts";
+
+const refreshMethods = ["cron.status", "cron.list", "cron.runs"];
+
+function controlVisibility(initial: DocumentVisibilityState = "visible") {
+  let value = initial;
+  vi.spyOn(document, "visibilityState", "get").mockImplementation(() => value);
+  return (next: DocumentVisibilityState) => {
+    value = next;
+    document.dispatchEvent(new Event("visibilitychange"));
+  };
+}
+
+function settle() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("CronPage hidden refreshes", () => {
+  it("defers a hidden mount and reconnect, then catches up once with the current scope", async () => {
+    const visibility = controlVisibility("hidden");
+    const request = createRequest();
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const context = createContext(gateway);
+    const page = createPage(context);
+    await page.updateComplete;
+    gateway.emitSnapshot({ phase: "stopped" });
+    context.agentSelection.setScope("writer");
+    gateway.emitSnapshot({ phase: "connected" });
+    for (let event = 0; event < 20; event += 1) {
+      gateway.emitRetiredEvent({ event: "cron" } as never);
+    }
+    await settle();
+    expect(request.mock.calls.filter(([method]) => refreshMethods.includes(method))).toEqual([]);
+    expect(context.channels.refresh).not.toHaveBeenCalled();
+
+    visibility("visible");
+    globalThis.dispatchEvent(new Event("focus"));
+    await waitForCronPage(() => expect(page.cron.cronStatus).not.toBeNull());
+    await settle();
+    for (const method of refreshMethods) {
+      expect(
+        request.mock.calls.filter(([called]) => called === method),
+        method,
+      ).toHaveLength(1);
+    }
+    expect(request).toHaveBeenCalledWith(
+      "cron.list",
+      expect.objectContaining({ agentId: "writer" }),
+    );
+    expect(context.channels.refresh).toHaveBeenCalledTimes(1);
+    page.remove();
+    request.mockClear();
+    visibility("hidden");
+    visibility("visible");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it.each([true, false])(
+    "keeps a queued burst paused when its reads finish while hidden=%s",
+    async (finishHidden) => {
+      const visibility = controlVisibility();
+      const held = createDeferred();
+      let hold = true;
+      const fallback = createRequest();
+      const request = vi.fn(async (method: string, _params?: unknown) => {
+        if (hold && refreshMethods.includes(method)) {
+          await held.promise;
+        }
+        return fallback(method);
+      });
+      const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+      const page = createPage(createContext(gateway));
+      try {
+        await page.updateComplete;
+        const current = page.cron;
+        current.cronJobsQuery = "keep my filter";
+        current.cronCreateOpen = true;
+        current.cronForm.name = "Unsaved automation";
+        for (let event = 0; event < 20; event += 1) {
+          gateway.emitRetiredEvent({ event: "cron" } as never);
+        }
+        visibility("hidden");
+        current.cronRunsQuery = "keep my history filter";
+        hold = false;
+        if (finishHidden) {
+          held.resolve();
+          await settle();
+        }
+        for (const method of refreshMethods) {
+          expect(
+            request.mock.calls.filter(([called]) => called === method),
+            method,
+          ).toHaveLength(1);
+        }
+        visibility("visible");
+        globalThis.dispatchEvent(new Event("focus"));
+        held.resolve();
+        await waitForCronPage(() => expect(page.cron.cronLoading).toBe(false));
+        await settle();
+        for (const method of refreshMethods) {
+          expect(
+            request.mock.calls.filter(([called]) => called === method),
+            method,
+          ).toHaveLength(2);
+        }
+        expect(page.cron).toBe(current);
+        expect(current.cronCreateOpen).toBe(true);
+        expect(current.cronForm.name).toBe("Unsaved automation");
+        expect(
+          request.mock.calls.filter(([method]) => method === "cron.list").at(-1)?.[1],
+        ).toMatchObject({ query: "keep my filter" });
+        expect(
+          request.mock.calls.filter(([method]) => method === "cron.runs").at(-1)?.[1],
+        ).toMatchObject({ query: "keep my history filter" });
+      } finally {
+        held.resolve();
+        page.remove();
+      }
+    },
+  );
+
+  it("rebinds hidden catch-up to the replacement Gateway", async () => {
+    const visibility = controlVisibility();
+    const held = createDeferred();
+    const fallback = createRequest();
+    const oldRequest = vi.fn(async (method: string) => {
+      if (refreshMethods.includes(method)) {
+        await held.promise;
+      }
+      return fallback(method);
+    });
+    const oldGateway = createGateway(
+      { request: oldRequest } as unknown as GatewayBrowserClient,
+      true,
+    );
+    const page = createPage(createContext(oldGateway));
+    try {
+      await page.updateComplete;
+      oldGateway.emitRetiredEvent({ event: "cron" } as never);
+      visibility("hidden");
+      const request = createRequest();
+      const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+      page.context = createContext(gateway, "writer");
+      page.requestUpdate();
+      await page.updateComplete;
+      held.resolve();
+      await settle();
+      expect(request).not.toHaveBeenCalled();
+      oldRequest.mockClear();
+      visibility("visible");
+      globalThis.dispatchEvent(new Event("focus"));
+      oldGateway.emitRetiredEvent({ event: "cron" } as never);
+      await settle();
+      for (const method of refreshMethods) {
+        expect(
+          request.mock.calls.filter(([called]) => called === method),
+          method,
+        ).toHaveLength(1);
+      }
+      expect(oldRequest).not.toHaveBeenCalled();
+      expect(request).toHaveBeenCalledWith(
+        "cron.list",
+        expect.objectContaining({ agentId: "writer" }),
+      );
+    } finally {
+      held.resolve();
+      page.remove();
+    }
+  });
+
+  it("finishes an accepted create-and-run chain while hidden without background readbacks", async () => {
+    const visibility = controlVisibility();
+    const saved = createDeferred();
+    const fallback = createRequest();
+    const request = vi.fn(async (method: string, _params?: unknown) => {
+      if (method === "cron.add") {
+        await saved.promise;
+        return { id: "created-job" };
+      }
+      if (method === "cron.run") {
+        return { ok: true, enqueued: true, runId: "synthetic-run" };
+      }
+      return fallback(method);
+    });
+    const gateway = createGateway({ request } as unknown as GatewayBrowserClient, true);
+    const page = createPage(createContext(gateway), { render: true });
+    try {
+      await waitForCronPage(() => expect(page.cron.cronStatus).not.toBeNull());
+      (page.querySelector('[data-test-id="cron-new-task"]') as HTMLButtonElement).click();
+      await page.updateComplete;
+      for (const [selector, value] of [
+        ["#cron-name", "Synthetic task"],
+        ["#cron-payload-text", "Synthetic prompt"],
+      ]) {
+        const input = page.querySelector(selector) as HTMLInputElement;
+        input.value = value;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      await page.updateComplete;
+      (page.querySelector('[data-test-id="cron-submit-run"]') as HTMLButtonElement).click();
+      await waitForCronPage(() =>
+        expect(request.mock.calls.some(([method]) => method === "cron.add")).toBe(true),
+      );
+      visibility("hidden");
+      request.mockClear();
+      saved.resolve();
+      await waitForCronPage(() => expect(page.cron.cronBusy).toBe(false));
+      expect(request).toHaveBeenCalledExactlyOnceWith("cron.run", {
+        id: "created-job",
+        mode: "force",
+      });
+      expect(page.cron.cronError).toContain("Run queued. Run ID: synthetic-run");
+      expect(page.cron.cronCreateOpen).toBe(false);
+      visibility("visible");
+      await settle();
+      for (const method of refreshMethods) {
+        expect(
+          request.mock.calls.filter(([called]) => called === method),
+          method,
+        ).toHaveLength(1);
+      }
+    } finally {
+      saved.resolve();
+      page.remove();
+    }
+  });
+});

--- a/ui/src/pages/cron/cron-page.visibility.test.ts
+++ b/ui/src/pages/cron/cron-page.visibility.test.ts
@@ -161,6 +161,12 @@ describe("CronPage hidden refreshes", () => {
       held.resolve();
       await settle();
       expect(request).not.toHaveBeenCalled();
+      for (const method of refreshMethods) {
+        expect(
+          oldRequest.mock.calls.filter(([called]) => called === method),
+          method,
+        ).toHaveLength(1);
+      }
       oldRequest.mockClear();
       visibility("visible");
       globalThis.dispatchEvent(new Event("focus"));
@@ -206,7 +212,7 @@ describe("CronPage hidden refreshes", () => {
       for (const [selector, value] of [
         ["#cron-name", "Synthetic task"],
         ["#cron-payload-text", "Synthetic prompt"],
-      ]) {
+      ] as const) {
         const input = page.querySelector(selector) as HTMLInputElement;
         input.value = value;
         input.dispatchEvent(new Event("input", { bubbles: true }));

--- a/ui/src/pages/cron/cron-page.visibility.test.ts
+++ b/ui/src/pages/cron/cron-page.visibility.test.ts
@@ -22,7 +22,9 @@ function controlVisibility(initial: DocumentVisibilityState = "visible") {
 }
 
 function settle() {
-  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 }
 
 afterEach(() => {
@@ -122,10 +124,10 @@ describe("CronPage hidden refreshes", () => {
         expect(current.cronCreateOpen).toBe(true);
         expect(current.cronForm.name).toBe("Unsaved automation");
         expect(
-          request.mock.calls.filter(([method]) => method === "cron.list").at(-1)?.[1],
+          request.mock.calls.findLast(([method]) => method === "cron.list")?.[1],
         ).toMatchObject({ query: "keep my filter" });
         expect(
-          request.mock.calls.filter(([method]) => method === "cron.runs").at(-1)?.[1],
+          request.mock.calls.findLast(([method]) => method === "cron.runs")?.[1],
         ).toMatchObject({ query: "keep my history filter" });
       } finally {
         held.resolve();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users leaving the Automations page open in a background tab would continue generating scheduler-status, automation-list, and run-history requests. Refreshes queued before hiding the tab could also dispatch later.

## Why This Change Was Made

The page now decides whether all three refresh loaders may dispatch, including their queued continuations. Returning to the tab requests one coalesced catch-up through the existing refresh flow. Accepted saves, runs, and configuration-conflict recovery keep their existing behavior.

## User Impact

Hidden Automations tabs avoid unnecessary Gateway work. Returning to the tab refreshes the current selection while preserving filters and unsaved drafts. There are no new settings, dependencies, database changes, or protocol changes.

## Evidence

- Original-code Blacksmith proof reproduced hidden-mount/event traffic, queued refreshes dispatching after hiding, and unnecessary readbacks after an accepted create-and-run action.
- Corrected head `948e937c5392`: targeted lint and 274 focused tests across five files passed, covering queue completion, hidden mount/reconnect, Gateway replacement, retained filters/drafts, accepted create-and-run, conflict recovery, and existing lifecycle behavior.
- All three Chromium mocked-Gateway scenarios passed. The new scenario held page-specific inventory/history requests at one each while hidden, then observed exactly one additional request each after visibility and focus events. Visibility is controlled synthetically; this is not a production latency measurement.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34034232944) passed: 89 successful jobs, 12 skipped jobs, no failures, including the real-Gateway UI E2E lane.
- Full `check:changed` passed on the same head, including all 16 core-test type graphs, UI types, i18n, coercion/dead-export guards, and changed-file lint/styles. Independent P2 review and the current ClawSweeper review have no actionable findings.

The first browser attempt lacked Playwright's matching video encoder; installing its pinned FFmpeg asset made the complete browser file pass. CI also caught four test-only lint findings, which were fixed without changing production behavior.

The captures below show the same synthetic page while hidden and after catch-up. This change affects request scheduling, so its visible layout stays unchanged.

![Synthetic Automations page while document visibility is hidden](https://github.com/user-attachments/assets/a14682b3-3e34-481c-b80f-70ee8c9267e5)

![The same page after one coalesced catch-up on return](https://github.com/user-attachments/assets/b030b376-1d52-44b9-8cb0-3ac7265f68fc)
