### PR TITLE
refactor(tavily): test proxy endpoints through the client

### DIFF
--- a/extensions/tavily/src/tavily-client.test.ts
+++ b/extensions/tavily/src/tavily-client.test.ts
@@ -6,6 +6,7 @@ import { createStreamingResponse } from "../../test-support/streaming-error-resp
 const postTrustedWebToolsJson = vi.fn();
 const writeCache = vi.fn();
 const assertPluginCapabilitySecretAvailable = vi.fn();
+const resolveTavilyBaseUrl = vi.fn(() => "https://api.tavily.com");
 
 vi.mock("openclaw/plugin-sdk/secret-input-runtime", () => ({
   assertPluginCapabilitySecretAvailable,
@@ -25,7 +26,7 @@ vi.mock("./config.js", () => ({
   DEFAULT_TAVILY_BASE_URL: "https://api.tavily.com",
   TAVILY_API_KEY_CONFIG_PATH: "plugins.entries.tavily.config.webSearch.apiKey",
   resolveTavilyApiKey: () => "test-key",
-  resolveTavilyBaseUrl: () => "https://api.tavily.com",
+  resolveTavilyBaseUrl,
   resolveTavilySearchTimeoutSeconds: () => 30,
   resolveTavilyExtractTimeoutSeconds: () => 60,
 }));
@@ -42,6 +43,7 @@ describe("tavily client X-Client-Source header", () => {
     assertPluginCapabilitySecretAvailable.mockReset();
     postTrustedWebToolsJson.mockReset();
     writeCache.mockReset();
+    resolveTavilyBaseUrl.mockReset().mockReturnValue("https://api.tavily.com");
     postTrustedWebToolsJson.mockImplementation(
       async (_params: unknown, parse: (r: Response) => Promise<unknown>) =>
         parse(Response.json({ results: [] })),
@@ -69,6 +71,32 @@ describe("tavily client X-Client-Source header", () => {
       expect(postTrustedWebToolsJson).not.toHaveBeenCalled();
     },
   );
+
+  it("appends endpoints to reverse-proxy base urls", async () => {
+    resolveTavilyBaseUrl.mockReturnValueOnce("https://proxy.example/api/tavily");
+    await runTavilySearch({ query: "proxy search" });
+    resolveTavilyBaseUrl.mockReturnValueOnce("https://proxy.example/api/tavily/");
+    await runTavilyExtract({ urls: ["https://example.com"] });
+
+    expect(postTrustedWebToolsJson).toHaveBeenCalledTimes(2);
+    expect(postTrustedWebToolsJson.mock.calls[0]?.[0]?.url).toBe(
+      "https://proxy.example/api/tavily/search",
+    );
+    expect(postTrustedWebToolsJson.mock.calls[1]?.[0]?.url).toBe(
+      "https://proxy.example/api/tavily/extract",
+    );
+  });
+
+  it("falls back to the default host for invalid base urls", async () => {
+    resolveTavilyBaseUrl.mockReturnValueOnce("not a url");
+    await runTavilySearch({ query: "invalid base URL" });
+    resolveTavilyBaseUrl.mockReturnValueOnce("");
+    await runTavilyExtract({ urls: ["https://example.com"] });
+
+    expect(postTrustedWebToolsJson).toHaveBeenCalledTimes(2);
+    expect(postTrustedWebToolsJson.mock.calls[0]?.[0]?.url).toBe("https://api.tavily.com/search");
+    expect(postTrustedWebToolsJson.mock.calls[1]?.[0]?.url).toBe("https://api.tavily.com/extract");
+  });
 
   it("runTavilySearch sends X-Client-Source: openclaw", async () => {
     await runTavilySearch({ query: "test query" });

--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -416,7 +416,3 @@ export async function runTavilyExtract(
   );
   return result;
 }
-
-export const testing = {
-  resolveEndpoint,
-};

--- a/extensions/tavily/src/tavily-tools.test.ts
+++ b/extensions/tavily/src/tavily-tools.test.ts
@@ -47,7 +47,6 @@ describe("tavily tools", () => {
   let createTavilyContractWebSearchProvider: typeof import("../web-search-contract-api.js").createTavilyWebSearchProvider;
   let createTavilySearchTool: typeof import("./tavily-search-tool.js").createTavilySearchTool;
   let createTavilyExtractTool: typeof import("./tavily-extract-tool.js").createTavilyExtractTool;
-  let tavilyClientTesting: typeof import("./tavily-client.js").testing;
   let tavilyPlugin: typeof import("../index.js").default;
 
   beforeAll(async () => {
@@ -56,8 +55,6 @@ describe("tavily tools", () => {
       await import("../web-search-contract-api.js"));
     ({ createTavilySearchTool } = await import("./tavily-search-tool.js"));
     ({ createTavilyExtractTool } = await import("./tavily-extract-tool.js"));
-    ({ testing: tavilyClientTesting } =
-      await vi.importActual<typeof import("./tavily-client.js")>("./tavily-client.js"));
     ({ default: tavilyPlugin } = await import("../index.js"));
   });
 
@@ -506,23 +503,5 @@ describe("tavily tools", () => {
     expect(resolveTavilyExtractTimeoutSeconds(0.5)).toBe(1);
     expect(resolveTavilySearchTimeoutSeconds(0)).toBe(30);
     expect(resolveTavilyExtractTimeoutSeconds(Number.NaN)).toBe(60);
-  });
-
-  it("appends endpoints to reverse-proxy base urls", () => {
-    expect(tavilyClientTesting.resolveEndpoint("https://proxy.example/api/tavily", "/search")).toBe(
-      "https://proxy.example/api/tavily/search",
-    );
-    expect(
-      tavilyClientTesting.resolveEndpoint("https://proxy.example/api/tavily/", "/extract"),
-    ).toBe("https://proxy.example/api/tavily/extract");
-  });
-
-  it("falls back to the default host for invalid base urls", () => {
-    expect(tavilyClientTesting.resolveEndpoint("not a url", "/search")).toBe(
-      "https://api.tavily.com/search",
-    );
-    expect(tavilyClientTesting.resolveEndpoint("", "/extract")).toBe(
-      "https://api.tavily.com/extract",
-    );
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Tavily's proxy endpoint tests reach into a private resolver through a test-only production export. The tools suite loads the real client solely for those assertions, despite mocking it for its other cases.

## Why This Change Was Made

Move the two endpoint tests into the existing client suite and assert the URLs passed by `runTavilySearch` and `runTavilyExtract` to transport. Preserve all four vectors: proxy path prefix, trailing slash, invalid base URL, and empty base URL. Remove the private export and the tools suite's forced real-module import.

## User Impact

No user-visible behavior change. Endpoint construction and transport policy are unchanged; the tests now exercise the client wiring used by search and extraction. This is separate from the private-host behavior proposal in #139868.

## Evidence

- Baseline and candidate: 45/45 cases across the client, tools, and cache suites; identical case-title inventory.
- The four original expected URLs are retained. Existing cancellation, credential-state, bounded-response, hostile-output, and cache cases remain intact.
- Production diff: four lines removed, limited to the private export and its separating blank line. Tests: +29/-22.
- Independent source review through P2: clean. All 25 normal changed checks passed; the configured wrapper reported no ready remote provider and completed its local fallback. No authenticated Tavily call is claimed; this changes only test placement and removes an unused private export.
