### PR TITLE
perf(xai): fuse compatibility output projection

### DIFF
--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -697,6 +697,46 @@ describe("xai stream wrappers", () => {
   });
 
   it.each([
+    { text: ["first", "second"], output: "firstsecond" },
+    { text: ["", " "], output: " " },
+    { text: ["", ""], output: "(see attached image)" },
+    { text: ["\ud83d", "\ude48"], output: "🙈" },
+  ])("preserves interleaved text and image references for $output", ({ text, output }) => {
+    const firstImage = {
+      type: "input_image",
+      source: { type: "url", url: "https://example.com/first.png" },
+    };
+    const secondImage = { type: "input_image", image_url: "data:image/png;base64,QkJCQg==" };
+    const originalParts = [
+      { type: "input_text", text: text[0] },
+      firstImage,
+      { type: "input_text", text: text[1] },
+      secondImage,
+    ];
+    const originalBytes = JSON.stringify(originalParts);
+    const payload: Record<string, unknown> = {
+      input: [{ type: "function_call_output", call_id: "call_1", output: originalParts }],
+    };
+    runXaiToolPayloadWrapper({ payload, input: ["text", "image"] });
+
+    const input = payload.input as Array<Record<string, unknown>>;
+    expect(input[0]).toEqual({ type: "function_call_output", call_id: "call_1", output });
+    expect(input[1]).toEqual({
+      type: "message",
+      role: "user",
+      content: [
+        { type: "input_text", text: "Image(s) from tool result #1:" },
+        firstImage,
+        secondImage,
+      ],
+    });
+    const replayParts = input[1]?.content as unknown[];
+    expect(replayParts[1]).toBe(firstImage);
+    expect(replayParts[2]).toBe(secondImage);
+    expect(JSON.stringify(originalParts)).toBe(originalBytes);
+  });
+
+  it.each([
     ["Grok OAuth proxy", XAI_GROK_OAUTH_BASE_URL],
     ["custom endpoint", "https://proxy.example/v1"],
   ])("counts every function output before replaying sparse images for %s", (_label, baseUrl) => {

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -85,16 +85,7 @@ function ensureXaiResponsesEncryptedReasoningInclude(
   payloadObj.include = include;
 }
 
-type ReplayableInputImagePart =
-  | {
-      type: "input_image";
-      source: { type: "url"; url: string } | { type: "base64"; media_type: string; data: string };
-    }
-  | { type: "input_image"; image_url: string; detail?: string };
-
-function isReplayableInputImagePart(
-  part: Record<string, unknown>,
-): part is ReplayableInputImagePart {
+function isReplayableInputImagePart(part: Record<string, unknown>): boolean {
   if (part.type !== "input_image") {
     return false;
   }
@@ -189,19 +180,22 @@ function normalizeXaiResponsesToolResultPayload(
     }
 
     const outputParts = itemObj.output as Array<Record<string, unknown>>;
-    const textOutput = outputParts
-      .filter(
-        (part): part is { type: "input_text"; text: string } =>
-          part.type === "input_text" && typeof part.text === "string",
-      )
-      .map((part) => part.text)
-      .join("");
-    const images = includeImages ? outputParts.filter(isReplayableInputImagePart) : [];
-    if (images.length > 0) {
-      imageContentParts.push(
-        { type: "input_text", text: `Image(s) from tool result #${toolResultIndex}:` },
-        ...images,
-      );
+    let textOutput = "";
+    const imageStart = imageContentParts.length;
+    for (const part of outputParts) {
+      if (part.type === "input_text" && typeof part.text === "string") {
+        textOutput += part.text;
+      }
+      if (includeImages && isReplayableInputImagePart(part)) {
+        // Emit one ownership label before this result's first replayable image.
+        if (imageContentParts.length === imageStart) {
+          imageContentParts.push({
+            type: "input_text",
+            text: `Image(s) from tool result #${toolResultIndex}:`,
+          });
+        }
+        imageContentParts.push(part);
+      }
     }
     return {
       ...itemObj,


### PR DESCRIPTION
## What Problem This Solves

xAI OAuth and custom-endpoint requests do unnecessary local work when preparing tool results containing images, especially with several result groups in the conversation.

## Why This Change Was Made

Project text and replayable images in one ordered pass, removing three temporary arrays and the private filter-result type. Keep the existing image labels, call IDs, image references, text bytes and lazy media fallback unchanged. Native xAI's call-bound media path still bypasses this conversion.

## User Impact

Larger compatibility payloads take less local preparation time with identical output. No configuration or behavior changes. Production is **−6 lines**, with **+40 test lines** protecting interleaved images, whitespace, UTF-16 text and object identity.

## Evidence

- **135 tests passed** across the complete xAI wrapper and Responses producer files; **all 29 normal changed checks passed**. Independent P2 review: scoped-clean, confidence 0.98.
- Fixed B0/C0/C1/B1 measurement on `ce7eb85ae413`: 12 fixtures, wrapper and wrapper+JSON modes, 24 batches of 16 calls after eight warmups. Values below are median batch means in microseconds, baseline → candidate.

| Payload and mode | Forward | Reverse |
| --- | ---: | ---: |
| 24 mixed results, wrapper | 2.842 → 1.548 | 2.527 → 1.595 |
| 24 mixed results, wrapper+JSON | 8.052 → 6.415 | 7.113 → 6.682 |
| 24 image groups, wrapper | 6.858 → 2.254 | 5.090 → 2.481 |
| 24 image groups, wrapper+JSON | 24.837 → 18.367 | 20.914 → 17.840 |

**45/48 median comparisons improved.** All three adverse medians were reverse-order: non-Responses bypass+JSON **+0.1315% (+1.28125 ns)**; one text/image result **+3.4076% (+29.90625 ns)**; that result+JSON **+0.2618% (+3.90625 ns)**. **8/48 means and 18/48 maxima worsened**; all controls and adverse observations remain retained. Maxima are batch means, not individual-call tails; variation in untouched bypass controls is not credited to this change.

The actual wrapper used a synthetic, closed event-stream carrier. All **37,632 calls were verified in process**. Persisted evidence contains **96 expected payload descriptors and 64 distinct actual payloads**, not every successful return; independent audit reconstructed and checked those retained outputs. Every native process and the parent joined, and candidate source was restored.

This establishes a local projection improvement, not external xAI, Gateway-turn or memory savings. No external provider request was made; full-child reverse wall time and peak RSS were slightly worse, so neither supports a broader performance claim.
