### PR TITLE
perf(gateway): skip unused HEAD reads for unrelated PR landings

### DIFF
--- a/src/gateway/control-ui-session-prs-landing.test.ts
+++ b/src/gateway/control-ui-session-prs-landing.test.ts
@@ -32,27 +32,36 @@ describe("resolveBranchLanding", () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it("resolves an unpublished branch without reading an unused HEAD", async () => {
-    const base = await sha("HEAD");
-    await git("checkout", "-b", "feature");
-    await fs.appendFile(path.join(root, "a.txt"), "two\n");
-    await git("commit", "-am", "unpublished work");
-    const runGit = vi.spyOn(worktreeGit, "runGit");
+  it.each([
+    { scenario: "no merged PRs", mergedHeads: [] },
+    {
+      scenario: "a merge into another base without a propagation commit",
+      mergedHeads: [{ sha: "1".repeat(40), baseRef: "release" }],
+    },
+  ])(
+    "resolves an unpublished branch with $scenario without reading an unused HEAD",
+    async ({ mergedHeads }) => {
+      const base = await sha("HEAD");
+      await git("checkout", "-b", "feature");
+      await fs.appendFile(path.join(root, "a.txt"), "two\n");
+      await git("commit", "-am", "unpublished work");
+      const runGit = vi.spyOn(worktreeGit, "runGit");
 
-    expect(
-      await resolveBranchLanding(root, {
-        branch: "feature",
-        defaultBranch: "main",
-        mergedHeads: [],
-      }),
-    ).toEqual({
-      pushedSha: null,
-      statsBase: base,
-      hasLandedPullRequest: false,
-      provenNewPushedWork: false,
-    });
-    expect(runGit).not.toHaveBeenCalledWith(root, ["rev-parse", "HEAD"]);
-  });
+      expect(
+        await resolveBranchLanding(root, {
+          branch: "feature",
+          defaultBranch: "main",
+          mergedHeads,
+        }),
+      ).toEqual({
+        pushedSha: null,
+        statsBase: base,
+        hasLandedPullRequest: false,
+        provenNewPushedWork: false,
+      });
+      expect(runGit).not.toHaveBeenCalledWith(root, ["rev-parse", "HEAD"]);
+    },
+  );
 
   it("marks a squash-landed tip and bases stats on the merged head", async () => {
     await git("checkout", "-b", "feature");

--- a/src/gateway/control-ui-session-prs-landing.ts
+++ b/src/gateway/control-ui-session-prs-landing.ts
@@ -95,8 +95,12 @@ export async function resolveBranchLanding(
     "--quiet",
     `refs/remotes/origin/${params.branch}`,
   ]);
-  // HEAD is only used to compare landed PR heads; keep its read order when needed.
-  const headSha = params.mergedHeads.length ? await gitOutput(root, ["rev-parse", "HEAD"]) : null;
+  const possibleLandings = params.mergedHeads.filter(
+    (head) =>
+      head.baseRef === params.defaultBranch || Boolean(params.defaultBranch && head.mergeCommitSha),
+  );
+  // Only possible landings consume HEAD; keep its read order for those records.
+  const headSha = possibleLandings.length ? await gitOutput(root, ["rev-parse", "HEAD"]) : null;
   // Only merges whose content reached this checkout's default branch prove
   // the tip landed there: a direct default-base merge, or a landing through
   // another branch (feature -> release -> main) whose merge commit is now
@@ -105,7 +109,7 @@ export async function resolveBranchLanding(
   // the snapshot cache, because the cache key has no default branch.
   const defaultRef = params.defaultBranch ? `refs/remotes/origin/${params.defaultBranch}` : null;
   const landedHeads: MergedPullHead[] = [];
-  for (const head of params.mergedHeads) {
+  for (const head of possibleLandings) {
     if (head.baseRef === params.defaultBranch) {
       landedHeads.push(head);
     } else if (


### PR DESCRIPTION
## What Problem This Solves

PR-status refreshes do unnecessary local Git work when a session's merged PRs target another branch and carry no commit that could prove propagation to the checkout's default branch.

Related: #139137.

## Why This Change Was Made

Filter statically ineligible landing records before deciding whether to read HEAD, then use that same candidate set for landing resolution. Possible direct and propagated landings retain their original Git command order, including the existing equality behavior when both base names are absent.

## User Impact

One fewer Git subprocess for affected cold or forced PR-status refreshes. PR chips, branch statistics, cache lifetimes, forced-refresh behavior, and failure handling remain the same. This is a bounded reduction in unnecessary work; no claim is made about production frequency or eliminating a measured stall.

## Evidence

- Seven native Git scenarios return identical landing values. Different-base/no-propagation records reduce three subprocesses to two; absent-default/named-base records reduce two to one. All other scenarios retain the original command order and counts.
- That characterization runs the actual landing function with an import-only native Git adapter; it is not a compiled Gateway test.
- Independent P2 review: no actionable findings.
- Linux Node24.19.0 / Git2.52.0: original baseline4 passed /1 expected unused-HEAD assertion failure; candidate96/96 passed across six suites covering native Git branch statistics, landing, cache retention, and forced-refresh subscription ordering.
- The complete two-file `check:changed` gate passed, including core/test typechecks, lint, and selected guards.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34033263042) passed for `fff8e89c1acbc144bac6bd6bb9b0349f59434117`.
- The initial private baseline verifier failed to match Vitest’s truncated table-test name. The raw report confirmed the intended failure at the exact unused-HEAD assertion; no source/test change or baseline rerun was needed.
