### PR TITLE
fix(media): stop image setup after cancellation

### DIFF
--- a/src/media-understanding/image-model-runtime.ts
+++ b/src/media-understanding/image-model-runtime.ts
@@ -34,6 +34,7 @@ type ImageRuntimeParams = {
   model: string;
   profile?: string;
   preferredProfile?: string;
+  signal?: AbortSignal;
   authStore?: ImageDescriptionRequest["authStore"];
   agentId?: string;
   workspaceDir?: string;
@@ -135,6 +136,7 @@ async function prepareResolvedImageRuntime(
     store: params.authStore,
     secretSentinels: true,
   });
+  params.signal?.throwIfAborted();
   if (
     providerUsesCredentialScopedModelMetadata({
       provider: model.provider,
@@ -164,6 +166,7 @@ async function prepareResolvedImageRuntime(
             : {}),
       },
     );
+    params.signal?.throwIfAborted();
     model = requireImageCapableModel({
       model: authoritative.model,
       resolvedProvider: model.provider,
@@ -182,25 +185,27 @@ async function prepareResolvedImageRuntime(
     return bindResolvedImageRuntime(params, "", bindPreparedModel(model));
   }
   let apiKey = requireApiKey(apiKeyInfo, model.provider);
-  const preparedAuth = protectPreparedProviderRuntimeAuth({
+  const runtimeAuth = await prepareProviderRuntimeAuth({
     provider: model.provider,
-    preparedAuth: await prepareProviderRuntimeAuth({
-      provider: model.provider,
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+    env: process.env,
+    context: {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
       env: process.env,
-      context: {
-        config: params.cfg,
-        workspaceDir: params.workspaceDir,
-        env: process.env,
-        provider: model.provider,
-        modelId: model.id,
-        model,
-        apiKey,
-        authMode: apiKeyInfo.mode,
-        profileId: apiKeyInfo.profileId,
-      },
-    }),
+      provider: model.provider,
+      modelId: model.id,
+      model,
+      apiKey,
+      authMode: apiKeyInfo.mode,
+      profileId: apiKeyInfo.profileId,
+    },
+  });
+  params.signal?.throwIfAborted();
+  const preparedAuth = protectPreparedProviderRuntimeAuth({
+    provider: model.provider,
+    preparedAuth: runtimeAuth,
   });
   apiKey = preparedAuth?.apiKey?.trim() || apiKey;
   model = applyPreparedRuntimeAuthToModel(model, preparedAuth);
@@ -242,7 +247,7 @@ export async function resolveImageRuntime(
           ],
         },
         // The request already chose a model; full inventory discovery must stay outside setup.
-        { catalogMode: "static" },
+        { catalogMode: "static", abortSignal: params.signal },
       );
   let leaseRetained = false;
   const retainLease = (resolved: PreparedImageRuntime): ResolvedImageRuntime => {
@@ -250,6 +255,7 @@ export async function resolveImageRuntime(
     return { ...resolved, release: preparedRuntimeLease.release };
   };
   try {
+    params.signal?.throwIfAborted();
     const preparedRuntime = preparedRuntimeLease.snapshot;
     const preparedWorkspaceDir = preparedRuntime.workspaceDir ?? runtimeParams.workspaceDir;
     const preparedParams: ImageRuntimeParams = {
@@ -280,6 +286,8 @@ export async function resolveImageRuntime(
         preparedParams.cfg,
         resolveOptions,
       );
+      // Setup may have closed during model lookup; do not start auth for a late result.
+      params.signal?.throwIfAborted();
       const model = requireImageCapableModel({
         model: resolved.model,
         resolvedProvider: resolvedRef.provider,

--- a/src/media-understanding/image.runtime-profile.test.ts
+++ b/src/media-understanding/image.runtime-profile.test.ts
@@ -572,7 +572,7 @@ describe("describeImageWithModelCore", () => {
           { provider: "google", modelId: "gemini-2.5-flash", agentId: "vision-agent" },
         ],
       }),
-      { catalogMode: "static" },
+      { catalogMode: "static", abortSignal: expect.any(AbortSignal) },
     );
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(
       "google",

--- a/src/media-understanding/image.runtime-timeout.test.ts
+++ b/src/media-understanding/image.runtime-timeout.test.ts
@@ -3,6 +3,8 @@
 import { expectDefined } from "@openclaw/normalization-core/expect";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createEmptyPluginMetadataSnapshot } from "../agents/test-helpers/embedded-agent-runner-e2e-mocks.js";
 import {
   SET_RUNTIME_API_KEY_FIELD,
   imageRuntimeMocks,
@@ -12,6 +14,10 @@ import {
 
 const {
   completeMock,
+  acquireAgentRunPreparedModelRuntimeMock,
+  shouldPreferProviderRuntimeResolvedModelMock,
+  getApiKeyForModelMock,
+  prepareProviderRuntimeAuthMock,
   setRuntimeApiKeyMock,
   discoverModelsMock,
   releasePreparedModelRuntimeMock,
@@ -602,21 +608,62 @@ describe("describeImageWithModelCore", () => {
     expect(completeMock).not.toHaveBeenCalled();
   });
 
-  it("releases a prepared generation that resolves after the setup timeout", async () => {
+  it.each(
+    (["timeout", "cancellation"] as const).flatMap((mode) =>
+      (["admission", "model", "credential", "credential-model", "runtime-auth"] as const).map(
+        (stage) => ({ mode, stage }),
+      ),
+    ),
+  )("stops image setup after $mode during $stage", async ({ mode, stage }) => {
     vi.useFakeTimers();
-    let finishResolution!: (value: {
-      authStorage: typeof preparedAuthStorage;
-      model: { provider: string; id: string; api: string; input: string[] };
-      modelRegistry: object;
-    }) => void;
-    resolveModelAsyncMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          finishResolution = resolve;
+    const started = createDeferred();
+    const finish = createDeferred();
+    const delay = async <T>(value: T): Promise<T> => {
+      started.resolve();
+      await finish.promise;
+      return value;
+    };
+    const resolved = {
+      authStorage: preparedAuthStorage,
+      model: {
+        provider: "openai",
+        id: "gpt-5.4-mini",
+        api: "openai-responses",
+        input: ["text", "image"],
+      },
+      modelRegistry: {},
+    };
+    resolveModelAsyncMock.mockResolvedValue(resolved);
+    shouldPreferProviderRuntimeResolvedModelMock.mockReturnValue(stage === "credential-model");
+    if (stage === "admission") {
+      acquireAgentRunPreparedModelRuntimeMock.mockImplementationOnce(() =>
+        delay({
+          snapshot: {
+            agentDir: "/tmp/openclaw-agent",
+            config: {},
+            metadataSnapshot: createEmptyPluginMetadataSnapshot(),
+            createStores: () => ({ authStorage: preparedAuthStorage, modelRegistry: {} }),
+          },
+          release: releasePreparedModelRuntimeMock,
         }),
-    );
-
-    const result = describeImageWithModelCore({
+      );
+    } else if (stage === "model") {
+      resolveModelAsyncMock.mockImplementationOnce(() => delay(resolved));
+    } else if (stage === "credential") {
+      getApiKeyForModelMock.mockImplementationOnce(() =>
+        delay({ apiKey: "test-token", source: "test", mode: "oauth" }),
+      );
+    } else if (stage === "credential-model") {
+      resolveModelAsyncMock
+        .mockResolvedValueOnce(resolved)
+        .mockImplementationOnce(() => delay(resolved));
+    } else {
+      prepareProviderRuntimeAuthMock.mockImplementationOnce(() =>
+        delay({ apiKey: "prepared-test-token" }),
+      );
+    }
+    const controller = new AbortController();
+    const pending = describeImageWithModelCore({
       cfg: {},
       agentDir: "/tmp/openclaw-agent",
       provider: "openai",
@@ -626,72 +673,32 @@ describe("describeImageWithModelCore", () => {
       mime: "image/png",
       prompt: "Describe the image.",
       timeoutMs: 25,
-    });
-    const assertion = expect(result).rejects.toThrow(
-      "image description setup timed out after 25ms before provider request started",
-    );
-    await vi.advanceTimersByTimeAsync(25);
-    await assertion;
-
-    finishResolution({
-      authStorage: preparedAuthStorage,
-      model: {
-        provider: "openai",
-        id: "gpt-5.4-mini",
-        api: "openai-responses",
-        input: ["text", "image"],
-      },
-      modelRegistry: {},
-    });
-    await vi.runAllTimersAsync();
-    await vi.waitFor(() => expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce());
-    expect(completeMock).not.toHaveBeenCalled();
-  });
-
-  it("releases a prepared generation when cancellation wins during setup", async () => {
-    let finishResolution!: (value: {
-      authStorage: typeof preparedAuthStorage;
-      model: { provider: string; id: string; api: string; input: string[] };
-      modelRegistry: object;
-    }) => void;
-    resolveModelAsyncMock.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          finishResolution = resolve;
-        }),
-    );
-    const controller = new AbortController();
-    const result = describeImageWithModelCore({
-      cfg: {},
-      agentDir: "/tmp/openclaw-agent",
-      provider: "openai",
-      model: "gpt-5.4-mini",
-      buffer: Buffer.from("png-bytes"),
-      fileName: "image.png",
-      mime: "image/png",
-      prompt: "Describe the image.",
-      timeoutMs: 1000,
       signal: controller.signal,
     });
-
-    await vi.waitFor(() => expect(resolveModelAsyncMock).toHaveBeenCalledOnce());
-    const assertion = expect(result).rejects.toThrow("caller cancelled during setup");
-    controller.abort(new Error("caller cancelled during setup"));
-    await assertion;
+    const rejected = expect(pending).rejects.toThrow(
+      mode === "timeout"
+        ? "image description setup timed out after 25ms before provider request started"
+        : "caller cancelled during setup",
+    );
+    await started.promise;
+    if (mode === "timeout") {
+      await vi.advanceTimersByTimeAsync(25);
+    } else {
+      controller.abort(new Error("caller cancelled during setup"));
+    }
+    await rejected;
     expect(releasePreparedModelRuntimeMock).not.toHaveBeenCalled();
-
-    finishResolution({
-      authStorage: preparedAuthStorage,
-      model: {
-        provider: "openai",
-        id: "gpt-5.4-mini",
-        api: "openai-responses",
-        input: ["text", "image"],
-      },
-      modelRegistry: {},
-    });
-
+    finish.resolve();
+    await vi.runAllTimersAsync();
     await vi.waitFor(() => expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce());
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(
+      stage === "admission" ? 0 : stage === "credential-model" ? 2 : 1,
+    );
+    expect(getApiKeyForModelMock).toHaveBeenCalledTimes(
+      stage === "admission" || stage === "model" ? 0 : 1,
+    );
+    expect(prepareProviderRuntimeAuthMock).toHaveBeenCalledTimes(stage === "runtime-auth" ? 1 : 0);
+    expect(setRuntimeApiKeyMock).not.toHaveBeenCalled();
     expect(completeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -525,7 +525,7 @@ describe("describeImageWithModelCore", () => {
         agentDir: "/tmp/openclaw-agent",
         workspaceDir: "/tmp/openclaw-workspace",
       }),
-      { catalogMode: "static" },
+      { catalogMode: "static", abortSignal: expect.any(AbortSignal) },
     );
     expect(releasePreparedModelRuntimeMock).toHaveBeenCalledOnce();
     expect(resolveModelAsyncMock).toHaveBeenCalledWith(

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -428,7 +428,7 @@ async function describeImagesWithModelInternal(
   let runtimeValue: string;
   let model: Model | undefined;
   let releaseRuntime: (() => void) | undefined;
-  const resolutionTask = resolveImageRuntime(params);
+  const resolutionTask = resolveImageRuntime({ ...params, signal: requestSignal });
 
   try {
     const resolved = await withImageDescriptionTimeout({


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where a canceled or timed-out image description could continue authentication when pending setup work completed. Late setup could also publish a runtime credential after the caller had already received its cancellation error.

## Why This Change Was Made

Carry the existing combined caller/timeout signal through image runtime admission and check it after each asynchronous setup stage, before starting the next stage or publishing a runtime credential. The existing owner still releases the prepared runtime when pending work settles.

## User Impact

Cancellation prevents further image setup and inference. In-flight operations finish their cleanup without starting a new authentication stage.

## Evidence

- Regression: the original two late-success cases fail before the repair; eight additional cases fail with only the initial model-lookup guard. The final timeout/cancellation table covers admission, model lookup, credential lookup, credential-scoped model lookup, and runtime auth. All 50 focused image tests pass.
- Required changed gate, independent P2 review, and full `pnpm build` pass.
- Thirteen behavioral checks pass with a loaded fixture plugin and synthetic loopback HTTP: ten use the compiled public image SDK; three source-loader OAuth checks additionally observe exact lease counts through credential refresh. Canceled/timed-out requests reject before held work completes, start no subsequent auth or inference, and release their owner after late completion.
- Build/proof ran before commit on source identical to `7e0589437ae84eae5e2c84196c7afcbf6a91b367`. The committed patch hash and 29,248 source/tooling/package hashes match; all 11,131 runtime files stayed unchanged during proof. Original build stamps are retained.

Production: **+8 lines** for the existing cancellation boundary. Tests: **+7 lines**, consolidating two narrow cases into ten. This focused extraction participates in the overall production reduction from #130706.
