### PR TITLE
refactor(daemon): simplify status collection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2296,7 +2296,6 @@ src/cli/daemon-cli/lifecycle.ts	1
 src/cli/daemon-cli/restart-health-probe.ts	9
 src/cli/daemon-cli/restart-health.ts	1
 src/cli/daemon-cli/start-repair.ts	1
-src/cli/daemon-cli/status.gather.ts	10
 src/cli/deps.ts	2
 src/cli/devices-cli.runtime.ts	10
 src/cli/directory-cli.ts	7

--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -460,7 +460,6 @@ src/cli/command-secret-targets.ts
 src/cli/config-cli.test.ts
 src/cli/cron-cli.test.ts
 src/cli/daemon-cli/status.gather.test.ts
-src/cli/daemon-cli/status.gather.ts
 src/cli/daemon-cli/status.print.test.ts
 src/cli/devices-cli.runtime.ts
 src/cli/devices-cli.test.ts

--- a/src/cli/daemon-cli/status.gateway.ts
+++ b/src/cli/daemon-cli/status.gateway.ts
@@ -1,0 +1,167 @@
+// Gateway target projection and port diagnostics for daemon status.
+import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
+import { resolveGatewayPort } from "../../config/paths.js";
+import type { GatewayBindMode, OpenClawConfig } from "../../config/types.js";
+import { projectGatewayUrlForDiagnostics } from "../../gateway/connection-details.js";
+import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
+import { trimToUndefined } from "../../gateway/credentials.js";
+import { resolveGatewayRequiredListenHosts } from "../../gateway/net.js";
+import {
+  inspectBestEffortPrimaryTailnetIPv4,
+  resolveBestEffortGatewayBindHostForDisplay,
+} from "../../infra/network-discovery-display.js";
+import { inspectPortUsage, inspectPortUsages } from "../../infra/ports-inspect.js";
+import type { PortListener, PortUsageStatus } from "../../infra/ports-types.js";
+import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
+import type { WindowsGatewayFirewallDiagnostic } from "../../infra/windows-gateway-firewall-diagnostics.js";
+import { pickProbeHostForBind } from "./shared.js";
+
+export type GatewayStatusSummary = {
+  bindMode: GatewayBindMode;
+  bindHost: string;
+  customBindHost?: string;
+  tlsEnabled?: boolean;
+  port: number;
+  portSource: "cli" | "service args" | "env/config";
+  probeUrl: string;
+  controlUiLinks?: { httpUrl: string; wsUrl: string };
+  probeNote?: string;
+  version?: string | null;
+  windowsFirewall?: WindowsGatewayFirewallDiagnostic;
+};
+
+type PortStatusSummary = {
+  port: number;
+  status: PortUsageStatus;
+  listeners: PortListener[];
+  hints: string[];
+};
+
+type ResolvedGatewayStatus = {
+  gateway: GatewayStatusSummary;
+  daemonPort: number;
+  cliPort: number;
+  probeUrl: string;
+  probeUrlOverride: string | null;
+};
+
+function appendProbeNote(
+  existing: string | undefined,
+  extra: string | undefined,
+): string | undefined {
+  const values = [existing, extra].filter((value): value is string => Boolean(value?.trim()));
+  if (values.length === 0) {
+    return undefined;
+  }
+  return uniqueStrings(values).join(" ");
+}
+
+export async function resolveGatewayStatusSummary(params: {
+  daemonCfg: OpenClawConfig;
+  cliCfg: OpenClawConfig;
+  mergedDaemonEnv: Record<string, string | undefined>;
+  commandProgramArguments?: string[];
+  rpcUrlOverride?: string;
+  localPortOverride?: number;
+}): Promise<ResolvedGatewayStatus> {
+  const portFromArgs = parseTcpPortFromArgs(params.commandProgramArguments);
+  const daemonPort =
+    params.localPortOverride ??
+    portFromArgs ??
+    resolveGatewayPort(params.daemonCfg, params.mergedDaemonEnv);
+  const portSource: GatewayStatusSummary["portSource"] =
+    params.localPortOverride !== undefined ? "cli" : portFromArgs ? "service args" : "env/config";
+  const bindMode: GatewayBindMode = params.daemonCfg.gateway?.bind ?? "loopback";
+  const customBindHost = params.daemonCfg.gateway?.customBindHost;
+  const { bindHost, warning: bindHostWarning } = await resolveBestEffortGatewayBindHostForDisplay({
+    bindMode,
+    customBindHost,
+    warningPrefix: "Status is using fallback network details because interface discovery failed",
+  });
+  const { tailnetIPv4, warning: tailnetWarning } = inspectBestEffortPrimaryTailnetIPv4({
+    warningPrefix: "Status could not inspect tailnet addresses",
+  });
+  const probeHost =
+    params.localPortOverride !== undefined
+      ? "127.0.0.1"
+      : pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost);
+  const probeUrlOverride = trimToUndefined(params.rpcUrlOverride) ?? null;
+  const tlsEnabled = params.daemonCfg.gateway?.tls?.enabled === true;
+  const scheme = tlsEnabled ? "wss" : "ws";
+  const probeUrl = probeUrlOverride ?? `${scheme}://${probeHost}:${daemonPort}`;
+  const diagnosticProbeUrl = projectGatewayUrlForDiagnostics(probeUrl);
+  const controlUiLinks =
+    params.daemonCfg.gateway?.controlUi?.enabled === false
+      ? undefined
+      : await resolveAdvertisedControlUiLinks({
+          port: daemonPort,
+          bind: bindMode,
+          customBindHost,
+          basePath: params.daemonCfg.gateway?.controlUi?.basePath,
+          tlsEnabled,
+        });
+  let probeNote =
+    !probeUrlOverride && bindMode === "lan"
+      ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`
+      : !probeUrlOverride && bindMode === "loopback"
+        ? "Loopback-only gateway; only local clients can connect."
+        : undefined;
+  probeNote = appendProbeNote(probeNote, bindHostWarning);
+  probeNote = appendProbeNote(probeNote, tailnetWarning);
+
+  return {
+    gateway: {
+      bindMode,
+      bindHost,
+      customBindHost,
+      ...(tlsEnabled ? { tlsEnabled } : {}),
+      port: daemonPort,
+      portSource,
+      probeUrl: diagnosticProbeUrl,
+      ...(controlUiLinks ? { controlUiLinks } : {}),
+      ...(probeNote ? { probeNote } : {}),
+    },
+    daemonPort,
+    cliPort: resolveGatewayPort(params.cliCfg, process.env),
+    probeUrl,
+    probeUrlOverride,
+  };
+}
+
+function toPortStatusSummary(
+  diagnostics: Awaited<ReturnType<typeof inspectPortUsage>> | null,
+): PortStatusSummary | undefined {
+  if (!diagnostics) {
+    return undefined;
+  }
+  return {
+    port: diagnostics.port,
+    status: diagnostics.status,
+    listeners: diagnostics.listeners,
+    hints: diagnostics.hints,
+  };
+}
+
+export async function inspectDaemonPortStatuses(params: {
+  daemonPort: number;
+  cliPort: number;
+  daemonBindHost: string;
+}): Promise<{ portStatus?: PortStatusSummary; portCliStatus?: PortStatusSummary }> {
+  const daemonProbeHosts = resolveGatewayRequiredListenHosts(params.daemonBindHost);
+  if (params.cliPort === params.daemonPort) {
+    const portDiagnostics = await inspectPortUsage(params.daemonPort, {
+      probeHosts: daemonProbeHosts,
+    }).catch(() => null);
+    return {
+      portStatus: toPortStatusSummary(portDiagnostics),
+      portCliStatus: undefined,
+    };
+  }
+  const portDiagnosticsByPort = await inspectPortUsages([params.daemonPort, params.cliPort], {
+    probeHostsByPort: new Map([[params.daemonPort, daemonProbeHosts]]),
+  }).catch(() => new Map());
+  return {
+    portStatus: toPortStatusSummary(portDiagnosticsByPort.get(params.daemonPort) ?? null),
+    portCliStatus: toPortStatusSummary(portDiagnosticsByPort.get(params.cliPort) ?? null),
+  };
+}

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -1,19 +1,16 @@
 // Collects daemon status from service files, config snapshots, ports, probes, and plugin drift.
 import fs from "node:fs/promises";
 import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import JSON5 from "json5";
 import type { classifyGatewayConnectFailure } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
   isDefaultInstallIdentity,
   resolveConfigPath,
-  resolveGatewayPort,
   resolveStateDir,
 } from "../../config/paths.js";
 import type {
   OpenClawConfig,
   ConfigFileSnapshot,
-  GatewayBindMode,
   GatewayControlUiConfig,
 } from "../../config/types.js";
 import { resolveSecretInputRef } from "../../config/types.secrets.js";
@@ -29,10 +26,7 @@ import type {
   GatewayServiceLoadState,
 } from "../../daemon/service-types.js";
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
-import { projectGatewayUrlForDiagnostics } from "../../gateway/connection-details.js";
-import { resolveAdvertisedControlUiLinks } from "../../gateway/control-ui-links.js";
 import { gatewaySecretInputPathCanWin } from "../../gateway/credentials-secret-inputs.js";
-import { trimToUndefined } from "../../gateway/credentials.js";
 import type { HostDesktopStatus } from "../../gateway/desktop/host-source.js";
 import { resolveGatewayRequiredListenHosts } from "../../gateway/net.js";
 import { resolveGatewayProbeCredentialConfig } from "../../gateway/probe-auth.js";
@@ -41,26 +35,14 @@ import {
   readGatewaySecretInputValue,
 } from "../../gateway/secret-input-paths.js";
 import { isGatewayExternallySupervised } from "../../infra/gateway-supervision.js";
-import {
-  inspectBestEffortPrimaryTailnetIPv4,
-  resolveBestEffortGatewayBindHostForDisplay,
-} from "../../infra/network-discovery-display.js";
 import { formatPortDiagnostics } from "../../infra/ports-format.js";
-import {
-  inspectPortConnections,
-  inspectPortUsage,
-  inspectPortUsages,
-} from "../../infra/ports-inspect.js";
+import { inspectPortConnections } from "../../infra/ports-inspect.js";
 import type { PortConnection, PortListener, PortUsageStatus } from "../../infra/ports-types.js";
 import {
   readGatewayRestartHandoffSync,
   type GatewayRestartHandoff,
 } from "../../infra/restart-handoff.js";
-import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
-import {
-  inspectWindowsGatewayFirewall,
-  type WindowsGatewayFirewallDiagnostic,
-} from "../../infra/windows-gateway-firewall-diagnostics.js";
+import { inspectWindowsGatewayFirewall } from "../../infra/windows-gateway-firewall-diagnostics.js";
 import { resolveConfiguredLogFilePath } from "../../logging/log-file-path.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-record-reader.js";
 import {
@@ -73,7 +55,12 @@ import { createLazyPromise } from "../../shared/lazy-promise.js";
 import { VERSION } from "../../version.js";
 import { resolveGatewayLocalPortOverride } from "../gateway-port-option.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
-import { normalizeListenerAddress, pickProbeHostForBind } from "./shared.js";
+import { normalizeListenerAddress } from "./shared.js";
+import {
+  inspectDaemonPortStatuses,
+  resolveGatewayStatusSummary,
+  type GatewayStatusSummary,
+} from "./status.gateway.js";
 import type { GatewayRpcOpts } from "./types.js";
 
 type ConfigSummary = {
@@ -83,27 +70,6 @@ type ConfigSummary = {
   issues?: Array<{ path: string; message: string }>;
   warnings?: ConfigFileSnapshot["warnings"];
   controlUi?: GatewayControlUiConfig;
-};
-
-type GatewayStatusSummary = {
-  bindMode: GatewayBindMode;
-  bindHost: string;
-  customBindHost?: string;
-  tlsEnabled?: boolean;
-  port: number;
-  portSource: "cli" | "service args" | "env/config";
-  probeUrl: string;
-  controlUiLinks?: { httpUrl: string; wsUrl: string };
-  probeNote?: string;
-  version?: string | null;
-  windowsFirewall?: WindowsGatewayFirewallDiagnostic;
-};
-
-type PortStatusSummary = {
-  port: number;
-  status: PortUsageStatus;
-  listeners: PortListener[];
-  hints: string[];
 };
 
 type DaemonConfigContext = {
@@ -121,14 +87,6 @@ type StatusConfigRead = {
   mode: "fast" | "full";
 };
 
-type ResolvedGatewayStatus = {
-  gateway: GatewayStatusSummary;
-  daemonPort: number;
-  cliPort: number;
-  probeUrl: string;
-  probeUrlOverride: string | null;
-};
-
 type CliStatusSummary = {
   version: string;
   entrypoint?: string;
@@ -144,28 +102,6 @@ const loadServiceAuditModule = createLazyPromise(() => import("../../daemon/serv
 const loadGatewayTlsModule = createLazyPromise(() => import("../../infra/tls/gateway.js"));
 const loadDaemonProbeModule = createLazyPromise(() => import("./probe.js"));
 const loadRestartHealthModule = createLazyPromise(() => import("./restart-health.js"));
-
-function resolveSnapshotRuntimeConfig(snapshot: ConfigFileSnapshot | null): OpenClawConfig | null {
-  if (!snapshot?.valid || !snapshot.runtimeConfig) {
-    return null;
-  }
-  return snapshot.runtimeConfig;
-}
-
-function coerceStatusConfig(value: unknown): OpenClawConfig {
-  return asNonArrayRecord(value) as OpenClawConfig;
-}
-
-function hasOwnKey(value: unknown, key: string): boolean {
-  return Boolean(
-    value && typeof value === "object" && !Array.isArray(value) && Object.hasOwn(value, key),
-  );
-}
-
-function needsFullStatusConfigRead(raw: string, parsed: unknown): boolean {
-  // Fast reads skip config expansion; includes/env placeholders require full config IO.
-  return raw.includes("$include") || raw.includes("${") || hasOwnKey(parsed, "env");
-}
 
 async function readFastStatusConfig(configPath: string): Promise<StatusConfigRead | null> {
   let raw: string;
@@ -198,11 +134,12 @@ async function readFastStatusConfig(configPath: string): Promise<StatusConfigRea
     };
   }
 
-  if (needsFullStatusConfigRead(raw, parsed)) {
+  const cfg: OpenClawConfig = asNonArrayRecord(parsed);
+  // Includes and environment expansion require the full config owner.
+  if (raw.includes("$include") || raw.includes("${") || Object.hasOwn(cfg, "env")) {
     return null;
   }
 
-  const cfg = coerceStatusConfig(parsed);
   return {
     summary: {
       path: configPath,
@@ -232,7 +169,7 @@ async function readFullStatusConfig(params: {
     },
   });
   const snapshot = await io.readConfigFileSnapshot().catch(() => null);
-  const cfg = resolveSnapshotRuntimeConfig(snapshot) ?? io.loadConfig();
+  const cfg = (snapshot?.valid && snapshot.runtimeConfig) || io.loadConfig();
   return {
     summary: {
       path: snapshot?.path ?? params.configPath,
@@ -262,16 +199,6 @@ async function readStatusConfig(params: {
   );
 }
 
-function appendProbeNote(
-  existing: string | undefined,
-  extra: string | undefined,
-): string | undefined {
-  const values = [existing, extra].filter((value): value is string => Boolean(value?.trim()));
-  if (values.length === 0) {
-    return undefined;
-  }
-  return uniqueStrings(values).join(" ");
-}
 export type DaemonStatus = {
   cli?: CliStatusSummary;
   logFile?: string;
@@ -353,16 +280,6 @@ export type DaemonStatus = {
   pluginVersionRestartReadiness?: PluginVersionRestartReadiness;
 };
 
-function shouldReportPortUsage(status: PortUsageStatus | undefined, rpcOk?: boolean) {
-  if (status === undefined || status === "free") {
-    return false;
-  }
-  if (rpcOk === true) {
-    return false;
-  }
-  return true;
-}
-
 function resolveCliStatusSummary(argv: string[] = process.argv): CliStatusSummary {
   const entrypoint = argv[1]?.trim();
   return {
@@ -376,15 +293,12 @@ async function loadDaemonConfigContext(
   opts: { deep?: boolean } = {},
 ): Promise<DaemonConfigContext> {
   const mergedDaemonEnv = {
-    ...(process.env as Record<string, string | undefined>),
+    ...process.env,
     ...(serviceEnv ?? undefined),
   } satisfies Record<string, string | undefined>;
 
   const cliConfigPath = resolveConfigPath(process.env, resolveStateDir(process.env));
-  const daemonConfigPath = resolveConfigPath(
-    mergedDaemonEnv as NodeJS.ProcessEnv,
-    resolveStateDir(mergedDaemonEnv as NodeJS.ProcessEnv),
-  );
+  const daemonConfigPath = resolveConfigPath(mergedDaemonEnv, resolveStateDir(mergedDaemonEnv));
   const sameConfigPath = cliConfigPath === daemonConfigPath;
   const cliConfigRead = await readStatusConfig({
     env: process.env,
@@ -396,7 +310,7 @@ async function loadDaemonConfigContext(
   const daemonConfigRead = sharesDaemonConfigContext
     ? cliConfigRead
     : await readStatusConfig({
-        env: mergedDaemonEnv as NodeJS.ProcessEnv,
+        env: mergedDaemonEnv,
         configPath: daemonConfigPath,
         deep: opts.deep,
       });
@@ -408,116 +322,6 @@ async function loadDaemonConfigContext(
     cliConfigSummary: cliConfigRead.summary,
     daemonConfigSummary: daemonConfigRead.summary,
     configMismatch: cliConfigRead.summary.path !== daemonConfigRead.summary.path,
-  };
-}
-
-async function resolveGatewayStatusSummary(params: {
-  daemonCfg: OpenClawConfig;
-  cliCfg: OpenClawConfig;
-  mergedDaemonEnv: Record<string, string | undefined>;
-  commandProgramArguments?: string[];
-  rpcUrlOverride?: string;
-  localPortOverride?: number;
-}): Promise<ResolvedGatewayStatus> {
-  const portFromArgs = parseTcpPortFromArgs(params.commandProgramArguments);
-  const daemonPort =
-    params.localPortOverride ??
-    portFromArgs ??
-    resolveGatewayPort(params.daemonCfg, params.mergedDaemonEnv);
-  const portSource: GatewayStatusSummary["portSource"] =
-    params.localPortOverride !== undefined ? "cli" : portFromArgs ? "service args" : "env/config";
-  const bindMode: GatewayBindMode = params.daemonCfg.gateway?.bind ?? "loopback";
-  const customBindHost = params.daemonCfg.gateway?.customBindHost;
-  const { bindHost, warning: bindHostWarning } = await resolveBestEffortGatewayBindHostForDisplay({
-    bindMode,
-    customBindHost,
-    warningPrefix: "Status is using fallback network details because interface discovery failed",
-  });
-  const { tailnetIPv4, warning: tailnetWarning } = inspectBestEffortPrimaryTailnetIPv4({
-    warningPrefix: "Status could not inspect tailnet addresses",
-  });
-  const probeHost =
-    params.localPortOverride !== undefined
-      ? "127.0.0.1"
-      : pickProbeHostForBind(bindMode, tailnetIPv4, customBindHost);
-  const probeUrlOverride = trimToUndefined(params.rpcUrlOverride) ?? null;
-  const tlsEnabled = params.daemonCfg.gateway?.tls?.enabled === true;
-  const scheme = tlsEnabled ? "wss" : "ws";
-  const probeUrl = probeUrlOverride ?? `${scheme}://${probeHost}:${daemonPort}`;
-  const diagnosticProbeUrl = projectGatewayUrlForDiagnostics(probeUrl);
-  const controlUiLinks =
-    params.daemonCfg.gateway?.controlUi?.enabled === false
-      ? undefined
-      : await resolveAdvertisedControlUiLinks({
-          port: daemonPort,
-          bind: bindMode,
-          customBindHost,
-          basePath: params.daemonCfg.gateway?.controlUi?.basePath,
-          tlsEnabled,
-        });
-  let probeNote =
-    !probeUrlOverride && bindMode === "lan"
-      ? `bind=lan listens on 0.0.0.0 (all interfaces); probing via ${probeHost}.`
-      : !probeUrlOverride && bindMode === "loopback"
-        ? "Loopback-only gateway; only local clients can connect."
-        : undefined;
-  probeNote = appendProbeNote(probeNote, bindHostWarning);
-  probeNote = appendProbeNote(probeNote, tailnetWarning);
-
-  return {
-    gateway: {
-      bindMode,
-      bindHost,
-      customBindHost,
-      ...(tlsEnabled ? { tlsEnabled } : {}),
-      port: daemonPort,
-      portSource,
-      probeUrl: diagnosticProbeUrl,
-      ...(controlUiLinks ? { controlUiLinks } : {}),
-      ...(probeNote ? { probeNote } : {}),
-    },
-    daemonPort,
-    cliPort: resolveGatewayPort(params.cliCfg, process.env),
-    probeUrl,
-    probeUrlOverride,
-  };
-}
-
-function toPortStatusSummary(
-  diagnostics: Awaited<ReturnType<typeof inspectPortUsage>> | null,
-): PortStatusSummary | undefined {
-  if (!diagnostics) {
-    return undefined;
-  }
-  return {
-    port: diagnostics.port,
-    status: diagnostics.status,
-    listeners: diagnostics.listeners,
-    hints: diagnostics.hints,
-  };
-}
-
-async function inspectDaemonPortStatuses(params: {
-  daemonPort: number;
-  cliPort: number;
-  daemonBindHost: string;
-}): Promise<{ portStatus?: PortStatusSummary; portCliStatus?: PortStatusSummary }> {
-  const daemonProbeHosts = resolveGatewayRequiredListenHosts(params.daemonBindHost);
-  if (params.cliPort === params.daemonPort) {
-    const portDiagnostics = await inspectPortUsage(params.daemonPort, {
-      probeHosts: daemonProbeHosts,
-    }).catch(() => null);
-    return {
-      portStatus: toPortStatusSummary(portDiagnostics),
-      portCliStatus: undefined,
-    };
-  }
-  const portDiagnosticsByPort = await inspectPortUsages([params.daemonPort, params.cliPort], {
-    probeHostsByPort: new Map([[params.daemonPort, daemonProbeHosts]]),
-  }).catch(() => new Map());
-  return {
-    portStatus: toPortStatusSummary(portDiagnosticsByPort.get(params.daemonPort) ?? null),
-    portCliStatus: toPortStatusSummary(portDiagnosticsByPort.get(params.cliPort) ?? null),
   };
 }
 
