### PR TITLE
fix(daemon): keep trailing backslash when quoting cmd arguments

### DIFF
--- a/src/daemon/arg-split.ts
+++ b/src/daemon/arg-split.ts
@@ -1,5 +1,5 @@
 /** Shared argument splitter for service command lines rendered by platform adapters. */
-type ArgSplitEscapeMode = "none" | "backslash" | "backslash-quote-only";
+type ArgSplitEscapeMode = "none" | "backslash" | "backslash-quote-only" | "windows-cmd";
 type ArgSplitQuoteChar = '"' | "'";
 type ArgSplitQuoteStart = "anywhere" | "item-start";
 
@@ -39,6 +39,35 @@ export function splitArgsPreservingQuotes(
       // their backslashes literal.
       current += '"';
       i++;
+      continue;
+    }
+    if (escapeMode === "windows-cmd" && char === "\\") {
+      // CommandLineToArgvW: 2n backslashes + " closes the quote with n
+      // backslashes; 2n+1 backslashes + " is n backslashes and a literal ".
+      let slashCount = 1;
+      while (i + slashCount < value.length && value.charAt(i + slashCount) === "\\") {
+        slashCount += 1;
+      }
+      const quoteIndex = i + slashCount;
+      if (quoteIndex < value.length && value.charAt(quoteIndex) === '"') {
+        current += "\\".repeat(Math.floor(slashCount / 2));
+        if (slashCount % 2 === 1) {
+          current += '"';
+        } else if (quoteChar === '"') {
+          quoteChar = null;
+        } else {
+          const canOpenQuote = quoteStart === "anywhere" || current.length === 0;
+          if (!quoteChar && canOpenQuote) {
+            quoteChar = '"';
+          } else {
+            current += '"';
+          }
+        }
+        i = quoteIndex;
+        continue;
+      }
+      current += "\\".repeat(slashCount);
+      i += slashCount - 1;
       continue;
     }
     if (quoteChars.has(char as ArgSplitQuoteChar)) {

--- a/src/daemon/cmd-argv.test.ts
+++ b/src/daemon/cmd-argv.test.ts
@@ -14,6 +14,9 @@ describe("cmd argv helpers", () => {
     "%TEMP%",
     "!token!",
     'he said "hi"',
+    "C:\\Program Files\\OpenClaw\\",
+    "\\\\server\\share\\folder\\",
+    'C:\\temp\\file with "quotes"\\',
   ])("round-trips single arg: %p", (arg) => {
     const encoded = quoteCmdScriptArg(arg);
     expect(parseCmdScriptCommandLine(encoded)).toEqual([arg]);
@@ -34,6 +37,17 @@ describe("cmd argv helpers", () => {
     ];
     const encoded = args.map((arg) => quoteCmdScriptArg(arg)).join(" ");
     expect(parseCmdScriptCommandLine(encoded)).toEqual(args);
+  });
+
+  it("does not let a trailing backslash escape the closing quote", () => {
+    const workingDirectory = "C:\\Program Files\\OpenClaw\\";
+    const encoded = quoteCmdScriptArg(workingDirectory);
+    // CommandLineToArgvW / cmd treat an odd run of backslashes before " as
+    // escaping that quote. The wrapper must emit an even run so the closer
+    // stays a closer. This assertion is portable; it fails on macOS too.
+    expect(encoded.endsWith('\\\\"')).toBe(true);
+    expect(encoded).toBe('"C:\\Program Files\\OpenClaw\\\\"');
+    expect(parseCmdScriptCommandLine(encoded)).toEqual([workingDirectory]);
   });
 
   it("rejects CR/LF in command arguments", () => {

--- a/src/daemon/cmd-argv.ts
+++ b/src/daemon/cmd-argv.ts
@@ -10,12 +10,14 @@ export function quoteCmdScriptArg(
   if (!value) {
     return '""';
   }
-  const quoted = value.replace(/"/g, '\\"').replace(/%/g, "%%");
-  const escaped = options.delayedExpansion === false ? quoted : quoted.replace(/!/g, "^!");
+  const quoted = value.replace(/(\\*)"/g, (_match, slashes: string) => `${slashes}${slashes}\\"`);
+  const expanded = quoted.replace(/%/g, "%%");
+  const escaped = options.delayedExpansion === false ? expanded : expanded.replace(/!/g, "^!");
   if (!/[ \t"&|<>^()%!]/g.test(value)) {
     return escaped;
   }
-  return `"${escaped}"`;
+  // A trailing backslash would otherwise escape the wrapper quote (`\"`).
+  return `"${escaped.replace(/(\\+)$/, (slashes) => slashes + slashes)}"`;
 }
 
 function unescapeCmdScriptArg(value: string): string {
@@ -23,9 +25,7 @@ function unescapeCmdScriptArg(value: string): string {
 }
 
 export function parseCmdScriptCommandLine(value: string): string[] {
-  // Script renderer escapes quotes (`\"`) and cmd expansions (`%%`, `^!`).
-  // Keep all other backslashes literal so Windows drive/UNC paths survive.
-  return splitArgsPreservingQuotes(value, { escapeMode: "backslash-quote-only" }).map(
-    unescapeCmdScriptArg,
-  );
+  // Script renderer uses CommandLineToArgvW quote rules plus cmd expansions
+  // (`%%`, `^!`). Drive and UNC backslashes stay literal unless they precede ".
+  return splitArgsPreservingQuotes(value, { escapeMode: "windows-cmd" }).map(unescapeCmdScriptArg);
 }

--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -215,6 +215,16 @@ export function resolveTaskLauncherScriptPath(env: GatewayServiceEnv, scriptPath
   return path.join(parsed.dir, `${parsed.name}.vbs`);
 }
 
+function parseCmdWorkingDirectory(directoryArg: string): string {
+  const recovered = parseCmdScriptCommandLine(directoryArg)[0] ?? "";
+  // Older quoteCmdScriptArg wrapped trailing-backslash dirs as `..."\`.
+  // cmd.exe still treats that closer as a closer; CRT does not.
+  if (directoryArg.startsWith('"') && recovered.endsWith('"') && /[^\\]\\"$/.test(directoryArg)) {
+    return directoryArg.slice(1, -1);
+  }
+  return recovered;
+}
+
 export async function readScheduledTaskCommand(
   env: GatewayServiceEnv,
   options?: GatewayServiceReadOptions,
@@ -249,7 +259,8 @@ export async function readScheduledTaskCommand(
         continue;
       }
       if (lower.startsWith("cd /d ")) {
-        workingDirectory = line.slice("cd /d ".length).trim().replace(/^"|"$/g, "");
+        const directoryArg = line.slice("cd /d ".length).trim();
+        workingDirectory = parseCmdWorkingDirectory(directoryArg);
         continue;
       }
       // Generated launchers redirect stdin so a hidden service console never

--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -216,11 +216,19 @@ export function resolveTaskLauncherScriptPath(env: GatewayServiceEnv, scriptPath
 }
 
 function parseCmdWorkingDirectory(directoryArg: string): string {
-  const recovered = parseCmdScriptCommandLine(directoryArg)[0] ?? "";
+  const trimmed = directoryArg.trim();
+  if (!trimmed) {
+    return "";
+  }
+  // cmd.exe `cd` with extensions accepts unquoted spaces. Do not argv-split.
+  if (!trimmed.startsWith('"')) {
+    return trimmed;
+  }
+  const recovered = parseCmdScriptCommandLine(trimmed)[0] ?? "";
   // Older quoteCmdScriptArg wrapped trailing-backslash dirs as `..."\`.
   // cmd.exe still treats that closer as a closer; CRT does not.
-  if (directoryArg.startsWith('"') && recovered.endsWith('"') && /[^\\]\\"$/.test(directoryArg)) {
-    return directoryArg.slice(1, -1);
+  if (recovered.endsWith('"') && /[^\\]\\"$/.test(trimmed)) {
+    return trimmed.slice(1, -1);
   }
   return recovered;
 }

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -303,6 +303,22 @@ describe("readScheduledTaskCommand", () => {
     );
   });
 
+  it("reads an unquoted working directory that contains spaces", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", "cd /d C:\\Program Files\\OpenClaw", "node gateway.js"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js"],
+          workingDirectory: "C:\\Program Files\\OpenClaw",
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
   it("reads legacy quoted working directories that ended with a single backslash", async () => {
     await withScheduledTaskScript(
       {

--- a/src/daemon/schtasks.test.ts
+++ b/src/daemon/schtasks.test.ts
@@ -287,6 +287,38 @@ describe("readScheduledTaskCommand", () => {
     );
   });
 
+  it("reads a quoted working directory that ends with a backslash", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", 'cd /d "C:\\Program Files\\OpenClaw\\\\"', "node gateway.js"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js"],
+          workingDirectory: "C:\\Program Files\\OpenClaw\\",
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
+  it("reads legacy quoted working directories that ended with a single backslash", async () => {
+    await withScheduledTaskScript(
+      {
+        scriptLines: ["@echo off", 'cd /d "C:\\Program Files\\OpenClaw\\"', "node gateway.js"],
+      },
+      async (env) => {
+        const result = await readScheduledTaskCommand(env);
+        expect(result).toEqual({
+          programArguments: ["node", "gateway.js"],
+          workingDirectory: "C:\\Program Files\\OpenClaw\\",
+          sourcePath: resolveTaskScriptPath(env),
+        });
+      },
+    );
+  });
+
   it("reads legacy UTF-8 scripts with CJK paths written before the encoding fix", async () => {
     await withScheduledTaskScript(
       {


### PR DESCRIPTION
## What Problem This Solves

Windows service and restart helpers quote paths with `quoteCmdScriptArg`. When a path contains spaces and ends with a backslash (the usual `C:\Program Files\OpenClaw\` install directory), the helper wrapped it as `"C:\Program Files\OpenClaw\"`. CreateProcess / CommandLineToArgvW treat that last `\"` as an escaped quote, so the closer is lost. `cd /d` lines, Scheduled Task command lines, and `cmd /s /c` restart wrappers can then run the wrong command or swallow the next token.

This change doubles trailing backslashes (and backslashes before embedded quotes) before the wrapper quote, matching CommandLineToArgvW. The parser used to read generated `.cmd` scripts understands the same rules for quoted operands.

Reading `cd /d` is not argv parsing. cmd.exe `cd` with extensions accepts unquoted spaces. The first readback used the argv splitter and turned `cd /d C:\Program Files\OpenClaw` into `C:\Program`, which `launchFallbackTaskScript` would pass as the child cwd. Unquoted operands now keep the full remainder. Quoted lines still use the CommandLineToArgvW reader, including older `"...\"` closers.

## Evidence

Live `tsx` against the patched helpers on macOS, Node v26.7.0, worktree `/tmp/oc-f070-cmd-quote`.

Quoting helper, before (unpatched `quoteCmdScriptArg`):

```console
$ pnpm exec tsx proof-f070-before.mjs
{"value":"C:\\Program Files\\OpenClaw\\","encoded":"\"C:\\Program Files\\OpenClaw\\\"","oddCloser":true}
```

Quoting helper, after (patched `src/daemon/cmd-argv.ts`):

```console
$ pnpm exec tsx proof-f070.mjs
{"value":"C:\\Program Files\\OpenClaw\\","encoded":"\"C:\\Program Files\\OpenClaw\\\\\"","parsed":["C:\\Program Files\\OpenClaw\\"],"oddCloser":false,"roundTrip":true}
```

Working-directory readback through production `buildTaskScript` and `readScheduledTaskCommand` (the same path `launchFallbackTaskScript` uses for cwd):

```console
$ pnpm exec tsx proof-f070-cwd.mjs
generated_cd_line="cd /d \"C:\\Program Files\\OpenClaw\\\\\""
{"label":"existing_unquoted_spaces","workingDirectory":"C:\\Program Files\\OpenClaw","programArguments":["C:\\Program Files\\nodejs\\node.exe","gateway.js"]}
{"label":"generated_trailing_backslash","workingDirectory":"C:\\Program Files\\OpenClaw\\","programArguments":["C:\\Program Files\\nodejs\\node.exe","gateway.js"]}
{"label":"legacy_quoted_odd_closer","workingDirectory":"C:\\Program Files\\OpenClaw\\","programArguments":["C:\\Program Files\\nodejs\\node.exe","gateway.js"]}
```

The existing unquoted launcher keeps `C:\Program Files\OpenClaw` instead of `C:\Program`. Newly generated and legacy quoted lines keep the full directory, including a trailing backslash.

## Real behavior proof

- **Behavior or issue addressed:** Quoted Windows cmd arguments that end with a backslash no longer lose their closing quote. Reading a Scheduled Task `cd /d` line keeps the full working directory for both quoted generated scripts and existing unquoted spaced paths, so fallback spawn does not get a truncated cwd.
- **Real environment tested:** macOS 15 (Darwin 25.6.0 arm64), Node v26.7.0, worktree `/tmp/oc-f070-cmd-quote` rebased onto `origin/main` `11f2ea2921d`. Invoked the production helpers with `pnpm exec tsx`.
- **Exact steps or command run after this patch:** `pnpm exec tsx proof-f070-before.mjs`, `pnpm exec tsx proof-f070.mjs`, then `pnpm exec tsx proof-f070-cwd.mjs` (writes temporary `.cmd` launchers and calls `readScheduledTaskCommand`).
- **Evidence after fix:** terminal output copied below.

Before quoting:

```console
{"value":"C:\\Program Files\\OpenClaw\\","encoded":"\"C:\\Program Files\\OpenClaw\\\"","oddCloser":true}
```

After quoting and cwd readback:

```console
{"value":"C:\\Program Files\\OpenClaw\\","encoded":"\"C:\\Program Files\\OpenClaw\\\\\"","parsed":["C:\\Program Files\\OpenClaw\\"],"oddCloser":false,"roundTrip":true}
generated_cd_line="cd /d \"C:\\Program Files\\OpenClaw\\\\\""
{"label":"existing_unquoted_spaces","workingDirectory":"C:\\Program Files\\OpenClaw","programArguments":["C:\\Program Files\\nodejs\\node.exe","gateway.js"]}
{"label":"generated_trailing_backslash","workingDirectory":"C:\\Program Files\\OpenClaw\\","programArguments":["C:\\Program Files\\nodejs\\node.exe","gateway.js"]}
{"label":"legacy_quoted_odd_closer","workingDirectory":"C:\\Program Files\\OpenClaw\\","programArguments":["C:\\Program Files\\nodejs\\node.exe","gateway.js"]}
```

- **Observed result after fix:** The patched helper emits `"C:\Program Files\OpenClaw\\"`. Production readback of an existing unquoted `cd /d C:\Program Files\OpenClaw` returns that full directory (not `C:\Program`). Generated and legacy quoted forms also return the full directory. That is the cwd `launchFallbackTaskScript` would pass to spawn.
- **What was not tested:** Native `cmd.exe` / CreateProcess on a Windows host. This checkout is macOS and has no Parallels guest. The quoting contract is CommandLineToArgvW; the cwd contract is the same production reader used for fallback spawn.

## Summary

`quoteCmdScriptArg` has escaped `"` as `\"` since the helper was extracted in [`035832b4c53`](https://github.com/openclaw/openclaw/commit/035832b4c53) (2026-02-19). [`#131479`](https://github.com/openclaw/openclaw/pull/131479) later added delayed-expansion control but left trailing backslashes unescaped. Callers include `schtasks-layout.ts` (`cd /d` and startup `cmd /c`), `restart-helper.ts`, `windows-task-restart.ts`, and `openclaw-cli-shim.ts`.

ClawSweeper review on `a68a268430f` asked to preserve unquoted spaced `cd` operands. That readback defect is fixed in this update.

Same class as [`#133185`](https://github.com/openclaw/openclaw/pull/133185) (preserve arguments through Windows batch wrappers) and [`#117375`](https://github.com/openclaw/openclaw/pull/117375) (keep backslashes intact in generated units).
