### PR TITLE
fix(transcripts): settle occupancy retry diagnostics

### DIFF
--- a/src/transcripts/auto-start.ts
+++ b/src/transcripts/auto-start.ts
@@ -404,6 +404,10 @@ export function createTranscriptsAutoStartService(
             capture = undefined;
           }
         }
+        // A cancelled attempt settles only after its capture cleanup owner releases.
+        if (!capture) {
+          diagnostics?.record(index, diagnosticToken);
+        }
       })().finally(() => {
         stopping = undefined;
         pendingStops.delete(task);
@@ -427,6 +431,7 @@ export function createTranscriptsAutoStartService(
             throw new Error("provider is not available");
           }
           if (!provider.watchOccupancy) {
+            diagnostics?.record(index, diagnosticToken, "start-failed");
             ctx.logger.warn(
               `${label} cannot report occupancy; remove whenOccupied or select a provider that supports occupancy watching.`,
             );
@@ -446,6 +451,7 @@ export function createTranscriptsAutoStartService(
             const key = JSON.stringify([provider.id, source.accountId, source.guildId]);
             const owner = guildOwners.get(key);
             if (owner !== undefined && owner !== index) {
+              diagnostics?.record(index, diagnosticToken, "start-failed");
               ctx.logger.warn(
                 `${label} skipped: autoStart[${owner}] already owns this provider account and guild; configure only one whenOccupied entry per account and guild.`,
               );
@@ -487,6 +493,8 @@ export function createTranscriptsAutoStartService(
           }
           watchers.add(result.value);
           ready = true;
+          // An empty room still settles the watch retry before its next capture attempt.
+          diagnostics?.record(index, diagnosticToken);
           // Initial occupancy can be reported inline by watchOccupancy. Admit
           // capture only after subscription succeeds, not after a failed watch.
           begin(1);

--- a/src/transcripts/status.occupancy.test.ts
+++ b/src/transcripts/status.occupancy.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { createTranscriptsAutoStartService } from "./auto-start.js";
+import * as providerRegistry from "./provider-registry.js";
+import type { TranscriptOccupancyWatchRequest, TranscriptStartRequest } from "./provider-types.js";
+import {
+  transcriptStatusRoom as room,
+  useTranscriptStatusFixture,
+} from "./status.producer.test-harness.js";
+
+const fixture = useTranscriptStatusFixture();
+
+describe("configured transcript occupancy diagnostics", () => {
+  it.each(["retrying", "starting", "reoccupied"] as const)(
+    "settles a %s capture when its room becomes empty",
+    async (mode) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const f = fixture({ transcripts: { autoStart: [{ ...room, whenOccupied: true }] } });
+      const gate = createDeferred();
+      const watch = vi.fn(async (request: TranscriptOccupancyWatchRequest) => {
+        request.onOccupied();
+        return { ok: true as const, value: { stop: vi.fn() } };
+      });
+      f.provider.watchOccupancy = watch;
+      const start = vi.fn(async (request: TranscriptStartRequest) => {
+        if (start.mock.calls.length === 1) {
+          if (mode === "retrying") {
+            return { ok: false as const, error: "temporary capture failure" };
+          }
+          await gate.promise;
+        }
+        return { ok: true as const, session: request.session };
+      });
+      f.provider.start = start;
+      const service = createTranscriptsAutoStartService(f.ctx);
+      try {
+        service.start();
+        await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]?.startDiagnostic).toBe(
+            mode === "retrying" ? "retrying" : "starting",
+          ),
+        );
+        const occupancy = watch.mock.calls[0]![0];
+        occupancy.onEmpty();
+        await vi.advanceTimersByTimeAsync(29_999);
+        expect(start).toHaveBeenCalledOnce();
+        if (mode !== "retrying") {
+          expect(start.mock.calls[0]![0].abortSignal?.aborted).toBe(false);
+        }
+        await vi.advanceTimersByTimeAsync(1);
+        if (mode !== "retrying") {
+          expect(start.mock.calls[0]![0].abortSignal?.aborted).toBe(true);
+        }
+        if (mode === "reoccupied") {
+          occupancy.onOccupied();
+          expect(start).toHaveBeenCalledOnce();
+        }
+        gate.resolve();
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources[0]?.state).toBe(
+            mode === "reoccupied" ? "armed" : "not-active",
+          ),
+        );
+        expect((await f.read()).configuredSources[0]).not.toHaveProperty("startDiagnostic");
+        await vi.advanceTimersByTimeAsync(65_000);
+        expect(start).toHaveBeenCalledTimes(mode === "reoccupied" ? 2 : 1);
+        expect((await f.read()).active).toHaveLength(mode === "reoccupied" ? 1 : 0);
+      } finally {
+        gate.resolve();
+        await service.stop();
+      }
+    },
+  );
+
+  it.each(["unsupported", "guild-conflict", "empty"] as const)(
+    "settles occupancy watcher retries after %s registration",
+    async (mode) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+      const entry = { ...room, whenOccupied: true };
+      const entries =
+        mode === "guild-conflict" ? [entry, { ...entry, channelId: "other-room" }] : [entry];
+      const f = fixture({ transcripts: { autoStart: entries } });
+      const watch = vi.fn(async (request: TranscriptOccupancyWatchRequest) => {
+        if (mode === "guild-conflict") {
+          request.onOccupied();
+        }
+        return { ok: true as const, value: { stop: vi.fn() } };
+      });
+      if (mode !== "unsupported") {
+        f.provider.watchOccupancy = watch;
+      }
+      const start = vi.fn(f.provider.start!);
+      f.provider.start = start;
+      vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(undefined);
+      const service = createTranscriptsAutoStartService(f.ctx);
+      try {
+        service.start();
+        await vi.waitFor(async () =>
+          expect(
+            (await f.read()).configuredSources.map((source) => source.startDiagnostic),
+          ).toEqual(entries.map(() => "retrying")),
+        );
+        vi.mocked(providerRegistry.getTranscriptSourceProvider).mockReturnValue(f.provider);
+        await vi.advanceTimersByTimeAsync(5_000);
+        await vi.waitFor(async () =>
+          expect((await f.read()).configuredSources.map((source) => source.state)).toEqual(
+            mode === "guild-conflict" ? ["armed", "not-active"] : ["not-active"],
+          ),
+        );
+        expect(watch).toHaveBeenCalledTimes(mode === "unsupported" ? 0 : 1);
+        expect(start).toHaveBeenCalledTimes(mode === "guild-conflict" ? 1 : 0);
+        if (mode === "empty") {
+          expect((await f.read()).configuredSources[0]).not.toHaveProperty("startDiagnostic");
+          expect(await f.store.listSessionEntries()).toHaveLength(0);
+          watch.mock.calls[0]![0].onOccupied();
+          await vi.waitFor(async () =>
+            expect((await f.read()).configuredSources[0]?.state).toBe("armed"),
+          );
+        } else {
+          expect((await f.read()).configuredSources.at(-1)?.startDiagnostic).toBe("start-failed");
+        }
+        await vi.advanceTimersByTimeAsync(65_000);
+        expect(watch).toHaveBeenCalledTimes(mode === "unsupported" ? 0 : 1);
+        expect(start).toHaveBeenCalledTimes(mode === "unsupported" ? 0 : 1);
+      } finally {
+        await service.stop();
+      }
+    },
+  );
+});

