### PR TITLE
fix(ollama): report cached prompt usage

### DIFF
--- a/extensions/ollama/ollama.live.test.ts
+++ b/extensions/ollama/ollama.live.test.ts
@@ -14,6 +14,7 @@ import { createOllamaWebSearchProvider } from "./src/web-search-provider.js";
 const LIVE = process.env.OPENCLAW_LIVE_TEST === "1" && process.env.OPENCLAW_LIVE_OLLAMA === "1";
 const OLLAMA_BASE_URL =
   process.env.OPENCLAW_LIVE_OLLAMA_BASE_URL?.trim() || "http://127.0.0.1:11434";
+const EXPECTED_OLLAMA_VERSION = process.env.OPENCLAW_LIVE_OLLAMA_VERSION?.trim();
 const CHAT_MODEL = process.env.OPENCLAW_LIVE_OLLAMA_MODEL?.trim() || "llama3.2:latest";
 const EMBEDDING_MODEL =
   process.env.OPENCLAW_LIVE_OLLAMA_EMBED_MODEL?.trim() || "embeddinggemma:latest";
@@ -50,6 +51,38 @@ function requireOllamaRuntimeApiKey(): string | undefined {
 
 function resolveOllamaDirectApiKey(): string {
   return requireOllamaRuntimeApiKey() ?? "ollama-local";
+}
+
+async function fetchOllamaApi(
+  pathname: string,
+  init?: RequestInit,
+): Promise<Record<string, unknown>> {
+  const apiKey = requireOllamaRuntimeApiKey();
+  const headers = new Headers(init?.headers);
+  if (apiKey) {
+    headers.set("Authorization", `Bearer ${apiKey}`);
+  }
+  const response = await fetch(new URL(pathname, OLLAMA_BASE_URL), {
+    ...init,
+    headers,
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`Ollama ${pathname} returned HTTP ${response.status}: ${body}`);
+  }
+  return JSON.parse(body) as Record<string, unknown>;
+}
+
+function ollamaModelNameMatches(candidate: unknown, expected: string): boolean {
+  if (typeof candidate !== "string") {
+    return false;
+  }
+  const normalize = (value: string) =>
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/:latest$/u, "");
+  return normalize(candidate) === normalize(expected);
 }
 
 async function collectStreamEvents<T>(stream: AsyncIterable<T>): Promise<T[]> {
@@ -160,6 +193,54 @@ function buildCliEnv(root: string): NodeJS.ProcessEnv {
 }
 
 describe.skipIf(!LIVE)("ollama live", () => {
+  it.skipIf(isOllamaCloudBaseUrl(OLLAMA_BASE_URL))(
+    "records the exact local daemon and model identity",
+    async () => {
+      const [versionPayload, tagsPayload, showPayload] = await Promise.all([
+        fetchOllamaApi("/api/version"),
+        fetchOllamaApi("/api/tags"),
+        fetchOllamaApi("/api/show", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: CHAT_MODEL }),
+        }),
+      ]);
+      const version = versionPayload.version;
+      expect(typeof version).toBe("string");
+      if (EXPECTED_OLLAMA_VERSION) {
+        expect(version).toBe(EXPECTED_OLLAMA_VERSION);
+      }
+      const models = Array.isArray(tagsPayload.models) ? tagsPayload.models : [];
+      const selected = models.find((entry) => {
+        if (!entry || typeof entry !== "object") {
+          return false;
+        }
+        const model = entry as Record<string, unknown>;
+        return (
+          ollamaModelNameMatches(model.name, CHAT_MODEL) ||
+          ollamaModelNameMatches(model.model, CHAT_MODEL)
+        );
+      }) as Record<string, unknown> | undefined;
+      expect(selected).toBeDefined();
+      expect(typeof selected?.digest).toBe("string");
+      const capabilities = Array.isArray(showPayload.capabilities)
+        ? showPayload.capabilities.filter((value): value is string => typeof value === "string")
+        : [];
+      console.info(
+        `[ollama:live] qualification ${JSON.stringify({
+          version,
+          platform: process.platform,
+          arch: process.arch,
+          osRelease: os.release(),
+          model: selected?.name ?? selected?.model ?? CHAT_MODEL,
+          digest: selected?.digest,
+          capabilities,
+        })}`,
+      );
+    },
+    15_000,
+  );
+
   it("runs infer model run through the local CLI path without static model discovery", async () => {
     await withTempOpenClawState(async ({ root }) => {
       const result = await runOpenClawCli(
@@ -213,51 +294,73 @@ describe.skipIf(!LIVE)("ollama live", () => {
         }
       | undefined;
 
-    const stream = streamFn(
-      {
-        id: `${PROVIDER_ID}/${CHAT_MODEL}`,
-        api: "ollama",
-        provider: PROVIDER_ID,
-        contextWindow: 8192,
-        params: { num_ctx: 4096, top_p: 0.9, thinking: false, keep_alive: "5m" },
-        requestTimeoutMs: 120_000,
-      } as never,
-      {
-        messages: [{ role: "user", content: "Reply exactly OK." }],
-        tools: [
-          {
-            name: "lookup_weather",
-            description: "Lookup weather for a city.",
-            parameters: {
-              properties: {
-                city: { enum: ["London", "Vienna"] },
-                units: { enum: ["metric", "imperial"] },
-                options: {
-                  properties: {
-                    includeWind: { type: "boolean" },
+    const runNativeChat = () =>
+      streamFn(
+        {
+          id: `${PROVIDER_ID}/${CHAT_MODEL}`,
+          api: "ollama",
+          provider: PROVIDER_ID,
+          input: ["text"],
+          contextWindow: 8192,
+          params: { num_ctx: 4096, top_p: 0.9, thinking: false, keep_alive: "5m" },
+          requestTimeoutMs: 120_000,
+        } as never,
+        {
+          messages: [{ role: "user", content: "Reply exactly OK." }],
+          tools: [
+            {
+              name: "lookup_weather",
+              description: "Lookup weather for a city.",
+              parameters: {
+                properties: {
+                  city: { enum: ["London", "Vienna"] },
+                  units: { enum: ["metric", "imperial"] },
+                  options: {
+                    properties: {
+                      includeWind: { type: "boolean" },
+                    },
                   },
+                  required: ["city"],
                 },
               },
-              required: ["city"],
             },
+          ],
+        } as never,
+        {
+          maxTokens: 32,
+          temperature: 0,
+          onPayload: (body: unknown) => {
+            payload = body as NonNullable<typeof payload>;
           },
-        ],
-      } as never,
-      {
-        maxTokens: 32,
-        temperature: 0,
-        onPayload: (body: unknown) => {
-          payload = body as NonNullable<typeof payload>;
-        },
-        apiKey: requireOllamaRuntimeApiKey(),
-      } as never,
-    );
+          apiKey: requireOllamaRuntimeApiKey(),
+        } as never,
+      );
 
-    const events = await collectStreamEvents(await Promise.resolve(stream));
+    const events = await collectStreamEvents(await Promise.resolve(runNativeChat()));
+    const warmEvents = await collectStreamEvents(await Promise.resolve(runNativeChat()));
     const error = events.find((event) => (event as { type?: string }).type === "error");
+    const warmError = warmEvents.find((event) => (event as { type?: string }).type === "error");
+    const warmDone = warmEvents.find((event) => event.type === "done");
 
     expect(error).toBeUndefined();
+    expect(warmError).toBeUndefined();
     expect(events.map((event) => (event as { type?: string }).type)).toContain("done");
+    expect(warmDone?.type).toBe("done");
+    if (warmDone?.type !== "done") {
+      throw new Error("missing warm Ollama terminal message");
+    }
+    const usage = warmDone.message.usage;
+    expect(usage.totalTokens).toBe(usage.input + usage.cacheRead + usage.cacheWrite + usage.output);
+    console.info(
+      `[ollama:live] usage ${JSON.stringify({
+        input: usage.input,
+        cacheRead: usage.cacheRead,
+        cacheWrite: usage.cacheWrite,
+        output: usage.output,
+        totalTokens: usage.totalTokens,
+        cacheTelemetry: usage.cacheTelemetry,
+      })}`,
+    );
     expect(payload?.model).toBe(CHAT_MODEL);
     expect(payload?.options?.num_ctx).toBe(4096);
     expect(payload?.options?.top_p).toBe(1);

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1202,7 +1202,54 @@ describe("buildAssistantMessage", () => {
       },
     );
     const result = buildAssistantMessage(response, modelInfo);
-    expect(result.usage.cacheTelemetry).toEqual({ state: "unavailable" });
+    expect(result.usage).toMatchObject({
+      input: 10,
+      output: 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 12,
+      cacheTelemetry: { state: "unavailable" },
+    });
+  });
+
+  it("records an available zero cache read when Ollama reports it", () => {
+    const response = createAssistantResponse(
+      { content: "ok" },
+      {
+        prompt_eval_count: 10,
+        prompt_eval_cached_count: 0,
+        eval_count: 2,
+      },
+    );
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.usage).toMatchObject({
+      input: 10,
+      output: 2,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 12,
+      cacheTelemetry: { state: "available" },
+    });
+  });
+
+  it("separates cached prompt tokens from uncached input without changing the total", () => {
+    const response = createAssistantResponse(
+      { content: "ok" },
+      {
+        prompt_eval_count: 10,
+        prompt_eval_cached_count: 6,
+        eval_count: 2,
+      },
+    );
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.usage).toMatchObject({
+      input: 4,
+      output: 2,
+      cacheRead: 6,
+      cacheWrite: 0,
+      totalTokens: 12,
+      cacheTelemetry: { state: "available" },
+    });
   });
 });
 

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -427,6 +427,7 @@ interface OllamaChatResponse extends Record<string, unknown> {
   total_duration?: number;
   load_duration?: number;
   prompt_eval_count?: number;
+  prompt_eval_cached_count?: number;
   prompt_eval_duration?: number;
   eval_count?: number;
   eval_duration?: number;
@@ -501,6 +502,10 @@ function resolveUsageCount(
     return estimate;
   }
   return 0;
+}
+
+function resolveOptionalUsageCount(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 type InputContentPart =
@@ -848,13 +853,27 @@ export function buildAssistantMessage(
     }
   }
 
+  const promptTokens = resolveUsageCount(response.prompt_eval_count, usageFallback?.input);
+  const outputTokens = resolveUsageCount(response.eval_count, usageFallback?.output);
+  const reportedCacheRead = resolveOptionalUsageCount(response.prompt_eval_cached_count);
+  // Ollama includes cached tokens in prompt_eval_count; OpenClaw records input as uncached.
+  const cacheRead =
+    reportedCacheRead === undefined ? undefined : Math.min(reportedCacheRead, promptTokens);
+
   return buildStreamAssistantMessage({
     model: modelInfo,
     content,
     stopReason: resolveOllamaStopReason(response),
     usage: buildUsageWithNoCost({
-      input: resolveUsageCount(response.prompt_eval_count, usageFallback?.input),
-      output: resolveUsageCount(response.eval_count, usageFallback?.output),
+      input: promptTokens - (cacheRead ?? 0),
+      output: outputTokens,
+      ...(cacheRead === undefined
+        ? {}
+        : {
+            cacheRead,
+            cacheWrite: 0,
+            totalTokens: promptTokens + outputTokens,
+          }),
     }),
   });
 }


### PR DESCRIPTION
## What Problem This Solves

Ollama users with prompt-cache hits currently see every prompt token counted as fresh input because OpenClaw ignores Ollama's cached-prompt counter.

## Why This Change Was Made

Ollama 0.33.3 adds `prompt_eval_cached_count` as an optional subset of `prompt_eval_count`. OpenClaw now records that subset as `cacheRead`, reports only uncached prompt tokens as `input`, and preserves the original prompt-plus-output total. Older Ollama versions that omit the field retain unavailable-cache telemetry.

The live Ollama test also accepts an expected daemon version and records the daemon version, platform, model digest, and capabilities for repeatable qualification. OpenClaw continues to use an externally installed Ollama daemon; this PR does not download or pin Ollama.

## User Impact

Usage reporting distinguishes cached prompt tokens from uncached input on compatible Ollama versions. Absent, zero, and positive cache counters are covered without changing total-token accounting.

## Evidence

- Current proven head: `7df39860de731e82b7bf0dd8fba8bbe118e591e9` (verified signed).
- Focused stream runtime: 190/190 passed on the current head.
- Path-scoped `check:changed`: formatting, typecheck, lint, plugin boundaries, dead-code, database-first, and import-cycle checks passed on the current head.
- Exact-head macOS ARM64 live rerun on Ollama 0.33.3: 3 passed, 2 intentionally skipped; mapped usage was `input=1`, `cacheRead=186`, `cacheWrite=0`, `output=3`, `totalTokens=190`.
- `git diff --check`, targeted `oxfmt --check`, and privacy scan passed.
- Broader Ollama plugin proof: 790/790 passed, followed by a full successful `check:changed` in the task proof checkout. The previously linked Testbox workflow was unrelated to this head and was cancelled, so it is not counted as evidence.

The nine-cell compatibility matrix ran on `9f89976474247b6c16845d34d6126fedba2d21dd`. The three touched file blobs were byte-identical at the final reviewed head `7df39860de731e82b7bf0dd8fba8bbe118e591e9`, but the full commit trees diverged, so the matrix is not exact-head proof. The final reviewed head was separately requalified with the focused suite, scoped gate, and macOS 0.33.3 live test.

| Platform | Ollama | Raw warm-cache field | OpenClaw usage | Chat / stream / restart |
| --- | --- | --- | --- | --- |
| macOS ARM64 | 0.32.15 | absent | input 187, cacheRead 0, output 3, total 190; cache unavailable | pass |
| macOS ARM64 | 0.33.1 | absent | input 187, cacheRead 0, output 3, total 190; cache unavailable | pass |
| macOS ARM64 | 0.33.3 | 783 of 784 prompt tokens | input 1, cacheRead 186, output 3, total 190 | pass |
| Windows ARM64 | 0.32.15 | absent | input 187, cacheRead 0, output 3, total 190; cache unavailable | pass |
| Windows ARM64 | 0.33.1 | absent | input 187, cacheRead 0, output 3, total 190; cache unavailable | pass |
| Windows ARM64 | 0.33.3 | 783 of 784 prompt tokens | input 1, cacheRead 186, output 3, total 190 | pass |
| WSL2 ARM64 | 0.32.15 | absent | input 187, cacheRead 0, output 3, total 190; cache unavailable | pass |
| WSL2 ARM64 | 0.33.1 | absent | input 187, cacheRead 0, output 3, total 190; cache unavailable | pass |
| WSL2 ARM64 | 0.33.3 | 783 of 784 prompt tokens | input 1, cacheRead 186, output 3, total 190 | pass |

All cells used `qwen3:0.6b` with digest `7df6b6e09427a769808717c0a93cadc4ae99ed4eb8bf5ca557c90846becea435`. Native Windows and WSL endpoints were reached through task-owned loopback-only tunnels; no Windows Node application or configuration was changed.

The documented non-interactive Ollama onboarding route discovered `qwen3:0.6b` from the live 0.33.3 daemon. The real Control UI then selected `ollama/qwen3:0.6b`, retained it across a browser reload, and retained it after a full Gateway restart. The Windows and WSL matrix observations and the UI screenshots are task-local contributor evidence, not durable public artifacts. ClawSweeper recorded `live_verification=absent`; it reviewed the supplied evidence but did not independently execute those live checks.

WSL2 exposed `/dev/dxg` but had no `nvidia-smi` evidence, so this PR does not change the existing WSL warning wording.

## Landing Status

Merged via squash as `c54c323275d94d4da5fcb5824873ffe07fcb2717`. Exact-head CI run https://github.com/openclaw/openclaw/actions/runs/34047928867 completed green with 32 successful jobs, 17 intentional skips, and 0 failures; `openclaw/ci-gate` passed.
