### PR TITLE
refactor(memory-wiki): remove unused CLI output plumbing

### DIFF
--- a/extensions/memory-wiki/src/cli.ts
+++ b/extensions/memory-wiki/src/cli.ts
@@ -66,64 +66,34 @@ const ANSI_ESCAPE_SEQUENCE_PATTERN = new RegExp(
 const TERMINAL_CONTROL_CHARACTER_PATTERN = new RegExp(String.raw`[\x00-\x1F\x7F-\x9F]+`, "g");
 const UNICODE_FORMAT_CONTROL_PATTERN = /[\u061C\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g;
 
-type WikiStatusCommandOptions = {
+type WikiJsonOptions = {
   json?: boolean;
 };
 
-type WikiDoctorCommandOptions = {
-  json?: boolean;
-};
-
-type WikiInitCommandOptions = {
-  json?: boolean;
-};
-
-type WikiCompileCommandOptions = {
-  json?: boolean;
-};
-
-type WikiLintCommandOptions = {
-  json?: boolean;
-};
-
-type WikiIngestCommandOptions = {
-  json?: boolean;
+type WikiIngestCommandOptions = WikiJsonOptions & {
   title?: string;
 };
 
-type WikiOkfImportCommandOptions = {
-  json?: boolean;
-};
-
-type WikiSearchCommandOptions = {
-  json?: boolean;
+type WikiSearchCommandOptions = WikiJsonOptions & {
   maxResults?: number;
   backend?: ResolvedMemoryWikiConfig["search"]["backend"];
   corpus?: ResolvedMemoryWikiConfig["search"]["corpus"];
   mode?: WikiSearchMode;
 };
 
-type WikiGetCommandOptions = {
-  json?: boolean;
+type WikiGetCommandOptions = WikiJsonOptions & {
   from?: number;
   lines?: number;
   backend?: ResolvedMemoryWikiConfig["search"]["backend"];
   corpus?: ResolvedMemoryWikiConfig["search"]["corpus"];
 };
 
-type WikiApplySynthesisCommandOptions = {
-  json?: boolean;
+type WikiApplySynthesisCommandOptions = Omit<WikiApplyMetadataCommandOptions, "clearConfidence"> & {
   body?: string;
   bodyFile?: string;
-  sourceId?: string[];
-  contradiction?: string[];
-  question?: string[];
-  confidence?: number;
-  status?: string;
 };
 
-type WikiApplyMetadataCommandOptions = {
-  json?: boolean;
+type WikiApplyMetadataCommandOptions = WikiJsonOptions & {
   sourceId?: string[];
   contradiction?: string[];
   question?: string[];
@@ -132,38 +102,9 @@ type WikiApplyMetadataCommandOptions = {
   status?: string;
 };
 
-type WikiBridgeImportCommandOptions = {
-  json?: boolean;
-};
-
-type WikiUnsafeLocalImportCommandOptions = {
-  json?: boolean;
-};
-
-type WikiChatGptImportCommandOptions = {
-  json?: boolean;
+type WikiChatGptImportCommandOptions = WikiJsonOptions & {
   dryRun?: boolean;
   export?: string;
-};
-
-type WikiChatGptRollbackCommandOptions = {
-  json?: boolean;
-};
-
-type WikiObsidianSearchCommandOptions = {
-  json?: boolean;
-};
-
-type WikiObsidianOpenCommandOptions = {
-  json?: boolean;
-};
-
-type WikiObsidianCommandCommandOptions = {
-  json?: boolean;
-};
-
-type WikiObsidianDailyCommandOptions = {
-  json?: boolean;
 };
 
 type WikiCommandOptions = {
@@ -197,8 +138,8 @@ function escapeGatewayJsonForTerminal(json: string): string {
   });
 }
 
-function writeOutput(output: string, writer: Pick<NodeJS.WriteStream, "write"> = process.stdout) {
-  writer.write(output.endsWith("\n") ? output : `${output}\n`);
+function writeOutput(output: string) {
+  process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
 
 function shouldRouteBridgeRuntimeThroughGateway(config: ResolvedMemoryWikiConfig): boolean {
@@ -406,12 +347,11 @@ function formatGatewayJsonOrText<T>(
 
 async function runWikiCommandWithSummary<T>(params: {
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
   run: () => Promise<T>;
   render: (result: T) => string;
 }): Promise<T> {
   const result = await params.run();
-  writeOutput(formatJsonOrText(result, params.json, params.render), params.stdout);
+  writeOutput(formatJsonOrText(result, params.json, params.render));
   return result;
 }
 
@@ -419,7 +359,6 @@ async function runSyncedWikiCommandWithSummary<T>(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
   run: () => Promise<T>;
   render: (result: T) => string;
 }): Promise<T> {
@@ -481,7 +420,6 @@ async function runWikiStatus(params: {
   appConfig?: OpenClawConfig;
   agentId?: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const routeThroughGateway = shouldRouteBridgeRuntimeThroughGateway(params.config);
   const status = routeThroughGateway
@@ -496,7 +434,6 @@ async function runWikiStatus(params: {
     routeThroughGateway
       ? formatGatewayJsonOrText(status, params.json, renderMemoryWikiStatus)
       : formatJsonOrText(status, params.json, renderMemoryWikiStatus),
-    params.stdout,
   );
   return status;
 }
@@ -506,7 +443,6 @@ async function runWikiDoctor(params: {
   appConfig?: OpenClawConfig;
   agentId?: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const routeThroughGateway = shouldRouteBridgeRuntimeThroughGateway(params.config);
   const report = routeThroughGateway
@@ -526,19 +462,13 @@ async function runWikiDoctor(params: {
     routeThroughGateway
       ? formatGatewayJsonOrText(report, params.json, renderMemoryWikiDoctor)
       : formatJsonOrText(report, params.json, renderMemoryWikiDoctor),
-    params.stdout,
   );
   return report;
 }
 
-async function runWikiInit(params: {
-  config: ResolvedMemoryWikiConfig;
-  json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
-}) {
+async function runWikiInit(params: { config: ResolvedMemoryWikiConfig; json?: boolean }) {
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () => initializeMemoryWikiVault(params.config),
     render: (value) =>
       `Initialized wiki vault at ${value.rootDir} (${value.createdDirectories.length} dirs, ${value.createdFiles.length} files).`,
@@ -549,13 +479,11 @@ async function runWikiCompile(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   return runSyncedWikiCommandWithSummary({
     config: params.config,
     appConfig: params.appConfig,
     json: params.json,
-    stdout: params.stdout,
     run: () => compileMemoryWikiVault(params.config),
     render: (value) =>
       `Compiled wiki vault at ${value.vaultRoot} (${value.pages.length} pages, ${value.updatedFiles.length} indexes updated).`,
@@ -566,13 +494,11 @@ async function runWikiLint(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   return runSyncedWikiCommandWithSummary({
     config: params.config,
     appConfig: params.appConfig,
     json: params.json,
-    stdout: params.stdout,
     run: () => lintMemoryWikiVault(params.config),
     render: (value) =>
       `Linted wiki vault at ${value.vaultRoot} (${value.issueCount} issues, report: ${value.reportPath}).`,
@@ -584,11 +510,9 @@ async function runWikiIngest(params: {
   inputPath: string;
   title?: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () =>
       ingestMemoryWikiSource({
         config: params.config,
@@ -604,11 +528,9 @@ async function runWikiOkfImport(params: {
   config: ResolvedMemoryWikiConfig;
   bundlePath: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () =>
       importMemoryWikiOkfBundle({
         config: params.config,
@@ -628,7 +550,6 @@ async function runWikiSearch(params: {
   searchCorpus?: ResolvedMemoryWikiConfig["search"]["corpus"];
   mode?: WikiSearchMode;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   if (params.mode && !(WIKI_SEARCH_MODES as readonly string[]).includes(params.mode)) {
     throw new Error(`wiki search --mode must be one of: ${WIKI_SEARCH_MODES.join(", ")}.`);
@@ -644,7 +565,7 @@ async function runWikiSearch(params: {
     searchCorpus: params.searchCorpus,
     mode: params.mode,
   });
-  writeOutput(formatJsonOrText(results, params.json, renderWikiSearchResults), params.stdout);
+  writeOutput(formatJsonOrText(results, params.json, renderWikiSearchResults));
   return results;
 }
 
@@ -658,7 +579,6 @@ async function runWikiGet(params: {
   searchBackend?: ResolvedMemoryWikiConfig["search"]["backend"];
   searchCorpus?: ResolvedMemoryWikiConfig["search"]["corpus"];
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
   const result = await getMemoryWikiPage({
@@ -674,7 +594,7 @@ async function runWikiGet(params: {
   const summary = params.json
     ? JSON.stringify(result, null, 2)
     : (result?.content ?? `Wiki page not found: ${params.lookup}`);
-  writeOutput(summary, params.stdout);
+  writeOutput(summary);
   return result;
 }
 
@@ -690,7 +610,6 @@ async function runWikiApplySynthesis(params: {
   confidence?: number;
   status?: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const sourceIds = normalizeCliStringList(params.sourceIds);
   if (!sourceIds) {
@@ -715,7 +634,7 @@ async function runWikiApplySynthesis(params: {
       ...(params.status?.trim() ? { status: params.status.trim() } : {}),
     },
   });
-  writeOutput(formatJsonOrText(result, params.json, renderWikiMutationSummary), params.stdout);
+  writeOutput(formatJsonOrText(result, params.json, renderWikiMutationSummary));
   return result;
 }
 
@@ -730,7 +649,6 @@ async function runWikiApplyMetadata(params: {
   clearConfidence?: boolean;
   status?: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   await syncMemoryWikiImportedSources({ config: params.config, appConfig: params.appConfig });
   const result = await applyMemoryWikiMutation({
@@ -755,7 +673,7 @@ async function runWikiApplyMetadata(params: {
       ...(params.status?.trim() ? { status: params.status.trim() } : {}),
     },
   });
-  writeOutput(formatJsonOrText(result, params.json, renderWikiMutationSummary), params.stdout);
+  writeOutput(formatJsonOrText(result, params.json, renderWikiMutationSummary));
   return result;
 }
 
@@ -764,18 +682,16 @@ async function runWikiBridgeImport(params: {
   appConfig?: OpenClawConfig;
   agentId?: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   const render = (value: MemoryWikiImportedSourceSyncResult) =>
     `Bridge import synced ${value.artifactCount} artifacts across ${value.workspaces} workspaces (${value.importedCount} new, ${value.updatedCount} updated, ${value.skippedCount} unchanged, ${value.removedCount} removed). Indexes ${value.indexesRefreshed ? `refreshed (${value.indexUpdatedFiles.length} files)` : `not refreshed (${value.indexRefreshReason})`}.`;
   if (shouldRouteBridgeRuntimeThroughGateway(params.config)) {
     const result = await callWikiGateway("wiki.bridge.import", params.agentId);
-    writeOutput(formatGatewayJsonOrText(result, params.json, render), params.stdout);
+    writeOutput(formatGatewayJsonOrText(result, params.json, render));
     return result;
   }
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () =>
       syncMemoryWikiImportedSources({
         config: params.config,
@@ -789,14 +705,12 @@ async function runWikiUnsafeLocalImport(params: {
   config: ResolvedMemoryWikiConfig;
   appConfig?: OpenClawConfig;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   if (params.config.vault.scope === "agent") {
     throw new Error("Unsafe-local import does not support memory-wiki vault.scope=agent.");
   }
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () =>
       syncMemoryWikiImportedSources({
         config: params.config,
@@ -807,14 +721,9 @@ async function runWikiUnsafeLocalImport(params: {
   });
 }
 
-async function runWikiObsidianStatus(params: {
-  config: ResolvedMemoryWikiConfig;
-  json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
-}) {
+async function runWikiObsidianStatus(params: { config: ResolvedMemoryWikiConfig; json?: boolean }) {
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () => probeObsidianCli(),
     render: (value) =>
       value.available
@@ -833,12 +742,10 @@ async function runWikiObsidianSearch(params: {
   config: ResolvedMemoryWikiConfig;
   query: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () => runObsidianSearch({ config: params.config, query: params.query }),
     render: (value) => value.stdout.trim(),
   });
@@ -848,12 +755,10 @@ async function runWikiObsidianOpenCli(params: {
   config: ResolvedMemoryWikiConfig;
   vaultPath: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () => runObsidianOpen({ config: params.config, vaultPath: params.vaultPath }),
     render: (value) => value.stdout.trim() || "Opened in Obsidian.",
   });
@@ -863,12 +768,10 @@ async function runWikiObsidianCommandCli(params: {
   config: ResolvedMemoryWikiConfig;
   id: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () => runObsidianCommand({ config: params.config, id: params.id }),
     render: (value) => value.stdout.trim() || "Command sent to Obsidian.",
   });
@@ -877,12 +780,10 @@ async function runWikiObsidianCommandCli(params: {
 async function runWikiObsidianDailyCli(params: {
   config: ResolvedMemoryWikiConfig;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   assertOfficialObsidianCliSupported(params.config);
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () => runObsidianDaily({ config: params.config }),
     render: (value) => value.stdout.trim() || "Opened today's daily note.",
   });
@@ -912,11 +813,9 @@ async function runWikiChatGptImport(params: {
   exportPath: string;
   dryRun?: boolean;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () =>
       importChatGptConversations({
         config: params.config,
@@ -931,11 +830,9 @@ async function runWikiChatGptRollback(params: {
   config: ResolvedMemoryWikiConfig;
   runId: string;
   json?: boolean;
-  stdout?: Pick<NodeJS.WriteStream, "write">;
 }) {
   return runWikiCommandWithSummary({
     json: params.json,
-    stdout: params.stdout,
     run: () =>
       rollbackChatGptImportRun({
         config: params.config,
@@ -1002,7 +899,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Show wiki vault status")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiStatusCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { agentId, appConfig, config } = requireCommandContext();
       await runWikiStatus({ config, appConfig, agentId, json: opts.json });
     });
@@ -1012,7 +909,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Audit wiki vault setup and report actionable fixes")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiDoctorCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { agentId, appConfig, config } = requireCommandContext();
       await runWikiDoctor({ config, appConfig, agentId, json: opts.json });
     });
@@ -1022,7 +919,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Initialize the wiki vault layout")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiInitCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiInit({ config, json: opts.json });
     });
@@ -1032,7 +929,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Refresh generated wiki indexes")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiCompileCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { appConfig, config } = requireCommandContext();
       await runWikiCompile({ config, appConfig, json: opts.json });
     });
@@ -1042,7 +939,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Lint the wiki vault and write a report")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiLintCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { appConfig, config } = requireCommandContext();
       await runWikiLint({ config, appConfig, json: opts.json });
     });
@@ -1066,7 +963,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .argument("<path>", "OKF bundle directory")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (bundlePath: string, opts: WikiOkfImportCommandOptions) => {
+    .action(async (bundlePath: string, opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiOkfImport({ config, bundlePath, json: opts.json });
     });
@@ -1187,7 +1084,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Sync bridge-backed memory artifacts into wiki source pages")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiBridgeImportCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { agentId, appConfig, config } = requireCommandContext();
       await runWikiBridgeImport({ config, appConfig, agentId, json: opts.json });
     });
@@ -1199,7 +1096,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .command("import")
     .description("Sync unsafe-local configured paths into wiki source pages")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiUnsafeLocalImportCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { appConfig, config } = requireCommandContext();
       await runWikiUnsafeLocalImport({ config, appConfig, json: opts.json });
     });
@@ -1229,7 +1126,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .argument("<run-id>", "Import run id")
     .option("--agent <id>", "Agent id (default: configured default agent)")
     .option("--json", "Print JSON")
-    .action(async (runId: string, opts: WikiChatGptRollbackCommandOptions) => {
+    .action(async (runId: string, opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiChatGptRollback({
         config,
@@ -1243,7 +1140,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .command("status")
     .description("Probe the Obsidian CLI")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiStatusCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiObsidianStatus({ config, json: opts.json });
     });
@@ -1252,7 +1149,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Search the current Obsidian vault")
     .argument("<query>", "Search query")
     .option("--json", "Print JSON")
-    .action(async (query: string, opts: WikiObsidianSearchCommandOptions) => {
+    .action(async (query: string, opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiObsidianSearch({ config, query, json: opts.json });
     });
@@ -1261,7 +1158,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Open a file in Obsidian by vault-relative path")
     .argument("<path>", "Vault-relative path")
     .option("--json", "Print JSON")
-    .action(async (vaultPath: string, opts: WikiObsidianOpenCommandOptions) => {
+    .action(async (vaultPath: string, opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiObsidianOpenCli({ config, vaultPath, json: opts.json });
     });
@@ -1270,7 +1167,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .description("Execute an Obsidian command palette command by id")
     .argument("<id>", "Obsidian command id")
     .option("--json", "Print JSON")
-    .action(async (id: string, opts: WikiObsidianCommandCommandOptions) => {
+    .action(async (id: string, opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiObsidianCommandCli({ config, id, json: opts.json });
     });
@@ -1278,7 +1175,7 @@ export function registerWikiCli(program: Command, registration: MemoryWikiCliReg
     .command("daily")
     .description("Open today's daily note in Obsidian")
     .option("--json", "Print JSON")
-    .action(async (opts: WikiObsidianDailyCommandOptions) => {
+    .action(async (opts: WikiJsonOptions) => {
       const { config } = requireCommandContext();
       await runWikiObsidianDailyCli({ config, json: opts.json });
     });


### PR DESCRIPTION
Related: #135868

## What Problem This Solves

The Memory Wiki CLI repeats identical private command-option shapes and carries output-stream injection through twenty handlers even though no caller supplies a stream. This maintainer-requested cleanup reduces the code to maintain while the #135868 recovery stack lands.

## Why This Change Was Made

Share the private JSON option shape, derive synthesis options from the existing metadata shape while excluding metadata-only `clearConfidence`, and write through the command owner's existing `process.stdout`. Every registered action retains its explicit argument projection. The four live Obsidian command-output reads remain intact.

This is the independent clean-broad companion to the split campaign (decision brief §1 concern map and §5 stack order), not a numbered feature stage; no #135868 feature content is extracted.

## User Impact

No user-visible behavior change. All commands, flags, agent selection, errors, output bytes, terminal sanitization, and import/rollback behavior remain the same.

## Evidence

- All twenty receivers are private and each has one caller in `registerWikiCli`; every caller supplies an explicit object with no `stdout` member or spread. The sole exported CLI function is registration; the plugin's public API barrel exposes neither these receivers nor their option types.
- The option block matches stable `v2026.9.2`. `git log -S` for the private stdout member and option types points to `e357203be57`; the proposed deletion retires no shipped command or public injection contract.
- The three existing CLI suites pass before and after: 69 tests covering registered Commander actions/output, agent selection, numeric validation, Gateway text/JSON sanitization, metadata body preservation, and ChatGPT import/rollback.
- Strict type equivalence: 100 shape/key/optionality/assignability assertions pass in each optional-property mode, with deliberate invalid changes detected. The complete emitted registration function is byte-identical.
- 109 differential cases /218 real Commander dispatches preserve all twenty commands in text/JSON modes, newline bytes, Obsidian output and exact writer-error propagation. Imported operations/renderers are synthetic; these probes supplement the existing integration suites. Negative newline/Obsidian mutations are detected.
- Independent Codex review: no actionable findings through P2. Full selected changed checks passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34040955110), including production/test typing, lint, all three dead-export scans, storage guards and zero runtime import cycles. The verified source tree equals the original committed candidate; command exit 0, lease independently confirmed stopped. Local lint had rejected a declaration input resolved from the ancestor install; isolated proof preserves that guard. An optional runner-portal metadata sync timed out after successful checks/cleanup. All 101 recorded proof inputs and the lockfile are unchanged after the main refresh. Initial exact-head [CI34041451389](https://github.com/openclaw/openclaw/actions/runs/34041451389) passed. Final freshness head `2909ea4249c56c22ecf8e07f0dff44ff95c1fa95` preserves all101proof inputs and lock; [final CI34041935507](https://github.com/openclaw/openclaw/actions/runs/34041935507) passed, with no failed jobs. Fresh final-head Codex review is clean throughP2. A full build is not required: this changes private declarations/output plumbing only, with identical command registration and no import, lazy-loading, package, build, or public SDK surface change.

| Judged class | Added | Deleted | Net | Before → after |
| --- | ---: | ---: | ---: | --- |
| Production | 31 | 134 | −103 | `cli.ts`: 1286 → 1183 |
| Tests | 0 | 0 | 0 | unchanged |
| Tooling | 0 | 0 | 0 | unchanged |
| Docs | 0 | 0 | 0 | unchanged |

The max-lines exemption remains because this file is still over the limit. No baseline, dependency, config, schema, or protocol changes.


ClawSweeper disposition (reviewed `80ab5122e71` at 2026-09-06T15:16:15Z): no code or security findings. Its data-model compatibility request is inapplicable: this diff changes private option declarations and removes unreachable output-stream forwarding. Stored records, vector/embedding metadata, schemas, migrations, mutation argument projections, and import/rollback operations are unchanged. Existing registered-command integration tests cover those retained operations. No migration or upgrade behavior is being retired.

The review could not retrieve the stable source; local Git independently verified the [v2026.9.2 option block](https://github.com/openclaw/openclaw/blob/v2026.9.2/extensions/memory-wiki/src/cli.ts#L69) is byte-identical to the pre-change block. The stable [public API barrel](https://github.com/openclaw/openclaw/blob/v2026.9.2/extensions/memory-wiki/api.ts) exposes none of the removed private option names or handler parameters. The Testbox result is recorded above as delegated command exit 0 with independently verified lease completion, rather than relying on the backing workflow's cleanup status.
