### PR TITLE
refactor(ui): simplify settings owners

### DIFF
--- a/ui/src/components/config-form.analyze.ts
+++ b/ui/src/components/config-form.analyze.ts
@@ -1,5 +1,8 @@
-import { arrayItemSchema, arrayItemSchemaIndexes } from "./config-form.array-items.ts";
-// Control UI view renders config form.analyze screen content.
+import {
+  arrayItemSchema,
+  arrayItemSchemaIndexes,
+  collectAllOfSchemas,
+} from "./config-form.array-items.ts";
 import {
   objectAdditionalPropertiesSchema,
   objectPropertyKeys,
@@ -203,18 +206,7 @@ function schemaAllowsNull(schema: JsonSchema, seen = new Set<JsonSchema>()): boo
 }
 
 function hasUnrepresentableComposedAdditionalProperties(schema: JsonSchema): boolean {
-  const schemas: JsonSchema[] = [];
-  const pending = [schema];
-  const seen = new Set<JsonSchema>();
-  while (pending.length > 0) {
-    const current = pending.pop();
-    if (!current || seen.has(current)) {
-      continue;
-    }
-    seen.add(current);
-    schemas.push(current);
-    pending.push(...(current.allOf ?? []));
-  }
+  const schemas = collectAllOfSchemas(schema);
   if (schemas.length <= 1) {
     return false;
   }

--- a/ui/src/components/config-form.constraints.ts
+++ b/ui/src/components/config-form.constraints.ts
@@ -506,16 +506,10 @@ export function normalizeNumericValue(value: number, schema: JsonSchema): number
     normalized = Math.min(constraints.max, normalized);
   }
   if (constraints.exclusiveMin !== undefined && normalized <= constraints.exclusiveMin) {
-    normalized =
-      typeof constraints.step === "number"
-        ? nextRepresentable(constraints.exclusiveMin, 1)
-        : nextRepresentable(constraints.exclusiveMin, 1);
+    normalized = nextRepresentable(constraints.exclusiveMin, 1);
   }
   if (constraints.exclusiveMax !== undefined && normalized >= constraints.exclusiveMax) {
-    normalized =
-      typeof constraints.step === "number"
-        ? nextRepresentable(constraints.exclusiveMax, -1)
-        : nextRepresentable(constraints.exclusiveMax, -1);
+    normalized = nextRepresentable(constraints.exclusiveMax, -1);
   }
   return normalizePrecision(
     normalized,
@@ -632,32 +626,19 @@ export function defaultValue(schema?: JsonSchema, depth = 0): unknown {
       if (itemCount === 0) {
         return validatedDefaultCandidate(schema, []);
       }
-      if (Array.isArray(schema.items)) {
-        const value: unknown[] = [];
-        for (let index = 0; index < itemCount; index += 1) {
-          const itemSchema =
-            schema.items[index] ??
-            (schema.additionalItems && typeof schema.additionalItems === "object"
-              ? schema.additionalItems
-              : undefined);
-          if (!itemSchema) {
-            return NO_SAFE_DEFAULT;
-          }
-          const itemDefault = defaultValue(itemSchema, depth + 1);
-          if (itemDefault === NO_SAFE_DEFAULT) {
-            return NO_SAFE_DEFAULT;
-          }
-          value.push(itemDefault);
-        }
-        return validatedDefaultCandidate(schema, value);
-      }
       const itemsSchema = schema.items;
-      if (!itemsSchema) {
-        return NO_SAFE_DEFAULT;
-      }
       const value: unknown[] = [];
       for (let index = 0; index < itemCount; index += 1) {
-        const itemDefault = defaultValue(itemsSchema, depth + 1);
+        const itemSchema = Array.isArray(itemsSchema)
+          ? (itemsSchema[index] ??
+            (schema.additionalItems && typeof schema.additionalItems === "object"
+              ? schema.additionalItems
+              : undefined))
+          : itemsSchema;
+        if (!itemSchema) {
+          return NO_SAFE_DEFAULT;
+        }
+        const itemDefault = defaultValue(itemSchema, depth + 1);
         if (itemDefault === NO_SAFE_DEFAULT) {
           return NO_SAFE_DEFAULT;
         }

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -842,35 +842,6 @@ suite.define(() => {
     );
   });
 
-  it("retries the missing identity bootstrap and opens the profile editor", async () => {
-    await suite.withPage(undefined, async ({ page }) => {
-      const gateway = await installMockGateway(page, {
-        basePath,
-        presenceUsers: testPresenceUsers,
-        methodResponses: {
-          "users.self": { sequence: [{}, { profile: testProfile }] },
-        },
-      });
-
-      const response = await page.goto(new URL(profilePath, suite.server.baseUrl).href);
-      expect(response?.status()).toBe(200);
-
-      const emptyState = page.locator(".profile-identity-empty");
-      await emptyState.waitFor({ timeout: 10_000 });
-      await expect(emptyState.textContent()).resolves.toContain("Identity is not set.");
-      await screenshot(page, "01-identity-not-set.png");
-
-      await page.getByRole("button", { name: "Set identity" }).click();
-
-      await page.locator('.identity-name-control input[type="text"]').waitFor({ timeout: 10_000 });
-      await expect.poll(async () => (await gateway.getRequests("users.self")).length).toBe(2);
-      await expect(page.locator(".identity-name-control input").inputValue()).resolves.toBe(
-        testProfile.displayName,
-      );
-      await screenshot(page, "02-identity-editor.png");
-    });
-  });
-
   it("keeps identity refresh single-flight and retries after a failed request", async () => {
     await suite.withPage(
       {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3460,8 +3460,6 @@ export const en: TranslationMap & {
       unidentified:
         "This connection has no personal profile; sign in through Cloudflare Access, Tailscale Serve, or a trusted proxy to set a name and avatar.",
       writeRequired: "Profile editing requires operator.write access.",
-      notSet: "Identity is not set.",
-      setIdentity: "Set identity",
       avatar: "Avatar",
       avatarDescription: "PNG, JPEG, or WebP. Images are resized to 256 × 256 or smaller.",
       chooseAvatar: "Choose image",

--- a/ui/src/pages/agents/panels-tools-skills.browser.test.ts
+++ b/ui/src/pages/agents/panels-tools-skills.browser.test.ts
@@ -1,6 +1,6 @@
 // Control UI tests cover agents panels tools skills behavior.
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 import type { SkillStatusEntry } from "../../api/types.ts";
 import { GitHubIdentityController } from "../../features/github-connections/github-identity-controller.ts";
 import { installBrowserHistoryIsolation } from "../../test-helpers/browser-history.ts";
@@ -670,6 +670,109 @@ describe("agents tools panel (browser)", () => {
       replaceState.mockRestore();
       container.remove();
     }
+  });
+
+  it.each([
+    {
+      name: "enables one profile tool",
+      tool: "session_status",
+      enabled: true,
+      expectedAllow: ["untouched", "exec", "web_*"],
+      expectedDeny: ["read", "web_*"],
+    },
+    {
+      name: "disables one aliased tool",
+      tool: "bash",
+      enabled: false,
+      expectedAllow: ["untouched", "web_*"],
+      expectedDeny: ["session_status", "read", "web_*", "exec"],
+    },
+    {
+      name: "enables the catalog without removing wildcard denies",
+      tool: null,
+      enabled: true,
+      expectedAllow: ["untouched", "exec", "web_*", "web_fetch"],
+      expectedDeny: ["read", "web_*"],
+    },
+    {
+      name: "disables the catalog without removing wildcard allows",
+      tool: null,
+      enabled: false,
+      expectedAllow: ["untouched", "web_*"],
+      expectedDeny: ["session_status", "read", "web_*", "exec", "web_fetch"],
+    },
+    {
+      name: "publishes one normalized update for an empty catalog",
+      tool: null,
+      enabled: true,
+      emptyCatalog: true,
+      expectedAllow: ["untouched", "exec", "web_*"],
+      expectedDeny: ["session_status", "read", "web_*"],
+    },
+  ])("$name with one immutable override update", async (testCase) => {
+    const tools = {
+      profile: "minimal",
+      alsoAllow: [" untouched ", " BASH ", "exec", "", "web_*"],
+      deny: [" SESSION_STATUS ", "read", "web_*", "", "read"],
+    };
+    const configForm = { agents: { entries: { main: { tools } } } };
+    const originalConfig = structuredClone(configForm);
+    const onOverridesChange = vi.fn();
+    const toolIds = testCase.emptyCatalog ? [] : ["session_status", "bash", "web_fetch"];
+    const container = document.createElement("div");
+    render(
+      renderAgentTools(
+        createBaseParams({
+          configForm,
+          onOverridesChange,
+          toolsCatalogResult: {
+            agentId: "main",
+            profiles: [{ id: "minimal", label: "Minimal" }],
+            groups: [
+              {
+                id: "policy",
+                label: "Policy",
+                source: "core",
+                tools: toolIds.map((id) => ({
+                  id,
+                  label: id,
+                  description: id,
+                  source: "core" as const,
+                  defaultProfiles: [],
+                })),
+              },
+            ],
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    if (testCase.tool) {
+      const card = Array.from(container.querySelectorAll(".agent-tool-card")).find(
+        (entry) => entry.querySelector(".agent-tool-title")?.textContent?.trim() === testCase.tool,
+      );
+      const toggle = card?.querySelector<HTMLElement & { checked: boolean }>("wa-switch");
+      assert(toggle, `Missing tool switch: ${testCase.tool}`);
+      expect(toggle.checked).toBe(!testCase.enabled);
+      toggle.checked = testCase.enabled;
+      toggle.dispatchEvent(new Event("change", { bubbles: true }));
+    } else {
+      const label = testCase.enabled ? "Enable All" : "Disable All";
+      const button = Array.from(container.querySelectorAll("button")).find(
+        (entry) => entry.textContent?.trim() === label,
+      );
+      assert(button, `Missing bulk control: ${label}`);
+      button.click();
+    }
+
+    expect(onOverridesChange).toHaveBeenCalledExactlyOnceWith(
+      "main",
+      testCase.expectedAllow,
+      testCase.expectedDeny,
+    );
+    expect(configForm).toEqual(originalConfig);
   });
 
   it.each([

--- a/ui/src/pages/agents/panels-tools-skills.ts
+++ b/ui/src/pages/agents/panels-tools-skills.ts
@@ -1,8 +1,8 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-// Control UI view renders agents panels tools skills screen content.
 import { html, nothing } from "lit";
 import {
+  normalizeToolList,
   normalizeToolPolicyName,
   resolveToolProfilePolicy,
 } from "../../../../src/agents/tool-policy-shared.js";
@@ -324,35 +324,10 @@ export function renderAgentTools(params: {
       return left.label.localeCompare(right.label);
     });
 
-  const updateTool = (toolId: string, nextEnabled: boolean) => {
-    const nextAllow = new Set(
-      alsoAllow.map((entry) => normalizeToolPolicyName(entry)).filter((entry) => entry.length > 0),
-    );
-    const nextDeny = new Set(
-      deny.map((entry) => normalizeToolPolicyName(entry)).filter((entry) => entry.length > 0),
-    );
-    const baseAllowed = resolveAllowed(toolId).baseAllowed;
-    const normalized = normalizeToolPolicyName(toolId);
-    if (nextEnabled) {
-      nextDeny.delete(normalized);
-      if (!baseAllowed) {
-        nextAllow.add(normalized);
-      }
-    } else {
-      nextAllow.delete(normalized);
-      nextDeny.add(normalized);
-    }
-    params.onOverridesChange(params.agentId, [...nextAllow], [...nextDeny]);
-  };
-
-  const updateAll = (nextEnabled: boolean) => {
-    const nextAllow = new Set(
-      alsoAllow.map((entry) => normalizeToolPolicyName(entry)).filter((entry) => entry.length > 0),
-    );
-    const nextDeny = new Set(
-      deny.map((entry) => normalizeToolPolicyName(entry)).filter((entry) => entry.length > 0),
-    );
-    for (const toolId of toolIds) {
+  const updateTools = (targetIds: string[], nextEnabled: boolean) => {
+    const nextAllow = new Set(normalizeToolList(alsoAllow));
+    const nextDeny = new Set(normalizeToolList(deny));
+    for (const toolId of targetIds) {
       const baseAllowed = resolveAllowed(toolId).baseAllowed;
       const normalized = normalizeToolPolicyName(toolId);
       if (nextEnabled) {
@@ -446,10 +421,18 @@ export function renderAgentTools(params: {
             })}</span
           >`,
         actions: html`
-          <button class="btn btn--sm" ?disabled=${!editable} @click=${() => updateAll(true)}>
+          <button
+            class="btn btn--sm"
+            ?disabled=${!editable}
+            @click=${() => updateTools(toolIds, true)}
+          >
             ${t("agentTools.enableAll")}
           </button>
-          <button class="btn btn--sm" ?disabled=${!editable} @click=${() => updateAll(false)}>
+          <button
+            class="btn btn--sm"
+            ?disabled=${!editable}
+            @click=${() => updateTools(toolIds, false)}
+          >
             ${t("agentTools.disableAll")}
           </button>
           <button
@@ -670,7 +653,7 @@ export function renderAgentTools(params: {
                                   : "agentTools.enableNamed",
                                 { name: tool.label },
                               ),
-                              onChange: (checked) => updateTool(tool.id, checked),
+                              onChange: (checked) => updateTools([tool.id], checked),
                             })}
                           </span>
                         </summary>

--- a/ui/src/pages/config/config-page.selection.test.ts
+++ b/ui/src/pages/config/config-page.selection.test.ts
@@ -1,0 +1,237 @@
+/* @vitest-environment jsdom */
+
+import { expectDefined } from "@openclaw/normalization-core";
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationContext } from "../../app/context.ts";
+import { resetServerUiPrefsSync } from "../../app/server-prefs.ts";
+import {
+  createApplicationContextProvider,
+  createApplicationGateway,
+} from "../../test-helpers/application-context.ts";
+import { settleLitElement, settleLitElements } from "../../test-helpers/lit-settle.ts";
+import { createStorageMock } from "../../test-helpers/storage.ts";
+import { ConfigPage, configSelectionFromSearch, type ConfigPageId } from "./config-page.ts";
+import type { ConfigRouteData } from "./route-data.ts";
+import { pages } from "./route.ts";
+
+beforeEach(() => {
+  window.history.replaceState({}, "", "/");
+  vi.stubGlobal("localStorage", createStorageMock());
+  resetServerUiPrefsSync();
+});
+
+afterEach(async () => {
+  const mounted = document.querySelectorAll<ConfigPage>("openclaw-config-page");
+  document.body.replaceChildren();
+  await settleLitElements(mounted);
+  resetServerUiPrefsSync();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("configSelectionFromSearch", () => {
+  it("opens a valid linked Settings section", () => {
+    expect(configSelectionFromSearch("communications", "?section=tts")).toEqual({
+      activeSection: "tts",
+      activeSubsection: null,
+    });
+  });
+
+  it("falls back when a linked section does not belong to the page", () => {
+    expect(configSelectionFromSearch("communications", "?section=gateway")).toEqual({
+      activeSection: "messages",
+      activeSubsection: null,
+    });
+  });
+
+  it("keeps MCP separate from Infrastructure", () => {
+    expect(configSelectionFromSearch("mcp", "?section=browser")).toEqual({
+      activeSection: "mcp",
+      activeSubsection: null,
+    });
+    expect(configSelectionFromSearch("infrastructure", "?section=mcp")).toEqual({
+      activeSection: "gateway",
+      activeSubsection: null,
+    });
+  });
+
+  it("keeps the Updates section off Advanced", () => {
+    expect(configSelectionFromSearch("advanced", "?section=update")).toEqual({
+      activeSection: null,
+      activeSubsection: null,
+    });
+  });
+});
+
+describe("ConfigPage advanced selection guard", () => {
+  it("keeps curated sections off the Advanced page", () => {
+    expect(configSelectionFromSearch("advanced", "?section=messages")).toEqual({
+      activeSection: null,
+      activeSubsection: null,
+    });
+    expect(configSelectionFromSearch("advanced", "?section=env")).toEqual({
+      activeSection: "env",
+      activeSubsection: null,
+    });
+    expect(configSelectionFromSearch("advanced", "?section=mcp")).toEqual({
+      activeSection: null,
+      activeSubsection: null,
+    });
+    expect(configSelectionFromSearch("advanced", "?section=tts")).toEqual({
+      activeSection: null,
+      activeSubsection: null,
+    });
+    expect(configSelectionFromSearch("advanced", "?section=broadcast")).toEqual({
+      activeSection: "broadcast",
+      activeSubsection: null,
+    });
+    expect(configSelectionFromSearch("advanced", "?section=models")).toEqual({
+      activeSection: "models",
+      activeSubsection: null,
+    });
+  });
+});
+
+describe("ConfigPage default selections", () => {
+  it.each([
+    ["communications", "messages"],
+    ["appearance", "__appearance__"],
+    ["notifications", "__notifications__"],
+    ["security", "security"],
+    ["automation", "commands"],
+    ["mcp", "mcp"],
+    ["memory", "memory"],
+    ["talk", "talk"],
+    ["infrastructure", "gateway"],
+    ["updates", "update"],
+    ["ai-agents", "agents"],
+    ["advanced", null],
+  ] as const)("opens %s at its default when no section is selected", (pageId, activeSection) => {
+    for (const search of ["", "?section="]) {
+      expect(configSelectionFromSearch(pageId, search)).toEqual({
+        activeSection,
+        activeSubsection: null,
+      });
+    }
+  });
+
+  it.each(["unknown", "toString", "constructor", "__proto__"])(
+    "rejects an unsupported runtime page id: %s",
+    (pageId) => {
+      expect(() => configSelectionFromSearch(pageId as ConfigPageId, "")).toThrow(
+        "Unknown config page",
+      );
+    },
+  );
+
+  it("keeps subsequent defaults independent from a mutated selection", () => {
+    const selection = configSelectionFromSearch("communications", "");
+    selection.activeSection = "tts";
+    selection.activeSubsection = "provider";
+
+    expect(configSelectionFromSearch("communications", "")).toEqual({
+      activeSection: "messages",
+      activeSubsection: null,
+    });
+  });
+});
+
+function routeContext(): ApplicationContext {
+  const config = { messages: { ackReaction: "!" }, tts: { provider: "synthetic" } };
+  const subscribe = () => () => undefined;
+  const { gateway } = createApplicationGateway({
+    client: null,
+    phase: "offline",
+    offlineStable: true,
+    hello: null,
+    canvasPluginSurfaceUrl: null,
+    assistantAgentId: "main",
+    sessionKey: "main",
+    lastError: null,
+    lastErrorCode: null,
+  });
+  return {
+    basePath: "",
+    gateway,
+    agentSelection: { state: { selectedId: "main" }, subscribe },
+    config: {
+      current: { assistantIdentity: { name: "OpenClaw" }, serverVersion: "test" },
+      subscribe,
+    },
+    runtimeConfig: {
+      state: {
+        connected: false,
+        configLoading: false,
+        configSchemaLoading: false,
+        configSnapshot: { config, runtimeConfig: config, hash: "settings-defaults" },
+        configSchema: {
+          type: "object",
+          properties: {
+            messages: { type: "object", properties: { ackReaction: { type: "string" } } },
+            tts: { type: "object", properties: { provider: { type: "string" } } },
+          },
+        },
+        configUiHints: {},
+        configForm: config,
+        configFormOriginal: config,
+        configRaw: JSON.stringify(config),
+        configRawOriginal: JSON.stringify(config),
+        configValid: true,
+        configIssues: [],
+      },
+      ensureLoaded: async () => undefined,
+      ensureSchemaLoaded: async () => undefined,
+      subscribe,
+    },
+    theme: { serverSelection: null, subscribe },
+    overlays: { snapshot: {}, subscribe },
+    webPush: { snapshot: undefined, subscribe },
+  } as unknown as ApplicationContext;
+}
+
+describe("ConfigPage route selections", () => {
+  it.each([
+    ["communications", "", "config-section-messages", "config-section-tts"],
+    ["communications", "?section=tts", "config-section-tts", "config-section-messages"],
+    ["notifications", "", "settings-communications-notifications", "config-section-messages"],
+  ] as const)(
+    "renders the selected section for %s%s",
+    async (pageId, search, visibleId, absentId) => {
+      const route = expectDefined(
+        pages.find((entry) => entry.id === pageId),
+        "config route",
+      );
+      const context = routeContext();
+      const location = { pathname: `/settings/${pageId}`, search, hash: "" };
+      const data = await route.loader?.(context, {
+        location,
+        signal: new AbortController().signal,
+        shouldRun: () => true,
+        revalidating: false,
+        deps: expectDefined(route.loaderDeps, "config route dependencies")(context, location),
+        cause: "navigation",
+      });
+      if (!data || typeof data !== "object" || !("section" in data)) {
+        throw new Error("Config route did not return section data");
+      }
+      const module = await route.component();
+      const provider = createApplicationContextProvider(context);
+      document.body.append(provider);
+      render(module.render(data as ConfigRouteData), provider);
+      const page = expectDefined(
+        provider.querySelector<ConfigPage>("openclaw-config-page"),
+        "mounted config page",
+      );
+      await settleLitElement(page);
+
+      expect(page.querySelector(`#${visibleId}`)).not.toBeNull();
+      expect(page.querySelector(`#${absentId}`)).toBeNull();
+      if (pageId === "communications") {
+        expect(page.querySelector('wa-tab[aria-selected="true"]')?.textContent?.trim()).toBe(
+          search ? "Voice" : "Messages",
+        );
+      }
+    },
+  );
+});

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -18,11 +18,7 @@ import {
 } from "../../test-helpers/modal-dialog.ts";
 import { createStorageMock } from "../../test-helpers/storage.ts";
 import * as realtimeTalk from "../chat/realtime-talk.ts";
-import {
-  ConfigPage,
-  configSelectionFromSearch,
-  extractQuickSettingsSecurity,
-} from "./config-page.ts";
+import { ConfigPage, extractQuickSettingsSecurity } from "./config-page.ts";
 import { serverUiPrefProvenanceHint } from "./view-appearance-preferences.ts";
 import type { ConfigViewState } from "./view.ts";
 
@@ -48,40 +44,6 @@ afterEach(() => {
   document.body.replaceChildren();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
-});
-
-describe("configSelectionFromSearch", () => {
-  it("opens a valid linked Settings section", () => {
-    expect(configSelectionFromSearch("communications", "?section=tts")).toEqual({
-      activeSection: "tts",
-      activeSubsection: null,
-    });
-  });
-
-  it("falls back when a linked section does not belong to the page", () => {
-    expect(configSelectionFromSearch("communications", "?section=gateway")).toEqual({
-      activeSection: "messages",
-      activeSubsection: null,
-    });
-  });
-
-  it("keeps MCP separate from Infrastructure", () => {
-    expect(configSelectionFromSearch("mcp", "?section=browser")).toEqual({
-      activeSection: "mcp",
-      activeSubsection: null,
-    });
-    expect(configSelectionFromSearch("infrastructure", "?section=mcp")).toEqual({
-      activeSection: "gateway",
-      activeSubsection: null,
-    });
-  });
-
-  it("keeps the Updates section off Advanced", () => {
-    expect(configSelectionFromSearch("advanced", "?section=update")).toEqual({
-      activeSection: null,
-      activeSubsection: null,
-    });
-  });
 });
 
 describe("extractQuickSettingsSecurity", () => {
@@ -439,35 +401,6 @@ describe("ConfigPage moved section routes", () => {
     state.syncRouteData();
 
     expect(navigate).toHaveBeenCalledWith("model-providers", { search: "", hash: "" });
-  });
-});
-
-describe("ConfigPage advanced selection guard", () => {
-  it("keeps curated sections off the Advanced page", () => {
-    expect(configSelectionFromSearch("advanced", "?section=messages")).toEqual({
-      activeSection: null,
-      activeSubsection: null,
-    });
-    expect(configSelectionFromSearch("advanced", "?section=env")).toEqual({
-      activeSection: "env",
-      activeSubsection: null,
-    });
-    expect(configSelectionFromSearch("advanced", "?section=mcp")).toEqual({
-      activeSection: null,
-      activeSubsection: null,
-    });
-    expect(configSelectionFromSearch("advanced", "?section=tts")).toEqual({
-      activeSection: null,
-      activeSubsection: null,
-    });
-    expect(configSelectionFromSearch("advanced", "?section=broadcast")).toEqual({
-      activeSection: "broadcast",
-      activeSubsection: null,
-    });
-    expect(configSelectionFromSearch("advanced", "?section=models")).toEqual({
-      activeSection: "models",
-      activeSubsection: null,
-    });
   });
 });
 

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -143,33 +143,11 @@ const SESSION_OBSERVER_STATUS_POLL_INTERVAL_MS = 10_000;
 const EMPTY_SESSION_CATALOG_LABELS: ReadonlyMap<string, string> = new Map();
 
 function defaultConfigSelection(pageId: ConfigPageId): ConfigSelection {
-  switch (pageId) {
-    case "communications":
-      return { activeSection: "messages", activeSubsection: null };
-    case "appearance":
-      return { activeSection: "__appearance__", activeSubsection: null };
-    case "notifications":
-      return { activeSection: "__notifications__", activeSubsection: null };
-    case "security":
-      return { activeSection: "security", activeSubsection: null };
-    case "automation":
-      return { activeSection: "commands", activeSubsection: null };
-    case "mcp":
-      return { activeSection: "mcp", activeSubsection: null };
-    case "memory":
-      return { activeSection: "memory", activeSubsection: null };
-    case "talk":
-      return { activeSection: "talk", activeSubsection: null };
-    case "infrastructure":
-      return { activeSection: "gateway", activeSubsection: null };
-    case "updates":
-      return { activeSection: "update", activeSubsection: null };
-    case "ai-agents":
-      return { activeSection: "agents", activeSubsection: null };
-    case "advanced":
-      return { activeSection: null, activeSubsection: null };
+  const activeSection = configSectionKeysForPage(pageId)?.[0] ?? null;
+  if (activeSection === null && pageId !== "advanced") {
+    throw new Error("Unknown config page");
   }
-  throw new Error("Unknown config page");
+  return { activeSection, activeSubsection: null };
 }
 
 function normalizeConfigSelection(

--- a/ui/src/pages/config/config-sections.ts
+++ b/ui/src/pages/config/config-sections.ts
@@ -1,17 +1,3 @@
-export type ConfigPageId =
-  | "communications"
-  | "appearance"
-  | "notifications"
-  | "security"
-  | "automation"
-  | "mcp"
-  | "memory"
-  | "talk"
-  | "infrastructure"
-  | "updates"
-  | "ai-agents"
-  | "advanced";
-
 const COMMUNICATION_SECTION_KEYS = ["messages", "tts", "transcripts"] as const;
 
 // Curated Talk home: catalog-driven provider/model/voice pickers render above
@@ -43,6 +29,7 @@ const AI_AGENTS_SECTION_KEYS = ["agents", "skills", "tools", "session"] as const
 
 // Advanced renders without an include list: it shows every section that has no
 // curated home (config-page computes its exclude list).
+// Each curated page opens at its first section.
 const CONFIG_SECTION_KEYS_BY_PAGE = {
   communications: COMMUNICATION_SECTION_KEYS,
   appearance: APPEARANCE_SECTION_KEYS,
@@ -56,7 +43,9 @@ const CONFIG_SECTION_KEYS_BY_PAGE = {
   updates: UPDATE_SECTION_KEYS,
   "ai-agents": AI_AGENTS_SECTION_KEYS,
   advanced: undefined,
-} as const satisfies Record<ConfigPageId, readonly string[] | undefined>;
+} as const satisfies Record<string, readonly string[] | undefined>;
+
+export type ConfigPageId = keyof typeof CONFIG_SECTION_KEYS_BY_PAGE;
 
 // Search and page rendering must agree on section ownership, or a result can
 // open a page whose editor rejects the section it promised to reveal.

--- a/ui/src/pages/connection/connection-page.test.ts
+++ b/ui/src/pages/connection/connection-page.test.ts
@@ -18,7 +18,8 @@ import {
 import { deviceSystemInfo } from "../../test-helpers/devices-fixtures.ts";
 import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
 import { settleLitElement } from "../../test-helpers/lit-settle.ts";
-import { ConnectionPage, supportsSystemInfo } from "./connection-page.ts";
+import { ConnectionPage } from "./connection-page.ts";
+import { supportsSystemInfo } from "./system-info.ts";
 
 function source(client: GatewayBrowserClient) {
   return createApplicationGateway({

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -29,8 +29,6 @@ import { renderConnection } from "./view.ts";
 const SYSTEM_INFO_POLL_INTERVAL_MS = 10_000;
 const CONNECTION_DOCS_URL = "https://docs.openclaw.ai/gateway/remote";
 
-export { supportsSystemInfo } from "./system-info.ts";
-
 export class ConnectionPage extends OpenClawLightDomElement {
   @consume({ context: applicationContext, subscribe: true })
   private context!: ApplicationContext;

--- a/ui/src/pages/logs/logs-page.ts
+++ b/ui/src/pages/logs/logs-page.ts
@@ -58,14 +58,13 @@ class LogsPage extends OpenClawLightDomElement {
   );
   private contentScrollFrame: number | null = null;
   private logsTaskQuiet = false;
-  private logsTaskArgs(opts?: { reset?: boolean; quiet?: boolean }) {
+  private logsTaskArgs(opts?: { reset?: boolean }) {
     return [
       this.gateway.connected ? this.gateway.gateway : null,
       this.gateway.connected ? this.gateway.client : null,
       opts?.reset ? null : this.logsCursor,
       this.logsFile,
       opts?.reset === true,
-      opts?.quiet === true,
     ] as const;
   }
   private readonly logsTask = new Task(this, {
@@ -73,7 +72,7 @@ class LogsPage extends OpenClawLightDomElement {
     // A cursor belongs to one file; recover source changes inside this task so
     // no mixed-source page can publish between the incremental and reset reads.
     args: () => this.logsTaskArgs(),
-    task: async ([gateway, client, cursor, file, reset, quiet], { signal }) => {
+    task: async ([gateway, client, cursor, file, reset], { signal }) => {
       if (!gateway || !client) {
         return initialState;
       }
@@ -96,9 +95,9 @@ class LogsPage extends OpenClawLightDomElement {
         if (sourceChanged) {
           payload = await requestTail();
         }
-        return { ok: true as const, payload, cursor, reset: reset || sourceChanged, quiet };
+        return { ok: true as const, payload, cursor, reset: reset || sourceChanged };
       } catch (error) {
-        return { ok: false as const, error, quiet };
+        return { ok: false as const, error };
       }
     },
     onComplete: (result) => {
@@ -141,7 +140,7 @@ class LogsPage extends OpenClawLightDomElement {
     },
     invalidateRequests: () => {
       this.logsTaskQuiet = false;
-      void this.logsTask.run([null, null, null, null, false, false]);
+      void this.logsTask.run([null, null, null, null, false]);
     },
     onSnapshot: () => this.syncPolling(),
     // Only connection/identity transitions own automatic resets. Metadata snapshots
@@ -193,7 +192,7 @@ class LogsPage extends OpenClawLightDomElement {
 
   override disconnectedCallback() {
     this.logsTaskQuiet = false;
-    void this.logsTask.run([null, null, null, null, false, false]);
+    void this.logsTask.run([null, null, null, null, false]);
     if (this.contentScrollFrame !== null) {
       cancelAnimationFrame(this.contentScrollFrame);
       this.contentScrollFrame = null;

--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -579,40 +579,6 @@ it("fetches a protected hero avatar with the current Control UI credential", asy
   expect(revokeObjectURL).toHaveBeenCalledWith("blob:hero-avatar");
 });
 
-it("retries the identity bootstrap when users.self returns no profile", async () => {
-  const profile = { ...modelAccountProfile };
-  let identityRequests = 0;
-  const request = vi.fn(async (method: string) => {
-    if (method === "users.self") {
-      identityRequests += 1;
-      return identityRequests === 1 ? {} : { profile };
-    }
-    throw new Error(`unexpected method: ${method}`);
-  });
-  const harness = createConnectedContext(request as GatewayBrowserClient["request"], {
-    id: "profile-1",
-    email: "ada@example.test",
-    name: "Ada",
-  });
-  const page = mountProfilePage(harness.context);
-
-  await waitForFast(() => expect(page.querySelector(".profile-identity-empty")).not.toBeNull());
-  const emptyState = page.querySelector<HTMLElement>(".profile-identity-empty");
-  const setIdentityButton = emptyState?.querySelector<HTMLButtonElement>("button");
-  expect(emptyState?.textContent).toContain(t("profilePage.identity.notSet"));
-  expect(setIdentityButton?.textContent?.trim()).toBe(t("profilePage.identity.setIdentity"));
-  expect(page.textContent).not.toContain("Cannot read properties of undefined");
-
-  setIdentityButton?.click();
-
-  await waitForFast(() =>
-    expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(2),
-  );
-  await waitForFast(() =>
-    expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe("Ada"),
-  );
-});
-
 it("keeps identity refresh single-flight and allows retry after settlement", async () => {
   const profile = { ...modelAccountProfile };
   let rejectIdentity: ((reason: Error) => void) | undefined;
@@ -725,13 +691,8 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
     ...modelAccountProfile,
     emails: ["ada@example.test", "ada@work.test"],
   };
-  let omitNextProfile = false;
   const request = vi.fn(async (method: string, params?: unknown) => {
     if (method === "users.self") {
-      if (omitNextProfile) {
-        omitNextProfile = false;
-        return {};
-      }
       return { profile };
     }
     if (method === "users.listModelAccounts") {
@@ -850,7 +811,6 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
     ).toContain(`/api/users/profile-1/avatar?v=${avatarRevision}`),
   );
 
-  omitNextProfile = true;
   request.mockClear();
   page.querySelector<HTMLButtonElement>(".profile-refresh")?.click();
   await waitForFast(() =>
@@ -864,8 +824,6 @@ it("bootstraps and refreshes the connected user's profile through users.self", a
   expect(page.querySelector<HTMLInputElement>(".identity-name-control input")?.value).toBe(
     "Unsaved draft",
   );
-  expect(page.querySelector(".profile-identity-empty")).toBeNull();
-
   const pageWithState = page as ProfilePageElement & {
     identityBusy: "display-name" | "avatar" | null;
   };

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -154,14 +154,11 @@ export class ProfilePage extends OpenClawLightDomElement {
     this.identityLoading = true;
     this.identityError = null;
     try {
-      const result = await client.request<Partial<UsersSelfResult> | null>("users.self", {});
+      const result = await client.request<UsersSelfResult>("users.self", {});
       if (requestId !== this.identityRequestId) {
         return;
       }
-      const profile = result?.profile;
-      if (!profile) {
-        return;
-      }
+      const profile = result.profile;
       this.ownProfile = profile;
       this.displayName = hasUnsavedDisplayName ? displayNameDraft : (profile.displayName ?? "");
       this.gitCoauthorEnabled = true;
@@ -349,22 +346,14 @@ export class ProfilePage extends OpenClawLightDomElement {
       </div>`;
     }
     if (!this.ownProfile) {
-      // users.self is the idempotent gateway-owned profile ensure path. Retrying
-      // keeps profile ids and authenticated email linkage authoritative server-side.
-      const emptyState = this.identityError
-        ? this.identityError
-        : html`<div class="profile-identity-empty">
-            <span>${t("profilePage.identity.notSet")}</span>
-            <button type="button" class="btn btn--sm" @click=${() => void this.loadIdentity()}>
-              ${t("profilePage.identity.setIdentity")}
-            </button>
-          </div>`;
       return html`<div id=${PROFILE_SETTINGS_TARGET_IDS.identity}>
         ${renderSettingsSection(
           { title: t("profilePage.identity.title") },
           this.identityLoading
             ? renderSettingsLoadingSkeleton({ label: t("profilePage.identity.loading"), rows: 2 })
-            : renderSettingsEmpty(emptyState),
+            : renderSettingsEmpty(
+                this.identityError ?? t("profilePage.identity.profileUnavailable"),
+              ),
         )}
       </div>`;
     }

--- a/ui/src/styles/logs.css
+++ b/ui/src/styles/logs.css
@@ -75,41 +75,26 @@ openclaw-logs-page {
 }
 
 .log-level.trace,
-.log-level.debug {
-  color: var(--muted);
-}
-
-.log-level.info {
-  color: var(--info);
-  border-color: color-mix(in srgb, var(--info) 30%, transparent);
-}
-
-.log-level.warn {
-  color: var(--warn);
-  border-color: var(--warn-subtle);
-}
-
-.log-level.error,
-.log-level.fatal {
-  color: var(--danger);
-  border-color: var(--danger-subtle);
-}
-
+.log-level.debug,
 .log-chip.trace,
 .log-chip.debug {
   color: var(--muted);
 }
 
+.log-level.info,
 .log-chip.info {
   color: var(--info);
   border-color: color-mix(in srgb, var(--info) 30%, transparent);
 }
 
+.log-level.warn,
 .log-chip.warn {
   color: var(--warn);
   border-color: var(--warn-subtle);
 }
 
+.log-level.error,
+.log-level.fatal,
 .log-chip.error,
 .log-chip.fatal {
   color: var(--danger);

--- a/ui/src/styles/profile.css
+++ b/ui/src/styles/profile.css
@@ -91,13 +91,6 @@
   padding: 2px 8px;
 }
 
-.profile-identity-empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-3);
-}
-
 /* Personal connected accounts and sign-in steps. */
 
 .model-accounts__id {


### PR DESCRIPTION
## What Problem This Solves

Settings repeated page defaults, tool override updates, schema traversal/default construction and log styling. The Logs task also carried an unread field, and Profile supported a successful response without a profile even though the Gateway contract never produces one.

This maintainer-requested cleanup removes those duplicate and unsupported paths through existing owners.

Related: #139597

## Why This Change Was Made

Derive page IDs and defaults from the section registry, use one single/bulk tool update with canonical normalization, and reuse the existing schema collector and one array-default loop. Keep section order, independent selections, Advanced boundaries, bookmarks, aliases, wildcard entries, callback counts, input immutability and schema constraints intact.

Profile now consumes the declared successful response and retains its real rejection/Refresh flow. Remove only the unsupported success fixtures, their dedicated CSS and unused English keys. Logs keeps its real quiet-polling state while dropping unread task transport, and shares identical badge/filter tones in its existing lazy stylesheet. The Connection capability test imports its helper directly from its owner.

Production is 115 lines smaller; tests grow by 203 lines after discounting moved selection cases. No new configuration, schema, protocol, dependency or public API removal.

## User Impact

No intended change to supported behavior or appearance. Authorization, saving, lifecycle fencing, retries, avatar revisions, log-source recovery and accessibility remain covered.

## Evidence

- Original/candidate settings and tool characterization: 130 tests each, including mounted route-to-page selections and actual tool interactions.
- Original schema/Profile preservation: 92 tests. The rebased candidate passes 342 tests across 23 files, including all 46 Logs/Connection cases and the new meeting-capture integration on main.
- The unchanged Gateway user handler passes all 35 cases, confirming successful profile responses and rejected unresolved/error outcomes.
- Original/candidate built Control UI Profile browser flows pass all three selected cases: normal rendering, single-flight failure/Refresh recovery and avatar revisions. Synthetic error and avatar captures were inspected; no live account or provider action is claimed.
- Independent P0–P2 reviews cover all changed files and their owner/dependency contracts with no findings. All files pass formatting and whitespace checks.
- Original and candidate Logs layout, auto-follow and isolated real-Gateway source/error/reconnect flows pass. All 24 badge/filter color samples per version match in light/dark mode; the captured Logs main panel is pixel-identical.
- Full changed checks and the production Control UI build pass, including type, lint, style, i18n, dead-code and bundle-budget gates.

The attached synthetic captures show Logs before/after and preserved Profile error redaction. They contain no live user/account data.

![Logs before consolidation](https://github.com/user-attachments/assets/a09c7b7a-2f0b-4f89-8306-b5cf3222fb47)

![Logs after consolidation](https://github.com/user-attachments/assets/bd2d4b65-32a8-453a-9ae8-1e2ec9f6d1f5)

![Profile error before consolidation](https://github.com/user-attachments/assets/9d3c4520-b31d-4f81-8de8-a83ffac3b6ec)

![Profile error after consolidation](https://github.com/user-attachments/assets/1d5e46cd-3328-48a6-9025-fe41a8b16ccb)
