### PR TITLE
perf(ui): reuse Usage filter inventories per render

### DIFF
--- a/ui/src/pages/usage/query.test.ts
+++ b/ui/src/pages/usage/query.test.ts
@@ -4,6 +4,7 @@ import {
   applySuggestionToQuery,
   buildQuerySuggestions,
   buildSessionsCsv,
+  buildUsageFilterOptions,
   removeQueryToken,
   setQueryTokensForKey,
 } from "./query.ts";
@@ -36,8 +37,44 @@ describe("usage query token mutations", () => {
     expect(applySuggestionToQuery(`${quotedLabel} provider:o`, "provider:openai")).toBe(
       `${quotedLabel} provider:openai `,
     );
-    expect(buildQuerySuggestions(quotedLabel, [])).toEqual([]);
+    expect(buildQuerySuggestions(quotedLabel, buildUsageFilterOptions([]))).toEqual([]);
   });
+});
+
+it("limits suggestions before matching while preserving raw option spelling", () => {
+  const values = [
+    "OpenAI",
+    "OpenAI",
+    "openai",
+    " ",
+    "",
+    undefined,
+    "four",
+    "five",
+    "six",
+    "seventh",
+  ];
+  const sessions = values.map((value, index) => ({
+    key: `session-${index}`,
+    agentId: value,
+    channel: value,
+    modelProvider: value,
+    model: value,
+    usage: null,
+  }));
+  const options = buildUsageFilterOptions(sessions);
+  expect(options.agent).toEqual(["OpenAI", "openai", " ", "four", "five", "six"]);
+  for (const key of ["agent", "channel", "provider", "model"]) {
+    expect(buildQuerySuggestions(`${key}:OPEN`, options).map((entry) => entry.value)).toEqual([
+      `${key}:OpenAI`,
+      `${key}:openai`,
+    ]);
+    expect(buildQuerySuggestions(`${key}:seventh`, options)).toEqual([]);
+  }
+  expect(buildQuerySuggestions("constructor:", options)).toEqual([]);
+  expect(buildQuerySuggestions("has:err", options)).toEqual([
+    { label: "has:errors", value: "has:errors" },
+  ]);
 });
 
 describe("usage query CSV export", () => {

--- a/ui/src/pages/usage/query.ts
+++ b/ui/src/pages/usage/query.ts
@@ -1,6 +1,5 @@
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { extractQueryTerms } from "./helpers.ts";
 import type { CostDailyEntry, UsageAggregates, UsageSessionEntry } from "./types.ts";
 
@@ -121,11 +120,43 @@ type QuerySuggestion = {
   value: string;
 };
 
-const buildQuerySuggestions = (
-  query: string,
-  sessions: UsageSessionEntry[],
+type UsageFilterOptions = Record<"agent" | "channel" | "provider" | "model" | "tool", string[]>;
+
+function appendFilterValues<T>(
+  values: string[],
+  entries: readonly T[],
+  read: (entry: T) => string | undefined,
+  limit = 12,
+): void {
+  for (const entry of entries) {
+    if (values.length >= limit) {
+      break;
+    }
+    const value = read(entry);
+    if (value && !values.includes(value)) {
+      values.push(value);
+    }
+  }
+}
+
+export function buildUsageFilterOptions(
+  sessions: readonly UsageSessionEntry[],
   aggregates?: UsageAggregates | null,
-): QuerySuggestion[] => {
+): UsageFilterOptions {
+  const options: UsageFilterOptions = { agent: [], channel: [], provider: [], model: [], tool: [] };
+  appendFilterValues(options.agent, sessions, (session) => session.agentId, 6);
+  appendFilterValues(options.channel, sessions, (session) => session.channel);
+  appendFilterValues(options.provider, sessions, (session) => session.modelProvider);
+  // Overrides follow every observed provider, preserving the menu's first-seen order.
+  appendFilterValues(options.provider, sessions, (session) => session.providerOverride);
+  appendFilterValues(options.provider, aggregates?.byProvider ?? [], (entry) => entry.provider);
+  appendFilterValues(options.model, sessions, (session) => session.model);
+  appendFilterValues(options.model, aggregates?.byModel ?? [], (entry) => entry.model);
+  appendFilterValues(options.tool, aggregates?.tools.tools ?? [], (entry) => entry.name);
+  return options;
+}
+
+const buildQuerySuggestions = (query: string, options: UsageFilterOptions): QuerySuggestion[] => {
   const trimmed = query.trim();
   if (!trimmed) {
     return [];
@@ -141,23 +172,6 @@ const buildQuerySuggestions = (
 
   const key = normalizeLowercaseStringOrEmpty(rawKey);
   const value = normalizeLowercaseStringOrEmpty(rawValue);
-
-  const unique = (items: Array<string | undefined>): string[] => {
-    return uniqueStrings(items.filter((item): item is string => Boolean(item)));
-  };
-
-  const agents = unique(sessions.map((s) => s.agentId)).slice(0, 6);
-  const channels = unique(sessions.map((s) => s.channel)).slice(0, 6);
-  const providers = unique([
-    ...sessions.map((s) => s.modelProvider),
-    ...sessions.map((s) => s.providerOverride),
-    ...(aggregates?.byProvider.map((p) => p.provider) ?? []),
-  ]).slice(0, 6);
-  const models = unique([
-    ...sessions.map((s) => s.model),
-    ...(aggregates?.byModel.map((m) => m.model) ?? []),
-  ]).slice(0, 6);
-  const tools = unique(aggregates?.tools.tools.map((t) => t.name) ?? []).slice(0, 6);
 
   if (!key) {
     return [
@@ -175,7 +189,7 @@ const buildQuerySuggestions = (
 
   const suggestions: QuerySuggestion[] = [];
   const addValues = (prefix: string, values: string[]) => {
-    for (const val of values) {
+    for (const val of values.slice(0, 6)) {
       if (!value || normalizeLowercaseStringOrEmpty(val).includes(value)) {
         suggestions.push({ label: `${prefix}:${val}`, value: `${prefix}:${val}` });
       }
@@ -184,19 +198,19 @@ const buildQuerySuggestions = (
 
   switch (key) {
     case "agent":
-      addValues("agent", agents);
+      addValues("agent", options.agent);
       break;
     case "channel":
-      addValues("channel", channels);
+      addValues("channel", options.channel);
       break;
     case "provider":
-      addValues("provider", providers);
+      addValues("provider", options.provider);
       break;
     case "model":
-      addValues("model", models);
+      addValues("model", options.model);
       break;
     case "tool":
-      addValues("tool", tools);
+      addValues("tool", options.tool);
       break;
     case "has":
       ["errors", "tools", "context", "usage", "model", "provider"].forEach((entry) => {

--- a/ui/src/pages/usage/view.test.ts
+++ b/ui/src/pages/usage/view.test.ts
@@ -3,6 +3,7 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { buildAggregatesFromSessions } from "./metrics.ts";
+import { buildUsageFilterOptions } from "./query.ts";
 import type { UsageProps, UsageSessionEntry, UsageTotals } from "./types.ts";
 import { renderUsage } from "./view.ts";
 
@@ -548,6 +549,85 @@ describe("renderUsage", () => {
       ?.dispatchEvent(new CustomEvent("wa-select", { detail: { item: option }, bubbles: true }));
 
     expect(onQueryDraftChange).toHaveBeenCalledWith(expect.stringContaining("provider:clear"));
+  });
+
+  it("keeps bounded filter inventories in source order across observed and aggregate values", () => {
+    const sessions = ["observed-a", "observed-b", "observed-a"].map((provider, index) =>
+      Object.assign(usageSession(`session-${index}`, "main", provider), {
+        providerOverride: `override-${index}`,
+        modelOverride: "override-only-model",
+        channel: index === 0 ? "" : "Chat",
+      }),
+    );
+    const aggregates = buildAggregatesFromSessions(
+      Array.from({ length: 14 }, (_, index) =>
+        usageSession(`aggregate-${index}`, "other", `aggregate-${index}`),
+      ),
+    );
+    aggregates.tools.tools = Array.from({ length: 14 }, (_, index) => ({
+      name: `tool-${index}`,
+      count: 1,
+    }));
+    const options = buildUsageFilterOptions(sessions, aggregates);
+    expect(options.channel).toEqual(["Chat"]);
+    expect(options.provider).toEqual([
+      "observed-a",
+      "observed-b",
+      "override-0",
+      "override-1",
+      "override-2",
+      ...Array.from({ length: 7 }, (_, index) => `aggregate-${index}`),
+    ]);
+    expect(options.model).toEqual([
+      "observed-a-model",
+      "observed-b-model",
+      ...Array.from({ length: 10 }, (_, index) => `aggregate-${index}-model`),
+    ]);
+    expect(options.tool).toEqual(Array.from({ length: 12 }, (_, index) => `tool-${index}`));
+  });
+
+  it("refreshes filter order and draft selections when chart mode, agent, or source changes", () => {
+    const container = document.createElement("div");
+    const props = createUsageProps();
+    props.data.sessions = [
+      usageSession("first", "main", "first", { totalTokens: 200, totalCost: 1 }),
+      usageSession("second", "other", "second", { totalTokens: 100, totalCost: 2 }),
+    ];
+    props.filters.query = "provider:absent";
+    props.filters.queryDraft = 'label:"Team  Planning" provider:second';
+    props.callbacks.filters.onQueryDraftChange = vi.fn();
+    const providerOptions = () =>
+      [...container.querySelectorAll<HTMLElement>(".usage-filter-select")]
+        .find(
+          (menu) => menu.querySelector(".usage-filter-trigger span")?.textContent === "Provider",
+        )!
+        .querySelectorAll<HTMLElement & { checked: boolean }>(".usage-filter-option");
+    const values = () => [...providerOptions()].map((option) => option.textContent?.trim());
+
+    render(renderUsage(props), container);
+    expect(values()).toEqual(["first", "second"]);
+    expect([...providerOptions()].find((option) => option.checked)?.textContent?.trim()).toBe(
+      "second",
+    );
+    expect(container.querySelector(".usage-query-suggestion")?.textContent?.trim()).toBe(
+      "provider:second",
+    );
+
+    props.display.chartMode = "cost";
+    render(renderUsage(props), container);
+    expect(values()).toEqual(["second", "first"]);
+    props.filters.agentId = "main";
+    render(renderUsage(props), container);
+    expect(values()).toEqual(["first"]);
+    expect(container.querySelector(".usage-query-suggestion")).toBeNull();
+
+    props.data.sessions = [usageSession("replacement", "main", "second-new")];
+    render(renderUsage(props), container);
+    expect(values()).toEqual(["second-new"]);
+    container.querySelector<HTMLButtonElement>(".usage-query-suggestion")?.click();
+    expect(props.callbacks.filters.onQueryDraftChange).toHaveBeenCalledWith(
+      'label:"Team  Planning" provider:second-new ',
+    );
   });
 
   it("reports a stalled provider refresh instead of hiding the section", () => {

--- a/ui/src/pages/usage/view.ts
+++ b/ui/src/pages/usage/view.ts
@@ -28,6 +28,7 @@ import {
   buildDailyCsv,
   buildQuerySuggestions,
   buildSessionsCsv,
+  buildUsageFilterOptions,
   normalizeQueryText,
   removeQueryToken,
   setQueryTokensForKey,
@@ -168,7 +169,7 @@ export function renderUsage(props: UsageProps) {
   const selectedSessionSet = new Set(filters.selectedSessions);
 
   // Sort sessions by tokens or cost depending on mode
-  const sortedSessions = [...data.sessions].toSorted((a, b) => {
+  const sortedSessions = data.sessions.toSorted((a, b) => {
     const valA = isTokenMode ? (a.usage?.totalTokens ?? 0) : (a.usage?.totalCost ?? 0);
     const valB = isTokenMode ? (b.usage?.totalTokens ?? 0) : (b.usage?.totalCost ?? 0);
     return valB - valA;
@@ -200,11 +201,8 @@ export function renderUsage(props: UsageProps) {
   };
   const filteredSessions = queryResult.sessions.filter(matchesSelectedDays);
   const queryWarnings = queryResult.warnings;
-  const querySuggestions = buildQuerySuggestions(
-    filters.queryDraft,
-    agentScopedSessions,
-    data.aggregates,
-  );
+  const filterOptions = buildUsageFilterOptions(agentScopedSessions, data.aggregates);
+  const querySuggestions = buildQuerySuggestions(filters.queryDraft, filterOptions);
   const queryTerms = extractQueryTerms(filters.queryDraft);
   const selectedValuesFor = (key: string): string[] => {
     const normalized = normalizeQueryText(key);
@@ -213,29 +211,6 @@ export function renderUsage(props: UsageProps) {
       .map((term) => term.value)
       .filter(Boolean);
   };
-  const unique = (items: Array<string | undefined>) => {
-    const set = new Set<string>();
-    for (const item of items) {
-      if (item) {
-        set.add(item);
-      }
-    }
-    return Array.from(set);
-  };
-  const channelOptions = unique(agentScopedSessions.map((s) => s.channel)).slice(0, 12);
-  const providerOptions = unique([
-    ...agentScopedSessions.map((s) => s.modelProvider),
-    ...agentScopedSessions.map((s) => s.providerOverride),
-    ...(data.aggregates?.byProvider.map((entry) => entry.provider) ?? []),
-  ]).slice(0, 12);
-  const modelOptions = unique([
-    ...agentScopedSessions.map((s) => s.model),
-    ...(data.aggregates?.byModel.map((entry) => entry.model) ?? []),
-  ]).slice(0, 12);
-  const toolOptions = unique(data.aggregates?.tools.tools.map((tool) => tool.name) ?? []).slice(
-    0,
-    12,
-  );
 
   // Get first selected session for detail view (timeseries, logs)
   const primarySelectedEntry =
@@ -666,10 +641,10 @@ export function renderUsage(props: UsageProps) {
                 </div>
               </div>
               <div class="usage-filter-row">
-                ${renderFilterSelect("channel", t("usage.filters.channel"), channelOptions)}
-                ${renderFilterSelect("provider", t("usage.filters.provider"), providerOptions)}
-                ${renderFilterSelect("model", t("usage.filters.model"), modelOptions)}
-                ${renderFilterSelect("tool", t("usage.filters.tool"), toolOptions)}
+                ${renderFilterSelect("channel", t("usage.filters.channel"), filterOptions.channel)}
+                ${renderFilterSelect("provider", t("usage.filters.provider"), filterOptions.provider)}
+                ${renderFilterSelect("model", t("usage.filters.model"), filterOptions.model)}
+                ${renderFilterSelect("tool", t("usage.filters.tool"), filterOptions.tool)}
                 <span class="usage-query-hint">${t("usage.query.tip")}</span>
               </div>
               ${


### PR DESCRIPTION
## What Problem This Solves

The Usage page separately rebuilds categorical lists for filter menus and query suggestions on every render, creating duplicate arrays and Sets across the same session data.

## Why This Change Was Made

Prepare one bounded transient inventory per render and share it between both consumers. Preserve first-seen raw values, provider/override/aggregate precedence, twelve menu options versus six suggestions before matching, draft selection, chart/agent scope, and locale behavior. Remove the redundant array copy before sorting. Production code shrinks by 11 lines without introducing a cache.

## User Impact

Usage filter preparation allocates less temporary data while keeping the same menus, query suggestions, and interactions. The inventory refreshes with each render as chart mode, agent scope, data, and query drafts change.

## Evidence

- **47 focused tests**, the complete changed-code gate, and the normal full Control UI build pass. The build transforms 3,337 modules, verifies 822 compressed sidecars, and passes asset budgets. Independent source/test review and fresh managed autoreview are clean.
- Six paired built-renderer scenarios produce identical outputs, including English/Spanish, quoted drafts, cost sorting, agent scope, an applied no-match query, repeated values, and empty data.
- Two samples per arm of 120 actual `renderUsage` calls on synthetic 1,000-session fixtures show **48.6% lower sampled allocation / 47.7% lower derivation time** for distinct values and mixed drafts, and **17.8% / 11.2% lower** for repeated values with empty drafts. This includes the additional bounded agent scan for blank drafts; other datasets may differ.
- These are descriptive Chrome samples of template derivation without DOM commit. They do not establish paint/input latency, retained heap, RSS, statistical significance, or whole-Gateway improvement.
- The attached English before/after captures show the same twelve provider choices in a **standalone built renderer with synthetic 24-session display data**. They are not full-application or live-Gateway screenshots. The recorded Spanish pair is byte-identical.
- An initial fixture-only lint issue and missing standalone theme class were corrected before final proof. The full tests/checks/review were repeated after the lint fix; the theme correction changed only capture setup.
- Required hosted CI passed on the exact reviewed head ([run 34042488866](https://github.com/openclaw/openclaw/actions/runs/34042488866)); the native workflow merged this change in [0189ce9](https://github.com/openclaw/openclaw/commit/0189ce9d776fbec3b4094915588cb103ea331580).

Before and after: the synthetic provider menu remains visually equivalent.

![Before: English provider menu in the synthetic standalone renderer](https://github.com/user-attachments/assets/f7f1bed0-7602-4b5e-bb2c-5e41a2ab86a3)

![After: English provider menu in the synthetic standalone renderer](https://github.com/user-attachments/assets/a381d338-471d-4e62-b1ea-4185af6cf350)
