### PR TITLE
refactor(ui): remove obsolete update status plumbing

### DIFF
--- a/ui/src/app/update-overlay-helpers.ts
+++ b/ui/src/app/update-overlay-helpers.ts
@@ -109,12 +109,7 @@ function readUpdateAttemptId(sentinel: UpdateRestartStatusResponse["sentinel"]):
 }
 
 /** One projection owns the recorded display facts and the typed triage transition. */
-export function projectUpdateSentinel(
-  sentinel: UpdateRestartStatusResponse["sentinel"],
-  requestId?: string,
-): {
-  outcome: ReturnType<typeof classifyUpdateOutcome>;
-  record: UpdateOutcomeRecord;
+export function projectUpdateSentinel(sentinel: UpdateRestartStatusResponse["sentinel"]): {
   attempt: RecordedUpdateAttempt | null;
   banner: ApplicationStatusBanner | null;
   failure: UpdateFailureTriage | null;
@@ -159,20 +154,11 @@ export function projectUpdateSentinel(
       (typeof sentinel.ts === "number" ? `recorded:${sentinel.ts}` : null),
     timestampMs: sentinel.ts ?? null,
   };
-  const id = record.id ?? requestId;
   const failure: UpdateFailureTriage | null =
-    outcome === "failed" && id && banner ? { id, outcome, attempt, banner } : null;
-  // A response can carry a newer failure than the persisted status record.
-  if (failure && (record.id !== null || record.timestampMs !== null)) {
-    failure.reconciledRecord = record;
-  }
-  return {
-    outcome,
-    record,
-    attempt,
-    banner,
-    failure,
-  };
+    outcome === "failed" && record.id && banner
+      ? { id: record.id, outcome, attempt, banner, reconciledRecord: record }
+      : null;
+  return { attempt, banner, failure };
 }
 
 function lastLogLine(tail: string | null | undefined): string | null {
@@ -217,22 +203,6 @@ export type UpdateRunResponse = {
   sentinel?: { payload?: UpdateRestartStatusResponse["sentinel"] } | null;
 };
 
-async function requestUpdateRestartStatus(
-  client: Pick<GatewayBrowserClient, "request">,
-  timeoutMs: number,
-  request: { refreshCheckout?: true } = {},
-  onError?: (error: unknown) => void,
-): Promise<UpdateRestartStatusResponse | null> {
-  try {
-    return await client.request<UpdateRestartStatusResponse>("update.status", request, {
-      timeoutMs,
-    });
-  } catch (error) {
-    onError?.(error);
-    return null;
-  }
-}
-
 export function createUpdateStatusRefresher(params: {
   getClient: () => GatewayBrowserClient | null;
   getEpoch: () => number;
@@ -267,16 +237,18 @@ export function createUpdateStatusRefresher(params: {
       params.onRefreshing(true);
     }
     try {
-      const response = await requestUpdateRestartStatus(
-        client,
-        5_000,
-        refreshCheckout ? { refreshCheckout: true } : {},
-        (error) => {
+      const response = await client
+        .request<UpdateRestartStatusResponse>(
+          "update.status",
+          refreshCheckout ? { refreshCheckout: true } : {},
+          { timeoutMs: 5_000 },
+        )
+        .catch((error: unknown) => {
           if (mode !== "background" && isCurrent()) {
             params.onError(error);
           }
-        },
-      );
+          return null;
+        });
       if (response && isCurrent()) {
         params.onStatus(response);
       }

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -414,6 +414,9 @@ describe("sidebar attention refresh ownership", () => {
       if (method === "exec.approval.resolve") {
         return resolution.promise;
       }
+      if (method === "update.status") {
+        return Promise.resolve({ sentinel: null, updateAvailable: null });
+      }
       if (method === "cron.list") {
         return Promise.resolve(cronListResponse([]));
       }


### PR DESCRIPTION
## What Problem This Solves

Removes obsolete plumbing from Control UI update status refresh and recorded-outcome projection after #138737 removed the verification controller. This is a small deletion follow-up to the #135868 split campaign and #139701.

## Why This Change Was Made

The remaining refresher owns a single fixed-timeout request. Keeping its error handling there makes request failures and status projection visibly separate. The projection now returns only fields its callers consume.

Deletion evidence:
- `requestUpdateRestartStatus`: its variable-timeout consumer was removed in `9b1d9c29ec2` (#138737); the sole remaining caller always requests the same 5-second timeout. `GatewayBrowserClient.request` is async, so the attached rejection handler preserves request-error behavior.
- `projectUpdateSentinel` request-ID argument: the only supplying caller was the removed verification controller, confirmed by `git log -S` and the parent-relative patch. Neither current production caller supplies it.
- Top-level projection `outcome` and `record`: their consumer, `classifyUpdateObservation`, was removed in the same commit. Current callers consume only attempt, banner and failure.
- Conditional failure-record attachment: without the unused request-ID fallback, every projected failure already has a record ID. Attach the same record directly.

## User Impact

No user-visible behavior or appearance changes. Refresh ownership, cancellation/revision checks, error reporting, translations, sentinel parsing and both shipped browser-receipt formats retain their existing contracts.

## Evidence

- 212 tests passed across 9 update overlay, helper, receipt and sidebar files. The original sidebar fixture reproduced two unhandled errors locally; adding its missing empty update.status bootstrap response made the same suite pass without changing approval-focus assertions.
- Full `node scripts/check-changed.mjs` passed.
- Independent Codex branch review: scoped-clean, no accepted/actionable P0–P2 findings.
- Production: +14 / −42 = **−28 lines**. Tests/support: +3 / −0. Tooling and docs: unchanged. This PR changes 59 lines in two files.

CI notes: the initial head exposed the corrected sidebar fixture omission. Its unrelated browser-extension E2E failure was `bootstrap.chromium.test.ts`, “pre-registers before the first native call, auto-pairs, and revokes a paused tab” (expected one newly created relay tab, observed none after access revocation). The revised head must pass exact-head CI before landing.

ClawSweeper reviewed the production cleanup with no correctness/security findings and no rank-up changes requested; the missing bootstrap fixture is corrected separately as described above.
