### PR TITLE
test(android): avoid idle waits and await outbox publication

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -334,7 +334,7 @@ class NodeForegroundServiceTest {
   }
 
   @Test
-  @Config(shadows = [ServiceRuntimePrefsShadow::class])
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, SessionDisconnectShadow::class])
   fun stopRetiresQueuedActivityConnect() = assertStopRetiresQueuedGatewayAction(QueuedGatewayAction.Connect)
 
   @Test
@@ -354,11 +354,11 @@ class NodeForegroundServiceTest {
   fun stopRetiresQueuedForgetGateway() = assertStopRetiresQueuedGatewayAction(QueuedGatewayAction.Forget)
 
   @Test
-  @Config(shadows = [ServiceRuntimePrefsShadow::class, ConnectAdmissionShadow::class])
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, ConnectAdmissionShadow::class, SessionDisconnectShadow::class])
   fun stopRetiresConnectAfterViewModelAdmissionCheck() = assertStopRetiresQueuedGatewayAction(QueuedGatewayAction.Connect, gateAtConnectEntry = true)
 
   @Test
-  @Config(shadows = [ServiceRuntimePrefsShadow::class, ConnectAdmissionShadow::class])
+  @Config(shadows = [ServiceRuntimePrefsShadow::class, ConnectAdmissionShadow::class, SessionDisconnectShadow::class])
   fun anotherActivityResumeDoesNotReviveStoppedConnect() = assertStopRetiresQueuedGatewayAction(QueuedGatewayAction.Connect, gateAtConnectEntry = true, resumeFromAnotherActivity = true)
 
   @Test
@@ -470,6 +470,14 @@ class NodeForegroundServiceTest {
           runtime.gatewayConnectionDisplay.first { it.isConnected && runtime.nodeConnected.value }
         }
       }
+      if (action == QueuedGatewayAction.Connect) {
+        val initialRoles =
+          appFixture.sessionConnections
+            .filter { it.endpoint.port == initialGateway.port }
+            .map { it.role }
+            .toSet()
+        assertEquals(setOf("node", "operator"), initialRoles)
+      }
       while (initialGateway.takeRequest(0, TimeUnit.MILLISECONDS) != null) {
         // The initial ready sockets are not requests issued by the queued action.
       }
@@ -514,6 +522,13 @@ class NodeForegroundServiceTest {
         }
       }
       assertTrue("Queued action did not reach runtime adoption", gate.entered.await(10, TimeUnit.SECONDS))
+      if (action == QueuedGatewayAction.Connect) {
+        assertTrue(
+          "Queued Connect target must remain unknown to background gateway selection",
+          app.prefs.gatewayRegistry.entries.value
+            .none { it.stableId == nextEndpoint.stableId },
+        )
+      }
       val operation =
         viewModel.viewModelScope.coroutineContext.job.children
           .single { it !in existingOperations }
@@ -545,7 +560,7 @@ class NodeForegroundServiceTest {
       }
       gate.release.countDown()
       drainWithMainLooper { withTimeout(10_000) { operation.join() } }
