### PR TITLE
fix: avoid repeated database copies for legacy Workshop backups

### DIFF
--- a/src/commands/doctor-skill-workshop-collection-backups.test.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.test.ts
@@ -6,6 +6,7 @@ import {
   resolveLegacyWorkspaceSourcePaths,
 } from "../agents/workspace-legacy-state.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import * as sqliteReadOnlyLocation from "../infra/sqlite-readonly-location.js";
 import {
   detectLegacyWorkspaceState,
   migrateLegacyWorkspaceState,
@@ -49,6 +50,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await testState.cleanup();
   await tempDirs.cleanup();
 });
@@ -862,7 +864,10 @@ describe("doctor Skill Workshop collection backup migration", () => {
       `)
           .run(`shared-review-${index}`, owner, backupId);
       }
+      const prepareSnapshot = vi.spyOn(sqliteReadOnlyLocation, "prepareSqliteReadOnlyLocation");
       const result = await migrateLegacySkillWorkshopProposals({ config, env: testState.env });
+      expect(prepareSnapshot).not.toHaveBeenCalled();
+      expect(database.db.prepare("SELECT 1 AS open").get()).toEqual({ open: 1 });
 
       await expect(fs.access(legacyRoot)).resolves.toBeUndefined();
       if (!archived) {

--- a/src/commands/doctor-skill-workshop-collection-backups.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.ts
@@ -23,7 +23,10 @@ import { openSkillWorkshopStore } from "../skills/workshop/store-sqlite-schema.j
 import { resolveSkillProposalTarget } from "../skills/workshop/store.js";
 import { tableHasColumn } from "../state/openclaw-state-db-schema-helpers.js";
 import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
-import { openExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db.js";
+import {
+  openExistingOpenClawStateDatabaseReadOnly,
+  type OpenClawStateDatabase as OpenClawStateDatabaseHandle,
+} from "../state/openclaw-state-db.js";
 
 const LEGACY_COLLECTION_BACKUP_SCHEMA = "openclaw.skill-collection-backup.v1";
 const MAX_BACKUP_MANIFEST_BYTES = 1024 * 1024;
@@ -40,6 +43,8 @@ type LegacyCollectionBackupRoot =
 export async function listPendingLegacyCollectionBackupRoots(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
+  // null means the caller already checked and no state database exists.
+  database?: OpenClawStateDatabaseHandle | null,
 ): Promise<LegacyCollectionBackupRoot[]> {
   const backupRoot = path.join(resolveStateDir(env), "skill-workshop", "collection-backups");
   if (!(await pathExists(backupRoot))) {
@@ -49,41 +54,60 @@ export async function listPendingLegacyCollectionBackupRoots(
     .filter((entry) => entry.isDirectory() && /^[a-f0-9]{16}$/u.test(entry.name))
     .map((entry) => entry.name);
   const roots: LegacyCollectionBackupRoot[] = [];
-  for (const name of names) {
-    const legacyRoot = path.join(backupRoot, name);
-    try {
-      const backups = await readLegacyCollectionBackups(legacyRoot);
-      if (backups.length === 0) {
-        continue;
+  let ownedDatabase: OpenClawStateDatabaseHandle | undefined;
+  let databaseRead: Promise<OpenClawStateDatabaseHandle | undefined> | undefined;
+  // Standalone listing owns one verified snapshot. Doctor and migration borrow
+  // their existing verified handle, whose caller retains responsibility for closing it.
+  const readDatabase = () =>
+    (databaseRead ??= openExistingOpenClawStateDatabaseReadOnly({ env }).then((opened) => {
+      ownedDatabase = opened;
+      return opened;
+    }));
+  try {
+    for (const name of names) {
+      const legacyRoot = path.join(backupRoot, name);
+      try {
+        const backups = await readLegacyCollectionBackups(legacyRoot);
+        if (backups.length === 0) {
+          continue;
+        }
+        const workspaceDirs = new Set(backups.map((backup) => backup.workspaceDir));
+        const workspaceDir = [...workspaceDirs][0];
+        const ownerAgentId =
+          workspaceDirs.size === 1 && workspaceDir
+            ? inferLegacyCollectionBackupOwnerAgentId(
+                config,
+                env,
+                workspaceDir,
+                backups,
+                database === undefined ? await readDatabase() : database,
+              )
+            : undefined;
+        if (!ownerAgentId) {
+          throw new Error("workspace does not map to exactly one configured agent");
+        }
+        assertWorkspaceStateMigrationReady({ workspaceDirs: [...workspaceDirs], env });
+        const destinationRoot = resolveSkillCollectionBackupRoot(config, ownerAgentId, env);
+        const alreadyArchived = await Promise.all(
+          backups.map((backup) =>
+            isHistoryOnlyBackup(path.join(destinationRoot, backup.manifest.id)),
+          ),
+        );
+        // History-only archives retain their source. Exclude each completed copy
+        // so an interrupted root can resume its remaining backups.
+        const pendingBackups = backups.filter((_, index) => !alreadyArchived[index]);
+        if (pendingBackups.length > 0) {
+          roots.push({ legacyRoot, backups: pendingBackups, ownerAgentId, destinationRoot });
+        }
+      } catch (error) {
+        roots.push({
+          legacyRoot,
+          warning: `Preserved legacy collection backup root ${legacyRoot}: ${String(error)}`,
+        });
       }
-      const workspaceDirs = new Set(backups.map((backup) => backup.workspaceDir));
-      const workspaceDir = [...workspaceDirs][0];
-      const ownerAgentId =
-        workspaceDirs.size === 1 && workspaceDir
-          ? await inferLegacyCollectionBackupOwnerAgentId(config, env, workspaceDir, backups)
-          : undefined;
-      if (!ownerAgentId) {
-        throw new Error("workspace does not map to exactly one configured agent");
-      }
-      assertWorkspaceStateMigrationReady({ workspaceDirs: [...workspaceDirs], env });
-      const destinationRoot = resolveSkillCollectionBackupRoot(config, ownerAgentId, env);
-      const alreadyArchived = await Promise.all(
-        backups.map((backup) =>
-          isHistoryOnlyBackup(path.join(destinationRoot, backup.manifest.id)),
-        ),
-      );
-      // History-only archives retain their source. Exclude each completed copy
-      // so an interrupted root can resume its remaining backups.
-      const pendingBackups = backups.filter((_, index) => !alreadyArchived[index]);
-      if (pendingBackups.length > 0) {
-        roots.push({ legacyRoot, backups: pendingBackups, ownerAgentId, destinationRoot });
-      }
-    } catch (error) {
-      roots.push({
-        legacyRoot,
-        warning: `Preserved legacy collection backup root ${legacyRoot}: ${String(error)}`,
-      });
     }
+  } finally {
+    ownedDatabase?.walMaintenance.close();
   }
   return roots;
 }
@@ -108,53 +132,47 @@ export function inferWorkspaceOwnerAgentId(
   return workspaceMatches.length === 1 ? workspaceMatches[0] : undefined;
 }
 
-async function inferLegacyCollectionBackupOwnerAgentId(
+function inferLegacyCollectionBackupOwnerAgentId(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
   workspaceDir: string,
   backups: readonly LegacyCollectionBackup[],
-): Promise<string | undefined> {
+  database: OpenClawStateDatabaseHandle | null | undefined,
+): string | undefined {
   const workspaceOwner = inferWorkspaceOwnerAgentId(config, env, workspaceDir);
-  // Listing is also used by read-only inspection. Never initialize or migrate
-  // Workshop state merely to recover the owner already recorded by a review.
-  const database = await openExistingOpenClawStateDatabaseReadOnly({ env });
-  try {
-    if (
-      !database ||
-      !tableHasColumn(database.db, "skill_workshop_collection_reviews", "owner_agent_id")
-    ) {
-      return workspaceOwner;
-    }
-    const kysely = getNodeSqliteKysely<
-      Pick<OpenClawStateDatabase, "skill_workshop_collection_reviews">
-    >(database.db);
-    const rootOwners = new Set<string>();
-    for (const backup of backups) {
-      const owners = new Set(
-        executeSqliteQuerySync(
-          database.db,
-          kysely
-            .selectFrom("skill_workshop_collection_reviews")
-            .select("owner_agent_id")
-            .where("backup_id", "=", backup.manifest.id),
-        ).rows.map((row) => row.owner_agent_id),
-      );
-      const owner =
-        owners.size === 0 ? workspaceOwner : owners.size === 1 ? [...owners][0] : undefined;
-      if (
-        !owner ||
-        !listAgentIds(config).includes(owner) ||
-        resolveCanonicalWorkspacePath(resolveAgentWorkspaceDir(config, owner, env)) !==
-          resolveCanonicalWorkspacePath(workspaceDir)
-      ) {
-        return undefined;
-      }
-      rootOwners.add(owner);
-    }
-    return rootOwners.size === 1 ? [...rootOwners][0] : undefined;
-  } finally {
-    database?.walMaintenance.close();
+  if (
+    !database ||
+    !tableHasColumn(database.db, "skill_workshop_collection_reviews", "owner_agent_id")
+  ) {
+    return workspaceOwner;
   }
+  const kysely = getNodeSqliteKysely<
+    Pick<OpenClawStateDatabase, "skill_workshop_collection_reviews">
+  >(database.db);
+  const rootOwners = new Set<string>();
+  for (const backup of backups) {
+    const owners = new Set(
+      executeSqliteQuerySync(
+        database.db,
+        kysely
+          .selectFrom("skill_workshop_collection_reviews")
+          .select("owner_agent_id")
+          .where("backup_id", "=", backup.manifest.id),
+      ).rows.map((row) => row.owner_agent_id),
+    );
+    const owner =
+      owners.size === 0 ? workspaceOwner : owners.size === 1 ? [...owners][0] : undefined;
+    if (
+      !owner ||
+      !listAgentIds(config).includes(owner) ||
+      resolveCanonicalWorkspacePath(resolveAgentWorkspaceDir(config, owner, env)) !==
+        resolveCanonicalWorkspacePath(workspaceDir)
+    ) {
+      return undefined;
+    }
+    rootOwners.add(owner);
+  }
+  return rootOwners.size === 1 ? [...rootOwners][0] : undefined;
 }
 
 function legacyCollectionSkillPath(workspaceDir: string, relativeDir: string): string {
@@ -496,8 +514,9 @@ async function publishLegacyCollectionBackup(
 export async function migrateLegacyCollectionBackups(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
+  database: OpenClawStateDatabaseHandle,
 ): Promise<{ migrated: number; warnings: string[] }> {
-  const roots = await listPendingLegacyCollectionBackupRoots(config, env);
+  const roots = await listPendingLegacyCollectionBackupRoots(config, env, database);
   let migrated = 0;
   const warnings: string[] = [];
   for (const root of roots) {

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -1,14 +1,16 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
+import * as sqliteReadOnlyLocation from "../infra/sqlite-readonly-location.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
 import { importLegacySkillProposal } from "../skills/workshop/store.js";
 import type { SkillProposalRecord } from "../skills/workshop/types.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { listPendingLegacyCollectionBackupRoots } from "./doctor-skill-workshop-collection-backups.js";
 import { inspectLegacySkillWorkshopMigration } from "./doctor-skill-workshop-sqlite.js";
 import {
   createAppliedLegacyProposal,
@@ -35,6 +37,8 @@ async function snapshotDatabase(databasePath: string) {
     database.close();
   }
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 describe("read-only Skill Workshop migration inspection", () => {
   it.each([
@@ -107,16 +111,28 @@ describe("read-only Skill Workshop migration inspection", () => {
             resultSkillHashes: {},
           }),
         );
+        await fs.cp(
+          path.dirname(backupDir),
+          path.join(path.dirname(path.dirname(backupDir)), "1111111111111111"),
+          { recursive: true },
+        );
         const before = await snapshotDatabase(databasePath);
+        const prepareSnapshot = vi.spyOn(sqliteReadOnlyLocation, "prepareSqliteReadOnlyLocation");
 
         await expect(
           inspectLegacySkillWorkshopMigration({ config, env: state.env }),
         ).resolves.toEqual({
           externalProposalCount: 1,
           externalProposalCountsByAgent: { main: 1 },
-          legacyBackupRootCount: 1,
+          legacyBackupRootCount: 2,
         });
 
+        expect(prepareSnapshot).toHaveBeenCalledTimes(1);
+        prepareSnapshot.mockClear();
+        await expect(
+          listPendingLegacyCollectionBackupRoots(config, state.env),
+        ).resolves.toHaveLength(2);
+        expect(prepareSnapshot).toHaveBeenCalledTimes(1);
         closeOpenClawStateDatabaseForTest();
         expect(await snapshotDatabase(databasePath)).toEqual(before);
         expect(await fs.readFile(skillFile, "utf8")).toBe(content);

--- a/src/commands/doctor-skill-workshop-sqlite.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.ts
@@ -128,21 +128,25 @@ export async function inspectLegacySkillWorkshopMigration(params: {
         }
       });
     }
+    // Lint needs ownership counts, not adoption verification through writable recovery readers.
+    const { external } = classifyWorkshopRelocation(records, params.config, env);
+    const backups = await listPendingLegacyCollectionBackupRoots(
+      params.config,
+      env,
+      database ?? null,
+    );
+    return {
+      externalProposalCount: external.length,
+      externalProposalCountsByAgent: external.reduce<Record<string, number>>((counts, plan) => {
+        const ownerAgentId = plan.ownerAgentId ?? plan.unconfiguredOwnerAgentId ?? "unknown";
+        counts[ownerAgentId] = (counts[ownerAgentId] ?? 0) + 1;
+        return counts;
+      }, {}),
+      legacyBackupRootCount: backups.length,
+    };
   } finally {
     database?.walMaintenance.close();
   }
-  // Lint needs ownership counts, not adoption verification through writable recovery readers.
-  const { external } = classifyWorkshopRelocation(records, params.config, env);
-  const backups = await listPendingLegacyCollectionBackupRoots(params.config, env);
-  return {
-    externalProposalCount: external.length,
-    externalProposalCountsByAgent: external.reduce<Record<string, number>>((counts, plan) => {
-      const ownerAgentId = plan.ownerAgentId ?? plan.unconfiguredOwnerAgentId ?? "unknown";
-      counts[ownerAgentId] = (counts[ownerAgentId] ?? 0) + 1;
-      return counts;
-    }, {}),
-    legacyBackupRootCount: backups.length,
-  };
 }
 
 async function relocateLegacyWorkshopTargets(
@@ -287,7 +291,7 @@ async function relocateLegacyWorkshopTargets(
   }
   persistUpdates(plan.updates);
   await finishWorkshopWorkspaceRelocations(env);
-  const backupMigration = await migrateLegacyCollectionBackups(config, env);
+  const backupMigration = await migrateLegacyCollectionBackups(config, env, database);
   const updates = [...plan.updates, ...plan.moves.flatMap((move) => move.updates)];
   const staleProposals = updates.filter((update) => update.record.status === "stale").length;
   return {


### PR DESCRIPTION
Related: #140117

## What Problem This Solves

Fixes an issue where users running Doctor with legacy Skill Workshop collection backups would repeatedly copy and verify the entire state database while resolving backup ownership. Inspection repeated the work for every backup root; migration repeated it despite already holding a verified database.

## Why This Change Was Made

Carry the caller's verified database handle through collection-backup ownership lookup. Read-only inspection retains its private snapshot until all ownership reads finish, migration borrows its existing handle, and standalone listing owns one lazy snapshot across all roots. Only the owner closes its handle. Existing integrity checks and backup ownership rules remain in place.

## User Impact

Doctor avoids redundant full-database work when inspecting or migrating legacy collection backups. Uncertain ownership still preserves the source and produces a warning; history-only archives retain their restore restrictions.

## Evidence

- Real filesystem and SQLite regression tests failed before this patch: inspection with two backup roots prepared 3 snapshots instead of 1; migration prepared 1 extra snapshot instead of 0.
- After this patch, both focused test files pass all 29 tests. Inspection and standalone listing each prepare 1 snapshot across two roots; migration prepares no extra snapshot and leaves the borrowed handle usable.
- The same tests preserve schema 15/16, database bytes and permissions, proposal counts, recorded-owner resolution, conflicting/missing-owner warnings, and history-only archives.
- Required changed-file checks and fresh independent autoreview passed (exit 0; no accepted/actionable findings). Hosted CI will validate the exact PR head. Production timing has not been measured for this patch.
