### PR TITLE
docs: replace private paths and document the ClawHub docs source

### DIFF
--- a/docs/.i18n/README.md
+++ b/docs/.i18n/README.md
@@ -5,7 +5,7 @@ This folder stores translation config for the source docs repo.
 Generated locale trees and live translation memory now live in the publish repo:
 
 - repo: `openclaw/docs`
-- local checkout: `~/Projects/openclaw-docs`
+- local checkout: `~/path/to/openclaw-docs`
 
 ## Source of truth
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,31 +4,32 @@ This directory owns docs authoring, published link rules, and docs i18n policy.
 
 ## Source Ownership
 
-- `/clawhub/**` pages are authored in [openclaw/clawhub](https://github.com/openclaw/clawhub/tree/main/docs). `scripts/docs-sync-publish.mjs` replaces the entire publish `docs/clawhub/` tree from that source; do not keep authored copies here.
-- Keep OpenClaw-specific skill and plugin installation, update, verification, removal, and release-trust guidance in the owning OpenClaw docs, such as `docs/cli/skills.md` and `docs/cli/plugins.md`. Standalone ClawHub CLI and publishing reference belongs upstream.
+- Maintainers author `/clawhub/**` pages in [openclaw/clawhub](https://github.com/openclaw/clawhub/tree/main/docs). `scripts/docs-sync-publish.mjs` replaces the entire publish `docs/clawhub/` tree from that source. Do not keep authored copies here.
+- This repo therefore holds no `/clawhub/**` page sources, even though `docs/docs.json` lists them in the navigation. A local docs preview and `pnpm docs:check-links` report those routes as missing until you point `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` at a ClawHub checkout.
+- Keep OpenClaw-specific skill and plugin guidance in the owning OpenClaw docs, such as `docs/cli/skills.md` and `docs/cli/plugins.md`. That guidance covers installation, update, verification, removal, and release trust. Standalone ClawHub CLI and publishing reference belongs upstream.
 - For links into `/clawhub/**`, run `pnpm docs:check-links:anchors` with `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` pointing to the actual ClawHub source checkout. Local-only pages cannot prove published ClawHub routes or anchors.
 
 ## Published Link Rules
 
-- Docs are published to `https://docs.openclaw.ai` from the `openclaw/docs` mirror.
+- The publish pipeline pushes docs to `https://docs.openclaw.ai` from the `openclaw/docs` mirror.
 - Internal doc links in `docs/**/*.md` must stay root-relative with no `.md` or `.mdx` suffix (example: `[Config](/gateway/configuration)`).
 - Section cross-references should use anchors on root-relative paths (example: `[Hooks](/gateway/configuration-reference#hooks)`).
-- Anchor IDs come from the shared publishing parser in `scripts/lib/docs-markdown.mjs`; verify them with `pnpm docs:check-links:anchors`, not Mintlify's independent checker. Published heading IDs stay stable; compatibility aliases never replace an existing target.
+- Anchor IDs come from the shared publishing parser in `scripts/lib/docs-markdown.mjs`. Verify them with `pnpm docs:check-links:anchors`, not Mintlify's independent checker. Published heading IDs stay stable. Compatibility aliases never replace an existing target.
 - Use an explicit `<a id="stable-section-name" />` for a durable section link when heading wording may change. Keep existing named anchors when reorganizing content.
 - README and other GitHub-rendered docs should keep absolute docs URLs so links work outside the docs site.
-- Docs content must stay generic: no personal device names, hostnames, or local paths; use placeholders like `user@gateway-host`.
+- Docs content must stay generic: no personal device names, hostnames, or local paths. Use placeholders like `user@gateway-host` and `~/path/to/skills`.
 
 ## Docs Content Rules
 
-- For docs, UI copy, and picker lists, order services/providers alphabetically unless the section is explicitly describing runtime order or auto-detection order.
+- For docs, UI copy, and picker lists, order services and providers alphabetically. The one exception is a section that explicitly describes runtime order or auto-detection order.
 - Keep bundled plugin naming consistent with the repo-wide plugin terminology rules in the root `AGENTS.md`.
-- JSON5/JSON config fences that look like whole `openclaw.json` documents are schema-validated in CI with `pnpm docs:check-config-examples`; deliberately partial or legacy snippets opt out with `validate=false` in the fence info string.
-- Generated docs, never hand-edit: `docs/plugins/reference/**`, `docs/plugins/reference.md`, and `docs/plugins/plugin-inventory.md` come from `pnpm plugins:inventory:gen`; `docs/maturity/**` from `pnpm maturity:render`.
-- The public and packaged docs map is generated from `pnpm docs:list --headings` during publishing and packaging. Keep only the small source stub at `docs/docs_map.md`; never commit the expanded heading mirror.
+- CI verifies JSON5 and JSON config fences that look like whole `openclaw.json` documents against the schema. `pnpm docs:check-config-examples` runs that verification. Deliberately partial or legacy snippets opt out with `validate=false` in the fence info string.
+- Generated docs, never hand-edit: `docs/plugins/reference/**`, `docs/plugins/reference.md`, and `docs/plugins/plugin-inventory.md` come from `pnpm plugins:inventory:gen`. `docs/maturity/**` comes from `pnpm maturity:render`.
+- Publishing and packaging generate the public and packaged docs map from `pnpm docs:list --headings`. Keep only the small source stub at `docs/docs_map.md`. Never commit the expanded heading mirror.
 
 ## Internal Docs
 
-- Long-lived private operator docs belong in `~/Projects/manager/docs/`.
+- Long-lived private operator docs belong in a private operator repo outside this one.
 - Repo-local internal scratch/mirror docs may live under ignored `docs/internal/`.
 - Never add `docs/internal/**` pages to `docs/docs.json` navigation or link them from public docs.
 - `scripts/docs-sync-publish.mjs` excludes and prunes `docs/internal/**` from the public `openclaw/docs` publish repo if a page is force-added later.
@@ -36,19 +37,20 @@ This directory owns docs authoring, published link rules, and docs i18n policy.
 
 ## Maturity Scorecard Editing
 
-`taxonomy.yaml` and `qa/maturity-scores.yaml` are the source inputs; generated maturity docs under `docs/maturity/` are projections and should not be hand-edited for score, LTS, taxonomy, QA profile, or evidence tables.
-`scripts/qa/render-maturity-docs.ts` owns generation; use `pnpm maturity:render` to refresh committed docs and `pnpm maturity:check` to verify them.
-`.github/workflows/maturity-scorecard.yml` renders artifact previews and can open generated-doc PRs; `.github/workflows/openclaw-release-checks.yml` dispatches it for release QA.
-Keep deterministic `qa-evidence.json.scorecard` data in GitHub Actions artifacts unless a maintainer explicitly asks for a sanitized committed projection.
-Human overrides must change source state in a PR and explain the reason plus public or redacted evidence.
+- `taxonomy.yaml` and `qa/maturity-scores.yaml` are the source inputs.
+- Generated maturity docs under `docs/maturity/` are projections. Do not hand-edit their score, LTS, taxonomy, QA profile, or evidence tables.
+- `scripts/qa/render-maturity-docs.ts` owns generation. Use `pnpm maturity:render` to refresh committed docs and `pnpm maturity:check` to verify them.
+- `.github/workflows/maturity-scorecard.yml` renders artifact previews and can open generated-doc PRs. `.github/workflows/openclaw-release-checks.yml` dispatches it for release QA.
+- Keep deterministic `qa-evidence.json.scorecard` data in GitHub Actions artifacts unless a maintainer explicitly asks for a sanitized committed projection.
+- Human overrides must change source state in a PR and explain the reason plus public or redacted evidence.
 
 ## Docs i18n
 
 - Foreign-language docs are not maintained in this repo. The generated publish output lives in the separate `openclaw/docs` repo (often cloned locally as `../openclaw-docs`).
 - Do not add or edit localized docs under `docs/<locale>/**` here.
-- Treat OpenClaw-owned English docs in this repo plus glossary files as the source of truth; ClawHub English sources follow Source Ownership above.
+- Treat OpenClaw-owned English docs in this repo plus glossary files as the source of truth. ClawHub English sources follow Source Ownership above.
 - Pipeline: update English docs here, update `docs/.i18n/glossary.<locale>.json` as needed, then let the publish-repo sync and `scripts/docs-i18n` run in `openclaw/docs`.
-- Before rerunning `scripts/docs-i18n`, add glossary entries for any new technical terms, page titles, or short nav labels that must stay in English or use a fixed translation.
+- Before rerunning `scripts/docs-i18n`, add glossary entries for new technical terms, page titles, and short nav labels. Add an entry for each term that must stay in English or use a fixed translation.
 - `pnpm docs:check-i18n-glossary` is the guard for changed English doc titles and short internal doc labels.
 - Translation memory lives in generated `docs/.i18n/*.tm.jsonl` files in the publish repo.
 - See `docs/.i18n/README.md`.

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -191,11 +191,11 @@ openclaw exec-policy preset yolo
 ## Allowlist helpers
 
 ```bash
-openclaw approvals allowlist add "~/Projects/**/bin/rg"
+openclaw approvals allowlist add "~/path/to/**/bin/rg"
 openclaw approvals allowlist add --agent main --node <id|name|ip> "/usr/bin/uptime"
 openclaw approvals allowlist add --agent "*" "/usr/bin/uname"
 
-openclaw approvals allowlist remove "~/Projects/**/bin/rg"
+openclaw approvals allowlist remove "~/path/to/**/bin/rg"
 ```
 
 Adding an existing pattern or removing a missing one succeeds without writing.

--- a/docs/cli/openclaw.md
+++ b/docs/cli/openclaw.md
@@ -54,7 +54,7 @@ openclaw setup
 openclaw setup --json
 openclaw setup --message "models"
 openclaw setup --message "validate config"
-openclaw setup --message "setup workspace ~/Projects/work" --yes
+openclaw setup --message "setup workspace ~/path/to/work" --yes
 openclaw setup --message "set default model openai/gpt-5.6" --yes
 openclaw onboard --modern
 ```
@@ -67,7 +67,7 @@ health
 doctor
 validate config
 setup
-setup workspace ~/Projects/work
+setup workspace ~/path/to/work
 config set gateway.port 19001
 config set-ref gateway.auth.token env OPENCLAW_GATEWAY_TOKEN
 gateway status
@@ -75,7 +75,7 @@ configure gateway
 open gateway wizard
 restart gateway
 agents
-create agent work workspace ~/Projects/work
+create agent work workspace ~/path/to/work
 models
 configure model provider
 set default model openai/gpt-5.6
@@ -91,7 +91,7 @@ plugins list
 plugins search slack
 plugin install clawhub:openclaw-codex-app-server
 talk to work agent
-talk to agent for ~/Projects/work
+talk to agent for ~/path/to/work
 audit
 quit
 ```
@@ -229,7 +229,7 @@ completes a real live turn. Start OpenClaw again after onboarding succeeds.
 
 ```text
 setup
-setup workspace ~/Projects/work
+setup workspace ~/path/to/work
 ```
 
 `setup` preserves the verified effective model. It does not configure or
@@ -358,8 +358,8 @@ OpenClaw: Applied. Audit entry written.
 Agent creation can also be queued locally or via rescue:
 
 ```text
-create agent work workspace ~/Projects/work model openai/gpt-5.6-sol
-/openclaw create agent work workspace ~/Projects/work
+create agent work workspace ~/path/to/work model openai/gpt-5.6-sol
+/openclaw create agent work workspace ~/path/to/work
 ```
 
 Agent creation may name only the current live-verified default model. Omit the

--- a/docs/docs_map.md
+++ b/docs/docs_map.md
@@ -1,9 +1,7 @@
 ---
-summary: "Generated heading map for OpenClaw docs pages"
+summary: "Source stub for the generated docs map"
 read_when: "Finding which docs page covers a topic before reading the page"
 title: "Docs map source"
 ---
-
-# Docs map source
 
 The public and packaged docs map is generated from all docs headings during publishing and packaging. Run `pnpm docs:list --headings` to render the same map from a source checkout.

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -51,7 +51,7 @@ in the managed agent workspace.
 {
   agents: {
     defaults: { workspace: "~/.openclaw/workspace" },
-    entries: { coder: { cwd: "~/Projects/app", sandbox: { mode: "off" } } },
+    entries: { coder: { cwd: "~/path/to/app", sandbox: { mode: "off" } } },
   },
 }
 ```
@@ -69,7 +69,7 @@ Optional repository root shown in the system prompt's Runtime line. If unset, Op
 
 ```json5
 {
-  agents: { defaults: { repoRoot: "~/Projects/openclaw" } },
+  agents: { defaults: { repoRoot: "~/path/to/openclaw" } },
 }
 ```
 

--- a/docs/gateway/configuration-examples.md
+++ b/docs/gateway/configuration-examples.md
@@ -434,8 +434,8 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
   skills: {
     allowBundled: ["gemini", "peekaboo"],
     load: {
-      extraDirs: ["~/Projects/agent-scripts/skills"],
-      allowSymlinkTargets: ["~/Projects/agent-scripts/skills"],
+      extraDirs: ["~/path/to/agent-scripts/skills"],
+      allowSymlinkTargets: ["~/path/to/agent-scripts/skills"],
     },
     install: {
       preferBrew: true,
@@ -457,14 +457,14 @@ Save to `~/.openclaw/openclaw.json` and you can DM the bot from that number.
 ### Symlinked sibling skill repo
 
 Use this when a built-in skill root contains a symlink into a sibling repo, for
-example `~/.agents/skills/manager -> ~/Projects/manager/skills`.
+example `~/.agents/skills/manager -> ~/path/to/skills`.
 
 ```json5
 {
   skills: {
     load: {
-      extraDirs: ["~/Projects/manager/skills"],
-      allowSymlinkTargets: ["~/Projects/manager/skills"],
+      extraDirs: ["~/path/to/skills"],
+      allowSymlinkTargets: ["~/path/to/skills"],
     },
   },
 }

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -218,8 +218,8 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
   skills: {
     allowBundled: ["gemini", "peekaboo"],
     load: {
-      extraDirs: ["~/Projects/agent-scripts/skills"],
-      allowSymlinkTargets: ["~/Projects/manager/skills"],
+      extraDirs: ["~/path/to/agent-scripts/skills"],
+      allowSymlinkTargets: ["~/path/to/skills"],
     },
     install: {
       preferBrew: true,
@@ -266,7 +266,7 @@ See [MCP](/cli/mcp#openclaw-as-an-mcp-client-registry) and
     allow: ["voice-call"],
     deny: [],
     load: {
-      paths: ["~/Projects/oss/voice-call-plugin"],
+      paths: ["~/path/to/oss/voice-call-plugin"],
     },
     entries: {
       "voice-call": {

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -144,8 +144,8 @@ If the target is intentional, configure both the direct skill root and the allow
 {
   skills: {
     load: {
-      extraDirs: ["~/Projects/manager/skills"],
-      allowSymlinkTargets: ["~/Projects/manager/skills"],
+      extraDirs: ["~/path/to/skills"],
+      allowSymlinkTargets: ["~/path/to/skills"],
     },
   },
 }

--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -554,7 +554,7 @@ First-run Q&A - install, onboard, auth routes, subscriptions, initial failures -
     {
       agents: {
         defaults: {
-          workspace: "~/Projects/my-repo",
+          workspace: "~/path/to/my-repo",
         },
       },
     }

--- a/docs/prose.md
+++ b/docs/prose.md
@@ -8,7 +8,8 @@ read_when:
   - You want to install the maintained upstream OpenProse Agent Skill
 ---
 
-OpenClaw no longer bundles the OpenProse plugin or its `/prose` command. OpenProse
+OpenClaw no longer bundles the OpenProse plugin or its `/prose` command. The
+v2026.8.1 release removed both. OpenProse
 continues as a maintained upstream Agent Skill. Existing `.prose` source files
 remain yours; the removed plugin did not store state in OpenClaw's SQLite database.
 
@@ -29,7 +30,11 @@ remain yours; the removed plugin did not store state in OpenClaw's SQLite databa
    npx skills add openprose/prose --skill open-prose --agent codex --copy -y
    ```
 
-   This copies the skill to `.agents/skills/open-prose`, which OpenClaw loads as
+   `skills` is a third-party CLI from npm, not an OpenClaw command. Keep
+   `--agent codex`: that value writes the shared `.agents/skills` layout, which
+   OpenClaw reads even though the flag names another agent.
+
+   The command copies the skill to `.agents/skills/open-prose`, which OpenClaw loads as
    a project Agent Skill. It does not restore the removed bundled plugin or the
    `/prose` command.
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -150,14 +150,14 @@ Example schema:
       "allowlist": [
         {
           "id": "B0C8C0B3-2C2D-4F8A-9A3C-5A4B3C2D1E0F",
-          "pattern": "~/Projects/**/bin/rg",
+          "pattern": "~/path/to/**/bin/rg",
           "argPattern": "sha256:argv:...",
           "source": "allow-always",
           "lastUsedAt": 1737150000000,
           "lastResolvedPath": "/Users/user/Projects/.../bin/rg"
         },
         {
-          "pattern": "~/Projects/**/bin/git"
+          "pattern": "~/path/to/**/bin/git"
         }
       ],
       "mcpTools": [
@@ -404,7 +404,7 @@ to satisfy allowlist rules.
 Examples:
 
 - `rg`
-- `~/Projects/**/bin/peekaboo`
+- `~/path/to/**/bin/peekaboo`
 - `~/.local/bin/*`
 - `/opt/homebrew/bin/rg`
 

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -187,7 +187,7 @@ The common plugin config shape is:
     enabled: true,
     allow: ["voice-call"],
     deny: ["untrusted-plugin"],
-    load: { paths: ["~/Projects/oss/voice-call-plugin"] },
+    load: { paths: ["~/path/to/oss/voice-call-plugin"] },
     slots: { memory: "memory-core" },
     entries: {
       "voice-call": { enabled: true, config: { provider: "twilio" } },

--- a/docs/tools/skills-config.md
+++ b/docs/tools/skills-config.md
@@ -17,8 +17,8 @@ Most skills configuration lives under `skills` in
   skills: {
     allowBundled: ["gemini", "peekaboo"],
     load: {
-      extraDirs: ["~/Projects/agent-scripts/skills"],
-      allowSymlinkTargets: ["~/Projects/manager/skills"],
+      extraDirs: ["~/path/to/agent-scripts/skills"],
+      allowSymlinkTargets: ["~/path/to/skills"],
       watch: true,
     },
     install: {
@@ -62,8 +62,8 @@ Most skills configuration lives under `skills` in
   Trusted real target directories that symlinked skill folders may resolve
   into, even when the symlink lives outside the configured root. Use this for
   intentional sibling-repo layouts such as
-  `<workspace>/skills/manager -> ~/Projects/manager/skills`. Keep this list
-  narrow — do not point at broad roots like `~` or `~/Projects`.
+  `<workspace>/skills/manager -> ~/path/to/skills`. Keep this list
+  narrow — do not point at broad roots like `~` or a whole projects directory.
 </ParamField>
 
 <ParamField path="skills.load.watch" type="boolean" default="true">
@@ -403,14 +403,14 @@ To allow an intentional symlink layout, declare the trusted target:
 {
   skills: {
     load: {
-      extraDirs: ["~/Projects/manager/skills"],
-      allowSymlinkTargets: ["~/Projects/manager/skills"],
+      extraDirs: ["~/path/to/skills"],
+      allowSymlinkTargets: ["~/path/to/skills"],
     },
   },
 }
 ```
 
-With this config, `<workspace>/skills/manager -> ~/Projects/manager/skills`
+With this config, `<workspace>/skills/manager -> ~/path/to/skills`
 is accepted after realpath resolution. `extraDirs` scans the sibling repo
 directly; `allowSymlinkTargets` preserves the symlinked path for existing
 layouts.

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -721,8 +721,8 @@ restoring watch capacity to enable native watching again.
     {
       skills: {
         load: {
-          extraDirs: ["~/Projects/agent-scripts/skills"],
-          allowSymlinkTargets: ["~/Projects/manager/skills"],
+          extraDirs: ["~/path/to/agent-scripts/skills"],
+          allowSymlinkTargets: ["~/path/to/skills"],
           watch: true, // default
         },
       },
@@ -732,7 +732,7 @@ restoring watch capacity to enable native watching again.
     Watcher events use a built-in 250 ms debounce. Use `allowSymlinkTargets`
     for intentional symlinked layouts where a skill
     root symlink points outside the configured root, for example
-    `<workspace>/skills/manager -> ~/Projects/manager/skills`.
+    `<workspace>/skills/manager -> ~/path/to/skills`.
     Skill Workshop does not use these configured symlink targets.
 
   </Accordion>
@@ -797,5 +797,8 @@ read every admitted skill. Native harnesses retain their own prompt policy.
   </Card>
   <Card title="Plugins" href="/tools/plugin" icon="plug">
     Plugins can ship skills alongside the tools they document.
+  </Card>
+  <Card title="OpenProse migration" href="/prose" icon="pen-nib">
+    Move from the removed OpenProse plugin to the upstream Agent Skill.
   </Card>
 </CardGroup>

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -621,4 +621,7 @@ See [BTW side questions](/tools/btw) for the full behavior.
   <Card title="Steer" href="/tools/steer" icon="compass">
     Guide the agent mid-run with `/steer`.
   </Card>
+  <Card title="OpenProse migration" href="/prose" icon="pen-nib">
+    Where the removed `/prose` command went.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
Docs governance and publish-hygiene pass over `docs/AGENTS.md` and the pages its rules cover. Findings come from a docs audit taken at `a1e8a18`; every finding was re-checked against current `main` before editing.

## What changed and why

### 1. Private operator paths in public pages (`r3-0907`, `r3-2278`)

`docs/AGENTS.md` bans local paths in docs content, yet `grep -rn '~/Projects' docs/` returned **38 hits across 13 files**, including the private repo path `~/Projects/manager/skills`.

All 38 are gone:

- 37 became neutral placeholders (`~/Projects/manager/skills` -> `~/path/to/skills`, `~/Projects/` -> `~/path/to/` elsewhere).
- 1 was prose about broad roots (`docs/tools/skills-config.md`: "do not point at broad roots like `~` or `~/Projects`"), reworded to "a whole projects directory" because a placeholder path would have destroyed the sentence's point.
- `docs/AGENTS.md` Internal Docs now says private operator docs "belong in a private operator repo outside this one" instead of naming `~/Projects/manager/docs/`.
- The Published Link Rules bullet that bans local paths now names `~/path/to/skills` alongside `user@gateway-host` as an approved placeholder.

No hit fell inside a generated tree (`docs/plugins/reference/`, `docs/releases/`, `docs/maturity/`), so nothing here needed a generator change.

This touches 13 pages rather than the 3 files the audit row lists. That is the finding: the rule lives in `docs/AGENTS.md`, the violations live in the pages. The diff in those pages is path replacements only.

### 2. ClawHub source note (`r4-clawhub-0001`)

Verified against `scripts/docs-sync-publish.mjs`: `CLAWHUB_REPO_ENV = "OPENCLAW_DOCS_SYNC_CLAWHUB_REPO"` (L21), and `syncClawHubDocsTree` mirrors `openclaw/clawhub` docs into the publish `docs/clawhub/` tree.

Drift note: `docs/clawhub/` no longer exists in this repo at all, so **all 14** navigation entries under `clawhub/` in `docs/docs.json` resolve only after the sync. The audit saw 12 external plus 2 local.

Added one Source Ownership bullet saying this repo holds no `/clawhub/**` page sources, and that a local preview and `pnpm docs:check-links` report those routes as missing until `OPENCLAW_DOCS_SYNC_CLAWHUB_REPO` points at a ClawHub checkout.

### 3. Strict-STE rate on `docs/AGENTS.md` (`r3-0734`, `r3-0910`)

Mechanical only: semicolons split, sentences over 20 words split, passive voice fixed where a real actor was available. No rule changed meaning; every hedge, condition, and list of items is preserved.

Before: `21 violations (18 hard, baseline 0), 616 words, 3.4 per 100 words`
After: `0 violations (0 hard, baseline 0), 679 words, 0.0 per 100 words`

### 4. `docs/prose.md` (`r3-0736`, `r3-2285`)

The removal notice named no release. Established from the repo, not guessed:

- `docs/releases/2026.8.1.md:9750` - `refactor(plugins)!: remove OpenProse (#128494)`
- `CHANGELOG.md:3585`, under the `## 2026.8.1` heading at L3566 - the breaking-change entry for the same PR.

The page now reads "The v2026.8.1 release removed both."

Step 2 also gained a sentence naming the third-party `skills` CLI and explaining why an OpenClaw migration passes `--agent codex`.

### 5. Smaller findings

- `r3-2277`: Maturity Scorecard section converted from a 5-sentence paragraph to a bulleted list, matching every other section.
- `r3-2286`: `/prose` linked from the Related card groups on `docs/tools/skills.md` and `docs/tools/slash-commands.md`.
- `r3-2287` / `r3-2288`: `docs/docs_map.md` summary corrected to describe the stub, and the H1 that repeated the frontmatter title removed. Safe: `writePublishedDocsMap` (`scripts/docs-sync-publish.mjs:836`) overwrites the published copy wholesale via `renderDocsHeadingMap`, which emits its own frontmatter and its own `# OpenClaw docs map` H1. The title is unchanged, so `docs:check-i18n-glossary` sees no churn.

## Not done, and why

### `r3-0906` - publish-tree exclusions (partial)

The private-path half is fixed. The script half is **not**, deliberately.

Confirmed the audit's premise still holds. `scripts/docs-sync-publish.mjs:800-811` rsyncs `docs/` into the publish repo excluding only:

```js
"--filter", "P .i18n/README.md",
"--exclude", ".i18n/README.md",
...INTERNAL_DOCS_DIRS.flatMap((dir) => ["--exclude", `${dir}/`]),   // INTERNAL_DOCS_DIRS = ["internal"]
```

So `docs/AGENTS.md`, `docs/CLAUDE.md` (a symlink to it), `docs/.generated/`, and the rest of `docs/.i18n/` do get copied into `openclaw/docs`.

I did not apply the audit's proposed fix, because part of it is wrong. Excluding `.i18n/` wholesale would break the pipeline that `docs/AGENTS.md` itself documents: `docs/.i18n/glossary.<locale>.json` and the `*-navigation.json` files have to reach the publish repo for `scripts/docs-i18n` to run there. A correct exclusion needs a per-file list, and `docs/.generated/` has consumers (`scripts/changed-lanes.mts`, `scripts/lib/packed-cargo-policy.mts`) whose publish-side expectations I could not establish from this repo. That is a sync-script change with its own blast radius, not a docs edit. Filed as a follow-up below.

### `r3-0909` - generated-file markers

`docs/AGENTS.md` declares `docs/plugins/reference/**` generated, but **0 of 151** leaf pages carry a marker (the audit found 4 of 151; it regressed). The fix is in `pnpm plugins:inventory:gen`, not in the docs. Hand-adding 151 markers would be overwritten on the next generation. Follow-up below.

## Validators

All run from the worktree root.

```
$ node scripts/check-docs-mdx.mjs docs README.md
Docs MDX check passed (753 files, 11509ms).

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=... node scripts/docs-link-audit.mjs
Synced 22 ClawHub doc asset(s).
checked_internal_links=8254
broken_links=0

$ OPENCLAW_DOCS_SYNC_CLAWHUB_REPO=... node scripts/docs-link-audit.mjs --anchors
checked_internal_links=8622
broken_links=2
omitted_compatibility_aliases=1
clawhub/publishing.md:260 :: /clawhub/http-api#post-apiv1publishattemptsidrecover :: fragment not found
clawhub/publishing.md:302 :: /clawhub/cli#package-transfer-name :: fragment not found

$ python3 ste-lint.py --max-words 20 docs/AGENTS.md
0 violations (0 hard, baseline 0), 679 words, 0.0 per 100 words
```

The 2 broken anchors are pre-existing upstream fragments in `openclaw/clawhub`, identical before and after this branch. No new one. Internal links went 8252 -> 8254, the two new `/prose` cards.

Also clean, since the diff touches JSON5 fences and markdown formatting:

```
$ node scripts/check-docs-config-examples.mjs
docs_config_fences_validated=1217   (exit 0)

$ node --import ./scripts/tsx.mjs scripts/format-docs.mts --check
Docs formatting clean (740 files).
```

## Suggested follow-ups

1. Exclude `docs/AGENTS.md`, `docs/CLAUDE.md`, and `docs/.generated/` from the publish rsync in `scripts/docs-sync-publish.mjs`, with a per-file rather than directory-wide rule for `docs/.i18n/` so the glossary and navigation JSON still reach `openclaw/docs`. (`r3-0906`)
2. Make `pnpm plugins:inventory:gen` write a do-not-edit header into every leaf page under `docs/plugins/reference/`. Currently 0 of 151 carry one. (`r3-0909`)
3. Consider a CI guard that fails on `~/Projects` (or any `~/`-rooted personal path) appearing in `docs/`, so this does not regress. The audit row suggested it and this PR does not add it.
