### PR TITLE
feat: preview available changes before confirming an update

### DIFF
--- a/ui/src/app/update-confirmation.runtime.test.ts
+++ b/ui/src/app/update-confirmation.runtime.test.ts
@@ -157,6 +157,26 @@ it("states a git distance once instead of labelling it as an available version",
   await settled;
 });
 
+it("previews available commit subjects before confirmation without starting an update", async () => {
+  const { settled, startGatewayUpdate } = startUpdate({
+    updateAvailable: {
+      ...UPDATE_AVAILABLE,
+      currentSha: "1111111",
+      commitsBehind: 6,
+      commits: [{ sha: "abc1234", subject: "fix: preserve active sessions" }],
+    },
+  });
+  const { modal } = await getRenderedModalDialog(document.body);
+  expect(modal.textContent).toContain("Available changes");
+  expect(modal.textContent).toContain("Showing 1 of 6 commits");
+  expect(modal.textContent).toContain("fix: preserve active sessions");
+  expect(modal.textContent).toContain("abc1234");
+  expect(startGatewayUpdate).not.toHaveBeenCalled();
+  findButton("Cancel").click();
+  await settled;
+  expect(startGatewayUpdate).not.toHaveBeenCalled();
+});
+
 it("keeps a repeated request from stacking a second confirmation or update", async () => {
   const first = startUpdate();
   const second = startUpdate();

--- a/ui/src/app/update-confirmation.runtime.ts
+++ b/ui/src/app/update-confirmation.runtime.ts
@@ -10,6 +10,7 @@
 import { html, nothing, render } from "lit";
 import type { UpdateRunRecord } from "../../../src/infra/update-run-record.ts";
 import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+import { renderUpdateChangePreview } from "../components/update-change-preview.ts";
 import { t } from "../i18n/index.ts";
 import { registerUpdateActionsEnglish } from "../i18n/locales/en-update-actions.ts";
 import "../components/modal-dialog.ts";
@@ -172,6 +173,11 @@ export async function confirmAndStartUpdateRuntime(
               ${
                 details && current.kind === "confirm"
                   ? html`<div class="exec-approval-command mono">${details}</div>`
+                  : nothing
+              }
+              ${
+                current.kind === "confirm"
+                  ? renderUpdateChangePreview(params.updateAvailable, params.updateSchedule)
                   : nothing
               }
               ${

--- a/ui/src/components/sidebar-update-card.test.ts
+++ b/ui/src/components/sidebar-update-card.test.ts
@@ -61,6 +61,26 @@ afterEach(() => {
 });
 
 describe("SidebarUpdateCard", () => {
+  it("shows commit subjects in the expanded Inbox without starting an update", async () => {
+    const element = await mount({
+      channel: "dev",
+      currentVersion: "1.0.0",
+      latestVersion: "1.0.0",
+      currentSha: "1111111",
+      commitsBehind: 6,
+      commits: [{ sha: "abc1234", subject: "fix: preserve active sessions" }],
+    });
+    const onUpdate = vi.fn();
+    element.onUpdate = onUpdate;
+    element.compact = true;
+    await element.updateComplete;
+    expect(element.querySelector(".sidebar-issues-panel__body")?.textContent).toContain(
+      "fix: preserve active sessions",
+    );
+    expect(element.textContent).toContain("Showing 1 of 6 commits");
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
   it("renders the refresh state and invokes its action", async () => {
     const element = await mount(null);
     const onRefresh = vi.fn(async () => false);

--- a/ui/src/components/sidebar-update-card.ts
+++ b/ui/src/components/sidebar-update-card.ts
@@ -20,6 +20,7 @@ import { PollController } from "../lit/poll-controller.ts";
 import "../styles/sidebar-update-card.css";
 import { icons } from "./icons.ts";
 import { isUpdateRunAttentionVisible } from "./sidebar-attention-update.ts";
+import { renderUpdateChangePreview } from "./update-change-preview.ts";
 import "./tooltip.ts";
 
 class SidebarUpdateCard extends OpenClawLightDomContentsElement {
@@ -458,6 +459,7 @@ class SidebarUpdateCard extends OpenClawLightDomContentsElement {
         aria-live=${campaign ? nothing : "polite"}
       >
         ${this.renderStatus()}
+        ${!busy && actionable ? renderUpdateChangePreview(update, this.updateSchedule) : nothing}
         ${
           actionable
             ? html`<div class="sidebar-update-card__actions">

--- a/ui/src/components/update-change-preview.test.ts
+++ b/ui/src/components/update-change-preview.test.ts
@@ -1,0 +1,63 @@
+import { render } from "lit";
+import { afterEach, expect, it } from "vitest";
+import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+import { renderUpdateChangePreview } from "./update-change-preview.ts";
+
+const update: UpdateAvailable = {
+  channel: "dev",
+  currentVersion: "1.0.0",
+  latestVersion: "1.0.0",
+  currentSha: "1111111",
+  upstreamSha: "abcdef0",
+  commitsBehind: 6,
+  commits: Array.from({ length: 5 }, (_, index) => ({
+    sha: `abc123${index}`,
+    subject: index === 0 ? "fix: <img src=x onerror=alert(1)>" : `docs: change ${index}`,
+  })),
+};
+
+function preview(value: UpdateAvailable | null, schedule: UpdateScheduleState | null = null) {
+  const host = document.createElement("div");
+  document.body.append(host);
+  render(renderUpdateChangePreview(value, schedule), host);
+  return host;
+}
+
+afterEach(() => document.body.replaceChildren());
+
+it("labels a partial preview and renders all subjects as text, including docs", () => {
+  const host = preview(update);
+  expect(host.textContent).toContain("Showing 5 of 6 commits");
+  expect(host.querySelectorAll("li")).toHaveLength(5);
+  expect(host.textContent).toContain("fix: <img src=x onerror=alert(1)>");
+  expect(host.querySelector("img")).toBeNull();
+  expect(host.textContent).toContain("docs: change 4");
+});
+
+it("does not call a complete preview partial", () => {
+  expect(preview({ ...update, commitsBehind: 5 }).textContent).not.toContain("Showing");
+});
+
+it.each([null, { ...update, commits: [] }, { ...update, commits: undefined }])(
+  "omits unavailable metadata without inventing release notes",
+  (value) => expect(preview(value).querySelector("section")).toBeNull(),
+);
+
+it.each([
+  { target: { kind: "package", version: "2.0.0" } },
+  { target: { kind: "git", commitsBehind: 7, upstreamSha: "abcdef0" } },
+  { target: { kind: "git", commitsBehind: 6, upstreamSha: "fffffff" } },
+  { install: { kind: "git", git: { status: "current" } } },
+  { install: { kind: "git", git: { status: "behind", commitsBehind: 7 } } },
+  {
+    install: { kind: "git", git: { status: "behind", commitsBehind: 6, currentSha: "2222222" } },
+  },
+])("hides previews contradicted by the current comparison: %j", (schedule) => {
+  expect(
+    preview(update, schedule as unknown as UpdateScheduleState).querySelector("section"),
+  ).toBeNull();
+});
+
+it("hides commits when there is no git update to review", () => {
+  expect(preview({ ...update, commitsBehind: 0 }).querySelector("section")).toBeNull();
+});

--- a/ui/src/components/update-change-preview.ts
+++ b/ui/src/components/update-change-preview.ts
@@ -1,0 +1,49 @@
+import { html, nothing } from "lit";
+import type { UpdateAvailable, UpdateScheduleState } from "../api/types.ts";
+import { t } from "../i18n/index.ts";
+import "../styles/update-change-preview.css";
+
+/** Display only the Gateway's existing preview, not inferred release notes. */
+export function renderUpdateChangePreview(
+  update: UpdateAvailable | null,
+  schedule: UpdateScheduleState | null,
+) {
+  const target = schedule?.target;
+  const comparison = schedule?.install?.git;
+  const commits = update?.commits;
+  if (
+    !commits?.length ||
+    target?.kind === "package" ||
+    (!update?.currentSha && target?.kind !== "git") ||
+    (target?.kind === "git" &&
+      (target.commitsBehind !== update?.commitsBehind ||
+        (update.upstreamSha && target.upstreamSha !== update.upstreamSha))) ||
+    update?.commitsBehind === 0 ||
+    (comparison &&
+      ((comparison.status !== "behind" && comparison.status !== "diverged") ||
+        comparison.commitsBehind !== update?.commitsBehind ||
+        (comparison.currentSha &&
+          update?.currentSha &&
+          comparison.currentSha !== update.currentSha)))
+  ) {
+    return nothing;
+  }
+  const total = update?.commitsBehind;
+  return html`<section class="update-change-preview" aria-label=${t("updates.preview.title")}>
+    <div class="update-change-preview__title">${t("updates.preview.title")}</div>
+    ${
+      total !== undefined && total > commits.length
+        ? html`<p class="update-change-preview__count">
+            ${t("updates.preview.partial", { shown: String(commits.length), total: String(total) })}
+          </p>`
+        : nothing
+    }
+    <ul class="update-change-preview__list">
+      ${commits.map(
+        (commit) => html`<li>
+          <span>${commit.subject}</span><code title=${commit.sha}>${commit.sha}</code>
+        </li>`,
+      )}
+    </ul>
+  </section>`;
+}

--- a/ui/src/e2e/update-change-preview.e2e.test.ts
+++ b/ui/src/e2e/update-change-preview.e2e.test.ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { createUpdateRunFixture } from "./update-run.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Update change preview E2E",
+  startServerBeforeBrowser: true,
+});
+
+suite.define(() => {
+  it.each([1280, 390])("shows changes before updating at width %i", async (width) => {
+    const proof = createControlUiE2eArtifactDir("update-change-preview");
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { width, height: 844 } },
+      async ({ page }) => {
+        const subjects = [
+          "feat: preview available changes before updating",
+          "fix: preserve session state during reconnect",
+          "fix: improve keyboard navigation in Settings",
+          "docs: clarify update recovery guidance",
+          "chore: refresh development tooling",
+        ];
+        const run = createUpdateRunFixture();
+        const gateway = await installMockGateway(page, {
+          operatorScopes: ["operator.admin", "operator.read"],
+          updateAvailable: {
+            channel: "dev",
+            currentVersion: "2026.9.1",
+            latestVersion: "2026.9.1",
+            currentSha: "1111111",
+            upstreamRef: "origin/main",
+            upstreamSha: "abcdef0",
+            commitsBehind: 6,
+            commits: subjects.map((subject, index) => ({ sha: `abc123${index}`, subject })),
+          },
+          methodResponses: {
+            "update.run": { ok: true, runId: run.runId, restart: null, result: { status: "ok" } },
+            "update.runs.get": { run },
+          },
+        });
+        expect((await page.goto(`${suite.server.baseUrl}chat`))?.status()).toBe(200);
+        await gateway.waitForRequest("chat.startup");
+        if (width < 640) {
+          await page.getByRole("button", { name: "Expand sidebar", exact: true }).click();
+        }
+        await page.locator(".sidebar-issues-button:visible").click();
+        const card = page.locator(
+          'openclaw-sidebar-update-card[data-attention-kind="updateAvailable"]',
+        );
+        await card.locator("summary").click();
+        await card.getByText("Showing 5 of 6 commits", { exact: true }).waitFor();
+        expect(await card.locator(".update-change-preview li").count()).toBe(5);
+        await page.screenshot({
+          path: path.join(proof, `inbox-${width}.png`),
+          animations: "disabled",
+        });
+        const action = card.locator(".sidebar-update-card__action");
+        await action.click();
+        const modal = page.locator("openclaw-modal-dialog");
+        await modal.getByText("Showing 5 of 6 commits", { exact: true }).waitFor();
+        for (const subject of subjects) {
+          expect(await modal.textContent()).toContain(subject);
+        }
+        await page.screenshot({
+          path: path.join(proof, `confirmation-${width}.png`),
+          animations: "disabled",
+        });
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        await modal.getByRole("button", { name: "Cancel", exact: true }).click();
+        await modal.waitFor({ state: "detached" });
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        // Opening the confirmation closes the Inbox popover.
+        await page.locator(".sidebar-issues-button:visible").click();
+        await card.locator("summary").click();
+        await action.click();
+        await modal.getByRole("button", { name: "Update and restart", exact: true }).click();
+        await gateway.waitForRequest("update.run");
+        expect(await gateway.getRequests("update.run")).toHaveLength(1);
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -543,6 +543,10 @@ export const en: TranslationMap & {
     dismissFailed: "Invitation dismissed, but your preference couldn't be saved.",
   },
   updates: {
+    preview: {
+      title: "Available changes",
+      partial: "Showing {shown} of {total} commits",
+    },
     adminRequired: "Administrator access is required to change update settings or start an update.",
     campaign: {
       countdown: "Updating in {time}",

--- a/ui/src/styles/update-change-preview.css
+++ b/ui/src/styles/update-change-preview.css
@@ -1,0 +1,31 @@
+.update-change-preview {
+  min-width: 0;
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+.update-change-preview__title {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.update-change-preview__count {
+  margin: 4px 0;
+  color: var(--muted);
+}
+
+.update-change-preview__list {
+  display: grid;
+  gap: 8px;
+  margin: 8px 0 0;
+  padding-inline-start: 18px;
+  overflow-wrap: anywhere;
+}
+
+.update-change-preview__list code {
+  margin-inline-start: 6px;
+  color: var(--muted);
+  font-size: 11px;
+}


### PR DESCRIPTION
Closes #140141

## What Problem This Solves

Operators reviewing an update in the Control UI Inbox or confirmation see how many commits are available, but not what they change. Deciding whether to interrupt active work requires leaving the decision surface for Settings or GitHub.

## Why This Change Was Made

Expose the existing Gateway-provided commit preview in the expanded Inbox card and shared update confirmation. Keep subjects and SHAs intact, label partial previews (for example, "Showing 5 of 6 commits"), and suppress metadata contradicted by the current update comparison. This reuses the contract already shipped in #120769; it does not fetch release notes or change update routing, permissions, installation, or restart behavior.

Hermes provides related prior art through its [update overlay](https://github.com/NousResearch/hermes-agent/blob/7166071fcaadb36df26f6d753dda97da6b5d699e/apps/desktop/src/app/updates-overlay.tsx) and deterministic commit grouping. OpenClaw's existing bounded list is reused here without copying Hermes's category filtering.

## User Impact

Operators of git/dev installations can inspect available commit subjects before accepting the restart, directly where the decision happens. The existing five-commit limit remains explicit rather than implying the preview is a complete changelog. Package updates and updates without commit metadata remain unchanged.

## Evidence

- Regression proof: the new confirmation assertion failed on the pre-change behavior because the preview was absent, then passed with the implementation.
- Focused unit tests: 31 shared UI tests and 13 isolated SidebarUpdateCard tests passed. Coverage includes partial counts, absent/stale metadata, escaped subjects, cancellation, and existing native/update-progress routing.
- Chromium mock-Gateway E2E: desktop (1280 px) and narrow (390 px) flows passed; each verifies Inbox and confirmation copy, zero `update.run` calls on cancel, and exactly one after confirmation.
- Production UI build, performance budgets, and keyless i18n verification passed. No generated foreign translation catalogs or dependency manifests changed.
- Inspected synthetic desktop/narrow screenshots are retained locally. The GitHub attachment endpoint returned HTTP 404, so this PR does not claim public screenshot artifacts. The original operator screenshot was inspected but not uploaded because its background contains private content.
- Changed-file guards and both core-test/UI typechecks passed. Focused Oxlint and Stylelint passed. The aggregate changed check did not pass: the dead-export retry reported `scripts/crabbox-wrapper-providers.mts:canonicalProviderName` and `scripts/lib/static-extension-assets.mts:listPackagedStaticExtensionAssetOutputs`; both files are unchanged from the pinned base and outside this patch. The production unused-export scan timed out after 600 seconds. These are recorded gaps, not passing checks.
- Independent autoreview identified one P2 stale-installed-SHA case. Reproduced it with a failing regression, then fixed it and reran the focused tests and both browser flows successfully. Final re-review completed scoped-clean with no actionable P0–P2 findings.

The browser proof uses a mocked Gateway; no installed Gateway was updated or restarted, and native macOS execution was not exercised.

Hosted CI is [running for commit 312d01e930db43c4250c49f4cfde28554ba3c901](https://github.com/openclaw/openclaw/actions/runs/34039592869) at publication; this is not yet a passing CI result.
