### PR TITLE
perf: defer unused Doctor migration imports

### DIFF
--- a/extensions/canvas/doctor-contract-api.ts
+++ b/extensions/canvas/doctor-contract-api.ts
@@ -1,9 +1,8 @@
-// Canvas doctor contract migrates documents from configured host roots into core storage.
+// Canvas Doctor keeps copy-time dependencies cold until legacy documents exist.
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginDoctorStateMigration } from "openclaw/plugin-sdk/runtime-doctor-migrations";
-import { pathExists } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   listLegacyCanvasDocumentIds,
   migrateCanvasHostConfig,
@@ -64,6 +63,7 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       if (documentIds.length === 0) {
         return { changes, warnings };
       }
+      const { pathExists } = await import("openclaw/plugin-sdk/text-utility-runtime");
 
       const coreDir = path.resolve(params.stateDir, "canvas", "documents");
       await fs.mkdir(coreDir, { recursive: true });

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -13,8 +13,6 @@ import {
 } from "openclaw/plugin-sdk/runtime-doctor-migrations";
 // This doctor closure must stay dependency-light while accepting legacy array-backed objects.
 import { asOptionalObjectRecord as readLegacyObjectRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-// sqlite-runtime re-exports the agent-db/kysely graph; keep it lazy so doctor
-// enumeration does not cold-load it with this closure.
 import {
   importLegacyMemorySidecarIndex,
   LEGACY_MEMORY_SIDECAR_SUFFIXES,
@@ -169,7 +167,6 @@ async function collectLegacyMemorySidecarSources(params: {
   env: NodeJS.ProcessEnv;
   stateDir: string;
 }): Promise<LegacyMemorySidecarSource[]> {
-  const { resolveOpenClawAgentSqlitePath } = await import("openclaw/plugin-sdk/sqlite-runtime");
   const agentIds = new Set(resolveConfiguredAgentIds(params.config));
   const legacyDir = path.join(params.stateDir, "memory");
   const retrySidecars: Array<{ agentId: string; legacyPath: string }> = [];
@@ -199,6 +196,9 @@ async function collectLegacyMemorySidecarSources(params: {
       return;
     }
     seen.add(key);
+    // Most startups have no legacy sidecars. Load the SQLite graph only after
+    // finding a source that needs its canonical database path checked.
+    const { resolveOpenClawAgentSqlitePath } = await import("openclaw/plugin-sdk/sqlite-runtime");
     const agentDatabasePath = resolveOpenClawAgentSqlitePath({
       agentId,
       env: migrationEnv,

--- a/extensions/workboard/doctor-contract-api.ts
+++ b/extensions/workboard/doctor-contract-api.ts
@@ -10,8 +10,6 @@ import type {
   PersistedWorkboardNotificationSubscription,
   WorkboardKeyedStore,
 } from "./src/persistence-types.js";
-// Doctor enumeration cold-loads this closure; sqlite-store pulls the
-// plugin-state-runtime/kysely graph, so it stays behind lazy imports below.
 
 const MAX_CARDS = 2000;
 
@@ -177,7 +175,6 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     id: "workboard-28-kv-to-sqlite",
     label: "Workboard .28 plugin-state KV",
     async detectLegacyState(params) {
-      const { resolveWorkboardSqlitePath } = await import("./src/sqlite-store.js");
       const env = migrationEnv(params);
       const cards = await openLegacyStore<PersistedWorkboardCard>({
         context: params.context,
@@ -207,6 +204,9 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
       if (count === 0) {
         return null;
       }
+      // Empty legacy namespaces need no SQLite runtime. Resolve the target only
+      // when there is state to preview and migrate.
+      const { resolveWorkboardSqlitePath } = await import("./src/sqlite-store.js");
       return {
         preview: [
           `- Workboard: ${count} legacy .28 plugin-state KV ${count === 1 ? "entry" : "entries"} → ${resolveWorkboardSqlitePath(env)}`,


### PR DESCRIPTION
## What Problem This Solves

Doctor migration detection loads runtime dependencies even when the corresponding legacy state is absent. In a fresh-process Skill Workshop migration test, unrelated plugin detection accounts for most of the first case's runtime.

## Why This Change Was Made

Move three existing imports behind their existing no-work checks:

- Memory Core resolves the canonical SQLite path after finding a legacy sidecar.
- Workboard resolves its SQLite target after finding legacy KV entries.
- Canvas loads its copy-time text utility after finding documents to migrate.

Present-state paths use the same helpers. Source discovery, canonical symlink handling, conflicts, retries, migration ordering and cleanup remain unchanged. There are no schema, stored-data, configuration, dependency or test-inventory changes.

## Evidence

A controlled original/candidate run in the same checkout passed both schema cases. The cold first case improved from 18.265 to 15.861 seconds; whole-command time was 33.24 versus 28.45 seconds. Whole-command timing includes test tooling and is not a claim about end-to-end CI.

Phase and actual-loader diagnostics identified the unnecessary imports. Moving the Memory Core import alone exposed Workboard loading the same SQLite graph, so both detection paths are corrected together. The temporary diagnostics are absent from this PR.

Existing preservation proof passed: 64 Memory Core migration cases, five Workboard cases, five Canvas cases, and two Memory Core startup cases. These cover actual migration, canonical aliases, corrupt and missing inputs, conflicting data, attachment recovery and cleanup. The two Skill Workshop migration cases also passed before and after.

Independent P2 review and the full changed-file gates passed, including production/test typechecks, SDK declarations, lint, all dead-export scans and import-cycle checks. The full `pnpm build` also passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34040750797) passed with 9,093 passing tests in its selected plugin jobs. One initial job never acquired a self-hosted runner and executed no steps; a targeted same-head retry used the existing hosted fallback and passed. The core cold-workshop case was not selected by this PR plan, so its timing above remains local evidence.

Production delta is +8/-8, including relocated comments. No tests were deleted or assertions weakened.

## User Impact

Startup and Doctor avoid unnecessary dependency loading when these legacy inputs are absent. Existing migrations retain their behavior.
