### PR TITLE
docs(i18n): date the locale-support note and keep one publish sequence

### DIFF
--- a/docs/.i18n/README.md
+++ b/docs/.i18n/README.md
@@ -15,26 +15,20 @@ Generated locale trees and live translation memory now live in the publish repo:
 
 ## End-to-end flow
 
-1. Edit English docs in `openclaw/openclaw`.
-2. Push to `main`.
-3. `openclaw/openclaw/.github/workflows/docs-sync-publish.yml` mirrors the OpenClaw docs tree into `openclaw/docs`, then replaces `docs/clawhub/` with the current `openclaw/clawhub/docs` input.
-4. The sync script rewrites the publish `docs/docs.json` so the generated locale picker blocks exist there even though they are no longer committed in the source repo.
-5. `openclaw/docs/.github/workflows/translate-all.yml` waits for `main` to settle, translates only stale or missing locale pages, and uploads per-locale artifacts.
-6. The publish repo finalizer applies successful locale artifacts and pushes one aggregate `chore(i18n): refresh translations` commit.
-7. A weekly `full` run reconciles every locale/page path so flaky model failures are retried without making hot docs commits wait.
+Edit English docs in `openclaw/openclaw` and push to `main`. The sync, translation, and publish sequence is documented in [translation-workflow.md](translation-workflow.md). Keep that file as the single description of the pipeline.
 
 ## Why the split exists
 
 - Keep generated locale output out of the main product repo.
 - Keep Mintlify on a single published docs tree.
 - Preserve the built-in language switcher for Mintlify-supported generated locales by letting the publish repo own generated locale trees.
-- Keep generated Thai (`th`) and Persian (`fa`) docs plus translation memory even though Mintlify does not currently accept those codes in `navigation.languages`. Their absence from the built-in docs language picker is a host limitation, not a failed translation run.
+- Keep generated Thai (`th`) and Persian (`fa`) docs plus translation memory even though Mintlify does not accept those codes in `navigation.languages` (checked 2026-09-06). Their absence from the built-in docs language picker is a host limitation, not a failed translation run.
 
 ## Locale visibility
 
 - Control UI supports `en`, `zh-CN`, `zh-TW`, `pt-BR`, `de`, `es`, `ja-JP`, `ko`, `fr`, `hi`, `ar`, `it`, `vi`, `nl`, `fa`, `ru`, `tr`, `uk`, `id`, `pl`, and `th`.
 - Docs translation workflows generate the same non-English locale set in `openclaw/docs`.
-- The Mintlify docs language picker can expose only the locales accepted by Mintlify `navigation.languages`; Russian (`ru`) and Hindi (`hi`) are now included in the publish configuration.
+- The Mintlify docs language picker can expose only the locales accepted by Mintlify `navigation.languages`. As of 2026-09-06, the publish configuration includes Russian (`ru`) and Hindi (`hi`).
 - Do not treat locale visibility in generated `docs/docs.json` as proof that translation artifacts exist. Verify each generated locale folder and its translation memory in `openclaw/docs`.
 
 ## Files in this folder

--- a/docs/.i18n/translation-workflow.md
+++ b/docs/.i18n/translation-workflow.md
@@ -13,9 +13,9 @@ Internal note for the docs publish pipeline. This file is under `docs/.i18n`, wh
 
 ## Event flow
 
-1. `openclaw/openclaw` syncs English docs into `openclaw/docs`.
+1. `openclaw/openclaw/.github/workflows/docs-sync-publish.yml` mirrors the OpenClaw docs tree into `openclaw/docs`, then replaces `docs/clawhub/` with the current `openclaw/clawhub/docs` input. The sync script also rewrites the publish `docs/docs.json`. The generated locale picker blocks exist there even though the source repo no longer commits them.
 2. GitHub Pages deploys English/source changes immediately from the sync commit.
-3. `Translate All` is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
+3. `Translate All` (`openclaw/docs/.github/workflows/translate-all.yml`) is triggered by the sync commit, release dispatch, manual dispatch, or weekly schedule.
 4. The coordinator waits a cooldown window before starting translation.
 5. After the cooldown, the coordinator reads the current `origin/main` source metadata.
 6. If a newer docs sync arrived during cooldown, the coordinator uses the newer source state.


### PR DESCRIPTION
## What

Two small fixes in `docs/.i18n/`:

1. `README.md` said Russian and Hindi "are now included" with no date. Undated temporal wording goes stale silently, so it now reads "As of 2026-09-06, the publish configuration includes `ru` and `hi`".
2. The end-to-end publish sequence was written twice, in `README.md` (7 steps) and `translation-workflow.md` (11 steps), and the copies had drifted. The README copy omitted the cooldown wait, the Pages deploy dispatch, and the live smoke step. The full sequence now lives in `translation-workflow.md` only, and the README links to it.

No information was dropped: the steps that existed in only one copy were kept in the surviving copy.

## Why

Two copies of one procedure drift, and a reader cannot tell which is current. An undated "now" cannot be checked by the next reader.

## Validation

```
node scripts/check-docs-mdx.mjs docs README.md      # passed, 753 files
node scripts/docs-link-audit.mjs                    # 8203 links, 0 broken
```

Found during a full documentation audit.