### PR TITLE
fix(imessage): settle failures on errored stdio closure

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -21,10 +21,11 @@ vi.mock("./cli-output.js", () => ({
 // real gateway surfaces as an uncaughtException and crashes the process (#75438
 // covered stdin only). The mock child mirrors that stdio shape so we can assert
 // each stream's `error` is caught and routed to failAll.
+type MockStream = EventEmitter & { errored: Error | null };
 type MockChild = EventEmitter & {
-  stdout: EventEmitter;
-  stderr: EventEmitter;
-  stdin: EventEmitter & {
+  stdout: MockStream;
+  stderr: MockStream;
+  stdin: MockStream & {
     write: (line: string, cb?: (err?: Error | null) => void) => boolean;
     end: () => void;
   };
@@ -34,9 +35,9 @@ type MockChild = EventEmitter & {
 
 function createMockChild(): MockChild {
   const child = new EventEmitter() as MockChild;
-  child.stdout = new EventEmitter();
-  child.stderr = new EventEmitter();
-  const stdin = new EventEmitter() as MockChild["stdin"];
+  child.stdout = Object.assign(new EventEmitter(), { errored: null });
+  child.stderr = Object.assign(new EventEmitter(), { errored: null });
+  const stdin = Object.assign(new EventEmitter(), { errored: null }) as MockChild["stdin"];
   // Resolve every write cleanly so the pending request only settles via the
   // stream error path under test.
   stdin.write = (_line, cb) => {
@@ -94,9 +95,16 @@ describe("IMessageRpcClient child stream error handling", () => {
     );
   });
 
-  it.each(["stdout", "stderr", "stdin"] as const)(
-    "catches a %s stream error and rejects in-flight requests instead of crashing",
-    async (streamName) => {
+  it.each(
+    (["stdout", "stderr", "stdin"] as const).flatMap((streamName) =>
+      (["error event then close", "errored close only"] as const).map((notification) => ({
+        streamName,
+        notification,
+      })),
+    ),
+  )(
+    "catches a $streamName stream error via $notification and rejects in-flight requests instead of crashing",
+    async ({ streamName, notification }) => {
       const client = new IMessageRpcClient({ cliPath: "imsg" });
       await client.start();
 
@@ -106,15 +114,22 @@ describe("IMessageRpcClient child stream error handling", () => {
       pending.catch(() => {});
 
       const streamError = new Error(`${streamName} broke`);
-      expect(() => child[streamName].emit("error", streamError)).not.toThrow();
-
-      await expect(pending).rejects.toThrow(`${streamName} broke`);
-      await expect(client.waitForClose()).rejects.toThrow(`${streamName} broke`);
-      expect(child.kill).toHaveBeenCalledOnce();
-      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
-
-      child.emit("close", null, "SIGTERM");
-      await client.stop();
+      child[streamName].errored = streamError;
+      try {
+        expect(() => {
+          if (notification === "error event then close") {
+            child[streamName].emit("error", streamError);
+          }
+          child[streamName].emit("close");
+        }).not.toThrow();
+        expect(child.kill).toHaveBeenCalledOnce();
+        expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+        await expect(pending).rejects.toThrow(`${streamName} broke`);
+        await expect(client.waitForClose()).rejects.toThrow(`${streamName} broke`);
+      } finally {
+        child.emit("close", null, "SIGTERM");
+        await client.stop();
+      }
     },
   );
 
@@ -316,6 +331,7 @@ describe("IMessageRpcClient child stream error handling", () => {
     const pending = client.request("ping", {}, { timeoutMs: 0 });
     pending.catch(() => {});
     child.stderr.emit("data", Buffer.from("unrelated warning"));
+    child.stderr.emit("close");
     child.emit("close", 1, null);
 
     await expect(pending).rejects.toThrow("imsg rpc exited (code 1)");

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -203,9 +203,16 @@ export class IMessageRpcClient {
     // monitor can wait forever on an unusable child. #75438 covered stdin only.
     const failFromProcessError = (err: unknown) => this.failTransport(err, child);
     child.on("error", failFromProcessError);
-    child.stdin.on("error", failFromProcessError);
-    child.stdout.on("error", failFromProcessError);
-    child.stderr.on("error", failFromProcessError);
+    for (const stream of [child.stdin, child.stdout, child.stderr]) {
+      stream.on("error", failFromProcessError);
+      stream.once("close", () => {
+        // Bun can close an errored stdio stream without emitting its error event.
+        const error = stream.errored;
+        if (error) {
+          failFromProcessError(error);
+        }
+      });
+    }
 
     child.on("close", (code, signal) => {
       if (this.child === child) {


### PR DESCRIPTION
## What Problem This Solves

An errored child stdio stream can close without the RPC client observing an error event, leaving pending iMessage RPC requests waiting on an unusable transport.

## Why This Change Was Made

On each stdio close, inspect the public stream.errored state and route an error through the existing failure handler for the captured child. Its idempotent terminal completion keeps error-then-close notification from terminating twice. Normal stream closure and final decoder diagnostics retain their existing behavior.

## User Impact

Pending RPC requests and close waiters fail promptly when a pipe has already failed, and the associated helper receives the existing termination signal once. No configuration, timeout, protocol, or service policy changes are introduced.

## Evidence

- Three synthetic close-only regression cases fail immediately before the repair because the child is not terminated.
- Ten approved benign cases pass on Node and Bun: all three stdio streams with error-then-close and errored-close-only notification, plus four existing sibling cases. Twelve other cases were not selected locally.
- The tests preserve the original rejection messages and assert immediate, single termination; a normal-close diagnostic case remains covered.
- Complete two-path checks and fresh independent P0–P2 review passed. No full build was run locally for this event-handling change.
- Local proof used mocked children; no real iMessage service, database, configuration, network, or security cases were exercised. Hosted CI is tracked separately.
