### PR TITLE
refactor(plugins): stage managed npm installs before publication

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3370,9 +3370,8 @@ src/plugins/host-hook-runtime.ts	1
 src/plugins/host-hook-scheduled-turns.ts	7
 src/plugins/host-hook-state.ts	8
 src/plugins/host-hooks.ts	1
-src/plugins/install-managed-npm-state.ts	5
+src/plugins/install-managed-npm-state.ts	2
 src/plugins/install-npm-metadata.ts	1
-src/plugins/install-npm-pack.ts	2
 src/plugins/install-persistence.ts	1
 src/plugins/install-record-commit.ts	3
 src/plugins/install-security-scan.runtime.ts	1

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -229,7 +229,11 @@ pin becomes the exact replacement version on the same registry.
 
   </Accordion>
   <Accordion title="--force confirmation and reinstall vs update">
-    `--force` confirms a non-ClawHub source without prompting. It does not bypass `security.installPolicy` or remaining install safety checks. When the plugin or hook pack is already installed, it also reuses the existing target and overwrites it in place. Use it after reviewing an arbitrary npm, local, archive, git, or marketplace source, or when intentionally reinstalling the same id. For routine upgrades of an already tracked npm plugin, prefer `openclaw plugins update <id-or-npm-spec>`.
+    `--force` confirms a non-ClawHub source without prompting. It does not bypass `security.installPolicy` or remaining install safety checks. When the plugin or hook pack is already installed, it also permits replacing the existing install. Use it after reviewing an arbitrary npm, local, archive, git, or marketplace source, or when intentionally reinstalling the same id. For routine upgrades of an already tracked npm plugin, prefer `openclaw plugins update <id-or-npm-spec>`.
+
+    Managed npm installs prepare the package and its dependencies in a private staging directory. Integrity and platform-package checks, install policy, and artifact consent finish before the installed directory is replaced. Rejection or cancellation before publication leaves the previous project unchanged. Upgrades retain generation paths that running plugins may still need for later imports.
+
+    For recognized npm project corruption or incomplete install metadata, OpenClaw quarantines the affected `node_modules`, lockfile, and shrinkwrap files outside the staging directory and attempts one rebuild. The reported quarantine path remains available after failure; failed recovery leaves the previous project unchanged.
 
     Reinstalling preserves an authored `plugins.entries.<id>.enabled: false`. `--force` does not approve capabilities: when no valid prior acceptance can be reused, review and accept them before the install commits. Use `openclaw plugins enable <id>` to activate the plugin afterward. See [Capability consent](/plugins/manage-plugins#capability-consent).
 

--- a/src/infra/install-package-dir.ts
+++ b/src/infra/install-package-dir.ts
@@ -231,14 +231,14 @@ export function resolvePackageDirInstallTransaction(
 }
 
 /**
- * Publishes a package directory into an install target via a staged copy.
+ * Publishes a copied package or a privately prepared package directory into its install target.
  * Update mode backs up the existing target, runs optional validation hooks,
  * and rolls back when copy, dependency install, or validation fails.
  */
 export async function installPackageDir<
   TAfterInstallFailure extends InstallPackageDirFailure = InstallPackageDirFailure,
 >(params: {
-  sourceDir: string;
+  sourceDir?: string;
   targetDir: string;
   mode: "install" | "update";
   timeoutMs: number;
@@ -336,13 +336,15 @@ export async function installPackageDir<
       candidatePaths: [canonicalTargetDir],
     });
     stageDir = await fs.mkdtemp(path.join(installBaseRealPath, ".openclaw-install-stage-"));
-    await fs.cp(params.sourceDir, stageDir, {
-      recursive: true,
-      // Keep relative symlinks relative to the staged copy. Node's default
-      // rewrites them toward the source tree, which makes valid vendored
-      // package links look like install-root escapes during post-copy scans.
-      verbatimSymlinks: true,
-    });
+    if (params.sourceDir !== undefined) {
+      await fs.cp(params.sourceDir, stageDir, {
+        recursive: true,
+        // Keep relative symlinks relative to the staged copy. Node's default
+        // rewrites them toward the source tree, which makes valid vendored
+        // package links look like install-root escapes during post-copy scans.
+        verbatimSymlinks: true,
+      });
+    }
   } catch (err) {
     return await fail(`${params.copyErrorPrefix}: ${String(err)}`, err);
   }

--- a/src/infra/npm-managed-root.test.ts
+++ b/src/infra/npm-managed-root.test.ts
@@ -11,11 +11,9 @@ import { captureEnv } from "../test-utils/env.js";
 import {
   listMissingRequiredPlatformPackages,
   repairManagedNpmRootOpenClawPeer,
-  removeManagedNpmRootDependency,
   readManagedNpmRootInstalledDependency,
   readOpenClawManagedNpmRootOverrides,
   resolveManagedNpmRootDependencySpec,
-  restoreManagedNpmRootPeerDependencySnapshot,
   syncManagedNpmRootPeerDependencies,
   upsertManagedNpmRootDependency,
 } from "./npm-managed-root.js";
