### PR TITLE
refactor(imessage): consolidate approval reaction routing tests

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -112,7 +112,6 @@ extensions/google/transport-stream.test.ts
 extensions/google/transport-stream.ts
 extensions/imessage/src/actions.test.ts
 extensions/imessage/src/actions.ts
-extensions/imessage/src/approval-reactions.test.ts
 extensions/imessage/src/monitor.last-route.test.ts
 extensions/imessage/src/monitor/inbound-processing.ts
 extensions/imessage/src/monitor/monitor-provider.ts

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -734,30 +734,78 @@ describe("iMessage approval reactions", () => {
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
   });
 
-  it("resolves a reaction when the approver was configured with a service-prefixed allowFrom entry", async () => {
-    // Regression test for the ClawSweeper-flagged normalizer bug: a previous
-    // version of normalizeIMessageApproverId rejected service-prefixed direct
-    // handles (`imessage:+...`, `sms:+...`, `auto:+...`) before stripping the
-    // prefix, so the approver list collapsed to empty and reaction resolution
-    // silently denied with "reactions require explicit approvers".
+  it.each([
+    {
+      name: "resolves a reaction when the approver was configured with a service-prefixed allowFrom entry",
+      conversation: { handle: "+15551230000" },
+      approvalId: "exec-service-prefix",
+      approvalKind: "exec" as const,
+      allowedDecisions: ["allow-once", "deny"] as const,
+      approver: "imessage:+15551230000",
+      senderId: "+15551230000",
+      emoji: "👍",
+      decision: "allow-once",
+      message: {},
+    },
+    {
+      name: "resolves DM reactions even when send registered under handle but inbound carries chat_guid",
+      conversation: { handle: "+15551230000" },
+      approvalId: "exec-dm",
+      approvalKind: "exec" as const,
+      allowedDecisions: ["allow-once", "deny"] as const,
+      approver: "+15551230000",
+      senderId: "+15551230000",
+      emoji: "👍",
+      decision: "allow-once",
+      message: {
+        chat_guid: "iMessage;-;+15551230000",
+        chat_identifier: "+15551230000",
+        chat_id: 17,
+        is_group: false,
+      },
+    },
+    {
+      name: "resolves a direct approval reaction from an authorized sender",
+      conversation: { handle: "+15551230000" },
+      approvalId: "plugin:abc",
+      approvalKind: "plugin" as const,
+      allowedDecisions: ["allow-once", "allow-always", "deny"] as const,
+      approver: "+15551230000",
+      senderId: "+15551230000",
+      emoji: "👍",
+      decision: "allow-once",
+      message: {},
+    },
+    {
+      name: "resolves a group approval reaction keyed by chat_guid using the participant identity",
+      conversation: { chatGuid: "iMessage;+;chat42" },
+      approvalId: "exec-group",
+      approvalKind: "exec" as const,
+      allowedDecisions: ["allow-once", "deny"] as const,
+      approver: "+15551239999",
+      senderId: "+15551239999",
+      emoji: "👎",
+      decision: "deny",
+      message: { chat_guid: "iMessage;+;chat42", chat_id: 42, is_group: true },
+    },
+  ])("$name", async (testCase) => {
     registerIMessageApprovalReactionTarget({
       accountId: "default",
-      conversation: { handle: "+15551230000" },
+      conversation: testCase.conversation,
       messageId: "approval-message",
-      approvalId: "exec-service-prefix",
-      allowedDecisions: ["allow-once", "deny"],
+      approvalId: testCase.approvalId,
+      approvalKind: testCase.approvalKind,
+      allowedDecisions: testCase.allowedDecisions,
     });
-
-    const cfg = {
-      channels: { imessage: { allowFrom: ["imessage:+15551230000"] } },
-    };
+    const cfg = { channels: { imessage: { allowFrom: [testCase.approver] } } };
     const handled = await maybeResolveIMessageApprovalReaction({
       cfg,
       accountId: "default",
       message: buildTapbackReactionPayload({
-        sender: "+15551230000",
-        reaction_emoji: "👍",
+        sender: testCase.senderId,
+        reaction_emoji: testCase.emoji,
         reacted_to_guid: "approval-message",
+        ...testCase.message,
       }),
       bodyText: "",
     });
@@ -765,12 +813,12 @@ describe("iMessage approval reactions", () => {
     expect(handled).toBe(true);
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       cfg,
-      approvalId: "exec-service-prefix",
-      approvalKind: "exec",
-      decision: "allow-once",
+      approvalId: testCase.approvalId,
+      approvalKind: testCase.approvalKind,
+      decision: testCase.decision,
       channel: "imessage",
       accountId: "default",
-      senderId: "+15551230000",
+      senderId: testCase.senderId,
       gatewayUrl: undefined,
     });
   });
@@ -839,46 +887,6 @@ describe("iMessage approval reactions", () => {
     ).resolves.toBeNull();
   });
 
-  it("resolves DM reactions even when send registered under handle but inbound carries chat_guid", async () => {
-    registerIMessageApprovalReactionTarget({
-      accountId: "default",
-      // Send path keys by handle (target.kind === 'handle').
-      conversation: { handle: "+15551230000" },
-      messageId: "approval-message",
-      approvalId: "exec-dm",
-      allowedDecisions: ["allow-once", "deny"],
-    });
-
-    const cfg = { channels: { imessage: { allowFrom: ["+15551230000"] } } };
-    const handled = await maybeResolveIMessageApprovalReaction({
-      cfg,
-      accountId: "default",
-      message: buildTapbackReactionPayload({
-        sender: "+15551230000",
-        // Inbound DM payload populates chat_guid (chat.db always sets it).
-        chat_guid: "iMessage;-;+15551230000",
-        chat_identifier: "+15551230000",
-        chat_id: 17,
-        is_group: false,
-        reaction_emoji: "👍",
-        reacted_to_guid: "approval-message",
-      }),
-      bodyText: "",
-    });
-
-    expect(handled).toBe(true);
-    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
-      cfg,
-      approvalId: "exec-dm",
-      approvalKind: "exec",
-      decision: "allow-once",
-      channel: "imessage",
-      accountId: "default",
-      senderId: "+15551230000",
-      gatewayUrl: undefined,
-    });
-  });
-
   it("ignores removed tapbacks for approval reactions", async () => {
     registerIMessageApprovalReactionTarget({
       accountId: "default",
@@ -907,86 +915,6 @@ describe("iMessage approval reactions", () => {
 
     expect(handled).toBe(false);
     expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
-  });
-
-  it("resolves a direct approval reaction from an authorized sender", async () => {
-    registerIMessageApprovalReactionTarget({
-      accountId: "default",
-      conversation: { handle: "+15551230000" },
-      messageId: "approval-message",
-      approvalId: "plugin:abc",
-      approvalKind: "plugin",
-      allowedDecisions: ["allow-once", "allow-always", "deny"],
-    });
-
-    const cfg = {
-      channels: {
-        imessage: { allowFrom: ["+15551230000"] },
-      },
-    };
-    const handled = await maybeResolveIMessageApprovalReaction({
-      cfg,
-      accountId: "default",
-      message: buildTapbackReactionPayload({
-        sender: "+15551230000",
-        reaction_emoji: "👍",
-        reacted_to_guid: "approval-message",
-      }),
-      bodyText: "",
-    });
-
-    expect(handled).toBe(true);
-    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
-      cfg,
-      approvalId: "plugin:abc",
-      approvalKind: "plugin",
-      decision: "allow-once",
-      channel: "imessage",
-      accountId: "default",
-      senderId: "+15551230000",
-      gatewayUrl: undefined,
-    });
-  });
-
-  it("resolves a group approval reaction keyed by chat_guid using the participant identity", async () => {
-    registerIMessageApprovalReactionTarget({
-      accountId: "default",
-      conversation: { chatGuid: "iMessage;+;chat42" },
-      messageId: "approval-message",
-      approvalId: "exec-group",
-      allowedDecisions: ["allow-once", "deny"],
-    });
-
-    const cfg = {
-      channels: {
-        imessage: { allowFrom: ["+15551239999"] },
-      },
-    };
-    const handled = await maybeResolveIMessageApprovalReaction({
-      cfg,
-      accountId: "default",
-      message: buildTapbackReactionPayload({
-        sender: "+15551239999",
-        chat_guid: "iMessage;+;chat42",
-        chat_id: 42,
-        is_group: true,
-        reaction_emoji: "👎",
-        reacted_to_guid: "approval-message",
-      }),
-      bodyText: "",
-    });
-
-    expect(handled).toBe(true);
-    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
-      cfg,
-      approvalId: "exec-group",
-      approvalKind: "exec",
-      decision: "deny",
-      channel: "imessage",
-      accountId: "default",
-      senderId: "+15551239999",
-      gatewayUrl: undefined,
-    });
   });
 
   it("denies reactions from senders not on the approvers list", async () => {
@@ -1147,4 +1075,3 @@ describe("iMessage approval reactions", () => {
     expect(resolverMocks.resolveApprovalOverGateway).not.toHaveBeenCalled();
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

Maintainer-requested test-debt cleanup for the #135868 campaign. The iMessage approval-reaction suite repeated the same binding, authorization, and Gateway assertion flow in four cases and required a max-lines exception.

## Why This Change Was Made

Use four independent table rows for service-prefixed approvers, direct-message key fallback, plugin approvals, and group participant approvals. Keep every original case name, actor, target key, allowed decision set, expected decision, and exact Gateway-call object. The existing beforeEach runs for each row.

The suite shrinks from 1,150 to 1,077 physical lines (1,042 to 987 counted code lines), removing 73 test lines and its exact max-lines baseline entry. Production is unchanged; total 208 changed lines. All 25 other test bodies are byte-identical.

## User Impact

No runtime behavior change. Approval routing, actor authorization, GUID cleanup, replay suppression, and self-originated reaction coverage remain protected.

## Evidence

- All 43 focused approval-reaction, approval-auth, poller, and durable-replay tests passed on macOS.
- Independent Codex review: no actionable P0–P2 findings.
- Source comparison verified all 25 untouched test bodies are byte-identical and every consolidated case name survives.
- Full changed gate passed on [clean Blacksmith Testbox run 34035709556](https://github.com/openclaw/openclaw/actions/runs/34035709556), command exit 0; lease confirmed completed. This uses the established clean-checkout route for the nested ancestor-install boundary. No build is required for this test-only and baseline-only change.

Every removed standalone body survives under its original test name in `extensions/imessage/src/approval-reactions.test.ts`:

| Preserved case | Surviving table row |
| --- | --- |
| resolves a reaction when the approver was configured with a service-prefixed allowFrom entry | `extensions/imessage/src/approval-reactions.test.ts:739` |
| resolves DM reactions even when send registered under handle but inbound carries chat_guid | `extensions/imessage/src/approval-reactions.test.ts:751` |
| resolves a direct approval reaction from an authorized sender | `extensions/imessage/src/approval-reactions.test.ts:768` |
| resolves a group approval reaction keyed by chat_guid using the participant identity | `extensions/imessage/src/approval-reactions.test.ts:780` |

The full Gateway assertion remains exact, not a partial object match. Self-originated runtime identity, prefixed/raw GUID cleanup, replay suppression, denied actors, removed reactions, and stale approvals remain separate tests. No scenario, production seam, fixture, or security guard was removed.

Exact-head [CI 34036247641](https://github.com/openclaw/openclaw/actions/runs/34036247641) is green. ClawSweeper’s initial live-item read was throttled. Its queue subsequently completed a current-head review with no actionable findings, before-merge requests, or rank-up moves. No manual duplicate review request or guard change was made.
