### PR TITLE
docs: silence codespell false positives so the check stays useful

### DIFF
--- a/scripts/codespell-ignore.txt
+++ b/scripts/codespell-ignore.txt
@@ -16,3 +16,9 @@ allowIn
 planText
 nwe
 smoe
+thirdParty
+doubleClick
+ND
+CNA
+unparseable
+afterAll


### PR DESCRIPTION
## What

Adds six words to `scripts/codespell-ignore.txt`. No prose changes.

## Why

`pnpm docs:spellcheck` reported six hits and every one is a false positive:

| Word | Why it is not a typo |
|---|---|
| `thirdParty` | Gradle source set, and the real path `apps/android/app/src/thirdParty/AndroidManifest.xml` (docs/ci.md:470) |
| `doubleClick` | Browser tool API name, quoted inside a release-notes PR title |
| `afterAll` | Test hook name, written in backticks (docs/reference/test.md:609) |
| `ND` | Mermaid node id in the trust-boundary diagram (docs/start/why-openclaw.md:75) |
| `CNA` | CVE Numbering Authority, used in its standard sense (docs/start/why-openclaw.md:222) |
| `unparseable` | Legitimate variant spelling, and one occurrence sits inside a quoted PR title that must not be reworded |

A check that always reports the same known-good hits stops being read. These join the existing entries `optIn`, `allowIn`, and `planText`, which are the same kind of identifier false positive.

## Validation

```
bash scripts/docs-spellcheck.sh   # exits 0, no output
```

Found while running the repo's own docs validators as part of a documentation audit.