--- a/src/transcripts/status.producer.test-harness.ts
+++ b/src/transcripts/status.producer.test-harness.ts
@@ -1,0 +1,87 @@
+import path from "node:path";
+import { afterEach, beforeEach, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createTranscriptsTool } from "../agents/tools/transcripts-tool.js";
+import { resetConfigRuntimeState } from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import {
+  captureActivePluginRegistrySnapshot,
+  restoreActivePluginRegistrySnapshot,
+  setActivePluginRegistry,
+} from "../plugins/runtime.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { activeSessions, startTranscripts } from "./capture.js";
+import * as providerRegistry from "./provider-registry.js";
+import type { TranscriptSourceProvider } from "./provider-types.js";
+import { readTranscriptLibraryStatus } from "./status.js";
+import { TranscriptsStore } from "./store.js";
+
+export const transcriptStatusRoom = {
+  providerId: "fixture-voice",
+  accountId: "work",
+  guildId: "guild",
+  channelId: "room",
+};
+
+export function useTranscriptStatusFixture() {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let previousRegistry: ReturnType<typeof captureActivePluginRegistrySnapshot>;
+  beforeEach(() => {
+    previousRegistry = captureActivePluginRegistrySnapshot();
+  });
+  afterEach(() => {
+    activeSessions.clear();
+    resetConfigRuntimeState();
+    closeOpenClawStateDatabaseForTest();
+    restoreActivePluginRegistrySnapshot(previousRegistry);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  return function fixture(
+    config: OpenClawConfig = { transcripts: { autoStart: [transcriptStatusRoom] } },
+  ) {
+    const stateDir = tempDirs.make("transcript-status-producer-");
+    const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+    });
+    const provider: TranscriptSourceProvider = {
+      id: transcriptStatusRoom.providerId,
+      aliases: ["voice-alias"],
+      name: "Fixture voice",
+      sourceKinds: ["live-audio"],
+      accessControl: {
+        channelId: "discord",
+        resolveAccountId: ({ source }) => ({ ok: true, value: source.accountId ?? "default" }),
+        authorize: async ({ caller }) =>
+          caller.kind === "operator"
+            ? { ok: true, value: undefined }
+            : { ok: false, error: "operator required" },
+      },
+      start: async ({ session }) => ({ ok: true, session }),
+      stop: async ({ sessionId }) => ({ ok: true, sessionId }),
+    };
+    vi.spyOn(providerRegistry, "getTranscriptSourceProvider").mockReturnValue(provider);
+    vi.spyOn(providerRegistry, "listTranscriptSourceProviders").mockReturnValue([provider]);
+    const registry = createEmptyPluginRegistry();
+    registry.transcriptSourceProviders.push({ pluginId: "fixture", source: "fixture", provider });
+    setActivePluginRegistry(registry);
+    const ctx = { config, stateDir, agentId: "main", logger: { warn: vi.fn() } };
+    const tool = createTranscriptsTool({ ...ctx, caller: { kind: "operator", source: "local" } });
+    return {
+      ctx,
+      store,
+      provider,
+      tool,
+      read: () => readTranscriptLibraryStatus(store, config),
+      start: (rawParams: Record<string, unknown>, configuredLifecycle?: true) =>
+        startTranscripts({
+          ctx: { ...ctx, caller: { kind: "operator", source: "local" } },
+          store,
+          rawParams,
+          configuredLifecycle,
+        }),
+    };
+  };
+}

