### PR TITLE
refactor(plugins): share enablement mutation ownership

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2330,7 +2330,6 @@ src/cli/pairing-cli.ts	1
 src/cli/parse-duration.ts	2
 src/cli/plugin-install-plan.ts	1
 src/cli/plugins-authoring-command.ts	8
-src/cli/plugins-cli.runtime.ts	2
 src/cli/plugins-command-helpers.ts	1
 src/cli/plugins-install-config.ts	2
 src/cli/plugins-uninstall-command.ts	4

--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -1,10 +1,15 @@
 // Plugins CLI policy tests cover plugin command policy checks and warnings.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { recordInstalledPluginIndexInstallOwner } from "../plugins/installed-plugin-index-install-owner.js";
+import { recordPluginManifestInstallOwner } from "../plugins/manifest-install-owner.js";
+import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import {
-  buildPluginRegistrySnapshotReportMock,
+  applyExclusiveSlotSelectionMock,
+  createTestInstalledPluginIndex,
   enablePluginInConfigMock,
   loadPluginManifestRegistryMock,
   pluginCliConfigMock,
@@ -20,19 +25,61 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock,
 } from "./plugins-cli-test-helpers.js";
 
+const inventory = vi.hoisted(() => ({ load: vi.fn(), hostedCatalog: vi.fn() }));
+
+vi.mock("../plugins/plugin-registry-snapshot.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/plugin-registry-snapshot.js")>()),
+  loadPluginRegistrySnapshotWithMetadata: (...args: unknown[]) => inventory.load(...args),
+}));
+
+vi.mock("../plugins/official-external-plugin-catalog.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/official-external-plugin-catalog.js")>()),
+  loadConfiguredHostedOfficialExternalPluginCatalogEntries: (...args: unknown[]) =>
+    inventory.hostedCatalog(...args),
+}));
+
 const ORIGINAL_OPENCLAW_NIX_MODE = process.env.OPENCLAW_NIX_MODE;
 
 describe("plugins cli policy mutations", () => {
+  let readInstallRecords: (typeof import("../plugins/installed-plugin-index-record-reader.js"))["loadInstalledPluginIndexInstallRecordsSync"];
   const compatibilityPluginIds = [
     { alias: "google-gemini-cli", pluginId: "google" },
     { alias: "minimax-portal-auth", pluginId: "minimax" },
   ] as const;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     resetPluginsCliTestState();
+    // Resolve after the shared CLI fixture registers its record-IO mock.
+    ({ loadInstalledPluginIndexInstallRecordsSync: readInstallRecords } =
+      await import("../plugins/installed-plugin-index-record-reader.js"));
+    clearPluginMetadataLifecycleCaches();
+    inventory.load.mockReset();
+    inventory.hostedCatalog.mockReset();
+    inventory.hostedCatalog.mockRejectedValue(
+      new Error("Toggle must not fetch the hosted catalog"),
+    );
+    const enable =
+      await vi.importActual<typeof import("../plugins/enable.js")>("../plugins/enable.js");
+    const slots =
+      await vi.importActual<typeof import("../plugins/slots.js")>("../plugins/slots.js");
+    enablePluginInConfigMock.mockImplementation((config, pluginId, options) =>
+      enable.enableExplicitlySelectedPluginInConfig(
+        config as OpenClawConfig,
+        pluginId as string,
+        options as Parameters<typeof enable.enableExplicitlySelectedPluginInConfig>[2],
+      ),
+    );
+    applyExclusiveSlotSelectionMock.mockImplementation((params) =>
+      slots.applyExclusiveSlotSelection(
+        params as Parameters<typeof slots.applyExclusiveSlotSelection>[0],
+      ),
+    );
+    mockPluginRegistry([]);
   });
 
   afterEach(() => {
+    expect(inventory.hostedCatalog).not.toHaveBeenCalled();
+    clearPluginMetadataLifecycleCaches();
     if (ORIGINAL_OPENCLAW_NIX_MODE === undefined) {
       delete process.env.OPENCLAW_NIX_MODE;
     } else {
@@ -40,12 +87,61 @@ describe("plugins cli policy mutations", () => {
     }
   });
 
-  function mockPluginRegistry(ids: string[]) {
-    buildPluginRegistrySnapshotReportMock.mockReturnValue({
-      plugins: ids.map((id) => ({ id })),
-      diagnostics: [],
-      registrySource: "derived",
-      registryDiagnostics: [],
+  function mockPluginRegistry(
+    ids: string[],
+    kinds: Record<string, "memory" | "context-engine"> = {},
+  ) {
+    inventory.load.mockImplementation(({ config }: { config: OpenClawConfig }) => {
+      const installRecords = readInstallRecords();
+      const installedManifests = loadPluginManifestRegistryMock({
+        installRecords,
+      }) as PluginManifestRegistry;
+      const plugins = ids.map((id): PluginManifestRecord => {
+        const installed = installedManifests.plugins.find((plugin) => plugin.id === id);
+        return (
+          installed ?? {
+            id,
+            origin: "bundled",
+            rootDir: `/tmp/bundled-${id}`,
+            source: `/tmp/bundled-${id}/index.js`,
+            manifestPath: `/tmp/bundled-${id}/openclaw.plugin.json`,
+            channels: [],
+            providers: [],
+            cliBackends: [],
+            skills: [],
+            hooks: [],
+            ...(kinds[id] ? { kind: kinds[id] } : {}),
+            legacyPluginIds: compatibilityPluginIds
+              .filter((entry) => entry.pluginId === id)
+              .map((entry) => entry.alias),
+          }
+        );
+      });
+      return {
+        source: "derived",
+        diagnostics: [],
+        manifestRegistry: { plugins, diagnostics: [] },
+        snapshot: createTestInstalledPluginIndex({
+          policyHash: JSON.stringify(config.plugins ?? {}),
+          installRecords,
+          plugins: plugins.map((plugin) =>
+            recordInstalledPluginIndexInstallOwner(
+              {
+                pluginId: plugin.id,
+                rootDir: plugin.rootDir,
+                source: plugin.source,
+                manifestPath: plugin.manifestPath,
+                manifestHash: "fixture",
+                origin: plugin.origin,
+                enabled: config.plugins?.entries?.[plugin.id]?.enabled ?? false,
+                startup: { sidecar: false, memory: plugin.kind === "memory", agentHarnesses: [] },
+                compat: [],
+              },
+              Object.hasOwn(installRecords, plugin.id) ? plugin.id : undefined,
+            ),
+          ),
+        }),
+      };
     });
   }
 
@@ -80,18 +176,10 @@ describe("plugins cli policy mutations", () => {
       },
     } as OpenClawConfig;
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    enablePluginInConfigMock.mockReturnValue({
-      config: enabledConfig,
-      enabled: true,
-      pluginId: "alpha",
-    });
     mockPluginRegistry(["alpha"]);
 
     await runPluginsCommand(["plugins", "enable", "alpha"]);
 
-    expect(enablePluginInConfigMock).toHaveBeenCalledWith(sourceConfig, "alpha", {
-      updateChannelConfig: false,
-    });
     expect(replaceConfigFileMock).toHaveBeenCalledWith({
       nextConfig: enabledConfig,
       baseHash: "mock",
@@ -100,12 +188,15 @@ describe("plugins cli policy mutations", () => {
       },
     });
     expect(configWriteMock).toHaveBeenCalledWith(enabledConfig);
-    expect(refreshPluginRegistryMock).toHaveBeenCalledWith({
-      config: enabledConfig,
-      installRecords: {},
-      policyPluginIds: ["alpha"],
-      reason: "policy-changed",
-    });
+    expect(refreshPluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: enabledConfig,
+        installRecords: {},
+        policyPluginIds: ["alpha"],
+        reason: "policy-changed",
+      }),
+    );
+    expect(runtimeErrors).toEqual([]);
   });
 
   it("rejects enabling an unconsented installed plugin without --accept-capabilities", async () => {
@@ -118,6 +209,7 @@ describe("plugins cli policy mutations", () => {
       setInstalledPluginIndexInstallRecords({
         alpha: { source: "npm", spec: "@acme/alpha", installPath: rootDir },
       });
+      expect(readInstallRecords().alpha?.installPath).toBe(rootDir);
       mockPluginRegistry(["alpha"]);
       await expect(runPluginsCommand(["plugins", "enable", "alpha"])).rejects.toThrow("__exit__:1");
 
@@ -149,8 +241,6 @@ describe("plugins cli policy mutations", () => {
   ])("$name", async ({ commandArgs, enabled, expectsConsent }) => {
     await withTempDir("openclaw-cli-capability-consent-enabled-", async (rootDir) => {
       const fixture = createColdPluginFixture({ rootDir, pluginId: "alpha" });
-      const { recordPluginManifestInstallOwner } =
-        await import("../plugins/manifest-install-owner.js");
       loadPluginManifestRegistryMock.mockReturnValue({
         plugins: [
           recordPluginManifestInstallOwner(
@@ -178,12 +268,8 @@ describe("plugins cli policy mutations", () => {
       setInstalledPluginIndexInstallRecords({
         alpha: { source: "npm", spec: "@acme/alpha", installPath: rootDir },
       });
-      buildPluginRegistrySnapshotReportMock.mockReturnValue({
-        plugins: [{ id: "alpha", enabled }],
-        diagnostics: [],
-        registrySource: "derived",
-        registryDiagnostics: [],
-      });
+      expect(readInstallRecords().alpha?.installPath).toBe(rootDir);
+      mockPluginRegistry(["alpha"]);
 
       await runPluginsCommand(commandArgs);
 
@@ -223,23 +309,64 @@ describe("plugins cli policy mutations", () => {
       reason: "blocked by allowlist",
     },
   ])("fails without mutations when $policy blocks enablement", async ({ plugins, reason }) => {
-    const sourceConfig = { plugins } as OpenClawConfig;
-    pluginCliConfigMock.mockReturnValue(sourceConfig);
-    enablePluginInConfigMock.mockReturnValue({
-      config: sourceConfig,
-      enabled: false,
-      pluginId: "alpha",
-      reason,
+    await withTempDir("openclaw-cli-blocked-capability-consent-", async (rootDir) => {
+      const fixture = createColdPluginFixture({
+        rootDir,
+        pluginId: "alpha",
+        manifest: { kind: "memory" },
+      });
+      const sourceConfig: OpenClawConfig = {
+        plugins: {
+          ...plugins,
+          entries: { alpha: { enabled: false } },
+          slots: { memory: "previous" },
+        },
+      };
+      const originalConfig = structuredClone(sourceConfig);
+      const records = {
+        alpha: { source: "npm" as const, spec: "@acme/alpha", installPath: rootDir },
+      };
+      pluginCliConfigMock.mockReturnValue(sourceConfig);
+      setInstalledPluginIndexInstallRecords(records);
+      loadPluginManifestRegistryMock.mockReturnValue({
+        plugins: [
+          recordPluginManifestInstallOwner(
+            {
+              id: "alpha",
+              kind: "memory",
+              origin: "global",
+              rootDir,
+              source: fixture.runtimeSource,
+              manifestPath: `${rootDir}/openclaw.plugin.json`,
+              channels: [fixture.channelId],
+              providers: [fixture.providerId],
+              cliBackends: [],
+              skills: [],
+              hooks: [],
+            },
+            "alpha",
+          ),
+        ],
+        diagnostics: [],
+      });
+      expect(readInstallRecords().alpha?.installPath).toBe(rootDir);
+      mockPluginRegistry(["alpha"]);
+
+      await expect(
+        runPluginsCommand(["plugins", "enable", "alpha", "--accept-capabilities"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(replaceConfigFileMock).not.toHaveBeenCalled();
+      expect(configWriteMock).not.toHaveBeenCalled();
+      expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
+      expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
+      expect(readInstallRecords()).toEqual(records);
+      expect(sourceConfig).toEqual(originalConfig);
+      expect(runtimeErrors).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
+      expect(pluginsCliRuntimeLogs).not.toContain(
+        `Plugin "alpha" could not be enabled (${reason}).`,
+      );
     });
-    mockPluginRegistry(["alpha"]);
-
-    await expect(runPluginsCommand(["plugins", "enable", "alpha"])).rejects.toThrow("__exit__:1");
-
-    expect(replaceConfigFileMock).not.toHaveBeenCalled();
-    expect(configWriteMock).not.toHaveBeenCalled();
-    expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
-    expect(runtimeErrors).toContain(`Plugin "alpha" could not be enabled (${reason}).`);
-    expect(pluginsCliRuntimeLogs).not.toContain(`Plugin "alpha" could not be enabled (${reason}).`);
   });
 
   it("refuses plugin enablement in Nix mode before config mutation", async () => {
@@ -257,7 +384,6 @@ describe("plugins cli policy mutations", () => {
       }
     }
 
-    expect(enablePluginInConfigMock).not.toHaveBeenCalled();
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
@@ -283,12 +409,15 @@ describe("plugins cli policy mutations", () => {
         explicitSetPaths: [["plugins", "entries", "alpha"]],
       },
     });
-    expect(refreshPluginRegistryMock).toHaveBeenCalledWith({
-      config: nextConfig,
-      installRecords: {},
-      policyPluginIds: ["alpha"],
-      reason: "policy-changed",
-    });
+    expect(refreshPluginRegistryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: nextConfig,
+        installRecords: {},
+        policyPluginIds: ["alpha"],
+        reason: "policy-changed",
+      }),
+    );
+    expect(runtimeErrors).toEqual([]);
   });
 
   it.each(compatibilityPluginIds)(
@@ -303,18 +432,10 @@ describe("plugins cli policy mutations", () => {
         },
       } as OpenClawConfig;
       pluginCliConfigMock.mockReturnValue(sourceConfig);
-      enablePluginInConfigMock.mockReturnValue({
-        config: enabledConfig,
-        enabled: true,
-        pluginId,
-      });
       mockPluginRegistry([pluginId]);
 
       await runPluginsCommand(["plugins", "enable", alias]);
 
-      expect(enablePluginInConfigMock).toHaveBeenCalledWith(sourceConfig, pluginId, {
-        updateChannelConfig: false,
-      });
       expect(replaceConfigFileMock).toHaveBeenCalledWith({
         nextConfig: enabledConfig,
         baseHash: "mock",
@@ -354,23 +475,60 @@ describe("plugins cli policy mutations", () => {
     },
   );
 
-  it.each(["enable", "disable"] as const)(
-    "rejects %s for a plugin that is not discovered",
-    async (command) => {
-      mockPluginRegistry(["alpha"]);
+  it.each(
+    ["enable", "disable"].flatMap((command) =>
+      ["missing-plugin", "alpha-provider", "alpha-channel"].map((id) => ({ command, id })),
+    ),
+  )("rejects $command for undiscovered plugin id $id", async ({ command, id }) => {
+    loadPluginManifestRegistryMock.mockReturnValue({
+      plugins: [
+        {
+          id: "alpha",
+          origin: "bundled",
+          rootDir: "/tmp/bundled-alpha",
+          source: "/tmp/bundled-alpha/index.js",
+          manifestPath: "/tmp/bundled-alpha/openclaw.plugin.json",
+          providers: ["alpha-provider"],
+          channels: ["alpha-channel"],
+          cliBackends: [],
+          skills: [],
+          hooks: [],
+        },
+      ],
+      diagnostics: [],
+    });
+    mockPluginRegistry(["alpha"]);
 
-      await expect(runPluginsCommand(["plugins", command, "missing-plugin"])).rejects.toThrow(
-        "__exit__:1",
-      );
+    await expect(runPluginsCommand(["plugins", command, id])).rejects.toThrow("__exit__:1");
 
-      expect(runtimeErrors).toContain(
-        "Plugin not found: missing-plugin. Run `openclaw plugins list` to see installed plugins, or `openclaw plugins search missing-plugin` to look for installable plugins.",
-      );
-      expect(enablePluginInConfigMock).not.toHaveBeenCalled();
-      expect(configWriteMock).not.toHaveBeenCalled();
-      expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
-    },
-  );
+    expect(runtimeErrors).toContain(
+      `Plugin not found: ${id}. Run \`openclaw plugins list\` to see installed plugins, or \`openclaw plugins search ${id}\` to look for installable plugins.`,
+    );
+    expect(configWriteMock).not.toHaveBeenCalled();
+    expect(writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock).not.toHaveBeenCalled();
+    expect(refreshPluginRegistryMock).not.toHaveBeenCalled();
+  });
+
+  it("persists exclusive-slot selection and reports its warning without fetching a hosted catalog", async () => {
+    pluginCliConfigMock.mockReturnValue({
+      plugins: {
+        entries: { alpha: { enabled: false }, previous: { enabled: true } },
+        slots: { memory: "previous" },
+      },
+    });
+    mockPluginRegistry(["alpha", "previous"], { alpha: "memory", previous: "memory" });
+
+    await runPluginsCommand(["plugins", "enable", "alpha"]);
+
+    expect(requireFirstWrittenConfig().plugins).toMatchObject({
+      entries: { alpha: { enabled: true } },
+      slots: { memory: "alpha" },
+    });
+    expect(pluginsCliRuntimeLogs.join("\n")).toContain(
+      'Exclusive slot "memory" switched from "previous" to "alpha".',
+    );
+    expect(inventory.hostedCatalog).not.toHaveBeenCalled();
+  });
 
   it("does not create a channel config when disabling a channel plugin by policy", async () => {
     pluginCliConfigMock.mockReturnValue({} as OpenClawConfig);

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -11,7 +11,6 @@ import {
   assertConfigWriteAllowedInCurrentMode,
   getRuntimeConfig,
   readConfigFileSnapshot,
-  replaceConfigFile,
 } from "../config/config.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -47,13 +46,8 @@ function createModuleLoader<T>(load: () => Promise<T>): () => Promise<T> {
   return () => (promise ??= load());
 }
 
-const loadPluginsConfigState = createModuleLoader(() => import("../plugins/config-state.js"));
 const loadPluginsStatus = createModuleLoader(() => import("../plugins/status.js"));
-const loadPluginSlotSelection = createModuleLoader(() => import("../plugins/slot-selection.js"));
 const loadPluginsCommandHelpers = createModuleLoader(() => import("./plugins-command-helpers.js"));
-const loadPluginsRegistryRefresh = createModuleLoader(
-  () => import("../plugins/registry-refresh.js"),
-);
 
 function countEnabledPlugins(plugins: readonly { enabled: boolean }[]): number {
   return plugins.filter((plugin) => plugin.enabled).length;
@@ -183,58 +177,49 @@ function collectConfiguredRuntimePluginWarnings(params: {
 
 /** Enable a plugin in config and refresh the registry snapshot for the changed policy. */
 export async function runPluginsEnableCommand(
-  idInput: string,
+  id: string,
   opts: { acceptCapabilities?: boolean } = {},
 ): Promise<void> {
-  assertConfigWriteAllowedInCurrentMode();
-  return await withPluginLifecycleLease(
-    {},
-    async () => await runPluginsEnableCommandUnlocked(idInput, opts),
-  );
+  await runPluginPolicyCommand(id, true, opts.acceptCapabilities);
 }
 
-async function runPluginsEnableCommandUnlocked(
-  idInput: string,
-  opts: { acceptCapabilities?: boolean },
-): Promise<void> {
-  let id = idInput;
-  assertConfigWriteAllowedInCurrentMode();
+/** Disable a plugin in config and refresh the registry snapshot for the changed policy. */
+export async function runPluginsDisableCommand(id: string): Promise<void> {
+  await runPluginPolicyCommand(id, false);
+}
 
-  const { enableExplicitlySelectedPluginInConfig } = await import("../plugins/enable.js");
-  const { normalizePluginId } = await loadPluginsConfigState();
-  const { buildPluginRegistrySnapshotReport } = await loadPluginsStatus();
-  const snapshot = await readConfigFileSnapshot();
-  const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const report = buildPluginRegistrySnapshotReport({ config: cfg });
-  id = normalizePluginId(id);
-  const plugin = report.plugins.find((entry) => entry.id === id);
-  if (!plugin) {
-    return reportMissingPlugin(id);
-  }
-  const enableResult = enableExplicitlySelectedPluginInConfig(cfg, id, {
-    updateChannelConfig: false,
-  });
-  // A blocked request must not displace the active slot or rewrite persisted state.
-  if (!enableResult.enabled) {
-    defaultRuntime.error(
-      `Plugin "${id}" could not be enabled (${enableResult.reason ?? "unknown reason"}).`,
-    );
-    return defaultRuntime.exit(1);
-  }
-  if (!plugin.enabled || opts.acceptCapabilities) {
-    const { resolvePluginCapabilityConsent } = await import("../plugins/capability-consent.js");
-    const { ManagedPluginLifecycleError } =
-      await import("../plugins/management-lifecycle-error.js");
-    const consent = resolvePluginCapabilityConsentCliOptions({
-      acceptCapabilities: opts.acceptCapabilities,
-      action: "enable",
-    });
+async function runPluginPolicyCommand(
+  id: string,
+  enabled: boolean,
+  acceptCapabilities?: boolean,
+): Promise<void> {
+  assertConfigWriteAllowedInCurrentMode();
+  const { mutateManagedPluginEnabled } = await import("../plugins/management-mutations.js");
+  const { ManagedPluginLifecycleError } = await import("../plugins/management-lifecycle-error.js");
+  await withPluginLifecycleLease({}, async () => {
     try {
-      await resolvePluginCapabilityConsent({
-        config: cfg,
+      const result = await mutateManagedPluginEnabled({
         pluginId: id,
-        ...consent,
+        enabled,
+        caller: "cli",
+        requestCapabilityConsent: acceptCapabilities,
+        ...resolvePluginCapabilityConsentCliOptions({ acceptCapabilities, action: "enable" }),
       });
+      if (result.status === "missing") {
+        return reportMissingPlugin(result.pluginId);
+      }
+      if (result.status === "blocked") {
+        defaultRuntime.error(
+          `Plugin "${result.pluginId}" could not be enabled (${result.reason ?? "unknown reason"}).`,
+        );
+        return defaultRuntime.exit(1);
+      }
+      for (const warning of result.warnings) {
+        defaultRuntime.log(theme.warn(warning));
+      }
+      defaultRuntime.log(
+        `${enabled ? "Enabled" : "Disabled"} plugin "${result.pluginId}". Restart the gateway to apply.`,
+      );
     } catch (error) {
       if (!(error instanceof ManagedPluginLifecycleError) || !error.capabilityConsent) {
         throw error;
@@ -242,82 +227,7 @@ async function runPluginsEnableCommandUnlocked(
       defaultRuntime.error(error.message);
       return defaultRuntime.exit(1);
     }
-  }
-
-  const { applySlotSelectionForPlugin } = await loadPluginSlotSelection();
-  const { logSlotWarnings } = await loadPluginsCommandHelpers();
-  const { refreshPluginRegistryAfterConfigMutation } = await loadPluginsRegistryRefresh();
-  let next: OpenClawConfig = enableResult.config;
-  const slotResult = applySlotSelectionForPlugin(next, id);
-  next = slotResult.config;
-  await replaceConfigFile({
-    nextConfig: next,
-    ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-    // Source/runtime projection must retain the explicitly merged canonical
-    // entry; otherwise compatibility-only nested settings are silently lost.
-    writeOptions: {
-      explicitSetPaths: [["plugins", "entries", enableResult.pluginId]],
-    },
   });
-  await refreshPluginRegistryAfterConfigMutation({
-    config: next,
-    reason: "policy-changed",
-    invalidateRuntimeCache: false,
-    policyPluginIds: [enableResult.pluginId],
-    logger: {
-      warn: (message) => defaultRuntime.log(theme.warn(message)),
-    },
-  });
-  logSlotWarnings(slotResult.warnings);
-  defaultRuntime.log(`Enabled plugin "${id}". Restart the gateway to apply.`);
-}
-
-/** Disable a plugin in config and refresh the registry snapshot for the changed policy. */
-export async function runPluginsDisableCommand(idInput: string): Promise<void> {
-  assertConfigWriteAllowedInCurrentMode();
-  return await withPluginLifecycleLease(
-    {},
-    async () => await runPluginsDisableCommandUnlocked(idInput),
-  );
-}
-
-async function runPluginsDisableCommandUnlocked(idInput: string): Promise<void> {
-  let id = idInput;
-  assertConfigWriteAllowedInCurrentMode();
-
-  const { normalizePluginId } = await loadPluginsConfigState();
-  const { buildPluginRegistrySnapshotReport } = await loadPluginsStatus();
-  const { setPluginEnabledInConfig } = await import("./plugins-config.js");
-  const { refreshPluginRegistryAfterConfigMutation } = await loadPluginsRegistryRefresh();
-  const snapshot = await readConfigFileSnapshot();
-  const cfg = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const report = buildPluginRegistrySnapshotReport({ config: cfg });
-  id = normalizePluginId(id);
-  if (!report.plugins.some((plugin) => plugin.id === id)) {
-    return reportMissingPlugin(id);
-  }
-  const next = setPluginEnabledInConfig(cfg, id, false, {
-    updateChannelConfig: false,
-  });
-  await replaceConfigFile({
-    nextConfig: next,
-    ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-    // `id` was normalized before discovery; persist that same canonical entry
-    // so alias invocations cannot lose settings during source projection.
-    writeOptions: {
-      explicitSetPaths: [["plugins", "entries", id]],
-    },
-  });
-  await refreshPluginRegistryAfterConfigMutation({
-    config: next,
-    reason: "policy-changed",
-    invalidateRuntimeCache: false,
-    policyPluginIds: [id],
-    logger: {
-      warn: (message) => defaultRuntime.log(theme.warn(message)),
-    },
-  });
-  defaultRuntime.log(`Disabled plugin "${id}". Restart the gateway to apply.`);
 }
 
 export async function runPluginsInstallAction(

--- a/src/cli/plugins-config.test.ts
+++ b/src/cli/plugins-config.test.ts
@@ -1,7 +1,6 @@
-// Plugin config tests cover plugin config command parsing and output formatting.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { setPluginEnabledInConfig } from "./plugins-config.js";
+import { setPluginEnabledInConfig } from "../plugins/toggle-config.js";
 
 describe("setPluginEnabledInConfig", () => {
   it("sets enabled flag for an existing plugin entry", () => {

--- a/src/cli/plugins-config.ts
+++ b/src/cli/plugins-config.ts
@@ -1,3 +1,0 @@
-// Public CLI barrel for plugin config mutations.
-/** Toggle plugin enablement inside an OpenClaw config object. */
-export { setPluginEnabledInConfig } from "../plugins/toggle-config.js";

--- a/src/plugins/management-mutations.ts
+++ b/src/plugins/management-mutations.ts
@@ -5,6 +5,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { collectChangedPaths } from "../config/config-change-paths.js";
 import {
   assertConfigWriteAllowedInCurrentMode,
+  readConfigFileSnapshot,
   readConfigFileSnapshotForWrite,
   replaceConfigFile,
 } from "../config/config.js";
@@ -15,8 +16,10 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   resolvePluginCapabilityConsent,
   type PluginCapabilityConsentAcknowledgment,
+  type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "./clawhub-error-codes.js";
+import { normalizePluginId } from "./config-state.js";
 import { resolvePluginControlPlaneWorkspace } from "./control-plane-workspace.js";
 import { getProcessGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { enableExplicitlySelectedPluginInConfig } from "./enable.js";
@@ -369,57 +372,83 @@ export async function installManagedPlugin(params: {
   });
 }
 
-/** Persist desired plugin policy while preserving allow/deny, slot, include, and hash guards. */
-export async function setManagedPluginEnabled(params: {
+type ManagedPluginEnableRequest = {
   pluginId: string;
   enabled: boolean;
   acknowledgeCapabilities?: PluginCapabilityConsentAcknowledgment;
   env?: NodeJS.ProcessEnv;
-}): Promise<{
-  plugin: ManagedPluginCatalogEntry;
-  changedPaths: string[];
-  warnings?: string[];
-}> {
+};
+
+/** Commit plugin policy without requiring the management catalog's hosted projection. */
+export async function mutateManagedPluginEnabled(
+  params: ManagedPluginEnableRequest & {
+    caller: "cli" | "management";
+    onCapabilityConsent?: PluginCapabilityConsentHandler;
+    requestCapabilityConsent?: boolean;
+  },
+) {
   const env = params.env ?? process.env;
+  const cli = params.caller === "cli";
   return await withPluginLifecycleLease({ env }, async () => {
-    const snapshot = await readPluginMutationSnapshot(env);
+    if (cli) {
+      assertConfigWriteAllowedInCurrentMode({ env });
+    }
+    // CLI policy writes retain their config owner's include admission. Management
+    // additionally requires the install mutation preflight before any consent.
+    const snapshot = cli
+      ? await readConfigFileSnapshot().then((file) => ({
+          config: file.sourceConfig,
+          baseHash: file.hash,
+          writeOptions: {},
+        }))
+      : await readPluginMutationSnapshot(env);
     const metadata = loadFreshManagedPluginMetadata(snapshot.config, env);
-    const pluginId = metadata.normalizePluginId(params.pluginId.trim());
+    const pluginId = cli
+      ? normalizePluginId(params.pluginId)
+      : metadata.normalizePluginId(params.pluginId.trim());
     const installedPlugin = metadata.index.plugins.find((plugin) => plugin.pluginId === pluginId);
     if (!installedPlugin) {
-      throw new ManagedPluginLifecycleError(`plugin not installed: ${params.pluginId}`);
+      return { status: "missing" as const, pluginId };
     }
-    if (params.enabled && !installedPlugin.enabled) {
-      await resolvePluginCapabilityConsent({
-        config: snapshot.config,
-        env,
-        pluginId,
-        acknowledge: params.acknowledgeCapabilities,
-        metadata,
-      });
+    const resolveConsent = async () => {
+      if (params.enabled && (!installedPlugin.enabled || params.requestCapabilityConsent)) {
+        await resolvePluginCapabilityConsent({
+          config: snapshot.config,
+          env,
+          pluginId,
+          acknowledge: params.acknowledgeCapabilities,
+          onCapabilityConsent: params.onCapabilityConsent,
+          metadata,
+        });
+      }
+    };
+    if (!cli) {
+      await resolveConsent();
     }
     let next = snapshot.config;
-    const warnings: string[] = [];
+    const slotWarnings: string[] = [];
     let policyPluginId = pluginId;
     if (params.enabled) {
-      // The admin-scoped enable RPC is an explicit trust action. Preserve the
-      // existing inventory while admitting only the selected installed plugin.
-      if ((next.plugins?.allow?.length ?? 0) > 0) {
+      // Admin selection admits one installed plugin; CLI preserves restrictive policy.
+      if (!cli && (next.plugins?.allow?.length ?? 0) > 0) {
         next = ensurePluginAllowlisted(next, pluginId);
       }
       const enableResult = enableExplicitlySelectedPluginInConfig(next, pluginId, {
         updateChannelConfig: false,
       });
       if (!enableResult.enabled) {
-        throw new ManagedPluginLifecycleError(
-          `plugin "${pluginId}" could not be enabled (${enableResult.reason ?? "unknown reason"})`,
-        );
+        return { status: "blocked" as const, pluginId, reason: enableResult.reason };
+      }
+      // CLI rejection precedes consent; reuse this exact config after review.
+      if (cli) {
+        await resolveConsent();
       }
       next = enableResult.config;
       policyPluginId = enableResult.pluginId;
-      const slotResult = applySlotSelectionForPlugin(next, pluginId, metadata);
+      // CLI slot inspection uses the enabled config, including legacy runtime-only kinds.
+      const slotResult = applySlotSelectionForPlugin(next, pluginId, cli ? undefined : metadata);
       next = slotResult.config;
-      warnings.push(...slotResult.warnings);
+      slotWarnings.push(...slotResult.warnings);
     } else {
       next = setPluginEnabledInConfig(next, pluginId, false, { updateChannelConfig: false });
     }
@@ -428,28 +457,60 @@ export async function setManagedPluginEnabled(params: {
     await replaceConfigFile({
       nextConfig: next,
       baseHash: snapshot.baseHash,
-      writeOptions: snapshot.writeOptions,
+      // CLI alias writes preserve merged canonical settings during source projection.
+      writeOptions: cli
+        ? { explicitSetPaths: [["plugins", "entries", policyPluginId]] }
+        : snapshot.writeOptions,
     });
+    const registryWarnings: string[] = [];
     await refreshPluginRegistryAfterConfigMutation({
       config: next,
       env,
       reason: "policy-changed",
       invalidateRuntimeCache: false,
       policyPluginIds: [policyPluginId],
-      logger: { warn: (message) => warnings.push(message) },
+      logger: { warn: (message) => registryWarnings.push(message) },
     });
-    const updatedMetadata = refreshManagedPluginMetadata({ config: next, env });
-    const catalog = await listManagedPlugins({ config: next, env, metadata: updatedMetadata });
-    const plugin = catalog.plugins.find((entry) => entry.id === pluginId);
+    return {
+      status: "committed" as const,
+      pluginId,
+      config: next,
+      changedPaths: [...changedPaths].filter(Boolean).toSorted(),
+      warnings: cli
+        ? [...registryWarnings, ...slotWarnings]
+        : [...slotWarnings, ...registryWarnings],
+    };
+  });
+}
+
+/** Persist desired policy and project the committed candidate into the management catalog. */
+export async function setManagedPluginEnabled(params: ManagedPluginEnableRequest): Promise<{
+  plugin: ManagedPluginCatalogEntry;
+  changedPaths: string[];
+  warnings?: string[];
+}> {
+  const env = params.env ?? process.env;
+  return await withPluginLifecycleLease({ env }, async () => {
+    const result = await mutateManagedPluginEnabled({ ...params, caller: "management" });
+    if (result.status !== "committed") {
+      throw new ManagedPluginLifecycleError(
+        result.status === "missing"
+          ? `plugin not installed: ${params.pluginId}`
+          : `plugin "${result.pluginId}" could not be enabled (${result.reason ?? "unknown reason"})`,
+      );
+    }
+    const metadata = refreshManagedPluginMetadata({ config: result.config, env });
+    const catalog = await listManagedPlugins({ config: result.config, env, metadata });
+    const plugin = catalog.plugins.find((entry) => entry.id === result.pluginId);
     if (!plugin) {
       throw new ManagedPluginLifecycleError(
-        `updated plugin missing from refreshed registry: ${pluginId}`,
+        `updated plugin missing from refreshed registry: ${result.pluginId}`,
       );
     }
     return {
       plugin,
-      changedPaths: [...changedPaths].filter(Boolean).toSorted(),
-      ...(warnings.length > 0 ? { warnings } : {}),
+      changedPaths: result.changedPaths,
+      ...(result.warnings.length > 0 ? { warnings: result.warnings } : {}),
     };
   });
 }


### PR DESCRIPTION
CLI enable/disable and plugin management duplicated config, consent, slot and registry mutations. Share one leased mutation owner and leave terminal output and hosted catalog projection in their respective adapters.

Preserve each caller’s existing contract: restrictive CLI allowlists and policy-before-consent ordering; admin allowlist admission and consent-first ordering; explicit CLI review of already-enabled plugins; distinct ID normalization; original include/hash and canonical-entry write handling; slot lookup, warning order, Nix checks and output before the lease’s final ownership check. Commands retain their existing restart guidance.

Validation: 95 focused tests passed, along with the complete changed-code gate and an independent P0–P2 review. The policy tests now use real metadata, enablement and slot owners instead of asserting mocked helper calls. Eight real CLI scenarios (27 commands plus the canonical build) matched the pinned-main baseline’s semantics and output: consent, global/deny/allow blocks, include writes/rejections and alias settings. Proof used synthetic local packages and isolated state. Cold index refreshes were recorded separately from config and capability-acceptance writes.

Production LOC: 130 added, 162 removed, net −32. Tests: +157. The assertion baseline shrinks by one obsolete entry. Part of the smaller refactors extracted from #135599.

CI found the CLI config re-export had become production-dead after the shared owner removed its last runtime caller. The follow-up deletes that three-line barrel and imports the unchanged implementation directly in all seven retained config tests. Both production/full-tree unused-file scans and independent review pass; the earlier real CLI proof remains applicable because executable mutation code is unchanged.
