### PR TITLE
fix(memory): avoid full vector scans for small source updates

### DIFF
--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -542,13 +542,19 @@ export abstract class MemoryManagerSyncBase extends MemoryManagerDatabaseContext
       return;
     }
     try {
-      this.db
-        .prepare(
-          `DELETE FROM ${VECTOR_TABLE} WHERE id IN (
-             SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?
-           )`,
-        )
-        .run(pathname, source);
+      // sqlite-vec uses a full scan for non-KNN IN queries. Select from the
+      // indexed source table and reuse point deletes so unrelated vectors do
+      // not add work. The caller keeps these chunk rows until cleanup finishes.
+      const ids = this.db.prepare(
+        "SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?",
+      );
+      const deleteVector = this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`);
+      for (const row of ids.iterate(pathname, source)) {
+        if (typeof row.id !== "string") {
+          throw new Error("Invalid memory chunk id");
+        }
+        deleteVector.run(row.id);
+      }
     } catch {
       this.markVectorRebuildRequired();
     }

--- a/extensions/memory-core/src/memory/manager-vector-delete.test.ts
+++ b/extensions/memory-core/src/memory/manager-vector-delete.test.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, vi } from "vitest";
+import { createManagerIndexFixture } from "./manager-index.test-support.js";
+
+const { closeAllMemorySearchManagers, getMemorySearchManager } = await import("./index.js");
+
+describe("memory vector source deletion", () => {
+  const fixture = createManagerIndexFixture({
+    getMemorySearchManager,
+    closeAllMemorySearchManagers,
+  });
+
+  it("updates and removes a memory file without scanning unrelated vectors", async () => {
+    const memoryPath = path.join(fixture.paths.workspace, "MEMORY.md");
+    await fs.writeFile(memoryPath, "# Original\n\noriginal amber constellation\n");
+    const manager = await fixture.getFreshManager(
+      fixture.createConfig({ provider: "gemini", vectorEnabled: true }),
+      "cli",
+    );
+    try {
+      await manager.sync({ reason: "test", force: true });
+      const db = Reflect.get(manager, "db") as DatabaseSync;
+      const vectors = () =>
+        db
+          .prepare(
+            "SELECT id, hex(embedding) AS embedding FROM memory_index_chunks_vec ORDER BY id",
+          )
+          .all();
+      const targetIds = () =>
+        db
+          .prepare(
+            "SELECT id FROM memory_index_chunks WHERE path = 'MEMORY.md' AND source = 'memory' ORDER BY id",
+          )
+          .all()
+          .map((row) => row.id);
+      const originalIds = targetIds();
+      expect(originalIds.length).toBeGreaterThan(0);
+      const survivors = vectors().filter((row) => !originalIds.includes(row.id));
+      expect(survivors.length).toBeGreaterThan(0);
+
+      const deleteQueries = new Set<string>();
+      for (const contents of ["# Replacement\n\nreplacement sapphire constellation\n", null]) {
+        if (contents === null) {
+          await fs.unlink(memoryPath);
+        } else {
+          await fs.writeFile(memoryPath, contents);
+        }
+        Reflect.set(manager, "dirty", true);
+        const prepare = vi.spyOn(db, "prepare");
+        try {
+          await manager.sync({ reason: "test" });
+          for (const [sql] of prepare.mock.calls) {
+            if (/^\s*DELETE FROM memory_index_chunks_vec\b/i.test(sql)) {
+              deleteQueries.add(sql);
+            }
+          }
+        } finally {
+          prepare.mockRestore();
+        }
+        const currentIds = targetIds();
+        expect(vectors().filter((row) => !currentIds.includes(row.id))).toEqual(survivors);
+        expect(
+          vectors()
+            .filter((row) => currentIds.includes(row.id))
+            .map((row) => row.id),
+        ).toEqual(currentIds);
+        expect(currentIds.some((id) => originalIds.includes(id))).toBe(false);
+        if (contents === null) {
+          expect(currentIds).toEqual([]);
+        } else {
+          expect(currentIds.length).toBeGreaterThan(0);
+          expect(
+            db.prepare("SELECT text FROM memory_index_chunks WHERE path = 'MEMORY.md'").all(),
+          ).toEqual([
+            expect.objectContaining({ text: expect.stringContaining("replacement sapphire") }),
+          ]);
+        }
+      }
+      expect(deleteQueries.size).toBeGreaterThan(0);
+      for (const sql of deleteQueries) {
+        const plans = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all();
+        // sqlite-vec's non-KNN IN plan is a full scan (plan 1); scalar key
+        // lookups use plan 2. Check the actual sync SQL, without timing gates.
+        expect(
+          plans.filter((row) =>
+            /memory_index_chunks_vec .*INDEX \d+:1(?:$|\s)/.test(String(row.detail)),
+          ),
+        ).toEqual([]);
+      }
+    } finally {
+      await manager.close();
+    }
+  });
+
+  it.each([false, true])(
+    "preserves source isolation, rollback, and rebuild debt (delete failure: %s)",
+    async (failDelete) => {
+      const manager = await fixture.getFreshManager(
+        fixture.createConfig({ provider: "gemini", vectorEnabled: true }),
+        "cli",
+      );
+      try {
+        await manager.sync({ reason: "test", force: true });
+        await expect(manager.probeVectorAvailability()).resolves.toBe(true);
+        const db = Reflect.get(manager, "db") as DatabaseSync;
+        const insert = db.prepare(`INSERT INTO memory_index_chunks
+        (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+        VALUES (?, ?, ?, 1, 1, 'fixture', ?, 'fixture', '[]', 1)`);
+        for (const [id, pathname, source, model] of [
+          ["target-old", "memory/shared.md", "memory", "old-model"],
+          ["target-new", "memory/shared.md", "memory", "new-model"],
+          ["target-missing-vector", "memory/shared.md", "memory", "new-model"],
+          ["other-source", "memory/shared.md", "sessions", "new-model"],
+          ["other-path", "memory/other.md", "memory", "new-model"],
+        ] as const) {
+          insert.run(id, pathname, source, model);
+          if (id !== "target-missing-vector") {
+            db.prepare(
+              "INSERT INTO memory_index_chunks_vec (id, embedding) VALUES (?, '[1,0,0,0]')",
+            ).run(id);
+          }
+        }
+        const snapshot = () => ({
+          chunks: db.prepare("SELECT * FROM memory_index_chunks ORDER BY id").all(),
+          vectors: db
+            .prepare(
+              "SELECT id, hex(embedding) AS embedding FROM memory_index_chunks_vec ORDER BY id",
+            )
+            .all(),
+        });
+        const before = snapshot();
+        const clear = () =>
+          Reflect.apply(Reflect.get(manager, "clearIndexedFileData"), manager, [
+            "memory/shared.md",
+            "memory",
+          ]);
+        db.exec("BEGIN IMMEDIATE");
+        try {
+          clear();
+        } finally {
+          db.exec("ROLLBACK");
+        }
+        expect(snapshot()).toEqual(before);
+
+        let deleteAttempts = 0;
+        const nativePrepare = db.prepare.bind(db);
+        const prepare = vi.spyOn(db, "prepare").mockImplementation((sql) => {
+          const statement = nativePrepare(sql);
+          if (failDelete && /^\s*DELETE FROM memory_index_chunks_vec\b/i.test(sql)) {
+            const nativeRun = statement.run.bind(statement);
+            vi.spyOn(statement, "run").mockImplementation((...args) => {
+              if (++deleteAttempts === 2) {
+                throw new Error("injected vector deletion failure");
+              }
+              return nativeRun(...args);
+            });
+          }
+          return statement;
+        });
+        db.exec("BEGIN IMMEDIATE");
+        try {
+          clear();
+          // Clearing an already empty source must remain successful.
+          clear();
+          db.exec("COMMIT");
+        } catch (error) {
+          db.exec("ROLLBACK");
+          throw error;
+        } finally {
+          prepare.mockRestore();
+        }
+        const after = snapshot();
+        expect(after.chunks).toEqual(
+          before.chunks.filter((row) => !String(row.id).startsWith("target-")),
+        );
+        expect(after.vectors.filter((row) => !String(row.id).startsWith("target-"))).toEqual(
+          before.vectors.filter((row) => !String(row.id).startsWith("target-")),
+        );
+        expect(after.vectors.filter((row) => String(row.id).startsWith("target-"))).toHaveLength(
+          failDelete ? 1 : 0,
+        );
+        if (failDelete) {
+          expect(deleteAttempts).toBe(2);
+        }
+        expect(
+          db
+            .prepare("SELECT value FROM memory_index_meta WHERE key = 'memory_vector_rebuild_v1'")
+            .get(),
+        ).toEqual({ value: failDelete ? "1" : "clean" });
+      } finally {
+        await manager.close();
+      }
+    },
+  );
+});


### PR DESCRIPTION
Related: #134575

## What Problem This Solves

Resolves a problem where updating or removing a small memory source scans the entire vector index. As unrelated memory accumulates, each incremental cleanup spends more time synchronously occupying the Gateway thread. The full-scan query remains in current main.

## Why This Change Was Made

sqlite-vec 0.1.9 gives the existing `DELETE ... WHERE id IN (SELECT ...)` a full-scan plan. Select source IDs through the existing `(path, source)` index and stream them through one prepared scalar-key delete instead. This preserves the deletion set across models, surrounding transactions, missing-vector handling, and rebuild-debt policy without introducing schema, worker, or configuration changes.

This complements #103201 (session chunk deltas) and #136482 (publication isolation); their inspected changes retain the source-wide `IN` delete. It does not replace either effort.

## User Impact

Small memory updates and removals no longer scan unrelated vector rows. Newly indexed sources also avoid a full scan when they have no old vectors to remove. This is a sparse-cleanup scaling fix, not a claim that all memory operations or the whole Gateway become faster.

**Tradeoff:** individual point deletes are slower for dense deletion. In the synthetic 100,000-vector case below, deleting half the index takes about 655 ms rather than 450 ms. Keeping one simple, source-scoped path avoids adding global counting or adaptive deletion policy; the table includes both sparse and dense workloads.

## Evidence

- The new regression first failed on unmodified production code because the actual public memory-sync query planned `SCAN memory_index_chunks_vec VIRTUAL TABLE INDEX 0:1`. It passes with the repair. Scalar deletion uses sqlite-vec's point plan (`... INDEX 1:2!___`); regression assertions use query plans rather than wall-clock thresholds.
- **142 tests passed across 7 files**, covering memory indexing/search, reindex recovery, vector writes/rebuild state, legacy cleanup, and the new regression. New coverage verifies replacement vectors exist, unrelated vectors retain identical bytes, same-path/different-source isolation, old-model cleanup, missing/empty vector sets, transaction rollback, and rebuild debt after an injected second-delete failure.
- `node scripts/check-changed.mjs` passed, including production/test typechecks, lint, formatting, plugin boundaries, dead-export scans, storage guards, and import-cycle checks. Independent autoreview found no actionable P0–P2 findings; the final regression rerun passed after test-only typing/ordering cleanup.
- Upstream checks on `8fbaac420e2d91a1e1472887bdca63bd96ca7ba2`: 54 successful checks, none failed or pending when checked on September 6.

### After-fix OpenClaw CLI behavior proof

Ran the normal `pnpm openclaw memory index`, `memory search`, and `memory status --deep --json` flow on the submitted head, using the built production Memory Core plugin, a task-owned workspace/database, and real local Ollama 0.32.9 embeddings. No embedding-provider mocks. Model: [`all-minilm`](https://ollama.com/library/all-minilm), digest `1b226e2802dbb772b5fc32a58f103ca1804ef7501331012de126ab22f67475ef`, native 384-dimensional vectors. All indexed documents are synthetic. Updates/removals used incremental indexing, **without `--force`**.

Terminal excerpts below omit startup/config warnings and unrelated JSON fields; file edits and database verification are annotated separately:

```text
$ pnpm openclaw memory index --verbose
Provider: ollama (requested: ollama)
Model: all-minilm
Memory index updated (main): 2 files indexed.
$ pnpm openclaw memory search 'lighthouse emergency signal' --json
  "path": "MEMORY.md",
  "snippet": "# Lighthouse operations\nThe lighthouse emergency signal is amber-kestrel. The keeper checks the backup lantern every Friday.\n",

[Edit the synthetic MEMORY.md: amber-kestrel/Friday -> cobalt-heron/Sunday]
$ pnpm openclaw memory index --verbose
Memory index updated (main): 2 files indexed.
$ pnpm openclaw memory search 'lighthouse emergency signal' --json
  "path": "MEMORY.md",
  "snippet": "# Lighthouse operations\nThe lighthouse emergency signal is now cobalt-heron. The keeper checks the backup lantern every Sunday.\n",

[Move MEMORY.md outside the indexed workspace]
$ pnpm openclaw memory index --verbose
Memory index updated (main): 1 file indexed.
$ pnpm openclaw memory search 'lighthouse emergency signal' --json
{ "results": [] }
$ pnpm openclaw memory search 'heritage orchard irrigation' --json
  "path": "memory/unrelated.md",
  "vectorScore": 0.6090167760848999,
  "snippet": "# Orchard notes\nThe heritage orchard grows silver-birch apples. Irrigation starts every Tuesday at sunrise.\n",
```

Before/update/removal snapshots contained 2/2/1 canonical chunks and 2/2/1 vectors. The replacement vector ID/bytes changed; the removed source had no remaining vector. The ordered ID+embedding SHA-256 for `memory/unrelated.md` stayed `f3590cdf171bd187d2dad81f09a42df19755206b2d1ea582646ccc7b22e9d10c` through all three states. Its search content and vector score were preserved; hybrid final scores vary slightly with corpus statistics. The production cleanup observer recorded one old row for both update and removal. Rebuild state remained `clean`.

### Dense source removal through the real CLI

Also indexed two generated maintenance journals with default chunking, then removed one through `memory index`. These are chosen synthetic source sizes, not a claim about the distribution of real user documents. Each size ran three removal rounds; the closed, checkpointed fixture database was restored between rounds. All embeddings were generated by the real provider through OpenClaw indexing.

| Removed source bytes | Removed / total vectors | Vector cleanup median (range), ms | Write transaction held median (range), ms |
| ---: | ---: | ---: | ---: |
| 131,217 (~128 KiB) | 119 / 238 | 2.057 (2.025–2.062) | 17.214 (16.799–24.687) |
| 1,048,647 (~1 MiB) | 944 / 1,882 | 16.862 (16.675–18.724) | 55.151 (51.525–62.183) |

All six commands exited successfully and committed. The resulting databases contained 119 and 938 chunks/vectors respectively, no target rows, unchanged retained vector IDs/bytes, and clean rebuild state. Final `memory status --deep --json` reported `dirty: false`, `index.state: complete`, `semanticAvailable: true`, `dims: 384`, and `embeddingProbe.ok: true`.

Timing used an external observational Node preloader, leaving the submitted source and SQL unchanged. It wraps the exact source-ID statement's native `iterate()`; the synchronous production point deletes execute between yielded rows. One record is buffered per cleanup and written at process exit. Vector timing therefore includes native iteration and the actual production delete loop, excludes statement preparation, and includes observer overhead. Transaction timing starts after `BEGIN IMMEDIATE` succeeds and ends after `COMMIT`, excluding lock acquisition and including FTS/canonical work and commit. CLI startup/model-loading time is not reported as cleanup time.

These measurements quantify the after-fix cost at these source sizes; they do **not** establish a before/after end-to-end speedup or Gateway responsiveness guarantee. The disclosed 50,000-row dense microbenchmark regression below remains a real tradeoff. Large replacement writes also remain synchronous: growing the retained journal from ~128 KiB to ~1 MiB held its write transaction for 344 ms, of which old-vector cleanup was 1.746 ms. This patch targets dependence on unrelated vector count, not all synchronous indexing work.

<details>
<summary>Production-loop timing observer (loaded through NODE_OPTIONS=--import)</summary>

The observer delegates to the native iterator; it neither substitutes SQL nor synthesizes embeddings. This excerpt shows the cleanup timing mechanism; transaction timing separately observes native `exec` boundaries as described above.

```js
import { DatabaseSync } from 'node:sqlite';
import fs from 'node:fs';
const records = [];
const prepare = DatabaseSync.prototype.prepare;
DatabaseSync.prototype.prepare = function (sql, ...args) {
  const statement = prepare.call(this, sql, ...args);
  if (sql.trim() === 'SELECT id FROM memory_index_chunks WHERE path = ? AND source = ?') {
    const iterate = statement.iterate.bind(statement);
    statement.iterate = function* (...bindings) {
      const start = performance.now();
      let rows = 0;
      try {
        for (const row of iterate(...bindings)) { rows++; yield row; }
      } finally {
        records.push({ path: bindings[0], source: bindings[1], rows,
          cleanupMs: performance.now() - start });
      }
    };
  }
  return statement;
};
process.on('exit', () => {
  if (records.length) fs.appendFileSync(process.env.PROOF_OBSERVATIONS,
    JSON.stringify(records) + '\n');
});
```

</details>

### SQL strategy comparison

Synthetic SQLite microbenchmark, Apple M4 / macOS ARM64, Node 26.7.0, SQLite 3.53.4, sqlite-vec 0.1.9. In-memory tables, 128-dimensional vectors, same database restored by rollback between runs; one warm-up and six measured rounds with alternating baseline/candidate order. Values are conventional medians. Timing includes statement preparation and deletion, excludes transaction begin/rollback and result verification.

| Total vectors | Target vectors | Before (ms) | After (ms) |
| ---: | ---: | ---: | ---: |
| 1,000 | 0 | 0.555 | 0.008 |
| 1,000 | 10 | 0.632 | 0.142 |
| 1,000 | 500 | 4.217 | 7.381 |
| 10,000 | 0 | 5.149 | 0.007 |
| 10,000 | 10 | 5.565 | 0.148 |
| 10,000 | 5,000 | 45.584 | 69.231 |
| 100,000 | 0 | 58.772 | 0.021 |
| 100,000 | 10 | 61.698 | 0.172 |
| 100,000 | 50,000 | 450.261 | 654.930 |

The microbenchmark executes the two SQL strategies against generated rows in real vec0 tables; the CLI proof above separately exercises the production memory manager with real local embeddings. Neither is an end-to-end Gateway latency benchmark or a reproduction of the full 12–24-second incident in #134575.

<details>
<summary>Regression commands and standalone benchmark reproduction</summary>

```sh
node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/manager-vector-delete.test.ts \
  extensions/memory-core/src/memory/manager-vector-write.test.ts \
  extensions/memory-core/src/memory/manager-vector-rebuild-state.test.ts \
  extensions/memory-core/src/memory/manager.legacy-migration-cleanup.test.ts \
  extensions/memory-core/src/memory/index.test.ts \
  extensions/memory-core/src/memory/manager.reindex-recovery.test.ts \
  extensions/memory-core/src/memory/manager-search.test.ts
node scripts/check-changed.mjs
```

From a checkout with pinned dependencies installed:

```sh
node --input-type=module <<'JS'
import { DatabaseSync } from 'node:sqlite';
import { performance } from 'node:perf_hooks';
import * as vec from 'sqlite-vec';
const median = xs => {
  const a = [...xs].sort((x, y) => x - y), m = Math.floor(a.length / 2);
  return a.length % 2 ? a[m] : (a[m - 1] + a[m]) / 2;
};
for (const size of [1000, 10000, 100000]) {
  const db = new DatabaseSync(':memory:', { allowExtension: true });
  vec.load(db);
  db.exec(`CREATE VIRTUAL TABLE vectors USING vec0(id TEXT PRIMARY KEY, embedding FLOAT[128]);
    CREATE TABLE chunks(id TEXT PRIMARY KEY, path TEXT, source TEXT);
    CREATE INDEX chunks_path_source ON chunks(path, source);`);
  const insert = db.prepare('INSERT INTO vectors VALUES (?,?)');
  const chunk = db.prepare('INSERT INTO chunks VALUES (?,?,?)');
  const embedding = new Float32Array(128).fill(0.125);
  db.exec('BEGIN');
  for (let i = 0; i < size; i++) {
    insert.run(`id-${i}`, embedding);
    chunk.run(`id-${i}`, 'other', 'memory');
  }
  db.exec('COMMIT');
  for (const target of [0, 10, size / 2]) {
    db.prepare("UPDATE chunks SET path='other'").run();
    db.prepare("UPDATE chunks SET path='target' WHERE rowid<=?").run(target);
    const times = { baseline: [], candidate: [] };
    for (let round = 0; round < 7; round++) {
      for (const mode of (round % 2 ? ['candidate', 'baseline'] : ['baseline', 'candidate'])) {
        db.exec('BEGIN IMMEDIATE');
        const start = performance.now();
        if (mode === 'baseline') {
          db.prepare('DELETE FROM vectors WHERE id IN (SELECT id FROM chunks WHERE path=? AND source=?)')
            .run('target', 'memory');
        } else {
          const ids = db.prepare('SELECT id FROM chunks WHERE path=? AND source=?');
          const del = db.prepare('DELETE FROM vectors WHERE id=?');
          for (const row of ids.iterate('target', 'memory')) del.run(row.id);
        }
        const elapsed = performance.now() - start;
        if (db.prepare('SELECT count(*) AS n FROM vectors').get().n !== size - target) {
          throw new Error('wrong deletion set');
        }
        db.exec('ROLLBACK');
        if (round > 0) times[mode].push(elapsed);
      }
    }
    console.log({ size, target, baselineMs: median(times.baseline), candidateMs: median(times.candidate), samples: times });
  }
  db.close();
}
JS
```

</details>
