### PR TITLE
perf(agents): reduce bootstrap accounting overhead

### DIFF
--- a/src/agents/bootstrap-budget-warning.ts
+++ b/src/agents/bootstrap-budget-warning.ts
@@ -50,7 +50,7 @@ function buildBootstrapTruncationSignature(analysis: BootstrapBudgetAnalysis): s
       path: file.path || file.name,
       rawChars: file.rawChars,
       injectedChars: file.injectedChars,
-      causes: [...file.causes].toSorted(),
+      causes: file.causes.toSorted(),
     }))
     .toSorted((a, b) => {
       const pathCmp = a.path.localeCompare(b.path);

--- a/src/agents/bootstrap-budget.test.ts
+++ b/src/agents/bootstrap-budget.test.ts
@@ -45,6 +45,7 @@ describe("buildBootstrapBudgetState", () => {
     expect(state.bootstrapMaxChars).toBe(10);
     expect(state.bootstrapTotalMaxChars).toBe(12);
     expect(state.bootstrapPromptWarningMode).toBe("always");
+    expect(state.bootstrapAnalysis.totalNearLimit).toBe(true);
     expect(state.bootstrapAnalysis.truncatedFiles[0]?.causes).toEqual(["total-limit"]);
     expect(state.bootstrapPromptWarning.warningShown).toBe(true);
   });
@@ -120,7 +121,7 @@ describe("buildBootstrapInjectionStats", () => {
 });
 
 describe("analyzeBootstrapBudget", () => {
-  it("reports per-file and total-limit causes", () => {
+  it("reports causes while excluding missing-file markers from file totals", () => {
     const analysis = analyzeBootstrapBudget({
       files: [
         {
@@ -132,11 +133,19 @@ describe("analyzeBootstrapBudget", () => {
           truncated: true,
         },
         {
+          name: "IDENTITY.md",
+          path: "/tmp/IDENTITY.md",
+          missing: true,
+          rawChars: 0,
+          injectedChars: 40,
+          truncated: false,
+        },
+        {
           name: "SOUL.md",
           path: "/tmp/SOUL.md",
           missing: false,
-          rawChars: 90,
-          injectedChars: 80,
+          rawChars: 50,
+          injectedChars: 40,
           truncated: true,
         },
       ],
@@ -144,8 +153,10 @@ describe("analyzeBootstrapBudget", () => {
       bootstrapTotalMaxChars: 200,
     });
     expect(analysis.hasTruncation).toBe(true);
-    expect(analysis.totalNearLimit).toBe(true);
+    expect(analysis.totalNearLimit).toBe(false);
     expect(analysis.truncatedFiles).toHaveLength(2);
+    expect(analysis.totals).toMatchObject({ rawChars: 200, injectedChars: 160 });
+    expect(analysis.files[1]).toMatchObject({ nearLimit: false, causes: [] });
     const agents = analysis.truncatedFiles.find((file) => file.name === "AGENTS.md");
     const soul = analysis.truncatedFiles.find((file) => file.name === "SOUL.md");
     expect(agents?.causes).toContain("per-file-limit");

--- a/src/agents/bootstrap-budget.ts
+++ b/src/agents/bootstrap-budget.ts
@@ -137,10 +137,8 @@ export function analyzeBootstrapBudget(params: {
     params.nearLimitRatio < 1
       ? params.nearLimitRatio
       : DEFAULT_BOOTSTRAP_NEAR_LIMIT_RATIO;
-  const nonMissing = params.files.filter((file) => !file.missing);
-  const rawChars = nonMissing.reduce((sum, file) => sum + file.rawChars, 0);
-  const injectedChars = nonMissing.reduce((sum, file) => sum + file.injectedChars, 0);
-  const totalNearLimit = injectedChars >= Math.ceil(bootstrapTotalMaxChars * nearLimitRatio);
+  let rawChars = 0;
+  let injectedChars = 0;
   let remainingTotalChars = bootstrapTotalMaxChars;
   const files = params.files.map((file) => {
     const effectiveFileLimit = effectiveBootstrapFileLimit(file.name, bootstrapMaxChars);
@@ -149,6 +147,9 @@ export function analyzeBootstrapBudget(params: {
     if (file.missing) {
       return { ...file, effectiveFileLimit, nearLimit: false, causes: [] };
     }
+    // Missing-file markers consume budget above but do not enter reported file totals.
+    rawChars += file.rawChars;
+    injectedChars += file.injectedChars;
     const perFileOverLimit = file.rawChars > effectiveFileLimit;
     const nearLimit = file.rawChars >= Math.ceil(effectiveFileLimit * nearLimitRatio);
     const causes: BootstrapTruncationCause[] = [];
@@ -170,7 +171,7 @@ export function analyzeBootstrapBudget(params: {
     files,
     truncatedFiles,
     nearLimitFiles,
-    totalNearLimit,
+    totalNearLimit: injectedChars >= Math.ceil(bootstrapTotalMaxChars * nearLimitRatio),
     hasTruncation: truncatedFiles.length > 0,
     totals: {
       rawChars,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Agent preparation and bootstrap diagnostics spend avoidable time accounting for workspace-file budgets, especially as the number of injected files grows.

## Why This Change Was Made

Accumulate non-missing totals during the existing classification pass, and remove a redundant array copy before sorting warning causes. Missing-file markers still consume the running budget without entering reported totals; file ordering, object references, warning bytes, limits and the original short-circuit warning scans remain unchanged.

## User Impact

Less local bootstrap bookkeeping, with the same context and diagnostics. No configuration, API, storage, matching or provider behavior changes. Production is +1 line, including the comment protecting the missing-marker accounting distinction; tests are +11 lines within existing cases. No whole-Gateway latency or memory improvement is claimed.

## Evidence

All 29 normal changed checks passed, along with 26 focused tests across the budget, Doctor and embedded-preparation suites. Fresh independent P2 review found no actionable issues (confidence 0.98).

The fixed 39-workload comparison used actual exports: 45,084 calls checked in-process, 39,936 timed calls and 1,248 batch means. All 156 retained initial outputs and encodings match; these are not 45,084 serialized payloads. Another 80 setup calls are source-derived. Every composed workload improved its median batch mean in both orders:

| Workload | Forward change | Reverse change |
| --- | ---: | ---: |
| Seven ordinary files, analyzer | −53.81% | −51.83% |
| Seven ordinary files, composed state | −30.61% | −39.17% |
| 32 truncated files, composed state | −16.37% | −18.06% |

Retained adverse results: 2/78 medians, 18/312 derived metrics and 52/624 same-index comparisons. The two adverse medians were forward empty-warning (+26.688 ns/+10.07%) and USER total-limit warning (+11.734 ns/+1.39%); both improved in reverse. Batch maxima also regressed, up to +2.672 µs/+28.54%. The unchanged injection-stat control appeared 11.83%/22.15% faster; that is uncredited variation.

The forward pair is interrupted: one controller preflight refused before running any phase; the next ran B0 once, then stopped because it kept checking retired gate PID integers. After the controller ownership correction, the exact B0 output was retained and independently validated, and only C0,C1,B1 ran. B0→C0 spans a 28.30-minute gap; reverse C1→B1 is adjacent. No baseline rerun, favorable phase replacement or corpus change occurred. All current numeric children closed and the complete owned dependency fingerprint matched before/after.

Startup-inclusive child wall time changed +6.88%/−11.64%; kernel RSS increased +0.86%/+0.60%, sampled RSS +0.60%/+0.04%. These synthetic frozen-object component measurements are not provider latency, population tails or a general memory claim.

An earlier warning-pass fusion was rejected after repeated USER-only/warning regressions; its complete data remains preserved and is not pooled into these results. Validation also exposed stale package-local dependency links: a normal gate failed to resolve libphonenumber-js/min, the verified local links were detached, and an ordinary frozen install restored a fully owned graph before successful checks and measurement. A disk-floor test interruption is retained separately; it was not counted as a pass.
