### PR TITLE
refactor(doctor): share preview warning rendering

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -515,7 +515,6 @@ src/commands/doctor/shared/legacy-config-migrate.test.ts
 src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
 src/commands/doctor/shared/missing-configured-plugin-install.test.ts
 src/commands/doctor/shared/preview-warnings.test.ts
-src/commands/doctor/shared/preview-warnings.ts
 src/commands/doctor/shared/stale-auth-order.test.ts
 src/commands/gateway-status.test.ts
 src/commands/migrate.test.ts

--- a/src/commands/doctor/shared/preview-message-tool-policy.ts
+++ b/src/commands/doctor/shared/preview-message-tool-policy.ts
@@ -1,0 +1,81 @@
+import { isRecord as hasRecord } from "@openclaw/normalization-core/record-coerce";
+import { listAgentEntries, resolveAgentConfig } from "../../../agents/agent-scope-config.js";
+import { resolveProviderToolPolicy } from "../../../agents/provider-tool-policy.js";
+import { pickSandboxToolPolicy } from "../../../agents/sandbox-tool-policy.js";
+import { isToolAllowedByPolicies } from "../../../agents/tool-policy-match.js";
+import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../../agents/tool-policy.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { AgentToolsConfig, ToolsConfig } from "../../../config/types.tools.js";
+import { resolveDoctorPrimaryModelRef } from "./primary-model-ref.js";
+
+export function resolveMessageToolAvailability(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+  globalTools?: ToolsConfig;
+  agentTools?: AgentToolsConfig;
+  runtimeAlsoAllow?: string[];
+}): boolean {
+  const agentConfig = params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined;
+  const modelRef = resolveDoctorPrimaryModelRef(params.cfg, agentConfig?.model);
+  const providerPolicy = resolveProviderToolPolicy({
+    byProvider: params.globalTools?.byProvider,
+    modelProvider: modelRef.provider,
+    modelId: modelRef.model,
+  });
+  const agentProviderPolicy = resolveProviderToolPolicy({
+    byProvider: params.agentTools?.byProvider,
+    modelProvider: modelRef.provider,
+    modelId: modelRef.model,
+  });
+  const profile = params.agentTools?.profile ?? params.globalTools?.profile;
+  const configuredAlsoAllow = Array.isArray(params.agentTools?.alsoAllow)
+    ? params.agentTools.alsoAllow
+    : Array.isArray(params.globalTools?.alsoAllow)
+      ? params.globalTools.alsoAllow
+      : [];
+  const providerAlsoAllow = Array.isArray(agentProviderPolicy?.alsoAllow)
+    ? agentProviderPolicy.alsoAllow
+    : Array.isArray(providerPolicy?.alsoAllow)
+      ? providerPolicy.alsoAllow
+      : [];
+  const profileAlsoAllow = [...configuredAlsoAllow, ...(params.runtimeAlsoAllow ?? [])];
+  const providerProfileAlsoAllow = [...providerAlsoAllow, ...(params.runtimeAlsoAllow ?? [])];
+  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
+  const providerProfilePolicy = mergeAlsoAllowPolicy(
+    resolveToolProfilePolicy(agentProviderPolicy?.profile ?? providerPolicy?.profile),
+    providerProfileAlsoAllow,
+  );
+  return isToolAllowedByPolicies("message", [
+    profilePolicy,
+    providerProfilePolicy,
+    pickSandboxToolPolicy(providerPolicy),
+    pickSandboxToolPolicy(agentProviderPolicy),
+    pickSandboxToolPolicy(params.globalTools),
+    pickSandboxToolPolicy(params.agentTools),
+  ]);
+}
+
+export const SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW = ["message"];
+
+export function collectUnavailableSourceReplyTargets(cfg: OpenClawConfig): string[] {
+  const agents = listAgentEntries(cfg).filter(hasRecord);
+  if (agents.length === 0) {
+    const available = resolveMessageToolAvailability({
+      cfg,
+      globalTools: cfg.tools,
+      runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
+    });
+    return available ? [] : ["default tool policy"];
+  }
+  return agents.flatMap((agent) => {
+    const agentId = typeof agent.id === "string" ? agent.id : "unknown";
+    const available = resolveMessageToolAvailability({
+      cfg,
+      agentId,
+      globalTools: cfg.tools,
+      agentTools: agent.tools,
+      runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
+    });
+    return available ? [] : [`agent "${agentId}"`];
+  });
+}

