### PR TITLE
refactor(plugins): share install entry validation

### DIFF
--- a/src/plugins/package-entry-resolution.runtime.test.ts
+++ b/src/plugins/package-entry-resolution.runtime.test.ts
@@ -129,27 +129,32 @@ describe("canonical installed package runtime entries", () => {
   it.each([".ts", ".tsx", ".mts", ".cts"])(
     "rejects published source-only %s entries while allowing linked source checkouts",
     async (sourceExtension) => {
-      const { packageDir, sourceEntry, manifest } = createPackageFixture({ sourceExtension });
-      const installResult = await validatePackageExtensionEntriesForInstall({
-        packageDir,
-        extensions: [sourceEntry],
-        manifest,
+      const { packageDir, sourceEntry, manifest } = createPackageFixture({
+        sourceExtension,
+        runtimeOutputs: ["index.js"],
       });
-      const linkedInstallResult = await validatePackageExtensionEntriesForInstall({
-        packageDir,
-        extensions: [sourceEntry],
-        manifest,
-        allowSourceTypeScriptEntries: true,
-      });
+      // A valid JS extension lets the source-only setup entry reach its own validation.
+      for (const extensions of [[sourceEntry], ["./index.js"]]) {
+        const installParams = {
+          packageDir,
+          extensions,
+          manifest: { ...manifest, openclaw: { ...manifest.openclaw, extensions } },
+        };
+        expect(await validatePackageExtensionEntriesForInstall(installParams)).toEqual({
+          ok: false,
+          error: expect.stringContaining("requires compiled runtime output"),
+        });
+        expect(
+          await validatePackageExtensionEntriesForInstall({
+            ...installParams,
+            allowSourceTypeScriptEntries: true,
+          }),
+        ).toEqual({ ok: true });
+      }
       const diagnostics: Parameters<
         typeof resolvePackageRuntimeExtensionSources
       >[0]["diagnostics"] = [];
 
-      expect(installResult).toEqual({
-        ok: false,
-        error: expect.stringContaining("requires compiled runtime output"),
-      });
-      expect(linkedInstallResult).toEqual({ ok: true });
       expect(
         resolvePackageRuntimeExtensionSources({
           packageDir,

--- a/src/plugins/package-entry-resolution.ts
+++ b/src/plugins/package-entry-resolution.ts
@@ -136,6 +136,68 @@ async function validatePackageExtensionEntry(params: {
   return { ok: true, exists: true };
 }
 
+async function validatePackageEntryForInstall(params: {
+  packageDir: string;
+  entry: string;
+  runtimeEntry?: string;
+  entryKind: "extension" | "setup";
+  allowSourceTypeScriptEntries?: boolean;
+}): Promise<{ ok: true } | { ok: false; error: string }> {
+  const sourceEntry = await validatePackageExtensionEntry({
+    packageDir: params.packageDir,
+    entry: params.entry,
+    label: `${params.entryKind} entry`,
+    requireExisting: false,
+  });
+  if (!sourceEntry.ok) {
+    return sourceEntry;
+  }
+
+  if (params.runtimeEntry) {
+    const runtimeResult = await validatePackageExtensionEntry({
+      packageDir: params.packageDir,
+      entry: params.runtimeEntry,
+      label: `runtime ${params.entryKind} entry`,
+      requireExisting: true,
+    });
+    return runtimeResult.ok ? { ok: true } : runtimeResult;
+  }
+
+  const builtEntryCandidates = listBuiltRuntimeEntryCandidates(params.entry);
+  for (const builtEntry of builtEntryCandidates) {
+    const builtResult = await validatePackageExtensionEntry({
+      packageDir: params.packageDir,
+      entry: builtEntry,
+      label: `inferred runtime ${params.entryKind} entry`,
+      requireExisting: false,
+    });
+    if (!builtResult.ok) {
+      return builtResult;
+    }
+    if (builtResult.exists) {
+      return { ok: true };
+    }
+  }
+
+  if (
+    sourceEntry.exists &&
+    (!isTypeScriptPackageEntry(params.entry) || params.allowSourceTypeScriptEntries)
+  ) {
+    return { ok: true };
+  }
+  if (builtEntryCandidates.length > 0) {
+    return {
+      ok: false,
+      error: missingCompiledRuntimeEntryMessage({
+        label: "package install",
+        entry: params.entry,
+        candidates: builtEntryCandidates,
+      }),
+    };
+  }
+  return { ok: false, error: `${params.entryKind} entry not found: ${params.entry}` };
+}
+
 /** Validates package extension/setup entries before installing a plugin package. */
 export async function validatePackageExtensionEntriesForInstall(params: {
   packageDir: string;
@@ -152,87 +214,16 @@ export async function validatePackageExtensionEntriesForInstall(params: {
   }
 
   for (const [index, entry] of params.extensions.entries()) {
-    const sourceEntry = await validatePackageExtensionEntry({
+    const result = await validatePackageEntryForInstall({
       packageDir: params.packageDir,
       entry,
-      label: "extension entry",
-      requireExisting: false,
+      runtimeEntry: runtimeResolution.runtimeExtensions[index],
+      entryKind: "extension",
+      allowSourceTypeScriptEntries: params.allowSourceTypeScriptEntries,
     });
-    if (!sourceEntry.ok) {
-      return sourceEntry;
+    if (!result.ok) {
+      return result;
     }
-
-    const runtimeEntry = runtimeResolution.runtimeExtensions[index];
-    if (runtimeEntry) {
-      const runtimeResult = await validatePackageExtensionEntry({
-        packageDir: params.packageDir,
-        entry: runtimeEntry,
-        label: "runtime extension entry",
-        requireExisting: true,
-      });
-      if (!runtimeResult.ok) {
-        return runtimeResult;
-      }
-      continue;
-    }
-
-    let foundBuiltEntry = false;
-    const builtEntryCandidates = listBuiltRuntimeEntryCandidates(entry);
-    for (const builtEntry of builtEntryCandidates) {
-      const builtResult = await validatePackageExtensionEntry({
-        packageDir: params.packageDir,
-        entry: builtEntry,
-        label: "inferred runtime extension entry",
-        requireExisting: false,
-      });
-      if (!builtResult.ok) {
-        return builtResult;
-      }
-      if (builtResult.exists) {
-        foundBuiltEntry = true;
-        break;
-      }
-    }
-
-    if (foundBuiltEntry) {
-      continue;
-    }
-
-    if (
-      sourceEntry.exists &&
-      isTypeScriptPackageEntry(entry) &&
-      params.allowSourceTypeScriptEntries
-    ) {
-      continue;
-    }
-
-    if (sourceEntry.exists && isTypeScriptPackageEntry(entry)) {
-      return {
-        ok: false,
-        error: missingCompiledRuntimeEntryMessage({
-          label: "package install",
-          entry,
-          candidates: builtEntryCandidates,
-        }),
-      };
-    }
-
-    if (sourceEntry.exists) {
-      continue;
-    }
-
-    if (builtEntryCandidates.length > 0) {
-      return {
-        ok: false,
-        error: missingCompiledRuntimeEntryMessage({
-          label: "package install",
-          entry,
-          candidates: builtEntryCandidates,
-        }),
-      };
-    }
-
-    return { ok: false, error: `extension entry not found: ${entry}` };
   }
 
   const packageManifest = getPackageManifestMetadata(params.manifest);
@@ -245,86 +236,13 @@ export async function validatePackageExtensionEntriesForInstall(params: {
     };
   }
   if (setupEntry) {
-    const sourceEntry = await validatePackageExtensionEntry({
+    return await validatePackageEntryForInstall({
       packageDir: params.packageDir,
       entry: setupEntry,
-      label: "setup entry",
-      requireExisting: false,
+      runtimeEntry: runtimeSetupEntry,
+      entryKind: "setup",
+      allowSourceTypeScriptEntries: params.allowSourceTypeScriptEntries,
     });
-    if (!sourceEntry.ok) {
-      return sourceEntry;
-    }
-
-    if (runtimeSetupEntry) {
-      const runtimeResult = await validatePackageExtensionEntry({
-        packageDir: params.packageDir,
-        entry: runtimeSetupEntry,
-        label: "runtime setup entry",
-        requireExisting: true,
-      });
-      if (!runtimeResult.ok) {
-        return runtimeResult;
-      }
-      return { ok: true };
-    }
-
-    let foundBuiltSetupEntry = false;
-    const builtSetupCandidates = listBuiltRuntimeEntryCandidates(setupEntry);
-    for (const builtEntry of builtSetupCandidates) {
-      const builtResult = await validatePackageExtensionEntry({
-        packageDir: params.packageDir,
-        entry: builtEntry,
-        label: "inferred runtime setup entry",
-        requireExisting: false,
-      });
-      if (!builtResult.ok) {
-        return builtResult;
-      }
-      if (builtResult.exists) {
-        foundBuiltSetupEntry = true;
-        break;
-      }
-    }
-
-    if (foundBuiltSetupEntry) {
-      return { ok: true };
-    }
-
-    if (
-      sourceEntry.exists &&
-      isTypeScriptPackageEntry(setupEntry) &&
-      params.allowSourceTypeScriptEntries
-    ) {
-      return { ok: true };
-    }
-
-    if (sourceEntry.exists && isTypeScriptPackageEntry(setupEntry)) {
-      return {
-        ok: false,
-        error: missingCompiledRuntimeEntryMessage({
-          label: "package install",
-          entry: setupEntry,
-          candidates: builtSetupCandidates,
-        }),
-      };
-    }
-
-    if (sourceEntry.exists) {
-      return { ok: true };
-    }
-
-    if (builtSetupCandidates.length > 0) {
-      return {
-        ok: false,
-        error: missingCompiledRuntimeEntryMessage({
-          label: "package install",
-          entry: setupEntry,
-          candidates: builtSetupCandidates,
-        }),
-      };
-    }
-
-    return { ok: false, error: `setup entry not found: ${setupEntry}` };
   }
 
   return { ok: true };


### PR DESCRIPTION
## What Problem This Solves

Plugin installation repeats the same entry-validation sequence for plugin runtime and setup files. Previous compiled-output fixes had to be applied to both copies, leaving one packaging contract maintained in two places.

## Why This Change Was Made

Both paths now use one private install-entry validator. Source validation, explicit runtime artifacts, inferred compiled-file order, linked-source support, diagnostics and the exact result shape stay the same. Entries from `openclaw.extensions` still validate before setup. The lower-level file checker and separate runtime resolver are unchanged.

## User Impact

No intended behavior change. This removes 82 production lines and gives future packaging fixes one implementation to update.

## Evidence

The original nine ordinary packaging cases passed. The same expanded nine cases then passed before and after the refactor; the existing TypeScript-format rows now also exercise setup validation behind a valid JavaScript extension. Six metadata sibling cases passed (15 selected cases in the final combined run; 43 unrelated cases were filtered).

All 29 canonical changed checks passed, including production and consuming-test typechecks, lint and architecture guards. One independent P2 review is clean. Test LOC is +5. [Exact CI 34034845442](https://github.com/openclaw/openclaw/actions/runs/34034845442) passed 107 jobs with 17 skipped. Tested merge 13bef4f9c0b6293ad3146c40ee7c1582c6ba0d3a has parents 427abe8b + 93e095b8; both changed blobs match the reviewed source. No new package, configuration option or runtime import edge was added.
