### PR TITLE
perf(agents): reduce tool catalog formatting work

### DIFF
--- a/src/agents/tool-schema-hints.test.ts
+++ b/src/agents/tool-schema-hints.test.ts
@@ -196,6 +196,28 @@ describe("tool schema hints", () => {
     );
   });
 
+  it.each([
+    { limit: 300, delta: -1 },
+    { limit: 300, delta: 0 },
+    { limit: 300, delta: 1 },
+    { limit: 800, delta: -1 },
+    { limit: 800, delta: 0 },
+    { limit: 800, delta: 1 },
+  ])("preserves the $limit UTF-16 boundary at offset $delta", ({ limit, delta }) => {
+    const literal = "x".repeat(limit - 24 + delta);
+    const schema = Type.Object(
+      { a: Type.String(), "z😀": Type.Literal(literal) },
+      { additionalProperties: false },
+    );
+    const render = limit === 300 ? compactToolInputHint : compactToolOutputHint;
+    const expected = `{ a: string; "z😀": "${literal}" }`;
+
+    expect(expected.length).toBe(limit + delta);
+    expect(render(schema)).toBe(
+      delta <= 0 ? expected : limit === 300 ? "{ a: string; ... }" : undefined,
+    );
+  });
+
   it("renders a bare top-type schema as unknown without demoting", () => {
     expect(compactToolOutputHint(Type.Unknown())).toBe("unknown");
     expect(compactToolOutputHint(Type.Any())).toBe("unknown");

--- a/src/agents/tool-schema-hints.ts
+++ b/src/agents/tool-schema-hints.ts
@@ -280,27 +280,28 @@ function compactObjectHint(
     schema.additionalProperties === true ||
     isRecord(schema.additionalProperties);
   let complete = !structurallyIncomplete && schema.additionalProperties === false;
-  const parts: string[] = [];
+  let body = "";
   for (const key of keys) {
     const name = IDENTIFIER_RE.test(key) ? key : JSON.stringify(key);
     const propertyHint = compactSchemaType(properties[key], depth, limits);
     complete &&= propertyHint.complete;
     const part = `${name}${required.has(key) ? "" : "?"}: ${propertyHint.text}`;
-    const next = `{ ${[...parts, part].join("; ")} }`;
-    if (next.length > limits.maxChars) {
+    const next = body ? `${body}; ${part}` : part;
+    // The budget includes both braces and their inner spaces.
+    if (next.length + 4 > limits.maxChars) {
       omitted = true;
       complete = false;
       break;
     }
-    parts.push(part);
+    body = next;
   }
-  if (parts.length === 0) {
+  if (!body) {
     return keys.length === 0 && !omitted
       ? { text: "{}", complete }
       : { text: "{ ... }", complete: false };
   }
   return {
-    text: `{ ${parts.join("; ")}${omitted ? "; ..." : ""} }`,
+    text: `{ ${body}${omitted ? "; ..." : ""} }`,
     complete,
   };
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Please keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Tool Search spends avoidable local time preparing compact input and output signatures when displaying catalogs with many fields. This improves that preparation without changing the descriptions or schemas the model receives.

## Why This Change Was Made

Keep the accepted object-hint body and append each field once instead of repeatedly copying and joining every preceding field just to check its length. Reuse that body in the final result. Preserve the existing UTF-16 budgets, field order, completeness/omission behavior, and final-ellipsis overflow fallback. Numeric constraints, nullable shapes, validation, and tool execution are unchanged.

Production is +1 line for the explanatory budget comment; six boundary cases add 22 test lines. No API, config, dependency, or storage change.

## User Impact

Measured catalog preparation is faster for the tested OpenClaw-owned tool entries, with identical returned content. This is a component result; it does not establish faster Gateway turns, lower memory use, or a universal improvement for every schema.

## Evidence

Both source variants passed 259 tests across `tool-schema-hints.test.ts`, `tool-search-runtime.test.ts`, and `tool-search.test.ts`, including below/exact/above the 300- and 800-code-unit UTF-16 limits with a separator and quoted Unicode key. Independent P0–P2 review found no actionable issue.

Normal validation is **28+1 separate checks**: the full changed gate passed its first 28 checks, then hit its unchanged 600-second outer deadline during the final pairing-account guard. The exact remaining `pnpm lint:auth:pairing-account-scope` command passed separately in 7.04s under the same deadline. The original full gate remains recorded as failed 143; it was not rerun or relabeled green. Source and selected dependency pins remained unchanged.

One fixed verify-B/verify-C/B0/C0/C1/B1 cohort covered 30 rows, 6,528 timed operations and 6,948 complete returned values. Independent audit verified full output parity and retained all 960 samples. Operations call the real hint exports or map the real catalog-entry export over 1/32/128 entries. Medians below reduce eight sample means per row; they are not percentiles.

| Catalog entries | Forward median, µs | Change | Reverse median, µs | Change |
| --- | ---: | ---: | ---: | ---: |
| 1 | 15.104 → 11.166 | -26.07% | 15.021 → 11.511 | -23.37% |
| 32 | 437.916 → 331.271 | -24.35% | 657.729 → 364.729 | -44.55% |
| 128 | 1671.292 → 1271.114 | -23.94% | 1615.438 → 1309.948 | -18.91% |

Across both orders and all 30 rows, 8/60 median, 13/60 mean and 18/60 maximum-sample-mean comparisons were adverse. All eight adverse medians remain included: nullable forward +150.89% (+9.37µs), literal union forward +12.48%, structural union reverse +26.98%, quoted Unicode reverse +3.45%; unchanged MCP 32 controls +10.36/+1.44% and MCP 128 controls +10.56/+9.68%. MCP bypasses the changed hint path, so its variation is neither credited as a gain nor discarded.

Additional spikes remain visible: numeric constraints forward mean +72.06% and maximum sample mean +673.59%; nested objects reverse mean +68.53% and maximum +615.26%; the 32-entry OpenClaw catalog forward maximum +69.97%. These observations are not explained away as noise. Eight samples in two orders do not establish significance, population tails, or a traffic-weighted aggregate benefit.

The operation stopwatch excludes serialization, persistence, and assertions. Kernel peak RSS increased 6.86%/2.26%; no memory reduction is claimed. No Gateway or model-turn latency was measured for this patch. All six children and the measurement parent closed, and the candidate source was restored.

Measured/validated base: `ec46a506639c`. Read-only comparison with current main `dfd5211a4b46` found identical owner, baseline test, callers, relevant guides, and Tool Search docs. This is source comparison, not a new current-main runtime run. Exact-head CI remains for the normal publication/landing workflow.
