### PR TITLE
refactor(browser): remove unreachable pending probe path

### DIFF
--- a/extensions/browser/src/browser/chrome-mcp-session.ts
+++ b/extensions/browser/src/browser/chrome-mcp-session.ts
@@ -202,9 +202,8 @@ async function getExistingSession(
   profileName: string,
   timeoutMs?: number,
   signal?: AbortSignal,
-  includePending = true,
 ): Promise<ChromeMcpSession | null> {
-  if (!includePending && pendingSessions.has(cacheKey)) {
+  if (pendingSessions.has(cacheKey)) {
     return null;
   }
 
@@ -213,42 +212,6 @@ async function getExistingSession(
     sessions.delete(cacheKey);
     await closeTrackedChromeMcpSession(cacheKey, session);
     session = undefined;
-  }
-
-  const pending = pendingSessions.get(cacheKey);
-  if (includePending && pending) {
-    const pendingLease = await waitForSharedPendingChromeMcpSession(pending, signal);
-    let pendingLeaseReleased = false;
-    session = pendingLease.session;
-    try {
-      await waitForChromeMcpReady(session, profileName, timeoutMs, signal);
-      if (session.transport.pid === null) {
-        forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
-        forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
-        await pendingLease.release(true);
-        pendingLeaseReleased = true;
-        return null;
-      }
-      return session;
-    } catch (err) {
-      if (signal?.aborted) {
-        await pendingLease.release(true);
-        pendingLeaseReleased = true;
-      } else if (pending.state.waiters > 1) {
-        await pendingLease.release(false);
-        pendingLeaseReleased = true;
-      } else {
-        forgetCachedChromeMcpSessionIfCurrent(cacheKey, session);
-        forgetPendingChromeMcpSessionIfCurrent(cacheKey, pending);
-        await pendingLease.release(true);
-        pendingLeaseReleased = true;
-      }
-      throw err;
-    } finally {
-      if (!pendingLeaseReleased) {
-        await pendingLease.release(false);
-      }
-    }
   }
 
   if (session) {
@@ -325,7 +288,6 @@ export async function leaseSession(
     profileName,
     options.timeoutMs,
     options.signal,
-    false,
   );
   if (existingSession) {
     return {


### PR DESCRIPTION
## What Problem This Solves

The Chrome MCP cached-session probe retained a second pending-session join and cleanup implementation even though its only caller always disabled that path. Keeping it made session ownership harder to follow.

## Why This Change Was Made

Remove the unreachable branch, its private parameter and the sole false argument. The probe keeps its initial pending-session rejection; ordinary shared attachment still uses the existing active session owner. This removes 37 production code lines without introducing another helper.

## User Impact

Existing probe behavior is preserved: a healthy cached session can be reused, an in-progress shared attach is not joined by a temporary probe, and cancellation and cleanup retain their current ownership. No public API, configuration or dependency changes.

## Evidence

The same five Chrome MCP session, cleanup, ownership, snapshot and subprocess-connection suites pass all 150 tests before and after. No tests or expectations changed. These use fake sessions and isolated synthetic MCP subprocesses; no real browser was started or controlled.

Fresh P2 review found no actionable issues. The complete selected changed gate passes, including both extension typecheck lanes, typed lint, full export scans and repository guards. The final source matches the reviewed and tested snapshot.
