### PR TITLE
perf(gateway): avoid repeated ancestry reads for merged PR heads

### DIFF
--- a/src/gateway/control-ui-session-prs-landing.test.ts
+++ b/src/gateway/control-ui-session-prs-landing.test.ts
@@ -85,35 +85,68 @@ describe("resolveBranchLanding", () => {
     });
   });
 
-  it("proves new pushed work once the merge base contains the landing", async () => {
-    await git("checkout", "-b", "feature");
-    await fs.appendFile(path.join(root, "a.txt"), "two\n");
-    await git("add", "a.txt");
-    await git("commit", "-m", "feature work");
-    const mergedHead = await sha("HEAD");
-    await git("checkout", "main");
-    await fs.appendFile(path.join(root, "a.txt"), "two\n");
-    await git("add", "a.txt");
-    await git("commit", "-m", "squash land");
-    const mergeCommit = await sha("HEAD");
-    await git("update-ref", "refs/remotes/origin/main", "HEAD");
-    await git("checkout", "feature");
-    await git("reset", "--hard", "refs/remotes/origin/main");
-    await fs.writeFile(path.join(root, "b.txt"), "second\n");
-    await git("add", "b.txt");
-    await git("commit", "-m", "second PR work");
-    await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+  it.each(["single", "duplicate", "distinct"])(
+    "checks %s landing receipts per unique head",
+    async (scenario) => {
+      const base = await sha("HEAD");
+      await git("checkout", "-b", "feature");
+      await fs.appendFile(path.join(root, "a.txt"), "two\n");
+      await git("add", "a.txt");
+      await git("commit", "-m", "feature work");
+      const mergedHead = await sha("HEAD");
+      await git("checkout", "main");
+      await fs.appendFile(path.join(root, "a.txt"), "two\n");
+      await git("add", "a.txt");
+      await git("commit", "-m", "squash land");
+      const mergeCommit = await sha("HEAD");
+      // A reset of main can land the same head without incorporating the older merge.
+      const otherMerge =
+        scenario === "distinct"
+          ? (
+              await git(
+                "commit-tree",
+                (await git("write-tree")).stdout.trim(),
+                "-p",
+                base,
+                "-m",
+                "another landing",
+              )
+            ).stdout.trim()
+          : mergeCommit;
+      await git("update-ref", "refs/remotes/origin/main", "HEAD");
+      await git("checkout", "feature");
+      await git("reset", "--hard", "refs/remotes/origin/main");
+      await fs.writeFile(path.join(root, "b.txt"), "second\n");
+      await git("add", "b.txt");
+      await git("commit", "-m", "second PR work");
+      await git("update-ref", "refs/remotes/origin/feature", "HEAD");
+      const head = await sha("HEAD");
+      const runGit = vi.spyOn(worktreeGit, "runGit");
+      const landedHead = { sha: mergedHead, baseRef: "main", mergeCommitSha: mergeCommit };
 
-    const landing = await resolveBranchLanding(root, {
-      branch: "feature",
-      defaultBranch: "main",
-      mergedHeads: [{ sha: mergedHead, baseRef: "main", mergeCommitSha: mergeCommit }],
-    });
+      const landing = await resolveBranchLanding(root, {
+        branch: "feature",
+        defaultBranch: "main",
+        mergedHeads:
+          scenario === "single"
+            ? [landedHead]
+            : [landedHead, { ...landedHead, mergeCommitSha: otherMerge }],
+      });
 
-    expect(landing.provenNewPushedWork).toBe(true);
-    // The rebase incorporated the landing, so the merge base is the baseline.
-    expect(landing.statsBase).toBe(mergeCommit);
-  });
+      expect(landing.provenNewPushedWork).toBe(scenario !== "distinct");
+      // The first squash remains the baseline even when another landing is missing.
+      expect(landing.statsBase).toBe(mergeCommit);
+      expect(
+        runGit.mock.calls.filter(
+          ([, args]) =>
+            args[0] === "merge-base" &&
+            args[1] === "--is-ancestor" &&
+            args[2] === mergedHead &&
+            args[3] === head,
+        ),
+      ).toHaveLength(1);
+    },
+  );
 
   it("selects the newest of three related baselines via the batched path", async () => {
     // Linear chain: fork point (merge base) -> merged head 1 -> merged head 2

--- a/src/gateway/control-ui-session-prs-landing.ts
+++ b/src/gateway/control-ui-session-prs-landing.ts
@@ -120,7 +120,8 @@ export async function resolveBranchLanding(
       landedHeads.push(head);
     }
   }
-  const landedShas = landedHeads.map((head) => head.sha);
+  // PRs may share a head; their distinct landing receipts still need individual checks below.
+  const landedShas = new Set(landedHeads.map((head) => head.sha));
   const mergeBase = defaultRef ? await gitOutput(root, ["merge-base", defaultRef, "HEAD"]) : null;
   // The stats base is the newest commit whose content is known-published:
   // the ordinary default-branch merge base, or a merged PR head related to
@@ -151,7 +152,7 @@ export async function resolveBranchLanding(
   // head or a fetch-stale tracking ref proves nothing, so those states keep
   // the row stats-only until a rebase or fetch.
   let provenNewPushedWork = false;
-  if (pushedSha && mergeBase && !landedShas.includes(pushedSha.toLowerCase())) {
+  if (pushedSha && mergeBase && !landedShas.has(pushedSha.toLowerCase())) {
     provenNewPushedWork = landedHeads.length > 0;
     for (const head of landedHeads) {
       const incorporated =


### PR DESCRIPTION
## What Problem This Solves

PR-status refreshes repeat the same local Git ancestry probes when multiple merged PR records share one head commit. This can happen across distinct landings of the same branch tip.

## Why This Change Was Made

Represent the head-commit projection as a set, preserving first-seen order. Keep the complete landing-record list for the separate check that every merge is incorporated; sharing a head does not make two merge receipts interchangeable.

Related: #139186 and #140098.

## User Impact

Fewer Git subprocesses for affected uncached PR-status refreshes. Branch statistics and PR creation eligibility remain unchanged, including when a newer landing is missing from the checkout. No cache, refresh policy, configuration, or public payload changes.

## Evidence

- Native synthetic Git characterization of the actual landing function with an import-only Git adapter: a duplicate-head/distinct-landing case drops from 10 calls to 8; reversed landing order drops from 9 to 7. Results are identical and the unincorporated landing still prevents PR creation. A single landing remains 6 calls.
- This characterizes Git work, not production frequency or the cause of a historical stall. It is not compiled Gateway execution.
- Independent P2 review found no actionable issues.
- Linux Node24.19.0 / Git2.52.0: original repository baseline5 passed /2 intended duplicate-ancestry failures; candidate98/98 passed across six native Git, branch, cache, and subscription suites.
- The complete two-file `check:changed` gate passed, including core/test types, lint, and selected guards.
- [Initial exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34040993978) failed in the unchanged `src/transcripts/status.producer.test.ts` duplicate-startup test. The independently reproduced startup-owner bug is addressed separately in #140220. The one failed-job rerun passed on the unchanged Git-only head (`769198514d95a6fc4d3563530483d040f25adeda`, attempt2). The original transcript defect and its separate repair remain recorded; the rerun is not claimed to fix it.
