### PR TITLE
refactor: remove redundant package state and filtering

### DIFF
--- a/packages/acp-core/src/session.test.ts
+++ b/packages/acp-core/src/session.test.ts
@@ -23,24 +23,14 @@ describe("acp session manager", () => {
     const controller = new AbortController();
     store.setActiveRun(session.sessionId, "run-1", controller);
 
-    expect(store.getSessionByRunId("run-1")?.sessionId).toBe(session.sessionId);
+    expect(session.activeRunId).toBe("run-1");
+    expect(session.abortController).toBe(controller);
 
     const cancelled = store.cancelActiveRun(session.sessionId);
     expect(cancelled).toBe(true);
-    expect(store.getSessionByRunId("run-1")).toBeUndefined();
-  });
-
-  it("removes stale run lookup entries when rebinding an active run", () => {
-    const session = store.createSession({
-      sessionKey: "acp:rebind",
-      cwd: "/tmp",
-    });
-
-    store.setActiveRun(session.sessionId, "run-old", new AbortController());
-    store.setActiveRun(session.sessionId, "run-new", new AbortController());
-
-    expect(store.getSessionByRunId("run-old")).toBeUndefined();
-    expect(store.getSessionByRunId("run-new")?.sessionId).toBe(session.sessionId);
+    expect(controller.signal.aborted).toBe(true);
+    expect(session.activeRunId).toBeNull();
+    expect(session.abortController).toBeNull();
   });
 
   it.each(["clear", "cancel"] as const)(
@@ -62,7 +52,6 @@ describe("acp session manager", () => {
 
       expect(session.activeRunId).toBe("run-new");
       expect(replacementController.signal.aborted).toBe(false);
-      expect(store.getSessionByRunId("run-new")?.sessionId).toBe(session.sessionId);
     },
   );
 
@@ -79,7 +68,6 @@ describe("acp session manager", () => {
 
     expect(controller.signal.aborted).toBe(true);
     expect(store.hasSession(session.sessionId)).toBe(false);
-    expect(store.getSessionByRunId("run-close")).toBeUndefined();
   });
 
   it("reports false when deleting a missing session", () => {

--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -13,7 +13,6 @@ export type AcpSessionStore = {
   }) => AcpSession;
   hasSession: (sessionId: string) => boolean;
   getSession: (sessionId: string) => AcpSession | undefined;
-  getSessionByRunId: (runId: string) => AcpSession | undefined;
   /** Binds an active runtime run to a session so cancel/close can abort it later. */
   setActiveRun: (sessionId: string, runId: string, abortController: AbortController) => void;
   clearActiveRun: (sessionId: string, expectedRunId?: string) => void;
@@ -43,7 +42,6 @@ export function createInMemorySessionStore(
   const idleTtlMs = resolveIntegerOption(options.idleTtlMs, DEFAULT_IDLE_TTL_MS, { min: 1_000 });
   const now = options.now ?? Date.now;
   const sessions = new Map<string, AcpSession>();
-  const runIdToSessionId = new Map<string, string>();
 
   const touchSession = (session: AcpSession, nowMs: number) => {
     session.lastTouchedAt = nowMs;
@@ -53,9 +51,6 @@ export function createInMemorySessionStore(
     const session = sessions.get(sessionId);
     if (!session) {
       return false;
-    }
-    if (session.activeRunId) {
-      runIdToSessionId.delete(session.activeRunId);
     }
     session.abortController?.abort();
     sessions.delete(sessionId);
@@ -139,36 +134,17 @@ export function createInMemorySessionStore(
     return session;
   };
 
-  const getSessionByRunId: AcpSessionStore["getSessionByRunId"] = (runId) => {
-    const sessionId = runIdToSessionId.get(runId);
-    if (!sessionId) {
-      return undefined;
-    }
-    const session = sessions.get(sessionId);
-    if (session) {
-      touchSession(session, now());
-    }
-    return session;
-  };
-
   const setActiveRun: AcpSessionStore["setActiveRun"] = (sessionId, runId, abortController) => {
     const session = sessions.get(sessionId);
     if (!session) {
       return;
     }
-    if (session.activeRunId && session.activeRunId !== runId) {
-      runIdToSessionId.delete(session.activeRunId);
-    }
     session.activeRunId = runId;
     session.abortController = abortController;
-    runIdToSessionId.set(runId, sessionId);
     touchSession(session, now());
   };
 
   const releaseActiveRun = (session: AcpSession) => {
-    if (session.activeRunId) {
-      runIdToSessionId.delete(session.activeRunId);
-    }
     session.activeRunId = null;
     session.abortController = null;
     touchSession(session, now());
@@ -201,14 +177,12 @@ export function createInMemorySessionStore(
       session.abortController?.abort();
     }
     sessions.clear();
-    runIdToSessionId.clear();
   };
 
   return {
     createSession,
     hasSession,
     getSession,
-    getSessionByRunId,
     setActiveRun,
     clearActiveRun,
     cancelActiveRun,

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1620,16 +1620,10 @@ export function markdownToIRWithMeta(
       : [];
   });
   const blocks = state.blocks
-    .flatMap((block) => {
+    .map((block) => {
       const start = Math.min(block.start, finalLength);
       const end = Math.min(block.end, finalLength);
-      return end > start ||
-        block.kind === "blockquote" ||
-        block.kind === "code_block" ||
-        block.kind === "heading" ||
-        block.kind === "thematic_break"
-        ? [{ ...block, start, end }]
-        : [];
+      return { ...block, start, end };
     })
     .toSorted(
       (left, right) =>

--- a/packages/terminal-core/src/stream-writer.test.ts
+++ b/packages/terminal-core/src/stream-writer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createSafeStreamWriter } from "./stream-writer.js";
 
 describe("createSafeStreamWriter", () => {
@@ -45,5 +45,97 @@ describe("createSafeStreamWriter", () => {
     expect(writer.write(stream, "hi")).toBe(false);
     expect(writer.isClosed()).toBe(true);
     expect(brokenPipeCount).toBe(1);
+  });
+
+  it("notifies once when a reentrant write closes before the outer write", () => {
+    const failure = Object.assign(new Error("closed pipe"), { code: "EPIPE" });
+    let entered = false;
+    let nestedResult: boolean | undefined;
+    let callbackResult: boolean | undefined;
+    let notifications = 0;
+    const writer = createSafeStreamWriter({
+      beforeWrite: () => {
+        if (!entered) {
+          entered = true;
+          nestedResult = writer.write(process.stdout, "nested");
+        }
+      },
+      onBrokenPipe: () => {
+        notifications += 1;
+        callbackResult = writer.write(process.stdout, "callback");
+      },
+    });
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => {
+      throw failure;
+    });
+    try {
+      expect(writer.write(process.stdout, "outer")).toBe(false);
+      expect(nestedResult).toBe(false);
+      expect(callbackResult).toBe(false);
+      expect(writer.isClosed()).toBe(true);
+      expect(notifications).toBe(1);
+      expect(write.mock.calls.map(([text]) => text)).toEqual(["nested", "outer"]);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("keeps a callback reset effective through a reentrant successful write", () => {
+    const failure = Object.assign(new Error("closed pipe"), { code: "EPIPE" });
+    let notifications = 0;
+    let recoveredResult: boolean | undefined;
+    const writer = createSafeStreamWriter({
+      onBrokenPipe: () => {
+        notifications += 1;
+        if (notifications === 1) {
+          writer.reset();
+          recoveredResult = writer.write(process.stdout, "recovered");
+        }
+      },
+    });
+    const write = vi.spyOn(process.stdout, "write").mockImplementation((text) => {
+      if (text === "recovered") {
+        return true;
+      }
+      throw failure;
+    });
+    try {
+      expect(writer.write(process.stdout, "first")).toBe(false);
+      expect(recoveredResult).toBe(true);
+      expect(writer.isClosed()).toBe(false);
+      expect(writer.write(process.stdout, "retry")).toBe(false);
+      expect(writer.isClosed()).toBe(true);
+      expect(notifications).toBe(2);
+      expect(write.mock.calls.map(([text]) => text)).toEqual(["first", "recovered", "retry"]);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("keeps the output closed when the notification callback throws", () => {
+    const failure = Object.assign(new Error("closed pipe"), { code: "EPIPE" });
+    const callbackError = new Error("notification failed");
+    const writer = createSafeStreamWriter({
+      onBrokenPipe: () => {
+        throw callbackError;
+      },
+    });
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => {
+      throw failure;
+    });
+    try {
+      let thrown: unknown;
+      try {
+        writer.write(process.stdout, "first");
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).toBe(callbackError);
+      expect(writer.isClosed()).toBe(true);
+      expect(writer.write(process.stdout, "ignored")).toBe(false);
+      expect(write).toHaveBeenCalledTimes(1);
+    } finally {
+      write.mockRestore();
+    }
   });
 });

--- a/packages/terminal-core/src/stream-writer.ts
+++ b/packages/terminal-core/src/stream-writer.ts
@@ -23,22 +23,15 @@ function isBrokenPipeError(err: unknown): err is NodeJS.ErrnoException {
 /** Create a stream writer that stops writing after EPIPE/EIO. */
 export function createSafeStreamWriter(options: SafeStreamWriterOptions = {}): SafeStreamWriter {
   let closed = false;
-  let notified = false;
-
-  const noteBrokenPipe = (err: NodeJS.ErrnoException, stream: NodeJS.WriteStream) => {
-    if (notified) {
-      return;
-    }
-    notified = true;
-    options.onBrokenPipe?.(err, stream);
-  };
 
   const handleError = (err: unknown, stream: NodeJS.WriteStream): boolean => {
     if (!isBrokenPipeError(err)) {
       throw err;
     }
-    closed = true;
-    noteBrokenPipe(err, stream);
+    if (!closed) {
+      closed = true;
+      options.onBrokenPipe?.(err, stream);
+    }
     return false;
   };
 
@@ -67,7 +60,6 @@ export function createSafeStreamWriter(options: SafeStreamWriterOptions = {}): S
     writeLine,
     reset: () => {
       closed = false;
-      notified = false;
     },
     isClosed: () => closed,
   };


### PR DESCRIPTION
## What Problem This Solves

The internal ACP session registry maintained a reverse run-ID index with no production reader. Terminal output tracked two flags for the same closed state, and Markdown block construction retained a filter whose condition accepted every possible private block kind.

This maintainer-requested cleanup removes those redundant paths while preserving their observable behavior.

Related: #139597

## Why This Change Was Made

Delete the unread ACP index and lookup entirely; live prompt routing already uses pending requests and session-owned active-run state. Keep all cancellation, expected-run, TTL and eviction checks. Terminal output now records one close transition before notifying its callback, preserving reentrant reset and exception behavior. Markdown maps and clamps each block directly while keeping zero-length metadata and deterministic ordering.

Production is 40 lines smaller. Tests gain 80 lines for missing callback characterizations while dropping only reverse-index-only assertions. No public SDK, wire, configuration, persistence or dependency changes.

## User Impact

No intended behavior change. ACP cancellation and close, terminal broken-pipe recovery, and Markdown output retain their existing behavior.

## Evidence

- All 29 baseline-compatible characterization tests passed on original production.
- The candidate passed 91 tests in six owner/caller files, covering ACP prompt cancellation and disconnects, terminal callback reentry/reset/errors, CLI log output and Markdown block metadata.
- Full changed checks pass, including core/test typechecks, lint, dead exports, cycles and ownership/state guards.
- The exact fe8d366 candidate full build passed.
- Independent P0–P2 review is scoped-clean, with no findings. Public export and caller inspection confirms the removed ACP lookup belongs only to the private bridge store.
