### PR TITLE
fix(macos): preserve the selected CLI when inspecting a managed install

### DIFF
--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -223,14 +223,10 @@ enum CLIInstaller {
         }
 
         let preferredPaths = await CommandResolver.preferredPathsAsync()
-        let status = await self.status(
+        return await self.status(
             location: location,
             expectedVersion: expectedVersion,
             preferredPaths: preferredPaths)
-        if status.isReady {
-            self.rememberValidated(status, defaults: AppDefaults.standard)
-        }
-        return status
     }
 
     static func status(location: String) async -> Status {
@@ -375,6 +371,7 @@ enum CLIInstaller {
                         "or retry after the channel is updated.")
                 return false
             }
+            self.rememberValidated(managedStatus, defaults: AppDefaults.standard)
             let parsed = self.parseInstallEvents(response.stdout)
             let installedVersion = parsed.last { $0.event == "done" }?.version
             let summary = installedVersion.map { "Installed openclaw \($0)." } ?? "Installed openclaw."
@@ -549,6 +546,7 @@ enum CLIInstaller {
             return .failure(message: message, details: managedStatus.message)
         }
 
+        self.rememberValidated(managedStatus, defaults: AppDefaults.standard)
         self.rememberInstallPolicy(.exact(targetVersion))
         NotificationCenter.default.post(name: .openclawCLIInstalled, object: nil)
         await statusHandler(String(

--- a/apps/macos/Tests/OpenClawIPCTests/CLIInstallerSelectionTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CLIInstallerSelectionTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct CLIInstallerSelectionTests {
+    @Test func `managed inspection preserves the external CLI selected by discovery`() async throws {
+        try await self.withCLIInstallations { external, managed in
+            let selected = await CLIInstaller.status()
+            #expect(selected == .ready(location: external.path, version: "2026.9.2"))
+
+            // Startup performs discovery followed by managed inspection before deciding ownership.
+            let inspected = await CLIInstaller.managedStatus()
+            #expect(inspected == .ready(location: managed.path, version: "2026.9.1"))
+            #expect(AppDefaults.standard.string(forKey: cliValidatedExecutableKey) == external.path)
+            #expect(AppDefaults.standard.string(forKey: cliValidatedVersionKey) == "2026.9.2")
+            #expect(CommandResolver.openclawExecutable() == external.path)
+        }
+    }
+
+    @Test func `managed inspection does not select a CLI when no selection exists`() async throws {
+        try await self.withCLIInstallations { _, managed in
+            AppDefaults.standard.removeObject(forKey: cliValidatedExecutableKey)
+            AppDefaults.standard.removeObject(forKey: cliValidatedVersionKey)
+
+            #expect(await CLIInstaller.managedStatus() == .ready(location: managed.path, version: "2026.9.1"))
+            #expect(AppDefaults.standard.string(forKey: cliValidatedExecutableKey) == nil)
+            #expect(AppDefaults.standard.string(forKey: cliValidatedVersionKey) == nil)
+        }
+    }
+
+    @Test(arguments: [true, false])
+    func `managed update selects its CLI only after successful verification`(_ succeeds: Bool) async throws {
+        try await self.withCLIInstallations { external, managed in
+            let targetVersion = succeeds ? "2026.9.1" : "2026.9.2"
+            let outcome = await CLIInstaller.updateManaged(
+                targetVersion: targetVersion,
+                restartGateway: false,
+                statusHandler: { _ in })
+
+            if succeeds {
+                #expect(outcome == .success(fromVersion: "2026.8.1", toVersion: "2026.9.1"))
+                #expect(AppDefaults.standard.string(forKey: cliValidatedExecutableKey) == managed.path)
+                #expect(AppDefaults.standard.string(forKey: cliValidatedVersionKey) == "2026.9.1")
+                #expect(CommandResolver.openclawExecutable() == managed.path)
+            } else {
+                guard case .failure = outcome else {
+                    Issue.record("An updater success response must not override failed version verification")
+                    return
+                }
+                #expect(AppDefaults.standard.string(forKey: cliValidatedExecutableKey) == external.path)
+                #expect(AppDefaults.standard.string(forKey: cliValidatedVersionKey) == "2026.9.2")
+            }
+        }
+    }
+
+    private func withCLIInstallations(
+        _ body: (URL, URL) async throws -> Void) async throws
+    {
+        let root = try makeTempDirForTests().resolvingSymlinksInPath()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let external = root.appendingPathComponent("external/bin/openclaw")
+        try await TestIsolation.withIsolatedState(
+            env: ["CFFIXED_USER_HOME": root.path],
+            defaults: [
+                cliValidatedExecutableKey: external.path,
+                cliValidatedVersionKey: "2026.9.2",
+                cliInstallPolicyKey: nil,
+                "openclaw.gatewayProjectRootPath": root.path,
+            ])
+        {
+            // The native CI launcher owns OS isolation; never write an operator's managed tree.
+            try #require(FileManager().homeDirectoryForCurrentUser.resolvingSymlinksInPath() == root)
+            let managed = URL(fileURLWithPath: CLIInstaller.managedExecutableLocation())
+            try #require(managed.path.hasPrefix(root.path + "/"))
+            for (executable, version) in [(external, "2026.9.2"), (managed, "2026.9.1")] {
+                try makeExecutableForTests(at: executable)
+                try """
+                #!/bin/sh
+                if [ "$1" = "--version" ]; then
+                  printf 'OpenClaw \(version)\\n'
+                else
+                  printf '{"status":"ok","before":{"version":"2026.8.1"}}\\n'
+                fi
+
+                """.write(to: executable, atomically: false, encoding: .utf8)
+                let node = executable.deletingLastPathComponent().appendingPathComponent("node")
+                try makeExecutableForTests(at: node)
+                try "#!/bin/sh\nprintf 'v24.15.0\\n'\n".write(to: node, atomically: false, encoding: .utf8)
+            }
+            try await body(external, managed)
+        }
+    }
+}


### PR DESCRIPTION
Closes #140128

## What Problem This Solves

Resolves a problem where macOS users with coexisting external and app-managed CLI installations can have their selected CLI replaced merely because the app inspects the managed installation. Startup discovery can select the external CLI, then managed inspection overwrites that selection before the ownership decision.

## Why This Change Was Made

Managed inspection now returns status without persisting a selection. Successful discovery keeps its existing selection behavior; successful installation and update explicitly remember the verified managed executable at their completion boundary. Installation does this after channel compatibility checks, so a rejected channel does not change selection.

No installation is removed or migrated. Compatibility checks, install policy, Gateway ownership and lifecycle behavior are unchanged.

## User Impact

Inspecting another installation no longer silently changes which CLI the app prefers. An explicitly completed managed installation or update still becomes the selected CLI.

## Evidence

- Source trace covers `CLIInstaller`, startup inspection in `CLIInstallPrompter`, post-update inspection before ownership checks, and `CommandResolver` selection precedence.
- New native regression cases cover discovery followed by managed inspection, inspection with no prior selection, and successful versus failed managed-update verification.
- Both the original and corrected complete `CLIInstaller.swift` compiled with the same synthetic dependencies on macOS 26.6.2 / Swift 6.3.3. The original executable aborted inside the sandbox before `main`, including after ad-hoc signing; scoped AMFI diagnostics reported a signature problem, but the full cause is not established. No RED/GREEN or live-app success is claimed.
- `swiftc -frontend -parse` accepted the new native test: syntax only, not typechecking or execution.
- Local changed-file checks passed the conflict, attribution, registry, wildcard-export, duplicate-coverage, coercion, dependency-pin and package-patch guards. The native-state schema guard passed.
- The changed gate did not complete: the available shared toolchain has Vitest 4.1.10, while this source pins Vitest 5.0.0; startup failed with `defineCacheKeyGenerator is not a function`. No toolchain or test guard was changed to hide this failure.
- Native test execution, full-app build and Swift lint/format remain pending macOS CI. The new fixture's dynamic `CFFIXED_USER_HOME` precondition has not been executed; it fails before writing the managed tree if Foundation does not honor the isolated home.

Independent Codex autoreview: scoped-clean through P2; no accepted/actionable findings. `git diff --check` passed. Runtime/native CI proof remains required before merge.

CI attached to head `26236284165e3b172a3299588f940634ff3ec66e`: [run 34035700767](https://github.com/openclaw/openclaw/actions/runs/34035700767), queued at publication. This is not a passing result.
