### PR TITLE
perf(cron): reuse normalized history projection

### DIFF
--- a/src/cron/task-run-detail.ts
+++ b/src/cron/task-run-detail.ts
@@ -348,7 +348,6 @@ export function cronTaskRecordToRunLogEntry(task: TaskRecord): CronRunLogEntry |
       ts: resolveCronTaskRecordTimestamp(task),
       jobId: task.sourceId,
       action: "finished",
-      status: isCronRunStatus(task.detail.status) ? task.detail.status : undefined,
       sessionKey: task.childSessionKey,
       runId: typeof task.detail.runId === "string" ? task.detail.runId : undefined,
     },
@@ -357,13 +356,12 @@ export function cronTaskRecordToRunLogEntry(task: TaskRecord): CronRunLogEntry |
   if (!entry) {
     return null;
   }
-  // The legacy SQLite reader materializes these indexed columns even when absent.
-  return {
-    ...entry,
+  // The parsed entry is private; materialize the legacy reader’s absent indexed fields on it.
+  return Object.assign(entry, {
     delivered: entry.delivered,
     deliveryStatus: entry.deliveryStatus,
     deliveryError: entry.deliveryError,
     sessionId: entry.sessionId,
     sessionKey: entry.sessionKey,
-  };
+  });
 }

--- a/src/cron/task-run-history.test.ts
+++ b/src/cron/task-run-history.test.ts
@@ -473,7 +473,14 @@ describe("cron task run history", () => {
     );
   });
 
-  it("allowlists the legacy wire record", () => {
+  it.each([
+    { status: "ok", expectedStatus: "ok" },
+    { status: "error", expectedStatus: "error" },
+    { status: "skipped", expectedStatus: "skipped" },
+    { status: "invalid", expectedStatus: undefined },
+    { status: null, expectedStatus: undefined },
+    { status: undefined, expectedStatus: undefined },
+  ])("allowlists the legacy wire record with status $status", ({ status, expectedStatus }) => {
     const storeKey = "/internal/cron/store";
     const task = taskFromEntry(
       { ts: 100, jobId: JOB_ID, action: "finished", status: "ok" },
@@ -484,15 +491,21 @@ describe("cron task run history", () => {
     task.terminalSummary = "legacy summary";
     task.detail = {
       kind: "cron-run",
-      status: "ok",
+      ...(status === undefined ? {} : { status }),
       storeKey,
       internalFutureField: "secret",
       triggerState: { secret: true },
       delivery: "malformed",
       failureNotificationDelivery: { status: "invalid", internal: "secret" },
     };
+    Object.freeze(task.detail);
+    Object.freeze(task);
     const entry = cronTaskRecordToRunLogEntry(task);
     expect(entry).not.toBeNull();
+    expect(entry?.status).toBe(expectedStatus);
+    for (const key of ["delivered", "deliveryStatus", "deliveryError", "sessionId", "sessionKey"]) {
+      expect(Object.hasOwn(entry ?? {}, key)).toBe(true);
+    }
     expect(Object.hasOwn(entry ?? {}, "storeKey")).toBe(false);
     expect(Object.hasOwn(entry ?? {}, "internalFutureField")).toBe(false);
     expect(Object.hasOwn(entry ?? {}, "triggerState")).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Automation history requests incur avoidable per-record overhead as the number of stored runs grows.

## Why This Change Was Made

Use the existing full schema as the single status normalizer, then materialize the five legacy optional fields on its private result instead of copying it again. Input tasks, field exclusion and insertion order, authored-detail precedence, recovery decisions, and all database/configuration/concurrency behavior remain unchanged. Production −2 lines; the existing wire-record test expands by 13 lines.

## User Impact

Synthetic 50/500/2,000-record projector batches improved 45–57% in both orders. The real history-page caller, including SQLite reading/hydration, improved in 23 of 24 nonempty comparisons; the remaining 2,000-row ascending case was **4.06% slower forward** and 33.84% faster reverse. This does not claim faster whole-Gateway turns or a consistent memory reduction.

## Evidence

- 55/55 tests passed across the complete history, event-codec, and task-run recovery files; all 29 normal changed checks passed. Managed P2 review was scoped-clean, with no findings.
- Fixed B0/C0/C1/B1 fresh-process cohort on `ce7eb85ae413282d0d46b2b661d11788d5fde671`: 20 rows per phase, three warm calls and 12 fixed samples per row. All **5,040 full wrapper returns** (240 warm + 4,800 timed) matched, including undefined-valued own fields, insertion order, and reference graph. No retries or favorable subset selection.
- The table includes every row and all **7 adverse comparisons out of 40**. Six adverse comparisons are empty controls. Percentages compare candidate/baseline; negative means faster.

| Rows | Actual operation | Forward | Reverse |
|---:|---|---:|---:|
| 0 | Projector batch | +4.75% | -25.88% |
| 0 | History asc | +3.78% | +3.48% |
| 0 | History desc | -2.95% | +5.03% |
| 0 | History desc; status=error | +7.85% | -1.73% |
| 0 | History asc; query=needle | -2.14% | +3.76% |
| 50 | Projector batch | -45.12% | -49.59% |
| 50 | History asc | -27.52% | -26.59% |
| 50 | History desc | -27.55% | -23.06% |
| 50 | History desc; status=error | -30.89% | -27.07% |
| 50 | History asc; query=needle | -31.88% | -27.50% |
| 500 | Projector batch | -56.66% | -53.70% |
| 500 | History asc | -33.65% | -31.81% |
| 500 | History desc | -16.89% | -28.62% |
| 500 | History desc; status=error | -19.45% | -32.38% |
| 500 | History asc; query=needle | -31.57% | -34.11% |
| 2000 | Projector batch | -52.65% | -55.26% |
| 2000 | History asc | +4.06% | -33.84% |
| 2000 | History desc | -26.46% | -32.12% |
| 2000 | History desc; status=error | -45.43% | -33.17% |
| 2000 | History asc; query=needle | -32.28% | -33.64% |

Across the same 12 sample means per row, 7/40 mean comparisons and 8/40 maximum comparisons were slower. These are maxima of observed sample means, not population-tail estimates. Notable adverse observations: 50-row descending history maxima +5.45%/+4.87%; 2,000-row descending history forward maximum +40.37%; empty status-filtered history means +56.77%/+51.58% and maxima +367.77%/+370.99%. Every underlying sample remains retained.

Full-process wall improved 12.83%/11.32%, but includes imports, fixture creation, assertions and evidence writing. Forward kernel/sample-tree RSS rose 0.88%/1.10%; system CPU rose 8.85%/10.25% across the two orders. No memory or whole-Gateway improvement is claimed. All children closed and the exact candidate was restored. Independent retained-data audit passed: it decoded all 5,040 returns from 115,009,918 bytes, verified every journal ordinal and timing sum, and independently checked complete values, own-key order and bidirectional reference relationships.
