### PR TITLE
perf(ui): reuse board drag layout work

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -303,6 +303,7 @@ const boardFixtureHtml = `<!doctype html>
     <link rel="stylesheet" href="/src/styles.css" />
     <style>
       body { margin: 0; min-width: 320px; min-height: 100vh; background: var(--bg); }
+      #app { height: 100%; overflow: auto; }
       .board-fixture-shell { box-sizing: border-box; margin: 0 auto; max-width: 1440px; padding: 36px; }
       .board-fixture-header { align-items: end; display: flex; justify-content: space-between; margin-bottom: 24px; }
       .board-fixture-header span { color: var(--muted); font: 10px ui-monospace, monospace; letter-spacing: .15em; }

--- a/ui/src/components/board/board-view.ts
+++ b/ui/src/components/board/board-view.ts
@@ -398,11 +398,11 @@ class OpenClawBoardView extends OpenClawLightDomElement {
       const targetName = pointerElement?.closest<
         HTMLElementTagNameMap["openclaw-board-widget-cell"]
       >("openclaw-board-widget-cell")?.widget?.name;
-      const targetCell = layout(items).find((rect) => rect.name === targetName) ?? {
+      this.previewItems = previewDrag(items, gesture.name, {
+        name: targetName,
         x: Math.floor((event.clientX - bounds.left) / (columnWidth + BOARD_GRID_GAP)),
         y: Math.floor((event.clientY - bounds.top) / (BOARD_GRID_ROW_HEIGHT + BOARD_GRID_GAP)),
-      };
-      this.previewItems = previewDrag(items, gesture.name, targetCell).items;
+      });
       return;
     }
 

--- a/ui/src/lib/board/grid.test.ts
+++ b/ui/src/lib/board/grid.test.ts
@@ -106,13 +106,16 @@ describe("board grid layout", () => {
     }
   });
 
-  it("clamps invalid dimensions without mutating source items", () => {
+  it.each([
+    { maxHeight: undefined, expectedHeight: 20 },
+    { maxHeight: 240, expectedHeight: 99 },
+  ])("clamps invalid dimensions with height limit $maxHeight", ({ maxHeight, expectedHeight }) => {
     const items = [item("wide", 99, 0, 0), item("tall", -3, 99, 1)];
     const before = structuredClone(items);
-    const rects = layout(items);
+    const rects = layout(items, maxHeight);
     expect(rects).toEqual([
       { name: "wide", x: 0, y: 0, w: 12, h: 1 },
-      { name: "tall", x: 0, y: 1, w: 1, h: 20 },
+      { name: "tall", x: 0, y: 1, w: 1, h: expectedHeight },
     ]);
     expect(items).toEqual(before);
   });
@@ -121,31 +124,35 @@ describe("board grid layout", () => {
 describe("board grid drag preview", () => {
   const items = [item("a", 4, 2, 0), item("b", 4, 2, 1), item("c", 4, 2, 2)];
 
-  it("pushes an occupied target and its followers aside", () => {
-    const preview = previewDrag(items, "c", { x: 1, y: 0 });
-    expect(preview.items.map((entry) => [entry.name, entry.order])).toEqual([
+  it.each([
+    { name: undefined, x: 1, y: 0 },
+    { name: "missing", x: 1, y: 0 },
+    { name: "a", x: 100, y: 100 },
+  ])("pushes the named or fallback occupied target aside: %j", (target) => {
+    const preview = previewDrag(items, "c", target);
+    expect(preview.map((entry) => [entry.name, entry.order])).toEqual([
       ["c", 0],
       ["a", 1],
       ["b", 2],
     ]);
-    expect(preview.rects.map((rect) => rect.name)).toEqual(["c", "a", "b"]);
-    expectValid(preview.rects);
+    const rects = layout(preview);
+    expect(rects.map((rect) => rect.name)).toEqual(["c", "a", "b"]);
+    expectValid(rects);
   });
 
   it("keeps the order while the pointer remains inside the dragged rect", () => {
-    expect(previewDrag(items, "b", { x: 6, y: 1 }).items.map((entry) => entry.name)).toEqual([
-      "a",
-      "b",
-      "c",
-    ]);
+    expect(
+      previewDrag(items, "b", { name: undefined, x: 6, y: 1 }).map((entry) => entry.name),
+    ).toEqual(["a", "b", "c"]);
   });
 
   it("resolves occupied targets before removing and compacting the moving item", () => {
     const preview = previewDrag([item("a", 6, 1, 0), item("b", 6, 1, 1), item("c", 3, 1, 2)], "a", {
+      name: undefined,
       x: 6,
       y: 0,
     });
-    expect(preview.items.map((entry) => entry.name)).toEqual(["a", "b", "c"]);
+    expect(preview.map((entry) => entry.name)).toEqual(["a", "b", "c"]);
   });
 
   it("chooses the next empty-cell target by rendered row-major geometry", () => {
@@ -160,28 +167,24 @@ describe("board grid drag preview", () => {
       item("h", 11, 2, 7),
     ];
     expect(
-      previewDrag(heterogeneous, "a", { x: 10, y: 0 }).items.map((entry) => entry.name),
+      previewDrag(heterogeneous, "a", { name: undefined, x: 10, y: 0 }).map((entry) => entry.name),
     ).toEqual(["b", "c", "d", "e", "a", "f", "g", "h"]);
   });
 
   it("appends from an empty row tail or below the board", () => {
     const tailItems = [item("a", 3, 2, 0), item("b", 3, 2, 1), item("c", 3, 2, 2)];
-    expect(previewDrag(tailItems, "a", { x: 10, y: 0 }).items.map((entry) => entry.name)).toEqual([
-      "b",
-      "c",
-      "a",
-    ]);
-    expect(previewDrag(items, "a", { x: 100, y: 100 }).items.map((entry) => entry.name)).toEqual([
-      "b",
-      "c",
-      "a",
-    ]);
+    expect(
+      previewDrag(tailItems, "a", { name: undefined, x: 10, y: 0 }).map((entry) => entry.name),
+    ).toEqual(["b", "c", "a"]);
+    expect(
+      previewDrag(items, "a", { name: undefined, x: 100, y: 100 }).map((entry) => entry.name),
+    ).toEqual(["b", "c", "a"]);
   });
 
   it("is deterministic and leaves inputs unchanged", () => {
     const before = structuredClone(items);
-    expect(previewDrag(items, "c", { x: 0, y: 0 })).toEqual(
-      previewDrag(items, "c", { x: 0, y: 0 }),
+    expect(previewDrag(items, "c", { name: undefined, x: 0, y: 0 })).toEqual(
+      previewDrag(items, "c", { name: undefined, x: 0, y: 0 }),
     );
     expect(items).toEqual(before);
   });
@@ -191,12 +194,14 @@ describe("board grid drag preview", () => {
       const generated = propertyItems(seed, 24);
       const moving = generated[(seed * 7) % generated.length]!;
       const preview = previewDrag(generated, moving.name, {
+        name: undefined,
         x: (seed * 5) % BOARD_GRID_COLUMNS,
         y: (seed * 3) % 18,
       });
-      expectValid(preview.rects);
-      expectGravityTight(preview.rects);
-      expect(preview.items.map((entry) => entry.order)).toEqual(
+      const rects = layout(preview);
+      expectValid(rects);
+      expectGravityTight(rects);
+      expect(preview.map((entry) => entry.order)).toEqual(
         Array.from({ length: generated.length }, (_entry, order) => order),
       );
     }
@@ -204,14 +209,45 @@ describe("board grid drag preview", () => {
 
   it("returns a compact canonical board for an unknown item", () => {
     const preview = previewDrag([item("b", 3, 1, 5), item("a", 3, 1, 2)], "missing", {
+      name: "a",
       x: 0,
       y: 0,
     });
-    expect(preview.items.map((entry) => [entry.name, entry.order])).toEqual([
+    expect(preview.map((entry) => [entry.name, entry.order])).toEqual([
       ["a", 0],
       ["b", 1],
     ]);
-    expectValid(preview.rects);
+    expectValid(layout(preview));
+  });
+
+  it("preserves empty widget names in moving and target positions", () => {
+    const emptyNameItems = [item("", 6, 1, 0), item("b", 6, 1, 1)];
+    const preview = previewDrag(emptyNameItems, "b", {
+      name: "",
+      x: 100,
+      y: 100,
+    });
+    expect(preview.map((entry) => entry.name)).toEqual(["b", ""]);
+    expectValid(layout(preview));
+    expect(
+      previewDrag(emptyNameItems, "", { name: undefined, x: 100, y: 100 }).map(
+        (entry) => entry.name,
+      ),
+    ).toEqual(["b", ""]);
+  });
+
+  it("resolves successive named targets from the latest preview through pointerup", () => {
+    const before = structuredClone(items);
+    const first = previewDrag(items, "c", { name: "a", x: 100, y: 100 });
+    expect(first.map((entry) => entry.name)).toEqual(["c", "a", "b"]);
+    const firstSnapshot = structuredClone(first);
+    const second = previewDrag(first, "c", { name: "b", x: 100, y: 100 });
+    expect(second.map((entry) => entry.name)).toEqual(["a", "c", "b"]);
+    expect(first).toEqual(firstSnapshot);
+    expect(previewDrag(second, "c", { name: "b", x: 100, y: 100 })).toEqual(second);
+    expectValid(layout(second));
+    expectGravityTight(layout(second));
+    expect(items).toEqual(before);
   });
 });
 

--- a/ui/src/lib/board/grid.ts
+++ b/ui/src/lib/board/grid.ts
@@ -28,11 +28,6 @@ type BoardGridCell = {
 
 export type BoardGridDirection = "left" | "right" | "up" | "down";
 
-type BoardGridPreview = {
-  items: BoardGridItem[];
-  rects: BoardGridRect[];
-};
-
 function clampInteger(value: number, minimum: number, maximum: number): number {
   const integer = Number.isFinite(value) ? Math.round(value) : minimum;
   return Math.min(maximum, Math.max(minimum, integer));
@@ -96,9 +91,13 @@ export function layout(
   items: readonly BoardGridItem[],
   maxItemHeight = BOARD_GRID_MAX_HEIGHT,
 ): BoardGridRect[] {
+  return layoutCanonicalItems(canonicalItems(items, maxItemHeight));
+}
+
+function layoutCanonicalItems(items: readonly BoardGridItem[]): BoardGridRect[] {
   const occupied: boolean[][] = [];
   const rects: BoardGridRect[] = [];
-  for (const item of canonicalItems(items, maxItemHeight)) {
+  for (const item of items) {
     const placed = firstFit(occupied, item);
     occupy(occupied, placed);
     rects.push(placed);
@@ -113,34 +112,35 @@ function contains(rect: BoardGridRect, cell: BoardGridCell): boolean {
 }
 
 /**
- * Reorders one item around the target cell, then fully reflows the board.
- * Occupied targets insert before their occupant: that item and its followers
- * are pushed aside by the normal first-fit pass.
+ * Reorders against a named current rectangle or the fallback grid cell.
+ * Resolve targets before removing the moving item so responsive card stacking
+ * and successive previews keep the same logical target through pointerup.
  */
 export function previewDrag(
   items: readonly BoardGridItem[],
   name: string,
-  targetCell: BoardGridCell,
-): BoardGridPreview {
+  target: BoardGridCell & { name: string | undefined },
+): BoardGridItem[] {
   const canonical = canonicalItems(items);
   const movingIndex = canonical.findIndex((item) => item.name === name);
   if (movingIndex < 0) {
-    return { items: canonical, rects: layout(canonical) };
+    return canonical;
   }
 
-  const currentRects = layout(canonical);
+  const currentRects = layoutCanonicalItems(canonical);
+  const targetCell = currentRects.find((rect) => rect.name === target.name) ?? target;
   const cell = {
     x: clampInteger(targetCell.x, 0, BOARD_GRID_COLUMNS - 1),
     y: Math.max(0, Number.isFinite(targetCell.y) ? Math.floor(targetCell.y) : 0),
   };
   const currentRect = currentRects.find((rect) => rect.name === name);
   if (currentRect && contains(currentRect, cell)) {
-    return { items: canonical, rects: currentRects };
+    return canonical;
   }
 
   const [moving] = canonical.splice(movingIndex, 1);
   if (!moving) {
-    return { items: canonical, rects: layout(canonical) };
+    return canonical;
   }
   const occupiedTarget = currentRects.find((rect) => rect.name !== name && contains(rect, cell));
   const nextRect =
@@ -155,8 +155,7 @@ export function previewDrag(
     ? canonical.findIndex((item) => item.name === nextRect.name)
     : canonical.length;
   canonical.splice(Math.max(0, insertionIndex), 0, moving);
-  const reordered = canonical.map(withOrder);
-  return { items: reordered, rects: layout(reordered) };
+  return canonical.map(withOrder);
 }
 
 /** Returns a new canonical item list with one clamped size change. */


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Reduces the synchronous work needed to preview session dashboard rearrangements. Also fixes an issue where users could not reach lower cards or the append drop zone in the standalone dashboard fixture when its board extended below the viewport.

## Why This Change Was Made

The grid owner now resolves the target against one canonical current layout and returns only the reordered items the view uses; rendering still owns final placement. The fixture's existing `#app` gets its own scroll container, preserving the app's deliberate root clipping.

