### PR TITLE
perf(media): release rejected resize candidates

### DIFF
--- a/extensions/browser/src/browser/screenshot.ts
+++ b/extensions/browser/src/browser/screenshot.ts
@@ -41,7 +41,7 @@ export async function normalizeBrowserScreenshot(
   const sideStart = maxDim > 0 ? Math.min(maxSide, maxDim) : maxSide;
   const sideGrid = buildImageResizeSideGrid(maxSide, sideStart);
 
-  let smallest: { buffer: Buffer; size: number } | null = null;
+  let smallestSize: number | undefined;
   let processorUnavailableError: unknown;
 
   for (const side of sideGrid) {
@@ -62,8 +62,8 @@ export async function normalizeBrowserScreenshot(
         throw err;
       }
 
-      if (!smallest || out.byteLength < smallest.size) {
-        smallest = { buffer: out, size: out.byteLength };
+      if (smallestSize === undefined || out.byteLength < smallestSize) {
+        smallestSize = out.byteLength;
       }
 
       if (out.byteLength <= maxBytes) {
@@ -79,8 +79,8 @@ export async function normalizeBrowserScreenshot(
     throw toErrorObject(processorUnavailableError, "Non-Error thrown");
   }
 
-  const best = smallest?.buffer ?? buffer;
+  const bestSize = smallestSize ?? buffer.byteLength;
   throw new Error(
-    `Browser screenshot could not be reduced below ${(maxBytes / (1024 * 1024)).toFixed(0)}MB (got ${(best.byteLength / (1024 * 1024)).toFixed(2)}MB)`,
+    `Browser screenshot could not be reduced below ${(maxBytes / (1024 * 1024)).toFixed(0)}MB (got ${(bestSize / (1024 * 1024)).toFixed(2)}MB)`,
   );
 }

--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -32,7 +32,7 @@ vi.mock("../logging/subsystem.js", () => {
 vi.mock("../media/media-services.js", () => ({
   buildImageResizeSideGrid: () => [2000],
   getImageMetadata: vi.fn(),
-  IMAGE_REDUCE_QUALITY_STEPS: [85],
+  IMAGE_REDUCE_QUALITY_STEPS: [85, 75, 65],
   isImageProcessorUnavailableError: () => false,
   MAX_IMAGE_INPUT_PIXELS: 25_000_000,
   readImageMetadataFromHeader: () => ({ width: 2001, height: 8 }),
@@ -61,20 +61,37 @@ describe("tool-images log context", () => {
   });
 
   it.each([
-    { maxBytes: 512, outputBytes: 768, limit: "512B", actual: "768B" },
-    { maxBytes: 256 * 1024, outputBytes: 512 * 1024, limit: "256.0KB", actual: "512.0KB" },
+    { maxBytes: 512, outputBytes: [768], minimumBytes: 768, limit: "512B", actual: "768B" },
+    {
+      maxBytes: 512,
+      outputBytes: [900, 700, 800],
+      minimumBytes: 700,
+      limit: "512B",
+      actual: "700B",
+    },
+    {
+      maxBytes: 256 * 1024,
+      outputBytes: [512 * 1024],
+      minimumBytes: 512 * 1024,
+      limit: "256.0KB",
+      actual: "512.0KB",
+    },
     {
       maxBytes: 1.5 * 1024 * 1024,
-      outputBytes: 2 * 1024 * 1024,
+      outputBytes: [2 * 1024 * 1024],
+      minimumBytes: 2 * 1024 * 1024,
       limit: "1.50MB",
       actual: "2.00MB",
     },
   ])(
-    "reports the effective SDK image cap of $limit",
-    async ({ maxBytes, outputBytes, limit, actual }) => {
+    "reports the effective SDK image cap of $limit with smallest candidate $actual",
+    async ({ maxBytes, outputBytes, minimumBytes, limit, actual }) => {
       const filePath = path.join(tempDirs.make("tool-image-cap-"), "sample.png");
       await writeFile(filePath, png);
-      resizeToJpegMock.mockResolvedValue(Buffer.alloc(outputBytes, 2));
+      for (const bytes of outputBytes) {
+        const candidate = Buffer.alloc(bytes, 2);
+        resizeToJpegMock.mockResolvedValueOnce(candidate).mockResolvedValue(candidate);
+      }
 
       const result = await imageResultFromFile({
         label: "sdk:image",
@@ -95,6 +112,10 @@ describe("tool-images log context", () => {
         path: filePath,
         media: { outbound: false, mediaUrl: filePath },
       });
+      expect(warnMock).toHaveBeenLastCalledWith(
+        expect.any(String),
+        expect.objectContaining({ smallestCandidateBytes: minimumBytes }),
+      );
     },
   );
 

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -211,7 +211,7 @@ async function resizeImageBase64IfNeeded(params: {
   const sideStart = maxDim > 0 ? Math.min(params.maxDimensionPx, maxDim) : params.maxDimensionPx;
   const sideGrid = buildImageResizeSideGrid(params.maxDimensionPx, sideStart);
 
-  let smallest: { buffer: Buffer; size: number } | null = null;
+  let smallestSize: number | undefined;
   let processorUnavailableError: unknown;
   for (const side of sideGrid) {
     for (const quality of IMAGE_REDUCE_QUALITY_STEPS) {
@@ -230,8 +230,8 @@ async function resizeImageBase64IfNeeded(params: {
         }
         throw err;
       }
-      if (!smallest || out.byteLength < smallest.size) {
-        smallest = { buffer: out, size: out.byteLength };
+      if (smallestSize === undefined || out.byteLength < smallestSize) {
+        smallestSize = out.byteLength;
       }
       if (out.byteLength <= params.maxBytes) {
         const sourcePixels =
@@ -283,12 +283,12 @@ async function resizeImageBase64IfNeeded(params: {
     throw toErrorObject(processorUnavailableError, "Non-Error thrown");
   }
 
-  const best = smallest?.buffer ?? buf;
+  const bestSize = smallestSize ?? buf.byteLength;
   const sourcePixels =
     typeof width === "number" && typeof height === "number" ? `${width}x${height}px` : "unknown";
   const sourceWithFile = params.fileName ? `${params.fileName} ${sourcePixels}` : sourcePixels;
   log.warn(
-    `Image resize failed to fit limits: ${sourceWithFile} best=${formatBytesShort(best.byteLength)} limit=${formatBytesShort(params.maxBytes)}`,
+    `Image resize failed to fit limits: ${sourceWithFile} best=${formatBytesShort(bestSize)} limit=${formatBytesShort(params.maxBytes)}`,
     {
       label: params.label,
       fileName: params.fileName,
@@ -298,13 +298,13 @@ async function resizeImageBase64IfNeeded(params: {
       sourceBytes: buf.byteLength,
       maxDimensionPx: params.maxDimensionPx,
       maxBytes: params.maxBytes,
-      smallestCandidateBytes: best.byteLength,
+      smallestCandidateBytes: bestSize,
       triggerOverBytes: overBytes,
       triggerOverDimensions: overDimensions,
     },
   );
   throw new Error(
-    `Image could not be reduced below ${formatBytesShort(params.maxBytes)} (got ${formatBytesShort(best.byteLength)})`,
+    `Image could not be reduced below ${formatBytesShort(params.maxBytes)} (got ${formatBytesShort(bestSize)})`,
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Tool-image sanitization and browser screenshot normalization retain an earlier rejected JPEG while trying subsequent resize candidates, even though the earlier bytes are used only to report the smallest failed size.

## Why This Change Was Made

Keep the minimum encoded byte count instead of the rejected image buffer. Both resize owners preserve encode order, the first fitting result, unavailable-backend handling, ordinary errors, the original-input fallback, and minimum-size diagnostics.

## User Impact

Rejected image bytes can be released while resizing continues. Successful image output and failure messages retain their existing behavior. This is a maintainer-requested memory cleanup, verified with a controlled Buffer-lifetime experiment.

## Evidence

- Four focused suites pass: **25 tests**, including real image resizing, unchanged inputs, unavailable processors, tool-image diagnostics, and browser screenshot normalization.
- The existing diagnostic test now checks failed sizes of 900 → 700 → 800 bytes and verifies the 700-byte minimum in both the final error and telemetry. It protects against retaining the first/last size or incorrectly using the smaller source image as the minimum.
- Full changed-code checks pass, including core and plugin production/test typechecks, formatting, lint, guards, dead-export scans, and six doctor-contract tests. `git diff --check` passes.
- Independent source review and fresh managed autoreview found no actionable issues.
- **10 paired behavior cases match** across both complete source owners, preserving candidate order, minima, successful output, and error behavior.
- Eight retention observations in A/B/B/A order show the earlier rejected **12 MiB** candidate remains alive only in the baseline while a later encode is pending. Both owners retain exactly **12 MiB less** in `external` and `arrayBuffers` in the candidate. The harness uses synthetic encoders, weak references, explicit GC, immutable source hashes, and a paused third encode after rejected 12 MiB and 16 MiB outputs.
- RSS growth is about 28.1 MiB in both arms. This proves earlier Buffer release in the controlled case; it makes no RSS, CPU, or typical-image savings claim. All 12 probe processes joined successfully, and independent probe review confirmed the result.
- Required hosted CI passed for exact head `fc243c520ad9650a8ed4636da3e7172f26b8ce9e`: https://github.com/openclaw/openclaw/actions/runs/34039698584.
