### PR TITLE
perf(plugins): avoid full inspection for compatibility notices

### DIFF
--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -969,22 +969,32 @@ describe("plugin status reports", () => {
     expectNoCompatibilityWarnings();
   });
 
-  it("builds structured compatibility notices with deterministic ordering", () => {
-    setPluginLoadResult({
-      plugins: [
-        createPluginRecord({
-          id: "hook-only",
-          name: "Hook Only",
-          hookCount: 1,
-        }),
-      ],
-      hooks: [createCustomHook({ pluginId: "hook-only", events: ["message"] })],
-    });
+  it.each([false, true])(
+    "keeps compatibility notices ordered and attributed to their plugin (supplied report: %s)",
+    (suppliedReport) => {
+      const report = createPluginLoadResult({
+        plugins: [
+          createPluginRecord({ id: "old", hookCount: 1 }),
+          createPluginRecord({ id: "api", providerIds: ["api"] }),
+          createPluginRecord({ id: "bundled", origin: "bundled", error: "sessionFile missing" }),
+          createPluginRecord({ id: "unrelated" }),
+        ],
+        hooks: [createCustomHook({ pluginId: "old", events: ["message"] })],
+        diagnostics: [
+          { level: "error", pluginId: "api", message: "saveSessionStore missing" },
+          { level: "error", message: "sessionFile missing" },
+          { level: "error", pluginId: "old", message: "sessionFile missing" },
+        ],
+      });
+      setPluginLoadResult(suppliedReport ? { plugins: [] } : report);
 
-    expectCompatibilityOutput({
-      notices: [createCompatibilityNotice({ pluginId: "hook-only", code: "hook-only" })],
-    });
-  });
+      expect(buildPluginCompatibilityNotices(suppliedReport ? { report } : undefined)).toEqual([
+        createCompatibilityNotice({ pluginId: "old", code: "hook-only" }),
+        createCompatibilityNotice({ pluginId: "old", code: "removed-session-transcript-file-api" }),
+        createCompatibilityNotice({ pluginId: "api", code: "removed-session-transcript-file-api" }),
+      ]);
+    },
+  );
 
   it("does not warn for explicit startup-lazy metadata", () => {
     setSinglePluginLoadResult(

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -523,7 +523,14 @@ export function buildPluginCompatibilityWarnings(params?: PluginInspectParams): 
 export function buildPluginCompatibilityNotices(
   params?: PluginInspectParams,
 ): PluginCompatibilityNotice[] {
-  return buildAllPluginInspectReports(params).flatMap((inspect) => inspect.compatibility);
+  const registry = params?.report ?? buildPluginDiagnosticsReport(params);
+  return registry.plugins.flatMap((plugin) =>
+    buildCompatibilityNoticesForInspect({
+      plugin,
+      shape: buildPluginShapeSummary({ plugin, report: registry }).shape,
+      diagnostics: registry.diagnostics.filter((entry) => entry.pluginId === plugin.id),
+    }),
+  );
 }
 
 export function buildPluginCompatibilitySnapshotNotices(params?: {


### PR DESCRIPTION
## What Problem This Solves

Status and Doctor construct full plugin inspection reports just to collect compatibility notices. That also prepares unused runtime policy context and inspects MCP/LSP support, adding work to diagnostic paths with larger plugin registries.

## Why This Change Was Made

Project notices directly from the supplied registry, or build the diagnostics registry from the existing options when none is supplied. The projection reuses the established shape classifier, exact plugin diagnostic attribution, and notice builder. Full inspection and snapshot/live-registration merging retain their existing owners.

## User Impact

Compatibility warnings require less inspection work and preserve the same notice content and order. A supplied report remains authoritative even when the ambient registry differs. This is a maintainer-requested performance cleanup with no new cache or configuration surface.

## Evidence

- Both existing status suites pass **38 tests** against baseline, candidate, and final source. The expanded existing fixture covers supplied/generated reports, both notice kinds, interleaved/global diagnostics, bundled errors, and unrelated plugins.
- Changed-check types, guards, boundaries, and dead-export stages passed. The final lint stage initially caught an oversized test file; shortening synthetic fixture IDs and compacting expected calls retained the cases, after which the exact lint command, 38 tests, and formatting passed. `git diff --check` passes.
- Independent source review and final exact-diff managed autoreview found no actionable issues.
- The actual owner produced **49 notices with identical complete JSON** in a 100-plugin fixture. Per supplied-report call, native MCP inspection fell 50 → 0, bundle MCP 50 → 0, bundle LSP 50 → 0, and ambient runtime-context preparation 1 → 0. Count probes called through to the real inspection implementations.
- Across five samples of 40 warm calls, median component time fell **1.399 → 0.168 ms**. Existing dependency mocks and concurrent checks limit that timing claim; eliminated calls and exact output parity are the primary evidence. This is not a whole-Gateway latency, allocation-byte, heap, or RSS measurement.
- Required hosted CI passed for exact head `04f5f38db4364dd908b5e9241b07b121e2221ac6`: https://github.com/openclaw/openclaw/actions/runs/34040631123.
