### PR TITLE
refactor(gateway): reuse resolved discovery endpoints

### DIFF
--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -684,31 +684,23 @@ describe("gateway-cli coverage", () => {
     },
   );
 
-  it("registers gateway discover and prints json output", async () => {
-    discoverGatewayBeacons.mockClear();
-    discoverGatewayBeacons.mockResolvedValueOnce([
-      {
-        instanceName: "Studio (OpenClaw)",
+  it.each([
+    {
+      name: "prefers the resolved service address over TXT hints",
+      beacon: {
+        instanceName: "Studio gateway",
         displayName: "Studio",
         domain: "openclaw.internal.",
         host: "studio.openclaw.internal",
         port: 18789,
-        lanHost: "studio.local",
-        tailnetDns: "studio.tailnet.ts.net",
-        gatewayPort: 18789,
+        lanHost: "untrusted.example.test",
+        tailnetDns: "untrusted.tailnet.test",
+        gatewayPort: 12345,
         sshPort: 22,
-      },
-    ]);
-
-    await runGatewayCommand(["gateway", "discover", "--json"]);
-
-    expect(discoverGatewayBeacons).toHaveBeenCalledTimes(1);
-    const out = runtimeLogs.join("\n");
-    expect(out).toContain('"beacons"');
-    expect(out).toContain("ws://");
-  });
-
-  it.each([
+        txt: { gatewayPort: "12345" },
+      } satisfies DiscoveredBeacon,
+      wsUrl: "ws://studio.openclaw.internal:18789",
+    },
     {
       name: "uses the secure scheme advertised by a TLS gateway",
       beacon: {
@@ -736,7 +728,7 @@ describe("gateway-cli coverage", () => {
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
       expect.objectContaining({
         count: 1,
-        beacons: [expect.objectContaining({ wsUrl })],
+        beacons: [{ ...beacon, wsUrl }],
       }),
     );
   });

--- a/src/cli/gateway-cli/discover.ts
+++ b/src/cli/gateway-cli/discover.ts
@@ -1,6 +1,9 @@
 // Gateway discovery rendering helpers for Bonjour and wide-area DNS beacon output.
 import { colorize, theme } from "../../../packages/terminal-core/src/theme.js";
-import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
+import {
+  resolveGatewayDiscoveryEndpoint,
+  type GatewayBonjourBeacon,
+} from "../../infra/bonjour-discovery.js";
 import { buildGatewayDiscoveryTarget } from "../../infra/gateway-discovery-targets.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 
@@ -13,20 +16,12 @@ export function parseDiscoverTimeoutMs(raw: unknown, fallbackMs: number): number
   return parseTimeoutMsWithFallback(raw, fallbackMs, { invalidType: "error" });
 }
 
-export function pickBeaconHost(beacon: GatewayBonjourBeacon): string | null {
-  return buildGatewayDiscoveryTarget(beacon).endpoint?.host ?? null;
-}
-
-export function pickGatewayPort(beacon: GatewayBonjourBeacon): number | null {
-  return buildGatewayDiscoveryTarget(beacon).endpoint?.port ?? null;
-}
-
 export function dedupeBeacons(beacons: GatewayBonjourBeacon[]): GatewayBonjourBeacon[] {
   // Use display and endpoint fields; Bonjour can surface the same gateway on multiple interfaces.
   const out: GatewayBonjourBeacon[] = [];
   const seen = new Set<string>();
   for (const b of beacons) {
-    const host = pickBeaconHost(b) ?? "";
+    const host = resolveGatewayDiscoveryEndpoint(b)?.host ?? "";
     const key = [
       b.domain ?? "",
       b.instanceName ?? "",

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -135,8 +135,6 @@ vi.mock("../progress.js", () => ({
 vi.mock("./discover.js", () => ({
   dedupeBeacons: (beacons: unknown[]) => beacons,
   parseDiscoverTimeoutMs: () => 2000,
-  pickBeaconHost: () => null,
-  pickGatewayPort: () => 18789,
   renderBeaconLines: () => [],
 }));
 

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -831,15 +831,9 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
         async () => {
           const [
             { readSourceConfigBestEffort },
-            { discoverGatewayBeacons },
+            { discoverGatewayBeacons, resolveGatewayDiscoveryEndpoint },
             { resolveWideAreaDiscoveryDomain },
-            {
-              dedupeBeacons,
-              parseDiscoverTimeoutMs,
-              pickBeaconHost,
-              pickGatewayPort,
-              renderBeaconLines,
-            },
+            { dedupeBeacons, parseDiscoverTimeoutMs, renderBeaconLines },
             { withProgress },
           ] = await Promise.all([
             loadConfigModule(),
@@ -869,12 +863,10 @@ export function registerGatewayCli(program: Command, deps: GatewayCliDependencie
           );
 
           if (opts.json) {
-            const enriched = deduped.map((b) => {
-              const host = pickBeaconHost(b);
-              const port = pickGatewayPort(b);
-              const scheme = b.gatewayTls === true ? "wss" : "ws";
-              return { ...b, wsUrl: host ? `${scheme}://${host}:${port}` : null };
-            });
+            const enriched = deduped.map((beacon) => ({
+              ...beacon,
+              wsUrl: resolveGatewayDiscoveryEndpoint(beacon)?.wsUrl ?? null,
+            }));
             defaultRuntime.writeJson({
               timeoutMs,
               domains,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { HostedGatewayStop } from "../../daemon/hosted-stop.js";
 import type { GatewayServer, GatewayStartupOperation } from "../../gateway/server-public.js";
-import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import type { GatewayActiveWorkSnapshot } from "../../infra/gateway-active-work.js";
 import type { GatewayBootLifecycleCompletion } from "../../infra/gateway-boot-lifecycle.js";
 import type { GatewayRestartIntent } from "../../infra/restart-intent.js";
@@ -17,7 +16,6 @@ import {
   OpenClawAgentDatabaseMediaMigrationRequiredError,
 } from "../../state/openclaw-agent-db-migration-required.js";
 import { captureEnv, deleteTestEnvValue } from "../../test-utils/env.js";
-import { pickBeaconHost, pickGatewayPort } from "./discover.js";
 
 const acquireGatewayLock = vi.fn(async (_opts?: { port?: number }) => ({
   release: vi.fn(async () => {}),
@@ -3606,36 +3604,4 @@ describe("runGatewayLoop", () => {
   });
 });
 
-describe("gateway discover routing helpers", () => {
-  it("prefers resolved service host over TXT hints", () => {
-    const beacon: GatewayBonjourBeacon = {
-      instanceName: "Test",
-      host: "10.0.0.2",
-      port: 18789,
-      lanHost: "evil.example.com",
-      tailnetDns: "evil.example.com",
-    };
-    expect(pickBeaconHost(beacon)).toBe("10.0.0.2");
-  });
-
-  it("prefers resolved service port over TXT gatewayPort", () => {
-    const beacon: GatewayBonjourBeacon = {
-      instanceName: "Test",
-      host: "10.0.0.2",
-      port: 18789,
-      gatewayPort: 12345,
-    };
-    expect(pickGatewayPort(beacon)).toBe(18789);
-  });
-
-  it("fails closed when resolve data is missing", () => {
-    const beacon: GatewayBonjourBeacon = {
-      instanceName: "Test",
-      lanHost: "test-host.local",
-      gatewayPort: 18789,
-    };
-    expect(pickBeaconHost(beacon)).toBeNull();
-    expect(pickGatewayPort(beacon)).toBeNull();
-  });
-});
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

Gateway discovery rebuilt the same resolved endpoint through separate host and port wrappers, then reconstructed the URL again for JSON output. This deletion follow-up to the #135868 split removes that duplicate work and consolidates its tests at the command boundary.

## Why This Change Was Made

The registered discovery command and beacon deduplication now read the canonical `resolveGatewayDiscoveryEndpoint` result directly. JSON output still spreads the original beacon, retaining every existing field; the separate display/SSH projection remains with human-readable output.

Deletion evidence:
- `pickBeaconHost` and `pickGatewayPort` only delegated through `buildGatewayDiscoveryTarget`, which also computed unused display and SSH fields. Their only production consumers were deduplication and JSON enrichment. Both now use the canonical endpoint owner.
- Three wrapper tests in `run-loop.test.ts` are covered by the existing registered-command JSON table, strengthened for resolved host/port precedence over conflicting TXT data, TLS, unresolved endpoints and exact raw-field retention.
- Two unused mock exports are removed from the option-collision suite. The weaker generic JSON smoke case is absorbed into the same command table.

The local history reaches a shallow boundary for the old wrappers, so no unverified introduction or release history is claimed. They are internal helpers with no separate public contract. The canonical resolver and SSH rendering behavior are unchanged.

## User Impact

No user-visible behavior change. Resolved service data remains authoritative over TXT hints, TLS still selects `wss`, and invalid/unresolved endpoints still return a null URL.

## Evidence

- 152 tests passed across discovery, registered CLI output, option collisions and Gateway run-loop suites.
- Full `node scripts/check-changed.mjs` and `pnpm build` passed. The final rebase preserved all five changed files byte-for-byte and left the lockfile unchanged.
- Independent Codex review: scoped-clean, no actionable P0–P2 findings.
- Production: +11 / −24 = **−13 lines**. Tests/support: +13 / −57 = **−44 lines**. Tooling and docs unchanged. 105 changed lines across five files.
