### PR TITLE
fix(telegram): avoid repeating native choices in message text

### DIFF
--- a/extensions/telegram/src/interactive-fallback.test.ts
+++ b/extensions/telegram/src/interactive-fallback.test.ts
@@ -48,12 +48,21 @@ describe("canonicalizeTelegramPresentationPayload", () => {
     });
   });
 
-  it("keeps control-only payloads deliverable without duplicating their labels", () => {
-    const result = canonicalizeTelegramPresentationPayload({
-      presentation: {
-        blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "retry" }] }],
+  it.each([
+    { richTables: false, text: undefined },
+    { richTables: false, text: "Retry the operation." },
+    { richTables: true, text: "Retry the operation." },
+  ])("keeps control-only payloads deliverable: %j", ({ richTables, text }) => {
+    const result = canonicalizeTelegramPresentationPayload(
+      {
+        text,
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "retry" }] }],
+        },
       },
-    });
+      { richTables },
+    );
 
     expect(result).toMatchObject({
       text: "Choose an option.",
@@ -64,6 +73,44 @@ describe("canonicalizeTelegramPresentationPayload", () => {
     expect(result.text).not.toContain("Retry");
     expect(result.presentation).toBeUndefined();
   });
+
+  it.each([false, true])(
+    "replaces marked choice text with native actions (richTables=%s)",
+    (richTables) => {
+      const result = canonicalizeTelegramPresentationPayload(
+        {
+          text: "Choose the next step.\n\nContinue: /continue\nReference: https://example.com/reference",
+          presentationTextMode: "fallback",
+          presentation: {
+            blocks: [
+              { type: "text", text: "Choose the next step." },
+              {
+                type: "buttons",
+                buttons: [
+                  { label: "Continue", action: { type: "command", command: "/continue" } },
+                  {
+                    label: "Reference",
+                    action: { type: "url", url: "https://example.com/reference" },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        { richTables },
+      );
+
+      expect(result.text).toBe("Choose the next step.");
+      expect(result.channelData?.telegram).toEqual({
+        buttons: [
+          [
+            { text: "Continue", callback_data: "tgcmd:/continue" },
+            { text: "Reference", url: "https://example.com/reference" },
+          ],
+        ],
+      });
+    },
+  );
 
   it("keeps native Telegram button-only payloads deliverable", () => {
     const buttons = [[{ text: "Retry", callback_data: "retry" }]];
@@ -357,6 +404,55 @@ describe("canonicalizeTelegramPresentationPayload", () => {
         text: "Open app:\n\n- Launch: https://example.com/app",
       },
     );
+  });
+
+  it.each(["buttons", "select"] as const)("keeps full fallback labels beside native %s", (type) => {
+    const nativeLabel =
+      "Continue with the selected workspace and its existing settings for production";
+    const fallbackLabel =
+      "Open the workspace with the complete deployment instructions for production";
+    const nativeControl = {
+      label: nativeLabel,
+      action: { type: "command" as const, command: "/continue" },
+    };
+    const result = canonicalizeTelegramPresentationPayload(
+      {
+        text: `${nativeLabel}: /continue\n${fallbackLabel}: https://example.com/app`,
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [
+            type === "buttons"
+              ? {
+                  type,
+                  buttons: [
+                    nativeControl,
+                    {
+                      label: fallbackLabel,
+                      action: { type: "web-app", url: "https://example.com/app" },
+                    },
+                  ],
+                }
+              : {
+                  type,
+                  options: [
+                    nativeControl,
+                    {
+                      label: fallbackLabel,
+                      action: { type: "callback", value: "unavailable".repeat(8) },
+                    },
+                  ],
+                },
+          ],
+        },
+      },
+      { allowWebAppButtons: false },
+    );
+
+    expect(result.text).toContain(fallbackLabel);
+    expect(result.text).not.toContain(nativeLabel);
+    expect(result.channelData?.telegram).toEqual({
+      buttons: [[{ text: nativeLabel.slice(0, 64), callback_data: "tgcmd:/continue" }]],
+    });
   });
 
   it("falls back presentation controls when explicit Telegram buttons take precedence", () => {

--- a/extensions/telegram/src/interactive-fallback.ts
+++ b/extensions/telegram/src/interactive-fallback.ts
@@ -37,13 +37,11 @@ const TELEGRAM_PRESENTATION_CAPABILITIES = {
     actions: {
       maxActions: 100,
       maxActionsPerRow: 3,
-      maxLabelLength: 64,
       supportsStyles: false,
       supportsDisabled: false,
     },
     selects: {
       maxOptions: 100,
-      maxLabelLength: 64,
     },
     text: {
       markdownDialect: "markdown" as const,
@@ -240,10 +238,17 @@ export function canonicalizeTelegramPresentationPayload(
     presentationControlsSelected,
     buttonOptions,
   });
+  // Only native labels are clipped; unavailable controls retain their full text.
   const presentationButtons = buildTelegramPresentationButtons(
-    {
-      blocks: nativeControlBlocks,
-    },
+    adaptMessagePresentationForChannel({
+      presentation: { blocks: nativeControlBlocks },
+      capabilities: {
+        limits: {
+          actions: { maxLabelLength: 64 },
+          selects: { maxLabelLength: 64 },
+        },
+      },
+    }),
     buttonOptions,
   );
   const buttons = existingButtons ?? presentationButtons;
@@ -259,13 +264,14 @@ export function canonicalizeTelegramPresentationPayload(
   const hasFallback =
     fallbackText.length > 0 &&
     (currentText === fallbackText || currentText.endsWith(`\n\n${fallbackText}`));
-  // presentationTextMode "fallback" marks payload.text as the authored plain
-  // rendering of the same presentation: rich accounts replace it with the
-  // native block rendering, plain accounts keep it and drop the generic flatten.
+  // Native controls replace their choice text, including control-only replies.
+  // Text-only delivery keeps the producer's complete authored fallback.
   const text = textIsFallback
-    ? richTables
-      ? fallbackText || currentText
-      : currentText || fallbackText
+    ? nativeControlBlocks.length > 0
+      ? fallbackText
+      : richTables
+        ? fallbackText || currentText
+        : currentText || fallbackText
     : hasFallback
       ? currentText
       : [currentText, fallbackText].filter(Boolean).join("\n\n");

--- a/extensions/telegram/src/outbound-adapter.presentation.test.ts
+++ b/extensions/telegram/src/outbound-adapter.presentation.test.ts
@@ -41,32 +41,38 @@ describe("telegramOutbound presentation", () => {
     sendMessageTelegramMock.mockReset();
   });
 
-  it("keeps presentation-only controls deliverable without duplicating labels", async () => {
-    sendMessageTelegramMock.mockResolvedValueOnce({
-      messageId: "tg-presentation-buttons",
-      chatId: "12345",
-    });
+  it.each([false, true])(
+    "keeps native controls deliverable (authored fallback=%s)",
+    async (hasAuthoredFallback) => {
+      sendMessageTelegramMock.mockResolvedValueOnce({
+        messageId: "tg-presentation-buttons",
+        chatId: "12345",
+      });
 
-    const result = await telegramOutbound.sendPayload!({
-      cfg: {} as never,
-      to: "12345",
-      text: "",
-      payload: {
-        presentation: {
-          blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "cmd:retry" }] }],
+      const result = await telegramOutbound.sendPayload!({
+        cfg: {} as never,
+        to: "12345",
+        text: "",
+        payload: {
+          ...(hasAuthoredFallback
+            ? { text: "Retry the operation.", presentationTextMode: "fallback" as const }
+            : {}),
+          presentation: {
+            blocks: [{ type: "buttons", buttons: [{ label: "Retry", value: "cmd:retry" }] }],
+          },
         },
-      },
-      deps: { sendTelegram: sendMessageTelegramMock },
-    });
+        deps: { sendTelegram: sendMessageTelegramMock },
+      });
 
-    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Choose an option.");
-    expect(options.buttons).toEqual([[{ text: "Retry", callback_data: "cmd:retry" }]]);
-    expect(result).toEqual({
-      channel: "telegram",
-      messageId: "tg-presentation-buttons",
-      target: { kind: "chat", id: "12345" },
-    });
-  });
+      const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Choose an option.");
+      expect(options.buttons).toEqual([[{ text: "Retry", callback_data: "cmd:retry" }]]);
+      expect(result).toEqual({
+        channel: "telegram",
+        messageId: "tg-presentation-buttons",
+        target: { kind: "chat", id: "12345" },
+      });
+    },
+  );
 
   it("renders presentation tables as native islands for payload sends on rich accounts", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-rich-table", chatId: "12345" });
@@ -144,6 +150,36 @@ describe("telegramOutbound presentation", () => {
 
     expect(rendered?.text).toBe("plain fallback");
     expect(rendered?.text).not.toContain("<table");
+  });
+
+  it("preserves fallback labels after core capability adaptation", async () => {
+    const label = "Open the workspace with the complete deployment instructions for production";
+    const sourcePresentation = {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [
+            { label: "Continue", action: { type: "command" as const, command: "/continue" } },
+            { label, action: { type: "web-app" as const, url: "https://example.com/app" } },
+          ],
+        },
+      ],
+    };
+    const rendered = await telegramOutbound.renderPresentation?.({
+      payload: { presentationTextMode: "fallback" },
+      presentation: adaptMessagePresentationForChannel({
+        presentation: sourcePresentation,
+        capabilities: telegramOutbound.presentationCapabilities,
+      }),
+      sourcePresentation,
+      ctx: { cfg: {}, to: "-10012345" } as never,
+    });
+
+    expect(rendered?.text).toContain(label);
+    expect(rendered?.text).toContain("https://example.com/app");
+    expect(rendered?.channelData?.telegram).toEqual({
+      buttons: [[{ text: "Continue", callback_data: "tgcmd:/continue" }]],
+    });
   });
 
   it("renders presentation web app buttons for payload sends", async () => {


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Telegram could show the same choices in both message text and native controls. Control-only replies also repeated the choice list.

## Why This Change Was Made

The presentation owner uses the text remaining after native controls are selected. Plain delivery keeps the authored fallback, and native label limits no longer shorten unavailable text-only choices.

## User Impact

Choices appear once while independent prose, tables, prompts, unavailable choices, and command targets remain intact.

## Evidence

A real Gateway with controlled channel responses reproduced duplication before the fix and showed one prompt with controls afterward. Native command callbacks cleared the keyboard and produced one result. All 171 focused presentation and delivery tests passed. Live Telegram proof was blocked by the required group-membership check.

Consumers: Telegram native presentation uses the remaining text; plain delivery preserves the authored fallback.
