### PR TITLE
refactor(acp): remove duplicate runtime lifecycle plumbing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3,10 +3,9 @@
 # Format: repo-relative path, tab, positive count. Zero-count files are omitted.
 extensions/acpx/src/codex-auth-bridge.ts	7
 extensions/acpx/src/codex-trust-config.ts	1
-extensions/acpx/src/config.ts	1
 extensions/acpx/src/pi-session-catalog-runtime.ts	1
 extensions/acpx/src/process-lease.ts	3
-extensions/acpx/src/runtime.ts	13
+extensions/acpx/src/runtime.ts	10
 extensions/acpx/src/service.ts	2
 extensions/acpx/src/state.ts	1
 extensions/active-memory/config.ts	2

--- a/extensions/acpx/src/codex-auth-bridge.ts
+++ b/extensions/acpx/src/codex-auth-bridge.ts
@@ -225,10 +225,6 @@ const DIAGNOSTIC_REDACTION_RULES: DiagnosticRedactionRuleSpec[] = [
   },
 ];
 
-function renderDiagnosticRedactionRuleSpecs(): string {
-  return JSON.stringify(DIAGNOSTIC_REDACTION_RULES);
-}
-
 function buildAdapterWrapperScript(params: {
   displayName: string;
   packageSpec: string;
@@ -296,7 +292,7 @@ function resolveStderrLogPath(args) {
   return fileURLToPath(new URL("./" + fileName, import.meta.url));
 }
 
-const diagnosticRedactionRules = ${renderDiagnosticRedactionRuleSpecs()}.map((rule) => [
+const diagnosticRedactionRules = ${JSON.stringify(DIAGNOSTIC_REDACTION_RULES)}.map((rule) => [
   new RegExp(rule.source, rule.flags),
   rule.replacement,
 ]);
@@ -717,31 +713,21 @@ async function prepareIsolatedCodexHome(params: {
   return codexHome;
 }
 
-async function makeGeneratedWrapperExecutableIfPossible(wrapperPath: string): Promise<void> {
+async function writeAdapterWrapper(
+  baseDir: string,
+  fileName: string,
+  script: string,
+): Promise<string> {
+  await fs.mkdir(baseDir, { recursive: true });
+  const wrapperPath = path.join(baseDir, fileName);
+  await fs.writeFile(wrapperPath, script, {
+    encoding: "utf8",
+  });
   try {
     await fs.chmod(wrapperPath, 0o755);
   } catch {
     // The wrapper is invoked via `node wrapper.mjs`; executable mode is only a convenience.
   }
-}
-
-async function writeCodexAcpWrapper(baseDir: string, installedBinPath?: string): Promise<string> {
-  await fs.mkdir(baseDir, { recursive: true });
-  const wrapperPath = path.join(baseDir, "codex-acp-wrapper.mjs");
-  await fs.writeFile(wrapperPath, buildCodexAcpWrapperScript(installedBinPath), {
-    encoding: "utf8",
-  });
-  await makeGeneratedWrapperExecutableIfPossible(wrapperPath);
-  return wrapperPath;
-}
-
-async function writeClaudeAcpWrapper(baseDir: string, installedBinPath?: string): Promise<string> {
-  await fs.mkdir(baseDir, { recursive: true });
-  const wrapperPath = path.join(baseDir, "claude-agent-acp-wrapper.mjs");
-  await fs.writeFile(wrapperPath, buildClaudeAcpWrapperScript(installedBinPath), {
-    encoding: "utf8",
-  });
-  await makeGeneratedWrapperExecutableIfPossible(wrapperPath);
   return wrapperPath;
 }
 
@@ -908,20 +894,6 @@ function resolveCodexAdapterLaunch(
   return { args: maintainedAdapterArgs };
 }
 
-function buildCodexAcpWrapperCommand(
-  wrapperPath: string,
-  configuredCommand?: AcpxAgentCommand,
-): string[] {
-  const launch = resolveCodexAdapterLaunch(configuredCommand);
-  if (launch) {
-    return buildWrapperCommand(wrapperPath, launch.args);
-  }
-  return buildWrapperCommand(wrapperPath, [
-    RUN_CONFIGURED_COMMAND_SENTINEL,
-    ...splitCommandParts(configuredCommand ?? []),
-  ]);
-}
-
 async function persistMigratedCodexMcpConfig(params: {
   codexHome: string;
   migratedConfig: Record<string, unknown> | undefined;
@@ -978,14 +950,28 @@ export async function prepareAcpxCodexAuthConfig(params: {
   const installedClaudeBinPath = await (
     params.resolveInstalledClaudeAcpBinPath ?? resolveInstalledClaudeAcpBinPath
   )();
-  const wrapperPath = await writeCodexAcpWrapper(codexBaseDir, installedCodexBinPath);
-  const claudeWrapperPath = await writeClaudeAcpWrapper(codexBaseDir, installedClaudeBinPath);
+  const wrapperPath = await writeAdapterWrapper(
+    codexBaseDir,
+    "codex-acp-wrapper.mjs",
+    buildCodexAcpWrapperScript(installedCodexBinPath),
+  );
+  const claudeWrapperPath = await writeAdapterWrapper(
+    codexBaseDir,
+    "claude-agent-acp-wrapper.mjs",
+    buildClaudeAcpWrapperScript(installedClaudeBinPath),
+  );
 
   return {
     ...params.pluginConfig,
     agents: {
       ...params.pluginConfig.agents,
-      codex: buildCodexAcpWrapperCommand(wrapperPath, configuredCodexCommand),
+      codex: buildWrapperCommand(
+        wrapperPath,
+        codexLaunch?.args ?? [
+          RUN_CONFIGURED_COMMAND_SENTINEL,
+          ...splitCommandParts(configuredCodexCommand ?? []),
+        ],
+      ),
       claude: buildClaudeAcpWrapperCommand(claudeWrapperPath, configuredClaudeCommand),
     },
   };

--- a/extensions/acpx/src/config-schema.ts
+++ b/extensions/acpx/src/config-schema.ts
@@ -31,21 +31,6 @@ export type AcpxMcpServer = {
   env: Array<{ name: string; value: string }>;
 };
 
-/** User-provided ACPX plugin configuration before defaults are resolved. */
-export type AcpxPluginConfig = {
-  cwd?: string;
-  stateDir?: string;
-  probeAgent?: string;
-  permissionMode?: AcpxPermissionMode;
-  nonInteractivePermissions?: AcpxNonInteractivePermissionPolicy;
-  pluginToolsMcpBridge?: boolean;
-  openClawToolsMcpBridge?: boolean;
-  timeoutSeconds?: number;
-  piSessionCatalog?: { enabled?: boolean };
-  mcpServers?: Record<string, McpServerConfig>;
-  agents?: Record<string, { command: string; args?: string[] }>;
-};
-
 /** Fully resolved ACPX config consumed by the runtime service. */
 export type ResolvedAcpxPluginConfig = {
   cwd: string;

--- a/extensions/acpx/src/config.ts
+++ b/extensions/acpx/src/config.ts
@@ -9,9 +9,8 @@ import { fileURLToPath } from "node:url";
 import { formatPluginConfigIssue } from "openclaw/plugin-sdk/extension-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { splitCommandParts } from "./command-line.js";
-import { AcpxPluginConfigSchema, DEFAULT_ACPX_TIMEOUT_SECONDS } from "./config-schema.js";
+import { AcpxPluginConfigSchema } from "./config-schema.js";
 import type {
-  AcpxPluginConfig,
   AcpxPermissionMode,
   AcpxNonInteractivePermissionPolicy,
   McpServerConfig,
@@ -103,25 +102,7 @@ export function resolveAcpxPluginRoot(moduleUrl: string = import.meta.url): stri
 const DEFAULT_PERMISSION_MODE: AcpxPermissionMode = "approve-reads";
 const DEFAULT_NON_INTERACTIVE_POLICY: AcpxNonInteractivePermissionPolicy = "fail";
 
-type ParseResult =
-  | { ok: true; value: AcpxPluginConfig | undefined }
-  | { ok: false; message: string };
-
-function parseAcpxPluginConfig(value: unknown): ParseResult {
-  if (value === undefined) {
-    return { ok: true, value: undefined };
-  }
-  const parsed = AcpxPluginConfigSchema.safeParse(value);
-  if (!parsed.success) {
-    return { ok: false, message: formatPluginConfigIssue(parsed.error.issues[0]) };
-  }
-  return {
-    ok: true,
-    value: parsed.data as AcpxPluginConfig,
-  };
-}
-
-function resolveOpenClawRoot(currentRoot: string): string {
+export function resolveOpenClawRoot(currentRoot: string): string {
   if (
     path.basename(currentRoot) === "acpx" &&
     path.basename(path.dirname(currentRoot)) === "extensions"
@@ -143,34 +124,20 @@ function resolveTsxImportSpecifier(): string {
   }
 }
 
-function resolvePluginToolsMcpServerConfig(moduleUrl: string = import.meta.url): McpServerConfig {
+function resolveManagedToolsMcpServerConfig(
+  entryPoint: "plugin-tools-serve" | "openclaw-tools-serve",
+  moduleUrl: string = import.meta.url,
+): McpServerConfig {
   const pluginRoot = resolveAcpxPluginRoot(moduleUrl);
   const openClawRoot = resolveOpenClawRoot(pluginRoot);
-  const distEntry = path.join(openClawRoot, "dist", "mcp", "plugin-tools-serve.js");
+  const distEntry = path.join(openClawRoot, "dist", "mcp", `${entryPoint}.js`);
   if (fs.existsSync(distEntry)) {
     return {
       command: process.execPath,
       args: [distEntry],
     };
   }
-  const sourceEntry = path.join(openClawRoot, "src", "mcp", "plugin-tools-serve.ts");
-  return {
-    command: process.execPath,
-    args: ["--import", resolveTsxImportSpecifier(), sourceEntry],
-  };
-}
-
-function resolveOpenClawToolsMcpServerConfig(moduleUrl: string = import.meta.url): McpServerConfig {
-  const pluginRoot = resolveAcpxPluginRoot(moduleUrl);
-  const openClawRoot = resolveOpenClawRoot(pluginRoot);
-  const distEntry = path.join(openClawRoot, "dist", "mcp", "openclaw-tools-serve.js");
-  if (fs.existsSync(distEntry)) {
-    return {
-      command: process.execPath,
-      args: [distEntry],
-    };
-  }
-  const sourceEntry = path.join(openClawRoot, "src", "mcp", "openclaw-tools-serve.ts");
+  const sourceEntry = path.join(openClawRoot, "src", "mcp", `${entryPoint}.ts`);
   return {
     command: process.execPath,
     args: ["--import", resolveTsxImportSpecifier(), sourceEntry],
@@ -195,12 +162,14 @@ function resolveConfiguredMcpServers(params: {
     );
   }
   if (params.pluginToolsMcpBridge) {
-    resolved[ACPX_PLUGIN_TOOLS_MCP_SERVER_NAME] = resolvePluginToolsMcpServerConfig(
+    resolved[ACPX_PLUGIN_TOOLS_MCP_SERVER_NAME] = resolveManagedToolsMcpServerConfig(
+      "plugin-tools-serve",
       params.moduleUrl,
     );
   }
   if (params.openClawToolsMcpBridge) {
-    resolved[ACPX_OPENCLAW_TOOLS_MCP_SERVER_NAME] = resolveOpenClawToolsMcpServerConfig(
+    resolved[ACPX_OPENCLAW_TOOLS_MCP_SERVER_NAME] = resolveManagedToolsMcpServerConfig(
+      "openclaw-tools-serve",
       params.moduleUrl,
     );
   }
@@ -226,14 +195,14 @@ export function resolveAcpxPluginConfig(params: {
   workspaceDir?: string;
   moduleUrl?: string;
 }): ResolvedAcpxPluginConfig {
-  const parsed = parseAcpxPluginConfig(params.rawConfig);
-  if (!parsed.ok) {
-    throw new Error(parsed.message);
+  const { rawConfig } = params;
+  const parsed = AcpxPluginConfigSchema.safeParse(rawConfig === undefined ? {} : rawConfig);
+  if (!parsed.success) {
+    throw new Error(formatPluginConfigIssue(parsed.error.issues[0]));
   }
-  const normalized = parsed.value ?? {};
+  const normalized = parsed.data;
   const workspaceDir = params.workspaceDir?.trim() || process.cwd();
-  const fallbackCwd = workspaceDir;
-  const cwd = path.resolve(normalized.cwd?.trim() || fallbackCwd);
+  const cwd = path.resolve(normalized.cwd?.trim() || workspaceDir);
   const stateDir = path.resolve(normalized.stateDir?.trim() || path.join(workspaceDir, "state"));
   const pluginToolsMcpBridge = normalized.pluginToolsMcpBridge === true;
   const openClawToolsMcpBridge = normalized.openClawToolsMcpBridge === true;
@@ -262,7 +231,7 @@ export function resolveAcpxPluginConfig(params: {
       normalized.nonInteractivePermissions ?? DEFAULT_NON_INTERACTIVE_POLICY,
     pluginToolsMcpBridge,
     openClawToolsMcpBridge,
-    timeoutSeconds: normalized.timeoutSeconds ?? DEFAULT_ACPX_TIMEOUT_SECONDS,
+    timeoutSeconds: normalized.timeoutSeconds,
     mcpServers,
     agents,
   };

--- a/extensions/acpx/src/process-lease.ts
+++ b/extensions/acpx/src/process-lease.ts
@@ -2,7 +2,7 @@
  * Persistent lease store for ACPX wrapper processes. Leases let OpenClaw attach
  * gateway/session identity to spawned ACP processes and clean them up later.
  */
-import { randomUUID, createHash } from "node:crypto";
+import { createHash } from "node:crypto";
 import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
@@ -182,11 +182,6 @@ export function createAcpxProcessLeaseStore(params: {
       });
     },
   };
-}
-
-/** Create a unique lease id for one ACPX wrapper process. */
-export function createAcpxProcessLeaseId(): string {
-  return randomUUID();
 }
 
 /** Hash a wrapper command so process leases can detect command drift. */

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -8,7 +8,7 @@ import { isPidAlive, runExec } from "openclaw/plugin-sdk/process-runtime";
 import { escapeRegExp } from "openclaw/plugin-sdk/text-utility-runtime";
 import { CODEX_ACP_PACKAGE, LEGACY_CODEX_ACP_PACKAGE } from "./codex-adapter.js";
 import type { AcpxAgentCommand } from "./command-line.js";
-import { resolveAcpxPluginRoot } from "./config.js";
+import { resolveAcpxPluginRoot, resolveOpenClawRoot } from "./config.js";
 import { readAcpxProcessLeaseIdentity } from "./process-lease.js";
 
 const requireFromHere = createRequire(import.meta.url);
@@ -96,20 +96,9 @@ function resolvePackageRoot(packageName: string): string | undefined {
   }
 }
 
-function resolveOpenClawInstallRoot(pluginRoot: string): string {
-  if (
-    path.basename(pluginRoot) === "acpx" &&
-    path.basename(path.dirname(pluginRoot)) === "extensions"
-  ) {
-    const parent = path.dirname(path.dirname(pluginRoot));
-    return path.basename(parent) === "dist" ? path.dirname(parent) : parent;
-  }
-  return path.resolve(pluginRoot, "..");
-}
-
 function resolveOwnedAcpPackageRootCandidates(packageName: string): string[] {
   const pluginRoot = resolveAcpxPluginRoot(import.meta.url);
-  const openClawRoot = resolveOpenClawInstallRoot(pluginRoot);
+  const openClawRoot = resolveOpenClawRoot(pluginRoot);
   return [
     resolvePackageRoot(packageName),
     path.join(pluginRoot, "node_modules", packageName),
@@ -362,36 +351,14 @@ export async function cleanupOpenClawOwnedAcpxProcessTree(params: {
   const storedCommandWasGeneratedWrapper = commandMentionsGeneratedWrapper(
     normalizePathLike(params.rootCommand ?? ""),
   );
-  if (!liveCommandWasGeneratedWrapper && storedCommandWasGeneratedWrapper) {
-    return {
-      inspectedPids: listedTree.map((processInfo) => processInfo.pid),
-      terminatedPids: [],
-      skippedReason: "not-openclaw-owned",
-    };
-  }
   if (
-    !liveCommandWasGeneratedWrapper &&
-    !commandsReferToSameRootCommand(rootCommand ?? "", params.rootCommand)
-  ) {
-    return {
-      inspectedPids: listedTree.map((processInfo) => processInfo.pid),
-      terminatedPids: [],
-      skippedReason: "not-openclaw-owned",
-    };
-  }
-  if (
+    (!liveCommandWasGeneratedWrapper &&
+      (storedCommandWasGeneratedWrapper ||
+        !commandsReferToSameRootCommand(rootCommand ?? "", params.rootCommand))) ||
     !isOpenClawOwnedAcpxProcessCommand({
       command: rootCommand,
       wrapperRoot: params.wrapperRoot,
-    })
-  ) {
-    return {
-      inspectedPids: listedTree.map((processInfo) => processInfo.pid),
-      terminatedPids: [],
-      skippedReason: "not-openclaw-owned",
-    };
-  }
-  if (
+    }) ||
     !liveCommandMatchesLeaseIdentity({
       command: rootCommand,
       expectedLeaseId: params.expectedLeaseId,

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -3,6 +3,7 @@
  * OpenClaw session metadata, lease tracking, model scoping, and cleanup policy.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path, { resolve as resolvePath } from "node:path";
 import { isDeepStrictEqual } from "node:util";
@@ -23,6 +24,7 @@ import {
   type AcpRuntimeTurnResult,
   type SessionAgentOptions,
 } from "acpx/runtime";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -32,7 +34,6 @@ import { CODEX_ACP_PACKAGE, OPENCLAW_CODEX_CONFIG_ARG } from "./codex-adapter.js
 import { renderAgentCommand, splitCommandParts, type AcpxAgentCommand } from "./command-line.js";
 import {
   ACPX_PROBE_LEASE_SESSION_KEY,
-  createAcpxProcessLeaseId,
   hashAcpxProcessCommand,
   readAcpxProcessLeaseIdentity,
   withAcpxLeaseArgs,
@@ -86,23 +87,14 @@ type OpenClawLeaseSessionMetadata = {
   openclawGatewayInstanceId: string;
 };
 
-function withOpenClawManagedTurnTimeout<T extends object>(input: T): T & { timeoutMs: 0 } {
-  // OpenClaw owns ACP turn deadlines. acpx treats timeout after partial agent
-  // output as a completed turn, which can mark background work done early.
-  return {
-    ...input,
-    timeoutMs: 0,
-  };
-}
-
 function withOpenClawLeaseSessionMetadata<T extends object>(
   record: T,
-  metadata: OpenClawLeaseSessionMetadata,
+  lease: AcpxProcessLeaseIdentity,
 ): T & OpenClawLeaseSessionMetadata {
   return {
     ...record,
-    openclawLeaseId: metadata.openclawLeaseId,
-    openclawGatewayInstanceId: metadata.openclawGatewayInstanceId,
+    openclawLeaseId: lease.leaseId,
+    openclawGatewayInstanceId: lease.gatewayInstanceId,
   };
 }
 
@@ -140,10 +132,7 @@ function isGenericInternalAcpErrorMessage(message: string): boolean {
 }
 
 function isGenericInternalAcpError(error: unknown): error is Error {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return isGenericInternalAcpErrorMessage(error.message);
+  return error instanceof Error && isGenericInternalAcpErrorMessage(error.message);
 }
 
 async function readCodexWrapperStderrTail(params: {
@@ -290,10 +279,7 @@ function createResetAwareSessionStore(
       if (!lease) {
         return record;
       }
-      return withOpenClawLeaseSessionMetadata(record, {
-        openclawLeaseId: lease.leaseId,
-        openclawGatewayInstanceId: lease.gatewayInstanceId,
-      });
+      return withOpenClawLeaseSessionMetadata(record, lease);
     },
     async save(record: AcpSessionRecord): Promise<void> {
       let recordToSave = record;
@@ -365,10 +351,7 @@ function createResetAwareSessionStore(
               agentCommand: renderAgentCommand(persistedCommand),
               agentArgv: Array.isArray(persistedCommand) ? persistedCommand : undefined,
             },
-            {
-              openclawLeaseId: leaseIdentity.leaseId,
-              openclawGatewayInstanceId: leaseIdentity.gatewayInstanceId,
-            },
+            leaseIdentity,
           );
         }
       }
@@ -433,13 +416,7 @@ function readAgentFromSessionKey(sessionKey: string | undefined): string | undef
 
 function readAgentFromHandle(handle: OpenClawRuntimeHandle): string | undefined {
   const decoded = decodeAcpxRuntimeHandleState(handle.runtimeSessionName);
-  if (typeof decoded === "object" && decoded !== null) {
-    const { agent } = decoded as { agent?: unknown };
-    if (typeof agent === "string") {
-      return normalizeAgentName(agent) ?? readAgentFromSessionKey(handle.sessionKey);
-    }
-  }
-  return readAgentFromSessionKey(handle.sessionKey);
+  return normalizeAgentName(decoded?.agent) ?? readAgentFromSessionKey(handle.sessionKey);
 }
 
 function basename(value: string): string {
@@ -534,31 +511,25 @@ function isClaudeAcpCommand(command: AcpxAgentCommand | undefined): boolean {
   });
 }
 
-function failUnsupportedCodexAcpModel(rawModel: string, detail?: string): never {
+function failUnsupportedCodexAcpModel(rawModel: string): never {
   throw new AcpRuntimeError(
     "ACP_INVALID_RUNTIME_OPTION",
-    detail ??
-      `Codex ACP model "${rawModel}" is not supported. Use openai/<model> or <model>/<reasoning-effort>.`,
+    `Codex ACP model "${rawModel}" is not supported. Use openai/<model> or <model>/<reasoning-effort>.`,
   );
 }
 
-// acpx's `decodeAcpxRuntimeHandleState` only accepts `persistent` and `oneshot`; any other
-// value silently round-trips through the encoded handle as `persistent` and later throws
-// `SessionResumeRequiredError` on agent restart. Fail fast at this boundary instead.
-// See openclaw/openclaw#73071.
-const SUPPORTED_RUNTIME_SESSION_MODES = new Set(["persistent", "oneshot"] as const);
 const WIRE_TIMEOUT_CONFIG_KEYS = new Set(["timeout", "timeout_seconds"]);
 
+// The handle codec coerces unknown modes to persistent; reject them before encoding.
 function assertSupportedRuntimeSessionMode(
   mode: unknown,
 ): asserts mode is "persistent" | "oneshot" {
-  if (typeof mode === "string" && SUPPORTED_RUNTIME_SESSION_MODES.has(mode as never)) {
+  if (mode === "persistent" || mode === "oneshot") {
     return;
   }
-  const supported = Array.from(SUPPORTED_RUNTIME_SESSION_MODES).join(", ");
   throw new AcpRuntimeError(
     "ACP_INVALID_RUNTIME_OPTION",
-    `Unsupported ACP runtime session mode ${JSON.stringify(mode)}. Expected one of: ${supported}.`,
+    `Unsupported ACP runtime session mode ${JSON.stringify(mode)}. Expected one of: persistent, oneshot.`,
   );
 }
 
@@ -614,10 +585,7 @@ function classifyCodexAcpModelRequest(
   }
 
   if (hadOpenAiQualifier && (!model || model.includes("/"))) {
-    failUnsupportedCodexAcpModel(
-      raw,
-      `Codex ACP model "${raw}" is not supported. Use openai/<model> or <model>/<reasoning-effort>.`,
-    );
+    failUnsupportedCodexAcpModel(raw);
   }
   if (!model || model.includes("/")) {
     return thinkingOnlyOverride
@@ -720,12 +688,8 @@ function resolveAgentCommand(params: {
   return splitCommandParts(params.agentRegistry.resolve(normalizedAgentName));
 }
 
-function shouldUseBridgeSafeDelegateForCommand(command: AcpxAgentCommand | undefined): boolean {
-  return isOpenClawBridgeCommand(command);
-}
-
 function shouldUseDistinctBridgeDelegate(options: AcpRuntimeOptions): boolean {
-  const { mcpServers } = options as { mcpServers?: unknown };
+  const { mcpServers } = options;
   return Array.isArray(mcpServers) && mcpServers.length > 0;
 }
 
@@ -797,8 +761,8 @@ export class AcpxRuntime implements CompleteAcpRuntime {
   private readonly gatewayInstanceId: string | undefined;
   private readonly processLeaseStore: AcpxProcessLeaseStore | undefined;
   private readonly launchLeaseScope = new AsyncLocalStorage<AcpxLaunchLeaseContext | undefined>();
-  private readonly ensureSessionTails = new Map<string, Promise<void>>();
-  private readonly processLeaseTransitionTails = new Map<string, Promise<void>>();
+  private readonly sessionEnsureQueue = new KeyedAsyncQueue();
+  private readonly processLeaseTransitionQueue = new KeyedAsyncQueue();
   private readonly processLeaseOperationCounts = new Map<string, number>();
   private readonly uncertainProcessLeaseIds = new Set<string>();
   private readonly cwd: string;
@@ -855,7 +819,7 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     });
     this.probeCommand = probeCommand;
     const useBridgeSafeProbe =
-      this.managedToolsMcpBridgeEnabled || shouldUseBridgeSafeDelegateForCommand(probeCommand);
+      this.managedToolsMcpBridgeEnabled || isOpenClawBridgeCommand(probeCommand);
     this.probeDelegate = useBridgeSafeProbe ? this.bridgeSafeDelegate : this.delegate;
   }
 
@@ -864,7 +828,7 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     sessionKey: string;
     agentId?: string;
   }): BaseAcpxRuntime {
-    if (shouldUseBridgeSafeDelegateForCommand(params.command)) {
+    if (isOpenClawBridgeCommand(params.command)) {
       return this.bridgeSafeDelegate;
     }
     return this.resolveManagedToolsDelegateForSession(params);
@@ -1017,7 +981,7 @@ export class AcpxRuntime implements CompleteAcpRuntime {
         ? `probe-${hashAcpxProcessCommand(
             `${this.gatewayInstanceId}\0${extractGeneratedWrapperPath(params.command)}`,
           )}`
-        : createAcpxProcessLeaseId();
+        : randomUUID();
     const leasedCommand = withAcpxLeaseArgs({
       command: params.command,
       leaseId,
@@ -1157,33 +1121,11 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     return identity;
   }
 
-  private async runSerializedProcessLeaseTransition<T>(
-    leaseId: string,
-    run: () => Promise<T>,
-  ): Promise<T> {
-    const previous = this.processLeaseTransitionTails.get(leaseId) ?? Promise.resolve();
-    let release!: () => void;
-    const current = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const tail = previous.then(() => current);
-    this.processLeaseTransitionTails.set(leaseId, tail);
-    await previous;
-    try {
-      return await run();
-    } finally {
-      release();
-      if (this.processLeaseTransitionTails.get(leaseId) === tail) {
-        this.processLeaseTransitionTails.delete(leaseId);
-      }
-    }
-  }
-
   private async retainProcessLeaseOperation(
     identity: AcpxProcessLeaseIdentity,
     prepare: () => Promise<void>,
   ): Promise<void> {
-    await this.runSerializedProcessLeaseTransition(identity.leaseId, async () => {
+    await this.processLeaseTransitionQueue.enqueue(identity.leaseId, async () => {
       await prepare();
       this.processLeaseOperationCounts.set(
         identity.leaseId,
@@ -1199,7 +1141,7 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     if (!identity) {
       return;
     }
-    await this.runSerializedProcessLeaseTransition(identity.leaseId, async () => {
+    await this.processLeaseTransitionQueue.enqueue(identity.leaseId, async () => {
       const count = this.processLeaseOperationCounts.get(identity.leaseId) ?? 0;
       if (count > 1) {
         this.processLeaseOperationCounts.set(identity.leaseId, count - 1);
@@ -1327,29 +1269,6 @@ export class AcpxRuntime implements CompleteAcpRuntime {
       return await resultPromise;
     } finally {
       await this.finalizeProcessLeaseForOperation(handle, await identityPromise);
-    }
-  }
-
-  private async runSerializedSessionEnsure<T>(
-    sessionKey: string,
-    run: () => Promise<T>,
-  ): Promise<T> {
-    const key = sessionKey.trim() || sessionKey;
-    const previous = this.ensureSessionTails.get(key) ?? Promise.resolve();
-    let release!: () => void;
-    const current = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const tail = previous.then(() => current);
-    this.ensureSessionTails.set(key, tail);
-    await previous;
-    try {
-      return await run();
-    } finally {
-      release();
-      if (this.ensureSessionTails.get(key) === tail) {
-        this.ensureSessionTails.delete(key);
-      }
     }
   }
 
@@ -1487,7 +1406,9 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     input: Parameters<AcpRuntime["ensureSession"]>[0],
   ): Promise<OpenClawRuntimeHandle> {
     const resource = assertAcpxSessionOwnerLocator(input, this.legacyBareSessionKeys);
-    return await this.runSerializedSessionEnsure(resource, () => this.ensureSessionUnlocked(input));
+    return await this.sessionEnsureQueue.enqueue(resource.trim() || resource, () =>
+      this.ensureSessionUnlocked(input),
+    );
   }
 
   private async ensureSessionUnlocked(
@@ -1605,7 +1526,11 @@ export class AcpxRuntime implements CompleteAcpRuntime {
       const delegate = this.resolveDelegateForOperationSnapshot(input.handle, snapshot);
       return withTurnDiagnostics(command, async () => ({
         command,
-        turn: delegate.startTurn(withOpenClawManagedTurnTimeout(toAcpxResourceInput(input))),
+        turn: delegate.startTurn({
+          ...toAcpxResourceInput(input),
+          // OpenClaw owns deadlines; acpx timeouts can report partial output as completed.
+          timeoutMs: 0,
+        }),
       }));
     });
 

--- a/src/acp/control-plane/manager.cancel-session.test.ts
+++ b/src/acp/control-plane/manager.cancel-session.test.ts
@@ -7,6 +7,7 @@ import {
   withAcpManagerTaskStateDir,
 } from "../../../test/helpers/acp-manager-task-state.js";
 import {
+  AcpRuntimeError,
   AcpSessionManager,
   baseCfg,
   createRuntime,
@@ -16,10 +17,53 @@ import {
   installAcpSessionManagerTestLifecycle,
   mockParentedAcpSessionEntries,
   mockCallArg,
+  readySessionMeta,
 } from "./manager.test-helpers.js";
 
 describe("AcpSessionManager cancelSession", () => {
   installAcpSessionManagerTestLifecycle();
+
+  it.each(["generic", "acp"] as const)(
+    "records idle cancellation failures without losing %s error identity",
+    async (kind) => {
+      const runtimeState = createRuntime();
+      const error =
+        kind === "generic"
+          ? new Error("Cancel transport failed")
+          : new AcpRuntimeError("ACP_BACKEND_UNAVAILABLE", "Cancel backend unavailable", {
+              detailCode: "CANCEL_UNAVAILABLE",
+            });
+      runtimeState.cancel.mockRejectedValue(error);
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      const sessionKey = "agent:codex:acp:idle-cancel";
+      hoisted.readAcpSessionEntryMock.mockReturnValue({
+        sessionKey,
+        storeSessionKey: sessionKey,
+        acp: readySessionMeta(),
+      });
+
+      const cancellation = new AcpSessionManager().cancelSession({
+        cfg: baseCfg,
+        sessionKey,
+        reason: "manual-cancel",
+      });
+      if (kind === "generic") {
+        await expect(cancellation).rejects.toMatchObject({
+          code: "ACP_TURN_FAILED",
+          message: error.message,
+          cause: error,
+        });
+      } else {
+        await expect(cancellation).rejects.toBe(error);
+      }
+      expect(runtimeState.cancel).toHaveBeenCalledOnce();
+      expectRecordFields(mockCallArg(runtimeState.cancel), { reason: "manual-cancel" });
+      expect(extractStatesFromUpserts().at(-1)).toBe("error");
+    },
+  );
 
   it("preempts an active turn on cancel and returns to idle state", async () => {
     await withAcpManagerTaskStateDir(async () => {

--- a/src/acp/control-plane/manager.cancel-session.ts
+++ b/src/acp/control-plane/manager.cancel-session.ts
@@ -1,5 +1,4 @@
 /** Cancellation path for active ACP turns and idle runtime handles. */
-import type { AcpRuntime, AcpRuntimeHandle } from "@openclaw/acp-core/runtime/types";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   AcpRuntimeError,
@@ -42,7 +41,6 @@ export async function runManagerCancelSession(params: {
     ) {
       throw new AcpRuntimeError("ACP_TURN_FAILED", "ACP task is no longer the active run.");
     }
-    return current;
   };
   const requireExpectedOwner = () => {
     if (!expectedOwnerKey) {
@@ -86,8 +84,7 @@ export async function runManagerCancelSession(params: {
       meta: resolvedMeta,
     });
     try {
-      await cancelRuntimeHandle({
-        runtime,
+      await runtime.cancel({
         handle,
         reason: params.reason,
       });
@@ -99,7 +96,11 @@ export async function runManagerCancelSession(params: {
         clearLastError: true,
       });
     } catch (error) {
-      const acpError = normalizeCancelError(error);
+      const acpError = toAcpRuntimeError({
+        error,
+        fallbackCode: "ACP_TURN_FAILED",
+        fallbackMessage: "ACP cancel failed before completion.",
+      });
       await params.setSessionState({
         cfg: params.cfg,
         sessionKey: params.sessionKey,
@@ -128,30 +129,6 @@ export async function cancelManagerActiveTurn(params: {
   }
   await withAcpRuntimeErrorBoundary({
     run: async () => await params.activeTurn.cancelPromise!,
-    fallbackCode: "ACP_TURN_FAILED",
-    fallbackMessage: "ACP cancel failed before completion.",
-  });
-}
-
-async function cancelRuntimeHandle(params: {
-  runtime: AcpRuntime;
-  handle: AcpRuntimeHandle;
-  reason?: string;
-}): Promise<void> {
-  await withAcpRuntimeErrorBoundary({
-    run: async () =>
-      await params.runtime.cancel({
-        handle: params.handle,
-        reason: params.reason,
-      }),
-    fallbackCode: "ACP_TURN_FAILED",
-    fallbackMessage: "ACP cancel failed before completion.",
-  });
-}
-
-function normalizeCancelError(error: unknown): AcpRuntimeError {
-  return toAcpRuntimeError({
-    error,
     fallbackCode: "ACP_TURN_FAILED",
     fallbackMessage: "ACP cancel failed before completion.",
   });

--- a/src/acp/control-plane/manager.close-session.ts
+++ b/src/acp/control-plane/manager.close-session.ts
@@ -3,7 +3,7 @@ import {
   identityHasStableSessionId,
   resolveSessionIdentityFromMeta,
 } from "@openclaw/acp-core/runtime/session-identity";
-import { toAcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
+import { toAcpRuntimeError } from "../runtime/errors.js";
 import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
 import { isAcpOwnerRepairRequired } from "./manager.runtime-owner.js";
 import {
@@ -75,15 +75,10 @@ export async function runManagerCloseSession(params: {
         agentId,
         meta,
       });
-      await withAcpRuntimeErrorBoundary({
-        run: async () =>
-          await ensuredRuntime.close({
-            handle,
-            reason: input.reason,
-            discardPersistentState: input.discardPersistentState,
-          }),
-        fallbackCode: "ACP_TURN_FAILED",
-        fallbackMessage: "ACP close failed before completion.",
+      await ensuredRuntime.close({
+        handle,
+        reason: input.reason,
+        discardPersistentState: input.discardPersistentState,
       });
       runtimeClosed = true;
       params.runtimeHandles.clear(params);
@@ -123,7 +118,6 @@ export async function runManagerCloseSession(params: {
     }
   }
 
-  let metaCleared = false;
   if (input.discardPersistentState && !input.clearMeta) {
     await discardPersistedManagerRuntimeState({
       cfg: input.cfg,
@@ -133,20 +127,15 @@ export async function runManagerCloseSession(params: {
     });
   }
 
-  if (input.clearMeta) {
+  const metaCleared = Boolean(input.clearMeta);
+  if (metaCleared) {
     await params.writeSessionMeta({
       cfg: input.cfg,
       sessionKey,
       agentId,
-      mutate: (_current, entry) => {
-        if (!entry) {
-          return null;
-        }
-        return null;
-      },
+      mutate: () => null,
       failOnError: true,
     });
-    metaCleared = true;
   }
 
   return {

--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1,7 +1,6 @@
 /** Main ACP session manager implementation and public control-plane facade. */
 import type {
   AcpRuntime,
-  AcpRuntimeCapabilities,
   AcpRuntimeHandle,
   AcpRuntimeStatus,
 } from "@openclaw/acp-core/runtime/types";
@@ -16,7 +15,6 @@ import { runManagerCloseSession } from "./manager.close-session.js";
 import { reconcileManagerRuntimeSessionIdentifiers } from "./manager.identity-reconcile.js";
 import { runManagerInitializeSession } from "./manager.initialize-session.js";
 import { registerAcpSessionManagerDisposer } from "./manager.lifecycle.js";
-import { resolveManagerRuntimeCapabilities } from "./manager.runtime-controls.js";
 import { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
 import { ensureManagerRuntimeHandle } from "./manager.runtime-handle-ensure.js";
 import {
@@ -213,7 +211,6 @@ export class AcpSessionManager {
           throwIfAborted: this.throwIfAborted.bind(this),
           resolveSession: this.resolveSession.bind(this),
           ensureRuntimeHandle: this.ensureRuntimeHandle.bind(this),
-          resolveRuntimeCapabilities: this.resolveRuntimeCapabilities.bind(this),
           reconcileRuntimeSessionIdentifiers: this.reconcileRuntimeSessionIdentifiers.bind(this),
         }),
       params.signal,
@@ -380,7 +377,6 @@ export class AcpSessionManager {
       runtimeHandles: this.runtimeHandles,
       resolveSession: this.resolveSession.bind(this),
       ensureRuntimeHandle: this.ensureRuntimeHandle.bind(this),
-      resolveRuntimeCapabilities: this.resolveRuntimeCapabilities.bind(this),
       writeSessionMeta: this.writeSessionMeta.bind(this),
     };
   }
@@ -400,14 +396,6 @@ export class AcpSessionManager {
   private recordErrorCode(code: string): void {
     const normalized = normalizeAcpErrorCode(code);
     this.errorCountsByCode.set(normalized, (this.errorCountsByCode.get(normalized) ?? 0) + 1);
-  }
-
-  private async resolveRuntimeCapabilities(params: {
-    runtime: AcpRuntime;
-    handle: AcpRuntimeHandle;
-    includeStatusConfigOptionKeys?: boolean;
-  }): Promise<AcpRuntimeCapabilities> {
-    return await resolveManagerRuntimeCapabilities(params);
   }
 
   private async setSessionState(params: {

--- a/src/acp/control-plane/manager.runtime-options-commands.ts
+++ b/src/acp/control-plane/manager.runtime-options-commands.ts
@@ -1,8 +1,8 @@
 /** Command handlers for changing ACP runtime mode and config options on live sessions. */
-import type { AcpRuntime, AcpRuntimeHandle } from "@openclaw/acp-core/runtime/types";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { AcpRuntimeError, withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
+import { resolveManagerRuntimeCapabilities } from "./manager.runtime-controls.js";
 import type { ManagerRuntimeHandleCache } from "./manager.runtime-handle-cache.js";
 import type {
   AcpSessionRuntimeOptions,
@@ -25,11 +25,6 @@ export type RuntimeOptionCommandServices = {
   runtimeHandles: ManagerRuntimeHandleCache;
   resolveSession: ResolveManagerSession;
   ensureRuntimeHandle: EnsureManagerRuntimeHandle;
-  resolveRuntimeCapabilities: (params: {
-    runtime: AcpRuntime;
-    handle: AcpRuntimeHandle;
-    includeStatusConfigOptionKeys?: boolean;
-  }) => Promise<{ controls: string[]; configOptionKeys?: string[] }>;
   writeSessionMeta: WriteManagerSessionMeta;
 };
 
@@ -55,7 +50,7 @@ export async function runSetManagerSessionRuntimeMode(
     agentId: params.agentId,
     meta: resolvedMeta,
   });
-  const capabilities = await params.resolveRuntimeCapabilities({ runtime, handle });
+  const capabilities = await resolveManagerRuntimeCapabilities({ runtime, handle });
   if (!capabilities.controls.includes("session/set_mode") || !runtime.setMode) {
     throw createUnsupportedControlError({
       backend: handle.backend || meta.backend,
@@ -101,7 +96,7 @@ export async function runSetManagerSessionConfigOption(
     meta: resolvedMeta,
   });
   const inferredPatch = inferRuntimeOptionPatchFromConfigOption(params.key, params.value);
-  const capabilities = await params.resolveRuntimeCapabilities({
+  const capabilities = await resolveManagerRuntimeCapabilities({
     runtime,
     handle,
     includeStatusConfigOptionKeys: true,

--- a/src/acp/control-plane/manager.status.ts
+++ b/src/acp/control-plane/manager.status.ts
@@ -1,13 +1,9 @@
 /** Reads ACP session status from the runtime and reconciles persisted identity metadata. */
 import { resolveSessionIdentityFromMeta } from "@openclaw/acp-core/runtime/session-identity";
-import type {
-  AcpRuntime,
-  AcpRuntimeCapabilities,
-  AcpRuntimeHandle,
-  AcpRuntimeStatus,
-} from "@openclaw/acp-core/runtime/types";
+import type { AcpRuntimeStatus } from "@openclaw/acp-core/runtime/types";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withAcpRuntimeErrorBoundary } from "../runtime/errors.js";
+import { resolveManagerRuntimeCapabilities } from "./manager.runtime-controls.js";
 import type {
   AcpSessionStatus,
   EnsureManagerRuntimeHandle,
@@ -26,10 +22,6 @@ export async function runManagerGetSessionStatus(params: {
   throwIfAborted: (signal?: AbortSignal) => void;
   resolveSession: ResolveManagerSession;
   ensureRuntimeHandle: EnsureManagerRuntimeHandle;
-  resolveRuntimeCapabilities: (params: {
-    runtime: AcpRuntime;
-    handle: AcpRuntimeHandle;
-  }) => Promise<AcpRuntimeCapabilities>;
   reconcileRuntimeSessionIdentifiers: ReconcileManagerRuntimeSessionIdentifiers;
 }): Promise<AcpSessionStatus> {
   params.throwIfAborted(params.signal);
@@ -50,7 +42,7 @@ export async function runManagerGetSessionStatus(params: {
     meta: resolvedMeta,
   });
   let handle = ensuredHandle;
-  const capabilities = await params.resolveRuntimeCapabilities({ runtime, handle });
+  const capabilities = await resolveManagerRuntimeCapabilities({ runtime, handle });
   let runtimeStatus: AcpRuntimeStatus | undefined;
   if (runtime.getStatus) {
     runtimeStatus = await withAcpRuntimeErrorBoundary({


### PR DESCRIPTION
Related: #139685, #139776

## What Problem This Solves

ACP/acpx retained duplicate serialization, validation, wrapper-writing, and error-normalization paths after the recent output and cancellation repairs. This maintainer-requested follow-up reduces the code that must stay consistent when maintaining session lifecycle behavior.

## Why This Change Was Made

Reuse the existing SDK keyed queue for session initialization and process lease transitions, keeping their lock domains separate. Let the config schema own parsing/defaults, share identical wrapper/root resolution logic, and call the existing capability and error owners directly. Remove the unused raw-config type, redundant casts, one-use forwarding helpers, and duplicate error boundaries.

Production TypeScript: +105 / -337, net **−232 lines**. Tests: +44 lines covering idle cancellation error causes/identity and persisted error state. The assertion baseline only shrinks. No configuration, protocol, dependency, storage, or public API changes.

## User Impact

No intentional behavior change. Existing ACP output delivery, cancellation, session reuse, model selection, wrapper launch, and process cleanup behavior is preserved with fewer duplicate paths.

## Evidence

- Focused ACP control-plane, acpx plugin, and SDK queue suite: **505 tests across 45 files passed**.
- New idle cancellation compatibility cases also pass against the original implementation.
- Live Codex through the real acpx 0.13.2 runtime and generated wrapper, using isolated temporary state: slow output delivery retained the final response; status/text delivery failures cancelled; subsequent turns reused the same session successfully; abandoning the legacy stream cancelled and allowed reuse.
- Dependency source checked directly: ACPX handle decoder and fallback, SDK queue ordering/failure cleanup, canonical ACP error normalization; Codex app-server turn interruption, completion notification, and persisted resume metadata.
- Full `pnpm build` passed, including generated plugin/SDK declarations and plugin load checks.
- Fresh independent autoreview through P2: no actionable findings.
- `node scripts/check-changed.mjs` passed all selected formatting, core/plugin typechecks, lint, dead-export and repository guards.
- Exact-head [CI run 34038807845](https://github.com/openclaw/openclaw/actions/runs/34038807845) passed.

ClawSweeper follow-up: both pre-merge proof requests are addressed without code changes.

- **Published decoder contract:** directly inspected acpx 0.13.2 `dist/runtime.js:1799-1821` and the matching [tagged decoder source](https://github.com/openclaw/acpx/blob/v0.13.2/src/runtime/public/handle-state.ts#L12). It returns either null or a record whose agent/name/cwd are nonempty strings and mode is persistent/oneshot. A direct probe of the installed published runtime passed two valid and seven invalid handle cases. The removed cast and checks duplicated this decoder contract.
- **Data-model compatibility:** this PR does not change a stored format, schema, migration algorithm, or persisted field. `persistMigratedCodexMcpConfig`, TOML serialization, isolated-home preparation, generated wrapper contents/filenames, and lease/session record shapes remain intact. The shared writer retains the same mkdir/write/chmod sequence; launch construction reuses the already parsed command. All **27 existing wrapper/auth/migration tests** pass on both original and candidate implementations, including legacy Codex command/MCP migration, maintained argv forwarding, isolated-home/rebuild isolation, existing auth preservation, and rejected chmod. Candidate coverage is included in the 505-test run; original-source compatibility runs passed separately. The data-model classification is a false positive for this refactor, so no new migration is needed.
