### PR TITLE
test: prepare captured routes for iOS approval events

### DIFF
--- a/apps/ios/Tests/NodeAppModelInvokeTests.swift
+++ b/apps/ios/Tests/NodeAppModelInvokeTests.swift
@@ -7432,7 +7432,7 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
         #expect(NodeAppModel.execApprovalEventID(from: AnyCodable(["other": "approval-1"])) == nil)
     }
 
-    @Test @MainActor func `operator gateway resolved event waits for canonical readback`() async throws {
+    @Test @MainActor func `resolved operator event after disconnect preserves approval state`() async throws {
         NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState()
         defer { NodeAppModel._test_resetPersistedWatchExecApprovalBridgeState() }
         let notificationCenter = MockBootstrapNotificationCenter()
@@ -7446,6 +7446,8 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
                 ],
             ])]
         let appModel = NodeAppModel(notificationCenter: notificationCenter)
+        let gatewayStableID = "test-gateway"
+        appModel.connectedGatewayID = gatewayStableID
         appModel._test_recordPendingWatchExecApprovalRecoveryID(
             "approval-event-resolved",
             gatewayDeviceId: "gateway-device-a")
@@ -7453,16 +7455,45 @@ private final class TimingOutDeviceStatusService: DeviceStatusServicing {
             #require(
                 NodeAppModel._test_makeExecApprovalPrompt(
                     id: "approval-event-resolved",
+                    gatewayStableID: gatewayStableID,
                     commandText: "echo clear",
                     agentId: nil,
                     expiresAtMs: Int64(Date().timeIntervalSince1970 * 1000) + 60000)))
 
-        await appModel.handleOperatorGatewayServerEvent(EventFrame(
-            type: "event",
-            event: ExecApprovalNotificationBridge.resolvedKind,
-            payload: AnyCodable(["id": "approval-event-resolved"]),
-            seq: nil,
-            stateversion: nil))
+        var options = GatewayWebSocketTestSupport.identityFreeOperatorConnectOptions
+        options.allowStoredDeviceAuth = false
+        options.deviceAuthGatewayID = gatewayStableID
+        let operatorSession = appModel.operatorSession
+        let eventRoute: GatewayNodeSessionRoute
+        do {
+            try await operatorSession.connect(
+                url: #require(URL(string: "ws://approval-event-test.invalid")),
+                credentials: .init(),
+                connectOptions: options,
+                sessionBox: WebSocketSessionBox(session: GatewayTestWebSocketSession()),
+                onConnected: {},
+                onDisconnected: { _ in },
+                onInvoke: { BridgeInvokeResponse(id: $0.id, ok: true) })
+            eventRoute = try #require(await operatorSession.currentRoute())
+            await operatorSession.disconnect()
+        } catch {
+            await operatorSession.disconnect()
+            throw error
+        }
+        #expect(await operatorSession.currentRoute() == nil)
+        #expect(!appModel.isOperatorGatewayConnected)
+        #expect(appModel.pendingExecApprovalResolvedPushes.isEmpty)
+
+        // The event subscriber captures its route before delivery; a late event
+        // must retain approval state after that route disconnects, without reconnecting.
+        await appModel.handleOperatorGatewayServerEvent(
+            EventFrame(
+                type: "event",
+                event: ExecApprovalNotificationBridge.resolvedKind,
+                payload: AnyCodable(["id": "approval-event-resolved"]),
+                seq: nil,
+                stateversion: nil),
+            expectedOperatorRoute: eventRoute)
 
         #expect(appModel.pendingExecApprovalPrompt?.id == "approval-event-resolved")
         #expect(appModel._test_pendingWatchExecApprovalRecoveryIDs() == ["approval-event-resolved"])


### PR DESCRIPTION
## What Problem This Solves

The operator resolved-event test omits the route captured by its production event subscriber. That selects an incidental reconnect fallback and waits roughly 12 seconds before reaching the unavailable-readback state its assertions cover.

## Why This Change Was Made

Prepare an actual route through the existing test WebSocket transport, capture it, await disconnection, and pass that captured route with the event, matching the production caller. The model remains offline, so the real handler defers the resolved event without attempting a reconnect.

The fixture explicitly records its logical gateway owner, distinct from the notification's device ID. Stored device authentication is disabled, and session teardown is awaited on success and error paths. Existing prompt, recovery, notification and deferred-event assertions remain. Preconditions verify the route is retired and the deferred queue starts empty, preventing an ignored event from passing vacuously.

No production code, new test seam, timeout change or broad mock is introduced.

## Evidence

- Baseline [native CI job](https://github.com/openclaw/openclaw/actions/runs/34027652988/job/101471486792): the original “operator gateway resolved event waits for canonical readback” case passed in 12.098 seconds.
- The renamed case is “resolved operator event after disconnect preserves approval state”; all four original behavioral assertions remain.
- Existing production caller, route acquisition/retirement, test transport and cleanup contracts were inspected directly.
- Swift parsing, formatting, the complete static changed-file gate and independent P2 review passed.
- [Exact-head native CI](https://github.com/openclaw/openclaw/actions/runs/34035823124/job/101493658120) passed: the changed case took **0.163 seconds**, down from **12.098 seconds**.
- The same 324 Swift tests across eight suites, six logic tests and 48 Watch tests passed, along with the Watch settings UI test. Five adjacent approval scenarios passed; the existing speech-playback skip remains unchanged.
- iOS Release passed. The landed screenshot classifier correctly skipped capture for this unit-test-only diff while preserving native validation. Native compilation remains a separate, larger cost.

Test delta: +38/-7, primarily real route preparation and awaited cleanup. Production delta: zero. This is a scoped fixture improvement, not a claim about whole-iOS build time.
