### PR TITLE
fix(android): keep voice and connection controls readable

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -97,6 +97,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -977,39 +978,38 @@ private fun VoiceSetupActionRow(
     contentColor = ClawTheme.colors.text,
     border = BorderStroke(1.dp, ClawTheme.colors.border),
   ) {
-    Row(
-      modifier = Modifier.fillMaxWidth().padding(horizontal = ClawTheme.spacing.xs, vertical = ClawTheme.spacing.xxs),
-      verticalAlignment = Alignment.CenterVertically,
-      horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs),
-    ) {
-      Surface(
-        modifier = Modifier.size(ClawTheme.spacing.iconSlot),
-        shape = CircleShape,
-        color = ClawTheme.colors.canvas,
-        contentColor = ClawTheme.colors.text,
-        border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
-      ) {
-        Box(contentAlignment = Alignment.Center) {
-          Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(ClawTheme.spacing.icon))
+    ClawListItem(
+      title = title,
+      subtitle = subtitle,
+      modifier = Modifier.padding(horizontal = ClawTheme.spacing.xs),
+      leading = {
+        Surface(
+          modifier = Modifier.size(ClawTheme.spacing.iconSlot),
+          shape = CircleShape,
+          color = ClawTheme.colors.canvas,
+          contentColor = ClawTheme.colors.text,
+          border = BorderStroke(1.dp, ClawTheme.colors.borderStrong),
+        ) {
+          Box(contentAlignment = Alignment.Center) {
+            Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(ClawTheme.spacing.icon))
+          }
         }
-      }
-      Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(2.dp)) {
-        Text(text = title, style = ClawTheme.type.section, color = ClawTheme.colors.text, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        Text(text = subtitle, style = ClawTheme.type.body, color = ClawTheme.colors.textMuted, maxLines = 1, overflow = TextOverflow.Ellipsis)
-      }
-      Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs)) {
-        Box(
-          modifier =
-            Modifier
-              .size(6.dp)
-              .background(if (ready) ClawTheme.colors.success else ClawTheme.colors.textSubtle, CircleShape),
-        )
-        Text(text = statusText, style = ClawTheme.type.body, color = ClawTheme.colors.textMuted, maxLines = 1)
-        if (onClick != null) {
-          Icon(imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, modifier = Modifier.size(16.dp), tint = ClawTheme.colors.textMuted)
+      },
+      trailing = {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(ClawTheme.spacing.xxs)) {
+          Box(
+            modifier =
+              Modifier
+                .size(6.dp)
+                .background(if (ready) ClawTheme.colors.success else ClawTheme.colors.textSubtle, CircleShape),
+          )
+          Text(text = statusText, style = ClawTheme.type.body, color = ClawTheme.colors.textMuted)
+          if (onClick != null) {
+            Icon(imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, modifier = Modifier.size(16.dp), tint = ClawTheme.colors.textMuted)
+          }
         }
-      }
-    }
+      },
+    )
   }
 }
 
@@ -1824,7 +1824,11 @@ private fun GatewaySettingsScreen(
         }
       }
     }
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+    FlowRow(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(8.dp),
+      verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
       ClawPrimaryButton(text = nativeString("Reconnect"), onClick = viewModel::refreshGatewayConnection, modifier = Modifier.weight(1f))
       ClawSecondaryButton(text = nativeString("Disconnect"), onClick = viewModel::disconnect, modifier = Modifier.weight(1f))
     }
@@ -1847,8 +1851,6 @@ private fun GatewaySettingsScreen(
           text = nativeString("Scan or paste a setup code to add another gateway."),
           style = ClawTheme.type.body,
           color = ClawTheme.colors.textMuted,
-          maxLines = 2,
-          overflow = TextOverflow.Ellipsis,
         )
         ClawSecondaryButton(text = nativeString("Scan QR"), onClick = viewModel::pairNewGateway, modifier = Modifier.fillMaxWidth(), icon = Icons.Default.QrCode2)
         ClawTextField(value = setupCode, onValueChange = { setupCode = it }, placeholder = nativeString("Setup code"), secret = true)

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/design/ClawComponents.kt
@@ -138,7 +138,7 @@ internal fun ClawPrimaryButton(
       Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(16.dp))
       Spacer(modifier = Modifier.width(6.dp))
     }
