### PR TITLE
refactor(plugins): derive catalog types from the Gateway protocol

### DIFF
--- a/src/plugins/management-catalog.ts
+++ b/src/plugins/management-catalog.ts
@@ -2,6 +2,10 @@
 import { asSafeIntegerInRange } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import type {
+  PluginCatalogEntry,
+  PluginsListResult,
+} from "../../packages/gateway-protocol/src/schema/plugins.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
@@ -34,32 +38,8 @@ import {
 } from "./plugin-cache.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 
-export type ManagedPluginCatalogEntry = {
-  id: string;
-  name: string;
-  packageName?: string;
-  description?: string;
-  version?: string;
-  kind?: string[];
-  origin?: string;
-  installed: boolean;
-  enabled: boolean;
-  state: "enabled" | "disabled" | "not-installed" | "error";
-  featured?: boolean;
-  featuredAt?: number;
-  order?: number;
-  hasIcon?: boolean;
-  install?: { source: "clawhub"; packageName: string } | { source: "official"; pluginId: string };
-  error?: string;
-  category?: string;
-  removable?: boolean;
-};
-
-export type ManagedPluginCatalog = {
-  plugins: ManagedPluginCatalogEntry[];
-  diagnostics: unknown[];
-  mutationAllowed: boolean;
-};
+export type ManagedPluginCatalogEntry = PluginCatalogEntry;
+export type ManagedPluginCatalog = PluginsListResult;
 
 export type OfficialCatalogResult = Pick<
   HostedOfficialExternalPluginCatalogLoadResult,


### PR DESCRIPTION
The plugin catalog maintained handwritten copies of the Gateway's catalog entry and list-result types. These copies could drift from the protocol returned by `plugins.list`.

Use the existing protocol types through type-only imports, preserving the catalog's exported names and every field. This independently extracted cleanup from #135599 removes 20 production lines; runtime behavior and protocol schemas are unchanged.

Validation: strict TypeScript structural equality checks match both former declarations to their canonical protocol types. The complete catalog module emits byte-identical JavaScript before and after the change. Independent Codex review found no actionable issues. Full `check:changed` passed, including production/test typechecks, typed lint, dead-export scans, and architecture/storage guards.
