### PR TITLE
fix(doctor): avoid repeated plugin discovery in multi-agent startup

### DIFF
--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -254,7 +254,7 @@ describe("Doctor plugin persistence", () => {
   });
 
   it.each(["alpha", "beta"])(
-    "persists the original %s scope while retaining the config-wide inventory",
+    "reuses and persists the original %s scope while retaining the config-wide inventory",
     async (first) => {
       const names = [first, first === "alpha" ? "beta" : "alpha"];
       await withPreflightPluginFixture(async (writeVersion, config, workspaces) => {
@@ -268,6 +268,38 @@ describe("Doctor plugin persistence", () => {
               .map((p) => p.pluginId)
               .toSorted(),
           ).toEqual(["preflight-alpha", "preflight-beta"]);
+          const sourceConfig = initial.snapshot.sourceConfig;
+          const metadataScope = createDoctorPluginMetadataSnapshotScope({
+            baseSnapshot: aggregate,
+          });
+          // Unqualified Doctor work inherits its prepared view, not the system-agent workspace.
+          metadataScope.run({ config: sourceConfig }, () => {
+            expect(getCurrentPluginMetadataSnapshot({ config: sourceConfig }) === aggregate).toBe(
+              true,
+            );
+          });
+          const otherWorkspace = workspaces[names[1]!];
+          metadataScope.run({ config: sourceConfig, workspaceDir: otherWorkspace }, () => {
+            const selected = getCurrentPluginMetadataSnapshot({ config: sourceConfig });
+            expect(selected === aggregate).toBe(false);
+            expect(selected?.workspaceDir).toBe(otherWorkspace);
+          });
+          const changedPolicy = {
+            ...sourceConfig,
+            plugins: { ...sourceConfig.plugins, deny: ["preflight-alpha"] },
+          };
+          metadataScope.run({ config: changedPolicy }, () => {
+            const selected = getCurrentPluginMetadataSnapshot({ config: changedPolicy });
+            expect(selected === aggregate).toBe(false);
+            expect(selected?.policyHash).toBe(
+              resolveInstalledPluginIndexPolicyHash(changedPolicy, process.env),
+            );
+          });
+          metadataScope.run({ config: sourceConfig }, () => {
+            expect(getCurrentPluginMetadataSnapshot({ config: sourceConfig }) === aggregate).toBe(
+              true,
+            );
+          });
           const preflight = () =>
             runDoctorConfigPreflight({
               migrateState: false,

--- a/src/commands/doctor/shared/plugin-metadata-snapshot-scope.ts
+++ b/src/commands/doctor/shared/plugin-metadata-snapshot-scope.ts
@@ -93,23 +93,30 @@ export function createDoctorPluginMetadataSnapshotScope(params: {
   };
 
   const resolveSnapshot = (config: OpenClawConfig, workspaceDir: string | undefined) => {
-    const current = snapshotsByWorkspace.get(workspaceDir);
-    if (
-      current &&
-      isPluginMetadataSnapshotCompatible({
-        snapshot: current,
-        config,
-        env,
-        workspaceDir,
-      })
-    ) {
-      const snapshot = resolveConfigWideDoctorPluginMetadataSnapshot({
-        snapshot: current,
-        config,
-        env,
-      });
-      snapshotsByWorkspace.set(workspaceDir, snapshot);
-      return snapshot;
+    // An unqualified operation inherits compatible prepared context, not the system workspace.
+    // Explicit workspace requests and narrower bases must retain their exact scope.
+    const inheritedBase =
+      workspaceDir === undefined && currentBaseSnapshot?.pluginIds === undefined
+        ? currentBaseSnapshot
+        : undefined;
+    for (const current of [snapshotsByWorkspace.get(workspaceDir), inheritedBase]) {
+      if (
+        current &&
+        isPluginMetadataSnapshotCompatible({
+          snapshot: current,
+          config,
+          env,
+          workspaceDir: workspaceDir ?? current.workspaceDir,
+        })
+      ) {
+        const snapshot = resolveConfigWideDoctorPluginMetadataSnapshot({
+          snapshot: current,
+          config,
+          env,
+        });
+        snapshotsByWorkspace.set(workspaceDir, snapshot);
+        return snapshot;
+      }
     }
     const snapshot = resolveConfigWideDoctorPluginMetadataSnapshot({
       snapshot: loadPluginMetadataSnapshot({


### PR DESCRIPTION
Related: [retention startup investigation #136639](https://github.com/openclaw/openclaw/pull/136639) and [prior startup plugin preparation #131503](https://github.com/openclaw/openclaw/pull/131503).

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch in this repository; maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where multi-agent Doctor and startup-preflight work repeated plugin metadata preparation even after a config-wide view was already available. An operation that omitted its workspace could lose that prepared context and resolve another view instead.

## Why This Change Was Made

The existing Doctor scope now considers its compatible, unprojected prepared base for unqualified operations, through the same compatibility check used for cached workspace views. Explicit workspace selection, policy matching, base replacement, invalidation, and the original persisted workspace leaf remain intact; the global comparator and migration-lease freshness checks are unchanged.

## User Impact

Doctor avoids an unnecessary metadata reconstruction without changing configuration, validation, plugin activation, repair behavior, or persistence. No new cache, setting, schema, dependency, or public API is introduced.

This was found during startup profiling, but **does not claim to resolve the retention investigation's 500 ms timing gate**. The larger preflight rereads protect freshness after lease acquisition and repairs and are deliberately retained.

## Evidence

- Extended the existing real two-workspace fixture, whose system agent deliberately differs from the prepared aggregate's first workspace. Both workspace orders failed the new identity assertion before the production change and passed afterward.
- The same cases retain explicit-other-workspace and incompatible-policy controls, then return to the original compatible context. Existing tests still cover secondary-workspace validation, duplicate-owner rejection, package replacement before lease acquisition, invalidation, cache ownership, and persisted-leaf selection.
- **82 tests passed** across `doctor-config-preflight.plugin-persistence.test.ts` and `doctor-config-flow.test.ts` using `node scripts/run-vitest.mjs`.
- `node scripts/check-changed.mjs` passed.
- Fresh isolated Codex autoreview was scoped-clean at P0, with no accepted/actionable findings. No broader-priority certification is claimed.
- Normal `pnpm build` passed in **7m 58.2s**, including UI, SDK, and bootstrap gates. The existing `doctor-config-preflight.process.test.ts` suite then passed **11/11 real-process cases** after its normal dirty-tree runtime preparation. Together with the owner/caller suites, this is **93 passing tests**; it is not a startup-latency benchmark.

- Exact-head [CI run 34036134885](https://github.com/openclaw/openclaw/actions/runs/34036134885) passed for `18f600426d431d4cd6770df11c5a63afa240a52f`; the native watcher finished GREEN with no pending checks.

Exact local test commands:

```bash
node scripts/run-vitest.mjs src/commands/doctor-config-preflight.plugin-persistence.test.ts src/commands/doctor-config-flow.test.ts
```

```bash
node scripts/run-vitest.mjs src/commands/doctor-config-preflight.process.test.ts
```

### Review follow-through: data-model compatibility

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/140135#issuecomment-5559606286) found no correctness or security defect, but classified the Doctor scope path as a migration/backfill/repair data-model change. That classification does not apply to this diff: the production change only selects an existing in-memory metadata snapshot. It changes no stored representation, schema, migration, registry writer, checkpoint, or upgrade contract.

The existing persistence fixture remains the relevant boundary proof: both workspace orders preserve the original stored leaf while retaining the config-wide inventory (`src/commands/doctor-config-preflight.plugin-persistence.test.ts:303–374`); replacement before lease acquisition, invalidation, policy migration convergence, and checkpoint-after-durable-verification controls also pass in the same suite. Fresh reads after lease acquisition remain unchanged. No new data-model migration or older-reader contract is introduced, so a new cross-version migration harness is not warranted for this repair.

Production delta: **+24/−17 = +7 lines** in the existing scope owner. Tests: **+33/−1 = +32 lines** in the existing persistence suite. No new source or test files.