-    Text(text = text, style = ClawTheme.type.label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    Text(text = text, style = ClawTheme.type.label)
   }
 }
 
@@ -169,7 +169,7 @@ internal fun ClawSecondaryButton(
         Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(16.dp))
         Spacer(modifier = Modifier.width(6.dp))
       }
-      Text(text = text, style = ClawTheme.type.label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+      Text(text = text, style = ClawTheme.type.label)
     }
   }
 }
@@ -533,8 +533,6 @@ internal fun ClawSegmentedControl(
                   enabled -> ClawTheme.colors.textMuted
                   else -> ClawTheme.colors.textSubtle
                 },
-              maxLines = 1,
-              overflow = TextOverflow.Ellipsis,
             )
           }
         }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsScreensContrastTest.kt
@@ -1,13 +1,18 @@
 package ai.openclaw.app.ui
 
+import ai.openclaw.app.GatewayTalkSetupReadiness
 import ai.openclaw.app.MainViewModel
 import ai.openclaw.app.NodeApp
 import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.bindNodeRuntimeTestFixture
 import ai.openclaw.app.closeNodeRuntimeTestFixture
 import ai.openclaw.app.gateway.GatewayEndpoint
+import ai.openclaw.app.i18n.NativeStringResources
+import ai.openclaw.app.i18n.nativeString
 import ai.openclaw.app.ui.design.ClawDesignTheme
+import ai.openclaw.app.ui.design.assertCompleteText
 import ai.openclaw.app.ui.design.contrastThemeCases
 import ai.openclaw.app.ui.design.renderedLabelContrast
 import android.content.Context
@@ -17,9 +22,13 @@ import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
@@ -28,6 +37,9 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import kotlinx.coroutines.CoroutineScope
@@ -115,6 +127,132 @@ class SettingsScreensContrastTest {
           }
         },
       ).around(composeRule)
