### PR TITLE
test(memory): observe native watcher lifecycle across runtimes

### DIFF
--- a/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
@@ -24,6 +24,7 @@ describe("memory watchers on the real filesystem", () => {
     async (operation) => {
       const state = await createOpenClawTestState({ label: "memory-watch-filesystem" });
       const initialWatchers = activeFilesystemWatchers();
+      const openWatchers = new Set<nativeFs.FSWatcher>();
       const turnContext = new AsyncLocalStorage<string>();
       const pendingInputContext = new AsyncLocalStorage<string>();
       const watcherContexts: Array<{ turn?: string; pendingInput?: string }> = [];
@@ -34,7 +35,10 @@ describe("memory watchers on the real filesystem", () => {
           turn: turnContext.getStore(),
           pendingInput: pendingInputContext.getStore(),
         });
-        return originalWatch(...args);
+        const watcher = originalWatch(...args);
+        openWatchers.add(watcher);
+        watcher.once("close", () => openWatchers.delete(watcher));
+        return watcher;
       });
       syncBuiltinESMExports();
       const originalSetTimeout = globalThis.setTimeout;
@@ -83,7 +87,11 @@ describe("memory watchers on the real filesystem", () => {
         const activeManager = manager;
         await activeManager.sync({ reason: "test-initial-index" });
         expect(activeManager.status().fts?.available).toBe(true);
-        expect(activeFilesystemWatchers()).toBeGreaterThan(initialWatchers);
+        expect(openWatchers.size).toBeGreaterThan(0);
+        // Bun emits watcher close events but does not expose Node's FSEventWrap census.
+        if (!process.versions.bun) {
+          expect(activeFilesystemWatchers()).toBeGreaterThan(initialWatchers);
+        }
         const indexPath = activeManager.status().dbPath;
         if (!indexPath) {
           throw new Error("memory index path unavailable");
@@ -136,7 +144,10 @@ describe("memory watchers on the real filesystem", () => {
         index.close();
         index = undefined;
         await activeManager.close();
-        await expect.poll(activeFilesystemWatchers).toBe(initialWatchers);
+        await expect.poll(() => openWatchers.size).toBe(0);
+        if (!process.versions.bun) {
+          await expect.poll(activeFilesystemWatchers).toBe(initialWatchers);
+        }
       } finally {
         index?.close();
         await manager?.close();


### PR DESCRIPTION
## What Problem This Solves

The memory filesystem watcher tests assume native watchers appear in Node's FSEventWrap resource census. Bun creates and closes native watchers without exposing that same census entry, so the tests fail before checking indexing behavior.

## Why This Change Was Made

Track the actual native watcher handles returned by the existing fixture spy until their close events. Require open watchers during use and no remaining watchers after manager closure on both runtimes, while retaining Node's additional resource-census assertions. Real filesystem indexing and AsyncLocalStorage assertions remain unchanged.

## User Impact

One test file changes. Production watcher behavior, storage semantics, timeouts, and indexing policy are unchanged.

## Evidence

- The original local Bun run failed both cases at the resource census.
- Exact-source Linux proof passed both existing cases under Node 24.19.0 and Bun 1.4.2, including root replacement/removal, indexing, and watcher closure. Source hashes were verified before execution. [Testbox proof run](https://github.com/openclaw/openclaw/actions/runs/34040443585); wrapper exited zero and the lease is completed.
- The complete changed-file gate and fresh independent P0–P2 review passed.
- Local macOS Node after-proof failed unchanged indexing polls. Separate native Node and Bun probes received no directory events on that host. This is an explicit local environment/proof gap: no passing macOS functional proof or Bun-only event-delivery defect is claimed. No service restart or polling workaround was introduced.
