### PR TITLE
fix(memory): preserve keyword recall in project sessions

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -107,6 +107,11 @@ MMR then reorders the scored hybrid candidate set to reduce redundant
 snippets. It does not change scores, threshold eligibility, or make another
 provider call.
 
+Search preserves keyword matches when every ranked result falls below the
+configured minimum score. Hybrid search can also fill remaining result slots
+with keyword-only matches. These rules also apply in project sessions;
+semantic-only matches still need to meet the configured minimum score.
+
 ## Deterministic trigger recall
 
 On eligible interactive turns, the builtin engine also compares the inbound

--- a/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
+++ b/extensions/memory-core/src/memory/manager-keyword-retrieval.test.ts
@@ -56,6 +56,107 @@ describe("memory index", () => {
     expect(noResults.length).toBe(0);
   });
 
+  it.each(["keyword-only", "lexical-only", "hybrid"] as const)(
+    "preserves relaxed global lexical recall with active projects in %s search",
+    async (mode) => {
+      providerFixture.forceNoProvider = mode === "keyword-only";
+      const manager = await getPersistentManager(
+        createCfg({ provider: mode === "keyword-only" ? "none" : undefined, minScore: 0.35 }),
+      );
+      expect(manager.status().fts?.available).toBe(true);
+      await fs.writeFile(
+        path.join(fixture.paths.memory, "2000-01-01.md"),
+        "Quokka archive detail.",
+      );
+      await manager.sync({ reason: "test" });
+
+      for (const activeProjectKeys of [undefined, ["unrelated-project"]]) {
+        const options = {
+          maxResults: 1,
+          activeProjectKeys,
+          lexicalOnly: mode === "lexical-only",
+        };
+        await expect(manager.search("unfindabletermxyz", options)).resolves.toEqual([]);
+        const partials: Array<Awaited<ReturnType<typeof manager.search>> | null> = [];
+        const results = await manager.search("quokka", {
+          ...options,
+          onPartialResults: (snapshot) => partials.push(snapshot),
+        });
+        expect(
+          results,
+          `activeProjectKeys=${JSON.stringify(activeProjectKeys ?? [])}`,
+        ).toHaveLength(1);
+        expect(results[0]).toMatchObject({
+          path: "memory/2000-01-01.md",
+          source: "memory",
+          snippet: expect.stringContaining("Quokka archive detail."),
+        });
+        expect(results[0]?.projectKey).toBeUndefined();
+        expect(results[0]?.score).toBeGreaterThan(0);
+        expect(results[0]?.score).toBeLessThan(0.35);
+        if (mode === "hybrid") {
+          expect(partials).toEqual([[expect.objectContaining({ path: "memory/2000-01-01.md" })]]);
+        }
+      }
+    },
+  );
+
+  it("keeps lexical spare capacity behind strict hybrid hits with active projects", async () => {
+    const manager = await getPersistentManager(createCfg({ minScore: 0.35 }));
+    expect(manager.status().fts?.available).toBe(true);
+    await fs.writeFile(path.join(fixture.paths.memory, "current.md"), "Current quokka detail.");
+    await fs.writeFile(path.join(fixture.paths.memory, "2000-01-01.md"), "Current archive detail.");
+    await manager.sync({ reason: "test" });
+
+    for (const activeProjectKeys of [undefined, ["unrelated-project"]]) {
+      const results = await manager.search("current", { maxResults: 2, activeProjectKeys });
+      expect(
+        results.map((entry) => entry.path),
+        `activeProjectKeys=${JSON.stringify(activeProjectKeys ?? [])}`,
+      ).toEqual(["memory/current.md", "memory/2000-01-01.md"]);
+      expect(results[0]?.score).toBeGreaterThanOrEqual(0.35);
+      expect(results[1]?.score).toBeLessThan(0.35);
+      expect(results[1]).toMatchObject({ vectorScore: 0 });
+      const limited = await manager.search("current", { maxResults: 1, activeProjectKeys });
+      expect(limited.map((entry) => entry.path)).toEqual(["memory/current.md"]);
+    }
+  });
+
+  it("keeps the strict threshold for semantic-only hits with active projects", async () => {
+    const manager = await getPersistentManager(createCfg({ minScore: 0.35 }));
+    expect(manager.status().fts?.available).toBe(true);
+    await fs.writeFile(path.join(fixture.paths.memory, "current.md"), "Alpha current detail.");
+    await fs.writeFile(path.join(fixture.paths.memory, "2000-01-01.md"), "Alpha archive detail.");
+    await manager.sync({ reason: "test" });
+
+    // The fixture embeds the alpha substring, while FTS requires the complete alphabet token.
+    for (const activeProjectKeys of [undefined, ["unrelated-project"]]) {
+      const candidates = await manager.search("alphabet", {
+        maxResults: 6,
+        minScore: 0,
+        activeProjectKeys,
+      });
+      expect(candidates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: "memory/2000-01-01.md",
+            vectorScore: 1,
+            textScore: 0,
+          }),
+        ]),
+      );
+      const partials: Array<Awaited<ReturnType<typeof manager.search>> | null> = [];
+      const results = await manager.search("alphabet", {
+        maxResults: 6,
+        activeProjectKeys,
+        onPartialResults: (snapshot) => partials.push(snapshot),
+      });
+      expect(results.map((entry) => entry.path)).toEqual(["memory/current.md"]);
+      expect(results[0]?.score).toBeGreaterThanOrEqual(0.35);
+      expect(partials).toEqual([]);
+    }
+  });
+
   it.each([
     {
       name: "slug path stem",

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -61,12 +61,9 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
     const candidateMaxResults = hasActiveProject
       ? Math.min(200, Math.max(maxResults, maxResults * 4))
       : maxResults;
-    const selectResults = (results: MemorySearchResult[]) =>
-      hasActiveProject
-        ? results.filter((entry) => entry.score >= minScore).slice(0, maxResults)
-        : results;
-    // Retrieval owners apply project scores before selection; use the final threshold
-    // so ineligible exact hits cannot fill the bounded candidate window.
+    // Retrieval owners apply project ranking and eligibility, including lexical recall.
+    // Only cap the expanded window here so partial and final recall survive together.
+    const selectResults = (results: MemorySearchResult[]) => results.slice(0, maxResults);
     const results = await this.searchCandidates(normalizedQuery, {
       ...opts,
       maxResults: candidateMaxResults,


### PR DESCRIPTION
Closes #140103

## What Problem This Solves

Fixes an issue where users searching memory from a project session could receive no results for an indexed keyword match that the same search returned outside the project. Older dated notes were particularly easy to lose after recency scoring, despite successful indexing and no tool error.

## Why This Change Was Made

Keyword and hybrid retrieval already decide which low-scoring keyword matches remain eligible. The project orchestration layer reapplied a strict score cutoff and discarded those accepted results. It now only caps the result window, preserving the existing retrieval decisions for both partial and final results.

Project ranking, candidate-window sizing, semantic-only thresholds, visibility filtering, and invalidation of stale partial results remain with their existing owners. No configuration, dependency, storage, or schema change is introduced. PR #136984 addresses the separate candidate-window monotonicity problem; this change does not expand retrieval to that PR's proposed window.

## User Impact

Project sessions retain the same keyword fallback and spare hybrid keyword matches available outside projects. Semantic-only results still need to meet the configured minimum score, and strict matches keep priority when the result limit is full.

## Evidence

The same built-product fixture indexed two synthetic files and inspected actual `memory_search` outputs before and after the change:

| Actual tool result | Baseline ordinary | Baseline project | Fixed ordinary | Fixed project |
| --- | ---: | ---: | ---: | ---: |
| `MEMORY.md` context-gauge score | 1 | 1.15 | 1 | 1.15 |
| Dated keyword-note result count | 1 | 0 | 1 | 1 |

The gauge independently confirms project context. Direct CLI search finds the note in every case. Each context has exactly three scripted localhost Responses requests, two actual tool outputs, and no tool failures. The result comparison uses tool output rather than scripted final text. This proves the built CLI, indexing, FTS, project preparation, and tool serialization path; it does not claim an external-model or semantic/hybrid product run.

- 138 focused tests passed across retrieval, hybrid selection, tools, and real-manager integration, including project/no-project fallback, hybrid spare capacity, partial results, and semantic-only threshold controls.
- The exact-base changed gate passed all 25 stages, including plugin type checks and targeted lint/format checks.
- Baseline and candidate builds passed with sealed source, dependency, and artifact checks. Candidate product proof passed at `51796d746d339d28bde89ddf550bb37c1de78353`.
- Five independent review passes with complete primary source context completed without actionable P0–P2 findings.

Production delta is -3 lines; tests add 101 lines and docs add 5. [Required PR CI34033951186](https://github.com/openclaw/openclaw/actions/runs/34033951186) passed on the exact tested head `51796d746d339d28bde89ddf550bb37c1de78353`. Latest ClawSweeper review at 12:48 UTC has no findings or before-merge actions. Source comparison through main `75f84a311d0cc9e9068c6ae08117901af644e55a` leaves all inspected memory owners unchanged; the original tested head is retained for native integration.

