### PR TITLE
perf(slack): reduce table reply preparation work

### DIFF
--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -25,6 +25,7 @@ import {
   buildSlackDataTableBlock,
   countSlackDataTableBlocksCellCharacters,
   countSlackDataTableCellCharacters,
+  resolveSlackDataTableCellCharacterCount,
   SLACK_DATA_TABLE_AGGREGATE_CELL_CHARACTERS_MAX,
 } from "./data-table.js";
 import {
@@ -442,13 +443,13 @@ function canRenderSlackPresentationTables(
     if (block.type !== "table") {
       continue;
     }
-    const rendered = buildSlackDataTableBlock(block, {
+    const tableCellCharacterCount = resolveSlackDataTableCellCharacterCount(block, {
       cellCharacterCountOffset: cellCharacterCount,
     });
-    if (!rendered) {
+    if (tableCellCharacterCount === undefined) {
       return false;
     }
-    cellCharacterCount += countSlackDataTableCellCharacters(rendered);
+    cellCharacterCount += tableCellCharacterCount;
   }
   return true;
 }

--- a/extensions/slack/src/data-table.ts
+++ b/extensions/slack/src/data-table.ts
@@ -237,20 +237,20 @@ function resolvePortableTableCellCharacterCount(
   return values.reduce((total, value) => total + countCharacters(value), 0);
 }
 
-/** True when a portable table fits Slack's per-table and per-message contracts. */
-function canRenderSlackDataTable(
+/** Count portable table cells when the table fits Slack's native message budget. */
+export function resolveSlackDataTableCellCharacterCount(
   block: MessagePresentationTableBlock,
   options: SlackDataTableBuildOptions = {},
-): boolean {
+): number | undefined {
   const cellCharacterCountOffset = options.cellCharacterCountOffset ?? 0;
   if (!Number.isSafeInteger(cellCharacterCountOffset) || cellCharacterCountOffset < 0) {
-    return false;
+    return undefined;
   }
   const cellCharacterCount = resolvePortableTableCellCharacterCount(block);
-  return (
-    cellCharacterCount !== undefined &&
+  return cellCharacterCount !== undefined &&
     cellCharacterCountOffset + cellCharacterCount <= SLACK_DATA_TABLE_AGGREGATE_CELL_CHARACTERS_MAX
-  );
+    ? cellCharacterCount
+    : undefined;
 }
 
 /** Map a validated portable table to Slack's current app-facing Block Kit shape. */
@@ -258,7 +258,7 @@ export function buildSlackDataTableBlock(
   block: MessagePresentationTableBlock,
   options: SlackDataTableBuildOptions = {},
 ): SlackDataTableBlock | undefined {
-  if (!canRenderSlackDataTable(block, options)) {
+  if (resolveSlackDataTableCellCharacterCount(block, options) === undefined) {
     return undefined;
   }
   const header: SlackDataTableCell[] = block.headers.map((text) => ({ type: "raw_text", text }));

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -928,6 +928,34 @@ describe("buildSlackPresentationBlocks", () => {
 
     expect(blocks).toEqual([]);
   });
+
+  it.each([
+    { offset: 9_985, native: true },
+    { offset: 9_986, native: false },
+  ])("counts Unicode, whitespace, and numeric cells at offset $offset", ({ offset, native }) => {
+    const presentation = {
+      blocks: [
+        {
+          type: "table" as const,
+          caption: "First",
+          headers: [" Name "],
+          rows: [[" 😀 "], [42]],
+        },
+        {
+          type: "table" as const,
+          caption: "Second",
+          headers: [" B "],
+          rows: [["🦀"]],
+        },
+      ],
+    };
+    const options = { dataTableCellCharacterCountOffset: offset };
+
+    expect(canRenderSlackPresentation(presentation, options)).toBe(native);
+    expect(buildSlackPresentationBlocks(presentation, options).map((block) => block.type)).toEqual(
+      native ? ["data_table", "data_table"] : [],
+    );
+  });
 });
 
 describe("resolveSlackReplyBlocks", () => {


### PR DESCRIPTION
## What Problem This Solves

Preparing Slack replies with native tables builds and discards complete table payloads just to check whether their cells fit the message budget. Ordinary reply preparation repeats that preflight before building the payload that is actually sent.

## Why This Change Was Made

Reuse the character count already computed by the portable-table validator for the native-rendering eligibility check. This removes disposable native table construction and reparsing while preserving validation order, Unicode code-point counts, numeric cells, whitespace, and aggregate offsets. The final block builder continues to own the Slack payload shape.

## User Impact

Table replies require less intermediate payload construction. Native rendering, complete text fallback, message limits, and accessibility text retain their existing behavior. This is a maintainer-requested performance cleanup with measured reductions in transient allocation for large accepted native tables.

## Evidence

- Five focused Slack suites pass: **159 tests**, covering table validation, presentation rendering, reply compilation, action dispatch, and outbound payload preparation with a mocked Slack client.
- The added boundary cases contain exactly 15 characters across two tables, including padded strings, astral Unicode, and numbers. An existing offset of 9,985 permits native rendering; 9,986 selects fallback.
- Full changed-code checks pass, including extension production/test typechecks, lint, dead-export scans, formatting, and plugin boundaries. `git diff --check` passes.
- Independent source review and fresh managed autoreview found no actionable issues.
- All **16 before/after owner fixtures are byte-identical**, covering valid/invalid table shapes, Unicode budget boundaries, offsets, and raw-table rollover.
- Actual owner profiles on a synthetic 100-row × 20-column table (2,020 cells including headers) estimate **29.2% lower allocation** in direct presentation building (1,057,427 → 748,448 sampled bytes/call) and **30.0% lower allocation** in reply preparation (2,453,210 → 1,716,635). Both arms used Node 26.8.1 on macOS arm64, the same dependencies, and 300 profiled calls with V8 sampling at 16,384 bytes, including collected objects.
- Timing under concurrent checks was mixed: direct building was 3.1% slower and reply preparation 25.4% faster. These allocation estimates are not retained-heap, RSS, or live Slack latency measurements. Small or invalid tables are not expected to show the same absolute savings.
- Required hosted CI passed against `9be34391df1127948d8ff3d39bd0ce12891b38e7`: https://github.com/openclaw/openclaw/actions/runs/34039186972.

The outbound tests exercise the Slack transport boundary with a mock client; they are not live Slack delivery evidence.