## User Impact

Drag/drop ordering, dimensions, and mounted widget frames stay unchanged while geometry preparation gets cheaper. The standalone fixture can now scroll to its lower cards and append target. Across four changed files, production LOC is unchanged and tests add 36 lines.

## Evidence

- **Behavior:** 113 tests passed: 73 whole grid/view/sizing tests, 22 real-Chromium board tests, and 18 whole standalone fixture E2E tests. All 25 expanded changed checks passed; fresh P2 review was scoped-clean (0.96 confidence).
- **Geometry:** One fixed run retained and checked all 9,460 complete returns across 24 cohorts, two layout controls, and eight ABBA rounds. Independent reconciliation confirms all 768 batch means. All 48 per-order medians improved (7.4–66.8%); occupied drops on 8/24/35-widget boards improved about 49–53%. However, 2/48 means and 8/48 maximum batch means worsened. The adverse means were reverse-order empty (+10.8%, +0.057µs) and forward-order named-target/invalid-fallback (+57.3%, +2.801µs); the largest relative maximum increase was +591.1% on that invalid-fallback control, while the 35-widget occupied-drop maximum also increased 72.5% (+79.177µs).
- **Browser:** Four cases at 390/1280×1000 on each board-code variant passed exact state, geometry, hit-target, operation, and cell/iframe identity checks. All eight inspected screenshots are synthetic, with corresponding before/after PNGs byte-identical. Both variants share the fixed fixture; the original clipped-host failure remains a separate pre-fix reproduction.

