### PR TITLE
refactor(gateway): share workspace recovery and publication replay checks

### DIFF
--- a/src/gateway/github-personal-publication.test-support.ts
+++ b/src/gateway/github-personal-publication.test-support.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { vi } from "vitest";
+import { expect, vi } from "vitest";
 import { stringify as stringifyYaml } from "yaml";
 import { resolveManagedGitHubProfileDir } from "../agents/github-tool-identity.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
@@ -26,26 +26,46 @@ export const personalPublicationAccount = { accountId: 101, login: "personal-ali
 const account = personalPublicationAccount;
 const profileId = "ghp_22222222222222222222222222222222";
 
-export function personalPublicationReplayCases(generation: string) {
+export async function expectPersonalPublicationReplay(
+  {
+    generation,
+    coordinator,
+    action,
+  }: Pick<
+    Awaited<ReturnType<typeof createPersonalPublicationFixture>>,
+    "coordinator" | "action"
+  > & { generation: string },
+  capture: (requestId: string) => unknown,
+) {
   const selection = { source: "personal" as const, generation, account };
   const request = { sessionKey: SESSION_KEY, idempotencyKey: "personal-replay", selection };
-  return {
-    request,
-    caseOnly: {
-      ...request,
-      selection: { ...selection, account: { ...account, login: account.login.toUpperCase() } },
-    },
-    mismatches: [
-      { ...request, selection: { ...selection, generation: `${generation}-changed` } },
+  const published = await coordinator.requestPersonalForSession(request, action);
+  expect(published.status).toBe("published");
+  const before = capture(published.requestId);
+  await expect(
+    coordinator.requestPersonalForSession(
       {
         ...request,
-        selection: { ...selection, account: { ...account, accountId: account.accountId + 1 } },
+        selection: { ...selection, account: { ...account, login: account.login.toUpperCase() } },
       },
-      { ...request, selection: { ...selection, account: { ...account, login: "different-user" } } },
-      { ...request, title: "Different title" },
-      { ...request, body: "Different body" },
-    ],
-  };
+      action,
+    ),
+  ).resolves.toEqual(published);
+  for (const changed of [
+    { ...request, selection: { ...selection, generation: `${generation}-changed` } },
+    {
+      ...request,
+      selection: { ...selection, account: { ...account, accountId: account.accountId + 1 } },
+    },
+    { ...request, selection: { ...selection, account: { ...account, login: "different-user" } } },
+    { ...request, title: "Different title" },
+    { ...request, body: "Different body" },
+  ]) {
+    await expect(coordinator.requestPersonalForSession(changed, action)).rejects.toThrow(
+      "My GitHub publication idempotency key was reused with a different selection.",
+    );
+  }
+  expect(capture(published.requestId)).toEqual(before);
 }
 
 export async function createPersonalPublicationFixture() {

--- a/src/gateway/github-personal-publication.test-support.ts
+++ b/src/gateway/github-personal-publication.test-support.ts
@@ -26,6 +26,28 @@ export const personalPublicationAccount = { accountId: 101, login: "personal-ali
 const account = personalPublicationAccount;
 const profileId = "ghp_22222222222222222222222222222222";
 
+export function personalPublicationReplayCases(generation: string) {
+  const selection = { source: "personal" as const, generation, account };
+  const request = { sessionKey: SESSION_KEY, idempotencyKey: "personal-replay", selection };
+  return {
+    request,
+    caseOnly: {
+      ...request,
+      selection: { ...selection, account: { ...account, login: account.login.toUpperCase() } },
+    },
+    mismatches: [
+      { ...request, selection: { ...selection, generation: `${generation}-changed` } },
+      {
+        ...request,
+        selection: { ...selection, account: { ...account, accountId: account.accountId + 1 } },
+      },
+      { ...request, selection: { ...selection, account: { ...account, login: "different-user" } } },
+      { ...request, title: "Different title" },
+      { ...request, body: "Different body" },
+    ],
+  };
+}
+
 export async function createPersonalPublicationFixture() {
   const owner = ensureProfileForEmail("alice@example.test").id;
   const otherOwner = ensureProfileForEmail("bob@example.test").id;

--- a/src/gateway/github-personal-publication.test.ts
+++ b/src/gateway/github-personal-publication.test.ts
@@ -31,7 +31,7 @@ import {
   createForeignPublicationSession,
   createPersonalPublicationFixture,
   personalPublicationAccount as account,
-  personalPublicationReplayCases,
+  expectPersonalPublicationReplay,
 } from "./github-personal-publication.test-support.js";
 import {
   BRANCH,
@@ -455,23 +455,10 @@ describe("personal publication authority and recovery", () => {
   });
 
   it("replays only the original personal selection and content without new publication work", async () => {
-    const cases = personalPublicationReplayCases(generation);
-    const published = await coordinator.requestPersonalForSession(cases.request, action);
-    expect(published.status).toBe("published");
-    const receipt = readPersonalGitHubPublication(owner, { requestId: published.requestId });
-    const commandCount = commands.length;
-    await expect(coordinator.requestPersonalForSession(cases.caseOnly, action)).resolves.toEqual(
-      published,
-    );
-    for (const changed of cases.mismatches) {
-      await expect(coordinator.requestPersonalForSession(changed, action)).rejects.toThrow(
-        "My GitHub publication idempotency key was reused with a different selection.",
-      );
-    }
-    expect(commands).toHaveLength(commandCount);
-    expect(readPersonalGitHubPublication(owner, { requestId: published.requestId })).toEqual(
-      receipt,
-    );
+    await expectPersonalPublicationReplay({ generation, coordinator, action }, (requestId) => ({
+      receipt: readPersonalGitHubPublication(owner, { requestId }),
+      commandCount: commands.length,
+    }));
   });
 
   it("keeps credential locations out of publication errors when refresh materialization fails", async () => {

--- a/src/gateway/github-personal-publication.test.ts
+++ b/src/gateway/github-personal-publication.test.ts
@@ -31,6 +31,7 @@ import {
   createForeignPublicationSession,
   createPersonalPublicationFixture,
   personalPublicationAccount as account,
+  personalPublicationReplayCases,
 } from "./github-personal-publication.test-support.js";
 import {
   BRANCH,
@@ -451,6 +452,26 @@ describe("personal publication authority and recovery", () => {
     expect(openOpenClawStateDatabase().db.prepare("PRAGMA integrity_check").get()).toEqual({
       integrity_check: "ok",
     });
+  });
+
+  it("replays only the original personal selection and content without new publication work", async () => {
+    const cases = personalPublicationReplayCases(generation);
+    const published = await coordinator.requestPersonalForSession(cases.request, action);
+    expect(published.status).toBe("published");
+    const receipt = readPersonalGitHubPublication(owner, { requestId: published.requestId });
+    const commandCount = commands.length;
+    await expect(coordinator.requestPersonalForSession(cases.caseOnly, action)).resolves.toEqual(
+      published,
+    );
+    for (const changed of cases.mismatches) {
+      await expect(coordinator.requestPersonalForSession(changed, action)).rejects.toThrow(
+        "My GitHub publication idempotency key was reused with a different selection.",
+      );
+    }
+    expect(commands).toHaveLength(commandCount);
+    expect(readPersonalGitHubPublication(owner, { requestId: published.requestId })).toEqual(
+      receipt,
+    );
   });
 
   it("keeps credential locations out of publication errors when refresh materialization fails", async () => {

--- a/src/gateway/github-personal-publication.ts
+++ b/src/gateway/github-personal-publication.ts
@@ -39,6 +39,28 @@ export type PersonalGitHubSessionAction = PersonalGitHubAction & {
 };
 type Selection = { generation: string; account: { accountId: number; login: string } };
 
+export function assertPersonalGitHubPublicationReplay(
+  existing: {
+    connection_generation: string | null;
+    identity_account_id: number;
+    identity_login: string;
+    title: string | null;
+    body: string | null;
+  },
+  input: Pick<SessionGitHubPublishParams, "title" | "body">,
+  selected: Selection,
+): void {
+  if (
+    existing.connection_generation !== selected.generation ||
+    existing.identity_account_id !== selected.account.accountId ||
+    existing.identity_login.toLowerCase() !== selected.account.login.toLowerCase() ||
+    existing.title !== (input.title ?? null) ||
+    existing.body !== (input.body ?? null)
+  ) {
+    throw new Error("My GitHub publication idempotency key was reused with a different selection.");
+  }
+}
+
 export function bindPersonalGitHubPublicationSelection(
   action: PersonalGitHubSessionAction,
   selected: Selection,
@@ -279,17 +301,7 @@ export function createPersonalGitHubPublicationCoordinator(
         });
       const existing = readRequest();
       if (existing) {
-        if (
-          existing.connection_generation !== selected.generation ||
-          existing.identity_account_id !== selected.account.accountId ||
-          existing.identity_login.toLowerCase() !== selected.account.login.toLowerCase() ||
-          existing.title !== (input.title ?? null) ||
-          existing.body !== (input.body ?? null)
-        ) {
-          throw new Error(
-            "My GitHub publication idempotency key was reused with a different selection.",
-          );
-        }
+        assertPersonalGitHubPublicationReplay(existing, input, selected);
         action.assertCurrent();
         return status(existing, action, action).result;
       }

--- a/src/gateway/github-repository-publication.test.ts
+++ b/src/gateway/github-repository-publication.test.ts
@@ -8,6 +8,7 @@ import {
   callPersonalPublicationRpc,
   createPersonalPublicationFixture,
   personalPublicationAccount,
+  personalPublicationReplayCases,
 } from "./github-personal-publication.test-support.js";
 import {
   SESSION_ID,
@@ -57,6 +58,34 @@ describe("repository checkpoint GitHub publication", () => {
     expect(f.runtime.effects).toEqual(["push", "pull_request"]);
     expect(mocks.findWorktree).not.toHaveBeenCalled();
     expect(mocks.resolveRepository).not.toHaveBeenCalled();
+  });
+
+  it("replays only the original personal selection and content without new repository publication work", async () => {
+    const f = await repositoryFixture();
+    const person = await createPersonalPublicationFixture();
+    f.runtime.accountId = personalPublicationAccount.accountId;
+    const cases = personalPublicationReplayCases(person.generation);
+    const published = await person.coordinator.requestPersonalForSession(
+      cases.request,
+      person.action,
+    );
+    expect(published.status).toBe("published");
+    const receipt = readRepositoryGitHubPublication(published.requestId);
+    const commandCount = mocks.runCommand.mock.calls.length;
+    const effects = [...f.runtime.effects];
+    await expect(
+      person.coordinator.requestPersonalForSession(cases.caseOnly, person.action),
+    ).resolves.toEqual(published);
+    for (const changed of cases.mismatches) {
+      await expect(
+        person.coordinator.requestPersonalForSession(changed, person.action),
+      ).rejects.toThrow(
+        "My GitHub publication idempotency key was reused with a different selection.",
+      );
+    }
+    expect(mocks.runCommand).toHaveBeenCalledTimes(commandCount);
+    expect(f.runtime.effects).toEqual(effects);
+    expect(readRepositoryGitHubPublication(published.requestId)).toEqual(receipt);
   });
 
   it.each(["shared", "personal"] as const)(

--- a/src/gateway/github-repository-publication.test.ts
+++ b/src/gateway/github-repository-publication.test.ts
@@ -8,7 +8,7 @@ import {
   callPersonalPublicationRpc,
   createPersonalPublicationFixture,
   personalPublicationAccount,
-  personalPublicationReplayCases,
+  expectPersonalPublicationReplay,
 } from "./github-personal-publication.test-support.js";
 import {
   SESSION_ID,
@@ -64,28 +64,11 @@ describe("repository checkpoint GitHub publication", () => {
     const f = await repositoryFixture();
     const person = await createPersonalPublicationFixture();
     f.runtime.accountId = personalPublicationAccount.accountId;
-    const cases = personalPublicationReplayCases(person.generation);
-    const published = await person.coordinator.requestPersonalForSession(
-      cases.request,
-      person.action,
-    );
-    expect(published.status).toBe("published");
-    const receipt = readRepositoryGitHubPublication(published.requestId);
-    const commandCount = mocks.runCommand.mock.calls.length;
-    const effects = [...f.runtime.effects];
-    await expect(
-      person.coordinator.requestPersonalForSession(cases.caseOnly, person.action),
-    ).resolves.toEqual(published);
-    for (const changed of cases.mismatches) {
-      await expect(
-        person.coordinator.requestPersonalForSession(changed, person.action),
-      ).rejects.toThrow(
-        "My GitHub publication idempotency key was reused with a different selection.",
-      );
-    }
-    expect(mocks.runCommand).toHaveBeenCalledTimes(commandCount);
-    expect(f.runtime.effects).toEqual(effects);
-    expect(readRepositoryGitHubPublication(published.requestId)).toEqual(receipt);
+    await expectPersonalPublicationReplay(person, (requestId) => ({
+      receipt: readRepositoryGitHubPublication(requestId),
+      commandCount: mocks.runCommand.mock.calls.length,
+      effects: [...f.runtime.effects],
+    }));
   });
 
   it.each(["shared", "personal"] as const)(

--- a/src/gateway/github-repository-publication.ts
+++ b/src/gateway/github-repository-publication.ts
@@ -8,6 +8,7 @@ import type { PreparedGitHubPublicationIdentity } from "../agents/github-tool-id
 import type { SessionRepositoryWorkspaceRecord } from "../state/session-repository-workspaces.js";
 import { personalGitHubStatus, type PersonalGitHubAction } from "./github-personal-oauth.js";
 import {
+  assertPersonalGitHubPublicationReplay,
   bindPersonalGitHubPublicationSelection,
   preparePersonalGitHubPublicationSelection,
   type PersonalGitHubSessionAction,
@@ -516,17 +517,7 @@ export function createRepositoryGitHubPublicationCoordinator(
       action.assertCurrent();
       const existing = requestByKey(action.sessionId, input.idempotencyKey, action.owner);
       if (existing) {
-        if (
-          existing.connection_generation !== selected.generation ||
-          existing.identity_account_id !== selected.account.accountId ||
-          existing.identity_login.toLowerCase() !== selected.account.login.toLowerCase() ||
-          existing.title !== (input.title ?? null) ||
-          existing.body !== (input.body ?? null)
-        ) {
-          throw new Error(
-            "My GitHub publication idempotency key was reused with a different selection.",
-          );
-        }
+        assertPersonalGitHubPublicationReplay(existing, input, selected);
         return personalStatus(existing, action, action).result;
       }
       const bound = bindPersonalGitHubPublicationSelection(action, selected, {

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -363,24 +363,24 @@ export async function recoverPendingWorkspaceResults(
           .catch(() => undefined);
         continue;
       }
+      const owner = {
+        sessionId: active.sessionId,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+        placementGeneration: pending.placementGeneration,
+      };
+      const journal = {
+        load: () => placements.loadWorkspaceReconciliation(owner),
+        begin: (next: Parameters<typeof placements.beginWorkspaceReconciliation>[1]) =>
+          placements.beginWorkspaceReconciliation(owner, next),
+        commit: (manifestRef: string) =>
+          placements.updateWorkspaceBaseManifest({ claim: turnClaim, manifestRef }),
+        abort: () => placements.abortWorkspaceReconciliation(owner),
+      };
       if (stagedResultRef) {
         let ownedStagedResultRef = stagedResultRef;
         // A staged result must never be destroyed by environment lifecycle.
         // Keep its fence and placement until the local apply is durably accepted.
-        const owner = {
-          sessionId: active.sessionId,
-          environmentId: active.environmentId,
-          ownerEpoch: active.activeOwnerEpoch,
-          placementGeneration: pending.placementGeneration,
-        };
-        const journal = {
-          load: () => placements.loadWorkspaceReconciliation(owner),
-          begin: (next: Parameters<typeof placements.beginWorkspaceReconciliation>[1]) =>
-            placements.beginWorkspaceReconciliation(owner, next),
-          commit: (manifestRef: string) =>
-            placements.updateWorkspaceBaseManifest({ claim: turnClaim, manifestRef }),
-          abort: () => placements.abortWorkspaceReconciliation(owner),
-        };
         await deps.workspaceOperations.run(active.environmentId, async () => {
           if (!placements.validateWorkspaceResultClaim(turnClaim)) {
             throw new Error("Recovered workspace result lost its placement owner");
@@ -484,20 +484,6 @@ export async function recoverPendingWorkspaceResults(
         }
         continue;
       }
-      const owner = {
-        sessionId: active.sessionId,
-        environmentId: active.environmentId,
-        ownerEpoch: active.activeOwnerEpoch,
-        placementGeneration: pending.placementGeneration,
-      };
-      const journal = {
-        load: () => placements.loadWorkspaceReconciliation(owner),
-        begin: (next: Parameters<typeof placements.beginWorkspaceReconciliation>[1]) =>
-          placements.beginWorkspaceReconciliation(owner, next),
-        commit: (manifestRef: string) =>
-          placements.updateWorkspaceBaseManifest({ claim: turnClaim, manifestRef }),
-        abort: () => placements.abortWorkspaceReconciliation(owner),
-      };
       const tunnel = await environments.startTunnel({
         environmentId: active.environmentId,
         ownerEpoch: active.activeOwnerEpoch,


### PR DESCRIPTION
## What Problem This Solves

Workspace-result recovery and personal GitHub publication replay each carried duplicate code for the same ownership contract. This maintainer-requested cleanup consolidates those copies so staged/live recovery and local/repository publication cannot drift when those contracts change.

Related: #139597

## Why This Change Was Made

Recovery constructs its journal once after drain and missing-ref handling, retaining the pending result's admitted placement generation. The two personal-publication coordinators share the synchronous replay assertion through their existing common owner. Generation, numeric account identity, case-insensitive login, exact title/body comparison, error text, and every authority check remain in their original order.

Production is 11 lines smaller (+39/−50); behavioral tests/support add 62 lines. No configuration, schema, persistence, protocol, SDK, or dependency contract changes.

## User Impact

No intended behavior change. Existing recovery fences, accepted checkpoint handling, publication receipts, and idempotent replay remain intact.

## Evidence

Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34035967700) on f4fb23e87f0e15a5393d444849a2109dbdce8013.

- The same 169 tests in five owner/sibling files passed on original production with the added replay cases, then passed on the candidate. These cover local/repository publication, staged/live recovery, drain generation, dead-worker recovery, quiescence resume failure, and accepted repository checkpoints.
- Replay coverage checks case-only logins, all five mismatch fields, unchanged receipts, and no additional publication commands or effects.
- Source inspection confirms placement reads return fresh DTO snapshots; the hoist follows the only reassignment of the active placement and crosses no successful-path await.
- The final publication test consolidation passed all 95 tests in its two files and targeted lint. The 74 worker tests and all production behavior remain unchanged from the 169-test run.
- Independent P0–P2 reviews of the complete production change and subsequent test consolidation are clean. Full changed checks pass, including core/test typechecks, lint, dead-export checks, import cycles, and ownership/schema guards.

The publication and worker transports use the existing isolated synthetic fixtures; no real GitHub publication or external worker was performed. This change moves only synchronous local comparison/construction and leaves transport calls unchanged.
