### PR TITLE
fix: revert updater policy and Workshop ownership changes

### DIFF
--- a/src/cli/update-cli/update-command-fresh-doctor.test.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../../test-utils/env.js";
 import type { PostCorePluginUpdateResult } from "./update-command-plugins.js";
 
 const mocks = vi.hoisted(() => ({
@@ -30,10 +29,7 @@ vi.mock("./shared.js", async (importOriginal) => ({
   resolveNodeRunner: vi.fn(() => "/usr/bin/node"),
 }));
 
-import {
-  completePostCorePluginUpdate,
-  runUpdateFinalizationDoctorInFreshProcess,
-} from "./update-command-fresh-doctor.js";
+import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
 
 const pluginUpdate: PostCorePluginUpdateResult = {
   status: "ok",
@@ -101,47 +97,6 @@ describe("post-plugin update readiness", () => {
     ]);
     expect(mocks.runExec.mock.calls[2]?.[2]).toMatchObject({
       env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
-    });
-  });
-
-  it.each(["pre-plugin", "post-plugin"] as const)(
-    "forwards an established external service-repair policy to the %s fresh Doctor child",
-    async (phase) => {
-      await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "external" }, async () => {
-        await runUpdateFinalizationDoctorInFreshProcess({
-          phase,
-          root: "/opt/openclaw",
-          entryPath: "/opt/openclaw/dist/index.js",
-          yes: true,
-          json: true,
-          timeoutMs: 5_000,
-        });
-      });
-
-      expect(mocks.runExec.mock.calls[0]?.[2]).toMatchObject({
-        env: expect.objectContaining({
-          OPENCLAW_SERVICE_REPAIR_POLICY: "external",
-        }),
-      });
-    },
-  );
-
-  it("does not invent an external service-repair policy for an unknown owner", async () => {
-    await withEnvAsync({ OPENCLAW_SERVICE_REPAIR_POLICY: "unknown" }, async () => {
-      await runUpdateFinalizationDoctorInFreshProcess({
-        phase: "post-plugin",
-        root: "/opt/openclaw",
-        entryPath: "/opt/openclaw/dist/index.js",
-        yes: true,
-        json: true,
-        timeoutMs: 5_000,
-      });
-    });
-
-    expect(mocks.runExec.mock.calls[0]?.[2]).toMatchObject({
-      env: expect.objectContaining({
-        OPENCLAW_SERVICE_REPAIR_POLICY: undefined,
-      }),
     });
   });
 

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -140,10 +140,6 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
           allowGatewayServiceRepair: false,
           allowGatewayActivation: false,
           deferConfiguredPluginInstallRepair: true,
-          serviceRepairPolicy:
-            process.env.OPENCLAW_SERVICE_REPAIR_POLICY?.trim().toLowerCase() === "external"
-              ? "external"
-              : undefined,
         }),
         ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
       },

