### PR TITLE
fix(process): join relay reaping before extinction probe

### DIFF
--- a/src/process/supervisor/service-child-relay-host.test.ts
+++ b/src/process/supervisor/service-child-relay-host.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
 import * as childAdapter from "./adapters/child.js";
 import { createStubChild, firstMockArg } from "./adapters/child.test-support.js";
+import { GRACEFUL_CANCEL_TIMEOUT_MS } from "./cancellation-policy.js";
 import {
   encodeServiceChildMessage,
   type ServiceChildAnchorPayload,
@@ -35,7 +36,7 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-async function createRelay(platform: "linux" | "win32") {
+async function createRelay(platform: "linux" | "darwin" | "win32") {
   platformMock = mockProcessPlatform(platform);
   const groupProbe = vi.spyOn(process, "kill").mockImplementation(() => {
     throw Object.assign(new Error("synthetic missing process group"), { code: "ESRCH" });
@@ -108,10 +109,14 @@ async function createRelay(platform: "linux" | "win32") {
     emit({ type: "root-result", code: 0, signal: null });
     endOutput();
   };
-  const close = () => {
-    control.destroy();
+  const closeControl = () => control.destroy();
+  const exitRelay = () => {
     stub.disconnectMock();
     stub.emitExit(0);
+  };
+  const close = () => {
+    closeControl();
+    exitRelay();
   };
   const floodControl = (chunk: string | Buffer) => {
     control.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
@@ -126,6 +131,8 @@ async function createRelay(platform: "linux" | "win32") {
     completeRoot,
     endOutput,
     close,
+    closeControl,
+    exitRelay,
     floodControl,
     controlEncoding,
     killSpy,
@@ -460,6 +467,81 @@ it("drains output after losing cleanup authority without erasing the observed ro
   expect(settled).not.toHaveBeenCalled();
   endOutput();
   await expect(root).resolves.toEqual({ code: 23, signal: null });
+});
+
+it("waits for relay reaping before observing POSIX group extinction", async () => {
+  const { adapter, completeRoot, emit, closeControl, exitRelay, groupProbe } =
+    await createRelay("darwin");
+  groupProbe.mockImplementation(() => {
+    throw Object.assign(new Error("synthetic unreaped anchor group"), { code: "EPERM" });
+  });
+  completeRoot();
+  await expect(adapter.wait()).resolves.toEqual({ code: 0, signal: null });
+  emit({ type: "closing", reason: "lineage-closed" });
+  await nextTurn();
+  const settled = vi.fn();
+  const extinction = adapter.waitForExtinction();
+  void extinction.then(settled, settled);
+
+  closeControl();
+  await nextTurn();
+  expect(settled).not.toHaveBeenCalled();
+  expect(groupProbe).not.toHaveBeenCalled();
+
+  groupProbe.mockImplementation(() => {
+    throw Object.assign(new Error("synthetic reaped anchor group"), { code: "ESRCH" });
+  });
+  exitRelay();
+  await expect(extinction).resolves.toBeUndefined();
+  expect(groupProbe).toHaveBeenCalledExactlyOnceWith(-1235, 0);
+});
+
+it("does not renew the group disappearance deadline after joining the relay", async () => {
+  const { adapter, completeRoot, emit, closeControl, exitRelay, groupProbe } =
+    await createRelay("darwin");
+  const now = vi.spyOn(Date, "now").mockReturnValue(10_000);
+  groupProbe.mockReturnValue(true);
+  completeRoot();
+  await adapter.wait();
+  emit({ type: "closing", reason: "lineage-closed" });
+  await nextTurn();
+  const settled = vi.fn();
+  void adapter.waitForExtinction().then(settled, settled);
+
+  closeControl();
+  await nextTurn();
+  expect(groupProbe).not.toHaveBeenCalled();
+  now.mockReturnValue(10_000 + GRACEFUL_CANCEL_TIMEOUT_MS);
+  exitRelay();
+  await nextTurn();
+
+  expect(settled).toHaveBeenCalledExactlyOnceWith(
+    expect.objectContaining({
+      message: expect.stringContaining("owned process group remained after its anchor closed"),
+    }),
+  );
+  expect(groupProbe).toHaveBeenCalledExactlyOnceWith(-1235, 0);
+});
+
+it("bounds relay reaping by the original graceful cleanup deadline", async () => {
+  const { adapter, completeRoot, emit, closeControl, groupProbe } = await createRelay("darwin");
+  completeRoot();
+  await adapter.wait();
+  emit({ type: "closing", reason: "lineage-closed" });
+  await nextTurn();
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  try {
+    const rejected = expect(adapter.waitForExtinction()).rejects.toThrow(
+      "service child relay did not exit before cleanup deadline",
+    );
+    closeControl();
+    await nextTurn();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_CANCEL_TIMEOUT_MS);
+    await rejected;
+    expect(groupProbe).not.toHaveBeenCalled();
+  } finally {
+    vi.useRealTimers();
+  }
 });
 
 it.each(["EPERM", "EIO", "still present"])(

--- a/src/process/supervisor/service-child-relay-host.ts
+++ b/src/process/supervisor/service-child-relay-host.ts
@@ -4,6 +4,7 @@ import type { Duplex, Readable, Writable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 import { setTimeout as delay } from "node:timers/promises";
 import { toErrorObject } from "../../infra/errors.js";
+import { withTimeout } from "../../infra/fs-safe.js";
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import {
   resolveRuntimeWorkerArgv,
@@ -217,6 +218,7 @@ export async function createServiceChildRelayAdapter(
   let childError: Error | undefined;
   let childDisconnected = false;
   let childExited = false;
+  const relayExit = createDeferredCore();
   let requestedSignal: "SIGTERM" | "SIGKILL" | undefined;
   let waitError: Error | undefined;
   const startup = createDeferredCore();
@@ -343,6 +345,28 @@ export async function createServiceChildRelayAdapter(
     // Only kernel group disappearance certifies closure. The anchor's census is
     // advisory: hidden or concurrently forked members can be absent from ps.
     const deadline = Date.now() + GRACEFUL_CANCEL_TIMEOUT_MS;
+    if (!childExited) {
+      // Control EOF can precede the relay reaping its anchor. Darwin reports
+      // EPERM for that unreaped zombie group, so join before observing it.
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        loseIdentity("service child relay did not exit before cleanup deadline");
+        return;
+      }
+      try {
+        await withTimeout(
+          Promise.race([relayExit.promise, extinctionCompletion.promise]),
+          remainingMs,
+          { message: "service child relay did not exit before cleanup deadline" },
+        );
+      } catch {
+        loseIdentity("service child relay did not exit before cleanup deadline");
+        return;
+      }
+      if (state !== "closing") {
+        return;
+      }
+    }
     for (;;) {
       try {
         // Observation only: signalling a retired numeric PGID could hit a reused group.
@@ -525,6 +549,7 @@ export async function createServiceChildRelayAdapter(
   });
   child.once("exit", () => {
     childExited = true;
+    relayExit.resolve();
     removeConstructionAbortListener();
     if (useWindowsJobAnchor) {
       finishWindowsAuthority();


### PR DESCRIPTION
## What Problem This Solves

Fixes a race where a service-managed command can report uncertain cleanup after its control channel closes but before the relay reaps the anchor process. On Darwin, querying an unreaped zombie process group can return EPERM even though its leader has exited.

## Why This Change Was Made

Join the existing relay child-exit lifecycle before the first POSIX group-disappearance probe. Joining consumes the same deadline captured when control closes. The existing kernel check still requires ESRCH to confirm extinction; EPERM and other errors remain failures after the join. No new receipt, signal, timeout increase or retry of EPERM is introduced.

## User Impact

Normal command cleanup waits for its owner to reap the anchor before observing group disappearance. Root-result/output delivery stays independent, and cancellation, missing-receipt failure, source authority and Windows Job cleanup retain their current behavior. The join remains bounded when the relay stalls.

## Evidence

Found while diagnosing the macOS argv0 service-lifecycle failure in [run 34032828960](https://github.com/openclaw/openclaw/actions/runs/34032828960) for #139995. That native change does not modify process sources. The failure's PID state was not captured; an isolated owned-child Darwin probe separately demonstrates live-group success, zombie-group EPERM, then ESRCH after parent reaping. A deterministic regression using the actual host implementation reproduces premature failure when control EOF precedes relay exit, and fails before this repair.

All 32 host cases pass, including the original ordering, unchanged deadline, stalled relay, EPERM/EIO, missing receipt and Windows branches. Real service-child lifecycle tests pass 26 cases on macOS and 26 on Linux, including argv0. A normal Linux build and root lifecycle E2E pass at source tree 1e605bc1f37f630ca9c6970655028ded4c3c9b69: [Testbox run 34035221374](https://github.com/openclaw/openclaw/actions/runs/34035221374). The owned lease is stopped and verified completed.

All 29 selected checks and fresh complete-candidate P2 review pass. The existing timeout helper clears its timer; its import adds no new runtime module to the prior source closure. This correctness repair adds 23 production and 75 test code lines. No schema, configuration, dependency or protocol change.