--- a/src/commands/doctor/shared/preview-warnings.ts
+++ b/src/commands/doctor/shared/preview-warnings.ts
@@ -6,23 +6,20 @@ import {
   resolveProviderToolPolicy,
   resolveProviderToolPolicyEntry,
 } from "../../../agents/provider-tool-policy.js";
-import { pickSandboxToolPolicy } from "../../../agents/sandbox-tool-policy.js";
-import {
-  isToolAllowedByPolicies,
-  isToolAllowedByPolicyName,
-} from "../../../agents/tool-policy-match.js";
+import { isToolAllowedByPolicyName } from "../../../agents/tool-policy-match.js";
 import { mergeAlsoAllowPolicy, resolveToolProfilePolicy } from "../../../agents/tool-policy.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import type {
-  AgentToolsConfig,
-  ToolPolicyConfig,
-  ToolsConfig,
-} from "../../../config/types.tools.js";
+import type { ToolPolicyConfig } from "../../../config/types.tools.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../../../plugins/current-plugin-metadata-snapshot.js";
 import { collectChannelRouteTargets } from "../../../routing/channel-route-targets.js";
 import { createLazyImportLoader } from "../../../shared/lazy-promise.js";
 import { VERSION_BOUND_RUNTIME_PLUGIN_POLICY_IDS_BY_SURFACE } from "./configured-runtime-plugin-installs.js";
 import type { BlockedLegacyOpenAICodexProviderPlan } from "./legacy-config-migrations.runtime.models.js";
+import {
+  collectUnavailableSourceReplyTargets,
+  resolveMessageToolAvailability,
+  SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
+} from "./preview-message-tool-policy.js";
 import { resolveDoctorPrimaryModelRef } from "./primary-model-ref.js";
 
 type ChannelDoctorModule = typeof import("./channel-doctor.js");
@@ -83,78 +80,6 @@ function hasConfiguredSafeBins(cfg: OpenClawConfig): boolean {
     return (
       hasRecord(agentExec) && Array.isArray(agentExec.safeBins) && agentExec.safeBins.length > 0
     );
-  });
-}
-
-function resolveMessageToolAvailability(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  globalTools?: ToolsConfig;
-  agentTools?: AgentToolsConfig;
-  runtimeAlsoAllow?: string[];
-}): boolean {
-  const agentConfig = params.agentId ? resolveAgentConfig(params.cfg, params.agentId) : undefined;
-  const modelRef = resolveDoctorPrimaryModelRef(params.cfg, agentConfig?.model);
-  const providerPolicy = resolveProviderToolPolicy({
-    byProvider: params.globalTools?.byProvider,
-    modelProvider: modelRef.provider,
-    modelId: modelRef.model,
-  });
-  const agentProviderPolicy = resolveProviderToolPolicy({
-    byProvider: params.agentTools?.byProvider,
-    modelProvider: modelRef.provider,
-    modelId: modelRef.model,
-  });
-  const profile = params.agentTools?.profile ?? params.globalTools?.profile;
-  const configuredAlsoAllow = Array.isArray(params.agentTools?.alsoAllow)
-    ? params.agentTools.alsoAllow
-    : Array.isArray(params.globalTools?.alsoAllow)
-      ? params.globalTools.alsoAllow
-      : [];
-  const providerAlsoAllow = Array.isArray(agentProviderPolicy?.alsoAllow)
-    ? agentProviderPolicy.alsoAllow
-    : Array.isArray(providerPolicy?.alsoAllow)
-      ? providerPolicy.alsoAllow
-      : [];
-  const profileAlsoAllow = [...configuredAlsoAllow, ...(params.runtimeAlsoAllow ?? [])];
-  const providerProfileAlsoAllow = [...providerAlsoAllow, ...(params.runtimeAlsoAllow ?? [])];
-  const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), profileAlsoAllow);
-  const providerProfilePolicy = mergeAlsoAllowPolicy(
-    resolveToolProfilePolicy(agentProviderPolicy?.profile ?? providerPolicy?.profile),
-    providerProfileAlsoAllow,
-  );
-  return isToolAllowedByPolicies("message", [
-    profilePolicy,
-    providerProfilePolicy,
-    pickSandboxToolPolicy(providerPolicy),
-    pickSandboxToolPolicy(agentProviderPolicy),
-    pickSandboxToolPolicy(params.globalTools),
-    pickSandboxToolPolicy(params.agentTools),
-  ]);
-}
-
-const SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW = ["message"];
-
-function collectUnavailableSourceReplyTargets(cfg: OpenClawConfig): string[] {
-  const agents = listAgentRecords(cfg);
-  if (agents.length === 0) {
-    const available = resolveMessageToolAvailability({
-      cfg,
-      globalTools: cfg.tools,
-      runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
-    });
-    return available ? [] : ["default tool policy"];
-  }
-  return agents.flatMap((agent) => {
-    const agentId = typeof agent.id === "string" ? agent.id : "unknown";
-    const available = resolveMessageToolAvailability({
-      cfg,
-      agentId,
-      globalTools: cfg.tools,
-      agentTools: agent.tools,
-      runtimeAlsoAllow: SOURCE_REPLY_RUNTIME_MESSAGE_ALLOW,
-    });
-    return available ? [] : [`agent "${agentId}"`];
   });
 }
 
