### PR TITLE
fix: preserve Markdown values and simplify plugin adapters

### DIFF
--- a/docs/cli/path.md
+++ b/docs/cli/path.md
@@ -206,9 +206,10 @@ depending on the per-kind AST shape.
 `set` writes one concrete target:
 
 - Markdown frontmatter values and `- key: value` item fields are string
-  leaves. Markdown insertions append sections, frontmatter keys, or section
-  items and render a canonical markdown shape for the changed file. Section
-  bodies are not writable as a whole through `set`.
+  leaves. Values are literal, including `$1`, `$&`, and `$$`. Markdown
+  insertions append sections, frontmatter keys, or section items and render a
+  canonical Markdown shape for the changed file. Section bodies are not
+  writable as a whole through `set`.
 - JSONC leaf writes coerce the string value to the existing leaf type
   (`string`, finite `number`, `true`/`false`, or `null`). Use `--value-json`
   when a JSONC/JSON/JSONL leaf replacement should parse `<value>` as JSON and
@@ -515,10 +516,10 @@ auto-detection.
 
 ## Notes
 
-- `set` writes bytes through the substrate's emit path, which applies the
-  redaction-sentinel guard automatically. A leaf carrying
-  `__OPENCLAW_REDACTED__` (verbatim or as a substring) is refused at write
-  time.
+- `set` refuses string leaf values containing `__OPENCLAW_REDACTED__`
+  (verbatim or as a substring) before a write or dry-run preview. This includes
+  Markdown insertion values for frontmatter, items, and headings. Ordinary
+  edits retain unrelated pre-existing marker text.
 - JSONC parsing and leaf edits use the plugin-local `jsonc-parser`
   dependency, so comments and formatting are preserved on ordinary leaf
   writes instead of going through a hand-rolled parser/re-render path.

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -584,6 +584,17 @@ catalog, API-key auth, and dynamic model resolution.
     that discovery inside `catalog.run`, gated on usable auth, and keep
     `staticRun` network-free for offline catalog generation.
 
+    Official provider plugins that share credentials can use
+    `resolveFirstProviderCatalogAuth(ctx.resolveProviderApiKey, providerIds)` from
+    the private runtime `openclaw/plugin-sdk/provider-catalog-shared` subpath.
+    Keep provider precedence in the caller's ordered IDs. The helper stops at
+    the first result with an `apiKey` or `discoveryApiKey` and returns that whole
+    result, preserving its profile and auth mode. An unresolved SecretRef marker
+    takes precedence over another provider's live key; fields are never mixed
+    across accounts. It returns `undefined` when no provider has auth and
+    propagates lookup failures. Official plugin releases using this host export
+    must require a host version that provides it in their `compat.pluginApi`.
+
   </Step>
 
   <Step title="Add dynamic model resolution">

