### PR TITLE
fix(transcripts): settle duplicate auto-start retries

### DIFF
--- a/src/transcripts/auto-start.ts
+++ b/src/transcripts/auto-start.ts
@@ -223,7 +223,7 @@ export function createTranscriptsAutoStartService(
     attempt: number,
     store: TranscriptsStore,
   ) => {
-    if (stopped || startedSessions.has(entry.sessionId ?? "")) {
+    if (stopped) {
       return;
     }
     const capture: OwnedCapture = {
@@ -233,6 +233,14 @@ export function createTranscriptsAutoStartService(
     };
     void runPending(async (controller) => {
       try {
+        // A consumed fixed ID stays suppressed after capture ends; settle the
+        // duplicate's retry diagnostic without reopening its saved history.
+        if (startedSessions.has(entry.sessionId ?? "")) {
+          throw new TranscriptStartError(
+            "id-conflict",
+            new Error("transcripts session already started by this service"),
+          );
+        }
         await startCapture(capture, index, {
           store,
           abortSignal: controller.signal,

--- a/src/transcripts/status.producer.test.ts
+++ b/src/transcripts/status.producer.test.ts
@@ -710,6 +710,64 @@ describe("configured transcript source provenance", () => {
     }
   });
 
+  it("rejects a duplicate fixed ID after its first capture ends without changing saved notes", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    // Crossing midnight lets an accidental second capture create a distinct archive row.
+    vi.setSystemTime(new Date("2026-09-05T23:59:58.000Z"));
+    const entry = { ...room, sessionId: "daily" };
+    const delayedId = "delayed-voice";
+    const f = fixture({
+      transcripts: { autoStart: [entry, { ...entry, providerId: delayedId }] },
+    });
+    const start = vi.fn(f.provider.start!);
+    const delayedStart = vi.fn(f.provider.start!);
+    f.provider.start = start;
+    const delayedProvider = { ...f.provider, id: delayedId, start: delayedStart };
+    vi.mocked(providerRegistry.getTranscriptSourceProvider).mockImplementation((id) =>
+      id === room.providerId ? f.provider : undefined,
+    );
+    const service = createTranscriptsAutoStartService(f.ctx);
+    try {
+      service.start();
+      await vi.waitFor(async () =>
+        expect((await f.read()).configuredSources).toMatchObject([
+          { state: "armed" },
+          { startDiagnostic: "retrying" },
+        ]),
+      );
+      const request = start.mock.calls[0]![0];
+      await request.onUtterance({ text: "Saved before the duplicate retry", final: true });
+      await request.onStatus!({ active: false });
+      expect((await f.read()).active).toEqual([]);
+      const session = (await f.store.readSession(entry.sessionId))!;
+      expect(session.stoppedAt).toEqual(expect.any(String));
+      const notes = await f.store.readSummary(session);
+      expect(notes.summary?.transcript).toEqual(["Saved before the duplicate retry"]);
+      const revision = f.store.readSummaryInputRevision(session);
+      vi.mocked(providerRegistry.getTranscriptSourceProvider).mockImplementation((id) =>
+        id === delayedId ? delayedProvider : f.provider,
+      );
+      await vi.advanceTimersByTimeAsync(5_000);
+      await vi.waitFor(async () =>
+        expect((await f.read()).configuredSources[1]?.startDiagnostic).not.toBe("starting"),
+      );
+      expect.soft((await f.read()).configuredSources[1]).toMatchObject({
+        state: "not-active",
+        startDiagnostic: "id-conflict",
+        activeSelectors: [],
+      });
+      await vi.advanceTimersByTimeAsync(65_000);
+      expect(start).toHaveBeenCalledOnce();
+      expect(delayedStart).not.toHaveBeenCalled();
+      expect(await f.store.listSessionEntries()).toHaveLength(1);
+      expect(await f.store.readSession(entry.sessionId)).toEqual(session);
+      expect(await f.store.readSummary(session)).toEqual(notes);
+      expect(f.store.readSummaryInputRevision(session)).toBe(revision);
+    } finally {
+      await service.stop();
+    }
+  });
+
   it("fences late diagnostics and teardown against a replacement service and a manual capture", async () => {
     const f = fixture({ transcripts: { autoStart: [{ ...room, sessionId: "pending" }] } });
     const gate = createDeferred();


### PR DESCRIPTION
Related: #136293

## What Problem This Solves

Fixes an issue where Meeting capture health could remain `retrying` indefinitely for a configured source whose custom session ID had already been used by another auto-start entry in the same Gateway service.

## Why This Change Was Made

Keep the service's existing suppression of consumed session IDs and route that decision through its existing terminal `id-conflict` handler. The same handler releases retry authority, records the terminal diagnostic, and tells the operator to check Meeting capture settings. Capture ownership, occupancy behavior, stored history, schemas, and configuration remain unchanged.

## User Impact

The duplicate source reports `not-active` with `id-conflict`. Completed notes retain their original session, source, summary, and revision, and the duplicate does not start another capture after the first one ends.

## Evidence

- The original failure is recorded in [CI run 34035022076, job 101491511508](https://github.com/openclaw/openclaw/actions/runs/34035022076/job/101491511508): the duplicate source reported `unknown` instead of `not-active`; 2,192 sibling tests passed.
- The added regression fails on trusted main `ff930fa95e359b59960b7c911f549c1bb79f2a6f` with `retrying`/`unknown`. It uses the real auto-start, capture, status, and SQLite store with synthetic provider callbacks.
- A negative control that removes suppression actually admits the delayed provider across UTC midnight and reports a second active capture. This proves why suppression must remain after the original capture ends.
- The final uninstrumented candidate passes **105 tests across six files**: transcript producer/status/cleanup tests and transcript tool/occupancy/auto-stop tests, using the normal repository runner on Node 24.19.0.
- [Exact-head CI run 34041900013](https://github.com/openclaw/openclaw/actions/runs/34041900013) completed successfully for `a91d5b3f53c3608ad0de9f29c4a4aea8b2f394da`, including the required `openclaw/ci-gate`. CI checked out the PR merged into main `7aa175749c93b96573548b0900bfd23b09ef1338`.
- The complete changed-scope check passes against the pinned main base, including core and test typechecking, lint, formatting, dependency and architecture guards. Independent Codex review found no actionable P0–P2 issues.

Earlier full local attempts failed initial startup waits in existing occupancy cases. Same-order original-source and matched-instrumentation comparisons, followed by the final uninstrumented pass, are retained; no timeout or assertion was relaxed. Follow-up: investigate those intermittent startup waits. Their cause is not established by this repair.

Production delta: **+8 lines** to route the existing suppression through its terminal owner; test delta: **+58 lines**. This is a supporting correctness repair, not a performance benchmark claim.
