### PR TITLE
refactor(update): trim Doctor environment plumbing

### DIFF
--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -30,12 +30,12 @@ import {
 type UpdateDoctorPhase = "pre-plugin" | "post-plugin";
 
 export async function withPrePluginUpdateDoctorEnv<T>(run: () => Promise<T>): Promise<T> {
-  const previousUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
-  const previousDeferConfiguredPluginInstallRepair =
-    process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
-  const previousParentSupportsDoctorConfigWrite =
-    process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
-  const previousPostCoreConvergence = process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
+  const previousValues = [
+    "OPENCLAW_UPDATE_IN_PROGRESS",
+    UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
+    UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
+    UPDATE_POST_CORE_CONVERGENCE_ENV,
+  ].map((key) => [key, process.env[key]] as const);
   process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
   process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
   process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
@@ -43,27 +43,12 @@ export async function withPrePluginUpdateDoctorEnv<T>(run: () => Promise<T>): Pr
   try {
     return await run();
   } finally {
-    if (previousUpdateInProgress === undefined) {
-      delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
-    } else {
-      process.env.OPENCLAW_UPDATE_IN_PROGRESS = previousUpdateInProgress;
-    }
-    if (previousDeferConfiguredPluginInstallRepair === undefined) {
-      delete process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
-    } else {
-      process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] =
-        previousDeferConfiguredPluginInstallRepair;
-    }
-    if (previousParentSupportsDoctorConfigWrite === undefined) {
-      delete process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
-    } else {
-      process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] =
-        previousParentSupportsDoctorConfigWrite;
-    }
-    if (previousPostCoreConvergence === undefined) {
-      delete process.env[UPDATE_POST_CORE_CONVERGENCE_ENV];
-    } else {
-      process.env[UPDATE_POST_CORE_CONVERGENCE_ENV] = previousPostCoreConvergence;
+    for (const [key, value] of previousValues) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
   }
 }

--- a/src/infra/update-runner-global.ts
+++ b/src/infra/update-runner-global.ts
@@ -37,8 +37,6 @@ export async function runGlobalUpdate(params: {
   timeoutMs: number;
   startedAt: number;
   beforeVersion: string | null;
-  allowGatewayServiceRepair: boolean;
-  allowGatewayActivation: boolean;
 }): Promise<UpdateRunResult> {
   const { opts, pkgRoot, globalManager, runCommand, timeoutMs, startedAt, beforeVersion } = params;
   const channel = opts.channel ?? DEFAULT_PACKAGE_CHANNEL;

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -94,8 +94,6 @@ async function runGatewayUpdateInternal(opts: UpdateRunnerOptions): Promise<Upda
       timeoutMs,
       startedAt,
       beforeVersion,
-      allowGatewayServiceRepair: opts.allowGatewayServiceRepair !== false,
-      allowGatewayActivation: opts.allowGatewayActivation === true,
     });
   }
   return {


### PR DESCRIPTION
## What Problem This Solves

Update Doctor setup retained repetitive environment restoration and unused global-update parameters after service ownership was consolidated. This small deletion follow-up to the #135868 split keeps the existing policy easier to audit.

## Why This Change Was Made

The pre-plugin Doctor wrapper now snapshots its four existing environment keys and restores them in one loop, matching the existing scoped-environment pattern in `withUpdateInProgressEnv`. Its writes, convergence-marker deletion and `try`/`await`/`finally` boundary are unchanged.

Deletion evidence:
- Four repeated restoration branches in `withPrePluginUpdateDoctorEnv` express the same absent-versus-present rule. The fixed-key loop preserves empty strings, synchronous throws, rejected promises and unrelated environment changes. #122161 (`0e52f4c4ce0`) established the pre-plugin convergence boundary; that policy is retained.
- `runGlobalUpdate` has one production caller. #135462 (`d11b4d59f4a`) removed reads of its service-repair and activation parameters and explicitly denied both permissions during staged Doctor. Delete the dead signature fields and forwarding arguments. The shared `UpdateRunnerOptions` fields remain because Git updates still consume them.

## User Impact

No user-visible behavior change. Staged Doctor continues to leave service repair and activation with its outer owner, and the invoking process receives the same environment after pre-plugin finalization.

## Evidence

- 541 tests passed across the update CLI, fresh Doctor and update runner suites.
- Full `node scripts/check-changed.mjs` passed.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production: +12 / −31 = **−19 lines**. Tests/support, tooling and docs unchanged. 43 changed lines across three files.

### ClawSweeper disposition and compatibility evidence

ClawSweeper found no actionable correctness or security defect. Its data-model classification is not applicable: the complete diff changes only equivalent bookkeeping for four existing process-environment keys and removes already-unread parameters. Schema, schema version, migration calls, stored representation, retention, projections, lease semantics and public contracts are unchanged.

No migration is required. Existing upgrade compatibility is preserved by the unchanged pre-plugin phase markers and staged Doctor permissions. The existing `updateFinalizeCommand defers plugin installation during pre-plugin doctor` and `keeps service repair external during staged global npm Doctor` tests passed in the 541-test run and verify this compatibility boundary. The generic data-model checklist is resolved by this evidence; no new stored-data format is introduced.
