### PR TITLE
refactor(tui): remove unused picker mutation hooks

### DIFF
--- a/src/tui/components/searchable-select-list.test.ts
+++ b/src/tui/components/searchable-select-list.test.ts
@@ -72,7 +72,7 @@ describe("SearchableSelectList", () => {
     ];
     const list = new SearchableSelectList(items, 5, mockTheme);
     // Ensure first row is non-selected so description styling path is exercised.
-    list.setSelectedIndex(1);
+    list.handleInput("\x1b[B");
     const output = list.render(width).join("\n");
     if (shouldContainDescription) {
       expect(output).toContain("(desc)");
@@ -155,8 +155,6 @@ describe("SearchableSelectList", () => {
       { value: "other", label: "other", description: "Other description" },
     ];
     const list = new SearchableSelectList(items, 5, ansiHighlightTheme);
-    list.setSelectedIndex(1); // make first row non-selected so description styling is applied
-
     typeInput(list, "provider");
 
     const width = 80;
@@ -335,7 +333,7 @@ describe("SearchableSelectList", () => {
     expect(output).toContain("*gpt*");
   });
 
-  it("renders the current query during selection callbacks after clearing and replacing it", () => {
+  it("renders the current query after clearing and replacing it", () => {
     const list = new SearchableSelectList(
       [{ value: "match", label: "alpha beta", description: "alpha beta description" }],
       5,
@@ -343,16 +341,14 @@ describe("SearchableSelectList", () => {
     );
     list.handleInput("alpha");
     list.render(80);
-    const frames: string[] = [];
-    list.onSelectionChange = () => frames.push(list.render(80).join("\n"));
-
     list.handleInput("\u0015");
+    const cleared = list.render(80).join("\n");
     list.handleInput("beta");
+    const replaced = list.render(80).join("\n");
 
-    expect(frames).toHaveLength(2);
-    expect(frames[0]).not.toContain("\u001b[31m");
-    expect(frames[1]?.split("alpha \u001b[31mbeta\u001b[0m")).toHaveLength(3);
-    expect(list.render(80).join("\n")).toBe(frames[1]);
+    expect(cleared).not.toContain("\u001b[31m");
+    expect(replaced.split("alpha \u001b[31mbeta\u001b[0m")).toHaveLength(3);
+    expect(list.render(80).join("\n")).toBe(replaced);
   });
 
   it("shows no match message when filter yields no results", () => {

--- a/src/tui/components/searchable-select-list.ts
+++ b/src/tui/components/searchable-select-list.ts
@@ -49,7 +49,6 @@ export class SearchableSelectList implements Component, Focusable {
 
   onSelect?: (item: SearchableSelectItem) => void;
   onCancel?: () => void;
-  onSelectionChange?: (item: SearchableSelectItem) => void;
 
   private static readonly DESCRIPTION_LAYOUT_MIN_WIDTH = 40;
   private static readonly DESCRIPTION_MIN_WIDTH = 12;
@@ -85,7 +84,6 @@ export class SearchableSelectList implements Component, Focusable {
 
     // Reset selection when filter changes
     this.selectedIndex = 0;
-    this.notifySelectionChange();
   }
 
   /**
@@ -201,10 +199,6 @@ export class SearchableSelectList implements Component, Focusable {
       parts = nextParts;
     }
     return parts.map((part) => part.text).join("");
-  }
-
-  setSelectedIndex(index: number) {
-    this.selectedIndex = Math.max(0, Math.min(index, this.filteredItems.length - 1));
   }
 
   invalidate() {
@@ -352,13 +346,11 @@ export class SearchableSelectList implements Component, Focusable {
     // Navigation keys
     if (matchesKey(keyData, "up") || matchesKey(keyData, "ctrl+p")) {
       this.selectedIndex = Math.max(0, this.selectedIndex - 1);
-      this.notifySelectionChange();
       return;
     }
 
     if (matchesKey(keyData, "down") || matchesKey(keyData, "ctrl+n")) {
       this.selectedIndex = Math.min(this.filteredItems.length - 1, this.selectedIndex + 1);
-      this.notifySelectionChange();
       return;
     }
 
@@ -379,13 +371,6 @@ export class SearchableSelectList implements Component, Focusable {
       // Only current-query patterns are reusable; retaining older edits grows without bound.
       this.highlightPatterns = undefined;
       this.updateFilter();
-    }
-  }
-
-  private notifySelectionChange() {
-    const item = this.filteredItems[this.selectedIndex];
-    if (item && this.onSelectionChange) {
-      this.onSelectionChange(item);
     }
   }
 


### PR DESCRIPTION
## What Problem This Solves

The searchable TUI picker exposes a selection setter and change callback used only by its tests. Real picker callers use keyboard input, rendering, selection and cancellation, leaving an extra state-changing path and notification logic to maintain.

## Why This Change Was Made

Remove the unused setter, callback and notification method. Existing tests now use the normal Down key and render after changing the search query, preserving the layout and current-query highlighting assertions. The terminal loop already requests a render after keyboard input; selection, cancellation, focus, ranking and caching keep their existing owners.

## User Impact

No intended visual or keyboard behavior change. Production LOC decreases by 15 and test LOC by four; no test cases, dependencies or configuration options are added.

## Evidence

The same adapted tests passed before and after: 310 unit cases across six files and nine selected fake-backend PTY cases. The PTY selection includes eight cancellation rows and the compact model/session selection flow; 68 unrelated PTY cases were unselected on each side. All 29 canonical changed checks passed, and one independent P2 review is clean.

The before/after images replay text from actual captured synthetic PTY frames. Surrounding session headers differ because the original test-file execution order differed; picker/control/result text and assertions agree. These are text replays, not terminal-color or desktop-pixel captures, and no whole-frame identity is claimed. The harness does not establish live Gateway/provider behavior. [Exact CI 34035179848](https://github.com/openclaw/openclaw/actions/runs/34035179848) passed 107 jobs with 17 skipped. Tested merge `ad19cee64eb7f1b57e74d0a3399fea412700fe6f` has parents `13b19222` and `fac74630`; both changed blobs match the independently reviewed source. The 29 canonical checks ran on the final source; the unit and selected PTY comparisons ran before and after.

![Before: captured synthetic model-picker text](https://github.com/user-attachments/assets/2bcc7e7e-134c-45fc-8003-379dc9fa32a9)

![After: captured synthetic model-picker text](https://github.com/user-attachments/assets/b8223e49-5e67-40e4-8e0b-47710da01e30)
