### PR TITLE
fix(android): retire resolved approval cards with their result

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/GatewayExecApprovals.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/GatewayExecApprovals.kt
@@ -32,6 +32,13 @@ data class GatewayExecApprovalSummary(
   val errorText: String? = null,
 )
 
+internal data class GatewayExecApprovalInboxState(
+  val approvals: List<GatewayExecApprovalSummary> = emptyList(),
+  val refreshing: Boolean = false,
+  val errorText: String? = null,
+  val notice: GatewayExecApprovalNotice? = null,
+)
+
 internal enum class GatewayApprovalTerminalStatus {
   Allowed,
   Denied,
@@ -75,7 +82,7 @@ data class GatewayExecApprovalNotice(
   val message: String,
   val warning: Boolean,
   // Distinct per constructed notice: a re-requested approval can lose again with an
-  // identical id/message, and the dismiss compareAndSet must not treat the stale
+  // identical id/message, and conditional dismissal must not treat the stale
   // banner as equal to its replacement.
   val publication: Long = execApprovalNoticePublications.incrementAndGet(),
 )

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -666,10 +666,8 @@ class MainViewModel private constructor(
   val chatOutboxPresentationRestored: StateFlow<Boolean> = runtimeState(initial = false) { it.chatOutboxPresentationRestored }
   internal val chatMessageSpeech: StateFlow<MessageSpeechState?> =
     runtimeState(initial = null) { it.messageSpeechState }
-  val execApprovals: StateFlow<List<GatewayExecApprovalSummary>> = runtimeState(initial = emptyList()) { it.execApprovals }
-  val execApprovalsRefreshing: StateFlow<Boolean> = runtimeState(initial = false) { it.execApprovalsRefreshing }
-  val execApprovalsErrorText: StateFlow<String?> = runtimeState(initial = null) { it.execApprovalsErrorText }
-  val execApprovalsNotice: StateFlow<GatewayExecApprovalNotice?> = runtimeState(initial = null) { it.execApprovalsNotice }
+  internal val execApprovalInbox: StateFlow<GatewayExecApprovalInboxState> =
+    runtimeState(initial = GatewayExecApprovalInboxState()) { it.execApprovalInbox }
 
   /**
    * Attaches Activity-owned permission and lifecycle seams after runtime initialization.

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1481,14 +1481,8 @@ class NodeRuntime private constructor(
   val devicePairingMutation: StateFlow<GatewayDevicePairingMutation?> = _devicePairingMutation.asStateFlow()
   private val devicePairingMutationLock = Any()
   private val nodeApprovalRefreshGuard = LatestGatewayRefreshGuard()
-  private val _execApprovals = MutableStateFlow<List<GatewayExecApprovalSummary>>(emptyList())
-  val execApprovals: StateFlow<List<GatewayExecApprovalSummary>> = _execApprovals.asStateFlow()
-  private val _execApprovalsRefreshing = MutableStateFlow(false)
-  val execApprovalsRefreshing: StateFlow<Boolean> = _execApprovalsRefreshing.asStateFlow()
-  private val _execApprovalsErrorText = MutableStateFlow<String?>(null)
-  val execApprovalsErrorText: StateFlow<String?> = _execApprovalsErrorText.asStateFlow()
-  private val _execApprovalsNotice = MutableStateFlow<GatewayExecApprovalNotice?>(null)
-  val execApprovalsNotice: StateFlow<GatewayExecApprovalNotice?> = _execApprovalsNotice.asStateFlow()
+  private val mutableExecApprovalInbox = MutableStateFlow(GatewayExecApprovalInboxState())
+  internal val execApprovalInbox: StateFlow<GatewayExecApprovalInboxState> = mutableExecApprovalInbox.asStateFlow()
   private val execApprovalsRefreshSeq = AtomicLong(0)
   private val execApprovalsStateLock = Any()
   private var execApprovalsSnapshotReady = false
@@ -1799,10 +1793,11 @@ class NodeRuntime private constructor(
 
   private fun currentWearAgentPulseApprovals(): WearAgentPulseApprovalSnapshot =
     synchronized(execApprovalsStateLock) {
+      val inbox = mutableExecApprovalInbox.value
       WearAgentPulseApprovalSnapshot(
-        pendingCount = _execApprovals.value.size,
-        available = execApprovalsSnapshotReady && _execApprovalsErrorText.value == null,
-        refreshing = _execApprovalsRefreshing.value,
+        pendingCount = inbox.approvals.size,
+        available = execApprovalsSnapshotReady && inbox.errorText == null,
+        refreshing = inbox.refreshing,
       )
     }
 
@@ -1926,10 +1921,7 @@ class NodeRuntime private constructor(
         pendingExecApprovalWrites.clear()
       }
     }
-    _execApprovals.value = emptyList()
-    _execApprovalsRefreshing.value = false
-    _execApprovalsErrorText.value = null
-    _execApprovalsNotice.value = null
+    mutableExecApprovalInbox.value = GatewayExecApprovalInboxState()
     channelsSummary.reset()
     dreamingSummary.reset()
     healthLogsSummary.reset()
@@ -2930,10 +2922,10 @@ class NodeRuntime private constructor(
   }
 
   fun dismissExecApprovalsNotice(expected: GatewayExecApprovalNotice) {
-    // Atomic conditional clear: not every notice publisher holds execApprovalsStateLock
-    // (refreshExecApprovalFromGateway's terminal branch), so a locked check-then-clear
-    // could still let a stale dismiss clobber a freshly published replacement.
-    _execApprovalsNotice.compareAndSet(expected, null)
+    // A stale banner callback must not clear a replacement publication or overwrite newer rows.
+    mutableExecApprovalInbox.update { inbox ->
+      if (inbox.notice == expected) inbox.copy(notice = null) else inbox
+    }
   }
 
   fun refreshChannels() = launchGatewayRefresh { refreshChannelsFromGateway() }
@@ -5676,8 +5668,8 @@ class NodeRuntime private constructor(
         approvalId?.let { id ->
           resolvedExecApprovalIds.remove(id)
           synchronized(execApprovalsStateLock) {
-            if (_execApprovalsNotice.value?.approvalId == id) {
-              _execApprovalsNotice.value = null
+            mutableExecApprovalInbox.update { inbox ->
+              if (inbox.notice?.approvalId == id) inbox.copy(notice = null) else inbox
             }
           }
         }
@@ -5705,12 +5697,13 @@ class NodeRuntime private constructor(
           -> {
             val terminal = parseGatewayExecApprovalResolvedEventTerminal(payloadJson ?: return, json)
             synchronized(execApprovalsStateLock) {
-              if (terminal != null && _execApprovals.value.any { it.id == approvalId }) {
-                _execApprovalsNotice.value = gatewayExecApprovalRemoteTerminalNotice(terminal)
-              }
+              val notice =
+                terminal
+                  ?.takeIf { mutableExecApprovalInbox.value.approvals.any { it.id == approvalId } }
+                  ?.let(::gatewayExecApprovalRemoteTerminalNotice)
               // Noncanonical peers cannot prove terminal state by readback. The
               // authenticated event is the fail-closed tombstone for this exact ID.
-              markExecApprovalResolved(approvalId)
+              markExecApprovalResolved(approvalId, notice)
             }
           }
         }
@@ -7927,8 +7920,7 @@ class NodeRuntime private constructor(
         nextGeneration
       }
     publishGatewayData(gatewayScope) {
-      _execApprovalsRefreshing.value = true
-      _execApprovalsErrorText.value = null
+      mutableExecApprovalInbox.update { it.copy(refreshing = true, errorText = null) }
       // The terminal notice reports an outcome the reviewer has not acknowledged yet.
       // Refresh must not wipe it; it clears on user dismissal, a replacement terminal
       // notice, a re-requested approval with the same id, or gateway teardown.
@@ -7936,8 +7928,7 @@ class NodeRuntime private constructor(
     if (!operatorConnected) {
       publishGatewayData(gatewayScope) {
         if (execApprovalsRefreshSeq.get() == refreshGeneration) {
-          _execApprovals.value = emptyList()
-          _execApprovalsRefreshing.value = false
+          mutableExecApprovalInbox.update { it.copy(approvals = emptyList(), refreshing = false) }
         }
       }
       return
@@ -7946,7 +7937,7 @@ class NodeRuntime private constructor(
       // TODO(#103505): replace legacy full-request discovery with the sanitized
       // session approval lifecycle projection before removing this list seam.
       val res = requestGatewayData(gatewayScope, "exec.approval.list", "{}")
-      val existing = _execApprovals.value.associateBy { it.id }
+      val existing = mutableExecApprovalInbox.value.approvals.associateBy { it.id }
       val terminalApprovals = mutableListOf<GatewayExecApprovalSnapshot.Terminal>()
       val rows =
         parseGatewayExecApprovalListPayload(res, json)
@@ -8004,13 +7995,13 @@ class NodeRuntime private constructor(
     } catch (_: Throwable) {
       publishGatewayData(gatewayScope) {
         if (execApprovalsRefreshSeq.get() == refreshGeneration) {
-          _execApprovalsErrorText.value = execApprovalLoadFailureMessage()
+          mutableExecApprovalInbox.update { it.copy(errorText = execApprovalLoadFailureMessage()) }
         }
       }
     } finally {
       publishGatewayData(gatewayScope) {
         if (execApprovalsRefreshSeq.get() == refreshGeneration) {
-          _execApprovalsRefreshing.value = false
+          mutableExecApprovalInbox.update { it.copy(refreshing = false) }
         }
       }
     }
@@ -8022,7 +8013,7 @@ class NodeRuntime private constructor(
     if (!operatorConnected) return
     if (id in resolvedExecApprovalIds) return
     try {
-      val current = _execApprovals.value.firstOrNull { it.id == id }
+      val current = mutableExecApprovalInbox.value.approvals.firstOrNull { it.id == id }
       val methodsSnapshot = captureGatewayMethods()
       val lookup =
         fetchExecApprovalDetailFromGateway(
@@ -8053,10 +8044,13 @@ class NodeRuntime private constructor(
 
         is GatewayExecApprovalSnapshot.Terminal -> {
           publishGatewayApprovalData(gatewayScope, methodsSnapshot) {
-            if (_execApprovals.value.any { it.id == id }) {
-              _execApprovalsNotice.value = gatewayExecApprovalRemoteTerminalNotice(lookup)
+            synchronized(execApprovalsStateLock) {
+              val notice =
+                lookup
+                  .takeIf { mutableExecApprovalInbox.value.approvals.any { it.id == id } }
+                  ?.let(::gatewayExecApprovalRemoteTerminalNotice)
+              markExecApprovalResolved(id, notice)
             }
-            markExecApprovalResolved(id)
           }
         }
       }
@@ -8117,7 +8111,7 @@ class NodeRuntime private constructor(
       publishGatewayApprovalData(gatewayScope, methodsSnapshot) {
         synchronized(execApprovalsStateLock) {
           if (!operatorConnected || id in resolvedExecApprovalIds) return@synchronized
-          val currentRows = _execApprovals.value
+          val currentRows = mutableExecApprovalInbox.value.approvals
           if (currentRows.none { it.id == id && it.resolvingDecision == null }) return@synchronized
           if (pendingExecApprovalWrites.containsKey(id)) return@synchronized
           val pendingWrite =
@@ -8130,10 +8124,14 @@ class NodeRuntime private constructor(
           pendingExecApprovalWrites[id] = pendingWrite
           registeredWrite = pendingWrite
           invalidateExecApprovalRefreshes()
-          _execApprovals.value =
-            currentRows.map { row ->
-              if (row.id == id) row.copy(resolvingDecision = decision, errorText = null) else row
-            }
+          mutableExecApprovalInbox.update { inbox ->
+            inbox.copy(
+              approvals =
+                currentRows.map { row ->
+                  if (row.id == id) row.copy(resolvingDecision = decision, errorText = null) else row
+                },
+            )
+          }
           // Do not clear the notice here: it reports a different approval's terminal
           // outcome (a same-id write cannot start after its terminal notice retired the
           // row) and must stay visible until the user acknowledges it.
@@ -8148,8 +8146,7 @@ class NodeRuntime private constructor(
         synchronized(execApprovalsStateLock) {
           if (pendingExecApprovalWrites[id] !== pendingWrite || id in resolvedExecApprovalIds) return@synchronized
           // `applied=false` carries the canonical winner from another surface.
-          _execApprovalsNotice.value = gatewayExecApprovalResolutionNotice(resolution)
-          markExecApprovalResolved(id)
+          markExecApprovalResolved(id, gatewayExecApprovalResolutionNotice(resolution))
         }
       }
       if (pendingExecApprovalWrite(id, gatewayScope.stableId) === pendingWrite) {
@@ -8272,12 +8269,13 @@ class NodeRuntime private constructor(
       synchronized(execApprovalsStateLock) {
         val id = pendingWrite.id
         if (pendingExecApprovalWrites[id] !== pendingWrite) return@synchronized
-        if (_execApprovals.value.any { it.id == id }) {
-          _execApprovalsNotice.value = gatewayExecApprovalPriorResolutionNotice(id)
-        }
+        val notice =
+          id
+            .takeIf { mutableExecApprovalInbox.value.approvals.any { row -> row.id == id } }
+            ?.let(::gatewayExecApprovalPriorResolutionNotice)
         // The legacy rejection proves only that another verdict won. Retire the
         // exact card without inventing that unavailable winner's decision.
-        markExecApprovalResolved(id)
+        markExecApprovalResolved(id, notice)
       }
     }
   }
@@ -8297,22 +8295,26 @@ class NodeRuntime private constructor(
           pendingWrite.requestInFlight = false
         }
         invalidateExecApprovalRefreshes()
-        if (!operatorConnected || id in resolvedExecApprovalIds || _execApprovals.value.none { it.id == id }) {
+        if (!operatorConnected || id in resolvedExecApprovalIds || mutableExecApprovalInbox.value.approvals.none { it.id == id }) {
           return@synchronized
         }
         val error =
           if (outcomeUnknown) execApprovalOutcomeUnknownMessage() else execApprovalResolveFailureMessage()
-        _execApprovals.value =
-          _execApprovals.value.map { row ->
-            if (row.id == id) {
-              row.copy(
-                resolvingDecision = pendingWrite.decision.takeIf { outcomeUnknown },
-                errorText = error,
-              )
-            } else {
-              row
-            }
-          }
+        mutableExecApprovalInbox.update { inbox ->
+          inbox.copy(
+            approvals =
+              inbox.approvals.map { row ->
+                if (row.id == id) {
+                  row.copy(
+                    resolvingDecision = pendingWrite.decision.takeIf { outcomeUnknown },
+                    errorText = error,
+                  )
+                } else {
+                  row
+                }
+              },
+          )
+        }
       }
     }
   }
@@ -8348,7 +8350,9 @@ class NodeRuntime private constructor(
           id = pendingWrite.id,
           createdAtMs =
             pendingWrite.createdAtMs
-              ?: _execApprovals.value.firstOrNull { it.id == pendingWrite.id }?.createdAtMs,
+              ?: mutableExecApprovalInbox.value.approvals
+                .firstOrNull { it.id == pendingWrite.id }
+                ?.createdAtMs,
         )
       } catch (err: CancellationException) {
         throw err
@@ -8360,8 +8364,7 @@ class NodeRuntime private constructor(
         if (!operatorConnected || pendingExecApprovalWrites[pendingWrite.id] !== pendingWrite) return@synchronized
         when (snapshot) {
           is GatewayExecApprovalSnapshot.Terminal -> {
-            _execApprovalsNotice.value = gatewayExecApprovalRemoteTerminalNotice(snapshot)
-            markExecApprovalResolved(pendingWrite.id)
+            markExecApprovalResolved(pendingWrite.id, gatewayExecApprovalRemoteTerminalNotice(snapshot))
           }
 
           is GatewayExecApprovalSnapshot.Pending -> {
@@ -8372,12 +8375,12 @@ class NodeRuntime private constructor(
                 resolvingDecision = null,
                 errorText = execApprovalStillPendingMessage(),
               )
-            val retained = _execApprovals.value.filterNot { it.id == pendingWrite.id }
+            val retained = mutableExecApprovalInbox.value.approvals.filterNot { it.id == pendingWrite.id }
             val nextRows =
               (retained + row)
                 .filterActiveExecApprovals()
                 .sortedBy { it.createdAtMs ?: Long.MAX_VALUE }
-            _execApprovals.value = nextRows
+            mutableExecApprovalInbox.update { it.copy(approvals = nextRows) }
             scheduleExecApprovalExpiryPrune(nextRows)
           }
         }
@@ -8464,7 +8467,7 @@ class NodeRuntime private constructor(
     synchronized(execApprovalsStateLock) {
       if (!operatorConnected || row.id in resolvedExecApprovalIds) return
       if (row.isExpiredExecApproval()) return
-      val rows = _execApprovals.value
+      val rows = mutableExecApprovalInbox.value.approvals
       val replaced = rows.any { it.id == row.id }
       val nextRows =
         (
@@ -8484,7 +8487,7 @@ class NodeRuntime private constructor(
           }
         ).filterActiveExecApprovals()
           .sortedBy { it.createdAtMs ?: Long.MAX_VALUE }
-      _execApprovals.value = nextRows
+      mutableExecApprovalInbox.update { it.copy(approvals = nextRows) }
       scheduleExecApprovalExpiryPrune(nextRows)
     }
   }
@@ -8492,16 +8495,22 @@ class NodeRuntime private constructor(
   private fun invalidateExecApprovalRefreshes() {
     synchronized(execApprovalsStateLock) {
       execApprovalsRefreshSeq.incrementAndGet()
-      _execApprovalsRefreshing.value = false
+      mutableExecApprovalInbox.update { it.copy(refreshing = false) }
     }
   }
 
-  private fun markExecApprovalResolved(id: String) {
+  private fun markExecApprovalResolved(
+    id: String,
+    notice: GatewayExecApprovalNotice?,
+  ) {
     synchronized(execApprovalsStateLock) {
       resolvedExecApprovalIds.add(id)
       pendingExecApprovalWrites.remove(id)
-      invalidateExecApprovalRefreshes()
-      _execApprovals.value = _execApprovals.value.filterNot { it.id == id }
+      execApprovalsRefreshSeq.incrementAndGet()
+      // One publication prevents consumers from pairing a terminal notice with its actionable card.
+      mutableExecApprovalInbox.update { inbox ->
+        inbox.copy(approvals = inbox.approvals.filterNot { it.id == id }, refreshing = false, notice = notice ?: inbox.notice)
+      }
     }
   }
 
@@ -8514,20 +8523,21 @@ class NodeRuntime private constructor(
     publishGatewayData(gatewayScope) {
       synchronized(execApprovalsStateLock) {
         if (execApprovalsRefreshSeq.get() == refreshGeneration && operatorConnected) {
-          val visibleIds = _execApprovals.value.mapTo(mutableSetOf()) { it.id }
+          val visibleIds = mutableExecApprovalInbox.value.approvals.mapTo(mutableSetOf()) { it.id }
           val pendingWriteIds =
             pendingExecApprovalWrites.values
               .filter { it.stableId == gatewayScope.stableId }
               .mapTo(mutableSetOf()) { it.id }
-          terminalApprovals.lastOrNull { it.id in visibleIds || it.id in pendingWriteIds }?.let { terminal ->
-            _execApprovalsNotice.value = gatewayExecApprovalRemoteTerminalNotice(terminal)
-          }
+          val notice =
+            terminalApprovals
+              .lastOrNull { it.id in visibleIds || it.id in pendingWriteIds }
+              ?.let(::gatewayExecApprovalRemoteTerminalNotice)
           val terminalIds = terminalApprovals.map { it.id }
           resolvedExecApprovalIds.addAll(terminalIds)
           terminalIds.forEach(pendingExecApprovalWrites::remove)
           val nextRows = rows.filterNot { it.id in resolvedExecApprovalIds }.filterActiveExecApprovals()
           execApprovalsSnapshotReady = true
-          _execApprovals.value = nextRows
+          mutableExecApprovalInbox.update { it.copy(approvals = nextRows, notice = notice ?: it.notice) }
           scheduleExecApprovalExpiryPrune(nextRows)
         }
       }
@@ -8545,7 +8555,7 @@ class NodeRuntime private constructor(
 
   private fun pruneExpiredExecApprovals() {
     synchronized(execApprovalsStateLock) {
-      _execApprovals.value = _execApprovals.value.filterActiveExecApprovals()
+      mutableExecApprovalInbox.update { it.copy(approvals = it.approvals.filterActiveExecApprovals()) }
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -592,13 +592,10 @@ private fun ApprovalsSettingsScreen(
   onBack: () -> Unit,
 ) {
   val isConnected by viewModel.isConnected.collectAsState()
-  val execApprovals by viewModel.execApprovals.collectAsState()
-  val execApprovalsRefreshing by viewModel.execApprovalsRefreshing.collectAsState()
-  val execApprovalsErrorText by viewModel.execApprovalsErrorText.collectAsState()
-  val execApprovalsNotice by viewModel.execApprovalsNotice.collectAsState()
+  val inbox by viewModel.execApprovalInbox.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val pendingRunCount by viewModel.pendingRunCount.collectAsState()
-  val issueCount = execApprovals.count { it.errorText != null } + pendingToolCalls.count { it.isError == true }
+  val issueCount = inbox.approvals.count { it.errorText != null } + pendingToolCalls.count { it.isError == true }
 
   LaunchedEffect(isConnected) {
     if (isConnected) {
@@ -610,26 +607,26 @@ private fun ApprovalsSettingsScreen(
     SettingsMetricPanel(
       rows =
         listOf(
-          SettingsMetric(nativeString("Gateway Pending"), execApprovals.size.toString()),
+          SettingsMetric(nativeString("Gateway Pending"), inbox.approvals.size.toString()),
           SettingsMetric(nativeString("Thread Activity"), pendingToolCalls.size.toString()),
           SettingsMetric(nativeString("Issues"), issueCount.toString()),
           SettingsMetric(nativeString("Active Runs"), pendingRunCount.toString()),
         ),
     )
     ClawSecondaryButton(
-      text = if (execApprovalsRefreshing) nativeString("Refreshing") else nativeString("Refresh"),
+      text = if (inbox.refreshing) nativeString("Refreshing") else nativeString("Refresh"),
       onClick = viewModel::refreshExecApprovals,
-      enabled = isConnected && !execApprovalsRefreshing,
+      enabled = isConnected && !inbox.refreshing,
       modifier = Modifier.fillMaxWidth(),
     )
-    if (execApprovalsErrorText != null) {
+    inbox.errorText?.let { errorText ->
       ClawPanel {
-        Text(text = gatewayExecApprovalTextForDisplay(execApprovalsErrorText ?: ""), style = ClawTheme.type.body, color = ClawTheme.colors.warning)
+        Text(text = gatewayExecApprovalTextForDisplay(errorText), style = ClawTheme.type.body, color = ClawTheme.colors.warning)
       }
     }
-    // Terminal outcomes always retire their card first, so the notice renders as a
-    // standalone banner above the list; it stays visible until the user dismisses it.
-    execApprovalsNotice?.let { notice ->
+    // The inbox publishes terminal notices with their cards retired in the same snapshot.
+    // Keep the banner independent of remaining cards until the user dismisses it.
+    inbox.notice?.let { notice ->
       ExecApprovalNotice(notice = notice, onDismiss = { viewModel.dismissExecApprovalsNotice(notice) })
     }
     if (!isConnected) {
@@ -639,7 +636,7 @@ private fun ApprovalsSettingsScreen(
           Text(text = nativeString("Connect the gateway to load approval requests in the app."), style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
         }
       }
-    } else if (execApprovals.isEmpty()) {
+    } else if (inbox.approvals.isEmpty()) {
       ClawPanel {
         Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
           Text(text = nativeString("No gateway approvals."), style = ClawTheme.type.section, color = ClawTheme.colors.text)
@@ -648,7 +645,7 @@ private fun ApprovalsSettingsScreen(
       }
     } else {
       ExecApprovalsPanel(
-        approvals = execApprovals,
+        approvals = inbox.approvals,
         onResolve = viewModel::resolveExecApproval,
       )
     }

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ShellScreen.kt
@@ -413,7 +413,7 @@ private fun OverviewScreen(
   val isConnected = gatewayConnectionDisplay.isConnected
   val models by viewModel.providerModelCatalog.collectAsState()
   val providers by viewModel.modelAuthProviders.collectAsState()
-  val execApprovals by viewModel.execApprovals.collectAsState()
+  val approvalInbox by viewModel.execApprovalInbox.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val cronStatus by viewModel.cronStatus.collectAsState()
   val nodesDevicesSummary by viewModel.nodesDevicesSummary.collectAsState()
@@ -424,7 +424,7 @@ private fun OverviewScreen(
   val providerRows = providerRows(providers = providers, models = models)
   val readyProviderCount = providerRows.count { it.ready }
   val unknownProviderCount = providerRows.count { it.availability == ProviderAvailability.Unknown }
-  val pendingApprovalsCount = execApprovals.size + pendingToolCalls.size
+  val pendingApprovalsCount = approvalInbox.approvals.size + pendingToolCalls.size
   val attentionRows =
     homeAttentionRows(
       isConnected = isConnected,
@@ -1469,7 +1469,7 @@ private fun SettingsShellScreen(
   val notificationForwardingEnabled by viewModel.notificationForwardingEnabled.collectAsState()
   val speakerEnabled by viewModel.speakerEnabled.collectAsState()
   val agents by viewModel.gatewayAgents.collectAsState()
-  val execApprovals by viewModel.execApprovals.collectAsState()
+  val approvalInbox by viewModel.execApprovalInbox.collectAsState()
   val pendingToolCalls by viewModel.chatPendingToolCalls.collectAsState()
   val cronStatus by viewModel.cronStatus.collectAsState()
   val usageState by viewModel.usageState.collectAsState()
@@ -1487,7 +1487,7 @@ private fun SettingsShellScreen(
   val providerRows = providerRows(providers = providers, models = models)
   val readyProviderCount = providerRows.count { it.ready }
   val unknownProviderCount = providerRows.count { it.availability == ProviderAvailability.Unknown }
-  val pendingApprovalsCount = execApprovals.size + pendingToolCalls.size
+  val pendingApprovalsCount = approvalInbox.approvals.size + pendingToolCalls.size
 
   LaunchedEffect(isConnected) {
     if (isConnected) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayExecApprovalRuntimeTest.kt
@@ -55,14 +55,21 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
 
       assertEquals(listOf("approval.resolve"), requests.map { it.first })
       assertEquals(
         """{"id":"approval-1","kind":"exec","decision":"allow-once"}""",
         requests.single().second,
       )
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -96,13 +103,16 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.resolveExecApproval(controlPrefixedId, "deny")
       val params = Json.parseToJsonElement(withTimeout(2_000) { requestParams.await() }).jsonObject
-      waitUntil { runtime.execApprovals.value.map { it.id } == listOf("approval-1") }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id } == listOf("approval-1")
+      }
 
       assertEquals(1, requestCount.get())
       assertEquals(controlPrefixedId, params["id"]?.jsonPrimitive?.content)
       assertEquals(
         "approval-1",
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .single()
           .id,
       )
@@ -140,7 +150,7 @@ class GatewayExecApprovalRuntimeTest {
         """{"id":${JsonPrimitive(controlPrefixedId)}}""",
       )
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.id == controlPrefixedId
       }
@@ -168,12 +178,16 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
 
       assertEquals(listOf("approval.resolve", "approval.get"), methods)
       assertEquals(
         "A prior response already allowed this command and saved the choice.",
-        runtime.execApprovalsNotice.value?.message,
+        runtime.execApprovalInbox.value.notice
+          ?.message,
       )
     }
 
@@ -190,12 +204,14 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.resolveExecApproval("approval-1", "deny")
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.errorText
           ?.startsWith("Resolution outcome unknown") == true
       }
-      val frozen = runtime.execApprovals.value.single()
+      val frozen =
+        runtime.execApprovalInbox.value.approvals
+          .single()
       assertEquals("deny", frozen.resolvingDecision)
 
       invokeClearOperatorState(runtime, retirePendingRuns = false)
@@ -211,10 +227,17 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.refreshExecApprovals()
-      waitUntil { reconnectMethods.contains("approval.get") && runtime.execApprovalsNotice.value != null }
+      waitUntil { reconnectMethods.contains("approval.get") && runtime.execApprovalInbox.value.notice != null }
 
-      assertTrue(runtime.execApprovals.value.isEmpty())
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertTrue(
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty(),
+      )
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -230,10 +253,12 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.refreshExecApprovals()
       withTimeout(2_000) { requestStarted.await() }
-      waitUntil { !runtime.execApprovalsRefreshing.value }
+      waitUntil { !runtime.execApprovalInbox.value.refreshing }
 
-      val retainedApproval = runtime.execApprovals.value.single()
-      assertNull(runtime.execApprovalsErrorText.value)
+      val retainedApproval =
+        runtime.execApprovalInbox.value.approvals
+          .single()
+      assertNull(runtime.execApprovalInbox.value.errorText)
       assertEquals("approval-1", retainedApproval.id)
       assertNull(retainedApproval.errorText)
     }
@@ -251,7 +276,7 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.resolveExecApproval("approval-1", "deny")
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.errorText
           ?.startsWith("Resolution outcome unknown") == true
@@ -276,10 +301,17 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.refreshExecApprovals()
-      waitUntil { runtime.execApprovalsNotice.value != null }
+      waitUntil { runtime.execApprovalInbox.value.notice != null }
 
-      assertTrue(runtime.execApprovals.value.isEmpty())
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertTrue(
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty(),
+      )
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -330,9 +362,11 @@ class GatewayExecApprovalRuntimeTest {
       seedConnectedRuntime(runtime, unifiedMethods)
       runtime.refreshExecApprovals()
       withTimeout(2_000) { pendingReadCompleted.await() }
-      waitUntil { !runtime.execApprovalsRefreshing.value }
+      waitUntil { !runtime.execApprovalInbox.value.refreshing }
 
-      val reconnected = runtime.execApprovals.value.single()
+      val reconnected =
+        runtime.execApprovalInbox.value.approvals
+          .single()
       assertEquals("deny", reconnected.resolvingDecision)
       assertTrue(reconnected.errorText?.startsWith("Resolution outcome unknown") == true)
       assertFalse(releaseUnknownOutcome.isCompleted)
@@ -342,9 +376,16 @@ class GatewayExecApprovalRuntimeTest {
       withTimeout(2_000) { winnerReadStarted.await() }
       releaseWinnerRead.complete(Unit)
 
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
       assertTrue(approvalReads.get() >= 2)
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -383,17 +424,26 @@ class GatewayExecApprovalRuntimeTest {
       withTimeout(10_000) { resolveStarted.await() }
       runtime.refreshExecApprovals()
       withTimeout(2_000) { refreshReadCompleted.await() }
-      waitUntil { !runtime.execApprovalsRefreshing.value }
+      waitUntil { !runtime.execApprovalInbox.value.refreshing }
       delay(100)
 
-      val inFlight = runtime.execApprovals.value.single()
+      val inFlight =
+        runtime.execApprovalInbox.value.approvals
+          .single()
       assertEquals("deny", inFlight.resolvingDecision)
       assertNull(inFlight.errorText)
       assertEquals(1, approvalReads.get())
 
       releaseResolve.complete(Unit)
-      waitUntil { runtime.execApprovals.value.isEmpty() }
-      assertEquals("Approval denied.", runtime.execApprovalsNotice.value?.message)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
+      assertEquals(
+        "Approval denied.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -456,7 +506,7 @@ class GatewayExecApprovalRuntimeTest {
 
       releaseUnknownOutcome.complete(Unit)
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .firstOrNull { it.id == "approval-1" }
           ?.errorText
           ?.startsWith("Resolution outcome unknown") == true
@@ -466,10 +516,15 @@ class GatewayExecApprovalRuntimeTest {
       withTimeout(2_000) { retainedReadReturning.await() }
       delay(100)
 
-      val selected = runtime.execApprovals.value.first { it.id == "approval-1" }
+      val selected =
+        runtime.execApprovalInbox.value.approvals
+          .first { it.id == "approval-1" }
       assertEquals("deny", selected.resolvingDecision)
       assertTrue(selected.errorText?.startsWith("Resolution outcome unknown") == true)
-      assertTrue(runtime.execApprovals.value.any { it.id == "approval-2" })
+      assertTrue(
+        runtime.execApprovalInbox.value.approvals
+          .any { it.id == "approval-2" },
+      )
       assertTrue(selectedReads.get() >= 2)
     }
 
@@ -527,7 +582,7 @@ class GatewayExecApprovalRuntimeTest {
 
       releasePendingRead.complete(Unit)
       waitUntil {
-        runtime.execApprovals.value.singleOrNull()?.let { row ->
+        runtime.execApprovalInbox.value.approvals.singleOrNull()?.let { row ->
           row.resolvingDecision == null &&
             row.errorText == "The Gateway still shows this approval as pending. Review it before trying again."
         } == true
@@ -537,7 +592,9 @@ class GatewayExecApprovalRuntimeTest {
       withTimeout(2_000) { staleRefreshResponseReturning.await() }
       delay(100)
 
-      val finalRow = runtime.execApprovals.value.single()
+      val finalRow =
+        runtime.execApprovalInbox.value.approvals
+          .single()
       assertNull(finalRow.resolvingDecision)
       assertEquals(
         "The Gateway still shows this approval as pending. Review it before trying again.",
@@ -559,14 +616,14 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.resolveExecApproval("approval-1", "deny")
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.errorText
           ?.startsWith("Resolution outcome unknown") == true
       }
       assertEquals(
         "deny",
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .single()
           .resolvingDecision,
       )
@@ -597,14 +654,17 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.refreshExecApprovals()
       waitUntil {
-        runtime.execApprovals.value.singleOrNull()?.let { row ->
+        runtime.execApprovalInbox.value.approvals.singleOrNull()?.let { row ->
           row.resolvingDecision == null &&
             row.errorText == "The Gateway still shows this approval as pending. Review it before trying again."
         } == true
       }
 
       runtime.resolveExecApproval("approval-1", "deny")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
 
       assertEquals(
         listOf(
@@ -627,9 +687,16 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
 
-      assertEquals("Gateway recorded approval once.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        "Gateway recorded approval once.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -663,12 +730,23 @@ class GatewayExecApprovalRuntimeTest {
         "exec.approval.resolved",
         """{"id":"approval-1","decision":"deny","resolvedBy":"other","ts":150}""",
       )
-      waitUntil { runtime.execApprovals.value.isEmpty() }
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
 
       releaseResolve.complete(Unit)
       delay(100)
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -705,20 +783,40 @@ class GatewayExecApprovalRuntimeTest {
         """{"id":"approval-1","decision":"deny","resolvedBy":"other","ts":150,"request":{}}""",
       )
 
-      assertEquals(listOf("approval-2"), runtime.execApprovals.value.map { it.id })
-      assertEquals("approval-1", runtime.execApprovalsNotice.value?.approvalId)
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        listOf("approval-2"),
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id },
+      )
+      assertEquals(
+        "approval-1",
+        runtime.execApprovalInbox.value.notice
+          ?.approvalId,
+      )
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
       assertEquals(listOf("exec.approval.resolve"), methods)
 
       releaseResolve.complete(Unit)
       delay(100)
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
 
       runtime.refreshExecApprovals()
-      waitUntil { runtime.execApprovalsErrorText.value != null && !runtime.execApprovalsRefreshing.value }
+      waitUntil { runtime.execApprovalInbox.value.errorText != null && !runtime.execApprovalInbox.value.refreshing }
 
       assertEquals(listOf("exec.approval.resolve", "exec.approval.list"), methods)
-      assertEquals(listOf("approval-2"), runtime.execApprovals.value.map { it.id })
+      assertEquals(
+        listOf("approval-2"),
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id },
+      )
     }
 
   @Test
@@ -740,15 +838,29 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.map { it.id } == listOf("approval-2") }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id } == listOf("approval-2")
+      }
 
-      assertEquals("approval-1", runtime.execApprovalsNotice.value?.approvalId)
-      assertEquals("A prior response already resolved this approval.", runtime.execApprovalsNotice.value?.message)
-      assertTrue(runtime.execApprovalsNotice.value?.warning == true)
+      assertEquals(
+        "approval-1",
+        runtime.execApprovalInbox.value.notice
+          ?.approvalId,
+      )
+      assertEquals(
+        "A prior response already resolved this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
+      assertTrue(
+        runtime.execApprovalInbox.value.notice
+          ?.warning == true,
+      )
 
       runtime.resolveExecApproval("approval-2", "deny")
       waitUntil {
-        runtime.execApprovals.value.singleOrNull()?.let { row ->
+        runtime.execApprovalInbox.value.approvals.singleOrNull()?.let { row ->
           row.id == "approval-2" &&
             row.resolvingDecision == null &&
             row.errorText == "Could not resolve approval. Refresh and try again."
@@ -794,7 +906,7 @@ class GatewayExecApprovalRuntimeTest {
       // The settled rejection must reconcile through current canonical state instead
       // of freezing until a perfectly timed manual refresh.
       waitUntil {
-        runtime.execApprovals.value.singleOrNull()?.let { row ->
+        runtime.execApprovalInbox.value.approvals.singleOrNull()?.let { row ->
           row.resolvingDecision == null &&
             row.errorText == "The Gateway still shows this approval as pending. Review it before trying again."
         } == true
@@ -813,8 +925,15 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.map { it.id } == listOf("approval-2") }
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id } == listOf("approval-2")
+      }
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
 
       val refreshMethods = mutableListOf<String>()
       runtime.gatewayDataRequestOverrideForTests = { _, method, _ ->
@@ -834,16 +953,28 @@ class GatewayExecApprovalRuntimeTest {
         }
       }
       runtime.refreshExecApprovals()
-      waitUntil { refreshMethods.contains("approval.get") && !runtime.execApprovalsRefreshing.value }
-      assertEquals(listOf("approval-2"), runtime.execApprovals.value.map { it.id })
+      waitUntil { refreshMethods.contains("approval.get") && !runtime.execApprovalInbox.value.refreshing }
+      assertEquals(
+        listOf("approval-2"),
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id },
+      )
 
       // A refresh must not wipe an unacknowledged losing outcome; only the user (or a
       // replacement terminal notice) clears the banner.
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
-      assertEquals("approval-1", runtime.execApprovalsNotice.value?.approvalId)
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
+      assertEquals(
+        "approval-1",
+        runtime.execApprovalInbox.value.notice
+          ?.approvalId,
+      )
 
-      runtime.dismissExecApprovalsNotice(requireNotNull(runtime.execApprovalsNotice.value))
-      assertNull(runtime.execApprovalsNotice.value)
+      runtime.dismissExecApprovalsNotice(requireNotNull(runtime.execApprovalInbox.value.notice))
+      assertNull(runtime.execApprovalInbox.value.notice)
     }
 
   @Test
@@ -869,12 +1000,19 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.map { it.id } == listOf("approval-2") }
-      assertEquals("approval-1", runtime.execApprovalsNotice.value?.approvalId)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id } == listOf("approval-2")
+      }
+      assertEquals(
+        "approval-1",
+        runtime.execApprovalInbox.value.notice
+          ?.approvalId,
+      )
 
       runtime.resolveExecApproval("approval-2", "deny")
       waitUntil {
-        runtime.execApprovals.value.singleOrNull()?.let { row ->
+        runtime.execApprovalInbox.value.approvals.singleOrNull()?.let { row ->
           row.id == "approval-2" &&
             row.resolvingDecision == null &&
             row.errorText == "Could not resolve approval. Refresh and try again."
@@ -883,8 +1021,16 @@ class GatewayExecApprovalRuntimeTest {
 
       // Starting (and failing) a write for approval-2 must not clear the unacknowledged
       // losing outcome for approval-1; only the user or a replacement terminal clears it.
-      assertEquals("approval-1", runtime.execApprovalsNotice.value?.approvalId)
-      assertEquals("A prior response already denied this approval.", runtime.execApprovalsNotice.value?.message)
+      assertEquals(
+        "approval-1",
+        runtime.execApprovalInbox.value.notice
+          ?.approvalId,
+      )
+      assertEquals(
+        "A prior response already denied this approval.",
+        runtime.execApprovalInbox.value.notice
+          ?.message,
+      )
     }
 
   @Test
@@ -905,22 +1051,28 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.map { it.id } == listOf("approval-2") }
-      val staleNotice = requireNotNull(runtime.execApprovalsNotice.value)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id } == listOf("approval-2")
+      }
+      val staleNotice = requireNotNull(runtime.execApprovalInbox.value.notice)
       assertEquals("approval-1", staleNotice.approvalId)
 
       invokeApprovalEvent(runtime, "exec.approval.resolved", """{"id":"approval-2"}""")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
-      val replacement = requireNotNull(runtime.execApprovalsNotice.value)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
+      val replacement = requireNotNull(runtime.execApprovalInbox.value.notice)
       assertEquals("approval-2", replacement.approvalId)
 
       // compareAndSet semantics: a close tap captured for the first notice must leave
       // the replacement untouched; only dismissing the rendered notice clears it.
       runtime.dismissExecApprovalsNotice(staleNotice)
-      assertEquals(replacement, runtime.execApprovalsNotice.value)
+      assertEquals(replacement, runtime.execApprovalInbox.value.notice)
 
       runtime.dismissExecApprovalsNotice(replacement)
-      assertNull(runtime.execApprovalsNotice.value)
+      assertNull(runtime.execApprovalInbox.value.notice)
     }
 
   @Test
@@ -936,16 +1088,25 @@ class GatewayExecApprovalRuntimeTest {
       }
 
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
-      val staleNotice = requireNotNull(runtime.execApprovalsNotice.value)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
+      val staleNotice = requireNotNull(runtime.execApprovalInbox.value.notice)
 
       // The same approval id is re-requested and loses again: the replacement notice
       // carries identical id/message/warning but is a distinct publication.
       invokeApprovalEvent(runtime, "exec.approval.requested", """{"id":"approval-1"}""")
-      waitUntil { runtime.execApprovals.value.map { it.id } == listOf("approval-1") }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .map { it.id } == listOf("approval-1")
+      }
       runtime.resolveExecApproval("approval-1", "allow-once")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
-      val replacement = requireNotNull(runtime.execApprovalsNotice.value)
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
+      val replacement = requireNotNull(runtime.execApprovalInbox.value.notice)
       assertEquals(staleNotice.approvalId, replacement.approvalId)
       assertEquals(staleNotice.message, replacement.message)
       assertEquals(staleNotice.warning, replacement.warning)
@@ -954,10 +1115,10 @@ class GatewayExecApprovalRuntimeTest {
       // A close tap captured for the first banner must not clear the equal-looking
       // replacement outcome the user has not acknowledged yet.
       runtime.dismissExecApprovalsNotice(staleNotice)
-      assertEquals(replacement, runtime.execApprovalsNotice.value)
+      assertEquals(replacement, runtime.execApprovalInbox.value.notice)
 
       runtime.dismissExecApprovalsNotice(replacement)
-      assertNull(runtime.execApprovalsNotice.value)
+      assertNull(runtime.execApprovalInbox.value.notice)
     }
 
   @Test
@@ -991,12 +1152,15 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.refreshExecApprovals()
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.allowedDecisions == listOf("allow-once", "deny")
       }
       runtime.resolveExecApproval("approval-1", "deny")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
 
       assertEquals(
         listOf("exec.approval.list", "exec.approval.get", "exec.approval.resolve"),
@@ -1026,14 +1190,14 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.refreshExecApprovals()
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.errorText ==
           "Could not load approval details. Refresh and try again."
       }
       runtime.resolveExecApproval("approval-1", "deny")
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.let { row ->
             row.resolvingDecision == null && row.errorText == "Could not resolve approval. Refresh and try again."
@@ -1071,7 +1235,7 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.refreshExecApprovals()
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.errorText ==
           "Could not load approval details. Refresh and try again."
@@ -1104,7 +1268,7 @@ class GatewayExecApprovalRuntimeTest {
 
       runtime.resolveExecApproval("approval-1", "deny")
       waitUntil {
-        runtime.execApprovals.value
+        runtime.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.let { row ->
             row.resolvingDecision == null && row.errorText == "Could not resolve approval. Refresh and try again."
@@ -1155,7 +1319,10 @@ class GatewayExecApprovalRuntimeTest {
       delay(100)
 
       runtime.resolveExecApproval("approval-1", "deny")
-      waitUntil { runtime.execApprovals.value.isEmpty() }
+      waitUntil {
+        runtime.execApprovalInbox.value.approvals
+          .isEmpty()
+      }
 
       assertEquals(listOf("approval.resolve", "approval.resolve"), methods)
     }
@@ -1209,8 +1376,8 @@ class GatewayExecApprovalRuntimeTest {
     runtime: NodeRuntime,
     approvals: List<GatewayExecApprovalSummary>,
   ) {
-    readField<MutableStateFlow<List<GatewayExecApprovalSummary>>>(runtime, "_execApprovals").value =
-      approvals
+    readField<MutableStateFlow<GatewayExecApprovalInboxState>>(runtime, "mutableExecApprovalInbox").value =
+      runtime.execApprovalInbox.value.copy(approvals = approvals)
   }
 
   private fun approvalSummary(

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -15,6 +15,9 @@ import android.graphics.Bitmap
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.captureToImage
@@ -27,6 +30,15 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
@@ -59,6 +71,8 @@ import java.io.File
 import java.net.InetAddress
 import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [36], qualifiers = "en-rUS-w360dp-h800dp-mdpi")
@@ -70,6 +84,11 @@ class SettingsScreensContrastTest {
   private lateinit var runtime: NodeRuntime
   private var previousRuntime: NodeRuntime? = null
   private lateinit var gateway: OperationalCaptionsGateway
+  private val noticeReached = CountDownLatch(1)
+  private val releaseNotice = CountDownLatch(1)
+  private val observationScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+  @Volatile private var noticeReleasedWithinBound = false
 
   // Dispose Compose before joining the actual runtime and socket, including on the contrast red.
   @get:Rule
@@ -79,6 +98,8 @@ class SettingsScreensContrastTest {
         object : ExternalResource() {
           override fun after() {
             try {
+              releaseNotice.countDown()
+              runBlocking { observationScope.coroutineContext[Job]!!.cancelAndJoin() }
               models.clear()
             } finally {
               try {
@@ -190,7 +211,7 @@ class SettingsScreensContrastTest {
     composeRule.runOnIdle { route.value = SettingsRoute.Approvals }
     composeRule.waitUntil(10_000) {
       composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty() &&
-        !model.execApprovalsRefreshing.value && model.execApprovals.value
+        !model.execApprovalInbox.value.refreshing && model.execApprovalInbox.value.approvals
           .singleOrNull()
           ?.commandPreview == "echo"
     }
@@ -211,7 +232,11 @@ class SettingsScreensContrastTest {
     composeRule.waitUntil(10_000) {
       composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isNotEmpty()
     }
-    assertTrue(model.execApprovals.value.isEmpty() && model.execApprovalsNotice.value?.approvalId == "approval-1")
+    assertTrue(
+      model.execApprovalInbox.value.approvals
+        .isEmpty() && model.execApprovalInbox.value.notice
+        ?.approvalId == "approval-1",
+    )
     assertTrue(gateway.methods.count { it == "approval.get" } > readsBeforeRefresh)
     composeRule.onNodeWithText("A prior response already denied this approval.").performScrollTo().assertIsDisplayed()
     themes.forEach { theme ->
@@ -220,7 +245,7 @@ class SettingsScreensContrastTest {
     }
     composeRule.onNodeWithContentDescription("Dismiss approval notice").performClick()
     composeRule.waitUntil(10_000) { composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isEmpty() }
-    assertEquals(null, model.execApprovalsNotice.value)
+    assertEquals(null, model.execApprovalInbox.value.notice)
     assertTrue(composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isEmpty())
     assertFalse(gateway.methods.any { it in setOf("approval.resolve", "exec.approval.resolve", "chat.send", "cron.run") })
     File(evidence, "observations.json").writeText(
@@ -236,6 +261,110 @@ class SettingsScreensContrastTest {
         .toString(2),
     )
     assertTrue("Operational captions must retain 4.5:1 contrast:\n${failures.joinToString("\n")}", failures.isEmpty())
+  }
+
+  @Test
+  fun terminalNoticeDoesNotCoexistWithItsActionableCard() {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    previousRuntime = app.peekRuntime()
+    gateway = OperationalCaptionsGateway()
+    val prefs = SecurePrefs(app, app.getSharedPreferences("approval-coherence-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    prefs.setManualTls(false)
+    prefs.saveGatewayCredentials(gateway.endpoint.stableId, token = "synthetic-coherence-proof")
+    runtime = NodeRuntime(app, prefs)
+    bindNodeRuntimeTestFixture(app, runtime)
+    val model = MainViewModel(app, prefs, SavedStateHandle())
+    models.put("approval-coherence", model)
+    model.setForeground(true)
+    val evidence = File("build/outputs/approval-inbox-coherence", UUID.randomUUID().toString())
+    check(!evidence.exists() && evidence.mkdirs())
+    composeRule.setContent {
+      ClawDesignTheme(dark = false) {
+        SettingsDetailScreen(viewModel = model, route = SettingsRoute.Approvals, onBack = {})
+      }
+    }
+    composeRule.runOnIdle { model.connect(gateway.endpoint) }
+    composeRule.waitUntil(10_000) {
+      composeRule.onAllNodesWithText("Refresh").fetchSemanticsNodes().any {
+        SemanticsActions.OnClick in it.config && SemanticsProperties.Disabled !in it.config
+      } && composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isNotEmpty() &&
+        !model.execApprovalInbox.value.refreshing && model.execApprovalInbox.value.approvals
+          .singleOrNull()
+          ?.id == "approval-1"
+    }
+    composeRule
+      .onNodeWithText("Deny")
+      .performScrollTo()
+      .assertIsDisplayed()
+      .assertIsEnabled()
+    // Public subscription pauses the publisher, not the UI or an injected state setter.
+    observationScope.launch(start = CoroutineStart.UNDISPATCHED) {
+      runtime.execApprovalInbox.collect { inbox ->
+        if (inbox.notice?.approvalId == "approval-1" && noticeReached.count != 0L) {
+          noticeReached.countDown()
+          noticeReleasedWithinBound = releaseNotice.await(10, TimeUnit.SECONDS)
+        }
+      }
+    }
+    val renderedTogether =
+      try {
+        gateway.terminal = true
+        composeRule.onNodeWithText("Refresh").performScrollTo().performClick()
+        composeRule.waitUntil(10_000) {
+          composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isNotEmpty() && noticeReached.count == 0L
+        }
+        composeRule.onNodeWithText("A prior response already denied this approval.").assertIsDisplayed()
+        composeRule.onNodeWithText("Approval approval-1").assertIsDisplayed()
+        val commands = composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes()
+        val deny = composeRule.onAllNodesWithText("Deny").fetchSemanticsNodes()
+        val mixed =
+          commands.isNotEmpty() &&
+            deny.any {
+              SemanticsActions.OnClick in it.config && SemanticsProperties.Disabled !in it.config
+            }
+        if (mixed) {
+          composeRule.onNodeWithText("echo ok").assertIsDisplayed()
+          composeRule
+            .onNodeWithText("Deny")
+            .assertIsDisplayed()
+            .assertIsEnabled()
+            .assertHasClickAction()
+          assertEquals(
+            "approval-1",
+            model.execApprovalInbox.value.approvals
+              .single()
+              .id,
+          )
+        }
+        assertEquals(
+          "approval-1",
+          model.execApprovalInbox.value.notice
+            ?.approvalId,
+        )
+        val bitmap = composeRule.onRoot().captureToImage().asAndroidBitmap()
+        File(evidence, "terminal-inbox.png").outputStream().use {
+          assertTrue(bitmap.compress(Bitmap.CompressFormat.PNG, 100, it))
+        }
+        mixed
+      } finally {
+        releaseNotice.countDown()
+        runBlocking { observationScope.coroutineContext[Job]!!.cancelAndJoin() }
+      }
+    assertTrue(noticeReleasedWithinBound)
+    composeRule.waitUntil(10_000) {
+      composeRule.onAllNodesWithText("echo ok").fetchSemanticsNodes().isEmpty() &&
+        model.execApprovalInbox.value.approvals
+          .isEmpty() && model.execApprovalInbox.value.notice
+          ?.approvalId == "approval-1"
+    }
+    composeRule.onNodeWithText("Approval approval-1").assertIsDisplayed()
+    composeRule.onNodeWithText("Deny").assertDoesNotExist()
+    composeRule.onNodeWithContentDescription("Dismiss approval notice").performClick()
+    composeRule.waitUntil(10_000) {
+      composeRule.onAllNodesWithText("Approval approval-1").fetchSemanticsNodes().isEmpty() && model.execApprovalInbox.value.notice == null
+    }
+    assertFalse(gateway.methods.any { it in setOf("approval.resolve", "exec.approval.resolve", "chat.send", "cron.run") })
+    assertFalse("A rendered terminal notice must not coexist with its same-ID actionable card", renderedTogether)
   }
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensTest.kt
@@ -382,13 +382,13 @@ class SettingsScreensTest {
   @Test
   fun terminalNoticeRendersAsStandaloneDismissibleBannerRegardlessOfRemainingCards() {
     val source = settingsScreensSource()
-    // Terminal outcomes retire their card before the notice publishes, so any
+    // Terminal outcomes publish their notice with the card retired, so any
     // card-scoped or empty-inbox-only rendering hides losing outcomes whenever
     // another approval card remains visible.
     assertFalse(source.contains("execApprovalNoticeForCard"))
     assertFalse(source.contains("execApprovalEmptyInboxNotice"))
     val screenStart = source.indexOf("private fun ApprovalsSettingsScreen(")
-    val bannerCall = source.indexOf("execApprovalsNotice?.let", screenStart)
+    val bannerCall = source.indexOf("inbox.notice?.let", screenStart)
     val listPanelCall = source.indexOf("ExecApprovalsPanel(", screenStart)
     assertTrue(screenStart >= 0 && bannerCall > screenStart && listPanelCall > bannerCall)
 


### PR DESCRIPTION
Closes #140109. Related: #134939 and #139789.

## What Problem This Solves

Fixes an issue where users reviewing Android command approvals could see “already denied” while the same request still showed enabled Allow/Deny controls and counted as pending. A controlled real-Compose/loopback reproduction captures this contradictory frame on unchanged production.

## Why This Change Was Made

NodeRuntime previously published rows, refresh/error state, and terminal notices through four independent StateFlows. MainViewModel and Compose collected them separately, so a writer lock could not provide an atomic UI snapshot.

One internal immutable approval inbox now owns those facts. All six terminal-producing paths retire the matching card and publish its result together. Settings, Home, and Wear read that coherent state; the old parallel flows are removed. Conditional dismissal preserves replacement notices, and existing refresh generations, Gateway lifecycle/method checks, ambiguous-write recovery, expiry, and decision authorization remain intact.

## User Impact

A resolved request disappears from the pending list when its outcome appears. Other pending requests remain actionable and the result stays visible until dismissed. No configuration, dependency, protocol, storage/schema, or permission change is introduced. This repairs the existing documented approval behavior rather than adding a new approval policy.

## Evidence

- The final old-production control fails the intended rendered-coherence assertion. The corresponding repaired test passes using real NodeRuntime/MainViewModel, Compose, and a synthetic loopback Gateway. Both release/join the paused publisher, verify settled retirement and Dismiss, and make no approval-resolution/execution/chat request.
- 152 focused and sibling tests passed on the repaired source, including canonical/legacy outcomes, unknown-write recovery, stale dismissal, runtime/model lifecycle, Home counts, and Wear projection. After the small nullable-error rendering cleanup, the two affected UI suites passed again: 30 tests.
- The complete 14-check changed-file gate passed on exact `efdd37fed1a9dcca63b377ac54d456641b55ee0c`. Its rebase onto `0a753eb92f6f687476654f68c12143b68ea804fa` preserves all eight reviewed/tested afterimages byte-for-byte; current-main Android drift is four unrelated generated protocol method names.
- Independent ownership review and Codex autoreview found no actionable P0–P2 issues. Production is +112/−100 (net +12); tests are +389/−93. The small production increase replaces parallel state surfaces with one owner boundary; most runtime-test churn is migration to the shared snapshot.

### Before and after

These are synthetic Compose/Robolectric captures under controlled scheduling, inspected in full by the maintainer agent. They are not installed-device screenshots. Refreshing legitimately remains visible while the publisher is paused.

![Before: denied notice beside its enabled approval card](https://github.com/user-attachments/assets/9ab5196c-193c-4cbf-8491-cfa72e70e8f7)

![After: denied notice with Pending 0 and no approval card](https://github.com/user-attachments/assets/018d5487-6f23-4163-a053-979a9a9635c2)

### Validation and limits

Exact-head hosted [CI 34034559425](https://github.com/openclaw/openclaw/actions/runs/34034559425) passed, including Play/third-party/Wear tests, Play/Wear builds, ktlint, and the required CI gate. The installed API 36 Play/debug flow also passed: fresh install and manual TLS onboarding, Pending 1 with enabled controls, remote denial followed by canonical `approval.get`, Pending 0 with the matching notice and no approval card, Dismiss, and ordinary Disconnect. Installed APK bytes match reviewed `efdd37fed1a9dcca63b377ac54d456641b55ee0c` (SHA-256 `8ce416b74867fd592efb874aaf01a16f7ab19e51a7f5fbdc3c6871f3a5a3a16a`). No approval resolution/request or chat-send RPC occurred. Display and locale remained unchanged. Complete evidence was downloaded; native processes/ports closed and the Testbox was stopped. The regression measures controlled rendered inconsistency, not natural recurrence frequency, duplicate execution, or an authorization bypass. The first candidate witness stopped on Refresh readiness; that failed attempt is retained, and the final old/new controls use the same explicit rendered-ready condition without increasing its timeout.

### Installed-app sequence

These unmodified full-frame captures are from the installed app using an isolated synthetic Gateway fixture, personally inspected by the maintainer agent. They show the ordinary fixed-app flow, not a controlled scheduling reproduction or a production Gateway authorization test.

![Installed: pending approval with enabled controls](https://github.com/user-attachments/assets/74fd1d35-c43d-490f-b96f-97cbd1b3d677)

![Installed: remote denial retires the card and shows its notice](https://github.com/user-attachments/assets/ca77f8ba-0b3f-4a63-b645-65273a4e6d72)

![Installed: Dismiss preserves the empty inbox](https://github.com/user-attachments/assets/f82e9ce1-9882-4db1-af86-01dc0cdb4af3)

### Review disposition

The latest ClawSweeper review reported no source/security findings and requested completion of the declared installed flow. That flow is now complete; its image-fetch limitation is addressed by direct full-frame inspection of both the existing controlled Compose captures and the installed sequence above. This is the maintainer agent’s evidence review, not a claim of separate human review. The reviewed owner-boundary design is unchanged. Two earlier large-input sync attempts failed before native execution; both leases were stopped. The successful run used ordinary remote builds and local-on-Testbox archive assembly without changing providers, timeout guards, or transport behavior.

### Post-merge integration audit

The landed tree preserves the reviewed runtime changes and the unrelated provider-refresh work on main. The audit also caught two test-only references which moving main had added to the removed getters; #140247 repairs that clean-merge composition. Its compiler reproduction and 30-test validation are recorded there.
