### PR TITLE
refactor(update): remove unused restart channel input

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -2429,7 +2429,6 @@ describe("update-cli", () => {
 
     await expect(
       maybeRestartService({
-        channel: "stable",
         shouldRestart: true,
         result: makeOkUpdateResult({ mode: "npm", after: { version: "2026.4.24" } }),
         opts: { json: true },

--- a/src/cli/update-cli/update-command-generation.test-support.ts
+++ b/src/cli/update-cli/update-command-generation.test-support.ts
@@ -62,7 +62,6 @@ export function registerGenerationRecoveryTests(
           steps: [],
           durationMs: 0,
         },
-        channel: "stable",
         opts: { json: true, run },
         refreshServiceEnv: false,
         serviceUpdateVerdict: before.serviceUpdateVerdict,

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -997,7 +997,6 @@ describe("successful update finalization ordering", () => {
             refreshDefinition: false,
             fingerprint: "sealed",
           },
-          channel: unloaded ? "dev" : "stable",
           result: expect.objectContaining({
             after: { version: "2026.4.24", ...(unloaded ? { buildId: "new-build" } : {}) },
           }),

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -504,7 +504,6 @@ export async function finishUpdate(params: FinishUpdateParams): Promise<UpdateRu
         maybeRestartService({
           shouldRestart: params.shouldRestart && serviceMutationAllowed,
           result: resultWithPostUpdate,
-          channel: params.channel,
           opts: params.opts,
           refreshServiceEnv: refreshGatewayServiceEnv,
           serviceUpdateVerdict,

--- a/src/cli/update-cli/update-command-rollback.ts
+++ b/src/cli/update-cli/update-command-rollback.ts
@@ -297,7 +297,6 @@ export async function rollbackFailedUpdate(params: {
     const restartOutcome = await maybeRestartService({
       shouldRestart: true,
       result,
-      channel: "stable",
       opts,
       refreshServiceEnv: false,
       serviceUpdateVerdict: verdict,

--- a/src/cli/update-cli/update-command-service-recovery.test-support.ts
+++ b/src/cli/update-cli/update-command-service-recovery.test-support.ts
@@ -129,7 +129,6 @@ export function registerRecoveryTests(params: {
       });
 
       const activated = await maybeRestartService({
-        channel: "stable",
         shouldRestart: true,
         result: {
           status: "ok",

--- a/src/cli/update-cli/update-command-service-transition.test-support.ts
+++ b/src/cli/update-cli/update-command-service-transition.test-support.ts
@@ -178,7 +178,6 @@ export function registerInstallRootTransitionTests(getFixture: () => InstallRoot
           steps: [],
           durationMs: 0,
         },
-        channel: mode === "git" ? "dev" : "stable",
         opts: { json: true },
         refreshServiceEnv: true,
         serviceUpdateVerdict: verdict,
@@ -299,7 +298,6 @@ export function registerRestartOutcomeTests(
         await maybeRestartService({
           shouldRestart: true,
           result: { status: "ok", mode: "npm", root, steps: [], durationMs: 0 },
-          channel: "stable",
           opts: { json: false },
           refreshServiceEnv: false,
           serviceUpdateVerdict: {

--- a/src/cli/update-cli/update-command-service.integration.test.ts
+++ b/src/cli/update-cli/update-command-service.integration.test.ts
@@ -305,7 +305,7 @@ describe("preserved update activation with real version guards", () => {
       mode,
       outcome,
       denial: "sealed" as const,
-      channel: "stable" as const,
+      json: true,
       phase: "initial",
     })),
     ...(["git", "npm", "pnpm", "bun"] as const).flatMap((mode) =>
@@ -317,7 +317,7 @@ describe("preserved update activation with real version guards", () => {
           mode,
           denial,
           outcome,
-          channel: "stable" as const,
+          json: outcome === "json denial",
           phase: "late",
         })),
       ),
@@ -328,14 +328,14 @@ describe("preserved update activation with real version guards", () => {
           mode: "git" as const,
           denial,
           outcome,
-          channel: "dev" as const,
+          json: false,
           phase,
         })),
       ),
     ),
   ])(
-    "handles $phase $denial denial for $channel $mode activation ($outcome)",
-    async ({ mode, denial, outcome, channel, phase }) => {
+    "handles $phase $denial denial for $mode activation ($outcome; json=$json)",
+    async ({ mode, denial, outcome, json, phase }) => {
       let nowMs = 0;
       vi.spyOn(performance, "now").mockImplementation(() => nowMs);
       vi.spyOn(runtimeUtils, "sleep").mockImplementation(async (ms) => {
@@ -444,7 +444,6 @@ describe("preserved update activation with real version guards", () => {
         return await waitForGatewayHealthyRestart(params);
       });
       const activated = await maybeRestartService({
-        channel,
         shouldRestart: true,
         result: {
           status: "ok",
@@ -455,7 +454,7 @@ describe("preserved update activation with real version guards", () => {
           before: { version: "2026.1.1" },
           after: { version: VERSION, buildId: "new-build" },
         },
-        opts: { json: outcome === "json denial" || (!late && channel === "stable") },
+        opts: { json },
         refreshServiceEnv: late,
         serviceUpdateVerdict: before.serviceUpdateVerdict,
         serviceEnv: before.serviceEnv,
@@ -472,9 +471,7 @@ describe("preserved update activation with real version guards", () => {
       for (const [args, options] of restarts) {
         expect(args).toContain("--preserve-definition");
         expect(typeof options === "object" && options.env?.MANAGED_VALUE).toBe("revalidated");
-        if (!late && channel === "stable") {
-          expect(args).toContain("--json");
-        }
+        expect(args).toContain("--json");
       }
       expect(mocks.start).not.toHaveBeenCalled();
       expect(mocks.child.mock.calls.filter(([args]) => args.includes("install"))).toHaveLength(
@@ -569,7 +566,6 @@ describe("preserved update activation with real version guards", () => {
       }
     });
     const activated = await maybeRestartService({
-      channel: "stable",
       shouldRestart: true,
       result: {
         status: "ok",
@@ -696,7 +692,6 @@ describe("preserved update activation with real version guards", () => {
       });
 
       const activated = await maybeRestartService({
-        channel: "stable",
         shouldRestart: true,
         result: {
           status: "ok",
@@ -942,7 +937,6 @@ describe("preserved update activation with real version guards", () => {
         portUsage: { port, status: "free", listeners: [], hints: [] },
       }));
       result = await maybeRestartService({
-        channel: "stable",
         shouldRestart: true,
         result: {
           status: "ok",

--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -65,42 +65,38 @@ describe("maybeRestartService", () => {
     });
   });
 
-  it.each(["dev", "stable", "beta"] as const)(
-    "enforces the built Git identity for the %s channel",
-    async (channel) => {
-      const result = {
-        status: "ok",
-        mode: "git",
-        root: "/tmp/openclaw-configured-ui-update",
-        after: { buildId: "new-build" },
-        steps: [],
-        durationMs: 0,
-      } satisfies UpdateRunResult;
+  it("enforces the built Git identity after restart", async () => {
+    const result = {
+      status: "ok",
+      mode: "git",
+      root: "/tmp/openclaw-configured-ui-update",
+      after: { buildId: "new-build" },
+      steps: [],
+      durationMs: 0,
+    } satisfies UpdateRunResult;
 
-      await expect(
-        maybeRestartService({
-          shouldRestart: true,
-          result,
-          channel,
-          opts: { json: true },
-          refreshServiceEnv: false,
-          serviceEnv: { HOME: "/home/operator" },
-          serviceInstallEnv: {},
-          gatewayPort: 18789,
-          restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
-          timeoutMs: 1_000,
-        }),
-      ).resolves.toBe("ok");
+    await expect(
+      maybeRestartService({
+        shouldRestart: true,
+        result,
+        opts: { json: true },
+        refreshServiceEnv: false,
+        serviceEnv: { HOME: "/home/operator" },
+        serviceInstallEnv: {},
+        gatewayPort: 18789,
+        restartScriptPath: "/tmp/openclaw-configured-ui-restart.sh",
+        timeoutMs: 1_000,
+      }),
+    ).resolves.toBe("ok");
 
-      expect(mocks.runRestartScript).toHaveBeenCalledWith(
-        "/tmp/openclaw-configured-ui-restart.sh",
-        1_000,
-      );
-      expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
-        expect.objectContaining({ expectedBuildId: "new-build" }),
-      );
-    },
-  );
+    expect(mocks.runRestartScript).toHaveBeenCalledWith(
+      "/tmp/openclaw-configured-ui-restart.sh",
+      1_000,
+    );
+    expect(mocks.waitForGatewayHealthyRestart).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedBuildId: "new-build" }),
+    );
+  });
 
   it("does not infer activation from a detached script when the expected Git build is never observed", async () => {
     mocks.runRestartScript.mockResolvedValueOnce(false);
@@ -129,7 +125,6 @@ describe("maybeRestartService", () => {
           steps: [],
           durationMs: 0,
         },
-        channel: "dev",
         opts: { json: true },
         refreshServiceEnv: false,
         serviceEnv: { HOME: "/home/operator" },
@@ -162,7 +157,6 @@ describe("maybeRestartService", () => {
           steps: [],
           durationMs: 0,
         },
-        channel: "dev",
         opts: { json: true },
         refreshServiceEnv,
         serviceEnv: { HOME: "/home/operator" },
@@ -202,7 +196,6 @@ describe("maybeRestartService", () => {
       maybeRestartService({
         shouldRestart: true,
         result: { status: "ok", mode: "git", steps: [], durationMs: 0 },
-        channel: "stable",
         opts: { json: true },
         refreshServiceEnv: false,
         serviceEnv: { HOME: "/home/operator" },
@@ -228,7 +221,6 @@ describe("maybeRestartService", () => {
           steps: [],
           durationMs: 0,
         },
-        channel: "stable",
         opts: { json: true },
         refreshServiceEnv: false,
         gatewayPort: 18789,

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -9,7 +9,6 @@ import {
 } from "../../commands/doctor-completion.js";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import type { UpdateChannel } from "../../infra/update-channels.js";
 import {
   recordUpdateRunPhase,
   recordUpdateRunVerification,
@@ -185,7 +184,6 @@ export async function recordFailedUpdateGatewayState(
 export async function maybeRestartService(params: {
   shouldRestart: boolean;
   result: UpdateRunResult;
-  channel: UpdateChannel;
   opts: UpdateCommandOptions;
   refreshServiceEnv: boolean;
   serviceEnv?: NodeJS.ProcessEnv;

--- a/src/commands/doctor-update.ts
+++ b/src/commands/doctor-update.ts
@@ -300,7 +300,6 @@ export async function maybeOfferUpdateBeforeDoctor(params: {
         const activated = await serviceLifecycle.maybeRestartService({
           shouldRestart: true,
           result,
-          channel: "dev",
           opts: {},
           refreshServiceEnv: false,
           serviceUpdateVerdict:


### PR DESCRIPTION
## What Problem This Solves

The internal restart helper still accepted a channel after Git build-identity verification became unconditional. Its callers and tests carried an input with no effect.

This is the mandatory Stage 4 follow-up to #139701 in the #135868 split.

## Why This Change Was Made

Remove the unused `maybeRestartService.channel` input, its type import, and three production arguments. Collapse the three identical tests of build identity for separate channels into one boundary case, and represent integration output modes directly with `json`.

## User Impact

Restart, repair, rollback, ownership checks, and public update-channel selection retain their behavior. No public CLI, config, SDK, storage, or dependency contract changes.

## Evidence

687 focused tests passed across nine files: update CLI, service unit/integration, post-update/repair/recovery, rollback, Doctor and Doctor flow.

The full changed-file gate passed, including core/test types, lint, dead exports, storage guards and runtime cycles. The freshness rebase preserved all eleven changed-file blobs and the lockfile.

Fresh autoreview: no accepted/actionable P0–P2 findings. Build identity verification and every distinct integration scenario remain covered. No new test-support file, baseline, suppression, or timeout change.

| Class | Added | Deleted | Net |
| --- | ---: | ---: | ---: |
| Production | 0 | 5 | −5 |
| Tests/support | 39 | 59 | −20 |
| Tooling | 0 | 0 | 0 |
| Docs | 0 | 0 | 0 |


Exact-head CI on `255c1a9a278ee13bd96d8a9a27e801d6b723af08` is green: [run 34036703138](https://github.com/openclaw/openclaw/actions/runs/34036703138). ClawSweeper found no code or security defect and requested no rank-up move; its compatibility question is confirmed below.

### Migration / upgrade compatibility proof

Maintainer verification: the only Doctor change removes `channel: "dev"` from an internal function call. `maybeRestartService` never reads or serializes that argument. The production diff deletes only that input, its type import/declaration, and the three caller properties. No database schema or version, migration, stored representation, retention rule, or database operation changes; no migration or backfill is needed. Public channel selection remains in the existing update target/config flow and its tests pass. The native schema guard also passed unchanged.
