### PR TITLE
refactor(plugins): consolidate installed-index metadata tests

### DIFF
--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -334,19 +334,21 @@ describe("installed plugin index", () => {
       name: "tolerates stale manifest records without normalized channels",
       id: "stale-record",
       idHint: "demo",
+      installOwner: undefined,
     },
     {
       name: "does not read inherited prototype names as install records",
       id: "toString",
       idHint: "toString",
+      installOwner: "toString",
     },
-  ])("$name", ({ id, idHint }) => {
+  ])("$name", ({ id, idHint, installOwner }) => {
     const rootDir = makeTempDir();
     writeRuntimeEntry(rootDir);
     const manifestPath = path.join(rootDir, "openclaw.plugin.json");
 
     const records = buildInstalledPluginIndexRecords({
-      candidates: [createPluginCandidate({ rootDir, idHint })],
+      candidates: [createPluginCandidate({ rootDir, idHint, installOwner })],
       registry: {
         plugins: [
           {

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 // Covers installed plugin index read, write, and policy behavior.
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -54,14 +53,6 @@ function writeRuntimeEntry(rootDir: string) {
 }
 
 const requireRecord = createRequireRecord("record", "expected-label-object-capitalized");
-
-function readRecordField(record: Record<string, unknown>, key: string, label: string) {
-  const value = record[key];
-  if (!isRecord(value)) {
-    throw new Error(`Expected ${label} to be an object`);
-  }
-  return value;
-}
 
 function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
   for (const [key, value] of Object.entries(fields)) {
@@ -226,7 +217,7 @@ describe("installed plugin index", () => {
         "activation-provider-hint",
       ],
     });
-    expectRecordFields(readRecordField(plugin, "packageInstall", "package install"), {
+    expectRecordFields(requireRecord(plugin.packageInstall, "package install"), {
       defaultChoice: "npm",
       npm: {
         spec: "@vendor/demo-plugin@1.2.3",
@@ -239,7 +230,7 @@ describe("installed plugin index", () => {
       },
       warnings: [],
     });
-    expectRecordFields(readRecordField(plugin, "packageChannel", "package channel"), {
+    expectRecordFields(requireRecord(plugin.packageChannel, "package channel"), {
       id: "demo",
       label: "Demo",
       blurb: "Demo channel",
@@ -249,7 +240,7 @@ describe("installed plugin index", () => {
         nativeSkillsAutoEnabled: false,
       },
     });
-    expectRecordFields(readRecordField(plugin, "packageBuild", "package build"), {
+    expectRecordFields(requireRecord(plugin.packageBuild, "package build"), {
       bundledDist: false,
     });
     expectSha256(plugin.manifestHash);
@@ -298,41 +289,68 @@ describe("installed plugin index", () => {
     expect(index.plugins[0]?.startup.sidecar).toBe(false);
   });
 
-  it("does not classify legacy plugins as startup sidecars", () => {
+  it.each([
+    {
+      name: "does not classify legacy plugins as startup sidecars",
+      manifest: { id: "legacy-sidecar" },
+      expected: { compat: [] },
+      sidecar: false,
+    },
+    {
+      name: "keeps explicit startup opt-outs out of startup sidecars",
+      manifest: { id: "modern-inert", activation: { onStartup: false } },
+      expected: { compat: [] },
+      sidecar: false,
+    },
+    {
+      name: "classifies explicit startup activation as a gateway startup sidecar",
+      manifest: {
+        id: "explicit-startup-provider",
+        providers: ["demo"],
+        activation: { onStartup: true },
+      },
+      expected: {},
+      sidecar: true,
+    },
+  ])("$name", ({ manifest, expected, sidecar }) => {
     const rootDir = makeTempDir();
     writeRuntimeEntry(rootDir);
-    writePluginManifest(rootDir, {
-      id: "legacy-sidecar",
-      configSchema: { type: "object" },
-    });
+    writePluginManifest(rootDir, { ...manifest, configSchema: { type: "object" } });
 
     const index = loadInstalledPluginIndex({
-      candidates: [
-        createPluginCandidate({
-          rootDir,
-        }),
-      ],
+      candidates: [createPluginCandidate({ rootDir })],
       env: hermeticEnv(),
     });
 
     expectRecordFields(requireRecord(index.plugins[0], "installed plugin record"), {
-      pluginId: "legacy-sidecar",
-      compat: [],
+      pluginId: manifest.id,
+      ...expected,
     });
-    expect(index.plugins[0]?.startup.sidecar).toBe(false);
+    expect(index.plugins[0]?.startup.sidecar).toBe(sidecar);
   });
 
-  it("tolerates stale manifest records without normalized channels", () => {
+  it.each([
+    {
+      name: "tolerates stale manifest records without normalized channels",
+      id: "stale-record",
+      idHint: "demo",
+    },
+    {
+      name: "does not read inherited prototype names as install records",
+      id: "toString",
+      idHint: "toString",
+    },
+  ])("$name", ({ id, idHint }) => {
     const rootDir = makeTempDir();
     writeRuntimeEntry(rootDir);
     const manifestPath = path.join(rootDir, "openclaw.plugin.json");
 
     const records = buildInstalledPluginIndexRecords({
-      candidates: [createPluginCandidate({ rootDir })],
+      candidates: [createPluginCandidate({ rootDir, idHint })],
       registry: {
         plugins: [
           {
-            id: "stale-record",
+            id,
             providers: [],
             cliBackends: [],
             skills: [],
@@ -350,40 +368,10 @@ describe("installed plugin index", () => {
     });
 
     expectRecordFields(requireRecord(records[0], "installed plugin record"), {
-      pluginId: "stale-record",
+      pluginId: id,
       compat: [],
     });
     expect(records[0]?.startup.sidecar).toBe(false);
-  });
-
-  it("does not read inherited prototype names as install records", () => {
-    const rootDir = makeTempDir();
-    writeRuntimeEntry(rootDir);
-    const manifestPath = path.join(rootDir, "openclaw.plugin.json");
-
-    const records = buildInstalledPluginIndexRecords({
-      candidates: [createPluginCandidate({ rootDir, idHint: "toString" })],
-      registry: {
-        plugins: [
-          {
-            id: "toString",
-            providers: [],
-            cliBackends: [],
-            skills: [],
-            hooks: [],
-            origin: "global",
-            rootDir,
-            source: path.join(rootDir, "index.ts"),
-            manifestPath,
-          } as unknown as PluginManifestRecord,
-        ],
-        diagnostics: [],
-      },
-      diagnostics: [],
-      installRecords: {},
-    });
-
-    expect(records[0]?.pluginId).toBe("toString");
     expect(records[0]?.installRecordHash).toBeUndefined();
   });
 
@@ -450,60 +438,6 @@ describe("installed plugin index", () => {
     );
 
     expect(second.plugins[0]?.manifestHash).not.toBe(first.plugins[0]?.manifestHash);
-  });
-
-  it("keeps explicit startup opt-outs out of startup sidecars", () => {
-    const rootDir = makeTempDir();
-    writeRuntimeEntry(rootDir);
-    writePluginManifest(rootDir, {
-      id: "modern-inert",
-      activation: {
-        onStartup: false,
-      },
-      configSchema: { type: "object" },
-    });
-
-    const index = loadInstalledPluginIndex({
-      candidates: [
-        createPluginCandidate({
-          rootDir,
-        }),
-      ],
-      env: hermeticEnv(),
-    });
-
-    expectRecordFields(requireRecord(index.plugins[0], "installed plugin record"), {
-      pluginId: "modern-inert",
-      compat: [],
-    });
-    expect(index.plugins[0]?.startup.sidecar).toBe(false);
-  });
-
-  it("classifies explicit startup activation as a gateway startup sidecar", () => {
-    const rootDir = makeTempDir();
-    writeRuntimeEntry(rootDir);
-    writePluginManifest(rootDir, {
-      id: "explicit-startup-provider",
-      providers: ["demo"],
-      activation: {
-        onStartup: true,
-      },
-      configSchema: { type: "object" },
-    });
-
-    const index = loadInstalledPluginIndex({
-      candidates: [
-        createPluginCandidate({
-          rootDir,
-        }),
-      ],
-      env: hermeticEnv(),
-    });
-
-    expectRecordFields(requireRecord(index.plugins[0], "installed plugin record"), {
-      pluginId: "explicit-startup-provider",
-    });
-    expect(index.plugins[0]?.startup.sidecar).toBe(true);
   });
 
   it("keeps bundle format metadata needed for manifest reconstruction", () => {
@@ -687,13 +621,11 @@ describe("installed plugin index", () => {
       },
     });
     expectRecordFields(
-      readRecordField(
-        readRecordField(
-          requireRecord(index.plugins[0], "installed plugin record"),
-          "packageInstall",
+      requireRecord(
+        requireRecord(
+          requireRecord(index.plugins[0], "installed plugin record").packageInstall,
           "package install",
-        ),
-        "npm",
+        ).npm,
         "npm package install",
       ),
       {


### PR DESCRIPTION
## What Problem This Solves

The installed-plugin index suite repeats fixture construction for equivalent metadata classification cases and carries a second copy of its record-validation helper. This is maintainer-requested test-debt cleanup following the #135868 split campaign.

## Why This Change Was Made

Retain legacy startup omission, explicit opt-out, explicit startup activation, missing normalized channels, and prototype-name safety as five independent table rows. Reuse the record validator already imported by the suite; its non-array object check and error messages match the removed helper.

Production 0; tests −66; tooling 0. Total diff: 172 changed lines. The suite remains above its line budget, so its existing exception stays; this bounded cleanup does not force unrelated persistence and lifecycle cases into a generic fixture.

## User Impact

No runtime or public-contract change. Tests retain real temporary files and a throwing runtime entrypoint, so metadata indexing still proves it does not execute plugin runtime. Every original assertion remains; both stale-record rows now check compatibility, sidecar classification, and absent install-record hashes. The prototype-name row now declares its install owner: without that tag, the old fixture never reached the lookup it claimed to test.

## Evidence

- 33 installed-index and compatibility tests passed on macOS.
- Twenty untouched standalone bodies are byte-identical; two others only migrate calls to the identical canonical record validator.
- Independent Codex review: no actionable P0–P2 findings.
- Full local `node scripts/check-changed.mjs` passed with exit 0, including plugins/platform test typechecking, all three dead-export scans, and targeted core lint.
- No build needed for this test-only change.

All consolidated tests retain their original names and run independently with per-test cleanup:

| Protected case | Surviving row |
| --- | --- |
| Legacy omission does not imply startup activation | `src/plugins/installed-plugin-index.test.ts:294` |
| Explicit startup opt-out stays inert | `src/plugins/installed-plugin-index.test.ts:300` |
| Explicit startup activation produces a sidecar | `src/plugins/installed-plugin-index.test.ts:306` |
| Stale records tolerate absent normalized channels | `src/plugins/installed-plugin-index.test.ts:334` |
| Inherited prototype names are not install records | `src/plugins/installed-plugin-index.test.ts:340` |

The migration-provider fixture remains separate because it exercises distinct package metadata. Symlink boundaries, persisted install records, discovery, cache invalidation, and enablement tests remain separate. The stale rows retain their intentionally incomplete records and original candidate id hints.

The removed record-reader helper remains covered through “builds a runtime-free installed plugin snapshot from manifest and package metadata” at `src/plugins/installed-plugin-index.test.ts:190` and “records explicit install records separately from package install intent” at `src/plugins/installed-plugin-index.test.ts:589`. Their expectations are unchanged.

Mutation proof: replacing the own-property lookup with direct indexing still passes the old ownerless fixture, but fails the corrected row when inherited `toString` reaches the hasher. The production file was restored byte-for-byte before final validation; no runtime change is included.

Exact-head [CI run 34041396805](https://github.com/openclaw/openclaw/actions/runs/34041396805) is green. ClawSweeper reviewed `f31fe00210897f0f1fd32ad6841de214c9a448ea` with no findings, before-merge requests, or rank-up moves. The watcher reconciled superseded cancellations in GitHub’s raw aggregate; no failed job or workflow rerun was involved.