-      if (gateAtConnectEntry) assertFalse("Call-through probe must not crash the gateway operation", operation.isCancelled)
+      if (action == QueuedGatewayAction.Connect) assertFalse("Call-through probe must not crash the gateway operation", operation.isCancelled)
 
       if (action == QueuedGatewayAction.Forget) {
         val savedId = GatewayEndpoint.manual("127.0.0.1", initialGateway.port).stableId
@@ -553,6 +568,13 @@ class NodeForegroundServiceTest {
           "Stop must retire queued Forget before deleting the saved gateway",
           app.prefs.gatewayRegistry.entries.value
             .any { it.stableId == savedId },
+        )
+      } else if (action == QueuedGatewayAction.Connect) {
+        // This unsaved cleartext target reaches session admission before the direct operation returns.
+        // Observe admission rather than delayed HTTP arrival; newer activity sockets remain valid.
+        assertTrue(
+          "Stopped activity work must not admit another Gateway connection",
+          appFixture.sessionConnections.none { it.endpoint.stableId == nextEndpoint.stableId },
         )
       } else {
         val target = if (action == QueuedGatewayAction.Refresh) initialGateway else nextGateway
@@ -640,6 +662,15 @@ class NodeForegroundServiceTest {
       fixture.operatorTokenReadGate = authRead
       runtime.setGatewayConnectionEnabled(endpoint.stableId, true)
       assertTrue("Secondary connection did not reach its credential read", authRead.entered.await(10, TimeUnit.SECONDS))
+      // Capture the held admission's completion before Stop can retire it; the queue below owns the verdict.
+      val stoppedAdmission =
+        if (reenable) {
+          null
+        } else {
+          ReflectionHelpers.getField<CompletableDeferred<Unit>>(runtime, "gatewayConnectOperationsDrained").also {
+            assertFalse("Held secondary admission must remain unfinished", it.isCompleted)
+          }
+        }
       if (reenable) {
         runtime.disconnect()
         runtime.setGatewayConnectionEnabled(endpoint.stableId, true)
@@ -651,13 +682,14 @@ class NodeForegroundServiceTest {
 
       authRead.release.countDown()
 
-      val connection = fixture.sessionConnections.poll(10, TimeUnit.SECONDS)
       if (reenable) {
+        val connection = fixture.sessionConnections.poll(10, TimeUnit.SECONDS)
         assertNotNull("Reenabled admission must reach the session owner", connection)
         assertEquals("operator", connection!!.role)
         assertNotNull("Reenabled admission must reach the Gateway", gateway.takeRequest(10, TimeUnit.SECONDS))
       } else {
-        assertNull("Stopped fleet work must not start an authenticated secondary connection", connection)
+        drainWithMainLooper { withTimeout(10_000) { checkNotNull(stoppedAdmission).await() } }
+        assertNull("Stopped fleet work must not start an authenticated secondary connection", fixture.sessionConnections.poll())
       }
     } finally {
       authRead.release.countDown()

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatControllerBranchCoordinationTest.kt
@@ -1544,6 +1544,8 @@ class ChatControllerBranchCoordinationTest {
           "Canonical history must retire the accepted Room row before the health response",
           outbox.load("gateway-a").any { it.id == head.id },
         )
+        // A newer refresh can still own the visible snapshot when this history reaches health.
+        awaitBranchProgress { controller.outboxItems.value.isEmpty() }
         assertTrue(controller.outboxItems.value.isEmpty())
         assertEquals(1, gateway.callCount("chat.send"))
 


### PR DESCRIPTION
## What Problem This Solves

Four foreground connection tests spend ten seconds checking that stopped work does not admit a connection, even when the fixture can already observe completion. The full 33-case suite took about 97 seconds in the baseline. Full CI also exposed a chat-outbox fixture that treated health-request entry as completion of the latest visible outbox publication.

## Why This Change Was Made

For the held secondary connection, capture the existing incomplete operation-drain receipt before Stop, await that receipt after releasing the credential-read gate, and inspect the same admission queue immediately.

For three queued Connect cases, retain the direct ViewModel operation join and use the existing call-through session recorder to inspect the fresh target. Preconditions verify initial node/operator admissions and that the target is not registered for background selection. The fixture's unsaved cleartext connection reaches admission before the direct operation completes. The newer Activity's legitimate connection remains allowed.

The chat-history fixture now uses its existing bounded progress helper to observe the empty outbox while the health RPC remains held. Immediate durable-retirement and transcript assertions, the visible-state assertion, single-send proof and failed-health result all remain. Production intentionally lets newer outbox reads supersede older ones; entering health does not join that newer presentation work.

All 33 cases remain. Positive wire checks, Stop ordering, held-work preconditions, completion bounds and cleanup are preserved. Other negative waits retain their existing observation windows because they do not have the same completion guarantee. No production code, lifecycle/auth guard, runtime option or shard count changes.

## Evidence

| Full foreground suite | Original | Candidate |
|---|---:|---:|
| Play | 96.719s | 58.437s |
| ThirdParty | 97.438s | 58.145s |

These are separate comparable Linux Testbox samples, both exposing four CPUs and about 15.4 GiB RAM, with unchanged Gradle/JVM/worker limits. They are not a statistical benchmark or an end-to-end CI claim. Both candidate flavors passed all 33 tests, with actual test execution rather than cached results.

The secondary case also had an earlier same-lease original/candidate comparison: 10.033 to 0.046 seconds on Play, and 10.026 to 0.027 seconds on ThirdParty. The full selected 129-case bootstrap/session/foreground workload passed in both flavors before and after that change.

Temporary fixture-only controls preserved production guards. Leaving the secondary service legitimately running made the negative assertion fail at the intended admission check in both flavors. A current, accepted Connect recorded both target roles at direct-operation completion, rejected the inverse absence predicate, and produced both real wire requests. The controls were removed before the final full-file runs.

Pinned local formatting, the native four-module Kotlin lint gate, independent P2 review, and all 12 other selected static/common guards passed. The native lint ran on Linux; the remaining guards ran locally without changing or suppressing any gate. All test leases were stopped and candidate bytes verified after cleanup. The first full CI run passed ThirdParty and the other Android jobs, but Play reported one failure among 2,820 tests at the existing immediate outbox assertion. The two-line fixture correction passed pinned formatting and independent P2 review; a subsequent run stopped at an unrelated test compilation error before either phone suite executed. The branch includes the canonical fix from #140247, with both reviewed commits unchanged. Final exact-head [CI 34046359018](https://github.com/openclaw/openclaw/actions/runs/34046359018) passed all six Android jobs and the required aggregate gate. Both full phone test tasks actually executed successfully, covering the outbox repair. CI published no per-case timings or JUnit artifacts; the table above remains focused Testbox evidence.

Test delta: +40/-6 across two existing test files. Production delta: zero. No tests were removed.
