### PR TITLE
fix(providers): avoid saving generated setup model rows

### DIFF
--- a/docs/providers/fireworks.md
+++ b/docs/providers/fireworks.md
@@ -76,6 +76,9 @@ openclaw onboard --non-interactive \
 
 ## Built-in catalog
 
+Setup saves connection settings and aliases without copying generated catalog rows into your config.
+Explicit `models.mode: "replace"` keeps catalog seeding enabled; custom model rows stay intact.
+
 | Model ref                                              | Name           | Input        | Context | Max output | Thinking     |
 | ------------------------------------------------------ | -------------- | ------------ | ------- | ---------- | ------------ |
 | `fireworks/accounts/fireworks/routers/glm-5p2-fast`    | GLM 5.2 Fast   | text         | 256,000 | 256,000    | On (default) |

--- a/docs/providers/moonshot.md
+++ b/docs/providers/moonshot.md
@@ -17,6 +17,9 @@ Moonshot and Kimi Coding are **separate providers**, each shipped as a separate 
 
 ## Built-in model catalog
 
+Moonshot and Kimi Coding setup save connection settings and aliases without copying generated catalog rows into your config.
+Explicit `models.mode: "replace"` keeps catalog seeding enabled; custom model rows stay intact.
+
 [//]: # "moonshot-kimi-k2-ids:start"
 
 | Model ref                           | Name                     | Reasoning        | Input              | Context   | Max output |

--- a/docs/providers/qianfan.md
+++ b/docs/providers/qianfan.md
@@ -64,6 +64,9 @@ openclaw gateway restart
 
 The catalog is static; there is no live model discovery.
 
+Setup saves connection settings and aliases without copying generated catalog rows into your config.
+Explicit `models.mode: "replace"` keeps catalog seeding enabled; custom model rows stay intact.
+
 <Tip>
 You only need to override `models.providers.qianfan` when you need a custom base URL or model metadata.
 </Tip>

--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -214,6 +214,9 @@ Override with a custom `baseUrl` in config.
 
 ## Built-in catalog
 
+Setup keeps connection settings and model aliases, including `modelstudio` aliases, without copying generated catalog rows into your config.
+Explicit `models.mode: "replace"` keeps catalog seeding enabled; custom model rows stay intact.
+
 OpenClaw discovers models from the configured endpoint's authenticated `/models`
 API. The plugin keeps the following seed metadata for offline discovery and for
 endpoints that return only model IDs. Coding Plan configs omit models that are

--- a/docs/providers/stepfun.md
+++ b/docs/providers/stepfun.md
@@ -33,6 +33,9 @@ Auth env var: `STEPFUN_API_KEY`
 
 ## Built-in catalog
 
+Setup saves connection settings and aliases without copying generated catalog rows into your config.
+Explicit `models.mode: "replace"` keeps catalog seeding enabled; custom model rows stay intact.
+
 Standard (`stepfun`):
 
 | Model ref                | Context | Max output | Notes                          |

--- a/docs/providers/xiaomi.md
+++ b/docs/providers/xiaomi.md
@@ -80,6 +80,9 @@ Onboarding validates the key shape and warns when a `tp-...` key is entered into
 
 ## Token Plan catalog
 
+Token Plan setup saves connection settings and aliases without copying generated catalog rows into your config.
+Explicit `models.mode: "replace"` keeps catalog seeding enabled; custom model rows stay intact.
+
 Choose the Token Plan auth choice that matches the regional base URL shown in Xiaomi's subscription UI:
 
 | Auth choice             | Base URL                                   |

--- a/extensions/fireworks/onboard.test.ts
+++ b/extensions/fireworks/onboard.test.ts
@@ -4,8 +4,8 @@ import { applyFireworksConfig } from "./onboard.js";
 import { FIREWORKS_DEFAULT_MODEL_REF, buildFireworksCatalogModels } from "./provider-catalog.js";
 
 describe("Fireworks onboarding", () => {
-  it("applies the manifest catalog, default, and alias", () => {
-    const config = applyFireworksConfig({});
+  it("applies the manifest catalog, default, and alias in replace mode", () => {
+    const config = applyFireworksConfig({ models: { mode: "replace" } });
 
     expect(config.models?.providers?.fireworks?.models).toEqual(buildFireworksCatalogModels());
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
@@ -14,5 +14,15 @@ describe("Fireworks onboarding", () => {
     expect(config.agents?.defaults?.models).toEqual({
       [FIREWORKS_DEFAULT_MODEL_REF]: { alias: "GLM 5.2 Fast" },
     });
+  });
+
+  it.each([undefined, "merge"] as const)("leaves ordinary %s catalogs runtime-owned", (mode) => {
+    const config = applyFireworksConfig({ models: { mode } });
+
+    expect(config.models?.providers?.fireworks?.models).toEqual([]);
+    expect(config.agents?.defaults?.models?.[FIREWORKS_DEFAULT_MODEL_REF]).toEqual({
+      alias: "GLM 5.2 Fast",
+    });
+    expect(applyFireworksConfig(config)).toEqual(config);
   });
 });

--- a/extensions/fireworks/onboard.ts
+++ b/extensions/fireworks/onboard.ts
@@ -8,13 +8,13 @@ import {
 
 export const { applyConfig: applyFireworksConfig } = createDefaultModelsPresetAppliers<[]>({
   primaryModelRef: FIREWORKS_DEFAULT_MODEL_REF,
-  resolveParams: () => {
+  resolveParams: (cfg) => {
     const defaultProvider = buildFireworksProvider();
     return {
       providerId: "fireworks",
       api: defaultProvider.api ?? "openai-completions",
       baseUrl: defaultProvider.baseUrl,
-      defaultModels: buildFireworksCatalogModels(),
+      defaultModels: cfg.models?.mode === "replace" ? buildFireworksCatalogModels() : [],
       defaultModelId: FIREWORKS_DEFAULT_MODEL_ID,
       aliases: [{ modelRef: FIREWORKS_DEFAULT_MODEL_REF, alias: "GLM 5.2 Fast" }],
     };

--- a/extensions/kimi-coding/onboard.test.ts
+++ b/extensions/kimi-coding/onboard.test.ts
@@ -9,8 +9,8 @@ describe("kimi coding onboard", () => {
     expect(KIMI_CODING_MODEL_REF).toBe(KIMI_MODEL_REF);
   });
 
-  it("adds the Kimi coding provider defaults", () => {
-    const cfg = applyKimiCodeConfig({});
+  it("adds the Kimi coding provider defaults in replace mode", () => {
+    const cfg = applyKimiCodeConfig({ models: { mode: "replace" } });
     const provider = cfg.models?.providers?.kimi;
 
     expect(provider).toEqual({
@@ -30,6 +30,14 @@ describe("kimi coding onboard", () => {
     });
     expect(provider?.models?.map((model) => model.id)).toEqual(["kimi-for-coding"]);
     expect(cfg.agents?.defaults?.models?.[KIMI_MODEL_REF]?.alias).toBe("Kimi");
+  });
+
+  it.each([undefined, "merge"] as const)("leaves ordinary %s catalogs runtime-owned", (mode) => {
+    const cfg = applyKimiCodeConfig({ models: { mode } });
+
+    expect(cfg.models?.providers?.kimi?.models).toEqual([]);
+    expect(cfg.agents?.defaults?.models?.[KIMI_MODEL_REF]).toEqual({ alias: "Kimi" });
+    expect(applyKimiCodeConfig(cfg)).toEqual(cfg);
   });
 
   it("sets the agent primary model when applying the full Kimi coding preset", () => {

--- a/extensions/kimi-coding/onboard.ts
+++ b/extensions/kimi-coding/onboard.ts
@@ -1,6 +1,6 @@
 // Kimi Coding setup module handles plugin onboarding behavior.
 import {
-  createDefaultModelPresetAppliers,
+  createDefaultModelsPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
 import {
@@ -18,9 +18,9 @@ function resolveKimiCodingDefaultModel() {
   );
 }
 
-const kimiCodingPresetAppliers = createDefaultModelPresetAppliers({
+const kimiCodingPresetAppliers = createDefaultModelsPresetAppliers({
   primaryModelRef: KIMI_MODEL_REF,
-  resolveParams: (_cfg: OpenClawConfig) => {
+  resolveParams: (cfg: OpenClawConfig) => {
     const defaultModel = resolveKimiCodingDefaultModel();
     if (!defaultModel) {
       return null;
@@ -29,7 +29,7 @@ const kimiCodingPresetAppliers = createDefaultModelPresetAppliers({
       providerId: "kimi",
       api: "anthropic-messages",
       baseUrl: KIMI_CODING_BASE_URL,
-      defaultModel,
+      defaultModels: cfg.models?.mode === "replace" ? [defaultModel] : [],
       defaultModelId: KIMI_CODING_DEFAULT_MODEL_ID,
       aliases: [{ modelRef: KIMI_MODEL_REF, alias: "Kimi" }],
     };

--- a/extensions/moonshot/onboard.test.ts
+++ b/extensions/moonshot/onboard.test.ts
@@ -13,18 +13,35 @@ describe("Moonshot onboarding", () => {
   it.each([
     ["international", applyMoonshotConfig, MOONSHOT_BASE_URL],
     ["China", applyMoonshotConfigCn, MOONSHOT_CN_BASE_URL],
-  ])("applies the manifest default on the %s endpoint", (_name, applyConfig, baseUrl) => {
-    const config = applyConfig({});
-    const provider = config.models?.providers?.moonshot;
+  ])(
+    "applies the replace-mode manifest default on the %s endpoint",
+    (_name, applyConfig, baseUrl) => {
+      const config = applyConfig({ models: { mode: "replace" } });
+      const provider = config.models?.providers?.moonshot;
 
-    expect(MOONSHOT_DEFAULT_MODEL_ID).toBe(manifest.modelCatalog.providers.moonshot.defaultModel);
-    expect(provider?.baseUrl).toBe(baseUrl);
-    expect(provider?.models.map((model) => model.id)).toEqual([MOONSHOT_DEFAULT_MODEL_ID]);
-    expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
-      MOONSHOT_DEFAULT_MODEL_REF,
-    );
-    expect(config.agents?.defaults?.models).toEqual({
-      [MOONSHOT_DEFAULT_MODEL_REF]: { alias: "Kimi" },
-    });
+      expect(MOONSHOT_DEFAULT_MODEL_ID).toBe(manifest.modelCatalog.providers.moonshot.defaultModel);
+      expect(provider?.baseUrl).toBe(baseUrl);
+      expect(provider?.models.map((model) => model.id)).toEqual([MOONSHOT_DEFAULT_MODEL_ID]);
+      expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
+        MOONSHOT_DEFAULT_MODEL_REF,
+      );
+      expect(config.agents?.defaults?.models).toEqual({
+        [MOONSHOT_DEFAULT_MODEL_REF]: { alias: "Kimi" },
+      });
+    },
+  );
+
+  it.each([
+    ["international", applyMoonshotConfig],
+    ["China", applyMoonshotConfigCn],
+  ] as const)("leaves ordinary %s catalogs runtime-owned", (_name, applyConfig) => {
+    for (const mode of [undefined, "merge"] as const) {
+      const config = applyConfig({ models: { mode } });
+      expect(config.models?.providers?.moonshot?.models).toEqual([]);
+      expect(config.agents?.defaults?.models?.[MOONSHOT_DEFAULT_MODEL_REF]).toEqual({
+        alias: "Kimi",
+      });
+      expect(applyConfig(config)).toEqual(config);
+    }
   });
 });

--- a/extensions/moonshot/onboard.ts
+++ b/extensions/moonshot/onboard.ts
@@ -1,6 +1,6 @@
 // Moonshot setup module handles plugin onboarding behavior.
 import {
-  createDefaultModelPresetAppliers,
+  createDefaultModelsPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
 import {
@@ -11,9 +11,9 @@ import {
   MOONSHOT_DEFAULT_MODEL_REF,
 } from "./provider-catalog.js";
 
-const moonshotPresetAppliers = createDefaultModelPresetAppliers<[string]>({
+const moonshotPresetAppliers = createDefaultModelsPresetAppliers<[string]>({
   primaryModelRef: MOONSHOT_DEFAULT_MODEL_REF,
-  resolveParams: (_cfg: OpenClawConfig, baseUrl: string) => {
+  resolveParams: (cfg: OpenClawConfig, baseUrl: string) => {
     const defaultModel = buildMoonshotProvider().models.find(
       ({ id }) => id === MOONSHOT_DEFAULT_MODEL_ID,
     );
@@ -22,7 +22,7 @@ const moonshotPresetAppliers = createDefaultModelPresetAppliers<[string]>({
           providerId: "moonshot",
           api: "openai-completions",
           baseUrl,
-          defaultModel,
+          defaultModels: cfg.models?.mode === "replace" ? [defaultModel] : [],
           defaultModelId: MOONSHOT_DEFAULT_MODEL_ID,
           aliases: [{ modelRef: MOONSHOT_DEFAULT_MODEL_REF, alias: "Kimi" }],
         }

--- a/extensions/qianfan/index.test.ts
+++ b/extensions/qianfan/index.test.ts
@@ -213,11 +213,28 @@ describe("qianfan provider plugin", () => {
     }
   });
 
-  it("sets Qianfan as the agent primary model in full onboarding mode", () => {
-    const cfg = applyQianfanConfig({});
+  it.each([
+    { mode: undefined, modelIds: [] },
+    { mode: "merge" as const, modelIds: [] },
+    {
+      mode: "replace" as const,
+      modelIds: [
+        "deepseek-v4-pro",
+        "ernie-5.1",
+        "ernie-5.0",
+        "deepseek-v3.2",
+        "ernie-5.0-thinking-preview",
+      ],
+    },
+  ])(
+    "sets Qianfan's default without persisting ordinary $mode catalog rows",
+    ({ mode, modelIds }) => {
+      const cfg = applyQianfanConfig({ models: { mode } });
 
-    const agentsConfig = expectRecord(cfg.agents, "agents config");
-    const agentDefaults = expectRecord(agentsConfig.defaults, "agent defaults");
-    expect(resolveAgentModelPrimaryValue(agentDefaults.model)).toBe(QIANFAN_DEFAULT_MODEL_REF);
-  });
+      const agentsConfig = expectRecord(cfg.agents, "agents config");
+      const agentDefaults = expectRecord(agentsConfig.defaults, "agent defaults");
+      expect(resolveAgentModelPrimaryValue(agentDefaults.model)).toBe(QIANFAN_DEFAULT_MODEL_REF);
+      expect(cfg.models?.providers?.qianfan?.models.map((model) => model.id)).toEqual(modelIds);
+    },
+  );
 });

--- a/extensions/qianfan/onboard.ts
+++ b/extensions/qianfan/onboard.ts
@@ -17,7 +17,6 @@ function resolveQianfanPreset(cfg: OpenClawConfig): {
   baseUrl: string;
   defaultModels: NonNullable<ReturnType<typeof buildQianfanProvider>["models"]>;
 } {
-  const defaultProvider = buildQianfanProvider();
   const existingProvider = cfg.models?.providers?.qianfan as
     | {
         baseUrl?: unknown;
@@ -34,7 +33,7 @@ function resolveQianfanPreset(cfg: OpenClawConfig): {
   return {
     api,
     baseUrl: existingBaseUrl || QIANFAN_BASE_URL,
-    defaultModels: defaultProvider.models ?? [],
+    defaultModels: cfg.models?.mode === "replace" ? (buildQianfanProvider().models ?? []) : [],
   };
 }
 

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -262,7 +262,7 @@ describe("qwen provider plugin", () => {
   });
 
   it("switches Token Plan regions without replacing custom catalog rows", () => {
-    const initialGlobal = applyQwenTokenPlanConfig({}, "global");
+    const initialGlobal = applyQwenTokenPlanConfig({ models: { mode: "replace" } }, "global");
     const globalProvider = initialGlobal.models?.providers?.[QWEN_TOKEN_PLAN_PROVIDER_ID];
     if (!globalProvider) {
       throw new Error("Token Plan provider missing after onboarding");
@@ -287,6 +287,7 @@ describe("qwen provider plugin", () => {
       ...initialGlobal,
       models: {
         ...initialGlobal.models,
+        mode: "merge",
         providers: {
           ...initialGlobal.models?.providers,
           [QWEN_TOKEN_PLAN_PROVIDER_ID]: {

--- a/extensions/qwen/onboard.test.ts
+++ b/extensions/qwen/onboard.test.ts
@@ -1,0 +1,58 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
+import { describe, expect, it } from "vitest";
+import {
+  applyQwenConfig,
+  applyQwenConfigCn,
+  applyQwenStandardConfig,
+  applyQwenStandardConfigCn,
+  applyQwenTokenPlanConfig,
+} from "./onboard.js";
+
+describe.each([
+  { name: "coding global", provider: "qwen", apply: applyQwenConfig, rows: 10 },
+  { name: "coding China", provider: "qwen", apply: applyQwenConfigCn, rows: 10 },
+  { name: "standard global", provider: "qwen", apply: applyQwenStandardConfig, rows: 14 },
+  { name: "standard China", provider: "qwen", apply: applyQwenStandardConfigCn, rows: 14 },
+  {
+    name: "Token Plan global",
+    provider: "qwen-token-plan",
+    apply: (cfg: OpenClawConfig) => applyQwenTokenPlanConfig(cfg, "global"),
+    rows: 8,
+  },
+  {
+    name: "Token Plan China",
+    provider: "qwen-token-plan",
+    apply: (cfg: OpenClawConfig) => applyQwenTokenPlanConfig(cfg, "cn"),
+    rows: 8,
+  },
+])("Qwen $name setup", ({ provider, apply, rows }) => {
+  it.each([undefined, "merge"] as const)(
+    "leaves ordinary %s rows runtime-owned and retains aliases",
+    (mode) => {
+      const input: OpenClawConfig = {
+        models: { mode },
+        agents: {
+          defaults: {
+            models: { "qwen/qwen3.5-plus": { alias: "Authored", params: { temperature: 0.2 } } },
+          },
+        },
+      };
+      const config = apply(input);
+
+      expect(config.models?.providers?.[provider]?.models).toEqual([]);
+      expect(config.agents?.defaults?.models?.["qwen/qwen3.5-plus"]).toEqual(
+        input.agents?.defaults?.models?.["qwen/qwen3.5-plus"],
+      );
+      expect(config.agents?.defaults?.models?.[`${provider}/qwen3.7-plus`]).toBeDefined();
+      if (provider === "qwen") {
+        expect(config.agents?.defaults?.models?.["modelstudio/qwen3.7-plus"]).toBeDefined();
+      }
+      expect(apply(config)).toEqual(config);
+    },
+  );
+
+  it("retains the shipped replace catalog", () => {
+    const config = apply({ models: { mode: "replace" } });
+    expect(config.models?.providers?.[provider]?.models).toHaveLength(rows);
+  });
+});

--- a/extensions/qwen/onboard.ts
+++ b/extensions/qwen/onboard.ts
@@ -18,13 +18,13 @@ import { buildQwenProvider, buildQwenTokenPlanProvider } from "./provider-catalo
 
 const qwenPresetAppliers = createModelCatalogPresetAppliers<[string]>({
   primaryModelRef: QWEN_DEFAULT_MODEL_REF,
-  resolveParams: (_cfg: OpenClawConfig, baseUrl: string) => {
+  resolveParams: (cfg: OpenClawConfig, baseUrl: string) => {
     const provider = buildQwenProvider({ baseUrl });
     return {
       providerId: "qwen",
       api: provider.api ?? "openai-completions",
       baseUrl,
-      catalogModels: provider.models ?? [],
+      catalogModels: cfg.models?.mode === "replace" ? (provider.models ?? []) : [],
       aliases: [
         ...(provider.models ?? []).flatMap((model) => [
           `qwen/${model.id}`,
@@ -38,13 +38,13 @@ const qwenPresetAppliers = createModelCatalogPresetAppliers<[string]>({
 
 const qwenTokenPlanPresetAppliers = createModelCatalogPresetAppliers<[string]>({
   primaryModelRef: QWEN_TOKEN_PLAN_DEFAULT_MODEL_REF,
-  resolveParams: (_cfg: OpenClawConfig, baseUrl: string) => {
+  resolveParams: (cfg: OpenClawConfig, baseUrl: string) => {
     const provider = buildQwenTokenPlanProvider({ baseUrl });
     return {
       providerId: QWEN_TOKEN_PLAN_PROVIDER_ID,
       api: provider.api ?? "openai-completions",
       baseUrl,
-      catalogModels: provider.models ?? [],
+      catalogModels: cfg.models?.mode === "replace" ? (provider.models ?? []) : [],
       aliases: [
         ...(provider.models ?? []).map((model) => `${QWEN_TOKEN_PLAN_PROVIDER_ID}/${model.id}`),
         { modelRef: QWEN_TOKEN_PLAN_DEFAULT_MODEL_REF, alias: "Qwen Token Plan" },

--- a/extensions/stepfun/onboard.test.ts
+++ b/extensions/stepfun/onboard.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyStepFunPlanConfig,
+  applyStepFunPlanConfigCn,
+  applyStepFunStandardConfig,
+  applyStepFunStandardConfigCn,
+} from "./onboard.js";
+
+describe.each([
+  {
+    name: "standard global",
+    provider: "stepfun",
+    apply: applyStepFunStandardConfig,
+    rows: ["step-3.7-flash", "step-3.5-flash"],
+  },
+  {
+    name: "standard China",
+    provider: "stepfun",
+    apply: applyStepFunStandardConfigCn,
+    rows: ["step-3.7-flash", "step-3.5-flash"],
+  },
+  {
+    name: "plan global",
+    provider: "stepfun-plan",
+    apply: applyStepFunPlanConfig,
+    rows: ["step-3.7-flash", "step-3.5-flash", "step-3.5-flash-2603"],
+  },
+  {
+    name: "plan China",
+    provider: "stepfun-plan",
+    apply: applyStepFunPlanConfigCn,
+    rows: ["step-3.7-flash", "step-3.5-flash", "step-3.5-flash-2603"],
+  },
+])("StepFun $name setup", ({ provider, apply, rows }) => {
+  it.each([undefined, "merge"] as const)(
+    "leaves ordinary %s rows runtime-owned and retains aliases",
+    (mode) => {
+      const config = apply({ models: { mode } });
+
+      expect(config.models?.providers?.[provider]?.models).toEqual([]);
+      expect(config.agents?.defaults?.models?.[`${provider}/step-3.7-flash`]).toEqual({});
+      expect(config.agents?.defaults?.models?.[`${provider}/step-3.5-flash`]?.alias).toBeDefined();
+      expect(apply(config)).toEqual(config);
+    },
+  );
+
+  it("retains the shipped replace catalog", () => {
+    const config = apply({ models: { mode: "replace" } });
+    expect(config.models?.providers?.[provider]?.models.map((model) => model.id)).toEqual(rows);
+  });
+});

--- a/extensions/stepfun/onboard.ts
+++ b/extensions/stepfun/onboard.ts
@@ -26,14 +26,14 @@ function createStepFunPresetAppliers(params: {
 }): ProviderOnboardPresetAppliers<[string]> {
   return createModelCatalogPresetAppliers<[string]>({
     primaryModelRef: params.primaryModelRef,
-    resolveParams: (_cfg: OpenClawConfig, baseUrl: string) => {
+    resolveParams: (cfg: OpenClawConfig, baseUrl: string) => {
       const provider = params.buildProvider(baseUrl);
       const models = provider.models ?? [];
       return {
         providerId: params.providerId,
         api: provider.api ?? "openai-completions",
         baseUrl,
-        catalogModels: models,
+        catalogModels: cfg.models?.mode === "replace" ? models : [],
         aliases: [
           ...models.map((model) => `${params.providerId}/${model.id}`),
           { modelRef: params.primaryModelRef, alias: params.alias },

--- a/extensions/xiaomi/onboard.test.ts
+++ b/extensions/xiaomi/onboard.test.ts
@@ -42,8 +42,8 @@ describe("xiaomi onboard", () => {
     ]);
   });
 
-  it("adds Xiaomi Token Plan provider with a regional endpoint preset", () => {
-    const cfg = applyXiaomiTokenPlanConfig({}, "ams");
+  it("adds Xiaomi Token Plan replace rows with a regional endpoint preset", () => {
+    const cfg = applyXiaomiTokenPlanConfig({ models: { mode: "replace" } }, "ams");
     const provider = cfg.models?.providers?.["xiaomi-token-plan"];
     expect(provider).toEqual({
       ...buildXiaomiTokenPlanProvider(),
@@ -60,7 +60,7 @@ describe("xiaomi onboard", () => {
     });
   });
 
-  it("merges Xiaomi Token Plan models and rewrites the selected regional base URL", () => {
+  it("preserves authored Xiaomi Token Plan models and rewrites the regional base URL", () => {
     const provider = expectProviderOnboardMergedLegacyConfig({
       applyProviderConfig: (config) => applyXiaomiTokenPlanConfig(config, "sgp"),
       providerId: "xiaomi-token-plan",
@@ -70,10 +70,20 @@ describe("xiaomi onboard", () => {
       legacyModelId: "custom-token-plan-model",
       legacyModelName: "Custom Token Plan",
     });
-    expect(provider?.models.map((m) => m.id)).toEqual([
-      "custom-token-plan-model",
-      "mimo-v2.5-pro",
-      "mimo-v2.5",
-    ]);
+    expect(provider?.models.map((m) => m.id)).toEqual(["custom-token-plan-model"]);
   });
+
+  it.each(["ams", "cn", "sgp"] as const)(
+    "leaves ordinary Token Plan %s rows runtime-owned",
+    (region) => {
+      for (const mode of [undefined, "merge"] as const) {
+        const cfg = applyXiaomiTokenPlanConfig({ models: { mode } }, region);
+        expect(cfg.models?.providers?.["xiaomi-token-plan"]?.models).toEqual([]);
+        expect(cfg.agents?.defaults?.models?.["xiaomi-token-plan/mimo-v2.5-pro"]).toEqual({
+          alias: "Xiaomi MiMo V2.5 Pro",
+        });
+        expect(applyXiaomiTokenPlanConfig(cfg, region)).toEqual(cfg);
+      }
+    },
+  );
 });

--- a/extensions/xiaomi/onboard.ts
+++ b/extensions/xiaomi/onboard.ts
@@ -35,13 +35,13 @@ export const { applyConfig: applyXiaomiConfig, applyProviderConfig: applyXiaomiP
 
 const xiaomiTokenPlanPresetAppliers = createDefaultModelsPresetAppliers<[]>({
   primaryModelRef: XIAOMI_TOKEN_PLAN_DEFAULT_MODEL_REF,
-  resolveParams: () => {
+  resolveParams: (cfg) => {
     const defaultProvider = buildXiaomiTokenPlanProvider();
     return {
       providerId: XIAOMI_TOKEN_PLAN_PROVIDER_ID,
       api: defaultProvider.api ?? "openai-completions",
       baseUrl: defaultProvider.baseUrl,
-      defaultModels: defaultProvider.models ?? [],
+      defaultModels: cfg.models?.mode === "replace" ? (defaultProvider.models ?? []) : [],
       defaultModelId: XIAOMI_TOKEN_PLAN_DEFAULT_MODEL_ID,
       aliases: (() => {
         const defaultModel = defaultProvider.models?.find(


### PR DESCRIPTION
## What Problem This Solves

Seven provider setup routes copied generated catalog rows into ordinary configuration, mixing plugin-owned metadata with authored settings.

## Why This Change Was Made

Generate preset rows only in explicit replace mode. Preserve existing merge/default behavior, aliases, regional endpoints, and public helper defaults.

## User Impact

Ordinary setup saves connections without generated catalog pins. Replace mode still seeds its catalog, and authored entries remain intact. This does not migrate existing rows or change authentication.

## Evidence

Real noninteractive onboarding covered 44 before/after cases across 17 regional routes. Thirty-two regressions failed before the change; 69 focused tests passed afterward. Compatibility controls and 153 product commands verified repeated setup and model-list continuation without restoring generated rows. Canonical plugin builds and changed checks passed. One existing regional CLI auth choice still rejected before setup; live service availability and inference were not tested.

Related: #136257.