--- a/src/commands/doctor-skill-workshop-collection-backups.test.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.test.ts
@@ -20,7 +20,6 @@ import {
 import { readSkillProposalTargetTreeSha256 } from "../skills/workshop/proposal-bundle.js";
 import { applySkillProposal, proposeCreateSkill } from "../skills/workshop/service.js";
 import { resolveWorkshopSkillsDir } from "../skills/workshop/skills-root.js";
-import { openSkillWorkshopStore } from "../skills/workshop/store-sqlite-schema.js";
 import * as workshopStore from "../skills/workshop/store.js";
 import {
   createOpenClawTestState,
@@ -786,115 +785,30 @@ describe("doctor Skill Workshop collection backup migration", () => {
     ).resolves.toMatchObject({ backupId, restored: ["interrupted-backup"] });
   });
 
-  it.each([
-    { label: "no review", owners: [], archived: false },
-    { label: "recorded owner", owners: ["alpha", "alpha"], archived: true },
-    { label: "conflicting reviews", owners: ["alpha", "beta"], archived: false },
-    { label: "removed owner", owners: ["removed"], archived: false },
-    { label: "different workspace", owners: ["other"], archived: false },
-    { label: "unrelated review", owners: ["alpha"], archived: false, matchingReview: false },
-    {
-      label: "second backup missing review",
-      owners: ["alpha"],
-      archived: false,
-      secondOwner: null,
-    },
-    {
-      label: "second backup conflicting owner",
-      owners: ["alpha"],
-      archived: false,
-      secondOwner: "beta",
-    },
-    {
-      label: "multiple backups with one owner",
-      owners: ["alpha"],
-      archived: true,
-      secondOwner: "alpha",
-    },
-  ])(
-    "preserves shared-workspace backup ownership with $label",
-    async ({ owners, archived, matchingReview, secondOwner }) => {
-      const workspaceDir = await fs.realpath(
-        await tempDirs.make("openclaw-workshop-ambiguous-backup-workspace-"),
-      );
-      const legacyRoot = await seedLegacyCollectionBackup({
-        workspaceDir,
-        backupId: "2026-09-01T00-00-00.000Z-legacy2",
-        backupContent:
-          "---\nname: legacy-collection-skill\ndescription: Legacy backup\n---\n\n# Backup\n",
-        resultContent:
-          "---\nname: legacy-collection-skill\ndescription: Current skill\n---\n\n# Current\n",
-      });
-      const config = {
-        agents: {
-          list: [
-            { id: "alpha", default: true, workspace: workspaceDir },
-            { id: "beta", workspace: workspaceDir },
-            { id: "other", workspace: path.join(workspaceDir, "other") },
-          ],
-        },
-      };
+  it("preserves a legacy collection backup when its workspace has ambiguous owners", async () => {
+    const workspaceDir = await fs.realpath(
+      await tempDirs.make("openclaw-workshop-ambiguous-backup-workspace-"),
+    );
+    const legacyRoot = await seedLegacyCollectionBackup({
+      workspaceDir,
+      backupId: "2026-09-01T00-00-00.000Z-legacy2",
+      backupContent:
+        "---\nname: legacy-collection-skill\ndescription: Legacy backup\n---\n\n# Backup\n",
+      resultContent:
+        "---\nname: legacy-collection-skill\ndescription: Current skill\n---\n\n# Current\n",
+    });
+    const config = {
+      agents: {
+        list: [
+          { id: "alpha", default: true, workspace: workspaceDir },
+          { id: "beta", workspace: workspaceDir },
+        ],
+      },
+    };
 
-      const secondBackupId = "2026-09-02T00-00-00.000Z-legacy3";
-      if (secondOwner !== undefined) {
-        await seedLegacyCollectionBackup({
-          workspaceDir,
-          backupId: secondBackupId,
-          backupContent: "---\nname: legacy-collection-skill\n---\n\n# Second backup\n",
-        });
-      }
-      const { database } = openSkillWorkshopStore({ env: testState.env });
-      const reviews = owners.map((owner) => ({
-        owner,
-        backupId:
-          matchingReview === false ? "unrelated-backup" : "2026-09-01T00-00-00.000Z-legacy2",
-      }));
-      if (secondOwner) {
-        reviews.push({ owner: secondOwner, backupId: secondBackupId });
-      }
-      for (const [index, { owner, backupId }] of reviews.entries()) {
-        database.db
-          .prepare(`
-        INSERT INTO skill_workshop_collection_reviews (
-          review_id, owner_agent_id, backup_id, create_time,
-          kept_names_json, written_names_json, dropped_json
-        ) VALUES (?, ?, ?, 0, '[]', '[]', '[]')
-      `)
-          .run(`shared-review-${index}`, owner, backupId);
-      }
-      const result = await migrateLegacySkillWorkshopProposals({ config, env: testState.env });
+    const result = await migrateLegacySkillWorkshopProposals({ config, env: testState.env });
 
-      await expect(fs.access(legacyRoot)).resolves.toBeUndefined();
-      if (!archived) {
-        expect(result.warnings.join("\n")).toContain(legacyRoot);
-        return;
-      }
-      expect(result.warnings).toEqual([]);
-      const destination = path.join(
-        resolveSkillCollectionBackupRoot(config, "alpha", testState.env),
-        "2026-09-01T00-00-00.000Z-legacy2",
-      );
-      const manifest = JSON.parse(
-        await fs.readFile(path.join(destination, "manifest.json"), "utf8"),
-      );
-      expect(manifest.restoreUnavailableReason).toContain("not proven Workshop-owned");
-      expect(manifest.skillDirs).toEqual([]);
-      expect(
-        await fs.readFile(
-          path.join(
-            destination,
-            "history",
-            "workspace",
-            "skills",
-            "legacy-collection-skill",
-            "SKILL.md",
-          ),
-          "utf8",
-        ),
-      ).toContain("# Backup");
-      await expect(
-        collectionBackups.listPendingLegacyCollectionBackupRoots(config, testState.env),
-      ).resolves.toEqual([]);
-    },
-  );
+    await expect(fs.access(legacyRoot)).resolves.toBeUndefined();
+    expect(result.warnings.join("\n")).toContain(legacyRoot);
+  });
 });