@@ -220,16 +145,6 @@ function collectVisibleReplyToolPolicyWarnings(cfg: OpenClawConfig): string[] {
   return warnings;
 }
 
-function formatChannelList(channels: string[]): string {
-  if (channels.length <= 2) {
-    return channels.map((channel) => `"${channel}"`).join(" and ");
-  }
-  return `${channels
-    .slice(0, 2)
-    .map((channel) => `"${channel}"`)
-    .join(", ")}, and ${channels.length - 2} more`;
-}
-
 /** Warn when routed channel agents lack the message tool required for channel actions. */
 function collectChannelBoundMessageToolPolicyWarnings(cfg: OpenClawConfig): string[] {
   return collectChannelRouteTargets(cfg).flatMap((target) => {
@@ -248,8 +163,8 @@ function collectChannelBoundMessageToolPolicyWarnings(cfg: OpenClawConfig): stri
       return [];
     }
     return [
-      `- Agent "${target.agentId}" is routed from channel ${formatChannelList(
-        target.channels,
+      `- Agent "${target.agentId}" is routed from channel ${formatTargets(
+        target.channels.map((channel) => `"${channel}"`),
       )}, but the message tool is unavailable for that agent; explicit channel actions such as sendAttachment, upload-file, thread-reply, or reply can fail. Add "message" to the agent tool allowlist, add "group:messaging", or switch the agent to a profile that includes messaging tools.`,
     ];
   });
@@ -295,36 +210,44 @@ function readPreviewStringList(value: unknown): string[] | undefined {
     : undefined;
 }
 
-function collectUncoveredConfiguredToolSectionGrantEntries(
-  configuredEntries: ConfiguredToolSectionGrantEntry[],
-  profilePolicy: ToolPolicyConfig | undefined,
-): ConfiguredToolSectionGrantEntry[] {
-  if (!profilePolicy) {
+function collectProfileConfiguredSectionWarnings(params: {
+  configuredEntries: ConfiguredToolSectionGrantEntry[];
+  profilePolicy: ToolPolicyConfig | undefined;
+  profile: string;
+  profilePath: string;
+  advicePath?: string;
+  profileKind: "active" | "provider" | "inherited provider";
+  hasAllow: boolean;
+}): string[] {
+  if (!params.profilePolicy) {
     return [];
   }
-  return configuredEntries
+  const uncoveredEntries = params.configuredEntries
     .map((entry) => ({
       ...entry,
       grants: entry.grants.filter(
-        (toolName) => !isToolAllowedByPolicyName(toolName, profilePolicy),
+        (toolName) => !isToolAllowedByPolicyName(toolName, params.profilePolicy),
       ),
     }))
     .filter((entry) => entry.grants.length > 0);
-}
-
-function formatProfileConfiguredSectionGrantAdvice(params: {
-  pathLabel: string;
-  grants: string[];
-  hasAllow: boolean;
-  provider?: boolean;
-}): string {
-  const providerSuffix = params.provider ? " for that provider" : "";
-  if (params.hasAllow) {
-    return `Add these grants to ${params.pathLabel}.allow and set ${params.pathLabel}.profile to "full" if these tools should be available${providerSuffix}.`;
+  if (uncoveredEntries.length === 0) {
+    return [];
   }
-  return `Add ${params.pathLabel}.alsoAllow: [${formatQuotedList(
-    params.grants,
-  )}] if these tools should be available${providerSuffix}.`;
+  const grants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
+  const advicePath = params.advicePath ?? params.profilePath;
+  const providerSuffix = params.profileKind === "active" ? "" : " for that provider";
+  const advice = params.hasAllow
+    ? `Add these grants to ${advicePath}.allow and set ${advicePath}.profile to "full" if these tools should be available${providerSuffix}.`
+    : `Add ${advicePath}.alsoAllow: [${formatQuotedList(
+        grants,
+      )}] if these tools should be available${providerSuffix}.`;
+  return [
+    `- ${params.profilePath}.profile is "${params.profile}" and ${uncoveredEntries
+      .map((entry) => entry.label)
+      .join(
+        " / ",
+      )} is configured, but configured sections no longer widen the ${params.profileKind} profile. ${advice}`,
+  ];
 }
 
 function collectProfileConfiguredToolSectionScopeWarnings(params: {
@@ -358,29 +281,14 @@ function collectProfileConfiguredToolSectionScopeWarnings(params: {
     ? tools.alsoAllow.filter((entry): entry is string => typeof entry === "string")
     : params.inheritedAlsoAllow;
   const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
-  if (!profilePolicy) {
-    return [];
-  }
-  const uncoveredEntries = collectUncoveredConfiguredToolSectionGrantEntries(
+  return collectProfileConfiguredSectionWarnings({
     configuredEntries,
     profilePolicy,
-  );
-  if (uncoveredEntries.length === 0) {
-    return [];
-  }
-  const uncoveredGrants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
-  const advice = formatProfileConfiguredSectionGrantAdvice({
-    pathLabel: params.pathLabel,
-    grants: uncoveredGrants,
+    profile,
+    profilePath: params.pathLabel,
+    profileKind: "active",
     hasAllow: hasNonEmptyStringList(tools?.allow),
   });
-  return [
-    `- ${params.pathLabel}.profile is "${profile}" and ${uncoveredEntries
-      .map((entry) => entry.label)
-      .join(
-        " / ",
-      )} is configured, but configured sections no longer widen the active profile. ${advice}`,
-  ];
 }
 
 function collectByProviderConfiguredToolSectionWarnings(params: {
@@ -412,31 +320,14 @@ function collectByProviderConfiguredToolSectionWarnings(params: {
     const alsoAllow =
       readPreviewStringList(policy.alsoAllow) ?? readPreviewStringList(inheritedPolicy?.alsoAllow);
     const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
-    if (!profilePolicy) {
-      return [];
-    }
-    const uncoveredEntries = collectUncoveredConfiguredToolSectionGrantEntries(
-      params.configuredEntries,
+    return collectProfileConfiguredSectionWarnings({
+      configuredEntries: params.configuredEntries,
       profilePolicy,
-    );
-    if (uncoveredEntries.length === 0) {
-      return [];
-    }
-    const providerPath = `${params.pathLabel}.byProvider.${providerKey}`;
-    const uncoveredGrants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
-    const advice = formatProfileConfiguredSectionGrantAdvice({
-      pathLabel: providerPath,
-      grants: uncoveredGrants,
+      profile,
+      profilePath: `${params.pathLabel}.byProvider.${providerKey}`,
+      profileKind: "provider",
       hasAllow: hasNonEmptyStringList(policy.allow),
-      provider: true,
     });
-    return [
-      `- ${providerPath}.profile is "${profile}" and ${uncoveredEntries
-        .map((entry) => entry.label)
-        .join(
-          " / ",
-        )} is configured, but configured sections no longer widen the provider profile. ${advice}`,
-    ];
   });
 }
 
@@ -512,34 +403,15 @@ function collectInheritedByProviderConfiguredToolSectionWarnings(params: {
       readPreviewStringList(overridingPolicy?.alsoAllow) ??
       readPreviewStringList(inheritedPolicy.alsoAllow);
     const profilePolicy = mergeAlsoAllowPolicy(resolveToolProfilePolicy(profile), alsoAllow);
-    if (!profilePolicy) {
-      return [];
-    }
-    const uncoveredEntries = collectUncoveredConfiguredToolSectionGrantEntries(
-      params.configuredEntries,
+    return collectProfileConfiguredSectionWarnings({
+      configuredEntries: params.configuredEntries,
       profilePolicy,
-    );
-    if (uncoveredEntries.length === 0) {
-      return [];
-    }
-    const overridePath = `${params.overridingPathLabel}.byProvider.${
-      overridingEntry?.key ?? providerKey
-    }`;
-    const inheritedPath = `${params.inheritedPathLabel}.byProvider.${providerKey}`;
-    const uncoveredGrants = [...new Set(uncoveredEntries.flatMap((entry) => entry.grants))];
-    const advice = formatProfileConfiguredSectionGrantAdvice({
-      pathLabel: overridePath,
-      grants: uncoveredGrants,
+      profile,
+      profilePath: `${params.inheritedPathLabel}.byProvider.${providerKey}`,
+      advicePath: `${params.overridingPathLabel}.byProvider.${overridingEntry?.key ?? providerKey}`,
+      profileKind: "inherited provider",
       hasAllow: hasNonEmptyStringList(overridingPolicy?.allow),
-      provider: true,
     });
-    return [
-      `- ${inheritedPath}.profile is "${profile}" and ${uncoveredEntries
-        .map((entry) => entry.label)
-        .join(
-          " / ",
-        )} is configured, but configured sections no longer widen the inherited provider profile. ${advice}`,
-    ];
   });
 }
 
@@ -877,4 +749,3 @@ export async function collectDoctorPreviewNotes(params: {
 
   return { infoNotes, warningNotes: warnings };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
Related: #135868
Follow-up to #140124.

## What Problem This Solves

Doctor’s oversized preview collector repeated the same configured-profile warning construction in three paths and duplicated channel-list truncation. This is a maintainer-requested cleanup in the #135868 split campaign; it adds no recovery feature content.

## Why This Change Was Made

Share the common warning rendering after each caller selects its policy, and keep message-tool availability evaluation together with source-reply target collection in a small private module. Reuse the existing list formatter for quoted channel names, removing enough duplication to retire the collector’s max-lines exemption.

## User Impact

No warning or policy behavior changes. Source and advice paths, provider/model selection, allow/deny intersections, explicit empty-list precedence, warning order, and channel quoting remain intact. No persisted data model, schema, migration, config key, or write path changes.

## Evidence

- Production: +134/−182 = **−48**. The aggregator shrinks 880→751 physical lines (699 counted); the policy module has 81 physical lines (78 counted). One exact production max-lines baseline row is deleted; the test exemption remains. Tests/docs unchanged; 317 total changed lines.
- The three callers keep policy selection and inheritance. The common helper owns only their identical filtering, grant deduplication, advice and warning construction. The extracted availability function is unchanged, and source-target collection retains the exact canonical roster filter. No package/API barrel exports; canonical dependencies and existing lazy imports are unchanged.
- 121 existing tests passed before/after across preview warnings, provider policy, Doctor config flow, and startup channel maintenance.
- 7,824 configurations / 23,472 exact collector comparisons, plus six quoted-channel expression cases, preserve warning strings/order and frozen inputs through the actual new policy module. Strict import/binding checks prevent omission of its implementation. Negative removed-grant, bypassed-denial, wrong inherited-source, and wrong advice-path controls detect 2,217 / 170 / 215 / 215 changed cases.
- Full selected changed checks passed, including full core lint, scripts lint, all core test-type lanes, three dead-export scans, and zero runtime cycles. Build passed in 8m01s, including native module loading and Doctor closures; generated assets match committed bytes. Local and committed-branch Codex reviews are clean through P2. Exact-head CI follows publication.

ClawSweeper disposition (reviewed `029b9bdc4319`): no correctness or security findings. Its data-model compatibility request is inapplicable: these helpers only interpret existing configuration and return transient diagnostic strings; no schema, store, migration, serialization, config key, or write path changes. The baseline file is tooling. Existing tests and exact frozen-input/output comparisons cover the actual compatibility contract; no migration test or data-model change is warranted. Initial exact-head CI passed in [run 34038914129](https://github.com/openclaw/openclaw/actions/runs/34038914129); final freshness rebase preserves all recorded proof inputs and lockfile.

Final-head CI attempt 1 completed with 105 successful jobs and 17 skipped jobs. Its only substantive failure was a PyPI read timeout while installing the pinned `zizmor` wheel in `security-fast`; the private-key scan passed and later scanner steps had not started. The single failed-check rerun passed on the same head; final CI [run 34039465784](https://github.com/openclaw/openclaw/actions/runs/34039465784) is green. No source, dependency pin, timeout, scanner rule, or gate was changed.
