### PR TITLE
fix(test): avoid false native polling timeouts

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeModeCoordinatorTests.swift
@@ -220,19 +220,18 @@ struct MacNodeModeCoordinatorTests {
 
     private func waitUntil(
         _ description: String,
-        timeout: Duration = .seconds(2),
         condition: @escaping @Sendable () async -> Bool) async throws
     {
         let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
+        let deadline = clock.now.advanced(by: .seconds(2))
         while clock.now < deadline {
-            if await condition() {
-                return
-            }
+            if await condition() { return }
             // Some callers run on MainActor; a real suspension lets the
             // notification task make progress instead of polling it out.
             try await Task.sleep(for: .milliseconds(10))
         }
+        // Completion can arrive during the final suspension.
+        if await condition() { return }
         throw CoordinatorWaitTimeout(operation: description)
     }
 
@@ -252,6 +251,24 @@ struct MacNodeModeCoordinatorTests {
         }
         await gateway.disconnect()
         await coordinator.stopAndWait()
+    }
+
+    @Test func `waiter rechecks a completed async snapshot after its deadline`() async throws {
+        let probe = CoordinatorDrainSnapshotProbe()
+
+        try await self.waitUntil("completed async snapshot") {
+            let captured = await probe.hasCaptured()
+            if captured { return captured }
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return captured
+            }
+            await probe.recordCapture()
+            return captured
+        }
+
+        #expect(await probe.hasCaptured())
     }
 
     @Test func `stale endpoint attempt is rejected after a suspended permission query`() {

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpers.swift
@@ -20,5 +20,7 @@ func waitUntil(
         if await condition() { return }
         try await Task.sleep(nanoseconds: pollMs * 1_000_000)
     }
+    // Completion can arrive during the final suspension, before this waiter resumes.
+    if await condition() { return }
     throw AsyncWaitTimeoutError(label: label)
 }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpersTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TestAsyncHelpersTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+private actor CompletingAsyncCondition {
+    private(set) var completed = false
+
+    func snapshot() async -> Bool {
+        let snapshot = self.completed
+        if snapshot { return snapshot }
+
+        // Predicate entry follows the helper's deadline construction, so this
+        // stale observation returns after that unchanged 15-second deadline.
+        let deadline = Date().addingTimeInterval(15)
+        do {
+            while Date() < deadline {
+                try await Task.sleep(nanoseconds: 10_000_000)
+            }
+        } catch {
+            return snapshot
+        }
+        self.completed = true
+        return snapshot
+    }
+}
+
+struct TestAsyncHelpersTests {
+    @Test func `rechecks completion after an async predicate outlasts the deadline`() async throws {
+        let condition = CompletingAsyncCondition()
+
+        try await waitUntil("completed async snapshot") { await condition.snapshot() }
+
+        #expect(await condition.completed)
+    }
+
+    @Test func `an incomplete condition retains its timeout label`() async throws {
+        let label = "incomplete condition"
+        do {
+            try await waitUntil(label, timeoutSeconds: 0) { false }
+            Issue.record("Expected a timeout for an incomplete condition")
+        } catch let error as AsyncWaitTimeoutError {
+            #expect(error.label == label)
+        }
+    }
+
+    @Test func `cancellation from an incomplete predicate reaches its caller`() async {
+        let task = Task {
+            try await waitUntil("cancelled condition") {
+                withUnsafeCurrentTask { $0?.cancel() }
+                return false
+            }
+        }
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

Resolves false native test timeouts when an asynchronous observation and the final polling sleep cross the deadline after the observed work has completed. The shared test helper and the macOS coordinator's test waiter previously threw without reading the condition again.

## Why This Change Was Made

Both waiters check the condition once more before their existing timeout error. This follows their existing semantics: a true asynchronous result can already finish after the polling deadline. The shared helper retains its 15-second default and wall clock; the coordinator retains its two-second continuous-clock deadline. Both retain 10ms polling, typed errors and cancellation propagation from their throwing sleep. The coordinator's unused timeout parameter is removed.

## User Impact

Test reliability only; production code is unchanged. Shared tests cover completed asynchronous state, the unchanged incomplete-condition timeout label, and cancellation of an owned child task. The coordinator regression reuses its existing completion probe. The total change is 76 net test and test-support lines across three files.

## Evidence

Isolated Foundation/Testing targets reproduced the false timeout with each original waiter and passed with each repair. The shared helper's exact three permanent cases failed only the stale-observation regression before the fix and passed all three afterward. The coordinator's exact new regression likewise failed before and passed afterward. These runs imported no app modules and touched no operator state; they do not establish a historical CI scheduling interval.

Formatting and typechecking passed. All 13 canonical changed checks passed, including 1,125 Node/tooling executions across 21 file runs. One independent P2 review of the complete three-file change is clean. The committed files match that reviewed candidate exactly.

The combined head's [CI run](https://github.com/openclaw/openclaw/actions/runs/34058290091) is green. All four regressions passed in their actual native targets. The shared package reports 1,673 tests / 127 suites, and the macOS default profile reports 2,075 / 226. Its three normal skips remain recorded; separate isolation (2 / 1) and health-render (1 / 1) invocations passed. The response-loss and embedded-handshake probes remain unexecuted. The tested merge contains the exact three reviewed files, and iOS/Android tests, builds and screenshot jobs passed.

The earlier shared-only [CI run](https://github.com/openclaw/openclaw/actions/runs/34035178347) passed its native waiter proof but failed an Android composer assertion and the aggregate gate. That historical failure is retained without attributing it to this repair; the fresh combined-head Android Play job passed.
