### PR TITLE
refactor(doctor): simplify preview policy warnings

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2487,7 +2487,6 @@ src/commands/doctor/shared/legacy-web-tools-migrate.ts	1
 src/commands/doctor/shared/open-policy-allowfrom.ts	2
 src/commands/doctor/shared/plugin-runtime-symlinks.ts	4
 src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts	2
-src/commands/doctor/shared/preview-warnings.ts	2
 src/commands/doctor/shared/pristine-startup-state.ts	3
 src/commands/doctor/shared/stale-agent-model-ref-repair.ts	3
 src/commands/doctor/shared/stale-auth-order-store.ts	3

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -31,20 +31,8 @@ const channelDoctorModuleLoader = createLazyImportLoader<ChannelDoctorModule>(
   () => import("./channel-doctor.js"),
 );
 
-function loadChannelDoctorModule(): Promise<ChannelDoctorModule> {
-  return channelDoctorModuleLoader.load();
-}
-
-function listAgentRecords(cfg: OpenClawConfig): Record<string, unknown>[] {
+function listAgentRecords(cfg: OpenClawConfig) {
   return listAgentEntries(cfg).filter(hasRecord);
-}
-
-function hasChannels(cfg: OpenClawConfig): boolean {
-  return hasRecord(cfg.channels);
-}
-
-function hasPlugins(cfg: OpenClawConfig): boolean {
-  return hasRecord(cfg.plugins);
 }
 
 function hasPluginLoadPaths(cfg: OpenClawConfig): boolean {
@@ -98,7 +86,6 @@ function hasConfiguredSafeBins(cfg: OpenClawConfig): boolean {
   });
 }
 
