### PR TITLE
feat(providers): leave generated setup catalogs to discovery

### DIFF
--- a/docs/providers/cohere.md
+++ b/docs/providers/cohere.md
@@ -58,6 +58,8 @@ openclaw models list --provider cohere
 
 Onboarding only sets Cohere as the primary model when no primary model is already configured.
 
+Onboarding preserves your model entries and leaves generated catalog rows to discovery. With `models.mode: "replace"`, it also writes the built-in catalog because that mode skips discovery.
+
 ## Environment-only setup
 
 Make `COHERE_API_KEY` available to the Gateway process, then select the Cohere model:

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -52,6 +52,8 @@ openclaw gateway restart
   </Step>
 </Steps>
 
+Onboarding preserves your model entries and leaves generated catalog rows to discovery. With `models.mode: "replace"`, it also writes the built-in catalog because that mode skips discovery.
+
 <AccordionGroup>
   <Accordion title="Non-interactive setup">
     For scripted or headless installations, pass all flags directly:

--- a/docs/providers/kilocode.md
+++ b/docs/providers/kilocode.md
@@ -47,6 +47,8 @@ openclaw gateway restart
   </Step>
 </Steps>
 
+Onboarding preserves your model entries and leaves generated catalog rows to discovery. With `models.mode: "replace"`, it also writes the built-in catalog because that mode skips discovery.
+
 ## Default model and catalog
 
 The default model is `kilocode/kilo-auto/balanced`, Kilo Gateway's balanced smart-routing tier.

--- a/docs/providers/tencent.md
+++ b/docs/providers/tencent.md
@@ -69,6 +69,8 @@ export TOKENPLAN_API_KEY=...
   </Step>
 </Steps>
 
