### PR TITLE
refactor(gateway): reuse reclaim dependency types

### DIFF
--- a/src/gateway/worker-environments/placement-reclaim.ts
+++ b/src/gateway/worker-environments/placement-reclaim.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import {
   isExactAttachedEnvironment,
-  type WorkerDispatchEnvironmentService,
   type WorkerDispatchPlacement,
-  type WorkerDispatchPlacementStore,
 } from "./placement-dispatch-failure.js";
-import { resolvePriorWorkspaceResultConflict } from "./placement-dispatch-pending-results.js";
+import {
+  type PlacementRecoveryDeps,
+  resolvePriorWorkspaceResultConflict,
+} from "./placement-dispatch-pending-results.js";
 import type { WorkerPlacementMoveIntent } from "./placement-move-intent.js";
 import type {
   WorkerPlacementReclaimBarriers,
@@ -24,12 +25,10 @@ import {
   createWorkerWorkspaceReconcileRequest,
   sessionWorkspaceRoot,
 } from "./session-workspace.js";
-import type { WorkspaceResultConflictLookup } from "./workspace-conflicts.js";
 import {
   verifyReconciledWorkspaceFinal,
   WorkerWorkspaceFinalFenceError,
 } from "./workspace-finalize.js";
-import type { WorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
 import { recoverWorkerWorkspaceReconciliation } from "./workspace-reconcile.js";
 import {
   finalizeWorkspaceResultConflicts,
@@ -44,28 +43,16 @@ import {
 export type WorkerPlacementReclaimOptions = Pick<
   WorkerPlacementReclaimBarriers,
   "runReclaimBarrier"
-> & {
-  placements: WorkerDispatchPlacementStore;
-  environments: WorkerDispatchEnvironmentService;
-  workspaceOperations: WorkerWorkspaceOperationCoordinator;
-  prepareGatewayMove?: (params: {
-    sessionId: string;
-    sessionKey: string;
-    agentId: string;
-    assertCurrent: () => void;
-  }) => Promise<void>;
-  reportWorkspaceResultConflict: (
-    params: { sessionId: string; sessionKey: string; agentId: string } & (
-      | { paths: string[]; stagedResultRef: string; totalCount: number }
-      | { cleared: true }
-    ),
-  ) => Promise<void>;
-  resolveWorkspaceResultConflict: (params: {
-    sessionId: string;
-    sessionKey: string;
-    agentId: string;
-  }) => Promise<WorkspaceResultConflictLookup>;
-};
+> &
+  Pick<
+    PlacementRecoveryDeps,
+    | "placements"
+    | "environments"
+    | "workspaceOperations"
+    | "prepareGatewayMove"
+    | "reportWorkspaceResultConflict"
+    | "resolveWorkspaceResultConflict"
+  >;
 
 export function createWorkerPlacementReclaim(options: WorkerPlacementReclaimOptions) {
   const { environments, placements } = options;


### PR DESCRIPTION
## What Problem This Solves

Worker reclaim duplicates six dependency declarations already owned by workspace recovery. The same dispatch service supplies both consumers, so the copied declarations can drift apart as that shared contract changes.

## Why This Change Was Made

Reclaim selects its six fields from the existing recovery dependency type and retains its own reclaim barrier. Optional gateway-move preparation stays optional. Four unused type imports disappear; runtime statements and module dependencies are unchanged.

## User Impact

No behavior change. This removes 13 production lines and keeps the shared callback signatures under one owner.

## Evidence

The same four existing suites passed 107 tests before and after. All 28 canonical changed checks passed, including the production and consuming-test typegraphs. One independent P2 review is clean.

The runtime function body is byte-identical. Compiler output is equivalent: the raw output differs only by a legal trailing comma in an existing import, and identically formatted output matches. No tests were changed or added. [Exact CI 34034703860](https://github.com/openclaw/openclaw/actions/runs/34034703860) passed 107 jobs with 17 skipped. Tested merge 4474fd9e838d3ae715a8265b83c457c7080017c9 has parents 427abe8b + bc2cb371; its reclaim blob matches the reviewed source.
