### PR TITLE
fix(memory): return JSON when the memory backend is unavailable

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -21,6 +21,20 @@ Related: [Memory](/concepts/memory) concept, [Dreaming](/concepts/dreaming),
 [Memory config reference](/reference/memory-config), [Memory Wiki](/plugins/memory-wiki),
 [wiki](/cli/wiki), [Plugins](/tools/plugin).
 
+## JSON availability
+
+With `--json`, `search`, `promote`, `promote-explain`, `rem-harness`,
+`rem-backfill`, and `session-backfill` report when the memory backend is
+unavailable before any work runs:
+
+- Disabled memory returns `{"agentId":"main","status":"disabled"}` with a successful exit.
+- Backend acquisition failures return the standard `{"ok":false,"error":{"type":"cli_error","message":"..."}}` envelope, plus `agentId`, and exit with code 1.
+
+Handle these outcomes before reading the command's normal result fields. An
+enabled search with no matches still returns `{"results":[]}`. `status --json`
+keeps its aggregate array of available agents, including `[]` when all are
+disabled; acquisition failures still set a nonzero exit code.
+
 ## `memory status`
 
 ```bash

--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -209,6 +209,7 @@ export async function runMemorySearch(
     commandName: "memory search",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
+    onUnavailable: opts.json ? defaultRuntime.writeJson : undefined,
     purpose: "cli",
     inspectSources: true,
     ...hostOptions,
@@ -376,6 +377,7 @@ export async function runMemoryPromote(
     commandName: "memory promote",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
+    onUnavailable: opts.json ? defaultRuntime.writeJson : undefined,
     purpose: "status",
     ...hostOptions,
     run: async ({ manager, cfg, agentId }) => {
@@ -554,6 +556,7 @@ export async function runMemoryPromoteExplain(
     commandName: "memory promote-explain",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
+    onUnavailable: opts.json ? defaultRuntime.writeJson : undefined,
     purpose: "status",
     ...hostOptions,
     run: async ({ manager, cfg, agentId }) => {

--- a/extensions/memory-core/src/cli-rem.runtime.ts
+++ b/extensions/memory-core/src/cli-rem.runtime.ts
@@ -25,6 +25,7 @@ export async function runMemorySessionBackfill(
     commandName: "memory session-backfill",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
+    onUnavailable: opts.json ? defaultRuntime.writeJson : undefined,
     purpose: "status",
     ...hostOptions,
     run: async ({ manager, cfg, agentId }) => {
@@ -121,6 +122,7 @@ export async function runMemoryRemHarness(
     commandName: "memory rem-harness",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
+    onUnavailable: opts.json ? defaultRuntime.writeJson : undefined,
     purpose: "status",
     ...hostOptions,
     run: async ({ manager, cfg, agentId }) => {
@@ -286,6 +288,7 @@ export async function runMemoryRemBackfill(
     commandName: "memory rem-backfill",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
+    onUnavailable: opts.json ? defaultRuntime.writeJson : undefined,
     purpose: "status",
     ...hostOptions,
     run: async ({ manager, cfg, agentId }) => {

--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -10,6 +10,7 @@ import { buildAgentSessionKey } from "openclaw/plugin-sdk/routing";
 import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   defaultRuntime,
+  formatCliJsonFailure,
   formatErrorMessage,
   getMemoryEmbeddingCommandSecretTargetIds,
   getMemorySearchManager,
@@ -28,6 +29,10 @@ export type MemoryManager = NonNullable<
   Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]
 >;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
+type MemoryCommandUnavailable = { agentId: string } & (
+  | { status: "disabled" }
+  | ReturnType<typeof formatCliJsonFailure>
+);
 function isMemorySecretOwnerFailure(error: unknown, message: string): boolean {
   const candidate = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
   if (
@@ -154,51 +159,13 @@ export function formatExtraPaths(workspaceDir: string, extraPaths: MemoryExtraPa
     return entry.pattern ? `${root} (pattern: ${entry.pattern})` : root;
   });
 }
-async function withMemoryManagerForAgent(params: {
-  commandName: string;
-  cfg: OpenClawConfig;
-  agentId: string;
-  purpose?: MemoryManagerPurpose;
-  inspectSources?: boolean;
-  acquireLocalService?: MemoryCoreAcquireLocalService;
-  run: (manager: MemoryManager) => Promise<void>;
-}): Promise<void> {
-  const managerParams: Parameters<typeof getMemorySearchManager>[0] = {
-    cfg: params.cfg,
-    agentId: params.agentId,
-  };
-  if (params.purpose) {
-    managerParams.purpose = params.purpose;
-  }
-  if (params.inspectSources) {
-    managerParams.inspectSources = true;
-  }
-  if (params.acquireLocalService) {
-    managerParams.acquireLocalService = params.acquireLocalService;
-  }
-  await withManager<MemoryManager>({
-    getManager: () => getMemorySearchManager(managerParams),
-    onMissing: (error) => {
-      if (!error?.trim()) {
-        defaultRuntime.log("Memory search disabled.");
-        return;
-      }
-      defaultRuntime.error(`${params.commandName} failed (${params.agentId}): ${error}`);
-      process.exitCode = 1;
-    },
-    onCloseError: (err) =>
-      defaultRuntime.error(`Memory manager close failed: ${formatErrorMessage(err)}`),
-    close: async (manager) => {
-      await manager.close?.();
-    },
-    run: params.run,
-  });
-}
 export async function withMemoryCommand(params: {
   commandName: string;
   agent?: string;
   allAgents?: boolean;
   diagnosticsToStderr?: boolean;
+  // Single-command writers opt in; status owns one aggregate document after this scope.
+  onUnavailable?: (result: MemoryCommandUnavailable) => void;
   purpose?: MemoryManagerPurpose;
   inspectSources?: boolean;
   acquireLocalService?: MemoryCoreAcquireLocalService;
@@ -213,13 +180,37 @@ export async function withMemoryCommand(params: {
     ? resolveMemoryAgentIds(cfg, params.agent)
     : [resolveMemoryAgent(cfg, params.agent)];
   for (const agentId of agentIds) {
-    await withMemoryManagerForAgent({
-      commandName: params.commandName,
+    const managerParams: Parameters<typeof getMemorySearchManager>[0] = {
       cfg,
       agentId,
-      purpose: params.purpose,
-      inspectSources: params.inspectSources,
-      acquireLocalService: params.acquireLocalService,
+    };
+    if (params.purpose) {
+      managerParams.purpose = params.purpose;
+    }
+    if (params.inspectSources) {
+      managerParams.inspectSources = true;
+    }
+    if (params.acquireLocalService) {
+      managerParams.acquireLocalService = params.acquireLocalService;
+    }
+    await withManager<MemoryManager>({
+      getManager: () => getMemorySearchManager(managerParams),
+      onMissing: (error) => {
+        if (!error?.trim()) {
+          defaultRuntime.log("Memory search disabled.");
+          params.onUnavailable?.({ agentId, status: "disabled" });
+          return;
+        }
+        const message = `${params.commandName} failed (${agentId}): ${error}`;
+        defaultRuntime.error(message);
+        process.exitCode = 1;
+        params.onUnavailable?.({ ...formatCliJsonFailure(message), agentId });
+      },
+      onCloseError: (err) =>
+        defaultRuntime.error(`Memory manager close failed: ${formatErrorMessage(err)}`),
+      close: async (manager) => {
+        await manager.close?.();
+      },
       run: async (manager) => params.run({ manager, cfg, agentId }),
     });
   }

--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -1,6 +1,7 @@
 // Memory Core plugin module implements cli.host behavior.
 export {
   defaultRuntime,
+  formatCliJsonFailure,
   formatErrorMessage,
   getMemoryEmbeddingCommandSecretTargetIds,
   resolveCommandSecretRefsViaGateway,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -92,6 +92,7 @@ vi.mock("./cli.host.runtime.js", async () => {
     {
       defaultRuntime,
       formatErrorMessage,
+      formatCliJsonFailure,
       getMemoryEmbeddingCommandSecretTargetIds,
       setVerbose,
       shortenHomeInString,
@@ -111,6 +112,7 @@ vi.mock("./cli.host.runtime.js", async () => {
   return {
     defaultRuntime,
     formatErrorMessage,
+    formatCliJsonFailure,
     getMemoryEmbeddingCommandSecretTargetIds,
     getMemorySearchManager,
     listMemoryFiles,
@@ -1980,13 +1982,131 @@ describe("memory cli", () => {
     expect(hasLoggedInactiveSecretDiagnostic(error)).toBe(true);
   });
 
-  it("logs default message when memory manager is missing", async () => {
+  describe.each([
+    {
+      availability: "disabled",
+      managerError: undefined,
+      expectedExitCode: 0,
+    },
+    {
+      availability: "failed",
+      managerError: "fixture memory acquisition failed",
+      expectedExitCode: 1,
+    },
+  ])("missing-manager JSON output ($availability)", ({ managerError, expectedExitCode }) => {
+    it.each([
+      ["search", ["search", "--query", "fixture query"]],
+      ["promote", ["promote"]],
+      ["promote-explain", ["promote-explain", "fixture candidate"]],
+      ["rem-harness", ["rem-harness"]],
+      ["rem-backfill", ["rem-backfill", "--rollback"]],
+      ["session-backfill", ["session-backfill"]],
+    ])("reports unavailable %s once without claiming completed work", async (_name, args) => {
+      getMemorySearchManager.mockResolvedValueOnce({
+        manager: null,
+        ...(managerError ? { error: managerError } : {}),
+      });
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      const errors = spyRuntimeErrors(defaultRuntime);
+      spyRuntimeLogs(defaultRuntime);
+
+      await runMemoryCli([...args, "--json"]);
+
+      expect(writeJson).toHaveBeenCalledTimes(1);
+      expect(firstWrittenJsonArg(writeJson)).toEqual(
+        managerError
+          ? {
+              agentId: "main",
+              ok: false,
+              error: {
+                type: "cli_error",
+                message: `memory ${args[0]} failed (main): ${managerError}`,
+              },
+            }
+          : { agentId: "main", status: "disabled" },
+      );
+      expect(process.exitCode).toBe(expectedExitCode);
+      if (managerError) {
+        expect(errors).toHaveBeenCalledWith(`memory ${args[0]} failed (main): ${managerError}`);
+      } else {
+        expect(errors).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  it.each([
+    { name: "all disabled", healthyOps: false, managerError: undefined, exitCode: 0 },
+    { name: "one disabled", healthyOps: true, managerError: undefined, exitCode: 0 },
+    {
+      name: "one failed",
+      healthyOps: true,
+      managerError: "fixture memory acquisition failed",
+      exitCode: 1,
+    },
+  ])(
+    "keeps one aggregate JSON status document with $name",
+    async ({ healthyOps, managerError, exitCode }) => {
+      getRuntimeConfig.mockReturnValue(configuredAgents);
+      const healthyStatus = makeMemoryStatus({ workspaceDir: undefined });
+      const close = vi.fn(async () => {});
+      getMemorySearchManager.mockImplementation(async ({ agentId }: { agentId: string }) =>
+        healthyOps && agentId === "ops"
+          ? { manager: { status: () => healthyStatus, close } }
+          : { manager: null, ...(managerError ? { error: managerError } : {}) },
+      );
+      const writeJson = spyRuntimeJson(defaultRuntime);
+      spyRuntimeErrors(defaultRuntime);
+      spyRuntimeLogs(defaultRuntime);
+
+      await runMemoryCli(["status", "--json"]);
+
+      expect(writeJson).toHaveBeenCalledTimes(1);
+      const output = firstWrittenJsonArg<Array<{ agentId: string; status: unknown }>>(writeJson);
+      if (healthyOps) {
+        expect(output).toHaveLength(1);
+        expect(output).toMatchObject([{ agentId: "ops", status: healthyStatus }]);
+        expect(close).toHaveBeenCalledTimes(1);
+      } else {
+        expect(output).toEqual([]);
+      }
+      expect(process.exitCode).toBe(exitCode);
+    },
+  );
+
+  it("keeps an enabled empty search distinct from unavailable JSON", async () => {
+    getRuntimeConfig.mockReturnValue({
+      plugins: { entries: { "memory-core": { config: { dreaming: { enabled: false } } } } },
+    });
+    const close = vi.fn(async () => {});
+    mockManager({
+      search: vi.fn(async () => []),
+      status: () => makeMemoryStatus({ workspaceDir: undefined }),
+      close,
+    });
+    const writeJson = spyRuntimeJson(defaultRuntime);
+
+    await runMemoryCli(["search", "--query", "absent fixture query", "--json"]);
+
+    expect(writeJson).toHaveBeenCalledTimes(1);
+    expect(firstWrittenJsonArg(writeJson)).toEqual({ results: [] });
+    expect(process.exitCode).toBe(0);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["status", ["status"]],
+    ["search", ["search", "fixture query"]],
+    ["index", ["index"]],
+  ])("preserves disabled human %s output without adding JSON", async (_name, args) => {
     getMemorySearchManager.mockResolvedValueOnce({ manager: null });
 
     const log = spyRuntimeLogs(defaultRuntime);
-    await runMemoryCli(["status"]);
+    const writeJson = spyRuntimeJson(defaultRuntime);
+    await runMemoryCli(args);
 
     expect(log).toHaveBeenCalledWith("Memory search disabled.");
+    expect(writeJson).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(0);
   });
 
   it.each([

--- a/src/plugin-sdk/memory-core-host-runtime-cli.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-cli.ts
@@ -5,6 +5,7 @@
 export { formatErrorMessage, withManager } from "../cli/cli-utils.js";
 export { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
 export { getMemoryEmbeddingCommandSecretTargetIds } from "../cli/command-secret-targets.js";
+export { formatCliJsonFailure } from "../cli/failure-output.js";
 export { formatHelpExamples } from "../cli/help-format.js";
 export { withProgress, withProgressTotals } from "../cli/progress.js";
 export { isVerbose, setVerbose } from "../globals.js";


### PR DESCRIPTION
Closes #140184

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled when applicable.

</details>

## What Problem This Solves

Fixes an issue where users running `memory search --json` receive an empty stdout stream and exit code 0 when memory search is disabled. JSON consumers cannot parse that response or distinguish an unavailable backend from a completed search. Five other single-agent JSON commands share the same missing-manager branch.

## Why This Change Was Made

The memory plugin's manager-acquisition owner now emits one availability result for `search`, `promote`, `promote-explain`, `rem-harness`, `rem-backfill`, and `session-backfill` when their `--json` option is selected. The change absorbs a redundant one-caller wrapper and reuses the canonical CLI error formatter through the existing private memory host facade; status retains ownership of its single aggregate array.

## User Impact

Disabled commands return `{"agentId":"main","status":"disabled"}` with the existing successful exit behavior. Acquisition failures return the standard `{"ok":false,"error":{"type":"cli_error","message":"..."}}` envelope plus `agentId`, with exit code 1. The memory CLI documentation explains these alternate outcomes before consumers read normal result fields.

Successful result shapes remain intact, including `{"results":[]}` for an enabled search with no matches. Status still returns its array of available agents, including `[]` when all are disabled. Existing diagnostics, argument validation, and manager cleanup remain at their current owners; unavailable commands do not run search, promotion, or backfill work or invent completed-work counts. No configuration, database schema, migration, or protocol change is included.

## Evidence

Candidate: `90b87fa859f2a85f99de69ea6a4fb1b0761ceed2` on `codex/qa-memory-json-20260906`.

| Proof | Observed result |
| --- | --- |
| Built CLI before the fix, source `c2ffbec6fc9af0da51921acfb5bbb19b66aecd78`, Node v24.20.0 | Disabled search: exit 0, stdout 0 bytes, stderr `Memory search disabled.` and newline. Disabled status: `[]`. Enabled positive and no-match searches: valid JSON. The isolated fixture was cleaned up. |
| Focused source regression before/after | All 12 disabled/error cases across the six commands failed before the fix because no JSON result was written. Those cases and four status/empty-search controls passed after the fix. |
| Full memory CLI and manager-acquisition suites | 123 passed, 0 failed, 0 skipped. |
| Relevant core CLI helper, error and JSON-routing suites | 92 passed, 0 failed, 0 skipped. Focused total: 215 passing cases. |
| Fresh independent review | No actionable findings. |
| Doctor contract checks | 6 passed as part of changed-file validation. |
| Changed-file checks | All 36 stages passed, including formatting, lint, typechecks, guards, package exports, and SDK surface checks. |
| Candidate build | One uncached runtime, SDK and UI build passed in 122.04 seconds at `90b87fa859f2a85f99de69ea6a4fb1b0761ceed2`; source, dependency and artifact identities verified. |
| Expanded real CLI before/after | 25 commands per build: all six disabled branches and six genuine backend-open failures reproduce empty JSON stdout on baseline and emit exactly one documented JSON object on the candidate. All thirteen human/status/index/enabled/no-match controls pass on both builds. Root independently checked 50 raw streams per build, exit codes, source/build/dependency/mode seals and cleanup. |
| Published-head CI | [CI 34043066614](https://github.com/openclaw/openclaw/actions/runs/34043066614) completed successfully on `90b87fa859f2a85f99de69ea6a4fb1b0761ceed2`. |

The backend-open fixture is an empty directory at the database filename inside fresh isolated state; it exercises real acquisition errors without writing database records. No model or external provider request is involved.

The candidate contains 44 added / 45 removed production lines (net −1), 122 added / 2 removed test lines (net +120), and 14 added documentation lines. No generated files, lockfiles, or snapshots changed.

## Review follow-through

The September 6, 15:46 UTC ClawSweeper review of the exact candidate found no correctness or security defects. Its sole before-merge item, “Add data-model compatibility proof,” is not applicable to this patch: the six edits in the search/promotion and REM/backfill callers only pass the JSON writer to the shared acquisition owner. That owner preserves the same configuration, agent, purpose, source-inspection and local-service arguments; missing managers still return before work, and successful managers retain the same cleanup.

Compared with the PR parent, the complete memory storage implementation, state database owners, memory host SDK, configuration, plugin manifest and canonical database schema documentation are unchanged. The patch changes no stored vector/embedding metadata, schema, migration or persisted representation. The existing paired built-CLI proof confirms real backend-open failure handling and unchanged enabled indexing/search/status controls; it is not presented as a migration test. No migration is needed for an output-only availability result.
