### PR TITLE
fix: preserve emoji in remote desktop text input

### DIFF
--- a/ui/src/components/desktop/desktop-client.test.ts
+++ b/ui/src/components/desktop/desktop-client.test.ts
@@ -23,6 +23,7 @@ function createFakeRfb() {
     viewOnly = false;
     scaleViewport = false;
     readonly disconnect = vi.fn();
+    readonly sendKey = vi.fn();
 
     constructor(
       readonly target: HTMLElement,
@@ -138,8 +139,9 @@ describe("DesktopClient", () => {
     handle.sendText("m");
     handle.sendBackspace();
     expect(onKeyDown.mock.calls.map((call) => (call[0] as KeyboardEvent | undefined)?.key)).toEqual(
-      ["k", "m", "Backspace"],
+      ["k", "m"],
     );
+    expect(instances[0]?.sendKey).toHaveBeenCalledExactlyOnceWith(0xff08, "Backspace");
 
     handle.disableInput();
     expect(instances[0]?.viewOnly).toBe(true);
@@ -186,7 +188,6 @@ describe("DesktopClient", () => {
     ["LF", "é\nΩ", ["é", "Enter", "Ω"]],
     ["CRLF", "é\r\nΩ", ["é", "Enter", "Ω"]],
     ["CR", "é\rΩ", ["é", "Enter", "Ω"]],
-    ["astral Unicode", "🦞\nΩ", ["\ud83e", "\udd9e", "Enter", "Ω"]],
     ["blank lines", "\n\r\n\r", ["Enter", "Enter", "Enter"]],
   ] as const)("sends %s text line breaks as single Enter presses", async (_name, text, keys) => {
     const { Rfb } = createFakeRfb();

--- a/ui/src/components/desktop/desktop-client.ts
+++ b/ui/src/components/desktop/desktop-client.ts
@@ -35,6 +35,7 @@ export type DesktopConnectionHandle = {
 type RfbClient = EventTarget & {
   background: string;
   disconnect(): void;
+  sendKey(keysym: number, code: string | null, down?: boolean): void;
   scaleViewport: boolean;
   viewOnly: boolean;
 };
@@ -154,10 +155,16 @@ export class DesktopClient {
         // keyboard owner to translate each inserted character and emit a
         // balanced press/release. Line breaks need Enter rather than Unicode LF.
         const normalizedText = text.replace(/\r\n?/g, "\n");
-        for (let index = 0; index < normalizedText.length; index += 1) {
+        for (const character of normalizedText) {
+          // noVNC 1.7's DOM key translator only accepts BMP characters. Its
+          // public RFB sender supports the full Unicode scalar keysym directly.
+          if (character.length === 2) {
+            rfb.sendKey(0x01000000 | character.codePointAt(0)!, null);
+            continue;
+          }
           dispatchKeyboardEvent(
             new KeyboardEvent("keydown", {
-              key: normalizedText.charAt(index) === "\n" ? "Enter" : normalizedText.charAt(index),
+              key: character === "\n" ? "Enter" : character,
               code: "Unidentified",
               bubbles: true,
               cancelable: true,
@@ -165,18 +172,7 @@ export class DesktopClient {
           );
         }
       },
-      sendBackspace: () => {
-        for (const type of ["keydown", "keyup"]) {
-          dispatchKeyboardEvent(
-            new KeyboardEvent(type, {
-              key: "Backspace",
-              code: "Backspace",
-              bubbles: true,
-              cancelable: true,
-            }),
-          );
-        }
-      },
+      sendBackspace: () => rfb.sendKey(0xff08, "Backspace"),
     };
   }
 }

--- a/ui/src/components/desktop/desktop-mobile-keyboard.ts
+++ b/ui/src/components/desktop/desktop-mobile-keyboard.ts
@@ -51,14 +51,18 @@ export class DesktopMobileKeyboard {
     const nextValue = input.value;
     const connection = this.options.connection();
     let prefixLength = 0;
-    const comparableLength = Math.min(this.value.length, nextValue.length);
-    while (
-      prefixLength < comparableLength &&
-      this.value.charAt(prefixLength) === nextValue.charAt(prefixLength)
-    ) {
-      prefixLength += 1;
+    for (const character of this.value) {
+      if (!nextValue.startsWith(character, prefixLength)) {
+        break;
+      }
+      prefixLength += character.length;
     }
-    for (let index = this.value.length - prefixLength; index > 0; index -= 1) {
+    // DOM offsets use UTF-16; a removed supplementary character is one key action.
+    for (
+      let remaining = Array.from(this.value.slice(prefixLength)).length;
+      remaining > 0;
+      remaining -= 1
+    ) {
       connection?.sendBackspace();
     }
     connection?.sendText(nextValue.slice(prefixLength));

--- a/ui/src/e2e/desktop-keyboard.e2e.test.ts
+++ b/ui/src/e2e/desktop-keyboard.e2e.test.ts
@@ -1,0 +1,116 @@
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { installScriptedRfbServer } from "./desktop-rfb-test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "desktop keyboard wire input",
+  startServerBeforeBrowser: true,
+});
+
+async function openKeyboard(page: Page) {
+  const gateway = await installMockGateway(page, {
+    deferredMethods: ["environments.list"],
+    featureMethods: ["desktop.observe", "environments.list"],
+    methodResponses: {
+      "desktop.observe": {
+        transport: "rfb",
+        wsPath: "/desktop/observe?token=synthetic-keyboard",
+        expiresAtMs: 60_000,
+        control: true,
+      },
+    },
+  });
+  await page.goto(`${suite.server.baseUrl}focus/desktop/control/source/gateway`);
+  await gateway.waitForRequest("environments.list");
+  const peer = await installScriptedRfbServer(page);
+  await gateway.resolveDeferred("environments.list", {
+    environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
+  });
+  const panel = page.locator("openclaw-desktop-panel");
+  await panel.locator(".desktop-surface canvas").waitFor();
+  await expect.poll(peer.events).toEqual(["authenticated:1"]);
+  await panel.getByText("Connecting to desktop…", { exact: true }).waitFor({ state: "hidden" });
+  await panel.getByRole("button", { name: "Keyboard", exact: true }).click();
+  return { peer, input: panel.locator(".desktop-keyboard-input") };
+}
+
+function keyPresses(keysyms: readonly number[]) {
+  return keysyms.flatMap((keysym) => [
+    { down: true, keysym },
+    { down: false, keysym },
+  ]);
+}
+
+suite.define(() => {
+  it("preserves all 32 pasted ASCII characters through padding reset and Backspace", async () => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const { peer, input } = await openKeyboard(page);
+      const padding = await input.inputValue();
+      const text = "Aa7!z?Bb8@x#Cc9$w%Dd0^v&Ee1*f(G)";
+      const expected = keyPresses(Array.from(text, (character) => character.charCodeAt(0)));
+
+      await page.keyboard.insertText(text);
+      await expect.poll(peer.keyEvents).toEqual(expected);
+      expect(await input.inputValue()).toBe(padding);
+
+      await page.keyboard.insertText("Z");
+      await page.keyboard.press("Backspace");
+      await expect.poll(peer.keyEvents).toEqual([...expected, ...keyPresses([0x5a, 0xff08])]);
+    });
+  });
+
+  it.each([
+    { name: "deletion", replacement: "", inputType: "deleteContentBackward", keysyms: [0xff08] },
+    {
+      name: "replacement",
+      replacement: "🦀",
+      inputType: "insertReplacementText",
+      keysyms: [0xff08, 0x0101f980],
+    },
+  ])(
+    "keeps supplementary characters intact during mobile $name",
+    async ({ replacement, inputType, keysyms }) => {
+      await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+        const { peer, input } = await openKeyboard(page);
+        const padding = await input.inputValue();
+        await page.keyboard.insertText("🦞");
+        await expect.poll(peer.keyEvents).toEqual(keyPresses([0x0101f99e]));
+        await input.evaluate(
+          (element, edit) => {
+            if (!(element instanceof HTMLTextAreaElement)) {
+              throw new Error("Expected the desktop keyboard textarea");
+            }
+            element.value = edit.value;
+            element.dispatchEvent(
+              new InputEvent("input", {
+                bubbles: true,
+                inputType: edit.inputType,
+                data: edit.replacement || null,
+              }),
+            );
+          },
+          { value: padding + replacement, inputType, replacement },
+        );
+        await expect.poll(peer.keyEvents).toEqual(keyPresses([0x0101f99e, ...keysyms]));
+      });
+    },
+  );
+
+  it.each([
+    { name: "BMP", text: "éΩ漢", keysyms: [0x00e9, 0x07d9, 0x01006f22] },
+    {
+      name: "line endings",
+      text: "a\r\nb\rc\nd",
+      keysyms: [0x61, 0xff0d, 0x62, 0xff0d, 0x63, 0xff0d, 0x64],
+    },
+    { name: "supplementary Unicode", text: "A🦞B", keysyms: [0x41, 0x0101f99e, 0x42] },
+  ])("emits balanced $name keysyms through real noVNC", async ({ text, keysyms }) => {
+    await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+      const { peer } = await openKeyboard(page);
+      await page.keyboard.insertText(text);
+      await expect.poll(peer.keyEvents).toEqual(keyPresses(keysyms));
+    });
+  });
+});

--- a/ui/src/e2e/desktop-rfb-test-support.ts
+++ b/ui/src/e2e/desktop-rfb-test-support.ts
@@ -67,6 +67,8 @@ export async function installScriptedRfbServer(
     const GatewaySocket = window.WebSocket;
     const sockets = new Set<FakeRfbSocket>();
     const events: string[] = [];
+    const keyEvents: Array<{ down: boolean; keysym: number }> = [];
+    let keyEventError: string | undefined;
     let nextId = 0;
     let desktopTeardown = false;
     class FakeRfbSocket extends EventTarget {
@@ -114,7 +116,29 @@ export async function installScriptedRfbServer(
           }
         }, 0);
       }
-      send(): void {
+      send(data: Uint8Array): void {
+        if (this.authenticated) {
+          if (data[0] === 4) {
+            // noVNC flushes each KeyEvent and reuses its send buffer immediately.
+            const bytes = data.slice();
+            if (
+              bytes.length !== 8 ||
+              (bytes[1] !== 0 && bytes[1] !== 1) ||
+              bytes[2] !== 0 ||
+              bytes[3] !== 0
+            ) {
+              keyEventError = "Malformed RFB KeyEvent";
+            } else if (keyEvents.length === 1024) {
+              keyEventError = "Scripted RFB keyboard observation limit exceeded";
+            } else {
+              keyEvents.push({
+                down: bytes[1] === 1,
+                keysym: new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(4),
+              });
+            }
+          }
+          return;
+        }
         // Handshake replies are fixed-size, so respond by stage instead of
         // parsing: version -> security types, choice -> ok, init -> ServerInit.
         this.handshake += 1;
@@ -189,6 +213,16 @@ export async function installScriptedRfbServer(
     (window as typeof window & { desktopRfbEvents?: () => string[] }).desktopRfbEvents = () => [
       ...events,
     ];
+    (
+      window as typeof window & {
+        desktopRfbKeyEvents?: () => Array<{ down: boolean; keysym: number }>;
+      }
+    ).desktopRfbKeyEvents = () => {
+      if (keyEventError) {
+        throw new Error(keyEventError);
+      }
+      return keyEvents.map(({ down, keysym }) => ({ down, keysym }));
+    };
     (window as typeof window & { desktopRfbSend?: (chunks: number[][]) => void }).desktopRfbSend = (
       chunks,
     ) => {
@@ -202,6 +236,15 @@ export async function installScriptedRfbServer(
     };
   }, options);
   return {
+    keyEvents: () =>
+      page.evaluate(
+        () =>
+          (
+            window as typeof window & {
+              desktopRfbKeyEvents?: () => Array<{ down: boolean; keysym: number }>;
+            }
+          ).desktopRfbKeyEvents?.() ?? [],
+      ),
     send: (chunks: number[][]) =>
       page.evaluate(
         (messages) =>


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users entering emoji or other supplementary Unicode characters through the remote desktop keyboard would send invalid characters. The browser split each character into UTF-16 surrogate halves, and the old unit test explicitly expected those halves. Editing an emoji through a mobile keyboard could also send two Backspaces or an isolated surrogate.

## Why This Change Was Made

Iterate text by Unicode code point. Keep noVNC's existing BMP and legacy keysym translation, and use its documented RFB.sendKey API for supplementary Unicode scalars. The same public API replaces the synthetic-event Backspace wrapper. The mobile input diff now matches complete code points and counts removed code points rather than UTF-16 units.

No dependency patch, version, configuration, protocol, permission, or persistent state changes. This does not claim universal grapheme-editing behavior across remote applications, nor does it claim to resolve the separate macOS native-paste discrepancy.

## User Impact

Emoji and supplementary characters reach the remote desktop as one valid Unicode keysym. Existing ASCII, accented text, legacy Greek keysyms, newline handling, physical keyboard forwarding, and view-only behavior remain intact.

## Evidence

The regression runs Chromium, the production DesktopClient, and real noVNC against the existing scripted RFB peer. It records bounded copies of actual transmitted key frames rather than mocking the keyboard converter.

- Before: `A🦞B` emitted eight frames with invalid Unicode keysyms `0x0100d83e` and `0x0100dd9e`. After: six balanced frames with the correct scalar `0x0101f99e`.
- A separate before-fix mobile run reproduced duplicate Backspace and isolated-surrogate replacement. Both cases pass after repair.
- 32-character ASCII paste, padding reset, subsequent input, Backspace, BMP text, line endings, supplementary insertion, and virtual replacement/deletion are covered.
- 56 unit tests and 33 real-browser desktop E2E tests passed. Scoped lint is clean. A fixture typing error found by the clean-machine gate was repaired with explicit bit validation, without an assertion or suppression.
- Independent review is clean through P2. The reviewer could not resolve upstream references from its sandbox; the maintainer directly inspected the installed pinned noVNC 1.7 implementation and public API, and the real-noVNC regression verifies the resulting wire behavior.
- Full clean-machine changed gate passed on the exact candidate tree (690 seconds): core/UI types, lint/style, dead-export checks, i18n and guards. The full dev runtime/UI build also passed, and the candidate is serving with the existing service definition and authentication. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34039795521) passed all 88 selected jobs, including every browser shard and the real-Gateway suite. Real WebVNC on the retained macOS host passed connection, view-only/control transfer, ASCII insertion, and Backspace cleanup. The macOS secure field showed only two masked characters for `A🦞B`; this is explicitly not proof of supplementary-character acceptance by macOS applications. No OS login was submitted.

Production LOC is net-neutral. The new wire tests replace the prior assertion that preserved invalid surrogate handling. There are no appearance/layout changes. Browser-to-RFB delivery is distinguished from acceptance by a particular remote application.