+
+  @Test
+  @Config(qualifiers = "fr-rFR-w320dp-h800dp-mdpi")
+  fun voiceInformationKeepsCompleteTextAndSpeakerActionAtLargeFont() {
+    try {
+      val model = offlineTypographyModel()
+      composeRule.setContent {
+        DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(2f)) {
+          ClawDesignTheme(dark = false) {
+            SettingsDetailScreen(model, SettingsRoute.Voice, onBack = {})
+          }
+        }
+      }
+      assertEquals(GatewayTalkSetupReadiness.unverified(), model.talkSetupReadiness.value)
+      for (key in listOf("Realtime Talk", "Dictation", "Gateway talk catalog not loaded", "Unverified", "Wake listener", "Pauses during other voice activity.", "Add wake phrase", "Save wake words")) {
+        val label = nativeString(key)
+        val nodes = composeRule.onAllNodesWithText(label, useUnmergedTree = true)
+        assertTrue("$key must have a rendered caller", nodes.fetchSemanticsNodes().isNotEmpty())
+        for (index in nodes.fetchSemanticsNodes().indices) {
+          nodes[index].performScrollTo()
+          captureTypography("voice-$key-$index")
+          nodes[index].assertCompleteText(label)
+        }
+      }
+      val wakeStatus = composeRule.runOnIdle { model.voiceWakeStatusText.value }
+      composeRule.onNodeWithText(wakeStatus, useUnmergedTree = true).assertCompleteText(wakeStatus)
+      for (key in listOf("Realtime Talk", "Dictation", "Wake listener", "Save wake words")) {
+        composeRule.onNodeWithText(nativeString(key)).assertIsNotEnabled()
+      }
+      for ((action, description) in listOf("Mute speaker" to "Replies play aloud", "Enable speaker" to "Assistant speech muted")) {
+        composeRule.onNodeWithText(nativeString(description), useUnmergedTree = true).assertCompleteText(nativeString(description))
+        composeRule.onNodeWithText(nativeString(action), useUnmergedTree = true).assertCompleteText(nativeString(action))
+        val before = model.speakerEnabled.value
+        val status = nativeString(if (before) "On" else "Muted")
+        composeRule.onNodeWithText(status, useUnmergedTree = true).assertCompleteText(status)
+        captureTypography("voice-$action")
+        // The merged Surface can center over status; exercise the visible title's actual hit.
+        composeRule.onNodeWithText(nativeString(action), useUnmergedTree = true).performScrollTo().performClick()
+        composeRule.runOnIdle { assertEquals(!before, model.speakerEnabled.value) }
+      }
+      assertTrue(model.speakerEnabled.value)
+    } finally {
+      NativeStringResources.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "fr-rFR-w320dp-h800dp-mdpi")
+  fun gatewayExplanationAndSecurityKeepCompleteTextAndTlsRestriction() {
+    try {
+      val model = offlineTypographyModel()
+      val fontScale = mutableStateOf(2f)
+      composeRule.setContent {
+        DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(fontScale.value)) {
+          ClawDesignTheme(dark = false) {
+            SettingsDetailScreen(model, SettingsRoute.Gateway, onBack = {})
+          }
+        }
+      }
+      for (key in listOf("Reconnect", "Disconnect")) {
+        val label = nativeString(key)
+        val node = composeRule.onNodeWithText(label, useUnmergedTree = true)
+        node.assertCompleteText(label)
+        captureTypography("gateway-$key")
+        val layouts = mutableListOf<TextLayoutResult>()
+        node.performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+        val layout = layouts.single()
+        assertTrue(
+          "$label must move below its peer rather than break inside its action word",
+          (0 until layout.lineCount - 1).none { line ->
+            val end = layout.getLineEnd(line, visibleEnd = true)
+            end > 0 && end < label.length && label[end - 1].isLetter() && label[end].isLetter()
+          },
+        )
+      }
+      for (key in listOf("Scan or paste a setup code to add another gateway.", "Unencrypted", "Secure (TLS)")) {
+        val label = nativeString(key)
+        composeRule.onNodeWithText(label, useUnmergedTree = true).performScrollTo()
+        captureTypography("gateway-$key")
+        composeRule.onNodeWithText(label, useUnmergedTree = true).assertCompleteText(label)
+      }
+      composeRule.onNodeWithText(nativeString("Unencrypted")).assertIsNotEnabled().performClick()
+      composeRule.onNodeWithText(nativeString("Secure (TLS)")).assertIsSelected()
+      assertFalse("Presenting required TLS does not rewrite saved preferences", model.manualTls.value)
+
+      composeRule.runOnIdle { fontScale.value = 1f }
+      val reconnect = composeRule.onNodeWithText(nativeString("Reconnect")).performScrollTo()
+      val disconnect = composeRule.onNodeWithText(nativeString("Disconnect"))
+      disconnect.assertIsDisplayed()
+      val first = reconnect.fetchSemanticsNode().boundsInRoot
+      val second = disconnect.fetchSemanticsNode().boundsInRoot
+      assertTrue("Fitting normal-font actions stay beside one another", first.right <= second.left && first.top == second.top)
+      captureTypography("gateway-actions-normal-font")
+    } finally {
+      NativeStringResources.setApplicationLocales(LocaleListCompat.getEmptyLocaleList())
+    }
+  }
+
+  private fun offlineTypographyModel(): MainViewModel {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    previousRuntime = app.peekRuntime()
+    NativeStringResources.install(app)
+    NativeStringResources.setApplicationLocales(LocaleListCompat.forLanguageTags("fr"))
+    val prefs = SecurePrefs(app, app.getSharedPreferences("typography-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    prefs.setManualHost("wss://gateway.example.test")
+    prefs.setManualPort(443)
+    prefs.setManualTls(false)
+    runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    runtime.disconnect()
+    bindNodeRuntimeTestFixture(app, runtime)
+    return MainViewModel(app, prefs, SavedStateHandle()).also { models.put("typography", it) }
+  }
+
+  private fun captureTypography(name: String) {
+    val evidence = File("build/outputs/settings-typography", UUID.randomUUID().toString())
+    check(evidence.mkdirs())
+    File(evidence, "${name.replace(Regex("[^a-zA-Z0-9-]"), "-")}.png").outputStream().use {
+      assertTrue(
+        composeRule
+          .onRoot()
+          .captureToImage()
+          .asAndroidBitmap()
+          .compress(Bitmap.CompressFormat.PNG, 100, it),
+      )
+    }
+  }
 
   @Test
   fun operationalCaptionsRemainReadableThroughTheirSettingsCallers() {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/design/ClawComponentsTest.kt
@@ -335,19 +335,7 @@ class ClawComponentsTest {
           }
           val labels = listOfNotNull(row.title, row.subtitle, row.metadata, "Oublier".takeIf { row.slots == ListRowSlots.Gateway }, "Setup".takeIf { row.slots == ListRowSlots.Skill })
           for (label in labels) {
-            val layouts = mutableListOf<TextLayoutResult>()
-            composeRule
-              .onNodeWithText(label, useUnmergedTree = true)
-              .performScrollTo()
-              .assertIsDisplayed()
-              .performSemanticsAction(SemanticsActions.GetTextLayoutResult) { action -> assertTrue(action(layouts)) }
-            val layout = layouts.single()
-            // Paragraph width can exceed a tight Text node even when every glyph fits.
-            assertFalse("${row.slots}/$rowWidth/$scale: $label must retain every line", layout.multiParagraph.didExceedMaxLines)
-            assertTrue("$label must fit vertically", layout.multiParagraph.height <= layout.size.height + 1f)
-            assertTrue("${row.slots}/$rowWidth/$scale: $label must fit horizontally", (0 until layout.lineCount).all { layout.getLineLeft(it) >= -1f && layout.getLineRight(it) <= layout.size.width + 1f })
-            assertTrue("$label must not be ellipsized", (0 until layout.lineCount).none(layout::isLineEllipsized))
-            assertEquals(label.length, layout.getLineEnd(layout.lineCount - 1, visibleEnd = true))
+            composeRule.onNodeWithText(label, useUnmergedTree = true).assertCompleteText(label)
           }
           if (row.slots == ListRowSlots.Skill) {
             assertEquals(
@@ -549,6 +537,74 @@ class ClawComponentsTest {
   }
 
   @Test
+  fun longActionLabelsWrapWithoutLosingTheirClickOrDisabledState() {
+    val enabled = mutableStateOf(true)
+    var primaryClicks = 0
+    var secondaryClicks = 0
+    val primary = "Reconnecter"
+    val secondary = "Déconnecter"
+    composeRule.setContent {
+      DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(2f)) {
+        ClawDesignTheme {
+          LazyColumn(Modifier.width(280.dp)) {
+            item {
+              Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                ClawPrimaryButton(primary, { primaryClicks++ }, Modifier.weight(1f), enabled.value, Icons.Default.Cloud)
+                ClawSecondaryButton(secondary, { secondaryClicks++ }, Modifier.weight(1f), enabled.value)
+              }
+            }
+          }
+        }
+      }
+    }
+    for (label in listOf(primary, secondary)) {
+      composeRule.onNodeWithText(label, useUnmergedTree = true).assertCompleteText(label)
+      composeRule.onNodeWithText(label).performScrollTo().performClick()
+    }
+    composeRule.runOnIdle {
+      assertEquals(1, primaryClicks)
+      assertEquals(1, secondaryClicks)
+      enabled.value = false
+    }
+    for (label in listOf(primary, secondary)) {
+      composeRule
+        .onNodeWithText(label)
+        .assertIsNotEnabled()
+        .performScrollTo()
+        .performClick()
+      composeRule.onNodeWithText(label, useUnmergedTree = true).assertCompleteText(label)
+    }
+    composeRule.runOnIdle {
+      assertEquals(1, primaryClicks)
+      assertEquals(1, secondaryClicks)
+    }
+  }
+
+  @Test
+  fun securityLabelsWrapInsideTheirSegmentsWithoutRegrouping() {
+    val options = listOf("Non chiffré", "Sécurisé (TLS)")
+    val selected = mutableStateOf(options.first())
+    composeRule.setContent {
+      DeviceConfigurationOverride(DeviceConfigurationOverride.FontScale(2f)) {
+        ClawDesignTheme {
+          LazyColumn(Modifier.width(280.dp)) {
+            item {
+              ClawSegmentedControl(options, selected.value, { selected.value = it })
+            }
+          }
+        }
+      }
+    }
+    for (label in options) composeRule.onNodeWithText(label, useUnmergedTree = true).assertCompleteText(label)
+    val first = composeRule.onNodeWithText(options.first()).fetchSemanticsNode().boundsInRoot
+    val second = composeRule.onNodeWithText(options.last()).fetchSemanticsNode().boundsInRoot
+    assertTrue("Segments stay beside one another; their labels gain height", first.right <= second.left && first.top == second.top)
+    composeRule.onNodeWithText(options.first()).assertIsSelected()
+    composeRule.onNodeWithText(options.last()).performClick().assertIsSelected()
+    composeRule.onNodeWithText(options.first()).assertIsNotSelected()
+  }
+
+  @Test
   fun filterPillsExposeAndUpdateTheirSelection() {
     val selected = mutableStateOf("All")
     composeRule.setContent {
@@ -609,6 +665,19 @@ class ClawComponentsTest {
     assertEquals(listOf(4, 3, 3), rows.map { it.size })
     assertEquals((1..10).map(Int::toString), rows.flatten())
   }
+}
+
+internal fun SemanticsNodeInteraction.assertCompleteText(label: String) {
+  val layouts = mutableListOf<TextLayoutResult>()
+  performScrollTo().assertIsDisplayed().performSemanticsAction(SemanticsActions.GetTextLayoutResult) { assertTrue(it(layouts)) }
+  val layout = layouts.single()
+  assertEquals(label, layout.layoutInput.text.text)
+  assertFalse("$label must retain every line", layout.multiParagraph.didExceedMaxLines)
+  assertTrue("$label must fit vertically", layout.multiParagraph.height <= layout.size.height + 1f)
+  // Paragraph width can exceed a tight Text node even when every glyph fits.
+  assertTrue("$label must fit horizontally", (0 until layout.lineCount).all { layout.getLineLeft(it) >= -1f && layout.getLineRight(it) <= layout.size.width + 1f })
+  assertTrue("$label must not be ellipsized", (0 until layout.lineCount).none(layout::isLineEllipsized))
+  assertEquals("$label must display its final character", label.length, layout.getLineEnd(layout.lineCount - 1, visibleEnd = true))
 }
 
 internal data class ContrastThemeCase(


### PR DESCRIPTION
Closes #140179. Related: #134939 and #139789.

## What Problem This Solves

Fixes an issue where Android Settings cut off voice feature names, readiness explanations, security choices and connection actions at large text sizes. Read-only Voice rows had no detail action to reveal their hidden explanation; the primary Add Gateway instruction was also truncated.

## Why This Change Was Made

Voice cards now use the existing adaptive ClawListItem inside their original Surface. This removes the duplicate rigid text/status layout and preserves the sole click/disabled owner, icon, status and caret. Titles/descriptions deliberately adopt the shared body/caption typography; accessibility fontScale is unchanged.

The existing button and segmented-label owners now allow wrapping. Segmented options keep their current one-row grouping unless their caller already opts into wrapping. Gateway's paired Reconnect/Disconnect actions use the existing FlowRow: equal-width peers when they fit, separate rows when needed. No new wrapper, font threshold, reduced text scale, configuration or dependency is added.

## User Impact

Required labels and explanations remain readable, including at French 320dp / 2× text. Action callbacks, minimum targets, disabled states and TLS restrictions are preserved. This does not redesign app bars or expand compact technical metrics, and it leaves the landed shared-row repair intact.

## Evidence

- Original production fails four real-Compose glyph-layout regressions: Voice title, Gateway instruction, security label and action label. The fixed tests pass. A further actual-caller test caught an intermediate Reconnecter word split; the final FlowRow repair passes that check while retaining side-by-side normal-size controls.
- Original focused validation: 60 tests across five existing suites, zero failures/errors/skips. Current-main integration passed 138 tests across the same five complete test classes, including the landed approval-coherence regression. Coverage includes full visible character ends, per-line geometry and ellipsis, not merely accessible string presence; enabled/disabled clicks, speaker toggling/restoration, TLS restriction, segmented selection/grouping and 1×/2× Gateway layouts remain covered.
- Play and third-party Kotlin compilation, scoped Kotlin checks and native i18n verification passed. The complete changed-file gate passed in the Git-backed checkout. Independent source review and Codex autoreview found no actionable P0–P2 finding.
- Current committed patch: `d823ebd89396a11956b992e846e820a1c5088042`, parent `b741a0d5926de88ac6b4cf1ed8bd8ae2c43af954`. Rebase conflict resolution was only the import union in the shared Settings test. The original typography behavior/tests are preserved along with #140111’s atomic inbox and coherence test and #140247’s canonical readiness predicate. The integrated source passed both Kotlin flavors, the complete changed-file gate, independent composition review and fresh Codex autoreview. Production +38/−38 (net zero); tests +220/−13, including factoring existing glyph assertions without removing their coverage.

### Inspected synthetic captures

These are Compose/Robolectric renders from the original reviewed candidate, not installed-device screenshots. Their typography changes remain byte-preserved in the current integration. The large-text captures use 320dp / 2× font; scrolling positions differ as content gains height. All were inspected in full by the maintainer agent. Ordinary viewport cropping is not a claim that every border is simultaneously visible.

**Before — truncated connection actions and instruction:**

![Before: truncated connection actions and setup instruction](https://github.com/user-attachments/assets/b18c5724-0e3b-47d3-b004-18760de511a0)

**After — full actions and instruction:**

![After: full connection actions and setup instruction](https://github.com/user-attachments/assets/564ef67b-5817-465d-b672-084a51fb811c)

**After — full Voice feature names, explanations and status:**

![After: readable Voice readiness cards](https://github.com/user-attachments/assets/8cef1da7-fa7d-4e8b-84d8-01b9287589ca)

**Normal font — fitting actions still stay beside one another:**

![Normal font: side-by-side connection actions](https://github.com/user-attachments/assets/6b2db2c3-a0cc-4012-8f5b-459a5a4ffd54)

### Installed before/after comparison

The declared installed comparison is complete on the exact current head. Genuine Play debug APKs were built from `b741a0d5926de88ac6b4cf1ed8bd8ae2c43af954` and `d823ebd89396a11956b992e846e820a1c5088042`, verified independently, then installed and updated once on the same fresh Android API 36 emulator. These captures are from the installed app, not Compose previews.

Eight ordered cases covered French/light Voice and Gateway settings at the original display/normal font and at 320dp/2× font, followed by restoration in both phases. The actual enlarged BEFORE frames show truncation; AFTER shows complete provider titles/explanations, wake-action labels, connection actions, security choices and setup instructions. Normal connection actions remain side by side; enlarged ones stack. Speaker off/on captions were observed and restored. Ordinary reconnect/disconnect completed, the active Gateway switch stayed disabled, and the loopback TLS choice stayed selected without being changed.

This uses an isolated synthetic WSS fixture, not a canonical Gateway or model/provider test. Background list/history reads are included; unsupported optional RPCs are deliberately rejected. No chat send, approval decision, TLS-option mutation, wake-word save, microphone capture or model/provider execution is claimed. Settings-scope state, app language, effective theme, display size/density and font scale were restored; Chat selection/draft state was not part of this Settings-only comparison.

The complete 17-part export was reconstructed and all 14,823 files rehashed. Root inspected 24 original full frames; an independent reviewer checked the artifacts, key frames, action/state records and cleanup. All owned runtime processes and ports closed; the Testbox was stopped and verified completed.

<details>
<summary>Installed before/after captures — normal and enlarged text</summary>

| Surface/profile | Before | After |
| --- | --- | --- |
| Voice — normal text | ![Voice — normal text before](https://github.com/user-attachments/assets/3f8fe28e-793b-40ef-a8a3-0901db3863b9) | ![Voice — normal text after](https://github.com/user-attachments/assets/7ea9cfe8-5dbf-482a-a760-9d5378f406ca) |
| Voice — 320dp / 2× text | ![Voice — 320dp / 2× text before](https://github.com/user-attachments/assets/f6c41ae0-b23b-4ad6-adb6-66b3819d9a54) | ![Voice — 320dp / 2× text after](https://github.com/user-attachments/assets/3e0b18bb-e59c-41bf-b604-9681a2baffa6) |
| Gateway — normal text | ![Gateway — normal text before](https://github.com/user-attachments/assets/43f78efd-2f6e-4d33-aeab-b3c2e353289c) | ![Gateway — normal text after](https://github.com/user-attachments/assets/0690a782-80af-40a6-a591-f69a40db0f8b) |
| Gateway actions and instruction — 320dp / 2× | ![Gateway actions and instruction — 320dp / 2× before](https://github.com/user-attachments/assets/1bd7e688-b4ec-4eef-a84c-4706a29324fd) | ![Gateway actions and instruction — 320dp / 2× after](https://github.com/user-attachments/assets/09cc4673-b8e5-4870-a11e-dba1784988fe) |
| Security labels — 320dp / 2× | ![Security labels — 320dp / 2× before](https://github.com/user-attachments/assets/c342fa4b-bfb6-4567-ad93-0907a7026ec0) | ![Security labels — 320dp / 2× after](https://github.com/user-attachments/assets/99624a20-2722-4d31-b63e-58b52ff1904e) |
| Wake actions — 320dp / 2× | ![Wake actions — 320dp / 2× before](https://github.com/user-attachments/assets/ac9c095f-a818-4ce9-a3f8-7a0094074d90) | ![Wake actions — 320dp / 2× after](https://github.com/user-attachments/assets/03633521-1024-46d6-a908-ceb2d93e0d6d) |

Scroll positions differ as content gains height. Off-target viewport cropping is not label truncation; click any image for its complete original frame. All captures contain only the synthetic test fixture and were inspected before upload.

</details>

### Landing evidence and limits

Exact-head [CI 34046777789](https://github.com/openclaw/openclaw/actions/runs/34046777789) and the required `openclaw/ci-gate` passed for `d823ebd89396a11956b992e846e820a1c5088042`. The completed ClawSweeper review identified no code finding; its remaining installed-comparison request and Rank-up move are addressed above. Its attachment-fetch limitation is not represented as bot visual inspection.

No permission, transport, Gateway/provider, protocol or persistent-state policy changed. Remote-host disabled TLS policy remains covered by the actual Compose caller test, not by this loopback-only installed run. The initial test-only stale Wake status observation was corrected to read current state on Compose idle; no production retry, timeout increase or test suppression was added.

Named follow-ups for the continuing Android sweep: existing large-text diagnostic key/value truncation and mid-word wrapping of the narrow **Amorçage** credential placeholder. Both are visible before and after and are outside this label/control repair. App-bar layout remains separate.
