### PR TITLE
refactor(routing): keep binding candidates and indexes together

### DIFF
--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -96,7 +96,9 @@ Routing picks **one agent** for each inbound message:
 6. **Team match** (Slack) via `teamId`.
 7. **Account match** (`accountId` on the channel).
 8. **Channel match** (any account on that channel, `accountId: "*"`).
-9. **Default agent** (`agents.entries.*.default`, else first list entry, fallback to `main`).
+9. **Fallback owner**: an owner supplied by the caller, otherwise the sole configured agent or a retained legacy owner. Multiple agents without an owner require a matching binding; routing does not pick the first roster entry.
+
+Raw legacy default markers and the `main` fallback for raw configurations without an agent roster remain supported for compatibility.
 
 When a binding includes multiple match fields (`peer`, `guildId`, `teamId`, `roles`), **all provided fields must match** for that binding to apply.
 

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -210,8 +210,7 @@ type BindingScope = {
 type EvaluatedBindingsCache = {
   bindingsRef: OpenClawConfig["bindings"];
   byChannel: Map<string, EvaluatedBindingsByChannel>;
-  byChannelAccount: Map<string, EvaluatedBinding[]>;
-  byChannelAccountIndex: Map<string, EvaluatedBindingsIndex>;
+  byChannelAccount: Map<string, EvaluatedBindingsEntry>;
 };
 
 const evaluatedBindingsCacheByCfg = new WeakMap<OpenClawConfig, EvaluatedBindingsCache>();
@@ -235,6 +234,12 @@ type EvaluatedBindingsIndex = {
   byTeam: Map<string, EvaluatedBinding[]>;
   byAccount: EvaluatedBinding[];
   byChannel: EvaluatedBinding[];
+};
+
+// Source-order candidates and their lookup index share one cache generation.
+type EvaluatedBindingsEntry = {
+  bindings: EvaluatedBinding[];
+  index: EvaluatedBindingsIndex;
 };
 
 type EvaluatedBindingsByChannel = {
@@ -413,7 +418,7 @@ function getEvaluatedBindingsForChannelAccount(
   cfg: OpenClawConfig,
   channel: string,
   accountId: string,
-): EvaluatedBinding[] {
+): EvaluatedBindingsEntry {
   const bindingsRef = cfg.bindings;
   const existing = evaluatedBindingsCacheByCfg.get(cfg);
   const cache =
@@ -422,8 +427,7 @@ function getEvaluatedBindingsForChannelAccount(
       : {
           bindingsRef,
           byChannel: buildEvaluatedBindingsByChannel(cfg),
-          byChannelAccount: new Map<string, EvaluatedBinding[]>(),
-          byChannelAccountIndex: new Map<string, EvaluatedBindingsIndex>(),
+          byChannelAccount: new Map<string, EvaluatedBindingsEntry>(),
         };
   if (cache !== existing) {
     evaluatedBindingsCacheByCfg.set(cfg, cache);
@@ -438,35 +442,16 @@ function getEvaluatedBindingsForChannelAccount(
   const channelBindings = cache.byChannel.get(channel);
   const accountScoped = channelBindings?.byAccount.get(accountId) ?? [];
   const anyAccount = channelBindings?.byAnyAccount ?? [];
-  const evaluated = mergeEvaluatedBindingsInSourceOrder(accountScoped, anyAccount);
+  const bindings = mergeEvaluatedBindingsInSourceOrder(accountScoped, anyAccount);
+  const evaluated = { bindings, index: buildEvaluatedBindingsIndex(bindings) };
 
   cache.byChannelAccount.set(cacheKey, evaluated);
-  cache.byChannelAccountIndex.set(cacheKey, buildEvaluatedBindingsIndex(evaluated));
   if (cache.byChannelAccount.size > MAX_EVALUATED_BINDINGS_CACHE_KEYS) {
     cache.byChannelAccount.clear();
-    cache.byChannelAccountIndex.clear();
     cache.byChannelAccount.set(cacheKey, evaluated);
-    cache.byChannelAccountIndex.set(cacheKey, buildEvaluatedBindingsIndex(evaluated));
   }
 
   return evaluated;
-}
-
-function getEvaluatedBindingIndexForChannelAccount(
-  cfg: OpenClawConfig,
-  channel: string,
-  accountId: string,
-): EvaluatedBindingsIndex {
-  const bindings = getEvaluatedBindingsForChannelAccount(cfg, channel, accountId);
-  const existing = evaluatedBindingsCacheByCfg.get(cfg);
-  const cacheKey = `${channel}\t${accountId}`;
-  const indexed = existing?.byChannelAccountIndex.get(cacheKey);
-  if (indexed) {
-    return indexed;
-  }
-  const built = buildEvaluatedBindingsIndex(bindings);
-  existing?.byChannelAccountIndex.set(cacheKey, built);
-  return built;
 }
 
 /** @internal Lists matchable candidates from the canonical channel/account binding index. */
@@ -477,7 +462,7 @@ export function listChannelAccountRouteBindings(
     input.cfg,
     normalizeLowercaseStringOrEmpty(input.channel),
     normalizeAccountId(input.accountId),
-  ).map(({ binding }) => binding);
+  ).bindings.map(({ binding }) => binding);
 }
 
 /** @internal Lists exact DM peers from the canonical channel/account binding index. */
@@ -486,11 +471,11 @@ export function listExactDirectMessageBindingPeerIds(
 ): string[] {
   const prefix = "direct:";
   return [
-    ...getEvaluatedBindingIndexForChannelAccount(
+    ...getEvaluatedBindingsForChannelAccount(
       input.cfg,
       normalizeLowercaseStringOrEmpty(input.channel),
       normalizeAccountId(input.accountId),
-    ).byPeer.keys(),
+    ).index.byPeer.keys(),
   ].flatMap((key) => (key.startsWith(prefix) ? [key.slice(prefix.length)] : []));
 }
 
@@ -652,8 +637,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
   }
 
-  const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
-  const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
+  const { bindings, index: bindingsIndex } = getEvaluatedBindingsForChannelAccount(
+    input.cfg,
+    channel,
+    accountId,
+  );
 
   const choose = (
     agentId: string,


### PR DESCRIPTION
## What Problem This Solves

Routing needs a consistent view of configured bindings when a cache fills or the binding configuration is replaced. The routing guide also incorrectly said an unmatched message would fall back to the first configured agent.

## Why This Change Was Made

Keep ordered binding candidates and their derived index in one private cache entry. This removes the second cache lifecycle, redundant lookup, and missing-index rebuild while preserving the existing rollover and invalidation rules. The guide now describes the supplied, sole, or retained legacy owner and the need for a binding when no owner is available.

## User Impact

Route selection and public APIs are unchanged. Operators get accurate guidance for unmatched routes. Production code is reduced by 12 lines; existing tests are unchanged.

## Evidence

The same 193 focused cases passed before and after. A synthetic check through the public routing/list helpers also produced identical results for cold and warm lookups, 2,001 account keys crossing the cache limit, and replacement of the binding array. This establishes behavior preservation; it is not a performance measurement.

All 28 canonical changed checks and the independent P2 review passed. Docs validation passed. No channel service or live account was needed for this internal cache refactor.