@@ -532,56 +530,6 @@ describe("managed npm root", () => {
       dependencies: {
         plugin: "1.0.0",
         "runtime-peer": "5.0.0",
-      },
-    });
-  });
-
-  it("realigns restored managed peer pins with manifest overrides", async () => {
-    const npmRoot = await makeTempRoot();
-    await fs.writeFile(
-      path.join(npmRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: {
-            plugin: "1.0.0",
-            "runtime-peer": "4.12.18",
-          },
-          overrides: {
-            "runtime-peer": "4.12.18",
-          },
-          openclaw: {
-            managedOverrides: ["runtime-peer"],
-            managedPeerDependencies: ["runtime-peer"],
-          },
-        },
-        null,
-        2,
-      )}\n`,
-    );
-
-    await restoreManagedNpmRootPeerDependencySnapshot({
-      npmRoot,
-      snapshot: {
-        dependencies: { "runtime-peer": "4.12.23" },
-        managedPeerDependencies: ["runtime-peer"],
-      },
-    });
-
-    await expect(
-      fs.readFile(path.join(npmRoot, "package.json"), "utf8").then((raw) => JSON.parse(raw)),
-    ).resolves.toEqual({
-      private: true,
-      dependencies: {
-        plugin: "1.0.0",
-        "runtime-peer": "4.12.18",
-      },
-      overrides: {
-        "runtime-peer": "4.12.18",
-      },
-      openclaw: {
-        managedOverrides: ["runtime-peer"],
-        managedPeerDependencies: ["runtime-peer"],
       },
     });
   });
@@ -1297,44 +1245,6 @@ describe("managed npm root", () => {
       private: true,
       dependencies: {
         plugin: "file:./plugin.tgz",
-      },
-    });
-  });
-
-  it("removes one managed dependency without dropping unrelated metadata", async () => {
-    const npmRoot = await makeTempRoot();
-    await fs.writeFile(
-      path.join(npmRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: {
-            "@openclaw/discord": "2026.5.2",
-            "@openclaw/voice-call": "2026.5.2",
-          },
-          devDependencies: {
-            fixture: "1.0.0",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-    );
-
-    await removeManagedNpmRootDependency({
-      npmRoot,
-      packageName: "@openclaw/voice-call",
-    });
-
-    await expect(
-      fs.readFile(path.join(npmRoot, "package.json"), "utf8").then((raw) => JSON.parse(raw)),
-    ).resolves.toEqual({
-      private: true,
-      dependencies: {
-        "@openclaw/discord": "2026.5.2",
-      },
-      devDependencies: {
-        fixture: "1.0.0",
       },
     });
   });

--- a/src/infra/npm-managed-root.ts
+++ b/src/infra/npm-managed-root.ts
@@ -37,12 +37,6 @@ type ManagedNpmRootOpenClawMetadata = {
   [key: string]: unknown;
 };
 
-/** Snapshot of root dependencies that were inserted only for peer satisfaction. */
-export type ManagedNpmRootPeerDependencySnapshot = {
-  dependencies: Record<string, string>;
-  managedPeerDependencies: string[];
-};
-
 /** Installed dependency metadata read from a managed root lockfile. */
 export type ManagedNpmRootInstalledDependency = {
   version?: string;
@@ -890,74 +884,6 @@ async function collectNpmResolvedManagedNpmRootPeerDependencyPins(params: {
   }
 }
 
-/** Snapshot managed peer dependencies before a risky install/update operation. */
-export async function readManagedNpmRootPeerDependencySnapshot(params: {
-  npmRoot: string;
-}): Promise<ManagedNpmRootPeerDependencySnapshot> {
-  const manifest = await readManagedNpmRootManifest(path.join(params.npmRoot, "package.json"));
-  const dependencies = readDependencyRecord(manifest.dependencies);
-  const managedPeerDependencies = readManagedPeerDependencyKeys(manifest.openclaw).toSorted();
-  const dependencySnapshot: Record<string, string> = {};
-  for (const packageName of managedPeerDependencies) {
-    const dependencySpec = dependencies[packageName];
-    if (dependencySpec) {
-      dependencySnapshot[packageName] = dependencySpec;
-    }
-  }
-  return {
-    dependencies: dependencySnapshot,
-    managedPeerDependencies,
-  };
-}
-
-/** Restore a previously captured managed peer dependency snapshot. */
-export async function restoreManagedNpmRootPeerDependencySnapshot(params: {
-  npmRoot: string;
-  snapshot: ManagedNpmRootPeerDependencySnapshot;
-}): Promise<void> {
-  const manifestPath = path.join(params.npmRoot, "package.json");
-  const manifest = await readManagedNpmRootManifest(manifestPath);
-  const dependencies = readDependencyRecord(manifest.dependencies);
-  for (const packageName of readManagedPeerDependencyKeys(manifest.openclaw)) {
-    delete dependencies[packageName];
-  }
-  Object.assign(dependencies, params.snapshot.dependencies);
-  const overrides = readOverrideRecord(manifest.overrides);
-  const currentManagedOverrideKeys = readManagedOverrideKeys(manifest.openclaw);
-  // Restored pins predate the overrides currently in the manifest; realign them so a
-  // rollback never persists a root npm rejects with EOVERRIDE.
-  reconcileManagedNpmRootOverrideConflicts({
-    dependencies,
-    overrides,
-    managedDependencyNames: new Set(params.snapshot.managedPeerDependencies),
-    managedOverrideNames: new Set(currentManagedOverrideKeys),
-  });
-  const managedOverrideKeys = currentManagedOverrideKeys
-    .filter((key) => Object.hasOwn(overrides, key))
-    .toSorted();
-  const openclawMetadata = buildManagedOpenClawMetadata({
-    current: manifest.openclaw,
-    managedOverrideKeys,
-    managedPeerDependencyKeys: params.snapshot.managedPeerDependencies.toSorted(),
-  });
-  const next: ManagedNpmRootManifest = {
-    ...manifest,
-    private: true,
-    dependencies,
-  };
-  if (Object.keys(overrides).length > 0) {
-    next.overrides = overrides;
-  } else {
-    delete next.overrides;
-  }
-  if (openclawMetadata) {
-    next.openclaw = openclawMetadata;
-  } else {
-    delete next.openclaw;
-  }
-  await writeJson(manifestPath, next, { trailingNewline: true });
-}
-
 /** Sync package.json with peer dependency pins resolved from npm's lock plan. */
 export async function syncManagedNpmRootPeerDependencies(params: {
   npmRoot: string;
@@ -1310,23 +1236,4 @@ export async function readManagedNpmRootInstalledDependency(params: {
   };
 }
 
-/** Remove a dependency from the managed root manifest. */
-export async function removeManagedNpmRootDependency(params: {
-  npmRoot: string;
-  packageName: string;
-}): Promise<void> {
-  const manifestPath = path.join(params.npmRoot, "package.json");
-  const manifest = await readManagedNpmRootManifest(manifestPath);
-  const dependencies = readDependencyRecord(manifest.dependencies);
-  if (!(params.packageName in dependencies)) {
-    return;
-  }
-  const { [params.packageName]: _removed, ...nextDependencies } = dependencies;
-  const next: ManagedNpmRootManifest = {
-    ...manifest,
-    private: true,
-    dependencies: nextDependencies,
-  };
-  await writeJson(manifestPath, next, { trailingNewline: true });
-}
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/plugins/install-managed-npm-state.ts
+++ b/src/plugins/install-managed-npm-state.ts
@@ -1,33 +1,20 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants, type Dirent } from "node:fs";
+import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import type { NpmSpecResolution } from "../infra/install-source-utils.js";
-import {
-  type ManagedNpmRootPeerDependencySnapshot,
-  readManagedNpmRootPeerDependencySnapshot,
-  removeManagedNpmRootDependency,
-  repairManagedNpmRootOpenClawPeer,
-  restoreManagedNpmRootPeerDependencySnapshot,
-} from "../infra/npm-managed-root.js";
 import { parseRegistryNpmSpec, validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { isNotFoundPathError } from "../infra/path-guards.js";
-import { createSafeNpmInstallEnv } from "../infra/safe-package-install.js";
-import { runCommandWithTimeout } from "../process/exec.js";
 import {
   resolvePluginNpmGenerationProjectDir,
   resolvePluginNpmGenerationProjectDirPrefix,
   resolvePluginNpmProjectDir,
 } from "./install-paths.js";
 import { loadPluginInstallRuntime, resolveEffectiveInstallMode } from "./install-shared.js";
-import type { PluginInstallLogger } from "./install-types.js";
 import { hasRetainedManagedNpmInstallMarker } from "./managed-npm-retention.js";
 import type { OpenClawPackageManifest } from "./manifest.js";
 import { listNpmPackageDirs } from "./npm-package-dirs.js";
-import { relinkOpenClawPeerDependenciesInManagedNpmRoot } from "./plugin-peer-link.js";
 
-const rollbackSnapshotCopyMode = fsConstants.COPYFILE_FICLONE;
 const MANAGED_NPM_PROJECT_QUARANTINE_DIR = "_openclaw-quarantined-npm-projects";
 const MANAGED_NPM_PROJECT_REBUILD_ARTIFACTS = [
   "node_modules",
@@ -36,6 +23,32 @@ const MANAGED_NPM_PROJECT_REBUILD_ARTIFACTS = [
   "npm-shrinkwrap.json",
 ] as const;
 
+/** Preserve npm project policy and relative archive inputs without copying its installed tree. */
+export async function copyManagedNpmProjectInputs(params: {
+  npmRoot: string;
+  stageDir: string;
+}): Promise<void> {
+  for (const name of [
+    "package.json",
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    ".npmrc",
+    "_openclaw-pack-archives",
+  ]) {
+    try {
+      // Copy bytes, not links that could let npm mutate the original manifest through its stage.
+      await fs.cp(path.join(params.npmRoot, name), path.join(params.stageDir, name), {
+        recursive: true,
+        dereference: true,
+      });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+}
+
 export function isNpmAliasOverrideCompatibilityError(result: {
   stdout: string;
   stderr: string;
@@ -43,187 +56,13 @@ export function isNpmAliasOverrideCompatibilityError(result: {
   return `${result.stderr}\n${result.stdout}`.includes("Invalid comparator: npm:");
 }
 
-export async function rollbackManagedNpmPluginInstall(params: {
-  npmRoot: string;
-  packageName: string;
-  targetDir: string;
-  timeoutMs: number;
-  logger: PluginInstallLogger;
-  peerDependencySnapshot?: ManagedNpmRootPeerDependencySnapshot;
-  snapshot?: ManagedNpmPluginInstallRollbackSnapshot;
-}): Promise<void> {
-  if (params.snapshot) {
-    try {
-      await restoreManagedNpmPluginInstallRollbackSnapshot({
-        npmRoot: params.npmRoot,
-        snapshot: params.snapshot,
-      });
-      await relinkOpenClawPeerDependenciesInManagedNpmRoot({
-        npmRoot: params.npmRoot,
-        logger: params.logger,
-      });
-    } catch (error) {
-      params.logger.warn?.(
-        `Failed to restore managed npm plugin root after installing ${params.packageName}: ${String(error)}`,
-      );
-    }
-    return;
-  }
-
-  try {
-    await runCommandWithTimeout(
-      [
-        "npm",
-        "uninstall",
-        "--loglevel=error",
-        "--legacy-peer-deps",
-        "--ignore-scripts",
-        "--no-audit",
-        "--no-fund",
-        params.packageName,
-      ],
-      {
-        cwd: params.npmRoot,
-        timeoutMs: Math.max(params.timeoutMs, 300_000),
-        env: createSafeNpmInstallEnv(process.env, {
-          legacyPeerDeps: true,
-          npmConfigCwd: params.npmRoot,
-          packageLock: true,
-          quiet: true,
-        }),
-      },
-    );
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to run npm uninstall rollback for ${params.packageName}: ${String(error)}`,
-    );
-  }
-  try {
-    await fs.rm(params.targetDir, { recursive: true, force: true });
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to remove failed plugin install directory ${params.targetDir}: ${String(error)}`,
-    );
-  }
-  try {
-    await removeManagedNpmRootDependency({
-      npmRoot: params.npmRoot,
-      packageName: params.packageName,
-    });
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to remove managed npm dependency ${params.packageName}: ${String(error)}`,
-    );
-  }
-  if (params.peerDependencySnapshot) {
-    try {
-      const preRestorePeerDependencySnapshot = await readManagedNpmRootPeerDependencySnapshot({
-        npmRoot: params.npmRoot,
-      });
-      const restoredPeerDependencyNames = new Set(
-        params.peerDependencySnapshot.managedPeerDependencies,
-      );
-      const addedPeerDependencyNames =
-        preRestorePeerDependencySnapshot.managedPeerDependencies.filter(
-          (packageName) => !restoredPeerDependencyNames.has(packageName),
-        );
-      await restoreManagedNpmRootPeerDependencySnapshot({
-        npmRoot: params.npmRoot,
-        snapshot: params.peerDependencySnapshot,
-      });
-      const cleanupResult = await runCommandWithTimeout(
-        [
-          "npm",
-          "install",
-          "--omit=dev",
-          "--omit=peer",
-          "--loglevel=error",
-          "--legacy-peer-deps",
-          "--ignore-scripts",
-          "--no-audit",
-          "--no-fund",
-        ],
-        {
-          cwd: params.npmRoot,
-          timeoutMs: Math.max(params.timeoutMs, 300_000),
-          env: createSafeNpmInstallEnv(process.env, {
-            legacyPeerDeps: true,
-            npmConfigCwd: params.npmRoot,
-            packageLock: true,
-            quiet: true,
-          }),
-        },
-      );
-      if (cleanupResult.code !== 0) {
-        params.logger.warn?.(
-          `npm install cleanup after rollback for ${params.packageName} exited ${cleanupResult.code}: ${cleanupResult.stderr.trim() || cleanupResult.stdout.trim()}`,
-        );
-        await Promise.all(
-          addedPeerDependencyNames.map(async (packageName) => {
-            try {
-              await fs.rm(resolveManagedNpmRootPackageDir(params.npmRoot, packageName), {
-                recursive: true,
-                force: true,
-              });
-            } catch (error) {
-              params.logger.warn?.(
-                `Failed to remove rolled-back managed peer dependency ${packageName}: ${String(error)}`,
-              );
-            }
-          }),
-        );
-      }
-    } catch (error) {
-      params.logger.warn?.(
-        `Failed to restore managed npm peer dependencies after rollback for ${params.packageName}: ${String(error)}`,
-      );
-    }
-  }
-  if (params.packageName !== "openclaw") {
-    try {
-      await repairManagedNpmRootOpenClawPeer({
-        npmRoot: params.npmRoot,
-        timeoutMs: params.timeoutMs,
-        logger: params.logger,
-      });
-    } catch (error) {
-      params.logger.warn?.(
-        `Failed to repair managed npm openclaw peer after rollback: ${String(error)}`,
-      );
-    }
-  }
-  try {
-    await relinkOpenClawPeerDependenciesInManagedNpmRoot({
-      npmRoot: params.npmRoot,
-      logger: params.logger,
-    });
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to repair managed npm peer links after rollback for ${params.packageName}: ${String(error)}`,
-    );
-  }
-}
-
-export type ManagedNpmPluginInstallRollbackSnapshot = {
-  packageJson?: string;
-  packageLockJson?: string;
-  nodeModulesBackupDir?: string;
-  tempDir: string;
-};
-
-export type ManagedNpmRootPreparedDependency = {
-  dependencySpec: string;
-  rollback?: () => Promise<void>;
-  cleanup?: () => Promise<void>;
-};
-
 export type ManagedNpmProjectQuarantine = {
   quarantineDir: string;
   movedArtifactNames: string[];
 };
 
 type ManagedNpmRootPrepareDependencyResult =
-  | ({ ok: true } & ManagedNpmRootPreparedDependency)
+  | { ok: true; dependencySpec: string }
   | {
       ok: false;
       error: string;
@@ -258,184 +97,6 @@ export async function resolveManagedNpmRootDependencySpecForInstall(params: {
   return { ok: true, dependencySpec: params.dependencySpec };
 }
 
-export async function rollbackManagedNpmRootPreparedDependency(params: {
-  packageName: string;
-  preparedDependency: ManagedNpmRootPreparedDependency;
-  logger: PluginInstallLogger;
-}) {
-  if (!params.preparedDependency.rollback) {
-    return;
-  }
-  try {
-    await params.preparedDependency.rollback();
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to roll back prepared managed npm dependency artifacts for ${params.packageName}: ${String(error)}`,
-    );
-  }
-}
-
-export async function cleanupManagedNpmRootPreparedDependency(params: {
-  packageName: string;
-  preparedDependency: ManagedNpmRootPreparedDependency | undefined;
-  logger: PluginInstallLogger;
-}) {
-  if (!params.preparedDependency?.cleanup) {
-    return;
-  }
-  try {
-    await params.preparedDependency.cleanup();
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to clean up prepared managed npm dependency artifacts for ${params.packageName}: ${String(error)}`,
-    );
-  }
-}
-
-export async function removeEmptyDirectoryIfPresent(dir: string) {
-  try {
-    await fs.rmdir(dir);
-  } catch (error) {
-    if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes((error as NodeJS.ErrnoException).code ?? "")) {
-      throw error;
-    }
-  }
-}
-
-async function readRollbackFileIfPresent(filePath: string): Promise<string | undefined> {
-  try {
-    return await fs.readFile(filePath, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return undefined;
-    }
-    throw error;
-  }
-}
-
-async function writeOrRemoveRollbackFile(filePath: string, contents: string | undefined) {
-  if (contents === undefined) {
-    await fs.rm(filePath, { force: true });
-    return;
-  }
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, contents, "utf8");
-}
-
-export async function createManagedNpmPluginInstallRollbackSnapshot(params: {
-  npmRoot: string;
-}): Promise<ManagedNpmPluginInstallRollbackSnapshot> {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npm-plugin-rollback-"));
-  let nodeModulesBackupDir: string | undefined;
-  const nodeModulesDir = path.join(params.npmRoot, "node_modules");
-  try {
-    await fs.stat(nodeModulesDir);
-    nodeModulesBackupDir = path.join(tempDir, "node_modules");
-    await fs.cp(nodeModulesDir, nodeModulesBackupDir, {
-      recursive: true,
-      force: true,
-      filter: (sourcePath) =>
-        shouldCopyManagedNpmRollbackSnapshotEntry({
-          nodeModulesDir,
-          sourcePath,
-        }),
-      mode: rollbackSnapshotCopyMode,
-      verbatimSymlinks: true,
-    });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      await fs.rm(tempDir, { recursive: true, force: true });
-      throw error;
-    }
-  }
-
-  try {
-    return {
-      packageJson: await readRollbackFileIfPresent(path.join(params.npmRoot, "package.json")),
-      packageLockJson: await readRollbackFileIfPresent(
-        path.join(params.npmRoot, "package-lock.json"),
-      ),
-      ...(nodeModulesBackupDir ? { nodeModulesBackupDir } : {}),
-      tempDir,
-    };
-  } catch (error) {
-    await fs.rm(tempDir, { recursive: true, force: true });
-    throw error;
-  }
-}
-
-async function shouldCopyManagedNpmRollbackSnapshotEntry(params: {
-  nodeModulesDir: string;
-  sourcePath: string | URL;
-}): Promise<boolean> {
-  if (typeof params.sourcePath !== "string") {
-    return true;
-  }
-
-  const relativeParts = path.relative(params.nodeModulesDir, params.sourcePath).split(path.sep);
-  const isPluginLocalOpenClawPeer =
-    (relativeParts.length === 3 &&
-      relativeParts[1] === "node_modules" &&
-      relativeParts[2] === "openclaw") ||
-    (relativeParts.length === 4 &&
-      relativeParts[0]?.startsWith("@") &&
-      relativeParts[2] === "node_modules" &&
-      relativeParts[3] === "openclaw");
-  if (!isPluginLocalOpenClawPeer) {
-    return true;
-  }
-
-  try {
-    return !(await fs.lstat(params.sourcePath)).isSymbolicLink();
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw error;
-  }
-}
-
-async function restoreManagedNpmPluginInstallRollbackSnapshot(params: {
-  npmRoot: string;
-  snapshot: ManagedNpmPluginInstallRollbackSnapshot;
-}) {
-  const nodeModulesDir = path.join(params.npmRoot, "node_modules");
-  await fs.rm(nodeModulesDir, { recursive: true, force: true });
-  if (params.snapshot.nodeModulesBackupDir) {
-    await fs.mkdir(params.npmRoot, { recursive: true });
-    await fs.cp(params.snapshot.nodeModulesBackupDir, nodeModulesDir, {
-      recursive: true,
-      force: true,
-      mode: rollbackSnapshotCopyMode,
-      verbatimSymlinks: true,
-    });
-  }
-  await writeOrRemoveRollbackFile(
-    path.join(params.npmRoot, "package.json"),
-    params.snapshot.packageJson,
-  );
-  await writeOrRemoveRollbackFile(
-    path.join(params.npmRoot, "package-lock.json"),
-    params.snapshot.packageLockJson,
-  );
-}
-
-export async function cleanupManagedNpmPluginInstallRollbackSnapshot(params: {
-  snapshot: ManagedNpmPluginInstallRollbackSnapshot | undefined;
-  logger: PluginInstallLogger;
-}) {
-  if (!params.snapshot) {
-    return;
-  }
-  try {
-    await fs.rm(params.snapshot.tempDir, { recursive: true, force: true });
-  } catch (error) {
-    params.logger.warn?.(
-      `Failed to remove temporary managed npm rollback snapshot ${params.snapshot.tempDir}: ${String(error)}`,
-    );
-  }
-}
-
 export function isManagedNpmProjectCorruptionInstallFailure(result: {
   stdout: string;
   stderr: string;
@@ -456,7 +117,11 @@ export async function quarantineManagedNpmProjectRebuildArtifacts(params: {
   npmRoot: string;
 }): Promise<ManagedNpmProjectQuarantine> {
   await fs.mkdir(params.npmRoot, { recursive: true });
-  const quarantineParent = path.join(params.npmRoot, MANAGED_NPM_PROJECT_QUARANTINE_DIR);
+  // Keep diagnosed input beside private stages so failed-stage cleanup cannot discard it.
+  const quarantineParent = path.join(
+    path.dirname(params.npmRoot),
+    MANAGED_NPM_PROJECT_QUARANTINE_DIR,
+  );
   await fs.mkdir(quarantineParent, { recursive: true });
   const quarantineDir = await fs.mkdtemp(path.join(quarantineParent, "corrupt-"));
   const movedArtifactNames: string[] = [];
@@ -489,7 +154,7 @@ export async function listManagedNpmRootPackageNames(npmRoot: string): Promise<S
   );
 }
 
-function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): string {
+export function resolveManagedNpmRootPackageDir(npmRoot: string, packageName: string): string {
   return path.join(npmRoot, "node_modules", ...packageName.split("/"));
 }
 
@@ -697,15 +362,4 @@ export function resolveRequiredPlatformPackageNames(
     packageNames.add(parsed.name);
   }
   return { ok: true, packageNames: [...packageNames] };
-}
-
-export async function listNewManagedNpmRootPackageDirs(params: {
-  beforeInstallPackageNames: Set<string>;
-  npmRoot: string;
-}): Promise<string[]> {
-  const afterInstallPackageNames = await listManagedNpmRootPackageNames(params.npmRoot);
-  return [...afterInstallPackageNames]
-    .filter((packageName) => !params.beforeInstallPackageNames.has(packageName))
-    .map((packageName) => resolveManagedNpmRootPackageDir(params.npmRoot, packageName))
-    .toSorted((left, right) => left.localeCompare(right));
 }

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -2,6 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  installPackageDir,
+  requestDeferredPackageDirInstall,
+  resolvePackageDirInstallTransaction,
+} from "../infra/install-package-dir.js";
+import {
   buildNpmResolutionFields,
   formatNpmCommandFailureOutput,
   type NpmIntegrityDrift,
@@ -10,7 +15,6 @@ import {
 import {
   listMissingRequiredPlatformPackages,
   readManagedNpmRootInstalledDependency,
-  readManagedNpmRootPeerDependencySnapshot,
   readOpenClawManagedNpmRootOverrides,
   repairManagedNpmRootOpenClawPeer,
   syncManagedNpmRootPeerDependencies,
@@ -25,25 +29,18 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { installPluginFromInstalledPackageDir } from "./install-installed-package.js";
 import {
-  cleanupManagedNpmPluginInstallRollbackSnapshot,
-  cleanupManagedNpmRootPreparedDependency,
-  createManagedNpmPluginInstallRollbackSnapshot,
+  copyManagedNpmProjectInputs,
   formatManagedNpmProjectQuarantineArtifacts,
   isManagedNpmProjectCorruptionInstallFailure,
   isNpmAliasOverrideCompatibilityError,
   listManagedNpmRootPackageNames,
-  listNewManagedNpmRootPackageDirs,
   quarantineManagedNpmProjectRebuildArtifacts,
-  removeEmptyDirectoryIfPresent,
   resolveManagedNpmInstallPlan,
   resolveManagedNpmRootDependencySpecForInstall,
+  resolveManagedNpmRootPackageDir,
   resolveRequiredPlatformPackageNames,
-  rollbackManagedNpmPluginInstall,
-  rollbackManagedNpmRootPreparedDependency,
-  type ManagedNpmPluginInstallRollbackSnapshot,
   type ManagedNpmProjectQuarantine,
   type ManagedNpmRootDependencySpecPreparation,
-  type ManagedNpmRootPreparedDependency,
 } from "./install-managed-npm-state.js";
 import { verifyInstalledNpmResolution } from "./install-npm-resolution.js";
 import { resolveDefaultPluginNpmDir } from "./install-paths.js";
@@ -98,6 +95,7 @@ export async function installPluginFromManagedNpmRoot(
     expectedReplacementPluginId?: string;
     integrityDrift?: NpmIntegrityDrift;
     onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
+    beforePersistentApply?: () => void;
   },
 ): Promise<InstallPluginResult> {
   const runtime = await loadPluginInstallRuntime();
@@ -107,7 +105,12 @@ export async function installPluginFromManagedNpmRoot(
   );
   const expectedPluginId = params.expectedPluginId;
   const npmBaseDir = params.npmDir ? resolveUserPath(params.npmDir) : resolveDefaultPluginNpmDir();
-  const { npmRoot, installRoot, targetMode, policyMode } = await resolveManagedNpmInstallPlan({
+  const {
+    npmRoot: targetNpmRoot,
+    installRoot: targetPackageDir,
+    targetMode,
+    policyMode,
+  } = await resolveManagedNpmInstallPlan({
     runtime,
     npmBaseDir,
     packageName: params.packageName,
@@ -116,7 +119,7 @@ export async function installPluginFromManagedNpmRoot(
   });
   const availability = await ensureInstallTargetAvailableForMode({
     runtime,
-    targetPath: installRoot,
+    targetPath: targetPackageDir,
     mode: targetMode,
   });
   if (!availability.ok) {
@@ -140,7 +143,7 @@ export async function installPluginFromManagedNpmRoot(
           ...(expectedPluginId ? { pluginId: expectedPluginId } : {}),
           requestedSpecifier: params.installPolicyRequest.requestedSpecifier ?? params.displaySpec,
           source: params.installPolicyRequest.source,
-          sourcePath: params.policyPreflightSourcePath ?? npmRoot,
+          sourcePath: params.policyPreflightSourcePath ?? targetNpmRoot,
           sourcePathKind: params.policyPreflightSourcePathKind ?? "directory",
         }),
     });
@@ -153,7 +156,7 @@ export async function installPluginFromManagedNpmRoot(
     return {
       ok: true,
       pluginId: expectedPluginId ?? params.packageName,
-      targetDir: installRoot,
+      targetDir: targetPackageDir,
       extensions: [],
       npmResolution: params.npmResolution,
       ...(params.integrityDrift ? { integrityDrift: params.integrityDrift } : {}),
@@ -161,31 +164,23 @@ export async function installPluginFromManagedNpmRoot(
   }
   params.signal?.throwIfAborted();
 
-  let rollbackSnapshot: ManagedNpmPluginInstallRollbackSnapshot;
-  let preparedDependency: ManagedNpmRootPreparedDependency | undefined;
-  let rollbackPeerDependencySnapshot:
-    | Awaited<ReturnType<typeof readManagedNpmRootPeerDependencySnapshot>>
-    | undefined;
   let recovery:
     | {
         cause: { kind: "npm-corruption" | "incomplete-metadata"; error: string };
         quarantine: ManagedNpmProjectQuarantine;
       }
     | undefined;
-  let deferredTransaction = false;
-  let installSucceeded = false;
-  try {
-    rollbackSnapshot = await createManagedNpmPluginInstallRollbackSnapshot({ npmRoot });
-  } catch (error) {
-    return {
-      ok: false,
-      error: `Failed to snapshot managed npm root before installing ${params.packageName}: ${String(error)}`,
-    };
-  }
-
-  const runManagedNpmInstall = async (
-    prepared: ManagedNpmRootPreparedDependency,
-  ): Promise<InstallPluginResult> => {
+  const runManagedNpmInstall = async (npmRoot: string): Promise<InstallPluginResult> => {
+    const installRoot = resolveManagedNpmRootPackageDir(npmRoot, params.packageName);
+    const prepared = await resolveManagedNpmRootDependencySpecForInstall({
+      npmRoot,
+      packageName: params.packageName,
+      dependencySpec: params.dependencySpec,
+      prepareDependencySpec: params.prepareDependencySpec,
+    });
+    if (!prepared.ok) {
+      return prepared;
+    }
     logger.info?.(`Installing ${params.displaySpec} into ${npmRoot}…`);
     if (params.packageName !== "openclaw") {
       const repairedOpenClawPeer = await repairManagedNpmRootOpenClawPeer({
@@ -199,7 +194,6 @@ export async function installPluginFromManagedNpmRoot(
       }
     }
     const managedOverrides = await readOpenClawManagedNpmRootOverrides();
-    rollbackPeerDependencySnapshot ??= await readManagedNpmRootPeerDependencySnapshot({ npmRoot });
     const quarantineForRecovery = async (
       cause: NonNullable<typeof recovery>["cause"],
     ): Promise<Extract<InstallPluginResult, { ok: false }> | null> => {
@@ -239,7 +233,6 @@ export async function installPluginFromManagedNpmRoot(
         };
       }
     };
-    const preInstallRootPackageNames = await listManagedNpmRootPackageNames(npmRoot);
     await upsertManagedNpmRootDependency({
       npmRoot,
       packageName: params.packageName,
@@ -305,7 +298,7 @@ export async function installPluginFromManagedNpmRoot(
       if (recoveryFailure) {
         return recoveryFailure;
       }
-      return await runManagedNpmInstall(prepared);
+      return await runManagedNpmInstall(npmRoot);
     }
     if (install.code !== 0) {
       const error = recovery
@@ -502,7 +495,7 @@ export async function installPluginFromManagedNpmRoot(
         if (recoveryFailure) {
           return recoveryFailure;
         }
-        return await runManagedNpmInstall(prepared);
+        return await runManagedNpmInstall(npmRoot);
       }
       return {
         ok: false,
@@ -510,10 +503,9 @@ export async function installPluginFromManagedNpmRoot(
       };
     }
 
-    const newRootPackageDirs = await listNewManagedNpmRootPackageDirs({
-      beforeInstallPackageNames: preInstallRootPackageNames,
-      npmRoot,
-    });
+    const newRootPackageDirs = [...(await listManagedNpmRootPackageNames(npmRoot))]
+      .map((packageName) => resolveManagedNpmRootPackageDir(npmRoot, packageName))
+      .toSorted((left, right) => left.localeCompare(right));
     let installedExpectedPluginId = expectedPluginId;
     if (
       mode === "update" &&
@@ -556,7 +548,7 @@ export async function installPluginFromManagedNpmRoot(
     }
     await params.onBeforePluginArtifactCommit?.({
       pluginId: result.pluginId,
-      ...(policyMode === "update" ? { currentArtifactDir: installRoot } : {}),
+      ...(targetMode === "update" ? { currentArtifactDir: targetPackageDir } : {}),
       stagedArtifactDir: installRoot,
       mode: policyMode,
       ...(params.installPolicyRequest.source?.kind === "npm"
@@ -576,83 +568,52 @@ export async function installPluginFromManagedNpmRoot(
     };
   };
 
-  const rollback = async () => {
-    await rollbackManagedNpmPluginInstall({
-      npmRoot,
-      packageName: params.packageName,
-      targetDir: installRoot,
-      timeoutMs,
-      logger,
-      peerDependencySnapshot: rollbackPeerDependencySnapshot,
-      // Restoring a quarantined tree would recreate the corruption being repaired.
-      snapshot: recovery ? undefined : rollbackSnapshot,
-    });
-    if (preparedDependency) {
-      await rollbackManagedNpmRootPreparedDependency({
-        packageName: params.packageName,
-        preparedDependency,
-        logger,
-      });
-    }
-  };
-  const cleanup = async () => {
-    await cleanupManagedNpmRootPreparedDependency({
-      packageName: params.packageName,
-      preparedDependency,
-      logger,
-    });
-    await cleanupManagedNpmPluginInstallRollbackSnapshot({ snapshot: rollbackSnapshot, logger });
-    // Prepared npm-pack archives must be gone before retiring an empty failed project.
-    await removeEmptyDirectoryIfPresent(npmRoot).catch((error: unknown) =>
-      logger.warn?.(`Failed to remove empty managed npm project ${npmRoot}: ${String(error)}`),
-    );
-  };
-
-  try {
-    const dependencyResult = await resolveManagedNpmRootDependencySpecForInstall({
-      npmRoot,
-      packageName: params.packageName,
-      dependencySpec: params.dependencySpec,
-      prepareDependencySpec: params.prepareDependencySpec,
-    });
-    if (!dependencyResult.ok) {
-      return dependencyResult;
-    }
-    preparedDependency = dependencyResult;
-    const result = await runManagedNpmInstall(preparedDependency);
-    installSucceeded = result.ok;
-    if (!result.ok || !resolvePluginInstallTransactionRequest(params)) {
-      return result;
-    }
-    deferredTransaction = true;
-    let settled = false;
-    return attachPluginInstallTransaction(
-      { ...result },
+  const staged: { result?: InstallPluginResult; failure?: { cause: unknown } } = {};
+  const transactionRequest = resolvePluginInstallTransactionRequest(params);
+  const published = await installPackageDir(
+    requestDeferredPackageDirInstall(
       {
-        async commit() {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          await cleanup();
+        targetDir: targetNpmRoot,
+        mode: "update",
+        timeoutMs,
+        logger,
+        copyErrorPrefix: "Failed to publish managed npm project",
+        beforePersistentApply: () => {
+          params.signal?.throwIfAborted();
+          params.beforePersistentApply?.();
         },
-        async rollback() {
-          if (settled) {
-            return;
+        hasDeps: false,
+        sourceHardlinks: "package-manager",
+        depsLogMessage: "",
+        afterCopy: (stageDir) => copyManagedNpmProjectInputs({ npmRoot: targetNpmRoot, stageDir }),
+        afterInstall: async (stageDir) => {
+          try {
+            staged.result = await runManagedNpmInstall(stageDir);
+            return staged.result;
+          } catch (error) {
+            // The directory owner cleans its stage before the original consent/policy error escapes.
+            staged.failure = { cause: error };
+            return { ok: false, error: String(error) };
           }
-          settled = true;
-          await rollback();
-          await cleanup();
         },
       },
-    );
-  } finally {
-    if (!deferredTransaction) {
-      // Returned failures and throws must restore the snapshot before cleanup discards it.
-      if (!installSucceeded && preparedDependency) {
-        await rollback();
-      }
-      await cleanup();
-    }
+      transactionRequest?.assertOwned,
+    ),
+  );
+  if (staged.failure) {
+    throw staged.failure.cause;
   }
+  if (!published.ok) {
+    return published;
+  }
+  if (!staged.result?.ok) {
+    throw new Error("Managed npm project published without a validated plugin");
+  }
+  const transaction = resolvePackageDirInstallTransaction(published)!;
+  const result = { ...staged.result, targetDir: targetPackageDir };
+  if (transactionRequest) {
+    return attachPluginInstallTransaction(result, transaction);
+  }
+  await transaction.commit();
+  return result;
 }

--- a/src/plugins/install-npm-pack.ts
+++ b/src/plugins/install-npm-pack.ts
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { sha256HexPrefixCore } from "../infra/crypto-digest.js";
 import {
@@ -9,11 +8,7 @@ import {
 import { resolveNpmIntegrityDriftWithDefaultMessage } from "../infra/npm-integrity.js";
 import { parseRegistryNpmSpec, validateRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { resolveUserPath } from "../utils.js";
-import {
-  removeEmptyDirectoryIfPresent,
-  resolveManagedNpmInstallPlan,
-  type ManagedNpmRootPreparedDependency,
-} from "./install-managed-npm-state.js";
+import { resolveManagedNpmInstallPlan } from "./install-managed-npm-state.js";
 import { installPluginFromManagedNpmRoot } from "./install-managed-npm.js";
 import { resolveDefaultPluginNpmDir, safePluginInstallFileName } from "./install-paths.js";
 import type { InstallSafetyOverrides } from "./install-security-scan.js";
@@ -71,85 +66,17 @@ async function stageNpmPackArchiveInManagedRoot(params: {
   integrity?: string;
   shasum?: string;
   tarballName: string;
-}): Promise<
-  {
-    stableArchivePath: string;
-  } & ManagedNpmRootPreparedDependency
-> {
+}): Promise<{ dependencySpec: string }> {
   const archiveStoreDir = path.join(params.npmRoot, MANAGED_NPM_PACK_ARCHIVE_DIR);
   const identity = params.integrity ?? params.shasum ?? params.tarballName;
   const identitySlug = sha256HexPrefixCore(identity, 16);
   const packageSlug = safePluginInstallFileName(params.packageName) || "plugin";
   const versionSlug = safePluginInstallFileName(params.version ?? "pack") || "pack";
   const archiveFileName = `${packageSlug}-${versionSlug}-${identitySlug}.tgz`;
-  const stableArchivePath = path.join(archiveStoreDir, archiveFileName);
-  const tempArchivePath = path.join(
-    archiveStoreDir,
-    `.${archiveFileName}.${process.pid}.${Date.now()}.tmp`,
-  );
-  let archiveStoreExisted = true;
-  let backupTempDir: string | undefined;
-  let previousArchiveBackupPath: string | undefined;
-  const cleanupBackup = async () => {
-    if (!backupTempDir) {
-      return;
-    }
-    const tempDir = backupTempDir;
-    backupTempDir = undefined;
-    previousArchiveBackupPath = undefined;
-    await fs.rm(tempDir, { recursive: true, force: true });
-  };
-
-  try {
-    await fs.access(archiveStoreDir);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-    archiveStoreExisted = false;
-  }
-
-  try {
-    await fs.access(stableArchivePath);
-    backupTempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-npm-pack-archive-"));
-    previousArchiveBackupPath = path.join(backupTempDir, archiveFileName);
-    await fs.copyFile(stableArchivePath, previousArchiveBackupPath);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      await cleanupBackup();
-      throw error;
-    }
-  }
-
-  try {
-    await fs.mkdir(archiveStoreDir, { recursive: true });
-    await fs.copyFile(params.archivePath, tempArchivePath);
-    await fs.rename(tempArchivePath, stableArchivePath);
-  } catch (error) {
-    await fs.rm(tempArchivePath, { force: true });
-    await cleanupBackup();
-    if (!archiveStoreExisted) {
-      await removeEmptyDirectoryIfPresent(archiveStoreDir);
-    }
-    throw error;
-  }
-
+  await fs.mkdir(archiveStoreDir, { recursive: true });
+  await fs.copyFile(params.archivePath, path.join(archiveStoreDir, archiveFileName));
   return {
-    stableArchivePath,
     dependencySpec: `file:./${path.posix.join(MANAGED_NPM_PACK_ARCHIVE_DIR, archiveFileName)}`,
-    rollback: async () => {
-      if (previousArchiveBackupPath) {
-        await fs.mkdir(archiveStoreDir, { recursive: true });
-        await fs.copyFile(previousArchiveBackupPath, stableArchivePath);
-      } else {
-        await fs.rm(stableArchivePath, { force: true });
-      }
-      await cleanupBackup();
-      if (!archiveStoreExisted) {
-        await removeEmptyDirectoryIfPresent(archiveStoreDir);
-      }
-    },
-    cleanup: cleanupBackup,
   };
 }
 
@@ -167,6 +94,7 @@ export async function installPluginFromNpmPackArchive(
     expectedIntegrity?: string;
     onIntegrityDrift?: (params: PluginNpmIntegrityDriftParams) => boolean | Promise<boolean>;
     onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
+    beforePersistentApply?: () => void;
   },
 ): Promise<InstallPluginResult & { npmTarballName?: string }> {
   const runtime = await loadPluginInstallRuntime();
@@ -255,6 +183,7 @@ export async function installPluginFromNpmPackArchive(
       dryRun,
       expectedPluginId: params.expectedPluginId,
       onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
+      beforePersistentApply: params.beforePersistentApply,
       npmResolution,
       ...(driftResult.integrityDrift ? { integrityDrift: driftResult.integrityDrift } : {}),
     }),

--- a/src/plugins/install-npm.ts
+++ b/src/plugins/install-npm.ts
@@ -54,6 +54,7 @@ export async function installPluginFromNpmSpec(
     expectedIntegrity?: string;
     onIntegrityDrift?: (params: PluginNpmIntegrityDriftParams) => boolean | Promise<boolean>;
     onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
+    beforePersistentApply?: () => void;
   },
 ): Promise<InstallPluginResult> {
   const runtime = await loadPluginInstallRuntime();
@@ -256,6 +257,7 @@ export async function installPluginFromNpmSpec(
       expectedPluginId,
       expectedReplacementPluginId: params.expectedReplacementPluginId,
       onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
+      beforePersistentApply: params.beforePersistentApply,
       npmResolution,
       ...(driftResult.integrityDrift ? { integrityDrift: driftResult.integrityDrift } : {}),
     }),

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -17,6 +17,7 @@ import {
   requestDeferredPluginInstall,
   resolvePluginInstallTransaction,
 } from "./install-transaction.js";
+import type { PluginInstallArtifactConsentRequest } from "./install-types.js";
 import {
   hasRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
@@ -143,7 +144,12 @@ function expectNpmInstallIntoRoot(params: {
   const installOptions = installCalls[0]?.[1] as
     | { cwd?: unknown; env?: Record<string, string | undefined> }
     | undefined;
-  expect(installOptions?.cwd).toBe(params.npmRoot);
+  expect(typeof installOptions?.cwd).toBe("string");
+  const stageRoot = String(installOptions?.cwd);
+  expect(stageRoot).not.toBe(params.npmRoot);
+  expect(path.dirname(stageRoot)).toBe(path.dirname(params.npmRoot));
+  expect(fs.existsSync(stageRoot)).toBe(false);
+  expect(fs.existsSync(path.join(params.npmRoot, "package.json"))).toBe(true);
   expect(installCalls[0]?.[0]).toEqual([
     "npm",
     "install",
@@ -173,6 +179,24 @@ function expectNpmInstallIntoProject(params: {
       packageName: params.packageName,
     }),
   });
+}
+
+function expectManagedNpmQuarantine(diagnostics: string[]): string {
+  const installCall = runCommandWithTimeoutMock.mock.calls.find(([argv]) =>
+    isManagedNpmInstallCommand(argv),
+  );
+  const stageRoot = installCall?.[1]?.cwd;
+  if (typeof stageRoot !== "string") {
+    throw new Error("expected managed npm execution root");
+  }
+  expect(fs.existsSync(stageRoot)).toBe(false);
+  const quarantineParent = path.join(path.dirname(stageRoot), "_openclaw-quarantined-npm-projects");
+  const quarantines = fs.readdirSync(quarantineParent);
+  expect(quarantines).toHaveLength(1);
+  const quarantineDir = path.join(quarantineParent, quarantines[0]!);
+  expect(fs.statSync(quarantineDir).isDirectory()).toBe(true);
+  expect(diagnostics.some((message) => message.includes(quarantineDir))).toBe(true);
+  return quarantineDir;
 }
 
 function resolveTestPluginPackageDir(npmRoot: string, packageName: string): string {
@@ -855,6 +879,70 @@ describe("installPluginFromNpmSpec", () => {
     expect(runCommandWithTimeoutMock.mock.calls).toHaveLength(1);
   });
 
+  it.each(["fresh", "existing"] as const)(
+    "keeps the %s install target untouched while artifact consent runs",
+    async (targetState) => {
+      const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+      const packageName = "stage-consent-plugin";
+      const fixture = (version: string) => ({
+        spec: `${packageName}@${version}`,
+        packageName,
+        version,
+        pluginId: packageName,
+        npmRoot,
+        replaceExisting: true,
+        indexJs: "export const value = 'validated';\n",
+      });
+      let targetDir = resolveTestPluginPackageDir(npmRoot, packageName);
+      if (targetState === "existing") {
+        for (const version of ["1.0.0", "2.0.0"]) {
+          mockNpmViewAndInstall(fixture(version));
+          const installed = await installPluginFromNpmSpec({
+            spec: `${packageName}@${version}`,
+            npmDir: npmRoot,
+            mode: "update",
+            logger: { info: () => {}, warn: () => {} },
+          });
+          expect(installed.ok).toBe(true);
+          if (!installed.ok) {
+            return;
+          }
+          targetDir = installed.targetDir;
+        }
+        fs.writeFileSync(path.join(targetDir, "before-consent.txt"), "keep until consent", "utf8");
+      }
+      const projectRoot = path.dirname(path.dirname(targetDir));
+      const projectBefore = targetState === "existing" ? readTextFileTree(projectRoot) : undefined;
+      mockNpmViewAndInstall(fixture("2.0.0"));
+      const onBeforePluginArtifactCommit = vi.fn(
+        async (artifact: PluginInstallArtifactConsentRequest) => {
+          expect(fs.existsSync(targetDir)).toBe(targetState === "existing");
+          if (targetState === "existing") {
+            expect(readTextFileTree(projectRoot)).toEqual(projectBefore);
+            expect(artifact.currentArtifactDir).toBe(targetDir);
+          }
+          expect(artifact.stagedArtifactDir).not.toBe(targetDir);
+          expect(fs.existsSync(path.join(artifact.stagedArtifactDir, "package.json"))).toBe(true);
+        },
+      );
+      const result = await installPluginFromNpmSpec({
+        spec: `${packageName}@2.0.0`,
+        npmDir: npmRoot,
+        ...(targetState === "existing" ? { mode: "update" as const } : {}),
+        logger: { info: () => {}, warn: () => {} },
+        onBeforePluginArtifactCommit,
+      });
+      expect(result.ok).toBe(true);
+      expect(onBeforePluginArtifactCommit).toHaveBeenCalledTimes(1);
+      if (result.ok) {
+        expect(result.targetDir).toBe(targetDir);
+        expect(fs.readFileSync(path.join(targetDir, "dist", "index.js"), "utf8")).toBe(
+          "export const value = 'validated';\n",
+        );
+      }
+    },
+  );
+
   it.each(["commit", "rollback"] as const)(
     "settles staged npm pack updates with %s",
     async (settlement) => {
@@ -937,6 +1025,117 @@ describe("installPluginFromNpmSpec", () => {
         fs.existsSync(path.join(updateGenerationRoot, "node_modules", "@openclaw", "pack-demo")),
       ).toBe(settlement === "commit");
       expect(readTextFileTree(npmProjectRoot)).toEqual(projectBefore);
+    },
+  );
+
+  it.each(["commit", "rollback", "publication failure", "abort during consent"] as const)(
+    "settles a same-generation project replacement with %s",
+    async (settlement) => {
+      const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+      const packageName = "same-generation-plugin";
+      const install = (version: string) =>
+        installPluginFromNpmSpec({
+          spec: `${packageName}@${version}`,
+          npmDir: npmRoot,
+          mode: "update",
+        });
+      let targetDir = "";
+      for (const version of ["1.0.0", "2.0.0"]) {
+        mockNpmViewAndInstall({ spec: `${packageName}@${version}`, packageName, version, npmRoot });
+        const installed = await install(version);
+        expect(installed.ok).toBe(true);
+        if (!installed.ok) {
+          return;
+        }
+        targetDir = installed.targetDir;
+      }
+      const projectRoot = path.dirname(path.dirname(targetDir));
+      const manifestPath = path.join(projectRoot, "package.json");
+      const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
+        overrides?: Record<string, string>;
+        openclaw?: { managedPeerDependencies: string[]; managedOverrides: string[] };
+      };
+      manifest.overrides = { "existing-override": "1.0.0" };
+      manifest.openclaw = {
+        managedPeerDependencies: ["original-peer"],
+        managedOverrides: ["existing-override"],
+      };
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+      fs.writeFileSync(path.join(projectRoot, "original.txt"), "original bytes");
+      const original = readTextFileTree(projectRoot);
+      mockNpmViewAndInstall({
+        spec: `${packageName}@2.0.0`,
+        packageName,
+        version: "2.0.0",
+        npmRoot,
+        indexJs: "export const replacement = true;\n",
+      });
+      const controller = new AbortController();
+      let stageRoot = "";
+      let refusedPublication = false;
+      const rename = fs.promises.rename.bind(fs.promises);
+      const renameSpy = vi.spyOn(fs.promises, "rename").mockImplementation(async (from, to) => {
+        if (settlement === "publication failure" && from === stageRoot && to === projectRoot) {
+          refusedPublication = true;
+          throw Object.assign(new Error("publication refused"), { code: "EIO" });
+        }
+        return rename(from, to);
+      });
+      let updated: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
+      try {
+        updated = await installPluginFromNpmSpec(
+          requestDeferredPluginInstall({
+            spec: `${packageName}@2.0.0`,
+            npmDir: npmRoot,
+            mode: "update" as const,
+            signal: controller.signal,
+            onBeforePluginArtifactCommit: async (artifact: PluginInstallArtifactConsentRequest) => {
+              stageRoot = path.dirname(path.dirname(artifact.stagedArtifactDir));
+              expect(readTextFileTree(projectRoot)).toEqual(original);
+              if (settlement === "abort during consent") {
+                controller.abort();
+              }
+            },
+          }),
+        );
+      } finally {
+        renameSpy.mockRestore();
+      }
+      if (settlement === "abort during consent") {
+        expect(controller.signal.aborted).toBe(true);
+        expect(readTextFileTree(projectRoot)).toEqual(original);
+        expect(updated.ok).toBe(false);
+        expect(fs.existsSync(stageRoot)).toBe(false);
+        return;
+      }
+      if (settlement === "publication failure") {
+        expect(refusedPublication).toBe(true);
+        expect(updated).toMatchObject({
+          ok: false,
+          error: expect.stringContaining("publication refused"),
+        });
+        expect(readTextFileTree(projectRoot)).toEqual(original);
+        expect(fs.existsSync(stageRoot)).toBe(false);
+        return;
+      }
+      expect(updated.ok).toBe(true);
+      if (!updated.ok) {
+        return;
+      }
+      expect(updated.targetDir).toBe(targetDir);
+      expect(fs.readFileSync(path.join(targetDir, "dist", "index.js"), "utf8")).toContain(
+        "replacement",
+      );
+      const transaction = resolvePluginInstallTransaction(updated);
+      expect(transaction).toBeDefined();
+      await transaction?.[settlement]();
+      if (settlement === "rollback") {
+        expect(readTextFileTree(projectRoot)).toEqual(original);
+      } else {
+        expect(fs.readFileSync(path.join(targetDir, "dist", "index.js"), "utf8")).toContain(
+          "replacement",
+        );
+      }
     },
   );
 
@@ -1317,8 +1516,8 @@ describe("installPluginFromNpmSpec", () => {
     runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
       if (
         isManagedNpmInstallCommand(argv) &&
-        options?.cwd === npmProjectRoot &&
-        managedNpmRootHasDependency(npmProjectRoot, "drift-plugin")
+        typeof options?.cwd === "string" &&
+        managedNpmRootHasDependency(options.cwd, "drift-plugin")
       ) {
         managedInstallAttempts += 1;
       }
@@ -1339,9 +1538,9 @@ describe("installPluginFromNpmSpec", () => {
     expect(result.error).toContain("integrity sha512-evil");
     expect(result.error).toContain("expected sha512-safe");
     expect(managedInstallAttempts).toBe(1);
-    expect(fs.existsSync(path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects"))).toBe(
-      false,
-    );
+    expect(
+      fs.existsSync(path.join(path.dirname(npmProjectRoot), "_openclaw-quarantined-npm-projects")),
+    ).toBe(false);
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "drift-plugin"))).toBe(false);
   });
 
@@ -1398,7 +1597,7 @@ describe("installPluginFromNpmSpec", () => {
     }
     let managedInstallAttempts = 0;
     runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
-      if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+      if (isManagedNpmInstallCommand(argv) && typeof options?.cwd === "string") {
         managedInstallAttempts += 1;
       }
       return await delegate(argv, options);
@@ -1417,9 +1616,9 @@ describe("installPluginFromNpmSpec", () => {
     expect(result.error).toContain("version 1.0.1");
     expect(result.error).toContain("expected 1.0.0");
     expect(managedInstallAttempts).toBe(1);
-    expect(fs.existsSync(path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects"))).toBe(
-      false,
-    );
+    expect(
+      fs.existsSync(path.join(path.dirname(npmProjectRoot), "_openclaw-quarantined-npm-projects")),
+    ).toBe(false);
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "version-drift-plugin"))).toBe(false);
   });
 
@@ -1447,8 +1646,8 @@ describe("installPluginFromNpmSpec", () => {
     runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
       if (
         isManagedNpmInstallCommand(argv) &&
-        options?.cwd === npmProjectRoot &&
-        managedNpmRootHasDependency(npmProjectRoot, packageName)
+        typeof options?.cwd === "string" &&
+        managedNpmRootHasDependency(options.cwd, packageName)
       ) {
         managedInstallAttempts += 1;
         if (managedInstallAttempts === 2) {
@@ -1472,9 +1671,7 @@ describe("installPluginFromNpmSpec", () => {
       fs.readFileSync(path.join(npmProjectRoot, "package-lock.json"), "utf8"),
     ) as { packages?: Record<string, { integrity?: string }> };
     expect(installed.packages?.[`node_modules/${packageName}`]?.integrity).toBe("sha512-safe");
-    expect(
-      fs.readdirSync(path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects")),
-    ).toHaveLength(1);
+    expectManagedNpmQuarantine(warnings);
   });
 
   it.each(["integrity", "version"] as const)(
@@ -1482,7 +1679,6 @@ describe("installPluginFromNpmSpec", () => {
     async (missingField) => {
       const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
       const packageName = "persistently-incomplete-metadata-plugin";
-      const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
       mockNpmViewAndInstall({
         spec: `${packageName}@latest`,
         packageName,
@@ -1502,8 +1698,8 @@ describe("installPluginFromNpmSpec", () => {
       runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
         if (
           isManagedNpmInstallCommand(argv) &&
-          options?.cwd === npmProjectRoot &&
-          managedNpmRootHasDependency(npmProjectRoot, packageName)
+          typeof options?.cwd === "string" &&
+          managedNpmRootHasDependency(options.cwd, packageName)
         ) {
           managedInstallAttempts += 1;
         }
@@ -1526,21 +1722,20 @@ describe("installPluginFromNpmSpec", () => {
         "metadata remained incomplete after managed npm project recovery",
       );
       expect(result.error).toContain(`${missingField} missing`);
-      expect(
-        fs.readdirSync(path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects")),
-      ).toHaveLength(1);
+      expectManagedNpmQuarantine([result.error]);
       expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(false);
     },
   );
 
-  it("does not restore a quarantined tree when post-recovery validation fails", async () => {
+  it("preserves the original project and staged quarantine when post-recovery validation fails", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const packageName = "unsafe-recovered-plugin";
     const addedPeerName = "recovery-added-peer";
     const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
-    const stalePackageDir = path.join(npmProjectRoot, "node_modules", "stale-plugin");
-    fs.mkdirSync(stalePackageDir, { recursive: true });
-    fs.writeFileSync(path.join(stalePackageDir, "stale.txt"), "poisoned tree", "utf8");
+    fs.mkdirSync(npmProjectRoot, { recursive: true });
+    fs.writeFileSync(path.join(npmProjectRoot, "package.json"), '{"private":true}\n');
+    fs.writeFileSync(path.join(npmProjectRoot, "original.txt"), "original bytes", "utf8");
+    const originalProject = readTextFileTree(npmProjectRoot);
     const fixture: MockNpmPackage & { spec: string } = {
       spec: `${packageName}@latest`,
       packageName,
@@ -1564,14 +1759,22 @@ describe("installPluginFromNpmSpec", () => {
       throw new Error("expected npm mock implementation");
     }
     let managedInstallAttempts = 0;
+    let attemptedRoot = "";
+    const warnings: string[] = [];
     const outsideDependencyDir = suiteTempRootTracker.makeTempDir();
     runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
       if (
         isManagedNpmInstallCommand(argv) &&
-        options?.cwd === npmProjectRoot &&
-        managedNpmRootHasDependency(npmProjectRoot, packageName)
+        typeof options?.cwd === "string" &&
+        managedNpmRootHasDependency(options.cwd, packageName)
       ) {
+        attemptedRoot = options.cwd;
         managedInstallAttempts += 1;
+        if (managedInstallAttempts === 1) {
+          const corruptPackage = path.join(attemptedRoot, "node_modules", "stale-plugin");
+          fs.mkdirSync(corruptPackage, { recursive: true });
+          fs.writeFileSync(path.join(corruptPackage, "stale.txt"), "poisoned stage", "utf8");
+        }
         if (managedInstallAttempts === 2) {
           fixture.omitInstalledIntegrity = false;
         }
@@ -1580,11 +1783,11 @@ describe("installPluginFromNpmSpec", () => {
       if (
         managedInstallAttempts === 2 &&
         isManagedNpmInstallCommand(argv) &&
-        options?.cwd === npmProjectRoot
+        typeof options?.cwd === "string"
       ) {
         fs.symlinkSync(
           outsideDependencyDir,
-          path.join(npmProjectRoot, "node_modules", "outside-dependency"),
+          path.join(options.cwd, "node_modules", "outside-dependency"),
           "junction",
         );
       }
@@ -1592,7 +1795,7 @@ describe("installPluginFromNpmSpec", () => {
     });
     let mutatedPeerAfterQuarantine = false;
     const addPeerAfterQuarantine = () => {
-      const manifestPath = path.join(npmProjectRoot, "package.json");
+      const manifestPath = path.join(attemptedRoot, "package.json");
       const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8")) as {
         dependencies?: Record<string, string>;
         openclaw?: { managedPeerDependencies?: string[] };
@@ -1612,6 +1815,7 @@ describe("installPluginFromNpmSpec", () => {
       logger: {
         info: () => {},
         warn: (message) => {
+          warnings.push(message);
           if (message.includes("quarantined")) {
             addPeerAfterQuarantine();
           }
@@ -1627,38 +1831,19 @@ describe("installPluginFromNpmSpec", () => {
     expect(result.error).toContain("installed dependency scan found package outside install root");
     expect(managedInstallAttempts).toBe(2);
     expect(mutatedPeerAfterQuarantine).toBe(true);
-    const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
-    const quarantines = fs.readdirSync(quarantineParent);
-    expect(quarantines).toHaveLength(1);
+    const quarantineDir = expectManagedNpmQuarantine(warnings);
     expect(
       fs.readFileSync(
-        path.join(
-          quarantineParent,
-          quarantines[0] ?? "",
-          "node_modules",
-          "stale-plugin",
-          "stale.txt",
-        ),
+        path.join(quarantineDir, "node_modules", "stale-plugin", "stale.txt"),
         "utf8",
       ),
-    ).toBe("poisoned tree");
-    expect(fs.existsSync(stalePackageDir)).toBe(false);
-    const manifest = JSON.parse(
-      fs.readFileSync(path.join(npmProjectRoot, "package.json"), "utf8"),
-    ) as {
-      dependencies?: Record<string, string>;
-      openclaw?: { managedPeerDependencies?: string[] };
-    };
-    expect(manifest.dependencies?.[addedPeerName]).toBeUndefined();
-    expect(manifest.openclaw?.managedPeerDependencies ?? []).not.toContain(addedPeerName);
+    ).toBe("poisoned stage");
+    expect(readTextFileTree(npmProjectRoot)).toEqual(originalProject);
+    expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(false);
   });
 
   it("quarantines and retries once when package-lock omits the installed plugin", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
-    const npmProjectRoot = resolvePluginNpmProjectDir({
-      npmDir: npmRoot,
-      packageName: "missing-lock-plugin",
-    });
     mockNpmViewAndInstall({
       spec: "missing-lock-plugin@latest",
       packageName: "missing-lock-plugin",
@@ -1676,8 +1861,8 @@ describe("installPluginFromNpmSpec", () => {
     runCommandWithTimeoutMock.mockImplementation(async (argv, options) => {
       if (
         isManagedNpmInstallCommand(argv) &&
-        options?.cwd === npmProjectRoot &&
-        managedNpmRootHasDependency(npmProjectRoot, "missing-lock-plugin")
+        typeof options?.cwd === "string" &&
+        managedNpmRootHasDependency(options.cwd, "missing-lock-plugin")
       ) {
         managedInstallAttempts += 1;
       }
@@ -1698,9 +1883,7 @@ describe("installPluginFromNpmSpec", () => {
       "npm install did not record package-lock metadata for missing-lock-plugin",
     );
     expect(managedInstallAttempts).toBe(2);
-    expect(
-      fs.readdirSync(path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects")),
-    ).toHaveLength(1);
+    expectManagedNpmQuarantine([result.error]);
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, "missing-lock-plugin"))).toBe(false);
   });
 
@@ -1712,7 +1895,6 @@ describe("installPluginFromNpmSpec", () => {
       const packageName = "@openclaw/codex-fixture";
       const platformPackage = "@vendor/codex-platform";
       const canonicalPackage = "@vendor/codex";
-      const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
       const platformPackageLocation = path.posix.join(
         "node_modules",
         packageName,
@@ -1741,9 +1923,11 @@ describe("installPluginFromNpmSpec", () => {
       let removedIncompletePackageBeforeRepair = false;
       runCommandWithTimeoutMock.mockImplementation(
         async (argv: string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
+          const attemptRoot = options?.cwd;
+          const installEnv = options?.env;
           const isTargetInstall =
-            isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot;
-          const packageDir = path.join(npmProjectRoot, ...platformPackageLocation.split("/"));
+            isManagedNpmInstallCommand(argv) && typeof attemptRoot === "string";
+          const packageDir = path.join(attemptRoot ?? "", ...platformPackageLocation.split("/"));
           if (isTargetInstall && managedInstallAttempts === 1) {
             removedIncompletePackageBeforeRepair = !fs.existsSync(packageDir);
           }
@@ -1751,11 +1935,11 @@ describe("installPluginFromNpmSpec", () => {
           if (isTargetInstall) {
             managedInstallAttempts += 1;
             writeMissingCurrentPlatformOptionalPackage({
-              npmRoot: npmProjectRoot,
+              npmRoot: attemptRoot,
               packageName: platformPackage,
               packageLocation: platformPackageLocation,
             });
-            const lockPath = path.join(npmProjectRoot, "package-lock.json");
+            const lockPath = path.join(attemptRoot, "package-lock.json");
             const lockfile = JSON.parse(fs.readFileSync(lockPath, "utf8")) as {
               packages: Record<string, unknown>;
             };
@@ -1782,7 +1966,7 @@ describe("installPluginFromNpmSpec", () => {
                 fs.writeFileSync(path.join(nativeBinDir, "codex-helper"), "helper", "utf8");
               }
             } else {
-              repairCacheDir = options.env?.npm_config_cache ?? "";
+              repairCacheDir = installEnv?.npm_config_cache ?? "";
               fs.mkdirSync(packageDir, { recursive: true });
               fs.writeFileSync(
                 path.join(packageDir, "package.json"),
@@ -1828,7 +2012,6 @@ describe("installPluginFromNpmSpec", () => {
     const npmRoot = path.join(stateDir, "npm");
     const packageName = "@openclaw/codex-fixture";
     const platformPackage = "@vendor/codex-platform";
-    const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
     const platformPackageLocation = path.posix.join(
       "node_modules",
       packageName,
@@ -1855,10 +2038,10 @@ describe("installPluginFromNpmSpec", () => {
     runCommandWithTimeoutMock.mockImplementation(
       async (argv: string[], options?: { cwd?: string }) => {
         const result = await delegate(argv, options);
-        if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+        if (isManagedNpmInstallCommand(argv) && typeof options?.cwd === "string") {
           managedInstallAttempts += 1;
           writeMissingCurrentPlatformOptionalPackage({
-            npmRoot: npmProjectRoot,
+            npmRoot: options.cwd,
             packageName: platformPackage,
             packageLocation: platformPackageLocation,
           });
@@ -1890,15 +2073,8 @@ describe("installPluginFromNpmSpec", () => {
     const packageName = "@openclaw/voice-call";
     const warnings: string[] = [];
     const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
-    const stalePackageDir = path.join(npmProjectRoot, "node_modules", "stale-plugin");
-    fs.mkdirSync(stalePackageDir, { recursive: true });
-    fs.writeFileSync(path.join(stalePackageDir, "stale.txt"), "old tree", "utf8");
-    fs.writeFileSync(
-      path.join(npmProjectRoot, "package-lock.json"),
-      `${JSON.stringify({ lockfileVersion: 3, packages: {} })}\n`,
-      "utf8",
-    );
-    fs.writeFileSync(path.join(npmProjectRoot, "npm-shrinkwrap.json"), "{}\n", "utf8");
+    fs.mkdirSync(npmProjectRoot, { recursive: true });
+    fs.writeFileSync(path.join(npmProjectRoot, "original.txt"), "original bytes", "utf8");
 
     mockNpmViewAndInstall({
       spec: `${packageName}@1.0.0`,
@@ -1915,9 +2091,21 @@ describe("installPluginFromNpmSpec", () => {
     let managedInstallAttempts = 0;
     runCommandWithTimeoutMock.mockImplementation(
       async (argv: string[], options?: { cwd?: string }) => {
-        if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+        if (isManagedNpmInstallCommand(argv) && typeof options?.cwd === "string") {
           managedInstallAttempts += 1;
           if (managedInstallAttempts === 1) {
+            const stalePackageDir = path.join(options.cwd, "node_modules", "stale-plugin");
+            fs.mkdirSync(stalePackageDir, { recursive: true });
+            fs.writeFileSync(path.join(stalePackageDir, "stale.txt"), "corrupt stage", "utf8");
+            fs.writeFileSync(
+              path.join(options.cwd, "package-lock.json"),
+              '{"lockfileVersion":3,"packages":{"node_modules/stale-plugin":{}}}\n',
+              "utf8",
+            );
+            fs.writeFileSync(path.join(options.cwd, "npm-shrinkwrap.json"), "{}\n", "utf8");
+            expect(fs.readFileSync(path.join(npmProjectRoot, "original.txt"), "utf8")).toBe(
+              "original bytes",
+            );
             return failedSpawn(
               'npm ERR! code ERR_INVALID_ARG_TYPE\nnpm ERR! The "from" argument must be of type string. Received undefined',
             );
@@ -1943,18 +2131,18 @@ describe("installPluginFromNpmSpec", () => {
     expect(warnings.some((warning) => warning.includes("managed npm project corruption"))).toBe(
       true,
     );
-    const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
-    const quarantines = fs.readdirSync(quarantineParent);
-    expect(quarantines).toHaveLength(1);
-    const quarantineDir = path.join(quarantineParent, quarantines[0] ?? "");
+    const quarantineDir = expectManagedNpmQuarantine(warnings);
     expect(
       fs.readFileSync(
         path.join(quarantineDir, "node_modules", "stale-plugin", "stale.txt"),
         "utf8",
       ),
-    ).toBe("old tree");
-    expect(fs.existsSync(path.join(quarantineDir, "package-lock.json"))).toBe(true);
+    ).toBe("corrupt stage");
+    expect(fs.readFileSync(path.join(quarantineDir, "package-lock.json"), "utf8")).toBe(
+      '{"lockfileVersion":3,"packages":{"node_modules/stale-plugin":{}}}\n',
+    );
     expect(fs.existsSync(path.join(quarantineDir, "npm-shrinkwrap.json"))).toBe(true);
+    expect(fs.existsSync(path.join(npmProjectRoot, "node_modules", "stale-plugin"))).toBe(false);
   });
 
   it("allows rebuilt hoisted dependencies after managed npm project quarantine", async () => {
@@ -1962,9 +2150,6 @@ describe("installPluginFromNpmSpec", () => {
     const npmRoot = path.join(stateDir, "npm");
     const packageName = "unsafe-rebuild-plugin";
     const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
-    fs.mkdirSync(path.join(npmProjectRoot, "node_modules", "stale-hoisted-helper"), {
-      recursive: true,
-    });
 
     mockNpmViewAndInstall({
       spec: `${packageName}@1.0.0`,
@@ -1982,9 +2167,12 @@ describe("installPluginFromNpmSpec", () => {
     let managedInstallAttempts = 0;
     runCommandWithTimeoutMock.mockImplementation(
       async (argv: string[], options?: { cwd?: string }) => {
-        if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+        if (isManagedNpmInstallCommand(argv) && typeof options?.cwd === "string") {
           managedInstallAttempts += 1;
           if (managedInstallAttempts === 1) {
+            fs.mkdirSync(path.join(options.cwd, "node_modules", "stale-hoisted-helper"), {
+              recursive: true,
+            });
             return failedSpawn(
               'npm ERR! code ERR_INVALID_ARG_TYPE\nnpm ERR! The "from" argument must be of type string. Received undefined',
             );
@@ -2002,6 +2190,17 @@ describe("installPluginFromNpmSpec", () => {
 
     expect(result.ok).toBe(true);
     expect(managedInstallAttempts).toBe(2);
+    expect(
+      JSON.parse(
+        fs.readFileSync(
+          path.join(npmProjectRoot, "node_modules", "stale-hoisted-helper", "package.json"),
+          "utf8",
+        ),
+      ),
+    ).toMatchObject({
+      name: "stale-hoisted-helper",
+      version: "1.0.0",
+    });
   });
 
   it.each(npmCommandFailureCases)(
@@ -2010,7 +2209,6 @@ describe("installPluginFromNpmSpec", () => {
       const stateDir = suiteTempRootTracker.makeTempDir();
       const npmRoot = path.join(stateDir, "npm");
       const packageName = "empty-output-plugin";
-      const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
 
       mockNpmViewAndInstall({
         spec: `${packageName}@1.0.0`,
@@ -2026,7 +2224,7 @@ describe("installPluginFromNpmSpec", () => {
       }
       runCommandWithTimeoutMock.mockImplementation(
         async (argv: string[], options?: { cwd?: string }) => {
-          if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+          if (isManagedNpmInstallCommand(argv) && typeof options?.cwd === "string") {
             return npmResult;
           }
           return await delegate(argv, options);
@@ -2051,12 +2249,9 @@ describe("installPluginFromNpmSpec", () => {
     const npmRoot = path.join(stateDir, "npm");
     const packageName = "broken-plugin";
     const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
-    fs.mkdirSync(path.join(npmProjectRoot, "node_modules", "stale-plugin"), { recursive: true });
-    fs.writeFileSync(
-      path.join(npmProjectRoot, "node_modules", "stale-plugin", "stale.txt"),
-      "old tree",
-      "utf8",
-    );
+    fs.mkdirSync(npmProjectRoot, { recursive: true });
+    fs.writeFileSync(path.join(npmProjectRoot, "original.txt"), "original bytes", "utf8");
+    const originalProject = readTextFileTree(npmProjectRoot);
 
     mockNpmViewAndInstall({
       spec: `${packageName}@1.0.0`,
@@ -2073,9 +2268,12 @@ describe("installPluginFromNpmSpec", () => {
     let managedInstallAttempts = 0;
     runCommandWithTimeoutMock.mockImplementation(
       async (argv: string[], options?: { cwd?: string }) => {
-        if (isManagedNpmInstallCommand(argv) && options?.cwd === npmProjectRoot) {
+        if (isManagedNpmInstallCommand(argv) && typeof options?.cwd === "string") {
           managedInstallAttempts += 1;
           if (managedInstallAttempts === 1) {
+            const stalePackageDir = path.join(options.cwd, "node_modules", "stale-plugin");
+            fs.mkdirSync(stalePackageDir, { recursive: true });
+            fs.writeFileSync(path.join(stalePackageDir, "stale.txt"), "corrupt stage", "utf8");
             return failedSpawn(
               'npm ERR! code ERR_INVALID_ARG_TYPE\nnpm ERR! The "from" argument must be of type string. Received undefined',
             );
@@ -2096,24 +2294,17 @@ describe("installPluginFromNpmSpec", () => {
     if (result.ok) {
       return;
     }
-    expect(managedInstallAttempts).toBeGreaterThanOrEqual(2);
+    expect(managedInstallAttempts).toBe(2);
     expect(result.error).toContain("npm install failed after managed npm project recovery");
     expect(result.error).toContain("Original npm error");
-    const quarantineParent = path.join(npmProjectRoot, "_openclaw-quarantined-npm-projects");
-    const quarantines = fs.readdirSync(quarantineParent);
-    expect(quarantines).toHaveLength(1);
+    const quarantineDir = expectManagedNpmQuarantine([result.error]);
     expect(
       fs.readFileSync(
-        path.join(
-          quarantineParent,
-          quarantines[0] ?? "",
-          "node_modules",
-          "stale-plugin",
-          "stale.txt",
-        ),
+        path.join(quarantineDir, "node_modules", "stale-plugin", "stale.txt"),
         "utf8",
       ),
-    ).toBe("old tree");
+    ).toBe("corrupt stage");
+    expect(readTextFileTree(npmProjectRoot)).toEqual(originalProject);
     expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(false);
   });
 
@@ -2957,7 +3148,7 @@ describe("installPluginFromNpmSpec", () => {
       const failure = new Error("post-install logger failure");
       const info = vi.fn((message: string) => {
         if (message.startsWith("Plugin manifest id")) {
-          expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(true);
+          expect(readTextFileTree(npmProjectRoot)).toEqual(projectBefore);
           throw failure;
         }
       });
@@ -2985,7 +3176,7 @@ describe("installPluginFromNpmSpec", () => {
     { source: "npm-pack", initialProject: "absent" },
     { source: "npm-pack", initialProject: "empty" },
   ] as const)(
-    "removes an $initialProject managed project after refused $source relocation and permits retry",
+    "preserves an $initialProject managed project after refused $source relocation and permits retry",
     async ({ source, initialProject }) => {
       const stateDir = suiteTempRootTracker.makeTempDir();
       const npmRoot = path.join(stateDir, "npm");
@@ -3014,7 +3205,10 @@ describe("installPluginFromNpmSpec", () => {
           : installPluginFromNpmPackArchive({ ...params, archivePath });
       };
       await expect(install()).rejects.toBe(refused);
-      expect(fs.existsSync(npmProjectRoot)).toBe(false);
+      expect(fs.existsSync(npmProjectRoot)).toBe(initialProject === "empty");
+      if (initialProject === "empty") {
+        expect(fs.readdirSync(npmProjectRoot)).toEqual([]);
+      }
       const retry = await install();
       expect(retry).toMatchObject({ ok: true, pluginId: packageName });
       expect(
@@ -3025,156 +3219,74 @@ describe("installPluginFromNpmSpec", () => {
     },
   );
 
-  it("does not fail rollback snapshots on plugin-local openclaw peer symlinks", async () => {
-    const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
-    const npmProjectRoot = resolvePluginNpmProjectDir({
-      npmDir: npmRoot,
-      packageName: "@openclaw/codex",
-    });
-    fs.mkdirSync(npmProjectRoot, { recursive: true });
-    fs.writeFileSync(
-      path.join(npmProjectRoot, "package.json"),
-      `${JSON.stringify(
-        {
-          private: true,
-          dependencies: {
-            "@openclaw/codex": "0.0.1",
-          },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    writeNpmRootPackageLock({
-      npmRoot: npmProjectRoot,
-      dependencies: { "@openclaw/codex": "0.0.1" },
-      packages: [
-        {
-          packageName: "@openclaw/codex",
-          version: "0.0.1",
-          npmRoot: npmProjectRoot,
-        },
-      ],
-    });
-    const hostRoot = suiteTempRootTracker.makeTempDir();
-    fs.writeFileSync(
-      path.join(hostRoot, "package.json"),
-      `${JSON.stringify({ name: "openclaw", version: "0.0.0-test" }, null, 2)}\n`,
-      "utf8",
-    );
-    resolveOpenClawPackageRootSyncMock.mockReturnValue(hostRoot);
-    const installedDir = writeInstalledNpmPlugin({
-      npmRoot: npmProjectRoot,
-      packageName: "@openclaw/codex",
-      version: "0.0.1",
-      peerDependencies: { openclaw: "*" },
-    });
-    const peerLink = path.join(installedDir, "node_modules", "openclaw");
-    fs.mkdirSync(path.dirname(peerLink), { recursive: true });
-    fs.symlinkSync(hostRoot, peerLink, "junction");
-
-    const originalCp = fs.promises.cp.bind(fs.promises);
-    const cpSpy = vi.spyOn(fs.promises, "cp").mockImplementation(async (...args: unknown[]) => {
-      const [source, destination, options] = args as [
-        string,
-        string,
-        { filter?: (source: string, destination: string) => boolean | Promise<boolean> },
-      ];
-      const nodeModulesDir = path.join(npmProjectRoot, "node_modules");
-      if (source === nodeModulesDir && fs.existsSync(peerLink)) {
-        const destinationPeerLink = path.join(
-          destination,
-          "@openclaw",
-          "codex",
-          "node_modules",
-          "openclaw",
-        );
-        const shouldCopyPeerLink = options.filter
-          ? await options.filter(peerLink, destinationPeerLink)
-          : true;
-        if (shouldCopyPeerLink) {
-          throw Object.assign(
-            new Error(
-              `EPERM: operation not permitted, symlink '${peerLink}' -> '${destinationPeerLink}'`,
-            ),
-            { code: "EPERM" },
-          );
-        }
-      }
-      return await originalCp(...(args as Parameters<typeof fs.promises.cp>));
-    });
-    runCommandWithTimeoutMock.mockImplementation(
-      async (argv: string[], options?: { cwd?: string }) => {
-        if (JSON.stringify(argv) === JSON.stringify(npmViewArgv("@openclaw/codex@0.0.2"))) {
-          return successfulSpawn(
-            JSON.stringify({
-              name: "@openclaw/codex",
-              version: "0.0.2",
-              dist: {
-                integrity: "sha512-plugin-test",
-                shasum: "pluginshasum",
-              },
-            }),
-          );
-        }
-        if (isNpmPeerPlannerInstallCommand(argv)) {
-          const npmRootLocal = options?.cwd;
-          if (!npmRootLocal) {
-            throw new Error(`unexpected npm peer planner command: ${argv.join(" ")}`);
-          }
-          const manifest = JSON.parse(
-            fs.readFileSync(path.join(npmRootLocal, "package.json"), "utf8"),
-          ) as {
-            dependencies?: Record<string, string>;
-          };
-          writeNpmRootPackageLock({
-            npmRoot: npmRootLocal,
-            dependencies: manifest.dependencies ?? {},
-            packages: [
-              {
-                packageName: "@openclaw/codex",
-                version: "0.0.1",
-                npmRoot: npmRootLocal,
-              },
-            ],
-          });
-          return successfulSpawn();
-        }
-        if (isManagedNpmInstallCommand(argv)) {
-          return {
-            code: 1,
-            stdout: "",
-            stderr: "registry unavailable",
-            signal: null,
-            killed: false,
-            termination: "exit" as const,
-          };
-        }
-        throw new Error(`unexpected command: ${(argv as string[]).join(" ")}`);
-      },
-    );
-
-    try {
-      const result = await installPluginFromNpmSpec({
-        spec: "@openclaw/codex@0.0.2",
-        npmDir: npmRoot,
-        mode: "update",
-        logger: { info: () => {}, warn: () => {} },
+  it.each(["success", "failure"] as const)(
+    "preserves host peer links across a staged npm update ending in %s",
+    async (outcome) => {
+      const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
+      const packageName = "@openclaw/peer-fixture";
+      const hostRoot = suiteTempRootTracker.makeTempDir();
+      fs.writeFileSync(
+        path.join(hostRoot, "package.json"),
+        '{"name":"openclaw","version":"0.0.0-test"}\n',
+      );
+      resolveOpenClawPackageRootSyncMock.mockReturnValue(hostRoot);
+      const fixture = (version: string) => ({
+        spec: `${packageName}@${version}`,
+        packageName,
+        pluginId: "peer-fixture",
+        version,
+        npmRoot,
+        peerDependencies: { openclaw: "*" },
       });
-
-      expect(result.ok).toBe(false);
-      if (!result.ok) {
-        expect(result.error).toContain("registry unavailable");
-        expect(result.error).not.toContain("Failed to snapshot");
+      mockNpmViewAndInstall(fixture("1.0.0"));
+      const first = await installPluginFromNpmSpec({
+        spec: `${packageName}@1.0.0`,
+        npmDir: npmRoot,
+      });
+      expect(first.ok).toBe(true);
+      if (!first.ok) {
+        return;
       }
-      await expect(fs.promises.realpath(peerLink)).resolves.toBe(
+      const oldPeerLink = path.join(first.targetDir, "node_modules", "openclaw");
+      await expect(fs.promises.realpath(oldPeerLink)).resolves.toBe(
         await fs.promises.realpath(hostRoot),
       );
-    } finally {
-      cpSpy.mockRestore();
-    }
-  });
+      mockNpmViewAndInstall(fixture("2.0.0"));
+      if (outcome === "failure") {
+        const delegate = runCommandWithTimeoutMock.getMockImplementation()!;
+        runCommandWithTimeoutMock.mockImplementation(async (argv, options) =>
+          isManagedNpmInstallCommand(argv)
+            ? failedSpawn("registry unavailable")
+            : delegate(argv, options),
+        );
+      }
+      const onBeforePluginArtifactCommit = vi.fn(
+        async (artifact: PluginInstallArtifactConsentRequest) => {
+          await expect(
+            fs.promises.realpath(path.join(artifact.stagedArtifactDir, "node_modules", "openclaw")),
+          ).resolves.toBe(await fs.promises.realpath(hostRoot));
+        },
+      );
+      const updated = await installPluginFromNpmSpec({
+        spec: `${packageName}@2.0.0`,
+        npmDir: npmRoot,
+        mode: "update",
+        onBeforePluginArtifactCommit,
+      });
+      expect(updated.ok).toBe(outcome === "success");
+      expect(onBeforePluginArtifactCommit).toHaveBeenCalledTimes(outcome === "success" ? 1 : 0);
+      if (updated.ok) {
+        await expect(
+          fs.promises.realpath(path.join(updated.targetDir, "node_modules", "openclaw")),
+        ).resolves.toBe(await fs.promises.realpath(hostRoot));
+      } else {
+        expect(updated.error).toContain("registry unavailable");
+      }
+      await expect(fs.promises.realpath(oldPeerLink)).resolves.toBe(
+        await fs.promises.realpath(hostRoot),
+      );
+    },
+  );
 
   it("normalizes selectors before npm planning and retries only unsupported aliases", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");

--- a/src/plugins/npm-package-traversal.test.ts
+++ b/src/plugins/npm-package-traversal.test.ts
@@ -1,10 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  listManagedNpmRootPackageNames,
-  listNewManagedNpmRootPackageDirs,
-} from "./install-managed-npm-state.js";
+import { listManagedNpmRootPackageNames } from "./install-managed-npm-state.js";
 import {
   auditOpenClawPeerDependenciesInManagedNpmRoot,
   relinkOpenClawPeerDependenciesInManagedNpmRoot,
@@ -55,12 +52,6 @@ describe("managed npm package traversal", () => {
       "alpha",
       "zeta",
     ]);
-    expect(
-      await listNewManagedNpmRootPackageDirs({
-        npmRoot,
-        beforeInstallPackageNames: new Set([".hidden", "alpha"]),
-      }),
-    ).toEqual(["@scope/alpha", "@scope/zeta", "zeta"].map((name) => path.join(modules, name)));
     const repairNames = ["@scope/alpha", "@scope/zeta", "alpha", "openclaw", "zeta"];
     const before = await auditOpenClawPeerDependenciesInManagedNpmRoot({ npmRoot });
     expect(before.checked).toBe(5);


### PR DESCRIPTION
Managed npm installs wrote into their final project before artifact consent finished. Rejection then depended on copied node_modules snapshots, archive backups, or npm uninstall/peer repair to reconstruct the previous state.

Prepare the candidate in a private stage and let the existing package-directory transaction own publication, backup and rollback. Preserve the current generation-target rules, so older running Gateways can keep using native lazy imports. Existing npm manifest, lock/shrinkwrap, project .npmrc and relative archive inputs carry into the stage; installed node_modules does not. Consent refusal and cancellation before publication preserve the original project. A diagnosed corrupt candidate remains in durable quarantine outside stage cleanup and gets only one rebuild attempt.

This also fixes cancellation during artifact consent: the final mutation callback rechecks the existing AbortSignal before displacing or publishing a target. The original callback error survives stage cleanup unchanged. Dead snapshot/uninstall compensation helpers are removed; main's shared package traversal and peer synchronization are preserved. No runtime foundation, Gateway restart feature, configuration option, environment variable or database schema change is required.

Validation: 174 distinct owner tests passed: 104 managed-npm cases, 15 shared traversal cases and 55 npm-root/directory-publication cases. Causal tests first demonstrated premature target mutation and publication after cancellation. Five real npm 11.19 / Node 24.19 scenarios then passed through the installer API on this standalone candidate: late native dependency/asset imports across a generation update; same-generation deferred rollback; consent refusal with exact error identity; one injected missing-integrity result after actual npm materialization, durable quarantine and rejected rebuilt candidate; cancellation during consent. The real npm proof used generated local packages and isolated state, without a Gateway or credentials. Production source and dependencies match the final candidate byte-for-byte; later changes only capture optional fixture values and rename a test-local variable. The process group closed.

Production LOC: 125 added, 670 removed, net −545. Tests: net +13. Documentation explains staging and quarantine; the assertion baseline shrinks only for deleted casts (5→2 and 2→0). This is an independently landable preparation for #135599.

The complete normal changed-code gate passed against the real main base, including formatting, types, lint, dead exports and repository guards. Independent Codex P0–P2 review was clean (v3); its only subsequent source delta was the test-local `npmRoot` → `attemptRoot` rename required by lint. Earlier ratchet/type/lint failures are retained in the local evidence.
