### PR TITLE
docs: give pages with duplicate titles distinct names

### DIFF
--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -3,7 +3,7 @@ summary: "CLI reference for `openclaw dashboard` (securely open the Control UI)"
 read_when:
   - You want to open or re-pair the Control UI from the Gateway host
   - You want to print the URL without launching a browser
-title: "Dashboard"
+title: "Dashboard CLI"
 ---
 
 # `openclaw dashboard`

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -3,7 +3,7 @@ summary: "CLI reference for `openclaw doctor` (health checks + guided repairs)"
 read_when:
   - You have connectivity/auth issues and want guided fixes
   - You updated and want a sanity check
-title: "Doctor"
+title: "Doctor CLI"
 ---
 
 # `openclaw doctor`

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -4,7 +4,7 @@ read_when:
   - You want to inspect internal hooks on a local or remote Gateway
   - You want to enable or disable a hook in local config
   - You need hook command flags or JSON report fields
-title: "Hooks"
+title: "Hooks CLI"
 doc-schema-version: 1
 ---
 

--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -3,7 +3,7 @@ summary: "CLI reference for `openclaw nodes` (status, pairing, invoke, camera/sc
 read_when:
   - You're managing paired nodes (cameras, screen, or the macOS widget panel)
   - You need to approve requests or invoke node commands
-title: "Nodes"
+title: "Nodes CLI"
 ---
 
 # `openclaw nodes`

--- a/docs/cli/pairing.md
+++ b/docs/cli/pairing.md
@@ -2,7 +2,7 @@
 summary: "CLI reference for `openclaw pairing` (approve/list pairing requests)"
 read_when:
   - You're using pairing-mode DMs and need to approve senders
-title: "Pairing"
+title: "Pairing CLI"
 ---
 
 # `openclaw pairing`

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -4,7 +4,7 @@ read_when:
   - You want to install or manage Gateway plugins or compatible bundles
   - You want to scaffold or validate a simple tool plugin
   - You want to debug plugin load failures
-title: "Plugins"
+title: "Plugins CLI"
 sidebarTitle: "Plugins"
 ---
 

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -5,7 +5,7 @@ read_when:
   - Managing team-scoped values in the shared secret store
   - Auditing plaintext residues and unresolved refs
   - Configuring SecretRefs and applying one-way scrub changes
-title: "Secrets"
+title: "Secrets CLI"
 ---
 
 # `openclaw secrets`

--- a/docs/cli/security.md
+++ b/docs/cli/security.md
@@ -3,7 +3,7 @@ summary: "CLI reference for `openclaw security` (audit and fix common security f
 read_when:
   - You want to run a quick security audit on config/state
   - You want to apply safe "fix" suggestions (permissions, tighten defaults)
-title: "Security"
+title: "Security CLI"
 ---
 
 # `openclaw security`

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -5,7 +5,7 @@ read_when:
   - You're doing first-run setup with the onboarding wizard
   - You want to set the default workspace path
   - You need the baseline-only setup flag for scripts
-title: "Setup"
+title: "Setup CLI"
 ---
 
 # `openclaw setup`

--- a/docs/cli/skills.md
+++ b/docs/cli/skills.md
@@ -7,7 +7,7 @@ read_when:
   - You need to remove an installed ClawHub skill
   - You want to verify a ClawHub skill with ClawHub
   - You want to debug missing binaries/env/config for skills
-title: "Skills"
+title: "Skills CLI"
 ---
 
 # `openclaw skills`

--- a/docs/cli/tui.md
+++ b/docs/cli/tui.md
@@ -5,7 +5,7 @@ read_when:
   - You want to pass url/token/session from scripts
   - You want to run the TUI in local embedded mode without a Gateway
   - You want to use openclaw chat or openclaw tui --local
-title: "TUI"
+title: "openclaw tui"
 ---
 
 # `openclaw tui`

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -3,7 +3,7 @@ summary: "CLI reference for `openclaw uninstall` (remove gateway service + local
 read_when:
   - You want to remove the gateway service and/or local state
   - You want a dry-run first
-title: "Uninstall"
+title: "Uninstall CLI"
 ---
 
 # `openclaw uninstall`

--- a/docs/plugins/onepassword.md
+++ b/docs/plugins/onepassword.md
@@ -5,7 +5,7 @@ read_when:
   - You want OpenClaw config credentials to resolve from 1Password
   - You need per-secret approval policy and audit history
   - You are configuring a 1Password service account for OpenClaw
-title: "1Password"
+title: "1Password plugin"
 ---
 
 # 1Password


### PR DESCRIPTION
## What

Renames the frontmatter `title:` on 13 CLI pages so no two pages share a title. One line per file, no prose or route changes.

## Why

A frontmatter scan over `git ls-files docs` found 22 titles shared by two or more pages. Search results, breadcrumbs, and the sidebar showed two identical entries with no way to tell them apart, for example `docs/cli/hooks.md` and `docs/automation/hooks.md` both titled *Hooks*.

The topic page keeps the plain title. The command-scoped CLI page takes the disambiguated one, matching the style already used by its siblings in `docs/cli` (*Attach CLI*, *Inference CLI*, *Sandbox CLI*).

## Out of scope, deliberately

- 8 plugin-page pairs (`beam`, `geolocation`, `google-meet`, `logbook`, `teams-meetings`, `webhooks`, `workboard`, `zoom-meetings`): the second page in each pair is a generated stub under `docs/plugins/reference/`. The fix belongs in `scripts/generate-plugin-inventory-doc.mts`, not in a hand edit.
- `docs/reference/templates/CLAUDE.md`, which is a byte-identical copy of `AGENTS.md`. That needs a delete-or-differentiate decision and a redirect, so it is a separate change.

## Validation

```
node scripts/check-docs-mdx.mjs docs README.md      # passed, 753 files
node scripts/docs-link-audit.mjs                    # 8203 links, 0 broken
```
Duplicate-title count after the change: 22 to 9, and every remaining pair is one of the deferred cases above.

Found during a full documentation audit.