### PR TITLE
fix(android): show model status for the selected agent

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -1372,8 +1372,8 @@ class MainViewModel private constructor(
     ensureRuntime().refreshModelCatalog()
   }
 
-  fun refreshProviderModels() {
-    ensureRuntime().refreshProviderModels()
+  fun refreshProviderModels(refresh: Boolean = false) {
+    ensureRuntime().refreshProviderModels(refresh)
   }
 
   fun refreshTalkSetupReadiness() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1360,6 +1360,7 @@ class NodeRuntime private constructor(
   private val appearancePreferenceRefreshGuard = LatestGatewayRefreshGuard()
   private val appearancePreferenceWriteMutexes = appearancePreferenceKeys.associateWith { Mutex() }
   private val _modelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
+  private val modelCatalogRefreshGuard = LatestGatewayRefreshGuard()
   val modelCatalog: StateFlow<List<GatewayModelSummary>> = _modelCatalog.asStateFlow()
   private val _providerModelCatalog = MutableStateFlow<List<GatewayModelSummary>>(emptyList())
   val providerModelCatalog: StateFlow<List<GatewayModelSummary>> = _providerModelCatalog.asStateFlow()
@@ -1858,6 +1859,7 @@ class NodeRuntime private constructor(
     // physical lease still prevents requests and response publication.
     appearancePreferenceRefreshGuard.invalidate()
     _gatewayAgents.value = emptyList()
+    modelCatalogRefreshGuard.invalidate()
     _modelCatalog.value = emptyList()
     providerModelCatalogRefreshGuard.invalidate()
     _providerModelCatalog.value = emptyList()
@@ -2434,8 +2436,7 @@ class NodeRuntime private constructor(
   private fun syncMainSessionKey(agentId: String?) {
     val resolvedKey = resolveNodeMainSessionKey(agentId)
     talkMode.setMainSessionKey(resolvedKey)
-    if (_mainSessionKey.value == resolvedKey) return
-    _mainSessionKey.value = resolvedKey
+    if (!updateMainSessionKey(resolvedKey)) return
     if (operatorConnected) {
       chat.prepareMainSessionKey(resolvedKey)
       chat.onGatewayConnected(mainSessionBinding(resolvedKey))
@@ -2448,9 +2449,7 @@ class NodeRuntime private constructor(
     val resolvedKey = resolveNodeMainSessionKey(agentId)
     // Always push into TalkMode so a lazy instance cannot retain the "main" alias.
     talkMode.setMainSessionKey(resolvedKey)
-    if (_mainSessionKey.value != resolvedKey) {
-      _mainSessionKey.value = resolvedKey
-    }
+    updateMainSessionKey(resolvedKey)
     chat.prepareMainSessionKey(resolvedKey)
     return resolvedKey
   }
@@ -2458,7 +2457,7 @@ class NodeRuntime private constructor(
   private fun selectMainSessionKey(agentId: String) {
     val resolvedKey = resolveNodeMainSessionKey(agentId)
     talkMode.setMainSessionKey(resolvedKey)
-    _mainSessionKey.value = resolvedKey
+    updateMainSessionKey(resolvedKey)
     chat.prepareAndSelectMainSessionKey(resolvedKey)
     chat.onGatewayConnected(mainSessionBinding(resolvedKey))
   }
@@ -2468,6 +2467,21 @@ class NodeRuntime private constructor(
       key = sessionKey,
       label = buildAndroidAppSessionLabel(prefs.displayName.value, identityStore.loadOrCreate().deviceId),
     )
+
+  private fun updateMainSessionKey(sessionKey: String): Boolean =
+    synchronized(gatewayDataScopeLock) {
+      if (_mainSessionKey.value == sessionKey) return@synchronized false
+      // Retire reads before publishing an agent change, including a switch back to the same agent.
+      modelCatalogRefreshGuard.invalidate()
+      providerModelCatalogRefreshGuard.invalidate()
+      _modelCatalog.value = emptyList()
+      _providerModelCatalog.value = emptyList()
+      _modelAuthProviders.value = emptyList()
+      _providerModelCatalogRefreshing.value = false
+      _providerModelCatalogErrorText.value = null
+      _mainSessionKey.value = sessionKey
+      true
+    }
 
   private fun updateStatus(update: () -> Unit = {}) {
     synchronized(gatewayStatusLock) {
@@ -2530,7 +2544,7 @@ class NodeRuntime private constructor(
 
   fun refreshModelCatalog() = launchGatewayRefresh { refreshModelCatalogFromGateway() }
 
-  fun refreshProviderModels() = launchGatewayRefresh { refreshProviderModelsFromGateway() }
+  fun refreshProviderModels(refresh: Boolean = false) = launchGatewayRefresh { refreshProviderModelsFromGateway(refresh) }
 
   fun refreshTalkSetupReadiness() = launchGatewayRefresh { refreshTalkSetupReadinessFromGateway() }
 
@@ -5127,7 +5141,7 @@ class NodeRuntime private constructor(
     }
     if (retireRunState) {
       val defaultMainSessionKey = resolveNodeMainSessionKey()
-      _mainSessionKey.value = defaultMainSessionKey
+      updateMainSessionKey(defaultMainSessionKey)
       talkMode.setMainSessionKey(defaultMainSessionKey)
     }
     connectedEndpoint = null
@@ -6564,18 +6578,23 @@ class NodeRuntime private constructor(
   }
 
   private suspend fun refreshModelCatalogFromGateway() {
+    val refreshGeneration = modelCatalogRefreshGuard.begin()
     val gatewayScope = captureGatewayDataScope() ?: return
+    val agentId = selectedChatAgentId
     if (!operatorConnected) {
       _modelCatalog.value = emptyList()
       _modelAuthProviders.value = emptyList()
       return
     }
     try {
-      val modelsRes = requestGatewayData(gatewayScope, "models.list", "{}")
+      val params = buildJsonObject { if (agentId != null) put("agentId", JsonPrimitive(agentId)) }
+      val modelsRes = requestGatewayData(gatewayScope, "models.list", params.toString())
       val modelsRoot = json.parseToJsonElement(modelsRes).asObjectOrNull()
       val models = parseGatewayModels(modelsRoot?.get("models") as? JsonArray)
       publishGatewayData(gatewayScope) {
-        _modelCatalog.value = models
+        modelCatalogRefreshGuard.publishIfCurrent(refreshGeneration) {
+          _modelCatalog.value = models
+        }
       }
     } catch (err: CancellationException) {
       throw err
@@ -6584,9 +6603,10 @@ class NodeRuntime private constructor(
     }
   }
 
-  private suspend fun refreshProviderModelsFromGateway() {
+  private suspend fun refreshProviderModelsFromGateway(refresh: Boolean = false) {
     val refreshGeneration = providerModelCatalogRefreshGuard.begin()
     val gatewayScope = captureGatewayDataScope() ?: return
+    val agentId = selectedChatAgentId
     publishProviderModelRefresh(gatewayScope, refreshGeneration) {
       _providerModelCatalogRefreshing.value = true
       _providerModelCatalogErrorText.value = null
@@ -6601,7 +6621,8 @@ class NodeRuntime private constructor(
     }
     try {
       try {
-        val models = requestProviderModelCatalog(gatewayScope)
+        val response = requestProviderModelConfig(agentId, refresh) { requestGatewayData(gatewayScope, "models.list", it) }
+        val models = parseGatewayModels(json.parseToJsonElement(response).asObjectOrNull()?.get("models") as? JsonArray)
         publishProviderModelRefresh(gatewayScope, refreshGeneration) {
           _providerModelCatalog.value = models
         }
@@ -6619,7 +6640,9 @@ class NodeRuntime private constructor(
       // Keep readiness independent from the additive provider-config view so
       // older Gateways still populate provider status while prompting an upgrade.
       try {
-        val providers = requestModelAuthProviders(gatewayScope)
+        val params = buildJsonObject { if (agentId != null) put("agentId", JsonPrimitive(agentId)) }
+        val response = requestGatewayData(gatewayScope, "models.authStatus", params.toString())
+        val providers = parseGatewayModelProviders(json.parseToJsonElement(response).asObjectOrNull()?.get("providers") as? JsonArray)
         publishProviderModelRefresh(gatewayScope, refreshGeneration) {
           _modelAuthProviders.value = providers
         }
@@ -6636,21 +6659,6 @@ class NodeRuntime private constructor(
         _providerModelCatalogRefreshing.value = false
       }
     }
-  }
-
-  private suspend fun requestProviderModelCatalog(gatewayScope: GatewayDataScope): List<GatewayModelSummary> {
-    val modelsRes =
-      requestProviderModelConfig { paramsJson ->
-        requestGatewayData(gatewayScope, "models.list", paramsJson)
-      }
-    val modelsRoot = json.parseToJsonElement(modelsRes).asObjectOrNull()
-    return parseGatewayModels(modelsRoot?.get("models") as? JsonArray)
-  }
-
-  private suspend fun requestModelAuthProviders(gatewayScope: GatewayDataScope): List<GatewayModelProviderSummary> {
-    val authRes = requestGatewayData(gatewayScope, "models.authStatus", "{}")
-    val authRoot = json.parseToJsonElement(authRes).asObjectOrNull()
-    return parseGatewayModelProviders(authRoot?.get("providers") as? JsonArray)
   }
 
   private suspend fun refreshTalkSetupReadinessFromGateway() {
@@ -9390,9 +9398,19 @@ internal fun parseGatewayModels(models: JsonArray?): List<GatewayModelSummary> =
 
 internal class ProviderModelConfigUnsupported : Exception()
 
-internal suspend fun requestProviderModelConfig(request: suspend (String) -> String): String =
+internal suspend fun requestProviderModelConfig(
+  agentId: String?,
+  refresh: Boolean = false,
+  request: suspend (String) -> String,
+): String =
   try {
-    request("""{"view":"provider-config"}""")
+    request(
+      buildJsonObject {
+        put("view", JsonPrimitive("provider-config"))
+        if (agentId != null) put("agentId", JsonPrimitive(agentId))
+        if (refresh) put("refresh", JsonPrimitive(true))
+      }.toString(),
+    )
   } catch (err: GatewayRequestRejected) {
     if (err.gatewayError.code != "INVALID_REQUEST") throw err
     throw ProviderModelConfigUnsupported()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ProvidersModelsScreen.kt
@@ -104,7 +104,7 @@ internal fun ProvidersModelsScreen(
             isConnected = isConnected,
             providerRows = providerRows,
             modelCount = models.size,
-            onRefresh = viewModel::refreshProviderModels,
+            onRefresh = { viewModel.refreshProviderModels(refresh = true) },
             refreshing = refreshing,
           )
         }

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeAgentSelectionTest.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.SESSION_LIST_FETCH_LIMIT
 import ai.openclaw.app.chat.selectChatAgentSessionKey
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
 import android.content.Context
 import kotlinx.coroutines.CompletableDeferred
@@ -41,6 +42,159 @@ import java.util.concurrent.atomic.AtomicReference
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [34])
 class NodeRuntimeAgentSelectionTest {
+  @Test
+  fun defaultModelReadsKeepTheLegacyGatewayContract() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      val catalogJobs = Channel<Job>(Channel.UNLIMITED)
+      try {
+        runtime.gatewayDataRequestOverrideForTests = { _, method, paramsJson ->
+          when (method) {
+            "models.list" -> {
+              catalogJobs.send(currentCoroutineContext().job)
+              if ("agentId" in Json.parseToJsonElement(paramsJson.orEmpty()).jsonObject) {
+                throw GatewayRequestRejected(GatewaySession.ErrorShape("INVALID_REQUEST", "Legacy catalog parameters unsupported"))
+              }
+              """{"models":[{"id":"legacy-model","provider":"fixture","name":"Legacy"}]}"""
+            }
+
+            "models.authStatus" -> {
+              """{"providers":[{"provider":"legacy-credential","status":"ok","profiles":[]}]}"""
+            }
+
+            else -> {
+              error("Unexpected model request: $method")
+            }
+          }
+        }
+        runtime.refreshModelCatalog()
+        runtime.refreshProviderModels()
+        withTimeout(2_000) {
+          val jobs = listOf(catalogJobs.receive(), catalogJobs.receive())
+          jobs.forEach { it.join() }
+        }
+        assertEquals(listOf("legacy-model"), runtime.modelCatalog.value.map { it.id })
+        assertEquals(listOf("legacy-model"), runtime.providerModelCatalog.value.map { it.id })
+        assertEquals(listOf("legacy-credential"), runtime.modelAuthProviders.value.map { it.id })
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+        catalogJobs.close()
+      }
+    }
+
+  @Test
+  fun modelReadsUseTheSelectedAgent() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      try {
+        runtime.gatewayDataRequestOverrideForTests = { _, method, paramsJson ->
+          val agentId =
+            Json
+              .parseToJsonElement(paramsJson.orEmpty())
+              .jsonObject["agentId"]
+              ?.jsonPrimitive
+              ?.content ?: "alpha"
+          when (method) {
+            "models.list" -> """{"models":[{"id":"$agentId-model","provider":"fixture","name":"$agentId"}]}"""
+            "models.authStatus" -> """{"providers":[{"provider":"$agentId-credential","status":"ok","profiles":[]}]}"""
+            else -> error("Unexpected model request: $method")
+          }
+        }
+        runtime.selectChatAgent("beta")
+        runtime.refreshModelCatalog()
+        runtime.refreshProviderModels()
+
+        val catalog = withTimeout(2_000) { runtime.modelCatalog.first { it.isNotEmpty() } }
+        val providerCatalog = withTimeout(2_000) { runtime.providerModelCatalog.first { it.isNotEmpty() } }
+        val providers = withTimeout(2_000) { runtime.modelAuthProviders.first { it.isNotEmpty() } }
+        assertEquals("beta-model", catalog.single().id)
+        assertEquals("beta-model", providerCatalog.single().id)
+        assertEquals("beta-credential", providers.single().id)
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+
+  @Test
+  fun switchingAwayAndBackRetiresPendingModelReads() =
+    runBlocking {
+      val runtime = createConnectedRuntime()
+      val phase = AtomicInteger(0)
+      val catalogStarted = CompletableDeferred<Job>()
+      val providerCatalogStarted = CompletableDeferred<Job>()
+      val catalogResponse = CompletableDeferred<String>()
+      val providerCatalogResponse = CompletableDeferred<String>()
+      val models = """{"models":[{"id":"alpha-model","provider":"fixture","name":"Alpha"}]}"""
+      try {
+        runtime.gatewayDataRequestOverrideForTests = { _, method, paramsJson ->
+          when (method) {
+            "models.list" -> {
+              if (phase.get() == 1) {
+                if (Json
+                    .parseToJsonElement(paramsJson.orEmpty())
+                    .jsonObject["view"]
+                    ?.jsonPrimitive
+                    ?.content == "provider-config"
+                ) {
+                  providerCatalogStarted.complete(currentCoroutineContext().job)
+                  providerCatalogResponse.await()
+                } else {
+                  catalogStarted.complete(currentCoroutineContext().job)
+                  catalogResponse.await()
+                }
+              } else {
+                models
+              }
+            }
+
+            "models.authStatus" -> {
+              """{"providers":[{"provider":"alpha-credential","status":"ok","profiles":[]}]}"""
+            }
+
+            else -> {
+              error("Unexpected model request: $method")
+            }
+          }
+        }
+        runtime.selectChatAgent("alpha")
+        runtime.refreshModelCatalog()
+        runtime.refreshProviderModels()
+        withTimeout(2_000) { runtime.modelCatalog.first { it.isNotEmpty() } }
+        withTimeout(2_000) { runtime.modelAuthProviders.first { it.isNotEmpty() } }
+
+        phase.set(1)
+        runtime.refreshModelCatalog()
+        runtime.refreshProviderModels()
+        val catalogJob = withTimeout(2_000) { catalogStarted.await() }
+        val providerCatalogJob = withTimeout(2_000) { providerCatalogStarted.await() }
+        runtime.selectChatAgent("beta")
+        runtime.selectChatAgent("alpha")
+        assertTrue(runtime.modelCatalog.value.isEmpty())
+        assertTrue(runtime.providerModelCatalog.value.isEmpty())
+        assertTrue(runtime.modelAuthProviders.value.isEmpty())
+
+        phase.set(2)
+        catalogResponse.complete(models)
+        providerCatalogResponse.completeExceptionally(IllegalStateException("Retired model read failed"))
+        withTimeout(2_000) {
+          catalogJob.join()
+          providerCatalogJob.join()
+        }
+        assertTrue(runtime.modelCatalog.value.isEmpty())
+        assertTrue(runtime.providerModelCatalog.value.isEmpty())
+        assertTrue(runtime.modelAuthProviders.value.isEmpty())
+        assertEquals(null, runtime.providerModelCatalogErrorText.value)
+        assertFalse(runtime.providerModelCatalogRefreshing.value)
+
+        runtime.refreshModelCatalog()
+        runtime.refreshProviderModels()
+        assertEquals("alpha-model", withTimeout(2_000) { runtime.modelCatalog.first { it.isNotEmpty() } }.single().id)
+        assertEquals("alpha-credential", withTimeout(2_000) { runtime.modelAuthProviders.first { it.isNotEmpty() } }.single().id)
+      } finally {
+        closeNodeRuntimeTestFixture(runtime)
+      }
+    }
+
   @Test
   fun selectingAgentRebindsCanonicalMainSession() {
     val app = RuntimeEnvironment.getApplication()

--- a/apps/android/app/src/test/java/ai/openclaw/app/ProviderModelCatalogRequestTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ProviderModelCatalogRequestTest.kt
@@ -54,7 +54,7 @@ class ProviderModelCatalogRequestTest {
       var actual: Throwable? = null
 
       try {
-        requestProviderModelConfig { paramsJson ->
+        requestProviderModelConfig(agentId = "beta", refresh = true) { paramsJson ->
           requests += paramsJson
           throw GatewayRequestRejected(GatewaySession.ErrorShape("INVALID_REQUEST", "unsupported view"))
         }
@@ -63,7 +63,10 @@ class ProviderModelCatalogRequestTest {
       }
 
       assertTrue(actual is ProviderModelConfigUnsupported)
-      assertEquals(listOf("""{"view":"provider-config"}"""), requests)
+      assertEquals(
+        listOf(Json.parseToJsonElement("""{"view":"provider-config","agentId":"beta","refresh":true}""")),
+        requests.map(Json::parseToJsonElement),
+      )
     }
 
   @Test
@@ -73,7 +76,7 @@ class ProviderModelCatalogRequestTest {
       var actual: Throwable? = null
 
       try {
-        requestProviderModelConfig { throw expected }
+        requestProviderModelConfig(agentId = "beta") { throw expected }
       } catch (err: Throwable) {
         actual = err
       }

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -19,6 +19,7 @@ The official Android app is available on [Google Play](https://play.google.com/s
 - Install: [Google Play](https://play.google.com/store/apps/details?id=ai.openclaw.app&hl=en_IN) or `OpenClaw-Android.apk` from a supported [GitHub Release](https://github.com/openclaw/openclaw/releases), [Getting Started](/start/getting-started) for the Gateway, then [Pairing](/channels/pairing).
 - Gateway: [Runbook](/gateway) + [Configuration](/gateway/configuration).
   - Protocols: [Gateway protocol](/gateway/protocol) (nodes + control plane).
+- Select an agent in the sidebar to view its credential status in **Settings → Providers & Models**. Use **Refresh** to recheck model availability.
 - **Settings → OpenClaw** opens a dedicated Gateway settings assistant when the operator connection has `operator.admin` and the Gateway supports `openclaw.chat`. Its setup conversation stays separate from ordinary Chat, redacts secret replies locally, and moves to Chat only after you tap **Open Chat**.
 
 Its reply field switches to masked input for secret prompts. Tap it again if a prompt change closes the keyboard. Android sends sensitive replies without trimming them and clears unsent drafts when you leave this page or background the app.


### PR DESCRIPTION
## What Problem This Solves

Android model settings could show the default agent’s credentials after another agent was selected, and delayed responses could restore stale state after switching away and back.

## Why This Change Was Made

Model readers now carry explicit agent selection. The main-session owner clears state and invalidates pending reads before publishing the change; Refresh requests fresh discovery through the existing API. Default requests preserve older-Gateway compatibility.

## User Impact

Provider and model settings follow the selected agent. Late replies cannot overwrite the new selection, and existing upgrade guidance and reconnect behavior remain.

## Evidence

A real Android emulator and isolated Gateway reproduced the wrong credential row before repair and showed the selected agent afterward. Held success/error replies, away/back switching, explicit refresh, and recovery retained correct visible state. Simulated older-Gateway rejection kept upgrade guidance and independent credential status. All 65 focused tests, Android lint, and the debug build passed. Compatibility was simulated rather than run against an old server.

Related: #136257.