--- a/src/transcripts/status.producer.test.ts
+++ b/src/transcripts/status.producer.test.ts
@@ -1,13 +1,6 @@
-import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { createTranscriptsTool } from "../agents/tools/transcripts-tool.js";
-import {
-  getRuntimeConfigSnapshot,
-  resetConfigRuntimeState,
-  setRuntimeConfigSnapshot,
-} from "../config/runtime-snapshot.js";
+import { getRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { diffGatewayReloadPaths } from "../gateway/config-diff.js";
 import {
@@ -16,87 +9,19 @@ import {
   listConfigReloadRefinementPrefixes,
 } from "../gateway/config-reload-plan.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import {
-  captureActivePluginRegistrySnapshot,
-  restoreActivePluginRegistrySnapshot,
-  setActivePluginRegistry,
-} from "../plugins/runtime.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTranscriptsAutoStartService } from "./auto-start.js";
 import { activeSessions, readTranscriptCaptureSnapshot, startTranscripts } from "./capture.js";
 import * as providerRegistry from "./provider-registry.js";
-import type {
-  TranscriptOccupancyWatchRequest,
-  TranscriptSourceProvider,
-  TranscriptStartRequest,
-} from "./provider-types.js";
+import type { TranscriptOccupancyWatchRequest, TranscriptStartRequest } from "./provider-types.js";
 import { readTranscriptLibraryStatus } from "./status.js";
+import {
+  transcriptStatusRoom as room,
+  useTranscriptStatusFixture,
+} from "./status.producer.test-harness.js";
 import { transcriptSessionSelector, TranscriptsStore } from "./store.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-let previousRegistry: ReturnType<typeof captureActivePluginRegistrySnapshot>;
-beforeEach(() => {
-  previousRegistry = captureActivePluginRegistrySnapshot();
-});
-afterEach(() => {
-  activeSessions.clear();
-  resetConfigRuntimeState();
-  closeOpenClawStateDatabaseForTest();
-  restoreActivePluginRegistrySnapshot(previousRegistry);
-  vi.useRealTimers();
-  vi.restoreAllMocks();
-});
-
-const room = {
-  providerId: "fixture-voice",
-  accountId: "work",
-  guildId: "guild",
-  channelId: "room",
-};
-
-function fixture(config: OpenClawConfig = { transcripts: { autoStart: [room] } }) {
-  const stateDir = tempDirs.make("transcript-status-producer-");
-  const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-  });
-  const provider: TranscriptSourceProvider = {
-    id: room.providerId,
-    aliases: ["voice-alias"],
-    name: "Fixture voice",
-    sourceKinds: ["live-audio"],
-    accessControl: {
-      channelId: "discord",
-      resolveAccountId: ({ source }) => ({ ok: true, value: source.accountId ?? "default" }),
-      authorize: async ({ caller }) =>
-        caller.kind === "operator"
-          ? { ok: true, value: undefined }
-          : { ok: false, error: "operator required" },
-    },
-    start: async ({ session }) => ({ ok: true, session }),
-    stop: async ({ sessionId }) => ({ ok: true, sessionId }),
-  };
-  vi.spyOn(providerRegistry, "getTranscriptSourceProvider").mockReturnValue(provider);
-  vi.spyOn(providerRegistry, "listTranscriptSourceProviders").mockReturnValue([provider]);
-  const registry = createEmptyPluginRegistry();
-  registry.transcriptSourceProviders.push({ pluginId: "fixture", source: "fixture", provider });
-  setActivePluginRegistry(registry);
-  const ctx = { config, stateDir, agentId: "main", logger: { warn: vi.fn() } };
-  const tool = createTranscriptsTool({ ...ctx, caller: { kind: "operator", source: "local" } });
-  return {
-    ctx,
-    store,
-    provider,
-    tool,
-    read: () => readTranscriptLibraryStatus(store, config),
-    start: (rawParams: Record<string, unknown>, configuredLifecycle?: true) =>
-      startTranscripts({
-        ctx: { ...ctx, caller: { kind: "operator", source: "local" } },
-        store,
-        rawParams,
-        configuredLifecycle,
-      }),
-  };
-}
+const fixture = useTranscriptStatusFixture();
 
 describe("configured transcript source provenance", () => {
   it.each([


### PR DESCRIPTION
Related: #140202

## What Problem This Solves

Fixes an issue where Meeting capture health kept reporting a retry after an occupancy watcher had settled or its capture was cancelled for an empty room.

## Why This Change Was Made

The startup owner records terminal watcher failures and successful registration, and clears cancelled-attempt diagnostics after capture cleanup releases ownership. The final diff contains only occupancy diagnostic settlement and its tests; main's consumed session-ID protection from #140202 remains unchanged.

## User Impact

Health reports settled outcomes for unsupported or conflicting watchers and successfully registered empty rooms. Cancelled starts settle after the existing empty-room grace period, while later occupancy can still begin capture.

## Evidence

- Current-main baseline produces five failures: unsupported watcher, guild conflict, successful empty watcher, cancelled failed startup, and cancelled pending startup. Reoccupation and the consumed-ID/midnight controls pass.
- All **92 focused tests** pass after integration, including main's completed-capture duplicate regression, retained cleanup/finalization, the 29,999/30,000 ms grace boundary, and reoccupation while startup/stop settles.
- The continuous-start owner and main's midnight regression were verified byte-identical to the main baseline. Targeted lint and independent P0–P2 review pass.

Validation uses synthetic providers and isolated real transcript storage; it does not claim live meeting-provider coverage. Production delta is eight added lines using existing diagnostic values, with no new state, configuration, schema, or timing constants.
