### PR TITLE
perf(agents): reduce compaction planner allocations

### DIFF
--- a/src/agents/compaction-planning.ts
+++ b/src/agents/compaction-planning.ts
@@ -98,22 +98,16 @@ function normalizeCompactionParts(parts: number, messageCount: number): number {
   return Math.min(Math.max(1, Math.floor(parts)), Math.max(1, messageCount));
 }
 
-type CompactionMessageGroup = {
-  messages: AgentMessage[];
-  tokens: number;
-};
-
-function groupCompactionMessages(
+function forEachCompactionMessageGroup(
   messages: AgentMessage[],
   perMessageTokens: number[],
-): CompactionMessageGroup[] {
-  const groups: CompactionMessageGroup[] = [];
-  let current: AgentMessage[] = [];
+  visit: (start: number, end: number, tokens: number) => void,
+): void {
+  let start = 0;
   let currentTokens = 0;
   let pendingToolCalls = createToolCallOccurrenceQueue<true>();
 
   for (const [index, message] of messages.entries()) {
-    current.push(message);
     currentTokens += perMessageTokens[index]!;
 
     if (message.role === "assistant") {
@@ -138,16 +132,15 @@ function groupCompactionMessages(
     // A displaced user turn still belongs to an unfinished call/result batch;
     // splitting it would make one of the resulting provider transcripts invalid.
     if (pendingToolCalls.size === 0) {
-      groups.push({ messages: current, tokens: currentTokens });
-      current = [];
+      visit(start, index + 1, currentTokens);
+      start = index + 1;
       currentTokens = 0;
     }
   }
 
-  if (current.length > 0) {
-    groups.push({ messages: current, tokens: currentTokens });
+  if (start < messages.length) {
+    visit(start, messages.length, currentTokens);
   }
-  return groups;
 }
 
 /** Chunks atomic tool-call groups without splitting a provider-visible call/result pair. */
@@ -158,26 +151,21 @@ function chunkCompactionMessageGroups(
   maxChunks = Number.POSITIVE_INFINITY,
 ): AgentMessage[][] {
   const chunks: AgentMessage[][] = [];
-  let current: AgentMessage[] = [];
+  let chunkStart = 0;
   let currentTokens = 0;
 
-  for (const group of groupCompactionMessages(messages, perMessageTokens)) {
-    if (
-      current.length > 0 &&
-      chunks.length < maxChunks - 1 &&
-      currentTokens + group.tokens > maxTokens
-    ) {
-      chunks.push(current);
-      current = [];
+  forEachCompactionMessageGroup(messages, perMessageTokens, (start, _end, tokens) => {
+    if (start > chunkStart && chunks.length < maxChunks - 1 && currentTokens + tokens > maxTokens) {
+      chunks.push(messages.slice(chunkStart, start));
+      chunkStart = start;
       currentTokens = 0;
     }
 
-    current.push(...group.messages);
-    currentTokens += group.tokens;
-  }
+    currentTokens += tokens;
+  });
 
-  if (current.length > 0) {
-    chunks.push(current);
+  if (chunkStart < messages.length) {
+    chunks.push(messages.slice(chunkStart));
   }
 
   return chunks;
@@ -231,29 +219,30 @@ export function buildOversizedFallbackPlan(params: {
   // Reuse one sanitized token estimate per message across atomic fallback groups.
   const perMessageTokens = estimatePerMessageTokens(params.messages);
   const oversizedThreshold = params.contextWindow * 0.5;
-  let messageIndex = 0;
 
-  for (const group of groupCompactionMessages(params.messages, perMessageTokens)) {
-    const retainedMessages: AgentMessage[] = [];
+  forEachCompactionMessageGroup(params.messages, perMessageTokens, (start, end) => {
     let omitToolBatch = false;
-    for (const message of group.messages) {
-      const tokens = perMessageTokens[messageIndex++]!;
+    for (let index = start; index < end; index++) {
+      const message = params.messages[index]!;
+      const tokens = perMessageTokens[index]!;
       if (tokens * SAFETY_MARGIN > oversizedThreshold) {
         oversizedNotes.push(
           `[Large ${message.role} (~${Math.round(tokens / 1000)}K tokens) omitted from summary]`,
         );
         omitToolBatch ||= message.role === "assistant" || message.role === "toolResult";
-      } else {
-        retainedMessages.push(message);
       }
     }
     // Displaced real user turns survive even when their surrounding tool batch cannot.
-    for (const message of retainedMessages) {
+    for (let index = start; index < end; index++) {
+      if (perMessageTokens[index]! * SAFETY_MARGIN > oversizedThreshold) {
+        continue;
+      }
+      const message = params.messages[index]!;
       if (!omitToolBatch || (message.role !== "assistant" && message.role !== "toolResult")) {
         smallMessages.push(message);
       }
     }
-  }
+  });
 
   return { smallMessages, oversizedNotes };
 }


### PR DESCRIPTION
## What Problem This Solves

Compaction planning stages the transcript again as arrays for every atomic message group before assembling the final summary chunks or oversized fallback. Long histories therefore allocate intermediate message arrays that are immediately copied or discarded.

## Why This Change Was Made

Visit contiguous group spans and copy only the final chunk spans. Oversized fallback reads the same bounds and appends eligible original messages directly. The existing occurrence-counted tool queue still defines atomic groups; token estimates, split thresholds, chunk limits, order, message identity, and displaced-user retention keep their existing behavior. The change removes 11 production lines and introduces no persistent cache.

## User Impact

Compaction planning allocates less temporary data while keeping tool calls paired with their results and preserving the same summary/fallback inputs. This is a maintainer-requested performance cleanup; it does not change compaction policy or stored transcripts.

## Evidence

- All **68 existing focused tests** pass across compaction, compaction worker, and token-sanitization suites.
- Full changed-code checks and `git diff --check` pass. Independent source review and fresh managed autoreview found no actionable issues.
- **2,916 actual-owner comparisons** match across 108 synthetic histories, nine budget values, and summary chunking, staged splits, and oversized fallback. The comparison checks exact outputs, original message identity/indexes, independently owned chunk arrays, and input immutability. Cases include repeated/displaced calls, unfinished batches, empty histories, zero-pressure entries, exact thresholds, zero, NaN, and infinity.
- Five workloads ran in baseline/candidate/candidate/baseline order in 20 fresh processes. Sampled allocation fell **19.0–45.1%** across 32–10,000 ordinary messages, mixed tool/user histories, and oversized fallback. Median component timings fell 1.8–22.4%; the samples are short and few, and fallback timing is essentially flat.
- Process RSS was mixed, including small increases in two workloads. These measurements establish planner allocation savings, not retained-transcript reduction, end-to-end latency, or whole-Gateway memory improvement.
- Required hosted CI passed for exact head `aba041cc3340e7b7d9606ab377ffa33ea235940c`: https://github.com/openclaw/openclaw/actions/runs/34040020740.
