### PR TITLE
fix(exec): stop persisting reusable allow-always patterns for POSIX shell payloads on Windows

### DIFF
--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -1390,6 +1390,13 @@ function collectAllowAlwaysPatterns(params: {
   if (!isWindowsPlatform(params.platform)) {
     return;
   }
+  if (POSIX_SHELL_WRAPPERS.has(normalizeExecutableToken(segment.argv[0] ?? ""))) {
+    // The inline payload is owned by a POSIX shell (for example `sh -c` reached
+    // through a package-manager carrier), so windows-cmd/PowerShell nested
+    // analysis does not apply. POSIX shells only bind durable positional
+    // carriers (handled above), so nothing is reusable here.
+    return;
+  }
   const nested = analyzeWindowsShellCommand({
     command: inlineCommand,
     cwd: params.cwd,


### PR DESCRIPTION
Closes #139917

## What Problem This Solves

Fixes an issue where Windows operators who chose **Allow always** for a command routed through a shell carrier (for example `pnpm exec sh -c 'echo warmup-ok'`) silently granted a broader reusable approval than the approval dialog implies: the persisted rule targeted the innermost executable instead of staying one-shot, diverging from the one-shot contract the exec-approval suite documents and from the behavior on Linux/macOS.

## Why This Change Was Made

Allow-always pattern collection on Windows fed inline payloads owned by a POSIX shell (reached through package-manager or dispatch carriers) into the windows-cmd/PowerShell nested analyzer. The shipped solution skips that analyzer when the unwrapped wrapper is a POSIX shell — POSIX shells only bind durable positional carriers, handled earlier in the same collector — so shell-carrier payloads stay one-shot. The guard sits after the existing platform check, so Linux/macOS behavior is unchanged, and windows-cmd/PowerShell payloads continue through the nested analyzer as before.

## User Impact

"Allow always" on Windows no longer silently authorizes broader reuse than the approval flow implies for POSIX shell carrier commands; behavior now matches the suite's documented one-shot semantics on every platform.

## Evidence

The five failing "keeps … shell carriers one-shot" assertions in `src/infra/exec-allow-always-persistence.test.ts` now pass on Windows (before: 6 failed / 459 passed across the exec/shell test family; after: 1 failed / 464 passed — the remaining failure is the pre-existing test-only platform-pin case noted in #139917, unrelated to this change). `pnpm check:changed`: format and `typecheck core` / `typecheck core tests` pass; the local dead-export scan aborted with an oxc-parser `ArrayBuffer` allocation failure on this machine but reported 0 unused exports.

Real Windows approval-flow trace on this PR head, driven against the production chain — `evaluateShellAllowlistWithAuthorization` (the gateway's evaluator), `resolveAllowAlwaysPersistenceDecision`, `persistAllowAlwaysDecision`, and the real exec-approvals store under an isolated `OPENCLAW_STATE_DIR`. Fixture executables live in a temp dir shown redacted as `<FIXTURES>`; no model, socket, or private paths involved.

Fresh state:

```text
[state] fresh approval state: 0 allowlist entrie(s)
```

Shell-carrier command (fix under test):

```text
[carrier] command: pnpm exec sh -c 'echo warmup-ok'
[carrier] first evaluation: allowlistSatisfied=false (expected false -> prompt)
[carrier] allow-always decision: kind=one-shot reasons=["no-reusable-pattern"]

[state] after approving carrier with Allow-always: 0 allowlist entrie(s)

[carrier] repeat evaluation: allowlistSatisfied=false -> prompts again (one-shot, expected)
```

Approving the carrier persisted **no** reusable rule, and the same command re-prompts on the next run.

Positive control, same flow (`git status`):

```text
[control] allow-always decision: kind=patterns [{"pattern":"<FIXTURES>/git.exe","argPattern":"sha256:cwd-argv:v1:c21278f3…"}]

[state] after approving git status with Allow-always: 2 allowlist entrie(s)
  - {"pattern":"<FIXTURES>/git.exe","source":"allow-always","argPattern":"sha256:cwd-argv:v1:c21278f3…"}
  - {"pattern":"=node-command:e62b04aadf39df1a","source":"allow-always"}

[control] repeat evaluation: allowlistSatisfied=true -> auto-approved by saved rule (expected)
```

Saved rules for ordinary commands are still persisted, still auto-approve repeat runs, and coexist with the carrier staying one-shot — existing-rule compatibility intact.
