### PR TITLE
fix(code-mode): report accurate error locations

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1321,6 +1321,15 @@ tool inputs beyond existing OpenClaw trajectory policy.
 
 ## Debugging
 
+JavaScript failure frames labeled `openclaw-code-mode:user.js` use line numbers
+from the submitted code, excluding internal wrappers and headless setup. For
+TypeScript, compiler diagnostics labeled `openclaw-code-mode:user.ts` refer to
+the submitted TypeScript; runtime frames labeled `openclaw-code-mode:generated.js`
+refer to the transformed JavaScript. Internal wrapper and controller frames are
+omitted from new cells' failures; error messages still share the existing output
+budget. Resumed older snapshots without location metadata retain their previous
+stack format.
+
 Use targeted model transport logging when code mode behaves differently from
 a normal tool run:
 

--- a/src/agents/code-mode-source.ts
+++ b/src/agents/code-mode-source.ts
@@ -251,7 +251,14 @@ export async function prepareSource(input: {
   const diagnostics = transformed.diagnostics ?? [];
   if (diagnostics.some((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)) {
     const message = diagnostics
-      .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"))
+      .map((diagnostic) => {
+        const diagnosticMessage = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+        if (!diagnostic.file || diagnostic.start === undefined) {
+          return diagnosticMessage;
+        }
+        const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+        return `openclaw-code-mode:user.ts:${position.line + 1}:${position.character + 1}: ${diagnosticMessage}`;
+      })
       .join("\n");
     throw new ToolInputError(`typescript transform failed: ${message}`);
   }

--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -1,13 +1,15 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { EvalFlags, QuickJS, type Snapshot } from "quickjs-wasi";
 import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { observeWorkerActivity } from "../../test/helpers/worker-activity.js";
 import * as workerUrls from "../infra/runtime-worker-url.js";
 import { createCodeModeCatalogProjection } from "./code-mode-catalog.js";
+import { CODE_MODE_CONTROLLER_SOURCE } from "./code-mode-controller-source.js";
 import { CodeModeOutputState, EMPTY_CODE_MODE_OUTPUT } from "./code-mode-json.js";
 import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import { resolveCodeModeConfig, toToolSearchConfig } from "./code-mode-runtime.js";
@@ -80,6 +82,102 @@ afterEach(() => {
 });
 
 describe("Code Mode worker lifecycle", () => {
+  it("preserves legacy snapshot errors without source-location metadata", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const wasm = await WebAssembly.compile(
+      await readFile(createRequire(import.meta.url).resolve("quickjs-wasi/quickjs.wasm")),
+    );
+    const vm = await QuickJS.create({ wasm, memoryLimit: config.memoryLimitBytes });
+    let snapshot: Snapshot;
+    try {
+      vm.newFunction("__openclawHostRequest", (_method, _args, id) =>
+        vm.newString(id.toString()),
+      ).consume((handle) => vm.global.setProp("__openclawHostRequest", handle));
+      vm.newFunction("__openclawHostCancelRequest", () => vm.undefined).consume((handle) =>
+        vm.global.setProp("__openclawHostCancelRequest", handle),
+      );
+      for (const [name, value] of Object.entries({
+        __openclawCatalog: [],
+        __openclawNamespaces: [],
+        __openclawApiFiles: [],
+        __openclawSwarmEnabled: false,
+        __openclawMaxPendingToolCalls: config.maxPendingToolCalls,
+      })) {
+        vm.hostToHandle(value).consume((handle) => vm.global.setProp(name, handle));
+      }
+      vm.evalCode(CODE_MODE_CONTROLLER_SOURCE, "openclaw-code-mode:controller.js").dispose();
+      // The previous worker wrapped the same program without recording its source coordinates.
+      vm.evalCode(
+        'globalThis.__openclawResult = (async () => {\nawait yield_control();\nthrow new Error("legacy failure");\n})()',
+        "openclaw-code-mode:user.js",
+        EvalFlags.ASYNC,
+      ).dispose();
+      vm.executePendingJobs();
+      snapshot = vm.snapshot();
+    } finally {
+      vm.dispose();
+    }
+    const result = await runCodeModeWorker(
+      {
+        kind: "resume",
+        snapshot,
+        config,
+        settledRequests: [{ id: "bridge:yield:1", ok: true, value: null }],
+      },
+      10000,
+    );
+    expect(result).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("Error: legacy failure"),
+    });
+    if (result.status !== "failed") {
+      throw new Error("Expected legacy guest failure");
+    }
+    expect(result.error).toMatch(/openclaw-code-mode:user\.js:3:\d+/);
+  });
+
+  it.each(["const helper = 1;", "const helper = 'é🦞';"])(
+    "accounts for a same-line prelude in syntax locations: %s",
+    async (prelude) => {
+      const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+      const result = await runCodeModeWorker(
+        {
+          kind: "exec",
+          source: "const value = ;",
+          prelude,
+          config,
+          catalog: [],
+          namespaces: [],
+        },
+        10000,
+      );
+      expect(result).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("SyntaxError"),
+      });
+      if (result.status !== "failed") {
+        throw new Error("Expected guest syntax failure");
+      }
+      expect(result.error).toContain("openclaw-code-mode:user.js:1:15");
+    },
+  );
+
+  it("does not attribute a prelude failure to submitted source", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const result = await runCodeModeWorker(
+      {
+        kind: "exec",
+        source: "return true;",
+        prelude: 'throw new Error("prelude failure");\n',
+        config,
+        catalog: [],
+        namespaces: [],
+      },
+      10000,
+    );
+    expect(result).toMatchObject({ status: "failed", error: "Error: prelude failure" });
+  });
+
   it("transfers snapshot heaps across resumes without storage codec copies", async () => {
     const tempDirs = useAutoCleanupTempDirTracker(onTestFinished);
     const dir = tempDirs.make("code-mode-snapshot-transfer-");

--- a/src/agents/code-mode.guest.test.ts
+++ b/src/agents/code-mode.guest.test.ts
@@ -680,7 +680,7 @@ describe("Code Mode guest execution", () => {
     const details = resultDetails(
       await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
         "code-call-syntax",
-        { code: "const x = ;" },
+        { code: "const valid = 1;\nconst x = ;" },
       ),
     );
 
@@ -691,10 +691,18 @@ describe("Code Mode guest execution", () => {
     // actual cause dropped. The model now sees the name and message.
     expect(error).toContain("SyntaxError");
     expect(error).toContain("unexpected token");
+    expect(error).toMatch(/openclaw-code-mode:user\.js:2:\d+/);
     expect(error.startsWith("at ")).toBe(false);
   });
 
-  it("surfaces the QuickJS error name and message for guest runtime errors", async () => {
+  it.each([
+    {
+      name: "ReferenceError",
+      code: "const valid = 1;\nreturn missingFn();",
+      cause: "missingFn is not defined",
+    },
+    { name: "TypeError", code: "const value = 1;\nvalue();", cause: "not a function" },
+  ])("surfaces the QuickJS $name at the submitted source line", async ({ name, code, cause }) => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     applyCodeModeCatalog({
       tools: [...codeModeTools, pluginTool("fake_noop", "Noop")],
@@ -708,14 +716,16 @@ describe("Code Mode guest execution", () => {
     const details = resultDetails(
       await expectDefined(codeModeTools[0], "codeModeTools[0] test invariant").execute(
         "code-call-runtime",
-        { code: "return missingFn();" },
+        { code },
       ),
     );
 
     expect(details.status).toBe("failed");
     const error = String(details.error);
-    expect(error).toContain("ReferenceError");
-    expect(error).toContain("missingFn is not defined");
+    expect(error).toContain(name);
+    expect(error).toContain(cause);
+    expect(error).toMatch(/openclaw-code-mode:user\.js:2:\d+/);
+    expect(error).not.toContain("<eval>");
     expect(error.startsWith("at ")).toBe(false);
   });
 

--- a/src/agents/code-mode.rejections.test.ts
+++ b/src/agents/code-mode.rejections.test.ts
@@ -45,18 +45,28 @@ describe("Code Mode promise rejection settlement", () => {
   );
 
   it.each([
-    { name: "detached promise", code: 'void Promise.reject(new Error("lost failure"));' },
-    { name: "detached tool", code: "void failing_tool({});" },
-    { name: "detached combinator", code: "void Promise.all([failing_tool({})]);" },
+    {
+      name: "detached promise",
+      code: 'void Promise.reject(new Error("lost failure"));',
+      userFrame: true,
+    },
+    { name: "detached tool", code: "void failing_tool({});", userFrame: false },
+    {
+      name: "detached combinator",
+      code: "void Promise.all([failing_tool({})]);",
+      userFrame: false,
+    },
     {
       name: "rejection before snapshot",
       code: 'void Promise.reject(new Error("lost failure")); await yield_control();',
+      userFrame: true,
     },
     {
       name: "timer callback",
       code: 'setTimeout(() => { throw new Error("lost failure"); }, 0);',
+      userFrame: true,
     },
-  ])("reports an unhandled $name instead of success", async ({ code }) => {
+  ])("reports an unhandled $name instead of success", async ({ code, userFrame }) => {
     const { ctx, config, catalogRef, tools } = createCodeModeHarness();
     const failing = pluginToolWithExecute("failing_tool", "Fails without an outcome", async () => {
       throw new Error("lost failure");
@@ -65,14 +75,49 @@ describe("Code Mode promise rejection settlement", () => {
     const result = await runUntilCompleted({
       execTool: expectDefined(tools[0], "exec"),
       waitTool: expectDefined(tools[1], "wait"),
-      code: `${code} return "done";`,
+      code: `const marker = true;\n${code} return "done";`,
     });
     expect(result).toMatchObject({
       status: "failed",
       error: expect.stringContaining("lost failure"),
     });
+    expect(String(result.error)).not.toContain("openclaw-code-mode:controller.js");
+    if (userFrame) {
+      expect(String(result.error)).toMatch(/openclaw-code-mode:user\.js:2:\d+/);
+    }
     expect(testing.activeRuns.size).toBe(0);
   });
+
+  it.each(["wait", "headless"] as const)(
+    "reports the submitted JavaScript line through %s",
+    async (mode) => {
+      const code = "const value = 1;\nvalue();";
+      let result;
+      if (mode === "headless") {
+        result = await runCodeModeScriptHeadless({ ctx: createHeadlessCodeModeHarness(), code });
+      } else {
+        const { ctx, tools, config, catalogRef } = createCodeModeHarness();
+        applyCodeModeCatalog({ ...ctx, config, catalogRef, tools });
+        result = await runUntilCompleted({
+          execTool: expectDefined(tools[0], "exec"),
+          waitTool: expectDefined(tools[1], "wait"),
+          code: `await yield_control();\n${code}`,
+        });
+      }
+      expect(result).toMatchObject({
+        status: "failed",
+        error: expect.stringContaining("TypeError"),
+      });
+      if (result.status !== "failed") {
+        throw new Error("Expected guest runtime failure");
+      }
+      expect(String(result.error)).toContain(
+        `openclaw-code-mode:user.js:${mode === "wait" ? 3 : 2}:`,
+      );
+      expect(String(result.error)).not.toContain("<eval>");
+      expect(String(result.error)).not.toContain("controller.js");
+    },
+  );
 
   it.each([
     "try { await failing_tool({}); } catch {}",

--- a/src/agents/code-mode.typescript.test.ts
+++ b/src/agents/code-mode.typescript.test.ts
@@ -61,6 +61,34 @@ describe("Code Mode TypeScript execution", () => {
     resetCodeModeTestState();
   });
 
+  it.each([
+    {
+      name: "runtime error after erased declarations",
+      code: "type Ignored = string;\ninterface IgnoredToo {\n  value: number;\n}\nconst value: number = 1;\n(value as unknown as () => void)();",
+      location: /openclaw-code-mode:generated\.js:\d+:\d+/,
+      cause: "TypeError",
+    },
+    {
+      name: "compiler syntax error",
+      code: "type Ignored = string;\nconst value: number = ;",
+      location: /openclaw-code-mode:user\.ts:2:\d+/,
+      cause: "Expression expected",
+    },
+  ])("identifies the source of a $name", async ({ code, location, cause }) => {
+    const { ctx, config, catalogRef, tools } = createCodeModeHarness();
+    applyCodeModeCatalog({ ...ctx, config, catalogRef, tools });
+    const result = await runUntilCompleted({
+      execTool: expectDefined(tools[0], "exec"),
+      waitTool: expectDefined(tools[1], "wait"),
+      code,
+      language: "typescript",
+    });
+    expect(result).toMatchObject({ status: "failed", error: expect.stringContaining(cause) });
+    expect(String(result.error)).toMatch(location);
+    expect(String(result.error)).not.toContain("openclaw-code-mode:user.js");
+    expect(String(result.error)).not.toContain("controller.js");
+  });
+
   it("supports TypeScript source transform", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     applyCodeModeCatalog({

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -51,22 +51,128 @@ type BridgeState = {
   admissionFailure?: CodeModeWorkerFailure;
 };
 
+const USER_SOURCE_FILE = "openclaw-code-mode:user.js";
+const GENERATED_SOURCE_FILE = "openclaw-code-mode:generated.js";
+const SOURCE_LOCATION_KEY = "__openclawSourceLocation";
+
+type SourceLocation = {
+  file: typeof USER_SOURCE_FILE | typeof GENERATED_SOURCE_FILE;
+  lineOffset: number;
+  lineCount: number;
+  columnOffset: number;
+  endColumn: number;
+};
+
+function sourceExtent(source: string): { lines: number; lastColumn: number } {
+  let lines = 1;
+  let lastLineStart = 0;
+  for (const match of source.matchAll(/\r\n|[\r\n\u2028\u2029]/gu)) {
+    lines += 1;
+    lastLineStart = match.index + match[0].length;
+  }
+  // QuickJS columns count UTF-8 bytes, while JavaScript string indices count UTF-16 units.
+  return { lines, lastColumn: Buffer.byteLength(source.slice(lastLineStart), "utf8") + 1 };
+}
+
+function readSourceLocation(vm: QuickJS): SourceLocation | undefined {
+  // Old snapshots have no record. Read data descriptors without invoking guest getters.
+  const descriptor = vm.global.getOwnPropertyDescriptor(SOURCE_LOCATION_KEY);
+  if (!descriptor) {
+    return undefined;
+  }
+  try {
+    if (
+      descriptor.writable ||
+      descriptor.configurable ||
+      descriptor.enumerable ||
+      !descriptor.value?.isString ||
+      descriptor.value.length > 256
+    ) {
+      return undefined;
+    }
+    const value: unknown = JSON.parse(descriptor.value.toString());
+    if (!isRecord(value)) {
+      return undefined;
+    }
+    const { file, lineOffset, lineCount, columnOffset, endColumn } = value;
+    const isOffset = (offset: unknown): offset is number =>
+      typeof offset === "number" && Number.isSafeInteger(offset) && offset >= 0;
+    if (
+      (file !== USER_SOURCE_FILE && file !== GENERATED_SOURCE_FILE) ||
+      !isOffset(lineOffset) ||
+      !isOffset(lineCount) ||
+      lineCount === 0 ||
+      !isOffset(columnOffset) ||
+      !isOffset(endColumn) ||
+      endColumn === 0 ||
+      !Number.isSafeInteger(lineOffset + lineCount) ||
+      (lineCount === 1 && endColumn <= columnOffset)
+    ) {
+      return undefined;
+    }
+    return { file, lineOffset, lineCount, columnOffset, endColumn };
+  } catch {
+    return undefined;
+  } finally {
+    descriptor.value?.dispose();
+    descriptor.get?.dispose();
+    descriptor.set?.dispose();
+  }
+}
+
+function normalizeSourceStack(
+  stack: string | undefined,
+  location?: SourceLocation,
+): string | undefined {
+  if (!stack || !location) {
+    return stack;
+  }
+  // Leave arbitrary guest stack text opaque instead of copying every line into an array.
+  return stack.replace(
+    /^[^\S\r\n]+at [^\r\n]*openclaw-code-mode:(?:user|controller)\.js:\d+:\d+\)?(?:\r?\n|$)/gmu,
+    (frame) => {
+      const match = /openclaw-code-mode:user\.js:(\d+):(\d+)(?=\)?(?:\r?\n)?$)/u.exec(frame);
+      if (!match) {
+        return "";
+      }
+      const line = Number(match[1]) - location.lineOffset;
+      const originalColumn = Number(match[2]);
+      const column = originalColumn - (line === 1 ? location.columnOffset : 0);
+      if (
+        line < 1 ||
+        line > location.lineCount ||
+        column < 1 ||
+        (line === location.lineCount && originalColumn > location.endColumn)
+      ) {
+        return "";
+      }
+      return frame.replace(match[0], `${location.file}:${line}:${column}`);
+    },
+  );
+}
+
 // QuickJS error stacks are backtrace frames only ("    at file:line:col"), with
 // no leading "Name: message" header like V8. Returning .stack alone therefore
 // dropped the actual cause, surfacing failures to the model as a bare location
 // (e.g. "at openclaw-code-mode:user.js:2:37"). Lead with name+message so the
 // model can self-correct, and keep the frames for location.
-function formatQuickJsError(name: string, message: string, stack: string | undefined): string {
+function formatQuickJsError(
+  name: string,
+  message: string,
+  stack: string | undefined,
+  location?: SourceLocation,
+): string {
   const header = message ? `${name}: ${message}` : name;
-  if (!stack || stack.split(/\r?\n/, 1)[0] === header) {
+  const sourceStack = normalizeSourceStack(stack, location);
+  if (!sourceStack || sourceStack.split(/\r?\n/, 1)[0] === header) {
     return header;
   }
-  return `${header}\n${stack}`;
+  return `${header}\n${sourceStack}`;
 }
 
-function errorMessage(error: unknown): string {
+function errorMessage(error: unknown, location?: SourceLocation): string {
   if (error instanceof JSException) {
-    return formatQuickJsError(error.name, error.message, error.stack);
+    return formatQuickJsError(error.name, error.message, error.stack, location);
   }
   if (error instanceof Error) {
     return error.message || String(error);
@@ -74,8 +180,25 @@ function errorMessage(error: unknown): string {
   return String(error);
 }
 
-function buildUserSource(code: string): string {
-  return `globalThis.__openclawResult = (async () => {\n${code}\n})()`;
+function buildUserSource(
+  code: string,
+  prelude = "",
+  language?: CodeModeLanguage,
+): { source: string; location: SourceLocation } {
+  const prefix = `globalThis.__openclawResult = (async () => {\n${prelude}`;
+  const before = sourceExtent(prefix);
+  const body = sourceExtent(code);
+  const columnOffset = before.lastColumn - 1;
+  return {
+    source: `${prefix}${code}\n})()`,
+    location: {
+      file: language === "typescript" ? GENERATED_SOURCE_FILE : USER_SOURCE_FILE,
+      lineOffset: before.lines - 1,
+      lineCount: body.lines,
+      columnOffset,
+      endColumn: body.lastColumn + (body.lines === 1 ? columnOffset : 0),
+    },
+  };
 }
 
 function trackPromiseRejection(
@@ -280,7 +403,15 @@ function workerFailureResult(params: {
     return failedWorkerResult(params.error.code, params.error.message, output);
   }
   if (output.length > 0) {
-    return failedWorkerResult("internal_error", errorMessage(params.error), output);
+    return failedWorkerResult(
+      "internal_error",
+      errorMessage(params.error, readSourceLocation(params.vm)),
+      output,
+    );
+  }
+  if (params.error instanceof JSException) {
+    // Preserve guest coordinates before the VM is disposed and the outer catch formats the error.
+    throw new Error(errorMessage(params.error, readSourceLocation(params.vm)));
   }
   throw params.error;
 }
@@ -308,7 +439,7 @@ async function readCompletedResult(vm: QuickJS, resultHandle: JSValueHandle): Pr
       }
       const text =
         dumped instanceof Error
-          ? formatQuickJsError(dumped.name, dumped.message, dumped.stack)
+          ? formatQuickJsError(dumped.name, dumped.message, dumped.stack, readSourceLocation(vm))
           : errorMessage(dumped);
       throw new Error(text);
     });
@@ -438,11 +569,12 @@ async function run(input: CodeModeWorkerPayload): Promise<CodeModeWorkerResult> 
     config,
     prepare: () => {
       if (input.kind === "exec") {
-        vm.evalCode(
-          buildUserSource(`${input.prelude ?? ""}${source}`),
-          "openclaw-code-mode:user.js",
-          EvalFlags.ASYNC,
-        ).dispose();
+        const program = buildUserSource(source, input.prelude, input.language);
+        // Immutable guest state travels with the existing VM snapshot and its byte limit.
+        vm.newString(JSON.stringify(program.location)).consume((location) =>
+          vm.global.defineProp(SOURCE_LOCATION_KEY, location),
+        );
+        vm.evalCode(program.source, USER_SOURCE_FILE, EvalFlags.ASYNC).dispose();
         return;
       }
       vm.global.getProp("__openclawSettleBridge").consume((settle) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users debugging Code Mode failures would receive line numbers shifted by the runtime wrapper or headless setup. TypeScript runtime failures were also labeled as user source even when compilation had removed or rearranged source lines.

## Why This Change Was Made

The worker records compact, immutable source extents in its existing VM state, so the same coordinates survive waits and resumes without changing the snapshot envelope. Error formatting translates recognized JavaScript frames to submitted source and removes internal wrapper, setup, and controller frames while retaining the error cause and existing output limits. TypeScript runtime frames identify generated JavaScript; compiler diagnostics retain original TypeScript positions. Legacy snapshots without this metadata keep their previous stack format.

## User Impact

Code Mode errors point to the relevant submitted JavaScript line, including after a wait or in headless execution. TypeScript locations state which source they describe. This changes diagnostics only; execution, configuration, dependencies, and output budgets stay unchanged.

## Evidence

Synthetic failures reproduced the original one-line wrapper offset, extra headless offset, resumed offset, and missing TypeScript compiler position before the repair. Regression assertions failed on the original behavior. Coverage includes SyntaxError, TypeError, detached and timer rejections, waits, headless setup, legacy snapshots, and UTF-8 columns for a same-line prelude.

The final eight-file suite passed 271 tests, the complete changed-file gate passed, and independent review found no actionable P0–P2 issues. The canonical `pnpm build` also passed, including runtime packaging, declaration generation, plugin load checks, and UI asset checks.
