### PR TITLE
test(update): simplify fixtures and honor stable Node paths

### DIFF
--- a/src/cli/update-cli/update-command-fresh-doctor.test.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.test.ts
@@ -50,6 +50,15 @@ const pluginUpdate: PostCorePluginUpdateResult = {
   warnings: [],
 };
 
+const updateOptions = {
+  root: "/opt/openclaw",
+  pluginUpdate,
+  freshDoctorRequired: true,
+  yes: true,
+  json: true,
+  timeoutMs: 5_000,
+};
+
 const validConfigSnapshot = {
   valid: true as const,
   parsed: {},
@@ -75,12 +84,7 @@ describe("post-plugin update readiness", () => {
 
   it("runs declared readiness checks in the updated process before accepting restart", async () => {
     await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
-      pluginUpdate,
-      freshDoctorRequired: true,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
+      ...updateOptions,
     });
 
     expect(mocks.runExec.mock.calls.map(([, args]) => args)).toEqual([
@@ -144,12 +148,9 @@ describe("post-plugin update readiness", () => {
   it("runs updated readiness checks even when no plugin package changed", async () => {
     const beforeDoctor = vi.fn(async () => undefined);
     await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
+      ...updateOptions,
       pluginUpdate: { ...pluginUpdate, changed: false },
       freshDoctorRequired: false,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
       beforeDoctor,
     });
 
@@ -163,12 +164,7 @@ describe("post-plugin update readiness", () => {
   it("requires the lifecycle owner before starting fresh Doctor maintenance", async () => {
     const beforeDoctor = vi.fn(async () => undefined);
     await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
-      pluginUpdate,
-      freshDoctorRequired: true,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
+      ...updateOptions,
       beforeDoctor,
     });
     expect(beforeDoctor).toHaveBeenCalledOnce();
@@ -180,12 +176,9 @@ describe("post-plugin update readiness", () => {
   it("uses target validation when the unchanged-plugin parent retains an older schema", async () => {
     mocks.readConfig.mockResolvedValue({ ...validConfigSnapshot, valid: false });
     const result = await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
+      ...updateOptions,
       pluginUpdate: { ...pluginUpdate, changed: false },
       freshDoctorRequired: false,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
     });
     expect(result.pluginUpdate.status).toBe("ok");
     expect(result.configSnapshot.valid).toBe(false);
@@ -200,12 +193,7 @@ describe("post-plugin update readiness", () => {
       throw new Error("Gateway owner changed");
     });
     const result = await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
-      pluginUpdate,
-      freshDoctorRequired: true,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
+      ...updateOptions,
       beforeDoctor,
     });
     expect(beforeDoctor).toHaveBeenCalledOnce();
@@ -245,12 +233,7 @@ describe("post-plugin update readiness", () => {
     });
 
     const result = await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
-      pluginUpdate,
-      freshDoctorRequired: true,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
+      ...updateOptions,
     });
 
     expect(result.pluginUpdate).toMatchObject({
@@ -285,12 +268,7 @@ describe("post-plugin update readiness", () => {
     }));
 
     const result = await completePostCorePluginUpdate({
-      root: "/opt/openclaw",
-      pluginUpdate,
-      freshDoctorRequired: true,
-      yes: true,
-      json: true,
-      timeoutMs: 5_000,
+      ...updateOptions,
     });
 
     expect(result.pluginUpdate).toMatchObject({

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -368,9 +368,22 @@ describe("update global helpers", () => {
     });
   });
 
-  it("keeps npm self-updates on the running package root when the PATH probe diverges", async () => {
+  it.each([
+    {
+      name: "keeps npm self-updates on the running package root when the PATH probe diverges",
+      prefix: "openclaw-update-ephemeral-probe-",
+      packageParts: ["openclaw"],
+      packageOptions: {},
+    },
+    {
+      name: "keeps scoped npm self-updates on the running package root",
+      prefix: "openclaw-update-scoped-probe-",
+      packageParts: ["@scope", "cli"],
+      packageOptions: { packageName: "@scope/cli" },
+    },
+  ])("$name", async ({ prefix, packageParts, packageOptions }) => {
     await withMockedPlatform("darwin", async () => {
-      await withTestDir({ prefix: "openclaw-update-ephemeral-probe-" }, async (base) => {
+      await withTestDir({ prefix }, async (base) => {
         // The running install lives in an nvm tree while `npm root -g` on
         // PATH answers with a Homebrew Cellar root — the skew produced when a
         // per-Node npm shim is executed by a foreign node (e.g. a launchd
@@ -379,7 +392,7 @@ describe("update global helpers", () => {
         // install never loads from.
         const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
         const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
-        const pkgRoot = path.join(nvmRoot, "openclaw");
+        const pkgRoot = path.join(nvmRoot, ...packageParts);
         const cellarRoot = path.join(
           base,
           "opt",
@@ -400,6 +413,7 @@ describe("update global helpers", () => {
             runCommand,
             timeoutMs: 1000,
             pkgRoot,
+            ...packageOptions,
           }),
         ).resolves.toEqual({
           manager: "npm",
@@ -409,45 +423,6 @@ describe("update global helpers", () => {
           npmOwner: { version: "12.0.0", lifecyclePolicy: "allow-scripts" },
         });
         expect(runCommand.mock.calls.map(([argv]) => argv)).toEqual([["npm", "--version"]]);
-      });
-    });
-  });
-
-  it("keeps scoped npm self-updates on the running package root", async () => {
-    await withMockedPlatform("darwin", async () => {
-      await withTestDir({ prefix: "openclaw-update-scoped-probe-" }, async (base) => {
-        const nvmPrefix = path.join(base, "home", ".nvm", "versions", "node", "v24.5.0");
-        const nvmRoot = path.join(nvmPrefix, "lib", "node_modules");
-        const pkgRoot = path.join(nvmRoot, "@scope", "cli");
-        const cellarRoot = path.join(
-          base,
-          "opt",
-          "homebrew",
-          "Cellar",
-          "node",
-          "26.3.1",
-          "lib",
-          "node_modules",
-        );
-        await fs.mkdir(pkgRoot, { recursive: true });
-
-        const runCommand = createNpmRootRunner({ defaultNpmRoot: cellarRoot });
-
-        await expect(
-          resolveGlobalInstallTarget({
-            manager: "npm",
-            runCommand,
-            timeoutMs: 1000,
-            pkgRoot,
-            packageName: "@scope/cli",
-          }),
-        ).resolves.toEqual({
-          manager: "npm",
-          command: "npm",
-          globalRoot: nvmRoot,
-          packageRoot: pkgRoot,
-          npmOwner: { version: "12.0.0", lifecyclePolicy: "allow-scripts" },
-        });
       });
     });
   });

--- a/src/infra/update-runner-git-admission.test.ts
+++ b/src/infra/update-runner-git-admission.test.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { resolveStableNodePath } from "./stable-node-path.js";
 import { buildUpdateCommandRunner } from "./update-runner-command.js";
 import { updateGitCheckout } from "./update-runner-git.js";
 import type { CommandRunner, UpdateRunnerOptions } from "./update-runner-types.js";
@@ -61,7 +62,7 @@ function fixture(relativeRemote = false) {
   const target = commit("2026.7.2", 14);
   const calls: string[][] = [];
   const runCommand: CommandRunner = async (argv, options) => {
-    if (argv[0] === process.execPath && argv.includes("doctor")) {
+    if (argv.includes("doctor") && argv[0] === (await resolveStableNodePath(process.execPath))) {
       return { code: 0, stdout: "", stderr: "" };
     }
     if (argv[0] === "pnpm") {


### PR DESCRIPTION
## What Problem This Solves

On Homebrew, the Git-admission fixture rejected valid Doctor commands through the stable Node alias and obscured the admission behavior under test. Update ownership and fresh-Doctor readiness tests also repeated input setup that obscured the differences each case protects. This is test-deslop stage 4 of the #135868 split campaign, concern E (update CLI and remaining infra update paths, decision brief §1/§5).

## Why This Change Was Made

Share the fresh-Doctor input fixture while still passing a new top-level object to every call. Keep all original eight cases, explicit overrides and assertions; the rebase also preserves all three external-policy cases from #138771. Combine the two nvm installation-owner cases into named rows with their original temp prefixes and package layouts; the unscoped row still omits packageName. Preserve the complete resolved target and the existing version-only npm probe assertion, applying that assertion to both rows.

| Consolidated setup | Remaining behavior coverage |
| --- | --- |
| Seven repeated fresh-Doctor argument objects | All eight existing cases in `src/cli/update-cli/update-command-fresh-doctor.test.ts:81`: updated-process checks, unchanged plugins, lifecycle callback ordering/refusal, stale parent schema, remediation and malformed/empty readiness |
| Unscoped and scoped nvm owner test bodies | `src/infra/update-global.test.ts:384`, both original test names as table rows; running nvm installation wins over the divergent Homebrew PATH probe, scoped root stays intact and no unnecessary root probe runs |

The neighboring non-global checkout case stays separate because it requires the opposite npm-root probe policy. Active sibling #139701’s restart/service/handoff/lease/recovery files are untouched. Separate snapshot-isolation support remains a child-process boundary; it cannot be inlined into a Vitest test module without changing isolation.

The Git-admission fake now matches the canonical stable Node path already used by production and sibling tests. Its Doctor/pnpm/Git routing stays closed, and all seventeen admission cases and assertions remain. The baseline reproduced seven failures before this fixture correction; the stable-path resolver has independent contract tests.

## User Impact

No user-visible behavior change. The three test files are 46 lines smaller overall while retaining every existing case and assertion; the fixture correction lets Homebrew runs reach the intended Git-admission checks. No production, support, dependency, baseline, snapshot or timeout changes.

| Class | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production | 0 | 0 | 0 |
| Tests | 35 | 81 | -46 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |

After preserving #138771, Fresh-Doctor: 306→284 lines; global helpers: 1014→989; Git admission: 420→421; total: 1740→1694. If landed, the supplied expanded campaign tally moves from -7 to -53, excluding concurrent lanes’ subsequent changes.

## Evidence

Paired full standard-directory proof used the same baseline and all 690 files across six canonical owner batches. Every batch completed. Durations below are Vitest time and are not performance claims.

| Directory | Before: files / cases / duration | After: files / cases / duration |
| --- | --- | --- |
| `src/cli/update-cli` | 30 / 479 / 133.18 s | 30 / 479 / 154.16 s |
| `src/infra` | 660 / 11,570 / 2052.86 s | 660 / 11,570 / 2058.21 s |

Before: 12,006 passed, 9 failed, 34 skipped. After: 12,013 passed, 2 failed, 34 skipped. Total wrapper time: 2243.62→2229.60 s. The seven admission-fixture failures disappeared. Both broad runs retain an unchanged backup-exclusion test timeout at 120 seconds and a worktree-path migration refusal caused by actual free disk space below its 16 GiB reserve. A separate focused run with sufficient space passed that migration. No timeout, reserve, assertion or expected-failure setting was changed. Source audit did not establish a backup defect or a newer fix; the exact stalled backup stage remains unknown.

The four explicitly optional live/E2E files remain outside standard scope: `update-command-repair-isolation.e2e.test.ts`, `net/proxy/external-proxy.e2e.test.ts`, `push-apns-http2.live.test.ts`, and `update-repair-agent.e2e.test.ts`.

- Focused owner/sibling proof: 5 files, 91 cases passed, 28.79 s wrapper time, including all 17 admission cases and the independent stable-Node resolver tests.
- Complete changed-check plan passed: guards, formatting, core test types, dead exports, and targeted lint.
- Local Codex autoreview through P2: scoped-clean, no accepted/actionable findings.
- Counterfactual proof: a temporary uncommitted revert reproduced 7 admission failures / 10 passes in 17.23 s; restoring the reviewed patch passed all 17 cases in 28.49 s. No stash, timeout or assertion changes.
- Final rebased proof: 4 owner/sibling files, 92 cases passed, including all 11 fresh-Doctor cases. The lockfile is unchanged; all three policy tests from #138771 remain unchanged.
- Committed-branch Codex autoreview through P2: scoped-clean, no accepted/actionable findings.
- Final exact-head CI passed on `2175a9276976d27ee444564f21f358b53f091cee`: [run 34035937836](https://github.com/openclaw/openclaw/actions/runs/34035937836). The Labeler synchronize run was cancelled before any steps when the body-edit run superseded it; one evidence-backed rerun cleared that cancellation. No compiler or test failure occurred.
- Final exact-head [ClawSweeper review](https://github.com/openclaw/openclaw/pull/140126#issuecomment-5559465033) completed on that exact head: no findings, security issues, before-merge items, or rank-up actions to apply or skip.

The native baseline inspection caught #138771 landing new fresh-Doctor behavior while CI ran. Rebased over it, preserving its three policy tests unchanged. Fresh focused proof passed 92 cases and renewed committed-branch review is scoped-clean through P2. The full renewed changed-check plan also passed. CI and ClawSweeper review both passed on the final head. The paired 690-file before/after comparison above remains pinned to its original baseline.