+Onboarding preserves your model entries and leaves generated catalog rows to discovery. With `models.mode: "replace"`, it also writes the built-in catalog because that mode skips discovery.
+
 ## Non-interactive setup
 
 ```bash

--- a/extensions/cohere/onboard.test.ts
+++ b/extensions/cohere/onboard.test.ts
@@ -13,7 +13,7 @@ const COHERE_NORTH_MINI_CODE_MODEL_ID = "north-mini-code-1-0";
 
 describe("Cohere onboarding", () => {
   it("registers the manifest catalog through the onboarding preset", () => {
-    const result = applyCohereConfig({});
+    const result = applyCohereConfig({ models: { mode: "replace" } });
     const provider = result.models?.providers?.cohere;
 
     expect(provider).toMatchObject({
@@ -52,8 +52,23 @@ describe("Cohere onboarding", () => {
   it("uses Cohere as the first configured primary model", () => {
     const result = applyCohereConfig({});
 
+    expect(result.models?.providers?.cohere?.models).toEqual([]);
     expect(resolveAgentModelPrimaryValue(result.agents?.defaults?.model)).toBe(
       COHERE_DEFAULT_MODEL_REF,
     );
+  });
+
+  it.each([undefined, "merge"] as const)("preserves authored rows in %s mode", (mode) => {
+    const authored = buildCohereCatalogModels().map((model) =>
+      Object.assign({}, model, { id: `operator-${model.id}`, name: "My model" }),
+    );
+    const result = applyCohereConfig({
+      models: {
+        mode,
+        providers: { cohere: { baseUrl: COHERE_BASE_URL, models: authored } },
+      },
+    });
+
+    expect(result.models?.providers?.cohere?.models).toEqual(authored);
   });
 });

--- a/extensions/cohere/onboard.ts
+++ b/extensions/cohere/onboard.ts
@@ -7,11 +7,11 @@ const COHERE_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(manifest, "
 
 export const { applyConfig: applyCohereConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: COHERE_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: "cohere",
     api: "openai-completions",
     baseUrl: COHERE_BASE_URL,
-    catalogModels: buildCohereCatalogModels(),
+    catalogModels: cfg.models?.mode === "replace" ? buildCohereCatalogModels() : [],
     aliases: [{ modelRef: COHERE_DEFAULT_MODEL_REF, alias: "Cohere Command A+" }],
   }),
 });

--- a/extensions/deepseek/onboard.test.ts
+++ b/extensions/deepseek/onboard.test.ts
@@ -1,5 +1,6 @@
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { describe, expect, it } from "vitest";
+import { buildDeepSeekProvider } from "./api.js";
 import { applyDeepSeekConfig } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
@@ -7,7 +8,7 @@ const DEEPSEEK_DEFAULT_MODEL_REF = `deepseek/${manifest.modelCatalog.providers.d
 
 describe("DeepSeek onboarding", () => {
   it("applies the manifest catalog, default, and alias", () => {
-    const config = applyDeepSeekConfig({});
+    const config = applyDeepSeekConfig({ models: { mode: "replace" } });
 
     expect(config.models?.providers?.deepseek?.models.map((model) => model.id)).toEqual(
       manifest.modelCatalog.providers.deepseek.models.map((model) => model.id),
@@ -19,5 +20,22 @@ describe("DeepSeek onboarding", () => {
     expect(config.agents?.defaults?.models).toEqual({
       [DEEPSEEK_DEFAULT_MODEL_REF]: { alias: "DeepSeek" },
     });
+  });
+
+  it.each([undefined, "merge"] as const)("keeps discovery-owned rows out of %s config", (mode) => {
+    const empty = applyDeepSeekConfig({ models: { mode } });
+    expect(empty.models?.providers?.deepseek?.models).toEqual([]);
+    expect(resolveAgentModelPrimaryValue(empty.agents?.defaults?.model)).toBe(
+      DEEPSEEK_DEFAULT_MODEL_REF,
+    );
+
+    const provider = buildDeepSeekProvider();
+    const authored = provider.models.map((model) =>
+      Object.assign({}, model, { id: `operator-${model.id}` }),
+    );
+    const configured = applyDeepSeekConfig({
+      models: { mode, providers: { deepseek: { ...provider, models: authored } } },
+    });
+    expect(configured.models?.providers?.deepseek?.models).toEqual(authored);
   });
 });

--- a/extensions/deepseek/onboard.ts
+++ b/extensions/deepseek/onboard.ts
@@ -7,11 +7,11 @@ const DEEPSEEK_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(manifest,
 
 export const { applyConfig: applyDeepSeekConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: DEEPSEEK_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: "deepseek",
     api: "openai-completions",
     baseUrl: DEEPSEEK_BASE_URL,
-    catalogModels: structuredClone(DEEPSEEK_MODEL_CATALOG),
+    catalogModels: cfg.models?.mode === "replace" ? structuredClone(DEEPSEEK_MODEL_CATALOG) : [],
     aliases: [{ modelRef: DEEPSEEK_DEFAULT_MODEL_REF, alias: "DeepSeek" }],
   }),
 });

--- a/extensions/kilocode/onboard.test.ts
+++ b/extensions/kilocode/onboard.test.ts
@@ -61,7 +61,7 @@ describe("Kilo Gateway provider config", () => {
     });
 
     it("includes the default model in the provider model list", () => {
-      const result = applyKilocodeConfig(emptyCfg);
+      const result = applyKilocodeConfig({ models: { mode: "replace" } });
       const provider = result.models?.providers?.kilocode;
       const models = provider?.models;
       expect(Array.isArray(models)).toBe(true);
@@ -70,7 +70,7 @@ describe("Kilo Gateway provider config", () => {
     });
 
     it("surfaces the full Kilo model catalog", () => {
-      const result = applyKilocodeConfig(emptyCfg);
+      const result = applyKilocodeConfig({ models: { mode: "replace" } });
       const provider = result.models?.providers?.kilocode;
       const modelIds = provider?.models?.map((m) => m.id) ?? [];
       for (const modelId of KILOCODE_MODEL_IDS) {
@@ -101,6 +101,27 @@ describe("Kilo Gateway provider config", () => {
       const agentModel = result.agents?.defaults?.models?.[KILOCODE_DEFAULT_MODEL_REF];
       expect(agentModel).toEqual({ alias: "Kilo Gateway" });
     });
+
+    it.each([undefined, "merge"] as const)(
+      "preserves authored rows without seeding %s config",
+      (mode) => {
+        expect(
+          applyKilocodeConfig({ models: { mode } }).models?.providers?.kilocode?.models,
+        ).toEqual([]);
+        const authored = {
+          ...buildKilocodeModelDefinition(),
+          id: "operator-model",
+          name: "My model",
+        };
+        const result = applyKilocodeConfig({
+          models: {
+            mode,
+            providers: { kilocode: { baseUrl: KILOCODE_BASE_URL, models: [authored] } },
+          },
+        });
+        expect(result.models?.providers?.kilocode?.models).toEqual([authored]);
+      },
+    );
 
     it("preserves existing alias if already set", () => {
       const cfg: OpenClawConfig = {

--- a/extensions/kilocode/onboard.ts
+++ b/extensions/kilocode/onboard.ts
@@ -7,11 +7,11 @@ export { KILOCODE_DEFAULT_MODEL_REF };
 
 export const { applyConfig: applyKilocodeConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: KILOCODE_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: "kilocode",
     api: "openai-completions",
     baseUrl: KILOCODE_BASE_URL,
-    catalogModels: buildKilocodeProvider().models ?? [],
+    catalogModels: cfg.models?.mode === "replace" ? buildKilocodeProvider().models : [],
     aliases: [{ modelRef: KILOCODE_DEFAULT_MODEL_REF, alias: "Kilo Gateway" }],
   }),
 });

--- a/extensions/tencent/index.test.ts
+++ b/extensions/tencent/index.test.ts
@@ -129,27 +129,33 @@ describe("tencent provider plugin", () => {
     });
   });
 
-  it.each([
-    {
-      providerId: "tencent-tokenhub",
-      choiceId: "tokenhub-api-key",
-      flagValue: "tokenhub-test-key",
-      envVar: "TOKENHUB_API_KEY",
-      aliases: {
-        "tencent-tokenhub/hy3": { alias: "Hy3 (TokenHub)" },
-        "tencent-tokenhub/hy3-preview": { alias: "Hy3 preview (TokenHub)" },
-      },
-    },
-    {
-      providerId: "tencent-tokenplan",
-      choiceId: "tokenplan-api-key",
-      flagValue: "tokenplan-test-key",
-      envVar: "TOKENPLAN_API_KEY",
-      aliases: { "tencent-tokenplan/hy3": { alias: "Hy3 (TokenPlan)" } },
-    },
-  ] as const)(
-    "configures only $providerId through its registered auth method",
-    async ({ providerId, choiceId, flagValue, envVar, aliases }) => {
+  it.each(
+    (
+      [
+        {
+          providerId: "tencent-tokenhub",
+          choiceId: "tokenhub-api-key",
+          flagValue: "tokenhub-test-key",
+          envVar: "TOKENHUB_API_KEY",
+          aliases: {
+            "tencent-tokenhub/hy3": { alias: "Hy3 (TokenHub)" },
+            "tencent-tokenhub/hy3-preview": { alias: "Hy3 preview (TokenHub)" },
+          },
+        },
+        {
+          providerId: "tencent-tokenplan",
+          choiceId: "tokenplan-api-key",
+          flagValue: "tokenplan-test-key",
+          envVar: "TOKENPLAN_API_KEY",
+          aliases: { "tencent-tokenplan/hy3": { alias: "Hy3 (TokenPlan)" } },
+        },
+      ] as const
+    ).flatMap((provider) =>
+      ([undefined, "replace"] as const).map((mode) => Object.assign({}, provider, { mode })),
+    ),
+  )(
+    "configures only $providerId through its registered auth method in $mode mode",
+    async ({ providerId, choiceId, flagValue, envVar, aliases, mode }) => {
       const { providers } = await registerTencentPlugin();
       const provider = requireRegisteredProvider(providers, providerId);
       const resolveApiKey = vi.fn(async () => ({
@@ -163,8 +169,8 @@ describe("tencent provider plugin", () => {
       }
       const config = await method.runNonInteractive({
         authChoice: choiceId,
-        config: {},
-        baseConfig: {},
+        config: { models: { mode } },
+        baseConfig: { models: { mode } },
         opts: { tokenhubApiKey: "tokenhub-test-key", tokenplanApiKey: "tokenplan-test-key" },
         runtime: createRuntimeEnv(),
         resolveApiKey,
@@ -180,7 +186,9 @@ describe("tencent provider plugin", () => {
       expect(toApiKeyCredential).not.toHaveBeenCalled();
       expect(Object.keys(config?.models?.providers ?? {})).toEqual([providerId]);
       expect(config?.models?.providers?.[providerId]?.models.map((model) => model.id)).toEqual(
-        manifest.modelCatalog.providers[providerId].models.map((model) => model.id),
+        mode === "replace"
+          ? manifest.modelCatalog.providers[providerId].models.map((model) => model.id)
+          : [],
       );
       expect(config?.agents?.defaults?.model).toEqual({ primary: `${providerId}/hy3` });
       expect(config?.agents?.defaults?.models).toEqual(aliases);

--- a/extensions/tencent/onboard.test.ts
+++ b/extensions/tencent/onboard.test.ts
@@ -1,5 +1,6 @@
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { describe, expect, it } from "vitest";
+import { buildTokenHubProvider, buildTokenPlanProvider } from "./api.js";
 import {
   applyTokenHubConfig,
   applyTokenPlanConfig,
@@ -10,7 +11,7 @@ import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 describe("Tencent onboarding", () => {
   it("applies the TokenHub manifest catalog, default, and aliases", () => {
-    const config = applyTokenHubConfig({});
+    const config = applyTokenHubConfig({ models: { mode: "replace" } });
 
     expect(config.models?.providers?.["tencent-tokenhub"]?.models.map((model) => model.id)).toEqual(
       manifest.modelCatalog.providers["tencent-tokenhub"].models.map((model) => model.id),
@@ -25,7 +26,7 @@ describe("Tencent onboarding", () => {
   });
 
   it("applies the TokenPlan manifest catalog, default, and alias", () => {
-    const config = applyTokenPlanConfig({});
+    const config = applyTokenPlanConfig({ models: { mode: "replace" } });
 
     expect(
       config.models?.providers?.["tencent-tokenplan"]?.models.map((model) => model.id),
@@ -36,5 +37,20 @@ describe("Tencent onboarding", () => {
     expect(config.agents?.defaults?.models).toEqual({
       [TOKENPLAN_DEFAULT_MODEL_REF]: { alias: "Hy3 (TokenPlan)" },
     });
+  });
+
+  it.each([
+    { providerId: "tencent-tokenhub", apply: applyTokenHubConfig, build: buildTokenHubProvider },
+    { providerId: "tencent-tokenplan", apply: applyTokenPlanConfig, build: buildTokenPlanProvider },
+  ])("keeps $providerId generated rows out of merge config", ({ providerId, apply, build }) => {
+    expect(apply({}).models?.providers?.[providerId]?.models).toEqual([]);
+    const provider = build();
+    const authored = provider.models.map((model) =>
+      Object.assign({}, model, { id: `operator-${model.id}` }),
+    );
+    const result = apply({
+      models: { mode: "merge", providers: { [providerId]: { ...provider, models: authored } } },
+    });
+    expect(result.models?.providers?.[providerId]?.models).toEqual(authored);
   });
 });

--- a/extensions/tencent/onboard.ts
+++ b/extensions/tencent/onboard.ts
@@ -18,11 +18,11 @@ export const TOKENHUB_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(
 
 export const { applyConfig: applyTokenHubConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: TOKENHUB_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: TOKENHUB_PROVIDER_ID,
     api: "openai-completions",
     baseUrl: TOKENHUB_BASE_URL,
-    catalogModels: structuredClone(TOKENHUB_MODEL_CATALOG),
+    catalogModels: cfg.models?.mode === "replace" ? structuredClone(TOKENHUB_MODEL_CATALOG) : [],
     aliases: [
       { modelRef: TOKENHUB_DEFAULT_MODEL_REF, alias: "Hy3 (TokenHub)" },
       { modelRef: TOKENHUB_PREVIEW_MODEL_REF, alias: "Hy3 preview (TokenHub)" },
@@ -37,11 +37,11 @@ export const TOKENPLAN_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(
 
 export const { applyConfig: applyTokenPlanConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: TOKENPLAN_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: TOKENPLAN_PROVIDER_ID,
     api: "openai-completions",
     baseUrl: TOKENPLAN_BASE_URL,
-    catalogModels: structuredClone(TOKENPLAN_MODEL_CATALOG),
+    catalogModels: cfg.models?.mode === "replace" ? structuredClone(TOKENPLAN_MODEL_CATALOG) : [],
     aliases: [{ modelRef: TOKENPLAN_DEFAULT_MODEL_REF, alias: "Hy3 (TokenPlan)" }],
   }),
 });


### PR DESCRIPTION
## What Problem This Solves

Five provider setup routes wrote generated catalogs into ordinary configuration, turning discovery-owned rows into explicit model pins.

## Why This Change Was Made

Private setup presets now generate rows only for explicit replace mode, where automatic discovery is skipped. Public helper defaults, authored rows, metadata, aliases, endpoints, and selection rules remain.

## User Impact

New ordinary setups save connections and defaults without freezing a catalog, allowing newly advertised models to appear. Replace mode retains its built-in rows. Existing saved pins are not removed or migrated.

## Evidence

Real CLI onboarding → Gateway catalog → reply flows passed for all five routes using controlled endpoints. Ordinary generated rows fell to zero; defaults remained usable and new endpoint-only models appeared. Ten authored merge/replace controls retained metadata and selections. Nine regressions failed before the fix; all 28 affected tests passed after correction. Compatibility and no-op controls passed. Live provider authentication was not tested.

Related: #136257.
