### PR TITLE
fix(codex): use selected model after resuming managed sessions

### DIFF
--- a/extensions/codex/src/app-server/run-attempt-test-harness.ts
+++ b/extensions/codex/src/app-server/run-attempt-test-harness.ts
@@ -654,7 +654,11 @@ export function createResumeHarness(threadId = "thread-existing") {
       if (method === "thread/resume") {
         // Resume must echo the requested thread; a different id is rejected as
         // an unsafe subscription.
-        return threadStartResult((params as { threadId?: string })?.threadId ?? "thread-existing");
+        const resumeParams = params as { threadId?: string; modelProvider?: string };
+        return {
+          ...threadStartResult(resumeParams.threadId ?? "thread-existing"),
+          ...(resumeParams.modelProvider ? { modelProvider: resumeParams.modelProvider } : {}),
+        };
       }
       if (method === "turn/start") {
         return turnStartResult();

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -8199,6 +8199,43 @@ describe("runCodexAppServerAttempt", () => {
     },
   );
 
+  it("rejects a resumed provider mismatch before inference and preserves the binding", async () => {
+    const { sessionFile, workspaceDir } = createRunPaths();
+    await writeExistingBinding(sessionFile, workspaceDir, {
+      model: "gpt-5.4",
+      modelProvider: "openai",
+    });
+    const harness = createStartedThreadHarness(
+      async (method) => {
+        if (method === "thread/resume") {
+          return {
+            ...threadStartResult("thread-existing", { cwd: workspaceDir }),
+            model: "gpt-5.4",
+            modelProvider: "local-provider",
+          };
+        }
+        if (method === "turn/start") {
+          return { turn: { id: "turn-1", status: "completed", items: [] } };
+        }
+        return undefined;
+      },
+      { persistedThreads: ["thread-existing"] },
+    );
+    const params = createParams(sessionFile, workspaceDir);
+    params.provider = "openai";
+    params.modelId = "gpt-5.5";
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "Codex resumed a different model provider",
+    );
+    expect(harness.requests.some(({ method }) => method === "thread/resume")).toBe(true);
+    expect(harness.requests.some(({ method }) => method === "turn/start")).toBe(false);
+    expect(await readCodexAppServerBinding(sessionFile)).toMatchObject({
+      threadId: "thread-existing",
+      model: "gpt-5.4",
+      modelProvider: "openai",
+    });
+  });
+
   it("does not inherit a bound local provider for explicit native OpenAI resumed runs", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();
     await writeExistingBinding(sessionFile, workspaceDir, {
@@ -8238,6 +8275,13 @@ describe("runCodexAppServerAttempt", () => {
     expect(resumeRequestParams?.model).toBe("gpt-5.5");
     expect(resumeRequestParams).not.toHaveProperty("modelProvider");
     expect(resumeRequestParams?.approvalsReviewer).toBe("auto_review");
+    expect(requests.find((request) => request.method === "turn/start")).toMatchObject({
+      params: {
+        model: "gpt-5.5",
+        collaborationMode: { settings: { model: "gpt-5.5" } },
+      },
+    });
+    expect(await readCodexAppServerBinding(sessionFile)).toMatchObject({ model: "gpt-5.5" });
   });
   it("does not apply bound local model providers to provider-qualified resumed models", async () => {
     const { sessionFile, workspaceDir } = createRunPaths();

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -180,6 +180,11 @@ export async function resumeExistingCodexThread(
     acceptedConfiguration = configuration;
     assertCodexThreadAcceptsDirectInput(response.thread);
     configuration.assertConfigured();
+    if (requestModelProvider && response.modelProvider !== requestModelProvider) {
+      throw new Error(
+        "Codex resumed a different model provider than the one selected for this turn",
+      );
+    }
     // Current-policy denial must release this subscription and stop, not retry
     // as a fresh thread. A confirmed config change still follows normal rotation.
     const loadedPluginThreadConfig = await context.buildLoadedPluginThreadConfig?.(resumeBinding);
@@ -224,7 +229,8 @@ export async function resumeExistingCodexThread(
       cwd: params.cwd,
       rolloutPath: resolveCodexThreadRolloutPath(response.thread) ?? resumeBinding.rolloutPath,
       authProfileId,
-      model: response.model ?? resumeParams.model ?? params.params.modelId,
+      // Loaded native threads can ignore resume overrides; keep the prepared model for turn/start.
+      model: resumeParams.model ?? response.model ?? params.params.modelId,
       preserveNativeModel: resumeBinding.preserveNativeModel === true ? true : undefined,
       modelProvider: normalizeBindingModelProvider(
         authProfileId,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -2560,7 +2560,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
         return { requirements: null };
       }
       if (method === "thread/start" || method === "thread/resume") {
-        return threadStartResult("thread-warm-provider");
+        return {
+          ...threadStartResult("thread-warm-provider"),
+          ...(method === "thread/resume" ? { modelProvider: "custom-provider" } : {}),
+        };
       }
       throw new Error(`unexpected method: ${method}`);
     });


### PR DESCRIPTION
## What Problem This Solves

A loaded native thread could reply with its old model after the user selected a new model, despite the saved session showing the requested choice.

## Why This Change Was Made

The resumed-binding owner carries the prepared model into both turn-start fields. Native-owned sessions still omit that override. Explicit provider mismatch is rejected before binding mutation or inference because a native turn cannot switch providers.

## User Impact

Later turns use the selected model. Native-owned selection and locks remain intact, and conflicting-provider recovery preserves the conversation.

## Evidence

A real Gateway, installed native runtime, and controlled endpoint reproduced select B → infer A before the fix. The candidate sent and saved B, retaining it after restart and another message. Native ownership, active-turn ordering, provider mismatch, interrupted resume, and reconnect controls passed. All 25 focused tests, hosted type checks, and build passed. Independent runtime checks also covered defaults, named auth, reasoning, and tool effects.

Closes #140050. Reported by @josephbergvinson.