--- a/extensions/matrix/src/matrix/monitor/handler-context.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-context.ts
@@ -164,13 +164,11 @@ export async function resolveMatrixInboundContext(config: {
   let threadContext = threadRootId
     ? await resolveThreadContext({ roomId, threadRootId })
     : undefined;
-  let threadContextBlockedByPolicy = false;
   if (
     threadContext?.senderId &&
     !shouldIncludeRoomContextSender("thread", threadContext.senderId)
   ) {
     logVerboseMessage(`matrix: drop thread root context (mode=${contextVisibilityMode})`);
-    threadContextBlockedByPolicy = true;
     threadContext = undefined;
   }
   let replyContext: Awaited<ReturnType<typeof resolveReplyContext>> | undefined;
@@ -180,8 +178,6 @@ export async function resolveMatrixInboundContext(config: {
       replyToSender: threadContext.senderLabel,
       replyToSenderId: threadContext.senderId,
     };
-  } else if (replyToEventId && replyToEventId === threadRootId && threadContextBlockedByPolicy) {
-    replyContext = await resolveReplyContext({ roomId, eventId: replyToEventId });
   } else {
     replyContext = replyToEventId
       ? await resolveReplyContext({ roomId, eventId: replyToEventId })

--- a/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.body-for-agent.test.ts
@@ -371,52 +371,59 @@ describe("createMatrixRoomMessageHandler inbound body formatting", () => {
     expect(getMemberDisplayName).toHaveBeenCalledTimes(2);
   });
 
-  it("drops thread and reply context fetched from non-allowlisted room senders", async () => {
-    const { handler, finalizeInboundContext } = createMatrixHandlerTestHarness({
-      client: {
-        getEvent: async () =>
-          createMatrixTextMessageEvent({
-            eventId: "$thread-root",
-            sender: "@mallory:example.org",
-            body: "Malicious root topic",
-          }),
-      },
-      isDirectMessage: false,
-      cfg: {
-        channels: {
-          matrix: {
-            contextVisibility: "allowlist",
-            groupAllowFrom: ["@alice:example.org"],
+  it.each(["allowlist", "allowlist_quote"] as const)(
+    "filters disallowed thread context while applying %s quote visibility",
+    async (contextVisibility) => {
+      const { handler, finalizeInboundContext } = createMatrixHandlerTestHarness({
+        client: {
+          getEvent: async () =>
+            createMatrixTextMessageEvent({
+              eventId: "$thread-root",
+              sender: "@mallory:example.org",
+              body: "Malicious root topic",
+            }),
+        },
+        isDirectMessage: false,
+        cfg: {
+          channels: {
+            matrix: {
+              contextVisibility,
+              groupAllowFrom: ["@alice:example.org"],
+            },
           },
         },
-      },
-      groupPolicy: "allowlist",
-      groupAllowFrom: ["@alice:example.org"],
-      roomsConfig: { "*": {} },
-      getMemberDisplayName: async (_roomId, userId) =>
-        userId === "@alice:example.org" ? "Alice" : "Mallory",
-    });
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["@alice:example.org"],
+        roomsConfig: { "*": {} },
+        getMemberDisplayName: async (_roomId, userId) =>
+          userId === "@alice:example.org" ? "Alice" : "Mallory",
+      });
 
-    await handler(
-      "!room:example.org",
-      createMatrixTextMessageEvent({
-        eventId: "$reply1",
-        sender: "@alice:example.org",
-        body: "@room follow up",
-        relatesTo: {
-          rel_type: "m.thread",
-          event_id: "$thread-root",
-          "m.in_reply_to": { event_id: "$thread-root" },
-        },
-        mentions: { room: true },
-      }),
-    );
+      await handler(
+        "!room:example.org",
+        createMatrixTextMessageEvent({
+          eventId: "$reply1",
+          sender: "@alice:example.org",
+          body: "@room follow up",
+          relatesTo: {
+            rel_type: "m.thread",
+            event_id: "$thread-root",
+            "m.in_reply_to": { event_id: "$thread-root" },
+          },
+          mentions: { room: true },
+        }),
+      );
 
-    const finalized = latestFinalizedReplyContext(finalizeInboundContext);
-    expect(finalized.ThreadStarterBody).toBeUndefined();
-    expect(finalized.ReplyToBody).toBeUndefined();
-    expect(finalized.ReplyToSender).toBeUndefined();
-  });
+      const finalized = latestFinalizedReplyContext(finalizeInboundContext);
+      expect(finalized.ThreadStarterBody).toBeUndefined();
+      expect(finalized.ReplyToBody).toBe(
+        contextVisibility === "allowlist_quote" ? "Malicious root topic" : undefined,
+      );
+      expect(finalized.ReplyToSender).toBe(
+        contextVisibility === "allowlist_quote" ? "Mallory" : undefined,
+      );
+    },
+  );
 
   it("drops quoted reply context fetched from non-allowlisted room senders", async () => {
     const { handler, finalizeInboundContext } = createQuotedReplyVisibilityHarness("allowlist");

--- a/extensions/oc-path/src/cli.test.ts
+++ b/extensions/oc-path/src/cli.test.ts
@@ -582,6 +582,49 @@ describe("openclaw path CLI", () => {
       );
     });
 
+    it("writes literal dollar replacement text through the registered Markdown command", async () => {
+      const workspaceDir = tempDirs.make("oc-path-cli-");
+      const filePath = join(workspaceDir, "AGENTS.md");
+      writeFileSync(filePath, "## Tools\n\n- command: old\n- keep: stable\n", "utf-8");
+      const value = "literal $$ $& $1 $` $' $HOME";
+      const rt = createTestRuntime();
+
+      await pathSetCommand(
+        "oc://AGENTS.md/tools/command/command",
+        value,
+        { cwd: workspaceDir, json: true },
+        rt,
+      );
+
+      expect(rt.exitCode).toBe(0);
+      expect(readFileSync(filePath, "utf-8")).toBe(
+        `## Tools\n\n- command: ${value}\n- keep: stable\n`,
+      );
+    });
+
+    it.each([false, true])(
+      "refuses sentinel-bearing Markdown insertion in the CLI (dry-run=%s)",
+      async (dryRun) => {
+        const workspaceDir = tempDirs.make("oc-path-cli-");
+        const filePath = join(workspaceDir, "AGENTS.md");
+        const before = "---\nname: x\n---\n";
+        writeFileSync(filePath, before, "utf-8");
+        const rt = createTestRuntime();
+
+        await pathSetCommand(
+          "oc://AGENTS.md/[frontmatter]/+note",
+          "before__OPENCLAW_REDACTED__after",
+          { cwd: workspaceDir, json: true, dryRun },
+          rt,
+        );
+
+        expect(rt.exitCode).toBe(1);
+        expect(stderrText(rt)).toContain("OC_EMIT_SENTINEL");
+        expect(stderrText(rt)).toContain("oc://AGENTS.md/[frontmatter]/+note");
+        expect(readFileSync(filePath, "utf-8")).toBe(before);
+      },
+    );
+
     it("CLI-S03 sentinel-bearing value is refused at emit", async () => {
       const workspaceDir = tempDirs.make("oc-path-cli-");
       const filePath = join(workspaceDir, "gateway.jsonc");

--- a/extensions/oc-path/src/oc-path/edit.ts
+++ b/extensions/oc-path/src/oc-path/edit.ts
@@ -41,7 +41,7 @@ export function setMdOcPath(ast: MdAst, path: OcPath, newValue: string): MdEditR
     const newEntry: FrontmatterEntry = { ...existing, value: newValue };
     const newFm = ast.frontmatter.slice();
     newFm[idx] = newEntry;
-    return finalize({ ...ast, frontmatter: newFm });
+    return { ok: true, ast: rebuildMdRaw({ ...ast, frontmatter: newFm }) };
   }
 
   if (path.section === undefined || path.item === undefined || path.field === undefined) {
@@ -84,7 +84,7 @@ export function setMdOcPath(ast: MdAst, path: OcPath, newValue: string): MdEditR
   };
   const newBlocks = ast.blocks.slice();
   newBlocks[blockIdx] = newBlock;
-  return finalize({ ...ast, blocks: newBlocks });
+  return { ok: true, ast: rebuildMdRaw({ ...ast, blocks: newBlocks }) };
 }
 
 // In-place substitution on `bodyText` so round-trip emit reflects the
@@ -105,7 +105,8 @@ function rebuildBlockBody(block: AstBlock, newItems: readonly AstItem[]): string
       continue;
     }
     const re = new RegExp(`^(\\s*-\\s*${escapeRegex(oldItem.kv.key)}\\s*:\\s*).*$`, "m");
-    body = body.replace(re, `$1${newItem.kv.value}`);
+    const newValue = newItem.kv.value;
+    body = body.replace(re, (_match, prefix: string) => `${prefix}${newValue}`);
   }
   return body;
 }
@@ -114,7 +115,7 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function finalize(ast: MdAst): MdEditResult {
+export function rebuildMdRaw(ast: MdAst): MdAst {
   const parts: string[] = [];
   if (ast.frontmatter.length > 0) {
     parts.push("---");
@@ -138,5 +139,5 @@ function finalize(ast: MdAst): MdEditResult {
       parts.push(block.bodyText);
     }
   }
-  return { ok: true, ast: { ...ast, raw: parts.join("\n") } };
+  return { ...ast, raw: parts.join("\n") };
 }

--- a/extensions/oc-path/src/oc-path/jsonc/emit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/emit.ts
@@ -36,20 +36,28 @@ export function emitJsonc(ast: JsoncAst, opts: JsoncEmitOptions = {}): string {
   if (ast.root === null) {
     return "";
   }
-  return renderValue(ast.root, guardPath, []);
+  return renderJsoncValue(ast.root, guardPath, " ");
 }
 
-function renderValue(value: JsoncValue, guardPath: string, walked: readonly string[]): string {
+export function renderJsoncValue(
+  value: JsoncValue,
+  guardPath: string,
+  space: "" | " ",
+  walked: readonly string[] = [],
+): string {
   switch (value.kind) {
     case "object": {
       const parts = value.entries.map(
-        (e) => `${JSON.stringify(e.key)}: ${renderValue(e.value, guardPath, [...walked, e.key])}`,
+        (e) =>
+          `${JSON.stringify(e.key)}:${space}${renderJsoncValue(e.value, guardPath, space, [...walked, e.key])}`,
       );
-      return `{ ${parts.join(", ")} }`;
+      return `{${space}${parts.join(`,${space}`)}${space}}`;
     }
     case "array": {
-      const parts = value.items.map((v, i) => renderValue(v, guardPath, [...walked, String(i)]));
-      return `[ ${parts.join(", ")} ]`;
+      const parts = value.items.map((v, i) =>
+        renderJsoncValue(v, guardPath, space, [...walked, String(i)]),
+      );
+      return `[${space}${parts.join(`,${space}`)}${space}]`;
     }
     case "string":
       // Substring match: embedded sentinel leaks marker bytes too.

--- a/extensions/oc-path/src/oc-path/jsonl/emit.ts
+++ b/extensions/oc-path/src/oc-path/jsonl/emit.ts
@@ -5,7 +5,7 @@
  * @module @openclaw/oc-path/jsonl/emit
  */
 
-import type { JsoncValue } from "../jsonc/ast.js";
+import { renderJsoncValue } from "../jsonc/emit.js";
 import { OcEmitSentinelError, REDACTED_SENTINEL } from "../sentinel.js";
 import type { JsonlAst } from "./ast.js";
 
@@ -37,37 +37,9 @@ export function emitJsonl(ast: JsonlAst, opts: JsonlEmitOptions = {}): string {
       continue;
     }
     // Value lines always scan leaves so caller-injected sentinel is rejected.
-    out.push(renderValue(ln.value, `${guardPath}/L${ln.line}`, []));
+    out.push(renderJsoncValue(ln.value, `${guardPath}/L${ln.line}`, ""));
   }
   // Preserve line-ending convention; otherwise CRLF input edited via
   // setJsonlOcPath would emit mixed endings (silent corruption on Windows).
   return out.join(ast.lineEnding ?? "\n");
-}
-
-function renderValue(value: JsoncValue, guardPath: string, walked: readonly string[]): string {
-  switch (value.kind) {
-    case "object": {
-      const parts = value.entries.map(
-        (e) => `${JSON.stringify(e.key)}:${renderValue(e.value, guardPath, [...walked, e.key])}`,
-      );
-      return `{${parts.join(",")}}`;
-    }
-    case "array": {
-      const parts = value.items.map((v, i) => renderValue(v, guardPath, [...walked, String(i)]));
-      return `[${parts.join(",")}]`;
-    }
-    case "string":
-      // Substring match: embedded sentinel leaks marker bytes too.
-      if (value.value.includes(REDACTED_SENTINEL)) {
-        throw new OcEmitSentinelError(`${guardPath}/${walked.join("/")}`);
-      }
-      return JSON.stringify(value.value);
-    case "number":
-      return String(value.value);
-    case "boolean":
-      return String(value.value);
-    case "null":
-      return "null";
-  }
-  return "";
 }

--- a/extensions/oc-path/src/oc-path/sentinel.ts
+++ b/extensions/oc-path/src/oc-path/sentinel.ts
@@ -26,8 +26,8 @@ export class OcEmitSentinelError extends Error {
 
 // Substring match (not equality) — `prefix__OPENCLAW_REDACTED__suffix`
 // still leaks the marker. No-op on non-string input.
-export function guardSentinel(value: unknown, ocPath: string): void {
+export function guardSentinel(value: unknown, ocPath: string | (() => string)): void {
   if (typeof value === "string" && value.includes(REDACTED_SENTINEL)) {
-    throw new OcEmitSentinelError(ocPath);
+    throw new OcEmitSentinelError(typeof ocPath === "function" ? ocPath() : ocPath);
   }
 }

--- a/extensions/oc-path/src/oc-path/tests/edit.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/edit.test.ts
@@ -6,20 +6,19 @@ import { parseMd } from "../parse.js";
 import { OcEmitSentinelError, REDACTED_SENTINEL } from "../sentinel.js";
 
 describe("setOcPath — frontmatter", () => {
-  it("replaces a frontmatter value", () => {
+  it("replaces frontmatter while retaining unrelated pre-existing sentinel text", () => {
     const raw = `---
 name: github
 description: old desc
 ---
-
-Body.
-`;
+Body ${REDACTED_SENTINEL}.`;
     const { ast } = parseMd(raw);
     const r = setOcPath(ast, parseOcPath("oc://AGENTS.md/[frontmatter]/description"), "new desc");
     expect(r.ok).toBe(true);
     if (r.ok) {
-      expect(r.ast.raw).toContain("description: new desc");
-      expect(r.ast.raw).not.toContain("old desc");
+      expect(r.ast.raw).toBe(
+        `---\nname: github\ndescription: new desc\n---\n\nBody ${REDACTED_SENTINEL}.`,
+      );
     }
   });
 
@@ -40,6 +39,22 @@ Body.
 });
 
 describe("setOcPath — item kv field", () => {
+  it.each(["$$", "$&", "$1", "$`", "$'", "$HOME"])(
+    "preserves literal dollar replacement text %s",
+    (token) => {
+      const raw = "## Tools\n\n- command: old\n- keep: stable\n";
+      const { ast } = parseMd(raw);
+      const before = structuredClone(ast);
+      const value = `literal ${token}`;
+      const result = setOcPath(ast, parseOcPath("oc://X.md/tools/command/command"), value);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.ast.raw).toBe(`## Tools\n\n- command: ${value}\n- keep: stable\n`);
+      }
+      expect(ast).toEqual(before);
+    },
+  );
+
   it("replaces an item kv value and reflects it in the rebuilt body", () => {
     const raw = `## Boundaries
 
@@ -50,8 +65,7 @@ describe("setOcPath — item kv field", () => {
     const r = setOcPath(ast, parseOcPath("oc://AGENTS.md/boundaries/timeout/timeout"), "30");
     expect(r.ok).toBe(true);
     if (r.ok) {
-      expect(r.ast.raw).toContain("- timeout: 30");
-      expect(r.ast.raw).toContain("- enabled: true");
+      expect(r.ast.raw).toBe("## Boundaries\n\n- enabled: true\n- timeout: 30\n");
     }
   });
 

--- a/extensions/oc-path/src/oc-path/tests/jsonc/emit.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/jsonc/emit.test.ts
@@ -31,29 +31,24 @@ describe("emitJsonc — round-trip", () => {
 });
 
 describe("emitJsonc — render mode", () => {
-  it("re-stringifies the structural tree (no comments)", () => {
-    const { ast } = parseJsonc('{ /* drop me */ "x": 1, "y": [2, 3] }');
+  it("renders nested values with spaced containers and preserves entry order", () => {
+    const { ast } = parseJsonc(
+      '{ /* drop me */ "2": 2, "1": 1, "2": 3, "values": [{}, [], {"scalars": [true, false, null, -1.5, "text"]}] }',
+    );
     const out = emitJsonc(ast, { mode: "render" });
-    expect(out).not.toContain("drop me");
-    expect(JSON.parse(out)).toEqual({ x: 1, y: [2, 3] });
+    expect(out).toBe(
+      '{ "2": 2, "1": 1, "2": 3, "values": [ {  }, [  ], { "scalars": [ true, false, null, -1.5, "text" ] } ] }',
+    );
   });
 
-  it("throws OcEmitSentinelError when a leaf string is the sentinel", () => {
-    const ast = parseJsonc('{ "x": "ok" }').ast;
-    const tampered = {
-      ...ast,
-      root: {
-        kind: "object" as const,
-        entries: [
-          {
-            key: "x",
-            line: 1,
-            value: { kind: "string" as const, value: REDACTED_SENTINEL },
-          },
-        ],
-      },
-    };
-    expect(() => emitJsonc(tampered, { mode: "render" })).toThrow(OcEmitSentinelError);
+  it("reports the nested path when a leaf string is the sentinel", () => {
+    const { ast } = parseJsonc(`{"outer":[{"token":"${REDACTED_SENTINEL}"}]}`);
+    expect(() => emitJsonc(ast, { mode: "render", fileNameForGuard: "config" })).toThrow(
+      expect.objectContaining({
+        code: "OC_EMIT_SENTINEL",
+        path: "oc://config/outer/0/token",
+      }),
+    );
   });
 
   it("throws when a leaf string EMBEDS the sentinel (prefix/suffix wrap)", () => {

--- a/extensions/oc-path/src/oc-path/tests/jsonl/emit.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/jsonl/emit.test.ts
@@ -25,10 +25,14 @@ describe("emitJsonl — round-trip", () => {
 });
 
 describe("emitJsonl — render mode", () => {
-  it("rebuilds value lines via JSON-stringify", () => {
-    const { ast } = parseJsonl('{"a":1}\n{"b":2}\n');
+  it("renders nested values compactly and preserves entry order", () => {
+    const { ast } = parseJsonl(
+      '{ "2": 2, "1": 1, "2": 3, "values": [{}, [], {"scalars": [true, false, null, -1.5, "text"]}] }\n[ {}, [] ]\n',
+    );
     const out = emitJsonl(ast, { mode: "render" });
-    expect(out.split("\n")).toEqual(['{"a":1}', '{"b":2}']);
+    expect(out).toBe(
+      '{"2":2,"1":1,"2":3,"values":[{},[],{"scalars":[true,false,null,-1.5,"text"]}]}\n[{},[]]',
+    );
   });
 
   it("preserves blank and malformed lines verbatim in render mode", () => {
@@ -37,29 +41,14 @@ describe("emitJsonl — render mode", () => {
     expect(out.split("\n")).toEqual(['{"a":1}', "", "broken", '{"b":2}']);
   });
 
-  it("throws when a value-leaf is the sentinel under render mode", () => {
-    const ast = parseJsonl('{"a":"ok"}\n').ast;
-    const tampered = {
-      ...ast,
-      lines: [
-        {
-          kind: "value" as const,
-          line: 1,
-          raw: '{"a":"ok"}',
-          value: {
-            kind: "object" as const,
-            entries: [
-              {
-                key: "a",
-                line: 1,
-                value: { kind: "string" as const, value: REDACTED_SENTINEL },
-              },
-            ],
-          },
-        },
-      ],
-    };
-    expect(() => emitJsonl(tampered, { mode: "render" })).toThrow(OcEmitSentinelError);
+  it("reports the line and nested path when a value-leaf is the sentinel", () => {
+    const { ast } = parseJsonl(`{"ok":true}\n{"outer":[{"token":"${REDACTED_SENTINEL}"}]}\n`);
+    expect(() => emitJsonl(ast, { mode: "render", fileNameForGuard: "events" })).toThrow(
+      expect.objectContaining({
+        code: "OC_EMIT_SENTINEL",
+        path: "oc://events/L2/outer/0/token",
+      }),
+    );
   });
 
   it("throws when a value-leaf EMBEDS the sentinel (prefix/suffix wrap)", () => {

--- a/extensions/oc-path/src/oc-path/tests/universal.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/universal.test.ts
@@ -8,6 +8,7 @@ import { emitJsonl } from "../jsonl/emit.js";
 import { parseJsonl } from "../jsonl/parse.js";
 import { parseOcPath } from "../oc-path.js";
 import { parseMd } from "../parse.js";
+import { REDACTED_SENTINEL } from "../sentinel.js";
 import { resolveOcPath, setOcPath } from "../universal.js";
 import { parseYaml } from "../yaml/parse.js";
 
@@ -344,40 +345,59 @@ describe("setOcPath — jsonl leaf", () => {
 });
 
 describe("setOcPath — md insertion", () => {
-  it("appends item to section with `+`", () => {
-    const md = parseMd("## Tools\n\n- gh: GitHub CLI\n").ast;
-    const r = setOcPath(md, parseOcPath("oc://X.md/tools/+"), "docker: container CLI");
-    expect(r.ok).toBe(true);
-    if (r.ok) {
-      const out = emitMd(r.ast as Parameters<typeof emitMd>[0]);
-      expect(out).toContain("- gh: GitHub CLI");
-      expect(out).toContain("- docker: container CLI");
+  it.each([
+    ["oc://X.md/[frontmatter]/+note", "---\nname: x\n---\n"],
+    ["oc://X.md/tools/+", "## Tools\n- keep: stable\n"],
+    ["oc://X.md/+", "## Existing\n"],
+  ])("refuses sentinel-bearing Markdown insertion values at %s", (uri, raw) => {
+    const md = parseMd(raw).ast;
+    const before = structuredClone(md);
+    for (const value of [REDACTED_SENTINEL, `before${REDACTED_SENTINEL}after`]) {
+      expect(() => setOcPath(md, parseOcPath(uri), value)).toThrow(
+        expect.objectContaining({ code: "OC_EMIT_SENTINEL", path: uri }),
+      );
+      expect(md).toEqual(before);
     }
   });
 
-  it("appends new section at file root with `+`", () => {
-    const md = parseMd("## Existing\n").ast;
-    const r = setOcPath(md, parseOcPath("oc://X.md/+"), "New Section");
-    expect(r.ok).toBe(true);
-    if (r.ok) {
-      const out = emitMd(r.ast as Parameters<typeof emitMd>[0]);
-      expect(out).toContain("## Existing");
-      expect(out).toContain("## New Section");
-    }
-  });
-
-  it("adds new frontmatter key with +key", () => {
+  it("keeps the insertion-value guard separate from new frontmatter keys", () => {
     const md = parseMd("---\nname: x\n---\n").ast;
-    const r = setOcPath(
+    const result = setOcPath(
       md,
-      parseOcPath("oc://X.md/[frontmatter]/+description"),
-      "a new description",
+      parseOcPath(`oc://X.md/[frontmatter]/+${REDACTED_SENTINEL}`),
+      "safe",
     );
-    expect(r.ok).toBe(true);
-    if (r.ok) {
-      const out = emitMd(r.ast as Parameters<typeof emitMd>[0]);
-      expect(out).toContain("description: a new description");
+    expect(result).toMatchObject({
+      ok: true,
+      ast: { raw: `---\nname: x\n${REDACTED_SENTINEL}: safe\n---` },
+    });
+  });
+
+  it.each([
+    [
+      "item",
+      "## Tools\n\n- gh: __OPENCLAW_REDACTED__\n",
+      "oc://X.md/tools/+",
+      "docker: container CLI",
+      "## Tools\n\n- gh: __OPENCLAW_REDACTED__\n- docker: container CLI",
+    ],
+    ["section", "## Existing\n", "oc://X.md/+", "New Section", "## Existing\n\n## New Section"],
+    [
+      "frontmatter key",
+      "---\nname: x\n---\n",
+      "oc://X.md/[frontmatter]/+description",
+      "has: colon",
+      '---\nname: x\ndescription: "has: colon"\n---',
+    ],
+  ])("preserves output and input AST when inserting a %s", (_kind, raw, path, value, expected) => {
+    const md = parseMd(raw).ast;
+    const before = structuredClone(md);
+    const result = setOcPath(md, parseOcPath(path), value);
+    if (!result.ok || result.ast.kind !== "md") {
+      throw new Error("expected a successful Markdown insertion");
     }
+    expect(emitMd(result.ast)).toBe(expected);
+    expect(md).toEqual(before);
   });
 
   it("rejects duplicate frontmatter key on insertion", () => {

--- a/extensions/oc-path/src/oc-path/universal.ts
+++ b/extensions/oc-path/src/oc-path/universal.ts
@@ -18,18 +18,17 @@
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { isMap, isScalar, isSeq, type Pair } from "yaml";
 import type { MdAst } from "./ast.js";
-import { setMdOcPath } from "./edit.js";
-import { formatFrontmatterValue } from "./frontmatter-format.js";
+import { rebuildMdRaw, setMdOcPath } from "./edit.js";
 import type { JsoncAst, JsoncEntry, JsoncValue } from "./jsonc/ast.js";
 import { insertJsoncOcPath, setJsoncOcPath } from "./jsonc/edit.js";
 import { resolveJsoncOcPath } from "./jsonc/resolve.js";
 import type { JsonlAst } from "./jsonl/ast.js";
 import { appendJsonlOcPath as appendJsonlLine, setJsonlOcPath } from "./jsonl/edit.js";
-import { emitJsonl } from "./jsonl/emit.js";
 import { resolveJsonlOcPath } from "./jsonl/resolve.js";
 import type { OcPath } from "./oc-path.js";
 import { formatOcPath, isPattern, OcPathError, parseArrayIndexSegment } from "./oc-path.js";
 import { resolveMdOcPath } from "./resolve.js";
+import { guardSentinel } from "./sentinel.js";
 import type { YamlAst } from "./yaml/ast.js";
 import { insertYamlOcPath, setYamlOcPath } from "./yaml/edit.js";
 import { resolveYamlOcPath } from "./yaml/resolve.js";
@@ -438,6 +437,7 @@ export function setOcPath(
   if (insertion !== null) {
     switch (ast.kind) {
       case "md":
+        guardSentinel(value, () => formatOcPath(path));
         return setMdInsertion(ast, insertion, value);
       case "jsonc":
         return setJsoncInsertion(ast, insertion, value);
@@ -844,34 +844,6 @@ function jsonToJsoncValue(v: unknown): JsoncValue | null {
   }
   // JSON.parse never produces undefined / function / symbol.
   throw new Error(`unsupported JSON value type: ${typeof v}`);
-}
-
-function rebuildMdRaw(ast: MdAst): MdAst {
-  const parts: string[] = [];
-  if (ast.frontmatter.length > 0) {
-    parts.push("---");
-    for (const fm of ast.frontmatter) {
-      parts.push(`${fm.key}: ${formatFrontmatterValue(fm.value)}`);
-    }
-    parts.push("---");
-  }
-  if (ast.preamble.length > 0) {
-    if (parts.length > 0) {
-      parts.push("");
-    }
-    parts.push(ast.preamble);
-  }
-  for (const block of ast.blocks) {
-    if (parts.length > 0) {
-      parts.push("");
-    }
-    parts.push(`## ${block.heading}`);
-    if (block.bodyText.length > 0) {
-      parts.push(block.bodyText);
-    }
-  }
-  void emitJsonl;
-  return { ...ast, raw: parts.join("\n") };
 }
 
 function slugifyHeading(s: string): string {

--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -471,21 +471,17 @@ describe("opencode-go provider plugin", () => {
   it("does not mix provider-specific runtime auth with shared discovery auth", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("blocked fetch"));
+    const resolveProviderApiKey = vi.fn((providerId: string) =>
+      providerId === "opencode-go"
+        ? { apiKey: NON_ENV_SECRETREF_MARKER, discoveryApiKey: undefined }
+        : { apiKey: "shared-opencode-key", discoveryApiKey: "shared-opencode-key" },
+    );
 
     try {
       const result = await provider.catalog?.run({
         config: {},
         env: {},
-        resolveProviderApiKey: (providerId: string) =>
-          providerId === "opencode-go"
-            ? {
-                apiKey: NON_ENV_SECRETREF_MARKER,
-                discoveryApiKey: undefined,
-              }
-            : {
-                apiKey: "shared-opencode-key",
-                discoveryApiKey: "shared-opencode-key",
-              },
+        resolveProviderApiKey,
         resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
       } as never);
 
@@ -494,10 +490,33 @@ describe("opencode-go provider plugin", () => {
       }
       expect(result.provider.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
       expect(result.provider.models.map((model) => model.id)).toContain("deepseek-v4-pro");
+      expect(resolveProviderApiKey).toHaveBeenCalledExactlyOnceWith("opencode-go");
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {
       fetchMock.mockRestore();
     }
+  });
+
+  it("uses Zen credentials for the Go catalog only when Go has no credentials", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const resolveProviderApiKey = vi.fn((providerId?: string) => ({
+      apiKey: providerId === "opencode" ? NON_ENV_SECRETREF_MARKER : undefined,
+    }));
+
+    await expect(
+      provider.catalog?.run({
+        config: {},
+        env: {},
+        resolveProviderApiKey,
+        resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+      }),
+    ).resolves.toMatchObject({
+      provider: {
+        baseUrl: "https://opencode.ai/zen/go/v1",
+        apiKey: NON_ENV_SECRETREF_MARKER,
+      },
+    });
+    expect(resolveProviderApiKey.mock.calls).toEqual([["opencode-go"], ["opencode"]]);
   });
 
   it("caches both catalog requests without concealing later acquisition failure", async () => {

--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -1,5 +1,6 @@
 // Opencode Go plugin entrypoint registers its OpenClaw integration.
 import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { resolveFirstProviderCatalogAuth } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import { opencodeGoMediaUnderstandingProvider } from "./media-understanding-provider.js";
@@ -18,18 +19,6 @@ import { resolveThinkingProfile } from "./provider-policy-api.js";
 import { createOpencodeGoAttributionWrapper, createOpencodeGoWrapper } from "./stream.js";
 
 const PROVIDER_ID = "opencode-go";
-type OpencodeGoCatalogAuth = { apiKey?: string; discoveryApiKey?: string; profileId?: string };
-
-function resolveOpencodeGoCatalogAuth(
-  resolveProviderApiKey: (providerId: string) => OpencodeGoCatalogAuth,
-): OpencodeGoCatalogAuth | undefined {
-  const own = resolveProviderApiKey(PROVIDER_ID);
-  if (own.apiKey || own.discoveryApiKey) {
-    return own;
-  }
-  const shared = resolveProviderApiKey("opencode");
-  return shared.apiKey || shared.discoveryApiKey ? shared : undefined;
-}
 
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
@@ -99,7 +88,10 @@ export default defineSingleProviderPluginEntry({
         if (ctx.providerIds !== undefined && !ctx.providerIds.includes(PROVIDER_ID)) {
           return null;
         }
-        const auth = resolveOpencodeGoCatalogAuth(ctx.resolveProviderApiKey);
+        const auth = resolveFirstProviderCatalogAuth(ctx.resolveProviderApiKey, [
+          PROVIDER_ID,
+          "opencode",
+        ]);
         if (!auth) {
           return null;
         }

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -338,13 +338,15 @@ describe("opencode provider plugin", () => {
       .spyOn(globalThis, "fetch")
       .mockRejectedValue(new Error("unexpected fetch"));
     const provider = await registerSingleProviderPlugin(plugin);
+    const resolveProviderApiKey = vi.fn((providerId: string) =>
+      providerId === "opencode"
+        ? { apiKey: NON_ENV_SECRETREF_MARKER, discoveryApiKey: undefined }
+        : { apiKey: "shared-opencode-key", discoveryApiKey: "shared-opencode-key" },
+    );
     const result = await provider.catalog?.run({
       config: {},
       env: {},
-      resolveProviderApiKey: (providerId: string) =>
-        providerId === "opencode"
-          ? { apiKey: NON_ENV_SECRETREF_MARKER, discoveryApiKey: undefined }
-          : { apiKey: "shared-opencode-key", discoveryApiKey: "shared-opencode-key" },
+      resolveProviderApiKey,
       resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
     } as never);
 
@@ -353,8 +355,92 @@ describe("opencode provider plugin", () => {
     }
     expect(result.provider.apiKey).toBe(NON_ENV_SECRETREF_MARKER);
     expectSeedModels(result.provider.models);
+    expect(resolveProviderApiKey).toHaveBeenCalledExactlyOnceWith("opencode");
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { authProvider: "opencode", apiKey: NON_ENV_SECRETREF_MARKER },
+    { authProvider: "opencode-go", apiKey: NON_ENV_SECRETREF_MARKER },
+    { authProvider: "opencode", apiKey: undefined },
+  ])("keeps $authProvider catalog credentials and profile together ($apiKey)", async (fixture) => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("unexpected fetch"));
+    const liveCatalog = vi
+      .spyOn(await import("./provider-catalog.js"), "buildOpencodeZenLiveProviderConfig")
+      .mockImplementation(async (params = {}) => ({
+        baseUrl: "https://opencode.ai/zen/v1",
+        apiKey: params.apiKey,
+        models: [],
+      }));
+    const auth = {
+      apiKey: fixture.apiKey,
+      discoveryApiKey: "selected-discovery-key",
+      profileId: `${fixture.authProvider}:selected`,
+      mode: "api_key" as const,
+    };
+    const resolveProviderApiKey = vi.fn((providerId?: string) => {
+      if (providerId === fixture.authProvider) {
+        return auth;
+      }
+      if (providerId === "opencode") {
+        return { apiKey: undefined, profileId: "opencode:unconfigured" };
+      }
+      throw new Error("Unused sibling credentials must not be resolved");
+    });
+
+    await expect(
+      provider.catalog?.run({
+        config: {},
+        env: {},
+        resolveProviderApiKey,
+        resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+      }),
+    ).resolves.toEqual({
+      provider: {
+        baseUrl: "https://opencode.ai/zen/v1",
+        apiKey: auth.apiKey ?? auth.discoveryApiKey,
+        models: [],
+      },
+      outcomes: [{ provider: "opencode", profileId: auth.profileId, status: "ready" }],
+    });
+    expect(liveCatalog).toHaveBeenCalledExactlyOnceWith({
+      apiKey: auth.apiKey ?? auth.discoveryApiKey,
+      discoveryApiKey: auth.discoveryApiKey,
+    });
+    expect(resolveProviderApiKey.mock.calls).toEqual(
+      fixture.authProvider === "opencode" ? [["opencode"]] : [["opencode"], ["opencode-go"]],
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each(["opencode", "opencode-go"])(
+    "propagates %s credential lookup failures without selecting another account",
+    async (failedProvider) => {
+      const provider = await registerSingleProviderPlugin(plugin);
+      const failure = new Error("Selected account credentials are unavailable");
+      const resolveProviderApiKey = vi.fn((providerId?: string) => {
+        if (providerId === failedProvider) {
+          throw failure;
+        }
+        return { apiKey: undefined };
+      });
+
+      await expect(
+        provider.catalog?.run({
+          config: {},
+          env: {},
+          resolveProviderApiKey,
+          resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+        }),
+      ).rejects.toBe(failure);
+      expect(resolveProviderApiKey.mock.calls).toEqual(
+        failedProvider === "opencode" ? [["opencode"]] : [["opencode"], ["opencode-go"]],
+      );
+    },
+  );
 
   it("discovers previously unknown trusted models and their upstream-owned transport", async () => {
     const fetchGuard = createCatalogFetchGuard({

--- a/extensions/opencode/index.ts
+++ b/extensions/opencode/index.ts
@@ -1,5 +1,6 @@
 // Opencode plugin entrypoint registers its OpenClaw integration.
 import { runLiveProviderCatalog } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { resolveFirstProviderCatalogAuth } from "openclaw/plugin-sdk/provider-catalog-shared";
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import {
   buildProviderReplayFamilyHooks,
@@ -25,18 +26,6 @@ import { wrapOpencodeProviderStream } from "./stream.js";
 
 const PROVIDER_ID = "opencode";
 const MINIMAX_MODERN_MODEL_MATCHERS = ["minimax-m2.7"] as const;
-type OpencodeZenCatalogAuth = { apiKey?: string; discoveryApiKey?: string; profileId?: string };
-
-function resolveOpencodeZenCatalogAuth(
-  resolveProviderApiKey: (providerId: string) => OpencodeZenCatalogAuth,
-): OpencodeZenCatalogAuth | undefined {
-  const own = resolveProviderApiKey(PROVIDER_ID);
-  if (own.apiKey || own.discoveryApiKey) {
-    return own;
-  }
-  const shared = resolveProviderApiKey("opencode-go");
-  return shared.apiKey || shared.discoveryApiKey ? shared : undefined;
-}
 
 function isModernOpencodeModel(modelId: string): boolean {
   const lower = normalizeLowercaseStringOrEmpty(modelId);
@@ -131,7 +120,10 @@ export default defineSingleProviderPluginEntry({
         if (ctx.providerIds !== undefined && !ctx.providerIds.includes(PROVIDER_ID)) {
           return null;
         }
-        const auth = resolveOpencodeZenCatalogAuth(ctx.resolveProviderApiKey);
+        const auth = resolveFirstProviderCatalogAuth(ctx.resolveProviderApiKey, [
+          PROVIDER_ID,
+          "opencode-go",
+        ]);
         if (!auth) {
           return null;
         }

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -25,6 +25,7 @@ export {
   buildSingleProviderApiKeyCatalog,
   findCatalogTemplate,
   readManifestProviderDefaultModelRef,
+  resolveFirstProviderCatalogAuth,
   type ManifestProviderCatalogEntry,
   type ManifestProviderCatalogSurface,
 } from "../plugins/provider-catalog.js";

--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -46,6 +46,20 @@ export function findCatalogTemplate(params: {
     .find((entry) => entry !== undefined);
 }
 
+/** Selects one complete auth result in caller-defined order, including unresolved secret markers. */
+export function resolveFirstProviderCatalogAuth(
+  resolveProviderApiKey: ProviderCatalogContext["resolveProviderApiKey"],
+  providerIds: readonly string[],
+): ReturnType<ProviderCatalogContext["resolveProviderApiKey"]> | undefined {
+  for (const providerId of providerIds) {
+    const auth = resolveProviderApiKey(providerId);
+    if (auth.apiKey || auth.discoveryApiKey) {
+      return auth;
+    }
+  }
+  return undefined;
+}
+
 /** Builds a provider catalog result for providers that share one API key. */
 export async function buildSingleProviderApiKeyCatalog(params: {
   ctx: ProviderCatalogContext;


### PR DESCRIPTION
## What Problem This Solves

Path edits could report success while corrupting literal Markdown values containing JavaScript replacement sequences such as dollar-ampersand. Markdown insertion also accepted redaction-marker values that existing leaf edits reject, including successful dry-run previews.

This maintainer-requested batch also removes duplicate Markdown reconstruction, JSONC/JSONL value serialization, Matrix context branching, and paired provider catalog-auth selection.

Related: #139597

## Why This Change Was Made

Markdown replacement now uses a literal callback, and insertion validates incoming values before creating an AST. The existing Markdown owner handles reconstruction; JSONL reuses JSONC's recursive value renderer with its original compact spacing. Matrix's redundant branch falls through to its identical existing resolution path. Both OpenCode providers use one ordered catalog-auth selector that returns the complete selected result.

The selector remains synchronous and unbound. Provider precedence, short-circuiting, unresolved markers, auth/profile provenance, error propagation, JSONC/JSONL bytes, unrelated existing marker text, and Matrix quote policy remain unchanged.

Runtime is 52 lines smaller; tests grow by 173 lines and docs by 12. No new configuration, schema, dependency, SDK subpath, or version metadata.

## User Impact

Markdown values retain their literal dollar sequences. Incoming redaction-marker insertion values fail before a write or dry-run preview, while ordinary edits preserve unrelated marker text already in the file. Other touched behavior is unchanged.

The new private named host export requires a synchronized core/plugin release. Release preparation must advance the official plugins' compat.pluginApi floor to a host containing the selector. These plugins must not be independently published with the older floor; no older-host compatibility is claimed or added.

## Maintainer release decision

Select the review's recommended coordinated core/plugin release. This is the same release cohort already required by #140072. The existing normal release owner, `syncPluginVersions`, advances `compat.pluginApi` and the generated package peer requirement to that core release; install validation rejects hosts below the API floor. The eight existing version-sync and install-compatibility tests pass on unchanged owner code. The updated OpenCode packages will be published only with those synchronized floors. The compatibility item is resolved by this release constraint; this PR does not publish packages or change versions.

## Evidence

- All 183 preservation tests passed on original production.
- The new regression scope failed on original production in 11 cases for the intended reasons: corrupted literal bytes or missing sentinel refusal. Both preservation controls passed.
- The candidate passed 785 tests across the affected plugins, serializers, catalog owner and Matrix thread-media sibling.
- A real registered Commander CLI replay passed all 15 synthetic cases with actual file writes: literal replacement, refusal and unchanged disk, dry-run refusal, and pre-existing-marker controls. Source hashes and original evidence stayed unchanged.
- Both changed docs pass MDX validation. Independent P0–P2 review of the frozen implementation completed clean in two passes; the only later change narrows documentation wording to string leaf values.
- Full changed checks pass, including all selected typechecks, lint, SDK exports/surface, dead-code, import-cycle and state guards. The exact ec48194 candidate build passed.
- Canonically built standalone OpenCode packages passed 50 checks against the actual host export, native entry registration, and cache-backed catalog key/profile selection. No source import rewriting or provider request was used.
- The shipped openclaw.mjs launcher and built plugin discovery passed another five CLI write/dry-run cases with source imports, operator data, network and helper execution denied. That restrictive sandbox emitted a nonfatal config-health database warning, so this proof does not establish health-state initialization; the requested file bytes, exit codes and refusal behavior passed.

No provider network request, real account action, or Matrix send is used as evidence. The package-host proof establishes native artifact resolution and cache-backed catalog selection, without claiming live acquisition.
