### PR TITLE
perf(media): avoid repeated copies of accepted images

### DIFF
--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -14,7 +14,11 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { createImageProcessor, resizeToJpeg } from "./media-services.js";
+import {
+  createImageProcessor,
+  readImageMetadataFromHeader,
+  resizeToJpeg,
+} from "./media-services.js";
 import { encodePngRgba, fillPixel } from "./png-encode.js";
 
 let effectiveImageBytesCap: typeof import("./web-media.js").effectiveImageBytesCap;
@@ -480,6 +484,45 @@ describe("loadWebMedia", () => {
     expect(many.sides[0]).toBe(1280);
     expect(many.qualities).toEqual([70, 60, 50, 40]);
   });
+
+  it.each(["png", "jpeg", "webp"] as const)(
+    "preserves accepted original %s bytes and metadata with and without hard limits",
+    async (format) => {
+      const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
+      const sourcePng = createSolidPngBuffer(32, 16, { r: 12, g: 34, b: 56 });
+      let buffer =
+        format === "png"
+          ? sourcePng
+          : (await createImageProcessor().encode(sourcePng, { format })).data;
+      if (format === "jpeg") {
+        const orientation = Buffer.from(
+          "ffe1002245786966000049492a0008000000010012010300010000000600000000000000",
+          "hex",
+        );
+        buffer = Buffer.concat([buffer.subarray(0, 2), orientation, buffer.subarray(2)]);
+        expect(readImageMetadataFromHeader(buffer)).toEqual({ width: 16, height: 32 });
+      }
+      const original = Buffer.from(buffer);
+      const contentType = `image/${format}`;
+      const fileName = `portrait.${format}`;
+      for (const imageCompression of [
+        undefined,
+        { models: [{ maxSidePx: 32, maxPixels: 1024 }] },
+      ]) {
+        const result = await optimizeImageBufferForWebMedia({
+          buffer,
+          contentType,
+          fileName,
+          maxBytes: 1024 * 1024,
+          imageCompression,
+        });
+        expect(result.buffer).toBe(buffer);
+        expect(result.buffer).toEqual(original);
+        expect(result.contentType).toBe(contentType);
+        expect(result.fileName).toBe(fileName);
+      }
+    },
+  );
 
   it("preserves in-limit GIF buffers when optimizing direct image buffers", async () => {
     const { optimizeImageBufferForWebMedia } = await import("./web-media.js");

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -51,6 +51,7 @@ import {
   createImageProcessor,
   readImageMetadataFromHeader,
   readImageProbeFromHeader,
+  type ImageMetadata,
 } from "./media-services.js";
 import { extractOriginalFilename, getMediaDir } from "./store.js";
 import { formatMediaSize } from "./store.shared.js";
@@ -724,6 +725,7 @@ function imageMaxBytesForPolicy(policy?: ImageCompressionPolicy): number | undef
 function imageSatisfiesHardDimensionPolicy(
   buffer: Buffer,
   policy?: ImageCompressionPolicy,
+  metadata?: ImageMetadata,
 ): boolean {
   const models = policy?.models ?? [];
   const hardMaxSides = models
@@ -736,7 +738,7 @@ function imageSatisfiesHardDimensionPolicy(
     return true;
   }
 
-  const meta = readImageMetadataFromHeader(buffer);
+  const meta = metadata ?? readImageMetadataFromHeader(buffer);
   if (!meta) {
     return false;
   }
@@ -771,8 +773,9 @@ function resolvePreservableOriginalImageContentType(params: {
     return null;
   }
   const declaredContentType = normalizeMimeType(params.contentType);
-  const actualContentType = detectPreservableImageMime(params.buffer);
-  if (!actualContentType) {
+  const probe = readImageProbeFromHeader(params.buffer);
+  const actualContentType = probe ? `image/${probe.format}` : undefined;
+  if (!probe || !isPreservableImageMime(actualContentType)) {
     return null;
   }
   const declaredPreservableContentType = isPreservableImageMime(declaredContentType)
@@ -788,32 +791,15 @@ function resolvePreservableOriginalImageContentType(params: {
   if (isHeicSource({ contentType: resolvedContentType, fileName: params.fileName })) {
     return null;
   }
-  const meta = readImageMetadataFromHeader(params.buffer);
-  if (!meta) {
-    return null;
-  }
   const preferredSide =
     resolveImageCompressionGrid(params.policy).sides[0] ?? DEFAULT_VISION_MAX_SIDE;
   if (
-    Math.max(meta.width, meta.height) > preferredSide ||
-    !imageSatisfiesHardDimensionPolicy(params.buffer, params.policy)
+    Math.max(probe.width, probe.height) > preferredSide ||
+    !imageSatisfiesHardDimensionPolicy(params.buffer, params.policy, probe)
   ) {
     return null;
   }
   return resolvedContentType;
-}
-
-function detectPreservableImageMime(
-  buffer: Buffer,
-): "image/png" | "image/jpeg" | "image/webp" | null {
-  const format = readImageProbeFromHeader(buffer)?.format;
-  return format === "png"
-    ? "image/png"
-    : format === "jpeg"
-      ? "image/jpeg"
-      : format === "webp"
-        ? "image/webp"
-        : null;
 }
 
 function isPreservableImageMime(


### PR DESCRIPTION
## What Problem This Solves

Preserving an already acceptable PNG, JPEG, or WebP probes the same original bytes separately for MIME and dimensions. The image adapter copies the entire input for each probe, including another copy when hard dimension limits are present.

## Why This Change Was Made

Prepare one fresh header probe after the byte guard and reuse its format and dimensions for the preservation decision. The private hard-limit helper accepts those prepared dimensions; its raw/GIF callers keep their existing lazy behavior and error dimensions. Longest-side and pixel-area checks are invariant under EXIF axis swapping. The separate MIME detector is removed, reducing production code by 14 lines.

## User Impact

Accepted original images require fewer complete input-buffer copies while retaining the same original buffer, MIME, filename, and bytes. Byte limits, hard policies, MIME/HEIC exclusions, compression fallback, and raw/GIF behavior retain their existing contracts. No cache is introduced.

## Evidence

- **120 focused tests** pass across web-media and the Rastermill adapter. Full changed-code checks pass, including types, lint, formatting, guards, and dead-export scans; `git diff --check` passes. Independent final source review and managed autoreview found no actionable issues.
- Real PNG/JPEG/WebP preservation tests cover absent and hard-limit policies, including a non-square JPEG with EXIF orientation 6. Initial fixture-policy and formatting issues were corrected before the completed final checks.
- The complete source owner with real repository image wrappers, Rastermill 0.3.2, MIME utilities, and codecs preserves all outcomes in **24 paired cases**, including buffer identity, bytes, metadata, errors, repeated calls, tightened limits, compression, and raw/GIF controls.
- **64 measured A/B/B/A calls** use the same valid 7,081,647-byte PNG. Direct copies of the original buffer fall **2 → 1** without hard limits and **3 → 1** with them, avoiding **7,081,647 or 14,163,294 copied bytes per accepted-original call**. Instrumentation forwards the real `Buffer.from` operation unchanged and counts only exact-original input copies.
- All per-call RSS deltas were zero. These are avoided direct source copies, not overall allocation, retained-memory, process-RSS, CPU-speed, or whole-Gateway improvements.
- The final experiment completed and joined all six children with verified source/fixture hashes and cleanup. An earlier Python 3.9 runner incompatibility stopped before allocation sampling; the corrected runner preserved its length assertion and completed the full experiment.
- Required hosted CI passed for exact head `6df6edd8212dcbdff1159c78ed5b26b3bfe8d7de`: https://github.com/openclaw/openclaw/actions/runs/34042021900.
