### PR TITLE
fix(config): keep large model catalogs from stalling gateway startup

### DIFF
--- a/src/agents/model-auth-provider-config.runtime-snapshot.test.ts
+++ b/src/agents/model-auth-provider-config.runtime-snapshot.test.ts
@@ -1,0 +1,114 @@
+// Verifies provider snapshot matching stays cheap for large catalogs.
+import { afterEach, describe, expect, it } from "vitest";
+import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { providerConfigMatchesRuntimeSnapshot } from "./model-auth-provider-config.js";
+
+function createModelEntry(index: number): ModelDefinitionConfig {
+  return {
+    id: `openrouter/model-${index}`,
+    name: `Model ${index}`,
+    reasoning: index % 2 === 0,
+    input: ["text", "image"],
+    cost: { input: 1.5, output: 6, cacheRead: 0.15, cacheWrite: 1.5 },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+    headers: { "X-Model-Index": String(index) },
+    params: { temperature: 0.7, top_p: 1, frequency_penalty: 0 },
+  };
+}
+
+function createProviderConfig(
+  models: ModelDefinitionConfig[],
+  apiKey: string,
+): ModelProviderConfig {
+  return {
+    baseUrl: "https://openrouter.ai/api/v1",
+    apiKey,
+    api: "openai-completions",
+    models,
+  };
+}
+
+function createConfig(params: {
+  models?: ModelDefinitionConfig[];
+  apiKey?: string;
+  extraProviders?: OpenClawConfig["models"];
+}): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openrouter: createProviderConfig(params.models ?? [], params.apiKey ?? "sk-openrouter"),
+        openai: createProviderConfig([], "sk-openai"),
+        ...params.extraProviders?.providers,
+      },
+    },
+  };
+}
+
+function measureMs(run: () => void): number {
+  const startedAt = performance.now();
+  run();
+  return performance.now() - startedAt;
+}
+
+describe("providerConfigMatchesRuntimeSnapshot", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
+  it("matches equivalent small provider snapshots and rejects mismatches", () => {
+    const inputConfig = createConfig({ apiKey: "sk-match" });
+    const matchingRuntime = createConfig({ apiKey: "sk-match" });
+    const mismatchedRuntime = createConfig({ apiKey: "sk-other" });
+
+    expect(
+      providerConfigMatchesRuntimeSnapshot({
+        inputConfig,
+        runtimeConfig: matchingRuntime,
+        provider: "openrouter",
+      }),
+    ).toBe(true);
+    expect(
+      providerConfigMatchesRuntimeSnapshot({
+        inputConfig,
+        runtimeConfig: mismatchedRuntime,
+        provider: "openrouter",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps large catalog snapshot matching off the recursive stringify hot path", () => {
+    const models = Array.from({ length: 400 }, (_, index) => createModelEntry(index));
+    const inputConfig = createConfig({ models, apiKey: "sk-openrouter" });
+    const runtimeConfig = createConfig({ models, apiKey: "sk-openrouter" });
+    const mismatchedRuntime = createConfig({ models, apiKey: "sk-other" });
+    setRuntimeConfigSnapshot(runtimeConfig, inputConfig);
+
+    const params = {
+      inputConfig,
+      runtimeConfig,
+      provider: "openrouter",
+    };
+
+    const firstMs = measureMs(() => {
+      expect(providerConfigMatchesRuntimeSnapshot(params)).toBe(true);
+    });
+    expect(
+      providerConfigMatchesRuntimeSnapshot({
+        inputConfig,
+        runtimeConfig: mismatchedRuntime,
+        provider: "openrouter",
+      }),
+    ).toBe(false);
+
+    const repeatedMs = measureMs(() => {
+      for (let i = 0; i < 50; i += 1) {
+        expect(providerConfigMatchesRuntimeSnapshot(params)).toBe(true);
+      }
+    });
+    expect(firstMs).toBeLessThan(250);
+    expect(repeatedMs).toBeLessThan(50);
+  });
+});

--- a/src/agents/model-auth-provider-config.ts
+++ b/src/agents/model-auth-provider-config.ts
@@ -654,6 +654,9 @@ export function providerConfigMatchesRuntimeSnapshot(params: {
   if (!inputProvider || !runtimeProvider) {
     return false;
   }
+  if (inputProvider === runtimeProvider) {
+    return true;
+  }
   const toComparableConfig = (providerConfig: ModelProviderConfig): OpenClawConfig => ({
     models: { providers: { [params.provider]: providerConfig } },
   });

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -140,6 +140,23 @@ describe("runtime snapshot state", () => {
     expect(hashRuntimeConfigValue({ logging: { level: "info" } })).toBe(first);
   });
 
+  it("does not freeze process.env fingerprints across in-place mutations", () => {
+    const marker = `OPENCLAW_RUNTIME_SNAPSHOT_HASH_${process.pid}`;
+    const previous = process.env[marker];
+    try {
+      process.env[marker] = "before";
+      const before = hashRuntimeConfigValue(process.env);
+      process.env[marker] = "after";
+      expect(hashRuntimeConfigValue(process.env)).not.toBe(before);
+    } finally {
+      if (previous === undefined) {
+        delete process.env[marker];
+      } else {
+        process.env[marker] = previous;
+      }
+    }
+  });
+
   it.each([false, true])(
     "selects only matching runtime sources (resolution facts: %s)",
     (withFacts) => {

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -122,18 +122,38 @@ const managedRuntimeConfigWriteOwners = new Map<
 const runtimeConfigWriteListeners = new Set<(event: RuntimeConfigWriteNotification) => void>();
 const runtimeConfigSnapshotPreparers = new Set<(config: OpenClawConfig) => void>();
 
+const stableConfigStringifyCache = new WeakMap<object, string>();
+
+function canCacheStableConfigStringify(value: object): boolean {
+  // process.env is mutated in place. Caching it would freeze a stale fingerprint.
+  return value !== process.env;
+}
+
 function stableConfigStringify(value: unknown): string {
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value) ?? "null";
   }
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableConfigStringify(entry)).join(",")}]`;
+  const cacheable = canCacheStableConfigStringify(value);
+  if (cacheable) {
+    const cached = stableConfigStringifyCache.get(value);
+    if (cached !== undefined) {
+      return cached;
+    }
   }
-  const record = value as Record<string, unknown>;
-  const keys = Object.keys(record).toSorted();
-  return `{${keys
-    .map((key) => `${JSON.stringify(key)}:${stableConfigStringify(record[key])}`)
-    .join(",")}}`;
+  let serialized: string;
+  if (Array.isArray(value)) {
+    serialized = `[${value.map((entry) => stableConfigStringify(entry)).join(",")}]`;
+  } else {
+    const record = value as Record<string, unknown>;
+    serialized = `{${Object.keys(record)
+      .toSorted()
+      .map((key) => `${JSON.stringify(key)}:${stableConfigStringify(record[key])}`)
+      .join(",")}}`;
+  }
+  if (cacheable) {
+    stableConfigStringifyCache.set(value, serialized);
+  }
+  return serialized;
 }
 
 function configSnapshotsMatch(left: OpenClawConfig, right: OpenClawConfig): boolean {


### PR DESCRIPTION
Operators with a large provider model catalog (400+ OpenRouter entries) saw the gateway accept TCP connections but stay unresponsive for about two minutes during startup and provider-auth work.

Provider snapshot matching hashed the full provider subtree through recursive stableConfigStringify on every call. Cache stringify results by immutable object identity, skip process.env because it mutates in place, and keep comparison semantics unchanged.

Fail-before: 50 repeats 339ms (~6.8ms/call). After: 50 repeats 19ms (~0.38ms/call). Small matching snapshot still matches; small mismatch still does not.

Closes #138139
