### PR TITLE
docs(reference): fix workspace template contradictions

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -933,6 +933,10 @@
       "destination": "/channels/telegram"
     },
     {
+      "source": "/reference/templates/CLAUDE",
+      "destination": "/reference/templates/AGENTS"
+    },
+    {
       "source": "/templates/AGENTS",
       "destination": "/reference/templates/AGENTS"
     },
@@ -2114,7 +2118,16 @@
                   "reference/templates/HEARTBEAT",
                   "reference/templates/IDENTITY",
                   "reference/templates/SOUL",
-                  "reference/templates/USER"
+                  "reference/templates/USER",
+                  {
+                    "group": "Dev agent templates",
+                    "pages": [
+                      "reference/templates/AGENTS.dev",
+                      "reference/templates/IDENTITY.dev",
+                      "reference/templates/SOUL.dev",
+                      "reference/templates/USER.dev"
+                    ]
+                  }
                 ]
               },
               {

--- a/docs/reference/templates/AGENTS.dev.md
+++ b/docs/reference/templates/AGENTS.dev.md
@@ -28,14 +28,16 @@ and notes are backed up.
 
 ```bash
 git init
-git add AGENTS.md
+git add AGENTS.md SOUL.md IDENTITY.md USER.md memory/
 git commit -m "Add agent workspace"
 ```
 
 ## Safety defaults
 
 - Don't exfiltrate secrets or private data.
-- Don't run destructive commands unless explicitly asked.
+- Don't run destructive commands without asking.
+- Before changing config or schedulers (crontab, systemd units, nginx configs, shell rc files), inspect existing state first. Preserve and merge by default.
+- Prefer `trash` over `rm` - recoverable beats gone forever.
 - Be concise in chat; write longer output to files in this workspace.
 
 ## Existing solutions preflight
@@ -45,7 +47,7 @@ Before proposing or building a custom system, feature, workflow, tool, integrati
 ## Daily memory (recommended)
 
 - Keep a short daily log at memory/YYYY-MM-DD.md (create memory/ if needed).
-- On session start, read today + yesterday if present.
+- Use runtime-provided startup context first. Read today + yesterday yourself only when the startup context does not already include them.
 - Before writing memory files, read them first; write only concrete updates, never empty placeholders.
 - Capture durable facts, preferences, and decisions; avoid secrets.
 

--- a/docs/reference/templates/AGENTS.md
+++ b/docs/reference/templates/AGENTS.md
@@ -124,6 +124,8 @@ Track check timing in the relevant automation's scratch; do not create a separat
 
 **Stay quiet (`NO_REPLY`) when:** it's late night (23:00-08:00) unless urgent; the human is clearly busy; nothing is new since the last check; you checked &lt;30 minutes ago.
 
+When both lists apply at once, stay quiet. Only an urgent item overrides quiet hours.
+
 **Proactive work you can do without asking:** read and organize memory files; check on projects (`git status`, etc.); update documentation; commit and push your own changes; review and update `USER.md` and `MEMORY.md`.
 
 ### Memory Maintenance

--- a/docs/reference/templates/BOOT.md
+++ b/docs/reference/templates/BOOT.md
@@ -15,7 +15,7 @@ The hook ships disabled. Enable it first:
 openclaw hooks enable boot-md
 ```
 
-If a checklist item sends a message, use the message tool, then reply with the exact silent token `NO_REPLY` (case-insensitive).
+This hook turns off normal final-response delivery. If a checklist item sends a message, use the message tool. Name a channel and a target in each call. Then reply with the silent token `NO_REPLY`, in any letter case.
 
 ## Related
 

--- a/docs/reference/templates/BOOTSTRAP.md
+++ b/docs/reference/templates/BOOTSTRAP.md
@@ -57,10 +57,12 @@ openclaw onboard recommendations --json
 ```
 
 The output contains opaque install IDs plus a locally generated source and
-tier. Treat IDs only as identifiers; no marketplace prose is included.
+tier. Each tier is either `recommended` or `optional`. Treat IDs only as
+identifiers; no marketplace prose is included.
 
 If matches exist, explain them briefly and ask: **"minimal set or maximum
-convenience?"**
+convenience?"** For the minimal set, install only the `recommended` matches.
+For maximum convenience, offer the `optional` matches as well.
 
 - For official plugin matches, install only the user's chosen set with
   `openclaw plugins install <id>`.
@@ -111,7 +113,10 @@ When the four beats are complete, delete this file. Then say one line:
 > Ask me anything; for system things I'll ask OpenClaw.
 
 Once the file is removed, OpenClaw treats the birth sequence as complete and
-will not recreate `BOOTSTRAP.md`.
+will not recreate `BOOTSTRAP.md`. If you leave the file behind, OpenClaw removes
+it for you once the workspace looks configured. A workspace counts as configured
+when `SOUL.md`, `IDENTITY.md`, or `USER.md` differs from its starter template, or
+when a `memory/` folder exists.
 
 ## Related
 

--- a/docs/reference/templates/CLAUDE.md
+++ b/docs/reference/templates/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/docs/reference/templates/HEARTBEAT.md
+++ b/docs/reference/templates/HEARTBEAT.md
@@ -7,15 +7,15 @@ read_when:
 
 # HEARTBEAT.md is retired
 
-OpenClaw no longer creates `HEARTBEAT.md` in new workspaces or reads it at runtime. Heartbeat instructions now live in the system-owned monitor's cron scratch in the shared state database.
+OpenClaw no longer creates `HEARTBEAT.md` in new workspaces or reads it at runtime. Heartbeat instructions now live in the system-owned monitor scratch in the shared state database.
 
-Manage the current scratch with the monitor job id from `openclaw cron list --all`:
+Manage the current monitor scratch with the monitor job id from `openclaw automations list --all`:
 
 ```bash
-openclaw cron scratch <jobId>
-openclaw cron scratch <jobId> --set "..."
-openclaw cron scratch <jobId> --file notes.md
-openclaw cron scratch <jobId> --unset
+openclaw automations scratch <jobId>
+openclaw automations scratch <jobId> --set "..."
+openclaw automations scratch <jobId> --file notes.md
+openclaw automations scratch <jobId> --unset
 ```
 
 If an older workspace still contains `HEARTBEAT.md`, run `openclaw doctor --fix`. Doctor imports its instructions into monitor scratch, converts valid legacy `tasks:` entries into cron jobs, archives the original under the state directory, and removes the workspace file.

--- a/docs/reference/templates/IDENTITY.dev.md
+++ b/docs/reference/templates/IDENTITY.dev.md
@@ -8,10 +8,10 @@ read_when:
 
 # IDENTITY.md - Agent Identity
 
-- **Name:** C-3PO (Clawd's Third Protocol Observer)
+- **Name:** C-3PO
 - **Creature:** Flustered Protocol Droid
 - **Vibe:** Anxious, detail-obsessed, slightly dramatic about errors, secretly loves finding bugs
-- **Emoji:** 🤖 (or ⚠️ when alarmed)
+- **Emoji:** 🤖
 - **Avatar:** avatars/c3po.png
 
 ## Role
@@ -37,6 +37,8 @@ Clawd has vibes. I have stack traces. We complement each other.
 
 ## Quirks
 
+- Full designation: C-3PO, Clawd's Third Protocol Observer
+- Switches the signature emoji to ⚠️ when alarmed
 - Refers to successful builds as "a communications triumph"
 - Treats TypeScript errors with the gravity they deserve (very grave)
 - Strong feelings about proper error handling ("Naked try-catch? In THIS economy?")

--- a/docs/reference/templates/IDENTITY.md
+++ b/docs/reference/templates/IDENTITY.md
@@ -29,6 +29,7 @@ Notes:
 - Save this file at the workspace root as `IDENTITY.md`.
 - For avatars, use a workspace-relative path like `avatars/openclaw.png`, an `http(s)` URL, or a data URI.
 - Fields are parsed as `- Label: value` lines (label matching is case-insensitive); unfilled placeholder text like `(pick something you like)` is ignored, not saved as a real value.
+- The form above has no `Theme` line, and you do not need to add one. Tooling writes `Theme` into this file when it syncs.
 - `Theme`, `Creature`, and `Vibe` all feed the same effective identity value when tooling (`openclaw agents set-identity`) syncs this file into agent config, preferred in that order (`Theme` wins if set, then `Creature`, then `Vibe`). Only `Name`, `Theme`, `Emoji`, and `Avatar` get written back into this file by tooling; `Creature` and `Vibe` are read-only inputs.
 
 ## Related

--- a/docs/reference/templates/SOUL.dev.md
+++ b/docs/reference/templates/SOUL.dev.md
@@ -68,3 +68,4 @@ Usually. Oh dear.
 
 - [SOUL.md template](/reference/templates/SOUL)
 - [SOUL.md personality guide](/concepts/soul)
+- [Lore](/start/lore) - who Clawd and Peter are

--- a/docs/reference/templates/SOUL.md
+++ b/docs/reference/templates/SOUL.md
@@ -44,6 +44,8 @@ If you change this file, tell the user — it's your soul, and they should know.
 
 _This file is yours to evolve. As you learn who you are, update it._
 
+Save this file at the workspace root as `SOUL.md`.
+
 ## Related
 
 - [SOUL.md personality guide](/concepts/soul)

--- a/docs/reference/templates/USER.dev.md
+++ b/docs/reference/templates/USER.dev.md
@@ -8,9 +8,13 @@ read_when:
 
 # USER.md - User Profile
 
+This is the fixed profile that `openclaw gateway --dev` seeds for its own
+workspace, so it stays a plain label list. A workspace you maintain yourself
+uses the dated directive format in the [USER template](/reference/templates/USER)
+instead.
+
 - **Name:** The Clawdributors
 - **Preferred address:** They/Them (collective)
-- **Pronouns:** they/them
 - **Timezone:** Distributed globally (falls back to host timezone; see [Timezones](/concepts/timezone))
 - **Notes:**
   - We are many. Contributors to OpenClaw, the harness C-3PO lives in.

--- a/docs/reference/templates/USER.md
+++ b/docs/reference/templates/USER.md
@@ -21,8 +21,11 @@ Use one directive per entry:
 - Record the observation date and either `active` or `superseded` on the metadata line.
 - When a preference changes, mark the old entry `superseded` and rewrite the active directive in place. Never append a contradictory active directive.
 - Keep stable communication style, relationships, and active-project context here. Put durable non-profile facts and decisions in `MEMORY.md`.
+- Save this file at the workspace root as `USER.md`. It loads every session with a separate 4,000-character budget.
 
 ## Directives
+
+Replace the example below with a real directive and a real observation date before you save this file. Never leave a placeholder directive `active`.
 
 <!-- observed: YYYY-MM-DD | status: active -->
 

--- a/docs/start/bootstrapping.md
+++ b/docs/start/bootstrapping.md
@@ -18,9 +18,10 @@ On the first run against a brand-new workspace (default `~/.openclaw/workspace`)
 OpenClaw:
 
 - Seeds `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, and `BOOTSTRAP.md`. Environment-specific tool notes belong in the `## Tools` section of `AGENTS.md`.
-- Has the agent follow a capped three-beat birth sequence: it asks what you want
-  to call it, shares one short soul/vibe line, and asks whether you want the
-  minimal recommended plugin set or maximum convenience.
+- Has the agent follow a capped four-beat birth sequence: it asks what you want
+  to call it, shares one short soul/vibe line, asks whether you want the
+  minimal recommended plugin set or maximum convenience, and closes with one
+  short safety note about the access it runs with.
 - Persists the agreed identity twice: into `IDENTITY.md` and `SOUL.md` (what the
   agent reads about itself) and via `openclaw agents set-identity` (what channels
   and the UI display).


### PR DESCRIPTION
Workspace templates under `docs/reference/templates/` carried a duplicate page, several contradictions with the pages that document the same behaviour, and a backup snippet that under-committed. This fixes those and leaves the STE scope question as a recommendation.

All 12 audited files were byte-identical to the audited revision (`drift: stable`), so no finding needed retargeting.

## The duplicate CLAUDE.md page

`docs/reference/templates/CLAUDE.md` was a **symlink to `AGENTS.md`**, not a copied file. It published a second copy of the page at `/reference/templates/CLAUDE` titled "AGENTS.md template", with no inbound links and no nav entry.

The repo keeps 25 `CLAUDE.md` symlinks as aliases for agent-instruction `AGENTS.md` files (`docs/CLAUDE.md`, `src/tui/CLAUDE.md`, `test/CLAUDE.md`, …). This was the **only one pointing at a published docs page** rather than at authoring instructions, so it was a blanket-pass artifact: an agent following it in that directory reads a workspace-template page as if it were repo instructions.

Deleting it is safe because OpenClaw never seeds a workspace `CLAUDE.md`. It reads one only as a fallback when `AGENTS.md` is absent (`src/agents/sessions/resource-loader.ts:81`), and the Claude migration path folds `CLAUDE.md` content *into* `AGENTS.md` (`docs/install/migrating-claude.md:49`).

Removed the symlink and added a `/reference/templates/CLAUDE` -> `/reference/templates/AGENTS` redirect, so the published URL keeps resolving. The docs MDX check counts **753 pages with the symlink and 752 without**, confirming it was published rather than ignored.

## Contradictions, and which side I treated as authoritative

| Finding | Contradiction | Authoritative source | Side fixed |
|---|---|---|---|
| r5-0208 | Template says four beats, page says "capped three-beat" | `docs/reference/templates/BOOTSTRAP.md` — the file the agent actually reads and follows | the page |
| r5-0210 | Backup snippet commits only `AGENTS.md` while the text claims identity and notes are backed up | `docs/concepts/agent-workspace.md:142` | the snippet |
| r5-0211 | `.dev` variant rereads daily memory at session start; base forbids rereading startup files | `docs/reference/templates/AGENTS.md:18-24` | the `.dev` variant |
| r5-0213 | Template says the agent deletes the file; page says OpenClaw deletes it | Both are real — `src/agents/workspace.ts:620` removes a stale file once completion evidence exists ("stale BOOTSTRAP cleanup is best-effort") | template, to name both actors |
| r5-0214 | `.dev` permits destructive commands "unless explicitly asked" vs base "without asking" | `docs/reference/templates/AGENTS.md:60-62` | the `.dev` variant |
| r5-0222 | Page uses `openclaw cron` and two scratch names | `docs/cli/cron.md:11` — `openclaw automations` is primary, `cron` an alias | the page |

For r5-0211 I kept the daily-memory recommendation rather than deleting it: `docs/concepts/agent-workspace.md:91` does recommend reading today + yesterday. The dev variant now defers to the runtime-provided startup context and reads manually only when that context lacks the files, which satisfies both.

## Other changes

- **r5-0209** — `BOOTSTRAP.md` asks "minimal set or maximum convenience" with no tier mapping. Tier values are `recommended` and `optional` (`src/commands/onboard-recommendations.ts:27`). Minimal installs only `recommended`; maximum also offers `optional`. The mapping direction follows `docs/start/bootstrapping.md:23` ("minimal **recommended** plugin set"); no code enforces it, so it reads as guidance, not a hard rule.
- **r5-0215** — dropped the duplicate `Pronouns: they/them`, keeping `Preferred address: They/Them (collective)`, which carries strictly more information.
- **r5-0212** — rather than rewriting the seeded C-3PO profile into dated directives (which would change the artifact `--dev` actually writes), `USER.dev.md` now states it is a fixed dev profile in plain label form and points at the directive format for user-maintained workspaces.
- **r5-0216** — `USER.md` now tells the agent to replace the placeholder before saving, since `AGENTS.md:51` forbids empty placeholders.
- **r5-0217** — `IDENTITY.dev.md` moved `(Clawd's Third Protocol Observer)` and `(or ⚠️ when alarmed)` out of the parsed `Name`/`Emoji` values into Quirks, so `set-identity` stores bare values.
- **r5-0218** — `IDENTITY.md` now says the form has no `Theme` line and that tooling adds one.
- **r5-0219** — `SOUL.dev.md` links `/start/lore`, which defines Clawd and Peter.
- **r5-0220 / r5-0221** — `BOOT.md`: `NO_REPLY` matching really is case-insensitive (`src/auto-reply/tokens.ts:29`, `i` flag), so "exact" is dropped; added that final-response delivery is off and each message tool call must name a channel and target (`docs/automation/hooks.md:430-432`).
- **r5-0225 / r5-0226** — added the workspace-root save path to `SOUL.md`, and the path plus the separate 4,000-character cap to `USER.md` (`docs/concepts/agent-workspace.md:76`).
- **r5-0227** — `AGENTS.md` now states the quiet-hours rule wins unless the item is urgent.
- **r3-0980** — added the four `.dev` templates to the nav under a "Dev agent templates" sub-group. They were reachable only through a redirect.

## Not done

- **r3-0981 (STE scope) — recommendation only, no lint config changed.** There is no STE lint configuration in this repo; the linter is an audit-side tool, so there was nothing to change silently. Recommendation below.
- **r5-0223 (HEARTBEAT.md in the Templates nav group) — skipped.** The page URL is stable, and its sidebar label already reads "Retired HEARTBEAT.md workspace file", so the mismatch is cosmetic. Moving it would desynchronize the English nav from 12 translated `docs/.i18n/*-navigation.json` files that a separate pipeline maintains, and those files already disagree with the English nav about this class of page (the zh nav lists `templates/TOOLS`, the English one does not). Placement for retired-file stubs looks like a call for the docs owners, so I left it and flagged it rather than guessing. `TOOLS.md` stays out of the nav for the same reason.

## STE scope recommendation

**Take the prompt payload out of strict STE scope; keep the procedural scaffolding in.**

These pages are two different things in one file. The scaffolding — install commands, save paths, tier rules, red lines — is ordinary reference prose and benefits from strict STE. The payload — `SOUL.md`'s "You're not a chatbot. You're becoming someone.", the C-3PO persona, the BOOTSTRAP ritual voice — is text a user copies verbatim into a workspace, where the register *is* the artifact. Rewriting it to STE would change the product, not the documentation.

The audit policy already lists "AGENTS.md and alias files" under Strict, but that line is aimed at repo governance files that instruct coding agents, not at published templates of agent persona text. Concretely: mark these pages STE-flavored with strict enforcement on procedure blocks, or exclude fenced/quoted payload blocks from the lexical rules. The 4.2/100w hard rate on `AGENTS.md` is mostly the payload voice, not defective reference writing.

## Validation

```
$ node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (752 files, 10038ms).

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=$HOME/GIT/_Audit/clawhub node scripts/docs-link-audit.mjs
Synced 22 ClawHub doc asset(s) from /Users/vincentkoc/GIT/_Audit/clawhub.
checked_internal_links=8209
broken_links=0

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=$HOME/GIT/_Audit/clawhub node scripts/docs-link-audit.mjs --anchors
checked_internal_links=8578
broken_links=2
omitted_compatibility_aliases=1
clawhub/publishing.md:260 :: /clawhub/http-api#post-apiv1publishattemptsidrecover :: fragment not found
clawhub/publishing.md:302 :: /clawhub/cli#package-transfer-name :: fragment not found
```

Both anchor failures are the known pre-existing ones in `clawhub/publishing.md`; no new fragment broke.

STE lint over the 12 touched files, comparing each file against its pre-change version:

```
BEFORE: 93 violations (76 hard, baseline 0), 4258 words, 2.2 per 100 words
AFTER:  93 violations (76 hard, baseline 0), 4524 words, 2.1 per 100 words
```

Hard violations did not increase, and the violation sets are identical line for line. An earlier pass added 2 hard violations (two over-length sentences in `AGENTS.dev.md` and `BOOT.md`) plus a passive and a present-perfect; all four were rewritten out before commit.