-type VisibleReplyPolicyProvenance = "default" | "global-explicit" | "group-explicit";
 function resolveMessageToolAvailability(params: {
   cfg: OpenClawConfig;
   agentId?: string;
@@ -148,69 +135,37 @@ function resolveMessageToolAvailability(params: {
 
 const SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW = ["message"];
 
-function resolveSourceReplyMessageToolAvailability(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  globalTools?: ToolsConfig;
-  agentTools?: AgentToolsConfig;
-}): boolean {
-  return resolveMessageToolAvailability({
-    ...params,
-    runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
-  });
-}
-
-function sourceReplyRuntimeMayAllowMessageTool(cfg: OpenClawConfig): boolean {
-  const groupPolicy = resolveGroupVisibleReplyProvenance(cfg);
-  if (groupPolicy.value === "message_tool") {
-    return true;
-  }
-  if (cfg.messages?.visibleReplies === "message_tool") {
-    return true;
-  }
-  return false;
-}
-
-function collectMessageToolUnavailableTargets(
-  cfg: OpenClawConfig,
-  options: { sourceReplyRuntimeGrant?: boolean } = {},
-): string[] {
+function collectUnavailableSourceReplyTargets(cfg: OpenClawConfig): string[] {
   const agents = listAgentRecords(cfg);
   if (agents.length === 0) {
-    const available = options.sourceReplyRuntimeGrant
-      ? resolveSourceReplyMessageToolAvailability({ cfg, globalTools: cfg.tools })
-      : resolveMessageToolAvailability({ cfg, globalTools: cfg.tools });
+    const available = resolveMessageToolAvailability({
+      cfg,
+      globalTools: cfg.tools,
+      runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
+    });
     return available ? [] : ["default tool policy"];
   }
   return agents.flatMap((agent) => {
     const agentId = typeof agent.id === "string" ? agent.id : "unknown";
-    const available = options.sourceReplyRuntimeGrant
-      ? resolveSourceReplyMessageToolAvailability({
-          cfg,
-          agentId,
-          globalTools: cfg.tools,
-          agentTools: agent.tools as AgentToolsConfig | undefined,
-        })
-      : resolveMessageToolAvailability({
-          cfg,
-          agentId,
-          globalTools: cfg.tools,
-          agentTools: agent.tools as AgentToolsConfig | undefined,
-        });
+    const available = resolveMessageToolAvailability({
+      cfg,
+      agentId,
+      globalTools: cfg.tools,
+      agentTools: agent.tools,
+      runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
+    });
     return available ? [] : [`agent "${agentId}"`];
   });
 }
 
-function resolveGroupVisibleReplyProvenance(cfg: OpenClawConfig): {
+function resolveGroupVisibleReplyPolicy(cfg: OpenClawConfig): {
   path: "messages.groupChat.visibleReplies" | "messages.visibleReplies";
-  provenance: VisibleReplyPolicyProvenance;
   value: "automatic" | "message_tool";
 } {
   const groupVisibleReplies = cfg.messages?.groupChat?.visibleReplies;
   if (groupVisibleReplies) {
     return {
       path: "messages.groupChat.visibleReplies",
-      provenance: "group-explicit",
       value: groupVisibleReplies,
     };
   }
@@ -218,13 +173,11 @@ function resolveGroupVisibleReplyProvenance(cfg: OpenClawConfig): {
   if (globalVisibleReplies) {
     return {
       path: "messages.visibleReplies",
-      provenance: "global-explicit",
       value: globalVisibleReplies,
     };
   }
   return {
     path: "messages.groupChat.visibleReplies",
-    provenance: "default",
     value: "automatic",
   };
 }
@@ -238,10 +191,10 @@ function formatTargets(targets: string[]): string {
 
 /** Warn when visible-reply policy selects message_tool but message is unavailable. */
 function collectVisibleReplyToolPolicyWarnings(cfg: OpenClawConfig): string[] {
-  const groupPolicy = resolveGroupVisibleReplyProvenance(cfg);
+  const groupPolicy = resolveGroupVisibleReplyPolicy(cfg);
   const warnings: string[] = [];
   if (groupPolicy.value === "message_tool") {
-    const targets = collectMessageToolUnavailableTargets(cfg, { sourceReplyRuntimeGrant: true });
+    const targets = collectUnavailableSourceReplyTargets(cfg);
     if (targets.length === 0) {
       return warnings;
     }
@@ -254,7 +207,7 @@ function collectVisibleReplyToolPolicyWarnings(cfg: OpenClawConfig): string[] {
 
   const globalVisibleReplies = cfg.messages?.visibleReplies;
   if (globalVisibleReplies === "message_tool" && groupPolicy.path !== "messages.visibleReplies") {
-    const targets = collectMessageToolUnavailableTargets(cfg, { sourceReplyRuntimeGrant: true });
+    const targets = collectUnavailableSourceReplyTargets(cfg);
     if (targets.length === 0) {
       return warnings;
     }
@@ -281,20 +234,16 @@ function formatChannelList(channels: string[]): string {
 function collectChannelBoundMessageToolPolicyWarnings(cfg: OpenClawConfig): string[] {
   return collectChannelRouteTargets(cfg).flatMap((target) => {
     const agentTools = resolveAgentConfig(cfg, target.agentId)?.tools;
-    const runtimeMayAllowMessage = sourceReplyRuntimeMayAllowMessageTool(cfg);
-    const messageToolAvailable = runtimeMayAllowMessage
-      ? resolveSourceReplyMessageToolAvailability({
-          cfg,
-          agentId: target.agentId,
-          globalTools: cfg.tools,
-          agentTools,
-        })
-      : resolveMessageToolAvailability({
-          cfg,
-          agentId: target.agentId,
-          globalTools: cfg.tools,
-          agentTools,
-        });
+    const runtimeMayAllowMessage =
+      cfg.messages?.groupChat?.visibleReplies === "message_tool" ||
+      cfg.messages?.visibleReplies === "message_tool";
+    const messageToolAvailable = resolveMessageToolAvailability({
+      cfg,
+      agentId: target.agentId,
+      globalTools: cfg.tools,
+      agentTools,
+      runtimeAlsoAllow: runtimeMayAllowMessage ? SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW : undefined,
+    });
     if (messageToolAvailable) {
       return [];
     }
@@ -510,15 +459,6 @@ function resolveInheritedProviderPolicyForPreview(
   return policy && hasRecord(policy) ? policy : undefined;
 }
 
-function resolveProviderPolicyEntryForPreview(params: {
-  byProvider?: Record<string, unknown>;
-  modelProvider?: string;
-  modelId?: string;
-}): { key: string; policy: Record<string, unknown> } | undefined {
-  const entry = resolveProviderToolPolicyEntry(params);
-  return entry ? { key: entry.key, policy: entry.policy } : undefined;
-}
-
 function collectInheritedByProviderConfiguredToolSectionWarnings(params: {
   inheritedTools?: Record<string, unknown> | null;
   inheritedPathLabel: string;
@@ -537,7 +477,7 @@ function collectInheritedByProviderConfiguredToolSectionWarnings(params: {
   const overridingByProvider = hasRecord(params.overridingTools?.byProvider)
     ? params.overridingTools.byProvider
     : undefined;
-  const inheritedEntryForModel = resolveProviderPolicyEntryForPreview({
+  const inheritedEntryForModel = resolveProviderToolPolicyEntry({
     byProvider: inheritedByProvider,
     modelProvider: params.modelProvider,
     modelId: params.modelId,
@@ -556,7 +496,7 @@ function collectInheritedByProviderConfiguredToolSectionWarnings(params: {
       return [];
     }
     const overridingEntry =
-      resolveProviderPolicyEntryForPreview({
+      resolveProviderToolPolicyEntry({
         byProvider: overridingByProvider,
         modelProvider: params.modelProvider,
         modelId: params.modelId,
@@ -716,8 +656,8 @@ export async function collectDoctorPreviewNotes(params: {
   const infoNotes: string[] = [];
   const warnings: string[] = [];
   const env = params.env ?? process.env;
-  const hasChannelConfig = hasChannels(params.cfg);
-  const hasPluginConfig = hasPlugins(params.cfg);
+  const hasChannelConfig = hasRecord(params.cfg.channels);
+  const hasPluginConfig = hasRecord(params.cfg.plugins);
 
   warnings.push(...collectVisibleReplyToolPolicyWarnings(params.cfg));
   warnings.push(...collectChannelBoundMessageToolPolicyWarnings(params.cfg));
@@ -755,7 +695,7 @@ export async function collectDoctorPreviewNotes(params: {
       allowExec: params.allowExec,
     });
     warnings.push(...channelPreviewConfig.diagnostics);
-    const { collectChannelDoctorPreviewWarnings } = await loadChannelDoctorModule();
+    const { collectChannelDoctorPreviewWarnings } = await channelDoctorModuleLoader.load();
     const channelDoctorWarnings = await collectChannelDoctorPreviewWarnings({
       cfg: channelPreviewConfig.cfg,
       doctorFixCommand: params.doctorFixCommand,
@@ -849,7 +789,7 @@ export async function collectDoctorPreviewNotes(params: {
   }
 
   if (hasChannelConfig) {
-    const { createChannelDoctorEmptyAllowlistPolicyHooks } = await loadChannelDoctorModule();
+    const { createChannelDoctorEmptyAllowlistPolicyHooks } = await channelDoctorModuleLoader.load();
     const { scanEmptyAllowlistPolicyWarnings } = await import("./empty-allowlist-scan.js");
     const emptyAllowlistHooks = createChannelDoctorEmptyAllowlistPolicyHooks({
       cfg: params.cfg,


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Doctor preview duplicated message-tool availability requests and carried private wrappers and provenance fields that no caller needed. This is a maintainer-requested cleanup companion to the #135868 split campaign; it extracts no recovery feature content.

## Why This Change Was Made

Use the existing provider-policy and lazy-loader owners directly, build each availability request once, and remove the source-reply helper's unreachable no-grant option. Both callers always enabled that grant. Keep the filtered agent list's canonical inferred type, eliminating the two duplicated assertions and their exact baseline entry.

## User Impact

No user-visible behavior changes. Warning text and ordering, explicit provider/global/agent restrictions, direct/group reply selection, malformed-entry filtering, and lazy channel loading remain intact.

## Evidence

- Production: +34/−94 = **−60**, one file, 940→880 lines. Tooling: one exact assertion-baseline row removed. Tests/docs unchanged.
- Source and whole-repository caller inspection: removed helpers/data are private; provider-policy resolver already returns the same fresh key/policy pair; the same channel loader owns both awaited loads. The filtered roster helper remains shared by four callers.
- Stable `v2026.9.2` and the inspected main base have the identical original owner blob. Pickaxe history traces these helpers to `e357203be57`; this removes private plumbing while preserving the shipped warning contract.
- 121 existing tests passed before/after; the final source-reply simplification passed its 54 targeted tests. Suites cover preview warnings, provider tool policy, Doctor config flow, and startup channel maintenance. The final type refinement emits identical runtime JavaScript.
- 7,818 configurations produce 23,454 exact before/after comparisons through the three actual warning collectors and real policy/roster/route owners. Warning strings/order, frozen inputs, and 679 existing empty-roster error outcomes match. Removing the source grant changes 2,217 cases; bypassing provider denial changes 170. This is collector proof, not live provider execution.
- Full selected changed-check plan passed, including core/core test types, scripts lint, all three dead-export scans, and architecture guards. Build passed in 6m23s, including native module loads and Doctor closure checks; generated bundled assets match committed bytes. Pinned-base local and committed-branch Codex reviews are clean through P2. Exact-head hosted CI follows publication.

Initial exact-head CI [run 34035193405](https://github.com/openclaw/openclaw/actions/runs/34035193405) failed in the existing Codex containment fixture, `transport.process.test.ts:385` (the reparented case reports uncertain cleanup). Its test and runtime owners are unchanged on current main. The lead-requested second attempt passed on the same reviewed head; no test or runtime change was made. The final fresh-main rebase preserves all recorded proof inputs and the lockfile, and final-head CI passed in [run 34036825802](https://github.com/openclaw/openclaw/actions/runs/34036825802). Native prepare and merge completed successfully; merged as d4f67f2da766824e39322e52b1828a4801be2460.

ClawSweeper disposition (reviewed `029f7d840cca`): no code or security findings. Its requested data-model compatibility proof is inapplicable: the changed owner only reads configuration and produces transient diagnostic strings; the removed provenance field was private temporary data and never persisted. No schema, store, migration, serialization, config key, or write path changed. The other file is a tooling assertion-count ratchet, not an OpenClaw data store. Stable-tag source comparison, frozen-input comparisons, unchanged warning output, and existing Doctor tests cover the actual compatibility contract. No additional migration test or data-model change is warranted.

Follow-up diagnosis on the unchanged reviewed head: the targeted Codex case passed locally on macOS and in all ten Linux Testbox trials (run 34035880137; one-shot lease stopped). These trials did not establish the initial failure’s root cause. The subsequent lead-requested CI attempt passed; no assertion was weakened and no rerun is claimed as a source repair.
