### PR TITLE
refactor(browser): consolidate SSRF guard boundary tests

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -17,7 +17,6 @@ extensions/browser/src/browser/chrome.internal.test.ts
 extensions/browser/src/browser/chrome.ts
 extensions/browser/src/browser/extension-relay/relay-bridge.ts
 extensions/browser/src/browser/pw-session.create-page.navigation-guard.test.ts
-extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
 extensions/browser/src/browser/routes/agent.act.ts
 extensions/browser/src/browser/routes/agent.snapshot.ts
 extensions/browser/src/cli/browser-cli-manage.ts

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -1,11 +1,6 @@
 // Browser tests cover pw tools core ssrf guard plugin behavior.
-import { expectDefined } from "@openclaw/normalization-core";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-function requireInvocationOrder(mock: { invocationCallOrder: number[] }, context: string): number {
-  return expectDefined(mock.invocationCallOrder[0], context);
-}
 
 const pageState = vi.hoisted(() => ({
   page: null as Record<string, unknown> | null,
@@ -131,26 +126,60 @@ describe("pw-tools-core browser SSRF guards", () => {
     }
   });
 
-  it("re-checks click-triggered navigations with the session safety helper", async () => {
-    let currentUrl = "https://example.com";
-    installInteractionPage(
-      { url: vi.fn(() => currentUrl) },
-      {
-        click: vi.fn(async () => {
-          currentUrl = "https://target.example";
+  it.each([
+    {
+      kind: "click",
+      method: "click",
+      run: () => interactions.clickViaPlaywright({ ...strictNavigationOptions(), ref: "1" }),
+    },
+    {
+      kind: "select",
+      method: "selectOption",
+      run: () =>
+        interactions.selectOptionViaPlaywright({
+          ...strictNavigationOptions(),
+          ref: "1",
+          values: ["go"],
         }),
-      },
-    );
+    },
+    {
+      kind: "form fill",
+      method: "fill",
+      run: () =>
+        interactions.fillFormViaPlaywright({
+          ...strictNavigationOptions(),
+          fields: [{ ref: "1", type: "text", value: "go" }],
+        }),
+    },
+    {
+      kind: "batched click",
+      method: "click",
+      run: () =>
+        interactions.batchViaPlaywright({
+          ...strictNavigationOptions(),
+          actions: [{ kind: "click", ref: "1" }],
+        }),
+    },
+  ])(
+    "re-checks $kind-triggered navigations with the session safety helper",
+    async ({ method, run }) => {
+      let currentUrl = "https://example.com";
+      installInteractionPage(
+        { url: vi.fn(() => currentUrl) },
+        {
+          [method]: vi.fn(async () => {
+            currentUrl = "https://target.example";
+          }),
+        },
+      );
 
-    await interactions.clickViaPlaywright({
-      ...strictNavigationOptions(),
-      ref: "1",
-    });
+      await run();
 
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
-      completedNavigationExpectation(),
-    );
-  });
+      expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
+        completedNavigationExpectation(),
+      );
+    },
+  );
 
   it.each([
     {
@@ -424,25 +453,13 @@ describe("pw-tools-core browser SSRF guards", () => {
     );
   });
 
-  it("preserves declared async wait predicates", async () => {
-    const documentHandle = { dispose: vi.fn(async () => {}) };
-    const waitForFunction = vi.fn(async () => {});
-    pageState.page = {
-      url: vi.fn(() => "https://example.com"),
-      evaluateHandle: vi.fn(async () => documentHandle),
-      waitForFunction,
-    };
-
-    await interactions.waitForViaPlaywright({
-      ...strictNavigationOptions(),
-      fn: "async () => true",
-    });
-
-    expect(waitForFunction).toHaveBeenCalledOnce();
-    expect(documentHandle.dispose).toHaveBeenCalledOnce();
-  });
-
-  it("preserves synchronous wait predicates that return a promise", async () => {
+  it.each([
+    { name: "declared async wait predicates", fn: "async () => true" },
+    {
+      name: "synchronous wait predicates that return a promise",
+      fn: "() => Promise.resolve(true)",
+    },
+  ])("preserves $name", async ({ fn }) => {
     const documentHandle = { dispose: vi.fn(async () => {}) };
     pageState.page = {
       url: vi.fn(() => "https://example.com"),
@@ -462,9 +479,10 @@ describe("pw-tools-core browser SSRF guards", () => {
 
     await interactions.waitForViaPlaywright({
       ...strictNavigationOptions(),
-      fn: "() => Promise.resolve(true)",
+      fn,
     });
 
+    expect(pageState.page.waitForFunction).toHaveBeenCalledOnce();
     expect(sessionMocks.closeBlockedNavigationTarget).not.toHaveBeenCalled();
     expect(documentHandle.dispose).toHaveBeenCalledOnce();
   });
@@ -964,7 +982,7 @@ describe("pw-tools-core browser SSRF guards", () => {
         press,
       },
     );
-    mockNavigationGuardOnce(async ({ action, page }) => {
+    sessionMocks.withPageNavigationRequestGuard.mockImplementationOnce(async ({ action, page }) => {
       try {
         return await action(page.url());
       } finally {
@@ -991,49 +1009,6 @@ describe("pw-tools-core browser SSRF guards", () => {
     expect(press).not.toHaveBeenCalled();
   });
 
-  it("re-checks select-triggered navigations with the session safety helper", async () => {
-    let currentUrl = "https://example.com";
-    installInteractionPage(
-      { url: vi.fn(() => currentUrl) },
-      {
-        selectOption: vi.fn(async () => {
-          currentUrl = "https://target.example";
-        }),
-      },
-    );
-
-    await interactions.selectOptionViaPlaywright({
-      ...strictNavigationOptions(),
-      ref: "1",
-      values: ["go"],
-    });
-
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
-      completedNavigationExpectation(),
-    );
-  });
-
-  it("re-checks form fill-triggered navigations with the session safety helper", async () => {
-    let currentUrl = "https://example.com";
-    installInteractionPage(
-      { url: vi.fn(() => currentUrl) },
-      {
-        fill: vi.fn(async () => {
-          currentUrl = "https://target.example";
-        }),
-      },
-    );
-
-    await interactions.fillFormViaPlaywright({
-      ...strictNavigationOptions(),
-      fields: [{ ref: "1", type: "text", value: "go" }],
-    });
-
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
-      completedNavigationExpectation(),
-    );
-  });
-
   it("stops form filling when the first field's request guard denies navigation", async () => {
     const fill = vi.fn(async () => {});
     const blocked = new Error("blocked field navigation");
@@ -1058,128 +1033,40 @@ describe("pw-tools-core browser SSRF guards", () => {
     expect(sessionMocks.withPageNavigationRequestGuard).toHaveBeenCalledOnce();
   });
 
-  it("installs the request guard before evaluating page content", async () => {
-    const evaluate = vi.fn(async () => "ok");
-    pageState.page = {
-      evaluate,
-      url: vi.fn(() => "https://example.com"),
-    };
-
-    await interactions.evaluateViaPlaywright({
-      ...strictNavigationOptions(),
-      fn: "() => document.body.innerText",
-    });
-
-    expect(
-      requireInvocationOrder(
-        sessionMocks.withPageNavigationRequestGuard.mock,
-        "request guard invocation",
-      ),
-    ).toBeLessThan(requireInvocationOrder(evaluate.mock, "page evaluation invocation"));
-  });
-
-  it("preserves helper compatibility when no ssrfPolicy is provided", async () => {
-    pageState.page = { url: vi.fn(() => "https://example.com") };
-    pageState.locator = { click: vi.fn(async () => {}) };
-
-    await interactions.clickViaPlaywright({
-      cdpUrl: "http://127.0.0.1:18792",
-      targetId: "tab-1",
-      ref: "1",
-      // no ssrfPolicy: direct helper callers keep previous compatibility semantics
-    });
-
-    expect(sessionMocks.assertPageNavigationCompletedSafely).not.toHaveBeenCalled();
-  });
-
-  it("re-checks batched click-triggered navigations with the session safety helper", async () => {
-    let currentUrl = "https://example.com";
-    installInteractionPage(
-      { url: vi.fn(() => currentUrl) },
-      {
-        click: vi.fn(async () => {
-          currentUrl = "https://target.example";
-        }),
+  it.each([
+    {
+      name: "snapshotting AI content",
+      run: snapshots.snapshotAiViaPlaywright,
+      prepare: () => {
+        const ariaSnapshot = vi.fn(async () => 'button "Save"');
+        return { page: createSnapshotPage({ ariaSnapshot }), capture: ariaSnapshot };
       },
-    );
+    },
+    {
+      name: "role snapshots",
+      run: snapshots.snapshotRoleViaPlaywright,
+      prepare: () => {
+        const ariaSnapshot = vi.fn(async () => "");
+        return {
+          page: createSnapshotPage({ locator: vi.fn(() => ({ ariaSnapshot })) }),
+          capture: ariaSnapshot,
+        };
+      },
+    },
+    {
+      name: "aria snapshots",
+      run: snapshots.snapshotAriaViaPlaywright,
+      prepare: () => ({ page: {}, capture: pageCdpMocks.withPageScopedCdpClient }),
+    },
+  ])("re-checks current page URL before $name", async ({ run, prepare }) => {
+    const { page, capture } = prepare();
+    pageState.page = { ...page, url: vi.fn(() => "https://example.com") };
 
-    await interactions.batchViaPlaywright({
-      ...strictNavigationOptions(),
-      actions: [{ kind: "click", ref: "1" }],
-    });
-
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
-      completedNavigationExpectation(),
-    );
-  });
-
-  it("re-checks current page URL before snapshotting AI content", async () => {
-    const ariaSnapshot = vi.fn(async () => 'button "Save"');
-    pageState.page = createSnapshotPage({
-      ariaSnapshot,
-      url: vi.fn(() => "https://example.com"),
-    });
-
-    await snapshots.snapshotAiViaPlaywright({
-      ...strictNavigationOptions(),
-    });
-
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
-      completedNavigationExpectation(),
-    );
-    expect(
-      requireInvocationOrder(
-        sessionMocks.assertPageNavigationCompletedSafely.mock,
-        "safe-navigation assertion invocation",
-      ),
-    ).toBeLessThan(requireInvocationOrder(ariaSnapshot.mock, "ARIA snapshot invocation"));
-  });
-
-  it("re-checks current page URL before role snapshots", async () => {
-    const ariaSnapshot = vi.fn(async () => "");
-    pageState.page = createSnapshotPage({
-      locator: vi.fn(() => ({ ariaSnapshot })),
-      url: vi.fn(() => "https://example.com"),
-    });
-
-    await snapshots.snapshotRoleViaPlaywright({
-      ...strictNavigationOptions(),
-    });
+    await run(strictNavigationOptions());
 
     expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
       completedNavigationExpectation(),
     );
-    expect(
-      requireInvocationOrder(
-        sessionMocks.assertPageNavigationCompletedSafely.mock,
-        "safe-navigation assertion invocation",
-      ),
-    ).toBeLessThan(requireInvocationOrder(ariaSnapshot.mock, "ARIA snapshot invocation"));
-  });
-
-  it("re-checks current page URL before aria snapshots", async () => {
-    pageState.page = {
-      url: vi.fn(() => "https://example.com"),
-    };
-
-    await snapshots.snapshotAriaViaPlaywright({
-      ...strictNavigationOptions(),
-    });
-
-    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledWith(
-      completedNavigationExpectation(),
-    );
-    expect(
-      requireInvocationOrder(
-        sessionMocks.assertPageNavigationCompletedSafely.mock,
-        "safe-navigation assertion invocation",
-      ),
-    ).toBeLessThan(
-      requireInvocationOrder(
-        pageCdpMocks.withPageScopedCdpClient.mock,
-        "page-scoped CDP invocation",
-      ),
-    );
+    expect(sessionMocks.assertPageNavigationCompletedSafely).toHaveBeenCalledBefore(capture);
   });
 });
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The browser SSRF guard suite repeats navigation and snapshot setup and exceeds the test line budget. This is maintainer-requested test-debt cleanup following the #135868 split campaign.

## Why This Change Was Made

Table-drive the four navigation entrypoints, three snapshot boundaries, and two Promise-producing wait predicates. Use Vitest's native call-order assertion, which requires both calls and compares their first invocation. Remove two simpler cases whose stronger coverage already lives in the navigation suite, and retire this suite's max-lines exception.

Production 0; tests −113; tooling −1. Total diff: 294 changed lines. No runtime code changes.

## User Impact

No behavior change. Navigation policy, snapshot pre-check ordering, predicate execution and disposal, cancellation, and quarantine retain independent coverage. The declared-async predicate now executes the generated predicate instead of only checking its mock invocation.

## Evidence

- 151 focused SSRF, navigation, snapshot, snapshot navigation, and batch tests passed on macOS.
- All 16 untouched standalone test bodies are byte-identical. All nine consolidated cases retain their original names and remain independent Vitest rows.
- Configured lint/max-lines and diff whitespace checks passed. No build is needed for this test/baseline-only change.
- Independent Codex review: no actionable P0–P2 findings.
- Full changed gate passed with exit 0 on [clean Blacksmith Testbox run 34039122958](https://github.com/openclaw/openclaw/actions/runs/34039122958); lease confirmed completed. This uses a clean checkout because the local ancestor install previously caused unrelated punycode declaration resolution failures.

Surviving coverage for every removed or consolidated test body:

| Case | Remaining coverage |
| --- | --- |
| Click navigation post-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:131` |
| Select navigation post-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:136` |
| Form-fill navigation post-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:146` |
| Batched-click navigation post-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:155` |
| Declared async wait predicate | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:457`; actual predicate returns false while pending and true after its microtask |
| Synchronous Promise-returning predicate | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:459`; same execution and disposal proof |
| AI snapshot pre-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:1038` |
| Role snapshot pre-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:1046` |
| ARIA snapshot pre-check | `extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts:1057` |
| Request guard precedes page evaluation | `extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts:434`, “checks delayed subframe navigations in the action-error recovery path”; ordering assertion at `:469`, plus denied subframe and action-error recovery |
| No policy preserves unguarded helper behavior | `extensions/browser/src/browser/pw-tools-core.interactions.navigation-guard.test.ts:551`, “skips interaction navigation guards when no explicit SSRF policy is provided”; moves the URL, drains timers, and checks that no observer or post-check is installed |

Navigation rows preserve the original source/destination URLs, entrypoints, arguments, and only the intended fake locator method. Snapshot rows preserve their original content and distinct capture methods. Remaining cancellation, document replacement, policy-denial ordering, proxy, and grace-window tests are unchanged. No live browser or personal profile was used.

ClawSweeper reviewed current head `319a80f0d3ebbb27ae326ed6bfe26bfd12d675cd` with no findings, before-merge requests, or rank-up moves.

Exact-head [CI run 34039785720](https://github.com/openclaw/openclaw/actions/runs/34039785720) is green. Both main rebases were patch-identical and left the lockfile unchanged.
