### PR TITLE
perf(agents): reduce allocations for bounded file reads

### DIFF
--- a/src/agents/sessions/tools/read.test.ts
+++ b/src/agents/sessions/tools/read.test.ts
@@ -661,23 +661,48 @@ describe("read tool", () => {
     expect(textContent(second)).toContain("offset=3");
   });
 
-  it("preserves ordinary multi-line selection and trailing newlines", async () => {
+  it.each([
+    {
+      name: "CRLF lines through EOF",
+      contents: "first\r\nsecond\r\nthird\r\n",
+      args: { offset: 2 },
+      expected: "second\nthird\n",
+    },
+    {
+      name: "the last terminated line",
+      contents: "first\nsecond\nthird\n",
+      args: { offset: 3, limit: 1 },
+      expected: "third\n",
+    },
+    {
+      name: "a limit extending past an unterminated EOF",
+      contents: "first\nsecond\nthird",
+      args: { offset: 2, limit: 20 },
+      expected: "second\nthird",
+    },
+    {
+      name: "a later line cursor through EOF",
+      contents: "first\nsecond\nthird\n",
+      args: { offset: 2, limit: 2, cursor: 2 },
+      expected: "cond\nthird\n",
+    },
+  ])("preserves selected content for $name", async ({ contents, args, expected }) => {
     const tool = createReadToolDefinition("/workspace", {
       operations: {
         access: async () => {},
-        readFile: async () => Buffer.from("first\r\nsecond\r\nthird\r\n"),
+        readFile: async () => Buffer.from(contents),
       },
     });
 
     const selected = await tool.execute(
       "call-lines",
-      { path: "lines.txt", offset: 2 },
+      { path: "lines.txt", ...args },
       undefined,
       undefined,
       {} as never,
     );
 
-    expect(textContent(selected)).toBe("second\nthird\n");
+    expect(textContent(selected)).toBe(expected);
   });
 
   it("clamps non-positive line limits before slicing file content", async () => {
@@ -822,11 +847,12 @@ describe("read tool", () => {
     expect(textContent(result)).toBe("import value\nconst marker = '\uFEFF';");
   });
 
-  it("uses an injected backend decoder when declared", async () => {
+  it("preserves an injected backend decoder's exact UTF-16 text", async () => {
     const bytes = Buffer.from([0xc4, 0xe3, 0xba, 0xc3]);
     const tool = createReadToolDefinition("/workspace", {
       operations: {
-        decodeText: ({ buffer, absolutePath }) => `${absolutePath}:${buffer.toString("hex")}`,
+        decodeText: ({ buffer, absolutePath }) =>
+          `${absolutePath}:${buffer.toString("hex")}:\ud800a🦞b\udc00`,
         access: async () => {},
         detectImageMimeType: async () => null,
         readFile: async () => bytes,
@@ -841,7 +867,9 @@ describe("read tool", () => {
     );
 
     expect(decodeWindowsTextFileBufferMock).not.toHaveBeenCalled();
-    expect(textContent(result)).toBe(`${path.resolve("/workspace", "legacy.txt")}:c4e3bac3`);
+    expect(textContent(result)).toBe(
+      `${path.resolve("/workspace", "legacy.txt")}:c4e3bac3:\ud800a🦞b\udc00`,
+    );
   });
 
   it("waits for an aliased queued write before reading the same new file", async () => {

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -519,14 +519,33 @@ export function createReadToolDefinition(
               const textContent = (
                 decodedText.startsWith("\uFEFF") ? decodedText.slice(1) : decodedText
               ).replaceAll("\r\n", "\n");
-              const allLines = textContent.split("\n");
-              if (allLines.at(-1) === "") {
-                allLines.pop();
-              }
-              const totalFileLines = allLines.length;
-              // Apply offset if specified. Convert from 1-indexed input to 0-indexed array access.
               const startLine = offset === undefined ? 0 : offset - 1;
               const startLineDisplay = startLine + 1;
+              const requestedLines =
+                limit === undefined ? undefined : normalizePositiveLimit(limit, DEFAULT_MAX_LINES);
+              let selectedLines: string[] = [];
+              let totalFileLines = 0;
+              if (startLine === 0 && requestedLines === undefined) {
+                selectedLines = textContent.split("\n");
+                if (selectedLines.at(-1) === "") {
+                  selectedLines.pop();
+                }
+                totalFileLines = selectedLines.length;
+              } else {
+                // Count through EOF for continuation metadata, retaining only the requested range.
+                for (let start = 0; start < textContent.length;) {
+                  const newline = textContent.indexOf("\n", start);
+                  const end = newline === -1 ? textContent.length : newline;
+                  if (
+                    totalFileLines >= startLine &&
+                    (requestedLines === undefined || selectedLines.length < requestedLines)
+                  ) {
+                    selectedLines.push(textContent.slice(start, end));
+                  }
+                  totalFileLines += 1;
+                  start = end + 1;
+                }
+              }
               let outputText: string;
               if (totalFileLines === 0) {
                 outputText =
@@ -535,27 +554,20 @@ export function createReadToolDefinition(
                     : `File contains no readable text (${buffer.length} bytes).`;
               } else if (startLine >= totalFileLines) {
                 outputText = `Offset ${offset} is beyond end of file (${totalFileLines} lines total). Retry with offset <= ${totalFileLines}.`;
-              } else if (cursor > 0 && cursor >= allLines[startLine]!.length) {
+              } else if (cursor > 0 && cursor >= selectedLines[0]!.length) {
                 const nextLine =
                   startLine + 1 < totalFileLines
                     ? ` Use offset=${startLineDisplay + 1} to continue.`
                     : "";
-                outputText = `Cursor ${cursor} is at or beyond the end of line ${startLineDisplay} (${allLines[startLine]!.length} characters).${nextLine}`;
+                outputText = `Cursor ${cursor} is at or beyond the end of line ${startLineDisplay} (${selectedLines[0]!.length} characters).${nextLine}`;
               } else {
-                const firstLine = allLines[startLine]!;
+                const firstLine = selectedLines[0]!;
                 if (cursor > 0 && firstLine.codePointAt(cursor - 1)! > 0xffff) {
                   throw new Error(
                     `Cursor ${cursor} splits a UTF-16 surrogate pair; retry with cursor=${cursor - 1} or cursor=${cursor + 1}.`,
                   );
                 }
-                const endLine =
-                  limit === undefined
-                    ? totalFileLines
-                    : Math.min(
-                        startLine + normalizePositiveLimit(limit, DEFAULT_MAX_LINES),
-                        totalFileLines,
-                      );
-                const selectedLines = allLines.slice(startLine, endLine);
+                const endLine = startLine + selectedLines.length;
                 selectedLines[0] = firstLine.slice(cursor);
                 const userLimitedLines = limit === undefined ? undefined : endLine - startLine;
                 if (selectedLines.every((line) => line.length === 0)) {
@@ -591,6 +603,11 @@ export function createReadToolDefinition(
                     truncated = page;
                   }
                 }
+              }
+              if (selectedLines.length === 1 && truncated === undefined) {
+                // A singleton join can retain the decoded file. Copy only the bounded result,
+                // preserving UTF-16 code units from custom decoders, including lone surrogates.
+                outputText = Buffer.from(outputText, "utf16le").toString("utf16le");
               }
               content = [{ type: "text", text: outputText }];
             }


### PR DESCRIPTION
## What Problem This Solves

Reading a small range from a large file allocates an array for every file line before selecting the requested lines. A small one-line result can also keep the complete decoded file text alive after the read finishes.

## Why This Change Was Made

Count through EOF while collecting only requested lines, preserving native splitting for exact whole-file selections and removing the second array copy. After existing output limits are applied, detach only nontruncated singleton selections using UTF-16 copying so custom decoders retain their exact code units, including lone surrogates.

## User Impact

Small file reads allocate fewer intermediate line arrays, and nontruncated one-line results can release their source text. Offsets, limits, UTF-16 cursors, trailing newlines, diagnostics, byte/model caps, continuation metadata, and access behavior retain their existing contracts.

## Evidence

- **73 focused tests** pass: 54 reader tests and 19 downstream Code Mode/model-budget tests. The final full changed-code gate passes, including types, dead exports, lint, formatting, and guards; `git diff --check` passes. An earlier selection-only check was stopped when the ownership repair was added and is superseded by this completed final gate.
- Independent source/dependency/evidence review and final managed autoreview found no actionable issues. Expanded existing tests cover EOF/cursor boundaries and exact custom-decoder UTF-16 text.
- The actual read-tool owner preserves complete outputs/errors for **104 cases**, and all measured result hashes match. Probes use synthetic injected byte operations in fresh Node 26.8.1 processes.
- For an 80,000-line, 4,000,000-byte input, two process samples of 20 reads each show about **99.4% less sampled JavaScript allocation** for 20-line ranges and **4.9% less** for whole-file reads. The huge-line control is effectively unchanged. V8 sampling uses a 16 KiB interval and includes collected objects; it does not measure all external buffer/string allocation.
- Holding eight unconsumed interior one-line results retained **32,000,000 external bytes before and zero afterward** in both samples, with identical result bytes. Inputs remain live in both arms, and copying occurs only after the output budget.
- Several timing controls were slower. These runs do not support a latency improvement or consistent RSS reduction claim.
- A multiline selection that truncates to one rendered line remains a separate truncation-owner retention follow-up; this PR does not claim to fix it.
- Required hosted CI passed for exact head `efa7765950d3ea6c237491c18c9face152a94b2d`: https://github.com/openclaw/openclaw/actions/runs/34041663568.
