### PR TITLE
test(msteams): mock the formatter crypto module under Bun

### DIFF
--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -1,8 +1,12 @@
-import crypto, { randomUUID } from "node:crypto";
-import { syncBuiltinESMExports } from "node:module";
+import { randomUUID } from "node:crypto";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it, vi } from "vitest";
 import { formatMSTeamsMarkdown } from "./format.js";
+
+vi.mock("node:crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:crypto")>();
+  return { ...actual, randomUUID: vi.fn(actual.randomUUID) };
+});
 
 describe("formatMSTeamsMarkdown", () => {
   const fixtures = [
@@ -326,19 +330,20 @@ describe("formatMSTeamsMarkdown", () => {
     ],
     ["character references", `${encodedToken} ${mention}`, `${encodedToken} ${mention}`],
   ])("preserves forged placeholders in %s", (_name, source, expected) => {
-    const entropy = vi.spyOn(crypto, "randomUUID").mockImplementation(() => {
-      throw new Error("unexpected extra entropy request");
-    });
+    const entropy = vi
+      .mocked(randomUUID)
+      .mockClear()
+      .mockImplementation(() => {
+        throw new Error("unexpected extra entropy request");
+      });
     entropy
       .mockReturnValueOnce(collisionUuid)
       .mockReturnValueOnce("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
     try {
-      syncBuiltinESMExports();
-      expect(randomUUID).toBe(entropy);
       expect(formatMSTeamsMarkdown(source, "off")).toBe(expected);
+      expect(entropy).toHaveBeenCalledTimes(2);
     } finally {
-      entropy.mockRestore();
-      syncBuiltinESMExports();
+      entropy.mockReset();
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The Teams formatter fixture relies on synchronizing a builtin crypto export after spying on it, which does not provide the intended mock binding under Bun.

## Why This Change Was Made

Use the supported Vitest crypto-module factory mock while preserving the actual exports and real UUID implementation by default. The existing deterministic cases keep their one-shot UUID results, extra-call failure, exact outputs, and cleanup; an explicit call-count assertion observes the intended use. Reset restores the wrapper's original implementation.

## User Impact

This changes one formatter test file only. Production formatting, APIs, and dependencies are unchanged.

## Evidence

- Local Node and Bun proof selected four existing ordinary formatting cases per runtime; all passed. The three negative cases were retained in source but were not rerun locally, and 53 cases were unselected in each focused invocation.
- The initial zero-selection invocation is retained and is not counted as passing proof.
- Complete changed-file checks, formatting, and fresh independent P0–P2 review passed. The installed Vitest reset contract and the production named-import consumer were inspected.
- Required hosted CI is tracked separately; no complete local test-file or negative-regression proof is claimed.
