### PR TITLE
refactor(gateway): reuse canonical RPC parameter validation

### DIFF
--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -11,7 +11,6 @@ import {
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
   validateAgentsCreateParams,
   validateAgentsDeleteParams,
   validateAgentsFilesGetParams,
@@ -110,6 +109,7 @@ import {
 } from "./agents-config-mutations.js";
 import { readPreparedServerMethodModelCatalog } from "./optional-model-catalog.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import { assertValidParams } from "./validation.js";
 
 // Derived from the canonical workspace list so retiring a bootstrap file cannot
 // leave the Control UI advertising a file the runtime no longer reads.
@@ -309,21 +309,6 @@ function resolveAgentIdOrError(agentIdRaw: string, cfg: OpenClawConfig) {
     return null;
   }
   return agentId;
-}
-
-function respondInvalidMethodParams(
-  respond: RespondFn,
-  method: string,
-  errors: Parameters<typeof formatValidationErrors>[0],
-): void {
-  respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `invalid ${method} params: ${formatValidationErrors(errors)}`,
-    ),
-  );
 }
 
 function respondAgentNotFound(respond: RespondFn, agentId: string): void {
@@ -802,8 +787,7 @@ async function buildIdentityMarkdownOrRespondUnsafe(params: {
 
 export const agentsHandlers: GatewayRequestHandlers = {
   "agents.list": async ({ params, respond, context, client }) => {
-    if (!validateAgentsListParams(params)) {
-      respondInvalidMethodParams(respond, "agents.list", validateAgentsListParams.errors);
+    if (!assertValidParams(params, validateAgentsListParams, "agents.list", respond)) {
       return;
     }
 
@@ -830,8 +814,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     );
   },
   "agents.create": async ({ params, respond }) => {
-    if (!validateAgentsCreateParams(params)) {
-      respondInvalidMethodParams(respond, "agents.create", validateAgentsCreateParams.errors);
+    if (!assertValidParams(params, validateAgentsCreateParams, "agents.create", respond)) {
       return;
     }
 
@@ -859,8 +842,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     );
   },
   "agents.update": async ({ params, respond, context }) => {
-    if (!validateAgentsUpdateParams(params)) {
-      respondInvalidMethodParams(respond, "agents.update", validateAgentsUpdateParams.errors);
+    if (!assertValidParams(params, validateAgentsUpdateParams, "agents.update", respond)) {
       return;
     }
 
@@ -958,8 +940,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     respond(true, { ok: true, agentId }, undefined);
   },
   "agents.delete": async ({ params, respond, context }) => {
-    if (!validateAgentsDeleteParams(params)) {
-      respondInvalidMethodParams(respond, "agents.delete", validateAgentsDeleteParams.errors);
+    if (!assertValidParams(params, validateAgentsDeleteParams, "agents.delete", respond)) {
       return;
     }
 
@@ -1452,12 +1433,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     }
   },
   "agents.files.list": async ({ params, respond, context }) => {
-    if (!validateAgentsFilesListParams(params)) {
-      respondInvalidMethodParams(
-        respond,
-        "agents.files.list",
-        validateAgentsFilesListParams.errors,
-      );
+    if (!assertValidParams(params, validateAgentsFilesListParams, "agents.files.list", respond)) {
       return;
     }
     const cfg = context.getRuntimeConfig();
@@ -1477,8 +1453,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     respond(true, { agentId, workspace: workspaceDir, files }, undefined);
   },
   "agents.files.get": async ({ params, respond, context }) => {
-    if (!validateAgentsFilesGetParams(params)) {
-      respondInvalidMethodParams(respond, "agents.files.get", validateAgentsFilesGetParams.errors);
+    if (!assertValidParams(params, validateAgentsFilesGetParams, "agents.files.get", respond)) {
       return;
     }
     const resolved = resolveAgentWorkspaceFileOrRespondError(
@@ -1527,8 +1502,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
     );
   },
   "agents.files.set": async ({ params, respond, context }) => {
-    if (!validateAgentsFilesSetParams(params)) {
-      respondInvalidMethodParams(respond, "agents.files.set", validateAgentsFilesSetParams.errors);
+    if (!assertValidParams(params, validateAgentsFilesSetParams, "agents.files.set", respond)) {
       return;
     }
     const resolved = resolveAgentWorkspaceFileOrRespondError(

--- a/src/gateway/server-methods/question.ts
+++ b/src/gateway/server-methods/question.ts
@@ -2,7 +2,6 @@
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
   type Question,
   type QuestionRecord,
   type QuestionRequestParams,
@@ -42,25 +41,11 @@ import {
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
 import type { SecretStoreWriteService } from "./secrets.js";
 import type { GatewayClient, GatewayRequestHandlers, RespondFn } from "./types.js";
+import { assertValidParams } from "./validation.js";
 
 const DEFAULT_QUESTION_TIMEOUT_MS = 15 * 60 * 1_000;
 
 class QuestionRequestValidationError extends Error {}
-
-function validationError(
-  method: string,
-  errors: Parameters<typeof formatValidationErrors>[0],
-  respond: RespondFn,
-): void {
-  respond(
-    false,
-    undefined,
-    errorShape(
-      ErrorCodes.INVALID_REQUEST,
-      `invalid ${method} params: ${formatValidationErrors(errors)}`,
-    ),
-  );
-}
 
 function managerError(error: unknown, respond: RespondFn): boolean {
   if (!(error instanceof QuestionManagerError)) {
@@ -198,8 +183,7 @@ export function createQuestionHandlers(
 ): GatewayRequestHandlers {
   return {
     "question.request": ({ params, respond, context, client }) => {
-      if (!validateQuestionRequestParams(params)) {
-        validationError("question.request", validateQuestionRequestParams.errors, respond);
+      if (!assertValidParams(params, validateQuestionRequestParams, "question.request", respond)) {
         return;
       }
       let request = params as QuestionRequestParams;
@@ -342,8 +326,9 @@ export function createQuestionHandlers(
       }
     },
     "question.waitAnswer": async ({ params, respond, client, context }) => {
-      if (!validateQuestionWaitAnswerParams(params)) {
-        validationError("question.waitAnswer", validateQuestionWaitAnswerParams.errors, respond);
+      if (
+        !assertValidParams(params, validateQuestionWaitAnswerParams, "question.waitAnswer", respond)
+      ) {
         return;
       }
       const request = params;
@@ -388,8 +373,7 @@ export function createQuestionHandlers(
       }
     },
     "question.resolve": async ({ params, respond, client, context }) => {
-      if (!validateQuestionResolveParams(params)) {
-        validationError("question.resolve", validateQuestionResolveParams.errors, respond);
+      if (!assertValidParams(params, validateQuestionResolveParams, "question.resolve", respond)) {
         return;
       }
       const request = params;
@@ -506,8 +490,7 @@ export function createQuestionHandlers(
       }
     },
     "question.get": ({ params, respond, client, context }) => {
-      if (!validateQuestionGetParams(params)) {
-        validationError("question.get", validateQuestionGetParams.errors, respond);
+      if (!assertValidParams(params, validateQuestionGetParams, "question.get", respond)) {
         return;
       }
       const id = (params as { id: string }).id;
@@ -529,8 +512,7 @@ export function createQuestionHandlers(
       respond(true, { question }, undefined);
     },
     "question.list": ({ params, respond, client, context }) => {
-      if (!validateQuestionListParams(params)) {
-        validationError("question.list", validateQuestionListParams.errors, respond);
+      if (!assertValidParams(params, validateQuestionListParams, "question.list", respond)) {
         return;
       }
       const cfg = context.getRuntimeConfig();

--- a/src/gateway/server-methods/skills-upload.ts
+++ b/src/gateway/server-methods/skills-upload.ts
@@ -3,7 +3,6 @@
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
   type ErrorShape,
   type ProtocolValidator,
   validateSkillsUploadBeginParams,
@@ -20,13 +19,7 @@ import {
   SkillUploadRequestError,
 } from "../../skills/lifecycle/upload-store.js";
 import type { GatewayRequestHandlers } from "./types.js";
-
-function uploadErrorShape(
-  prefix: string,
-  errors: Parameters<typeof formatValidationErrors>[0],
-): ErrorShape {
-  return errorShape(ErrorCodes.INVALID_REQUEST, `${prefix}: ${formatValidationErrors(errors)}`);
-}
+import { assertValidParams } from "./validation.js";
 
 function mapUploadError(err: unknown): ErrorShape {
   if (err instanceof SkillUploadRequestError) {
@@ -69,8 +62,7 @@ function makeUploadHandler<P, R>(
       );
       return;
     }
-    if (!validator(params)) {
-      respond(false, undefined, uploadErrorShape(`invalid ${name} params`, validator.errors));
+    if (!assertValidParams(params, validator, name, respond)) {
       return;
     }
     try {

--- a/src/gateway/server-methods/task-suggestions.ts
+++ b/src/gateway/server-methods/task-suggestions.ts
@@ -3,7 +3,6 @@ import path from "node:path";
 import {
   ErrorCodes,
   errorShape,
-  formatValidationErrors,
   type ErrorShape,
   type TaskSuggestion,
   type TaskSuggestionsAcceptParams,
@@ -47,13 +46,7 @@ import type {
   GatewayRequestHandlers,
   RespondFn,
 } from "./types.js";
-
-function invalidParams(method: string, errors: Parameters<typeof formatValidationErrors>[0]) {
-  return errorShape(
-    ErrorCodes.INVALID_REQUEST,
-    `invalid ${method} params: ${formatValidationErrors(errors)}`,
-  );
-}
+import { assertValidParams } from "./validation.js";
 
 type TaskSuggestionAcceptanceResult =
   | { ok: true; result: TaskSuggestionsAcceptResult }
@@ -448,12 +441,9 @@ async function deliverSuggestedTaskToSourceSession(params: {
 
 export const taskSuggestionsHandlers: GatewayRequestHandlers = {
   "taskSuggestions.list": ({ params, respond, context, client }) => {
-    if (!validateTaskSuggestionsListParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("taskSuggestions.list", validateTaskSuggestionsListParams.errors),
-      );
+    if (
+      !assertValidParams(params, validateTaskSuggestionsListParams, "taskSuggestions.list", respond)
+    ) {
       return;
     }
     const requestedSessionKey = params.sessionKey;
@@ -494,12 +484,14 @@ export const taskSuggestionsHandlers: GatewayRequestHandlers = {
     );
   },
   "taskSuggestions.create": ({ params, respond, context }) => {
-    if (!validateTaskSuggestionsCreateParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("taskSuggestions.create", validateTaskSuggestionsCreateParams.errors),
-      );
+    if (
+      !assertValidParams(
+        params,
+        validateTaskSuggestionsCreateParams,
+        "taskSuggestions.create",
+        respond,
+      )
+    ) {
       return;
     }
     if (!path.isAbsolute(params.cwd)) {
@@ -543,12 +535,14 @@ export const taskSuggestionsHandlers: GatewayRequestHandlers = {
   },
   "taskSuggestions.accept": async (options) => {
     const { params, respond } = options;
-    if (!validateTaskSuggestionsAcceptParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("taskSuggestions.accept", validateTaskSuggestionsAcceptParams.errors),
-      );
+    if (
+      !assertValidParams(
+        params,
+        validateTaskSuggestionsAcceptParams,
+        "taskSuggestions.accept",
+        respond,
+      )
+    ) {
       return;
     }
     // Shipped RPC clients omit mode for an explicit worktree choice. Bundled
@@ -675,12 +669,14 @@ export const taskSuggestionsHandlers: GatewayRequestHandlers = {
     }
   },
   "taskSuggestions.dismiss": ({ params, respond, context, client }) => {
-    if (!validateTaskSuggestionsDismissParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("taskSuggestions.dismiss", validateTaskSuggestionsDismissParams.errors),
-      );
+    if (
+      !assertValidParams(
+        params,
+        validateTaskSuggestionsDismissParams,
+        "taskSuggestions.dismiss",
+        respond,
+      )
+    ) {
       return;
     }
     const config = context.getRuntimeConfig();


### PR DESCRIPTION
## What Problem This Solves

Four Gateway handler families maintained their own copies of the standard invalid-parameter response despite an existing shared validation owner. The copies made the same error contract harder to maintain across agent, question, task-suggestion and skill-upload methods.

## Why This Change Was Made

Replace the seventeen local validation blocks covering nineteen methods with the existing assertValidParams helper and delete the four local error helpers. Each call stays in its original position, using the same validator and method name. This removes 52 production code lines without adding an abstraction.

## User Impact

Valid requests continue through the same handlers. Invalid requests retain the exact error code, message and response arguments. Upload enablement still precedes validation, and authorization/admission checks retain their order. No schema, protocol, public API, configuration or persistence changes.

## Evidence

The same 191 owner tests across five files pass before and after, with no test changes. An external differential harness using the real protocol validators compares 1,221 valid/invalid cases across all nineteen methods plus 213 disabled-upload cases: response arguments, full messages, validator calls, error reads, continuation and pre-validation ordering match exactly. Business actions remain covered by the unchanged owner tests.

The full selected changed gate passes, including production/core-test types, typed lint, export scans and repository guards. Fresh complete-candidate P2 review is clean. Final source hashes match the tested and reviewed inputs. No live Gateway state was used.
