### PR TITLE
perf: defer unused health report formatting

### DIFF
--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -307,6 +307,25 @@ describe("formatHealthChannelLines", () => {
     ).toStrictEqual(["Matrix: ok (1ms)"]);
   });
 
+  it("keeps the selected username first, deduplicates it, and preserves webhook text", () => {
+    const summary = createMultiAccountHealthSummary(
+      { accountId: "1", probe: { ok: true, bot: { username: "sibling" } } },
+      {
+        accountId: "9",
+        probe: {
+          ok: true,
+          elapsedMs: 12,
+          bot: { username: "selected" },
+          webhook: { url: "https://example.test/hook" },
+        },
+      },
+    );
+
+    expect(formatHealthChannelLines(summary)).toStrictEqual([
+      "Matrix: ok (@selected, @sibling) (12ms) - webhook https://example.test/hook",
+    ]);
+  });
+
   it.each([undefined, {}])("preserves the channel snapshot when accounts are %j", (accounts) => {
     const summary = createHealthSummary({
       channels: {

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -63,7 +63,10 @@ export function formatHealthCheckFailure(err: unknown, opts: { rich?: boolean } 
   return out.join("\n");
 }
 
-const formatProbeLine = (probe: unknown, opts: { botUsernames?: string[] } = {}): string | null => {
+const formatProbeLine = (
+  probe: unknown,
+  accounts?: readonly ChannelAccountHealthSummary[],
+): string | null => {
   const record = asNullableRecord(probe);
   if (!record) {
     return null;
@@ -72,40 +75,38 @@ const formatProbeLine = (probe: unknown, opts: { botUsernames?: string[] } = {})
   if (ok === undefined) {
     return null;
   }
+  if (!ok) {
+    const status = typeof record.status === "number" ? record.status : null;
+    const error = typeof record.error === "string" ? record.error : null;
+    return `failed (${status ?? "unknown"})${error ? ` - ${error}` : ""}`;
+  }
+
   const elapsedMs = typeof record.elapsedMs === "number" ? record.elapsedMs : null;
-  const status = typeof record.status === "number" ? record.status : null;
-  const error = typeof record.error === "string" ? record.error : null;
   const bot = asNullableRecord(record.bot);
   const botUsername = bot && typeof bot.username === "string" ? bot.username : null;
   const webhook = asNullableRecord(record.webhook);
   const webhookUrl = webhook && typeof webhook.url === "string" ? webhook.url : null;
-
   const usernames = new Set<string>();
   if (botUsername) {
     usernames.add(botUsername);
   }
-  for (const extra of opts.botUsernames ?? []) {
-    if (extra) {
-      usernames.add(extra);
+  for (const account of accounts ?? []) {
+    const accountProbe = asNullableRecord(account.probe);
+    const accountBot = accountProbe ? asNullableRecord(accountProbe.bot) : null;
+    if (accountBot && typeof accountBot.username === "string" && accountBot.username) {
+      usernames.add(accountBot.username);
     }
   }
 
-  if (ok) {
-    let label = "ok";
-    if (usernames.size > 0) {
-      label += ` (@${Array.from(usernames).join(", @")})`;
-    }
-    if (elapsedMs != null) {
-      label += ` (${elapsedMs}ms)`;
-    }
-    if (webhookUrl) {
-      label += ` - webhook ${webhookUrl}`;
-    }
-    return label;
+  let label = "ok";
+  if (usernames.size > 0) {
+    label += ` (@${Array.from(usernames).join(", @")})`;
   }
-  let label = `failed (${status ?? "unknown"})`;
-  if (error) {
-    label += ` - ${error}`;
+  if (elapsedMs != null) {
+    label += ` (${elapsedMs}ms)`;
+  }
+  if (webhookUrl) {
+    label += ` - webhook ${webhookUrl}`;
   }
   return label;
 };
@@ -179,13 +180,6 @@ export const formatHealthChannelLines = (
       activeSummaries.find((account) => account.accountId === preferredSummary.accountId) ??
       activeSummaries[0] ??
       preferredSummary;
-    const botUsernames = activeSummaries
-      .map((account) => {
-        const probeRecord = asNullableRecord(account.probe);
-        const bot = probeRecord ? asNullableRecord(probeRecord.bot) : null;
-        return bot && typeof bot.username === "string" ? bot.username : null;
-      })
-      .filter((value): value is string => Boolean(value));
     const statusState =
       typeof selectedSummary.statusState === "string" ? selectedSummary.statusState : null;
     const healthState =
@@ -221,31 +215,30 @@ export const formatHealthChannelLines = (
       continue;
     }
 
-    const accountTimings =
-      accountMode === "all"
-        ? activeSummaries
-            .map((account) => formatAccountProbeTiming(account))
-            .filter((value): value is string => Boolean(value))
-        : [];
     const failedSummary = activeSummaries.find(
       (account) => asNullableRecord(account.probe)?.ok === false,
     );
     if (failedSummary) {
-      const failureLine = formatProbeLine(failedSummary.probe, { botUsernames });
+      const failureLine = formatProbeLine(failedSummary.probe);
       if (failureLine) {
         lines.push(`${label}: ${failureLine}`);
         continue;
       }
     }
 
+    const accountTimings =
+      accountMode === "all"
+        ? activeSummaries
+            .map((account) => formatAccountProbeTiming(account))
+            .filter((value): value is string => Boolean(value))
+        : [];
+
     if (accountTimings.length > 0) {
       lines.push(`${label}: ok (${accountTimings.join(", ")})`);
       continue;
     }
 
-    const probeLine = formatProbeLine(selectedSummary.probe, {
-      botUsernames,
-    });
+    const probeLine = formatProbeLine(selectedSummary.probe, activeSummaries);
     if (probeLine) {
       lines.push(`${label}: ${probeLine}`);
       continue;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Health and status reports prepare account names and timing strings that higher-priority failure or degraded-state output can discard. This removes that unnecessary formatting work.

## Why This Change Was Made

Prepare combined usernames only for successful probe output, and account timing strings only after checking for a failed sibling. Keep the existing account selection, output precedence, sanitization and diagnostic bounds unchanged. The cleanup removes **7 net production lines** (32 added, 39 deleted); one focused output test adds 19 lines.

## User Impact

Output and CLI options are unchanged. Multi-account failure and degraded reports require less formatting work, with a tradeoff on the measured single-account path below. These are formatter measurements, not whole-command, Gateway, provider or memory improvements.

## Evidence

- **107 tests pass before and after** across the three complete formatter, status-section and health-command test files. All **29 normal changed checks** pass.
- Twelve literal cases exercise the actual formatter and status-row composer. Independent V8 and JSON decoding verifies **197,520 full outputs**, and exact arithmetic reconciles all **3,072 batch means**.
- Isolated Codex P0–P2 review is clean (confidence 0.98). The added test checks selected-first username order, deduplication and webhook text through the existing export.

Fixed order: B0, C0, C1, B1; 32 batches of 64 calls per export/case. Values below are candidate-minus-baseline changes in median per-call batch means. Negative means faster; reverse compares B1→C1.

| Case | Formatter forward | Formatter reverse | Status rows forward | Status rows reverse |
| --- | ---: | ---: | ---: | ---: |
| Empty control | +3.79% | −2.17% | +3.58% | −40.55% |
| Single default account (H01) | **+54.31%** | **+101.42%** | −3.61% | −3.74% |
| Selected username/dedup/webhook | −17.07% | −12.69% | −12.44% | −13.94% |
| Healthy verbose accounts | −19.84% | −16.57% | −17.06% | −12.65% |
| Degraded, 16 accounts | −38.74% | −43.57% | −23.13% | −28.13% |
| Failed sibling, 16 accounts | −71.06% | −71.52% | −62.32% | −63.81% |
| Missing-channel control | −2.13% | +68.58% | +5.55% | +2.43% |

The H01 direct-formatter regression is **+113 ns / +210 ns** and remains part of the result. Its batches show a repeatable timing transition; JIT causation is **not proven**, and later batches were not substituted for the full-cohort score. Controls also vary substantially. All twelve cases remain: **12 of 48 median comparisons and 75 of 240 total metrics are adverse**. No samples, controls or adverse results were discarded, no follow-up timing rerun was used, and no universal speedup is claimed. Status-row timings include formatter work and must not be added to it; batch percentiles are not individual-call percentiles.

Retained harness setup failures: a review disk-admission stop and a temp-directory discovery error, both before reviewer spawn. The normal isolated review subsequently passed without relaxing limits. Full outputs, raw timings, setup failures and independent audits remain retained.
