### PR TITLE
fix(media): reach the size guard when decoding inline images

### DIFF
--- a/src/agents/tools/image-tool.helpers.test.ts
+++ b/src/agents/tools/image-tool.helpers.test.ts
@@ -1,0 +1,37 @@
+import { MAX_IMAGE_BYTES } from "@openclaw/media-core/constants";
+import { describe, expect, it } from "vitest";
+import { decodeDataUrl } from "./image-tool.helpers.js";
+
+describe("decodeDataUrl", () => {
+  it.each(["SGVsbG8=", "SGVsbG8", "\r\nSGVs\r\nbG8="])(
+    "preserves supported base64 spelling %j",
+    (payload) => {
+      const result = decodeDataUrl(` DATA:IMAGE/PNG;BASE64,${payload}\n `);
+      expect(result.mimeType).toBe("image/png");
+      expect(result.buffer.toString()).toBe("Hello");
+    },
+  );
+
+  it.each([
+    "data:image/png;base64,",
+    "data:image/png;base64\n,SGVsbG8=",
+    "data:image/png;charset=utf-8;base64,SGVsbG8=",
+    "data:image/png;base64,SGVs bG8=",
+    "data:image/png;base64,SGVsbG8%3D",
+    "data:image/png;base64,SGVsbG8=,",
+  ])("rejects unsupported data URL syntax %j", (input) => {
+    expect(() => decodeDataUrl(input)).toThrow("Invalid data URL (expected base64 data: URL).");
+  });
+
+  it.each([0, 1])("checks a canonical-size payload with %i extra bytes", (extraBytes) => {
+    const bytes = MAX_IMAGE_BYTES + extraBytes;
+    const input = `data:image/png;base64,${Buffer.alloc(bytes).toString("base64")}`;
+    if (extraBytes) {
+      expect(() => decodeDataUrl(input, { maxBytes: MAX_IMAGE_BYTES })).toThrow(
+        "Invalid data URL: payload exceeds size limit.",
+      );
+    } else {
+      expect(decodeDataUrl(input, { maxBytes: MAX_IMAGE_BYTES }).buffer.byteLength).toBe(bytes);
+    }
+  });
+});

--- a/src/agents/tools/image-tool.helpers.ts
+++ b/src/agents/tools/image-tool.helpers.ts
@@ -96,15 +96,16 @@ export function decodeDataUrl(
   kind: "image";
 } {
   const trimmed = dataUrl.trim();
-  const match = /^data:([^;,]+);base64,([a-z0-9+/=\r\n]+)$/i.exec(trimmed);
-  if (!match) {
+  // Capturing the full payload can exhaust the RegExp stack before the size guard.
+  const match = /^data:([^;,]+);base64,/i.exec(trimmed);
+  const b64 = match ? trimmed.slice(match[0].length) : "";
+  if (!match || !b64 || /[^a-z0-9+/=\r\n]/i.test(b64)) {
     throw new Error("Invalid data URL (expected base64 data: URL).");
   }
   const mimeType = normalizeLowercaseStringOrEmpty(match[1]);
   if (!mimeType.startsWith("image/")) {
     throw new Error(`Unsupported data URL type: ${mimeType || "unknown"}`);
   }
-  const b64 = (match[2] ?? "").trim();
   if (typeof opts?.maxBytes === "number" && estimateBase64DecodedBytes(b64) > opts.maxBytes) {
     // Estimate before decoding so oversized inline payloads do not allocate large buffers.
     throw new Error("Invalid data URL: payload exceeds size limit.");


### PR DESCRIPTION
## What Problem This Solves

`decodeDataUrl` validated an inline `data:` image URL with a single regular expression whose capturing group spanned the entire base64 payload. For a large payload the regular-expression engine can exhaust its stack before the existing size guard is ever consulted, so an oversized inline image fails with an engine-level error instead of the intended, actionable size rejection.

## Why This Change Was Made

The size limit is the contract this helper is supposed to enforce, so validation must reach it. The prefix is now matched on its own, the payload is taken with a slice, and its alphabet is checked with a character-class test. There is no large capture and no backtracking, so the existing `maxBytes` guard runs as designed and returns the intended message.

Accepted and rejected spellings are unchanged: leading and trailing whitespace, mixed case, embedded CR/LF, and missing padding are still accepted; an empty payload, a newline inside the prefix, an extra parameter, internal spaces, percent-encoding, and a trailing comma are still rejected.

## User Impact

An oversized inline image now reports "payload exceeds size limit" rather than failing inside the regular-expression engine. No configuration, schema, protocol, or public API change.

## Evidence

New table-driven coverage in `src/agents/tools/image-tool.helpers.test.ts` pins the three accepted spellings, six rejected syntaxes, and both sides of the size boundary (exactly at the cap, and one byte over). Local run: 11 tests passed.

Part of the #135868 split campaign (test-deslop lane); production delta +4/−3, tests +37.
