### PR TITLE
fix(ui): keep long agent menu labels inside the dropdown

### DIFF
--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -399,6 +399,7 @@ suite.define(() => {
       viewport: { height: 900, width: 1440 },
     });
     const page = await context.newPage();
+    const agentName = "Scheduled Automations";
     const agentsList = {
       agents: [{ id: "main" }, { id: "research" }, { id: "forge" }],
       defaultId: "main",
@@ -411,7 +412,7 @@ suite.define(() => {
           cases: [
             {
               match: { agentId: "main" },
-              response: { agentId: "main", avatar: "", emoji: "🦞", name: "Main" },
+              response: { agentId: "main", avatar: "", emoji: "🦞", name: agentName },
             },
             {
               match: { agentId: "research" },
@@ -444,7 +445,7 @@ suite.define(() => {
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.getByRole("button", { name: /Switch agent/ }).click();
       const menu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
-      const mainSwitch = menu.getByRole("menuitemradio", { name: "Main" });
+      const mainSwitch = menu.getByRole("menuitemradio", { name: agentName });
       const researchSwitch = menu.getByRole("menuitemradio", { name: "Research" });
       await expect
         .poll(() =>
@@ -512,6 +513,29 @@ suite.define(() => {
       await expect
         .poll(() => mainSwitch.evaluate((element) => element === document.activeElement))
         .toBe(true);
+      await page.evaluate(() => document.fonts.ready);
+      const capabilities = menu.locator('wa-dropdown-item[value="command:capabilities"]');
+      expect(await capabilities.ariaSnapshot()).toContain(agentName);
+      const actionBounds = await capabilities
+        .locator(".sidebar-customize-menu__text")
+        .evaluate((text) => {
+          const bounds = text
+            .closest("wa-dropdown")
+            ?.shadowRoot?.querySelector('[part~="menu"]')
+            ?.getBoundingClientRect();
+          if (!bounds) {
+            throw new Error("Expected the rendered agent menu");
+          }
+          const label = text.getBoundingClientRect();
+          return {
+            labelLeft: label.left,
+            labelRight: label.right,
+            menuLeft: bounds.left,
+            menuRight: bounds.right,
+          };
+        });
+      expect(actionBounds.labelLeft).toBeGreaterThanOrEqual(actionBounds.menuLeft);
+      expect(actionBounds.labelRight).toBeLessThanOrEqual(actionBounds.menuRight);
       await page.keyboard.press("End");
       await expect
         .poll(() =>

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2549,6 +2549,8 @@ wa-dropdown-item.sidebar-customize-menu__item {
 }
 
 .sidebar-customize-menu__text {
+  /* Slotted spans need a block box for ellipsis inside Web Awesome's label wrapper. */
+  display: block;
   flex: 1;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Closes #139946

## What Problem This Solves

Fixes an issue where users with a long agent display name would see the `What can <agent name> do?` action extend outside the Control UI's agent-switcher menu. The reported `Scheduled Automations` name reproduces the overflow on current main.

## Why This Change Was Made

### Root Cause

Web Awesome places the default slot inside its shrinkable `#label` wrapper. The slotted `.sidebar-customize-menu__text` span remained inline, so its existing `overflow: hidden` and `text-overflow: ellipsis` did not constrain its rendered text box. Direct inspection of the installed Web Awesome 3.12.0 render and stylesheet confirms that wrapper contract.

### Changes

- Give the existing sidebar text class a block box, allowing its existing ellipsis policy to work without adding a width constant or changing text.
- Extend the existing agent-grid/keyboard browser case with a long identity, full accessible-name coverage, and measured containment at its existing 1.4 text scale.

## User Impact

Long action labels stay inside the menu and truncate visually. The complete accessible name, menu dimensions, agent switching, and keyboard behavior are preserved.

## Evidence

### Real Behavior Proof

Built current-main baseline `dc0578ae67f5f6e2fd487fa4666dab252f796ea7`, then applied this repair and rebuilt the served Control UI. Both captures use real Chrome on macOS, a real isolated Gateway with token authentication, and synthetic agents; there is no mocked Gateway in this proof.

| Measured value | Before | After |
| --- | ---: | ---: |
| Menu right edge | 274px | 274px |
| Action text right edge | 279.703125px | 261px |
| Overflow | 5.703125px | 0px |
| Menu width | 264px | 264px |
| Full accessible agent name | Preserved | Preserved |

**Before**

![Long action text extends beyond the agent menu](https://github.com/user-attachments/assets/7dff058d-a0d3-4bc2-8153-783a283a337f)

**After**

![Long action text ellipsizes within the same agent menu](https://github.com/user-attachments/assets/ec88ad6b-ea77-4cfd-85e0-f196949fb3d1)

The real pre-fix containment assertion failed with `action label overflows the real menu by 5.703125px`. The after proof passed that same containment contract and verified that End / ArrowUp / Enter selected the capabilities action and supplied the existing draft. The credential-free provider setup correctly retained its disabled input and visible setup guidance; no model inference was requested. Enabled-composer focus is covered by the existing browser scenarios below, not claimed as live-provider proof.

The after capture was made before committing; its production stylesheet is byte-identical to commit `c4a438cebe18a411a3d3262767316fdf88237ce9` (Git blob `ec68b22c97d03c25033b211454aacc00d3d494c9`, SHA-256 `e45becb10d763fafd8323e8e383907213bbadc06ad0ebb8b208d42cace3cf44e`). The served JavaScript and stylesheet asset hashes changed after the UI rebuild. Every published capture was inspected; browser processes, Gateway ports, temporary state, and QA credentials were cleaned up.

### Test

- Unchanged agent-grid/keyboard characterization: passed before editing.
- Red-first browser regression at 1.4 text scale: failed before the fix with `expected 374.078125 to be less than or equal to 274`.
- `pnpm test:ui:e2e ui/src/e2e/sidebar-interactions.e2e.test.ts`: **7 passed**, no skipped cases.
- `pnpm build`: passed for the baseline runtime; `pnpm ui:build`: passed after the stylesheet change.
- `pnpm check:changed --base HEAD -- ui/src/styles/layout.css ui/src/e2e/sidebar-interactions.e2e.test.ts`: passed before commit, including UI/core-test typechecking, formatting, stylelint, oxlint, and repository guards.
- Independent scoped Codex review through the repository helper, including P3 findings: **scoped-clean**.
- `git diff --check`: passed.

## Risk

Low: one CSS declaration in the existing shared sidebar text class. The retained flex rule still supports direct flex-row callers; the block box constrains slotted callers. The focused suite covers capabilities, agent-grid geometry, keyboard switching, and sidebar menu interactions. No configuration, schema, dependency, routing, or model behavior changes.

Production delta: +2 lines (one declaration and its contract comment). Test delta: +24 net lines.

## Changelog

Release-note context is in User Impact; `CHANGELOG.md` remains release-owned.

## Notes

AI-assisted. The changed visual contract was tested through both the browser regression and the real running application. Maintainer edits are enabled.