@@ -657,7 +461,7 @@ export async function gatherDaemonStatus(
   const extraServices = opts.deep
     ? await loadDaemonInspectModule()
         .then(({ findExtraGatewayServices }) =>
-          findExtraGatewayServices(process.env as Record<string, string | undefined>, {
+          findExtraGatewayServices(process.env, {
             deep: true,
           }),
         )
@@ -692,7 +496,7 @@ export async function gatherDaemonStatus(
       opts.allowExecSecretRefs !== false ||
       !hasActiveGatewayExecProbeCredential({
         cfg: daemonCfg,
-        env: mergedDaemonEnv as NodeJS.ProcessEnv,
+        env: mergedDaemonEnv,
         explicitAuth,
         mode: probeMode,
       });
@@ -702,7 +506,7 @@ export async function gatherDaemonStatus(
           resolveGatewayProbeAuthSafeWithSecretInputs({
             cfg: daemonCfg,
             mode: probeMode,
-            env: mergedDaemonEnv as NodeJS.ProcessEnv,
+            env: mergedDaemonEnv,
             explicitAuth,
           }),
       );
@@ -766,7 +570,7 @@ export async function gatherDaemonStatus(
     (portStatus.status !== "busy" || rpc?.ok === false)
   ) {
     lastError =
-      (await readLastGatewayErrorLine(mergedDaemonEnv as NodeJS.ProcessEnv, {
+      (await readLastGatewayErrorLine(mergedDaemonEnv, {
         requirePatternMatch: portStatus.status === "busy",
       })) ?? undefined;
   }
@@ -784,7 +588,7 @@ export async function gatherDaemonStatus(
   if (shouldInspectLocalGateway) {
     const loadInstallRecords = () =>
       loadInstalledPluginIndexInstallRecords({
-        env: mergedDaemonEnv as NodeJS.ProcessEnv,
+        env: mergedDaemonEnv,
       });
     try {
       if (opts.pluginVersionTarget === "restart") {
@@ -923,26 +727,24 @@ export async function gatherDaemonStatus(
   };
 }
 
-export function renderPortDiagnosticsForCli(status: DaemonStatus, rpcOk?: boolean): string[] {
-  if (!status.port || !shouldReportPortUsage(status.port.status, rpcOk)) {
+export function renderPortDiagnosticsForCli({ port }: DaemonStatus, rpcOk?: boolean): string[] {
+  if (!port || port.status === undefined || port.status === "free" || rpcOk === true) {
     return [];
   }
   return formatPortDiagnostics({
-    port: status.port.port,
-    status: status.port.status,
-    listeners: status.port.listeners,
-    hints: status.port.hints,
+    port: port.port,
+    status: port.status,
+    listeners: port.listeners,
+    hints: port.hints,
   });
 }
 
 export function resolvePortListeningAddresses(status: DaemonStatus): string[] {
-  const addrs = Array.from(
+  return Array.from(
     new Set(
       status.port?.listeners
         ?.map((l) => (l.address ? normalizeListenerAddress(l.address) : ""))
         .filter((v): v is string => Boolean(v)) ?? [],
     ),
   );
-  return addrs;
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Daemon status collection had grown past the file-size budget and retained several private wrappers and redundant type assertions. This deletion follow-up to the #135868 split makes its existing ownership easier to read.

## Why This Change Was Made

Gateway target projection and listening-port diagnostics now live together in `status.gateway.ts`. Config loading, service-environment selection, credentials, probing and established-client inspection retain their existing owners and order.

Deletion evidence:
- `coerceStatusConfig` delegates to the canonical non-array record coercion and has one caller; the local type annotation retains its existing declared result contract.
- `hasOwnKey` and `needsFullStatusConfigRead` have one path. Coercion plus the same own-property/include/substitution checks preserves fast/full-read selection.
- `resolveSnapshotRuntimeConfig` has one caller; its valid-snapshot condition is inlined with the same `io.loadConfig()` fallback in the same owner.
- All ten config/environment assertions are structurally redundant; their assertion-baseline entry is deleted.
- `shouldReportPortUsage` has one caller; its false cases now guard that caller directly. The immediately returned address-array local is also removed.
- Splitting the existing projection owner puts the collector under 700 counted code lines, so its max-lines suppression and baseline entry are deleted.

No compatibility reader, service policy, recovery behavior or public contract is removed. Current callers and direct implementation equivalence support these deletions. Local `git log -S` for the private fast-read/port helpers reaches the shallow boundary, so no unverified historical introduction is claimed.

## User Impact

No user-visible behavior change. Missing/invalid config diagnostics, full/deep config validation, service-specific environments, secret handling, port precedence, TLS, probe redaction and status output retain their contracts.

## Evidence

- 138 status gather/print/command/install-hint tests passed; one existing skip.
- Full `node scripts/check-changed.mjs` and `pnpm build` passed. Rebase preserved both runtime files byte-for-byte and did not change the lockfile.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production: +194 / −225 = **−31 lines**. Tooling: 0 / −2. Tests/support and docs unchanged. 421 changed lines across four files.

ClawSweeper reviewed this exact head with no actionable correctness/security findings and no rank-up changes requested.