--- a/src/commands/doctor-skill-workshop-collection-backups.ts
+++ b/src/commands/doctor-skill-workshop-collection-backups.ts
@@ -9,7 +9,7 @@ import { resolveCanonicalWorkspacePath } from "../agents/workspace-state-identit
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pathExists } from "../infra/fs-safe.js";
-import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { executeSqliteQuerySync } from "../infra/kysely-sync.js";
 import { isPathStrictlyInside } from "../infra/path-guards.js";
 import { resolveSkillManifestMetadata } from "../skills/loading/frontmatter.js";
 import { readSkillFrontmatterSafe } from "../skills/loading/local-loader.js";
@@ -21,9 +21,6 @@ import { readSkillProposalTargetTreeSha256 } from "../skills/workshop/proposal-b
 import { parseSkillProposalRow } from "../skills/workshop/store-sqlite-record.js";
 import { openSkillWorkshopStore } from "../skills/workshop/store-sqlite-schema.js";
 import { resolveSkillProposalTarget } from "../skills/workshop/store.js";
-import { tableHasColumn } from "../state/openclaw-state-db-schema-helpers.js";
-import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
-import { openExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db.js";
 
 const LEGACY_COLLECTION_BACKUP_SCHEMA = "openclaw.skill-collection-backup.v1";
 const MAX_BACKUP_MANIFEST_BYTES = 1024 * 1024;
@@ -60,7 +57,7 @@ export async function listPendingLegacyCollectionBackupRoots(
       const workspaceDir = [...workspaceDirs][0];
       const ownerAgentId =
         workspaceDirs.size === 1 && workspaceDir
-          ? await inferLegacyCollectionBackupOwnerAgentId(config, env, workspaceDir, backups)
+          ? inferWorkspaceOwnerAgentId(config, env, workspaceDir)
           : undefined;
       if (!ownerAgentId) {
         throw new Error("workspace does not map to exactly one configured agent");
@@ -106,55 +103,6 @@ export function inferWorkspaceOwnerAgentId(
       resolveCanonicalWorkspacePath(workspaceDir),
   );
   return workspaceMatches.length === 1 ? workspaceMatches[0] : undefined;
-}
-
-async function inferLegacyCollectionBackupOwnerAgentId(
-  config: OpenClawConfig,
-  env: NodeJS.ProcessEnv,
-  workspaceDir: string,
-  backups: readonly LegacyCollectionBackup[],
-): Promise<string | undefined> {
-  const workspaceOwner = inferWorkspaceOwnerAgentId(config, env, workspaceDir);
-  // Listing is also used by read-only inspection. Never initialize or migrate
-  // Workshop state merely to recover the owner already recorded by a review.
-  const database = await openExistingOpenClawStateDatabaseReadOnly({ env });
-  try {
-    if (
-      !database ||
-      !tableHasColumn(database.db, "skill_workshop_collection_reviews", "owner_agent_id")
-    ) {
-      return workspaceOwner;
-    }
-    const kysely = getNodeSqliteKysely<
-      Pick<OpenClawStateDatabase, "skill_workshop_collection_reviews">
-    >(database.db);
-    const rootOwners = new Set<string>();
-    for (const backup of backups) {
-      const owners = new Set(
-        executeSqliteQuerySync(
-          database.db,
-          kysely
-            .selectFrom("skill_workshop_collection_reviews")
-            .select("owner_agent_id")
-            .where("backup_id", "=", backup.manifest.id),
-        ).rows.map((row) => row.owner_agent_id),
-      );
-      const owner =
-        owners.size === 0 ? workspaceOwner : owners.size === 1 ? [...owners][0] : undefined;
-      if (
-        !owner ||
-        !listAgentIds(config).includes(owner) ||
-        resolveCanonicalWorkspacePath(resolveAgentWorkspaceDir(config, owner, env)) !==
-          resolveCanonicalWorkspacePath(workspaceDir)
-      ) {
-        return undefined;
-      }
-      rootOwners.add(owner);
-    }
-    return rootOwners.size === 1 ? [...rootOwners][0] : undefined;
-  } finally {
-    database?.walMaintenance.close();
-  }
 }
 
 function legacyCollectionSkillPath(workspaceDir: string, relativeDir: string): string {

--- a/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
+++ b/src/commands/doctor-skill-workshop-sqlite.readonly.test.ts
@@ -86,27 +86,6 @@ describe("read-only Skill Workshop migration inspection", () => {
         } finally {
           seed.close();
         }
-        const backupId = "2026-09-01T00-00-00.000Z-readonly";
-        const backupDir = path.join(
-          state.stateDir,
-          "skill-workshop",
-          "collection-backups",
-          "0000000000000000",
-          backupId,
-        );
-        await fs.mkdir(backupDir, { recursive: true });
-        await fs.writeFile(
-          path.join(backupDir, "manifest.json"),
-          JSON.stringify({
-            schema: "openclaw.skill-collection-backup.v1",
-            id: backupId,
-            createdAt: "2026-09-01T00:00:00.000Z",
-            workspaceDir: state.workspaceDir,
-            skillDirs: ["skills/readonly-workshop"],
-            resultSkillDirs: [],
-            resultSkillHashes: {},
-          }),
-        );
         const before = await snapshotDatabase(databasePath);
 
         await expect(
@@ -114,7 +93,7 @@ describe("read-only Skill Workshop migration inspection", () => {
         ).resolves.toEqual({
           externalProposalCount: 1,
           externalProposalCountsByAgent: { main: 1 },
-          legacyBackupRootCount: 1,
+          legacyBackupRootCount: 0,
         });
 
         closeOpenClawStateDatabaseForTest();


### PR DESCRIPTION
Related: #138771, #140117

## What Problem This Solves

Withdraws the updater service-policy and Workshop recorded-owner changes merged in #138771 and #140117.

## Why This Change Was Made

Reverts commits `0ebb320906da7e1727934b3cf816cedf98270357` and `5696b219c7085a0813567bc4c1b07193638daa22` to restore the previous behavior. This is the exact inverse of those two commits and preserves intervening changes on main.

## User Impact

Restores the previous fresh-Doctor service policy and legacy Workshop backup ownership inference. The fixes introduced by the reverted PRs are withdrawn.

## Evidence

- Both commits reverted cleanly on current main.
- Reapplying exactly the two original patches to the reverted tree reproduces the current main tree byte-for-byte.
- Focused updater and Workshop tests: 29 passed, exit 0.
- Changed-file validation passed, exit 0. Exact-head CI remains the merge gate.
