### PR TITLE
perf(discord): avoid needless parsing for ordinary replies

### DIFF
--- a/extensions/discord/src/markdown.ts
+++ b/extensions/discord/src/markdown.ts
@@ -82,6 +82,9 @@ function markdownSemanticSignature(root: PositionedMarkdownNode): string {
 
 function normalizeDiscordBold(markdown: string): string {
   // This outbound contract is CommonMark: `__x__` is bold, never Discord-native underline.
+  if (!markdown.includes("__")) {
+    return markdown;
+  }
   const spans: Array<{ start: number; end: number }> = [];
   const contentEdits: Array<{
     spanId: number;


### PR DESCRIPTION
## What Problem This Solves

Discord outbound formatting builds and walks a full Markdown syntax tree even when the message has no underscore-bold marker to normalize. Ordinary replies pay that cost before the normalizer returns their text unchanged.

## Why This Change Was Made

Return immediately from the bold normalizer when the raw text does not contain `__`, which every eligible rewrite requires. The check runs after table conversion. Inputs containing the marker keep the complete parser and semantic validation, including existing code, link, native-token, and source-offset handling.

## User Impact

Ordinary Discord replies avoid unnecessary bold-normalization work while preserving the same rendered text and outbound requests. This is a maintainer-requested performance cleanup. Table conversion can still perform its own parsing, and text containing `__` anywhere keeps the prior parser path.

## Evidence

- Three existing focused suites pass: **103 tests**, covering Markdown rendering, basic channel sends, and thread chunking. Full changed-code checks, formatting, and `git diff --check` pass.
- Independent source/dependency review and fresh managed autoreview found no actionable issues. Existing behavior coverage was retained without adding parser-call assertions.
- **56 actual renderer/outbound cases match** across 14 inputs and all four table modes: 52 successful sends and four matching empty-message errors. The fake REST capture compares every request field except the random nonce. Fixtures include positive underscore-bold controls, code, links, native syntax, tables, and multi-chunk text.
- With a synthetic 1,120-unit plain message, the actual outbound owner estimates **70.8% lower sampled allocation**, from 123,746 to 36,105 bytes/call. Both arms used Node 26.8.1 on macOS arm64, 100 warmup calls, and a separate 300-call V8 sample phase at 16,384 bytes with collected-object sampling.
- Positive `__` controls remain roughly flat in allocation (+0.07% renderer, +0.46% outbound). Delimiter-free renderer samples approach the sampling floor; zero samples are not proof of zero allocations. Timings ran under concurrent checks and do not establish live Discord latency, cold loading, retained heap, or Gateway RSS savings.
- Required hosted CI passed for exact head `375f286a56a4f3ef0600fd52d84daa168350681f`: https://github.com/openclaw/openclaw/actions/runs/34040629555.

The outbound probe uses synthetic configuration and a fake REST client, with no live Discord delivery.