The first changed check failed only on test formatting; the repository formatter and full rerun passed. The original fixture capture passed an occupied drag but failed to reach the clipped append target, motivating the one-line scroll fix. All observed test, capture, and numeric processes closed. No numeric retry was used.

The numbers displayed on cards are static fixture data. Geometry timings measure the actual synchronous caller plus render-layout pipeline, not frame rate, pointer-to-paint, or whole-Gateway/provider latency.

| Case | Before board refactor, fixed fixture | After board refactor, fixed fixture |
| --- | --- | --- |
| Narrow occupied drop | ![Before 390px occupied drop](https://github.com/user-attachments/assets/7858e115-6aae-4180-b84a-022ed8c3b5ef) | ![After 390px occupied drop](https://github.com/user-attachments/assets/8e85cd5d-f190-44c9-ab8c-2f148ac851cb) |
| Narrow append drop | ![Before 390px append drop](https://github.com/user-attachments/assets/2c909cf0-1121-4cb5-af37-2426264f364d) | ![After 390px append drop](https://github.com/user-attachments/assets/abca90a9-2ed0-441c-a447-466bce7bb83b) |
| Wide occupied drop | ![Before 1280px occupied drop](https://github.com/user-attachments/assets/c99095d6-5f1f-487d-984e-2f790707fa49) | ![After 1280px occupied drop](https://github.com/user-attachments/assets/9e1e773b-3e94-46d7-8bd2-5eaa40df56f0) |
| Wide append drop | ![Before 1280px append drop](https://github.com/user-attachments/assets/6c5e162c-16ce-4054-9886-2b1d26e0dae4) | ![After 1280px append drop](https://github.com/user-attachments/assets/e7eb0579-8473-4ddf-9fa1-3303928d6310) |
