### PR TITLE
refactor(gateway): share HTTP tool-choice application

### DIFF
--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -80,9 +80,9 @@ import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
 import { resolveAgentRunUsage } from "./openai-agent-run-usage.js";
 import { resolveOpenAiCompatError, validateOpenAiSamplingParams } from "./openai-compat-errors.js";
 import {
+  applyToolChoice,
   isToolChoiceConstraintSatisfied,
   resolveUnsatisfiedToolChoiceMessage,
-  toolChoiceConstraintPrompt,
   type ToolChoiceConstraint,
 } from "./openai-tool-choice.js";
 import { authorizeGatewaySessionCreation } from "./operator-role-policy.js";
@@ -240,24 +240,15 @@ function extractClientToolsFromChatRequest(tools: unknown): ClientToolDefinition
   return clientTools;
 }
 
-function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice: unknown }): {
-  tools: ClientToolDefinition[];
-  extraSystemPrompt?: string;
-  constraint?: ToolChoiceConstraint;
-} {
-  const { tools, toolChoice } = params;
+function resolveChatToolChoice(toolChoice: unknown): ToolChoiceConstraint | "none" | undefined {
   if (toolChoice == null || toolChoice === "auto") {
-    return { tools };
+    return undefined;
   }
   if (toolChoice === "none") {
-    return { tools: [] };
+    return "none";
   }
   if (toolChoice === "required") {
-    if (tools.length === 0) {
-      throw new Error("tool_choice=required but no tools were provided");
-    }
-    const constraint: ToolChoiceConstraint = { type: "required" };
-    return { tools, extraSystemPrompt: toolChoiceConstraintPrompt(constraint), constraint };
+    return { type: "required" };
   }
   if (typeof toolChoice !== "object" || Array.isArray(toolChoice)) {
     throw new Error("tool_choice must be a string or object");
@@ -270,16 +261,7 @@ function applyChatToolChoice(params: { tools: ClientToolDefinition[]; toolChoice
     if (!targetName) {
       throw new Error("tool_choice.function.name is required");
     }
-    const matched = tools.filter((tool) => tool.function?.name === targetName);
-    if (matched.length === 0) {
-      throw new Error(`tool_choice requested unknown tool: ${targetName}`);
-    }
-    const constraint: ToolChoiceConstraint = { type: "function", name: targetName };
-    return {
-      tools: matched,
-      extraSystemPrompt: toolChoiceConstraintPrompt(constraint),
-      constraint,
-    };
+    return { type: "function", name: targetName };
   }
   if (typeof choiceType !== "string") {
     throw new Error("unsupported tool_choice type");
@@ -983,10 +965,10 @@ export async function handleOpenAiHttpRequest(
   let toolChoiceConstraint: ToolChoiceConstraint | undefined;
   try {
     const parsedClientTools = extractClientToolsFromChatRequest(payload.tools);
-    const toolChoiceResult = applyChatToolChoice({
-      tools: parsedClientTools,
-      toolChoice: payload.tool_choice,
-    });
+    const toolChoiceResult = applyToolChoice(
+      parsedClientTools,
+      resolveChatToolChoice(payload.tool_choice),
+    );
     resolvedClientTools = toolChoiceResult.tools;
     toolChoicePrompt = toolChoiceResult.extraSystemPrompt;
     toolChoiceConstraint = toolChoiceResult.constraint;

--- a/src/gateway/openai-tool-choice.ts
+++ b/src/gateway/openai-tool-choice.ts
@@ -4,13 +4,41 @@
 // The agent runtime cannot force every upstream provider, so the HTTP boundary
 // narrows exposed tools, nudges the model, then rejects turns without a matching
 // structured client-tool call. Keeping this here keeps the endpoints aligned.
+import type { ClientToolDefinition } from "../agents/command/shared-types.js";
 
 export type ToolChoiceConstraint = { type: "required" } | { type: "function"; name: string };
 
-export function toolChoiceConstraintPrompt(constraint: ToolChoiceConstraint): string {
-  return constraint.type === "function"
-    ? `You must call the ${constraint.name} tool before responding.`
-    : "You must call one of the available tools before responding.";
+export function applyToolChoice(
+  tools: ClientToolDefinition[],
+  choice: ToolChoiceConstraint | "none" | undefined,
+): {
+  tools: ClientToolDefinition[];
+  extraSystemPrompt?: string;
+  constraint?: ToolChoiceConstraint;
+} {
+  if (!choice) {
+    return { tools };
+  }
+  if (choice === "none") {
+    return { tools: [] };
+  }
+  const selectedTools =
+    choice.type === "function" ? tools.filter((tool) => tool.function.name === choice.name) : tools;
+  if (selectedTools.length === 0) {
+    throw new Error(
+      choice.type === "function"
+        ? `tool_choice requested unknown tool: ${choice.name}`
+        : "tool_choice=required but no tools were provided",
+    );
+  }
+  return {
+    tools: selectedTools,
+    extraSystemPrompt:
+      choice.type === "function"
+        ? `You must call the ${choice.name} tool before responding.`
+        : "You must call one of the available tools before responding.",
+    constraint: choice,
+  };
 }
 
 // True when no constraint is active, or the agent produced a structured tool

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -1399,7 +1399,7 @@ describe("OpenResponses HTTP API (e2e)", () => {
             strict: true,
           },
         ],
-        tool_choice: { type: "function", function: { name: "get_time" } },
+        tool_choice: { type: "function", function: { name: " get_time " } },
       });
       expect(resWrappedToolChoice.status).toBe(200);
       const wrappedClientTools =
@@ -1413,6 +1413,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
       expect(wrappedClientTools).toHaveLength(1);
       expect(wrappedClientTools[0]?.function?.name).toBe("get_time");
       expect(wrappedClientTools[0]?.function?.strict).toBe(true);
+      expect(firstAgentOpts().extraSystemPrompt).toContain(
+        "You must call the get_time tool before responding.",
+      );
       await ensureResponseConsumed(resWrappedToolChoice);
 
       const resUnknownTool = await postResponses(port, {
@@ -1422,7 +1425,9 @@ describe("OpenResponses HTTP API (e2e)", () => {
         tool_choice: { type: "function", name: "unknown_tool" },
       });
       expect(resUnknownTool.status).toBe(400);
-      await ensureResponseConsumed(resUnknownTool);
+      expect(await resUnknownTool.json()).toEqual({
+        error: { type: "invalid_request_error", message: "invalid tool configuration" },
+      });
 
       mockAgentOnce([{ text: "ok" }]);
       const resMaxTokens = await postResponses(port, {

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -88,9 +88,9 @@ import {
 import { resolveAgentRunUsage } from "./openai-agent-run-usage.js";
 import { resolveOpenAiCompatError } from "./openai-compat-errors.js";
 import {
+  applyToolChoice,
   isToolChoiceConstraintSatisfied,
   resolveUnsatisfiedToolChoiceMessage,
-  toolChoiceConstraintPrompt,
   type ToolChoiceConstraint,
 } from "./openai-tool-choice.js";
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
@@ -303,29 +303,19 @@ function extractClientTools(body: CreateResponseBody): ClientToolDefinition[] {
   }));
 }
 
-function applyToolChoice(params: {
-  tools: ClientToolDefinition[];
-  toolChoice: CreateResponseBody["tool_choice"];
-}): {
-  tools: ClientToolDefinition[];
-  extraSystemPrompt?: string;
-  constraint?: ToolChoiceConstraint;
-} {
-  const { tools, toolChoice } = params;
+function resolveToolChoice(
+  toolChoice: CreateResponseBody["tool_choice"],
+): ToolChoiceConstraint | "none" | undefined {
   if (!toolChoice) {
-    return { tools };
+    return undefined;
   }
 
   if (toolChoice === "none") {
-    return { tools: [] };
+    return "none";
   }
 
   if (toolChoice === "required") {
-    if (tools.length === 0) {
-      throw new Error("tool_choice=required but no tools were provided");
-    }
-    const constraint: ToolChoiceConstraint = { type: "required" };
-    return { tools, extraSystemPrompt: toolChoiceConstraintPrompt(constraint), constraint };
+    return { type: "required" };
   }
 
   if (typeof toolChoice === "object" && toolChoice.type === "function") {
@@ -333,19 +323,10 @@ function applyToolChoice(params: {
     if (!targetName) {
       throw new Error("tool_choice.name is required");
     }
-    const matched = tools.filter((tool) => tool.function?.name === targetName);
-    if (matched.length === 0) {
-      throw new Error(`tool_choice requested unknown tool: ${targetName}`);
-    }
-    const constraint: ToolChoiceConstraint = { type: "function", name: targetName };
-    return {
-      tools: matched,
-      extraSystemPrompt: toolChoiceConstraintPrompt(constraint),
-      constraint,
-    };
+    return { type: "function", name: targetName };
   }
 
-  return { tools };
+  return undefined;
 }
 
 export { buildAgentPrompt } from "./openresponses-prompt.js";
@@ -625,10 +606,7 @@ export async function handleOpenResponsesHttpRequest(
   let toolChoiceConstraint: ToolChoiceConstraint | undefined;
   let resolvedClientTools = clientTools;
   try {
-    const toolChoiceResult = applyToolChoice({
-      tools: clientTools,
-      toolChoice: payload.tool_choice,
-    });
+    const toolChoiceResult = applyToolChoice(clientTools, resolveToolChoice(payload.tool_choice));
     resolvedClientTools = toolChoiceResult.tools;
     toolChoicePrompt = toolChoiceResult.extraSystemPrompt;
     toolChoiceConstraint = toolChoiceResult.constraint;


### PR DESCRIPTION
## What Problem This Solves

The Chat Completions and Responses HTTP adapters independently apply the same client-tool availability checks, pinned-function filtering, constraints, and prompt text. Maintaining those decisions twice makes it easier for the endpoints to drift despite their shared tool-choice contract.

## Why This Change Was Made

Move normalized tool-choice application into the existing shared contract owner. Each adapter keeps its own raw/schema parsing and rejection handling. The shared path preserves automatic/none/required choices, trimmed function pins, all matching tools in original order, tool metadata and identity, exact prompt/error text, and stream/non-stream enforcement. Production code shrinks by 12 lines.

## User Impact

Developers maintain one canonical application path, while HTTP clients retain the same endpoint-specific inputs and outcomes. This is a maintainer-requested code-clarity improvement; no memory or latency gain is claimed.

## Evidence

- The original and final implementations pass the same **251 real HTTP tests**. The existing Responses case now covers a whitespace-padded wrapped function pin, its prompt constraint, and the exact unknown-tool error response.
- A source-derived differential probe matches **200 Chat and 48 schema-valid Responses cases** for selected tool shapes, array/tool identity and order, prompt bytes, constraint values, and exact errors. The unchanged Responses schema rejects another 52 invalid cases.
- Final focused lint, full changed-code checks, and `git diff --check` pass. An initial local parameter-reassignment lint issue was corrected with a separate selected-tools variable; parity, HTTP tests, lint, and the complete gate passed afterward.
- Independent contract/diff review and fresh final managed autoreview found no actionable issues. Test timing/RSS logs are execution telemetry, not performance comparisons.
- Required hosted CI passed for exact head `1b6e6e0c3f1d8758847145aa7db656bba364acc8`: https://github.com/openclaw/openclaw/actions/runs/34042022786.
