### PR TITLE
fix(ui): keep long agent action labels inside sidebar menus

### DIFF
--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -411,7 +411,12 @@ suite.define(() => {
           cases: [
             {
               match: { agentId: "main" },
-              response: { agentId: "main", avatar: "", emoji: "🦞", name: "Main" },
+              response: {
+                agentId: "main",
+                avatar: "",
+                emoji: "🦞",
+                name: "Scheduled Automations",
+              },
             },
             {
               match: { agentId: "research" },
@@ -444,7 +449,7 @@ suite.define(() => {
       const sidebar = page.locator("openclaw-app-sidebar");
       await sidebar.getByRole("button", { name: /Switch agent/ }).click();
       const menu = sidebar.locator("wa-dropdown.sidebar-agent-menu");
-      const mainSwitch = menu.getByRole("menuitemradio", { name: "Main" });
+      const mainSwitch = menu.getByRole("menuitemradio", { name: "Scheduled Automations" });
       const researchSwitch = menu.getByRole("menuitemradio", { name: "Research" });
       await expect
         .poll(() =>
@@ -489,9 +494,27 @@ suite.define(() => {
       expect(new Set(gridLayout.widths).size).toBe(1);
       expect(gridLayout.avatarOffsets).toEqual([0, 0, 0]);
       expect(gridLayout.labelOffsets).toEqual([0, 0, 0]);
-      await page.evaluate(() => {
-        document.documentElement.style.setProperty("--control-ui-text-scale", "1.4");
+      const capabilities = menu.getByRole("menuitem", {
+        name: "What can Scheduled Automations do?",
+        exact: true,
       });
+      for (const scale of [1, 1.4]) {
+        await page.evaluate((value) => {
+          document.documentElement.style.setProperty("--control-ui-text-scale", String(value));
+        }, scale);
+        await captureSidebarUiProof(suite, page, `agent-menu-long-label-${scale}.png`);
+        await expect
+          .poll(() =>
+            capabilities.evaluate((item) => {
+              const label = item.querySelector(".sidebar-customize-menu__text");
+              if (!label) {
+                throw new Error("Capabilities label is missing");
+              }
+              return label.getBoundingClientRect().right - item.getBoundingClientRect().right;
+            }),
+          )
+          .toBeLessThanOrEqual(0);
+      }
       await expect
         .poll(() =>
           menu.evaluate((dropdown) => {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2549,6 +2549,7 @@ wa-dropdown-item.sidebar-customize-menu__item {
 }
 
 .sidebar-customize-menu__text {
+  display: block;
   flex: 1;
   white-space: nowrap;
   overflow: hidden;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -3922,12 +3922,6 @@ wa-dropdown-item.sidebar-agent-menu__agent-switch:focus-visible {
   gap: 3px;
 }
 
-/* Help destinations are real hyperlinks; keep them looking like menu rows. */
-.sidebar-identity-menu a.sidebar-customize-menu__item {
-  color: inherit;
-  text-decoration: none;
-}
-
 /* The help flyout must escape the menu box, so the root stays
    overflow-visible; the viewport bound moves to a flex column where only
    the switcher list shrinks and scrolls (the action rows always fit). */


### PR DESCRIPTION
Closes #139946.

## What Problem This Solves

Fixes an issue where long agent action labels would extend outside the sidebar menu, particularly at larger text sizes. For example, “What can Scheduled Automations do?” could overflow the menu instead of truncating.

## Why This Change Was Made

Give the shared label a block box so its existing overflow and ellipsis rules work inside Web Awesome menu items. Remove an obsolete selector for direct Help links; the active nested-link styling and flex sizing remain intact. Production changes total +1/−6 lines.

## User Impact

Long labels stay inside the menu with an ellipsis. The full accessible action name, keyboard navigation, composer actions, and Help/More links are preserved in both text directions.

## Evidence

The real bundled Control UI with a synthetic mock Gateway passed all seven existing sidebar interaction tests and two additional browser scenarios. Checks covered normal and enlarged text in both directions, focused unsent composer text, keyboard navigation, and eight link actions. All 44 sibling link measurements matched the baseline exactly. The full changed-file check passed.

[Candidate browser proof](https://github.com/steipete/openclaw/actions/runs/34113491460/job/101714878277) passed. The original baseline recorded the overflowing labels; its unfinished link control was completed separately after correcting animation settlement in the proof harness, with the same geometry tolerances. These are synthetic browser scenarios, not live account data.

Thanks to @Dreamer-HIT for the original fix and regression test, and @MoerAI for the independently reported fix in #140106. Both PRs address the same root cause.

![Before: long agent action label overflows at enlarged text size](https://github.com/user-attachments/assets/e87441dd-10f2-48b8-8302-eae0d84285f2)

![After: the same label stays inside the menu with an ellipsis](https://github.com/user-attachments/assets/ae7c8dac-ffe4-4b19-b3cf-2349cb5d4d4d)